### PR TITLE
feat(core): add sign-in experience query and api

### DIFF
--- a/packages/core/src/queries/sign-in-experience.ts
+++ b/packages/core/src/queries/sign-in-experience.ts
@@ -1,38 +1,11 @@
 import { SignInExperience, CreateSignInExperience, SignInExperiences } from '@logto/schemas';
 import { sql } from 'slonik';
 
-import { buildFindMany } from '@/database/find-many';
-import { buildInsertInto } from '@/database/insert-into';
 import pool from '@/database/pool';
 import { buildUpdateWhere } from '@/database/update-where';
-import { convertToIdentifiers, getTotalRowCount } from '@/database/utils';
+import { convertToIdentifiers } from '@/database/utils';
 
 const { table, fields } = convertToIdentifiers(SignInExperiences);
-
-export const findTotalNumberOfSignInExperiences = async () => getTotalRowCount(table);
-
-const findSignInExperiencesMany = buildFindMany<CreateSignInExperience, SignInExperience>(
-  pool,
-  SignInExperiences
-);
-
-export const findAllSignInExperiences = async (limit: number, offset: number) =>
-  findSignInExperiencesMany({ limit, offset });
-
-export const findSignInExperienceById = async (id: string) =>
-  pool.one<SignInExperience>(sql`
-    select ${sql.join(Object.values(fields), sql`, `)}
-    from ${table}
-    where ${fields.id}=${id}
-  `);
-
-export const insertSignInExperience = buildInsertInto<CreateSignInExperience, SignInExperience>(
-  pool,
-  SignInExperiences,
-  {
-    returning: true,
-  }
-);
 
 const updateSignInExperience = buildUpdateWhere<CreateSignInExperience, SignInExperience>(
   pool,
@@ -49,5 +22,4 @@ export const findDefaultSignInExperience = async () =>
   pool.one<SignInExperience>(sql`
     select ${sql.join(Object.values(fields), sql`, `)}
     from ${table}
-    where ${fields.id}='default'
   `);

--- a/packages/core/src/queries/sign-in-experience.ts
+++ b/packages/core/src/queries/sign-in-experience.ts
@@ -1,0 +1,53 @@
+import { SignInExperience, CreateSignInExperience, SignInExperiences } from '@logto/schemas';
+import { sql } from 'slonik';
+
+import { buildFindMany } from '@/database/find-many';
+import { buildInsertInto } from '@/database/insert-into';
+import pool from '@/database/pool';
+import { buildUpdateWhere } from '@/database/update-where';
+import { convertToIdentifiers, getTotalRowCount } from '@/database/utils';
+
+const { table, fields } = convertToIdentifiers(SignInExperiences);
+
+export const findTotalNumberOfSignInExperiences = async () => getTotalRowCount(table);
+
+const findSignInExperiencesMany = buildFindMany<CreateSignInExperience, SignInExperience>(
+  pool,
+  SignInExperiences
+);
+
+export const findAllSignInExperiences = async (limit: number, offset: number) =>
+  findSignInExperiencesMany({ limit, offset });
+
+export const findSignInExperienceById = async (id: string) =>
+  pool.one<SignInExperience>(sql`
+    select ${sql.join(Object.values(fields), sql`, `)}
+    from ${table}
+    where ${fields.id}=${id}
+  `);
+
+export const insertSignInExperience = buildInsertInto<CreateSignInExperience, SignInExperience>(
+  pool,
+  SignInExperiences,
+  {
+    returning: true,
+  }
+);
+
+const updateSignInExperience = buildUpdateWhere<CreateSignInExperience, SignInExperience>(
+  pool,
+  SignInExperiences,
+  true
+);
+
+export const updateSignInExperienceById = async (
+  id: string,
+  set: Partial<CreateSignInExperience>
+) => updateSignInExperience({ set, where: { id } });
+
+export const findDefaultSignInExperience = async () =>
+  pool.one<SignInExperience>(sql`
+    select ${sql.join(Object.values(fields), sql`, `)}
+    from ${table}
+    where ${fields.id}='default'
+  `);

--- a/packages/core/src/routes/init.ts
+++ b/packages/core/src/routes/init.ts
@@ -9,6 +9,7 @@ import connectorRoutes from '@/routes/connector';
 import resourceRoutes from '@/routes/resource';
 import sessionRoutes from '@/routes/session';
 import settingRoutes from '@/routes/setting';
+import signInExperiencesRoutes from '@/routes/sign-in-experience';
 import statusRoutes from '@/routes/status';
 import swaggerRoutes from '@/routes/swagger';
 import userRoutes from '@/routes/user';
@@ -29,6 +30,7 @@ const createRouters = (provider: Provider) => {
   settingRoutes(router);
   connectorRoutes(router);
   resourceRoutes(router);
+  signInExperiencesRoutes(router);
 
   return [anonymousRouter, router];
 };

--- a/packages/core/src/routes/sign-in-experience.ts
+++ b/packages/core/src/routes/sign-in-experience.ts
@@ -1,0 +1,44 @@
+import { SignInExperiences } from '@logto/schemas';
+import { object, string } from 'zod';
+
+import koaGuard from '@/middleware/koa-guard';
+import {
+  findDefaultSignInExperience,
+  updateSignInExperienceById,
+} from '@/queries/sign-in-experience';
+
+import { AuthedRouter } from './types';
+
+export default function SignInExperiencesRoutes<T extends AuthedRouter>(router: T) {
+  /**
+   * As we only support single signInExperience settings for V1
+   * always return the default settings in DB for the /sign-in-ex get method
+   */
+  router.get('/sign-in-ex', async (ctx, next) => {
+    const SignInExperience = await findDefaultSignInExperience();
+    ctx.body = SignInExperience;
+
+    return next();
+  });
+
+  // TODO: LOG-1403 need to find a way to validate SignInMethod input
+  router.patch(
+    '/sign-in-ex/:id',
+    koaGuard({
+      params: object({ id: string().min(1) }),
+      body: SignInExperiences.createGuard.omit({ id: true }).partial(),
+    }),
+    async (ctx, next) => {
+      const {
+        params: { id },
+        body,
+      } = ctx.guard;
+
+      ctx.body = await updateSignInExperienceById(id, {
+        ...body,
+      });
+
+      return next();
+    }
+  );
+}

--- a/packages/core/src/routes/sign-in-experience.ts
+++ b/packages/core/src/routes/sign-in-experience.ts
@@ -9,14 +9,14 @@ import {
 
 import { AuthedRouter } from './types';
 
-export default function SignInExperiencesRoutes<T extends AuthedRouter>(router: T) {
+export default function signInExperiencesRoutes<T extends AuthedRouter>(router: T) {
   /**
    * As we only support single signInExperience settings for V1
    * always return the default settings in DB for the /sign-in-ex get method
    */
   router.get('/sign-in-ex', async (ctx, next) => {
-    const SignInExperience = await findDefaultSignInExperience();
-    ctx.body = SignInExperience;
+    const signInExperience = await findDefaultSignInExperience();
+    ctx.body = signInExperience;
 
     return next();
   });


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Add sign-in experience query and API

For v1 we only return the default settings to the developers. All `GET` method by default returns the `sign_in_experience`  data where id = 'default'.

Currently, `default` as an id is hardcoded in the query method.  Let me know if anyone has a better option.  Don't like it either. 


<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-1410
LOG-1061

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
GET /sign-in-ex should return `default` settings
<img width="1068" alt="image" src="https://user-images.githubusercontent.com/36393111/150919588-b6b2b7c1-4be5-447b-9dda-c4f9d050c359.png">

PATCH /sign-in-ex
case 1: more than there primary signInMethods are not allowed:
<img width="1075" alt="image" src="https://user-images.githubusercontent.com/36393111/150919656-dba28fa7-836d-44b5-a7c8-a13e9fadb832.png">

case 2:  at lease one primary signInMethods are required
<img width="937" alt="image" src="https://user-images.githubusercontent.com/36393111/150919751-d4bece0b-dc38-4c1a-b9de-e966835187fb.png">


case 3: success update
<img width="1086" alt="image" src="https://user-images.githubusercontent.com/36393111/150919839-b93151de-3933-4a1f-9411-5e0a360c9644.png">

@logto-io/eng 

