### PR TITLE
feat(core,phrases,schemas): get /dashboard with DNU counts

### DIFF
--- a/packages/core/src/queries/log.ts
+++ b/packages/core/src/queries/log.ts
@@ -45,6 +45,7 @@ export const findLogs = async (limit: number, offset: number, logCondition: LogC
     offset ${offset}
   `);
 
+// DNU: Daily New User
 export const getDnuCountsByTimeInterval = async (
   startTimeInclusive: number,
   endTimeExclusive: number

--- a/packages/core/src/queries/log.ts
+++ b/packages/core/src/queries/log.ts
@@ -1,4 +1,4 @@
-import { CreateLog, Log, Logs } from '@logto/schemas';
+import { CreateLog, Log, Logs, registerLogTypes } from '@logto/schemas';
 import { sql } from 'slonik';
 
 import { buildInsertInto } from '@/database/insert-into';
@@ -43,4 +43,18 @@ export const findLogs = async (limit: number, offset: number, logCondition: LogC
     ${buildLogConditionSql(logCondition)}
     limit ${limit}
     offset ${offset}
+  `);
+
+export const getDnuCountsByTimeInterval = async (
+  startTimeInclusive: number,
+  endTimeExclusive: number
+) =>
+  envSet.pool.any<{ date: string; count: number }>(sql`
+    select date(${fields.createdAt}), count(*)
+    from ${table}
+    where ${fields.createdAt} >= to_timestamp(${startTimeInclusive}::double precision / 1000)
+    and ${fields.createdAt} < to_timestamp(${endTimeExclusive}::double precision / 1000)
+    and ${fields.type} in (${sql.join(registerLogTypes, sql`,`)})
+    and ${fields.payload}->>'result' = 'Success'
+    group by date(${fields.createdAt})
   `);

