### PR TITLE
feat(console): support code editor in get-started steps

### DIFF
--- a/packages/console/src/components/CodeEditor/index.module.scss
+++ b/packages/console/src/components/CodeEditor/index.module.scss
@@ -1,7 +1,6 @@
 @use '@/scss/underscore' as _;
 
 .editor {
-  margin: _.unit(1) 0;
   border-radius: _.unit(4);
   padding: _.unit(4) 0;
   // Use fixed color for both light and dark mode, the same as vs-dark.

--- a/packages/console/src/components/CodeEditor/index.tsx
+++ b/packages/console/src/components/CodeEditor/index.tsx
@@ -8,7 +8,7 @@ import IconButton from '../IconButton';
 import * as styles from './index.module.scss';
 
 type Props = {
-  language: string;
+  language?: string;
   height?: string;
   isReadonly?: boolean;
   value?: string;

--- a/packages/console/src/pages/GetStarted/components/Step/index.tsx
+++ b/packages/console/src/pages/GetStarted/components/Step/index.tsx
@@ -5,6 +5,7 @@ import ReactMarkdown from 'react-markdown';
 import Button from '@/components/Button';
 import Card from '@/components/Card';
 import CardTitle from '@/components/CardTitle';
+import CodeEditor from '@/components/CodeEditor';
 import DangerousRaw from '@/components/DangerousRaw';
 import IconButton from '@/components/IconButton';
 import Spacer from '@/components/Spacer';
@@ -65,7 +66,19 @@ const Step = (
       </div>
       {isExpanded && (
         <>
-          <ReactMarkdown className={styles.markdownContent}>{metadata}</ReactMarkdown>
+          <ReactMarkdown
+            className={styles.markdownContent}
+            components={{
+              code: ({ className, children }) => {
+                const [, language] = /language-(\w+)/.exec(className ?? '') ?? [];
+                const content = String(children);
+
+                return <CodeEditor isReadonly language={language} value={content} />;
+              },
+            }}
+          >
+            {metadata}
+          </ReactMarkdown>
           <div className={styles.buttonWrapper}>
             <Button
               type="primary"


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Support code editor in get-started steps.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
[LOG-1682](https://linear.app/silverhand/issue/LOG-1682/support-code-editor-in-steps)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested in browser and it worked as expected

<img width="1511" alt="image" src="https://user-images.githubusercontent.com/12833674/161201740-041e8de0-780f-404d-b251-8b9b8658f80e.png">

