### PR TITLE
feat(console): connectors get-started page

### DIFF
--- a/packages/console/src/components/RadioGroup/index.tsx
+++ b/packages/console/src/components/RadioGroup/index.tsx
@@ -14,7 +14,7 @@ import * as styles from './index.module.scss';
 type Props = {
   name: string;
   children: ReactNode;
-  value: string;
+  value?: string;
   className?: string;
   onChange?: (value: string) => void;
 };

--- a/packages/console/src/pages/Connectors/components/GetStartedModal/index.module.scss
+++ b/packages/console/src/pages/Connectors/components/GetStartedModal/index.module.scss
@@ -27,21 +27,25 @@
   .content {
     flex: 1;
     display: flex;
-    flex-direction: column;
-    align-items: center;
-    overflow-y: auto;
-    padding: _.unit(6) 0 _.unit(20);
+    overflow: hidden;
+    padding: _.unit(6) _.unit(15);
 
     > * {
-      width: 858px;
+      flex: 1;
+      margin: 0 12px;
+      display: flex;
+      flex-direction: column;
+      overflow-y: auto;
     }
 
-    .banner {
-      margin-bottom: _.unit(6);
+    .readme {
+      background-color: var(--color-surface-variant);
+      border-radius: 16px;
+      padding: _.unit(6);
+    }
+
+    form + div {
+      margin-top: _.unit(6);
     }
   }
-}
-
-.markdownContent {
-  margin-top: _.unit(6);
 }

--- a/packages/console/src/pages/Connectors/components/GetStartedModal/index.tsx
+++ b/packages/console/src/pages/Connectors/components/GetStartedModal/index.tsx
@@ -1,0 +1,166 @@
+import { ConnectorDTO, ConnectorType } from '@logto/schemas';
+import i18next from 'i18next';
+import React, { useState } from 'react';
+import { Controller, FormProvider, useForm } from 'react-hook-form';
+import { toast } from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+import ReactMarkdown from 'react-markdown';
+import Modal from 'react-modal';
+
+import Button from '@/components/Button';
+import CardTitle from '@/components/CardTitle';
+import CodeEditor from '@/components/CodeEditor';
+import DangerousRaw from '@/components/DangerousRaw';
+import IconButton from '@/components/IconButton';
+import Spacer from '@/components/Spacer';
+import useApi from '@/hooks/use-api';
+import Close from '@/icons/Close';
+import SenderTester from '@/pages/ConnectorDetails/components/SenderTester';
+import Step from '@/pages/GetStarted/components/Step';
+import * as modalStyles from '@/scss/modal.module.scss';
+import { GetStartedForm } from '@/types/get-started';
+
+import * as styles from './index.module.scss';
+
+type Props = {
+  connector: ConnectorDTO;
+  isOpen: boolean;
+  onClose: () => void;
+  onComplete?: (data: GetStartedForm) => Promise<void>;
+};
+
+const onClickFetchSampleProject = (name: string) => {
+  const sampleUrl = `https://github.com/logto-io/js/tree/master/packages/connectors/${name}-sample`;
+  window.open(sampleUrl, '_blank');
+};
+
+const GetStartedModal = ({ connector, isOpen, onClose }: Props) => {
+  const api = useApi();
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const {
+    id: connectorId,
+    type: connectorType,
+    metadata: { name, configTemplate, readme },
+  } = connector;
+
+  const locale = i18next.language;
+  const connectorName = name[locale] ?? name.en;
+  const isSocialConnector =
+    connectorType !== ConnectorType.SMS && connectorType !== ConnectorType.Email;
+  const [activeStepIndex, setActiveStepIndex] = useState<number>(0);
+  const methods = useForm<GetStartedForm>({ reValidateMode: 'onBlur' });
+  const {
+    control,
+    formState: { isSubmitting },
+    handleSubmit,
+  } = methods;
+
+  const onSubmit = handleSubmit(async ({ connectorConfigJson }) => {
+    if (isSubmitting) {
+      return;
+    }
+
+    try {
+      const config = JSON.parse(connectorConfigJson) as JSON;
+      await api
+        .patch(`/api/connectors/${connectorId}`, {
+          json: { config },
+        })
+        .json<ConnectorDTO>();
+
+      setActiveStepIndex(activeStepIndex + 1);
+      toast.success(t('connector_details.save_success'));
+    } catch (error: unknown) {
+      if (error instanceof SyntaxError) {
+        toast.error(t('connector_details.save_error_json_parse_error'));
+      }
+    }
+  });
+
+  return (
+    <Modal isOpen={isOpen} className={modalStyles.fullScreen}>
+      <div className={styles.container}>
+        <div className={styles.header}>
+          <IconButton size="large" onClick={onClose}>
+            <Close />
+          </IconButton>
+          <div className={styles.separator} />
+          <CardTitle
+            size="small"
+            title={<DangerousRaw>{connectorName}</DangerousRaw>}
+            subtitle="connectors.get_started.subtitle"
+          />
+          <Spacer />
+          <Button type="plain" size="small" title="general.skip" onClick={onClose} />
+          {connectorName && (
+            <Button
+              type="outline"
+              title="admin_console.get_started.get_sample_file"
+              onClick={() => {
+                onClickFetchSampleProject(connectorName);
+              }}
+            />
+          )}
+        </div>
+        <div className={styles.content}>
+          <ReactMarkdown
+            className={styles.readme}
+            components={{
+              code: ({ node, inline, className, children, ...props }) => {
+                const [, codeBlockType] = /language-(\w+)/.exec(className ?? '') ?? [];
+
+                return inline ? (
+                  <code {...props}>{children}</code>
+                ) : (
+                  <CodeEditor isReadonly language={codeBlockType} value={String(children)} />
+                );
+              },
+            }}
+          >
+            {readme}
+          </ReactMarkdown>
+          <div>
+            <FormProvider {...methods}>
+              <form onSubmit={onSubmit}>
+                <Step
+                  title="Enter your json here"
+                  subtitle="Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
+                  index={0}
+                  isActive={activeStepIndex === 0}
+                  isComplete={activeStepIndex > 0}
+                  isFinalStep={isSocialConnector}
+                  buttonHtmlType="submit"
+                >
+                  <Controller
+                    name="connectorConfigJson"
+                    control={control}
+                    defaultValue={configTemplate}
+                    render={({ field: { onChange, value } }) => (
+                      <CodeEditor language="json" value={value} onChange={onChange} />
+                    )}
+                  />
+                </Step>
+              </form>
+            </FormProvider>
+            {!isSocialConnector && (
+              <Step
+                isFinalStep
+                title="Test your message"
+                subtitle="Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
+                index={1}
+                isActive={activeStepIndex === 1}
+                isComplete={activeStepIndex > 1}
+                buttonHtmlType="button"
+                onNext={onClose}
+              >
+                <SenderTester connectorType={connectorType} />
+              </Step>
+            )}
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default GetStartedModal;

--- a/packages/console/src/pages/Connectors/index.tsx
+++ b/packages/console/src/pages/Connectors/index.tsx
@@ -125,15 +125,13 @@ const Connectors = () => {
           </table>
         </div>
       </Card>
-      {data && (
-        <CreateForm
-          isOpen={Boolean(createType)}
-          type={createType}
-          onClose={() => {
-            setCreateType(undefined);
-          }}
-        />
-      )}
+      <CreateForm
+        isOpen={Boolean(createType)}
+        type={createType}
+        onClose={() => {
+          setCreateType(undefined);
+        }}
+      />
     </>
   );
 };

--- a/packages/console/src/pages/GetStarted/components/Step/index.module.scss
+++ b/packages/console/src/pages/GetStarted/components/Step/index.module.scss
@@ -50,10 +50,12 @@
   }
 
   .content {
+    margin-top: 0;
     max-height: 0;
     overflow: hidden;
 
     &.expanded {
+      margin-top: _.unit(6);
       max-height: 9999px;
       overflow: unset;
     }
@@ -61,9 +63,5 @@
 }
 
 .card + .card {
-  margin-top: _.unit(6);
-}
-
-.markdownContent {
   margin-top: _.unit(6);
 }

