### PR TITLE
refactor(core): move GET /sign-in-settings out of sessionRouter

### DIFF
--- a/packages/core/src/routes/init.ts
+++ b/packages/core/src/routes/init.ts
@@ -11,6 +11,7 @@ import resourceRoutes from '@/routes/resource';
 import sessionRoutes from '@/routes/session';
 import settingRoutes from '@/routes/setting';
 import signInExperiencesRoutes from '@/routes/sign-in-experience';
+import signInSettingsRoutes from '@/routes/sign-in-settings';
 import statusRoutes from '@/routes/status';
 import swaggerRoutes from '@/routes/swagger';
 
@@ -25,6 +26,7 @@ const createRouters = (provider: Provider) => {
   sessionRoutes(sessionRouter, provider);
 
   const anonymousRouter: AnonymousRouter = new Router();
+  signInSettingsRoutes(anonymousRouter);
   statusRoutes(anonymousRouter);
   swaggerRoutes(anonymousRouter);
 

--- a/packages/core/src/routes/session.test.ts
+++ b/packages/core/src/routes/session.test.ts
@@ -3,7 +3,6 @@ import { User } from '@logto/schemas';
 import { Provider } from 'oidc-provider';
 
 import {
-  mockSignInExperience,
   mockUser,
   mockAliyunDmConnectorInstance,
   mockAliyunSmsConnectorInstance,
@@ -15,7 +14,6 @@ import {
 } from '@/__mocks__';
 import { ConnectorType } from '@/connectors/types';
 import RequestError from '@/errors/RequestError';
-import * as signInExperienceQueries from '@/queries/sign-in-experience';
 import { createRequester } from '@/utils/test-utils';
 
 import sessionRoutes from './session';
@@ -908,41 +906,6 @@ describe('sessionRoutes', () => {
       await expect(sessionRequest.post('/session/consent')).resolves.toHaveProperty(
         'statusCode',
         400
-      );
-    });
-  });
-
-  describe('GET /sign-in-settings', () => {
-    const signInExperienceQuerySpyOn = jest
-      .spyOn(signInExperienceQueries, 'findDefaultSignInExperience')
-      .mockResolvedValue(mockSignInExperience);
-
-    it('should return github and facebook connector instances', async () => {
-      const response = await sessionRequest.get('/sign-in-settings');
-      expect(signInExperienceQuerySpyOn).toHaveBeenCalledTimes(1);
-      expect(response.status).toEqual(200);
-      expect(response.body).toMatchObject(
-        expect.objectContaining({
-          ...mockSignInExperience,
-          socialConnectors: [
-            {
-              ...mockGithubConnectorInstance.metadata,
-              id: mockGithubConnectorInstance.connector.id,
-            },
-            {
-              ...mockFacebookConnectorInstance.metadata,
-              id: mockFacebookConnectorInstance.connector.id,
-            },
-            {
-              ...mockWechatConnectorInstance.metadata,
-              id: mockWechatConnectorInstance.connector.id,
-            },
-            {
-              ...mockWechatNativeConnectorInstance.metadata,
-              id: mockWechatNativeConnectorInstance.connector.id,
-            },
-          ],
-        })
       );
     });
   });

