### PR TITLE
feat(console): page skeleton animation mixin

### DIFF
--- a/packages/console/src/scss/_colors.scss
+++ b/packages/console/src/scss/_colors.scss
@@ -149,6 +149,7 @@
 
   // Client specific variables (not available in design system)
   --color-danger-focused: rgba(186, 27, 27, 16%); // 16% Error-40
+  --color-skeleton-shimmer-rgb: 255, 255, 255; // rgb of Layer-1
 }
 
 @mixin dark-theme {
@@ -302,4 +303,5 @@
 
   // Client specific variables (not available in design system)
   --color-danger-focused: rgba(255, 180, 169, 16%); // 16% Error-40
+  --color-skeleton-shimmer-rgb: 42, 44, 50; // rgb of Layer-1
 }

--- a/packages/console/src/scss/_underscore.scss
+++ b/packages/console/src/scss/_underscore.scss
@@ -30,6 +30,28 @@
   animation: rotating 1s ease-in-out infinite;
 }
 
+@mixin shimmering-animation($baseColor: var(--color-neutral-95)) {
+  background-color: $baseColor;
+  position: relative;
+  overflow: hidden;
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    transform: translateX(-100%);
+    background-image:
+      linear-gradient(
+        90deg,
+        rgba(var(--color-skeleton-shimmer-rgb), 0) 0,
+        rgba(var(--color-skeleton-shimmer-rgb), 0.2) 20%,
+        rgba(var(--color-skeleton-shimmer-rgb), 0.5) 60%,
+        $baseColor
+      );
+    animation: shimmer 2s infinite;
+  }
+}
+
 @keyframes rotating {
   from {
     transform: rotate(0deg);
@@ -37,5 +59,11 @@
 
   to {
     transform: rotate(360deg);
+  }
+}
+
+@keyframes shimmer {
+  100% {
+    transform: translateX(100%);
   }
 }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Provide a SCSS mixin that offers page skeleton animation effects

https://user-images.githubusercontent.com/12833674/168198738-d8306f42-e54d-436d-bf6f-f6126d0086ba.mov

https://user-images.githubusercontent.com/12833674/168202126-26f0e1e4-28fa-4ed5-a45a-bd3f78197803.mov


Will add skeleton to each page in a follow-up task. [LOG-2423](https://linear.app/silverhand/issue/LOG-2423/add-page-skeleton-for-each-page-that-loads-data-on-init)

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally, animation works as expected.
