### PR TITLE
feat(application): set idToken and refreshToken ttl based on client metadata

### DIFF
--- a/packages/core/src/include.d/oidc-provider.d.ts
+++ b/packages/core/src/include.d/oidc-provider.d.ts
@@ -1,0 +1,6 @@
+import { CustomClientMetadata } from '@logto/schemas';
+import { AllClientMetadata } from 'oidc-provider';
+
+declare module 'oidc-provider' {
+  export interface AllClientMetadata extends CustomClientMetadata {}
+}

--- a/packages/core/src/oidc/adapter.ts
+++ b/packages/core/src/oidc/adapter.ts
@@ -23,6 +23,7 @@ export default function postgresAdapter(modelName: string): ReturnType<AdapterFa
       name: client_name,
       type,
       oidcClientMetadata,
+      customClientMetadata,
     }: ApplicationUpdate): AllClientMetadata => ({
       client_id,
       client_name,
@@ -30,6 +31,7 @@ export default function postgresAdapter(modelName: string): ReturnType<AdapterFa
       grant_types: ['authorization_code', 'refresh_token'],
       token_endpoint_auth_method: 'none',
       ...snakecaseKeys(oidcClientMetadata),
+      ...customClientMetadata, // OIDC Provider won't camelcase custom parameter keys
     });
 
     return {

--- a/packages/core/src/oidc/consts.ts
+++ b/packages/core/src/oidc/consts.ts
@@ -11,3 +11,6 @@ export const publicKey = crypto.createPublicKey(privateKey);
 
 export const issuer = getEnv('OIDC_ISSUER', `http://localhost:${port}/oidc`);
 export const adminResource = getEnv('ADMIN_RESOURCE', 'https://api.logto.io');
+
+export const defaultIdTokenTtl = 60 * 60;
+export const defaultRefreshTokenTtl = 14 * 24 * 60 * 60;

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -1,3 +1,4 @@
+import { customClientMetadataGuard, CustomClientMetadataType } from '@logto/schemas';
 import { fromKeyLike } from 'jose/jwk/from_key_like';
 import Koa from 'koa';
 import mount from 'koa-mount';
@@ -71,6 +72,15 @@ export default async function initOidc(app: Koa): Promise<Provider> {
         }
       },
     },
+    extraClientMetadata: {
+      properties: Object.keys(CustomClientMetadataType),
+      validator: (_ctx, key, value) => {
+        const result = customClientMetadataGuard.pick({ [key]: true }).safeParse({ key: value });
+        if (!result.success) {
+          throw new errors.InvalidClientMetadata(key);
+        }
+      },
+    },
     clientBasedCORS: (_, origin) => {
       console.log('origin', origin);
       return origin.startsWith('http://localhost:3000');
@@ -88,6 +98,19 @@ export default async function initOidc(app: Koa): Promise<Provider> {
           return { sub };
         },
       };
+    },
+    ttl: {
+      /**
+       * [OIDC Provider Default Settings](https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#ttl)
+       */
+      IdToken: (ctx, token, client) => {
+        const { idTokenTtl } = client.metadata();
+        return idTokenTtl ?? 60 * 60;
+      },
+      RefreshToken: (ctx, token, client) => {
+        const { refreshTokenTtl } = client.metadata();
+        return refreshTokenTtl ?? 14 * 24 * 60 * 60;
+      },
     },
   });
   app.use(mount('/oidc', oidc.app));

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -10,7 +10,7 @@ import { findAllScopesWithResourceId } from '@/queries/scopes';
 import { findUserById } from '@/queries/user';
 import { routes } from '@/routes/consts';
 
-import { issuer, privateKey } from './consts';
+import { issuer, privateKey, defaultIdTokenTtl, defaultRefreshTokenTtl } from './consts';
 
 export default async function initOidc(app: Koa): Promise<Provider> {
   const keys = [await fromKeyLike(privateKey)];
@@ -105,11 +105,11 @@ export default async function initOidc(app: Koa): Promise<Provider> {
        */
       IdToken: (ctx, token, client) => {
         const { idTokenTtl } = client.metadata();
-        return idTokenTtl ?? 60 * 60;
+        return idTokenTtl ?? defaultIdTokenTtl;
       },
       RefreshToken: (ctx, token, client) => {
         const { refreshTokenTtl } = client.metadata();
-        return refreshTokenTtl ?? 14 * 24 * 60 * 60;
+        return refreshTokenTtl ?? defaultRefreshTokenTtl;
       },
     },
   });

--- a/packages/schemas/src/db-entries/application.ts
+++ b/packages/schemas/src/db-entries/application.ts
@@ -5,6 +5,8 @@ import { z } from 'zod';
 import {
   OidcClientMetadata,
   oidcClientMetadataGuard,
+  CustomClientMetadata,
+  customClientMetadataGuard,
   GeneratedSchema,
   Guard,
 } from '../foundations';
@@ -16,8 +18,7 @@ export type ApplicationUpdate = {
   description?: string | null;
   type: ApplicationType;
   oidcClientMetadata: OidcClientMetadata;
-  idTokenTtl?: number;
-  refreshTokenTtl?: number;
+  customClientMetadata?: CustomClientMetadata | null;
   createdAt?: number;
 };
 
