### PR TITLE
refactor(core): replace `querystring` with `query-string`

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,6 +38,7 @@
     "nanoid": "^3.1.23",
     "oidc-provider": "^7.10.0",
     "p-retry": "^4.6.1",
+    "query-string": "^7.0.1",
     "slonik": "^23.8.3",
     "slonik-interceptor-preset": "^1.2.10",
     "snakecase-keys": "^5.1.0",

--- a/packages/core/src/utils/pagination.ts
+++ b/packages/core/src/utils/pagination.ts
@@ -1,7 +1,5 @@
-// eslint-disable-next-line no-restricted-imports
-import { stringify } from 'querystring';
-
 import { Request } from 'koa';
+import { stringify } from 'query-string';
 
 type LinkRelationType = 'first' | 'prev' | 'next' | 'last';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,7 @@ importers:
       openapi-types: ^9.1.0
       p-retry: ^4.6.1
       prettier: ^2.3.2
+      query-string: ^7.0.1
       slonik: ^23.8.3
       slonik-interceptor-preset: ^1.2.10
       snakecase-keys: ^5.1.0
@@ -90,6 +91,7 @@ importers:
       nanoid: 3.1.23
       oidc-provider: 7.10.0
       p-retry: 4.6.1
+      query-string: 7.0.1
       slonik: 23.8.5
       slonik-interceptor-preset: 1.2.10
       snakecase-keys: 5.1.0
@@ -6168,7 +6170,6 @@ packages:
   /decode-uri-component/0.2.0:
     resolution: {integrity: sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=}
     engines: {node: '>=0.10'}
-    dev: true
 
   /decompress-response/6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -7475,7 +7476,6 @@ packages:
   /filter-obj/1.1.0:
     resolution: {integrity: sha1-mzERErxsYSehbgFsbF1/GeCAXFs=}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /finalhandler/1.1.2:
     resolution: {integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==}
@@ -13275,6 +13275,16 @@ packages:
       strict-uri-encode: 2.0.0
     dev: true
 
+  /query-string/7.0.1:
+    resolution: {integrity: sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==}
+    engines: {node: '>=6'}
+    dependencies:
+      decode-uri-component: 0.2.0
+      filter-obj: 1.1.0
+      split-on-first: 1.1.0
+      strict-uri-encode: 2.0.0
+    dev: false
+
   /querystring/0.2.0:
     resolution: {integrity: sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=}
     engines: {node: '>=0.4.x'}
@@ -14813,7 +14823,6 @@ packages:
   /split-on-first/1.1.0:
     resolution: {integrity: sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==}
     engines: {node: '>=6'}
-    dev: true
 
   /split-string/3.1.0:
     resolution: {integrity: sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==}
@@ -14925,7 +14934,6 @@ packages:
   /strict-uri-encode/2.0.0:
     resolution: {integrity: sha1-ucczDHBChi9rFC3CdLvMWGbONUY=}
     engines: {node: '>=4'}
-    dev: true
 
   /string-argv/0.1.2:
     resolution: {integrity: sha512-mBqPGEOMNJKXRo7z0keX0wlAhbBAjilUdPW13nN0PecVryZxdHIeM7TqbsSUA7VYuS00HGC6mojP7DlQzfa9ZA==}


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
The querystring API is considered legacy and it just works on node env.
Replace it with query-string which is supported in all platforms.
FYI: [Slack Disscussion](https://silverhand-io.slack.com/archives/C02A8G4HVAM/p1638260142014900)


<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
* Replace `querystring` with `query-string` or URLSearchParams ([LOG-408](https://linear.app/silverhand/issue/LOG-408/replace-querystring-with-query-string-or-urlsearchparams))


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
None