### PR TITLE
feat(console): add preview in guide modal

### DIFF
--- a/packages/console/src/pages/SignInExperience/components/GuideModal.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/GuideModal.module.scss
@@ -54,11 +54,6 @@
     }
 
     .preview {
-      width: 636px;
-      height: 800px;
-      background: var(--color-layer-1);
-      padding: _.unit(6);
-      border-radius: 16px;
       margin-left: _.unit(8);
     }
   }

--- a/packages/console/src/pages/SignInExperience/components/GuideModal.tsx
+++ b/packages/console/src/pages/SignInExperience/components/GuideModal.tsx
@@ -20,6 +20,7 @@ import { signInExperienceParser } from '../utilities';
 import BrandingForm from './BrandingForm';
 import * as styles from './GuideModal.module.scss';
 import LanguagesForm from './LanguagesForm';
+import Preview from './Preview';
 import SignInMethodsForm from './SignInMethodsForm';
 import TermsForm from './TermsForm';
 
@@ -36,9 +37,11 @@ const GuideModal = ({ isOpen, onClose }: Props) => {
     reset,
     handleSubmit,
     formState: { isSubmitting },
+    watch,
   } = methods;
   const api = useApi();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const formData = watch();
 
   useEffect(() => {
     if (data) {
@@ -110,7 +113,12 @@ const GuideModal = ({ isOpen, onClose }: Props) => {
                     <LanguagesForm />
                   </div>
                 </div>
-                <div className={styles.preview}>TODO</div>
+                {formData.id && (
+                  <Preview
+                    signInExperience={signInExperienceParser.toRemoteModel(formData)}
+                    className={styles.preview}
+                  />
+                )}
               </div>
               <div className={styles.footer}>
                 <Button

--- a/packages/console/src/pages/SignInExperience/components/Preview.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/Preview.module.scss
@@ -2,6 +2,7 @@
 
 .preview {
   width: 578px;
+  max-height: 700px;
   display: flex;
   flex-direction: column;
   padding: 0;

--- a/packages/console/src/pages/SignInExperience/components/Preview.tsx
+++ b/packages/console/src/pages/SignInExperience/components/Preview.tsx
@@ -1,5 +1,6 @@
 import { Language } from '@logto/phrases';
 import { AppearanceMode, SignInExperience } from '@logto/schemas';
+import classNames from 'classnames';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -11,9 +12,10 @@ import * as styles from './Preview.module.scss';
 
 type Props = {
   signInExperience: SignInExperience;
+  className?: string;
 };
 
-const Preview = ({ signInExperience }: Props) => {
+const Preview = ({ signInExperience, className }: Props) => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const [language, setLanguage] = useState<Language>(Language.English);
   const [mode, setMode] = useState<AppearanceMode>(AppearanceMode.LightMode);
@@ -30,7 +32,7 @@ const Preview = ({ signInExperience }: Props) => {
   );
 
   return (
-    <Card className={styles.preview}>
+    <Card className={classNames(styles.preview, className)}>
       <div className={styles.header}>
         <div className={styles.title}>{t('sign_in_exp.preview.title')}</div>
         <div className={styles.selects}>


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Add preview component to GuideModal in sign in experience. Preview is an existing component, and its final styles is not set yet.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

<img width="1107" alt="截屏2022-05-16 下午1 48 33" src="https://user-images.githubusercontent.com/5717882/168527592-04f2e11d-e42c-4cba-8dd1-efc21b185c95.png">

