### PR TITLE
chore: align routers return process of updating DB

### DIFF
--- a/packages/core/src/queries/connector.ts
+++ b/packages/core/src/queries/connector.ts
@@ -25,4 +25,4 @@ export const insertConnector = buildInsertInto<CreateConnector, Connector>(pool,
   returning: true,
 });
 
-export const updateConnector = buildUpdateWhere<CreateConnector>(pool, Connectors);
+export const updateConnector = buildUpdateWhere<CreateConnector, Connector>(pool, Connectors, true);

--- a/packages/core/src/routes/connector.ts
+++ b/packages/core/src/routes/connector.ts
@@ -49,8 +49,7 @@ export default function connectorRoutes<T extends AuthedRouter>(router: T) {
         body: { enabled },
       } = ctx.guard;
       await findConnectorById(id);
-      await updateConnector({ set: { enabled }, where: { id } });
-      ctx.body = { enabled };
+      ctx.body = await updateConnector({ set: { enabled }, where: { id } });
 
       return next();
     }
@@ -75,8 +74,7 @@ export default function connectorRoutes<T extends AuthedRouter>(router: T) {
         await connectorInstance.validateConfig(body.config);
       }
 
-      await updateConnector({ set: body, where: { id } });
-      ctx.body = transpileConnectorInstance(await getConnectorInstanceById(id));
+      ctx.body = await updateConnector({ set: body, where: { id } });
 
       return next();
     }

--- a/packages/core/src/routes/connector.ts
+++ b/packages/core/src/routes/connector.ts
@@ -4,7 +4,7 @@ import { object, string } from 'zod';
 import { getConnectorInstances, getConnectorInstanceById } from '@/connectors';
 import { ConnectorInstance } from '@/connectors/types';
 import koaGuard from '@/middleware/koa-guard';
-import { findConnectorById, updateConnector } from '@/queries/connector';
+import { updateConnector } from '@/queries/connector';
 
 import { AuthedRouter } from './types';
 
@@ -48,8 +48,9 @@ export default function connectorRoutes<T extends AuthedRouter>(router: T) {
         params: { id },
         body: { enabled },
       } = ctx.guard;
-      await findConnectorById(id);
-      ctx.body = await updateConnector({ set: { enabled }, where: { id } });
+      const { metadata } = await getConnectorInstanceById(id);
+      const connector = await updateConnector({ set: { enabled }, where: { id } });
+      ctx.body = { ...connector, metadata };
 
       return next();
     }
@@ -68,13 +69,14 @@ export default function connectorRoutes<T extends AuthedRouter>(router: T) {
         params: { id },
         body,
       } = ctx.guard;
-      const connectorInstance = await getConnectorInstanceById(id);
+      const { metadata, validateConfig } = await getConnectorInstanceById(id);
 
       if (body.config) {
-        await connectorInstance.validateConfig(body.config);
+        await validateConfig(body.config);
       }
 
-      ctx.body = await updateConnector({ set: body, where: { id } });
+      const connector = await updateConnector({ set: body, where: { id } });
+      ctx.body = { ...connector, metadata };
 
       return next();
     }

--- a/packages/core/src/routes/user.ts
+++ b/packages/core/src/routes/user.ts
@@ -97,11 +97,10 @@ export default function userRoutes<T extends AnonymousRouter>(router: T, provide
 
       const { passwordEncrypted, passwordEncryptionSalt } = encryptUserPassword(userId, password);
 
-      await updateUserById(userId, {
+      const user = await updateUserById(userId, {
         passwordEncryptionSalt,
         passwordEncrypted,
       });
-      const user = await findUserById(userId);
       ctx.body = pick(user, ...userInfoSelectFields);
       return next();
     }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
align the routers' return process of updating DB properties. (stick to use the return value of `updateXXX` without re-requesting DB)

<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-1405

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
