### PR TITLE
fix(core): fix default enable value of new connectors

### DIFF
--- a/packages/schemas/tables/connectors.sql
+++ b/packages/schemas/tables/connectors.sql
@@ -3,7 +3,7 @@ create type connector_type as enum ('Email', 'SMS', 'Social');
 create table connectors (
   id varchar(128) not null,
   type connector_type not null,
-  enabled boolean not null default TRUE,
+  enabled boolean not null default FALSE,
   config jsonb /* @use ArbitraryObject */ not null default '{}'::jsonb,
   created_at timestamptz not null default(now()),
   primary key (id)


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Default `enabled` value of newly added connectors should be FALSE.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT.
