### PR TITLE
feat(schema): update application db

### DIFF
--- a/packages/core/src/oidc/adapter.ts
+++ b/packages/core/src/oidc/adapter.ts
@@ -13,14 +13,20 @@ import {
   upsertInstance,
 } from '@/queries/oidc-model-instance';
 
+import { getApplicationTypeString } from './utils';
+
 export default function postgresAdapter(modelName: string): ReturnType<AdapterFactory> {
   if (modelName === 'Client') {
     const reject = async () => Promise.reject(new Error('Not implemented'));
     const transpileClient = ({
-      id,
+      id: client_id,
+      name: client_name,
+      type,
       oidcClientMetadata,
     }: ApplicationDBEntry): AllClientMetadata => ({
-      client_id: id,
+      client_id,
+      client_name,
+      application_type: getApplicationTypeString(type),
       grant_types: ['authorization_code', 'refresh_token'],
       token_endpoint_auth_method: 'none',
       ...snakecaseKeys(oidcClientMetadata),

--- a/packages/core/src/oidc/utils.ts
+++ b/packages/core/src/oidc/utils.ts
@@ -1,14 +1,10 @@
 import { ApplicationType, OidcClientMetadata } from '@logto/schemas';
 
-const getApplicationTypeString = (type: ApplicationType) =>
+export const getApplicationTypeString = (type: ApplicationType) =>
   type === ApplicationType.Native ? 'native' : 'web';
 
-export const buildOidcClientMetadata = (
-  type: ApplicationType,
-  metadata?: OidcClientMetadata
-): OidcClientMetadata => ({
+export const buildOidcClientMetadata = (metadata?: OidcClientMetadata): OidcClientMetadata => ({
   redirectUris: [],
   postLogoutRedirectUris: [],
   ...metadata,
-  applicationType: getApplicationTypeString(type),
 });

--- a/packages/core/src/routes/application.ts
+++ b/packages/core/src/routes/application.ts
@@ -37,7 +37,7 @@ export default function applicationRoutes<T extends AuthedRouter>(router: T) {
         id: applicationId(),
         type,
         name,
-        oidcClientMetadata: buildOidcClientMetadata(type, oidcClientMetadata),
+        oidcClientMetadata: buildOidcClientMetadata(oidcClientMetadata),
         ...rest,
       });
       return next();
@@ -74,7 +74,7 @@ export default function applicationRoutes<T extends AuthedRouter>(router: T) {
 
       ctx.body = await updateApplicationById(id, {
         ...body,
-        oidcClientMetadata: buildOidcClientMetadata(body.type ?? application.type, {
+        oidcClientMetadata: buildOidcClientMetadata({
           ...application.oidcClientMetadata,
           ...body.oidcClientMetadata,
         }),

--- a/packages/schemas/src/db-entries/application.ts
+++ b/packages/schemas/src/db-entries/application.ts
@@ -13,24 +13,33 @@ import { ApplicationType } from './custom-types';
 export type ApplicationDBEntry = {
   id: string;
   name: string;
+  description?: string | null;
   type: ApplicationType;
   oidcClientMetadata: OidcClientMetadata;
+  idTokenTtl?: number;
+  refreshTokenTtl?: number;
   createdAt?: number;
 };
 
 export type Application = {
   id: string;
   name: string;
+  description: string | null;
   type: ApplicationType;
   oidcClientMetadata: OidcClientMetadata;
+  idTokenTtl: number;
+  refreshTokenTtl: number;
   createdAt: number;
 };
 
 const guard: Guard<ApplicationDBEntry> = z.object({
   id: z.string(),
   name: z.string(),
+  description: z.string().optional(),
   type: z.nativeEnum(ApplicationType),
   oidcClientMetadata: oidcClientMetadataGuard,
+  idTokenTtl: z.number().optional(),
+  refreshTokenTtl: z.number().optional(),
   createdAt: z.number().optional(),
 });
 
@@ -40,10 +49,22 @@ export const Applications: GeneratedSchema<ApplicationDBEntry> = Object.freeze({
   fields: {
     id: 'id',
     name: 'name',
+    description: 'description',
     type: 'type',
     oidcClientMetadata: 'oidc_client_metadata',
+    idTokenTtl: 'id_token_ttl',
+    refreshTokenTtl: 'refresh_token_ttl',
     createdAt: 'created_at',
   },
-  fieldKeys: ['id', 'name', 'type', 'oidcClientMetadata', 'createdAt'],
+  fieldKeys: [
+    'id',
+    'name',
+    'description',
+    'type',
+    'oidcClientMetadata',
+    'idTokenTtl',
+    'refreshTokenTtl',
+    'createdAt',
+  ],
   guard,
 });

--- a/packages/schemas/src/foundations/jsonb-types.ts
+++ b/packages/schemas/src/foundations/jsonb-types.ts
@@ -15,9 +15,9 @@ export const oidcModelInstancePayloadGuard = z
 export type OidcModelInstancePayload = z.infer<typeof oidcModelInstancePayloadGuard>;
 
 export const oidcClientMetadataGuard = z.object({
-  applicationType: z.enum(['web', 'native']),
   redirectUris: z.string().array(),
   postLogoutRedirectUris: z.string().array(),
+  logoUri: z.string().optional(),
 });
 
 export type OidcClientMetadata = z.infer<typeof oidcClientMetadataGuard>;

--- a/packages/schemas/tables/applications.sql
+++ b/packages/schemas/tables/applications.sql
@@ -3,8 +3,11 @@ create type application_type as enum ('Native', 'SPA', 'Traditional');
 create table applications (
   id varchar(128) not null,
   name varchar(256) not null,
+  description text,
   type application_type not null,
   oidc_client_metadata jsonb /* @use OidcClientMetadata */ not null,
+  id_token_ttL bigint not null default(86400),
+  refresh_token_ttL bigint not null default(2592000),
   created_at timestamptz not null default(now()),
   primary key (id)
 );

--- a/packages/schemas/tables/applications.sql
+++ b/packages/schemas/tables/applications.sql
@@ -6,8 +6,8 @@ create table applications (
   description text,
   type application_type not null,
   oidc_client_metadata jsonb /* @use OidcClientMetadata */ not null,
-  id_token_ttL bigint not null default(86400),
-  refresh_token_ttL bigint not null default(2592000),
+  id_token_ttl bigint not null default(86400),
+  refresh_token_ttl bigint not null default(2592000),
   created_at timestamptz not null default(now()),
   primary key (id)
 );


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
Update application DB

1. add optional field `description`
2. add optional field `logo_uri` to the `oidc_client_metadata`. As supported by the OIDC provider
3. add `idTokenTTL` with a default value
4. add `refreshTokenTTL` with a default value
5. remove the `application_type` field in `oidc_client_metadata` in order to keep a single source of truth of the application type
6. Update the OIDC provider adapter, load the application type from the ApplicationDB's type field directly 
7. Update the `buildOidcClientMetadata` util methods accordingly. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally on playground. 
public db updated accordingly. 
UT passed 

@logto-io/eng 