### PR TITLE
fix(console): set base url when needed

### DIFF
--- a/packages/console/src/App.tsx
+++ b/packages/console/src/App.tsx
@@ -9,6 +9,8 @@ import Sidebar, { getPath, sections } from './components/Sidebar';
 import Topbar from './components/Topbar';
 import initI18n from './i18n/init';
 
+const isProduction = process.env.NODE_ENV !== 'development' || process.env.PORT === '5002';
+
 void initI18n();
 
 const Main = () => {
@@ -33,7 +35,7 @@ const Main = () => {
 };
 
 const App = () => (
-  <BrowserRouter>
+  <BrowserRouter basename={isProduction ? '/console' : ''}>
     <Main />
   </BrowserRouter>
 );

--- a/packages/console/src/App.tsx
+++ b/packages/console/src/App.tsx
@@ -9,7 +9,7 @@ import Sidebar, { getPath, sections } from './components/Sidebar';
 import Topbar from './components/Topbar';
 import initI18n from './i18n/init';
 
-const isProduction = process.env.NODE_ENV !== 'development' || process.env.PORT === '5002';
+const isBasenameNeeded = process.env.NODE_ENV !== 'development' || process.env.PORT === '5002';
 
 void initI18n();
 
@@ -35,7 +35,7 @@ const Main = () => {
 };
 
 const App = () => (
-  <BrowserRouter basename={isProduction ? '/console' : ''}>
+  <BrowserRouter basename={isBasenameNeeded ? '/console' : ''}>
     <Main />
   </BrowserRouter>
 );

--- a/packages/console/src/components/Sidebar/components/Item/index.tsx
+++ b/packages/console/src/components/Sidebar/components/Item/index.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React, { ReactChild } from 'react';
+import { Link } from 'react-router-dom';
 
 import { getPath } from '../../utils';
 import * as styles from './index.module.scss';
@@ -12,10 +13,10 @@ type Props = {
 
 const Item = ({ icon, title, isActive = false }: Props) => {
   return (
-    <a href={getPath(title)} className={classNames(styles.row, isActive && styles.active)}>
+    <Link to={getPath(title)} className={classNames(styles.row, isActive && styles.active)}>
       {icon && <div className={styles.icon}>{icon}</div>}
       <div className={styles.title}>{title}</div>
-    </a>
+    </Link>
   );
 };
 

--- a/packages/console/src/include.d/node.d.ts
+++ b/packages/console/src/include.d/node.d.ts
@@ -1,0 +1,5 @@
+type Process = {
+  env: Record<string, string>;
+};
+
+declare const process: Process;

--- a/packages/core/src/middleware/koa-spa-proxy.ts
+++ b/packages/core/src/middleware/koa-spa-proxy.ts
@@ -39,6 +39,7 @@ export default function koaSpaProxy<StateT, ContextT extends IRouterParamContext
 
     // Route has been handled by one of mounted apps
     if (
+      !prefix &&
       Object.values(MountedApps).some((app) => app !== prefix && requestPath.startsWith(`/${app}`))
     ) {
       return next();


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- console: set base url when console is running under core
- console: replace `<a>` with `<Link>`
- core: check mounted apps only when no prefix is found

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

tested with global `pnpm dev` and `console: pnpm start`, router works as expected

@logto-io/eng 

