### PR TITLE
feat(console): support input form fields in get-started steps

### DIFF
--- a/packages/console/public/get-started/application/react/en/step3.md
+++ b/packages/console/public/get-started/application/react/en/step3.md
@@ -6,7 +6,7 @@ subtitle: 2 steps
 
 The Logto React SDK provides you tools and hooks to quickly implement your own authorization flow.  First, let’s enter your redirect URI
 
-```multitextinput
+```redirectUris
 Redirect URI
 ```
 

--- a/packages/console/public/get-started/application/react/en/step4.md
+++ b/packages/console/public/get-started/application/react/en/step4.md
@@ -4,7 +4,7 @@ subtitle: 1 steps
 ---
 Execute signOut() methods will redirect users to the Logto sign out page. After a success sign out, all use session data and auth status will be cleared. 
 
-```multitextinput
+```postLogoutRedirectUris
 Post sign out redirect URI
 ```
 

--- a/packages/console/public/get-started/application/react/zh-CN/step3.md
+++ b/packages/console/public/get-started/application/react/zh-CN/step3.md
@@ -6,7 +6,7 @@ subtitle: 2 steps
 
 The Logto React SDK provides you tools and hooks to quickly implement your own authorization flow.  First, let’s enter your redirect URI
 
-```multitextinput
+```redirectUris
 Redirect URI
 ```
 

--- a/packages/console/public/get-started/application/react/zh-CN/step4.md
+++ b/packages/console/public/get-started/application/react/zh-CN/step4.md
@@ -4,7 +4,7 @@ subtitle: 1 steps
 ---
 Execute signOut() methods will redirect users to the Logto sign out page. After a success sign out, all use session data and auth status will be cleared. 
 
-```multitextinput
+```postLogoutRedirectUris
 Post sign out redirect URI
 ```
 

--- a/packages/console/src/components/FormField/index.tsx
+++ b/packages/console/src/components/FormField/index.tsx
@@ -1,12 +1,13 @@
 import { I18nKey } from '@logto/phrases';
 import classNames from 'classnames';
-import React, { ReactNode } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import DangerousRaw from '../DangerousRaw';
 import * as styles from './index.module.scss';
 
 type Props = {
-  title: I18nKey;
+  title: I18nKey | ReactElement<typeof DangerousRaw>;
   children: ReactNode;
   isRequired?: boolean;
   className?: string;
@@ -18,7 +19,7 @@ const FormField = ({ title, children, isRequired, className }: Props) => {
   return (
     <div className={classNames(styles.field, className)}>
       <div className={styles.headline}>
-        <div className={styles.title}>{t(title)}</div>
+        <div className={styles.title}>{typeof title === 'string' ? t(title) : title}</div>
         {isRequired && <div className={styles.required}>{t('admin_console.form.required')}</div>}
       </div>
       {children}

--- a/packages/console/src/pages/ApplicationDetails/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/index.tsx
@@ -128,7 +128,7 @@ const ApplicationDetails = () => {
               required: t('application_details.redirect_uri_required'),
               pattern: {
                 regex: noSpaceRegex,
-                message: t('application_details.no_space_in_uri'),
+                message: t('errors.no_space_in_uri'),
               },
             }),
           }}
@@ -153,7 +153,7 @@ const ApplicationDetails = () => {
             validate: createValidatorForRhf({
               pattern: {
                 regex: noSpaceRegex,
-                message: t('application_details.no_space_in_uri'),
+                message: t('errors.no_space_in_uri'),
               },
             }),
           }}

--- a/packages/console/src/pages/Applications/components/GetStartedModal/index.tsx
+++ b/packages/console/src/pages/Applications/components/GetStartedModal/index.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import Modal from 'react-modal';
+
+import GetStarted from '@/pages/GetStarted';
+import * as modalStyles from '@/scss/modal.module.scss';
+import { SupportedJavascriptLibraries } from '@/types/applications';
+import { GetStartedForm } from '@/types/get-started';
+
+import LibrarySelector from '../LibrarySelector';
+
+type Props = {
+  appName: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onComplete: (data: GetStartedForm) => Promise<void>;
+};
+
+const GetStartedModal = ({ appName, isOpen, onClose, onComplete }: Props) => (
+  <Modal isOpen={isOpen} className={modalStyles.fullScreen}>
+    <GetStarted
+      bannerComponent={<LibrarySelector />}
+      title={appName}
+      subtitle="applications.get_started.header_description"
+      type="application"
+      defaultSubtype={SupportedJavascriptLibraries.React}
+      onClose={onClose}
+      onComplete={onComplete}
+    />
+  </Modal>
+);
+
+export default GetStartedModal;

