### PR TITLE
feat: validate access token if needed

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,7 +46,7 @@
     "@types/koa": "^2.13.3",
     "@types/koa-logger": "^3.1.1",
     "@types/koa-mount": "^4.0.0",
-    "@types/koa-router": "^7.4.2",
+    "@types/koa-router": "^7.4.4",
     "@types/koa-static": "^4.0.2",
     "@types/lodash.pick": "^4.4.6",
     "@types/node": "^16.3.1",

--- a/packages/core/src/env/consts.ts
+++ b/packages/core/src/env/consts.ts
@@ -3,5 +3,4 @@ import { assertEnv, getEnv } from '@/utils/env';
 export const signIn = assertEnv('UI_SIGN_IN_ROUTE');
 export const isProduction = getEnv('NODE_ENV') === 'production';
 export const port = Number(getEnv('PORT', '3001'));
-export const oidcIssuer = getEnv('OIDC_ISSUER', `http://localhost:${port}/oidc`);
 export const mountedApps = Object.freeze(['api', 'oidc']);

--- a/packages/core/src/middleware/koa-auth.ts
+++ b/packages/core/src/middleware/koa-auth.ts
@@ -1,15 +1,25 @@
 import assert from 'assert';
 import RequestError from '@/errors/RequestError';
-import { RequestErrorBody } from '@logto/schemas';
-import { Middleware } from 'koa';
+import { MiddlewareType } from 'koa';
+import { jwtVerify } from 'jose/jwt/verify';
+import { publicKey, issuer, adminResource } from '@/oidc/consts';
+import { IRouterParamContext } from 'koa-router';
+import { UserInfo, userInfoSelectFields } from '@logto/schemas';
+import { findUserById } from '@/queries/user';
+import pick from 'lodash.pick';
+
+export type WithAuthContext<ContextT extends IRouterParamContext = IRouterParamContext> =
+  ContextT & {
+    user: UserInfo;
+  };
 
 const bearerToken = 'Bearer';
 
-export default function koaAuth<StateT, ContextT>(): Middleware<
+export default function koaAuth<
   StateT,
-  ContextT,
-  RequestErrorBody
-> {
+  ContextT extends IRouterParamContext,
+  ResponseBodyT
+>(): MiddlewareType<StateT, WithAuthContext<ContextT>, ResponseBodyT> {
   return async (ctx, next) => {
     const { authorization } = ctx.request.headers;
     assert(
@@ -23,6 +33,22 @@ export default function koaAuth<StateT, ContextT>(): Middleware<
         { supportedTypes: [bearerToken] }
       )
     );
+    const jwt = authorization.slice(bearerToken.length + 1);
+
+    try {
+      const {
+        payload: { sub },
+      } = await jwtVerify(jwt, publicKey, {
+        issuer,
+        audience: adminResource,
+      });
+      assert(sub);
+      const user = await findUserById(sub);
+      ctx.user = pick(user, ...userInfoSelectFields);
+    } catch {
+      throw new RequestError({ code: 'auth.unauthorized', status: 401 });
+    }
+
     return next();
   };
 }

--- a/packages/core/src/middleware/koa-guard.ts
+++ b/packages/core/src/middleware/koa-guard.ts
@@ -17,7 +17,7 @@ export type Guarded<QueryT, BodyT, ParametersT> = {
   params: ParametersT;
 };
 
-export type WithGuarded<
+export type WithGuardedContext<
   ContextT extends IRouterParamContext,
   GuardQueryT,
   GuardBodyT,
@@ -53,12 +53,12 @@ export default function koaGuard<
   params,
 }: GuardConfig<GuardQueryT, GuardBodyT, GuardParametersT>): MiddlewareType<
   StateT,
