### PR TITLE
refactor: unify timestamp usage

### DIFF
--- a/packages/core/src/oidc/adapter.ts
+++ b/packages/core/src/oidc/adapter.ts
@@ -38,7 +38,7 @@ export default function postgresAdapter(modelName: string): ReturnType<AdapterFa
         modelName,
         id,
         payload,
-        expiresAt: dayjs().add(expiresIn, 'second').unix(),
+        expiresAt: dayjs().add(expiresIn, 'second').valueOf(),
       }),
     find: async (id) => findPayloadById(modelName, id),
     findByUserCode: async (userCode) => findPayloadByPayloadField(modelName, 'userCode', userCode),

--- a/packages/core/src/queries/oidc-model-instance.ts
+++ b/packages/core/src/queries/oidc-model-instance.ts
@@ -64,7 +64,7 @@ export const findPayloadByPayloadField = async <
 export const consumeInstanceById = async (modelName: string, id: string) => {
   await pool.query(sql`
     update ${table}
-    set ${fields.consumedAt}=${dayjs().unix()}
+    set ${fields.consumedAt}=${dayjs().valueOf()}
     where ${fields.modelName}=${modelName}
     and ${fields.id}=${id}
   `);

--- a/packages/schemas/src/gen/utils.ts
+++ b/packages/schemas/src/gen/utils.ts
@@ -82,7 +82,7 @@ const getRawType = (value: string): string => {
 // eslint-disable-next-line complexity
 export const getType = (
   value: string
-): 'string' | 'number' | 'boolean' | 'Record<string, unknown>' | 'Date' | undefined => {
+): 'string' | 'number' | 'boolean' | 'Record<string, unknown>' | undefined => {
   switch (getRawType(value)) {
     case 'bpchar':
     case 'char':
@@ -106,16 +106,15 @@ export const getType = (
     case 'numeric':
     case 'money':
     case 'oid':
+    case 'date':
+    case 'timestamp':
+    case 'timestamptz':
       return 'number';
     case 'bool':
       return 'boolean';
     case 'json':
     case 'jsonb':
       return 'Record<string, unknown>';
-    case 'date':
-    case 'timestamp':
-    case 'timestamptz':
-      return 'Date';
     default:
   }
 };

--- a/packages/schemas/tables/applications.sql
+++ b/packages/schemas/tables/applications.sql
@@ -5,6 +5,6 @@ create table applications (
   name varchar(256) not null,
   type application_type not null,
   oidc_client_metadata jsonb /* @use OidcClientMetadata */ not null,
-  created_at bigint not null default(extract(epoch from now())),
+  created_at timestamptz not null default(now()),
   primary key (id)
 );

--- a/packages/schemas/tables/oidc_model_instances.sql
+++ b/packages/schemas/tables/oidc_model_instances.sql
@@ -2,8 +2,8 @@ create table oidc_model_instances (
   model_name varchar(64) not null,
   id varchar(128) not null,
   payload jsonb /* @use OidcModelInstancePayload */ not null,
-  expires_at bigint not null,
-  consumed_at bigint,
+  expires_at timestamptz not null,
+  consumed_at timestamptz,
   primary key (model_name, id)
 );
 


### PR DESCRIPTION
## Summary

Per discussion, use `timestamptz` as database timestamp type. Value will still be `number` in Node.

## Testing

- [x] sign in/out
- [x] `POST /application`