### PR TITLE
refactor(core): refactor OIDCRequestError type

### DIFF
--- a/packages/core/src/errors/OIDCRequestError/oidc-request-error.test.ts
+++ b/packages/core/src/errors/OIDCRequestError/oidc-request-error.test.ts
@@ -1,0 +1,69 @@
+import pick from 'lodash.pick';
+import { errors } from 'oidc-provider';
+
+import OIDCRequestError from '.';
+import RequestError from '../RequestError';
+
+describe('OIDCRequestError', () => {
+  it('Invalid Scope Error', () => {
+    const scope = 'read:user';
+    const description = 'requested scope is not allowed';
+
+    const error = new errors.InvalidScope(description, scope);
+    const normalizedError = new OIDCRequestError(error);
+
+    expect(normalizedError instanceof RequestError).toEqual(true);
+    expect(normalizedError.code).toEqual('oidc.invalid_scope');
+    expect(normalizedError.status).toEqual(400);
+    expect(normalizedError.data).toEqual(pick(error, 'error_description', 'error_detail'));
+  });
+
+  it('InvalidToken Error', () => {
+    const description = 'token not found';
+
+    const error = new errors.InvalidToken(description);
+    const normalizedError = new OIDCRequestError(error);
+
+    expect(normalizedError instanceof RequestError).toEqual(true);
+    expect(normalizedError.code).toEqual('oidc.invalid_token');
+    expect(normalizedError.status).toEqual(401);
+    expect(normalizedError.data).toEqual(pick(error, 'error_description', 'error_detail'));
+  });
+
+  it('SessionNotFound Error', () => {
+    const description = 'session not found';
+
+    const error = new errors.SessionNotFound(description);
+    const normalizedError = new OIDCRequestError(error);
+
+    expect(normalizedError instanceof RequestError).toEqual(true);
+    expect(normalizedError.code).toEqual('session.not_found');
+    expect(normalizedError.status).toEqual(400);
+    expect(normalizedError.data).toEqual(pick(error, 'error_description', 'error_detail'));
+  });
+
+  it('InsufficientScope Error', () => {
+    const description = 'access token missing openid scope';
+    const scope = 'openid';
+
+    const error = new errors.InsufficientScope(description, scope);
+    const normalizedError = new OIDCRequestError(error);
+
+    expect(normalizedError instanceof RequestError).toEqual(true);
+    expect(normalizedError.code).toEqual('oidc.insufficient_scope');
+    expect(normalizedError.status).toEqual(403);
+    expect(normalizedError.data).toEqual(pick(error, 'error_description', 'error_detail'));
+  });
+
+  it('Unknow OIDC Error', () => {
+    const error = new errors.RegistrationNotSupported();
+    const normalizedError = new OIDCRequestError(error);
+
+    expect(normalizedError instanceof RequestError).toEqual(true);
+    expect(normalizedError.code).toEqual('oidc.provider_error');
+    expect(normalizedError.status).toEqual(error.status);
+    expect(normalizedError.data).toEqual(pick(error, 'error_description', 'error_detail'));
+  });
+});
+
+// TODO: need to add message assertation test with i18n mock

--- a/packages/core/src/errors/RequestError/index.ts
+++ b/packages/core/src/errors/RequestError/index.ts
@@ -13,13 +13,14 @@ export default class RequestError extends Error {
     const {
       code,
       status = 400,
+      expose = true,
       ...interpolation
     } = typeof input === 'string' ? { code: input } : input;
     const message = i18next.t<string, LogtoErrorI18nKey>(`errors:${code}`, interpolation);
 
     super(message);
 
-    this.expose = true;
+    this.expose = expose;
     this.code = code;
     this.status = status;
     this.data = data;

--- a/packages/schemas/src/api/error.ts
+++ b/packages/schemas/src/api/error.ts
@@ -3,6 +3,7 @@ import { LogtoErrorCode } from '@logto/phrases';
 export type RequestErrorMetadata = Record<string, unknown> & {
   code: LogtoErrorCode;
   status?: number;
+  expose?: boolean;
 };
 
 export type RequestErrorBody = { message: string; data: unknown; code: LogtoErrorCode };


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
 refactor OIDCRequestError type

1. make the error type extends RequestError
2. add some OIDCProvider errors
3. add some UT cases

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
ut passed 
@logto-io/eng 
