### PR TITLE
fix(console): input outline should be red in the error state on focused

### DIFF
--- a/packages/console/src/components/TextInput/index.module.scss
+++ b/packages/console/src/components/TextInput/index.module.scss
@@ -59,6 +59,9 @@
 
   &.error {
     border-color: var(--color-error);
-    outline-color: var(--color-error-80);
+
+    &:focus-within {
+      outline-color: var(--color-error-80);
+    }
   }
 }

--- a/packages/console/src/components/TextInput/index.module.scss
+++ b/packages/console/src/components/TextInput/index.module.scss
@@ -59,5 +59,6 @@
 
   &.error {
     border-color: var(--color-error);
+    outline-color: var(--color-error-80);
   }
 }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
fix(console): input outline should be red in the error state

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-1906

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Before fix
<img width="693" alt="error-input-before" src="https://user-images.githubusercontent.com/10806653/161213783-d637da29-9a35-4724-9091-0de7898d34e4.png">

### After fix
<img width="608" alt="error-input-after" src="https://user-images.githubusercontent.com/10806653/161213906-c3e01b82-c12d-4f2b-9544-ef79dd5419e5.png">

