### PR TITLE
fix(core): update timestamp field with millisecond precision

### DIFF
--- a/packages/core/src/database/utils.test.ts
+++ b/packages/core/src/database/utils.test.ts
@@ -56,9 +56,9 @@ describe('convertToPrimitiveOrSql()', () => {
   it('converts value to sql when key ends with special set and value is number', () => {
     for (const value of timestampKeyEndings) {
       expect(convertToPrimitiveOrSql(`${normalKey}${value}`, 12_341_234)).toEqual({
-        sql: 'to_timestamp($1)',
+        sql: 'to_timestamp($1::double precision / 1000)',
         type: SqlToken,
-        values: [12_341.234],
+        values: [12_341_234],
       });
     }
   });

--- a/packages/core/src/database/utils.ts
+++ b/packages/core/src/database/utils.ts
@@ -42,7 +42,7 @@ export const convertToPrimitiveOrSql = (
   }
 
   if (['_at', 'At'].some((value) => key.endsWith(value)) && typeof value === 'number') {
-    return sql`to_timestamp(${value / 1000})`;
+    return sql`to_timestamp(${value}::double precision / 1000)`;
   }
 
   if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {

--- a/packages/core/src/queries/oidc-model-instance.test.ts
+++ b/packages/core/src/queries/oidc-model-instance.test.ts
@@ -46,7 +46,7 @@ describe('oidc-model-instance query', () => {
   it('upsertInstance', async () => {
     const expectSql = sql`
       insert into ${table} ("model_name", "id", "payload", "expires_at")
-      values ($1, $2, $3, to_timestamp($4))
+      values ($1, $2, $3, to_timestamp($4::double precision / 1000))
       on conflict ("model_name", "id") do update
       set "payload"=excluded."payload", "expires_at"=excluded."expires_at"
     `;
@@ -57,7 +57,7 @@ describe('oidc-model-instance query', () => {
         instance.modelName,
         instance.id,
         JSON.stringify(instance.payload),
-        instance.expiresAt / 1000,
+        instance.expiresAt,
       ]);
 
       return createMockQueryResult([databaseValue]);


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Update timestamp field with millisecond precision in SQL

Past:
![image](https://user-images.githubusercontent.com/10594507/165451142-7322c410-cd6d-41d5-8d91-d06fd55a840e.png)
![image](https://user-images.githubusercontent.com/10594507/165451168-09cd118b-3093-43cc-8988-acfe8e5ba83d.png)

After fixing:
![image](https://user-images.githubusercontent.com/10594507/165451196-5a7f2319-63cc-4215-8fa6-9953aea9305c.png)
![image](https://user-images.githubusercontent.com/10594507/165451211-85d3858d-3850-43b4-94fa-ee4f65bb800b.png)

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2310

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Pass all existing tests.
