### PR TITLE
feat(core): add admin role validation to the koaAuth

### DIFF
--- a/packages/core/src/middleware/koa-auth.test.ts
+++ b/packages/core/src/middleware/koa-auth.test.ts
@@ -9,7 +9,7 @@ import { createContextWithRouteParameters } from '@/utils/test-utils';
 import koaAuth, { WithAuthContext } from './koa-auth';
 
 jest.mock('jose', () => ({
-  jwtVerify: jest.fn(() => ({ payload: { sub: 'fooUser', roles: ['admin'] } })),
+  jwtVerify: jest.fn(() => ({ payload: { sub: 'fooUser', roleNames: ['admin'] } })),
 }));
 
 describe('koaAuth middleware', () => {
@@ -81,7 +81,7 @@ describe('koaAuth middleware', () => {
     await expect(koaAuth()(ctx, next)).rejects.toMatchError(unauthorizedError);
   });
 
-  it('expect to throw if jwt roles is missing', async () => {
+  it('expect to throw if jwt roleNames is missing', async () => {
     const mockJwtVerify = jwtVerify as jest.Mock;
     mockJwtVerify.mockImplementationOnce(() => ({ payload: { sub: 'fooUser' } }));
 
@@ -95,9 +95,11 @@ describe('koaAuth middleware', () => {
     await expect(koaAuth()(ctx, next)).rejects.toMatchError(unauthorizedError);
   });
 
-  it('expect to throw if jwt roles does not include admin', async () => {
+  it('expect to throw if jwt roleNames does not include admin', async () => {
     const mockJwtVerify = jwtVerify as jest.Mock;
-    mockJwtVerify.mockImplementationOnce(() => ({ payload: { sub: 'fooUser', roles: ['foo'] } }));
+    mockJwtVerify.mockImplementationOnce(() => ({
+      payload: { sub: 'fooUser', roleNames: ['foo'] },
+    }));
 
     ctx.request = {
       ...ctx.request,

--- a/packages/core/src/middleware/koa-auth.ts
+++ b/packages/core/src/middleware/koa-auth.ts
@@ -41,7 +41,7 @@ const getUserInfoFromRequest = async (request: Request) => {
 
   const { publicKey, issuer } = oidc;
   const {
-    payload: { sub, roles },
+    payload: { sub, roleNames },
   } = await jwtVerify(extractBearerTokenFromHeaders(request.headers), publicKey, {
     issuer,
     audience: managementApiResource,
@@ -50,7 +50,7 @@ const getUserInfoFromRequest = async (request: Request) => {
   assertThat(sub, new RequestError({ code: 'auth.jwt_sub_missing', status: 401 }));
 
   assertThat(
-    Array.isArray(roles) && roles.includes(UserRole.Admin),
+    Array.isArray(roleNames) && roleNames.includes(UserRole.Admin),
     new RequestError({ code: 'auth.unauthorized', status: 401 })
   );
 

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -115,6 +115,19 @@ export default async function initOidc(app: Koa): Promise<Provider> {
         return refreshTokenTtl ?? defaultRefreshTokenTtl;
       },
     },
+    extraTokenClaims: async (ctx, token) => {
+      // AccessToken type is not exported by default, need to asset token is AccessToken
+      if (token.kind === 'AccessToken') {
+        const { accountId } = token;
+        const { roleNames } = await findUserById(accountId);
+
+        // Add User Roles to the AccessToken claims. Should be removed once we have RBAC implemented.
+        // User Roles should be hidden and  determined by the AccessToken scope only.
+        return {
+          roles: roleNames,
+        };
+      }
+    },
   });
 
   addOidcEventListeners(oidc);

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -124,7 +124,7 @@ export default async function initOidc(app: Koa): Promise<Provider> {
         // Add User Roles to the AccessToken claims. Should be removed once we have RBAC implemented.
         // User Roles should be hidden and  determined by the AccessToken scope only.
         return {
-          roles: roleNames,
+          roleNames,
         };
       }
     },


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
### Add admin role validation to the koaAuth

1. Add extra roles claims to the access_token
2. validate if roles exist and include admin role in koaAuth middleware

<img width="932" alt="image" src="https://user-images.githubusercontent.com/36393111/169679121-3d65f825-899f-432c-ad1e-d85e06265aca.png">
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/36393111/169679129-52ffb161-4da5-450e-bdab-c9749cff6f55.png">


This solution should be optimized once we have rbac feature implemented. As it should be controlled through scopes only.
<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
log-2598

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
@logto-io/eng  @gao-sun @wangsijie 
