### PR TITLE
fix(console): improve swr error handling to avoid app crash

### DIFF
--- a/packages/console/src/hooks/use-api.ts
+++ b/packages/console/src/hooks/use-api.ts
@@ -9,7 +9,7 @@ import { toast } from 'react-hot-toast';
 import { logtoApiResource } from '@/consts/api';
 
 export class RequestError extends Error {
-  body: RequestErrorBody;
+  body?: RequestErrorBody;
 
   constructor(body: RequestErrorBody) {
     super('Request error occurred.');

--- a/packages/console/src/pages/ApiResourceDetails/index.tsx
+++ b/packages/console/src/pages/ApiResourceDetails/index.tsx
@@ -84,7 +84,7 @@ const ApiResourceDetails = () => {
         className={styles.backLink}
       />
       {isLoading && <DetailsSkeleton />}
-      {error && <div>{`error occurred: ${error.body.message}`}</div>}
+      {!data && error && <div>{`error occurred: ${error.body?.message ?? error.message}`}</div>}
       {data && (
         <>
           <Card className={styles.header}>

--- a/packages/console/src/pages/ApiResources/index.tsx
+++ b/packages/console/src/pages/ApiResources/index.tsx
@@ -85,10 +85,10 @@ const ApiResources = () => {
             </tr>
           </thead>
           <tbody>
-            {error && (
+            {!data && error && (
               <TableError
                 columns={2}
-                content={error.body.message}
+                content={error.body?.message ?? error.message}
                 onRetry={async () => mutate(undefined, true)}
               />
             )}

--- a/packages/console/src/pages/Applications/index.tsx
+++ b/packages/console/src/pages/Applications/index.tsx
@@ -82,10 +82,10 @@ const Applications = () => {
             </tr>
           </thead>
           <tbody>
-            {error && (
+            {!data && error && (
               <TableError
                 columns={2}
-                content={error.body.message}
+                content={error.body?.message ?? error.message}
                 onRetry={async () => mutate(undefined, true)}
               />
             )}

--- a/packages/console/src/pages/ConnectorDetails/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/index.tsx
@@ -107,7 +107,7 @@ const ConnectorDetails = () => {
         className={styles.backLink}
       />
       {isLoading && <DetailsSkeleton />}
-      {error && <div>{`error occurred: ${error.body.message}`}</div>}
+      {!data && error && <div>{`error occurred: ${error.body?.message ?? error.message}`}</div>}
       {data && (
         <Card className={styles.header}>
           <div className={styles.imagePlaceholder}>

--- a/packages/console/src/pages/Connectors/index.tsx
+++ b/packages/console/src/pages/Connectors/index.tsx
@@ -85,10 +85,10 @@ const Connectors = () => {
               </tr>
             </thead>
             <tbody>
-              {error && (
+              {!data && error && (
                 <TableError
                   columns={3}
-                  content={error.body.message}
+                  content={error.body?.message ?? error.message}
                   onRetry={async () => mutate(undefined, true)}
                 />
               )}

--- a/packages/console/src/pages/Settings/index.tsx
+++ b/packages/console/src/pages/Settings/index.tsx
@@ -60,7 +60,7 @@ const Settings = () => {
         <TabNavItem href="/settings">{t('settings.tabs.general')}</TabNavItem>
       </TabNav>
       {!data && !error && <div>loading</div>}
-      {error && <div>{`error occurred: ${error.body.message}`}</div>}
+      {!data && error && <div>{`error occurred: ${error.body?.message ?? error.message}`}</div>}
       {data && (
         <form className={detailsStyles.body} onSubmit={onSubmit}>
           <div className={styles.fields}>

--- a/packages/console/src/pages/SignInExperience/components/ConnectorsTransfer.tsx
+++ b/packages/console/src/pages/SignInExperience/components/ConnectorsTransfer.tsx
@@ -26,8 +26,8 @@ const ConnectorsTransfer = ({ value, onChange }: Props) => {
     return <div>loading</div>;
   }
 
-  if (error) {
-    <div>{`error occurred: ${error.body.message}`}</div>;
+  if (!data && error) {
+    <div>{`error occurred: ${error.body?.message ?? error.message}`}</div>;
   }
 
   const datasource = data

--- a/packages/console/src/pages/SignInExperience/components/SignInMethodsPreview.tsx
+++ b/packages/console/src/pages/SignInExperience/components/SignInMethodsPreview.tsx
@@ -42,7 +42,7 @@ const SignInMethodsPreview = ({ data }: Props) => {
   return (
     <div>
       {!connectors && !error && <div>loading</div>}
-      {error && <div>{error.body.message}</div>}
+      {!connectors && error && <div>{error.body?.message ?? error.message}</div>}
       {connectors &&
         Object.values(SignInMethodKey)
           .filter((key) => signInMethods[key] !== SignInMethodState.Disabled)

--- a/packages/console/src/pages/SignInExperience/index.tsx
+++ b/packages/console/src/pages/SignInExperience/index.tsx
@@ -84,8 +84,8 @@ const SignInExperience = () => {
     return <div>loading</div>;
   }
 
-  if (configError) {
-    return <div>{configError.body.message}</div>;
+  if (!configs && configError) {
+    return <div>{configError.body?.message ?? configError.message}</div>;
   }
 
   if (configs?.customizeSignInExperience) {
@@ -109,7 +109,7 @@ const SignInExperience = () => {
             </TabNavItem>
           </TabNav>
           {!data && !error && <div>loading</div>}
-          {error && <div>{`error occurred: ${error.body.message}`}</div>}
+          {!data && error && <div>{`error occurred: ${error.body?.message ?? error.message}`}</div>}
           {data && (
             <FormProvider {...methods}>
               <form onSubmit={onSubmit}>

--- a/packages/console/src/pages/UserDetails/components/UserConnectors.tsx
+++ b/packages/console/src/pages/UserDetails/components/UserConnectors.tsx
@@ -31,20 +31,20 @@ const UserConnectors = ({ userId, connectors, onDelete }: Props) => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { data, error, mutate } = useSWR<ConnectorDTO[], RequestError>('/api/connectors');
   const isLoading = !data && !error;
-  const [isSubmiting, setIsSubmiting] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleDelete = async (connectorId: string) => {
-    if (isSubmiting) {
+    if (isSubmitting) {
       return;
     }
 
-    setIsSubmiting(true);
+    setIsSubmitting(true);
 
     try {
       await api.delete(`/api/users/${userId}/identities/${connectorId}`);
       onDelete?.(connectorId);
     } finally {
-      setIsSubmiting(false);
+      setIsSubmitting(false);
     }
   };
 
@@ -96,10 +96,10 @@ const UserConnectors = ({ userId, connectors, onDelete }: Props) => {
             </tr>
           </thead>
           <tbody>
-            {error && (
+            {!data && error && (
               <TableError
                 columns={3}
-                content={error.body.message}
+                content={error.body?.message ?? error.message}
                 onRetry={async () => mutate(undefined, true)}
               />
             )}

--- a/packages/console/src/pages/UserDetails/index.tsx
+++ b/packages/console/src/pages/UserDetails/index.tsx
@@ -113,7 +113,7 @@ const UserDetails = () => {
         className={styles.backLink}
       />
       {isLoading && <DetailsSkeleton />}
-      {error && <div>{`error occurred: ${error.body.message}`}</div>}
+      {!data && error && <div>{`error occurred: ${error.body?.message ?? error.message}`}</div>}
       {id && data && (
         <>
           <Card className={styles.header}>

--- a/packages/console/src/pages/Users/index.tsx
+++ b/packages/console/src/pages/Users/index.tsx
@@ -95,10 +95,10 @@ const Users = () => {
             </tr>
           </thead>
           <tbody>
-            {error && (
+            {!data && error && (
               <TableError
                 columns={3}
-                content={error.body.message}
+                content={error.body?.message ?? error.message}
                 onRetry={async () => mutate(undefined, true)}
               />
             )}


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Since not all error object has `body` prop (for example a canceled request), we need to improve the `RequestError` type and change `body` to optional.
This way, we can improve error handling in each page, in order to make the app not crash in case there is no error body returned.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
[LOG-2489](https://linear.app/silverhand/issue/LOG-2489/improve-requesterror-type-make-body-optional)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally with slow network and offline conditions, the app didn't crash with request errors
