### PR TITLE
refactor(core): getEnabledPasswordlessConnectorInstanceByType 

### DIFF
--- a/packages/core/src/connectors/index.test.ts
+++ b/packages/core/src/connectors/index.test.ts
@@ -3,7 +3,7 @@ import { NotFoundError } from 'slonik';
 
 import {
   getConnectorInstanceById,
-  getConnectorInstanceByType,
+  getEnabledPasswordlessConnectorInstanceByType,
   getConnectorInstances,
   getSocialConnectorInstanceById,
   initConnectors,
@@ -120,13 +120,15 @@ describe('getSocialConnectorInstanceById', () => {
 
 describe('getConnectorInstanceByType', () => {
   test('should return the enabled connector existing in DB', async () => {
-    const dmEnabledConnectorInstance = await getConnectorInstanceByType(ConnectorType.Email);
+    const dmEnabledConnectorInstance = await getEnabledPasswordlessConnectorInstanceByType(
+      ConnectorType.Email
+    );
     expect(dmEnabledConnectorInstance).toHaveProperty('connector', aliyunDmConnector);
   });
 
   test('should throw when there is no enabled connector existing in DB', async () => {
     const type = ConnectorType.SMS;
-    await expect(getConnectorInstanceByType(type)).rejects.toMatchError(
+    await expect(getEnabledPasswordlessConnectorInstanceByType(type)).rejects.toMatchError(
       new RequestError('connector.not_found', { type })
     );
   });

--- a/packages/core/src/connectors/index.ts
+++ b/packages/core/src/connectors/index.ts
@@ -59,8 +59,8 @@ export const getSocialConnectorInstanceById = async (
   return connector;
 };
 
-export const getConnectorInstanceByType = async <T extends ConnectorInstance>(
-  type: ConnectorType
+export const getEnabledPasswordlessConnectorInstanceByType = async <T extends ConnectorInstance>(
+  type: ConnectorType.Email | ConnectorType.SMS
 ): Promise<T> => {
   const connectors = await getConnectorInstances();
   const connector = connectors

--- a/packages/core/src/lib/passcode.test.ts
+++ b/packages/core/src/lib/passcode.test.ts
@@ -1,6 +1,6 @@
 import { Passcode, PasscodeType } from '@logto/schemas';
 
-import { getConnectorInstanceByType } from '@/connectors';
+import { getEnabledPasswordlessConnectorInstanceByType } from '@/connectors';
 import { ConnectorType } from '@/connectors/types';
 import RequestError from '@/errors/RequestError';
 import {
@@ -35,9 +35,10 @@ const mockedDeletePasscodesByIds = deletePasscodesByIds as jest.MockedFunction<
   typeof deletePasscodesByIds
 >;
 const mockedInsertPasscode = insertPasscode as jest.MockedFunction<typeof insertPasscode>;
-const mockedGetConnectorInstanceByType = getConnectorInstanceByType as jest.MockedFunction<
-  typeof getConnectorInstanceByType
->;
+const mockedGetConnectorInstanceByType =
+  getEnabledPasswordlessConnectorInstanceByType as jest.MockedFunction<
+    typeof getEnabledPasswordlessConnectorInstanceByType
+  >;
 const mockedUpdatePasscode = updatePasscode as jest.MockedFunction<typeof updatePasscode>;
 
 beforeAll(() => {

--- a/packages/core/src/lib/passcode.ts
+++ b/packages/core/src/lib/passcode.ts
@@ -1,7 +1,7 @@
 import { Passcode, PasscodeType } from '@logto/schemas';
 import { customAlphabet, nanoid } from 'nanoid';
 
-import { getConnectorInstanceByType } from '@/connectors';
+import { getEnabledPasswordlessConnectorInstanceByType } from '@/connectors';
 import { ConnectorType, EmailConnectorInstance, SmsConnectorInstance } from '@/connectors/types';
 import RequestError from '@/errors/RequestError';
 import {
@@ -44,8 +44,10 @@ export const sendPasscode = async (passcode: Passcode) => {
   }
 
   const connector = passcode.email
-    ? await getConnectorInstanceByType<EmailConnectorInstance>(ConnectorType.Email)
-    : await getConnectorInstanceByType<SmsConnectorInstance>(ConnectorType.SMS);
+    ? await getEnabledPasswordlessConnectorInstanceByType<EmailConnectorInstance>(
+        ConnectorType.Email
+      )
+    : await getEnabledPasswordlessConnectorInstanceByType<SmsConnectorInstance>(ConnectorType.SMS);
 
   return connector.sendMessage(emailOrPhone, passcode.type, {
     code: passcode.code,

--- a/packages/core/src/routes/connector.test.ts
+++ b/packages/core/src/routes/connector.test.ts
@@ -28,7 +28,7 @@ const findConnectorByIdPlaceHolder = jest.fn() as jest.MockedFunction<
 const getConnectorInstanceByIdPlaceHolder = jest.fn() as jest.MockedFunction<
   (connectorId: string) => Promise<ConnectorInstance>
 >;
-const getConnectorInstanceByTypePlaceHolder = jest.fn() as jest.MockedFunction<
+const getEnabledPasswordlessConnectorInstanceByTypePlaceHolder = jest.fn() as jest.MockedFunction<
   (type: ConnectorType) => Promise<ConnectorInstance>
 >;
 const getConnectorInstancesPlaceHolder = jest.fn() as jest.MockedFunction<
@@ -43,8 +43,8 @@ jest.mock('@/queries/connector', () => ({
 jest.mock('@/connectors', () => ({
   getConnectorInstanceById: async (connectorId: string) =>
     getConnectorInstanceByIdPlaceHolder(connectorId),
-  getConnectorInstanceByType: async (type: ConnectorType) =>
-    getConnectorInstanceByTypePlaceHolder(type),
+  getEnabledPasswordlessConnectorInstanceByType: async (type: ConnectorType) =>
+    getEnabledPasswordlessConnectorInstanceByTypePlaceHolder(type),
   getConnectorInstances: async () => getConnectorInstancesPlaceHolder(),
 }));
 
@@ -502,15 +502,19 @@ describe('connector route', () => {
         ): Promise<any> => {},
       };
 
-      getConnectorInstanceByTypePlaceHolder.mockImplementationOnce(async (_: ConnectorType) => {
-        return mockedEmailConnector;
-      });
+      getEnabledPasswordlessConnectorInstanceByTypePlaceHolder.mockImplementationOnce(
+        async (_: ConnectorType) => {
+          return mockedEmailConnector;
+        }
+      );
 
       const sendMessageSpy = jest.spyOn(mockedEmailConnector, 'sendMessage');
       const response = await connectorRequest
         .post('/connectors/test/email')
         .send({ email: 'test@email.com' });
-      expect(getConnectorInstanceByTypePlaceHolder).toHaveBeenCalledWith(ConnectorType.Email);
+      expect(getEnabledPasswordlessConnectorInstanceByTypePlaceHolder).toHaveBeenCalledWith(
+        ConnectorType.Email
+      );
       expect(sendMessageSpy).toHaveBeenCalledTimes(1);
       expect(response).toHaveProperty('statusCode', 204);
     });
@@ -547,15 +551,19 @@ describe('connector route', () => {
         ): Promise<any> => {},
       };
 
-      getConnectorInstanceByTypePlaceHolder.mockImplementationOnce(async (_: ConnectorType) => {
-        return mockedEmailConnector;
-      });
+      getEnabledPasswordlessConnectorInstanceByTypePlaceHolder.mockImplementationOnce(
+        async (_: ConnectorType) => {
+          return mockedEmailConnector;
+        }
+      );
 
       const sendMessageSpy = jest.spyOn(mockedEmailConnector, 'sendMessage');
       const response = await connectorRequest
         .post('/connectors/test/sms')
         .send({ phone: '12345678901' });
-      expect(getConnectorInstanceByTypePlaceHolder).toHaveBeenCalledWith(ConnectorType.SMS);
+      expect(getEnabledPasswordlessConnectorInstanceByTypePlaceHolder).toHaveBeenCalledWith(
+        ConnectorType.SMS
+      );
       expect(sendMessageSpy).toHaveBeenCalledTimes(1);
       expect(response).toHaveProperty('statusCode', 204);
     });

--- a/packages/core/src/routes/connector.ts
+++ b/packages/core/src/routes/connector.ts
@@ -4,7 +4,7 @@ import { object, string } from 'zod';
 import {
   getConnectorInstances,
   getConnectorInstanceById,
-  getConnectorInstanceByType,
+  getEnabledPasswordlessConnectorInstanceByType,
 } from '@/connectors';
 import {
   ConnectorInstance,
@@ -137,7 +137,7 @@ export default function connectorRoutes<T extends AuthedRouter>(router: T) {
     async (ctx, next) => {
       const { email } = ctx.guard.body;
 
-      const connector = await getConnectorInstanceByType<EmailConnectorInstance>(
+      const connector = await getEnabledPasswordlessConnectorInstanceByType<EmailConnectorInstance>(
         ConnectorType.Email
       );
 
@@ -162,7 +162,9 @@ export default function connectorRoutes<T extends AuthedRouter>(router: T) {
     async (ctx, next) => {
       const { phone } = ctx.guard.body;
 
-      const connector = await getConnectorInstanceByType<SmsConnectorInstance>(ConnectorType.SMS);
+      const connector = await getEnabledPasswordlessConnectorInstanceByType<SmsConnectorInstance>(
+        ConnectorType.SMS
+      );
 
       // TODO - LOG-1875: SMS & Email Template for Test
       await connector.sendMessage(phone, 'Test', {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- refactor(core): getEnabledPasswordlessConnectorInstanceByType
    - rename getConnectorInstanceByType to getEnabledPasswordlessConnectorInstanceByType
    - constrait `type` to `SMS | Email

Since this function is only used to get the first enabled connector by type —— SMS or Email.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-1947

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Pass all existing tests.

---
@logto-io/eng 