### PR TITLE
chore(core): hide settings default id

### DIFF
--- a/packages/core/src/routes/setting.test.ts
+++ b/packages/core/src/routes/setting.test.ts
@@ -38,7 +38,6 @@ describe('settings routes', () => {
 
     expect(response.status).toEqual(200);
     expect(response.body).toEqual({
-      ...mockSetting,
       customDomain,
       adminConsole,
     });

--- a/packages/core/src/routes/setting.ts
+++ b/packages/core/src/routes/setting.ts
@@ -20,7 +20,8 @@ export default function settingRoutes<T extends AuthedRouter>(router: T) {
     }),
     async (ctx, next) => {
       const { body: setting } = ctx.guard;
-      ctx.body = await updateSetting(setting);
+      const { id, ...rest } = await updateSetting(setting);
+      ctx.body = rest;
 
       return next();
     }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Hide default id from the return value after updating global settings.

<!-- Optional -->
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A
