### PR TITLE
refactor(core): fulfill correct `applicationType` when needed

### DIFF
--- a/packages/core/src/database/update-where.test.ts
+++ b/packages/core/src/database/update-where.test.ts
@@ -12,7 +12,10 @@ describe('buildUpdateWhere()', () => {
     );
     const updateWhere = buildUpdateWhere(pool, Users);
     await expect(
-      updateWhere({ set: { username: '123' }, where: { id: 'foo', username: '456' } })
+      updateWhere({
+        set: { username: '123', id: undefined },
+        where: { id: 'foo', username: '456' },
+      })
     ).resolves.toBe(undefined);
   });
 

--- a/packages/core/src/database/update-where.test.ts
+++ b/packages/core/src/database/update-where.test.ts
@@ -13,7 +13,7 @@ describe('buildUpdateWhere()', () => {
     const updateWhere = buildUpdateWhere(pool, Users);
     await expect(
       updateWhere({
-        set: { username: '123', id: undefined },
+        set: { username: '123' },
         where: { id: 'foo', username: '456' },
       })
     ).resolves.toBe(undefined);
@@ -33,6 +33,19 @@ describe('buildUpdateWhere()', () => {
     await expect(
       updateWhere({ set: { username: '123', primaryEmail: 'foo@bar.com' }, where: { id: 'foo' } })
     ).resolves.toStrictEqual(user);
+  });
+
+  it('throws an error when `undefined` found in values', async () => {
+    const pool = createTestPool(
+      'update "users"\nset "username"=$1\nwhere "id"=$2 and "username"=$3'
+    );
+    const updateWhere = buildUpdateWhere(pool, Users);
+    await expect(
+      updateWhere({
+        set: { username: '123', id: undefined },
+        where: { id: 'foo', username: '456' },
+      })
+    ).rejects.toMatchError(new TypeError("Cannot read property 'toString' of undefined"));
   });
 
   it('throws `entity.not_exists_with_id` error with `undefined` when `returning` is true', async () => {

--- a/packages/core/src/database/update-where.ts
+++ b/packages/core/src/database/update-where.ts
@@ -35,7 +35,6 @@ export const buildUpdateWhere: BuildUpdateWhere = <Schema extends SchemaLike>(
   const isKeyOfSchema = isKeyOf(schema);
   const connectKeyValueWithEqualSign = (data: Partial<Schema>) =>
     Object.entries(data)
-      .filter(([_, value]) => value !== undefined)
       .map(
         ([key, value]) =>
           isKeyOfSchema(key) && sql`${fields[key]}=${convertToPrimitiveOrSql(key, value)}`

--- a/packages/core/src/database/update-where.ts
+++ b/packages/core/src/database/update-where.ts
@@ -35,6 +35,7 @@ export const buildUpdateWhere: BuildUpdateWhere = <Schema extends SchemaLike>(
   const isKeyOfSchema = isKeyOf(schema);
   const connectKeyValueWithEqualSign = (data: Partial<Schema>) =>
     Object.entries(data)
+      .filter(([_, value]) => value !== undefined)
       .map(
         ([key, value]) =>
           isKeyOfSchema(key) && sql`${fields[key]}=${convertToPrimitiveOrSql(key, value)}`

--- a/packages/core/src/oidc/utils.ts
+++ b/packages/core/src/oidc/utils.ts
@@ -1,6 +1,14 @@
-import { OidcClientMetadata } from '@logto/schemas';
+import { ApplicationType, OidcClientMetadata } from '@logto/schemas';
 
-export const generateOidcClientMetadata = (): OidcClientMetadata => ({
+const getApplicationTypeString = (type: ApplicationType) =>
+  type === ApplicationType.Native ? 'native' : 'web';
+
+export const buildOidcClientMetadata = (
+  type: ApplicationType,
+  metadata?: OidcClientMetadata
+): OidcClientMetadata => ({
   redirectUris: [],
   postLogoutRedirectUris: [],
+  ...metadata,
+  applicationType: getApplicationTypeString(type),
 });

--- a/packages/schemas/src/foundations/jsonb-types.ts
+++ b/packages/schemas/src/foundations/jsonb-types.ts
@@ -15,7 +15,7 @@ export const oidcModelInstancePayloadGuard = z
 export type OidcModelInstancePayload = z.infer<typeof oidcModelInstancePayloadGuard>;
 
 export const oidcClientMetadataGuard = z.object({
-  applicationType: z.string().optional(),
+  applicationType: z.enum(['web', 'native']),
   redirectUris: z.string().array(),
   postLogoutRedirectUris: z.string().array(),
 });

--- a/packages/schemas/src/foundations/jsonb-types.ts
+++ b/packages/schemas/src/foundations/jsonb-types.ts
@@ -15,6 +15,7 @@ export const oidcModelInstancePayloadGuard = z
 export type OidcModelInstancePayload = z.infer<typeof oidcModelInstancePayloadGuard>;
 
 export const oidcClientMetadataGuard = z.object({
+  applicationType: z.string().optional(),
   redirectUris: z.string().array(),
   postLogoutRedirectUris: z.string().array(),
 });


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
1. fulfill correct `applicationType` for [`node-oidc-provider`](https://github.com/panva/node-oidc-provider/blob/a751406d5df178b2ce40c2e28b9ae40d379c34f2/lib/helpers/client_schema.js#L594) when creating and patching application.
2. remove `undefined` before updating


<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-135


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] `POST /application` with `"type": "Native"` -> `oidcClientMetadata.applicationType` shows `native`
- [x] `POST /application` with `"type": "Native"` and `"oidcClientMetadata.applicationType": "web"` -> `oidcClientMetadata.applicationType` shows `native`
- [x] `PATCH /application/:id-just-created` with `"type": "SPA"` -> `oidcClientMetadata.applicationType` shows `web`

