### PR TITLE
fix(console): prevent css overiding in table-loading

### DIFF
--- a/packages/console/src/components/Table/TableLoading.module.scss
+++ b/packages/console/src/components/Table/TableLoading.module.scss
@@ -1,7 +1,7 @@
 @use '@/scss/underscore' as _;
 
 .loading {
-  td > div {
+  .rect {
     border-radius: _.unit(2);
     background: var(--color-neutral-95);
     height: 32px;

--- a/packages/console/src/components/Table/TableLoading.tsx
+++ b/packages/console/src/components/Table/TableLoading.tsx
@@ -17,7 +17,7 @@ const TableLoading = ({ columns }: Props) => {
         {Array.from({ length: columns - 1 }).map((_, index) => (
           // eslint-disable-next-line react/no-array-index-key
           <td key={index}>
-            <div />
+            <div className={styles.rect} />
           </td>
         ))}
       </tr>


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

fix bug: ItemPreviewLoading's css has less priority than default TableLoading component.

Now set a explict class name as "rect".

@logto-io/eng 