--- a/packages/console/src/pages/GetStarted/components/Step/index.tsx
+++ b/packages/console/src/pages/GetStarted/components/Step/index.tsx
@@ -1,7 +1,15 @@
 import { conditional } from '@silverhand/essentials';
 import classNames from 'classnames';
-import React, { PropsWithChildren, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import ReactMarkdown from 'react-markdown';
+import React, {
+  cloneElement,
+  isValidElement,
+  PropsWithChildren,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { CodeProps } from 'react-markdown/lib/ast-to-react.js';
 
 import Button from '@/components/Button';
@@ -12,23 +20,33 @@ import IconButton from '@/components/IconButton';
 import Spacer from '@/components/Spacer';
 import { ArrowDown, ArrowUp } from '@/icons/Arrow';
 import Tick from '@/icons/Tick';
-import { StepMetadata } from '@/types/get-started';
 
 import CodeComponentRenderer from '../CodeComponentRenderer';
 import * as styles from './index.module.scss';
 
-type Props = {
-  data: StepMetadata;
+type Props = PropsWithChildren<{
+  title: string;
+  subtitle?: string;
   index: number;
   isActive: boolean;
   isComplete: boolean;
   isFinalStep: boolean;
+  buttonHtmlType: 'submit' | 'button';
   onNext?: () => void;
-};
+}>;
 
-const Step = ({ data, index, isActive, isComplete, isFinalStep, onNext }: Props) => {
+const Step = ({
+  children,
+  title,
+  subtitle,
+  index,
+  isActive,
+  isComplete,
+  isFinalStep,
+  buttonHtmlType,
+  onNext,
+}: Props) => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const { title, subtitle, metadata } = data;
   const ref = useRef<HTMLDivElement>(null);
 
   const scrollToStep = useCallback(() => {
@@ -61,11 +79,6 @@ const Step = ({ data, index, isActive, isComplete, isFinalStep, onNext }: Props)
     [onError]
   );
 
-  // Steps in get-started must have "title" declared in the Yaml header of the markdown source file
-  if (!title) {
-    return null;
-  }
-
   // TODO: add more styles to markdown renderer
   return (
     <Card key={title} ref={ref} className={styles.card}>
@@ -93,12 +106,10 @@ const Step = ({ data, index, isActive, isComplete, isFinalStep, onNext }: Props)
         <IconButton>{isExpanded ? <ArrowUp /> : <ArrowDown />}</IconButton>
       </div>
       <div className={classNames(styles.content, isExpanded && styles.expanded)}>
-        <ReactMarkdown className={styles.markdownContent} components={memoizedComponents}>
-          {metadata}
-        </ReactMarkdown>
+        {isValidElement(children) && cloneElement(children, { components: memoizedComponents })}
         <div className={styles.buttonWrapper}>
           <Button
-            htmlType={isFinalStep ? 'submit' : 'button'}
+            htmlType={buttonHtmlType}
             type="primary"
             title={`general.${isFinalStep ? 'done' : 'next'}`}
             onClick={conditional(!isFinalStep && onNext)}

--- a/packages/console/src/pages/GetStarted/index.tsx
+++ b/packages/console/src/pages/GetStarted/index.tsx
@@ -1,6 +1,7 @@
 import { AdminConsoleKey } from '@logto/phrases';
 import React, { cloneElement, isValidElement, PropsWithChildren, ReactNode, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
+import ReactMarkdown from 'react-markdown';
 
 import Button from '@/components/Button';
 import CardTitle from '@/components/CardTitle';
@@ -88,21 +89,30 @@ const GetStarted = ({
                   setActiveStepIndex(0);
                 },
               })}
-            {steps.map((step, index) => {
+            {steps.map(({ title, subtitle, metadata }, index) => {
+              if (!title) {
+                return null;
+              }
               const isFinalStep = index === steps.length - 1;
 
               return (
                 <Step
-                  key={step.title}
-                  data={step}
+                  key={title}
+                  title={title}
+                  subtitle={subtitle}
                   index={index}
                   isActive={activeStepIndex === index}
                   isComplete={activeStepIndex > index}
                   isFinalStep={isFinalStep}
+                  buttonHtmlType={isFinalStep ? 'submit' : 'button'}
                   onNext={() => {
                     setActiveStepIndex(index + 1);
                   }}
-                />
+                >
+                  {metadata && (
+                    <ReactMarkdown className={styles.markdownContent}>{metadata}</ReactMarkdown>
+                  )}
+                </Step>
               );
             })}
           </form>

--- a/packages/console/src/scss/_colors.scss
+++ b/packages/console/src/scss/_colors.scss
@@ -83,6 +83,7 @@
   --color-code-comment: #66bb6a;
   --color-surface-3: #e3dff5;
   --color-surface-5: #dfd9f5;
+  --color-surface-variant: var(--color-neutral-variant-90);
   --shadow-light-s1: 0 2px 8px rgba(0, 0, 0, 8%);
   --shadow-light-s2: 0 4px 12px rgba(0, 0, 0, 12%);
 }

--- a/packages/core/src/connectors/github/README.md
+++ b/packages/core/src/connectors/github/README.md
@@ -4,9 +4,9 @@ The GitHub connector provides the ability to easily integrate GitHub’s OAuth A
 
 Official guide on OAuth App: [https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app)
 
-## Prerequests
+## Prerequisites
 
-A GitHub account, both personal and organazation are OK.
+A GitHub account, both personal and organization are OK.
 
 ## Configuration On GitHub
 

--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -215,6 +215,10 @@ const translation = {
         sms: 'Setup SMS sender',
         social: 'Add social connector',
       },
+      get_started: {
+        subtitle:
+          'A step by step guide to integrate your connector or get a sample configured with your account settings',
+      },
     },
     connector_details: {
       back_to_connectors: 'Back to Connectors',

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -213,6 +213,9 @@ const translation = {
         sms: '设置短信服务商',
         social: '添加社会化登录',
       },
+      get_started: {
+        subtitle: '请参考下列分步指南，配置您的 connector，或点击按钮获取示例配置文件',
+      },
     },
     connector_details: {
       back_to_connectors: '返回连接器',


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Implement "get-started" page on creating connectors

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
[LOG-1943](https://linear.app/silverhand/issue/LOG-1943/connector-getstarted-page)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Go to connectors page, click "set up" button on SMS or Email connector, choose connector provider in the next popup, then click "Next" button. Get-started page pops up with readme and steps information (config json editor + config tester).
- [x] Switch to "Social connectors" tab, and click "Add social connector" button. Choose the connector provider in the next popup, and then click "Next". Get-started page pops up with readme and config json editor.

<img width="1511" alt="image" src="https://user-images.githubusercontent.com/12833674/162975301-b1864868-707d-497a-983c-241004d626d7.png">

<img width="1511" alt="image" src="https://user-images.githubusercontent.com/12833674/162979858-e5c1c5a8-2a49-40dc-9e13-45caee5e6540.png">
