### PR TITLE
chore(core): upgrade `oidc-provider`

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,7 @@
     "lodash.pick": "^4.4.0",
     "module-alias": "^2.2.2",
     "nanoid": "^3.1.23",
-    "oidc-provider": "^7.4.1",
+    "oidc-provider": "^7.7.0",
     "p-retry": "^4.6.1",
     "slonik": "^23.8.3",
     "slonik-interceptor-preset": "^1.2.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
       lodash.pick: ^4.4.0
       module-alias: ^2.2.2
       nanoid: ^3.1.23
-      oidc-provider: ^7.4.1
+      oidc-provider: ^7.7.0
       openapi-types: ^9.1.0
       p-retry: ^4.6.1
       prettier: ^2.3.2
@@ -86,7 +86,7 @@ importers:
       lodash.pick: 4.4.0
       module-alias: 2.2.2
       nanoid: 3.1.23
-      oidc-provider: 7.5.4
+      oidc-provider: 7.7.0
       p-retry: 4.6.1
       slonik: 23.8.5
       slonik-interceptor-preset: 1.2.10
@@ -12164,8 +12164,8 @@ packages:
   /obuf/1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
 
-  /oidc-provider/7.5.4:
-    resolution: {integrity: sha512-ffUkiXA2g+QB7CmlrAOBPg7h/j/AEa0k7x4qVrjBrkeTk3riPyHidFhkYwOt7rW/3rsOdcqXliEME+MeSiSkUA==}
+  /oidc-provider/7.7.0:
+    resolution: {integrity: sha512-SyqKP7ggRHbLbRXNiYZNmHiGWJ4vVv1SToSsr171miCHwYH4zhtJ6VoE9f14G9W1YryVIah2XQXAq5m/3h5o8A==}
     engines: {node: ^12.19.0 || ^14.15.0}
     dependencies:
       '@koa/cors': 3.1.0
@@ -12180,9 +12180,11 @@ packages:
       nanoid: 3.1.23
       object-hash: 2.2.0
       oidc-token-hash: 5.0.1
-      paseto: 2.1.3
+      paseto2: /paseto/2.1.3
       quick-lru: 5.1.1
       raw-body: 2.4.1
+    optionalDependencies:
+      paseto3: /paseto/3.0.1
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -12576,6 +12578,13 @@ packages:
     resolution: {integrity: sha512-BNkbvr0ZFDbh3oV13QzT5jXIu8xpFc9r0o5mvWBhDU1GBkVt1IzHK1N6dcYmN7XImrUmPQ0HCUXmoe2WPo8xsg==}
     engines: {node: ^12.19.0 || >=14.15.0}
     dev: false
+
+  /paseto/3.0.1:
+    resolution: {integrity: sha512-K43Fi/W3vogewQHcHX+etF8Kx7Va037xLauTamK0AGTOLsE3CPW4jdRaeFvoaVIh6ybZiFg+nXVSc6ckIr0XVw==}
+    engines: {node: '>=16.0.0'}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /passthrough-counter/1.0.0:
     resolution: {integrity: sha1-GWfZ5m2lcrXAI8eH2xEqOHqxZvo=}


### PR DESCRIPTION
Added [LOG-97](https://linear.app/silverhand/issue/LOG-97/paseto-access-tokens-research) for paseto access tokens research.
