### PR TITLE
chore(core): remove resource indicator

### DIFF
--- a/packages/core/src/init/oidc.ts
+++ b/packages/core/src/init/oidc.ts
@@ -38,14 +38,6 @@ export default async function initOidc(app: Koa): Promise<Provider> {
       revocation: { enabled: true },
       introspection: { enabled: true },
       devInteractions: { enabled: false },
-      resourceIndicators: {
-        // Type def for this is broken.
-        // Update when we return client-based default resource
-        defaultResource: () => ['https://api.logto.io'],
-        getResourceServerInfo: () => {
-          return { scope: 'api', accessTokenFormat: 'jwt' };
-        },
-      },
     },
     interactions: {
       url: (_, interaction) => {


### PR DESCRIPTION
temporarily remove resource indicator since jwt access token cannot call `/userinfo` endpoint.

will try to figure out how they (scope, claim, resource indicator) work and summarize into doc once dev environment has been set up.