### PR TITLE
chore: update vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
       "source.fixAll.stylelint": true
     }
   },
+  "stylelint.validate": ["css", "scss"],
   "cssVariables.lookupFiles": [
     "./packages/ui/src/components/AppContent/index.module.scss"
   ],


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
to enable stylelint extension on `css` and `scss` files.

we can ignore the warning for now as some plugins are still depending `stylelint@^13`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

- [x] make `scss` format wrong, save then auto-fix

@xiaoyijun 