### PR TITLE
fix(console): remove plain CopyToClipboard padding

### DIFF
--- a/packages/console/src/components/CopyToClipboard/index.module.scss
+++ b/packages/console/src/components/CopyToClipboard/index.module.scss
@@ -2,13 +2,13 @@
 
 .container {
   display: inline-block;
-  padding: _.unit(2) _.unit(3);
   border-radius: 6px;
   color: var(--color-on-secondary-container);
   font: var(--font-body-medium);
   cursor: default;
 
   &.contained {
+    padding: _.unit(2) _.unit(3);
     background: var(--color-inverse-on-surface);
   }
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Remove padding in CopyToClipboard when varient is not contained.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
before

<img width="273" alt="image" src="https://user-images.githubusercontent.com/5717882/165436019-4a6c90e2-155a-4712-a128-073daca04c4b.png">

after

<img width="303" alt="截屏2022-04-27 上午11 46 37" src="https://user-images.githubusercontent.com/5717882/165436031-346d3d4c-74a0-460f-8cda-54efeca07c15.png">

