### PR TITLE
feat(core,console): social connector targets

### DIFF
--- a/packages/console/src/hooks/use-connector-groups.ts
+++ b/packages/console/src/hooks/use-connector-groups.ts
@@ -1,0 +1,54 @@
+import { ConnectorDTO } from '@logto/schemas';
+import { useMemo } from 'react';
+import useSWR from 'swr';
+
+import { RequestError } from '@/hooks/use-api';
+import { ConnectorGroup } from '@/types/connector';
+
+// Group connectors by target
+const useConnectorGroups = () => {
+  const { data, ...rest } = useSWR<ConnectorDTO[], RequestError>('/api/connectors');
+
+  const groups = useMemo(() => {
+    if (!data) {
+      return;
+    }
+
+    return data.reduce<ConnectorGroup[]>((previous, item) => {
+      const groupIndex = previous.findIndex(({ target }) => target === item.target);
+
+      if (groupIndex === -1) {
+        return [
+          ...previous,
+          {
+            name: item.metadata.name,
+            logo: item.metadata.logo,
+            target: item.metadata.target,
+            enabled: item.enabled,
+            connectors: [item],
+          },
+        ];
+      }
+
+      return previous.map((group, index) => {
+        if (index !== groupIndex) {
+          return group;
+        }
+
+        return {
+          ...group,
+          connectors: [...group.connectors, item],
+          // Group is enabled when any of its connectors is enabled.
+          enabled: group.enabled || item.enabled,
+        };
+      });
+    }, []);
+  }, [data]);
+
+  return {
+    ...rest,
+    data: groups,
+  };
+};
+
+export default useConnectorGroups;

--- a/packages/console/src/pages/SignInExperience/components/ConnectorsTransfer.tsx
+++ b/packages/console/src/pages/SignInExperience/components/ConnectorsTransfer.tsx
@@ -1,14 +1,12 @@
-import { ConnectorDTO } from '@logto/schemas';
 import { conditionalString } from '@silverhand/essentials';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import useSWR from 'swr';
 
 import Alert from '@/components/Alert';
 import Transfer from '@/components/Transfer';
 import UnnamedTrans from '@/components/UnnamedTrans';
-import { RequestError } from '@/hooks/use-api';
+import useConnectorGroups from '@/hooks/use-connector-groups';
 
 import * as styles from './ConnectorsTransfer.module.scss';
 
