### PR TITLE
feat(core): add forgot password send passcode to phone route

### DIFF
--- a/packages/core/src/lib/user.test.ts
+++ b/packages/core/src/lib/user.test.ts
@@ -1,23 +1,22 @@
 import { UsersPasswordEncryptionMethod } from '@logto/schemas';
 
-import { hasUserWithId } from '@/queries/user';
+import { hasUserWithId, findUserById } from '@/queries/user';
 
 import { encryptUserPassword, generateUserId, findUserSignInMethodsById } from './user';
 
-const findUserById: jest.MockedFunction<() => Promise<unknown>> = jest.fn(async () => ({}));
-const hasUserWithIdPlaceHolder = jest.fn() as jest.MockedFunction<typeof hasUserWithId>;
 jest.mock('@/queries/user', () => ({
-  findUserById: async () => findUserById(),
-  hasUserWithId: async (_id: string) => hasUserWithIdPlaceHolder(_id),
+  findUserById: jest.fn(),
+  hasUserWithId: jest.fn(),
 }));
 
 describe('generateUserId()', () => {
   afterEach(() => {
-    hasUserWithIdPlaceHolder.mockClear();
+    jest.clearAllMocks();
   });
 
   it('generates user ID with correct length when no conflict found', async () => {
-    const mockedHasUserWithId = hasUserWithIdPlaceHolder.mockImplementationOnce(async () => false);
+    const mockedHasUserWithId = hasUserWithId as jest.Mock;
+    mockedHasUserWithId.mockImplementationOnce(async () => false);
 
     await expect(generateUserId()).resolves.toHaveLength(12);
     expect(mockedHasUserWithId).toBeCalledTimes(1);
@@ -26,7 +25,8 @@ describe('generateUserId()', () => {
   it('generates user ID with correct length when retry limit is not reached', async () => {
     // eslint-disable-next-line @silverhand/fp/no-let
     let tried = 0;
-    const mockedHasUserWithId = hasUserWithIdPlaceHolder.mockImplementation(async () => {
+    const mockedHasUserWithId = hasUserWithId as jest.Mock;
+    mockedHasUserWithId.mockImplementation(async () => {
       if (tried) {
         return false;
       }
@@ -42,7 +42,8 @@ describe('generateUserId()', () => {
   });
 
   it('rejects with correct error message when retry limit is reached', async () => {
-    const mockedHasUserWithId = hasUserWithIdPlaceHolder.mockImplementation(async () => true);
+    const mockedHasUserWithId = hasUserWithId as jest.Mock;
+    mockedHasUserWithId.mockImplementation(async () => true);
 
     await expect(generateUserId(10)).rejects.toThrow(
       'Cannot generate user ID in reasonable retries'
@@ -63,11 +64,12 @@ describe('encryptUserPassword()', () => {
 
 describe('findUserSignInMethodsById()', () => {
   afterEach(() => {
-    findUserById.mockClear();
+    jest.clearAllMocks();
   });
 
   it('generate and test user with username and password sign-in method', async () => {
-    findUserById.mockResolvedValue({
+    const mockFindUserById = findUserById as jest.Mock;
+    mockFindUserById.mockResolvedValue({
       username: 'abcd',
       passwordEncrypted: '1234567890',
       passwordEncryptionMethod: UsersPasswordEncryptionMethod.SaltAndPepper,
@@ -82,7 +84,8 @@ describe('findUserSignInMethodsById()', () => {
   });
 
   it('generate and test user with email passwordless sign-in method', async () => {
-    findUserById.mockResolvedValue({
+    const mockFindUserById = findUserById as jest.Mock;
+    mockFindUserById.mockResolvedValue({
       primaryEmail: 'b@a.com',
       identities: {},
     });
@@ -95,7 +98,8 @@ describe('findUserSignInMethodsById()', () => {
   });
 
   it('generate and test user with phone passwordless sign-in method', async () => {
-    findUserById.mockResolvedValue({
+    const mockFindUserById = findUserById as jest.Mock;
+    mockFindUserById.mockResolvedValue({
       primaryPhone: '13000000000',
     });
     const { usernameAndPassword, emailPasswordless, phonePasswordless, social } =
@@ -107,7 +111,8 @@ describe('findUserSignInMethodsById()', () => {
   });
 
   it('generate and test user with social sign-in method (single social connector information in record)', async () => {
-    findUserById.mockResolvedValue({
+    const mockFindUserById = findUserById as jest.Mock;
+    mockFindUserById.mockResolvedValue({
       identities: { connector1: { userId: 'foo1' } },
     });
     const { usernameAndPassword, emailPasswordless, phonePasswordless, social } =
@@ -119,7 +124,8 @@ describe('findUserSignInMethodsById()', () => {
   });
 
   it('generate and test user with social sign-in method (multiple social connectors information in record)', async () => {
-    findUserById.mockResolvedValue({
+    const mockFindUserById = findUserById as jest.Mock;
+    mockFindUserById.mockResolvedValue({
       identities: { connector1: { userId: 'foo1' }, connector2: { userId: 'foo2' } },
     });
     const { usernameAndPassword, emailPasswordless, phonePasswordless, social } =

--- a/packages/core/src/lib/user.test.ts
+++ b/packages/core/src/lib/user.test.ts
@@ -5,19 +5,19 @@ import { hasUserWithId } from '@/queries/user';
 import { encryptUserPassword, generateUserId, findUserSignInMethodsById } from './user';
 
 const findUserById: jest.MockedFunction<() => Promise<unknown>> = jest.fn(async () => ({}));
-const hasUserWithIdHelper = jest.fn() as jest.MockedFunction<typeof hasUserWithId>;
+const hasUserWithIdPlaceHolder = jest.fn() as jest.MockedFunction<typeof hasUserWithId>;
 jest.mock('@/queries/user', () => ({
   findUserById: async () => findUserById(),
-  hasUserWithId: async (_id: string) => hasUserWithIdHelper(_id),
+  hasUserWithId: async (_id: string) => hasUserWithIdPlaceHolder(_id),
 }));
 
 describe('generateUserId()', () => {
   afterEach(() => {
-    hasUserWithIdHelper.mockClear();
+    hasUserWithIdPlaceHolder.mockClear();
   });
 
   it('generates user ID with correct length when no conflict found', async () => {
-    const mockedHasUserWithId = hasUserWithIdHelper.mockImplementationOnce(async () => false);
+    const mockedHasUserWithId = hasUserWithIdPlaceHolder.mockImplementationOnce(async () => false);
 
     await expect(generateUserId()).resolves.toHaveLength(12);
     expect(mockedHasUserWithId).toBeCalledTimes(1);
@@ -26,7 +26,7 @@ describe('generateUserId()', () => {
   it('generates user ID with correct length when retry limit is not reached', async () => {
     // eslint-disable-next-line @silverhand/fp/no-let
     let tried = 0;
-    const mockedHasUserWithId = hasUserWithIdHelper.mockImplementation(async () => {
+    const mockedHasUserWithId = hasUserWithIdPlaceHolder.mockImplementation(async () => {
       if (tried) {
         return false;
       }
@@ -42,7 +42,7 @@ describe('generateUserId()', () => {
   });
 
   it('rejects with correct error message when retry limit is reached', async () => {
-    const mockedHasUserWithId = hasUserWithIdHelper.mockImplementation(async () => true);
+    const mockedHasUserWithId = hasUserWithIdPlaceHolder.mockImplementation(async () => true);
 
     await expect(generateUserId(10)).rejects.toThrow(
       'Cannot generate user ID in reasonable retries'

--- a/packages/core/src/lib/user.test.ts
+++ b/packages/core/src/lib/user.test.ts
@@ -62,6 +62,10 @@ describe('encryptUserPassword()', () => {
 });
 
 describe('findUserSignInMethodsById()', () => {
+  afterEach(() => {
+    findUserById.mockClear();
+  });
+
   it('generate and test user with username and password sign-in method', async () => {
     findUserById.mockResolvedValue({
       username: 'abcd',

--- a/packages/core/src/lib/user.test.ts
+++ b/packages/core/src/lib/user.test.ts
@@ -2,19 +2,22 @@ import { UsersPasswordEncryptionMethod } from '@logto/schemas';
 
 import { hasUserWithId } from '@/queries/user';
 
-import { encryptUserPassword, generateUserId } from './user';
+import { encryptUserPassword, generateUserId, findUserSignInMethodsById } from './user';
 
-jest.mock('@/queries/user');
+const findUserById: jest.MockedFunction<() => Promise<unknown>> = jest.fn(async () => ({}));
+const hasUserWithIdHelper = jest.fn() as jest.MockedFunction<typeof hasUserWithId>;
+jest.mock('@/queries/user', () => ({
+  findUserById: async () => findUserById(),
+  hasUserWithId: async (_id: string) => hasUserWithIdHelper(_id),
+}));
 
 describe('generateUserId()', () => {
   afterEach(() => {
-    (hasUserWithId as jest.MockedFunction<typeof hasUserWithId>).mockClear();
+    hasUserWithIdHelper.mockClear();
   });
 
   it('generates user ID with correct length when no conflict found', async () => {
-    const mockedHasUserWithId = (
-      hasUserWithId as jest.MockedFunction<typeof hasUserWithId>
-    ).mockImplementationOnce(async () => false);
+    const mockedHasUserWithId = hasUserWithIdHelper.mockImplementationOnce(async () => false);
 
     await expect(generateUserId()).resolves.toHaveLength(12);
     expect(mockedHasUserWithId).toBeCalledTimes(1);
@@ -23,9 +26,7 @@ describe('generateUserId()', () => {
   it('generates user ID with correct length when retry limit is not reached', async () => {
     // eslint-disable-next-line @silverhand/fp/no-let
     let tried = 0;
-    const mockedHasUserWithId = (
-      hasUserWithId as jest.MockedFunction<typeof hasUserWithId>
-    ).mockImplementation(async () => {
+    const mockedHasUserWithId = hasUserWithIdHelper.mockImplementation(async () => {
       if (tried) {
         return false;
       }
@@ -41,9 +42,7 @@ describe('generateUserId()', () => {
   });
 
   it('rejects with correct error message when retry limit is reached', async () => {
-    const mockedHasUserWithId = (
-      hasUserWithId as jest.MockedFunction<typeof hasUserWithId>
-    ).mockImplementation(async () => true);
+    const mockedHasUserWithId = hasUserWithIdHelper.mockImplementation(async () => true);
 
     await expect(generateUserId(10)).rejects.toThrow(
       'Cannot generate user ID in reasonable retries'
@@ -59,5 +58,70 @@ describe('encryptUserPassword()', () => {
     expect(passwordEncryptionMethod).toEqual(UsersPasswordEncryptionMethod.SaltAndPepper);
     expect(passwordEncrypted).toHaveLength(64);
     expect(passwordEncryptionSalt).toHaveLength(21);
+  });
+});
+
+describe('findUserSignInMethodsById()', () => {
+  it('generate and test user with username and password sign-in method', async () => {
+    findUserById.mockResolvedValue({
+      username: 'abcd',
+      passwordEncrypted: '1234567890',
+      passwordEncryptionMethod: UsersPasswordEncryptionMethod.SaltAndPepper,
+      passwordEncryptionSalt: '123456790',
+    });
+    const { usernameAndPassword, emailPasswordless, phonePasswordless, social } =
+      await findUserSignInMethodsById('');
+    expect(usernameAndPassword).toEqual(true);
+    expect(emailPasswordless).toBeFalsy();
+    expect(phonePasswordless).toBeFalsy();
+    expect(social).toBeFalsy();
+  });
+
+  it('generate and test user with email passwordless sign-in method', async () => {
+    findUserById.mockResolvedValue({
+      primaryEmail: 'b@a.com',
+    });
+    const { usernameAndPassword, emailPasswordless, phonePasswordless, social } =
+      await findUserSignInMethodsById('');
+    expect(usernameAndPassword).toBeFalsy();
+    expect(emailPasswordless).toEqual(true);
+    expect(phonePasswordless).toBeFalsy();
+    expect(social).toBeFalsy();
+  });
+
+  it('generate and test user with phone passwordless sign-in method', async () => {
+    findUserById.mockResolvedValue({
+      primaryPhone: '13000000000',
+    });
+    const { usernameAndPassword, emailPasswordless, phonePasswordless, social } =
+      await findUserSignInMethodsById('');
+    expect(usernameAndPassword).toBeFalsy();
+    expect(emailPasswordless).toBeFalsy();
+    expect(phonePasswordless).toEqual(true);
+    expect(social).toBeFalsy();
+  });
+
+  it('generate and test user with social sign-in method (single social connector information in record)', async () => {
+    findUserById.mockResolvedValue({
+      identities: { connector1: { userId: 'foo1' } },
+    });
+    const { usernameAndPassword, emailPasswordless, phonePasswordless, social } =
+      await findUserSignInMethodsById('');
+    expect(usernameAndPassword).toBeFalsy();
+    expect(emailPasswordless).toBeFalsy();
+    expect(phonePasswordless).toBeFalsy();
+    expect(social).toEqual(true);
+  });
+
+  it('generate and test user with social sign-in method (multiple social connectors information in record)', async () => {
+    findUserById.mockResolvedValue({
+      identities: { connector1: { userId: 'foo1' }, connector2: { userId: 'foo2' } },
+    });
+    const { usernameAndPassword, emailPasswordless, phonePasswordless, social } =
+      await findUserSignInMethodsById('');
+    expect(usernameAndPassword).toBeFalsy();
+    expect(emailPasswordless).toBeFalsy();
+    expect(phonePasswordless).toBeFalsy();
+    expect(social).toEqual(true);
   });
 });

--- a/packages/core/src/lib/user.test.ts
+++ b/packages/core/src/lib/user.test.ts
@@ -80,6 +80,7 @@ describe('findUserSignInMethodsById()', () => {
   it('generate and test user with email passwordless sign-in method', async () => {
     findUserById.mockResolvedValue({
       primaryEmail: 'b@a.com',
+      identities: {},
     });
     const { usernameAndPassword, emailPasswordless, phonePasswordless, social } =
       await findUserSignInMethodsById('');

--- a/packages/core/src/lib/user.ts
+++ b/packages/core/src/lib/user.ts
@@ -67,7 +67,8 @@ export const findUserSignInMethodsById = async (
   );
   const emailPasswordless = Boolean(primaryEmail);
   const phonePasswordless = Boolean(primaryPhone);
-  const social = Boolean(identities) && Object.keys(identities).length > 0;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const social = identities && Object.keys(identities).length > 0;
 
   return { usernameAndPassword, emailPasswordless, phonePasswordless, social };
 };

--- a/packages/core/src/lib/user.ts
+++ b/packages/core/src/lib/user.ts
@@ -67,7 +67,7 @@ export const findUserSignInMethodsById = async (
   );
   const emailPasswordless = Boolean(primaryEmail);
   const phonePasswordless = Boolean(primaryPhone);
-  const social = Boolean(identities);
+  const social = Boolean(identities) && Object.keys(identities).length > 0;
 
   return { usernameAndPassword, emailPasswordless, phonePasswordless, social };
 };

--- a/packages/core/src/lib/user.ts
+++ b/packages/core/src/lib/user.ts
@@ -2,7 +2,7 @@ import { UsersPasswordEncryptionMethod, User } from '@logto/schemas';
 import { nanoid } from 'nanoid';
 import pRetry from 'p-retry';
 
-import { findUserByUsername, hasUserWithId } from '@/queries/user';
+import { findUserById, findUserByUsername, hasUserWithId } from '@/queries/user';
 import assertThat from '@/utils/assert-that';
 import { buildIdGenerator } from '@/utils/id';
 import { encryptPassword } from '@/utils/password';
@@ -41,6 +41,35 @@ export const encryptUserPassword = (
   );
 
   return { passwordEncrypted, passwordEncryptionMethod, passwordEncryptionSalt };
+};
+
+export const findUserSignInMethodsById = async (
+  id: string
+): Promise<{
+  usernameAndPassword: boolean;
+  emailPasswordless: boolean;
+  phonePasswordless: boolean;
+  social: boolean;
+}> => {
+  const user = await findUserById(id);
+  const {
+    username,
+    passwordEncrypted,
+    passwordEncryptionMethod,
+    passwordEncryptionSalt,
+    primaryEmail,
+    primaryPhone,
+    identities,
+  } = user;
+
+  const usernameAndPassword = Boolean(
+    username && passwordEncrypted && passwordEncryptionMethod && passwordEncryptionSalt
+  );
+  const emailPasswordless = Boolean(primaryEmail);
+  const phonePasswordless = Boolean(primaryPhone);
+  const social = Boolean(identities);
+
+  return { usernameAndPassword, emailPasswordless, phonePasswordless, social };
 };
 
 export const findUserByUsernameAndPassword = async (

--- a/packages/core/src/routes/session.ts
+++ b/packages/core/src/routes/session.ts
@@ -16,7 +16,12 @@ import {
   getUserInfoByAuthCode,
   getUserInfoFromInteractionResult,
 } from '@/lib/social';
-import { encryptUserPassword, generateUserId, findUserByUsernameAndPassword } from '@/lib/user';
+import {
+  generateUserId,
+  encryptUserPassword,
+  findUserSignInMethodsById,
+  findUserByUsernameAndPassword,
+} from '@/lib/user';
 import koaGuard from '@/middleware/koa-guard';
 import {
   hasUserWithEmail,
@@ -470,6 +475,29 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
       });
 
       await assignInteractionResults(ctx, provider, { login: { accountId: id } });
+
+      return next();
+    }
+  );
+
+  router.post(
+    '/session/forgot-password/phone/send-passcode',
+    koaGuard({ body: object({ phone: string().regex(phoneRegEx) }) }),
+    async (ctx, next) => {
+      const { jti } = await provider.interactionDetails(ctx.req, ctx.res);
+      const { phone } = ctx.guard.body;
+      ctx.userLog.phone = phone;
+      ctx.userLog.type = UserLogType.ForgotPasswordPhone;
+
+      assertThat(await hasUserWithPhone(phone), 'user.phone_not_exists');
+      const { id } = await findUserByPhone(phone);
+      ctx.userLog.userId = id;
+      const { usernameAndPassword } = await findUserSignInMethodsById(id);
+      assertThat(usernameAndPassword, 'user.username_password_signin_not_exists');
+
+      const passcode = await createPasscode(jti, PasscodeType.ForgotPassword, { phone });
+      await sendPasscode(passcode);
+      ctx.status = 204;
 
       return next();
     }

--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -95,6 +95,8 @@ const errors = {
     phone_not_exists: 'The phone number has not been registered yet.',
     identity_not_exists: 'The social account has not been registered yet.',
     identity_exists: 'The social account has been registered.',
+    username_password_signin_not_exists:
+      'Signing in with username and password has not been enabled for this user.',
   },
   password: {
     unsupported_encryption_method: 'The encryption method {{name}} is not supported.',

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -96,6 +96,7 @@ const errors = {
     phone_not_exists: '手机号码尚未注册。',
     identity_not_exists: '该社交账号尚未注册。',
     identity_exists: '该社交账号已被注册。',
+    username_password_signin_not_exists: '该账号暂未开通账号密码登录方式。',
   },
   password: {
     unsupported_encryption_method: '不支持的加密方法 {{name}}。',

--- a/packages/schemas/src/db-entries/custom-types.ts
+++ b/packages/schemas/src/db-entries/custom-types.ts
@@ -19,6 +19,8 @@ export enum UserLogType {
   RegisterEmail = 'RegisterEmail',
   RegisterPhone = 'RegisterPhone',
   RegisterSocial = 'RegisterSocial',
+  ForgotPasswordEmail = 'ForgotPasswordEmail',
+  ForgotPasswordPhone = 'ForgotPasswordPhone',
   ExchangeAccessToken = 'ExchangeAccessToken',
 }
 export enum UserLogResult {

--- a/packages/schemas/tables/user_logs.sql
+++ b/packages/schemas/tables/user_logs.sql
@@ -1,4 +1,4 @@
-create type user_log_type as enum ('SignInUsernameAndPassword', 'SignInEmail', 'SignInPhone', 'SignInSocial', 'RegisterUsernameAndPassword', 'RegisterEmail', 'RegisterPhone', 'RegisterSocial', 'ExchangeAccessToken');
+create type user_log_type as enum ('SignInUsernameAndPassword', 'SignInEmail', 'SignInPhone', 'SignInSocial', 'RegisterUsernameAndPassword', 'RegisterEmail', 'RegisterPhone', 'RegisterSocial', 'ForgotPasswordEmail', 'ForgotPasswordPhone', 'ExchangeAccessToken');
 
 create type user_log_result as enum ('Success', 'Failed');
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add route POST /session/forgot-password/phone/send-passcode.
Add method to lib/user.ts which detects sign-in methods an account can use (as well as corresponding UTs).
Add 'ForgotPasswordEmail' and 'ForgotPasswordPhone' to user log type and re-generate dependent files.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-1814

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT.
