### PR TITLE
feat(schema): export schema guard directly

### DIFF
--- a/packages/core/src/routes/application.ts
+++ b/packages/core/src/routes/application.ts
@@ -1,4 +1,4 @@
-import { Applications } from '@logto/schemas';
+import { ApplicationSchemaGuard } from '@logto/schemas';
 import { object, string } from 'zod';
 
 import koaGuard from '@/middleware/koa-guard';
@@ -25,10 +25,9 @@ export default function applicationRoutes<T extends AuthedRouter>(router: T) {
   router.post(
     '/applications',
     koaGuard({
-      body: Applications.guard
-        .omit({ id: true, createdAt: true })
+      body: ApplicationSchemaGuard.omit({ id: true, createdAt: true })
         .partial()
-        .merge(Applications.guard.pick({ name: true, type: true })),
+        .merge(ApplicationSchemaGuard.pick({ name: true, type: true })),
     }),
     async (ctx, next) => {
       const { name, type, oidcClientMetadata, ...rest } = ctx.guard.body;
@@ -63,7 +62,7 @@ export default function applicationRoutes<T extends AuthedRouter>(router: T) {
     '/applications/:id',
     koaGuard({
       params: object({ id: string().min(1) }),
-      body: Applications.guard.omit({ id: true, createdAt: true }).partial(),
+      body: ApplicationSchemaGuard.omit({ id: true, createdAt: true }).partial(),
     }),
     async (ctx, next) => {
       const {

--- a/packages/schemas/src/db-entries/application.ts
+++ b/packages/schemas/src/db-entries/application.ts
@@ -2,12 +2,7 @@
 
 import { z } from 'zod';
 
-import {
-  OidcClientMetadata,
-  oidcClientMetadataGuard,
-  GeneratedSchema,
-  Guard,
-} from '../foundations';
+import { OidcClientMetadata, oidcClientMetadataGuard, GeneratedSchema } from '../foundations';
 import { ApplicationType } from './custom-types';
 
 export type ApplicationDBEntry = {
@@ -18,7 +13,7 @@ export type ApplicationDBEntry = {
   createdAt: number;
 };
 
-const guard: Guard<ApplicationDBEntry> = z.object({
+export const ApplicationSchemaGuard = z.object({
   id: z.string(),
   name: z.string(),
   type: z.nativeEnum(ApplicationType),
@@ -37,5 +32,4 @@ export const Applications: GeneratedSchema<ApplicationDBEntry> = Object.freeze({
     createdAt: 'created_at',
   },
   fieldKeys: ['id', 'name', 'type', 'oidcClientMetadata', 'createdAt'],
-  guard,
 });

--- a/packages/schemas/src/db-entries/oidc-model-instance.ts
+++ b/packages/schemas/src/db-entries/oidc-model-instance.ts
@@ -6,7 +6,6 @@ import {
   OidcModelInstancePayload,
   oidcModelInstancePayloadGuard,
   GeneratedSchema,
-  Guard,
 } from '../foundations';
 
 export type OidcModelInstanceDBEntry = {
@@ -17,7 +16,7 @@ export type OidcModelInstanceDBEntry = {
   consumedAt?: number;
 };
 
-const guard: Guard<OidcModelInstanceDBEntry> = z.object({
+export const OidcModelInstanceSchemaGuard = z.object({
   modelName: z.string(),
   id: z.string(),
   payload: oidcModelInstancePayloadGuard,
@@ -36,5 +35,4 @@ export const OidcModelInstances: GeneratedSchema<OidcModelInstanceDBEntry> = Obj
     consumedAt: 'consumed_at',
   },
   fieldKeys: ['modelName', 'id', 'payload', 'expiresAt', 'consumedAt'],
-  guard,
 });

--- a/packages/schemas/src/db-entries/resource-scope.ts
+++ b/packages/schemas/src/db-entries/resource-scope.ts
@@ -2,7 +2,7 @@
 
 import { z } from 'zod';
 
-import { GeneratedSchema, Guard } from '../foundations';
+import { GeneratedSchema } from '../foundations';
 
 export type ResourceScopeDBEntry = {
   id: string;
@@ -11,7 +11,7 @@ export type ResourceScopeDBEntry = {
   resourceId: string;
 };
 
-const guard: Guard<ResourceScopeDBEntry> = z.object({
+export const ResourceScopeSchemaGuard = z.object({
   id: z.string(),
   name: z.string(),
   description: z.string(),
@@ -28,5 +28,4 @@ export const ResourceScopes: GeneratedSchema<ResourceScopeDBEntry> = Object.free
     resourceId: 'resource_id',
   },
   fieldKeys: ['id', 'name', 'description', 'resourceId'],
-  guard,
 });

--- a/packages/schemas/src/db-entries/resource.ts
+++ b/packages/schemas/src/db-entries/resource.ts
@@ -2,7 +2,7 @@
 
 import { z } from 'zod';
 
-import { GeneratedSchema, Guard } from '../foundations';
+import { GeneratedSchema } from '../foundations';
 import { AccessTokenFormatType, SignAlgorithmType } from './custom-types';
 
 export type ResourceDBEntry = {
@@ -14,7 +14,7 @@ export type ResourceDBEntry = {
   signAlgorithm: SignAlgorithmType;
 };
 
-const guard: Guard<ResourceDBEntry> = z.object({
+export const ResourceSchemaGuard = z.object({
   id: z.string(),
   name: z.string(),
   identifier: z.string(),
@@ -35,5 +35,4 @@ export const Resources: GeneratedSchema<ResourceDBEntry> = Object.freeze({
     signAlgorithm: 'sign_algorithm',
   },
   fieldKeys: ['id', 'name', 'identifier', 'accessTokenTtl', 'accessTokenFormat', 'signAlgorithm'],
-  guard,
 });

--- a/packages/schemas/src/db-entries/user-log.ts
+++ b/packages/schemas/src/db-entries/user-log.ts
@@ -2,7 +2,7 @@
 
 import { z } from 'zod';
 
-import { UserLogPayload, userLogPayloadGuard, GeneratedSchema, Guard } from '../foundations';
+import { UserLogPayload, userLogPayloadGuard, GeneratedSchema } from '../foundations';
 import { UserLogType, UserLogResult } from './custom-types';
 
 export type UserLogDBEntry = {
@@ -14,7 +14,7 @@ export type UserLogDBEntry = {
   createdAt: number;
 };
 
-const guard: Guard<UserLogDBEntry> = z.object({
+export const UserLogSchemaGuard = z.object({
   id: z.string(),
   userId: z.string(),
   type: z.nativeEnum(UserLogType),
@@ -35,5 +35,4 @@ export const UserLogs: GeneratedSchema<UserLogDBEntry> = Object.freeze({
     createdAt: 'created_at',
   },
   fieldKeys: ['id', 'userId', 'type', 'result', 'payload', 'createdAt'],
-  guard,
 });

--- a/packages/schemas/src/db-entries/user.ts
+++ b/packages/schemas/src/db-entries/user.ts
@@ -2,7 +2,7 @@
 
 import { z } from 'zod';
 
-import { GeneratedSchema, Guard } from '../foundations';
+import { GeneratedSchema } from '../foundations';
 import { PasswordEncryptionMethod } from './custom-types';
 
 export type UserDBEntry = {
@@ -15,7 +15,7 @@ export type UserDBEntry = {
   passwordEncryptionSalt?: string;
 };
 
-const guard: Guard<UserDBEntry> = z.object({
+export const UserSchemaGuard = z.object({
   id: z.string(),
   username: z.string().optional(),
   primaryEmail: z.string().optional(),
@@ -46,5 +46,4 @@ export const Users: GeneratedSchema<UserDBEntry> = Object.freeze({
     'passwordEncryptionMethod',
     'passwordEncryptionSalt',
   ],
-  guard,
 });

--- a/packages/schemas/src/foundations/schemas.ts
+++ b/packages/schemas/src/foundations/schemas.ts
@@ -1,11 +1,3 @@
-import { ZodObject, ZodType } from 'zod';
-
-export type Guard<T extends Record<string, unknown>> = ZodObject<
-  {
-    [key in keyof T]: ZodType<T[key]>;
-  }
->;
-
 export type SchemaValuePrimitive = string | number | boolean | undefined;
 export type SchemaValue = SchemaValuePrimitive | Record<string, unknown>;
 export type SchemaLike<Key extends string = string> = {
@@ -20,6 +12,5 @@ export type GeneratedSchema<Schema extends SchemaLike> = keyof Schema extends st
         [key in keyof Schema]: string;
       };
       fieldKeys: ReadonlyArray<keyof Schema>;
-      guard: Guard<Schema>;
     }>
   : never;

--- a/packages/schemas/src/gen/index.ts
+++ b/packages/schemas/src/gen/index.ts
@@ -167,7 +167,7 @@ const generate = async () => {
       }));
 
       if (tableWithTypes.length > 0) {
-        tsTypes.push('GeneratedSchema', 'Guard');
+        tsTypes.push('GeneratedSchema');
       }
       /* eslint-enable @silverhand/fp/no-mutating-methods */
 

--- a/packages/schemas/src/gen/schema.ts
+++ b/packages/schemas/src/gen/schema.ts
@@ -5,7 +5,9 @@ import pluralize from 'pluralize';
 import { TableWithType } from './types';
 
 export const generateSchema = ({ name, fields }: TableWithType) => {
-  const databaseEntryType = `${pluralize(camelcase(name, { pascalCase: true }), 1)}DBEntry`;
+  const entryType = pluralize(camelcase(name, { pascalCase: true }), 1);
+  const databaseEntryType = `${entryType}DBEntry`;
+  const schemaGuardName = `${entryType}SchemaGuard`;
   return [
     `export type ${databaseEntryType} = {`,
     ...fields.map(
@@ -16,7 +18,7 @@ export const generateSchema = ({ name, fields }: TableWithType) => {
     ),
     '};',
     '',
-    `const guard: Guard<${databaseEntryType}> = z.object({`,
+    `export const ${schemaGuardName} = z.object({`,
     ...fields.map(({ name, type, isArray, isEnum, required, tsType }) => {
       if (tsType) {
         return `  ${camelcase(name)}: ${camelcase(tsType)}Guard${conditionalString(
@@ -43,7 +45,6 @@ export const generateSchema = ({ name, fields }: TableWithType) => {
     '  fieldKeys: [',
     ...fields.map(({ name }) => `    '${camelcase(name)}',`),
     '  ],',
-    '  guard,',
     '});',
   ].join('\n');
 };


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
[ZodObject with explicit type has an optional value can not be infered correctly after `omit` haven been called in Typescript.
](https://github.com/colinhacks/zod/issues/787)
In case of this issue block our development, now we use the zod object as our schema guard directly.

<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
* Declare guard type by the type of zodObject which has explicit properties ([LOG-415](https://linear.app/silverhand/issue/LOG-415/declare-guard-type-by-the-type-of-zodobject-which-has-explicit))


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Now we can infer guard type correctly in our project.
<img width="494" alt="after with option" src="https://user-images.githubusercontent.com/10806653/144375063-e8f81e11-9f36-418c-8008-cffdf489a4af.png">
<img width="813" alt="after" src="https://user-images.githubusercontent.com/10806653/144382656-35fe6b37-19df-454e-abb1-f22352a67e92.png">
