### PR TITLE
fix(console): long text should wrap in code editor

### DIFF
--- a/packages/console/src/components/CodeEditor/index.module.scss
+++ b/packages/console/src/components/CodeEditor/index.module.scss
@@ -36,10 +36,9 @@
       background: none;
       font-size: 14px;
       line-height: 1.5;
-      font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+      font-family: 'Roboto Mono', monospace;
       white-space: pre-wrap;
-      word-break: keep-all;
-      overflow-wrap: break-word;
+      word-break: break-all;
       position: absolute;
       inset: 0;
       resize: none;

--- a/packages/console/src/components/CodeEditor/index.tsx
+++ b/packages/console/src/components/CodeEditor/index.tsx
@@ -22,6 +22,8 @@ const CodeEditor = ({ language, isReadonly = false, value = '', onChange }: Prop
     <div className={styles.container}>
       <CopyToClipboard value={value} variant="icon" className={styles.copy} />
       <div className={styles.editor}>
+        {/* SyntaxHighlighter is a readonly component, so a transparent <textarea> layer is needed
+        in order to support user interactions, such as code editing, copy-pasting, etc. */}
         <textarea
           autoCapitalize="off"
           autoComplete="off"
@@ -32,13 +34,24 @@ const CodeEditor = ({ language, isReadonly = false, value = '', onChange }: Prop
           value={value}
           onChange={handleChange}
         />
+        {/* SyntaxHighlighter will generate a <pre> tag and a inner <code> tag. Both have
+        inline-styles by default. Therefore, We can only use inline styles to customize them.
+        Some styles have to be applied multiple times to each of them for the sake of consistency. */}
         <SyntaxHighlighter
+          wrapLongLines
+          codeTagProps={{
+            style: {
+              fontFamily: "'Roboto Mono', monospace", // Override default font-family of <code>
+            },
+          }}
           customStyle={{
             background: 'transparent',
             fontSize: '14px',
             margin: '0',
             padding: '0',
             borderRadius: '0',
+            wordBreak: 'break-all',
+            fontFamily: "'Roboto Mono', monospace", // Override default font-family of <pre>
           }}
           language={language}
           style={theme}


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
* Fixed an issue that long text in code editor did not wrap, so user was not able to see the whole content.
* Use `Roboto Mono` font face in editor

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested in social connector settings page, the json content can now be displayed properly.
