### PR TITLE
fix(core): extraClientMetadata properties

### DIFF
--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -77,7 +77,7 @@ export default async function initOidc(app: Koa): Promise<Provider> {
       },
     },
     extraClientMetadata: {
-      properties: Object.keys(CustomClientMetadataKey),
+      properties: Object.values(CustomClientMetadataKey),
       validator: (_, key, value) => {
         validateCustomClientMetadata(key, value);
       },


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fix extraClientMetadata properties

- CustomClientMetadataKey: Its keys are different from its values.

```ts
export enum CustomClientMetadataKey {
  CorsAllowedOrigins = 'corsAllowedOrigins',
  IdTokenTtl = 'idTokenTtl',
  RefreshTokenTtl = 'refreshTokenTtl',
}
```

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2102

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Pass all existing tests.

<img width="949" alt="image" src="https://user-images.githubusercontent.com/10594507/162676669-ba92c2ca-ab74-4b97-84b6-6b2817ac4eb2.png">
