### PR TITLE
fix(ui): fix useApi request in useEffect dead loop bug

### DIFF
--- a/packages/ui/src/hooks/use-api.ts
+++ b/packages/ui/src/hooks/use-api.ts
@@ -1,6 +1,6 @@
 import { RequestErrorBody } from '@logto/schemas';
 import { HTTPError } from 'ky';
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 
 type UseApi<T extends any[], U> = {
   result?: U;
@@ -16,26 +16,29 @@ function useApi<Args extends any[], Response>(
   const [error, setError] = useState<RequestErrorBody | null>(null);
   const [result, setResult] = useState<Response>();
 
-  const run = async (...args: Args) => {
-    setLoading(true);
-    setError(null);
+  const run = useCallback(
+    async (...args: Args) => {
+      setLoading(true);
+      setError(null);
 
-    try {
-      const result = await api(...args);
-      setResult(result);
-      setLoading(false);
-    } catch (error: unknown) {
-      if (error instanceof HTTPError) {
-        const kyError = await error.response.json<RequestErrorBody>();
-        setError(kyError);
+      try {
+        const result = await api(...args);
+        setResult(result);
         setLoading(false);
-        return;
-      }
+      } catch (error: unknown) {
+        if (error instanceof HTTPError) {
+          const kyError = await error.response.json<RequestErrorBody>();
+          setError(kyError);
+          setLoading(false);
+          return;
+        }
 
-      setLoading(false);
-      throw error;
-    }
-  };
+        setLoading(false);
+        throw error;
+      }
+    },
+    [api]
+  );
 
   return {
     loading,


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->

We have observed a dead loop call on the UI user consent page:

![image](https://user-images.githubusercontent.com/36393111/146868109-d44b5e9d-a166-48ab-a2a4-8676976142b7.png)


The root cause is when calling the request method within a `useEffect` hook:
![image](https://user-images.githubusercontent.com/36393111/146868174-1abd72ce-9d7a-441f-a927-81b11adeedc5.png)

Note: the `useEffect` dependency was newly added, that's why we observe the issue till recently. 

The request was refreshed after each request status change. 

 Fix: wrap up the request method in `useApi` hook into a `useCallback` hook. As it only depends on the `api` param.  Should not redefine every time. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

![image](https://user-images.githubusercontent.com/36393111/146868491-550635d6-7307-47d2-954c-b54c43699a53.png)


should successfully run the auth flow without dead loop. 

@logto-io/eng 
