### PR TITLE
feat(core): only allow one enabled sms/email

### DIFF
--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -163,6 +163,8 @@ const errors = {
     template_not_found: 'Unable to find correct template in connector config.',
     access_token_invalid: "Connector's access token is invalid.",
     oauth_code_invalid: 'Unable to get access token, please check authorization code.',
+    more_than_one_sms: 'The number of SMS connectors is larger then 1.',
+    more_than_one_email: 'The number of Email connectors is larger then 1.',
   },
   passcode: {
     phone_email_empty: 'Both phone and email are empty.',

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -163,6 +163,8 @@ const errors = {
     template_not_found: '无法从连接器配置中找到对应的模板。',
     access_token_invalid: '当前连接器的 access_token 无效。',
     oauth_code_invalid: '无法获取 access_token，请检查授权 code 是否有效。',
+    more_than_one_sms: '同时存在超过 1 个短信连接器。',
+    more_than_one_email: '同时存在超过 1 个邮件连接器。',
   },
   passcode: {
     phone_email_empty: '手机号与邮箱地址均为空。',


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Only allow one enabled SMS/Email connector:

1. `PATCH /connectors/:connectorId/enabled`, disable other connectors first.
2. `GET /connectors`, throw error if database data is against the rule.

@logto-io/eng 