### PR TITLE
fix(schemas): move `zod` into dependencies

### DIFF
--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -34,17 +34,14 @@
     "pluralize": "^8.0.0",
     "prettier": "^2.3.2",
     "ts-node": "^10.0.0",
-    "typescript": "^4.3.5",
-    "zod": "^3.8.1"
+    "typescript": "^4.3.5"
   },
   "eslintConfig": {
     "extends": "@logto"
   },
   "prettier": "@logto/eslint-config/.prettierrc",
   "dependencies": {
-    "@logto/phrases": "^0.1.0"
-  },
-  "peerDependencies": {
+    "@logto/phrases": "^0.1.0",
     "zod": "^3.8.1"
   }
 }

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "precommit": "lint-staged",
-    "generate": "ts-node src/gen/index.ts && eslint \"src/db-entries/**\" --fix",
+    "generate": "rm -rf src/db-entries && ts-node src/gen/index.ts && eslint \"src/db-entries/**\" --fix",
     "build": "pnpm generate && rm -rf lib/ && tsc --p tsconfig.build.json",
     "lint": "eslint --ext .ts src",
     "prepack": "pnpm build"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,7 @@ importers:
       zod: ^3.8.1
     dependencies:
       '@logto/phrases': link:../phrases
+      zod: 3.8.1
     devDependencies:
       '@logto/eslint-config': 0.1.3_aff669e8eb0d21fc4e2068e6112ef4d0
       '@logto/essentials': 1.1.0-rc.2
@@ -162,7 +163,6 @@ importers:
       prettier: 2.3.2
       ts-node: 10.1.0_13403c2f2d9ddab699dd2f492f123cbf
       typescript: 4.3.5
-      zod: 3.8.1
 
   packages/ui:
     specifiers:
@@ -16741,6 +16741,7 @@ packages:
 
   /zod/3.8.1:
     resolution: {integrity: sha512-u4Uodl7dLh8nXZwqXL1SM5FAl5b4lXYHOxMUVb9lqhlEAZhA2znX+0oW480m0emGFMxpoRHzUncAqRkc4h8ZJA==}
+    dev: false
 
   /zwitch/1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}


### PR DESCRIPTION
## Summary
schemas: move `zod` to dependencies to avoid unexpected prune on prod:

<img width="500" src="https://user-images.githubusercontent.com/14722250/131974796-74eb4fa0-39a5-4986-bc89-21ca2a6c6884.png" />

![image](https://user-images.githubusercontent.com/14722250/131974851-47a6f1ce-ac47-4829-bd9e-ebb54d3e6846.png)
