### PR TITLE
feat(core): allow jsonb partial update

### DIFF
--- a/packages/core/src/database/update-where.ts
+++ b/packages/core/src/database/update-where.ts
@@ -49,7 +49,15 @@ export const buildUpdateWhere: BuildUpdateWhere = <
            * all jsonb data field must be non-nullable
            * https://www.postgresql.org/docs/current/functions-json.html
            */
-          return sql`${fields[key]}= ${fields[key]} || ${convertToPrimitiveOrSql(key, value)}`;
+          return sql`
+            ${fields[key]}=(
+              case
+                when ${fields[key]} is not NULL
+                then ${fields[key]} || ${convertToPrimitiveOrSql(key, value)}
+                else ${convertToPrimitiveOrSql(key, value)}
+              end
+            )
+          `;
         }
 
         return sql`${fields[key]}=${convertToPrimitiveOrSql(key, value)}`;

--- a/packages/core/src/database/update-where.ts
+++ b/packages/core/src/database/update-where.ts
@@ -50,13 +50,8 @@ export const buildUpdateWhere: BuildUpdateWhere = <
            * https://www.postgresql.org/docs/current/functions-json.html
            */
           return sql`
-            ${fields[key]}=(
-              case
-                when ${fields[key]} is not NULL
-                then ${fields[key]} || ${convertToPrimitiveOrSql(key, value)}
-                else ${convertToPrimitiveOrSql(key, value)}
-              end
-            )
+            ${fields[key]}=
+              coalesce(${fields[key]},'{}'::jsonb)|| ${convertToPrimitiveOrSql(key, value)}
           `;
         }
 

--- a/packages/core/src/database/update-where.ts
+++ b/packages/core/src/database/update-where.ts
@@ -45,7 +45,7 @@ export const buildUpdateWhere: BuildUpdateWhere = <
 
         if (value && typeof value === 'object' && !Array.isArray(value)) {
           /**
-           * Jsonb || operator is used to merge to jsonb types of data
+           * Jsonb || operator is used to shallow merge two jsonb types of data
            * all jsonb data field must be non-nullable
            * https://www.postgresql.org/docs/current/functions-json.html
            */

--- a/packages/core/src/routes/application.ts
+++ b/packages/core/src/routes/application.ts
@@ -84,14 +84,9 @@ export default function applicationRoutes<T extends AuthedRouter>(router: T) {
         params: { id },
         body,
       } = ctx.guard;
-      const application = await findApplicationById(id);
 
       ctx.body = await updateApplicationById(id, {
         ...body,
-        oidcClientMetadata: buildOidcClientMetadata({
-          ...application.oidcClientMetadata,
-          ...body.oidcClientMetadata,
-        }),
       });
 
       return next();


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Following the pg [doc](https://www.postgresql.org/docs/current/functions-json.html) 
allow jsonb '||' oprator to shallow merge two jsonb object. 

- only works on the non-nullable field
- only merge map instead of list

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally 
<img width="1053" alt="image" src="https://user-images.githubusercontent.com/36393111/151656633-cc7060d6-8d73-40a8-9de7-da73c231e056.png">

@logto-io/eng 