### PR TITLE
refactor(core): rename `context` to `ctx` in test file

### DIFF
--- a/packages/core/src/middleware/koa-pagination.test.ts
+++ b/packages/core/src/middleware/koa-pagination.test.ts
@@ -37,74 +37,73 @@ afterEach(() => {
 
 describe('request', () => {
   it('should get limit and offset from queries', async () => {
-    const context = createContext({ page: '1', page_size: '30' });
-    await koaPagination()(context, next);
-    expect(context.pagination.limit).toEqual(30);
-    expect(context.pagination.offset).toEqual(0);
+    const ctx = createContext({ page: '1', page_size: '30' });
+    await koaPagination()(ctx, next);
+    expect(ctx.pagination.limit).toEqual(30);
+    expect(ctx.pagination.offset).toEqual(0);
   });
 
   it('should set default page to 1 (offset to 0) if non is provided', async () => {
-    const context = createContext({});
-    await koaPagination()(context, next);
-    expect(context.pagination.offset).toEqual(0);
+    const ctx = createContext({});
+    await koaPagination()(ctx, next);
+    expect(ctx.pagination.offset).toEqual(0);
   });
 
   it('should set default pageSize(limit) to 20', async () => {
-    const context = createContext({});
-    await koaPagination({ defaultPageSize: 20 })(context, next);
-    expect(context.pagination.limit).toEqual(20);
+    const ctx = createContext({});
+    await koaPagination({ defaultPageSize: 20 })(ctx, next);
+    expect(ctx.pagination.limit).toEqual(20);
   });
 
   it('throw when page value is not number-like', async () => {
-    const context = createContext({ page: 'invalid_number' });
-    await expect(koaPagination()(context, next)).rejects.toThrow();
+    const ctx = createContext({ page: 'invalid_number' });
+    await expect(koaPagination()(ctx, next)).rejects.toThrow();
   });
 
   it('throw when page number is 0', async () => {
-    const context = createContext({ page: '0' });
-    await expect(koaPagination()(context, next)).rejects.toThrow();
+    const ctx = createContext({ page: '0' });
+    await expect(koaPagination()(ctx, next)).rejects.toThrow();
   });
 
   it('throw when page_size value is not number-like', async () => {
-    const context = createContext({ page_size: 'invalid_number' });
-    await expect(koaPagination()(context, next)).rejects.toThrow();
+    const ctx = createContext({ page_size: 'invalid_number' });
+    await expect(koaPagination()(ctx, next)).rejects.toThrow();
   });
 
   it('throw when page_size number is 0', async () => {
-    const context = createContext({ page_size: '0' });
-    await expect(koaPagination()(context, next)).rejects.toThrow();
+    const ctx = createContext({ page_size: '0' });
+    await expect(koaPagination()(ctx, next)).rejects.toThrow();
   });
 
   it('throw when page_size number exceeds max', async () => {
-    const context = createContext({ page_size: '200' });
-    await expect(koaPagination({ maxPageSize: 100 })(context, next)).rejects.toThrow();
+    const ctx = createContext({ page_size: '200' });
+    await expect(koaPagination({ maxPageSize: 100 })(ctx, next)).rejects.toThrow();
   });
 });
 
-/* eslint-disable @silverhand/fp/no-mutation */
 describe('response', () => {
   it('should add Total-Number to response header', async () => {
-    const context = createContext({});
-    await koaPagination()(context, async () => {
-      context.pagination.totalCount = 100;
+    const ctx = createContext({});
+    await koaPagination()(ctx, async () => {
+      ctx.pagination.totalCount = 100;
     });
     expect(setHeader).toHaveBeenCalledWith('Total-Number', '100');
   });
 
   describe('Link in response header', () => {
     it('should append `first` and `last` in 1 of 1', async () => {
-      const context = createContext({});
-      await koaPagination({ defaultPageSize: 20 })(context, async () => {
-        context.pagination.totalCount = 10;
+      const ctx = createContext({});
+      await koaPagination({ defaultPageSize: 20 })(ctx, async () => {
+        ctx.pagination.totalCount = 10;
       });
       expect(links.has('<?page=1>; rel="first"')).toBeTruthy();
       expect(links.has('<?page=1>; rel="last"')).toBeTruthy();
     });
 
     it('should append `first`, `next`, `last` in 1 of 2', async () => {
-      const context = createContext({});
-      await koaPagination({ defaultPageSize: 20 })(context, async () => {
-        context.pagination.totalCount = 30;
+      const ctx = createContext({});
+      await koaPagination({ defaultPageSize: 20 })(ctx, async () => {
+        ctx.pagination.totalCount = 30;
       });
       expect(links.has('<?page=1>; rel="first"')).toBeTruthy();
       expect(links.has('<?page=2>; rel="next"')).toBeTruthy();
@@ -112,9 +111,9 @@ describe('response', () => {
     });
 
     it('should append `first`, `prev`, `last` in 2 of 2', async () => {
-      const context = createContext({ page: '2' });
-      await koaPagination({ defaultPageSize: 20 })(context, async () => {
-        context.pagination.totalCount = 30;
+      const ctx = createContext({ page: '2' });
+      await koaPagination({ defaultPageSize: 20 })(ctx, async () => {
+        ctx.pagination.totalCount = 30;
       });
       expect(links.has('<?page=1>; rel="first"')).toBeTruthy();
       expect(links.has('<?page=1>; rel="prev"')).toBeTruthy();
@@ -122,9 +121,9 @@ describe('response', () => {
     });
 
     it('should append `first`, `prev`, `next`, `last` in 2 of 3', async () => {
-      const context = createContext({ page: '2' });
-      await koaPagination({ defaultPageSize: 20 })(context, async () => {
-        context.pagination.totalCount = 50;
+      const ctx = createContext({ page: '2' });
+      await koaPagination({ defaultPageSize: 20 })(ctx, async () => {
+        ctx.pagination.totalCount = 50;
       });
       expect(links.has('<?page=1>; rel="first"')).toBeTruthy();
       expect(links.has('<?page=1>; rel="prev"')).toBeTruthy();
@@ -133,4 +132,3 @@ describe('response', () => {
     });
   });
 });
-/* eslint-enable @silverhand/fp/no-mutation */


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
Any mutation on object named `context` will trigger `no-mutation` lint error. 
So use `ctx` as context object name instead of `context`, because `ctx` is in eslint exception list.


<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
* Rename `context` to `ctx` in test file ([LOG-442](https://linear.app/silverhand/issue/LOG-442/rename-context-to-ctx-in-test-file))

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
None

