### PR TITLE
feat(ui): add global primary color settings

### DIFF
--- a/packages/ui/src/components/AppContent/index.module.scss
+++ b/packages/ui/src/components/AppContent/index.module.scss
@@ -2,6 +2,10 @@
 @use '@/scss/mobile' as mobile;
 @use '@/scss/desktop' as desktop;
 
+:root {
+  --light-primary-color: #5d34f2;
+  --dark-primary-color: #7958ff;
+}
 
 .content {
   @include _.flex_column;

--- a/packages/ui/src/components/AppContent/index.tsx
+++ b/packages/ui/src/components/AppContent/index.tsx
@@ -19,7 +19,8 @@ export type Props = {
 
 const AppContent = ({ children, mode, platform: platformOverwrite }: Props) => {
   const theme = useTheme(mode);
-  const { toast, loading, platform, setPlatform, setToast } = useContext(PageContext);
+  const { toast, loading, platform, setPlatform, setToast, experienceSettings } =
+    useContext(PageContext);
   const debouncedLoading = useDebouncedLoader(loading);
 
   // Prevent internal eventListener rebind
@@ -27,17 +28,34 @@ const AppContent = ({ children, mode, platform: platformOverwrite }: Props) => {
     setToast('');
   }, [setToast]);
 
+  // Set Primary ColorTheme
+  useEffect(() => {
+    if (!experienceSettings) {
+      return;
+    }
+
+    const {
+      branding: { primaryColor, darkPrimaryColor },
+    } = experienceSettings;
+
+    document.documentElement.style.setProperty('--light-primary-color', primaryColor);
+    document.documentElement.style.setProperty('--dark-primary-color', darkPrimaryColor);
+  }, [experienceSettings]);
+
+  // Set Platform
   useEffect(() => {
     if (platformOverwrite) {
       setPlatform(platformOverwrite);
     }
   }, [platformOverwrite, setPlatform]);
 
+  // Set Theme Mode
   useEffect(() => {
     document.body.classList.remove(conditionalString(styles.light), conditionalString(styles.dark));
     document.body.classList.add(conditionalString(styles[theme]));
   }, [theme]);
 
+  // Apply Platform Style
   useEffect(() => {
     document.body.classList.remove('desktop', 'mobile');
     document.body.classList.add(platform === 'mobile' ? 'mobile' : 'desktop');

--- a/packages/ui/src/scss/_desktop.scss
+++ b/packages/ui/src/scss/_desktop.scss
@@ -17,7 +17,7 @@ $font-family: -apple-system,
   --color-border: #c4c7c7;
   --color-caption: #747778;
   --color-icon: #747778;
-  --color-primary: #5d34f2;
+  --color-primary: var(--light-primary-color);
   --color-focused: rgba(25, 28, 29, 16%);
   --color-focused-variant: rgba(93, 52, 242, 16%);
   --color-pressed: rgba(25, 28, 29, 12%);
@@ -50,7 +50,7 @@ $font-family: -apple-system,
   --color-border: #5c5f60;
   --color-caption: #a9acac;
   --color-icon: #a9acac;
-  --color-primary: #7958ff;
+  --color-primary: var(--dark-primary-color);
   --color-focused: rgba(247, 248, 248, 16%);
   --color-focused-variant: rgba(202, 190, 255, 16%);
   --color-hover-variant: rgba(202, 190, 255, 8%);

--- a/packages/ui/src/scss/_mobile.scss
+++ b/packages/ui/src/scss/_mobile.scss
@@ -17,7 +17,7 @@ $font-family: -apple-system,
   --color-divider: #e0e3e3;
   --color-text-disabled: #c4c7c7;
   --color-border: #c4c7c7;
-  --color-primary: #5d34f2;
+  --color-primary: var(--light-primary-color);
   --color-layer: #eff1f1;
   --color-error: #ba1b1b;
   --color-toast: rgba(25, 28, 29, 80%);
@@ -35,7 +35,7 @@ $font-family: -apple-system,
   --color-divider: #444748;
   --color-text-disabled: #5c5f60;
   --color-border: #5c5f60;
-  --color-primary: #7958ff;
+  --color-primary: var(--dark-primary-color);
   --color-layer: linear-gradient(0deg, rgba(202, 190, 255, 14%), rgba(202, 190, 255, 14%)), linear-gradient(0deg, rgba(196, 199, 199, 2%), rgba(196, 199, 199, 2%)), #191c1d;
   --color-error: #dd3730;
   --color-toast: rgba(247, 248, 248, 80%);


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add global primary color settings. So we can easily sync primary color in the preview mode for now. Still WIP, overall color theme update need to be refined after design update. 
![May-17-2022 22-28-21](https://user-images.githubusercontent.com/36393111/168841231-d3a75b4a-f8ca-4b0b-bad0-4b098ad3b42e.gif)



<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
@logto-io/eng 
