### PR TITLE
feat: sign in to social related user

### DIFF
--- a/packages/core/src/routes/session.ts
+++ b/packages/core/src/routes/session.ts
@@ -21,6 +21,7 @@ import {
   signInWithEmailAndPasscode,
   signInWithPhoneAndPasscode,
   signInWithUsernameAndPassword,
+  signInWithSocialRelatedUser,
 } from '@/lib/sign-in';
 import { getUserInfoByAuthCode, getUserInfoFromInteractionResult } from '@/lib/social';
 import koaGuard from '@/middleware/koa-guard';
@@ -108,6 +109,23 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
 
       const userInfo = await getUserInfoByAuthCode(connectorId, code);
       await signInWithSocial(ctx, provider, connectorId, userInfo);
+
+      return next();
+    }
+  );
+
+  router.post(
+    '/session/sign-in/social-related-user',
+    koaGuard({
+      body: object({ connectorId: string() }),
+    }),
+    async (ctx, next) => {
+      const { connectorId } = ctx.guard.body;
+
+      const { result } = await provider.interactionDetails(ctx.req, ctx.res);
+      assertThat(result, 'session.connector_session_not_found');
+
+      await signInWithSocialRelatedUser(ctx, provider, { connectorId, result });
 
       return next();
     }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Implement the following sign in flow:

1. try to sign in with social, but cannot find Logto accout by social connector's userId. 
2. the API found a Logto account by social userInfo's phone or email, return this info.
3. the user confirm to sign in and bind this social info to the user found above.


<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->

LOG-1513

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

- [x] find related user
<img width="538" alt="截屏2022-02-19 下午12 50 35" src="https://user-images.githubusercontent.com/5717882/154787009-0d72b4f6-24da-4e01-848d-c0abf2fbd98a.png">

- [x] sign in with this user, and identity info updated
<img width="217" alt="image" src="https://user-images.githubusercontent.com/5717882/154787190-95b15830-7556-4cf1-85dd-362ea45042f0.png">

