### PR TITLE
fix: update VSCode settings to format js/ts on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
   "typescript.tsdk": "node_modules/typescript/lib",
-  "editor.formatOnSave": true,
   "[scss]": {
     "editor.codeActionsOnSave": {
       "source.fixAll.stylelint": true
@@ -13,5 +12,14 @@
     {
       "pattern": "./packages/*"
     }
-  ]
+  ],
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact",
+  ],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true,
+  }
 }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
enable eslint formatter on save for workspace

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
format on save successfully

