### PR TITLE
style(console): improve scrollbar styles, leaving 4px margin on both sides

### DIFF
--- a/packages/console/src/scss/normalized.scss
+++ b/packages/console/src/scss/normalized.scss
@@ -57,16 +57,18 @@ table {
 }
 
 ::-webkit-scrollbar {
-  width: 8px;
+  width: 16px;
 }
 
 ::-webkit-scrollbar:horizontal {
-  height: 8px;
+  height: 16px;
 }
 
 ::-webkit-scrollbar-thumb {
   background: var(--color-neutral-variant-80);
-  border-radius: 4px;
+  background-clip: content-box;
+  border: 4px solid transparent;
+  border-radius: 8px;
 }
 
 ::-webkit-scrollbar-track {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Improve scrollbar styles. leaving 4px margin on both sides, instead of directly sticking to the screen edge.

<img width="70" alt="image" src="https://user-images.githubusercontent.com/12833674/169285250-f07c0f77-fb61-447b-8410-b2c0400ae3c3.png">


<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally. Please refer to the screenshot above
