### PR TITLE
fix(console): correct form field registry

### DIFF
--- a/packages/console/src/pages/Applications/components/CreateForm/index.tsx
+++ b/packages/console/src/pages/Applications/components/CreateForm/index.tsx
@@ -81,9 +81,9 @@ const CreateForm = ({ onClose }: Props) => {
           title="admin_console.applications.application_description"
           className={styles.textField}
         >
-          <TextInput />
+          <TextInput {...register('description')} />
         </FormField>
-        <div className={styles.submit} {...register('description')}>
+        <div className={styles.submit}>
           <Button
             htmlType="submit"
             title="admin_console.applications.create"


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fixed a mismatched form field registry. Field `description` should be registered on the description field, not the submit button.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Created an application with description and the description was sent to backend and persisted in DB successfully