### PR TITLE
fix(console): connector details save changes footer

### DIFF
--- a/packages/console/src/pages/ConnectorDetails/index.module.scss
+++ b/packages/console/src/pages/ConnectorDetails/index.module.scss
@@ -66,4 +66,8 @@
   > :not(:first-child) {
     margin-top: _.unit(4);
   }
+
+  .main {
+    flex: 1;
+  }
 }

--- a/packages/console/src/pages/ConnectorDetails/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/index.tsx
@@ -186,17 +186,19 @@ const ConnectorDetails = () => {
               {t('connector_details.tab_settings')}
             </TabNavLink>
           </TabNav>
-          <CodeEditor
-            language="json"
-            value={config}
-            onChange={(value) => {
-              setConfig(value);
-            }}
-          />
-          {data.metadata.type !== ConnectorType.Social && (
-            <SenderTester connectorType={data.metadata.type} />
-          )}
-          {saveError && <div>{saveError}</div>}
+          <div className={styles.main}>
+            <CodeEditor
+              language="json"
+              value={config}
+              onChange={(value) => {
+                setConfig(value);
+              }}
+            />
+            {data.metadata.type !== ConnectorType.Social && (
+              <SenderTester connectorType={data.metadata.type} />
+            )}
+            {saveError && <div>{saveError}</div>}
+          </div>
           <div className={detailsStyles.footer}>
             <div className={detailsStyles.footerMain}>
               <Button


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fix connector details page footer display, make the content's flex to "1", in order to make the footer always "stick" to the bottom.

![image](https://user-images.githubusercontent.com/5717882/167053766-16232db2-b7c4-4375-9d0f-845bd041e50e.png)

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
N/A

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested.