@@ -27,8 +28,7 @@ export type Application = {
   description: string | null;
   type: ApplicationType;
   oidcClientMetadata: OidcClientMetadata;
-  idTokenTtl: number;
-  refreshTokenTtl: number;
+  customClientMetadata: CustomClientMetadata | null;
   createdAt: number;
 };
 
@@ -38,8 +38,7 @@ const guard: Guard<ApplicationUpdate> = z.object({
   description: z.string().optional(),
   type: z.nativeEnum(ApplicationType),
   oidcClientMetadata: oidcClientMetadataGuard,
-  idTokenTtl: z.number().optional(),
-  refreshTokenTtl: z.number().optional(),
+  customClientMetadata: customClientMetadataGuard.optional(),
   createdAt: z.number().optional(),
 });
 
@@ -52,8 +51,7 @@ export const Applications: GeneratedSchema<ApplicationUpdate> = Object.freeze({
     description: 'description',
     type: 'type',
     oidcClientMetadata: 'oidc_client_metadata',
-    idTokenTtl: 'id_token_ttl',
-    refreshTokenTtl: 'refresh_token_ttl',
+    customClientMetadata: 'custom_client_metadata',
     createdAt: 'created_at',
   },
   fieldKeys: [
@@ -62,8 +60,7 @@ export const Applications: GeneratedSchema<ApplicationUpdate> = Object.freeze({
     'description',
     'type',
     'oidcClientMetadata',
-    'idTokenTtl',
-    'refreshTokenTtl',
+    'customClientMetadata',
     'createdAt',
   ],
   guard,

--- a/packages/schemas/src/db-entries/application.ts
+++ b/packages/schemas/src/db-entries/application.ts
@@ -18,7 +18,7 @@ export type ApplicationUpdate = {
   description?: string | null;
   type: ApplicationType;
   oidcClientMetadata: OidcClientMetadata;
-  customClientMetadata?: CustomClientMetadata | null;
+  customClientMetadata?: CustomClientMetadata;
   createdAt?: number;
 };
 
@@ -28,7 +28,7 @@ export type Application = {
   description: string | null;
   type: ApplicationType;
   oidcClientMetadata: OidcClientMetadata;
-  customClientMetadata: CustomClientMetadata | null;
+  customClientMetadata: CustomClientMetadata;
   createdAt: number;
 };
 

--- a/packages/schemas/src/foundations/jsonb-types.ts
+++ b/packages/schemas/src/foundations/jsonb-types.ts
@@ -22,6 +22,18 @@ export const oidcClientMetadataGuard = z.object({
 
 export type OidcClientMetadata = z.infer<typeof oidcClientMetadataGuard>;
 
+export enum CustomClientMetadataType {
+  idTokenTtl = 'idTokenTtl',
+  refreshTokenTtl = 'refreshTokenTtl',
+}
+
+export const customClientMetadataGuard = z.object({
+  [CustomClientMetadataType.idTokenTtl]: z.number().optional(),
+  [CustomClientMetadataType.refreshTokenTtl]: z.number().optional(),
+});
+
+export type CustomClientMetadata = z.infer<typeof customClientMetadataGuard>;
+
 export const userLogPayloadGuard = z.object({
   ip: z.string().optional(),
   userAgent: z.string().optional(),

--- a/packages/schemas/tables/applications.sql
+++ b/packages/schemas/tables/applications.sql
@@ -6,8 +6,7 @@ create table applications (
   description text,
   type application_type not null,
   oidc_client_metadata jsonb /* @use OidcClientMetadata */ not null,
-  id_token_ttl bigint not null default(86400),
-  refresh_token_ttl bigint not null default(2592000),
+  custom_client_metadata jsonb /* @use CustomClientMetadata */,
   created_at timestamptz not null default(now()),
   primary key (id)
 );

--- a/packages/schemas/tables/applications.sql
+++ b/packages/schemas/tables/applications.sql
@@ -6,7 +6,7 @@ create table applications (
   description text,
   type application_type not null,
   oidc_client_metadata jsonb /* @use OidcClientMetadata */ not null,
-  custom_client_metadata jsonb /* @use CustomClientMetadata */,
+  custom_client_metadata jsonb /* @use CustomClientMetadata */ not null default '{}'::jsonb,
   created_at timestamptz not null default(now()),
   primary key (id)
 );


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->

Attempt to set `idToken` and `refreshToken` ttl based on the client metadata settings.


Researched on the OIDC Provider's [extra client metadata config ](https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#extraclientmetadataproperties). 
We should implement and manage all our potential customized client metadata within a single jsonb field and passed to the OIDC Provider as `extraClientMetadataProperties`, guarded using the Zod type guard. 

1. update the DB, remove the field of `idTokenTtl` and `refreshTokenTtl` add a new jsonb field called `customeClientMetadata` field instead
2. Implement an oidc-provider type declaration to extend the `AllClientMetadata` interface with our `CustomClientMetadata`.
3. Pass in the keys of `CustomClientMetadata` as OIDC-Provider extraClientMetadata along with their zod type guard validator.
4. Read the idTokenTtl and refreshTokenTtl config from client metadata. If set, replace the default ttl settings. 


<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
log-1293

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally 
![image](https://user-images.githubusercontent.com/36393111/149093044-8d65d72e-021a-458d-b755-73616df23fa6.png)

with db settings update 
![image](https://user-images.githubusercontent.com/36393111/149093098-6ae62106-0b97-4814-b977-7e84c4155533.png)

@logto-io/eng 