### PR TITLE
fix(core): fix response code for requesting WeChat APIs

### DIFF
--- a/packages/core/src/connectors/wechat/index.test.ts
+++ b/packages/core/src/connectors/wechat/index.test.ts
@@ -43,7 +43,7 @@ describe('getAccessToken', () => {
     nock(accessTokenEndpointUrl.origin)
       .get(accessTokenEndpointUrl.pathname)
       .query(parameters)
-      .reply(200, {
+      .reply(0, {
         access_token: 'access_token',
         openid: 'openid',
       });
@@ -56,7 +56,7 @@ describe('getAccessToken', () => {
     nock(accessTokenEndpointUrl.origin)
       .get(accessTokenEndpointUrl.pathname)
       .query(parameters)
-      .reply(200, {});
+      .reply(0, {});
     await expect(getAccessToken('code')).rejects.toMatchError(
       new ConnectorError(ConnectorErrorCodes.SocialAuthCodeInvalid)
     );
@@ -84,14 +84,11 @@ describe('getUserInfo', () => {
   const parameters = new URLSearchParams({ access_token: 'accessToken', openid: 'openid' });
 
   it('should get valid SocialUserInfo', async () => {
-    nock(userInfoEndpointUrl.origin)
-      .get(userInfoEndpointUrl.pathname)
-      .query(parameters)
-      .reply(200, {
-        unionid: 'this_is_an_arbitrary_wechat_union_id',
-        headimgurl: 'https://github.com/images/error/octocat_happy.gif',
-        nickname: 'wechat bot',
-      });
+    nock(userInfoEndpointUrl.origin).get(userInfoEndpointUrl.pathname).query(parameters).reply(0, {
+      unionid: 'this_is_an_arbitrary_wechat_union_id',
+      headimgurl: 'https://github.com/images/error/octocat_happy.gif',
+      nickname: 'wechat bot',
+    });
     const socialUserInfo = await getUserInfo({ accessToken: 'accessToken', openid: 'openid' });
     expect(socialUserInfo).toMatchObject({
       id: 'this_is_an_arbitrary_wechat_union_id',
@@ -119,7 +116,7 @@ describe('getUserInfo', () => {
     nock(userInfoEndpointUrl.origin)
       .get(userInfoEndpointUrl.pathname)
       .query(parameters)
-      .reply(200, { errcode: 40_003, errmsg: 'invalid openid' });
+      .reply(0, { errcode: 40_003, errmsg: 'invalid openid' });
     await expect(
       getUserInfo({ accessToken: 'accessToken', openid: 'openid' })
     ).rejects.toMatchError(new Error('invalid openid'));

--- a/packages/core/src/connectors/wechat/index.ts
+++ b/packages/core/src/connectors/wechat/index.ts
@@ -120,6 +120,8 @@ export const getUserInfo: GetUserInfo = async (accessTokenObject) => {
       // be the return value from getAccessToken per testing.
       // In another word, 'openid' is required but the response of getUserInfo is consistent as long as
       // access_token is valid.
+      // We are expecting to get 41009 'missing openid' response according to the developers doc, but the
+      // fact is that we still got 40001 'invalid credentials' response.
       if (errcode === 40_001) {
         throw new ConnectorError(ConnectorErrorCodes.SocialAccessTokenInvalid);
       }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
According to the WeChat open docs, the response of successful requests should be with code 0 (not 200).
<img width="1800" alt="image" src="https://user-images.githubusercontent.com/15182327/159205600-3415b567-aaaa-4f40-824b-f9a5a99db06e.png">
Add comments for error handling of not providing 'openid' when requesting user information.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT.
