### PR TITLE
refactor(core): phone method refactor

### DIFF
--- a/packages/core/src/routes/session.test.ts
+++ b/packages/core/src/routes/session.test.ts
@@ -213,7 +213,7 @@ describe('sessionRoutes', () => {
     });
   });
 
-  describe('POST /session/sign-in/passwordless/phone/send-passcode', () => {
+  describe('POST /session/sign-in/passwordless/sms/send-passcode', () => {
     beforeAll(() => {
       interactionDetails.mockResolvedValueOnce({
         jti: 'jti',
@@ -221,23 +221,23 @@ describe('sessionRoutes', () => {
     });
     it('it should call sendPasscode', async () => {
       const response = await sessionRequest
-        .post('/session/sign-in/passwordless/phone/send-passcode')
+        .post('/session/sign-in/passwordless/sms/send-passcode')
         .send({ phone: '13000000000' });
       expect(response.statusCode).toEqual(204);
       expect(sendPasscode).toHaveBeenCalled();
     });
     it('throw error if phone does not exist', async () => {
       const response = await sessionRequest
-        .post('/session/sign-in/passwordless/phone/send-passcode')
+        .post('/session/sign-in/passwordless/sms/send-passcode')
         .send({ phone: '13000000001' });
       expect(response.statusCode).toEqual(422);
     });
   });
 
-  describe('POST /session/sign-in/passwordless/phone/verify-passcode', () => {
+  describe('POST /session/sign-in/passwordless/sms/verify-passcode', () => {
     it('assign result and redirect', async () => {
       const response = await sessionRequest
-        .post('/session/sign-in/passwordless/phone/verify-passcode')
+        .post('/session/sign-in/passwordless/sms/verify-passcode')
         .send({ phone: '13000000000', code: '1234' });
       expect(response.statusCode).toEqual(200);
       expect(response.body).toHaveProperty('redirectTo');
@@ -250,13 +250,13 @@ describe('sessionRoutes', () => {
     });
     it('throw error if phone does not exist', async () => {
       const response = await sessionRequest
-        .post('/session/sign-in/passwordless/phone/verify-passcode')
+        .post('/session/sign-in/passwordless/sms/verify-passcode')
         .send({ phone: '13000000001', code: '1234' });
       expect(response.statusCode).toEqual(422);
     });
     it('throw error if verifyPasscode failed', async () => {
       const response = await sessionRequest
-        .post('/session/sign-in/passwordless/phone/verify-passcode')
+        .post('/session/sign-in/passwordless/sms/verify-passcode')
         .send({ phone: '13000000000', code: '1231' });
       expect(response.statusCode).toEqual(400);
     });
@@ -522,7 +522,7 @@ describe('sessionRoutes', () => {
     });
   });
 
-  describe('POST /session/register/passwordless/phone/send-passcode', () => {
+  describe('POST /session/register/passwordless/sms/send-passcode', () => {
     beforeAll(() => {
       interactionDetails.mockResolvedValueOnce({
         jti: 'jti',
@@ -531,7 +531,7 @@ describe('sessionRoutes', () => {
 
     it('it should call sendPasscode', async () => {
       const response = await sessionRequest
-        .post('/session/register/passwordless/phone/send-passcode')
+        .post('/session/register/passwordless/sms/send-passcode')
         .send({ phone: '13000000001' });
       expect(response.statusCode).toEqual(204);
       expect(sendPasscode).toHaveBeenCalled();
@@ -539,30 +539,30 @@ describe('sessionRoutes', () => {
 
     it('throw error if phone not valid (charactors other than digits)', async () => {
       const response = await sessionRequest
-        .post('/session/register/passwordless/phone/send-passcode')
+        .post('/session/register/passwordless/sms/send-passcode')
         .send({ phone: '1300000000a' });
       expect(response.statusCode).toEqual(400);
     });
 
     it('throw error if phone not valid (not exactly 11-digits)', async () => {
       const response = await sessionRequest
-        .post('/session/register/passwordless/phone/send-passcode')
+        .post('/session/register/passwordless/sms/send-passcode')
         .send({ phone: '1300000000' });
       expect(response.statusCode).toEqual(400);
     });
 
     it('throw error if phone exists', async () => {
       const response = await sessionRequest
-        .post('/session/register/passwordless/phone/send-passcode')
+        .post('/session/register/passwordless/sms/send-passcode')
         .send({ phone: '13000000000' });
       expect(response.statusCode).toEqual(422);
     });
   });
 
-  describe('POST /session/register/passwordless/phone/verify-passcode', () => {
+  describe('POST /session/register/passwordless/sms/verify-passcode', () => {
     it('assign result and redirect', async () => {
       const response = await sessionRequest
-        .post('/session/register/passwordless/phone/verify-passcode')
+        .post('/session/register/passwordless/sms/verify-passcode')
         .send({ phone: '13000000001', code: '1234' });
       expect(response.statusCode).toEqual(200);
       expect(response.body).toHaveProperty('redirectTo');
@@ -579,28 +579,28 @@ describe('sessionRoutes', () => {
 
     it('throw error if phone not valid (characters other than digits)', async () => {
       const response = await sessionRequest
-        .post('/session/register/passwordless/phone/verify-passcode')
+        .post('/session/register/passwordless/sms/verify-passcode')
         .send({ phone: '1300000000a', code: '1234' });
       expect(response.statusCode).toEqual(400);
     });
 
     it('throw error if phone not valid (not exactly 11-digits)', async () => {
       const response = await sessionRequest
-        .post('/session/register/passwordless/phone/verify-passcode')
+        .post('/session/register/passwordless/sms/verify-passcode')
         .send({ phone: '1300000000', code: '1234' });
       expect(response.statusCode).toEqual(400);
     });
 
     it('throw error if phone exists', async () => {
       const response = await sessionRequest
-        .post('/session/register/passwordless/phone/verify-passcode')
+        .post('/session/register/passwordless/sms/verify-passcode')
         .send({ phone: '13000000000', code: '1234' });
       expect(response.statusCode).toEqual(422);
     });
 
     it('throw error if verifyPasscode failed', async () => {
       const response = await sessionRequest
-        .post('/session/register/passwordless/phone/verify-passcode')
+        .post('/session/register/passwordless/sms/verify-passcode')
         .send({ phone: '13000000001', code: '1231' });
       expect(response.statusCode).toEqual(400);
     });

--- a/packages/core/src/routes/session.ts
+++ b/packages/core/src/routes/session.ts
@@ -76,7 +76,7 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
   );
 
   router.post(
-    '/session/sign-in/passwordless/phone/send-passcode',
+    '/session/sign-in/passwordless/sms/send-passcode',
     koaGuard({ body: object({ phone: string().regex(phoneRegEx) }) }),
     async (ctx, next) => {
       const { jti } = await provider.interactionDetails(ctx.req, ctx.res);
@@ -98,7 +98,7 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
   );
 
   router.post(
-    '/session/sign-in/passwordless/phone/verify-passcode',
+    '/session/sign-in/passwordless/sms/verify-passcode',
     koaGuard({ body: object({ phone: string().regex(phoneRegEx), code: string() }) }),
     async (ctx, next) => {
       const { jti } = await provider.interactionDetails(ctx.req, ctx.res);
@@ -345,7 +345,7 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
   );
 
   router.post(
-    '/session/register/passwordless/phone/send-passcode',
+    '/session/register/passwordless/sms/send-passcode',
     koaGuard({ body: object({ phone: string().regex(phoneRegEx) }) }),
     async (ctx, next) => {
       ctx.userLog.type = UserLogType.RegisterPhone;
@@ -367,7 +367,7 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
   );
 
   router.post(
-    '/session/register/passwordless/phone/verify-passcode',
+    '/session/register/passwordless/sms/verify-passcode',
     koaGuard({ body: object({ phone: string().regex(phoneRegEx), code: string() }) }),
     async (ctx, next) => {
       const { jti } = await provider.interactionDetails(ctx.req, ctx.res);

--- a/packages/ui/src/apis/index.test.ts
+++ b/packages/ui/src/apis/index.test.ts
@@ -4,16 +4,16 @@ import { consent } from './consent';
 import {
   register,
   sendEmailPasscode as registerSendEmailPasscode,
-  sendPhonePasscode as registerSendPhonePasscode,
+  sendSMSPasscode as registerSendSMSPasscode,
   verifyEmailPasscode as registerVerifyEmailPasscode,
-  verifyPhonePasscode as registerVerifyPhonePasscode,
+  verifySMSPasscode as registerVerifySMSPasscode,
 } from './register';
 import {
   signInBasic,
-  sendPhonePasscode,
+  sendSMSPasscode,
   sendEmailPasscode,
   verifyEmailPasscode,
-  verifyPhonePasscode,
+  verifySMSPasscode,
 } from './sign-in';
 import {
   invokeSocialSignIn,
@@ -51,8 +51,8 @@ describe('api', () => {
     });
   });
 
-  it('sendPhonePasscode', async () => {
-    await sendPhonePasscode(phone);
+  it('sendSMSPasscode', async () => {
+    await sendSMSPasscode(phone);
     expect(ky.post).toBeCalledWith('/api/session/sign-in/passwordless/sms/send-passcode', {
       json: {
         phone,
@@ -60,8 +60,8 @@ describe('api', () => {
     });
   });
 
-  it('verifyPhonePasscode', async () => {
-    await verifyPhonePasscode(phone, passcode);
+  it('verifySMSPasscode', async () => {
+    await verifySMSPasscode(phone, passcode);
     expect(ky.post).toBeCalledWith('/api/session/sign-in/passwordless/sms/verify-passcode', {
       json: {
         phone,
@@ -104,8 +104,8 @@ describe('api', () => {
     });
   });
 
-  it('registerSendPhonePasscode', async () => {
-    await registerSendPhonePasscode(phone);
+  it('registerSendSMSPasscode', async () => {
+    await registerSendSMSPasscode(phone);
     expect(ky.post).toBeCalledWith('/api/session/register/passwordless/sms/send-passcode', {
       json: {
         phone,
@@ -113,8 +113,8 @@ describe('api', () => {
     });
   });
 
-  it('registerVerifyPhonePasscode', async () => {
-    await registerVerifyPhonePasscode(phone, passcode);
+  it('registerVerifySMSPasscode', async () => {
+    await registerVerifySMSPasscode(phone, passcode);
     expect(ky.post).toBeCalledWith('/api/session/register/passwordless/sms/verify-passcode', {
       json: {
         phone,

--- a/packages/ui/src/apis/index.test.ts
+++ b/packages/ui/src/apis/index.test.ts
@@ -53,7 +53,7 @@ describe('api', () => {
 
   it('sendPhonePasscode', async () => {
     await sendPhonePasscode(phone);
-    expect(ky.post).toBeCalledWith('/api/session/sign-in/passwordless/phone/send-passcode', {
+    expect(ky.post).toBeCalledWith('/api/session/sign-in/passwordless/sms/send-passcode', {
       json: {
         phone,
       },
@@ -62,7 +62,7 @@ describe('api', () => {
 
   it('verifyPhonePasscode', async () => {
     await verifyPhonePasscode(phone, passcode);
-    expect(ky.post).toBeCalledWith('/api/session/sign-in/passwordless/phone/verify-passcode', {
+    expect(ky.post).toBeCalledWith('/api/session/sign-in/passwordless/sms/verify-passcode', {
       json: {
         phone,
         passcode,
@@ -106,7 +106,7 @@ describe('api', () => {
 
   it('registerSendPhonePasscode', async () => {
     await registerSendPhonePasscode(phone);
-    expect(ky.post).toBeCalledWith('/api/session/register/passwordless/phone/send-passcode', {
+    expect(ky.post).toBeCalledWith('/api/session/register/passwordless/sms/send-passcode', {
       json: {
         phone,
       },
@@ -115,7 +115,7 @@ describe('api', () => {
 
   it('registerVerifyPhonePasscode', async () => {
     await registerVerifyPhonePasscode(phone, passcode);
-    expect(ky.post).toBeCalledWith('/api/session/register/passwordless/phone/verify-passcode', {
+    expect(ky.post).toBeCalledWith('/api/session/register/passwordless/sms/verify-passcode', {
       json: {
         phone,
         passcode,

--- a/packages/ui/src/apis/index.test.ts
+++ b/packages/ui/src/apis/index.test.ts
@@ -4,13 +4,13 @@ import { consent } from './consent';
 import {
   register,
   sendEmailPasscode as registerSendEmailPasscode,
-  sendSMSPasscode as registerSendSMSPasscode,
+  sendSmsPasscode as registerSendSMSPasscode,
   verifyEmailPasscode as registerVerifyEmailPasscode,
   verifySMSPasscode as registerVerifySMSPasscode,
 } from './register';
 import {
   signInBasic,
-  sendSMSPasscode,
+  sendSmsPasscode,
   sendEmailPasscode,
   verifyEmailPasscode,
   verifySMSPasscode,
@@ -51,8 +51,8 @@ describe('api', () => {
     });
   });
 
-  it('sendSMSPasscode', async () => {
-    await sendSMSPasscode(phone);
+  it('sendSmsPasscode', async () => {
+    await sendSmsPasscode(phone);
     expect(ky.post).toBeCalledWith('/api/session/sign-in/passwordless/sms/send-passcode', {
       json: {
         phone,

--- a/packages/ui/src/apis/index.test.ts
+++ b/packages/ui/src/apis/index.test.ts
@@ -4,16 +4,16 @@ import { consent } from './consent';
 import {
   register,
   sendEmailPasscode as registerSendEmailPasscode,
-  sendSmsPasscode as registerSendSMSPasscode,
+  sendSmsPasscode as registerSendSmsPasscode,
   verifyEmailPasscode as registerVerifyEmailPasscode,
-  verifySMSPasscode as registerVerifySMSPasscode,
+  verifySmsPasscode as registerVerifySmsPasscode,
 } from './register';
 import {
   signInBasic,
   sendSmsPasscode,
   sendEmailPasscode,
   verifyEmailPasscode,
-  verifySMSPasscode,
+  verifySmsPasscode,
 } from './sign-in';
 import {
   invokeSocialSignIn,
@@ -60,8 +60,8 @@ describe('api', () => {
     });
   });
 
-  it('verifySMSPasscode', async () => {
-    await verifySMSPasscode(phone, passcode);
+  it('verifySmsPasscode', async () => {
+    await verifySmsPasscode(phone, passcode);
     expect(ky.post).toBeCalledWith('/api/session/sign-in/passwordless/sms/verify-passcode', {
       json: {
         phone,
@@ -104,8 +104,8 @@ describe('api', () => {
     });
   });
 
-  it('registerSendSMSPasscode', async () => {
-    await registerSendSMSPasscode(phone);
+  it('registerSendSmsPasscode', async () => {
+    await registerSendSmsPasscode(phone);
     expect(ky.post).toBeCalledWith('/api/session/register/passwordless/sms/send-passcode', {
       json: {
         phone,
@@ -113,8 +113,8 @@ describe('api', () => {
     });
   });
 
-  it('registerVerifySMSPasscode', async () => {
-    await registerVerifySMSPasscode(phone, passcode);
+  it('registerVerifySmsPasscode', async () => {
+    await registerVerifySmsPasscode(phone, passcode);
     expect(ky.post).toBeCalledWith('/api/session/register/passwordless/sms/verify-passcode', {
       json: {
         phone,

--- a/packages/ui/src/apis/register.ts
+++ b/packages/ui/src/apis/register.ts
@@ -15,7 +15,7 @@ export const register = async (username: string, password: string) => {
     .json<Response>();
 };
 
-export const sendSMSPasscode = async (phone: string) => {
+export const sendSmsPasscode = async (phone: string) => {
   return ky
     .post('/api/session/register/passwordless/sms/send-passcode', {
       json: {

--- a/packages/ui/src/apis/register.ts
+++ b/packages/ui/src/apis/register.ts
@@ -25,7 +25,7 @@ export const sendSmsPasscode = async (phone: string) => {
     .json();
 };
 
-export const verifySMSPasscode = async (phone: string, passcode: string) => {
+export const verifySmsPasscode = async (phone: string, passcode: string) => {
   type Response = {
     redirectTo: string;
   };

--- a/packages/ui/src/apis/register.ts
+++ b/packages/ui/src/apis/register.ts
@@ -15,7 +15,7 @@ export const register = async (username: string, password: string) => {
     .json<Response>();
 };
 
-export const sendPhonePasscode = async (phone: string) => {
+export const sendSMSPasscode = async (phone: string) => {
   return ky
     .post('/api/session/register/passwordless/sms/send-passcode', {
       json: {
@@ -25,7 +25,7 @@ export const sendPhonePasscode = async (phone: string) => {
     .json();
 };
 
-export const verifyPhonePasscode = async (phone: string, passcode: string) => {
+export const verifySMSPasscode = async (phone: string, passcode: string) => {
   type Response = {
     redirectTo: string;
   };

--- a/packages/ui/src/apis/register.ts
+++ b/packages/ui/src/apis/register.ts
@@ -17,7 +17,7 @@ export const register = async (username: string, password: string) => {
 
 export const sendPhonePasscode = async (phone: string) => {
   return ky
-    .post('/api/session/register/passwordless/phone/send-passcode', {
+    .post('/api/session/register/passwordless/sms/send-passcode', {
       json: {
         phone,
       },
@@ -31,7 +31,7 @@ export const verifyPhonePasscode = async (phone: string, passcode: string) => {
   };
 
   return ky
-    .post('/api/session/register/passwordless/phone/verify-passcode', {
+    .post('/api/session/register/passwordless/sms/verify-passcode', {
       json: {
         phone,
         passcode,

--- a/packages/ui/src/apis/sign-in.ts
+++ b/packages/ui/src/apis/sign-in.ts
@@ -15,7 +15,7 @@ export const signInBasic = async (username: string, password: string) => {
     .json<Response>();
 };
 
-export const sendSMSPasscode = async (phone: string) => {
+export const sendSmsPasscode = async (phone: string) => {
   return ky
     .post('/api/session/sign-in/passwordless/sms/send-passcode', {
       json: {

--- a/packages/ui/src/apis/sign-in.ts
+++ b/packages/ui/src/apis/sign-in.ts
@@ -25,7 +25,7 @@ export const sendSmsPasscode = async (phone: string) => {
     .json();
 };
 
-export const verifySMSPasscode = async (phone: string, passcode: string) => {
+export const verifySmsPasscode = async (phone: string, passcode: string) => {
   type Response = {
     redirectTo: string;
   };

--- a/packages/ui/src/apis/sign-in.ts
+++ b/packages/ui/src/apis/sign-in.ts
@@ -17,7 +17,7 @@ export const signInBasic = async (username: string, password: string) => {
 
 export const sendPhonePasscode = async (phone: string) => {
   return ky
-    .post('/api/session/sign-in/passwordless/phone/send-passcode', {
+    .post('/api/session/sign-in/passwordless/sms/send-passcode', {
       json: {
         phone,
       },
@@ -31,7 +31,7 @@ export const verifyPhonePasscode = async (phone: string, passcode: string) => {
   };
 
   return ky
-    .post('/api/session/sign-in/passwordless/phone/verify-passcode', {
+    .post('/api/session/sign-in/passwordless/sms/verify-passcode', {
       json: {
         phone,
         passcode,

--- a/packages/ui/src/apis/sign-in.ts
+++ b/packages/ui/src/apis/sign-in.ts
@@ -15,7 +15,7 @@ export const signInBasic = async (username: string, password: string) => {
     .json<Response>();
 };
 
-export const sendPhonePasscode = async (phone: string) => {
+export const sendSMSPasscode = async (phone: string) => {
   return ky
     .post('/api/session/sign-in/passwordless/sms/send-passcode', {
       json: {
@@ -25,7 +25,7 @@ export const sendPhonePasscode = async (phone: string) => {
     .json();
 };
 
-export const verifyPhonePasscode = async (phone: string, passcode: string) => {
+export const verifySMSPasscode = async (phone: string, passcode: string) => {
   type Response = {
     redirectTo: string;
   };

--- a/packages/ui/src/apis/utils.ts
+++ b/packages/ui/src/apis/utils.ts
@@ -2,15 +2,15 @@ import { UserFlow } from '@/types';
 
 import {
   verifyEmailPasscode as verifyRegisterEmailPasscode,
-  verifyPhonePasscode as verifyRegisterPhonePasscode,
+  verifySMSPasscode as verifyRegisterSMSPasscode,
   sendEmailPasscode as sendRegisterEmailPasscode,
-  sendPhonePasscode as sendRegisterPhonePasscode,
+  sendSMSPasscode as sendRegisterSMSPasscode,
 } from './register';
 import {
   verifyEmailPasscode as verifySignInEmailPasscode,
-  verifyPhonePasscode as verifySignInPhonePasscode,
+  verifySMSPasscode as verifySignInSMSPasscode,
   sendEmailPasscode as sendSignInEmailPasscode,
-  sendPhonePasscode as sendSignInPhonePasscode,
+  sendSMSPasscode as sendSignInSMSPasscode,
 } from './sign-in';
 
 export type PasscodeChannel = 'sms' | 'email';
@@ -21,14 +21,14 @@ export const getSendPasscodeApi = (type: UserFlow, channel: PasscodeChannel) => 
   }
 
   if (type === 'sign-in' && channel === 'sms') {
-    return sendSignInPhonePasscode;
+    return sendSignInSMSPasscode;
   }
 
   if (type === 'register' && channel === 'email') {
     return sendRegisterEmailPasscode;
   }
 
-  return sendRegisterPhonePasscode;
+  return sendRegisterSMSPasscode;
 };
 
 export const getVerifyPasscodeApi = (type: UserFlow, channel: PasscodeChannel) => {
@@ -37,12 +37,12 @@ export const getVerifyPasscodeApi = (type: UserFlow, channel: PasscodeChannel) =
   }
 
   if (type === 'sign-in' && channel === 'sms') {
-    return verifySignInPhonePasscode;
+    return verifySignInSMSPasscode;
   }
 
   if (type === 'register' && channel === 'email') {
     return verifyRegisterEmailPasscode;
   }
 
-  return verifyRegisterPhonePasscode;
+  return verifyRegisterSMSPasscode;
 };

--- a/packages/ui/src/apis/utils.ts
+++ b/packages/ui/src/apis/utils.ts
@@ -2,15 +2,15 @@ import { UserFlow } from '@/types';
 
 import {
   verifyEmailPasscode as verifyRegisterEmailPasscode,
-  verifySMSPasscode as verifyRegisterSMSPasscode,
+  verifySmsPasscode as verifyRegisterSmsPasscode,
   sendEmailPasscode as sendRegisterEmailPasscode,
-  sendSmsPasscode as sendRegisterSMSPasscode,
+  sendSmsPasscode as sendRegisterSmsPasscode,
 } from './register';
 import {
   verifyEmailPasscode as verifySignInEmailPasscode,
-  verifySMSPasscode as verifySignInSMSPasscode,
+  verifySmsPasscode as verifySignInSmsPasscode,
   sendEmailPasscode as sendSignInEmailPasscode,
-  sendSmsPasscode as sendSignInSMSPasscode,
+  sendSmsPasscode as sendSignInSmsPasscode,
 } from './sign-in';
 
 export type PasscodeChannel = 'sms' | 'email';
@@ -21,14 +21,14 @@ export const getSendPasscodeApi = (type: UserFlow, channel: PasscodeChannel) => 
   }
 
   if (type === 'sign-in' && channel === 'sms') {
-    return sendSignInSMSPasscode;
+    return sendSignInSmsPasscode;
   }
 
   if (type === 'register' && channel === 'email') {
     return sendRegisterEmailPasscode;
   }
 
-  return sendRegisterSMSPasscode;
+  return sendRegisterSmsPasscode;
 };
 
 export const getVerifyPasscodeApi = (type: UserFlow, channel: PasscodeChannel) => {
@@ -37,12 +37,12 @@ export const getVerifyPasscodeApi = (type: UserFlow, channel: PasscodeChannel) =
   }
 
   if (type === 'sign-in' && channel === 'sms') {
-    return verifySignInSMSPasscode;
+    return verifySignInSmsPasscode;
   }
 
   if (type === 'register' && channel === 'email') {
     return verifyRegisterEmailPasscode;
   }
 
-  return verifyRegisterSMSPasscode;
+  return verifyRegisterSmsPasscode;
 };

--- a/packages/ui/src/apis/utils.ts
+++ b/packages/ui/src/apis/utils.ts
@@ -4,13 +4,13 @@ import {
   verifyEmailPasscode as verifyRegisterEmailPasscode,
   verifySMSPasscode as verifyRegisterSMSPasscode,
   sendEmailPasscode as sendRegisterEmailPasscode,
-  sendSMSPasscode as sendRegisterSMSPasscode,
+  sendSmsPasscode as sendRegisterSMSPasscode,
 } from './register';
 import {
   verifyEmailPasscode as verifySignInEmailPasscode,
   verifySMSPasscode as verifySignInSMSPasscode,
   sendEmailPasscode as sendSignInEmailPasscode,
-  sendSMSPasscode as sendSignInSMSPasscode,
+  sendSmsPasscode as sendSignInSMSPasscode,
 } from './sign-in';
 
 export type PasscodeChannel = 'sms' | 'email';

--- a/packages/ui/src/apis/utils.ts
+++ b/packages/ui/src/apis/utils.ts
@@ -13,14 +13,14 @@ import {
   sendPhonePasscode as sendSignInPhonePasscode,
 } from './sign-in';
 
-export type PasscodeChannel = 'phone' | 'email';
+export type PasscodeChannel = 'sms' | 'email';
 
 export const getSendPasscodeApi = (type: UserFlow, channel: PasscodeChannel) => {
   if (type === 'sign-in' && channel === 'email') {
     return sendSignInEmailPasscode;
   }
 
-  if (type === 'sign-in' && channel === 'phone') {
+  if (type === 'sign-in' && channel === 'sms') {
     return sendSignInPhonePasscode;
   }
 
@@ -36,7 +36,7 @@ export const getVerifyPasscodeApi = (type: UserFlow, channel: PasscodeChannel) =
     return verifySignInEmailPasscode;
   }
 
-  if (type === 'sign-in' && channel === 'phone') {
+  if (type === 'sign-in' && channel === 'sms') {
     return verifySignInPhonePasscode;
   }
 

--- a/packages/ui/src/containers/PasscodeValidation/index.tsx
+++ b/packages/ui/src/containers/PasscodeValidation/index.tsx
@@ -16,7 +16,7 @@ import * as styles from './index.module.scss';
 
 type Props = {
   type: UserFlow;
-  channel: 'email' | 'phone';
+  channel: 'email' | 'sms';
   target: string;
   className?: string;
 };

--- a/packages/ui/src/containers/Passwordless/PhonePasswordless.test.tsx
+++ b/packages/ui/src/containers/Passwordless/PhonePasswordless.test.tsx
@@ -2,14 +2,14 @@ import { fireEvent, render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
-import { sendPhonePasscode as sendRegisterPhonePasscode } from '@/apis/register';
-import { sendPhonePasscode as sendSignInPhonePasscode } from '@/apis/sign-in';
+import { sendSMSPasscode as sendRegisterSMSPasscode } from '@/apis/register';
+import { sendSMSPasscode as sendSignInSMSPasscode } from '@/apis/sign-in';
 import { defaultCountryCallingCode } from '@/hooks/use-phone-number';
 
 import PhonePasswordless from './PhonePasswordless';
 
-jest.mock('@/apis/sign-in', () => ({ sendPhonePasscode: jest.fn(async () => Promise.resolve()) }));
-jest.mock('@/apis/register', () => ({ sendPhonePasscode: jest.fn(async () => Promise.resolve()) }));
+jest.mock('@/apis/sign-in', () => ({ sendSMSPasscode: jest.fn(async () => Promise.resolve()) }));
+jest.mock('@/apis/register', () => ({ sendSMSPasscode: jest.fn(async () => Promise.resolve()) }));
 jest.mock('@/hooks/page-context', () =>
   React.createContext({
     loading: false,
@@ -41,7 +41,7 @@ describe('<PhonePasswordless/>', () => {
 
     fireEvent.click(submitButton);
     expect(queryByText('invalid_phone')).not.toBeNull();
-    expect(sendSignInPhonePasscode).not.toBeCalled();
+    expect(sendSignInSMSPasscode).not.toBeCalled();
 
     const phoneInput = container.querySelector('input[name="phone"]');
 
@@ -91,7 +91,7 @@ describe('<PhonePasswordless/>', () => {
       fireEvent.click(submitButton);
     });
 
-    expect(sendSignInPhonePasscode).toBeCalledWith(`${defaultCountryCallingCode}${phoneNumber}`);
+    expect(sendSignInSMSPasscode).toBeCalledWith(`${defaultCountryCallingCode}${phoneNumber}`);
   });
 
   test('register method properly', async () => {
@@ -114,6 +114,6 @@ describe('<PhonePasswordless/>', () => {
       fireEvent.click(submitButton);
     });
 
-    expect(sendRegisterPhonePasscode).toBeCalledWith(`${defaultCountryCallingCode}${phoneNumber}`);
+    expect(sendRegisterSMSPasscode).toBeCalledWith(`${defaultCountryCallingCode}${phoneNumber}`);
   });
 });

--- a/packages/ui/src/containers/Passwordless/PhonePasswordless.test.tsx
+++ b/packages/ui/src/containers/Passwordless/PhonePasswordless.test.tsx
@@ -2,14 +2,14 @@ import { fireEvent, render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
-import { sendSMSPasscode as sendRegisterSMSPasscode } from '@/apis/register';
-import { sendSMSPasscode as sendSignInSMSPasscode } from '@/apis/sign-in';
+import { sendSmsPasscode as sendRegisterSMSPasscode } from '@/apis/register';
+import { sendSmsPasscode as sendSignInSMSPasscode } from '@/apis/sign-in';
 import { defaultCountryCallingCode } from '@/hooks/use-phone-number';
 
 import PhonePasswordless from './PhonePasswordless';
 
-jest.mock('@/apis/sign-in', () => ({ sendSMSPasscode: jest.fn(async () => Promise.resolve()) }));
-jest.mock('@/apis/register', () => ({ sendSMSPasscode: jest.fn(async () => Promise.resolve()) }));
+jest.mock('@/apis/sign-in', () => ({ sendSmsPasscode: jest.fn(async () => Promise.resolve()) }));
+jest.mock('@/apis/register', () => ({ sendSmsPasscode: jest.fn(async () => Promise.resolve()) }));
 jest.mock('@/hooks/page-context', () =>
   React.createContext({
     loading: false,

--- a/packages/ui/src/containers/Passwordless/PhonePasswordless.test.tsx
+++ b/packages/ui/src/containers/Passwordless/PhonePasswordless.test.tsx
@@ -2,8 +2,8 @@ import { fireEvent, render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
-import { sendSmsPasscode as sendRegisterSMSPasscode } from '@/apis/register';
-import { sendSmsPasscode as sendSignInSMSPasscode } from '@/apis/sign-in';
+import { sendSmsPasscode as sendRegisterSmsPasscode } from '@/apis/register';
+import { sendSmsPasscode as sendSignInSmsPasscode } from '@/apis/sign-in';
 import { defaultCountryCallingCode } from '@/hooks/use-phone-number';
 
 import PhonePasswordless from './PhonePasswordless';
@@ -41,7 +41,7 @@ describe('<PhonePasswordless/>', () => {
 
     fireEvent.click(submitButton);
     expect(queryByText('invalid_phone')).not.toBeNull();
-    expect(sendSignInSMSPasscode).not.toBeCalled();
+    expect(sendSignInSmsPasscode).not.toBeCalled();
 
     const phoneInput = container.querySelector('input[name="phone"]');
 
@@ -91,7 +91,7 @@ describe('<PhonePasswordless/>', () => {
       fireEvent.click(submitButton);
     });
 
-    expect(sendSignInSMSPasscode).toBeCalledWith(`${defaultCountryCallingCode}${phoneNumber}`);
+    expect(sendSignInSmsPasscode).toBeCalledWith(`${defaultCountryCallingCode}${phoneNumber}`);
   });
 
   test('register method properly', async () => {
@@ -114,6 +114,6 @@ describe('<PhonePasswordless/>', () => {
       fireEvent.click(submitButton);
     });
 
-    expect(sendRegisterSMSPasscode).toBeCalledWith(`${defaultCountryCallingCode}${phoneNumber}`);
+    expect(sendRegisterSmsPasscode).toBeCalledWith(`${defaultCountryCallingCode}${phoneNumber}`);
   });
 });

--- a/packages/ui/src/containers/Passwordless/PhonePasswordless.tsx
+++ b/packages/ui/src/containers/Passwordless/PhonePasswordless.tsx
@@ -49,7 +49,7 @@ const PhonePasswordless = ({ type }: Props) => {
 
   const { phoneNumber, setPhoneNumber, isValidPhoneNumber } = usePhoneNumber();
 
-  const sendPasscode = getSendPasscodeApi(type, 'phone');
+  const sendPasscode = getSendPasscodeApi(type, 'sms');
   const { error, result, run: asyncSendPasscode } = useApi(sendPasscode);
 
   const validations = useMemo<FieldValidations>(
@@ -99,7 +99,7 @@ const PhonePasswordless = ({ type }: Props) => {
     console.log(result);
 
     if (result) {
-      navigate(`/${type}/phone/passcode-validation`, { state: { phone: fieldState.phone } });
+      navigate(`/${type}/sms/passcode-validation`, { state: { phone: fieldState.phone } });
     }
   }, [fieldState.phone, navigate, result, type]);
 

--- a/packages/ui/src/containers/SignInMethodsLink/index.tsx
+++ b/packages/ui/src/containers/SignInMethodsLink/index.tsx
@@ -20,7 +20,7 @@ const SignInMethodsKeyMap: {
 } = {
   username: 'username',
   email: 'email',
-  phone: 'phone_number',
+  sms: 'phone_number',
 };
 
 const SignInMethodsLink = ({ signInMethods, type = 'secondary', classname }: Props) => {

--- a/packages/ui/src/pages/Passcode/index.tsx
+++ b/packages/ui/src/pages/Passcode/index.tsx
@@ -16,7 +16,7 @@ type Parameters = {
 
 type StateType = Nullable<{
   email?: string;
-  phone?: string;
+  sms?: string;
 }>;
 
 const Passcode = () => {
@@ -25,7 +25,7 @@ const Passcode = () => {
   const { channel, type } = useParams<Parameters>();
   const state = useLocation().state as StateType;
   const invalidSignInMethod = type !== 'sign-in' && type !== 'register';
-  const invalidChannel = channel !== 'email' && channel !== 'phone';
+  const invalidChannel = channel !== 'email' && channel !== 'sms';
 
   useEffect(() => {
     if (invalidSignInMethod || invalidChannel) {

--- a/packages/ui/src/pages/Register/index.test.tsx
+++ b/packages/ui/src/pages/Register/index.test.tsx
@@ -19,7 +19,7 @@ describe('<Register />', () => {
 
   test('renders phone', async () => {
     const { queryByText, container } = render(
-      <MemoryRouter initialEntries={['/register/phone']}>
+      <MemoryRouter initialEntries={['/register/sms']}>
         <Routes>
           <Route path="/register/:channel" element={<Register />} />
         </Routes>

--- a/packages/ui/src/pages/Register/index.tsx
+++ b/packages/ui/src/pages/Register/index.tsx
@@ -18,13 +18,13 @@ const Register = () => {
   const { channel = 'username' } = useParams<Parameters>();
 
   useEffect(() => {
-    if (channel !== 'email' && channel !== 'phone' && channel !== 'username') {
+    if (channel !== 'email' && channel !== 'sms' && channel !== 'username') {
       navigate('/404', { replace: true });
     }
   }, [channel, navigate]);
 
   const registerForm = useMemo(() => {
-    if (channel === 'phone') {
+    if (channel === 'sms') {
       return <PhonePasswordless type="register" />;
     }
 

--- a/packages/ui/src/pages/SecondarySignIn/index.test.tsx
+++ b/packages/ui/src/pages/SecondarySignIn/index.test.tsx
@@ -18,7 +18,7 @@ describe('<SecondarySignIn />', () => {
 
   test('renders phone', async () => {
     const { queryByText, container } = render(
-      <MemoryRouter initialEntries={['/sign-in/phone']}>
+      <MemoryRouter initialEntries={['/sign-in/sms']}>
         <Routes>
           <Route path="/sign-in/:channel" element={<SecondarySignIn />} />
         </Routes>

--- a/packages/ui/src/pages/SecondarySignIn/index.tsx
+++ b/packages/ui/src/pages/SecondarySignIn/index.tsx
@@ -18,13 +18,13 @@ const SecondarySignIn = () => {
   const { channel = 'username' } = useParams<Props>();
 
   useEffect(() => {
-    if (channel !== 'email' && channel !== 'phone' && channel !== 'username') {
+    if (channel !== 'email' && channel !== 'sms' && channel !== 'username') {
       navigate('/404', { replace: true });
     }
   }, [channel, navigate]);
 
   const signInForm = useMemo(() => {
-    if (channel === 'phone') {
+    if (channel === 'sms') {
       return <PhonePasswordless type="sign-in" />;
     }
 

--- a/packages/ui/src/types/index.ts
+++ b/packages/ui/src/types/index.ts
@@ -1,2 +1,2 @@
 export type UserFlow = 'sign-in' | 'register';
-export type SignInMethod = 'username' | 'email' | 'phone';
+export type SignInMethod = 'username' | 'email' | 'sms';


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Replace phone signin method with sms

Per our offline discussion, align sms as the phone passwordless signInMethod naming. 

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT case passed
test locally on demo app
@logto-io/eng 