### PR TITLE
refactor(core): remove unnecessary check in github and aliyun-sms connector

### DIFF
--- a/packages/core/src/connectors/aliyun-sms/index.ts
+++ b/packages/core/src/connectors/aliyun-sms/index.ts
@@ -68,10 +68,6 @@ const configGuard = z.object({
 });
 
 export const validateConfig: ValidateConfig = async (config: unknown) => {
-  if (!config) {
-    throw new ConnectorError(ConnectorErrorCodes.InvalidConfig, 'Missing config');
-  }
-
   const result = configGuard.safeParse(config);
 
   if (!result.success) {

--- a/packages/core/src/connectors/github/index.test.ts
+++ b/packages/core/src/connectors/github/index.test.ts
@@ -51,10 +51,7 @@ describe('validateConfig', () => {
     ).resolves.not.toThrow();
   });
   it('should throw on empty config', async () => {
-    // FIXME: @sijie
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
-    await expect(validateConfig()).rejects.toThrowError();
+    await expect(validateConfig({})).rejects.toThrowError();
   });
   it('should throw when missing clientSecret', async () => {
     await expect(validateConfig({ clientId: 'clientId' })).rejects.toThrowError();

--- a/packages/core/src/connectors/github/index.ts
+++ b/packages/core/src/connectors/github/index.ts
@@ -37,10 +37,6 @@ const githubConfigGuard = z.object({
 type GithubConfig = z.infer<typeof githubConfigGuard>;
 
 export const validateConfig: ValidateConfig = async (config: unknown) => {
-  if (!config) {
-    throw new ConnectorError(ConnectorErrorCodes.InvalidConfig, 'Missing config');
-  }
-
   const result = githubConfigGuard.safeParse(config);
 
   if (!result.success) {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
refactor(core): remove unnecessary check in github and aliyun-sms connector

- Since githubConfigGuard.safeParse can also assert it non-empty.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-1619
See #321
- [comment](https://github.com/logto-io/logto/pull/321#discussion_r820367231) : Since githubConfigGuard.safeParse can also assert it non-empty, remove unnecessary empty-check.
- [comment](https://github.com/logto-io/logto/pull/321#discussion_r820330689) : Since we have the input param type guard, remove the test case of no parameter.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Pass all existing tests.
