### PR TITLE
feat: Read and show error from API response

### DIFF
--- a/packages/core/src/middleware/koa-error-handler.ts
+++ b/packages/core/src/middleware/koa-error-handler.ts
@@ -1,5 +1,6 @@
 import RequestError from '@/errors/RequestError';
 import { RequestErrorBody } from '@logto/schemas';
+import { LogtoErrorCode } from '@logto/phrases';
 import decamelize from 'decamelize';
 import { Middleware } from 'koa';
 import { errors } from 'oidc-provider';
@@ -23,7 +24,8 @@ export default function koaErrorHandler<StateT, ContextT>(): Middleware<
         ctx.status = error.status;
         ctx.body = {
           message: error.error_description ?? error.message,
-          code: `oidc.${decamelize(error.name)}`,
+          // Assert error type of OIDCProviderError, code key should all covered in @logto/phrases
+          code: `oidc.${decamelize(error.name)}` as LogtoErrorCode,
           data: error.error_detail,
         };
         return;

--- a/packages/schemas/src/api/error.ts
+++ b/packages/schemas/src/api/error.ts
@@ -5,4 +5,4 @@ export type RequestErrorMetadata = Record<string, unknown> & {
   status?: number;
 };
 
-export type RequestErrorBody = { message: string; data: unknown; code: string };
+export type RequestErrorBody = { message: string; data: unknown; code: LogtoErrorCode };

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@logto/phrases": "^0.1.0",
+    "@logto/schemas": "^0.1.0",
     "classnames": "^2.3.1",
     "i18next": "^20.3.3",
     "i18next-browser-languagedetector": "^6.1.2",

--- a/packages/ui/razzle.config.js
+++ b/packages/ui/razzle.config.js
@@ -21,6 +21,11 @@ module.exports = {
     /** @type {import('@jest/types').Config.InitialOptions} **/
     const config = { ...jestConfig };
 
+    config.transformIgnorePatterns = [
+      '^.+\\.module\\.(css|sass|scss)$',
+      '[/\\\\]node_modules[/\\\\]((?!ky[/\\\\]).)+\\.(js|jsx|mjs|cjs|ts|tsx)$',
+    ];
+
     config.moduleNameMapper = {
       ...config.moduleNameMapper,
       '^.+\\.(css|less|scss)$': 'babel-jest',

--- a/packages/ui/src/hooks/use-api.ts
+++ b/packages/ui/src/hooks/use-api.ts
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { HTTPError } from 'ky';
+import { RequestErrorBody } from '@logto/schemas';
+
+type UseApi<T extends any[], U> = {
+  result?: U;
+  loading: boolean;
+  error: RequestErrorBody | null;
+  run: (...args: T) => Promise<void>;
+};
+
+function useApi<Args extends any[], Response>(
+  api: (...args: Args) => Promise<Response>
+): UseApi<Args, Response> {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<RequestErrorBody | null>(null);
+  const [result, setResult] = useState<Response>();
+
+  const run = async (...args: Args) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const result = await api(...args);
+      setResult(result);
+      setLoading(false);
+    } catch (error: unknown) {
+      if (error instanceof HTTPError) {
+        const kyError = await error.response.json<RequestErrorBody>();
+        setError(kyError);
+      }
+
+      setLoading(false);
+      throw error;
+    }
+  };
+
+  return {
+    loading,
+    error,
+    result,
+    run,
+  };
+}
+
+export default useApi;

--- a/packages/ui/src/include.d/dom.d.ts
+++ b/packages/ui/src/include.d/dom.d.ts
@@ -69,3 +69,7 @@ type AutoCompleteType =
   | 'sex'
   | 'url'
   | 'photo';
+
+interface Body {
+  json<T>(): Promise<T>;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,7 @@ importers:
       '@logto/eslint-config': ^0.1.0-rc.18
       '@logto/eslint-config-react': ^0.1.0-rc.18
       '@logto/phrases': ^0.1.0
+      '@logto/schemas': ^0.1.0
       '@logto/ts-config': ^0.1.0-rc.18
       '@logto/ts-config-react': ^0.1.0-rc.18
       '@testing-library/react': ^12.0.0
@@ -195,6 +196,7 @@ importers:
       webpack-dev-server: ^3.11.2
     dependencies:
       '@logto/phrases': link:../phrases
+      '@logto/schemas': link:../schemas
       classnames: 2.3.1
       i18next: 20.3.5
       i18next-browser-languagedetector: 6.1.2


### PR DESCRIPTION
Implement useApi hooks to handle api call flow. Wrap-up api call flow with `loading`, `error`, `result`, `fetch` as its return value. 

Leverage page loading status & error message with useApi hooks response.  Display the error message from api error response. 

![image](https://user-images.githubusercontent.com/36393111/129929376-5c99c975-9b4a-4243-b31c-3095fb113317.png)


update  jest config to allow babelTransform job runs on ky modules. As in jest env we are not able to access ky es6 modules.


By default all node_modules files are ignored by jest config:
![image](https://user-images.githubusercontent.com/36393111/130073054-95868eae-d21c-4d3c-8f3a-5af57ab6473b.png)

filter out /node_modules/ky/ paths.


@wangsijie @gao-sun 