### PR TITLE
refactor(core): connectKeyValueWithEqualSign

### DIFF
--- a/packages/core/src/database/find-many.ts
+++ b/packages/core/src/database/find-many.ts
@@ -1,5 +1,4 @@
 import { SchemaLike, GeneratedSchema } from '@logto/schemas';
-import { notFalsy, Truthy } from '@silverhand/essentials';
 import { DatabasePoolType, sql } from 'slonik';
 
 import { isKeyOf } from '@/utils/schema';
@@ -15,11 +14,8 @@ export const buildFindMany = <Schema extends SchemaLike, ReturnType extends Sche
   const isKeyOfSchema = isKeyOf(schema);
   const connectKeyValueWithEqualSign = (data: Partial<Schema>) =>
     Object.entries(data)
-      .map(
-        ([key, value]) =>
-          isKeyOfSchema(key) && sql`${fields[key]}=${convertToPrimitiveOrSql(key, value)}`
-      )
-      .filter((value): value is Truthy<typeof value> => notFalsy(value));
+      .filter((entry): entry is [keyof Schema & string, any] => isKeyOfSchema(entry[0]))
+      .map(([key, value]) => sql`${fields[key]}=${convertToPrimitiveOrSql(key, value)}`);
 
   return async ({ where, limit, offset }: FindManyData<Schema> = {}) => {
     return pool.any<ReturnType>(sql`


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
refactor(core): connectKeyValueWithEqualSign

- Filter first, and then map.

---

Why does `entry is [keyof Schema & string, any]`?

<img width="992" alt="image" src="https://user-images.githubusercontent.com/10594507/157410234-2ba90e4b-423e-4fab-9231-861c4524987d.png">

The entry type is `[string, any]` before `filter`.
After `filter` its type is restricted to `[keyof Schema & string, any]`.

<!--

<img width="999" alt="image" src="https://user-images.githubusercontent.com/10594507/157386291-bab777f3-fb37-4779-8bcb-68a58b1fff3b.png">

-->

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-1855

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Pass all existing tests.

---
@logto-io/eng 