### PR TITLE
feat: generate 2 types for db table schema

### DIFF
--- a/packages/core/src/database/insert-into.ts
+++ b/packages/core/src/database/insert-into.ts
@@ -33,11 +33,11 @@ type InsertIntoConfig = {
 };
 
 interface BuildInsertInto {
-  <Schema extends SchemaLike>(
+  <Schema extends SchemaLike, ReturnType extends SchemaLike>(
     pool: DatabasePoolType,
     { fieldKeys, ...rest }: GeneratedSchema<Schema>,
     config: InsertIntoConfigReturning
-  ): (data: OmitAutoSetFields<Schema>) => Promise<Schema>;
+  ): (data: OmitAutoSetFields<Schema>) => Promise<ReturnType>;
   <Schema extends SchemaLike>(
     pool: DatabasePoolType,
     { fieldKeys, ...rest }: GeneratedSchema<Schema>,
@@ -45,7 +45,10 @@ interface BuildInsertInto {
   ): (data: OmitAutoSetFields<Schema>) => Promise<void>;
 }
 
-export const buildInsertInto: BuildInsertInto = <Schema extends SchemaLike>(
+export const buildInsertInto: BuildInsertInto = <
+  Schema extends SchemaLike,
+  ReturnType extends SchemaLike
+>(
   pool: DatabasePoolType,
   { fieldKeys, ...rest }: GeneratedSchema<Schema>,
   config?: InsertIntoConfig | InsertIntoConfigReturning
@@ -55,10 +58,10 @@ export const buildInsertInto: BuildInsertInto = <Schema extends SchemaLike>(
   const returning = Boolean(config?.returning);
   const onConflict = config?.onConflict;
 
-  return async (data: OmitAutoSetFields<Schema>): Promise<Schema | void> => {
+  return async (data: OmitAutoSetFields<Schema>): Promise<ReturnType | void> => {
     const {
       rows: [entry],
-    } = await pool.query<Schema>(sql`
+    } = await pool.query<ReturnType>(sql`
     insert into ${table} (${sql.join(
       keys.map((key) => fields[key]),
       sql`, `

--- a/packages/core/src/queries/application.ts
+++ b/packages/core/src/queries/application.ts
@@ -1,4 +1,4 @@
-import { ApplicationDBEntry, Applications } from '@logto/schemas';
+import { Application, ApplicationDBEntry, Applications } from '@logto/schemas';
 import { sql } from 'slonik';
 
 import { buildInsertInto } from '@/database/insert-into';
@@ -10,13 +10,13 @@ import RequestError from '@/errors/RequestError';
 const { table, fields } = convertToIdentifiers(Applications);
 
 export const findAllApplications = async () =>
-  pool.many<ApplicationDBEntry>(sql`
+  pool.many<Application>(sql`
     select ${sql.join(Object.values(fields), sql`, `)}
     from ${table}
   `);
 
 export const findApplicationById = async (id: string) =>
-  pool.one<ApplicationDBEntry>(sql`
+  pool.one<Application>(sql`
     select ${sql.join(Object.values(fields), sql`, `)}
     from ${table}
     where ${fields.id}=${id}

--- a/packages/core/src/queries/application.ts
+++ b/packages/core/src/queries/application.ts
@@ -22,11 +22,19 @@ export const findApplicationById = async (id: string) =>
     where ${fields.id}=${id}
   `);
 
-export const insertApplication = buildInsertInto<ApplicationDBEntry>(pool, Applications, {
-  returning: true,
-});
+export const insertApplication = buildInsertInto<ApplicationDBEntry, Application>(
+  pool,
+  Applications,
+  {
+    returning: true,
+  }
+);
 
-const updateApplication = buildUpdateWhere<ApplicationDBEntry>(pool, Applications, true);
+const updateApplication = buildUpdateWhere<ApplicationDBEntry, Application>(
+  pool,
+  Applications,
+  true
+);
 
 export const updateApplicationById = async (
   id: string,

--- a/packages/core/src/queries/oidc-model-instance.ts
+++ b/packages/core/src/queries/oidc-model-instance.ts
@@ -1,4 +1,5 @@
 import {
+  OidcModelInstance,
   OidcModelInstanceDBEntry,
   OidcModelInstancePayload,
   OidcModelInstances,
@@ -11,11 +12,11 @@ import pool from '@/database/pool';
 import { convertToIdentifiers, convertToTimestamp } from '@/database/utils';
 
 export type WithConsumed<T> = T & { consumed?: boolean };
-export type QueryResult = Pick<OidcModelInstanceDBEntry, 'payload' | 'consumedAt'>;
+export type QueryResult = Pick<OidcModelInstance, 'payload' | 'consumedAt'>;
 
 const { table, fields } = convertToIdentifiers(OidcModelInstances);
 
-const withConsumed = <T>(data: T, consumedAt?: number): WithConsumed<T> => ({
+const withConsumed = <T>(data: T, consumedAt?: number | null): WithConsumed<T> => ({
   ...data,
   ...(consumedAt ? { consumed: true } : undefined),
 });

--- a/packages/core/src/queries/resources.ts
+++ b/packages/core/src/queries/resources.ts
@@ -1,4 +1,4 @@
-import { ResourceDBEntry, Resources } from '@logto/schemas';
+import { Resource, ResourceDBEntry, Resources } from '@logto/schemas';
 import { sql } from 'slonik';
 
 import { buildInsertInto } from '@/database/insert-into';
@@ -10,7 +10,7 @@ import RequestError from '@/errors/RequestError';
 const { table, fields } = convertToIdentifiers(Resources);
 
 export const findAllResources = async () =>
-  pool.many<ResourceDBEntry>(sql`
+  pool.many<Resource>(sql`
   select ${sql.join(Object.values(fields), sql`,`)}
   from ${table}
   `);
@@ -30,14 +30,14 @@ export const hasResourceWithId = async (id: string) =>
 `);
 
 export const findResourceByIdentifier = async (indentifier: string) =>
-  pool.maybeOne<ResourceDBEntry>(sql`
+  pool.maybeOne<Resource>(sql`
   select ${sql.join(Object.values(fields), sql`,`)}
   from ${table}
   where ${fields.identifier}=${indentifier}
 `);
 
 export const findResourceById = async (id: string) =>
-  pool.one<ResourceDBEntry>(sql`
+  pool.one<Resource>(sql`
   select ${sql.join(Object.values(fields), sql`,`)}
   from ${table}
   where ${fields.id}=${id}

--- a/packages/core/src/queries/resources.ts
+++ b/packages/core/src/queries/resources.ts
@@ -43,11 +43,11 @@ export const findResourceById = async (id: string) =>
   where ${fields.id}=${id}
 `);
 
-export const insertResource = buildInsertInto<ResourceDBEntry>(pool, Resources, {
+export const insertResource = buildInsertInto<ResourceDBEntry, Resource>(pool, Resources, {
   returning: true,
 });
 
-const updateResource = buildUpdateWhere<ResourceDBEntry>(pool, Resources, true);
+const updateResource = buildUpdateWhere<ResourceDBEntry, Resource>(pool, Resources, true);
 
 export const updateResourceById = async (
   id: string,

--- a/packages/core/src/queries/scopes.ts
+++ b/packages/core/src/queries/scopes.ts
@@ -1,4 +1,4 @@
-import { ResourceScopeDBEntry, ResourceScopes } from '@logto/schemas';
+import { ResourceScope, ResourceScopeDBEntry, ResourceScopes } from '@logto/schemas';
 import { sql } from 'slonik';
 
 import { buildInsertInto } from '@/database/insert-into';
@@ -9,7 +9,7 @@ import RequestError from '@/errors/RequestError';
 const { table, fields } = convertToIdentifiers(ResourceScopes);
 
 export const findAllScopesWithResourceId = async (resourceId: string) =>
-  pool.any<ResourceScopeDBEntry>(sql`
+  pool.any<ResourceScope>(sql`
     select ${sql.join(Object.values(fields), sql`,`)}
     from ${table}
     where ${fields.resourceId}=${resourceId}

--- a/packages/core/src/queries/scopes.ts
+++ b/packages/core/src/queries/scopes.ts
@@ -15,9 +15,13 @@ export const findAllScopesWithResourceId = async (resourceId: string) =>
     where ${fields.resourceId}=${resourceId}
 `);
 
-export const insertScope = buildInsertInto<ResourceScopeDBEntry>(pool, ResourceScopes, {
-  returning: true,
-});
+export const insertScope = buildInsertInto<ResourceScopeDBEntry, ResourceScope>(
+  pool,
+  ResourceScopes,
+  {
+    returning: true,
+  }
+);
 
 export const deleteScopeById = async (id: string) => {
   const { rowCount } = await pool.query(sql`

--- a/packages/core/src/queries/user.ts
+++ b/packages/core/src/queries/user.ts
@@ -37,7 +37,7 @@ export const hasUserWithId = async (id: string) =>
   where ${fields.id}=${id}
 `);
 
-export const insertUser = buildInsertInto<UserDBEntry>(pool, Users, { returning: true });
+export const insertUser = buildInsertInto<UserDBEntry, User>(pool, Users, { returning: true });
 
 export const findAllUsers = async () =>
   pool.many<User>(sql`
@@ -45,7 +45,7 @@ export const findAllUsers = async () =>
     from ${table}
   `);
 
-const updateUser = buildUpdateWhere<UserDBEntry>(pool, Users, true);
+const updateUser = buildUpdateWhere<UserDBEntry, User>(pool, Users, true);
 
 export const updateUserById = async (id: string, set: Partial<OmitAutoSetFields<UserDBEntry>>) =>
   updateUser({ set, where: { id } });

--- a/packages/core/src/queries/user.ts
+++ b/packages/core/src/queries/user.ts
@@ -1,4 +1,4 @@
-import { UserDBEntry, Users } from '@logto/schemas';
+import { User, UserDBEntry, Users } from '@logto/schemas';
 import { sql } from 'slonik';
 
 import { buildInsertInto } from '@/database/insert-into';
@@ -10,14 +10,14 @@ import RequestError from '@/errors/RequestError';
 const { table, fields } = convertToIdentifiers(Users);
 
 export const findUserByUsername = async (username: string) =>
-  pool.one<UserDBEntry>(sql`
+  pool.one<User>(sql`
   select ${sql.join(Object.values(fields), sql`,`)}
   from ${table}
   where ${fields.username}=${username}
 `);
 
 export const findUserById = async (id: string) =>
-  pool.one<UserDBEntry>(sql`
+  pool.one<User>(sql`
   select ${sql.join(Object.values(fields), sql`,`)}
   from ${table}
   where ${fields.id}=${id}
@@ -40,7 +40,7 @@ export const hasUserWithId = async (id: string) =>
 export const insertUser = buildInsertInto<UserDBEntry>(pool, Users, { returning: true });
 
 export const findAllUsers = async () =>
-  pool.many<UserDBEntry>(sql`
+  pool.many<User>(sql`
     select ${sql.join(Object.values(fields), sql`, `)}
     from ${table}
   `);

--- a/packages/schemas/src/db-entries/application.ts
+++ b/packages/schemas/src/db-entries/application.ts
@@ -15,6 +15,14 @@ export type ApplicationDBEntry = {
   name: string;
   type: ApplicationType;
   oidcClientMetadata: OidcClientMetadata;
+  createdAt?: number;
+};
+
+export type Application = {
+  id: string;
+  name: string;
+  type: ApplicationType;
+  oidcClientMetadata: OidcClientMetadata;
   createdAt: number;
 };
 
@@ -23,7 +31,7 @@ const guard: Guard<ApplicationDBEntry> = z.object({
   name: z.string(),
   type: z.nativeEnum(ApplicationType),
   oidcClientMetadata: oidcClientMetadataGuard,
-  createdAt: z.number(),
+  createdAt: z.number().optional(),
 });
 
 export const Applications: GeneratedSchema<ApplicationDBEntry> = Object.freeze({

--- a/packages/schemas/src/db-entries/oidc-model-instance.ts
+++ b/packages/schemas/src/db-entries/oidc-model-instance.ts
@@ -14,7 +14,15 @@ export type OidcModelInstanceDBEntry = {
   id: string;
   payload: OidcModelInstancePayload;
   expiresAt: number;
-  consumedAt?: number;
+  consumedAt?: number | null;
+};
+
+export type OidcModelInstance = {
+  modelName: string;
+  id: string;
+  payload: OidcModelInstancePayload;
+  expiresAt: number;
+  consumedAt: number | null;
 };
 
 const guard: Guard<OidcModelInstanceDBEntry> = z.object({

--- a/packages/schemas/src/db-entries/resource-scope.ts
+++ b/packages/schemas/src/db-entries/resource-scope.ts
@@ -11,6 +11,13 @@ export type ResourceScopeDBEntry = {
   resourceId: string;
 };
 
+export type ResourceScope = {
+  id: string;
+  name: string;
+  description: string;
+  resourceId: string;
+};
+
 const guard: Guard<ResourceScopeDBEntry> = z.object({
   id: z.string(),
   name: z.string(),

--- a/packages/schemas/src/db-entries/resource.ts
+++ b/packages/schemas/src/db-entries/resource.ts
@@ -9,6 +9,15 @@ export type ResourceDBEntry = {
   id: string;
   name: string;
   identifier: string;
+  accessTokenTtl?: number;
+  accessTokenFormat?: AccessTokenFormatType;
+  signAlgorithm?: SignAlgorithmType;
+};
+
+export type Resource = {
+  id: string;
+  name: string;
+  identifier: string;
   accessTokenTtl: number;
   accessTokenFormat: AccessTokenFormatType;
   signAlgorithm: SignAlgorithmType;
@@ -18,9 +27,9 @@ const guard: Guard<ResourceDBEntry> = z.object({
   id: z.string(),
   name: z.string(),
   identifier: z.string(),
-  accessTokenTtl: z.number(),
-  accessTokenFormat: z.nativeEnum(AccessTokenFormatType),
-  signAlgorithm: z.nativeEnum(SignAlgorithmType),
+  accessTokenTtl: z.number().optional(),
+  accessTokenFormat: z.nativeEnum(AccessTokenFormatType).optional(),
+  signAlgorithm: z.nativeEnum(SignAlgorithmType).optional(),
 });
 
 export const Resources: GeneratedSchema<ResourceDBEntry> = Object.freeze({

--- a/packages/schemas/src/db-entries/user-log.ts
+++ b/packages/schemas/src/db-entries/user-log.ts
@@ -11,6 +11,15 @@ export type UserLogDBEntry = {
   type: UserLogType;
   result: UserLogResult;
   payload: UserLogPayload;
+  createdAt?: number;
+};
+
+export type UserLog = {
+  id: string;
+  userId: string;
+  type: UserLogType;
+  result: UserLogResult;
+  payload: UserLogPayload;
   createdAt: number;
 };
 
@@ -20,7 +29,7 @@ const guard: Guard<UserLogDBEntry> = z.object({
   type: z.nativeEnum(UserLogType),
   result: z.nativeEnum(UserLogResult),
   payload: userLogPayloadGuard,
-  createdAt: z.number(),
+  createdAt: z.number().optional(),
 });
 
 export const UserLogs: GeneratedSchema<UserLogDBEntry> = Object.freeze({

--- a/packages/schemas/src/db-entries/user.ts
+++ b/packages/schemas/src/db-entries/user.ts
@@ -7,12 +7,22 @@ import { PasswordEncryptionMethod } from './custom-types';
 
 export type UserDBEntry = {
   id: string;
-  username?: string;
-  primaryEmail?: string;
-  primaryPhone?: string;
-  passwordEncrypted?: string;
-  passwordEncryptionMethod?: PasswordEncryptionMethod;
-  passwordEncryptionSalt?: string;
+  username?: string | null;
+  primaryEmail?: string | null;
+  primaryPhone?: string | null;
+  passwordEncrypted?: string | null;
+  passwordEncryptionMethod?: PasswordEncryptionMethod | null;
+  passwordEncryptionSalt?: string | null;
+};
+
+export type User = {
+  id: string;
+  username: string | null;
+  primaryEmail: string | null;
+  primaryPhone: string | null;
+  passwordEncrypted: string | null;
+  passwordEncryptionMethod: PasswordEncryptionMethod | null;
+  passwordEncryptionSalt: string | null;
 };
 
 const guard: Guard<UserDBEntry> = z.object({

--- a/packages/schemas/src/foundations/schemas.ts
+++ b/packages/schemas/src/foundations/schemas.ts
@@ -9,7 +9,7 @@ export type Guard<T extends Record<string, unknown>> = ZodObject<
 >;
 
 export type SchemaValuePrimitive = string | number | boolean | undefined;
-export type SchemaValue = SchemaValuePrimitive | Record<string, unknown>;
+export type SchemaValue = SchemaValuePrimitive | Record<string, unknown> | null;
 export type SchemaLike<Key extends string = string> = {
   [key in Key]: SchemaValue;
 };

--- a/packages/schemas/src/gen/index.ts
+++ b/packages/schemas/src/gen/index.ts
@@ -65,7 +65,8 @@ const generate = async () => {
                 const restLowercased = restJoined.toLowerCase();
                 // CAUTION: Only works for single dimension arrays
                 const isArray = Boolean(/\[.*]/.test(type)) || restLowercased.includes('array');
-                const required = restLowercased.includes('not null');
+                const hasDefaultValue = restLowercased.includes('default');
+                const nullable = !restLowercased.includes('not null');
                 const primitiveType = getType(type);
                 const tsType = /\/\* @use (.*) \*\//.exec(restJoined)?.[1];
                 assert(
@@ -81,7 +82,8 @@ const generate = async () => {
                   customType: conditional(!primitiveType && type),
                   tsType,
                   isArray,
-                  required,
+                  hasDefaultValue,
+                  nullable,
                 };
               });
             return { name, fields };

--- a/packages/schemas/src/gen/types.ts
+++ b/packages/schemas/src/gen/types.ts
@@ -3,7 +3,8 @@ export type Field = {
   type?: string;
   customType?: string;
   tsType?: string;
-  required: boolean;
+  hasDefaultValue: boolean;
+  nullable: boolean;
   isArray: boolean;
 };
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->

Each table in database will generate 2 interface: one for returning data, the other for insert and update.

An example:
```sql
create table users (
  id varchar(24) not null,
  username varchar(128),
  role varchar(24) not null default('guest'),
  primary key (id)
);
```
```ts
interface User {
  id: string;
  username: string | null;
  role: string;
}
interface UserDBEntry {
  id: string;
  username?: string | null;
  role?: string;
}
```

Please check if the naming rule `User` and `UserDBEntry` is suitable.

`buildUpdateWhere` and `buildInsertInto` are updated: now have 2 type templates, "insert type" and "return type".

tip: you can ingore auto generated files on reviewing this PR, considering remove those out of version control [LOG-439](https://linear.app/silverhand/issue/LOG-439/move-generated-schema-code-out-of-version-control)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

run `pnpm build` and got correct types.