### PR TITLE
feat(core): koaSessionChecker middleware

### DIFF
--- a/packages/core/src/middleware/koa-oidc-session-checker.test.ts
+++ b/packages/core/src/middleware/koa-oidc-session-checker.test.ts
@@ -1,0 +1,32 @@
+import { Provider } from 'oidc-provider';
+
+import koaOidcSessionChecker from '@/middleware/koa-oidc-session-checker';
+import { createContextWithRouteParameters } from '@/utils/test-utils';
+
+const interactionDetails: jest.MockedFunction<() => Promise<unknown>> = jest.fn(async () => ({}));
+
+jest.mock('oidc-provider', () => ({
+  Provider: jest.fn(() => ({
+    interactionDetails,
+  })),
+}));
+
+describe('koaOidcInteraction', () => {
+  const next = jest.fn();
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call interactionDetails from the provider', async () => {
+    const ctx = createContextWithRouteParameters();
+    await expect(koaOidcSessionChecker(new Provider(''))(ctx, next)).resolves.not.toThrow();
+    expect(interactionDetails).toHaveBeenCalled();
+  });
+
+  it('should call next', async () => {
+    const ctx = createContextWithRouteParameters();
+    await expect(koaOidcSessionChecker(new Provider(''))(ctx, next)).resolves.not.toThrow();
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/middleware/koa-oidc-session-checker.ts
+++ b/packages/core/src/middleware/koa-oidc-session-checker.ts
@@ -1,0 +1,15 @@
+import { MiddlewareType } from 'koa';
+import { Provider } from 'oidc-provider';
+
+export type Interaction = Awaited<ReturnType<Provider['interactionDetails']>>;
+
+export default function koaOidcSessionChecker<StateT, ContextT, ResponseBodyT>(
+  provider: Provider
+): MiddlewareType<StateT, ContextT, ResponseBodyT> {
+  return async (ctx, next) => {
+    // If OIDC session does not exist, it will throw SessionNotFound.
+    await provider.interactionDetails(ctx.req, ctx.res);
+
+    return next();
+  };
+}

--- a/packages/core/src/routes/init.ts
+++ b/packages/core/src/routes/init.ts
@@ -4,6 +4,7 @@ import Router from 'koa-router';
 import { Provider } from 'oidc-provider';
 
 import koaAuth from '@/middleware/koa-auth';
+import koaOidcSessionChecker from '@/middleware/koa-oidc-session-checker';
 import applicationRoutes from '@/routes/application';
 import connectorRoutes from '@/routes/connector';
 import resourceRoutes from '@/routes/resource';
@@ -18,23 +19,25 @@ import roleRoutes from './role';
 import { AnonymousRouter, AuthedRouter } from './types';
 
 const createRouters = (provider: Provider) => {
-  const anonymousRouter: AnonymousRouter = new Router();
+  const sessionRouter: AnonymousRouter = new Router();
+  sessionRouter.use(koaOidcSessionChecker(provider));
+  sessionRoutes(sessionRouter, provider);
 
+  const anonymousRouter: AnonymousRouter = new Router();
   statusRoutes(anonymousRouter);
-  sessionRoutes(anonymousRouter, provider);
   swaggerRoutes(anonymousRouter);
 
-  const router: AuthedRouter = new Router();
-  router.use(koaAuth());
-  applicationRoutes(router);
-  settingRoutes(router);
-  connectorRoutes(router);
-  resourceRoutes(router);
-  signInExperiencesRoutes(router);
-  adminUserRoutes(router);
-  roleRoutes(router);
+  const authedRouter: AuthedRouter = new Router();
+  authedRouter.use(koaAuth());
+  applicationRoutes(authedRouter);
+  settingRoutes(authedRouter);
+  connectorRoutes(authedRouter);
+  resourceRoutes(authedRouter);
+  signInExperiencesRoutes(authedRouter);
+  adminUserRoutes(authedRouter);
+  roleRoutes(authedRouter);
 
-  return [anonymousRouter, router];
+  return [sessionRouter, anonymousRouter, authedRouter];
 };
 
 export default function initRouter(app: Koa, provider: Provider) {

--- a/packages/core/src/routes/session.ts
+++ b/packages/core/src/routes/session.ts
@@ -564,7 +564,6 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
   );
 
   router.delete('/session', async (ctx, next) => {
-    await provider.interactionDetails(ctx.req, ctx.res);
     const error: LogtoErrorCode = 'oidc.aborted';
     await assignInteractionResults(ctx, provider, { error });
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- koaSessionChecker:
    - Get interaction info from OIDC provider and save it in koa context so that `/session/*` routes can use it directly from context
    - should check oidc session before `/session/*` routes, and we can do it by calling `provider.interactionDetails`

        ```ts
          async interactionDetails(req, res) {
            return getInteraction.call(this, req, res);
          }
        ```
        ![image](https://user-images.githubusercontent.com/10594507/167252545-6129cf0e-01c0-4c0d-88b4-0ab529335229.png)

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2256

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
![image](https://user-images.githubusercontent.com/10594507/167455462-67ea64c9-40b5-4740-ac9e-a54c724572fe.png)

and all existing tests.
