### PR TITLE
feat(core): disable introspection feature

### DIFF
--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -41,7 +41,6 @@ export default async function initOidc(app: Koa): Promise<Provider> {
     features: {
       userinfo: { enabled: true },
       revocation: { enabled: true },
-      introspection: { enabled: true },
       devInteractions: { enabled: false },
       resourceIndicators: {
         enabled: true,


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
per [offline disscussion](https://www.notion.so/silverhand/OIDC-Provider-d532ae5b67fb4beea1bb85450a8dca1b#10c1459996824ecba7a9286a7ed84964), we don't need this feature in v1.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
* LOG-2554


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
1. UT
2. The introspection configs are not included in the OIDC config.
