### PR TITLE
feat(console): multi-text-input delete reminder

### DIFF
--- a/packages/console/src/components/MultiTextInput/DeleteConfirm.tsx
+++ b/packages/console/src/components/MultiTextInput/DeleteConfirm.tsx
@@ -12,12 +12,12 @@ type Props = {
   onClose: () => void;
 };
 
-const DeletionReminder = ({ title, onConfirm, onClose }: Props) => {
+const DeleteConfirm = ({ title, onConfirm, onClose }: Props) => {
   const { t } = useTranslation();
 
   return (
     <ModalLayout
-      title="form.reminder"
+      title="form.confirm"
       footer={
         <>
           <Button type="outline" title="admin_console.form.cancel" onClick={onClose} />
@@ -41,4 +41,4 @@ const DeletionReminder = ({ title, onConfirm, onClose }: Props) => {
   );
 };
 
-export default DeletionReminder;
+export default DeleteConfirm;

--- a/packages/console/src/components/MultiTextInput/DeletionReminder.tsx
+++ b/packages/console/src/components/MultiTextInput/DeletionReminder.tsx
@@ -34,7 +34,9 @@ const DeletionReminder = ({ title, onConfirm, onClose }: Props) => {
       className={styles.content}
       onClose={onClose}
     >
-      <div>{t('admin_console.form.deletion_confirmation', { title: t(title) })}</div>
+      <div className={styles.confirmation}>
+        {t('admin_console.form.deletion_confirmation', { title: t(title) })}
+      </div>
     </ModalLayout>
   );
 };

--- a/packages/console/src/components/MultiTextInput/DeletionReminder.tsx
+++ b/packages/console/src/components/MultiTextInput/DeletionReminder.tsx
@@ -1,0 +1,42 @@
+import { I18nKey } from '@logto/phrases';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import Button from '../Button';
+import ModalLayout from '../ModalLayout';
+import * as styles from './index.module.scss';
+
+type Props = {
+  title: I18nKey;
+  onConfirm: () => void;
+  onClose: () => void;
+};
+
+const DeletionReminder = ({ title, onConfirm, onClose }: Props) => {
+  const { t } = useTranslation();
+
+  return (
+    <ModalLayout
+      title="form.reminder"
+      footer={
+        <>
+          <Button type="outline" title="admin_console.form.cancel" onClick={onClose} />
+          <Button
+            type="danger"
+            title="admin_console.form.delete"
+            onClick={() => {
+              onConfirm();
+              onClose();
+            }}
+          />
+        </>
+      }
+      className={styles.content}
+      onClose={onClose}
+    >
+      <div>{t('admin_console.form.deletion_confirmation', { title: t(title) })}</div>
+    </ModalLayout>
+  );
+};
+
+export default DeletionReminder;

--- a/packages/console/src/components/MultiTextInput/index.module.scss
+++ b/packages/console/src/components/MultiTextInput/index.module.scss
@@ -26,3 +26,15 @@
     margin-top: _.unit(1);
   }
 }
+
+.reminder {
+  .content {
+    > :not(:first-child) {
+      margin: _.unit(6) 0;
+    }
+
+    .confirmation {
+      font: var(--font-body-medium);
+    }
+  }
+}

--- a/packages/console/src/components/MultiTextInput/index.module.scss
+++ b/packages/console/src/components/MultiTextInput/index.module.scss
@@ -16,9 +16,13 @@
     }
   }
 
+  .addAnother {
+    margin-top: _.unit(1);
+  }
+
   .error {
     font: var(--font-body-medium);
     color: var(--color-error);
-    margin-top: _.unit(2);
+    margin-top: _.unit(1);
   }
 }

--- a/packages/console/src/components/MultiTextInput/index.tsx
+++ b/packages/console/src/components/MultiTextInput/index.tsx
@@ -10,7 +10,7 @@ import * as modalStyles from '@/scss/modal.module.scss';
 
 import IconButton from '../IconButton';
 import TextInput from '../TextInput';
-import DeletionReminder from './DeletionReminder';
+import DeleteConfirm from './DeleteConfirm';
 import * as styles from './index.module.scss';
 import { MultiTextInputError } from './types';
 
