### PR TITLE
fix(ui): add default success true for no response api

### DIFF
--- a/packages/ui/src/apis/index.test.ts
+++ b/packages/ui/src/apis/index.test.ts
@@ -34,7 +34,7 @@ describe('api', () => {
   const username = 'username';
   const password = 'password';
   const phone = '18888888';
-  const passcode = '111111';
+  const code = '111111';
   const email = 'foo@logto.io';
 
   const mockKyPost = ky.post as jest.Mock;
@@ -93,11 +93,11 @@ describe('api', () => {
         redirectTo: '/',
       }),
     });
-    await verifySignInSmsPasscode(phone, passcode);
+    await verifySignInSmsPasscode(phone, code);
     expect(ky.post).toBeCalledWith('/api/session/sign-in/passwordless/sms/verify-passcode', {
       json: {
         phone,
-        passcode,
+        code,
       },
     });
   });
@@ -117,11 +117,11 @@ describe('api', () => {
         redirectTo: '/',
       }),
     });
-    await verifySignInEmailPasscode(email, passcode);
+    await verifySignInEmailPasscode(email, code);
     expect(ky.post).toBeCalledWith('/api/session/sign-in/passwordless/email/verify-passcode', {
       json: {
         email,
-        passcode,
+        code,
       },
     });
   });
@@ -151,11 +151,11 @@ describe('api', () => {
   });
 
   it('verifyRegisterSmsPasscode', async () => {
-    await verifyRegisterSmsPasscode(phone, passcode);
+    await verifyRegisterSmsPasscode(phone, code);
     expect(ky.post).toBeCalledWith('/api/session/register/passwordless/sms/verify-passcode', {
       json: {
         phone,
-        passcode,
+        code,
       },
     });
   });
@@ -170,11 +170,11 @@ describe('api', () => {
   });
 
   it('verifyRegisterEmailPasscode', async () => {
-    await verifyRegisterEmailPasscode(email, passcode);
+    await verifyRegisterEmailPasscode(email, code);
     expect(ky.post).toBeCalledWith('/api/session/register/passwordless/email/verify-passcode', {
       json: {
         email,
-        passcode,
+        code,
       },
     });
   });

--- a/packages/ui/src/apis/register.ts
+++ b/packages/ui/src/apis/register.ts
@@ -16,13 +16,15 @@ export const register = async (username: string, password: string) => {
 };
 
 export const sendRegisterSmsPasscode = async (phone: string) => {
-  return api
+  await api
     .post('/api/session/register/passwordless/sms/send-passcode', {
       json: {
         phone,
       },
     })
     .json();
+
+  return { success: true };
 };
 
 export const verifyRegisterSmsPasscode = async (phone: string, passcode: string) => {
@@ -41,13 +43,15 @@ export const verifyRegisterSmsPasscode = async (phone: string, passcode: string)
 };
 
 export const sendRegisterEmailPasscode = async (email: string) => {
-  return api
+  await api
     .post('/api/session/register/passwordless/email/send-passcode', {
       json: {
         email,
       },
     })
     .json();
+
+  return { success: true };
 };
 
 export const verifyRegisterEmailPasscode = async (email: string, passcode: string) => {

--- a/packages/ui/src/apis/register.ts
+++ b/packages/ui/src/apis/register.ts
@@ -27,7 +27,7 @@ export const sendRegisterSmsPasscode = async (phone: string) => {
   return { success: true };
 };
 
-export const verifyRegisterSmsPasscode = async (phone: string, passcode: string) => {
+export const verifyRegisterSmsPasscode = async (phone: string, code: string) => {
   type Response = {
     redirectTo: string;
   };
@@ -36,7 +36,7 @@ export const verifyRegisterSmsPasscode = async (phone: string, passcode: string)
     .post('/api/session/register/passwordless/sms/verify-passcode', {
       json: {
         phone,
-        passcode,
+        code,
       },
     })
     .json<Response>();
@@ -54,7 +54,7 @@ export const sendRegisterEmailPasscode = async (email: string) => {
   return { success: true };
 };
 
-export const verifyRegisterEmailPasscode = async (email: string, passcode: string) => {
+export const verifyRegisterEmailPasscode = async (email: string, code: string) => {
   type Response = {
     redirectTo: string;
   };
@@ -63,7 +63,7 @@ export const verifyRegisterEmailPasscode = async (email: string, passcode: strin
     .post('/api/session/register/passwordless/email/verify-passcode', {
       json: {
         email,
-        passcode,
+        code,
       },
     })
     .json<Response>();

--- a/packages/ui/src/apis/sign-in.ts
+++ b/packages/ui/src/apis/sign-in.ts
@@ -36,7 +36,7 @@ export const sendSignInSmsPasscode = async (phone: string) => {
 
 export const verifySignInSmsPasscode = async (
   phone: string,
-  passcode: string,
+  code: string,
   socialToBind?: string
 ) => {
   type Response = {
@@ -47,7 +47,7 @@ export const verifySignInSmsPasscode = async (
     .post('/api/session/sign-in/passwordless/sms/verify-passcode', {
       json: {
         phone,
-        passcode,
+        code,
       },
     })
     .json<Response>();
@@ -73,7 +73,7 @@ export const sendSignInEmailPasscode = async (email: string) => {
 
 export const verifySignInEmailPasscode = async (
   email: string,
-  passcode: string,
+  code: string,
   socialToBind?: string
 ) => {
   type Response = {
@@ -84,7 +84,7 @@ export const verifySignInEmailPasscode = async (
     .post('/api/session/sign-in/passwordless/email/verify-passcode', {
       json: {
         email,
-        passcode,
+        code,
       },
     })
     .json<Response>();

--- a/packages/ui/src/apis/sign-in.ts
+++ b/packages/ui/src/apis/sign-in.ts
@@ -23,13 +23,15 @@ export const signInBasic = async (username: string, password: string, socialToBi
 };
 
 export const sendSignInSmsPasscode = async (phone: string) => {
-  return api
+  await api
     .post('/api/session/sign-in/passwordless/sms/send-passcode', {
       json: {
         phone,
       },
     })
     .json();
+
+  return { success: true };
 };
 
 export const verifySignInSmsPasscode = async (
@@ -58,13 +60,15 @@ export const verifySignInSmsPasscode = async (
 };
 
 export const sendSignInEmailPasscode = async (email: string) => {
-  return api
+  await api
     .post('/api/session/sign-in/passwordless/email/send-passcode', {
       json: {
         email,
       },
     })
     .json();
+
+  return { success: true };
 };
 
 export const verifySignInEmailPasscode = async (


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add default success true for no response api

Fix bug send passcode API success, front end does not redirect to the passcode validation page. 

<img width="600" alt="image" src="https://user-images.githubusercontent.com/36393111/168550583-4005b1c7-683a-448d-b62d-b501665b3da9.png">

As UI subscribes to the API result mutation to trigger the next step. Need to provide a default success result.

Also fix a API params name miss align issue:

passcode -> code

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
@wangsijie 
