### PR TITLE
feat(applications): add pagination middleware to findAllApplications

### DIFF
--- a/packages/core/src/database/utils.ts
+++ b/packages/core/src/database/utils.ts
@@ -1,8 +1,9 @@
 import { SchemaValuePrimitive, SchemaValue } from '@logto/schemas';
 import { Falsy, notFalsy } from '@silverhand/essentials';
 import dayjs from 'dayjs';
-import { sql, SqlSqlTokenType, SqlTokenType } from 'slonik';
+import { sql, SqlSqlTokenType, SqlTokenType, IdentifierSqlTokenType } from 'slonik';
 
+import pool from './pool';
 import { FieldIdentifiers, Table } from './types';
 
 export const conditionalSql = <T>(
@@ -70,3 +71,9 @@ export const convertToIdentifiers = <T extends Table>(
 });
 
 export const convertToTimestamp = (time = dayjs()) => sql`to_timestamp(${time.valueOf() / 1000})`;
+
+export const getTotalRowCount = async (table: IdentifierSqlTokenType) =>
+  pool.one<{ count: number }>(sql`
+    select count(*)
+    from ${table}
+  `);

--- a/packages/core/src/queries/application.ts
+++ b/packages/core/src/queries/application.ts
@@ -1,6 +1,7 @@
 import { Application, ApplicationDBEntry, Applications } from '@logto/schemas';
 import { sql } from 'slonik';
 
+import { buildFindMany } from '@/database/find-many';
 import { buildInsertInto } from '@/database/insert-into';
 import pool from '@/database/pool';
 import { buildUpdateWhere } from '@/database/update-where';
@@ -13,13 +14,10 @@ const { table, fields } = convertToIdentifiers(Applications);
 
 export const findTotalNumberOfApplications = async () => totalRowCount(table);
 
+const findApplicationMany = buildFindMany<ApplicationDBEntry, Application>(pool, Applications);
+
 export const findAllApplications = async (limit: number, offset: number) =>
-  pool.many<Application>(sql`
-    select ${sql.join(Object.values(fields), sql`, `)}
-    from ${table}
-    offset ${offset}
-    limit ${limit}
-  `);
+  findApplicationMany({ limit, offset });
 
 export const findApplicationById = async (id: string) =>
   pool.one<Application>(sql`

--- a/packages/core/src/queries/application.ts
+++ b/packages/core/src/queries/application.ts
@@ -5,14 +5,12 @@ import { buildFindMany } from '@/database/find-many';
 import { buildInsertInto } from '@/database/insert-into';
 import pool from '@/database/pool';
 import { buildUpdateWhere } from '@/database/update-where';
-import { convertToIdentifiers, OmitAutoSetFields } from '@/database/utils';
+import { convertToIdentifiers, OmitAutoSetFields, getTotalRowCount } from '@/database/utils';
 import RequestError from '@/errors/RequestError';
-
-import { totalRowCount } from './utils';
 
 const { table, fields } = convertToIdentifiers(Applications);
 
-export const findTotalNumberOfApplications = async () => totalRowCount(table);
+export const findTotalNumberOfApplications = async () => getTotalRowCount(table);
 
 const findApplicationMany = buildFindMany<ApplicationDBEntry, Application>(pool, Applications);
 

--- a/packages/core/src/queries/application.ts
+++ b/packages/core/src/queries/application.ts
@@ -7,12 +7,18 @@ import { buildUpdateWhere } from '@/database/update-where';
 import { convertToIdentifiers, OmitAutoSetFields } from '@/database/utils';
 import RequestError from '@/errors/RequestError';
 
+import { totalRowCount } from './utils';
+
 const { table, fields } = convertToIdentifiers(Applications);
 
-export const findAllApplications = async () =>
+export const findTotalNumberOfApplications = async () => totalRowCount(table);
+
+export const findAllApplications = async (limit: number, offset: number) =>
   pool.many<Application>(sql`
     select ${sql.join(Object.values(fields), sql`, `)}
     from ${table}
+    offset ${offset}
+    limit ${limit}
   `);
 
 export const findApplicationById = async (id: string) =>

--- a/packages/core/src/queries/utils.ts
+++ b/packages/core/src/queries/utils.ts
@@ -1,0 +1,9 @@
+import { sql, IdentifierSqlTokenType } from 'slonik';
+
+import pool from '@/database/pool';
+
+export const totalRowCount = async (table: IdentifierSqlTokenType) =>
+  pool.one<{ count: number }>(sql`
+    select count(*)
+    from ${table}
+  `);

--- a/packages/core/src/queries/utils.ts
+++ b/packages/core/src/queries/utils.ts
@@ -1,9 +1,0 @@
-import { sql, IdentifierSqlTokenType } from 'slonik';
-
-import pool from '@/database/pool';
-
-export const totalRowCount = async (table: IdentifierSqlTokenType) =>
-  pool.one<{ count: number }>(sql`
-    select count(*)
-    from ${table}
-  `);

--- a/packages/core/src/routes/application.ts
+++ b/packages/core/src/routes/application.ts
@@ -21,12 +21,15 @@ const applicationId = buildIdGenerator(21);
 export default function applicationRoutes<T extends AuthedRouter>(router: T) {
   router.get('/applications', koaPagination(), async (ctx, next) => {
     const { limit, offset } = ctx.pagination;
-    const { count } = await findTotalNumberOfApplications();
+
+    const [{ count }, applications] = await Promise.all([
+      findTotalNumberOfApplications(),
+      findAllApplications(limit, offset),
+    ]);
 
     // Return totalCount to pagination middleware
     ctx.pagination.totalCount = count;
-
-    ctx.body = await findAllApplications(limit, offset);
+    ctx.body = applications;
 
     return next();
   });

--- a/packages/core/src/routes/application.ts
+++ b/packages/core/src/routes/application.ts
@@ -1,7 +1,6 @@
 import { Applications } from '@logto/schemas';
 import { object, string } from 'zod';
 
-import RequestError from '@/errors/RequestError';
 import koaGuard from '@/middleware/koa-guard';
 import koaPagination from '@/middleware/koa-pagination';
 import { buildOidcClientMetadata } from '@/oidc/utils';
@@ -23,14 +22,6 @@ export default function applicationRoutes<T extends AuthedRouter>(router: T) {
   router.get('/applications', koaPagination(), async (ctx, next) => {
     const { limit, offset } = ctx.pagination;
     const { count } = await findTotalNumberOfApplications();
-
-    if (offset >= count) {
-      throw new RequestError({
-        code: 'entity.not_exists',
-        name: Applications.tableSingular,
-        status: 404,
-      });
-    }
 
     // Return totalCount to pagination middleware
     ctx.pagination.totalCount = count;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
Add pagination middleware to findAllApplications

1. update the `findAllApplications` query method to take limit and offset as its query input
2. add `koa-pagination` middle to the GET /applications api
3. Return total num of applications as totalCount to the pagination middleware

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally with post man

Request:
![image](https://user-images.githubusercontent.com/36393111/148753925-5d22e48d-d2f3-42ce-992f-15e130ee7d17.png)


Response:
![image](https://user-images.githubusercontent.com/36393111/148753945-549b9a14-814e-4007-ae1d-1b275aaad834.png)

Response Header:
![image](https://user-images.githubusercontent.com/36393111/148753978-a6cbd05b-dd6f-4770-ad25-607cf157f862.png)

@logto-io/eng 