@@ -94,7 +94,7 @@ const MultiTextInput = ({ title, value, onChange, error }: Props) => {
         className={modalStyles.content}
         overlayClassName={modalStyles.overlay}
       >
-        <DeletionReminder
+        <DeleteConfirm
           title={title}
           onClose={() => {
             setDeleteFieldIndex(undefined);

--- a/packages/console/src/components/MultiTextInput/index.tsx
+++ b/packages/console/src/components/MultiTextInput/index.tsx
@@ -1,24 +1,32 @@
-import React, { useMemo } from 'react';
+import { I18nKey } from '@logto/phrases';
+import classNames from 'classnames';
+import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import Modal from 'react-modal';
 
 import * as textButtonStyles from '@/components/TextButton/index.module.scss';
 import Minus from '@/icons/Minus';
+import * as modalStyles from '@/scss/modal.module.scss';
 
 import IconButton from '../IconButton';
 import TextInput from '../TextInput';
+import DeletionReminder from './DeletionReminder';
 import * as styles from './index.module.scss';
 import { MultiTextInputError } from './types';
 
 type Props = {
+  title: I18nKey;
   value?: string[];
   onChange: (value: string[]) => void;
   error?: MultiTextInputError;
 };
 
-const MultiTextInput = ({ value, onChange, error }: Props) => {
+const MultiTextInput = ({ title, value, onChange, error }: Props) => {
   const { t } = useTranslation(undefined, {
     keyPrefix: 'admin_console',
   });
+
+  const [deleteFieldIndex, setDeleteFieldIndex] = useState<number | undefined>();
 
   const fields = useMemo(() => {
     if (!value?.length) {
@@ -55,10 +63,10 @@ const MultiTextInput = ({ value, onChange, error }: Props) => {
                 handleInputChange(value, fieldIndex);
               }}
             />
-            {fields.length > 1 && (
+            {fieldIndex > 0 && (
               <IconButton
                 onClick={() => {
-                  handleRemove(fieldIndex);
+                  setDeleteFieldIndex(fieldIndex);
                 }}
               >
                 <Minus />
@@ -73,9 +81,26 @@ const MultiTextInput = ({ value, onChange, error }: Props) => {
           )}
         </div>
       ))}
-      <div className={textButtonStyles.button} onClick={handleAdd}>
+      <div className={classNames(textButtonStyles.button, styles.addAnother)} onClick={handleAdd}>
         {t('form.add_another')}
       </div>
+      <Modal
+        isOpen={deleteFieldIndex !== undefined}
+        className={modalStyles.content}
+        overlayClassName={modalStyles.overlay}
+      >
+        <DeletionReminder
+          title={title}
+          onClose={() => {
+            setDeleteFieldIndex(undefined);
+          }}
+          onConfirm={() => {
+            if (deleteFieldIndex !== undefined) {
+              handleRemove(deleteFieldIndex);
+            }
+          }}
+        />
+      </Modal>
     </div>
   );
 };

--- a/packages/console/src/components/MultiTextInput/index.tsx
+++ b/packages/console/src/components/MultiTextInput/index.tsx
@@ -68,10 +68,9 @@ const MultiTextInput = ({ title, value, onChange, error }: Props) => {
                 onClick={() => {
                   if (fieldValue.trim().length === 0) {
                     handleRemove(fieldIndex);
-
-                    return;
+                  } else {
+                    setDeleteFieldIndex(fieldIndex);
                   }
-                  setDeleteFieldIndex(fieldIndex);
                 }}
               >
                 <Minus />

--- a/packages/console/src/components/MultiTextInput/index.tsx
+++ b/packages/console/src/components/MultiTextInput/index.tsx
@@ -66,6 +66,11 @@ const MultiTextInput = ({ title, value, onChange, error }: Props) => {
             {fieldIndex > 0 && (
               <IconButton
                 onClick={() => {
+                  if (fieldValue.trim().length === 0) {
+                    handleRemove(fieldIndex);
+
+                    return;
+                  }
                   setDeleteFieldIndex(fieldIndex);
                 }}
               >

--- a/packages/console/src/components/MultiTextInput/index.tsx
+++ b/packages/console/src/components/MultiTextInput/index.tsx
@@ -26,7 +26,7 @@ const MultiTextInput = ({ title, value, onChange, error }: Props) => {
     keyPrefix: 'admin_console',
   });
 
-  const [deleteFieldIndex, setDeleteFieldIndex] = useState<number | undefined>();
+  const [deleteFieldIndex, setDeleteFieldIndex] = useState<number>();
 
   const fields = useMemo(() => {
     if (!value?.length) {

--- a/packages/console/src/pages/ApplicationDetails/components/Settings.tsx
+++ b/packages/console/src/pages/ApplicationDetails/components/Settings.tsx
@@ -67,6 +67,7 @@ const Settings = ({ oidcConfig }: Props) => {
           }}
           render={({ field: { onChange, value }, fieldState: { error } }) => (
             <MultiTextInput
+              title="admin_console.application_details.redirect_uri"
               value={value}
               error={convertRhfErrorMessage(error?.message)}
               onChange={onChange}
@@ -87,6 +88,7 @@ const Settings = ({ oidcConfig }: Props) => {
           }}
           render={({ field: { onChange, value }, fieldState: { error } }) => (
             <MultiTextInput
+              title="admin_console.application_details.post_sign_out_redirect_uri"
               value={value}
               error={convertRhfErrorMessage(error?.message)}
               onChange={onChange}
@@ -107,6 +109,7 @@ const Settings = ({ oidcConfig }: Props) => {
           }}
           render={({ field: { onChange, value }, fieldState: { error } }) => (
             <MultiTextInput
+              title="admin_console.application_details.cors_allowed_origins"
               value={value}
               error={convertRhfErrorMessage(error?.message)}
               onChange={onChange}

--- a/packages/console/src/pages/Guide/components/MultiTextInputField/index.tsx
+++ b/packages/console/src/pages/Guide/components/MultiTextInputField/index.tsx
@@ -1,8 +1,8 @@
+import { I18nKey } from '@logto/phrases';
 import React, { useRef } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
-import DangerousRaw from '@/components/DangerousRaw';
 import FormField from '@/components/FormField';
 import MultiTextInput from '@/components/MultiTextInput';
 import { createValidatorForRhf, convertRhfErrorMessage } from '@/components/MultiTextInput/utils';
@@ -11,7 +11,7 @@ import { uriValidator } from '@/utilities/validator';
 
 type Props = {
   name: 'redirectUris' | 'postLogoutRedirectUris';
-  title: string;
+  title: I18nKey;
   onError?: () => void;
 };
 
@@ -33,7 +33,7 @@ const MultiTextInputField = ({ name, title, onError }: Props) => {
   }
 
   return (
-    <FormField isRequired title={<DangerousRaw>{title}</DangerousRaw>}>
+    <FormField isRequired title={title}>
       <Controller
         name={name}
         control={control}
@@ -50,6 +50,7 @@ const MultiTextInputField = ({ name, title, onError }: Props) => {
         render={({ field: { onChange, value }, fieldState: { error } }) => (
           <div ref={ref}>
             <MultiTextInput
+              title={title}
               value={value}
               error={convertRhfErrorMessage(error?.message)}
               onChange={onChange}

--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -88,6 +88,10 @@ const translation = {
     form: {
       required: 'Required',
       add_another: '+ Add Another',
+      reminder: 'Reminder',
+      cancel: 'Cancel',
+      delete: 'Delete',
+      deletion_confirmation: 'Are you sure you want to delete this {{title}}?',
     },
     errors: {
       something_went_wrong: 'Oops! Something went wrong',

--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -88,7 +88,7 @@ const translation = {
     form: {
       required: 'Required',
       add_another: '+ Add Another',
-      reminder: 'Reminder',
+      confirm: 'Reminder',
       cancel: 'Cancel',
       delete: 'Delete',
       deletion_confirmation: 'Are you sure you want to delete this {{title}}?',

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -88,7 +88,7 @@ const translation = {
     form: {
       required: '必填',
       add_another: '+ 添加其他',
-      reminder: '注意',
+      confirm: '注意',
       cancel: '取消',
       delete: '删除',
       deletion_confirmation: '你确定要删除这个 {{title}} 吗?',

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -87,7 +87,11 @@ const translation = {
     },
     form: {
       required: '必填',
-      add_another: '+ Add Another',
+      add_another: '+ 添加其他',
+      reminder: '注意',
+      cancel: '取消',
+      delete: '删除',
+      deletion_confirmation: '你确定要删除这个 {{title}} 吗?',
     },
     errors: {
       something_went_wrong: '哎哟喂，遇到了一个错误',


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
feat(console): multi-text-input delete reminder

Refer to the design doc:
<img width="613" alt="image" src="https://user-images.githubusercontent.com/10806653/167240599-713239cb-5fb9-48b5-8878-c67e239f91ed.png">
https://www.figma.com/file/iroUuWbeZ9fqcqXNwqYZai/Admin-Console-UI?node-id=2371%3A51066

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
* LOG-2306

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
![multi-text-reminder](https://user-images.githubusercontent.com/10806653/167240579-d13b9424-b3d2-4e79-8e03-9a9e8ab6946e.gif)

<img width="890" alt="image" src="https://user-images.githubusercontent.com/10806653/167240554-fa48aa61-7de0-40fb-be63-2d09beb6f419.png">
