### PR TITLE
refactor(core): get sign-in experience

### DIFF
--- a/packages/core/src/connectors/index.test.ts
+++ b/packages/core/src/connectors/index.test.ts
@@ -5,6 +5,7 @@ import {
   getConnectorInstanceById,
   getConnectorInstanceByType,
   getConnectorInstances,
+  getEnabledSocialConnectorIds,
   getSocialConnectorInstanceById,
   initConnectors,
 } from '@/connectors/index';
@@ -115,6 +116,13 @@ describe('getSocialConnectorInstanceById', () => {
     await expect(getSocialConnectorInstanceById(id)).rejects.toMatchError(
       new RequestError({ code: 'entity.not_found', id, status: 404 })
     );
+  });
+});
+
+describe('getEnabledSocialConnectorIds', () => {
+  test('should return the enabled social connectors existing in DB', async () => {
+    const enabledSocialConnectorIds = await getEnabledSocialConnectorIds();
+    expect(enabledSocialConnectorIds).toEqual(['facebook', 'github']);
   });
 });
 

--- a/packages/core/src/connectors/index.ts
+++ b/packages/core/src/connectors/index.ts
@@ -59,6 +59,19 @@ export const getSocialConnectorInstanceById = async (
   return connector;
 };
 
+export const getEnabledSocialConnectorIds = async <T extends ConnectorInstance>(): Promise<
+  string[]
+> => {
+  const connectorInstances = await getConnectorInstances();
+
+  return connectorInstances
+    .filter<T>(
+      (instance): instance is T =>
+        instance.connector.enabled && instance.metadata.type === ConnectorType.Social
+    )
+    .map((instance) => instance.metadata.id);
+};
+
 export const getConnectorInstanceByType = async <T extends ConnectorInstance>(
   type: ConnectorType
 ): Promise<T> => {

--- a/packages/core/src/routes/sign-in-experience.test.ts
+++ b/packages/core/src/routes/sign-in-experience.test.ts
@@ -5,6 +5,11 @@ import { createRequester } from '@/utils/test-utils';
 
 import signInExperiencesRoutes from './sign-in-experience';
 
+jest.mock('@/connectors', () => ({
+  ...jest.requireActual('@/connectors'),
+  getEnabledSocialConnectorIds: jest.fn(async () => ['facebook', 'github']),
+}));
+
 jest.mock('@/queries/sign-in-experience', () => ({
   findDefaultSignInExperience: jest.fn(async (): Promise<SignInExperience> => mockSignInExperience),
   updateSignInExperienceById: jest.fn(

--- a/packages/core/src/utils/mock.ts
+++ b/packages/core/src/utils/mock.ts
@@ -181,7 +181,7 @@ export const mockSignInExperience: SignInExperience = {
     sms: SignInMethodState.disabled,
     social: SignInMethodState.secondary,
   },
-  socialSignInConnectorIds: ['foo', 'bar'],
+  socialSignInConnectorIds: ['github', 'facebook'],
 };
 
 export const mockConnectorList: Connector[] = [


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- feat(core): getEnabledSocialConnectorIds
- test(core): getEnabledSocialConnectorIds
- refactor(core): get sign-in experience
- test(core): get sign-in experience

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-1939

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="216" alt="image" src="https://user-images.githubusercontent.com/10594507/159228066-fd6efdb9-d309-4aa2-b8e8-a6694e267d75.png">
<img width="436" alt="image" src="https://user-images.githubusercontent.com/10594507/159228154-c72c9500-b950-487e-b642-804eb620ff1f.png">

---
@logto-io/eng 