### PR TITLE
refactor: throw an error when requesting invalid scope

### DIFF
--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -25,6 +25,8 @@ const errors = {
   },
   oidc: {
     aborted: 'The end-user aborted interaction.',
+    invalid_scope: 'Scope {{scopes}} is not supported.',
+    invalid_scope_plural: 'Scope {{scopes}} are not supported.',
   },
   user: {
     username_exists: 'The username already exists.',

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -27,6 +27,8 @@ const errors = {
   },
   oidc: {
     aborted: '用户终止了交互。',
+    invalid_scope: '不支持的 scope: {{scopes}}。',
+    invalid_scope_plural: '不支持的 scope: {{scopes}}。',
   },
   user: {
     username_exists: '用户名已存在。',


### PR DESCRIPTION
## Summary

when user tries to consent a session, the API should throw an error if user requested invalid scope (since user is signed in). thus, available scopes should be documented or we can offer a special scope for listing all scopes for an app after sign-in.

created [LOG-50](https://linear.app/silverhand/issue/LOG-50/discussion-available-scopes) for discussion.

## Testing

<img width="516" alt="{mesSage Scepe abc 1s Riot supported , code  oidc  invat2d_scope)" src="https://user-images.githubusercontent.com/14722250/131139623-cdc1ed3e-d1f5-4e0f-8afd-55841345847e.png">

<img width="579" alt="(nessage Scope abc, 1o0 are not supported ”  code oidc invalid_scope}" src="https://user-images.githubusercontent.com/14722250/131139635-ead4c4c5-39da-46d1-8734-c03c4d4cc86a.png">