--- a/packages/core/src/queries/log.ts
+++ b/packages/core/src/queries/log.ts
@@ -45,8 +45,7 @@ export const findLogs = async (limit: number, offset: number, logCondition: LogC
     offset ${offset}
   `);
 
-// DNU: Daily New User
-export const getDnuCountsByTimeInterval = async (
+export const getDailyNewUserCountsByTimeInterval = async (
   startTimeInclusive: number,
   endTimeExclusive: number
 ) =>

--- a/packages/core/src/routes/log.test.ts
+++ b/packages/core/src/routes/log.test.ts
@@ -4,6 +4,11 @@ import { createRequester } from '@/utils/test-utils';
 
 const mockLogs = [{ id: 1 }, { id: 2 }];
 
+const mockDnuCounts = [
+  { date: '2022-05-01', count: 5 },
+  { date: '2022-05-02', count: 10 },
+];
+
 /* eslint-disable @typescript-eslint/no-unused-vars */
 const countLogs = jest.fn(async (condition: LogCondition) => ({
   count: mockLogs.length,
@@ -11,12 +16,17 @@ const countLogs = jest.fn(async (condition: LogCondition) => ({
 const findLogs = jest.fn(
   async (limit: number, offset: number, condition: LogCondition) => mockLogs
 );
+const getDnuCountsByTimeInterval = jest.fn(
+  async (startTimeInclusive: number, endTimeExclusive: number) => mockDnuCounts
+);
 /* eslint-enable @typescript-eslint/no-unused-vars */
 
 jest.mock('@/queries/log', () => ({
   countLogs: async (condition: LogCondition) => countLogs(condition),
   findLogs: async (limit: number, offset: number, condition: LogCondition) =>
     findLogs(limit, offset, condition),
+  getDnuCountsByTimeInterval: async (startTimeInclusive: number, endTimeExclusive: number) =>
+    getDnuCountsByTimeInterval(startTimeInclusive, endTimeExclusive),
 }));
 
 describe('logRoutes', () => {
@@ -46,6 +56,30 @@ describe('logRoutes', () => {
       expect(response.status).toEqual(200);
       expect(response.body).toEqual(mockLogs);
       expect(response.header).toHaveProperty('total-number', `${mockLogs.length}`);
+    });
+  });
+
+  describe('GET /dashboard', () => {
+    it('should fail when start date is earlier than end date', async () => {
+      const start = '2022-05-01';
+      const end = '2022-04-30';
+      const response = await logRequest.get(`/dashboard?start=${start}&end=${end}`);
+      expect(response.status).toEqual(400);
+    });
+
+    it('should call getDnuCountsByTimeInterval with correct parameters', async () => {
+      const start = '2022-05-01';
+      const end = '2022-05-02';
+      await logRequest.get(`/dashboard?start=${start}&end=${end}`);
+      expect(getDnuCountsByTimeInterval).toHaveBeenCalledWith(1_651_334_400_000, 1_651_507_200_000);
+    });
+
+    it('should return correct response', async () => {
+      const start = '2022-05-01';
+      const end = '2022-05-02';
+      const response = await logRequest.get(`/dashboard?start=${start}&end=${end}`);
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({ dnuCounts: mockDnuCounts, dauCounts: {} });
     });
   });
 });

--- a/packages/core/src/routes/log.test.ts
+++ b/packages/core/src/routes/log.test.ts
@@ -83,7 +83,7 @@ describe('logRoutes', () => {
   });
 
   describe('GET /dashboard', () => {
-    it('should call getDnuCountsByTimeInterval with correct parameters', async () => {
+    it('should call getDnuCountsByTimeInterval with the time interval: [today, 14 days ago)', async () => {
       await logRequest.get('/dashboard');
       expect(getDailyNewUserCountsByTimeInterval).toHaveBeenCalledWith(
         dayjs().subtract(14, 'day').valueOf(),

--- a/packages/core/src/routes/log.test.ts
+++ b/packages/core/src/routes/log.test.ts
@@ -18,7 +18,7 @@ const mockDailyNewUserCounts = [
   { date: getDateString(dayjs().subtract(4, 'day')), count: 10 },
   { date: getDateString(dayjs().subtract(3, 'day')), count: 11 },
   { date: getDateString(dayjs().subtract(1, 'day')), count: 13 },
-  { date: getDateString(dayjs().subtract(0, 'day')), count: 14 },
+  { date: getDateString(dayjs()), count: 14 },
 ];
 
 /* eslint-disable @typescript-eslint/no-unused-vars */

--- a/packages/core/src/routes/log.test.ts
+++ b/packages/core/src/routes/log.test.ts
@@ -71,7 +71,7 @@ describe('logRoutes', () => {
       const start = '2022-05-01';
       const end = '2022-05-02';
       await logRequest.get(`/dashboard?start=${start}&end=${end}`);
-      expect(getDnuCountsByTimeInterval).toHaveBeenCalledWith(1_651_334_400_000, 1_651_507_200_000);
+      expect(getDnuCountsByTimeInterval).toHaveBeenCalledWith(1_651_363_200_000, 1_651_536_000_000);
     });
 
     it('should return correct response', async () => {

--- a/packages/core/src/routes/log.ts
+++ b/packages/core/src/routes/log.ts
@@ -1,10 +1,15 @@
+import dayjs from 'dayjs';
 import { object, string } from 'zod';
 
 import koaGuard from '@/middleware/koa-guard';
 import koaPagination from '@/middleware/koa-pagination';
-import { countLogs, findLogs } from '@/queries/log';
+import { countLogs, findLogs, getDnuCountsByTimeInterval } from '@/queries/log';
+import assertThat from '@/utils/assert-that';
+import { dateRegex } from '@/utils/regex';
 
 import { AuthedRouter } from './types';
+
+const millisecondsInOneDay = 86_400_000;
 
 export default function logRoutes<T extends AuthedRouter>(router: T) {
   router.get(
@@ -31,6 +36,38 @@ export default function logRoutes<T extends AuthedRouter>(router: T) {
       // Return totalCount to pagination middleware
       ctx.pagination.totalCount = count;
       ctx.body = logs;
+
+      return next();
+    }
+  );
+
+  router.get(
+    '/dashboard',
+    koaGuard({
+      query: object({
+        start: string().regex(dateRegex),
+        end: string().regex(dateRegex),
+      }),
+    }),
+    async (ctx, next) => {
+      const {
+        query: { start, end },
+      } = ctx.guard;
+
+      const startTime = dayjs(start).valueOf();
+      const endTime = dayjs(end).valueOf();
+      assertThat(startTime <= endTime, 'dashboard.wrong_date_range');
+
+      // Convert date closed interval to time left-closed right-open interval:
+      // e.g. [2022-05-01, 2022-05-02] -> [2022-05-01 00:00:00.000, 2022-05-03 00:00:00.000)
+      const endTimeExclusive = endTime + millisecondsInOneDay;
+      const dauCounts = await getDnuCountsByTimeInterval(startTime, endTimeExclusive);
+      ctx.body = {
+        // DNU: Daily New User
+        dnuCounts: dauCounts,
+        // DAU: Daily Active User
+        dauCounts: {},
+      };
 
       return next();
     }

--- a/packages/core/src/routes/log.ts
+++ b/packages/core/src/routes/log.ts
@@ -1,4 +1,3 @@
-import dayjs from 'dayjs';
 import { object, string } from 'zod';
 
 import koaGuard from '@/middleware/koa-guard';
@@ -54,8 +53,8 @@ export default function logRoutes<T extends AuthedRouter>(router: T) {
         query: { start, end },
       } = ctx.guard;
 
-      const startTime = dayjs(start).valueOf();
-      const endTime = dayjs(end).valueOf();
+      const startTime = new Date(start).valueOf();
+      const endTime = new Date(end).valueOf();
       assertThat(startTime <= endTime, 'dashboard.wrong_date_range');
 
       // Convert date closed interval to time left-closed right-open interval:

--- a/packages/core/src/routes/log.ts
+++ b/packages/core/src/routes/log.ts
@@ -61,10 +61,10 @@ export default function logRoutes<T extends AuthedRouter>(router: T) {
       // Convert date closed interval to time left-closed right-open interval:
       // e.g. [2022-05-01, 2022-05-02] -> [2022-05-01 00:00:00.000, 2022-05-03 00:00:00.000)
       const endTimeExclusive = endTime + millisecondsInOneDay;
-      const dauCounts = await getDnuCountsByTimeInterval(startTime, endTimeExclusive);
+      const dnuCounts = await getDnuCountsByTimeInterval(startTime, endTimeExclusive);
       ctx.body = {
         // DNU: Daily New User
-        dnuCounts: dauCounts,
+        dnuCounts,
         // DAU: Daily Active User
         dauCounts: {},
       };

--- a/packages/core/src/routes/log.ts
+++ b/packages/core/src/routes/log.ts
@@ -41,12 +41,12 @@ export default function logRoutes<T extends AuthedRouter>(router: T) {
   );
 
   router.get('/dashboard', async (ctx, next) => {
-    const twoWeekAgo = dayjs().subtract(14, 'day');
+    const fourteenDaysAgo = dayjs().subtract(14, 'day');
     const today = dayjs();
 
     const [{ count: totalUserCount }, dailyNewUserCounts] = await Promise.all([
       await countUsers(),
-      getDailyNewUserCountsByTimeInterval(twoWeekAgo.valueOf(), today.valueOf()),
+      getDailyNewUserCountsByTimeInterval(fourteenDaysAgo.valueOf(), today.valueOf()),
     ]);
 
     const recent14DaysDailyNewUserCounts = new Map(
@@ -61,7 +61,7 @@ export default function logRoutes<T extends AuthedRouter>(router: T) {
       .map((index) => getDateString(today.subtract(6 - index, 'day')))
       .reduce((sum, date) => sum + (recent14DaysDailyNewUserCounts.get(date) ?? 0), 0);
     const lastWeekNewUserCount = [...Array.from({ length: 7 }).keys()]
-      .map((index) => getDateString(twoWeekAgo.add(1 + index, 'day')))
+      .map((index) => getDateString(fourteenDaysAgo.add(1 + index, 'day')))
       .reduce((sum, date) => sum + (recent14DaysDailyNewUserCounts.get(date) ?? 0), 0);
 
     ctx.body = {

--- a/packages/core/src/utils/regex.ts
+++ b/packages/core/src/utils/regex.ts
@@ -4,4 +4,5 @@ export const usernameRegEx = /^.{3,}$/;
 export const nameRegEx = /^.{3,}$/;
 export const passwordRegEx = /^.{6,}$/;
 export const redirectUriRegEx = /^https?:\/\//;
+export const dateRegex = /^\d{4}(?:-\d{1,2}){2}/;
 export { hexColorRegEx } from '@logto/schemas';

--- a/packages/core/src/utils/regex.ts
+++ b/packages/core/src/utils/regex.ts
@@ -4,5 +4,5 @@ export const usernameRegEx = /^.{3,}$/;
 export const nameRegEx = /^.{3,}$/;
 export const passwordRegEx = /^.{6,}$/;
 export const redirectUriRegEx = /^https?:\/\//;
-export const dateRegex = /^\d{4}(?:-\d{1,2}){2}/;
+export const dateRegex = /^\d{4}(-\d{1,2}){2}/;
 export { hexColorRegEx } from '@logto/schemas';

--- a/packages/jest-config/jest.config.ts
+++ b/packages/jest-config/jest.config.ts
@@ -36,3 +36,5 @@ export const merge = (
 ): Config.InitialOptions => deepmerge(baseConfig, config, mergeOptions);
 
 export type { Config } from '@jest/types';
+
+process.env.TZ = 'UTC';

--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -603,6 +603,9 @@ const errors = {
     not_exists_with_id: 'The {{name}} with ID `{{id}}` does not exist.',
     not_found: 'The resource does not exist',
   },
+  dashboard: {
+    wrong_date_range: 'The start date must be greater than or equal to the end date.',
+  },
 };
 
 const en = Object.freeze({

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -595,6 +595,9 @@ const errors = {
     not_exists_with_id: 'ID 为 `{{id}}` 的 {{name}} 不存在。',
     not_found: '该资源不存在',
   },
+  dashboard: {
+    wrong_date_range: '开始日期必须大于或等于结束日期。',
+  },
 };
 
 const zhCN: typeof en = Object.freeze({

--- a/packages/schemas/src/types/log.ts
+++ b/packages/schemas/src/types/log.ts
@@ -120,3 +120,13 @@ export type LogPayloads = {
 export type LogType = keyof LogPayloads;
 
 export type LogPayload = LogPayloads[LogType];
+
+export const registerLogTypes: LogType[] = [
+  'RegisterUsernamePassword',
+  'RegisterEmailSendPasscode',
+  'RegisterEmail',
+  'RegisterSmsSendPasscode',
+  'RegisterSms',
+  'RegisterSocialBind',
+  'RegisterSocial',
+];

--- a/packages/schemas/src/types/log.ts
+++ b/packages/schemas/src/types/log.ts
@@ -123,10 +123,7 @@ export type LogPayload = LogPayloads[LogType];
 
 export const registerLogTypes: LogType[] = [
   'RegisterUsernamePassword',
-  'RegisterEmailSendPasscode',
   'RegisterEmail',
-  'RegisterSmsSendPasscode',
   'RegisterSms',
-  'RegisterSocialBind',
   'RegisterSocial',
 ];


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
`GET /dashboard` route responses with new user counts
- total new user count
- today new user count
- yesterday new user count
- this week new user count
- last week new user count

---

How to count daily new users: SQL like e.g.

![image](https://user-images.githubusercontent.com/10594507/168584543-77de23e3-bb72-4526-8c69-1f1e23a837d5.png)

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-942
LOG-2481

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
![image](https://user-images.githubusercontent.com/10594507/168580492-a1f768be-b0c6-4ac8-a555-e9a589aa085e.png)

![image](https://user-images.githubusercontent.com/10594507/168841026-14aff05e-6d9c-423d-b1b2-83e22acea068.png)

---

UT related: Fix the test failure due to different timezones in CI (UTC) and the local machine (+8:00)

- Use UTC timezone all the time in test environment

    ```ts
    // packages/jest-config/jest.config.ts
    process.env.TZ = 'UTC';
    ```
    
    reference: https://stackoverflow.com/questions/56261381/how-do-i-set-a-timezone-in-my-jest-config