### PR TITLE
feat(core): mask passcode in log when sending passcode

### DIFF
--- a/packages/core/src/routes/session.test.ts
+++ b/packages/core/src/routes/session.test.ts
@@ -9,6 +9,7 @@ import {
   mockFacebookConnectorInstance,
   mockGithubConnectorInstance,
   mockGoogleConnectorInstance,
+  mockPasscode,
   mockWechatConnectorInstance,
   mockWechatNativeConnectorInstance,
 } from '@/__mocks__';
@@ -78,7 +79,7 @@ jest.mock('@/queries/user', () => ({
 }));
 const sendPasscode = jest.fn(async () => ({ connector: { id: 'connectorIdValue' } }));
 jest.mock('@/lib/passcode', () => ({
-  createPasscode: async () => ({ id: 'id' }),
+  createPasscode: async () => mockPasscode,
   sendPasscode: async () => sendPasscode(),
   verifyPasscode: async (_a: unknown, _b: unknown, code: string) => {
     if (code !== '1234') {

--- a/packages/core/src/routes/session.ts
+++ b/packages/core/src/routes/session.ts
@@ -44,7 +44,7 @@ import {
   findUserByIdentity,
 } from '@/queries/user';
 import assertThat from '@/utils/assert-that';
-import { maskUserInfo } from '@/utils/format';
+import { maskPasscode, maskUserInfo } from '@/utils/format';
 
 import { AnonymousRouter } from './types';
 
@@ -101,7 +101,7 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
       );
 
       const passcode = await createPasscode(jti, PasscodeType.SignIn, { phone });
-      ctx.log(type, { passcode });
+      ctx.log(type, { passcode: maskPasscode(passcode) });
 
       const { connector } = await sendPasscode(passcode);
       ctx.log(type, { connectorId: connector.id });
@@ -151,7 +151,7 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
       );
 
       const passcode = await createPasscode(jti, PasscodeType.SignIn, { email });
-      ctx.log(type, { passcode });
+      ctx.log(type, { passcode: maskPasscode(passcode) });
 
       const { connector } = await sendPasscode(passcode);
       ctx.log(type, { connectorId: connector.id });
@@ -403,7 +403,7 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
       );
 
       const passcode = await createPasscode(jti, PasscodeType.Register, { phone });
-      ctx.log(type, { phone, passcode });
+      ctx.log(type, { passcode: maskPasscode(passcode) });
 
       const { connector } = await sendPasscode(passcode);
       ctx.log(type, { connectorId: connector.id });
@@ -454,7 +454,7 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
       );
 
       const passcode = await createPasscode(jti, PasscodeType.Register, { email });
-      ctx.log(type, { passcode });
+      ctx.log(type, { passcode: maskPasscode(passcode) });
 
       const { connector } = await sendPasscode(passcode);
       ctx.log(type, { connectorId: connector.id });

--- a/packages/core/src/utils/format.test.ts
+++ b/packages/core/src/utils/format.test.ts
@@ -1,5 +1,4 @@
-import { Passcode, PasscodeType } from '@logto/schemas';
-
+import { mockPasscode } from '@/__mocks__';
 import { maskPasscode, maskPasscodeString, maskUserInfo } from '@/utils/format';
 
 describe('maskUserInfo', () => {
@@ -28,17 +27,6 @@ describe('maskPasscodeString', () => {
 
 describe('maskPasscode', () => {
   it('should not equal to original content', () => {
-    const passcodeObject: Passcode = {
-      id: '0ciWkpLZBl_To87bjqkpo',
-      code: '123456',
-      type: PasscodeType.Register,
-      email: 'silverhand@silverhand.io',
-      phone: '12345678901',
-      consumed: false,
-      tryCount: 0,
-      createdAt: 1_652_854_353_183,
-      interactionJti: '_XuSax3F6byyYijXsxfpw',
-    };
-    expect(maskPasscode(passcodeObject)).not.toEqual(passcodeObject);
+    expect(maskPasscode(mockPasscode)).not.toEqual(mockPasscode);
   });
 });

--- a/packages/core/src/utils/format.test.ts
+++ b/packages/core/src/utils/format.test.ts
@@ -1,4 +1,6 @@
-import { maskUserInfo } from './format';
+import { Passcode, PasscodeType } from '@logto/schemas';
+
+import { maskPasscode, maskPasscodeString, maskUserInfo } from '@/utils/format';
 
 describe('maskUserInfo', () => {
   it('phone', () => {
@@ -9,5 +11,34 @@ describe('maskUserInfo', () => {
   });
   it('email with name more than 4', () => {
     expect(maskUserInfo({ type: 'email', value: 'foo_test@logto.io' })).toBe('foo_****@logto.io');
+  });
+});
+
+describe('maskPasscodeString', () => {
+  const passcode = '123456';
+
+  it('should not equal to original content', () => {
+    expect(maskPasscodeString(passcode)).not.toEqual(passcode);
+  });
+
+  it('should mask the first 3 characters', () => {
+    expect(maskPasscodeString(passcode)).toEqual('***456');
+  });
+});
+
+describe('maskPasscode', () => {
+  it('should not equal to original content', () => {
+    const passcodeObject: Passcode = {
+      id: '0ciWkpLZBl_To87bjqkpo',
+      code: '123456',
+      type: PasscodeType.Register,
+      email: 'silverhand@silverhand.io',
+      phone: '12345678901',
+      consumed: false,
+      tryCount: 0,
+      createdAt: 1_652_854_353_183,
+      interactionJti: '_XuSax3F6byyYijXsxfpw',
+    };
+    expect(maskPasscode(passcodeObject)).not.toEqual(passcodeObject);
   });
 });

--- a/packages/core/src/utils/format.ts
+++ b/packages/core/src/utils/format.ts
@@ -1,3 +1,5 @@
+import { Passcode } from '@logto/schemas';
+
 export const maskUserInfo = ({ type, value }: { type: 'email' | 'phone'; value: string }) => {
   if (!value) {
     return value;
@@ -13,3 +15,10 @@ export const maskUserInfo = ({ type, value }: { type: 'email' | 'phone'; value: 
 
   return `${preview}****@${domain}`;
 };
+
+export const maskPasscodeString = (passcode: string) => passcode.replace(/^.{3}/, '***');
+
+export const maskPasscode = (passcode: Passcode) => ({
+  ...passcode,
+  code: maskPasscodeString(passcode.code),
+});


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Mask passcode in log when sending passcode (before verifying)

See Slack thread [discussion](https://silverhand-io.slack.com/archives/C02A8G4HVAM/p1653024982687979).

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-322

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
![image](https://user-images.githubusercontent.com/10594507/169479940-7364add4-f01d-4395-b9ae-b47753e9165a.png)