--- a/packages/core/src/routes/sign-in-settings.test.ts
+++ b/packages/core/src/routes/sign-in-settings.test.ts
@@ -1,0 +1,89 @@
+import { ConnectorType } from '@logto/schemas';
+
+import {
+  mockAliyunDmConnectorInstance,
+  mockAliyunSmsConnectorInstance,
+  mockFacebookConnectorInstance,
+  mockGithubConnectorInstance,
+  mockGoogleConnectorInstance,
+  mockSignInExperience,
+  mockWechatConnectorInstance,
+  mockWechatNativeConnectorInstance,
+} from '@/__mocks__';
+import { getConnectorInstanceById } from '@/connectors';
+import RequestError from '@/errors/RequestError';
+import * as signInExperienceQueries from '@/queries/sign-in-experience';
+import signInSettingsRoutes from '@/routes/sign-in-settings';
+import { createRequester } from '@/utils/test-utils';
+
+const getConnectorInstances = jest.fn(async () => [
+  mockAliyunDmConnectorInstance,
+  mockAliyunSmsConnectorInstance,
+  mockFacebookConnectorInstance,
+  mockGithubConnectorInstance,
+  mockGoogleConnectorInstance,
+  mockWechatConnectorInstance,
+  mockWechatNativeConnectorInstance,
+]);
+jest.mock('@/connectors', () => ({
+  getSocialConnectorInstanceById: async (connectorId: string) => {
+    const connectorInstance = await getConnectorInstanceById(connectorId);
+
+    if (connectorInstance.metadata.type !== ConnectorType.Social) {
+      throw new RequestError({
+        code: 'entity.not_found',
+        status: 404,
+      });
+    }
+
+    return connectorInstance;
+  },
+  getConnectorInstances: async () => getConnectorInstances(),
+}));
+
+describe('GET /sign-in-settings', () => {
+  const sessionRequest = createRequester({
+    anonymousRoutes: signInSettingsRoutes,
+    middlewares: [
+      async (ctx, next) => {
+        ctx.addLogContext = jest.fn();
+        ctx.log = jest.fn();
+
+        return next();
+      },
+    ],
+  });
+
+  const signInExperienceQuerySpyOn = jest
+    .spyOn(signInExperienceQueries, 'findDefaultSignInExperience')
+    .mockResolvedValue(mockSignInExperience);
+
+  it('should return github and facebook connector instances', async () => {
+    const response = await sessionRequest.get('/sign-in-settings');
+    expect(signInExperienceQuerySpyOn).toHaveBeenCalledTimes(1);
+    expect(response.status).toEqual(200);
+    expect(response.body).toMatchObject(
+      expect.objectContaining({
+        ...mockSignInExperience,
+        socialConnectors: [
+          {
+            ...mockGithubConnectorInstance.metadata,
+            id: mockGithubConnectorInstance.connector.id,
+          },
+          {
+            ...mockFacebookConnectorInstance.metadata,
+            id: mockFacebookConnectorInstance.connector.id,
+          },
+          {
+            ...mockWechatConnectorInstance.metadata,
+            id: mockWechatConnectorInstance.connector.id,
+          },
+          {
+            ...mockWechatNativeConnectorInstance.metadata,
+            id: mockWechatNativeConnectorInstance.connector.id,
+          },
+        ],
+      })
+    );
+  });
+});

--- a/packages/core/src/routes/sign-in-settings.ts
+++ b/packages/core/src/routes/sign-in-settings.ts
@@ -1,0 +1,28 @@
+import { ConnectorMetadata } from '@logto/connector-types';
+
+import { getConnectorInstances } from '@/connectors';
+import { findDefaultSignInExperience } from '@/queries/sign-in-experience';
+
+import { AnonymousRouter } from './types';
+
+export default function signInSettingsRoutes<T extends AnonymousRouter>(router: T) {
+  router.get('/sign-in-settings', async (ctx, next) => {
+    const signInExperience = await findDefaultSignInExperience();
+    const connectorInstances = await getConnectorInstances();
+    const socialConnectors = signInExperience.socialSignInConnectorTargets.reduce<
+      Array<ConnectorMetadata & { id: string }>
+    >((previous, connectorTarget) => {
+      const connectors = connectorInstances.filter(
+        ({ metadata: { target } }) => target === connectorTarget
+      );
+
+      return [
+        ...previous,
+        ...connectors.map(({ metadata, connector: { id } }) => ({ ...metadata, id })),
+      ];
+    }, []);
+    ctx.body = { ...signInExperience, socialConnectors };
+
+    return next();
+  });
+}

--- a/packages/core/src/routes/sign-in-settings.ts
+++ b/packages/core/src/routes/sign-in-settings.ts
@@ -7,8 +7,10 @@ import { AnonymousRouter } from './types';
 
 export default function signInSettingsRoutes<T extends AnonymousRouter>(router: T) {
   router.get('/sign-in-settings', async (ctx, next) => {
-    const signInExperience = await findDefaultSignInExperience();
-    const connectorInstances = await getConnectorInstances();
+    const [signInExperience, connectorInstances] = await Promise.all([
+      findDefaultSignInExperience(),
+      getConnectorInstances(),
+    ]);
     const socialConnectors = signInExperience.socialSignInConnectorTargets.reduce<
       Array<ConnectorMetadata & { id: string }>
     >((previous, connectorTarget) => {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Move GET /sign-in-settings from sessionRouter to signInSettingsRouter

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2441

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
![image](https://user-images.githubusercontent.com/10594507/168980516-03abeb77-7aa7-4de2-a656-d5ebdda2925c.png)
