### PR TITLE
fix(console): change button border color to color-component-border

### DIFF
--- a/packages/console/src/components/Button/index.module.scss
+++ b/packages/console/src/components/Button/index.module.scss
@@ -57,7 +57,7 @@
   &.default {
     background: var(--color-on-primary);
     color: var(--color-component-text);
-    border-color: var(--color-outline);
+    border-color: var(--color-component-border);
     border-width: 1px;
     border-style: solid;
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Align with new design, set Button's default border-color to `color-component-border`.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