@@ -18,7 +16,7 @@ type Props = {
 };
 
 const ConnectorsTransfer = ({ value, onChange }: Props) => {
-  const { data, error } = useSWR<ConnectorDTO[], RequestError>('/api/connectors');
+  const { data, error } = useConnectorGroups();
   const isLoading = !data && !error;
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
@@ -31,8 +29,8 @@ const ConnectorsTransfer = ({ value, onChange }: Props) => {
   }
 
   const datasource = data
-    ? data.map(({ id, metadata: { name }, enabled }) => ({
-        value: id,
+    ? data.map(({ target, name, enabled }) => ({
+        value: target,
         title: (
           <UnnamedTrans
             resource={name}

--- a/packages/console/src/pages/SignInExperience/components/SignInMethodsForm.tsx
+++ b/packages/console/src/pages/SignInExperience/components/SignInMethodsForm.tsx
@@ -87,7 +87,7 @@ const SignInMethodsForm = () => {
       {primaryMethod === SignInMethodKey.Social && (
         <div className={styles.primarySocial}>
           <Controller
-            name="socialSignInConnectorIds"
+            name="socialSignInConnectorTargets"
             control={control}
             render={({ field: { value, onChange } }) => (
               <ConnectorsTransfer value={value} onChange={onChange} />
@@ -107,7 +107,7 @@ const SignInMethodsForm = () => {
           {social && (
             <FormField title="admin_console.sign_in_exp.sign_in_methods.define_social_methods">
               <Controller
-                name="socialSignInConnectorIds"
+                name="socialSignInConnectorTargets"
                 control={control}
                 render={({ field: { value, onChange } }) => (
                   <ConnectorsTransfer value={value} onChange={onChange} />

--- a/packages/console/src/pages/SignInExperience/utilities.ts
+++ b/packages/console/src/pages/SignInExperience/utilities.ts
@@ -81,11 +81,15 @@ export const compareSignInMethods = (
   before: SignInExperience,
   after: SignInExperience
 ): boolean => {
-  if (before.socialSignInConnectorIds.length !== after.socialSignInConnectorIds.length) {
+  if (before.socialSignInConnectorTargets.length !== after.socialSignInConnectorTargets.length) {
     return false;
   }
 
-  if (before.socialSignInConnectorIds.some((id) => !after.socialSignInConnectorIds.includes(id))) {
+  if (
+    before.socialSignInConnectorTargets.some(
+      (target) => !after.socialSignInConnectorTargets.includes(target)
+    )
+  ) {
     return false;
   }
 

--- a/packages/console/src/types/connector.ts
+++ b/packages/console/src/types/connector.ts
@@ -1,0 +1,6 @@
+import { ConnectorDTO } from '@logto/schemas';
+
+export type ConnectorGroup = Pick<ConnectorDTO['metadata'], 'name' | 'logo' | 'target'> & {
+  enabled: boolean;
+  connectors: ConnectorDTO[];
+};

--- a/packages/core/src/__mocks__/connector.ts
+++ b/packages/core/src/__mocks__/connector.ts
@@ -252,6 +252,36 @@ export const mockGithubConnectorInstance = {
   },
 };
 
+export const mockWechatConnectorInstance = {
+  connector: {
+    ...mockConnector,
+    id: 'wechat',
+    target: 'wechat',
+    platform: ConnectorPlatform.Web,
+  },
+  metadata: {
+    ...mockMetadata,
+    target: 'wechat',
+    type: ConnectorType.Social,
+    platform: ConnectorPlatform.Web,
+  },
+};
+
+export const mockWechatNativeConnectorInstance = {
+  connector: {
+    ...mockConnector,
+    id: 'wechat-native',
+    target: 'wechat',
+    platform: ConnectorPlatform.Native,
+  },
+  metadata: {
+    ...mockMetadata,
+    target: 'wechat',
+    type: ConnectorType.Social,
+    platform: ConnectorPlatform.Native,
+  },
+};
+
 export const mockGoogleConnectorInstance = {
   connector: {
     ...mockConnector,

--- a/packages/core/src/__mocks__/sign-in-experience.ts
+++ b/packages/core/src/__mocks__/sign-in-experience.ts
@@ -33,7 +33,7 @@ export const mockSignInExperience: SignInExperience = {
     sms: SignInMethodState.Disabled,
     social: SignInMethodState.Secondary,
   },
-  socialSignInConnectorTargets: ['github', 'facebook'],
+  socialSignInConnectorTargets: ['github', 'facebook', 'wechat'],
 };
 
 export const mockBranding: Branding = {

--- a/packages/core/src/__mocks__/sign-in-experience.ts
+++ b/packages/core/src/__mocks__/sign-in-experience.ts
@@ -33,7 +33,7 @@ export const mockSignInExperience: SignInExperience = {
     sms: SignInMethodState.Disabled,
     social: SignInMethodState.Secondary,
   },
-  socialSignInConnectorIds: ['github', 'facebook'],
+  socialSignInConnectorTargets: ['github', 'facebook'],
 };
 
 export const mockBranding: Branding = {

--- a/packages/core/src/lib/sign-in-experience.ts
+++ b/packages/core/src/lib/sign-in-experience.ts
@@ -27,7 +27,7 @@ export const isEnabled = (state: SignInMethodState) => state !== SignInMethodSta
 
 export const validateSignInMethods = (
   signInMethods: SignInMethods,
-  socialSignInConnectorIds: Optional<string[]>,
+  socialSignInConnectorTargets: Optional<string[]>,
   enabledConnectorInstances: ConnectorInstance[]
 ) => {
   const signInMethodStates = Object.values(signInMethods);
@@ -60,17 +60,17 @@ export const validateSignInMethods = (
     );
 
     assertThat(
-      socialSignInConnectorIds && socialSignInConnectorIds.length > 0,
+      socialSignInConnectorTargets && socialSignInConnectorTargets.length > 0,
       'sign_in_experiences.empty_social_connectors'
     );
 
-    const enabledSocialConnectorIds = new Set(
-      enabledConnectorInstances
-        .filter((instance) => instance.metadata.type === ConnectorType.Social)
-        .map((instance) => instance.connector.id)
-    );
     assertThat(
-      socialSignInConnectorIds.every((id) => enabledSocialConnectorIds.has(id)),
+      socialSignInConnectorTargets.every((connectorTarget) =>
+        enabledConnectorInstances.some(
+          ({ metadata: { target, type } }) =>
+            target === connectorTarget && type === ConnectorType.Social
+        )
+      ),
       'sign_in_experiences.invalid_social_connectors'
     );
   }

--- a/packages/core/src/queries/sign-in-experience.test.ts
+++ b/packages/core/src/queries/sign-in-experience.test.ts
@@ -24,14 +24,14 @@ describe('sign-in-experience query', () => {
     branding: JSON.stringify(mockSignInExperience.branding),
     termsOfUse: JSON.stringify(mockSignInExperience.termsOfUse),
     languageInfo: JSON.stringify(mockSignInExperience.languageInfo),
-    signInMethods: JSON.stringify(mockSignInExperience.socialSignInConnectorIds),
-    socialSignInConnectorIds: JSON.stringify(mockSignInExperience.socialSignInConnectorIds),
+    signInMethods: JSON.stringify(mockSignInExperience.socialSignInConnectorTargets),
+    socialSignInConnectorTargets: JSON.stringify(mockSignInExperience.socialSignInConnectorTargets),
   };
 
   it('findDefaultSignInExperience', async () => {
     /* eslint-disable sql/no-unsafe-query */
     const expectSql = `
-      select "id", "branding", "language_info", "terms_of_use", "sign_in_methods", "social_sign_in_connector_ids"
+      select "id", "branding", "language_info", "terms_of_use", "sign_in_methods", "social_sign_in_connector_targets"
       from "sign_in_experiences"
       where "id" = $1
     `;

--- a/packages/core/src/routes/session.test.ts
+++ b/packages/core/src/routes/session.test.ts
@@ -10,6 +10,8 @@ import {
   mockFacebookConnectorInstance,
   mockGithubConnectorInstance,
   mockGoogleConnectorInstance,
+  mockWechatConnectorInstance,
+  mockWechatNativeConnectorInstance,
 } from '@/__mocks__';
 import { ConnectorType } from '@/connectors/types';
 import RequestError from '@/errors/RequestError';
@@ -111,6 +113,8 @@ const getConnectorInstances = jest.fn(async () => [
   mockFacebookConnectorInstance,
   mockGithubConnectorInstance,
   mockGoogleConnectorInstance,
+  mockWechatConnectorInstance,
+  mockWechatNativeConnectorInstance,
 ]);
 jest.mock('@/connectors', () => ({
   getSocialConnectorInstanceById: async (connectorId: string) => {
@@ -924,6 +928,14 @@ describe('sessionRoutes', () => {
             {
               ...mockFacebookConnectorInstance.metadata,
               id: mockFacebookConnectorInstance.connector.id,
+            },
+            {
+              ...mockWechatConnectorInstance.metadata,
+              id: mockWechatConnectorInstance.connector.id,
+            },
+            {
+              ...mockWechatNativeConnectorInstance.metadata,
+              id: mockWechatNativeConnectorInstance.connector.id,
             },
           ],
         })

--- a/packages/core/src/routes/sign-in-experience.guard.test.ts
+++ b/packages/core/src/routes/sign-in-experience.guard.test.ts
@@ -195,7 +195,7 @@ describe('signInMethods', () => {
           sms: state,
           social: SignInMethodState.Primary,
         },
-        socialSignInConnectorIds: ['github'],
+        socialSignInConnectorTargets: ['github'],
       };
       await expectPatchResponseStatus(signInExperience, 200);
     });
@@ -211,7 +211,7 @@ describe('signInMethods', () => {
           sms: state,
           social: SignInMethodState.Primary,
         },
-        socialSignInConnectorIds: ['github'],
+        socialSignInConnectorTargets: ['github'],
       };
       await expectPatchResponseStatus(signInExperience, 400);
     });
@@ -229,7 +229,7 @@ describe('signInMethods', () => {
           sms: SignInMethodState.Disabled,
           social: state,
         },
-        socialSignInConnectorIds: ['github'],
+        socialSignInConnectorTargets: ['github'],
       };
       await expectPatchResponseStatus(signInExperience, 200);
     });
@@ -245,21 +245,21 @@ describe('signInMethods', () => {
           sms: SignInMethodState.Disabled,
           social: state,
         },
-        socialSignInConnectorIds: ['github'],
+        socialSignInConnectorTargets: ['github'],
       };
       await expectPatchResponseStatus(signInExperience, 400);
     });
   });
 });
 
-describe('socialSignInConnectorIds', () => {
+describe('socialSignInConnectorTargets', () => {
   test.each([[['facebook']], [['facebook', 'github']]])(
     '%p should success',
-    async (socialSignInConnectorIds) => {
+    async (socialSignInConnectorTargets) => {
       await expectPatchResponseStatus(
         {
           signInMethods: { ...mockSignInMethods, social: SignInMethodState.Secondary },
-          socialSignInConnectorIds,
+          socialSignInConnectorTargets,
         },
         200
       );
@@ -268,11 +268,11 @@ describe('socialSignInConnectorIds', () => {
 
   test.each([[[]], [[null, undefined]], [['', ' \t\n\r']], [[123, 456]]])(
     '%p should fail',
-    async (socialSignInConnectorIds: any[]) => {
+    async (socialSignInConnectorTargets: any[]) => {
       await expectPatchResponseStatus(
         {
           signInMethods: { ...mockSignInMethods, social: SignInMethodState.Secondary },
-          socialSignInConnectorIds,
+          socialSignInConnectorTargets,
         },
         400
       );

--- a/packages/core/src/routes/sign-in-experience.test.ts
+++ b/packages/core/src/routes/sign-in-experience.test.ts
@@ -115,7 +115,7 @@ describe('PATCH /sign-in-exp', () => {
 
   it('should succeed to update when the input is valid', async () => {
     const termsOfUse: TermsOfUse = { enabled: false };
-    const socialSignInConnectorTargets = ['github', 'facebook'];
+    const socialSignInConnectorTargets = ['github', 'facebook', 'wechat'];
 
     const validateBranding = jest.spyOn(signInExpLib, 'validateBranding');
     const validateTermsOfUse = jest.spyOn(signInExpLib, 'validateTermsOfUse');

--- a/packages/core/src/routes/sign-in-experience.test.ts
+++ b/packages/core/src/routes/sign-in-experience.test.ts
@@ -59,23 +59,6 @@ describe('GET /sign-in-exp', () => {
     expect(response.status).toEqual(200);
     expect(response.body).toEqual(mockSignInExperience);
   });
-
-  it('should filter enabled social connectors', async () => {
-    const signInExperience = {
-      ...mockSignInExperience,
-      signInMethods: { ...mockSignInMethods, social: SignInMethodState.Secondary },
-      socialSignInConnectorIds: ['facebook', 'github', 'google'],
-    };
-
-    findDefaultSignInExperience.mockImplementationOnce(async () => signInExperience);
-
-    const response = await signInExperienceRequester.get('/sign-in-exp');
-    expect(response.status).toEqual(200);
-    expect(response.body).toEqual({
-      ...signInExperience,
-      socialSignInConnectorIds: ['facebook', 'github'],
-    });
-  });
 });
 
 describe('PATCH /sign-in-exp', () => {
@@ -83,7 +66,7 @@ describe('PATCH /sign-in-exp', () => {
     const signInMethods = { ...mockSignInMethods, social: SignInMethodState.Disabled };
     const response = await signInExperienceRequester.patch('/sign-in-exp').send({
       signInMethods,
-      socialSignInConnectorIds: ['facebook'],
+      socialSignInConnectorTargets: ['facebook'],
     });
     expect(response).toMatchObject({
       status: 200,
@@ -96,10 +79,10 @@ describe('PATCH /sign-in-exp', () => {
 
   it('should update enabled social connector IDs only when social sign-in is enabled', async () => {
     const signInMethods = { ...mockSignInMethods, social: SignInMethodState.Secondary };
-    const socialSignInConnectorIds = ['facebook'];
+    const socialSignInConnectorTargets = ['facebook'];
     const signInExperience = {
       signInMethods,
-      socialSignInConnectorIds,
+      socialSignInConnectorTargets,
     };
     const response = await signInExperienceRequester.patch('/sign-in-exp').send(signInExperience);
     expect(response).toMatchObject({
@@ -107,17 +90,17 @@ describe('PATCH /sign-in-exp', () => {
       body: {
         ...mockSignInExperience,
         signInMethods,
-        socialSignInConnectorIds,
+        socialSignInConnectorTargets,
       },
     });
   });
 
   it('should update social connector IDs in correct sorting order', async () => {
     const signInMethods = { ...mockSignInMethods, social: SignInMethodState.Secondary };
-    const socialSignInConnectorIds = ['github', 'facebook'];
+    const socialSignInConnectorTargets = ['github', 'facebook'];
     const signInExperience = {
       signInMethods,
-      socialSignInConnectorIds,
+      socialSignInConnectorTargets,
     };
     const response = await signInExperienceRequester.patch('/sign-in-exp').send(signInExperience);
     expect(response).toMatchObject({
@@ -125,14 +108,14 @@ describe('PATCH /sign-in-exp', () => {
       body: {
         ...mockSignInExperience,
         signInMethods,
-        socialSignInConnectorIds,
+        socialSignInConnectorTargets,
       },
     });
   });
 
   it('should succeed to update when the input is valid', async () => {
     const termsOfUse: TermsOfUse = { enabled: false };
-    const socialSignInConnectorIds = ['github', 'facebook'];
+    const socialSignInConnectorTargets = ['github', 'facebook'];
 
     const validateBranding = jest.spyOn(signInExpLib, 'validateBranding');
     const validateTermsOfUse = jest.spyOn(signInExpLib, 'validateTermsOfUse');
@@ -142,14 +125,14 @@ describe('PATCH /sign-in-exp', () => {
       branding: mockBranding,
       termsOfUse,
       signInMethods: mockSignInMethods,
-      socialSignInConnectorIds,
+      socialSignInConnectorTargets,
     });
 
     expect(validateBranding).toHaveBeenCalledWith(mockBranding);
     expect(validateTermsOfUse).toHaveBeenCalledWith(termsOfUse);
     expect(validateSignInMethods).toHaveBeenCalledWith(
       mockSignInMethods,
-      socialSignInConnectorIds,
+      socialSignInConnectorTargets,
       [mockFacebookConnectorInstance, mockGithubConnectorInstance]
     );
 
@@ -160,7 +143,7 @@ describe('PATCH /sign-in-exp', () => {
         branding: mockBranding,
         termsOfUse,
         signInMethods: mockSignInMethods,
-        socialSignInConnectorIds,
+        socialSignInConnectorTargets,
       },
     });
   });

--- a/packages/schemas/src/foundations/jsonb-types.ts
+++ b/packages/schemas/src/foundations/jsonb-types.ts
@@ -126,9 +126,9 @@ export const signInMethodsGuard = z.object({
 
 export type SignInMethods = z.infer<typeof signInMethodsGuard>;
 
-export const connectorIdsGuard = z.string().array();
+export const connectorTargetsGuard = z.string().array();
 
-export type ConnectorIds = z.infer<typeof connectorIdsGuard>;
+export type ConnectorTargets = z.infer<typeof connectorTargetsGuard>;
 
 /**
  * Settings

--- a/packages/schemas/src/seeds/sign-in-experience.ts
+++ b/packages/schemas/src/seeds/sign-in-experience.ts
@@ -26,5 +26,5 @@ export const defaultSignInExperience: Readonly<CreateSignInExperience> = {
     sms: SignInMethodState.Disabled,
     social: SignInMethodState.Disabled,
   },
-  socialSignInConnectorIds: [],
+  socialSignInConnectorTargets: [],
 };

--- a/packages/schemas/tables/sign_in_experiences.sql
+++ b/packages/schemas/tables/sign_in_experiences.sql
@@ -4,6 +4,6 @@ create table sign_in_experiences (
   language_info jsonb /* @use LanguageInfo */ not null,
   terms_of_use jsonb /* @use TermsOfUse */ not null,
   sign_in_methods jsonb /* @use SignInMethods */ not null,
-  social_sign_in_connector_ids jsonb /* @use ConnectorIds */ not null default '[]'::jsonb,
+  social_sign_in_connector_targets jsonb /* @use ConnectorTargets */ not null default '[]'::jsonb,
   primary key (id)
 );

--- a/packages/ui/src/__mocks__/logto.tsx
+++ b/packages/ui/src/__mocks__/logto.tsx
@@ -139,7 +139,7 @@ export const mockSignInExperience: SignInExperience = {
     sms: SignInMethodState.Secondary,
     social: SignInMethodState.Secondary,
   },
-  socialSignInConnectorIds: ['BE8QXN0VsrOH7xdWFDJZ9', 'lcXT4o2GSjbV9kg2shZC7'],
+  socialSignInConnectorTargets: ['BE8QXN0VsrOH7xdWFDJZ9', 'lcXT4o2GSjbV9kg2shZC7'],
 };
 
 export const mockSignInExperienceSettings: SignInExperienceSettings = {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

In "sign in experience setup", as for connectors, we don't care about `platform`, we are actually sorting and setting connectors by `target`.

So change `socialConnectorIds` to `socialConnectorTargets`, when requesting settings (in UI), map targets to related connectors.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2438

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Pass all tests, and local tested:

<img width="855" alt="截屏2022-05-17 上午10 39 36" src="https://user-images.githubusercontent.com/5717882/168717799-8b1dd2f9-7b21-4d8f-a9d2-9c1ddad41e96.png">

