### PR TITLE
fix(core): fix sign-in settings api route

### DIFF
--- a/packages/core/src/routes/session.test.ts
+++ b/packages/core/src/routes/session.test.ts
@@ -4,6 +4,7 @@ import { Provider } from 'oidc-provider';
 import { mockSignInExperience } from '@/__mocks__';
 import { ConnectorType } from '@/connectors/types';
 import RequestError from '@/errors/RequestError';
+import * as signInExperienceQueries from '@/queries/sign-in-experience';
 import { createRequester } from '@/utils/test-utils';
 
 import sessionRoutes from './session';
@@ -862,12 +863,13 @@ describe('sessionRoutes', () => {
   });
 
   describe('GET /sign-in-settings', () => {
-    const findDefaultSignInExperience = jest.fn(async () => mockSignInExperience);
-    jest.mock('@/queries/sign-in-experience', async () => findDefaultSignInExperience());
+    const signInExperienceQuerySpon = jest
+      .spyOn(signInExperienceQueries, 'findDefaultSignInExperience')
+      .mockResolvedValue(mockSignInExperience);
 
     it('should call findDefaultSignInExperience', async () => {
       const response = await sessionRequest.get('/sign-in-settings');
-      expect(findDefaultSignInExperience).toHaveBeenCalledTimes(1);
+      expect(signInExperienceQuerySpon).toHaveBeenCalledTimes(1);
       expect(response.status).toEqual(200);
       expect(response.body).toEqual(mockSignInExperience);
     });

--- a/packages/core/src/routes/session.test.ts
+++ b/packages/core/src/routes/session.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines */
 import { Provider } from 'oidc-provider';
 
+import { mockSignInExperience } from '@/__mocks__';
 import { ConnectorType } from '@/connectors/types';
 import RequestError from '@/errors/RequestError';
 import { createRequester } from '@/utils/test-utils';
@@ -857,6 +858,18 @@ describe('sessionRoutes', () => {
         'statusCode',
         400
       );
+    });
+  });
+
+  describe('GET /sign-in-settings', () => {
+    const findDefaultSignInExperience = jest.fn(async () => mockSignInExperience);
+    jest.mock('@/queries/sign-in-experience', async () => findDefaultSignInExperience());
+
+    it('should call findDefaultSignInExperience', async () => {
+      const response = await sessionRequest.get('/sign-in-settings');
+      expect(findDefaultSignInExperience).toHaveBeenCalledTimes(1);
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual(mockSignInExperience);
     });
   });
 

--- a/packages/core/src/routes/session.ts
+++ b/packages/core/src/routes/session.ts
@@ -19,6 +19,7 @@ import {
 } from '@/lib/social';
 import { encryptUserPassword, generateUserId, findUserByUsernameAndPassword } from '@/lib/user';
 import koaGuard from '@/middleware/koa-guard';
+import { findDefaultSignInExperience } from '@/queries/sign-in-experience';
 import {
   hasUserWithEmail,
   hasUserWithPhone,
@@ -515,6 +516,14 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
     await provider.interactionDetails(ctx.req, ctx.res);
     const error: LogtoErrorCode = 'oidc.aborted';
     await assignInteractionResults(ctx, provider, { error });
+
+    return next();
+  });
+
+  router.get('/sign-in-settings', async (ctx, next) => {
+    // TODO: Social Connector Details
+    const signInExperience = await findDefaultSignInExperience();
+    ctx.body = signInExperience;
 
     return next();
   });

--- a/packages/core/src/routes/sign-in-experience.test.ts
+++ b/packages/core/src/routes/sign-in-experience.test.ts
@@ -78,19 +78,6 @@ describe('GET /sign-in-exp', () => {
   });
 });
 
-describe('GET /sign-in-settings', () => {
-  afterAll(() => {
-    jest.clearAllMocks();
-  });
-
-  it('should call findDefaultSignInExperience', async () => {
-    const response = await signInExperienceRequester.get('/sign-in-settings');
-    expect(findDefaultSignInExperience).toHaveBeenCalledTimes(1);
-    expect(response.status).toEqual(200);
-    expect(response.body).toEqual(mockSignInExperience);
-  });
-});
-
 describe('PATCH /sign-in-exp', () => {
   it('should not update social connector ids when social sign-in is disabled', async () => {
     const signInMethods = { ...mockSignInMethods, social: SignInMethodState.Disabled };

--- a/packages/core/src/routes/sign-in-experience.ts
+++ b/packages/core/src/routes/sign-in-experience.ts
@@ -41,14 +41,6 @@ export default function signInExperiencesRoutes<T extends AuthedRouter>(router: 
     return next();
   });
 
-  router.get('/sign-in-settings', async (ctx, next) => {
-    // TODO: Social Connector Details
-    const signInExperience = await findDefaultSignInExperience();
-    ctx.body = signInExperience;
-
-    return next();
-  });
-
   router.patch(
     '/sign-in-exp',
     koaGuard({


### PR DESCRIPTION

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fix sign-in settings api route not-authorized bug

<img width="1453" alt="image" src="https://user-images.githubusercontent.com/36393111/163768034-daf0a974-d1ea-4014-bea1-63dc1c2ac38e.png">

<img width="1162" alt="image" src="https://user-images.githubusercontent.com/36393111/163768055-3ebd9db6-1742-4976-b13f-a2278ae28d2a.png">


<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally 
@logto-io/eng 
