### PR TITLE
feat(phone passwordless): add passwordless sign-in with phone

### DIFF
--- a/packages/core/src/queries/user.ts
+++ b/packages/core/src/queries/user.ts
@@ -23,6 +23,13 @@ export const findUserByEmail = async (email: string) =>
     where ${fields.primaryEmail}=${email}
   `);
 
+export const findUserByPhone = async (phone: string) =>
+  pool.one<User>(sql`
+    select ${sql.join(Object.values(fields), sql`,`)}
+    from ${table}
+    where ${fields.primaryPhone}=${phone}
+  `);
+
 export const findUserById = async (id: string) =>
   pool.one<User>(sql`
     select ${sql.join(Object.values(fields), sql`,`)}
@@ -49,6 +56,13 @@ export const hasUserWithEmail = async (email: string) =>
     select ${fields.primaryEmail}
     from ${table}
     where ${fields.primaryEmail}=${email}
+  `);
+
+export const hasUserWithPhone = async (phone: string) =>
+  pool.exists(sql`
+    select ${fields.primaryPhone}
+    from ${table}
+    where ${fields.primaryPhone}=${phone}
   `);
 
 export const insertUser = buildInsertInto<CreateUser, User>(pool, Users, { returning: true });

--- a/packages/core/src/routes/session.ts
+++ b/packages/core/src/routes/session.ts
@@ -11,7 +11,9 @@ import {
 } from '@/lib/register';
 import {
   sendSignInWithEmailPasscode,
+  sendSignInWithPhonePasscode,
   signInWithEmailAndPasscode,
+  signInWithPhoneAndPasscode,
   signInWithUsernameAndPassword,
 } from '@/lib/sign-in';
 import koaGuard from '@/middleware/koa-guard';
@@ -27,6 +29,7 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
         username: string().optional(),
         password: string().optional(),
         email: string().optional(),
+        phone: string().optional(),
         code: string().optional(),
       }),
     }),
@@ -47,12 +50,16 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
       }
 
       if (name === 'login') {
-        const { username, password, email, code } = ctx.guard.body;
+        const { username, password, email, phone, code } = ctx.guard.body;
 
         if (email && !code) {
           await sendSignInWithEmailPasscode(ctx, jti, email);
         } else if (email && code) {
           await signInWithEmailAndPasscode(ctx, provider, { jti, email, code });
+        } else if (phone && !code) {
+          await sendSignInWithPhonePasscode(ctx, jti, phone);
+        } else if (phone && code) {
+          await signInWithPhoneAndPasscode(ctx, provider, { jti, phone, code });
         } else if (username && password) {
           await signInWithUsernameAndPassword(ctx, provider, username, password);
         } else {

--- a/packages/core/src/utils/regex.ts
+++ b/packages/core/src/utils/regex.ts
@@ -1,1 +1,2 @@
 export const emailRegEx = /^\S+@\S+\.\S+$/;
+export const phoneRegEx = /^[1-9]\d{10}$/;

--- a/packages/core/src/utils/regex.ts
+++ b/packages/core/src/utils/regex.ts
@@ -1,6 +1,2 @@
-<<<<<<< HEAD
 export const emailRegEx = /^\S+@\S+\.\S+$/;
-=======
-export const emailReg = /^\S+@\S+\.\S+$/;
->>>>>>> 1ad2b52 (feat(phone passwordless): rename phoneReg)
 export const phoneRegEx = /^[1-9]\d{10}$/;

--- a/packages/core/src/utils/regex.ts
+++ b/packages/core/src/utils/regex.ts
@@ -1,2 +1,6 @@
+<<<<<<< HEAD
 export const emailRegEx = /^\S+@\S+\.\S+$/;
+=======
+export const emailReg = /^\S+@\S+\.\S+$/;
+>>>>>>> 1ad2b52 (feat(phone passwordless): rename phoneReg)
 export const phoneRegEx = /^[1-9]\d{10}$/;

--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -47,7 +47,9 @@ const errors = {
     username_exists: 'The username already exists.',
     email_exists: 'The email already exists.',
     invalid_email: 'Invalid email address.',
+    invalid_phone: 'Invalid phone number.',
     email_not_exists: 'The email address has not been registered yet.',
+    phone_not_exists: 'The phone number has not been registered yet.',
   },
   password: {
     unsupported_encryption_method: 'The encryption method {{name}} is not supported.',

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -48,7 +48,9 @@ const errors = {
     username_exists: '用户名已存在。',
     email_exists: '邮箱地址已存在。',
     invalid_email: '邮箱地址不正确。',
+    invalid_phone: '手机号码不正确。',
     email_not_exists: '邮箱地址尚未注册。',
+    phone_not_exists: '手机号码尚未注册。',
   },
   password: {
     unsupported_encryption_method: '不支持的加密方法 {{name}}。',

--- a/packages/schemas/src/db-entries/custom-types.ts
+++ b/packages/schemas/src/db-entries/custom-types.ts
@@ -13,6 +13,7 @@ export enum PasscodeType {
 export enum UserLogType {
   SignInUsernameAndPassword = 'SignInUsernameAndPassword',
   SignInEmail = 'SignInEmail',
+  SignInSms = 'SignInSms',
   ExchangeAccessToken = 'ExchangeAccessToken',
 }
 export enum UserLogResult {

--- a/packages/schemas/tables/user_logs.sql
+++ b/packages/schemas/tables/user_logs.sql
@@ -1,4 +1,4 @@
-create type user_log_type as enum ('SignInUsernameAndPassword', 'SignInEmail', 'ExchangeAccessToken');
+create type user_log_type as enum ('SignInUsernameAndPassword', 'SignInEmail', 'SignInSms', 'ExchangeAccessToken');
 
 create type user_log_result as enum ('Success', 'Failed');
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Passwordless sign-in flow with SMS.
Added to `POST /session` router.
If no code but the phone number is provided in `body`, send passcode.
else, verify passcode and sign-in as well as its valid.


<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-867


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
1. no user can be found with phone number.
![image](https://user-images.githubusercontent.com/15182327/152930131-328a14b3-bdd5-4c3e-97d0-747f746d1231.png)

2. send and receive passcode on phone.
![image](https://user-images.githubusercontent.com/15182327/152942714-e960a672-66e9-442a-844c-1631661e2dd1.png)
![image](https://user-images.githubusercontent.com/15182327/152942930-db451084-f702-41c4-9bdd-d1e29f0939a9.png)

3. sign-in successfully.
![image](https://user-images.githubusercontent.com/15182327/152942833-4b867cd9-0cd5-4ad0-8cb5-1efb99bd6ec2.png)
