### PR TITLE
test(core): guard terms of use and language info

### DIFF
--- a/packages/core/src/routes/sign-in-experience.guard.test.ts
+++ b/packages/core/src/routes/sign-in-experience.guard.test.ts
@@ -1,6 +1,6 @@
 import { BrandingStyle, CreateSignInExperience, SignInExperience } from '@logto/schemas';
 
-import { mockBranding, mockSignInExperience } from '@/utils/mock';
+import { mockBranding, mockSignInExperience, mockTermsOfUse } from '@/utils/mock';
 import { createRequester } from '@/utils/test-utils';
 
 import signInExperiencesRoutes from './sign-in-experience';
@@ -120,6 +120,38 @@ describe('branding', () => {
       .patch('/sign-in-exp')
       .send({ branding: mockBranding });
     await expect(response).resolves.toMatchObject({ status: 200 });
+  });
+});
+
+describe('terms of use', () => {
+  describe('enabled', () => {
+    test.each([true, false])('%p should success', async (enabled) => {
+      const signInExperience = { termsOfUse: { ...mockTermsOfUse, enabled } };
+      await expectPatchResponseStatus(signInExperience, 200);
+    });
+
+    test.each([undefined, null, 0, 1, '0', '1', 'true', 'false'])(
+      '%p should fail',
+      async (enabled) => {
+        const signInExperience = { termsOfUse: { ...mockTermsOfUse, enabled } };
+        await expectPatchResponseStatus(signInExperience, 400);
+      }
+    );
+  });
+
+  describe('contentUrl', () => {
+    test.each([undefined, 'http://silverhand.com/terms', 'https://logto.dev/terms'])(
+      '%p should success',
+      async (contentUrl) => {
+        const signInExperience = { termsOfUse: { ...mockTermsOfUse, enabled: false, contentUrl } };
+        await expectPatchResponseStatus(signInExperience, 200);
+      }
+    );
+
+    test.each([null, '', ' \b \t\n\r', 'non-url'])('%p should fail', async (contentUrl) => {
+      const signInExperience = { termsOfUse: { ...mockTermsOfUse, enabled: false, contentUrl } };
+      await expectPatchResponseStatus(signInExperience, 400);
+    });
   });
 });
 

--- a/packages/core/src/routes/sign-in-experience.guard.test.ts
+++ b/packages/core/src/routes/sign-in-experience.guard.test.ts
@@ -1,6 +1,6 @@
-import { BrandingStyle, CreateSignInExperience, SignInExperience } from '@logto/schemas';
+import { BrandingStyle, CreateSignInExperience, Language, SignInExperience } from '@logto/schemas';
 
-import { mockBranding, mockSignInExperience, mockTermsOfUse } from '@/utils/mock';
+import { mockBranding, mockLanguageInfo, mockSignInExperience, mockTermsOfUse } from '@/utils/mock';
 import { createRequester } from '@/utils/test-utils';
 
 import signInExperiencesRoutes from './sign-in-experience';
@@ -20,6 +20,9 @@ const expectPatchResponseStatus = async (signInExperience: any, status: number) 
   const response = await signInExperienceRequester.patch('/sign-in-exp').send(signInExperience);
   expect(response.status).toEqual(status);
 };
