### PR TITLE
fix(console): center align image and error message in error boundary

### DIFF
--- a/packages/console/src/components/ErrorBoundary/index.module.scss
+++ b/packages/console/src/components/ErrorBoundary/index.module.scss
@@ -24,7 +24,7 @@
 
     img,
     h2 {
-      align-self: flex-end;
+      align-self: center;
     }
 
     details {

--- a/packages/console/src/components/ErrorBoundary/index.tsx
+++ b/packages/console/src/components/ErrorBoundary/index.tsx
@@ -1,6 +1,6 @@
 import { conditional } from '@silverhand/essentials';
 import React, { Component, ReactNode } from 'react';
-import { Namespace, TFunction, withTranslation } from 'react-i18next';
+import { TFunction, withTranslation } from 'react-i18next';
 
 import ErrorImage from '@/assets/images/table-error.svg';
 
@@ -8,7 +8,7 @@ import * as styles from './index.module.scss';
 
 type Props = {
   children: ReactNode;
-  t: TFunction<Namespace, 'admin_console'>;
+  t: TFunction;
 };
 
 type State = {
@@ -48,7 +48,7 @@ class ErrorBoundary extends Component<Props, State> {
         <div className={styles.container}>
           <div className={styles.wrapper}>
             <img src={ErrorImage} alt="oops" />
-            <h2>{t('errors.something_went_wrong')}</h2>
+            <h2>{t('admin_console.errors.something_went_wrong')}</h2>
             <details open>
               <summary>{errorMessage}</summary>
               {callStack}


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
* Fixed error boundary page content alignment. Image and title should be center aligned... Issue was caused by accidentally committed local testing code
* Fixed the error message localization issue

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] error boundary image and title are center aligned
- [x] error message localization works

<img width="1511" alt="image" src="https://user-images.githubusercontent.com/12833674/163809340-168318d3-d452-4700-b297-c2dd0f54e563.png">
