### PR TITLE
refactor(core): rename sign-in-experience api paths from sign-in-ex to sign-in-exp

### DIFF
--- a/packages/core/src/routes/sign-in-experience.test.ts
+++ b/packages/core/src/routes/sign-in-experience.test.ts
@@ -18,13 +18,13 @@ jest.mock('@/queries/sign-in-experience', () => ({
 describe('signInExperiences routes', () => {
   const signInExperienceRequester = createRequester({ authedRoutes: signInExperiencesRoutes });
 
-  it('GET /sign-in-ex', async () => {
-    const response = await signInExperienceRequester.get('/sign-in-ex');
+  it('GET /sign-in-exp', async () => {
+    const response = await signInExperienceRequester.get('/sign-in-exp');
     expect(response.status).toEqual(200);
     expect(response.body).toEqual(mockSignInExperience);
   });
 
-  it('PATCH /sign-in-ex/:id', async () => {
+  it('PATCH /sign-in-exp/:id', async () => {
     const branding: Branding = {
       primaryColor: '#000',
       backgroundColor: '#fff',
@@ -38,7 +38,7 @@ describe('signInExperiences routes', () => {
 
     const socialSignInConnectorIds = ['abc', 'def'];
 
-    const response = await signInExperienceRequester.patch('/sign-in-ex/default').send({
+    const response = await signInExperienceRequester.patch('/sign-in-exp/default').send({
       branding,
       socialSignInConnectorIds,
     });
@@ -51,10 +51,10 @@ describe('signInExperiences routes', () => {
     });
   });
 
-  it('PATCH /sign-in-ex/:id should throw with invalid inputs', async () => {
+  it('PATCH /sign-in-exp/:id should throw with invalid inputs', async () => {
     const socialSignInConnectorIds = [123, 456];
 
-    const response = await signInExperienceRequester.patch('/sign-in-ex/default').send({
+    const response = await signInExperienceRequester.patch('/sign-in-exp/default').send({
       socialSignInConnectorIds,
     });
     expect(response.status).toEqual(400);

--- a/packages/core/src/routes/sign-in-experience.ts
+++ b/packages/core/src/routes/sign-in-experience.ts
@@ -12,9 +12,9 @@ import { AuthedRouter } from './types';
 export default function signInExperiencesRoutes<T extends AuthedRouter>(router: T) {
   /**
    * As we only support single signInExperience settings for V1
-   * always return the default settings in DB for the /sign-in-ex get method
+   * always return the default settings in DB for the /sign-in-exp get method
    */
-  router.get('/sign-in-ex', async (ctx, next) => {
+  router.get('/sign-in-exp', async (ctx, next) => {
     const signInExperience = await findDefaultSignInExperience();
     ctx.body = signInExperience;
 
@@ -23,7 +23,7 @@ export default function signInExperiencesRoutes<T extends AuthedRouter>(router: 
 
   // TODO: LOG-1403 need to find a way to validate SignInMethod input
   router.patch(
-    '/sign-in-ex/:id',
+    '/sign-in-exp/:id',
     koaGuard({
       params: object({ id: string().min(1) }),
       body: SignInExperiences.createGuard.omit({ id: true }).partial(),


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- refactor(core): rename sign-in-experience api paths from sign-in-ex to sign-in-exp
    - See [discussion](https://silverhand-io.slack.com/archives/C02A8G4HVAM/p1647330937873609) on Slack

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-1811

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Pass all existing tests.

---
@logto-io/eng 