### PR TITLE
refactor(ui): main flow ui refine part 2

### DIFF
--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -47,7 +47,7 @@ const translation = {
       terms_of_use: 'Terms of Use',
       create_account: 'Create Account',
       forgot_password: 'Forgot Password?',
-      or: 'Or',
+      or: 'or',
       enter_passcode: 'The passcode has been sent to {{address}}',
       passcode_sent: 'The passcode has been sent',
       resend_after_seconds: 'Resend after {{seconds}} seconds',

--- a/packages/ui/src/components/AppContent/index.module.scss
+++ b/packages/ui/src/components/AppContent/index.module.scss
@@ -1,8 +1,15 @@
 @use '@/scss/underscore' as _;
 
 /* Foundation */
-$font-family: 'PingFang SC', 'SF Pro Display', 'Siyuan Heiti', 'Roboto';
-$font-family-small: 'PingFang SC', 'SF Pro Text', 'Siyuan Heiti', 'Roboto';
+$font-family: -apple-system,
+  system-ui,
+  'BlinkMacSystemFont',
+  'Segoe UI',
+  'Roboto',
+  'Helvetica Neue',
+  'Helvetica',
+  'Arial',
+  sans-serif;
 
 .content {
   position: absolute;
@@ -56,6 +63,6 @@ $font-family-small: 'PingFang SC', 'SF Pro Text', 'Siyuan Heiti', 'Roboto';
   --font-title: 600 32px/40px #{$font-family};
   --font-body-bold: 500 16px/20px #{$font-family};
   --font-body: 400 16px/20px #{$font-family};
-  --font-body-small: 500 14px/18px #{$font-family-small};
-  --font-caption: 400 14px/18px #{$font-family-small};
+  --font-body-small: 500 14px/18px #{$font-family};
+  --font-caption: 400 14px/18px #{$font-family};
 }

--- a/packages/ui/src/components/ConfirmModal/index.module.scss
+++ b/packages/ui/src/components/ConfirmModal/index.module.scss
@@ -6,7 +6,7 @@
 
 .container {
   background: var(--color-dialogue);
-  padding: _.unit(6) _.unit(5);
+  padding: _.unit(5);
   border-radius: var(--radius);
 }
 

--- a/packages/ui/src/components/ConfirmModal/index.tsx
+++ b/packages/ui/src/components/ConfirmModal/index.tsx
@@ -38,12 +38,10 @@ const ConfirmModal = ({
       parentSelector={() => document.querySelector('main') ?? document.body}
       ariaHideApp={false}
       onAfterOpen={() => {
-        /* eslint-disable @silverhand/fp/no-mutation */
-        document.body.style.overflow = 'hidden';
+        document.body.classList.add('static');
       }}
       onAfterClose={() => {
-        document.body.style.overflow = 'unset';
-        /* eslint-enable @silverhand/fp/no-mutation */
+        document.body.classList.remove('static');
       }}
     >
       <div className={styles.container}>

--- a/packages/ui/src/components/ConfirmModal/index.tsx
+++ b/packages/ui/src/components/ConfirmModal/index.tsx
@@ -37,6 +37,14 @@ const ConfirmModal = ({
       overlayClassName={classNames(modalStyles.overlay, styles.overlay)}
       parentSelector={() => document.querySelector('main') ?? document.body}
       ariaHideApp={false}
+      onAfterOpen={() => {
+        /* eslint-disable @silverhand/fp/no-mutation */
+        document.body.style.overflow = 'hidden';
+      }}
+      onAfterClose={() => {
+        document.body.style.overflow = 'unset';
+        /* eslint-enable @silverhand/fp/no-mutation */
+      }}
     >
       <div className={styles.container}>
         <div className={styles.content}>{children}</div>

--- a/packages/ui/src/components/Drawer/index.module.scss
+++ b/packages/ui/src/components/Drawer/index.module.scss
@@ -1,6 +1,8 @@
 @use '@/scss/underscore' as _;
 
 .container {
+  border-top-left-radius: 16px;
+  border-top-right-radius: 16px;
   padding: _.unit(5);
   background: var(--color-dialogue);
 }

--- a/packages/ui/src/components/Drawer/index.tsx
+++ b/packages/ui/src/components/Drawer/index.tsx
@@ -27,12 +27,10 @@ const Drawer = ({ className, isOpen = false, children, onClose }: Props) => {
       closeTimeoutMS={300}
       onRequestClose={onClose}
       onAfterOpen={() => {
-        /* eslint-disable @silverhand/fp/no-mutation */
-        document.body.style.overflow = 'hidden';
+        document.body.classList.add('static');
       }}
       onAfterClose={() => {
-        document.body.style.overflow = 'unset';
-        /* eslint-enable @silverhand/fp/no-mutation */
+        document.body.classList.remove('static');
       }}
     >
       <div className={styles.container}>

--- a/packages/ui/src/components/Drawer/index.tsx
+++ b/packages/ui/src/components/Drawer/index.tsx
@@ -26,6 +26,14 @@ const Drawer = ({ className, isOpen = false, children, onClose }: Props) => {
       appElement={document.querySelector('main') ?? document.body}
       closeTimeoutMS={300}
       onRequestClose={onClose}
+      onAfterOpen={() => {
+        /* eslint-disable @silverhand/fp/no-mutation */
+        document.body.style.overflow = 'hidden';
+      }}
+      onAfterClose={() => {
+        document.body.style.overflow = 'unset';
+        /* eslint-enable @silverhand/fp/no-mutation */
+      }}
     >
       <div className={styles.container}>
         <div className={styles.header}>

--- a/packages/ui/src/components/Input/index.module.scss
+++ b/packages/ui/src/components/Input/index.module.scss
@@ -8,6 +8,9 @@
   border: _.border();
   background: var(--color-layer);
   color: var(--color-text);
+  // fix in safari input field line-height issue
+  height: 46px;
+  overflow: hidden;
 
 
   > *:not(:first-child) {

--- a/packages/ui/src/components/Input/index.tsx
+++ b/packages/ui/src/components/Input/index.tsx
@@ -10,6 +10,7 @@ export type Props = HTMLProps<HTMLInputElement> & {
   className?: string;
   error?: ErrorType;
   onClear?: () => void;
+  errorStyling?: boolean;
 };
 
 const Input = ({
@@ -17,6 +18,7 @@ const Input = ({
   type = 'text',
   value,
   error,
+  errorStyling = true,
   onFocus,
   onBlur,
   onClear,
@@ -27,7 +29,11 @@ const Input = ({
   return (
     <div className={className}>
       <div
-        className={classNames(styles.wrapper, onInputFocus && styles.focus, error && styles.error)}
+        className={classNames(
+          styles.wrapper,
+          onInputFocus && styles.focus,
+          error && errorStyling && styles.error
+        )}
       >
         <input
           type={type}

--- a/packages/ui/src/components/NavBar/index.module.scss
+++ b/packages/ui/src/components/NavBar/index.module.scss
@@ -13,7 +13,7 @@
     left: _.unit(4);
     top: 50%;
     transform: translateY(-50%);
-    fill: var(--color-icon);
+    fill: var(--color-text);
   }
 
   .title {

--- a/packages/ui/src/components/Passcode/index.module.scss
+++ b/packages/ui/src/components/Passcode/index.module.scss
@@ -2,7 +2,6 @@
 
 .passcode {
   @include _.flex-row;
-  @include _.container-width;
   justify-content: space-between;
   margin: 0 auto;
 

--- a/packages/ui/src/components/Passcode/index.tsx
+++ b/packages/ui/src/components/Passcode/index.tsx
@@ -5,7 +5,6 @@ import React, {
   useEffect,
   FormEventHandler,
   KeyboardEventHandler,
-  FocusEventHandler,
   ClipboardEventHandler,
 } from 'react';
 
@@ -88,7 +87,6 @@ const Passcode = ({ name, className, value, length = defaultLength, error, onCha
       if (value) {
         const nextTarget = inputReferences.current[targetId + 1];
         nextTarget?.focus();
-        nextTarget?.select();
       }
     },
     [codes, onChange]
@@ -116,18 +114,15 @@ const Passcode = ({ name, className, value, length = defaultLength, error, onCha
       case 'Backspace':
         if (!value) {
           previousTarget?.focus();
-          previousTarget?.select();
         }
         break;
       case 'ArrowLeft':
         event.preventDefault();
         previousTarget?.focus();
-        previousTarget?.select();
         break;
       case 'ArrowRight':
         event.preventDefault();
         nextTarget?.focus();
-        nextTarget?.select();
         break;
       case 'ArrowUp':
       case 'ArrowDown':
@@ -136,10 +131,6 @@ const Passcode = ({ name, className, value, length = defaultLength, error, onCha
       default:
         break;
     }
-  }, []);
-
-  const onFocusHandler: FocusEventHandler<HTMLInputElement> = useCallback(({ target }) => {
-    target.select();
   }, []);
 
   const onPasteHandler: ClipboardEventHandler<HTMLInputElement> = useCallback(
@@ -206,7 +197,6 @@ const Passcode = ({ name, className, value, length = defaultLength, error, onCha
             onPaste={onPasteHandler}
             onInput={onInputHandler}
             onKeyDown={onKeyDownHandler}
-            onFocus={onFocusHandler}
           />
         ))}
       </div>

--- a/packages/ui/src/containers/CreateAccount/index.module.scss
+++ b/packages/ui/src/containers/CreateAccount/index.module.scss
@@ -13,10 +13,6 @@
     margin-bottom: _.unit(4);
   }
 
-  .confirmPassword > * {
-    border: _.border();
-  }
-
   .terms {
     margin: _.unit(8) 0 _.unit(4);
   }

--- a/packages/ui/src/containers/CreateAccount/index.tsx
+++ b/packages/ui/src/containers/CreateAccount/index.tsx
@@ -100,7 +100,7 @@ const CreateAccount = ({ className }: Props) => {
         }}
       />
       <Input
-        className={classNames(styles.inputField, styles.confirmPassword)}
+        className={styles.inputField}
         name="confirm_password"
         type="password"
         autoComplete="current-password"
@@ -108,6 +108,7 @@ const CreateAccount = ({ className }: Props) => {
         {...fieldRegister('confirmPassword', (confirmPassword) =>
           confirmPasswordValidation(fieldValue.password, confirmPassword)
         )}
+        errorStyling={false}
         onClear={() => {
           setFieldValue((state) => ({ ...state, confirmPassword: '' }));
         }}

--- a/packages/ui/src/containers/SignInMethodsLink/index.module.scss
+++ b/packages/ui/src/containers/SignInMethodsLink/index.module.scss
@@ -3,6 +3,10 @@
 
 .textLink {
   text-align: center;
+
+  .signInMethodLink {
+    font-size: inherit;
+  }
 }
 
 .methodsLinkList {

--- a/packages/ui/src/pages/Callback/index.module.scss
+++ b/packages/ui/src/pages/Callback/index.module.scss
@@ -3,6 +3,8 @@
 
 .wrapper {
   @include _.page-wrapper;
+  position: absolute;
+  inset: 0;
 }
 
 .connector {
@@ -13,6 +15,11 @@
   margin-bottom: _.unit(6);
 }
 
+.placeHolder {
+  flex: 1;
+}
+
 .button {
   @include _.container-width;
+  margin-bottom: _.unit(4);
 }

--- a/packages/ui/src/pages/Callback/index.tsx
+++ b/packages/ui/src/pages/Callback/index.tsx
@@ -41,6 +41,7 @@ const Callback = () => {
     <div className={styles.wrapper}>
       {connectorLabel}
       <div className={styles.loadingLabel}>loading...</div>
+      <div className={styles.placeHolder} />
       <Button className={styles.button} onClick={socialCallbackHandler}>
         {t('action.continue')}
       </Button>

--- a/packages/ui/src/scss/modal.module.scss
+++ b/packages/ui/src/scss/modal.module.scss
@@ -26,6 +26,10 @@
 /* stylelint-disable selector-class-pattern */
 /* stylelint-disable-next-line selector-pseudo-class-no-unknown */
 :global {
+  .static {
+    overflow: hidden;
+  }
+
   .ReactModal__Content[role='popup'] {
     transform: translateY(100%);
     transition: transform 0.3s ease-in-out;

--- a/packages/ui/src/scss/normalized.scss
+++ b/packages/ui/src/scss/normalized.scss
@@ -6,6 +6,11 @@ body {
 
 * {
   box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+}
+
+a {
+  text-underline-offset: 2px;
 }
 
 input {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
### main flow ui refine 2nd round

1. Update the divider Or content to lowercase
<img width="347" alt="image" src="https://user-images.githubusercontent.com/36393111/167095088-9b76c07e-3454-42d2-8e71-89996a06be9f.png">

2. Set the input field container height fixed with overflow hidden. As in safari input field,[ line-height is differ](https://stackoverflow.com/questions/42529257/input-text-height-is-broken-in-safari) 

3. Update the font-family settings that fix the passcode secret mast dot size and styling
<img width="363" alt="image" src="https://user-images.githubusercontent.com/36393111/167095477-b04b6d12-60f3-46ac-9129-9e876adbb3fd.png">

5. Disable all elements on-touch event shadow effect
6. Update the modal padding space
7. Adjust the text link underline space
<img width="177" alt="image" src="https://user-images.githubusercontent.com/36393111/167096330-d9f3560a-43f3-43bf-8c61-cd8acfc9b1e9.png">


9. Update the NavBar icon fill color use the base text color
<img width="347" alt="image" src="https://user-images.githubusercontent.com/36393111/167096384-5054120d-3c2e-4821-989c-6c2855871c76.png">

10. Add border-radius to the drawer element
<img width="367" alt="image" src="https://user-images.githubusercontent.com/36393111/167096423-9ca9845d-53c8-4f0c-9eeb-6cc0d916eacd.png">

11. Prevent body scall when modal occurred
12. Adjust the link size within hint text content.
13. Callback Page layout redesign
<img width="370" alt="image" src="https://user-images.githubusercontent.com/36393111/167096284-0e0885b7-f4ef-4bbc-857c-972ca86e8a9f.png">

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2367

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
@logto-io/eng 