+
+const validBooleans = [true, false];
+const invalidBooleans = [undefined, null, 0, 1, '0', '1', 'true', 'false'];
 
 describe('branding', () => {
   const colorKeys = ['primaryColor', 'backgroundColor', 'darkPrimaryColor', 'darkBackgroundColor'];
@@ -126,18 +129,15 @@ describe('branding', () => {
 
 describe('terms of use', () => {
   describe('enabled', () => {
-    test.each([true, false])('%p should success', async (enabled) => {
+    test.each(validBooleans)('%p should success', async (enabled) => {
       const signInExperience = { termsOfUse: { ...mockTermsOfUse, enabled } };
       await expectPatchResponseStatus(signInExperience, 200);
     });
 
-    test.each([undefined, null, 0, 1, '0', '1', 'true', 'false'])(
-      '%p should fail',
-      async (enabled) => {
-        const signInExperience = { termsOfUse: { ...mockTermsOfUse, enabled } };
-        await expectPatchResponseStatus(signInExperience, 400);
-      }
-    );
+    test.each(invalidBooleans)('%p should fail', async (enabled) => {
+      const signInExperience = { termsOfUse: { ...mockTermsOfUse, enabled } };
+      await expectPatchResponseStatus(signInExperience, 400);
+    });
   });
 
   describe('contentUrl', () => {
@@ -149,8 +149,49 @@ describe('terms of use', () => {
       }
     );
 
-    test.each([null, '', ' \b \t\n\r', 'non-url'])('%p should fail', async (contentUrl) => {
+    test.each([null, '', ' \t\n\r', 'non-url'])('%p should fail', async (contentUrl) => {
       const signInExperience = { termsOfUse: { ...mockTermsOfUse, enabled: false, contentUrl } };
+      await expectPatchResponseStatus(signInExperience, 400);
+    });
+  });
+});
+
+describe('languageInfo', () => {
+  describe('autoDetect', () => {
+    test.each(validBooleans)('%p should success', async (autoDetect) => {
+      const signInExperience = { languageInfo: { ...mockLanguageInfo, autoDetect } };
+      await expectPatchResponseStatus(signInExperience, 200);
+    });
+
+    test.each(invalidBooleans)('%p should fail', async (autoDetect) => {
+      const signInExperience = { languageInfo: { ...mockLanguageInfo, autoDetect } };
+      await expectPatchResponseStatus(signInExperience, 400);
+    });
+  });
+
+  const validLanguages = Object.values(Language);
+  const invalidLanguages = [undefined, null, '', ' \t\n\r', 'abc'];
+
+  describe('fallbackLanguage', () => {
+    test.each(validLanguages)('%p should success', async (fallbackLanguage) => {
+      const signInExperience = { languageInfo: { ...mockLanguageInfo, fallbackLanguage } };
+      await expectPatchResponseStatus(signInExperience, 200);
+    });
+
+    test.each(invalidLanguages)('%p should fail', async (fallbackLanguage) => {
+      const signInExperience = { languageInfo: { ...mockLanguageInfo, fallbackLanguage } };
+      await expectPatchResponseStatus(signInExperience, 400);
+    });
+  });
+
+  describe('fixedLanguage', () => {
+    test.each(validLanguages)('%p should success', async (fixedLanguage) => {
+      const signInExperience = { languageInfo: { ...mockLanguageInfo, fixedLanguage } };
+      await expectPatchResponseStatus(signInExperience, 200);
+    });
+
+    test.each(invalidLanguages)('%p should fail', async (fixedLanguage) => {
+      const signInExperience = { languageInfo: { ...mockLanguageInfo, fixedLanguage } };
       await expectPatchResponseStatus(signInExperience, 400);
     });
   });

--- a/packages/core/src/routes/sign-in-experience.guard.test.ts
+++ b/packages/core/src/routes/sign-in-experience.guard.test.ts
@@ -26,6 +26,7 @@ describe('branding', () => {
 
   const invalidColors = [
     undefined,
+    null,
     '',
     '#',
     '#1',
@@ -82,7 +83,7 @@ describe('branding', () => {
       }
     );
 
-    test.each([undefined, '', 'invalid'])('%p should fail', async (logoUrl) => {
+    test.each([undefined, null, '', 'invalid'])('%p should fail', async (logoUrl) => {
       const signInExperience = { branding: { ...mockBranding, logoUrl } };
       await expectPatchResponseStatus(signInExperience, 400);
     });
@@ -103,12 +104,12 @@ describe('branding', () => {
       }
     );
 
-    it('should fail when it is empty string', async () => {
+    test.each([null, ''])('%p should fail', async (slogan) => {
       const signInExperience = {
         branding: {
           ...mockBranding,
           style: BrandingStyle.Logo,
-          slogan: '',
+          slogan,
         },
       };
       await expectPatchResponseStatus(signInExperience, 400);

--- a/packages/core/src/utils/mock.ts
+++ b/packages/core/src/utils/mock.ts
@@ -22,6 +22,7 @@ import {
   SignInMethodState,
   Branding,
   SignInMethods,
+  TermsOfUse,
 } from '@logto/schemas';
 import pick from 'lodash.pick';
 
@@ -396,6 +397,11 @@ export const mockBranding: Branding = {
   style: BrandingStyle.Logo_Slogan,
   logoUrl: 'http://silverhand.png',
   slogan: 'Silverhand.',
+};
+
+export const mockTermsOfUse: TermsOfUse = {
+  enabled: true,
+  contentUrl: 'http://silverhand.com/terms',
 };
 
 export const mockSignInMethods: SignInMethods = {

--- a/packages/core/src/utils/mock.ts
+++ b/packages/core/src/utils/mock.ts
@@ -23,6 +23,7 @@ import {
   Branding,
   SignInMethods,
   TermsOfUse,
+  LanguageInfo,
 } from '@logto/schemas';
 import pick from 'lodash.pick';
 
@@ -402,6 +403,12 @@ export const mockBranding: Branding = {
 export const mockTermsOfUse: TermsOfUse = {
   enabled: true,
   contentUrl: 'http://silverhand.com/terms',
+};
+
+export const mockLanguageInfo: LanguageInfo = {
+  autoDetect: true,
+  fallbackLanguage: Language.english,
+  fixedLanguage: Language.chinese,
 };
 
 export const mockSignInMethods: SignInMethods = {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Test terms-of-use and language-info guards for sign-in experience

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2095

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="365" alt="image" src="https://user-images.githubusercontent.com/10594507/161894908-ac6bfb12-2b7f-4c99-bdcf-8dc440ce43f4.png">

