### PR TITLE
refactor(core): make getConnectorInstances access DB only once

### DIFF
--- a/packages/core/src/connectors/index.ts
+++ b/packages/core/src/connectors/index.ts
@@ -87,9 +87,9 @@ export const getConnectorInstanceByType = async <T extends ConnectorInstance>(
   type: ConnectorType
 ): Promise<T> => {
   const connectors = await getConnectorInstances();
-  const connector = connectors
-    .filter((connector) => connector.connector.enabled)
-    .find<T>((connector): connector is T => connector.metadata.type === type);
+  const connector = connectors.find<T>(
+    (connector): connector is T => connector.connector.enabled && connector.metadata.type === type
+  );
 
   if (!connector) {
     throw new RequestError('connector.not_found', { type });


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- refactor(core): make getConnectorInstances access DB only once
- test(core): make getConnectorInstances access DB only once
- refactor(core): getConnectorInstanceByType merge .filter into .find for running in one loop

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-1944

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="420" alt="image" src="https://user-images.githubusercontent.com/10594507/159235451-13263efe-f698-4f42-bc23-1e19c0e454c8.png">

---
@logto-io/eng 