### PR TITLE
refactor(core): make initConnectors check existing connectors in DB once

### DIFF
--- a/packages/core/src/connectors/index.ts
+++ b/packages/core/src/connectors/index.ts
@@ -1,10 +1,5 @@
 import RequestError from '@/errors/RequestError';
-import {
-  findAllConnectors,
-  findConnectorById,
-  hasConnector,
-  insertConnector,
-} from '@/queries/connector';
+import { findAllConnectors, findConnectorById, insertConnector } from '@/queries/connector';
 
 import * as AliyunDM from './aliyun-dm';
 import * as AliyunSMS from './aliyun-sms';
@@ -99,15 +94,16 @@ export const getConnectorInstanceByType = async <T extends ConnectorInstance>(
 };
 
 export const initConnectors = async () => {
+  const connectors = await findAllConnectors();
+  const existingConnectorIds = new Set(connectors.map((connector) => connector.id));
+
   await Promise.all(
     allConnectors.map(async ({ metadata: { id } }) => {
-      if (await hasConnector(id)) {
+      if (existingConnectorIds.has(id)) {
         return;
       }
 
-      await insertConnector({
-        id,
-      });
+      await insertConnector({ id });
     })
   );
 };

--- a/packages/core/src/queries/connector.test.ts
+++ b/packages/core/src/queries/connector.test.ts
@@ -7,7 +7,6 @@ import { expectSqlAssert, QueryType } from '@/utils/test-utils';
 import {
   findAllConnectors,
   findConnectorById,
-  hasConnector,
   insertConnector,
   updateConnector,
 } from './connector';
@@ -61,27 +60,6 @@ describe('connector queries', () => {
     });
 
     await expect(findConnectorById(id)).resolves.toEqual(rowData);
-  });
-
-  it('hasConnector', async () => {
-    const id = 'foo';
-
-    const expectSql = sql`
-      SELECT EXISTS(
-        select ${sql.join(Object.values(fields), sql`, `)}
-        from ${table}
-        where ${fields.id}=$1
-      )
-    `;
-
-    mockQuery.mockImplementationOnce(async (sql, values) => {
-      expectSqlAssert(sql, expectSql.sql);
-      expect(values).toEqual([id]);
-
-      return createMockQueryResult([{ exists: true }]);
-    });
-
-    await expect(hasConnector(id)).resolves.toEqual(true);
   });
 
   it('insertConnector', async () => {

--- a/packages/core/src/queries/connector.ts
+++ b/packages/core/src/queries/connector.ts
@@ -22,13 +22,6 @@ export const findConnectorById = async (id: string) =>
     where ${fields.id}=${id}
   `);
 
-export const hasConnector = async (id: string) =>
-  pool.exists(sql`
-    select ${sql.join(Object.values(fields), sql`, `)}
-    from ${table}
-    where ${fields.id}=${id}
-  `);
-
 export const insertConnector = buildInsertInto<CreateConnector, Connector>(pool, Connectors, {
   returning: true,
 });


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- refactor(core): make initConnectors check existing connectors in DB once
- refactor(core): remove unnecessary hasConnector

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-1944

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
![image](https://user-images.githubusercontent.com/10594507/159947632-339d9355-2633-4ffa-820c-c0e62caf7013.png)

---
@logto-io/eng 
