### PR TITLE
feat(core): getEnabledConnectorInstances

### DIFF
--- a/packages/core/src/connectors/index.test.ts
+++ b/packages/core/src/connectors/index.test.ts
@@ -5,6 +5,7 @@ import {
   getConnectorInstanceById,
   getConnectorInstanceByType,
   getConnectorInstances,
+  getEnabledConnectorInstances,
   getEnabledSocialConnectorIds,
   getSocialConnectorInstanceById,
   initConnectors,
@@ -72,6 +73,7 @@ const insertConnector = jest.fn(async (connector: Connector) => connector);
 
 jest.mock('@/queries/connector', () => ({
   ...jest.requireActual('@/queries/connector'),
+  findAllEnabledConnectors: async () => [aliyunDmConnector, facebookConnector, githubConnector],
   findAllConnectors: async () => findAllConnectors(),
   findConnectorById: async (id: string) => findConnectorById(id),
   insertConnector: async (connector: Connector) => insertConnector(connector),
@@ -80,7 +82,7 @@ jest.mock('@/queries/connector', () => ({
 describe('getConnectorInstances', () => {
   test('should return the connectors existing in DB', async () => {
     const connectorInstances = await getConnectorInstances();
-    expect(connectorInstances).toHaveLength(connectorInstances.length);
+    expect(connectorInstances).toHaveLength(connectors.length);
     expect(connectorInstances[0]).toHaveProperty('connector', aliyunDmConnector);
     expect(connectorInstances[1]).toHaveProperty('connector', aliyunSmsConnector);
     expect(connectorInstances[2]).toHaveProperty('connector', facebookConnector);
@@ -118,6 +120,16 @@ describe('getConnectorInstanceById', () => {
     await expect(getConnectorInstanceById(id)).rejects.toMatchError(
       new RequestError({ code: 'entity.not_found', id, status: 404 })
     );
+  });
+});
+
+describe('getEnabledConnectorInstances', () => {
+  test('should return the enabled connectors', async () => {
+    const enabledConnectorInstances = await getEnabledConnectorInstances();
+    expect(enabledConnectorInstances).toHaveLength(3);
+    expect(enabledConnectorInstances[0]).toHaveProperty('connector', aliyunDmConnector);
+    expect(enabledConnectorInstances[1]).toHaveProperty('connector', facebookConnector);
+    expect(enabledConnectorInstances[2]).toHaveProperty('connector', githubConnector);
   });
 });
 

--- a/packages/core/src/queries/connector.ts
+++ b/packages/core/src/queries/connector.ts
@@ -15,6 +15,14 @@ export const findAllConnectors = async () =>
     order by ${fields.enabled} desc, ${fields.id} asc
   `);
 
+export const findAllEnabledConnectors = async () =>
+  pool.many<Connector>(sql`
+    select ${sql.join(Object.values(fields), sql`, `)}
+    from ${table}
+    where ${fields.enabled} = true
+    order by ${fields.id} asc
+  `);
+
 export const findConnectorById = async (id: string) =>
   pool.one<Connector>(sql`
     select ${sql.join(Object.values(fields), sql`, `)}


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
`getEnabledConnectorInstances` only get enabled connectors from DB once.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2051
Will be used in LOG-1811 #391 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="413" alt="image" src="https://user-images.githubusercontent.com/10594507/160771390-8f021d7a-6468-459d-81b7-031dd38b2325.png">

---
@logto-io/eng 
