### PR TITLE
test(core): separate the color validation cases from tests of sign-in experience

### DIFF
--- a/packages/core/src/routes/sign-in-experience.branding.guard.test.ts
+++ b/packages/core/src/routes/sign-in-experience.branding.guard.test.ts
@@ -23,40 +23,24 @@ const expectPatchResponseStatus = async (signInExperience: any, status: number) 
 
 describe('branding', () => {
   const colorKeys = ['primaryColor', 'darkPrimaryColor'];
-
-  const invalidColors = [
-    undefined,
-    null,
-    '',
-    '#',
-    '#1',
-    '#2B',
-    '#3cZ',
-    '#4D9e',
-    '#5f80E',
-    '#6GHiXY',
-    '#78Cb5dA',
-    'rgb(0,13,255)',
-  ];
-
-  const validColors = ['#aB3', '#169deF'];
+  const invalidColors = [undefined, null, '#0'];
 
   describe('colors', () => {
-    test.each(validColors)('%p should succeed', async (validColor) => {
-      for (const colorKey of colorKeys) {
-        // eslint-disable-next-line no-await-in-loop
-        await expectPatchResponseStatus(
-          { branding: { ...mockBranding, [colorKey]: validColor } },
-          200
-        );
-      }
-    });
-    test.each(invalidColors)('%p should fail', async (invalidColor) => {
+    test.each(invalidColors)('should fail when color is %p', async (invalidColor) => {
       for (const colorKey of colorKeys) {
         // eslint-disable-next-line no-await-in-loop
         await expectPatchResponseStatus(
           { branding: { ...mockBranding, [colorKey]: invalidColor } },
           400
+        );
+      }
+    });
+    it('should succeed when color is valid', async () => {
+      for (const colorKey of colorKeys) {
+        // eslint-disable-next-line no-await-in-loop
+        await expectPatchResponseStatus(
+          { branding: { ...mockBranding, [colorKey]: '#169deF' } },
+          200
         );
       }
     });

--- a/packages/core/src/utils/regex.test.ts
+++ b/packages/core/src/utils/regex.test.ts
@@ -1,0 +1,25 @@
+import { hexColorRegEx } from '@/utils/regex';
+
+const invalidColors = [
+  '',
+  '#',
+  '#1',
+  '#2B',
+  '#3cZ',
+  '#4D9e',
+  '#5f80E',
+  '#6GHiXY',
+  '#78Cb5dA',
+  'rgb(0,13,255)',
+];
+
+const validColors = ['#aB3', '#169deF'];
+
+describe('hexColorRegEx', () => {
+  test.each(validColors)('%p should succeed', async (validColor) => {
+    expect(hexColorRegEx.test(validColor)).toBeTruthy();
+  });
+  test.each(invalidColors)('%p should fail', async (invalidColor) => {
+    expect(hexColorRegEx.test(invalidColor)).toBeFalsy();
+  });
+});


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- Separate the color validation cases from tests of sign-in experience

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2138

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="260" alt="image" src="https://user-images.githubusercontent.com/10594507/163957496-134de518-0b68-4877-b28f-c9bfe5c3f3c9.png">
<img width="380" alt="image" src="https://user-images.githubusercontent.com/10594507/163957043-877bf742-1ec3-4200-a9dc-531c5431c0e4.png">