### PR TITLE
feat: updateConnectorConfig

### DIFF
--- a/packages/core/src/connectors/utils.ts
+++ b/packages/core/src/connectors/utils.ts
@@ -3,10 +3,10 @@ import { ConnectorConfig, ConnectorType } from '@logto/schemas';
 import RequestError from '@/errors/RequestError';
 import { findConnectorByIdAndType, updateConnector } from '@/queries/connector';
 
-export const getConnectorConfig = async (
+export const getConnectorConfig = async <T extends ConnectorConfig>(
   id: string,
   type: ConnectorType
-): Promise<ConnectorConfig> => {
+): Promise<T> => {
   const connector = await findConnectorByIdAndType(id, type);
   if (!connector) {
     throw new RequestError({
@@ -17,13 +17,13 @@ export const getConnectorConfig = async (
     });
   }
 
-  return connector.config;
+  return connector.config as T;
 };
 
-export const updateConnectorConfig = async (
+export const updateConnectorConfig = async <T extends ConnectorConfig>(
   id: string,
   type: ConnectorType,
-  config: ConnectorConfig
+  config: T
 ): Promise<void> => {
   await updateConnector({
     where: { id, type },

--- a/packages/core/src/connectors/utils.ts
+++ b/packages/core/src/connectors/utils.ts
@@ -1,5 +1,6 @@
 import { ConnectorConfig, ConnectorType } from '@logto/schemas';
 
+import RequestError from '@/errors/RequestError';
 import { findConnectorByIdAndType, updateConnector } from '@/queries/connector';
 
 export const getConnectorConfig = async (
@@ -8,7 +9,12 @@ export const getConnectorConfig = async (
 ): Promise<ConnectorConfig> => {
   const connector = await findConnectorByIdAndType(id, type);
   if (!connector) {
-    throw new Error('Can not find connector in database');
+    throw new RequestError({
+      code: 'entity.not_exists_with_id',
+      name: 'connector',
+      id,
+      status: 404,
+    });
   }
 
   return connector.config;

--- a/packages/core/src/connectors/utils.ts
+++ b/packages/core/src/connectors/utils.ts
@@ -1,0 +1,26 @@
+import { ConnectorConfig, ConnectorType } from '@logto/schemas';
+
+import { findConnectorByIdAndType, updateConnector } from '@/queries/connector';
+
+export const getConnectorConfig = async (
+  id: string,
+  type: ConnectorType
+): Promise<ConnectorConfig> => {
+  const connector = await findConnectorByIdAndType(id, type);
+  if (!connector) {
+    throw new Error('Can not find connector in database');
+  }
+
+  return connector.config;
+};
+
+export const updateConnectorConfig = async (
+  id: string,
+  type: ConnectorType,
+  config: ConnectorConfig
+): Promise<void> => {
+  await updateConnector({
+    where: { id, type },
+    set: { config },
+  });
+};

--- a/packages/core/src/queries/connector.ts
+++ b/packages/core/src/queries/connector.ts
@@ -19,4 +19,4 @@ export const insertConnector = buildInsertInto<ConnectorUpdate, Connector>(pool,
   returning: true,
 });
 
-export const updateConnector = buildUpdateWhere<ConnectorDBEntry>(pool, Connectors);
+export const updateConnector = buildUpdateWhere<ConnectorUpdate>(pool, Connectors);

--- a/packages/core/src/queries/connector.ts
+++ b/packages/core/src/queries/connector.ts
@@ -3,6 +3,7 @@ import { sql } from 'slonik';
 
 import { buildInsertInto } from '@/database/insert-into';
 import pool from '@/database/pool';
+import { buildUpdateWhere } from '@/database/update-where';
 import { convertToIdentifiers } from '@/database/utils';
 
 const { table, fields } = convertToIdentifiers(Connectors);
@@ -17,3 +18,5 @@ export const findConnectorByIdAndType = async (id: string, type: ConnectorType) 
 export const insertConnector = buildInsertInto<ConnectorDBEntry, Connector>(pool, Connectors, {
   returning: true,
 });
+
+export const updateConnector = buildUpdateWhere<ConnectorDBEntry>(pool, Connectors);


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->

Wrap database query into `updateConnectorConfig` for connector.
Then the connector's code won't call database directly.
That is part of connector's convention design: https://www.notion.so/silverhand/updateConnectorConfig-aeca364ceefe4cbaa3a3b4a3ce79ef59
