### PR TITLE
refactor(ui): replace termsOfUse Component with Container

### DIFF
--- a/packages/ui/src/__mocks__/RenderWithPageContext/SettingsProvider.tsx
+++ b/packages/ui/src/__mocks__/RenderWithPageContext/SettingsProvider.tsx
@@ -3,12 +3,14 @@ import { useContext, useEffect, ReactElement } from 'react';
 import { PageContext } from '@/hooks/use-page-context';
 import { SignInExperienceSettings } from '@/types';
 
+import { mockSignInExperienceSettings } from '../logto';
+
 type Props = {
-  settings: SignInExperienceSettings;
+  settings?: SignInExperienceSettings;
   children: ReactElement;
 };
 
-const SettingsProvider = ({ settings, children }: Props) => {
+const SettingsProvider = ({ settings = mockSignInExperienceSettings, children }: Props) => {
   const { setExperienceSettings } = useContext(PageContext);
 
   useEffect(() => {

--- a/packages/ui/src/components/TermsOfUseModal/index.module.scss
+++ b/packages/ui/src/components/TermsOfUseModal/index.module.scss
@@ -1,0 +1,7 @@
+.content {
+  @include _.text-hint;
+
+  .link {
+    @include _.text-hint;
+  }
+}

--- a/packages/ui/src/components/TermsOfUseModal/index.module.scss
+++ b/packages/ui/src/components/TermsOfUseModal/index.module.scss
@@ -1,7 +1,0 @@
-.content {
-  @include _.text-hint;
-
-  .link {
-    @include _.text-hint;
-  }
-}

--- a/packages/ui/src/containers/CreateAccount/index.test.tsx
+++ b/packages/ui/src/containers/CreateAccount/index.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 
 import renderWithPageContext from '@/__mocks__/RenderWithPageContext';
+import SettingsProvider from '@/__mocks__/RenderWithPageContext/SettingsProvider';
 import { register } from '@/apis/register';
 
 import CreateAccount from '.';
@@ -15,6 +16,14 @@ describe('<CreateAccount/>', () => {
     expect(container.querySelector('input[name="password"]')).not.toBeNull();
     expect(container.querySelector('input[name="confirm_password"]')).not.toBeNull();
     expect(queryByText('action.create')).not.toBeNull();
+  });
+
+  test('render with terms settings enabled', () => {
+    const { queryByText } = renderWithPageContext(
+      <SettingsProvider>
+        <CreateAccount />
+      </SettingsProvider>
+    );
     expect(queryByText('description.terms_of_use')).not.toBeNull();
   });
 
@@ -131,8 +140,12 @@ describe('<CreateAccount/>', () => {
     expect(queryByText('passwords_do_not_match')).toBeNull();
   });
 
-  test('submit form properly', async () => {
-    const { getByText, container } = renderWithPageContext(<CreateAccount />);
+  test('submit form properly with terms settings enabled', async () => {
+    const { getByText, container } = renderWithPageContext(
+      <SettingsProvider>
+        <CreateAccount />
+      </SettingsProvider>
+    );
     const submitButton = getByText('action.create');
     const passwordInput = container.querySelector('input[name="password"]');
     const confirmPasswordInput = container.querySelector('input[name="confirm_password"]');

--- a/packages/ui/src/containers/Passwordless/EmailPasswordless.test.tsx
+++ b/packages/ui/src/containers/Passwordless/EmailPasswordless.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
 import renderWithPageContext from '@/__mocks__/RenderWithPageContext';
+import SettingsProvider from '@/__mocks__/RenderWithPageContext/SettingsProvider';
 import { sendRegisterEmailPasscode } from '@/apis/register';
 import { sendSignInEmailPasscode } from '@/apis/sign-in';
 
@@ -24,6 +25,16 @@ describe('<EmailPasswordless/>', () => {
     );
     expect(container.querySelector('input[name="email"]')).not.toBeNull();
     expect(queryByText('action.continue')).not.toBeNull();
+  });
+
+  test('render with terms settings enabled', () => {
+    const { queryByText } = renderWithPageContext(
+      <MemoryRouter>
+        <SettingsProvider>
+          <EmailPasswordless type="sign-in" />
+        </SettingsProvider>
+      </MemoryRouter>
+    );
     expect(queryByText('description.terms_of_use')).not.toBeNull();
   });
 
@@ -53,7 +64,9 @@ describe('<EmailPasswordless/>', () => {
   test('should call sign-in method properly', async () => {
     const { container, getByText } = renderWithPageContext(
       <MemoryRouter>
-        <EmailPasswordless type="sign-in" />
+        <SettingsProvider>
+          <EmailPasswordless type="sign-in" />
+        </SettingsProvider>
       </MemoryRouter>
     );
     const emailInput = container.querySelector('input[name="email"]');
@@ -76,7 +89,9 @@ describe('<EmailPasswordless/>', () => {
   test('should call register method properly', async () => {
     const { container, getByText } = renderWithPageContext(
       <MemoryRouter>
-        <EmailPasswordless type="register" />
+        <SettingsProvider>
+          <EmailPasswordless type="register" />
+        </SettingsProvider>
       </MemoryRouter>
     );
     const emailInput = container.querySelector('input[name="email"]');

--- a/packages/ui/src/containers/Passwordless/PhonePasswordless.test.tsx
+++ b/packages/ui/src/containers/Passwordless/PhonePasswordless.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
 import renderWithPageContext from '@/__mocks__/RenderWithPageContext';
+import SettingsProvider from '@/__mocks__/RenderWithPageContext/SettingsProvider';
 import { sendRegisterSmsPasscode } from '@/apis/register';
 import { sendSignInSmsPasscode } from '@/apis/sign-in';
 import { defaultCountryCallingCode } from '@/hooks/use-phone-number';
@@ -27,6 +28,16 @@ describe('<PhonePasswordless/>', () => {
     );
     expect(container.querySelector('input[name="phone"]')).not.toBeNull();
     expect(queryByText('action.continue')).not.toBeNull();
+  });
+
+  test('render with terms settings enabled', () => {
+    const { queryByText } = renderWithPageContext(
+      <MemoryRouter>
+        <SettingsProvider>
+          <PhonePasswordless type="sign-in" />
+        </SettingsProvider>
+      </MemoryRouter>
+    );
     expect(queryByText('description.terms_of_use')).not.toBeNull();
   });
 
@@ -56,7 +67,9 @@ describe('<PhonePasswordless/>', () => {
   test('should call sign-in method properly', async () => {
     const { container, getByText } = renderWithPageContext(
       <MemoryRouter>
-        <PhonePasswordless type="sign-in" />
+        <SettingsProvider>
+          <PhonePasswordless type="sign-in" />
+        </SettingsProvider>
       </MemoryRouter>
     );
     const phoneInput = container.querySelector('input[name="phone"]');
@@ -79,7 +92,9 @@ describe('<PhonePasswordless/>', () => {
   test('should call register method properly', async () => {
     const { container, getByText } = renderWithPageContext(
       <MemoryRouter>
-        <PhonePasswordless type="register" />
+        <SettingsProvider>
+          <PhonePasswordless type="register" />
+        </SettingsProvider>
       </MemoryRouter>
     );
     const phoneInput = container.querySelector('input[name="phone"]');

--- a/packages/ui/src/containers/TermsOfUse/intext.test.tsx
+++ b/packages/ui/src/containers/TermsOfUse/intext.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import renderWithPageContext from '@/__mocks__/RenderWithPageContext';
 import SettingsProvider from '@/__mocks__/RenderWithPageContext/SettingsProvider';
-import { mockSignInExperienceSettings } from '@/__mocks__/logto';
 
 import TermsOfUse from '.';
 
@@ -14,7 +13,7 @@ describe('TermsOfUse Container', () => {
 
   it('render with settings', async () => {
     const { queryByText } = renderWithPageContext(
-      <SettingsProvider settings={mockSignInExperienceSettings}>
+      <SettingsProvider>
         <TermsOfUse />
       </SettingsProvider>
     );

--- a/packages/ui/src/containers/UsernameSignin/index.test.tsx
+++ b/packages/ui/src/containers/UsernameSignin/index.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 
 import renderWithPageContext from '@/__mocks__/RenderWithPageContext';
+import SettingsProvider from '@/__mocks__/RenderWithPageContext/SettingsProvider';
 import { signInBasic } from '@/apis/sign-in';
 
 import UsernameSignin from '.';
@@ -14,6 +15,14 @@ describe('<UsernameSignin>', () => {
     expect(container.querySelector('input[name="username"]')).not.toBeNull();
     expect(container.querySelector('input[name="password"]')).not.toBeNull();
     expect(queryByText('action.sign_in')).not.toBeNull();
+  });
+
+  test('render with terms settings enabled', () => {
+    const { queryByText } = renderWithPageContext(
+      <SettingsProvider>
+        <UsernameSignin />
+      </SettingsProvider>
+    );
     expect(queryByText('description.agree_with_terms')).not.toBeNull();
   });
 
@@ -41,15 +50,15 @@ describe('<UsernameSignin>', () => {
       fireEvent.change(passwordInput, { target: { value: 'password' } });
     }
 
-    fireEvent.click(submitButton);
-
     expect(queryByText('required')).toBeNull();
-
-    expect(signInBasic).not.toBeCalled();
   });
 
   test('submit form', async () => {
-    const { getByText, container } = renderWithPageContext(<UsernameSignin />);
+    const { getByText, container } = renderWithPageContext(
+      <SettingsProvider>
+        <UsernameSignin />
+      </SettingsProvider>
+    );
     const submitButton = getByText('action.sign_in');
 
     const usernameInput = container.querySelector('input[name="username"]');

--- a/packages/ui/src/hooks/use-social.ts
+++ b/packages/ui/src/hooks/use-social.ts
@@ -6,6 +6,7 @@ import { generateRandomString, parseQueryParameters } from '@/utils';
 
 import useApi from './use-api';
 import { PageContext } from './use-page-context';
+import useTerms from './use-terms';
 
 /**
  * Social Connector State Utility Methods
@@ -65,6 +66,7 @@ const isNativeWebview = () => {
 
 const useSocial = () => {
   const { setToast } = useContext(PageContext);
+  const { termsValidation } = useTerms();
   const parameters = useParams();
 
   const { result: invokeSocialSignInResult, run: asyncInvokeSocialSignIn } =
@@ -74,6 +76,10 @@ const useSocial = () => {
 
   const invokeSocialSignInHandler = useCallback(
     async (connectorId: string) => {
+      if (!termsValidation()) {
+        return;
+      }
+
       const state = generateState();
       storeState(state, connectorId);
 
@@ -81,7 +87,7 @@ const useSocial = () => {
 
       return asyncInvokeSocialSignIn(connectorId, state, `${origin}/callback/${connectorId}`);
     },
-    [asyncInvokeSocialSignIn]
+    [asyncInvokeSocialSignIn, termsValidation]
   );
 
   const signInWithSocialHandler = useCallback(
@@ -166,7 +172,7 @@ const useSocial = () => {
     }
   }, [signInWithSocialResult]);
 
-  // SignIn Callback Page Handler
+  // Social Sign-In Callback Handler
   useEffect(() => {
     if (!location.pathname.includes('/sign-in/callback') || !parameters.connector) {
       return;

--- a/packages/ui/src/hooks/use-terms.ts
+++ b/packages/ui/src/hooks/use-terms.ts
@@ -12,12 +12,14 @@ const useTerms = () => {
   } = useContext(PageContext);
 
   const termsValidation = useCallback(() => {
-    if (termsAgreement) {
-      return;
+    if (termsAgreement || !experienceSettings?.termsOfUse.enabled) {
+      return true;
     }
 
     setShowTermsModal(true);
-  }, [setShowTermsModal, termsAgreement]);
+
+    return false;
+  }, [experienceSettings, termsAgreement, setShowTermsModal]);
 
   return {
     termsSettings: experienceSettings?.termsOfUse,


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Follow the latest design: Replace old `TermsOfUse` component in all sign-in/register forms with the new implemented `TermsOfUser` container.  
Run `termsValidation` logic from the `useTerms` hook  before submit.
Add the `termsValidation` logic be for `invokeSocialSignIn`


<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2258


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT case updated
test locally
<img width="387" alt="image" src="https://user-images.githubusercontent.com/36393111/164587656-3cb14221-e38a-444a-b492-6aebf31bc2f5.png">
<img width="382" alt="image" src="https://user-images.githubusercontent.com/36393111/164587696-6403d4fb-78f8-4dc8-93c7-259081d2c49b.png">
@logto-io/eng 