-  WithGuarded<ContextT, GuardQueryT, GuardBodyT, GuardParametersT>,
+  WithGuardedContext<ContextT, GuardQueryT, GuardBodyT, GuardParametersT>,
   ResponseBodyT
 > {
   const guard: MiddlewareType<
     StateT,
-    WithGuarded<ContextT, GuardQueryT, GuardBodyT, GuardParametersT>,
+    WithGuardedContext<ContextT, GuardQueryT, GuardBodyT, GuardParametersT>,
     ResponseBodyT
   > = async (ctx, next) => {
     try {
@@ -78,7 +78,7 @@ export default function koaGuard<
   const guardMiddleware: WithGuardConfig<
     MiddlewareType<
       StateT,
-      WithGuarded<ContextT, GuardQueryT, GuardBodyT, GuardParametersT>,
+      WithGuardedContext<ContextT, GuardQueryT, GuardBodyT, GuardParametersT>,
       ResponseBodyT
     >
   > = async function (ctx, next) {

--- a/packages/core/src/oidc/consts.ts
+++ b/packages/core/src/oidc/consts.ts
@@ -1,0 +1,11 @@
+import crypto from 'crypto';
+import { getEnv } from '@/utils/env';
+import { port } from '@/env/consts';
+
+export const privateKey = crypto.createPrivateKey(
+  Buffer.from(getEnv('OIDC_PROVIDER_PRIVATE_KEY_BASE64'), 'base64')
+);
+export const publicKey = crypto.createPublicKey(privateKey);
+
+export const issuer = getEnv('OIDC_ISSUER', `http://localhost:${port}/oidc`);
+export const adminResource = getEnv('ADMIN_RESOURCE', 'https://api.logto.io');

--- a/packages/core/src/routes/application.ts
+++ b/packages/core/src/routes/application.ts
@@ -2,10 +2,8 @@ import Router from 'koa-router';
 import { nativeEnum, object, string } from 'zod';
 import { ApplicationType } from '@logto/schemas';
 import koaGuard from '@/middleware/koa-guard';
-import koaAuth from '@/middleware/koa-auth';
 
-export default function applicationRoutes(router: Router) {
-  router.use('/application', koaAuth());
+export default function applicationRoutes<StateT, ContextT>(router: Router<StateT, ContextT>) {
   router.post(
     '/application',
     koaGuard({

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -1,3 +1,4 @@
 export * from './foundations';
 export * from './db-entries';
+export * from './types';
 export * from './api';

--- a/packages/schemas/src/types/index.ts
+++ b/packages/schemas/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './user';

--- a/packages/schemas/src/types/user.ts
+++ b/packages/schemas/src/types/user.ts
@@ -1,0 +1,13 @@
+import { UserDBEntry } from '../db-entries';
+
+export const userInfoSelectFields = Object.freeze([
+  'id',
+  'username',
+  'primaryEmail',
+  'primaryPhone',
+] as const);
+
+export type UserInfo<Keys extends keyof UserDBEntry = typeof userInfoSelectFields[number]> = Pick<
+  UserDBEntry,
+  Keys
+>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ importers:
       '@types/koa': ^2.13.3
       '@types/koa-logger': ^3.1.1
       '@types/koa-mount': ^4.0.0
-      '@types/koa-router': ^7.4.2
+      '@types/koa-router': ^7.4.4
       '@types/koa-static': ^4.0.2
       '@types/lodash.pick': ^4.4.6
       '@types/node': ^16.3.1


### PR DESCRIPTION
## Summary

1. Separate anonymous routes and authed routes into different routers.
2. Add `koaAuth()` middleware to verify JWT.

## Testing

`POST /api/application`

### With invalid JWT

<img width="567" src="https://user-images.githubusercontent.com/14722250/129483008-b36f3ee0-6548-4a10-a7c3-ca0e325e4df6.png">


### With valid JWT

Note: The valid JWT can be generated from playground now with `resource=https://api.logto.io` in auth request.

<img width="287" src="https://user-images.githubusercontent.com/14722250/129483039-fffabc30-b86c-49cc-83a2-ed572749fb50.png">
<img width="189" src="https://user-images.githubusercontent.com/14722250/129483048-cb8f2aec-3f53-493f-93f7-80454e1e50ce.png">

`GET /api/application`

<img width="186" alt="Status 405 Method Not Allowed" src="https://user-images.githubusercontent.com/14722250/129483112-e04e991b-54e9-460a-9ba3-de25e83aeeb9.png">
