### PR TITLE
feat(core): add email forgot password flow (send/verify passcode)

### DIFF
--- a/packages/core/src/routes/session.test.ts
+++ b/packages/core/src/routes/session.test.ts
@@ -780,6 +780,46 @@ describe('sessionRoutes', () => {
     });
   });
 
+  describe('POST /session/forgot-password/phone/verify-passcode-and-reset-password', () => {
+    beforeAll(() => {
+      interactionDetails.mockResolvedValueOnce({
+        jti: 'jti',
+      });
+    });
+
+    it('throw if no user can be found with phone', async () => {
+      const response = await sessionRequest
+        .post('/session/forgot-password/phone/verify-passcode-and-reset-password')
+        .send({ phone: '13000000001', code: '1234', password: '123456' });
+      expect(response).toHaveProperty('statusCode', 422);
+    });
+
+    it('fail to verify passcode', async () => {
+      const response = await sessionRequest
+        .post('/session/forgot-password/phone/verify-passcode-and-reset-password')
+        .send({ phone: '13000000000', code: '1231', password: '123456' });
+      expect(response).toHaveProperty('statusCode', 400);
+    });
+
+    it('verify passcode, reset password and assign result', async () => {
+      const response = await sessionRequest
+        .post('/session/forgot-password/phone/verify-passcode-and-reset-password')
+        .send({ phone: '13000000000', code: '1234', password: '123456' });
+      expect(response).toHaveProperty('statusCode', 200);
+      expect(updateUserById).toHaveBeenCalledWith('id', {
+        passwordEncryptionSalt: 'user1',
+        passwordEncrypted: 'id_123456_user1',
+        passwordEncryptionMethod: 'SaltAndPepper',
+      });
+      expect(interactionResult).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ login: { accountId: 'id' } }),
+        expect.anything()
+      );
+    });
+  });
+
   describe('POST /session/forgot-password/email/send-passcode', () => {
     beforeAll(() => {
       interactionDetails.mockResolvedValueOnce({

--- a/packages/core/src/routes/session.test.ts
+++ b/packages/core/src/routes/session.test.ts
@@ -826,7 +826,7 @@ describe('sessionRoutes', () => {
     });
   });
 
-  describe('POST /session/forgot-password/email/verify-passcode', () => {
+  describe('POST /session/forgot-password/email/verify-passcode-and-reset-password', () => {
     beforeAll(() => {
       interactionDetails.mockResolvedValueOnce({
         jti: 'jti',
@@ -835,22 +835,22 @@ describe('sessionRoutes', () => {
 
     it('throw if no user can be found with email', async () => {
       const response = await sessionRequest
-        .post('/session/forgot-password/email/verify-passcode')
-        .send({ email: 'b@a.com', code: '1234' });
+        .post('/session/forgot-password/email/verify-passcode-and-reset-password')
+        .send({ email: 'b@a.com', code: '1234', password: '123456' });
       expect(response).toHaveProperty('statusCode', 422);
     });
 
     it('fail to verify passcode', async () => {
       const response = await sessionRequest
-        .post('/session/forgot-password/email/verify-passcode')
-        .send({ email: 'a@a.com', code: '1231' });
+        .post('/session/forgot-password/email/verify-passcode-and-reset-password')
+        .send({ email: 'a@a.com', code: '1231', password: '123456' });
       expect(response).toHaveProperty('statusCode', 400);
     });
 
     it('verify passcode, reset password and assign result', async () => {
       const response = await sessionRequest
-        .post('/session/forgot-password/email/verify-passcode')
-        .send({ email: 'a@a.com', code: '1234' });
+        .post('/session/forgot-password/email/verify-passcode-and-reset-password')
+        .send({ email: 'a@a.com', code: '1234', password: '123456' });
       expect(response).toHaveProperty('statusCode', 200);
       expect(updateUserById).toHaveBeenCalledWith('id', {
         passwordEncryptionSalt: 'user1',

--- a/packages/core/src/routes/session.test.ts
+++ b/packages/core/src/routes/session.test.ts
@@ -781,10 +781,6 @@ describe('sessionRoutes', () => {
   });
 
   describe('POST /session/forgot-password/email/send-passcode', () => {
-    afterEach(() => {
-      findUserSignInMethodsByIdPlaceHolder.mockClear();
-    });
-
     beforeAll(() => {
       interactionDetails.mockResolvedValueOnce({
         jti: 'jti',
@@ -798,26 +794,7 @@ describe('sessionRoutes', () => {
       expect(response).toHaveProperty('statusCode', 422);
     });
 
-    it('throw if found user can not sign-in with username and password', async () => {
-      findUserSignInMethodsByIdPlaceHolder.mockResolvedValue({
-        usernameAndPassword: false,
-        emailPasswordless: false,
-        phonePasswordless: false,
-        social: false,
-      });
-      const response = await sessionRequest
-        .post('/session/forgot-password/email/send-passcode')
-        .send({ email: 'a@a.com' });
-      expect(response).toHaveProperty('statusCode', 400);
-    });
-
     it('create and send passcode', async () => {
-      findUserSignInMethodsByIdPlaceHolder.mockResolvedValue({
-        usernameAndPassword: true,
-        emailPasswordless: false,
-        phonePasswordless: false,
-        social: false,
-      });
       const response = await sessionRequest
         .post('/session/forgot-password/email/send-passcode')
         .send({ email: 'a@a.com' });

--- a/packages/core/src/routes/session.test.ts
+++ b/packages/core/src/routes/session.test.ts
@@ -740,7 +740,7 @@ describe('sessionRoutes', () => {
       const response = await sessionRequest
         .post('/session/forgot-password/phone/send-passcode')
         .send({ phone: '13000000001' });
-      expect(response).toHaveProperty('statusCode', 400);
+      expect(response).toHaveProperty('statusCode', 422);
     });
 
     it('create and send passcode', async () => {

--- a/packages/core/src/routes/session.ts
+++ b/packages/core/src/routes/session.ts
@@ -530,11 +530,17 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
   );
 
   router.post(
-    '/session/forgot-password/email/verify-passcode',
-    koaGuard({ body: object({ email: string().regex(emailRegEx), code: string() }) }),
+    '/session/forgot-password/email/verify-passcode-and-reset-password',
+    koaGuard({
+      body: object({
+        email: string().regex(emailRegEx),
+        code: string(),
+        password: string().regex(passwordRegEx),
+      }),
+    }),
     async (ctx, next) => {
       const { jti } = await provider.interactionDetails(ctx.req, ctx.res);
-      const { email, code } = ctx.guard.body;
+      const { email, code, password } = ctx.guard.body;
       ctx.userLog.email = email;
       ctx.userLog.type = UserLogType.ForgotPasswordEmail;
 

--- a/packages/core/src/routes/session.ts
+++ b/packages/core/src/routes/session.ts
@@ -484,7 +484,10 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
       ctx.userLog.phone = phone;
       ctx.userLog.type = UserLogType.ForgotPasswordPhone;
 
-      assertThat(await hasUserWithPhone(phone), 'user.phone_not_exists');
+      assertThat(
+        await hasUserWithPhone(phone),
+        new RequestError({ code: 'user.phone_not_exists', status: 422 })
+      );
       const { id } = await findUserByPhone(phone);
       ctx.userLog.userId = id;
 

--- a/packages/core/src/routes/session.ts
+++ b/packages/core/src/routes/session.ts
@@ -504,6 +504,43 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
   );
 
   router.post(
+    '/session/forgot-password/phone/verify-passcode-and-reset-password',
+    koaGuard({
+      body: object({
+        phone: string().regex(phoneRegEx),
+        code: string(),
+        password: string().regex(passwordRegEx),
+      }),
+    }),
+    async (ctx, next) => {
+      const { jti } = await provider.interactionDetails(ctx.req, ctx.res);
+      const { phone, code, password } = ctx.guard.body;
+      ctx.userLog.phone = phone;
+      ctx.userLog.type = UserLogType.ForgotPasswordPhone;
+
+      assertThat(
+        await hasUserWithPhone(phone),
+        new RequestError({ code: 'user.phone_not_exists', status: 422 })
+      );
+
+      await verifyPasscode(jti, PasscodeType.ForgotPassword, code, { phone });
+      const { id } = await findUserByPhone(phone);
+      ctx.userLog.userId = id;
+
+      const { passwordEncryptionSalt, passwordEncrypted, passwordEncryptionMethod } =
+        encryptUserPassword(id, password);
+      await updateUserById(id, {
+        passwordEncryptionSalt,
+        passwordEncrypted,
+        passwordEncryptionMethod,
+      });
+      await assignInteractionResults(ctx, provider, { login: { accountId: id } });
+
+      return next();
+    }
+  );
+
+  router.post(
     '/session/forgot-password/email/send-passcode',
     koaGuard({ body: object({ email: string().regex(emailRegEx) }) }),
     async (ctx, next) => {

--- a/packages/core/src/routes/session.ts
+++ b/packages/core/src/routes/session.ts
@@ -518,8 +518,6 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
       );
       const { id } = await findUserByEmail(email);
       ctx.userLog.userId = id;
-      const { usernameAndPassword } = await findUserSignInMethodsById(id);
-      assertThat(usernameAndPassword, 'user.username_password_signin_not_exists');
 
       const passcode = await createPasscode(jti, PasscodeType.ForgotPassword, { email });
       await sendPasscode(passcode);

--- a/packages/core/src/routes/session.ts
+++ b/packages/core/src/routes/session.ts
@@ -16,12 +16,7 @@ import {
   getUserInfoByAuthCode,
   getUserInfoFromInteractionResult,
 } from '@/lib/social';
-import {
-  generateUserId,
-  encryptUserPassword,
-  findUserSignInMethodsById,
-  findUserByUsernameAndPassword,
-} from '@/lib/user';
+import { generateUserId, encryptUserPassword, findUserByUsernameAndPassword } from '@/lib/user';
 import koaGuard from '@/middleware/koa-guard';
 import {
   hasUserWithEmail,
@@ -492,8 +487,6 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
       assertThat(await hasUserWithPhone(phone), 'user.phone_not_exists');
       const { id } = await findUserByPhone(phone);
       ctx.userLog.userId = id;
-      const { usernameAndPassword } = await findUserSignInMethodsById(id);
-      assertThat(usernameAndPassword, 'user.username_password_signin_not_exists');
 
       const passcode = await createPasscode(jti, PasscodeType.ForgotPassword, { phone });
       await sendPasscode(passcode);


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add two routes for email-based forgot password flow:
POST /session/forgot-password/email/send-passcode
POST /session/forgot-password/email/verify-passcode-and-reset-password

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-1816
LOG-1817

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT.
<img width="785" alt="image" src="https://user-images.githubusercontent.com/15182327/157191278-876ae63e-9806-4124-96b8-d0147f2c00f5.png">
<img width="770" alt="image" src="https://user-images.githubusercontent.com/15182327/157191324-8ce85aea-b9f5-4301-bc44-041886240460.png">
