### PR TITLE
refactor: allow start from project root

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "prepare": "if test \"$NODE_ENV\" != \"production\" && test \"$CI\" != \"true\" ; then husky install ; fi",
     "prepack": "lerna run --stream prepack",
     "dev": "lerna run --stream prepack && lerna --scope=@logto/{core,ui,console} exec -- pnpm dev",
-    "start": "cd packages/core && node ."
+    "start": "cd packages/core && node . --from-root"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.0.0",

--- a/packages/core/src/env-set/append-dot-env.ts
+++ b/packages/core/src/env-set/append-dot-env.ts
@@ -1,7 +1,0 @@
-import { appendFileSync } from 'fs';
-
-const appendDotEnv = (key: string, value: string) => {
-  appendFileSync('.env', `${key}=${value}\n`);
-};
-
-export default appendDotEnv;

--- a/packages/core/src/env-set/create-pool-by-env.ts
+++ b/packages/core/src/env-set/create-pool-by-env.ts
@@ -3,7 +3,7 @@ import inquirer from 'inquirer';
 import { createPool } from 'slonik';
 import { createInterceptors } from 'slonik-interceptor-preset';
 
-import appendDotEnv from './append-dot-env';
+import { appendDotEnv } from './dot-env';
 import { noInquiry } from './parameters';
 
 const createPoolByEnv = async (isTest: boolean) => {

--- a/packages/core/src/env-set/dot-env.ts
+++ b/packages/core/src/env-set/dot-env.ts
@@ -1,0 +1,18 @@
+import { appendFileSync } from 'fs';
+
+import dotenv from 'dotenv';
+
+import { fromRoot } from './parameters';
+
+export const appendDotEnv = (key: string, value: string) => {
+  appendFileSync('.env', `${key}=${value}\n`);
+};
+
+export const configDotEnv = () => {
+  // Started from project root, change working directory
+  if (fromRoot) {
+    process.chdir('../..');
+  }
+
+  dotenv.config();
+};

--- a/packages/core/src/env-set/oidc.ts
+++ b/packages/core/src/env-set/oidc.ts
@@ -6,11 +6,11 @@ import inquirer from 'inquirer';
 
 import { noInquiry } from './parameters';
 
-const readPrivateKey = async (path: string): Promise<string> => {
+const readPrivateKey = async (): Promise<string> => {
   const privateKeyPath = getEnv('OIDC_PRIVATE_KEY_PATH', 'oidc-private-key.pem');
 
   try {
-    return readFileSync(path, 'utf-8');
+    return readFileSync(privateKeyPath, 'utf-8');
   } catch (error: unknown) {
     if (noInquiry) {
       throw error;
@@ -44,12 +44,10 @@ const readPrivateKey = async (path: string): Promise<string> => {
 };
 
 const loadOidcValues = async (port: number) => {
-  const privateKeyPath = getEnv('OIDC_PRIVATE_KEY_PATH', 'oidc-private-key.pem');
-  const privateKey = crypto.createPrivateKey(await readPrivateKey(privateKeyPath));
+  const privateKey = crypto.createPrivateKey(await readPrivateKey());
   const publicKey = crypto.createPublicKey(privateKey);
 
   return Object.freeze({
-    privateKeyPath,
     privateKey,
     publicKey,
     issuer: getEnv('OIDC_ISSUER', `http://localhost:${port}/oidc`),

--- a/packages/core/src/env-set/parameters.ts
+++ b/packages/core/src/env-set/parameters.ts
@@ -1,2 +1,3 @@
-const parameters = process.argv.slice(2);
-export const noInquiry = parameters.includes('--no-inquiry');
+const parameters = new Set(process.argv.slice(2));
+export const noInquiry = parameters.has('--no-inquiry');
+export const fromRoot = parameters.has('--from-root');

--- a/packages/core/src/env-set/password.ts
+++ b/packages/core/src/env-set/password.ts
@@ -3,7 +3,7 @@ import inquirer from 'inquirer';
 import { nanoid } from 'nanoid';
 import { number, string } from 'zod';
 
-import appendDotEnv from './append-dot-env';
+import { appendDotEnv } from './dot-env';
 import { noInquiry } from './parameters';
 
 const loadPeppers = async (isTest: boolean): Promise<string[]> => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,9 +1,11 @@
 import 'module-alias/register.js';
 
-import dotenv from 'dotenv';
 import Koa from 'koa';
 
-dotenv.config();
+// eslint-disable-next-line import/order
+import { configDotEnv } from './env-set/dot-env';
+
+configDotEnv();
 
 /* eslint-disable import/first */
 import initApp from './app/init';

--- a/packages/core/src/middleware/koa-spa-proxy.ts
+++ b/packages/core/src/middleware/koa-spa-proxy.ts
@@ -7,6 +7,7 @@ import { IRouterParamContext } from 'koa-router';
 import serveStatic from 'koa-static';
 
 import envSet, { MountedApps } from '@/env-set';
+import { fromRoot } from '@/env-set/parameters';
 
 export default function koaSpaProxy<StateT, ContextT extends IRouterParamContext, ResponseBodyT>(
   packagePath = 'ui',
@@ -15,7 +16,8 @@ export default function koaSpaProxy<StateT, ContextT extends IRouterParamContext
 ): MiddlewareType<StateT, ContextT, ResponseBodyT> {
   type Middleware = MiddlewareType<StateT, ContextT, ResponseBodyT>;
 
-  const distPath = path.join('..', packagePath, 'dist');
+  const packagesPath = fromRoot ? 'packages/' : '..';
+  const distPath = path.join(packagesPath, packagePath, 'dist');
 
   const spaProxy: Middleware = envSet.values.isProduction
     ? serveStatic(distPath)


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
allow `[npm/pnpm/yarn] start` from project root by:

- add `--from-root` option to change working directory
- adjust UI proxy

also clean up unnecessary code when reading private key

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2259

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

start from project root, AC ok

<img width="437" alt="image" src="https://user-images.githubusercontent.com/14722250/164708617-8f33b58e-99c7-43b4-841e-6d8e6e7b04fd.png">