### PR TITLE
refactor(core): enable userinfo endpoint and resource scope consent

### DIFF
--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -36,11 +36,13 @@ export default async function initOidc(app: Koa): Promise<Provider> {
       keys,
     },
     features: {
+      userinfo: { enabled: true },
       revocation: { enabled: true },
       introspection: { enabled: true },
       devInteractions: { enabled: false },
       resourceIndicators: {
         enabled: true,
+        useGrantedResource: () => false,
         getResourceServerInfo: async (ctx, indicator) => {
           const resourceServer = await findResourceByIdentifier(indicator);
 

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -42,6 +42,8 @@ export default async function initOidc(app: Koa): Promise<Provider> {
       devInteractions: { enabled: false },
       resourceIndicators: {
         enabled: true,
+        // Disable the auto use of authorization_code granted resource feature
+        // https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#usegrantedresource
         useGrantedResource: () => false,
         getResourceServerInfo: async (ctx, indicator) => {
           const resourceServer = await findResourceByIdentifier(indicator);


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description bellow -->

This PR is aiming to unblock the possible incoming implementations and testings on the authorization endpoints did the following config updates on Logto core:

1. Enable userinfo feature of OIDC Provider. Allow access to the OIDC's `getUserInfo` endpoint
2. Set `resourceIndicators.useGrantedResource` to false. We allow users to request multiple resources on the authorization_code flow.  Disable the auto fulfill token resource with the granted resources feature. Users have to pass the request resource indicator through the resource param of the /token endpoint manully. 
3. Remove the restriction of OIDC scopes only on the user consent flow. Add the resource scopes consent logic. 

The settings are open to discussion and may be updated by the future's mainflow-related PR. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally on dev server.

@logto-io/eng 