### PR TITLE
refactor(phrases,schemas): move language enum and fix Lanugage.Chinese value

### DIFF
--- a/packages/core/src/__mocks__/sign-in-experience.ts
+++ b/packages/core/src/__mocks__/sign-in-experience.ts
@@ -1,7 +1,7 @@
+import { Language } from '@logto/phrases';
 import {
   Branding,
   BrandingStyle,
-  Language,
   LanguageInfo,
   SignInExperience,
   SignInMethods,

--- a/packages/core/src/routes/sign-in-experience.guard.test.ts
+++ b/packages/core/src/routes/sign-in-experience.guard.test.ts
@@ -1,9 +1,5 @@
-import {
-  CreateSignInExperience,
-  Language,
-  SignInExperience,
-  SignInMethodState,
-} from '@logto/schemas';
+import { Language } from '@logto/phrases';
+import { CreateSignInExperience, SignInExperience, SignInMethodState } from '@logto/schemas';
 
 import {
   mockAliyunDmConnectorInstance,

--- a/packages/phrases/src/index.ts
+++ b/packages/phrases/src/index.ts
@@ -10,9 +10,14 @@ export type Languages = keyof Resource;
 export type I18nKey = NormalizeKeyPaths<typeof en.translation>;
 export type AdminConsoleKey = NormalizeKeyPaths<typeof en.translation.admin_console>;
 
+export enum Language {
+  English = 'en',
+  Chinese = 'zh-CN',
+}
+
 const resource: Resource = {
-  en,
-  'zh-CN': zhCN,
+  [Language.English]: en,
+  [Language.Chinese]: zhCN,
 };
 
 export default resource;

--- a/packages/schemas/src/foundations/jsonb-types.ts
+++ b/packages/schemas/src/foundations/jsonb-types.ts
@@ -1,3 +1,4 @@
+import { Language } from '@logto/phrases';
 import { z } from 'zod';
 
 /**
@@ -118,11 +119,6 @@ export const termsOfUseGuard = z.object({
 });
 
 export type TermsOfUse = z.infer<typeof termsOfUseGuard>;
-
-export enum Language {
-  English = 'en',
-  Chinese = 'zh-cn',
-}
 
 export const languageInfoGuard = z.object({
   autoDetect: z.boolean(),

--- a/packages/schemas/src/seeds/sign-in-experience.ts
+++ b/packages/schemas/src/seeds/sign-in-experience.ts
@@ -1,5 +1,7 @@
+import { Language } from '@logto/phrases';
+
 import { CreateSignInExperience } from '../db-entries';
-import { BrandingStyle, Language, SignInMethodState } from '../foundations';
+import { BrandingStyle, SignInMethodState } from '../foundations';
 
 export const defaultSignInExperience: Readonly<CreateSignInExperience> = {
   id: 'default',


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- Move `Language` enum from `schemas` to `phrases`
- Fix `Language.Chinese` value from `zh-cn` → `zh-CN`

Reference: 

- Slack thread [discussion](https://silverhand-io.slack.com/archives/C02A8G4HVAM/p1650440942212639)
- http://www.i18nguy.com/unicode/language-identifiers.html

     ![image](https://user-images.githubusercontent.com/10594507/164182965-0eb5c2c0-5856-4a14-ac5d-85897ac7d833.png)

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
None

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Pass all existing tests.
