### PR TITLE
chore: update vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,9 +6,6 @@
     }
   },
   "stylelint.validate": ["css", "scss"],
-  "cssVariables.lookupFiles": [
-    "./packages/ui/src/components/AppContent/index.module.scss"
-  ],
   "eslint.workingDirectories": [
     {
       "pattern": "./packages/*"


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
removed `cssVariables.lookupFiles` since it's no longer needed.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

in VSCode, the extension works as expected