### PR TITLE
refactor(core): rename koa-user-log types and functions to avoid naming conflicts

### DIFF
--- a/packages/core/src/middleware/koa-user-log.test.ts
+++ b/packages/core/src/middleware/koa-user-log.test.ts
@@ -3,7 +3,7 @@ import { UserLogType, UserLogResult } from '@logto/schemas';
 import { insertUserLog } from '@/queries/user-log';
 import { createContextWithRouteParameters } from '@/utils/test-utils';
 
-import koaUserLog, { WithUserLogContext, LogContext } from './koa-user-log';
+import koaUserLog, { WithUserLogContext, UserLogContext } from './koa-user-log';
 
 const nanoIdMock = 'mockId';
 
@@ -19,7 +19,7 @@ describe('koaUserLog middleware', () => {
   const insertUserLogMock = insertUserLog as jest.Mock;
   const next = jest.fn();
 
-  const userLogMock: Partial<LogContext> = {
+  const userLogMock: Partial<UserLogContext> = {
     userId: 'foo',
     type: UserLogType.SignInEmail,
     email: 'foo@logto.io',

--- a/packages/core/src/middleware/koa-user-log.ts
+++ b/packages/core/src/middleware/koa-user-log.ts
@@ -5,10 +5,10 @@ import { nanoid } from 'nanoid';
 import { insertUserLog } from '@/queries/user-log';
 
 export type WithUserLogContext<ContextT> = ContextT & {
-  userLog: LogContext;
+  userLog: UserLogContext;
 };
 
-export interface LogContext {
+export interface UserLogContext {
   type?: UserLogType;
   userId?: string;
   username?: string;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
#587 → #588 (current) → #590

Rename koa-user-log types and functions to avoid naming conflicts

e.g. `insertLog` in #587 

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2238

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Pass all existing tests.
