### PR TITLE
fix(ui): fix create account page reload issue

### DIFF
--- a/packages/ui/src/components/TextLink/index.tsx
+++ b/packages/ui/src/components/TextLink/index.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import React, { ReactNode, AnchorHTMLAttributes } from 'react';
 import { TFuncKey, useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
 
 import * as styles from './index.module.scss';
 
@@ -9,10 +10,19 @@ export type Props = AnchorHTMLAttributes<HTMLAnchorElement> & {
   children?: ReactNode;
   text?: TFuncKey<'translation', 'main_flow'>;
   type?: 'primary' | 'secondary';
+  to?: string;
 };
 
-const TextLink = ({ className, children, text, type = 'primary', ...rest }: Props) => {
+const TextLink = ({ className, children, text, type = 'primary', to, ...rest }: Props) => {
   const { t } = useTranslation(undefined, { keyPrefix: 'main_flow' });
+
+  if (to) {
+    return (
+      <Link className={classNames(styles.link, styles[type], className)} to={to}>
+        {children ?? (text ? t(text) : '')}
+      </Link>
+    );
+  }
 
   return (
     <a className={classNames(styles.link, styles[type], className)} {...rest} rel="noreferrer">

--- a/packages/ui/src/pages/SignIn/registry.tsx
+++ b/packages/ui/src/pages/SignIn/registry.tsx
@@ -87,7 +87,7 @@ export const CreateAccountLink = ({
           <TextLink
             className={styles.createAccount}
             type="secondary"
-            href={`/register/${primarySignInMethod}`}
+            to={`/register/${primarySignInMethod}`}
             text="action.create_account"
           />
         </>


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Bug fixing. CreateAccount link uses href to navigate which causes an unexpected page to reload.  Apply the react-router link instead. 

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
log-2448

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
@logto-io/eng 
