### PR TITLE
feat(core): add koa-camelcase-transform middleware

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,7 @@
     "@logto/phrases": "^0.1.0",
     "@logto/schemas": "^0.1.0",
     "@silverhand/essentials": "^1.1.0",
+    "camelcase-keys": "^7.0.1",
     "dayjs": "^1.10.5",
     "decamelize": "^5.0.0",
     "dotenv": "^10.0.0",

--- a/packages/core/src/app/init.ts
+++ b/packages/core/src/app/init.ts
@@ -5,6 +5,7 @@ import Koa from 'koa';
 import koaLogger from 'koa-logger';
 
 import { port } from '@/env/consts';
+import koaCamelcaseTransform from '@/middleware/koa-camelcase-transform';
 import koaErrorHandler from '@/middleware/koa-error-handler';
 import koaI18next from '@/middleware/koa-i18next';
 import koaUIProxy from '@/middleware/koa-ui-proxy';
@@ -14,6 +15,7 @@ import initRouter from '@/routes/init';
 
 export default async function initApp(app: Koa): Promise<void> {
   app.use(koaErrorHandler());
+  app.use(koaCamelcaseTransform());
   // TODO move to specific router (LOG-454)
   app.use(koaUserLog());
   app.use(koaLogger());

--- a/packages/core/src/middleware/koa-camelcase-transform.test.ts
+++ b/packages/core/src/middleware/koa-camelcase-transform.test.ts
@@ -27,10 +27,10 @@ describe('koa-camelcase-transform', () => {
     expect(ctx.body).toHaveProperty('redirect_uri');
   });
 
-  it('should not transform body to camelcase with keycase header snakecase', async () => {
+  it('should not transform body to camelcase with keycase header not recognized', async () => {
     const ctx = createMockContext({
       headers: {
-        'response-keycase': ResponseKeyCase.snakecase,
+        'response-keycase': 'dummycase',
       },
     });
 

--- a/packages/core/src/middleware/koa-camelcase-transform.test.ts
+++ b/packages/core/src/middleware/koa-camelcase-transform.test.ts
@@ -5,7 +5,7 @@ import koaCamelcaseTransform, { ResponseKeyCase } from './koa-camelcase-transfor
 const next = jest.fn();
 
 describe('koa-camelcase-transform', () => {
-  it('should transform body snakecase to camel case with keycase header camecase', async () => {
+  it('should transform body snakecase to camelcase with keycase header camecase', async () => {
     const ctx = createMockContext({
       headers: {
         'response-keycase': ResponseKeyCase.camelcase,
@@ -19,7 +19,7 @@ describe('koa-camelcase-transform', () => {
     expect(ctx.body).toHaveProperty('redirectUri');
   });
 
-  it('should not transform body to camel case without keycase header', async () => {
+  it('should not transform body to camelcase without keycase header', async () => {
     const ctx = createMockContext();
     ctx.body = { redirect_uri: 'foo' };
     await koaCamelcaseTransform()(ctx, next);
@@ -27,7 +27,7 @@ describe('koa-camelcase-transform', () => {
     expect(ctx.body).toHaveProperty('redirect_uri');
   });
 
-  it('should not transform body to camel case with keycase header snakecase', async () => {
+  it('should not transform body to camelcase with keycase header snakecase', async () => {
     const ctx = createMockContext({
       headers: {
         'response-keycase': ResponseKeyCase.snakecase,

--- a/packages/core/src/middleware/koa-camelcase-transform.test.ts
+++ b/packages/core/src/middleware/koa-camelcase-transform.test.ts
@@ -1,0 +1,42 @@
+import { createMockContext } from '@shopify/jest-koa-mocks';
+
+import koaCamelcaseTransform, { ResponseKeyCase } from './koa-camelcase-transform';
+
+const next = jest.fn();
+
+describe('koa-camelcase-transform', () => {
+  it('should transform body snakecase to camel case with keycase header camecase', async () => {
+    const ctx = createMockContext({
+      headers: {
+        'response-keycase': ResponseKeyCase.camelcase,
+      },
+    });
+
+    ctx.body = { redirect_uri: 'foo' };
+
+    await koaCamelcaseTransform()(ctx, next);
+
+    expect(ctx.body).toHaveProperty('redirectUri');
+  });
+
+  it('should not transform body to camel case without keycase header', async () => {
+    const ctx = createMockContext();
+    ctx.body = { redirect_uri: 'foo' };
+    await koaCamelcaseTransform()(ctx, next);
+
+    expect(ctx.body).toHaveProperty('redirect_uri');
+  });
+
+  it('should not transform body to camel case with keycase header snakecase', async () => {
+    const ctx = createMockContext({
+      headers: {
+        'response-keycase': ResponseKeyCase.snakecase,
+      },
+    });
+
+    ctx.body = { redirect_uri: 'foo' };
+    await koaCamelcaseTransform()(ctx, next);
+
+    expect(ctx.body).toHaveProperty('redirect_uri');
+  });
+});

--- a/packages/core/src/middleware/koa-camelcase-transform.ts
+++ b/packages/core/src/middleware/koa-camelcase-transform.ts
@@ -1,0 +1,24 @@
+import camelcaseKeys from 'camelcase-keys';
+import { Middleware } from 'koa';
+
+export enum ResponseKeyCase {
+  camelcase = 'camelcase',
+  snakecase = 'snakecase',
+}
+
+export default function koaCamelcaseTransform<StateT, ContextT>(): Middleware<
+  StateT,
+  ContextT,
+  unknown
+> {
+  return async (ctx, next) => {
+    await next();
+    if (
+      ctx.headers['response-keycase'] === ResponseKeyCase.camelcase &&
+      ctx.body &&
+      typeof ctx.body === 'object'
+    ) {
+      ctx.body = camelcaseKeys(ctx.body, { deep: true });
+    }
+  };
+}

--- a/packages/core/src/middleware/koa-camelcase-transform.ts
+++ b/packages/core/src/middleware/koa-camelcase-transform.ts
@@ -3,7 +3,6 @@ import { Middleware } from 'koa';
 
 export enum ResponseKeyCase {
   camelcase = 'camelcase',
-  snakecase = 'snakecase',
 }
 
 export default function koaCamelcaseTransform<StateT, ContextT>(): Middleware<
@@ -15,7 +14,7 @@ export default function koaCamelcaseTransform<StateT, ContextT>(): Middleware<
     await next();
     if (
       ctx.headers['response-keycase'] === ResponseKeyCase.camelcase &&
-      ctx.body &&
+      ctx.body !== null &&
       typeof ctx.body === 'object'
     ) {
       ctx.body = camelcaseKeys(ctx.body, { deep: true });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,7 @@ importers:
       '@types/lodash.pick': ^4.4.6
       '@types/node': ^16.3.1
       '@types/oidc-provider': ^7.8.0
+      camelcase-keys: ^7.0.1
       codecov: ^3.8.3
       dayjs: ^1.10.5
       decamelize: ^5.0.0
@@ -73,6 +74,7 @@ importers:
       '@logto/phrases': link:../phrases
       '@logto/schemas': link:../schemas
       '@silverhand/essentials': 1.1.2
+      camelcase-keys: 7.0.1
       dayjs: 1.10.7
       decamelize: 5.0.1
       dotenv: 10.0.0
@@ -4986,6 +4988,16 @@ packages:
       map-obj: 4.3.0
       quick-lru: 4.0.1
     dev: true
+
+  /camelcase-keys/7.0.1:
+    resolution: {integrity: sha512-P331lEls98pW8JLyodNWfzuz91BEDVA4VpW2/SwXnyv2K495tq1N777xzDbFgnEigfA7UIY0xa6PwR/H9jijjA==}
+    engines: {node: '>=12'}
+    dependencies:
+      camelcase: 6.2.1
+      map-obj: 4.3.0
+      quick-lru: 5.1.1
+      type-fest: 1.4.0
+    dev: false
 
   /camelcase/5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
@@ -15755,6 +15767,11 @@ packages:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
     dev: true
+
+  /type-fest/1.4.0:
+    resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
+    engines: {node: '>=10'}
+    dev: false
 
   /type-fest/2.8.0:
     resolution: {integrity: sha512-O+V9pAshf9C6loGaH0idwsmugI2LxVNR7DtS40gVo2EXZVYFgz9OuNtOhgHLdHdapOEWNdvz9Ob/eeuaWwwlxA==}


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->
Per our offline alignment add a middleware to transform all snakecase response keys to camelcase, if and only if, a custom `response-keycase` is present and set to `camelcase`

Add koa-camelcase-transform middleware.

<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-721

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT case added.

Test on localhost:

With header set:
<img width="1097" alt="image" src="https://user-images.githubusercontent.com/36393111/149745554-82fcc26c-55d0-4c76-a8eb-625fe166b3a2.png">

<img width="1098" alt="image" src="https://user-images.githubusercontent.com/36393111/149745579-ddad5a3d-5db8-46ac-a835-17a8c247d3d7.png">

By default:
<img width="1092" alt="image" src="https://user-images.githubusercontent.com/36393111/149745661-c504da1d-0277-486c-8742-adfe4958a4a9.png">

<img width="1111" alt="image" src="https://user-images.githubusercontent.com/36393111/149745679-c7957c5e-417a-4616-b071-db72c15f74f4.png">

@logto-io/eng 
