### PR TITLE
refactor: conform RESTful convention

### DIFF
--- a/packages/core/src/init/apis.ts
+++ b/packages/core/src/init/apis.ts
@@ -1,16 +1,16 @@
 import Koa from 'koa';
 import Router from 'koa-router';
 import { Provider } from 'oidc-provider';
-import signInRoutes from '@/routes/sign-in';
-import registerRoutes from '@/routes/register';
+import sessionRoutes from '@/routes/session';
+import userRoutes from '@/routes/user';
 import swaggerRoutes from '@/routes/swagger';
 import mount from 'koa-mount';
 
 const createRouter = (provider: Provider): Router => {
   const router = new Router();
 
-  signInRoutes(router, provider);
-  registerRoutes(router);
+  sessionRoutes(router, provider);
+  userRoutes(router);
   swaggerRoutes(router);
 
   return router;

--- a/packages/core/src/routes/session.ts
+++ b/packages/core/src/routes/session.ts
@@ -9,9 +9,9 @@ import koaGuard from '@/middleware/koa-guard';
 import RequestError from '@/errors/RequestError';
 import { LogtoErrorCode } from '@logto/phrases';
 
-export default function signInRoutes(router: Router, provider: Provider) {
+export default function sessionRoutes(router: Router, provider: Provider) {
   router.post(
-    '/sign-in',
+    '/session',
     koaGuard({ body: object({ username: string().optional(), password: string().optional() }) }),
     async (ctx, next) => {
       const {
@@ -21,7 +21,7 @@ export default function signInRoutes(router: Router, provider: Provider) {
       if (name === 'login') {
         const { username, password } = ctx.guard.body;
 
-        assert(username && password, new RequestError('sign_in.insufficient_info'));
+        assert(username && password, new RequestError('session.insufficient_info'));
 
         try {
           const { id, passwordEncrypted, passwordEncryptionMethod, passwordEncryptionSalt } =
@@ -29,12 +29,12 @@ export default function signInRoutes(router: Router, provider: Provider) {
 
           assert(
             passwordEncrypted && passwordEncryptionMethod && passwordEncryptionSalt,
-            new RequestError('sign_in.invalid_sign_in_method')
+            new RequestError('session.invalid_sign_in_method')
           );
           assert(
             encryptPassword(id, password, passwordEncryptionSalt, passwordEncryptionMethod) ===
               passwordEncrypted,
-            new RequestError('sign_in.invalid_credentials')
+            new RequestError('session.invalid_credentials')
           );
 
           const redirectTo = await provider.interactionResult(
@@ -48,13 +48,13 @@ export default function signInRoutes(router: Router, provider: Provider) {
           ctx.body = { redirectTo };
         } catch (error: unknown) {
           if (!(error instanceof RequestError)) {
-            throw new RequestError('sign_in.invalid_credentials');
+            throw new RequestError('session.invalid_credentials');
           }
 
           throw error;
         }
       } else if (name === 'consent') {
-        ctx.body = { redirectTo: ctx.request.origin + '/sign-in/consent' };
+        ctx.body = { redirectTo: ctx.request.origin + '/session/consent' };
       } else {
         throw new Error(`Prompt not supported: ${name}`);
       }
@@ -63,7 +63,7 @@ export default function signInRoutes(router: Router, provider: Provider) {
     }
   );
 
-  router.post('/sign-in/consent', async (ctx, next) => {
+  router.post('/session/consent', async (ctx, next) => {
     const { session, grantId, params, prompt } = await provider.interactionDetails(
       ctx.req,
       ctx.res
@@ -99,7 +99,7 @@ export default function signInRoutes(router: Router, provider: Provider) {
     return next();
   });
 
-  router.post('/sign-in/abort', async (ctx, next) => {
+  router.delete('/session', async (ctx, next) => {
     await provider.interactionDetails(ctx.req, ctx.res);
     const error: LogtoErrorCode = 'oidc.aborted';
     const redirectTo = await provider.interactionResult(ctx.req, ctx.res, {

--- a/packages/core/src/routes/user.ts
+++ b/packages/core/src/routes/user.ts
@@ -22,9 +22,9 @@ const generateUserId = async (maxRetries = 500) => {
   throw new Error('Cannot generate user ID in reasonable retries');
 };
 
-export default function registerRoutes(router: Router) {
+export default function userRoutes(router: Router) {
   router.post(
-    '/register',
+    '/user',
     koaGuard({
       body: object({
         username: string().min(3),
@@ -35,7 +35,7 @@ export default function registerRoutes(router: Router) {
       const { username, password } = ctx.guard.body;
 
       if (await hasUser(username)) {
-        throw new RequestError('register.username_exists');
+        throw new RequestError('user.username_exists');
       }
 
       const id = await generateUserId();

--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -1,6 +1,6 @@
 const translation = {
   sign_in: {
-    title: 'Sign In',
+    action: 'Sign In',
     loading: 'Signing in...',
     error: 'Username or password is invalid.',
     username: 'Username',
@@ -8,8 +8,8 @@ const translation = {
   },
   register: {
     create_account: 'Create an Account',
-    title: 'Sign Up',
-    loading: 'Signing Up...',
+    action: 'Create',
+    loading: 'Creating Account...',
     have_account: 'Already have an account?',
   },
 };
@@ -21,10 +21,10 @@ const errors = {
   oidc: {
     aborted: 'The end-user aborted interaction.',
   },
-  register: {
+  user: {
     username_exists: 'The username already exists.',
   },
-  sign_in: {
+  session: {
     invalid_credentials: 'Invalid credentials. Please check your input.',
     invalid_sign_in_method: 'Current sign-in method is not available.',
     insufficient_info: 'Insufficent sign-in info.',

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -2,16 +2,16 @@ import en from './en';
 
 const translation = {
   sign_in: {
-    title: '登录',
+    action: '登录',
     loading: '登录中...',
     error: '用户名或密码错误。',
     username: '用户名',
     password: '密码',
   },
   register: {
-    create_account: '新用户注册',
-    title: '注册',
-    loading: '注册中...',
+    create_account: '创建新账户',
+    action: '创建',
+    loading: '创建中...',
     have_account: '已经有账户？',
   },
 };
@@ -23,10 +23,10 @@ const errors = {
   oidc: {
     aborted: '用户终止了交互。',
   },
-  register: {
+  user: {
     username_exists: '用户名已存在。',
   },
-  sign_in: {
+  session: {
     invalid_credentials: '用户名或密码错误，请检查您的输入。',
     invalid_sign_in_method: '当前登录方式不可用。',
     insufficient_info: '登录信息缺失，请检查您的输入。',

--- a/packages/ui/src/apis/consent.ts
+++ b/packages/ui/src/apis/consent.ts
@@ -4,5 +4,5 @@ export const consent = async () => {
   type Response = {
     redirectTo: string;
   };
-  return ky.post('/api/sign-in/consent').json<Response>();
+  return ky.post('/api/session/consent').json<Response>();
 };

--- a/packages/ui/src/apis/register.ts
+++ b/packages/ui/src/apis/register.ts
@@ -5,7 +5,7 @@ export const register = async (username: string, password: string) => {
     redirectTo: string;
   };
   return ky
-    .post('/api/register', {
+    .post('/api/user', {
       json: {
         username,
         password,

--- a/packages/ui/src/apis/sign-in.ts
+++ b/packages/ui/src/apis/sign-in.ts
@@ -5,7 +5,7 @@ export const signInBasic = async (username: string, password: string) => {
     redirectTo: string;
   };
   return ky
-    .post('/api/sign-in', {
+    .post('/api/session', {
       json: {
         username,
         password,

--- a/packages/ui/src/pages/Register/index.test.tsx
+++ b/packages/ui/src/pages/Register/index.test.tsx
@@ -11,7 +11,7 @@ describe('<Register />', () => {
     expect(queryByText('register.create_account')).not.toBeNull();
     expect(queryByText('register.have_account')).not.toBeNull();
 
-    const submit = getByText('register.title');
+    const submit = getByText('register.action');
     fireEvent.click(submit);
 
     await waitFor(() => {

--- a/packages/ui/src/pages/Register/index.tsx
+++ b/packages/ui/src/pages/Register/index.tsx
@@ -57,13 +57,13 @@ const App: FC = () => {
         )}
         <Button
           isDisabled={isLoading}
-          value={isLoading ? t('register.loading') : t('register.title')}
+          value={isLoading ? t('register.loading') : t('register.action')}
           onClick={signUp}
         />
 
         <div className={styles.haveAccount}>
           <span className={styles.prefix}>{t('register.have_account')}</span>
-          <TextLink href="/sign-in">{t('sign_in.title')}</TextLink>
+          <TextLink href="/sign-in">{t('sign_in.action')}</TextLink>
         </div>
       </form>
     </div>

--- a/packages/ui/src/pages/SignIn/index.test.tsx
+++ b/packages/ui/src/pages/SignIn/index.test.tsx
@@ -10,7 +10,7 @@ describe('<SignIn />', () => {
     const { queryByText, getByText } = render(<SignIn />);
     expect(queryByText('Sign in to Logto')).not.toBeNull();
 
-    const submit = getByText('sign_in.title');
+    const submit = getByText('sign_in.action');
     fireEvent.click(submit);
 
     await waitFor(() => {

--- a/packages/ui/src/pages/SignIn/index.tsx
+++ b/packages/ui/src/pages/SignIn/index.tsx
@@ -60,7 +60,7 @@ const Home: FC = () => {
         )}
         <Button
           isDisabled={isLoading}
-          value={isLoading ? t('sign_in.loading') : t('sign_in.title')}
+          value={isLoading ? t('sign_in.loading') : t('sign_in.action')}
           onClick={signIn}
         />
         <TextLink className={styles.createAccount} href="/register">


### PR DESCRIPTION
According to this [SO answer](https://stackoverflow.com/a/7252311/12514940), RESTful APIs should have noun in URL and use HTTP Method to describe its behavior. The changes in this PR:

1. Use `session` to imply the object of a sign-in flow. E.g. `POST /session` means user is try to create a new session (sign-in).
2. `POST /register` -> `POST /user`.

Tested in playground, looks good.
