### PR TITLE
fix(core): patch `/users/:userId` should not fail if only `name` or `avatar` is provided

### DIFF
--- a/packages/core/src/routes/admin-user.test.ts
+++ b/packages/core/src/routes/admin-user.test.ts
@@ -173,6 +173,25 @@ describe('adminUserRoutes', () => {
     });
   });
 
+  it('PATCH /users/:userId should updated with one field if the other is undefined', async () => {
+    const name = 'Micheal';
+
+    const updateNameResponse = await userRequest.patch('/users/foo').send({ name });
+    expect(updateNameResponse.status).toEqual(200);
+    expect(updateNameResponse.body).toEqual({
+      ...mockUserResponse,
+      name,
+    });
+
+    const avatar = 'https://www.miceal.png';
+    const updateAvatarResponse = await userRequest.patch('/users/foo').send({ avatar });
+    expect(updateAvatarResponse.status).toEqual(200);
+    expect(updateAvatarResponse.body).toEqual({
+      ...mockUserResponse,
+      avatar,
+    });
+  });
+
   it('PATCH /users/:userId throw with invalid input params', async () => {
     const name = 'Micheal';
     const avatar = 'http://www.micheal.png';

--- a/packages/core/src/routes/admin-user.ts
+++ b/packages/core/src/routes/admin-user.ts
@@ -115,14 +115,13 @@ export default function adminUserRoutes<T extends AuthedRouter>(router: T) {
     async (ctx, next) => {
       const {
         params: { userId },
-        body: { name, avatar },
+        body,
       } = ctx.guard;
 
       await findUserById(userId);
 
       const user = await updateUserById(userId, {
-        name,
-        avatar,
+        ...body,
       });
 
       ctx.body = pick(user, ...userInfoSelectFields);


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
fix(core): patch `/users/:userId` should not fail if only `name` or `avatar` is provided

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
None.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT
