### PR TITLE
test(core): add temp db test solutions

### DIFF
--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -2,6 +2,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  setupFiles: ['dotenv/config'],
   setupFilesAfterEnv: ['jest-matcher-specific-error'],
   globals: {
     'ts-jest': {

--- a/packages/core/src/queries/user.test.ts
+++ b/packages/core/src/queries/user.test.ts
@@ -1,0 +1,74 @@
+import { Users } from '@logto/schemas';
+
+import { createTestTable } from '@/utils/test-utils';
+
+import {
+  findUserByUsername,
+  findUserById,
+  hasUser,
+  hasUserWithId,
+  insertUser,
+  findAllUsers,
+  updateUserById,
+  deleteUserById,
+} from './user';
+
+const USER_ID = 'test_id';
+const USER_NAME = 'test_name';
+
+describe('user queries', () => {
+  beforeAll(async () => {
+    // Create temp table for users
+    await createTestTable(Users);
+  });
+
+  it('hasUser_should_return_true_after_insertUser', async () => {
+    await insertUser({
+      id: USER_ID,
+      username: USER_NAME,
+    });
+
+    const has = await hasUser(USER_NAME);
+    expect(has).toBe(true);
+  });
+
+  it('findUserByUsername_should_return', async () => {
+    const user = await findUserByUsername(USER_NAME);
+    expect(user.id).toBe(USER_ID);
+  });
+
+  it('findUserById_should_return', async () => {
+    const user = await findUserById(USER_ID);
+    expect(user.username).toBe(USER_NAME);
+  });
+
+  it('hasUserWithId_should_return_true', async () => {
+    const hasDummyUser = await hasUserWithId('dummy_user');
+    expect(hasDummyUser).toBe(false);
+
+    const hasTestUser = await hasUserWithId(USER_ID);
+    expect(hasTestUser).toBe(true);
+  });
+
+  it('findAllUsers_should_return_all_users', async () => {
+    const users = await findAllUsers();
+    expect(users).toHaveLength(1);
+    expect(users[0]?.id).toBe(USER_ID);
+  });
+
+  it('findUserById_should_return_email_after_updateUserById', async () => {
+    const EMAIL = 'test@logto.io';
+    const user = await findUserById(USER_ID);
+    expect(user.primaryEmail).toBeFalsy();
+
+    await updateUserById(USER_ID, { primaryEmail: EMAIL });
+    const updatedUser = await findUserById(USER_ID);
+    expect(updatedUser.primaryEmail).toBe(EMAIL);
+  });
+
+  it('hasUser_should_return_falsy_after_deleteUserById', async () => {
+    await deleteUserById(USER_ID);
+    const has = await hasUser(USER_NAME);
+    expect(has).toBe(false);
+  });
+});

--- a/packages/core/src/utils/test-utils.ts
+++ b/packages/core/src/utils/test-utils.ts
@@ -1,5 +1,9 @@
-import { createMockPool, createMockQueryResult, QueryResultRowType } from 'slonik';
+import { createMockPool, createMockQueryResult, QueryResultRowType, sql } from 'slonik';
 import { PrimitiveValueExpressionType } from 'slonik/dist/src/types.d';
+
+import pool from '@/database/pool';
+import { Table } from '@/database/types';
+import { convertToIdentifiers } from '@/database/utils';
 
 export const createTestPool = <T extends QueryResultRowType>(
   expectSql?: string,
@@ -21,3 +25,11 @@ export const createTestPool = <T extends QueryResultRowType>(
       );
     },
   });
+
+export const createTestTable = async <T extends Table>(parent: T) => {
+  const { table } = convertToIdentifiers(parent);
+
+  await pool.query(sql`create temp table ${table} (like ${table})`);
+  const rows = await pool.any(sql`select * from ${table}`);
+  expect(rows.length).toBe(0);
+};


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->



This is a sample PR that needs to be discussed;

Adding temp db test cases for users queries

Trying on the [doc's](https://medium.com/geoblinktech/testing-postgres-application-one-simple-trick-eec587cd964) recommended approach.  Create a temp table with the same parent table name for testing. Will automatically destroyed after disconnect. However it requires actual db connection. 

Implement some user query ut test following this temp db approach. Let's have a open discussion here. 

@gao-sun @wangsijie cc: @xiaoyijun @darcyYe @IceHe  


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT case added

