### PR TITLE
fix(console): improve horizontal scrollbar thumb styles

### DIFF
--- a/packages/console/src/scss/normalized.scss
+++ b/packages/console/src/scss/normalized.scss
@@ -60,6 +60,10 @@ table {
   width: 8px;
 }
 
+::-webkit-scrollbar:horizontal {
+  height: 8px;
+}
+
 ::-webkit-scrollbar-thumb {
   background: var(--color-neutral-variant-80);
   border-radius: 4px;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Improve horizontal scrollbar thumb styles, setting height to 8px

<img width="484" alt="image" src="https://user-images.githubusercontent.com/12833674/169084515-cec4446e-f7a9-46c3-ae31-fc8a1b902291.png">


<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally. See screenshot above
