### PR TITLE
fix(console): icon button classname

### DIFF
--- a/packages/console/src/components/IconButton/index.tsx
+++ b/packages/console/src/components/IconButton/index.tsx
@@ -7,9 +7,9 @@ export type Props = Omit<HTMLProps<HTMLButtonElement>, 'size' | 'type'> & {
   size?: 'small' | 'medium' | 'large';
 };
 
-const IconButton = ({ size = 'medium', children, ...rest }: Props) => {
+const IconButton = ({ size = 'medium', children, className, ...rest }: Props) => {
   return (
-    <button type="button" className={classNames(styles.button, styles[size])} {...rest}>
+    <button type="button" className={classNames(styles.button, styles[size], className)} {...rest}>
       {children}
     </button>
   );


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Fix a bug: if set classname to "IconButton", the inner classname will be overrided.

before:

<img width="258" alt="截屏2022-03-17 下午5 49 35" src="https://user-images.githubusercontent.com/5717882/158783270-a871f60b-4f52-438d-8150-2cdc1cb74b5b.png">

after:

<img width="324" alt="截屏2022-03-17 下午5 49 20" src="https://user-images.githubusercontent.com/5717882/158783294-31faea7a-000f-45f6-8ac3-93c54c070629.png">


<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

@logto-io/eng 