### PR TITLE
fix(console): call settings API after user authentication

### DIFF
--- a/packages/console/src/App.tsx
+++ b/packages/console/src/App.tsx
@@ -1,4 +1,4 @@
-import { LogtoProvider } from '@logto/react';
+import { LogtoProvider, useLogto } from '@logto/react';
 import { AppearanceMode, Setting } from '@logto/schemas';
 import React, { useEffect } from 'react';
 import { BrowserRouter, Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
@@ -33,12 +33,16 @@ void initI18n();
 const defaultTheme = localStorage.getItem(themeStorageKey) ?? AppearanceMode.SyncWithSystem;
 
 const Main = () => {
+  const { isAuthenticated } = useLogto();
   const location = useLocation();
   const navigate = useNavigate();
   const fetcher = useSwrFetcher();
 
   const settingsFetcher = useSwrFetcher<Setting>();
-  const { data } = useSWR<Setting, RequestError>('/api/settings', settingsFetcher);
+  const { data } = useSWR<Setting, RequestError>(
+    isAuthenticated && '/api/settings',
+    settingsFetcher
+  );
 
   useEffect(() => {
     const theme = data?.adminConsole.appearanceMode ?? defaultTheme;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fix an unexpected 401 response on settings API call, if user is not authenticated yet.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested in incognito browser tab, when user is not logged in to admin console, settings API will not be triggered. Hence no 401 response any more.
