### PR TITLE
fix(console): drawer component background

### DIFF
--- a/packages/console/src/components/Drawer/index.module.scss
+++ b/packages/console/src/components/Drawer/index.module.scss
@@ -7,7 +7,7 @@
   right: 0;
   bottom: 0;
   outline: none;
-  background: var(--color-card-background);
+  background: var(--color-on-primary);
   padding: _.unit(6);
   overflow-y: auto;
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Drawer component is using a background color that no longer exists in the code base. Hence, replace it with the correct color variable.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Check readme on connector details page, and drawer background display is as expected

<img width="1511" alt="image" src="https://user-images.githubusercontent.com/12833674/162934033-63293065-6dfb-4533-87d0-892956233ed7.png">

