### PR TITLE
feat(core): add user roles related api

### DIFF
--- a/packages/core/src/database/update-where.test.ts
+++ b/packages/core/src/database/update-where.test.ts
@@ -41,17 +41,12 @@ describe('buildUpdateWhere()', () => {
     );
     const updateWhere = buildUpdateWhere(pool, Users);
 
-    const errorMessage: Partial<Record<NodeJS.Platform, string>> = {
-      darwin: "Cannot read properties of undefined (reading 'toString')",
-      linux: "Cannot read property 'toString' of undefined",
-    };
-
     await expect(
       updateWhere({
         set: { username: '123', id: undefined },
         where: { id: 'foo', username: '456' },
       })
-    ).rejects.toMatchError(new TypeError(errorMessage[process.platform]));
+    ).rejects.toMatchError(new Error(`Cannot convert id to primitive`));
   });
 
   it('throws `entity.not_exists_with_id` error with `undefined` when `returning` is true', async () => {

--- a/packages/core/src/database/utils.test.ts
+++ b/packages/core/src/database/utils.test.ts
@@ -67,12 +67,6 @@ describe('convertToPrimitiveOrSql()', () => {
       expect(convertToPrimitiveOrSql(`${normalKey}${value}`, '123')).toEqual('123');
     }
   });
-
-  it('throws an error when value is not primitive', () => {
-    expect(() => convertToPrimitiveOrSql(normalKey, [123, 456])).toThrow(
-      'Cannot convert foo with 123,456 to primitive'
-    );
-  });
 });
 
 describe('convertToIdentifiers()', () => {

--- a/packages/core/src/database/utils.test.ts
+++ b/packages/core/src/database/utils.test.ts
@@ -50,6 +50,7 @@ describe('convertToPrimitiveOrSql()', () => {
     expect(convertToPrimitiveOrSql(normalKey, 123)).toEqual(123);
     expect(convertToPrimitiveOrSql(normalKey, true)).toEqual(true);
     expect(convertToPrimitiveOrSql(normalKey, { foo: 'bar' })).toEqual('{"foo":"bar"}');
+    expect(convertToPrimitiveOrSql(normalKey, ['bar'])).toEqual('["bar"]');
   });
 
   it('converts value to sql when key ends with special set and value is number', () => {

--- a/packages/core/src/database/utils.ts
+++ b/packages/core/src/database/utils.ts
@@ -40,7 +40,7 @@ export const convertToPrimitiveOrSql = (
     return null;
   }
 
-  if (typeof value === 'object' && !Array.isArray(value)) {
+  if (typeof value === 'object') {
     return JSON.stringify(value);
   }
 
@@ -52,7 +52,7 @@ export const convertToPrimitiveOrSql = (
     return value;
   }
 
-  throw new Error(`Cannot convert ${key} with ${value.toString()} to primitive`);
+  throw new Error(`Cannot convert ${key} to primitive`);
 };
 
 export const convertToIdentifiers = <T extends Table>(

--- a/packages/core/src/queries/roles.ts
+++ b/packages/core/src/queries/roles.ts
@@ -12,7 +12,7 @@ export const findAllRoles = async () =>
     from ${table}
   `);
 
-export const findRolesByRoleName = async (roleNames: string[]) =>
+export const findRolesByRoleNames = async (roleNames: string[]) =>
   pool.any<Role>(sql`
     select ${sql.join(Object.values(fields), sql`,`)}
     from ${table}

--- a/packages/core/src/queries/roles.ts
+++ b/packages/core/src/queries/roles.ts
@@ -13,7 +13,7 @@ export const findAllRoles = async () =>
   `);
 
 export const findRolesByRoleName = async (roleNames: string[]) =>
-  pool.many<Role>(sql`
+  pool.any<Role>(sql`
     select ${sql.join(Object.values(fields), sql`,`)}
     from ${table}
     where ${fields.name} in (${sql.join(roleNames, sql`,`)})

--- a/packages/core/src/queries/roles.ts
+++ b/packages/core/src/queries/roles.ts
@@ -1,0 +1,14 @@
+import { Roles, Role } from '@logto/schemas';
+import { sql } from 'slonik';
+
+import pool from '@/database/pool';
+import { convertToIdentifiers } from '@/database/utils';
+
+const { table, fields } = convertToIdentifiers(Roles);
+
+export const finRolesByRoleName = async (roleNames: string[]) =>
+  pool.many<Role>(sql`
+    select ${sql.join(Object.values(fields), sql`,`)}
+    from ${table}
+    where ${fields.name} in (${sql.join(roleNames, sql`,`)})
+  `);

--- a/packages/core/src/queries/roles.ts
+++ b/packages/core/src/queries/roles.ts
@@ -6,7 +6,13 @@ import { convertToIdentifiers } from '@/database/utils';
 
 const { table, fields } = convertToIdentifiers(Roles);
 
-export const finRolesByRoleName = async (roleNames: string[]) =>
+export const findAllRoles = async () =>
+  pool.many<Role>(sql`
+    select ${sql.join(Object.values(fields), sql`, `)}
+    from ${table}
+  `);
+
+export const findRolesByRoleName = async (roleNames: string[]) =>
   pool.many<Role>(sql`
     select ${sql.join(Object.values(fields), sql`,`)}
     from ${table}

--- a/packages/core/src/queries/roles.ts
+++ b/packages/core/src/queries/roles.ts
@@ -7,7 +7,7 @@ import { convertToIdentifiers } from '@/database/utils';
 const { table, fields } = convertToIdentifiers(Roles);
 
 export const findAllRoles = async () =>
-  pool.many<Role>(sql`
+  pool.any<Role>(sql`
     select ${sql.join(Object.values(fields), sql`, `)}
     from ${table}
   `);

--- a/packages/core/src/routes/admin-user.ts
+++ b/packages/core/src/routes/admin-user.ts
@@ -1,6 +1,6 @@
 import { userInfoSelectFields } from '@logto/schemas';
 import pick from 'lodash.pick';
-import { ForeignKeyIntegrityConstraintViolationError } from 'slonik';
+import { InvalidInputError } from 'slonik';
 import { object, string } from 'zod';
 
 import koaGuard from '@/middleware/koa-guard';
@@ -28,10 +28,10 @@ export default function adminUserRoutes<T extends AuthedRouter>(router: T) {
       if (roleNames?.length) {
         const roles = await findRolesByRoleName(roleNames);
         if (roles.length !== roleNames.length) {
-          throw new ForeignKeyIntegrityConstraintViolationError(
-            new Error('foreign_key_violation roleNames'),
-            'fk__users_role_names__roles_name'
+          const resourcesNotFound = roleNames.filter(
+            (rolesNames) => !roles.some(({ name }) => name === rolesNames)
           );
+          throw new InvalidInputError(`role names (${resourcesNotFound.join(',')}) are not valid`);
         }
       }
 

--- a/packages/core/src/routes/admin-user.ts
+++ b/packages/core/src/routes/admin-user.ts
@@ -13,6 +13,7 @@ export default function adminUserRoutes<T extends AuthedRouter>(router: T) {
   router.get('/users', async (ctx, next) => {
     const users = await findAllUsers();
     ctx.body = users.map((user) => pick(user, ...userInfoSelectFields));
+
     return next();
   });
 
@@ -20,7 +21,7 @@ export default function adminUserRoutes<T extends AuthedRouter>(router: T) {
     '/users/:userId/roleNames',
     koaGuard({
       params: object({ userId: string().min(1) }),
-      body: object({ names: string().array().nullable() }),
+      body: object({ names: string().array() }),
     }),
     async (ctx, next) => {
       const {
@@ -33,6 +34,7 @@ export default function adminUserRoutes<T extends AuthedRouter>(router: T) {
       // Temp solution to validate the existence of input roleNames
       if (names?.length) {
         const roles = await findRolesByRoleNames(names);
+
         if (roles.length !== names.length) {
           const resourcesNotFound = names.filter(
             (roleName) => !roles.some(({ name }) => roleName === name)
@@ -44,6 +46,7 @@ export default function adminUserRoutes<T extends AuthedRouter>(router: T) {
 
       const user = await updateUserById(userId, { roleNames: names });
       ctx.body = pick(user, ...userInfoSelectFields);
+
       return next();
     }
   );

--- a/packages/core/src/routes/admin-user.ts
+++ b/packages/core/src/routes/admin-user.ts
@@ -4,38 +4,45 @@ import { InvalidInputError } from 'slonik';
 import { object, string } from 'zod';
 
 import koaGuard from '@/middleware/koa-guard';
-import { findRolesByRoleName } from '@/queries/roles';
-import { findUserById, updateUserById } from '@/queries/user';
+import { findRolesByRoleNames } from '@/queries/roles';
+import { findAllUsers, findUserById, updateUserById } from '@/queries/user';
 
 import { AuthedRouter } from './types';
 
 export default function adminUserRoutes<T extends AuthedRouter>(router: T) {
+  router.get('/users', async (ctx, next) => {
+    const users = await findAllUsers();
+    ctx.body = users.map((user) => pick(user, ...userInfoSelectFields));
+    return next();
+  });
+
   router.patch(
-    '/users/:userId/roles',
+    '/users/:userId/roleNames',
     koaGuard({
       params: object({ userId: string().min(1) }),
-      body: object({ roleNames: string().array().nullable() }),
+      body: object({ names: string().array().nullable() }),
     }),
     async (ctx, next) => {
       const {
         params: { userId },
-        body: { roleNames },
+        body: { names },
       } = ctx.guard;
 
       await findUserById(userId);
 
       // Temp solution to validate the existence of input roleNames
-      if (roleNames?.length) {
-        const roles = await findRolesByRoleName(roleNames);
-        if (roles.length !== roleNames.length) {
-          const resourcesNotFound = roleNames.filter(
-            (rolesNames) => !roles.some(({ name }) => name === rolesNames)
+      if (names?.length) {
+        const roles = await findRolesByRoleNames(names);
+        if (roles.length !== names.length) {
+          const resourcesNotFound = names.filter(
+            (roleName) => !roles.some(({ name }) => roleName === name)
           );
+          // TODO: Should be cached by the error handler and return request error
           throw new InvalidInputError(`role names (${resourcesNotFound.join(',')}) are not valid`);
         }
       }
 
-      const user = await updateUserById(userId, { roleNames });
+      const user = await updateUserById(userId, { roleNames: names });
       ctx.body = pick(user, ...userInfoSelectFields);
       return next();
     }

--- a/packages/core/src/routes/admin-user.ts
+++ b/packages/core/src/routes/admin-user.ts
@@ -21,22 +21,22 @@ export default function adminUserRoutes<T extends AuthedRouter>(router: T) {
     '/users/:userId/roleNames',
     koaGuard({
       params: object({ userId: string().min(1) }),
-      body: object({ names: string().array() }),
+      body: object({ roleNames: string().array() }),
     }),
     async (ctx, next) => {
       const {
         params: { userId },
-        body: { names },
+        body: { roleNames },
       } = ctx.guard;
 
       await findUserById(userId);
 
       // Temp solution to validate the existence of input roleNames
-      if (names?.length) {
-        const roles = await findRolesByRoleNames(names);
+      if (roleNames.length > 0) {
+        const roles = await findRolesByRoleNames(roleNames);
 
-        if (roles.length !== names.length) {
-          const resourcesNotFound = names.filter(
+        if (roles.length !== roleNames.length) {
+          const resourcesNotFound = roleNames.filter(
             (roleName) => !roles.some(({ name }) => roleName === name)
           );
           // TODO: Should be cached by the error handler and return request error
@@ -44,7 +44,7 @@ export default function adminUserRoutes<T extends AuthedRouter>(router: T) {
         }
       }
 
-      const user = await updateUserById(userId, { roleNames: names });
+      const user = await updateUserById(userId, { roleNames });
       ctx.body = pick(user, ...userInfoSelectFields);
 
       return next();

--- a/packages/core/src/routes/admin-user.ts
+++ b/packages/core/src/routes/admin-user.ts
@@ -1,0 +1,43 @@
+import { userInfoSelectFields } from '@logto/schemas';
+import pick from 'lodash.pick';
+import { ForeignKeyIntegrityConstraintViolationError } from 'slonik';
+import { object, string } from 'zod';
+
+import koaGuard from '@/middleware/koa-guard';
+import { findRolesByRoleName } from '@/queries/roles';
+import { findUserById, updateUserById } from '@/queries/user';
+
+import { AuthedRouter } from './types';
+
+export default function adminUserRoutes<T extends AuthedRouter>(router: T) {
+  router.patch(
+    '/users/:userId/roles',
+    koaGuard({
+      params: object({ userId: string().min(1) }),
+      body: object({ roleNames: string().array().nullable() }),
+    }),
+    async (ctx, next) => {
+      const {
+        params: { userId },
+        body: { roleNames },
+      } = ctx.guard;
+
+      await findUserById(userId);
+
+      // Temp solution to validate the existence of input roleNames
+      if (roleNames?.length) {
+        const roles = await findRolesByRoleName(roleNames);
+        if (roles.length !== roleNames.length) {
+          throw new ForeignKeyIntegrityConstraintViolationError(
+            new Error('foreign_key_violation roleNames'),
+            'fk__users_role_names__roles_name'
+          );
+        }
+      }
+
+      const user = await updateUserById(userId, { roleNames });
+      ctx.body = pick(user, ...userInfoSelectFields);
+      return next();
+    }
+  );
+}

--- a/packages/core/src/routes/init.ts
+++ b/packages/core/src/routes/init.ts
@@ -14,6 +14,8 @@ import statusRoutes from '@/routes/status';
 import swaggerRoutes from '@/routes/swagger';
 import userRoutes from '@/routes/user';
 
+import adminUserRoutes from './admin-user';
+import roleRoutes from './role';
 import { AnonymousRouter, AuthedRouter } from './types';
 
 const createRouters = (provider: Provider) => {
@@ -31,6 +33,8 @@ const createRouters = (provider: Provider) => {
   connectorRoutes(router);
   resourceRoutes(router);
   signInExperiencesRoutes(router);
+  adminUserRoutes(router);
+  roleRoutes(router);
 
   return [anonymousRouter, router];
 };

--- a/packages/core/src/routes/role.ts
+++ b/packages/core/src/routes/role.ts
@@ -5,6 +5,7 @@ import { AuthedRouter } from './types';
 export default function roleRoutes<T extends AuthedRouter>(router: T) {
   router.get('/roles', async (ctx, next) => {
     ctx.body = await findAllRoles();
+
     return next();
   });
 }

--- a/packages/core/src/routes/role.ts
+++ b/packages/core/src/routes/role.ts
@@ -1,0 +1,10 @@
+import { findAllRoles } from '@/queries/roles';
+
+import { AuthedRouter } from './types';
+
+export default function roleRoutes<T extends AuthedRouter>(router: T) {
+  router.get('/roles', async (ctx, next) => {
+    ctx.body = await findAllRoles();
+    return next();
+  });
+}

--- a/packages/core/src/routes/user.ts
+++ b/packages/core/src/routes/user.ts
@@ -64,12 +64,12 @@ export default function userRoutes<T extends AnonymousRouter>(router: T) {
     '/users/:userId/roles',
     koaGuard({
       params: object({ userId: string().min(1) }),
-      body: object({ roles: string().array().nullable() }),
+      body: object({ roleNames: string().array().nullable() }),
     }),
     async (ctx, next) => {
       const {
         params: { userId },
-        body: { roles: roleNames },
+        body: { roleNames },
       } = ctx.guard;
 
       await findUserById(userId);
@@ -79,8 +79,8 @@ export default function userRoutes<T extends AnonymousRouter>(router: T) {
         const roles = await finRolesByRoleName(roleNames);
         if (roles.length !== roleNames.length) {
           throw new ForeignKeyIntegrityConstraintViolationError(
-            new Error('foreign_key_violation'),
-            'Invalid role names'
+            new Error('foreign_key_violation roleNames'),
+            'fk__users_role_names__roles_name'
           );
         }
       }

--- a/packages/core/src/routes/user.ts
+++ b/packages/core/src/routes/user.ts
@@ -1,11 +1,9 @@
 import { userInfoSelectFields } from '@logto/schemas';
 import pick from 'lodash.pick';
-import { ForeignKeyIntegrityConstraintViolationError } from 'slonik';
 import { object, string } from 'zod';
 
 import { encryptUserPassword } from '@/lib/user';
 import koaGuard from '@/middleware/koa-guard';
-import { finRolesByRoleName } from '@/queries/roles';
 import { deleteUserById, findAllUsers, findUserById, updateUserById } from '@/queries/user';
 
 import { AnonymousRouter } from './types';
@@ -56,37 +54,6 @@ export default function userRoutes<T extends AnonymousRouter>(router: T) {
       });
       ctx.body = pick(user, ...userInfoSelectFields);
 
-      return next();
-    }
-  );
-
-  router.patch(
-    '/users/:userId/roles',
-    koaGuard({
-      params: object({ userId: string().min(1) }),
-      body: object({ roleNames: string().array().nullable() }),
-    }),
-    async (ctx, next) => {
-      const {
-        params: { userId },
-        body: { roleNames },
-      } = ctx.guard;
-
-      await findUserById(userId);
-
-      // Temp solution to validate the existence of input roleNames
-      if (roleNames?.length) {
-        const roles = await finRolesByRoleName(roleNames);
-        if (roles.length !== roleNames.length) {
-          throw new ForeignKeyIntegrityConstraintViolationError(
-            new Error('foreign_key_violation roleNames'),
-            'fk__users_role_names__roles_name'
-          );
-        }
-      }
-
-      const user = await updateUserById(userId, { roleNames });
-      ctx.body = pick(user, ...userInfoSelectFields);
       return next();
     }
   );

--- a/packages/core/src/routes/user.ts
+++ b/packages/core/src/routes/user.ts
@@ -4,20 +4,13 @@ import { object, string } from 'zod';
 
 import { encryptUserPassword } from '@/lib/user';
 import koaGuard from '@/middleware/koa-guard';
-import { deleteUserById, findAllUsers, findUserById, updateUserById } from '@/queries/user';
+import { deleteUserById, findUserById, updateUserById } from '@/queries/user';
 
 import { AnonymousRouter } from './types';
 
 export default function userRoutes<T extends AnonymousRouter>(router: T) {
-  router.get('/users', async (ctx, next) => {
-    const users = await findAllUsers();
-    ctx.body = users.map((user) => pick(user, ...userInfoSelectFields));
-
-    return next();
-  });
-
   router.get(
-    '/users/:userId',
+    '/user/:userId',
     koaGuard({
       params: object({ userId: string().min(1) }),
     }),
@@ -33,7 +26,7 @@ export default function userRoutes<T extends AnonymousRouter>(router: T) {
   );
 
   router.patch(
-    '/users/:userId/password',
+    '/user/:userId/password',
     koaGuard({
       params: object({ userId: string().min(1) }),
       body: object({ password: string().min(6) }),
@@ -59,7 +52,7 @@ export default function userRoutes<T extends AnonymousRouter>(router: T) {
   );
 
   router.delete(
-    '/users/:userId',
+    '/user/:userId',
     koaGuard({
       params: object({ userId: string().min(1) }),
     }),

--- a/packages/schemas/src/db-entries/user.ts
+++ b/packages/schemas/src/db-entries/user.ts
@@ -13,7 +13,7 @@ export type CreateUser = {
   passwordEncrypted?: string | null;
   passwordEncryptionMethod?: PasswordEncryptionMethod | null;
   passwordEncryptionSalt?: string | null;
-  roleNames?: RoleNames | null;
+  roleNames?: RoleNames;
 };
 
 export type User = {
@@ -24,7 +24,7 @@ export type User = {
   passwordEncrypted: string | null;
   passwordEncryptionMethod: PasswordEncryptionMethod | null;
   passwordEncryptionSalt: string | null;
-  roleNames: RoleNames | null;
+  roleNames: RoleNames;
 };
 
 const createGuard: Guard<CreateUser> = z.object({
@@ -35,7 +35,7 @@ const createGuard: Guard<CreateUser> = z.object({
   passwordEncrypted: z.string().nullable().optional(),
   passwordEncryptionMethod: z.nativeEnum(PasswordEncryptionMethod).nullable().optional(),
   passwordEncryptionSalt: z.string().nullable().optional(),
-  roleNames: roleNamesGuard.nullable().optional(),
+  roleNames: roleNamesGuard.optional(),
 });
 
 export const Users: GeneratedSchema<CreateUser> = Object.freeze({

--- a/packages/schemas/src/types/user.ts
+++ b/packages/schemas/src/types/user.ts
@@ -5,6 +5,7 @@ export const userInfoSelectFields = Object.freeze([
   'username',
   'primaryEmail',
   'primaryPhone',
+  'roleNames',
 ] as const);
 
 export type UserInfo<Keys extends keyof CreateUser = typeof userInfoSelectFields[number]> = Pick<

--- a/packages/schemas/tables/users.sql
+++ b/packages/schemas/tables/users.sql
@@ -8,6 +8,6 @@ create table users (
   password_encrypted varchar(128),
   password_encryption_method password_encryption_method,
   password_encryption_salt varchar(128),
-  role_names jsonb /* @use RoleNames */,
+  role_names jsonb /* @use RoleNames */ not null default '[]'::jsonb,
   primary key (id)
 );


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
This PR includes the following update:
1. Add `roleNames` to the `userInfoSelectFields`. Let the GET /users API could return users rolename data
2. Add admin-user authed routers and PATCH /users/:id/roles API
   - add temp validation of the input roles, in not found in roles table, throw a foreign key exception.
3. Add role router and GET /roles api
4. Update the `convertToPrimitiveOrSql` that accepts array liked JSON inputs.

<!-- Optional -->
## Linear Issue Reference
<!-- If you PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally:
GET roles:
<img width="908" alt="image" src="https://user-images.githubusercontent.com/36393111/151322445-2aefe833-c9a8-4d57-b404-12a4a263e9bf.png">

GET user:
<img width="724" alt="image" src="https://user-images.githubusercontent.com/36393111/151322549-1d4fea69-a919-458f-88bb-74c9603d0073.png">

PATCH roleNames:
- set to Null:
<img width="691" alt="image" src="https://user-images.githubusercontent.com/36393111/151322757-fb5673c5-c174-41a4-9f96-ac8a9a0961da.png">

- Invalid roleNames:
<img width="1089" alt="image" src="https://user-images.githubusercontent.com/36393111/151324626-670c07ec-15dc-4f83-871a-616c2877caa6.png">
<img width="659" alt="image" src="https://user-images.githubusercontent.com/36393111/151324714-68f14ee9-a27e-4b16-b41d-0d8be987a53f.png">


