### PR TITLE
refactor(ui): load branding info from settings

### DIFF
--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -38,7 +38,7 @@ const translation = {
       redirecting: 'Redirecting...',
       agree_with_terms: 'I have read and agree to the ',
       terms_of_use: 'Terms of Use',
-      creat_account: 'Create Account',
+      create_account: 'Create Account',
       forgot_password: 'Forgot Password?',
       or: 'Or',
       enter_passcode: 'The passcode has been sent to {{address}}',

--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -34,6 +34,8 @@ const translation = {
       cancel: 'Cancel',
     },
     description: {
+      loading: 'Loading...',
+      redirecting: 'Redirecting...',
       agree_with_terms: 'I have read and agree to the ',
       terms_of_use: 'Terms of Use',
       creat_account: 'Create Account',

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -36,6 +36,8 @@ const translation = {
       confirm: '确认',
     },
     description: {
+      loading: '读取中...',
+      redirecting: '页面跳转中...',
       agree_with_terms: '我已阅读并同意 ',
       terms_of_use: '使用条款',
       creat_account: '创建账号',

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -40,7 +40,7 @@ const translation = {
       redirecting: '页面跳转中...',
       agree_with_terms: '我已阅读并同意 ',
       terms_of_use: '使用条款',
-      creat_account: '创建账号',
+      create_account: '创建账号',
       forgot_password: '忘记密码？',
       or: '或',
       enter_passcode: '验证码已经发送至 {{ address }}',

--- a/packages/ui/src/pages/Consent/index.module.scss
+++ b/packages/ui/src/pages/Consent/index.module.scss
@@ -1,0 +1,15 @@
+@use '@/scss/underscore' as _;
+
+.wrapper {
+  position: relative;
+  padding: _.unit(8) _.unit(5);
+  @include _.flex-column;
+
+  .header {
+    margin: _.unit(30) 0;
+  }
+
+  .content {
+    @include _.text-hint;
+  }
+}

--- a/packages/ui/src/pages/Consent/index.tsx
+++ b/packages/ui/src/pages/Consent/index.tsx
@@ -1,10 +1,19 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useContext } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { consent } from '@/apis/consent';
+import BrandingHeader from '@/components/BrandingHeader';
 import useApi from '@/hooks/use-api';
+import { PageContext } from '@/hooks/use-page-context';
+
+import * as styles from './index.module.scss';
 
 const Consent = () => {
+  const { experienceSettings } = useContext(PageContext);
+  const { logoUrl = '' } = experienceSettings?.branding ?? {};
   const { result, run: asyncConsent } = useApi(consent);
+
+  const { t } = useTranslation(undefined, { keyPrefix: 'main_flow' });
 
   useEffect(() => {
     void asyncConsent();
@@ -16,7 +25,12 @@ const Consent = () => {
     }
   }, [result]);
 
-  return <div>loading...</div>;
+  return (
+    <div className={styles.wrapper}>
+      <BrandingHeader className={styles.header} logo={logoUrl} />
+      <div className={styles.content}>{t('description.loading')}</div>
+    </div>
+  );
 };
 
 export default Consent;

--- a/packages/ui/src/pages/SignIn/index.test.tsx
+++ b/packages/ui/src/pages/SignIn/index.test.tsx
@@ -6,7 +6,6 @@ import SignIn from '@/pages/SignIn';
 describe('<SignIn />', () => {
   test('renders without exploding', async () => {
     const { queryByText } = render(<SignIn />);
-    expect(queryByText('Welcome to Logto')).not.toBeNull();
     expect(queryByText('action.sign_in')).not.toBeNull();
   });
 });

--- a/packages/ui/src/pages/SignIn/index.tsx
+++ b/packages/ui/src/pages/SignIn/index.tsx
@@ -1,20 +1,25 @@
+import { BrandingStyle } from '@logto/schemas';
 import classNames from 'classnames';
-import React from 'react';
+import React, { useContext } from 'react';
 
 import BrandingHeader from '@/components/BrandingHeader';
 import TextLink from '@/components/TextLink';
 import UsernameSignin from '@/containers/UsernameSignin';
+import { PageContext } from '@/hooks/use-page-context';
 
 import * as styles from './index.module.scss';
 
 const SignIn = () => {
+  const { experienceSettings } = useContext(PageContext);
+  const { slogan, logoUrl = '', style } = experienceSettings?.branding ?? {};
+
   return (
     <div className={classNames(styles.wrapper)}>
       {/* TODO: load content from sign-in experience  */}
       <BrandingHeader
         className={styles.header}
-        headline="Welcome to Logto"
-        logo="https://avatars.githubusercontent.com/u/84981374?s=400&u=6c44c3642f2fe15a59a56cdcb0358c0bd8b92f57&v=4"
+        headline={style === BrandingStyle.Logo_Slogan ? slogan : undefined}
+        logo={logoUrl}
       />
       <UsernameSignin />
       <TextLink


### PR DESCRIPTION


<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Load branding info from settings.
Update the sign-in home page style, load header info from sign-in experience settings.
Update the consent page, read the logo from sign-in experience settings.

<img width="392" alt="image" src="https://user-images.githubusercontent.com/36393111/164457939-9bf3abc6-cb42-429c-b04b-fafcf20c75dc.png">
<img width="391" alt="image" src="https://user-images.githubusercontent.com/36393111/164458012-c7dc829e-717e-4332-a3ac-b0d38e777561.png">


<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2163

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally 
@logto-io/eng 
