### PR TITLE
chore(core): throw out oidc-provider error

### DIFF
--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -20,6 +20,7 @@ export default async function initOidc(app: Koa): Promise<Provider> {
     adapter: postgresAdapter,
     renderError: (ctx, out, error) => {
       console.log('OIDC error', error);
+      throw error;
     },
     cookies: {
       // V2: Rotate this when necessary


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->

Issue:
oidc-provider error was logged but not exposed to the client side:
![image](https://user-images.githubusercontent.com/36393111/136933846-d53ce536-8550-4207-b3e9-a14ecc5ca084.png)


For better dev debugging experience we need to simply display detailed error on the page in json format i.e.

Fix:
Need to throw the oidc-provider error out and it will be catched by koa-error-handler and being handled as a koa exception with error detail injected to the response body. 

![image](https://user-images.githubusercontent.com/36393111/136933190-1c1e4270-e05c-43d7-825e-3b5b12781b86.png)

TODO: We need to redesign the error page with a more user friendly ui and walk through all the possible oidc errors. Need to be handled case by case. 

<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally on the playground. 
![image](https://user-images.githubusercontent.com/36393111/136933727-09698b8a-8294-4f2f-982a-f19d1650fed5.png)

@wangsijie @gao-sun cc: @xiaoyijun @IceHe 
