### PR TITLE
fix(console): fetch settings with swr on app init

### DIFF
--- a/packages/console/src/App.tsx
+++ b/packages/console/src/App.tsx
@@ -35,7 +35,9 @@ const Main = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const fetcher = useSwrFetcher();
-  const { data } = useSWR<Setting, RequestError>('/api/settings');
+
+  const settingsFetcher = useSwrFetcher<Setting>();
+  const { data } = useSWR<Setting, RequestError>('/api/settings', settingsFetcher);
 
   useEffect(() => {
     const theme = data?.adminConsole.appearanceMode ?? defaultTheme;

--- a/packages/console/src/hooks/use-swr-fetcher.ts
+++ b/packages/console/src/hooks/use-swr-fetcher.ts
@@ -1,4 +1,4 @@
-import { ArbitraryObject, RequestErrorBody } from '@logto/schemas';
+import { RequestErrorBody } from '@logto/schemas';
 import { HTTPError } from 'ky';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -6,14 +6,21 @@ import { BareFetcher } from 'swr';
 
 import useApi, { RequestError } from './use-api';
 
-const useSwrFetcher = () => {
+type withTotalNumber<T> = Array<Awaited<T> | number>;
+
+type useSwrFetcherHook = {
+  <T>(): BareFetcher<T>;
+  <T extends unknown[]>(): BareFetcher<withTotalNumber<T>>;
+};
+
+const useSwrFetcher: useSwrFetcherHook = <T>() => {
   const api = useApi({ hideErrorToast: true });
   const { t } = useTranslation();
-  const fetcher = useCallback<BareFetcher>(
+  const fetcher = useCallback<BareFetcher<T | withTotalNumber<T>>>(
     async (resource, init) => {
       try {
         const response = await api.get(resource, init);
-        const data = await response.json<ArbitraryObject>();
+        const data = await response.json<T>();
 
         if (typeof resource === 'string' && resource.includes('?')) {
           const parameters = new URLSearchParams(resource.split('?')[1]);


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fix the issue: current global setting's useSWR is outside the scope of SWRConfig, so it won't fetch the settings.
Need to manually set a fetcher object to it to make it work.

But there might still be a better way to handle it, and we'll leave it to [LOG-2357](https://linear.app/silverhand/issue/LOG-2357) for eng quality improvement.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Manually change settings data in DB, and switch back to app, it automatically loads settings through swr
- [x] Fetch applications with pagination still works, not impacted by this change.
