### PR TITLE
feat(console): code editor component

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@logto/phrases": "^0.1.0",
     "@logto/schemas": "^0.1.0",
+    "@monaco-editor/react": "^4.3.1",
     "@silverhand/essentials": "^1.1.6",
     "classnames": "^2.3.1",
     "csstype": "^3.0.11",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -26,6 +26,7 @@
     "i18next-browser-languagedetector": "^6.1.3",
     "ky": "^0.30.0",
     "lodash.kebabcase": "^4.1.1",
+    "monaco-editor": "^0.32.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-hook-form": "^7.27.1",

--- a/packages/console/src/components/CodeEditor/index.module.scss
+++ b/packages/console/src/components/CodeEditor/index.module.scss
@@ -2,8 +2,4 @@
 
 .editor {
   margin: _.unit(1) 0;
-
-  textarea {
-    width: 100%;
-  }
 }

--- a/packages/console/src/components/CodeEditor/index.tsx
+++ b/packages/console/src/components/CodeEditor/index.tsx
@@ -1,21 +1,50 @@
-import React, { ChangeEventHandler } from 'react';
+import MonacoEditor from '@monaco-editor/react';
+import React from 'react';
 
 import * as styles from './index.module.scss';
 
-// Will be implemented in LOG-1708, defined 2 basic props for now.
 type Props = {
+  language: string;
+  isDarkMode?: boolean;
+  height?: string;
+  isReadonly?: boolean;
   value?: string;
   onChange?: (value: string) => void;
 };
 
