### PR TITLE
fix(console): align usage of customizeSignInExperience

### DIFF
--- a/packages/console/src/pages/SignInExperience/components/GuideModal.tsx
+++ b/packages/console/src/pages/SignInExperience/components/GuideModal.tsx
@@ -63,7 +63,7 @@ const GuideModal = ({ isOpen, onClose }: Props) => {
       api.patch('/api/sign-in-exp', {
         json: signInExperienceParser.toRemoteModel(formData),
       }),
-      updateConfigs({ experienceGuideDone: true }),
+      updateConfigs({ customizeSignInExperience: true }),
     ]);
 
     location.reload();

--- a/packages/console/src/pages/SignInExperience/index.tsx
+++ b/packages/console/src/pages/SignInExperience/index.tsx
@@ -88,7 +88,7 @@ const SignInExperience = () => {
     return <div>{configError.body.message}</div>;
   }
 
-  if (configs?.customizeSignInExperience) {
+  if (!configs?.customizeSignInExperience) {
     return <Welcome />;
   }
 

--- a/packages/schemas/src/foundations/jsonb-types.ts
+++ b/packages/schemas/src/foundations/jsonb-types.ts
@@ -144,7 +144,6 @@ export const adminConsoleConfigGuard = z.object({
   language: z.nativeEnum(Language),
   appearanceMode: z.nativeEnum(AppearanceMode),
   experienceNoticeConfirmed: z.boolean().optional(),
-  experienceGuideDone: z.boolean().optional(),
   hideGetStarted: z.boolean().optional(),
   // Get started challenges
   checkDemo: z.boolean(),


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Align usage of `customizeSignInExperience` in settings.adminConsole.

Share this variable for "Get Started" and "Guide Modal in sign in experience".

@demonzoo 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested.