### PR TITLE
feat: token exchange log

### DIFF
--- a/packages/core/src/oidc/adapter.ts
+++ b/packages/core/src/oidc/adapter.ts
@@ -51,7 +51,7 @@ export default function postgresAdapter(modelName: string): ReturnType<AdapterFa
           result: UserLogResult.Success,
           payload: {
             applicationId: payload.clientId,
-            applicationName: application ? application.name : undefined,
+            applicationName: application?.name,
             details: {
               scope: payload.scope,
               grantId: payload.grantId,

--- a/packages/core/src/oidc/adapter.ts
+++ b/packages/core/src/oidc/adapter.ts
@@ -42,7 +42,7 @@ export default function postgresAdapter(modelName: string): ReturnType<AdapterFa
   return {
     upsert: async (id, payload, expiresIn) => {
       if (modelName === 'AccessToken' && payload.accountId) {
-        const application = payload.clientId ? await findApplicationById(payload.clientId) : null;
+        const application = payload.clientId && await findApplicationById(payload.clientId);
 
         await insertUserLog({
           id: nanoid(),

--- a/packages/core/src/oidc/adapter.ts
+++ b/packages/core/src/oidc/adapter.ts
@@ -1,5 +1,6 @@
-import { ApplicationDBEntry } from '@logto/schemas';
+import { ApplicationDBEntry, UserLogResult, UserLogType } from '@logto/schemas';
 import dayjs from 'dayjs';
+import { nanoid } from 'nanoid';
 import { AdapterFactory, AllClientMetadata } from 'oidc-provider';
 import snakecaseKeys from 'snakecase-keys';
 
@@ -12,6 +13,7 @@ import {
   revokeInstanceByGrantId,
   upsertInstance,
 } from '@/queries/oidc-model-instance';
+import { insertUserLog } from '@/queries/user-log';
 
 export default function postgresAdapter(modelName: string): ReturnType<AdapterFactory> {
   if (modelName === 'Client') {
@@ -38,13 +40,37 @@ export default function postgresAdapter(modelName: string): ReturnType<AdapterFa
   }
 
   return {
-    upsert: async (id, payload, expiresIn) =>
-      upsertInstance({
+    upsert: async (id, payload, expiresIn) => {
+      if (modelName === 'AccessToken' && payload.accountId) {
+        const application = payload.clientId ? await findApplicationById(payload.clientId) : null;
+
+        await insertUserLog({
+          id: nanoid(),
+          userId: payload.accountId,
+          type: UserLogType.ExchangeAccessToken,
+          result: UserLogResult.Success,
+          payload: {
+            applicationId: payload.clientId,
+            applicationName: application ? application.name : undefined,
+            details: {
+              scope: payload.scope,
+              grantId: payload.grantId,
+              sessionUid: payload.sessionUid,
+              exp: payload.exp,
+              iat: payload.iat,
+              gty: payload.gty,
+            },
+          },
+        });
+      }
+
+      return upsertInstance({
         modelName,
         id,
         payload,
         expiresAt: dayjs().add(expiresIn, 'second').valueOf(),
-      }),
+      });
+    },
     find: async (id) => findPayloadById(modelName, id),
     findByUserCode: async (userCode) => findPayloadByPayloadField(modelName, 'userCode', userCode),
     findByUid: async (uid) => findPayloadByPayloadField(modelName, 'uid', uid),


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->

When creating a new `access_token`, insert a log to `user_logs`.

Because access token is managed in `oidc-provider`, has to insert user log manually, not able to reuse userLogMiddleware

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Start `Logto` (core and UI) in localhost, use playground to perform a success sign in (token exchange), a user log is inserted.

![image](https://user-images.githubusercontent.com/5717882/146348187-45a153ed-32e8-47a8-9014-a162ae85b751.png)

