### PR TITLE
refactor(ui): remove /404 path

### DIFF
--- a/packages/ui/jest.config.ts
+++ b/packages/ui/jest.config.ts
@@ -3,6 +3,9 @@ import { merge, Config } from '@logto/jest-config';
 const config: Config.InitialOptions = merge({
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/src/jest.setup.ts'],
+  transformIgnorePatterns: [
+    '[/\\\\]node_modules[/\\\\]((?!ky[/\\\\]).)+\\.(js|jsx|mjs|cjs|ts|tsx)$',
+  ],
 });
 
 export default config;

--- a/packages/ui/jest.config.ts
+++ b/packages/ui/jest.config.ts
@@ -3,9 +3,6 @@ import { merge, Config } from '@logto/jest-config';
 const config: Config.InitialOptions = merge({
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/src/jest.setup.ts'],
-  transformIgnorePatterns: [
-    '[/\\\\]node_modules[/\\\\]((?!ky[/\\\\]).)+\\.(js|jsx|mjs|cjs|ts|tsx)$',
-  ],
 });
 
 export default config;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -54,7 +54,6 @@ const App = () => {
             <Route path="/callback/:connector" element={<Callback />} />
             <Route path="/social-register/:connector" element={<SocialRegister />} />
             <Route path="/:type/:method/passcode-validation" element={<Passcode />} />
-            <Route path="/404" element={<NotFound />} />
             <Route path="*" element={<NotFound />} />
           </Routes>
         </BrowserRouter>

--- a/packages/ui/src/pages/Passcode/index.test.tsx
+++ b/packages/ui/src/pages/Passcode/index.test.tsx
@@ -12,18 +12,6 @@ jest.mock('react-router-dom', () => ({
 }));
 
 describe('Passcode Page', () => {
-  it('render with invalid method should lead to 404 page', () => {
-    const { queryByText } = render(
-      <MemoryRouter initialEntries={['/sign-in/username/passcode-validation']}>
-        <Routes>
-          <Route path="/:type/:method/passcode-validation" element={<Passcode />} />
-        </Routes>
-      </MemoryRouter>
-    );
-
-    expect(queryByText('action.enter_passcode')).toBeNull();
-  });
-
   it('render properly', () => {
     const { queryByText } = render(
       <MemoryRouter initialEntries={['/sign-in/email/passcode-validation']}>
@@ -35,5 +23,31 @@ describe('Passcode Page', () => {
 
     expect(queryByText('action.enter_passcode')).not.toBeNull();
     expect(queryByText('description.enter_passcode')).not.toBeNull();
+  });
+
+  it('render with invalid method', () => {
+    const { queryByText } = render(
+      <MemoryRouter initialEntries={['/sign-in/username/passcode-validation']}>
+        <Routes>
+          <Route path="/:type/:method/passcode-validation" element={<Passcode />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(queryByText('action.enter_passcode')).toBeNull();
+    expect(queryByText('description.not_found')).not.toBeNull();
+  });
+
+  it('render with invalid type', () => {
+    const { queryByText } = render(
+      <MemoryRouter initialEntries={['/social-register/email/passcode-validation']}>
+        <Routes>
+          <Route path="/:type/:method/passcode-validation" element={<Passcode />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(queryByText('action.enter_passcode')).toBeNull();
+    expect(queryByText('description.not_found')).not.toBeNull();
   });
 });

--- a/packages/ui/src/pages/Passcode/index.test.tsx
+++ b/packages/ui/src/pages/Passcode/index.test.tsx
@@ -1,6 +1,7 @@
-import { render } from '@testing-library/react';
 import React from 'react';
 import { Routes, Route, MemoryRouter } from 'react-router-dom';
+
+import renderWithPageContext from '@/__mocks__/RenderWithPageContext';
 
 import Passcode from '.';
 
@@ -13,7 +14,7 @@ jest.mock('react-router-dom', () => ({
 
 describe('Passcode Page', () => {
   it('render properly', () => {
-    const { queryByText } = render(
+    const { queryByText } = renderWithPageContext(
       <MemoryRouter initialEntries={['/sign-in/email/passcode-validation']}>
         <Routes>
           <Route path="/:type/:method/passcode-validation" element={<Passcode />} />
@@ -26,7 +27,7 @@ describe('Passcode Page', () => {
   });
 
   it('render with invalid method', () => {
-    const { queryByText } = render(
+    const { queryByText } = renderWithPageContext(
       <MemoryRouter initialEntries={['/sign-in/username/passcode-validation']}>
         <Routes>
           <Route path="/:type/:method/passcode-validation" element={<Passcode />} />
@@ -39,7 +40,7 @@ describe('Passcode Page', () => {
   });
 
   it('render with invalid type', () => {
-    const { queryByText } = render(
+    const { queryByText } = renderWithPageContext(
       <MemoryRouter initialEntries={['/social-register/email/passcode-validation']}>
         <Routes>
           <Route path="/:type/:method/passcode-validation" element={<Passcode />} />

--- a/packages/ui/src/pages/Passcode/index.tsx
+++ b/packages/ui/src/pages/Passcode/index.tsx
@@ -6,9 +6,9 @@ import { useParams, useLocation } from 'react-router-dom';
 import NavBar from '@/components/NavBar';
 import PasscodeValidation from '@/containers/PasscodeValidation';
 import { PageContext } from '@/hooks/use-page-context';
+import NotFound from '@/pages/NotFound';
 import { UserFlow } from '@/types';
 
-import NotFound from '../NotFound';
 import * as styles from './index.module.scss';
 
 type Parameters = {

--- a/packages/ui/src/pages/Passcode/index.tsx
+++ b/packages/ui/src/pages/Passcode/index.tsx
@@ -1,10 +1,11 @@
 import { Nullable } from '@silverhand/essentials';
-import React from 'react';
+import React, { useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams, useLocation } from 'react-router-dom';
 
 import NavBar from '@/components/NavBar';
 import PasscodeValidation from '@/containers/PasscodeValidation';
+import { PageContext } from '@/hooks/use-page-context';
 import { UserFlow } from '@/types';
 
 import NotFound from '../NotFound';
@@ -15,10 +16,7 @@ type Parameters = {
   method: string;
 };
 
-type StateType = Nullable<{
-  email?: string;
-  sms?: string;
-}>;
+type StateType = Nullable<Record<string, string>>;
 
 const Passcode = () => {
   const { t } = useTranslation(undefined, { keyPrefix: 'main_flow' });
@@ -26,6 +24,13 @@ const Passcode = () => {
   const state = useLocation().state as StateType;
   const invalidType = type !== 'sign-in' && type !== 'register';
   const invalidMethod = method !== 'email' && method !== 'sms';
+  const { setToast } = useContext(PageContext);
+
+  useEffect(() => {
+    if (method && !state?.[method]) {
+      setToast(t(method === 'email' ? 'error.invalid_email' : 'error.invalid_phone'));
+    }
+  }, [method, setToast, state, t]);
 
   if (invalidType || invalidMethod) {
     return <NotFound />;
@@ -34,7 +39,7 @@ const Passcode = () => {
   const target = state?.[method];
 
   if (!target) {
-    return null;
+    return <NotFound />;
   }
 
   return (

--- a/packages/ui/src/pages/Passcode/index.tsx
+++ b/packages/ui/src/pages/Passcode/index.tsx
@@ -1,11 +1,10 @@
 import { Nullable } from '@silverhand/essentials';
-import React, { useContext } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams, useLocation } from 'react-router-dom';
 
 import NavBar from '@/components/NavBar';
 import PasscodeValidation from '@/containers/PasscodeValidation';
-import { PageContext } from '@/hooks/use-page-context';
 import { UserFlow } from '@/types';
 
 import NotFound from '../NotFound';
@@ -27,7 +26,6 @@ const Passcode = () => {
   const state = useLocation().state as StateType;
   const invalidType = type !== 'sign-in' && type !== 'register';
   const invalidMethod = method !== 'email' && method !== 'sms';
-  const { setToast } = useContext(PageContext);
 
   if (invalidType || invalidMethod) {
     return <NotFound />;
@@ -36,8 +34,6 @@ const Passcode = () => {
   const target = state?.[method];
 
   if (!target) {
-    setToast(t(method === 'email' ? 'error.invalid_email' : 'error.invalid_phone'));
-
     return null;
   }
 

--- a/packages/ui/src/pages/Passcode/index.tsx
+++ b/packages/ui/src/pages/Passcode/index.tsx
@@ -1,12 +1,14 @@
 import { Nullable } from '@silverhand/essentials';
-import React, { useEffect } from 'react';
+import React, { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate, useParams, useLocation } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router-dom';
 
 import NavBar from '@/components/NavBar';
 import PasscodeValidation from '@/containers/PasscodeValidation';
+import { PageContext } from '@/hooks/use-page-context';
 import { UserFlow } from '@/types';
 
+import NotFound from '../NotFound';
 import * as styles from './index.module.scss';
 
 type Parameters = {
@@ -21,32 +23,21 @@ type StateType = Nullable<{
 
 const Passcode = () => {
   const { t } = useTranslation(undefined, { keyPrefix: 'main_flow' });
-  const navigate = useNavigate();
   const { method, type } = useParams<Parameters>();
   const state = useLocation().state as StateType;
-  const invalidSignInMethod = type !== 'sign-in' && type !== 'register';
+  const invalidType = type !== 'sign-in' && type !== 'register';
   const invalidMethod = method !== 'email' && method !== 'sms';
+  const { setToast } = useContext(PageContext);
 
-  useEffect(() => {
-    if (invalidSignInMethod || invalidMethod) {
-      navigate('/404', { replace: true });
-
-      return;
-    }
-
-    // Navigate to the back if no method value found
-    if (!state?.[method]) {
-      navigate(-1);
-    }
-  }, [invalidMethod, invalidSignInMethod, method, navigate, state]);
-
-  if (invalidSignInMethod || invalidMethod) {
-    return null;
+  if (invalidType || invalidMethod) {
+    return <NotFound />;
   }
 
   const target = state?.[method];
 
   if (!target) {
+    setToast(t(method === 'email' ? 'error.invalid_email' : 'error.invalid_phone'));
+
     return null;
   }
 

--- a/packages/ui/src/pages/Register/index.test.tsx
+++ b/packages/ui/src/pages/Register/index.test.tsx
@@ -40,4 +40,16 @@ describe('<Register />', () => {
     expect(queryByText('action.create_account')).not.toBeNull();
     expect(container.querySelector('input[name="email"]')).not.toBeNull();
   });
+
+  test('renders non-recognized method', async () => {
+    const { queryByText } = render(
+      <MemoryRouter initialEntries={['/register/test']}>
+        <Routes>
+          <Route path="/register/:method" element={<Register />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(queryByText('action.create_account')).toBeNull();
+    expect(queryByText('description.not_found')).not.toBeNull();
+  });
 });

--- a/packages/ui/src/pages/Register/index.tsx
+++ b/packages/ui/src/pages/Register/index.tsx
@@ -1,11 +1,12 @@
-import React, { useMemo, useEffect } from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 import NavBar from '@/components/NavBar';
 import CreateAccount from '@/containers/CreateAccount';
 import { PhonePasswordless, EmailPasswordless } from '@/containers/Passwordless';
 
+import NotFound from '../NotFound';
 import * as styles from './index.module.scss';
 
 type Parameters = {
@@ -14,14 +15,7 @@ type Parameters = {
 
 const Register = () => {
   const { t } = useTranslation(undefined, { keyPrefix: 'main_flow' });
-  const navigate = useNavigate();
   const { method = 'username' } = useParams<Parameters>();
-
-  useEffect(() => {
-    if (!['email', 'sms', 'username'].includes(method)) {
-      navigate('/404', { replace: true });
-    }
-  }, [method, navigate]);
 
   const registerForm = useMemo(() => {
     if (method === 'sms') {
@@ -34,6 +28,10 @@ const Register = () => {
 
     return <CreateAccount />;
   }, [method]);
+
+  if (!['email', 'sms', 'username'].includes(method)) {
+    return <NotFound />;
+  }
 
   return (
     <div className={styles.wrapper}>

--- a/packages/ui/src/pages/Register/index.tsx
+++ b/packages/ui/src/pages/Register/index.tsx
@@ -5,8 +5,8 @@ import { useParams } from 'react-router-dom';
 import NavBar from '@/components/NavBar';
 import CreateAccount from '@/containers/CreateAccount';
 import { PhonePasswordless, EmailPasswordless } from '@/containers/Passwordless';
+import NotFound from '@/pages/NotFound';
 
-import NotFound from '../NotFound';
 import * as styles from './index.module.scss';
 
 type Parameters = {

--- a/packages/ui/src/pages/SecondarySignIn/index.test.tsx
+++ b/packages/ui/src/pages/SecondarySignIn/index.test.tsx
@@ -39,4 +39,16 @@ describe('<SecondarySignIn />', () => {
     expect(queryByText('action.sign_in')).not.toBeNull();
     expect(container.querySelector('input[name="email"]')).not.toBeNull();
   });
+
+  test('render un-recognized method', async () => {
+    const { queryByText } = render(
+      <MemoryRouter initialEntries={['/sign-in/test']}>
+        <Routes>
+          <Route path="/sign-in/:method" element={<SecondarySignIn />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(queryByText('action.sign_in')).toBeNull();
+    expect(queryByText('description.not_found')).not.toBeNull();
+  });
 });

--- a/packages/ui/src/pages/SecondarySignIn/index.tsx
+++ b/packages/ui/src/pages/SecondarySignIn/index.tsx
@@ -1,10 +1,11 @@
-import React, { useMemo, useEffect } from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 import NavBar from '@/components/NavBar';
 import { PhonePasswordless, EmailPasswordless } from '@/containers/Passwordless';
 import UsernameSignin from '@/containers/UsernameSignin';
+import NotFound from '@/pages/NotFound';
 
 import * as styles from './index.module.scss';
 
@@ -14,14 +15,7 @@ type Props = {
 
 const SecondarySignIn = () => {
   const { t } = useTranslation(undefined, { keyPrefix: 'main_flow' });
-  const navigate = useNavigate();
   const { method = 'username' } = useParams<Props>();
-
-  useEffect(() => {
-    if (method !== 'email' && method !== 'sms' && method !== 'username') {
-      navigate('/404', { replace: true });
-    }
-  }, [method, navigate]);
 
   const signInForm = useMemo(() => {
     if (method === 'sms') {
@@ -34,6 +28,10 @@ const SecondarySignIn = () => {
 
     return <UsernameSignin />;
   }, [method]);
+
+  if (!['email', 'sms', 'username'].includes(method)) {
+    return <NotFound />;
+  }
 
   return (
     <div className={styles.wrapper}>

--- a/packages/ui/src/pages/SocialRegister/index.test.tsx
+++ b/packages/ui/src/pages/SocialRegister/index.test.tsx
@@ -4,26 +4,8 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import SocialRegister from '.';
 
-const mockNavigate = jest.fn();
-
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useNavigate: () => mockNavigate,
-}));
-
 describe('SocialRegister', () => {
-  it('render null and redirect if no connector found', () => {
-    render(
-      <MemoryRouter initialEntries={['/social-register']}>
-        <Routes>
-          <Route path="/social-register" element={<SocialRegister />} />
-        </Routes>
-      </MemoryRouter>
-    );
-    expect(mockNavigate).toBeCalledWith('/404');
-  });
-
-  it('render with connection', () => {
+  it('render', () => {
     const { queryByText } = render(
       <MemoryRouter initialEntries={['/social-register/github']}>
         <Routes>

--- a/packages/ui/src/pages/SocialRegister/index.tsx
+++ b/packages/ui/src/pages/SocialRegister/index.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 import NavBar from '@/components/NavBar';
 import SocialCreateAccount from '@/containers/SocialCreateAccount';
@@ -14,13 +14,6 @@ type Parameters = {
 const SocialRegister = () => {
   const { t } = useTranslation(undefined, { keyPrefix: 'main_flow' });
   const { connector } = useParams<Parameters>();
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    if (!connector) {
-      navigate('/404');
-    }
-  }, [connector, navigate]);
 
   if (!connector) {
     return null;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Per @wangsijie suggestion, the /404 path should be removed. Instead of redirect user to the /404 route, should render the NotFound page directly under the current page

<img width="509" alt="image" src="https://user-images.githubusercontent.com/36393111/165911551-81c93254-2a92-4982-87b8-79cf9c112b4f.png">

<img width="398" alt="image" src="https://user-images.githubusercontent.com/36393111/165911591-947f5a4f-167f-4185-bc96-f76db1dbf0b1.png">

<img width="407" alt="image" src="https://user-images.githubusercontent.com/36393111/165911630-fef861ed-eb53-4b36-90fd-7b9165a9fffc.png">

Show error toast at the Passcode page if no email or phone is passed to the page

<img width="370" alt="image" src="https://user-images.githubusercontent.com/36393111/165914625-39f8b476-8c59-4198-ac1f-165decfcf65a.png">


<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2337


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
ut added
@wangsijie  cc: @logto-io/eng 