### PR TITLE
fix(console): page scroll should work when scrolling on monaco editor

### DIFF
--- a/packages/console/src/components/CodeEditor/index.tsx
+++ b/packages/console/src/components/CodeEditor/index.tsx
@@ -36,6 +36,9 @@ const CodeEditor = ({ value, onChange, language, height = '300px', isReadonly = 
       enabled: false,
     },
     folding: false,
+    scrollbar: {
+      alwaysConsumeMouseWheel: false,
+    },
   };
 
   return (


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Page scroll should not be affected when scrolling on top of a Monaco editor.
Previously if you scroll your mouse wheel on a Monaco editor, it only scrolls the editor content and consumes the scrolling event. So the page scroll would not work unless you move the mouse cursor out of the editor.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
[LOG-2098](https://linear.app/silverhand/issue/LOG-2098/fix-monaco-editor-consumes-scroll-events)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally and the page scroll works even if you scroll on the Monaco editor
