### PR TITLE
fix(console): add readonly style for text input

### DIFF
--- a/packages/console/src/components/TextInput/index.module.scss
+++ b/packages/console/src/components/TextInput/index.module.scss
@@ -28,6 +28,12 @@
       color: var(--color-disabled);
       border-color: var(--color-disabled);
     }
+
+    &:read-only {
+      background: var(--color-surface);
+      color: var(--color-readonly);
+      border-color: var(--color-disabled);
+    }
   }
 
   &.error input {

--- a/packages/console/src/scss/_colors.scss
+++ b/packages/console/src/scss/_colors.scss
@@ -76,6 +76,7 @@
   --color-component-text: var(--color-neutral-10);
   --color-outline: var(--color-neutral-variant-50);
   --color-disabled: var(--color-neutral-80);
+  --color-readonly: var(--color-neutral-50);
   --color-border: var(--color-neutral-80);
   --color-table-row-selected: rgba(25, 28, 29, 4%);
   --color-code-comment: #66bb6a;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Add readonly style for `<TextInput />`.

Readonly is different from "disabled", an input with readonly prop can still be focused.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-1914

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="665" alt="image" src="https://user-images.githubusercontent.com/5717882/159204133-de91f4cb-e1e3-47ae-bc9b-b5c8f643ecfd.png">

