### PR TITLE
fix(console): button inline flex

### DIFF
--- a/packages/console/src/components/Button/index.module.scss
+++ b/packages/console/src/components/Button/index.module.scss
@@ -7,7 +7,7 @@
   font: var(--font-button);
   transition: background 0.2s ease-in-out;
   @include _.text-ellipsis;
-  display: flex;
+  display: inline-flex;
   align-items: center;
 
   &:not(:disabled) {

--- a/packages/console/src/components/Button/index.module.scss
+++ b/packages/console/src/components/Button/index.module.scss
@@ -7,8 +7,11 @@
   font: var(--font-button);
   transition: background 0.2s ease-in-out;
   @include _.text-ellipsis;
-  display: inline-flex;
   align-items: center;
+
+  &.withIcon {
+    display: inline-flex;
+  }
 
   &:not(:disabled) {
     cursor: pointer;

--- a/packages/console/src/components/Button/index.tsx
+++ b/packages/console/src/components/Button/index.tsx
@@ -1,4 +1,5 @@
 import { I18nKey } from '@logto/phrases';
+import { conditionalString } from '@silverhand/essentials';
 import classNames from 'classnames';
 import React, { HTMLProps, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -35,7 +36,12 @@ const Button = ({
 
   return (
     <button
-      className={classNames(styles.button, styles[type], styles[size])}
+      className={classNames(
+        styles.button,
+        styles[type],
+        styles[size],
+        conditionalString(icon && styles.withIcon)
+      )}
       type={htmlType}
       {...rest}
     >


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

I set button's display to "flex" in previous PR, this will cause render problems. Now change to "inline-flex", and only apply to it if "icon" is present.

before:

<img width="269" alt="截屏2022-03-17 下午5 42 28" src="https://user-images.githubusercontent.com/5717882/158782340-6f88ff99-6ca8-4d2c-b947-bc8588158f04.png">

after:

<img width="321" alt=" " src="https://user-images.githubusercontent.com/5717882/158782318-ddd8a0e5-3b92-4da7-ac79-fd15e78858ee.png">

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

@logto-io/eng 