### PR TITLE
feat(application): add application query exceptions

### DIFF
--- a/packages/core/src/middleware/koa-error-handler.ts
+++ b/packages/core/src/middleware/koa-error-handler.ts
@@ -3,6 +3,7 @@ import { RequestErrorBody } from '@logto/schemas';
 import decamelize from 'decamelize';
 import { Middleware } from 'koa';
 import { errors } from 'oidc-provider';
+import { NotFoundError } from 'slonik';
 
 import RequestError from '@/errors/RequestError';
 
@@ -29,6 +30,13 @@ export default function koaErrorHandler<StateT, ContextT>(): Middleware<
           code: `oidc.${decamelize(error.name)}` as LogtoErrorCode,
           data: error.error_detail,
         };
+        return;
+      }
+
+      if (error instanceof NotFoundError) {
+        const error = new RequestError({ code: 'entity.not_found', status: 404 });
+        ctx.status = error.status;
+        ctx.body = error.body;
         return;
       }
 

--- a/packages/core/src/queries/application.ts
+++ b/packages/core/src/queries/application.ts
@@ -1,5 +1,5 @@
 import { Application, ApplicationUpdate, Applications } from '@logto/schemas';
-import { sql, NotFoundError } from 'slonik';
+import { sql, SlonikError } from 'slonik';
 
 import { buildFindMany } from '@/database/find-many';
 import { buildInsertInto } from '@/database/insert-into';
@@ -48,6 +48,6 @@ export const deleteApplicationById = async (id: string) => {
     where id=${id}
   `);
   if (rowCount < 1) {
-    throw new NotFoundError();
+    throw new SlonikError('Resource not found');
   }
 };

--- a/packages/core/src/queries/application.ts
+++ b/packages/core/src/queries/application.ts
@@ -14,15 +14,34 @@ export const findTotalNumberOfApplications = async () => getTotalRowCount(table)
 
 const findApplicationMany = buildFindMany<ApplicationUpdate, Application>(pool, Applications);
 
-export const findAllApplications = async (limit: number, offset: number) =>
-  findApplicationMany({ limit, offset });
+export const findAllApplications = async (limit: number, offset: number) => {
+  try {
+    return await findApplicationMany({ limit, offset });
+  } catch {
+    throw new RequestError({
+      code: 'entity.not_exists',
+      name: Applications.tableSingular,
+      status: 404,
+    });
+  }
+};
 
-export const findApplicationById = async (id: string) =>
-  pool.one<Application>(sql`
-    select ${sql.join(Object.values(fields), sql`, `)}
-    from ${table}
-    where ${fields.id}=${id}
-  `);
+export const findApplicationById = async (id: string) => {
+  try {
+    return await pool.one<Application>(sql`
+      select ${sql.join(Object.values(fields), sql`, `)}
+      from ${table}
+      where ${fields.id}=${id}
+    `);
+  } catch {
+    throw new RequestError({
+      code: 'entity.not_exists_with_id',
+      name: Applications.tableSingular,
+      id,
+      status: 404,
+    });
+  }
+};
 
 export const insertApplication = buildInsertInto<ApplicationUpdate, Application>(
   pool,

--- a/packages/core/src/routes/application.ts
+++ b/packages/core/src/routes/application.ts
@@ -101,6 +101,7 @@ export default function applicationRoutes<T extends AuthedRouter>(router: T) {
     async (ctx, next) => {
       const { id } = ctx.guard.params;
       // Note: will need delete cascade when application is joint with other tables
+      await findApplicationById(id);
       await deleteApplicationById(id);
       ctx.status = 204;
       return next();

--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -50,6 +50,7 @@ const errors = {
     create_failed: 'Failed to create {{name}}.',
     not_exists: 'The {{name}} does not exist.',
     not_exists_with_id: 'The {{name}} with ID `{{id}}` does not exist.',
+    not_found: 'The resource does not exist',
   },
 };
 

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -52,6 +52,7 @@ const errors = {
     create_failed: '创建 {{name}} 失败。',
     not_exists: '该 {{name}} 不存在。',
     not_exists_with_id: 'ID 为 `{{id}}` 的 {{name}} 不存在。',
+    not_found: '该资源不存在',
   },
 };
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
Add application query exceptions. Need to align the exception thrown logic. 

Pure our online & offline discussion:
1. Should not add any custom exception handle logic at the query script level by default. Exceptions on extreme cases may apply.
2. Should not handle slonik exceptions except for the "not found" error. Throw 500 for all the rest.
3. Catch the slonik NotFount error and return a 404 RequestError with a custom error message at the error-handler middleware.
4. Run query script first then delete script on all the delete apis. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
GET
![image](https://user-images.githubusercontent.com/36393111/149118992-1afcf415-1e7d-4d50-af7e-946e35b40524.png)

DELETE
![image](https://user-images.githubusercontent.com/36393111/149119184-330e0883-09da-4ce9-9c1a-11a0c756b777.png)



@logto-io/eng 