### PR TITLE
feat(core): empty path sould redirect to the console page

### DIFF
--- a/packages/core/src/app/init.ts
+++ b/packages/core/src/app/init.ts
@@ -7,12 +7,12 @@ import koaLogger from 'koa-logger';
 import mount from 'koa-mount';
 
 import envSet, { MountedApps } from '@/env-set';
-import koaClientSessionGuard from '@/middleware/koa-client-session-guard';
 import koaConnectorErrorHandler from '@/middleware/koa-connector-error-handle';
 import koaErrorHandler from '@/middleware/koa-error-handler';
 import koaI18next from '@/middleware/koa-i18next';
 import koaLog from '@/middleware/koa-log';
 import koaOIDCErrorHandler from '@/middleware/koa-oidc-error-handler';
+import koaProxyGuard from '@/middleware/koa-proxy-guard';
 import koaSlonikErrorHandler from '@/middleware/koa-slonik-error-handler';
 import koaSpaProxy from '@/middleware/koa-spa-proxy';
 import initOidc from '@/oidc/init';
@@ -39,7 +39,7 @@ export default async function initApp(app: Koa): Promise<void> {
     mount('/' + MountedApps.Console, koaSpaProxy(MountedApps.Console, 5002, MountedApps.Console))
   );
 
-  app.use(koaClientSessionGuard(provider));
+  app.use(koaProxyGuard(provider));
   app.use(koaSpaProxy());
 
   const { httpsCert, httpsKey, port } = envSet.values;

--- a/packages/core/src/middleware/koa-proxy-guard.test.ts
+++ b/packages/core/src/middleware/koa-proxy-guard.test.ts
@@ -3,7 +3,7 @@ import { Provider } from 'oidc-provider';
 import { MountedApps } from '@/env-set';
 import { createContextWithRouteParameters } from '@/utils/test-utils';
 
-import koaClientSessionGuard, { sessionNotFoundPath } from './koa-client-session-guard';
+import koaClientSessionGuard, { sessionNotFoundPath } from './koa-proxy-guard';
 
 jest.mock('fs/promises', () => ({
   ...jest.requireActual('fs/promises'),

--- a/packages/core/src/middleware/koa-proxy-guard.test.ts
+++ b/packages/core/src/middleware/koa-proxy-guard.test.ts
@@ -3,7 +3,7 @@ import { Provider } from 'oidc-provider';
 import { MountedApps } from '@/env-set';
 import { createContextWithRouteParameters } from '@/utils/test-utils';
 
-import koaClientSessionGuard, { sessionNotFoundPath } from './koa-proxy-guard';
+import koaProxyGuard, { sessionNotFoundPath } from './koa-proxy-guard';
 
 jest.mock('fs/promises', () => ({
   ...jest.requireActual('fs/promises'),
@@ -16,7 +16,7 @@ jest.mock('oidc-provider', () => ({
   })),
 }));
 
-describe('koaClientSessionGuard', () => {
+describe('koaProxyGuard', () => {
   const envBackup = process.env;
 
   beforeEach(() => {
@@ -38,7 +38,7 @@ describe('koaClientSessionGuard', () => {
         url: `/${app}/foo`,
       });
 
-      await koaClientSessionGuard(provider)(ctx, next);
+      await koaProxyGuard(provider)(ctx, next);
 
       expect(ctx.redirect).not.toBeCalled();
     });
@@ -49,7 +49,7 @@ describe('koaClientSessionGuard', () => {
     const ctx = createContextWithRouteParameters({
       url: `/sign-in`,
     });
-    await koaClientSessionGuard(provider)(ctx, next);
+    await koaProxyGuard(provider)(ctx, next);
     expect(ctx.redirect).not.toBeCalled();
   });
 
@@ -60,7 +60,7 @@ describe('koaClientSessionGuard', () => {
     const ctx = createContextWithRouteParameters({
       url: `${sessionNotFoundPath}`,
     });
-    await koaClientSessionGuard(provider)(ctx, next);
+    await koaProxyGuard(provider)(ctx, next);
     expect(ctx.redirect).not.toBeCalled();
   });
 
@@ -71,7 +71,7 @@ describe('koaClientSessionGuard', () => {
     const ctx = createContextWithRouteParameters({
       url: '/sign-in',
     });
-    await koaClientSessionGuard(provider)(ctx, next);
+    await koaProxyGuard(provider)(ctx, next);
     expect(ctx.redirect).toBeCalled();
   });
 });

--- a/packages/core/src/middleware/koa-proxy-guard.ts
+++ b/packages/core/src/middleware/koa-proxy-guard.ts
@@ -22,7 +22,6 @@ export default function koaSpaSessionGuard<
 
     // Empty path Redirect
     if (requestPath === '/') {
-      console.log(requestPath);
       ctx.redirect(`/${MountedApps.Console}`);
 
       return next();

--- a/packages/core/src/middleware/koa-proxy-guard.ts
+++ b/packages/core/src/middleware/koa-proxy-guard.ts
@@ -18,18 +18,26 @@ export default function koaSpaSessionGuard<
   return async (ctx, next) => {
     const requestPath = ctx.request.path;
     const packagesPath = fromRoot ? 'packages/' : '..';
-    const distPath = path.join(packagesPath, 'ui', 'dist');
+    const clientPath = path.join(packagesPath, 'ui', 'dist');
 
-    // Guard client routes only
+    // Empty path Redirect
+    if (requestPath === '/') {
+      console.log(requestPath);
+      ctx.redirect(`/${MountedApps.Console}`);
+
+      return next();
+    }
+
+    // Check client routes session status only
     if (Object.values(MountedApps).some((app) => requestPath.startsWith(`/${app}`))) {
       return next();
     }
 
+    // Client session guard
     try {
-      // Find session
       await provider.interactionDetails(ctx.req, ctx.res);
     } catch {
-      const spaDistFiles = await fs.readdir(distPath);
+      const spaDistFiles = await fs.readdir(clientPath);
 
       if (
         !spaDistFiles.some((file) => requestPath.startsWith('/' + file)) &&


### PR DESCRIPTION


<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Empty path should redirect to the console page.

Rename the koa-client-session-guard to koa-proxy-guard. 
Add console redirect if empty path. 

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
log-2597

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
UT passed
@logto-io/eng 