-const CodeEditor = ({ value, onChange }: Props) => {
-  const handleChange: ChangeEventHandler<HTMLTextAreaElement> = (event) => {
-    onChange?.(event.target.value);
+const CodeEditor = ({
+  value,
+  onChange,
+  language,
+  height = '300px',
+  isReadonly = false,
+  isDarkMode,
+}: Props) => {
+  const handleChange = (changedValue: string | undefined) => {
+    onChange?.(changedValue ?? '');
+  };
+
+  // See https://microsoft.github.io/monaco-editor/api/enums/monaco.editor.EditorOption.html
+  const options = {
+    readOnly: isReadonly,
+    scrollBeyondLastLine: false,
+    codeLens: false,
+    minimap: {
+      enabled: false,
+    },
+    folding: false,
   };
 
   return (
     <div className={styles.editor}>
-      <textarea rows={10} value={value} onChange={handleChange} />
+      <MonacoEditor
+        language={language}
+        height={height}
+        theme={isDarkMode ? 'vs-dark' : 'vs-light'}
+        value={value}
+        options={options}
+        onChange={handleChange}
+      />
     </div>
   );
 };

--- a/packages/console/src/components/CodeEditor/index.tsx
+++ b/packages/console/src/components/CodeEditor/index.tsx
@@ -1,4 +1,5 @@
 import MonacoEditor from '@monaco-editor/react';
+import * as monaco from 'monaco-editor';
 import React from 'react';
 
 import * as styles from './index.module.scss';
@@ -20,12 +21,12 @@ const CodeEditor = ({
   isReadonly = false,
   isDarkMode,
 }: Props) => {
-  const handleChange = (changedValue: string | undefined) => {
-    onChange?.(changedValue ?? '');
+  const handleChange = (changedValue = '') => {
+    onChange?.(changedValue);
   };
 
   // See https://microsoft.github.io/monaco-editor/api/enums/monaco.editor.EditorOption.html
-  const options = {
+  const options: monaco.editor.IStandaloneEditorConstructionOptions = {
     readOnly: isReadonly,
     scrollBeyondLastLine: false,
     codeLens: false,

--- a/packages/console/src/components/Status/index.tsx
+++ b/packages/console/src/components/Status/index.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import React, { ReactNode } from 'react';
 
-import styles from './index.module.scss';
+import * as styles from './index.module.scss';
 
 type Props = {
   status: 'operational' | 'offline';

--- a/packages/console/src/pages/ConnectorDetails/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/index.tsx
@@ -133,6 +133,7 @@ const ConnectorDetails = () => {
           </TabNav>
           <div className={styles.space} />
           <CodeEditor
+            language="json"
             value={config}
             onChange={(value) => {
               setConfig(value);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,7 @@ importers:
       ky: ^0.30.0
       lint-staged: ^11.1.1
       lodash.kebabcase: ^4.1.1
+      monaco-editor: ^0.32.1
       parcel: ^2.3.2
       postcss: ^8.4.6
       postcss-modules: ^4.3.0
@@ -59,7 +60,7 @@ importers:
     dependencies:
       '@logto/phrases': link:../phrases
       '@logto/schemas': link:../schemas
-      '@monaco-editor/react': 4.3.1_react-dom@17.0.2+react@17.0.2
+      '@monaco-editor/react': 4.3.1_e62f1489d5efe674a41c3f8d6971effe
       '@silverhand/essentials': 1.1.6
       classnames: 2.3.1
       csstype: 3.0.11
@@ -67,6 +68,7 @@ importers:
       i18next-browser-languagedetector: 6.1.3
       ky: 0.30.0
       lodash.kebabcase: 4.1.1
+      monaco-editor: 0.32.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-hook-form: 7.27.1_react@17.0.2
@@ -2206,22 +2208,24 @@ packages:
       write-file-atomic: 3.0.3
     dev: true
 
-  /@monaco-editor/loader/1.2.0:
+  /@monaco-editor/loader/1.2.0_monaco-editor@0.32.1:
     resolution: {integrity: sha512-cJVCG/T/KxXgzYnjKqyAgsKDbH9mGLjcXxN6AmwumBwa2rVFkwvGcUj1RJtD0ko4XqLqJxwqsN/Z/KURB5f1OQ==}
     peerDependencies:
       monaco-editor: '>= 0.21.0 < 1'
     dependencies:
+      monaco-editor: 0.32.1
       state-local: 1.0.7
     dev: false
 
-  /@monaco-editor/react/4.3.1_react-dom@17.0.2+react@17.0.2:
+  /@monaco-editor/react/4.3.1_e62f1489d5efe674a41c3f8d6971effe:
     resolution: {integrity: sha512-f+0BK1PP/W5I50hHHmwf11+Ea92E5H1VZXs+wvKplWUWOfyMa1VVwqkJrXjRvbcqHL+XdIGYWhWNdi4McEvnZg==}
     peerDependencies:
       monaco-editor: '>= 0.25.0 < 1'
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@monaco-editor/loader': 1.2.0
+      '@monaco-editor/loader': 1.2.0_monaco-editor@0.32.1
+      monaco-editor: 0.32.1
       prop-types: 15.8.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -9490,6 +9494,10 @@ packages:
 
   /module-alias/2.2.2:
     resolution: {integrity: sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q==}
+    dev: false
+
+  /monaco-editor/0.32.1:
+    resolution: {integrity: sha512-LUt2wsUvQmEi2tfTOK+tjAPvt7eQ+K5C4rZPr6SeuyzjAuAHrIvlUloTcOiGjZW3fn3a/jFQCONrEJbNOaCqbA==}
     dev: false
 
   /ms/2.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,7 @@ importers:
       '@logto/schemas': ^0.1.0
       '@parcel/core': ^2.3.2
       '@parcel/transformer-sass': ^2.3.2
+      '@monaco-editor/react': ^4.3.1
       '@silverhand/eslint-config': ^0.9.4
       '@silverhand/eslint-config-react': ^0.9.5
       '@silverhand/essentials': ^1.1.6
@@ -58,6 +59,7 @@ importers:
     dependencies:
       '@logto/phrases': link:../phrases
       '@logto/schemas': link:../schemas
+      '@monaco-editor/react': 4.3.1_react-dom@17.0.2+react@17.0.2
       '@silverhand/essentials': 1.1.6
       classnames: 2.3.1
       csstype: 3.0.11
@@ -2203,6 +2205,27 @@ packages:
       npmlog: 4.1.2
       write-file-atomic: 3.0.3
     dev: true
+
+  /@monaco-editor/loader/1.2.0:
+    resolution: {integrity: sha512-cJVCG/T/KxXgzYnjKqyAgsKDbH9mGLjcXxN6AmwumBwa2rVFkwvGcUj1RJtD0ko4XqLqJxwqsN/Z/KURB5f1OQ==}
+    peerDependencies:
+      monaco-editor: '>= 0.21.0 < 1'
+    dependencies:
+      state-local: 1.0.7
+    dev: false
+
+  /@monaco-editor/react/4.3.1_react-dom@17.0.2+react@17.0.2:
+    resolution: {integrity: sha512-f+0BK1PP/W5I50hHHmwf11+Ea92E5H1VZXs+wvKplWUWOfyMa1VVwqkJrXjRvbcqHL+XdIGYWhWNdi4McEvnZg==}
+    peerDependencies:
+      monaco-editor: '>= 0.25.0 < 1'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@monaco-editor/loader': 1.2.0
+      prop-types: 15.8.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+    dev: false
 
   /@nodelib/fs.scandir/2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -12269,6 +12292,10 @@ packages:
     dependencies:
       escape-string-regexp: 2.0.0
     dev: true
+
+  /state-local/1.0.7:
+    resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
+    dev: false
 
   /statuses/1.5.0:
     resolution: {integrity: sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=}


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Use VSCode's editor "Monaco Editor" as our code editor and code preview with hightlight.

Monaco editor is loaded on demand, won't increse the bundle size:

before:
<img width="505" alt="截屏2022-03-11 下午3 20 29" src="https://user-images.githubusercontent.com/5717882/157821161-69b643a3-8233-43fd-ab0b-e703f0a16c6f.png">

after:
<img width="512" alt="截屏2022-03-11 下午3 20 11" src="https://user-images.githubusercontent.com/5717882/157821201-38247cf1-38c1-43d7-8ed4-7a865ba7ac90.png">

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-1708

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

<img width="997" alt="截屏2022-03-11 下午3 15 17" src="https://user-images.githubusercontent.com/5717882/157821232-d0d7693d-4294-4499-8e17-84e8ecb90fe5.png">

dark mode:
<img width="941" alt="截屏2022-03-11 下午3 15 36" src="https://user-images.githubusercontent.com/5717882/157821248-66f429ea-e533-4fd6-b273-e768352b6758.png">

@demonzoo @gao-sun 
