### PR TITLE
ci(codecov): add jest coverage report

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
         run: pnpm -- lerna run --parallel lint
 
       - name: Test
-        run: pnpm -- lerna run --parallel test
+        run: pnpm -- lerna run --parallel test:coverage
 
       - name: Coverage Report
         run: pnpm -- lerna run --parallel test:report

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: Main
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   main:
@@ -24,3 +24,6 @@ jobs:
 
       - name: Test
         run: pnpm -- lerna run --parallel test
+
+      - name: Coverage Report
+        run: pnpm -- lerna run --parallel test:report

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 70%

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -11,4 +11,6 @@ module.exports = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
+  coveragePathIgnorePatterns: ['/node_modules/', '/build/'],
+  coverageReporters: ['text-summary', 'lcov'],
 };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,9 @@
     "lint": "eslint --ext .ts src",
     "dev": "rm -rf build/ && tsc-watch -p tsconfig.build.json --preserveWatchOutput --onSuccess \"node ./build/index.js\"",
     "start": "NODE_ENV=production node build/index.js",
-    "test": "jest"
+    "test": "jest",
+    "test:coverage": "jest --coverage --silent",
+    "test:report": "codecov -F core"
   },
   "dependencies": {
     "@logto/phrases": "^0.1.0",
@@ -57,6 +59,7 @@
     "@types/lodash.pick": "^4.4.6",
     "@types/node": "^16.3.1",
     "@types/oidc-provider": "^7.8.0",
+    "codecov": "^3.8.3",
     "eslint": "^8.1.0",
     "jest": "^27.0.6",
     "jest-matcher-specific-error": "^1.0.0",

--- a/packages/core/src/database/update-where.test.ts
+++ b/packages/core/src/database/update-where.test.ts
@@ -40,12 +40,18 @@ describe('buildUpdateWhere()', () => {
       'update "users"\nset "username"=$1\nwhere "id"=$2 and "username"=$3'
     );
     const updateWhere = buildUpdateWhere(pool, Users);
+
+    const errorMessage: Partial<Record<NodeJS.Platform, string>> = {
+      darwin: "Cannot read properties of undefined (reading 'toString')",
+      linux: "Cannot read property 'toString' of undefined",
+    };
+
     await expect(
       updateWhere({
         set: { username: '123', id: undefined },
         where: { id: 'foo', username: '456' },
       })
-    ).rejects.toMatchError(new TypeError("Cannot read property 'toString' of undefined"));
+    ).rejects.toMatchError(new TypeError(errorMessage[process.platform]));
   });
 
   it('throws `entity.not_exists_with_id` error with `undefined` when `returning` is true', async () => {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -14,7 +14,9 @@
     "lint": "eslint --ext .ts --ext .tsx src",
     "stylelint": "stylelint \"src/**/*.scss\"",
     "test": "pnpm -- test:watch --no-watch",
-    "test:watch": "razzle test --env=jsdom"
+    "test:watch": "razzle test --env=jsdom",
+    "test:coverage": "razzle test --env=jsdom --coverage --silent",
+    "test:report": "codecov -F ui"
   },
   "dependencies": {
     "@logto/phrases": "^0.1.0",
@@ -44,6 +46,7 @@
     "@types/webpack": "^4",
     "@types/webpack-env": "^1.16.2",
     "babel-preset-razzle": "4.0.5",
+    "codecov": "^3.8.3",
     "concurrently": "^6.2.0",
     "eslint": "^8.1.0",
     "html-webpack-plugin": "^4.5.2",

--- a/packages/ui/razzle.config.js
+++ b/packages/ui/razzle.config.js
@@ -11,10 +11,12 @@ module.exports = {
     /** @type {import('webpack').Configuration} **/
     const config = { ...webpackConfig };
 
+    // eslint-disable-next-line @silverhand/fp/no-mutation
     config.resolve.alias = {
       '@': path.resolve('src/'),
     };
 
+    // eslint-disable-next-line @silverhand/fp/no-mutating-methods
     config.module.rules.push({
       test: require.resolve('ky'),
       use: {
@@ -29,19 +31,22 @@ module.exports = {
   },
   modifyJestConfig: ({ jestConfig }) => {
     /** @type {import('@jest/types').Config.InitialOptions} **/
-    const config = { ...jestConfig };
 
-    config.transformIgnorePatterns = [
-      '^.+\\.module\\.(css|sass|scss)$',
-      '[/\\\\]node_modules[/\\\\]((?!ky[/\\\\]).)+\\.(js|jsx|mjs|cjs|ts|tsx)$',
-    ];
-
-    config.moduleNameMapper = {
-      ...config.moduleNameMapper,
-      '^.+\\.(css|less|scss)$': 'babel-jest',
-      '@/(.*)': '<rootDir>/src/$1',
+    const config = {
+      ...jestConfig,
+      transformIgnorePatterns: [
+        '^.+\\.module\\.(css|sass|scss)$',
+        '[/\\\\]node_modules[/\\\\]((?!ky[/\\\\]).)+\\.(js|jsx|mjs|cjs|ts|tsx)$',
+      ],
+      moduleNameMapper: {
+        ...jestConfig.moduleNameMapper,
+        '^.+\\.(css|less|scss)$': 'babel-jest',
+        '@/(.*)': '<rootDir>/src/$1',
+      },
+      setupFilesAfterEnv: [...jestConfig.setupFilesAfterEnv, './src/jest.setup.ts'],
+      coveragePathIgnorePatterns: ['/node_modules/', '/build/'],
+      coverageReporters: ['text-summary', 'lcov'],
     };
-    config.setupFilesAfterEnv = [...config.setupFilesAfterEnv, './src/jest.setup.ts'];
 
     return config;
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,7 @@ importers:
       '@types/lodash.pick': ^4.4.6
       '@types/node': ^16.3.1
       '@types/oidc-provider': ^7.8.0
+      codecov: ^3.8.3
       dayjs: ^1.10.5
       decamelize: ^5.0.0
       dotenv: ^10.0.0
@@ -109,6 +110,7 @@ importers:
       '@types/lodash.pick': 4.4.6
       '@types/node': 16.11.12
       '@types/oidc-provider': 7.8.1
+      codecov: 3.8.3
       eslint: 8.4.1
       jest: 27.4.4
       jest-matcher-specific-error: 1.0.0
@@ -192,6 +194,7 @@ importers:
       '@ungap/global-this': ^0.4.4
       babel-preset-razzle: 4.0.5
       classnames: ^2.3.1
+      codecov: ^3.8.3
       concurrently: ^6.2.0
       eslint: ^8.1.0
       html-webpack-plugin: ^4.5.2
@@ -241,6 +244,7 @@ importers:
       '@types/webpack': 4.41.32
       '@types/webpack-env': 1.16.3
       babel-preset-razzle: 4.0.5
+      codecov: 3.8.3
       concurrently: 6.4.0
       eslint: 8.4.1
       html-webpack-plugin: 4.5.2_webpack@5.65.0
@@ -4173,6 +4177,11 @@ packages:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
     dev: true
 
+  /argv/0.0.2:
+    resolution: {integrity: sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=}
+    engines: {node: '>=0.6.10'}
+    dev: true
+
   /aria-query/5.0.0:
     resolution: {integrity: sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==}
     engines: {node: '>=6.0'}
@@ -5254,6 +5263,21 @@ packages:
   /code-point-at/1.1.0:
     resolution: {integrity: sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /codecov/3.8.3:
+    resolution: {integrity: sha512-Y8Hw+V3HgR7V71xWH2vQ9lyS358CbGCldWlJFR0JirqoGtOoas3R3/OclRTvgUYFK29mmJICDPauVKmpqbwhOA==}
+    engines: {node: '>=4.0'}
+    deprecated: https://about.codecov.io/blog/codecov-uploader-deprecation-plan/
+    hasBin: true
+    dependencies:
+      argv: 0.0.2
+      ignore-walk: 3.0.4
+      js-yaml: 3.14.1
+      teeny-request: 7.1.1
+      urlgrey: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /collect-v8-coverage/1.0.1:
@@ -7237,6 +7261,12 @@ packages:
     dependencies:
       boolean: 3.1.4
     dev: false
+
+  /fast-url-parser/1.1.3:
+    resolution: {integrity: sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=}
+    dependencies:
+      punycode: 1.3.2
+    dev: true
 
   /fastest-levenshtein/1.0.12:
     resolution: {integrity: sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==}
@@ -14775,6 +14805,12 @@ packages:
       duplexer: 0.1.2
     dev: true
 
+  /stream-events/1.0.5:
+    resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
+    dependencies:
+      stubs: 3.0.0
+    dev: true
+
   /strict-uri-encode/1.1.0:
     resolution: {integrity: sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=}
     engines: {node: '>=0.10.0'}
@@ -14953,6 +14989,10 @@ packages:
       duplexer: 0.1.2
       minimist: 1.2.5
       through: 2.3.8
+    dev: true
+
+  /stubs/3.0.0:
+    resolution: {integrity: sha1-6NK6H6nJBXAwPAMLaQD31fiavls=}
     dev: true
 
   /style-loader/2.0.0_webpack@5.65.0:
@@ -15216,6 +15256,19 @@ packages:
       minizlib: 2.1.2
       mkdirp: 1.0.4
       yallist: 4.0.0
+    dev: true
+
+  /teeny-request/7.1.1:
+    resolution: {integrity: sha512-iwY6rkW5DDGq8hE2YgNQlKbptYpY5Nn2xecjQiNjOXWbKzPGUfmeUBCSQbbr306d7Z7U2N0TPl+/SwYRfua1Dg==}
+    engines: {node: '>=10'}
+    dependencies:
+      http-proxy-agent: 4.0.1
+      https-proxy-agent: 5.0.0
+      node-fetch: 2.6.6
+      stream-events: 1.0.5
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /temp-dir/1.0.0:
@@ -15927,6 +15980,12 @@ packages:
     dependencies:
       punycode: 1.3.2
       querystring: 0.2.0
+    dev: true
+
+  /urlgrey/1.0.0:
+    resolution: {integrity: sha512-hJfIzMPJmI9IlLkby8QrsCykQ+SXDeO2W5Q9QTW3QpqZVTx4a/K7p8/5q+/isD8vsbVaFgql/gvAoQCRQ2Cb5w==}
+    dependencies:
+      fast-url-parser: 1.1.3
     dev: true
 
   /use/3.1.1:


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
This PR includes the following updates:

- add the `cannot read properly of undefined` platform based TypeError message mapper in the UT , to bypass the test case fail issue.
- add coverage report on `core` and `ui` project
- add codecov uploader job

core
![image](https://user-images.githubusercontent.com/36393111/148516985-7db1f8de-be8a-41b7-b301-b38f9cc82937.png)

ui
![image](https://user-images.githubusercontent.com/36393111/148517123-35cdba78-f2fa-459a-8f11-2c012d1c8f77.png)


Using node deprecated version of `codecov` uploader as well. Need to track  LOG-1276  issue to migrate the deprecate uploader to the new one. 

current coverage settings are :
default overall 70%,
each individual project: no less than the previous commit report.

We use global [settings](https://app.codecov.io/account/gh/logto-io/yaml) in codecov for all over logto-io repos. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Run the test on CI

@logto-io/eng 