### PR TITLE
feat(console): extract total number from headers for useSWR

### DIFF
--- a/packages/console/src/pages/Users/index.tsx
+++ b/packages/console/src/pages/Users/index.tsx
@@ -10,6 +10,7 @@ import Card from '@/components/Card';
 import CardTitle from '@/components/CardTitle';
 import ImagePlaceholder from '@/components/ImagePlaceholder';
 import ItemPreview from '@/components/ItemPreview';
+import Pagination from '@/components/Pagination';
 import TableEmpty from '@/components/Table/TableEmpty';
 import TableError from '@/components/Table/TableError';
 import TableLoading from '@/components/Table/TableLoading';
@@ -19,12 +20,18 @@ import * as modalStyles from '@/scss/modal.module.scss';
 import CreateForm from './components/CreateForm';
 import * as styles from './index.module.scss';
 
+const pageSize = 20;
+
 const Users = () => {
   const [isCreateFormOpen, setIsCreateFormOpen] = useState(false);
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
-  const { data, error, mutate } = useSWR<User[], RequestError>('/api/users');
+  const [pageIndex, setPageIndex] = useState(1);
+  const { data, error, mutate } = useSWR<[User[], number], RequestError>(
+    `/api/users?page=${pageIndex}&page_size=${pageSize}`
+  );
   const isLoading = !data && !error;
   const navigate = useNavigate();
+  const [users, totalCount] = data ?? [];
 
   return (
     <Card>
@@ -74,7 +81,7 @@ const Users = () => {
             />
           )}
           {isLoading && <TableLoading columns={3} />}
-          {data?.length === 0 && (
+          {users?.length === 0 && (
             <TableEmpty>
               <Button
                 title="admin_console.users.create"
@@ -85,7 +92,7 @@ const Users = () => {
               />
             </TableEmpty>
           )}
-          {data?.map(({ id, name, username }) => (
+          {users?.map(({ id, name, username }) => (
             <tr
               key={id}
               className={styles.clickable}
@@ -107,6 +114,13 @@ const Users = () => {
           ))}
         </tbody>
       </table>
+      {totalCount && (
+        <Pagination
+          pageCount={Math.ceil(totalCount / pageSize)}
+          pageIndex={pageIndex}
+          onChange={setPageIndex}
+        />
+      )}
     </Card>
   );
 };

--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -40,6 +40,7 @@ const translation = {
       something_went_wrong: 'Oops! Something went wrong',
       unknown_server_error: 'Unknown server error occurred.',
       empty: 'No Data',
+      missing_total_number: 'Unable to find Total-Number in response headers.',
     },
     tab_sections: {
       overview: 'Overview',

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -42,6 +42,7 @@ const translation = {
       something_went_wrong: '哎哟喂，遇到了一个错误',
       unknown_server_error: '服务器发生未知错误。',
       empty: '没有数据',
+      missing_total_number: '无法从返回的头部信息中找到 Total-Number。',
     },
     tab_sections: {
       overview: '概览',


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Extract "Total-Number" from response header to useSWR's `data`, if `page` and `page_size` is present in url.

Is unnable to get response header in useSWR directly, so we have to "break" data.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-1979

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested.