--- a/packages/console/src/pages/Applications/components/LibrarySelector/index.module.scss
+++ b/packages/console/src/pages/Applications/components/LibrarySelector/index.module.scss
@@ -31,6 +31,7 @@
     flex-direction: row;
     align-items: center;
     flex: 0 0 56px;
+    height: 56px;
     background: var(--color-neutral-variant-90);
     border-radius: _.unit(2);
     padding: 0 _.unit(4);

--- a/packages/console/src/pages/GetStarted/components/CodeComponentRenderer/index.tsx
+++ b/packages/console/src/pages/GetStarted/components/CodeComponentRenderer/index.tsx
@@ -1,0 +1,79 @@
+import React, { PropsWithChildren, useEffect, useRef } from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { CodeProps } from 'react-markdown/lib/ast-to-react.js';
+
+import CodeEditor from '@/components/CodeEditor';
+import DangerousRaw from '@/components/DangerousRaw';
+import FormField from '@/components/FormField';
+import MultiTextInput from '@/components/MultiTextInput';
+import { createValidatorForRhf, convertRhfErrorMessage } from '@/components/MultiTextInput/utils';
+import { GetStartedForm } from '@/types/get-started';
+import { noSpaceRegex } from '@/utilities/regex';
+
+type Props = PropsWithChildren<CodeProps> & { onError: () => void };
+
+const CodeComponentRenderer = ({ className, children, onError }: Props) => {
+  const {
+    control,
+    formState: { errors },
+  } = useFormContext<GetStartedForm>();
+
+  const ref = useRef<HTMLDivElement>(null);
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const [, codeBlockType] = /language-(\w+)/.exec(className ?? '') ?? [];
+  const content = String(children);
+
+  /** Code block types defined in markdown. E.g.
+   * ```typescript
+   * some code
+   * ```
+   * These two custom code block types should be replaced with `MultiTextInput` component:
+   * 'redirectUris' and 'postLogoutRedirectUris'
+   */
+  const isMultilineInput =
+    codeBlockType === 'redirectUris' || codeBlockType === 'postLogoutRedirectUris';
+
+  const firstErrorKey = Object.keys(errors)[0];
+  const isFirstErrorField = firstErrorKey && firstErrorKey === codeBlockType;
+
+  useEffect(() => {
+    if (isFirstErrorField) {
+      onError();
+    }
+  }, [isFirstErrorField, onError]);
+
+  if (isMultilineInput) {
+    return (
+      <FormField isRequired title={<DangerousRaw>{content}</DangerousRaw>}>
+        <Controller
+          name={codeBlockType}
+          control={control}
+          defaultValue={[]}
+          rules={{
+            validate: createValidatorForRhf({
+              required: t('errors.required_field_missing_plural', { field: content }),
+              pattern: {
+                regex: noSpaceRegex,
+                message: t('errors.no_space_in_uri'),
+              },
+            }),
+          }}
+          render={({ field: { onChange, value }, fieldState: { error } }) => (
+            <div ref={ref}>
+              <MultiTextInput
+                value={value}
+                error={convertRhfErrorMessage(error?.message)}
+                onChange={onChange}
+              />
+            </div>
+          )}
+        />
+      </FormField>
+    );
+  }
+
+  return <CodeEditor isReadonly language={codeBlockType} value={content} />;
+};
+
+export default CodeComponentRenderer;

--- a/packages/console/src/pages/GetStarted/components/Step/index.module.scss
+++ b/packages/console/src/pages/GetStarted/components/Step/index.module.scss
@@ -6,7 +6,7 @@
   flex-direction: column;
   scroll-margin: _.unit(5);
 
-  .cardHeader {
+  .header {
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -47,6 +47,16 @@
     display: flex;
     justify-content: flex-end;
     margin-top: _.unit(6);
+  }
+
+  .content {
+    max-height: 0;
+    overflow: hidden;
+
+    &.expanded {
+      max-height: 9999px;
+      overflow: unset;
+    }
   }
 }
 

--- a/packages/console/src/pages/GetStarted/hooks/index.ts
+++ b/packages/console/src/pages/GetStarted/hooks/index.ts
@@ -3,9 +3,8 @@ import { useMemo } from 'react';
 // eslint-disable-next-line node/file-extension-in-import
 import useSWRImmutable from 'swr/immutable';
 
