### PR TITLE
refactor(core): change PATCH /sign-in-exp/:id to PATCH /sign-in-exp

### DIFF
--- a/packages/core/src/queries/sign-in-experience.ts
+++ b/packages/core/src/queries/sign-in-experience.ts
@@ -13,13 +13,14 @@ const updateSignInExperience = buildUpdateWhere<CreateSignInExperience, SignInEx
   true
 );
 
-export const updateSignInExperienceById = async (
-  id: string,
-  set: Partial<CreateSignInExperience>
-) => updateSignInExperience({ set, where: { id } });
+const id = 'default';
+
+export const updateDefaultSignInExperience = async (set: Partial<CreateSignInExperience>) =>
+  updateSignInExperience({ set, where: { id } });
 
 export const findDefaultSignInExperience = async () =>
   pool.one<SignInExperience>(sql`
     select ${sql.join(Object.values(fields), sql`, `)}
     from ${table}
+    where ${fields.id} = ${id}
   `);

--- a/packages/core/src/routes/sign-in-experience.test.ts
+++ b/packages/core/src/routes/sign-in-experience.test.ts
@@ -12,8 +12,8 @@ jest.mock('@/connectors', () => ({
 
 jest.mock('@/queries/sign-in-experience', () => ({
   findDefaultSignInExperience: jest.fn(async (): Promise<SignInExperience> => mockSignInExperience),
-  updateSignInExperienceById: jest.fn(
-    async (_, data: Partial<CreateSignInExperience>): Promise<SignInExperience> => ({
+  updateDefaultSignInExperience: jest.fn(
+    async (data: Partial<CreateSignInExperience>): Promise<SignInExperience> => ({
       ...mockSignInExperience,
       ...data,
     })
@@ -29,7 +29,7 @@ describe('signInExperiences routes', () => {
     expect(response.body).toEqual(mockSignInExperience);
   });
 
-  it('PATCH /sign-in-exp/:id', async () => {
+  it('PATCH /sign-in-exp', async () => {
     const branding: Branding = {
       primaryColor: '#000',
       backgroundColor: '#fff',
@@ -43,7 +43,7 @@ describe('signInExperiences routes', () => {
 
     const socialSignInConnectorIds = ['abc', 'def'];
 
-    const response = await signInExperienceRequester.patch('/sign-in-exp/default').send({
+    const response = await signInExperienceRequester.patch('/sign-in-exp').send({
       branding,
       socialSignInConnectorIds,
     });
@@ -56,10 +56,10 @@ describe('signInExperiences routes', () => {
     });
   });
 
-  it('PATCH /sign-in-exp/:id should throw with invalid inputs', async () => {
+  it('PATCH /sign-in-exp should throw with invalid inputs', async () => {
     const socialSignInConnectorIds = [123, 456];
 
-    const response = await signInExperienceRequester.patch('/sign-in-exp/default').send({
+    const response = await signInExperienceRequester.patch('/sign-in-exp').send({
       socialSignInConnectorIds,
     });
     expect(response.status).toEqual(400);

--- a/packages/core/src/routes/sign-in-experience.ts
+++ b/packages/core/src/routes/sign-in-experience.ts
@@ -1,11 +1,10 @@
 import { SignInExperiences } from '@logto/schemas';
-import { object, string } from 'zod';
 
 import { getEnabledSocialConnectorIds } from '@/connectors';
 import koaGuard from '@/middleware/koa-guard';
 import {
   findDefaultSignInExperience,
-  updateSignInExperienceById,
+  updateDefaultSignInExperience,
 } from '@/queries/sign-in-experience';
 
 import { AuthedRouter } from './types';
@@ -31,20 +30,15 @@ export default function signInExperiencesRoutes<T extends AuthedRouter>(router: 
     return next();
   });
 
-  // TODO: LOG-1403 need to find a way to validate SignInMethod input
   router.patch(
-    '/sign-in-exp/:id',
+    '/sign-in-exp',
     koaGuard({
-      params: object({ id: string().min(1) }),
       body: SignInExperiences.createGuard.omit({ id: true }).partial(),
     }),
     async (ctx, next) => {
-      const {
-        params: { id },
-        body,
-      } = ctx.guard;
+      const { body } = ctx.guard;
 
-      ctx.body = await updateSignInExperienceById(id, {
+      ctx.body = await updateDefaultSignInExperience({
         ...body,
       });
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- refactor(core): updateDefaultSignInExperience, findDefaultSignInExperience
- refactor(core): change PATCH /sign-in-exp/:id to PATCH /sign-in-exp

According to the sign-in experience design,
**since there is only one sign-in experience per DB instance, do not require `id`.**

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-1941

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="510" alt="image" src="https://user-images.githubusercontent.com/10594507/159229867-5b70731b-6495-4cbf-b52e-7c8023df6f60.png">
<img width="270" alt="image" src="https://user-images.githubusercontent.com/10594507/159229903-cf6af048-8e02-4d81-bcfc-f851fbaa0632.png">

---
@logto-io/eng 