### PR TITLE
refactor(core): allow read private key from env

### DIFF
--- a/packages/core/src/env-set/oidc.ts
+++ b/packages/core/src/env-set/oidc.ts
@@ -7,6 +7,12 @@ import inquirer from 'inquirer';
 import { noInquiry } from './parameters';
 
 const readPrivateKey = async (): Promise<string> => {
+  const privateKey = getEnv('OIDC_PRIVATE_KEY');
+
+  if (privateKey) {
+    return privateKey;
+  }
+
   const privateKeyPath = getEnv('OIDC_PRIVATE_KEY_PATH', 'oidc-private-key.pem');
 
   try {
@@ -19,7 +25,7 @@ const readPrivateKey = async (): Promise<string> => {
     const answer = await inquirer.prompt({
       type: 'confirm',
       name: 'confirm',
-      message: `No private key found in \`${privateKeyPath}\`, would you like to generate a new one?`,
+      message: `No private key found in env \`OIDC_PRIVATE_KEY\` nor \`${privateKeyPath}\`, would you like to generate a new one?`,
     });
 
     if (!answer.confirm) {

--- a/packages/core/src/env-set/oidc.ts
+++ b/packages/core/src/env-set/oidc.ts
@@ -6,6 +6,17 @@ import inquirer from 'inquirer';
 
 import { noInquiry } from './parameters';
 
+/**
+ * Try to read private key with the following order:
+ *
+ * 1. From `process.env.OIDC_PRIVATE_KEY`.
+ * 2. Fetch path from `process.env.OIDC_PRIVATE_KEY_PATH` then read from that path.
+ *
+ * If none of above succeed, then inquire user to generate a new key if no `--no-inquiry` presents in argv.
+ *
+ * @returns The private key for OIDC provider.
+ * @throws An error when failed to read a private key.
+ */
 const readPrivateKey = async (): Promise<string> => {
   const privateKey = getEnv('OIDC_PRIVATE_KEY');
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
since `dotenv` supports multi-line env now, we bring back this as it can also be good for docker environment

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2268

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

- [x] read key from env if `OIDC_PRIVATE_KEY` set
- [x] read key from file if `OIDC_PRIVATE_KEY_PATH` set
- [x] show inquiry if none of above fulfilled