### PR TITLE
fix(console): page layout issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ cache
 *.env
 .idea/
 *.pem
+.history

--- a/packages/console/src/App.module.scss
+++ b/packages/console/src/App.module.scss
@@ -5,4 +5,5 @@
   display: flex;
   padding-right: _.unit(5);
   margin-bottom: _.unit(6);
+  overflow: hidden;
 }

--- a/packages/console/src/components/Card/index.module.scss
+++ b/packages/console/src/components/Card/index.module.scss
@@ -3,6 +3,5 @@
 .card {
   background: var(--color-card-background);
   border-radius: _.unit(4);
-  padding: _.unit(6);
   height: 100%;
 }

--- a/packages/console/src/components/TabNav/index.tsx
+++ b/packages/console/src/components/TabNav/index.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import React from 'react';
 
 import * as styles from './index.module.scss';
@@ -5,9 +6,12 @@ import * as styles from './index.module.scss';
 export { default as TabNavLink } from './TabNavLink';
 
 type Props = {
+  className?: string;
   children: React.ReactNode;
 };
 
-const TabNav = ({ children }: Props) => <nav className={styles.nav}>{children}</nav>;
+const TabNav = ({ className, children }: Props) => (
+  <nav className={classNames(styles.nav, className)}>{children}</nav>
+);
 
 export default TabNav;

