### PR TITLE
chore: add boolean type for postgres

### DIFF
--- a/packages/schemas/src/gen/utils.ts
+++ b/packages/schemas/src/gen/utils.ts
@@ -114,7 +114,6 @@ export const getType = (
     case 'timestamp':
     case 'timestamptz':
       return 'number';
-    case 'bool':
     case 'boolean': // https://www.postgresql.org/docs/14/datatype-boolean.html
       return 'boolean';
     case 'json':

--- a/packages/schemas/src/gen/utils.ts
+++ b/packages/schemas/src/gen/utils.ts
@@ -115,6 +115,7 @@ export const getType = (
     case 'timestamptz':
       return 'number';
     case 'bool':
+    case 'boolean': // https://www.postgresql.org/docs/14/datatype-boolean.html
       return 'boolean';
     case 'json':
     case 'jsonb':


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->

Add DB type `boolean`.

According to [document](https://www.postgresql.org/docs/14/datatype-boolean.html), `boolean` is the standard name.

And support syntax highlighting.
