### PR TITLE
fix(ui): fix countdown bug

### DIFF
--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -58,7 +58,7 @@ const translation = {
       forgot_password: 'Forgot Password?',
       or: 'or',
       enter_passcode: 'The passcode has been sent to your {{address}}',
-      passcode_sent: 'The passcode has been sent',
+      passcode_sent: 'The passcode has been resent',
       resend_after_seconds: 'Resend after {{seconds}} seconds',
       resend_passcode: 'Resend Passcode',
       continue_with: 'Continue with',


### PR DESCRIPTION

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fix countdown bug. 
Issue: the `restart` method return by useTimer is not wrapped up in useCallback hook, so re-initialized every time when timer is reset. Which cause infinite call within the useEffect event. 


Instead of using useEffect to handle the resend passcode flow, simply provide a synchronized useCallback method.  Handler the result synchronizly. 



<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
log-2529

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
@logto-io/eng 
