### PR TITLE
refactor: wrap detailed user info extraction code block in koaAuth as a new middleware koaUser

### DIFF
--- a/packages/core/src/middleware/koa-auth.ts
+++ b/packages/core/src/middleware/koa-auth.ts
@@ -11,7 +11,7 @@ import assertThat from '@/utils/assert-that';
 
 export type WithAuthContext<ContextT extends IRouterParamContext = IRouterParamContext> =
   ContextT & {
-    userId: string;
+    auth: string;
   };
 
 const bearerTokenIdentifier = 'Bearer';
@@ -54,7 +54,7 @@ export default function koaAuth<
   return async (ctx, next) => {
     try {
       const userId = await getUserIdFromRequest(ctx.request);
-      ctx.userId = userId;
+      ctx.auth = userId;
     } catch {
       throw new RequestError({ code: 'auth.unauthorized', status: 401 });
     }

--- a/packages/core/src/middleware/koa-auth.ts
+++ b/packages/core/src/middleware/koa-auth.ts
@@ -1,20 +1,17 @@
 import { IncomingHttpHeaders } from 'http';
 
-import { UserInfo, userInfoSelectFields } from '@logto/schemas';
 import { jwtVerify } from 'jose/jwt/verify';
 import { MiddlewareType, Request } from 'koa';
 import { IRouterParamContext } from 'koa-router';
-import pick from 'lodash.pick';
 
 import { developmentUserId, isProduction } from '@/env/consts';
 import RequestError from '@/errors/RequestError';
 import { publicKey, issuer, adminResource } from '@/oidc/consts';
-import { findUserById } from '@/queries/user';
 import assertThat from '@/utils/assert-that';
 
 export type WithAuthContext<ContextT extends IRouterParamContext = IRouterParamContext> =
   ContextT & {
-    user: UserInfo;
+    userId: string;
   };
 
 const bearerTokenIdentifier = 'Bearer';
@@ -57,8 +54,7 @@ export default function koaAuth<
   return async (ctx, next) => {
     try {
       const userId = await getUserIdFromRequest(ctx.request);
-      const user = await findUserById(userId);
-      ctx.user = pick(user, ...userInfoSelectFields);
+      ctx.userId = userId;
     } catch {
       throw new RequestError({ code: 'auth.unauthorized', status: 401 });
     }

--- a/packages/core/src/middleware/koa-user-info.ts
+++ b/packages/core/src/middleware/koa-user-info.ts
@@ -10,7 +10,7 @@ export type WithUserInfoContext<ContextT extends WithAuthContext = WithAuthConte
   user: UserInfo;
 };
 
-export default function koaUser<
+export default function koaUserInfo<
   StateT,
   ContextT extends WithAuthContext,
   ResponseBodyT

--- a/packages/core/src/middleware/koa-user-info.ts
+++ b/packages/core/src/middleware/koa-user-info.ts
@@ -4,10 +4,10 @@ import pick from 'lodash.pick';
 
 import RequestError from '@/errors/RequestError';
 import { WithAuthContext } from '@/middleware/koa-auth';
-import { findUserById, hasUserWithId } from '@/queries/user';
+import { findUserById } from '@/queries/user';
 
 export type WithUserInfoContext<ContextT extends WithAuthContext = WithAuthContext> = ContextT & {
-  user: UserInfo;
+  userInfo: UserInfo;
 };
 
 export default function koaUserInfo<
@@ -17,14 +17,9 @@ export default function koaUserInfo<
 >(): MiddlewareType<StateT, WithUserInfoContext<ContextT>, ResponseBodyT> {
   return async (ctx, next) => {
     try {
-      const { userId } = ctx;
-      const userIdExists = await hasUserWithId(userId);
-      if (!userIdExists) {
-        throw new RequestError({ code: 'entity.not_exists_with_id', userId, status: 404 });
-      }
-
-      const user = await findUserById(userId);
-      ctx.user = pick(user, ...userInfoSelectFields);
+      const { auth: userId } = ctx;
+      const userInfo = await findUserById(userId);
+      ctx.userInfo = pick(userInfo, ...userInfoSelectFields);
     } catch {
       throw new RequestError({ code: 'auth.unauthorized', status: 401 });
     }

--- a/packages/core/src/middleware/koa-user.ts
+++ b/packages/core/src/middleware/koa-user.ts
@@ -1,0 +1,34 @@
+import { UserInfo, userInfoSelectFields } from '@logto/schemas';
+import { MiddlewareType } from 'koa';
+import pick from 'lodash.pick';
+
+import RequestError from '@/errors/RequestError';
+import { WithAuthContext } from '@/middleware/koa-auth';
+import { findUserById, hasUserWithId } from '@/queries/user';
+
+export type WithUserInfoContext<ContextT extends WithAuthContext = WithAuthContext> = ContextT & {
+  user: UserInfo;
+};
+
+export default function koaUser<
+  StateT,
+  ContextT extends WithAuthContext,
+  ResponseBodyT
+>(): MiddlewareType<StateT, WithUserInfoContext<ContextT>, ResponseBodyT> {
+  return async (ctx, next) => {
+    try {
+      const { userId } = ctx;
+      const userIdExists = await hasUserWithId(userId);
+      if (!userIdExists) {
+        throw new RequestError({ code: 'entity.not_exists_with_id', userId, status: 404 });
+      }
+
+      const user = await findUserById(userId);
+      ctx.user = pick(user, ...userInfoSelectFields);
+    } catch {
+      throw new RequestError({ code: 'auth.unauthorized', status: 401 });
+    }
+
+    return next();
+  };
+}

--- a/packages/core/src/routes/types.ts
+++ b/packages/core/src/routes/types.ts
@@ -2,6 +2,7 @@ import Router from 'koa-router';
 
 import { WithAuthContext } from '@/middleware/koa-auth';
 import { WithI18nContext } from '@/middleware/koa-i18next';
+import { WithUserInfoContext } from '@/middleware/koa-user';
 
 export type AnonymousRouter = Router<unknown, WithI18nContext>;
-export type AuthedRouter = Router<unknown, WithAuthContext<WithI18nContext>>;
+export type AuthedRouter = Router<unknown, WithUserInfoContext<WithAuthContext<WithI18nContext>>>;

--- a/packages/core/src/routes/types.ts
+++ b/packages/core/src/routes/types.ts
@@ -2,7 +2,7 @@ import Router from 'koa-router';
 
 import { WithAuthContext } from '@/middleware/koa-auth';
 import { WithI18nContext } from '@/middleware/koa-i18next';
-import { WithUserInfoContext } from '@/middleware/koa-user';
+import { WithUserInfoContext } from '@/middleware/koa-user-info';
 
 export type AnonymousRouter = Router<unknown, WithI18nContext>;
 export type AuthedRouter = Router<unknown, WithUserInfoContext<WithAuthContext<WithI18nContext>>>;


### PR DESCRIPTION
refactor: wrap detailed user info extraction code block in koaAuth as a new middleware koaUser

<!-- MANDATORY -->
## Summary
wrap detailed user info extraction code block in middleware koa-auth as a new middleware koa-user as detailed user info is not necessary in all cases.
<!-- Provide detail PR description bellow -->


<!-- Optional -->
## Linear Issue Reference
https://linear.app/silverhand/issue/LOG-270/koaauth-remove-finduserbyid-by-default
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
tested by sending requests with Postman App and checking console logs in both cases (with/without detailed user info).

case1 (only middleware koaAuth() was called when initializing AuthedRouter):
![image](https://user-images.githubusercontent.com/15182327/144193372-8f668b3b-45e2-40f6-a15e-ed6b5e6b688c.png)

case2 (both middleware koaAuth() and middleware koaUserInfo() were called when initializing AuthedRouter):
![image](https://user-images.githubusercontent.com/15182327/144193448-2dc6191f-644d-4d1c-ac6a-c3eecf694833.png)

<!-- How did you test this PR? -->

