### PR TITLE
feat: continue social sign in

### DIFF
--- a/packages/core/src/connectors/types.ts
+++ b/packages/core/src/connectors/types.ts
@@ -1,5 +1,6 @@
 import { Languages } from '@logto/phrases';
 import { ConnectorConfig, Connector, PasscodeType } from '@logto/schemas';
+import { z } from 'zod';
 
 export enum ConnectorType {
   SMS = 'SMS',
@@ -80,10 +81,12 @@ export type GetAccessToken = (code: string) => Promise<string>;
 
 export type GetUserInfo = (accessToken: string) => Promise<SocialUserInfo>;
 
-export interface SocialUserInfo {
-  id: string;
-  email?: string;
-  phone?: string;
-  name?: string;
-  avatar?: string;
-}
+export const socialUserInfoGuard = z.object({
+  id: z.string(),
+  email: z.string().optional(),
+  phone: z.string().optional(),
+  name: z.string().optional(),
+  avatar: z.string().optional(),
+});
+
+export type SocialUserInfo = z.infer<typeof socialUserInfoGuard>;

--- a/packages/core/src/lib/register.ts
+++ b/packages/core/src/lib/register.ts
@@ -2,6 +2,7 @@ import { PasscodeType, UserLogType } from '@logto/schemas';
 import { Context } from 'koa';
 import { Provider } from 'oidc-provider';
 
+import { getSocialConnectorInstanceById } from '@/connectors';
 import RequestError from '@/errors/RequestError';
 import { WithUserLogContext } from '@/middleware/koa-user-log';
 import {
@@ -158,6 +159,38 @@ export const registerWithSocial = async (
   { connectorId, code }: { connectorId: string; code: string }
 ) => {
   const userInfo = await getUserInfoByConnectorCode(connectorId, code);
+
+  assertThat(
+    !(await hasUserWithIdentity(connectorId, userInfo.id)),
+    new RequestError({
+      code: 'user.identity_exists',
+      status: 422,
+    })
+  );
+
+  const id = await generateUserId();
+  await insertUser({
+    id,
+    identities: {
+      [connectorId]: {
+        userId: userInfo.id,
+        details: userInfo,
+      },
+    },
+  });
+
+  await assignRegistrationResult(ctx, provider, id);
+};
+
+export const registerWithSocial = async (
+  ctx: WithUserLogContext<Context>,
+  provider: Provider,
+  { connectorId, code }: { connectorId: string; code: string }
+) => {
+  const connector = await getSocialConnectorInstanceById(connectorId);
+  const accessToken = await connector.getAccessToken(code);
+
+  const userInfo = await connector.getUserInfo(accessToken);
 
   assertThat(
     !(await hasUserWithIdentity(connectorId, userInfo.id)),

--- a/packages/core/src/lib/sign-in.ts
+++ b/packages/core/src/lib/sign-in.ts
@@ -1,6 +1,6 @@
 import { PasscodeType, UserLogType } from '@logto/schemas';
 import { Context } from 'koa';
-import { Provider } from 'oidc-provider';
+import { InteractionResults, Provider } from 'oidc-provider';
 
 import { getSocialConnectorInstanceById } from '@/connectors';
 import RequestError from '@/errors/RequestError';
@@ -17,7 +17,7 @@ import assertThat from '@/utils/assert-that';
 import { emailRegEx, phoneRegEx } from '@/utils/regex';
 
 import { createPasscode, sendPasscode, verifyPasscode } from './passcode';
-import { getUserInfoByConnectorCode } from './social';
+import { getUserInfoByConnectorCode, getUserInfoFromInteractionResult } from './social';
 import { findUserByUsernameAndPassword } from './user';
 
 const assignSignInResult = async (ctx: Context, provider: Provider, userId: string) => {
@@ -121,69 +121,15 @@ export const assignRedirectUrlForSocial = async (
 export const signInWithSocial = async (
   ctx: WithUserLogContext<Context>,
   provider: Provider,
-  { connectorId, code }: { connectorId: string; code: string }
+  { connectorId, code, result }: { connectorId: string; code: string; result?: InteractionResults }
 ) => {
   ctx.userLog.connectorId = connectorId;
   ctx.userLog.type = UserLogType.SignInSocial;
 
-  const userInfo = await getUserInfoByConnectorCode(connectorId, code);
-
-  assertThat(
-    await hasUserWithIdentity(connectorId, userInfo.id),
-    new RequestError({
-      code: 'user.identity_not_exists',
-      status: 422,
-    })
-  );
-
-  const { id } = await findUserByIdentity(connectorId, userInfo.id);
-  ctx.userLog.userId = id;
-  await assignSignInResult(ctx, provider, id);
-};
-
-// TODO: change this after frontend is ready.
-// Should combian baseUrl(domain) from database with a 'callback' endpoint.
-const connectorRedirectUrl = 'https://logto.dev/callback';
-
-export const assignRedirectUrlForSocial = async (
-  ctx: WithUserLogContext<Context>,
-  connectorId: string,
-  state: string
-) => {
-  const connector = await getSocialConnectorInstanceById(connectorId);
-  assertThat(connector.connector?.enabled, 'connector.not_enabled');
-  const redirectTo = await connector.getAuthorizationUri(connectorRedirectUrl, state);
-  ctx.body = { redirectTo };
-};
-
-const getConnector = async (connectorId: string) => {
-  try {
-    return await getSocialConnectorInstanceById(connectorId);
-  } catch (error: unknown) {
-    // Throw a new error with status 422 when connector not found.
-    if (error instanceof RequestError && error.code === 'entity.not_found') {
-      throw new RequestError({
-        code: 'session.invalid_connector_id',
-        status: 422,
-        data: { connectorId },
-      });
-    }
-    throw error;
-  }
-};
-
-export const signInWithSocial = async (
-  ctx: WithUserLogContext<Context>,
-  provider: Provider,
-  { connectorId, code }: { connectorId: string; code: string }
-) => {
-  ctx.userLog.connectorId = connectorId;
-  ctx.userLog.type = UserLogType.SignInSocial;
-
-  const connector = await getConnector(connectorId);
-  const accessToken = await connector.getAccessToken(code);
-
-  const userInfo = await connector.getUserInfo(accessToken);
+  const userInfo =
+    code === 'session'
+      ? await getUserInfoFromInteractionResult(connectorId, result)
+      : await getUserInfoByConnectorCode(connectorId, code);
 
   assertThat(
     await hasUserWithIdentity(connectorId, userInfo.id),

--- a/packages/core/src/routes/session.ts
+++ b/packages/core/src/routes/session.ts
@@ -48,6 +48,7 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
         // https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.7
         jti,
         prompt: { name },
+        result,
       } = interaction;
 
       if (name === 'consent') {
@@ -62,7 +63,7 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
         if (connectorId && state && !code) {
           await assignRedirectUrlForSocial(ctx, connectorId, state);
         } else if (connectorId && code) {
-          await signInWithSocial(ctx, provider, { connectorId, code });
+          await signInWithSocial(ctx, provider, { connectorId, code, result });
         } else if (email && !code) {
           await sendSignInWithEmailPasscode(ctx, jti, email);
         } else if (email && code) {

--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -64,6 +64,7 @@ const errors = {
     invalid_sign_in_method: 'Current sign-in method is not available.',
     invalid_connector_id: 'Unable to find available connector with id {{connectorId}}.',
     insufficient_info: 'Insufficent sign-in info.',
+    connector_id_mismatch: 'The connectorId is mismatched with session record.',
   },
   connector: {
     not_found: 'Cannot find any available connector for type: {{type}}.',

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -65,6 +65,7 @@ const errors = {
     invalid_sign_in_method: '当前登录方式不可用。',
     insufficient_info: '登录信息缺失，请检查您的输入。',
     invalid_connector_id: '无法找到 ID 为 {{connectorId}} 的可用连接器。',
+    connector_id_mismatch: '传入的 connectorId 与 session 中保存的记录不一致。',
   },
   connector: {
     not_found: '找不到可用的 {{type}} 类型的连接器。',


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Reuse social results(userInfo) to continue sign in.

Flow:
1. A user try to register with a social result (granted a code, exchanged accessToken, and got userInfo), but the user is exists in our database, throw an error with promt
2. The user then decide to sign in and reuse last step's social result

User info is cached in `oidc-provider`'s "interaction result".

Ignore the complex route, it will be refactored immediatly in LOG-1482.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->

LOG-1508