+import { StepMetadata } from '@/types/get-started';
 import { parseMarkdownWithYamlFrontmatter } from '@/utilities/markdown';
-
-import { StepMetadata } from '../components/Step';
 
 type DocumentFileNames = {
   files: string[];

--- a/packages/console/src/types/get-started.ts
+++ b/packages/console/src/types/get-started.ts
@@ -1,0 +1,11 @@
+export type StepMetadata = {
+  title?: string;
+  subtitle?: string;
+  metadata: string; // Markdown formatted string
+};
+
+export type GetStartedForm = {
+  redirectUris: string[];
+  postLogoutRedirectUris: string[];
+  connectorConfigJson: string;
+};

--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -51,6 +51,9 @@ const translation = {
       unknown_server_error: 'Unknown server error occurred.',
       empty: 'No Data',
       missing_total_number: 'Unable to find Total-Number in response headers.',
+      no_space_in_uri: 'Space is not allowed in URI',
+      required_field_missing: 'Please enter {{field}}',
+      required_field_missing_plural: 'You have to enter at least one {{field}}',
     },
     tab_sections: {
       overview: 'Overview',
@@ -103,7 +106,6 @@ const translation = {
       get_started: {
         header_description:
           'Follow a step by step guide to integrate your application or get a sample configured with your account settings',
-        get_sample_file: 'Get a sample file',
         title: 'Congratulations! The application has been created successfully.',
         subtitle:
           'Now follow the steps below to finish your app settings. Please select the JS library to continue.',
@@ -138,7 +140,6 @@ const translation = {
       application_deleted: 'The application {{name}} deleted.',
       save_success: 'Saved!',
       redirect_uri_required: 'You have to enter at least one redirect URI.',
-      no_space_in_uri: 'Space is not allowed in URI',
     },
     api_resources: {
       title: 'API Resources',
@@ -210,6 +211,9 @@ const translation = {
       options_change_sms: 'Change SMS connector',
       more_options: 'MORE OPTIONS',
       connector_deleted: 'The connector has been deleted.',
+    },
+    get_started: {
+      get_sample_file: 'Get a sample file',
     },
     users: {
       title: 'User Management',

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -53,6 +53,9 @@ const translation = {
       unknown_server_error: '服务器发生未知错误。',
       empty: '没有数据',
       missing_total_number: '无法从返回的头部信息中找到 Total-Number。',
+      no_space_in_uri: 'URI 中不能包含空格',
+      required_field_missing: '请输入{{field}}',
+      required_field_missing_plural: '{{field}}不能全部为空',
     },
     tab_sections: {
       overview: '概览',
@@ -105,7 +108,6 @@ const translation = {
       get_started: {
         header_description:
           '参考如下教程，将 Logto 集成到您的应用中。您也可以点击右侧链接，获取我们为您准备好的示范工程。',
-        get_sample_file: '获取示范工程',
         title: '恭喜！您的应用已成功创建。',
         subtitle: '请参考以下步骤完成您的应用设置。首先，请选择您要使用的 Javascript 框架：',
         description_by_library: '本教程向您演示如何在 {{library}} 应用中集成 Logto 登录功能',
@@ -138,7 +140,6 @@ const translation = {
       application_deleted: 'The application {{name}} deleted.',
       save_success: 'Saved!',
       redirect_uri_required: 'You have to enter at least one redirect URI.',
-      no_space_in_uri: 'Space is not allowed in URI',
     },
     api_resources: {
       title: 'API Resources',
@@ -210,6 +211,9 @@ const translation = {
       options_change_sms: '更换短信服务商',
       more_options: '更多选项',
       connector_deleted: '成功删除连接器。',
+    },
+    get_started: {
+      get_sample_file: '获取示例工程',
     },
     users: {
       title: '用户管理',


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
* Support form field inputs and form validation in get-started steps.
* Scroll to the first step that contains invalid fields on form submit

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
[LOG-1683](https://linear.app/silverhand/issue/LOG-1683/support-input-form-fields)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Create an application, the get-started guide launched
- [x] Check each step and click "Next" button to navigate to the next one. Click "Done" in the last step to submit the form.
- [x] If all required fields are provided, form submit will be successful and you can see the "redirectUri" and "postLogoutRedirectUri" are successfully saved in DB.
- [x] If "redirectUri" or "postLogoutRedirectUri" is not provided, form submit will be blocked and page will scroll to the step that contains the first invalid field.

https://user-images.githubusercontent.com/12833674/161924744-0d08dfdc-1170-4748-9e1f-fd3851f261e6.mov