--- a/packages/console/src/components/Topbar/index.module.scss
+++ b/packages/console/src/components/Topbar/index.module.scss
@@ -1,9 +1,9 @@
 @use '@/scss/underscore' as _;
 
 .topbar {
-  height: 80px;
+  flex: 0 0 66px;
   width: 100%;
-  padding: _.unit(3) _.unit(8);
+  padding: _.unit(4) _.unit(6);
   display: flex;
   align-items: center;
 

--- a/packages/console/src/pages/ApiResources/index.module.scss
+++ b/packages/console/src/pages/ApiResources/index.module.scss
@@ -3,17 +3,21 @@
 .headline {
   display: flex;
   justify-content: space-between;
+  padding: _.unit(6) _.unit(6) 0;
 }
 
 .table {
-  margin-top: _.unit(6);
-  width: 100%;
+  margin: _.unit(4) _.unit(6) _.unit(6);
 
-  tbody tr.clickable {
-    cursor: pointer;
+  tbody {
+    max-height: calc(100vh - _.unit(64));
 
-    &:hover {
-      background: var(--color-table-row-selected);
+    tr.clickable {
+      cursor: pointer;
+
+      &:hover {
+        background: var(--color-table-row-selected);
+      }
     }
   }
 }

--- a/packages/console/src/pages/ApiResources/index.tsx
+++ b/packages/console/src/pages/ApiResources/index.tsx
@@ -56,14 +56,14 @@ const ApiResources = () => {
       <table className={styles.table}>
         <thead>
           <tr>
-            <td className={styles.apiResourceName}>{t('api_resources.api_name')}</td>
-            <td>{t('api_resources.api_identifier')}</td>
+            <th className={styles.apiResourceName}>{t('api_resources.api_name')}</th>
+            <th>{t('api_resources.api_identifier')}</th>
           </tr>
         </thead>
         <tbody>
           {error && (
             <tr>
-              <td colSpan={2}>error occured: {error.metadata.code}</td>
+              <td colSpan={2}>error occurred: {error.metadata.code}</td>
             </tr>
           )}
           {isLoading && (
@@ -73,7 +73,7 @@ const ApiResources = () => {
           )}
           {data?.map(({ id, name, indicator }) => (
             <tr key={id} className={styles.clickable}>
-              <td>
+              <td className={styles.apiResourceName}>
                 <ItemPreview title={name} icon={<ImagePlaceholder />} to={`/api-resources/${id}`} />
               </td>
               <td>

--- a/packages/console/src/pages/Applications/index.module.scss
+++ b/packages/console/src/pages/Applications/index.module.scss
@@ -3,17 +3,21 @@
 .headline {
   display: flex;
   justify-content: space-between;
+  padding: _.unit(6) _.unit(6) 0;
 }
 
 .table {
-  margin-top: _.unit(6);
-  width: 100%;
+  margin: _.unit(4) _.unit(6) _.unit(6);
 
-  tbody tr.clickable {
-    cursor: pointer;
+  tbody {
+    max-height: calc(100vh - _.unit(64));
 
-    &:hover {
-      background: var(--color-table-row-selected);
+    tr.clickable {
+      cursor: pointer;
+
+      &:hover {
+        background: var(--color-table-row-selected);
+      }
     }
   }
 }

--- a/packages/console/src/pages/Applications/index.tsx
+++ b/packages/console/src/pages/Applications/index.tsx
@@ -65,8 +65,8 @@ const Applications = () => {
       <table className={styles.table}>
         <thead>
           <tr>
-            <td className={styles.applicationName}>{t('applications.application_name')}</td>
-            <td>{t('applications.client_id')}</td>
+            <th className={styles.applicationName}>{t('applications.application_name')}</th>
+            <th>{t('applications.client_id')}</th>
           </tr>
         </thead>
         <tbody>
@@ -88,7 +88,7 @@ const Applications = () => {
                 navigate(`/applications/${id}`);
               }}
             >
-              <td>
+              <td className={styles.applicationName}>
                 <ItemPreview
                   title={name}
                   subtitle={t(`${applicationTypeI18nKey[type]}.title`)}

--- a/packages/console/src/pages/Connectors/components/ConnectorRow.tsx
+++ b/packages/console/src/pages/Connectors/components/ConnectorRow.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import Button from '@/components/Button';
 import Status from '@/components/Status';
 
+import * as styles from '../index.module.scss';
 import ConnectorName from './ConnectorName';
 
 type Props = {
@@ -29,7 +30,7 @@ const ConnectorRow = ({ type, connector }: Props) => {
 
   return (
     <tr>
-      <td>
+      <td className={styles.connectorName}>
         <ConnectorName connector={connector} titlePlaceholder={typeLabel} />
       </td>
       <td>{typeLabel}</td>

--- a/packages/console/src/pages/Connectors/index.module.scss
+++ b/packages/console/src/pages/Connectors/index.module.scss
@@ -3,18 +3,25 @@
 .headline {
   display: flex;
   justify-content: space-between;
+  padding: _.unit(6) _.unit(6) 0;
+}
+
+.tabs {
+  margin: _.unit(4) _.unit(6) 0;
 }
 
 .table {
-  margin-top: _.unit(6);
-  width: 100%;
-  font-size: var(--font-small-text);
+  margin: _.unit(4) _.unit(6) _.unit(6);
 
-  tbody tr.clickable {
-    cursor: pointer;
+  tbody {
+    max-height: calc(100vh - _.unit(74));
 
-    &:hover {
-      background: var(--color-table-row-selected);
+    tr.clickable {
+      cursor: pointer;
+
+      &:hover {
+        background: var(--color-table-row-selected);
+      }
     }
   }
 }

--- a/packages/console/src/pages/Connectors/index.tsx
+++ b/packages/console/src/pages/Connectors/index.tsx
@@ -45,16 +45,16 @@ const Connectors = () => {
         <CardTitle title="connectors.title" subtitle="connectors.subtitle" />
         {isSocial && <Button disabled title="admin_console.connectors.create" type="primary" />}
       </div>
-      <TabNav>
+      <TabNav className={styles.tabs}>
         <TabNavLink href="/connectors">{t('connectors.tab_email_sms')}</TabNavLink>
         <TabNavLink href="/connectors/social">{t('connectors.tab_social')}</TabNavLink>
       </TabNav>
       <table className={styles.table}>
         <thead>
           <tr>
-            <td className={styles.connectorName}>{t('connectors.connector_name')}</td>
-            <td>{t('connectors.connector_type')}</td>
-            <td>{t('connectors.connector_status')}</td>
+            <th className={styles.connectorName}>{t('connectors.connector_name')}</th>
+            <th>{t('connectors.connector_type')}</th>
+            <th>{t('connectors.connector_status')}</th>
           </tr>
         </thead>
         <tbody>

--- a/packages/console/src/scss/normalized.scss
+++ b/packages/console/src/scss/normalized.scss
@@ -24,11 +24,21 @@ table {
   border-spacing: 0;
   overflow: hidden;
 
+  thead,
+  tbody,
+  tr {
+    display: table;
+    width: 100%;
+    table-layout: fixed;
+  }
+
   thead {
-    td {
+    th {
       font: var(--font-subhead-2);
       color: var(--color-component-caption);
       padding: _.unit(3) _.unit(4);
+      border-bottom: 1px solid var(--color-neutral-90);
+      text-align: left;
 
       &:first-child,
       &:last-child {
@@ -38,8 +48,13 @@ table {
   }
 
   tbody {
+    display: block;
+    overflow: auto;
+    table-layout: fixed;
+    max-height: calc(100% - _.unit(40));
+
     td {
-      border-top: 1px solid var(--color-neutral-90);
+      border-bottom: 1px solid var(--color-neutral-90);
       padding: _.unit(5) _.unit(4);
 
       &:first-child,
@@ -47,5 +62,9 @@ table {
         padding: _.unit(5) _.unit(8);
       }
     }
+  }
+
+  tr:last-child td {
+    border-bottom: none;
   }
 }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fix page layout issues by adding scroll wrapper to display tables and enforcing vertical scrollbar around table content.
This layout problem is seen on multiple pages:
* Applications
* API Resources
* Connectors

Before:

<img width="1584" alt="image" src="https://user-images.githubusercontent.com/12833674/157455680-716a9567-46c4-4e71-8913-6f8632635e24.png">

After:

<img width="1496" alt="image" src="https://user-images.githubusercontent.com/12833674/157591612-eebc406c-85d6-4eed-91e7-bc1e2e297ce5.png">

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Layout is not broken on Applications page, when there are more than 20 rows on the table.
- [x] A vertical scrollbar is seen around the table, when table content overflows the available vertical space.
- [x] Card header sticks to the top when scrolling the vertical scrollbar.
- [x] The "Settings" menu option is always visible on the sidebar, regardless of the page content.
