### PR TITLE
feat(core): separate passwordless flow routes

### DIFF
--- a/packages/core/src/lib/session.ts
+++ b/packages/core/src/lib/session.ts
@@ -1,6 +1,11 @@
 import { Context } from 'koa';
 import { InteractionResults, Provider } from 'oidc-provider';
 
+import RequestError from '@/errors/RequestError';
+import { hasUserWithEmail, hasUserWithPhone } from '@/queries/user';
+import assertThat from '@/utils/assert-that';
+import { emailRegEx, phoneRegEx } from '@/utils/regex';
+
 // TODO: change this after frontend is ready.
 // Should combine baseUrl(domain) from database with a 'callback' endpoint.
 export const connectorRedirectUrl = 'https://logto.dev/callback';
@@ -15,4 +20,36 @@ export const assignInteractionResults = async (
     mergeWithLastSubmission: merge,
   });
   ctx.body = { redirectTo };
+};
+
+export const checkEmailValidityAndAvailability = async (email: string) => {
+  assertThat(emailRegEx.test(email), new RequestError('user.invalid_email'));
+  assertThat(
+    !(await hasUserWithEmail(email)),
+    new RequestError({ code: 'user.email_exists_register', status: 422 })
+  );
+};
+
+export const checkEmailValidityAndExistence = async (email: string) => {
+  assertThat(emailRegEx.test(email), new RequestError('user.invalid_email'));
+  assertThat(
+    await hasUserWithEmail(email),
+    new RequestError({ code: 'user.email_not_exists', status: 422 })
+  );
+};
+
+export const checkPhoneNumberValidityAndAvailability = async (phone: string) => {
+  assertThat(phoneRegEx.test(phone), new RequestError('user.invalid_phone'));
+  assertThat(
+    !(await hasUserWithPhone(phone)),
+    new RequestError({ code: 'user.phone_exists_register', status: 422 })
+  );
+};
+
+export const checkPhoneNumberValidityAndExistence = async (phone: string) => {
+  assertThat(phoneRegEx.test(phone), new RequestError('user.invalid_phone'));
+  assertThat(
+    await hasUserWithPhone(phone),
+    new RequestError({ code: 'user.phone_not_exists', status: 422 })
+  );
 };

