### PR TITLE
refactor(ui): replace ky with axios

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,10 +19,10 @@
   "dependencies": {
     "@logto/phrases": "^0.1.0",
     "@logto/schemas": "^0.1.0",
+    "axios": "^0.24.0",
     "classnames": "^2.3.1",
     "i18next": "^20.3.3",
     "i18next-browser-languagedetector": "^6.1.2",
-    "ky": "^0.28.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-i18next": "^11.11.3",

--- a/packages/ui/razzle.config.js
+++ b/packages/ui/razzle.config.js
@@ -23,7 +23,6 @@ module.exports = {
 
     config.transformIgnorePatterns = [
       '^.+\\.module\\.(css|sass|scss)$',
-      '[/\\\\]node_modules[/\\\\]((?!ky[/\\\\]).)+\\.(js|jsx|mjs|cjs|ts|tsx)$',
     ];
 
     config.moduleNameMapper = {

--- a/packages/ui/razzle.config.js
+++ b/packages/ui/razzle.config.js
@@ -21,10 +21,6 @@ module.exports = {
     /** @type {import('@jest/types').Config.InitialOptions} **/
     const config = { ...jestConfig };
 
-    config.transformIgnorePatterns = [
-      '^.+\\.module\\.(css|sass|scss)$',
-    ];
-
     config.moduleNameMapper = {
       ...config.moduleNameMapper,
       '^.+\\.(css|less|scss)$': 'babel-jest',

--- a/packages/ui/src/App.test.tsx
+++ b/packages/ui/src/App.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter } from 'react-router-dom';
 
 import App from './App';
 
-jest.mock('ky', () => ({}));
+jest.mock('axios', () => ({}));
 
 describe('<App />', () => {
   test('renders without exploding', () => {

--- a/packages/ui/src/apis/consent.ts
+++ b/packages/ui/src/apis/consent.ts
@@ -1,8 +1,8 @@
-import ky from 'ky';
+import axios from 'axios';
 
 export const consent = async () => {
   type Response = {
     redirectTo: string;
   };
-  return ky.post('/api/session/consent').json<Response>();
+  return axios.post<Response>('/api/session/consent');
 };

--- a/packages/ui/src/apis/register.ts
+++ b/packages/ui/src/apis/register.ts
@@ -1,15 +1,11 @@
-import ky from 'ky';
+import axios from 'axios';
 
 export const register = async (username: string, password: string) => {
   type Response = {
     redirectTo: string;
   };
-  return ky
-    .post('/api/user', {
-      json: {
-        username,
-        password,
-      },
-    })
-    .json<Response>();
+  return axios.post<Response>('/api/user', {
+    username,
+    password,
+  });
 };

--- a/packages/ui/src/apis/sign-in.ts
+++ b/packages/ui/src/apis/sign-in.ts
@@ -1,15 +1,11 @@
-import ky from 'ky';
+import axios from 'axios';
 
 export const signInBasic = async (username: string, password: string) => {
   type Response = {
     redirectTo: string;
   };
-  return ky
-    .post('/api/session', {
-      json: {
-        username,
-        password,
-      },
-    })
-    .json<Response>();
+  return axios.post<Response>('/api/session', {
+    username,
+    password,
+  });
 };

--- a/packages/ui/src/pages/Register/index.test.tsx
+++ b/packages/ui/src/pages/Register/index.test.tsx
@@ -4,7 +4,9 @@ import React from 'react';
 import { register } from '@/apis/register';
 import Register from '@/pages/Register';
 
-jest.mock('@/apis/register', () => ({ register: jest.fn(async () => Promise.resolve()) }));
+jest.mock('@/apis/register', () => ({
+  register: jest.fn(async () => Promise.resolve({ data: { redirectUrl: '' } })),
+}));
 
 describe('<Register />', () => {
   test('renders without exploding', async () => {

--- a/packages/ui/src/pages/SignIn/index.test.tsx
+++ b/packages/ui/src/pages/SignIn/index.test.tsx
@@ -4,7 +4,9 @@ import React from 'react';
 import { signInBasic } from '@/apis/sign-in';
 import SignIn from '@/pages/SignIn';
 
-jest.mock('@/apis/sign-in', () => ({ signInBasic: jest.fn(async () => Promise.resolve()) }));
+jest.mock('@/apis/sign-in', () => ({
+  signInBasic: jest.fn(async () => Promise.resolve({ data: { redirectUrl: '' } })),
+}));
 
 describe('<SignIn />', () => {
   test('renders without exploding', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,6 +185,7 @@ importers:
       '@types/react-router-dom': ^5.1.8
       '@types/webpack': ^4
       '@types/webpack-env': ^1.16.2
+      axios: ^0.24.0
       babel-preset-razzle: 4.0.5
       classnames: ^2.3.1
       concurrently: ^6.2.0
@@ -192,7 +193,6 @@ importers:
       html-webpack-plugin: ^4.5.2
       i18next: ^20.3.3
       i18next-browser-languagedetector: ^6.1.2
-      ky: ^0.28.5
       lint-staged: ^11.1.1
       mini-css-extract-plugin: ^0.9.0
       postcss: ^8.3.6
@@ -211,10 +211,10 @@ importers:
     dependencies:
       '@logto/phrases': link:../phrases
       '@logto/schemas': link:../schemas
+      axios: 0.24.0
       classnames: 2.3.1
       i18next: 20.3.5
       i18next-browser-languagedetector: 6.1.2
-      ky: 0.28.5
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-i18next: 11.11.4_i18next@20.3.5+react@17.0.2
@@ -4522,6 +4522,14 @@ packages:
     resolution: {integrity: sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==}
     dev: true
 
+  /axios/0.24.0:
+    resolution: {integrity: sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==}
+    dependencies:
+      follow-redirects: 1.14.4
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /babel-jest/26.6.3_@babel+core@7.14.8:
     resolution: {integrity: sha512-pl4Q+GAVOHwvjrck6jKjvmGhnO3jHX/xuB9d27f+EJZ/6k+6nMuPjorrYp7s++bKKdANwzElBWnLWaObvTnaZA==}
     engines: {node: '>= 10.14.2'}
@@ -7812,6 +7820,16 @@ packages:
       debug: 4.3.2_supports-color@6.1.0
     dev: true
 
+  /follow-redirects/1.14.4:
+    resolution: {integrity: sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: false
+
   /for-in/1.0.2:
     resolution: {integrity: sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=}
     engines: {node: '>=0.10.0'}
@@ -10747,11 +10765,6 @@ packages:
       statuses: 1.5.0
       type-is: 1.6.18
       vary: 1.1.2
-    dev: false
-
-  /ky/0.28.5:
-    resolution: {integrity: sha512-O5gg9kF4MeyfSw+YkgPAafOPwEUU6xcdGEJKUJmKpIPbLzk3oxUtY4OdBNekG7mawofzkyZ/ZHuR9ev5uZZdAA==}
-    engines: {node: '>=12'}
     dev: false
 
   /lerna/4.0.0:


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
Introduce `axios` to the logto ui package. Replacing current `ky` library.  Out of the following two concerns:

1. Align the api library with client sdk
2. `ky` does not support older version of browsers well. We have observed a incompatible error on Chrome 64


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test on local server throw playground:

- successful login
- catch error successfully

![image](https://user-images.githubusercontent.com/36393111/139221769-c47fb378-687f-4b4f-a560-2dd948e047f6.png)

@gao-sun @wangsijie cc: @IceHe @xiaoyijun 
