### PR TITLE
style(console): add min & max widths to center stage page contents

### DIFF
--- a/packages/console/src/components/AppContent/index.module.scss
+++ b/packages/console/src/components/AppContent/index.module.scss
@@ -12,10 +12,16 @@
   display: flex;
   margin-bottom: _.unit(6);
   overflow: hidden;
+}
 
-  .main {
-    flex-grow: 1;
-    padding-right: _.unit(6);
-    overflow-y: auto;
+.main {
+  flex-grow: 1;
+  padding-right: _.unit(6);
+  overflow-y: auto;
+
+  > * {
+    max-width: 1168px;
+    min-width: 604px;
+    margin: 0 auto;
   }
 }

--- a/packages/console/src/components/Drawer/index.module.scss
+++ b/packages/console/src/components/Drawer/index.module.scss
@@ -2,10 +2,10 @@
 
 .content {
   position: absolute;
-  left: 50%;
   top: 0;
   right: 0;
   bottom: 0;
+  width: 700px;
   outline: none;
   background: var(--color-layer-1);
   padding: _.unit(6);

--- a/packages/console/src/pages/SignInExperience/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/index.module.scss
@@ -3,6 +3,7 @@
 .wrapper {
   display: flex;
   height: 100%;
+  min-width: 950px;
 
   .setup {
     flex: 1;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add min-width and max-width to  center stage page contents, especially the max-width. This will improve the overall user experience in extra wide screens, as the content is still kept in the central part of the screen.

<img width="2560" alt="image" src="https://user-images.githubusercontent.com/12833674/168578519-c2f57c0c-63e8-4580-bb6d-f0c969346966.png">

<img width="2560" alt="image" src="https://user-images.githubusercontent.com/12833674/168579492-b3a9d040-8183-4012-b2ad-10a3cd9bf92e.png">

<img width="2560" alt="image" src="https://user-images.githubusercontent.com/12833674/168578670-70ccc259-31ed-474a-baad-c54955a40ad4.png">

<img width="2560" alt="image" src="https://user-images.githubusercontent.com/12833674/168579102-2d176fc8-74bc-44ed-b038-72245460c18e.png">

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested in all admin console pages on a wide screen, and the layout looked good