--- a/packages/core/src/routes/session.ts
+++ b/packages/core/src/routes/session.ts
@@ -70,7 +70,7 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
   );
 
   router.post(
-    '/session/sign-in/passwordless/phone/send',
+    '/session/sign-in/passwordless/phone/send-passcode',
     koaGuard({ body: object({ phone: string() }) }),
     async (ctx, next) => {
       ctx.userLog.type = UserLogType.SignInPhone;
@@ -96,7 +96,7 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
   );
 
   router.post(
-    '/session/sign-in/passwordless/phone/verify',
+    '/session/sign-in/passwordless/phone/verify-passcode',
     koaGuard({ body: object({ phone: string(), code: string() }) }),
     async (ctx, next) => {
       ctx.userLog.type = UserLogType.SignInPhone;
@@ -124,7 +124,7 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
   );
 
   router.post(
-    '/session/sign-in/passwordless/email/send',
+    '/session/sign-in/passwordless/email/send-passcode',
     koaGuard({ body: object({ email: string() }) }),
     async (ctx, next) => {
       ctx.userLog.type = UserLogType.SignInEmail;
@@ -150,7 +150,7 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
   );
 
   router.post(
-    '/session/sign-in/passwordless/email/verify',
+    '/session/sign-in/passwordless/email/verify-passcode',
     koaGuard({ body: object({ email: string(), code: string() }) }),
     async (ctx, next) => {
       ctx.userLog.type = UserLogType.SignInEmail;
@@ -334,7 +334,7 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
   );
 
   router.post(
-    '/session/register/passwordless/phone/send',
+    '/session/register/passwordless/phone/send-passcode',
     koaGuard({ body: object({ phone: string() }) }),
     async (ctx, next) => {
       ctx.userLog.type = UserLogType.RegisterPhone;
@@ -357,7 +357,7 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
   );
 
   router.post(
-    '/session/register/passwordless/phone/verify',
+    '/session/register/passwordless/phone/verify-passcode',
     koaGuard({ body: object({ phone: string(), code: string() }) }),
     async (ctx, next) => {
       ctx.userLog.type = UserLogType.RegisterPhone;
@@ -383,7 +383,7 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
   );
 
   router.post(
-    '/session/register/passwordless/email/send',
+    '/session/register/passwordless/email/send-passcode',
     koaGuard({ body: object({ email: string() }) }),
     async (ctx, next) => {
       ctx.userLog.type = UserLogType.RegisterPhone;
@@ -406,7 +406,7 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
   );
 
   router.post(
-    '/session/register/passwordless/email/verify',
+    '/session/register/passwordless/email/verify-passcode',
     koaGuard({ body: object({ email: string(), code: string() }) }),
     async (ctx, next) => {
       ctx.userLog.type = UserLogType.RegisterPhone;

--- a/packages/core/src/routes/session.ts
+++ b/packages/core/src/routes/session.ts
@@ -10,7 +10,14 @@ import { object, string } from 'zod';
 import { getSocialConnectorInstanceById } from '@/connectors';
 import RequestError from '@/errors/RequestError';
 import { createPasscode, sendPasscode, verifyPasscode } from '@/lib/passcode';
-import { assignInteractionResults, connectorRedirectUrl } from '@/lib/session';
+import {
+  assignInteractionResults,
+  connectorRedirectUrl,
+  checkEmailValidityAndAvailability,
+  checkEmailValidityAndExistence,
+  checkPhoneNumberValidityAndAvailability,
+  checkPhoneNumberValidityAndExistence,
+} from '@/lib/session';
 import {
   findSocialRelatedUser,
   getUserInfoByAuthCode,
@@ -20,9 +27,7 @@ import { encryptUserPassword, generateUserId, findUserByUsernameAndPassword } fr
 import koaGuard from '@/middleware/koa-guard';
 import {
   hasUser,
-  hasUserWithEmail,
   hasUserWithIdentity,
-  hasUserWithPhone,
   insertUser,
   findUserById,
   updateUserById,
@@ -31,7 +36,6 @@ import {
   findUserByIdentity,
 } from '@/queries/user';
 import assertThat from '@/utils/assert-that';
-import { emailRegEx, phoneRegEx } from '@/utils/regex';
 
 import { AnonymousRouter } from './types';
 
@@ -76,16 +80,9 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
       ctx.userLog.type = UserLogType.SignInPhone;
       const { jti } = await provider.interactionDetails(ctx.req, ctx.res);
       const { phone } = ctx.guard.body;
-
-      assertThat(phoneRegEx.test(phone), new RequestError('user.invalid_phone'));
-      assertThat(
-        await hasUserWithPhone(phone),
-        new RequestError({
-          code: 'user.phone_not_exists',
-          status: 422,
-        })
-      );
       ctx.userLog.phone = phone;
+
+      await checkPhoneNumberValidityAndExistence(phone);
 
       const passcode = await createPasscode(jti, PasscodeType.SignIn, { phone });
       await sendPasscode(passcode);
@@ -102,16 +99,9 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
       ctx.userLog.type = UserLogType.SignInPhone;
       const { jti } = await provider.interactionDetails(ctx.req, ctx.res);
       const { phone, code } = ctx.guard.body;
-
-      assertThat(phoneRegEx.test(phone), new RequestError('user.invalid_phone'));
-      assertThat(
-        await hasUserWithPhone(phone),
-        new RequestError({
-          code: 'user.phone_not_exists',
-          status: 422,
-        })
-      );
       ctx.userLog.phone = phone;
+
+      await checkPhoneNumberValidityAndExistence(phone);
 
       await verifyPasscode(jti, PasscodeType.SignIn, code, { phone });
       const { id } = await findUserByPhone(phone);
@@ -130,16 +120,9 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
       ctx.userLog.type = UserLogType.SignInEmail;
       const { jti } = await provider.interactionDetails(ctx.req, ctx.res);
       const { email } = ctx.guard.body;
-
-      assertThat(emailRegEx.test(email), new RequestError('user.invalid_email'));
-      assertThat(
-        await hasUserWithEmail(email),
-        new RequestError({
-          code: 'user.email_not_exists',
-          status: 422,
-        })
-      );
       ctx.userLog.email = email;
+
+      await checkEmailValidityAndExistence(email);
 
       const passcode = await createPasscode(jti, PasscodeType.SignIn, { email });
       await sendPasscode(passcode);
@@ -156,16 +139,9 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
       ctx.userLog.type = UserLogType.SignInEmail;
       const { jti } = await provider.interactionDetails(ctx.req, ctx.res);
       const { email, code } = ctx.guard.body;
-
-      assertThat(emailRegEx.test(email), new RequestError('user.invalid_email'));
-      assertThat(
-        await hasUserWithEmail(email),
-        new RequestError({
-          code: 'user.email_not_exists',
-          status: 422,
-        })
-      );
       ctx.userLog.email = email;
+
+      await checkEmailValidityAndExistence(email);
 
       await verifyPasscode(jti, PasscodeType.SignIn, code, { email });
       const { id } = await findUserByEmail(email);
@@ -340,13 +316,9 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
       ctx.userLog.type = UserLogType.RegisterPhone;
       const { jti } = await provider.interactionDetails(ctx.req, ctx.res);
       const { phone } = ctx.guard.body;
-
-      assertThat(phoneRegEx.test(phone), 'user.invalid_phone');
-      assertThat(
-        !(await hasUserWithPhone(phone)),
-        new RequestError({ code: 'user.phone_exists_register', status: 422 })
-      );
       ctx.userLog.phone = phone;
+
+      await checkPhoneNumberValidityAndAvailability(phone);
 
       const passcode = await createPasscode(jti, PasscodeType.Register, { phone });
       await sendPasscode(passcode);
@@ -363,13 +335,9 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
       ctx.userLog.type = UserLogType.RegisterPhone;
       const { jti } = await provider.interactionDetails(ctx.req, ctx.res);
       const { phone, code } = ctx.guard.body;
-
-      assertThat(phoneRegEx.test(phone), 'user.invalid_phone');
-      assertThat(
-        !(await hasUserWithPhone(phone)),
-        new RequestError({ code: 'user.phone_exists_register', status: 422 })
-      );
       ctx.userLog.phone = phone;
+
+      await checkPhoneNumberValidityAndAvailability(phone);
 
       await verifyPasscode(jti, PasscodeType.Register, code, { phone });
       const id = await generateUserId();
@@ -386,16 +354,12 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
     '/session/register/passwordless/email/send-passcode',
     koaGuard({ body: object({ email: string() }) }),
     async (ctx, next) => {
-      ctx.userLog.type = UserLogType.RegisterPhone;
+      ctx.userLog.type = UserLogType.RegisterEmail;
       const { jti } = await provider.interactionDetails(ctx.req, ctx.res);
       const { email } = ctx.guard.body;
-
-      assertThat(emailRegEx.test(email), 'user.invalid_email');
-      assertThat(
-        !(await hasUserWithEmail(email)),
-        new RequestError({ code: 'user.email_exists_register', status: 422 })
-      );
       ctx.userLog.email = email;
+
+      await checkEmailValidityAndAvailability(email);
 
       const passcode = await createPasscode(jti, PasscodeType.Register, { email });
       await sendPasscode(passcode);
@@ -409,16 +373,12 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
     '/session/register/passwordless/email/verify-passcode',
     koaGuard({ body: object({ email: string(), code: string() }) }),
     async (ctx, next) => {
-      ctx.userLog.type = UserLogType.RegisterPhone;
+      ctx.userLog.type = UserLogType.RegisterEmail;
       const { jti } = await provider.interactionDetails(ctx.req, ctx.res);
       const { email, code } = ctx.guard.body;
-
-      assertThat(emailRegEx.test(email), 'user.invalid_email');
-      assertThat(
-        !(await hasUserWithEmail(email)),
-        new RequestError({ code: 'user.email_exists_register', status: 422 })
-      );
       ctx.userLog.email = email;
+
+      await checkEmailValidityAndAvailability(email);
 
       await verifyPasscode(jti, PasscodeType.Register, code, { email });
       const id = await generateUserId();

--- a/packages/core/src/routes/session.ts
+++ b/packages/core/src/routes/session.ts
@@ -77,10 +77,10 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
     '/session/sign-in/passwordless/phone/send-passcode',
     koaGuard({ body: object({ phone: string() }) }),
     async (ctx, next) => {
-      ctx.userLog.type = UserLogType.SignInPhone;
       const { jti } = await provider.interactionDetails(ctx.req, ctx.res);
       const { phone } = ctx.guard.body;
       ctx.userLog.phone = phone;
+      ctx.userLog.type = UserLogType.SignInPhone;
 
       await checkPhoneNumberValidityAndExistence(phone);
 
@@ -96,10 +96,10 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
     '/session/sign-in/passwordless/phone/verify-passcode',
     koaGuard({ body: object({ phone: string(), code: string() }) }),
     async (ctx, next) => {
-      ctx.userLog.type = UserLogType.SignInPhone;
       const { jti } = await provider.interactionDetails(ctx.req, ctx.res);
       const { phone, code } = ctx.guard.body;
       ctx.userLog.phone = phone;
+      ctx.userLog.type = UserLogType.SignInPhone;
 
       await checkPhoneNumberValidityAndExistence(phone);
 
@@ -117,10 +117,10 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
     '/session/sign-in/passwordless/email/send-passcode',
     koaGuard({ body: object({ email: string() }) }),
     async (ctx, next) => {
-      ctx.userLog.type = UserLogType.SignInEmail;
       const { jti } = await provider.interactionDetails(ctx.req, ctx.res);
       const { email } = ctx.guard.body;
       ctx.userLog.email = email;
+      ctx.userLog.type = UserLogType.SignInEmail;
 
       await checkEmailValidityAndExistence(email);
 
@@ -136,10 +136,10 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
     '/session/sign-in/passwordless/email/verify-passcode',
     koaGuard({ body: object({ email: string(), code: string() }) }),
     async (ctx, next) => {
-      ctx.userLog.type = UserLogType.SignInEmail;
       const { jti } = await provider.interactionDetails(ctx.req, ctx.res);
       const { email, code } = ctx.guard.body;
       ctx.userLog.email = email;
+      ctx.userLog.type = UserLogType.SignInEmail;
 
       await checkEmailValidityAndExistence(email);
 
@@ -159,10 +159,9 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
       body: object({ connectorId: string(), code: string().optional(), state: string() }),
     }),
     async (ctx, next) => {
-      ctx.userLog.type = UserLogType.SignInSocial;
       const { connectorId, code, state } = ctx.guard.body;
-
       ctx.userLog.connectorId = connectorId;
+      ctx.userLog.type = UserLogType.SignInSocial;
 
       if (!code) {
         assertThat(state, 'session.insufficient_info');
@@ -332,10 +331,10 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
     '/session/register/passwordless/phone/verify-passcode',
     koaGuard({ body: object({ phone: string(), code: string() }) }),
     async (ctx, next) => {
-      ctx.userLog.type = UserLogType.RegisterPhone;
       const { jti } = await provider.interactionDetails(ctx.req, ctx.res);
       const { phone, code } = ctx.guard.body;
       ctx.userLog.phone = phone;
+      ctx.userLog.type = UserLogType.RegisterPhone;
 
       await checkPhoneNumberValidityAndAvailability(phone);
 
@@ -354,10 +353,10 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
     '/session/register/passwordless/email/send-passcode',
     koaGuard({ body: object({ email: string() }) }),
     async (ctx, next) => {
-      ctx.userLog.type = UserLogType.RegisterEmail;
       const { jti } = await provider.interactionDetails(ctx.req, ctx.res);
       const { email } = ctx.guard.body;
       ctx.userLog.email = email;
+      ctx.userLog.type = UserLogType.RegisterEmail;
 
       await checkEmailValidityAndAvailability(email);
 
@@ -373,10 +372,10 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
     '/session/register/passwordless/email/verify-passcode',
     koaGuard({ body: object({ email: string(), code: string() }) }),
     async (ctx, next) => {
-      ctx.userLog.type = UserLogType.RegisterEmail;
       const { jti } = await provider.interactionDetails(ctx.req, ctx.res);
       const { email, code } = ctx.guard.body;
       ctx.userLog.email = email;
+      ctx.userLog.type = UserLogType.RegisterEmail;
 
       await checkEmailValidityAndAvailability(email);
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Separate passwordless flow routes.
Originally send passcode and verify passcode are integrated as a single route, this PR separates them.

Includes:
/session/sign-in/passwordless/email
/session/sign-in/passwordless/phone
/session/register/passwordless/email
/session/register/passwordless/phone

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-1603

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A
