### PR TITLE
refactor(console): refine scrollbar styles and positions

### DIFF
--- a/packages/console/src/components/AppContent/index.module.scss
+++ b/packages/console/src/components/AppContent/index.module.scss
@@ -10,12 +10,12 @@
 .content {
   flex-grow: 1;
   display: flex;
-  padding-right: _.unit(6);
   margin-bottom: _.unit(6);
   overflow: hidden;
 
   .main {
     flex-grow: 1;
+    padding-right: _.unit(6);
     overflow-y: auto;
   }
 }

--- a/packages/console/src/scss/normalized.scss
+++ b/packages/console/src/scss/normalized.scss
@@ -55,3 +55,16 @@ table {
     }
   }
 }
+
+::-webkit-scrollbar {
+  width: 8px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--color-neutral-variant-80);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Refine scrollbar styles and adjust positions
* Detail page scrollbar should stick to the very right of the page
* Customized scrollbar track and thumb

<img width="1511" alt="image" src="https://user-images.githubusercontent.com/12833674/168300794-869707ab-95c6-42b0-ad55-32183a56b2bc.png">

<img width="1511" alt="image" src="https://user-images.githubusercontent.com/12833674/168300826-9c2cdc31-ccf9-4ab0-9582-b5dc929c7414.png">

<img width="1511" alt="image" src="https://user-images.githubusercontent.com/12833674/168300867-f17ca2b4-025b-409a-a205-a132e2b8e2fa.png">


<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
https://www.figma.com/file/bcSRcMyKEQc0c7k7QfP9fG/%F0%9F%AA%90-%5BWeb%5D-AC-Design-System?node-id=1588%3A8826

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Detail page vertical scrollbar now sticks to the page right
- [x] Scrollbar styles are customized, with a transparent track and a light purple thumb
