### PR TITLE
feat: implement getResourceIndicators logic

### DIFF
--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -49,9 +49,10 @@ export default async function initOidc(app: Koa): Promise<Provider> {
 
           const { id, accessTokenFormat, accessTokenTtl: accessTokenTTl } = resourceServer;
           const scopes = await findAllScopesWithResourceId(id);
+          const scope = scopes.map(({ name }) => name).join(' ');
 
           return {
-            scope: scopes.join(','),
+            scope,
             accessTokenFormat,
             accessTokenTTl,
           };

--- a/packages/core/src/queries/resources.ts
+++ b/packages/core/src/queries/resources.ts
@@ -30,7 +30,7 @@ export const hasResourceWithId = async (id: string) =>
 `);
 
 export const findResourceByIdentifier = async (indentifier: string) =>
-  pool.one<ResourceDBEntry>(sql`
+  pool.maybeOne<ResourceDBEntry>(sql`
   select ${sql.join(Object.values(fields), sql`,`)}
   from ${table}
   where ${fields.identifier}=${indentifier}

--- a/packages/core/src/queries/scopes.ts
+++ b/packages/core/src/queries/scopes.ts
@@ -8,25 +8,12 @@ import RequestError from '@/errors/RequestError';
 
 const { table, fields } = convertToIdentifiers(ResourceScopes);
 
-/**
- * Query all scopes registered under the target resource
- * if no scopes found should return empty array
- * as no pool.maybeMany defined we wrap up the query method using a try..catch..
- * and hide the internal slonik db error
- * @param resourceId
- * @returns ResourceScopeDBEntry[]
- */
-export const findAllScopesWithResourceId = async (resourceId: string) => {
-  try {
-    return await pool.many<ResourceScopeDBEntry>(sql`
-      select ${sql.join(Object.values(fields), sql`,`)}
-      from ${table}
-      where ${fields.resourceId}=${resourceId}
-      `);
-  } catch {
-    return [];
-  }
-};
+export const findAllScopesWithResourceId = async (resourceId: string) =>
+  pool.any<ResourceScopeDBEntry>(sql`
+    select ${sql.join(Object.values(fields), sql`,`)}
+    from ${table}
+    where ${fields.resourceId}=${resourceId}
+`);
 
 export const insertScope = buildInsertInto<ResourceScopeDBEntry>(pool, ResourceScopes, {
   returning: true,

--- a/packages/core/src/queries/scopes.ts
+++ b/packages/core/src/queries/scopes.ts
@@ -8,12 +8,25 @@ import RequestError from '@/errors/RequestError';
 
 const { table, fields } = convertToIdentifiers(ResourceScopes);
 
-export const findAllScopesWithResourceId = async (resourceId: string) =>
-  pool.many<ResourceScopeDBEntry>(sql`
-    select ${sql.join(Object.values(fields), sql`,`)}
-    from ${table}
-    where ${fields.resourceId}=${resourceId}
-`);
+/**
+ * Query all scopes registered under the target resource
+ * if no scopes found should return empty array
+ * as no pool.maybeMany defined we wrap up the query method using a try..catch..
+ * and hide the internal slonik db error
+ * @param resourceId
+ * @returns ResourceScopeDBEntry[]
+ */
+export const findAllScopesWithResourceId = async (resourceId: string) => {
+  try {
+    return await pool.many<ResourceScopeDBEntry>(sql`
+      select ${sql.join(Object.values(fields), sql`,`)}
+      from ${table}
+      where ${fields.resourceId}=${resourceId}
+      `);
+  } catch {
+    return [];
+  }
+};
 
 export const insertScope = buildInsertInto<ResourceScopeDBEntry>(pool, ResourceScopes, {
   returning: true,

--- a/packages/schemas/tables/resource_scopes.sql
+++ b/packages/schemas/tables/resource_scopes.sql
@@ -12,5 +12,5 @@ create table resource_scopes (
 create unique index resource_scopes__resource_id_name
 on resource_scopes (
     resource_id,
-    name,
+    name
 );


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->

Following the [oidc-provide](https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#featuresresourceindicators)r docs  enable the `resourceIndicators` feature and provide a drafted `getResourceServerInfo` implementation. 

![image](https://user-images.githubusercontent.com/36393111/144214342-7707e07f-0409-4bd5-8fd6-8b848844676b.png)


connect to the `resources` & `resource-scopes` table to query resource server info & scopes info return the `resourceServer` data or throw a `invalidTarget` error. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test the cases locally 

1. insert test data to the dev table
![image](https://user-images.githubusercontent.com/36393111/144214659-2df578ad-ad07-4478-8bc2-c130059a7290.png)
![image](https://user-images.githubusercontent.com/36393111/144214688-4c66859d-94fd-47df-8410-5ed5b52993c2.png)

2. modify the client sdk to pass invalid & valid resource params

-  non URI resource indicator
    <img width="492" alt="WX20211201-174837@2x" src="https://user-images.githubusercontent.com/36393111/144214845-40fc03f3-0e15-4d97-ae86-8102dfaadc70.png">
-  unknown  resource indicator
    ![image](https://user-images.githubusercontent.com/36393111/144215019-e5087739-208e-4f79-b90f-0a743511ee2f.png)
- valid resource indicator
   ![image](https://user-images.githubusercontent.com/36393111/144215423-48167dda-de50-4652-a6bc-078bcdc54276.png)

 @wangsijie @xiaoyijun @gao-sun cc: @darcyYe @IceHe 
