### PR TITLE
build(core): add prepare script to the logto root postinstall life cycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "license": "MPL-2.0",
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "postinstall": "lerna run --stream prepack",
     "lerna": "lerna",
     "bootstrap": "lerna bootstrap",
     "prepare": "if test \"$NODE_ENV\" != \"production\" && test \"$CI\" != \"true\" ; then husky install ; fi",
+    "prepare:pack": "lerna run --stream prepack",
     "dev": "lerna run --stream prepack && lerna --scope=@logto/{core,ui,console} exec -- pnpm dev"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lerna": "lerna",
     "bootstrap": "lerna bootstrap",
     "prepare": "if test \"$NODE_ENV\" != \"production\" && test \"$CI\" != \"true\" ; then husky install ; fi",
-    "prepare:pack": "lerna run --stream prepack",
+    "prepack": "lerna run --stream prepack",
     "dev": "lerna run --stream prepack && lerna --scope=@logto/{core,ui,console} exec -- pnpm dev"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "preinstall": "npx only-allow pnpm",
+    "postinstall": "lerna run --stream prepack",
     "lerna": "lerna",
     "bootstrap": "lerna bootstrap",
     "prepare": "if test \"$NODE_ENV\" != \"production\" && test \"$CI\" != \"true\" ; then husky install ; fi",


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Add prepare script to the logto root post-install life cycle. Simplify the steps we need to run after schema and phrases repo updates. 
Run `pnpm i` under the logto root path should run all the prepack build.  


<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-1590

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
@logto-io/eng 

<img width="1065" alt="image" src="https://user-images.githubusercontent.com/36393111/155920725-61d0a47b-ef15-4a99-ad5a-ffa774a0cb97.png">
