### PR TITLE
fix(passcode): use interaction_jti instead of session_id

### DIFF
--- a/packages/core/src/queries/passcode.ts
+++ b/packages/core/src/queries/passcode.ts
@@ -9,24 +9,18 @@ import { DeletionError } from '@/errors/SlonikError';
 
 const { table, fields } = convertToIdentifiers(Passcodes);
 
-export const findUnconsumedPasscodeBySessionIdAndType = async (
-  sessionId: string,
-  type: PasscodeType
-) =>
+export const findUnconsumedPasscodeByJtiAndType = async (jti: string, type: PasscodeType) =>
   pool.maybeOne<Passcode>(sql`
     select ${sql.join(Object.values(fields), sql`, `)}
     from ${table}
-    where ${fields.sessionId}=${sessionId} and ${fields.type}=${type} and ${fields.consumed} = false
+    where ${fields.interactionJti}=${jti} and ${fields.type}=${type} and ${fields.consumed} = false
   `);
 
-export const findUnconsumedPasscodesBySessionIdAndType = async (
-  sessionId: string,
-  type: PasscodeType
-) =>
+export const findUnconsumedPasscodesByJtiAndType = async (jti: string, type: PasscodeType) =>
   pool.many<Passcode>(sql`
     select ${sql.join(Object.values(fields), sql`, `)}
     from ${table}
-    where ${fields.sessionId}=${sessionId} and ${fields.type}=${type} and ${fields.consumed} = false
+    where ${fields.interactionJti}=${jti} and ${fields.type}=${type} and ${fields.consumed} = false
   `);
 
 export const insertPasscode = buildInsertInto<CreatePasscode, Passcode>(pool, Passcodes, {

--- a/packages/schemas/src/db-entries/passcode.ts
+++ b/packages/schemas/src/db-entries/passcode.ts
@@ -7,7 +7,7 @@ import { PasscodeType } from './custom-types';
 
 export type CreatePasscode = {
   id: string;
-  sessionId: string;
+  interactionJti: string;
   phone?: string | null;
   email?: string | null;
   type: PasscodeType;
@@ -19,7 +19,7 @@ export type CreatePasscode = {
 
 export type Passcode = {
   id: string;
-  sessionId: string;
+  interactionJti: string;
   phone: string | null;
   email: string | null;
   type: PasscodeType;
@@ -31,7 +31,7 @@ export type Passcode = {
 
 const createGuard: Guard<CreatePasscode> = z.object({
   id: z.string(),
-  sessionId: z.string(),
+  interactionJti: z.string(),
   phone: z.string().nullable().optional(),
   email: z.string().nullable().optional(),
   type: z.nativeEnum(PasscodeType),
@@ -46,7 +46,7 @@ export const Passcodes: GeneratedSchema<CreatePasscode> = Object.freeze({
   tableSingular: 'passcode',
   fields: {
     id: 'id',
-    sessionId: 'session_id',
+    interactionJti: 'interaction_jti',
     phone: 'phone',
     email: 'email',
     type: 'type',
@@ -57,7 +57,7 @@ export const Passcodes: GeneratedSchema<CreatePasscode> = Object.freeze({
   },
   fieldKeys: [
     'id',
-    'sessionId',
+    'interactionJti',
     'phone',
     'email',
     'type',

--- a/packages/schemas/tables/passcodes.sql
+++ b/packages/schemas/tables/passcodes.sql
@@ -2,7 +2,7 @@ create type passcode_type as enum ('SignIn', 'Register', 'ForgotPassword');
 
 create table passcodes (
   id varchar(128) not null,
-  session_id varchar(128) not null,
+  interaction_jti varchar(128) not null,
   phone varchar(32),
   email varchar(128),
   type passcode_type not null,


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Rename `sessionId` to `interactionJti` in passcode.

According to `node-oidc-provider`'s [doc](https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#user-flows), `session` is not create before signing in, so there is no `sessionId`. `interaction.jti` is what we need.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

pass previous UTs.

