### PR TITLE
feat(core): get /dashboard/users/new

### DIFF
--- a/packages/core/src/queries/log.ts
+++ b/packages/core/src/queries/log.ts
@@ -60,14 +60,14 @@ const registerLogTypes: LogType[] = [
 ];
 
 export const getDailyNewUserCountsByTimeInterval = async (
-  startTimeInclusive: number,
-  endTimeExclusive: number
+  startTimeExclusive: number,
+  endTimeInclusive: number
 ) =>
   envSet.pool.any<{ date: string; count: number }>(sql`
     select date(${fields.createdAt}), count(*)
     from ${table}
-    where ${fields.createdAt} >= to_timestamp(${startTimeInclusive}::double precision / 1000)
-    and ${fields.createdAt} < to_timestamp(${endTimeExclusive}::double precision / 1000)
+    where ${fields.createdAt} > to_timestamp(${startTimeExclusive}::double precision / 1000)
+    and ${fields.createdAt} <= to_timestamp(${endTimeInclusive}::double precision / 1000)
     and ${fields.type} in (${sql.join(registerLogTypes, sql`, `)})
     and ${fields.payload}->>'result' = 'Success'
     group by date(${fields.createdAt})

--- a/packages/core/src/routes/dashboard.test.ts
+++ b/packages/core/src/routes/dashboard.test.ts
@@ -1,3 +1,5 @@
+import dayjs from 'dayjs';
+
 import dashboardRoutes from '@/routes/dashboard';
 import { createRequester } from '@/utils/test-utils';
 
@@ -8,8 +10,34 @@ jest.mock('@/queries/user', () => ({
   countUsers: async () => countUsers(),
 }));
 
+const getDailyNewUserCountsByTimeInterval = jest.fn(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async (startTimeInclusive: number, endTimeExclusive: number) => mockDailyNewUserCounts
+);
+
+jest.mock('@/queries/log', () => ({
+  getDailyNewUserCountsByTimeInterval: async (
+    startTimeInclusive: number,
+    endTimeExclusive: number
+  ) => getDailyNewUserCountsByTimeInterval(startTimeInclusive, endTimeExclusive),
+}));
+
+const mockDailyNewUserCounts = [
+  { date: '2022-05-01', count: 1 },
+  { date: '2022-05-02', count: 2 },
+  { date: '2022-05-03', count: 3 },
+  { date: '2022-05-06', count: 6 },
+  { date: '2022-05-07', count: 7 },
+  { date: '2022-05-08', count: 8 },
+  { date: '2022-05-09', count: 9 },
+  { date: '2022-05-10', count: 10 },
+  { date: '2022-05-13', count: 13 },
+  { date: '2022-05-14', count: 14 },
+];
+
 describe('dashboardRoutes', () => {
   const logRequest = createRequester({ authedRoutes: dashboardRoutes });
+  jest.useFakeTimers().setSystemTime(new Date('2022-05-14'));
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -25,6 +53,31 @@ describe('dashboardRoutes', () => {
       const response = await logRequest.get('/dashboard/users/total');
       expect(response.status).toEqual(200);
       expect(response.body).toEqual({ totalUserCount });
+    });
+  });
+
+  describe('GET /dashboard/users/new', () => {
+    it('should call getDnuCountsByTimeInterval with the time interval: [13 days ago, tomorrow)', async () => {
+      await logRequest.get('/dashboard/users/new');
+      expect(getDailyNewUserCountsByTimeInterval).toHaveBeenCalledWith(
+        dayjs().subtract(13, 'day').valueOf(),
+        dayjs().add(1, 'day').valueOf()
+      );
+    });
+
+    it('should return correct response', async () => {
+      const response = await logRequest.get('/dashboard/users/new');
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({
+        today: {
+          count: 14,
+          upPercent: 8,
+        },
+        past7Days: {
+          count: 54,
+          upPercent: 184,
+        },
+      });
     });
   });
 });

--- a/packages/core/src/routes/dashboard.test.ts
+++ b/packages/core/src/routes/dashboard.test.ts
@@ -25,14 +25,14 @@ const mockDailyNewUserCounts = [
 
 const getDailyNewUserCountsByTimeInterval = jest.fn(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async (startTimeInclusive: number, endTimeExclusive: number) => mockDailyNewUserCounts
+  async (startTimeExclusive: number, endTimeInclusive: number) => mockDailyNewUserCounts
 );
 
 jest.mock('@/queries/log', () => ({
   getDailyNewUserCountsByTimeInterval: async (
-    startTimeInclusive: number,
-    endTimeExclusive: number
-  ) => getDailyNewUserCountsByTimeInterval(startTimeInclusive, endTimeExclusive),
+    startTimeExclusive: number,
+    endTimeInclusive: number
+  ) => getDailyNewUserCountsByTimeInterval(startTimeExclusive, endTimeInclusive),
 }));
 
 describe('dashboardRoutes', () => {

--- a/packages/core/src/routes/dashboard.test.ts
+++ b/packages/core/src/routes/dashboard.test.ts
@@ -71,11 +71,11 @@ describe('dashboardRoutes', () => {
       expect(response.body).toEqual({
         today: {
           count: 14,
-          upPercent: 8,
+          difference: 1,
         },
         past7Days: {
           count: 54,
-          upPercent: 184,
+          difference: 35,
         },
       });
     });

--- a/packages/core/src/routes/dashboard.test.ts
+++ b/packages/core/src/routes/dashboard.test.ts
@@ -76,7 +76,7 @@ describe('dashboardRoutes', () => {
           count: 14,
           delta: 1,
         },
-        recent7Days: {
+        last7Days: {
           count: 54,
           delta: 35,
         },

--- a/packages/core/src/routes/dashboard.test.ts
+++ b/packages/core/src/routes/dashboard.test.ts
@@ -73,7 +73,7 @@ describe('dashboardRoutes', () => {
           count: 14,
           difference: 1,
         },
-        past7Days: {
+        recent7Days: {
           count: 54,
           difference: 35,
         },

--- a/packages/core/src/routes/dashboard.test.ts
+++ b/packages/core/src/routes/dashboard.test.ts
@@ -10,18 +10,6 @@ jest.mock('@/queries/user', () => ({
   countUsers: async () => countUsers(),
 }));
 
-const getDailyNewUserCountsByTimeInterval = jest.fn(
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async (startTimeInclusive: number, endTimeExclusive: number) => mockDailyNewUserCounts
-);
-
-jest.mock('@/queries/log', () => ({
-  getDailyNewUserCountsByTimeInterval: async (
-    startTimeInclusive: number,
-    endTimeExclusive: number
-  ) => getDailyNewUserCountsByTimeInterval(startTimeInclusive, endTimeExclusive),
-}));
-
 const mockDailyNewUserCounts = [
   { date: '2022-05-01', count: 1 },
   { date: '2022-05-02', count: 2 },
@@ -34,6 +22,18 @@ const mockDailyNewUserCounts = [
   { date: '2022-05-13', count: 13 },
   { date: '2022-05-14', count: 14 },
 ];
+
+const getDailyNewUserCountsByTimeInterval = jest.fn(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async (startTimeInclusive: number, endTimeExclusive: number) => mockDailyNewUserCounts
+);
+
+jest.mock('@/queries/log', () => ({
+  getDailyNewUserCountsByTimeInterval: async (
+    startTimeInclusive: number,
+    endTimeExclusive: number
+  ) => getDailyNewUserCountsByTimeInterval(startTimeInclusive, endTimeExclusive),
+}));
 
 describe('dashboardRoutes', () => {
   const logRequest = createRequester({ authedRoutes: dashboardRoutes });

--- a/packages/core/src/routes/dashboard.test.ts
+++ b/packages/core/src/routes/dashboard.test.ts
@@ -37,7 +37,6 @@ const mockDailyNewUserCounts = [
 
 describe('dashboardRoutes', () => {
   const logRequest = createRequester({ authedRoutes: dashboardRoutes });
-  jest.useFakeTimers().setSystemTime(new Date('2022-05-14'));
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -57,11 +56,15 @@ describe('dashboardRoutes', () => {
   });
 
   describe('GET /dashboard/users/new', () => {
-    it('should call getDnuCountsByTimeInterval with the time interval: [13 days ago, tomorrow)', async () => {
+    beforeEach(() => {
+      jest.useFakeTimers().setSystemTime(new Date('2022-05-14'));
+    });
+
+    it('should call getDailyNewUserCountsByTimeInterval with the time interval (13 days ago 23:59:59.999, today 23:59:59.999]', async () => {
       await logRequest.get('/dashboard/users/new');
       expect(getDailyNewUserCountsByTimeInterval).toHaveBeenCalledWith(
-        dayjs().subtract(13, 'day').valueOf(),
-        dayjs().add(1, 'day').valueOf()
+        dayjs().endOf('day').subtract(14, 'day').valueOf(),
+        dayjs().endOf('day').valueOf()
       );
     });
 

--- a/packages/core/src/routes/dashboard.test.ts
+++ b/packages/core/src/routes/dashboard.test.ts
@@ -74,11 +74,11 @@ describe('dashboardRoutes', () => {
       expect(response.body).toEqual({
         today: {
           count: 14,
-          difference: 1,
+          delta: 1,
         },
         recent7Days: {
           count: 54,
-          difference: 35,
+          delta: 35,
         },
       });
     });

--- a/packages/core/src/routes/dashboard.test.ts
+++ b/packages/core/src/routes/dashboard.test.ts
@@ -60,7 +60,7 @@ describe('dashboardRoutes', () => {
       jest.useFakeTimers().setSystemTime(new Date('2022-05-14'));
     });
 
-    it('should call getDailyNewUserCountsByTimeInterval with the time interval (13 days ago 23:59:59.999, today 23:59:59.999]', async () => {
+    it('should call getDailyNewUserCountsByTimeInterval with the time interval (14 days ago 23:59:59.999, today 23:59:59.999]', async () => {
       await logRequest.get('/dashboard/users/new');
       expect(getDailyNewUserCountsByTimeInterval).toHaveBeenCalledWith(
         dayjs().endOf('day').subtract(14, 'day').valueOf(),

--- a/packages/core/src/routes/dashboard.ts
+++ b/packages/core/src/routes/dashboard.ts
@@ -32,11 +32,7 @@ export default function dashboardRoutes<T extends AuthedRouter>(router: T) {
     const todayNewUserCount = recent14DaysDailyNewUserCounts.get(getDateString(today)) ?? 0;
     const yesterday = today.subtract(1, 'day');
     const yesterdayNewUserCount = recent14DaysDailyNewUserCounts.get(getDateString(yesterday)) ?? 0;
-    // If yesterdayNewUserCount is 0, todayUpPercent will be not applicable.
-    const todayUpPercent =
-      yesterdayNewUserCount > 0
-        ? Math.round((todayNewUserCount / yesterdayNewUserCount) * 100 - 100)
-        : undefined;
+    const todayDifference = todayNewUserCount - yesterdayNewUserCount;
 
     const recent7DaysNewUserCount = [...Array.from({ length: 7 }).keys()]
       .map((index) => getDateString(today.subtract(index, 'day')))
@@ -44,20 +40,16 @@ export default function dashboardRoutes<T extends AuthedRouter>(router: T) {
     const newUserCountFrom13DaysAgoTo7DaysAgo = [...Array.from({ length: 7 }).keys()]
       .map((index) => getDateString(today.subtract(7 + index, 'day')))
       .reduce((sum, date) => sum + (recent14DaysDailyNewUserCounts.get(date) ?? 0), 0);
-    // If newUserCountFrom13DaysAgoTo7DaysAgo is 0, past7DaysUpPercent will be not applicable.
-    const past7DaysUpPercent =
-      newUserCountFrom13DaysAgoTo7DaysAgo > 0
-        ? Math.round((recent7DaysNewUserCount / newUserCountFrom13DaysAgoTo7DaysAgo) * 100 - 100)
-        : undefined;
+    const recent7DaysDifference = recent7DaysNewUserCount - newUserCountFrom13DaysAgoTo7DaysAgo;
 
     ctx.body = {
       today: {
         count: todayNewUserCount,
-        upPercent: todayUpPercent,
+        difference: todayDifference,
       },
       past7Days: {
         count: recent7DaysNewUserCount,
-        upPercent: past7DaysUpPercent,
+        difference: recent7DaysDifference,
       },
     };
 

--- a/packages/core/src/routes/dashboard.ts
+++ b/packages/core/src/routes/dashboard.ts
@@ -25,21 +25,21 @@ export default function dashboardRoutes<T extends AuthedRouter>(router: T) {
       tomorrow.valueOf()
     );
 
-    const recent14DaysDailyNewUserCounts = new Map(
+    const recent14DaysNewUserCounts = new Map(
       dailyNewUserCounts.map(({ date, count }) => [date, count])
     );
 
-    const todayNewUserCount = recent14DaysDailyNewUserCounts.get(getDateString(today)) ?? 0;
+    const todayNewUserCount = recent14DaysNewUserCounts.get(getDateString(today)) ?? 0;
     const yesterday = today.subtract(1, 'day');
-    const yesterdayNewUserCount = recent14DaysDailyNewUserCounts.get(getDateString(yesterday)) ?? 0;
+    const yesterdayNewUserCount = recent14DaysNewUserCounts.get(getDateString(yesterday)) ?? 0;
     const todayDifference = todayNewUserCount - yesterdayNewUserCount;
 
     const recent7DaysNewUserCount = [...Array.from({ length: 7 }).keys()]
       .map((index) => getDateString(today.subtract(index, 'day')))
-      .reduce((sum, date) => sum + (recent14DaysDailyNewUserCounts.get(date) ?? 0), 0);
+      .reduce((sum, date) => sum + (recent14DaysNewUserCounts.get(date) ?? 0), 0);
     const newUserCountFrom13DaysAgoTo7DaysAgo = [...Array.from({ length: 7 }).keys()]
       .map((index) => getDateString(today.subtract(7 + index, 'day')))
-      .reduce((sum, date) => sum + (recent14DaysDailyNewUserCounts.get(date) ?? 0), 0);
+      .reduce((sum, date) => sum + (recent14DaysNewUserCounts.get(date) ?? 0), 0);
     const recent7DaysDifference = recent7DaysNewUserCount - newUserCountFrom13DaysAgoTo7DaysAgo;
 
     ctx.body = {
@@ -47,7 +47,7 @@ export default function dashboardRoutes<T extends AuthedRouter>(router: T) {
         count: todayNewUserCount,
         difference: todayDifference,
       },
-      past7Days: {
+      recent7Days: {
         count: recent7DaysNewUserCount,
         difference: recent7DaysDifference,
       },

--- a/packages/core/src/routes/dashboard.ts
+++ b/packages/core/src/routes/dashboard.ts
@@ -17,12 +17,11 @@ export default function dashboardRoutes<T extends AuthedRouter>(router: T) {
 
   router.get('/dashboard/users/new', async (ctx, next) => {
     const today = dayjs();
-
-    const thirteenDaysAgo = today.subtract(13, 'day');
-    const tomorrow = today.add(1, 'day');
+    const fourteenDaysAgo = today.subtract(14, 'day');
     const dailyNewUserCounts = await getDailyNewUserCountsByTimeInterval(
-      thirteenDaysAgo.valueOf(),
-      tomorrow.valueOf()
+      // Time interval: (14 days ago 23:59:59.999, today 23:59:59.999]
+      fourteenDaysAgo.endOf('day').valueOf(),
+      today.endOf('day').valueOf()
     );
 
     const recent14DaysNewUserCounts = new Map(

--- a/packages/core/src/routes/dashboard.ts
+++ b/packages/core/src/routes/dashboard.ts
@@ -1,11 +1,65 @@
+import dayjs, { Dayjs } from 'dayjs';
+
+import { getDailyNewUserCountsByTimeInterval } from '@/queries/log';
 import { countUsers } from '@/queries/user';
 
 import { AuthedRouter } from './types';
+
+const getDateString = (day: Dayjs) => day.format('YYYY-MM-DD');
 
 export default function dashboardRoutes<T extends AuthedRouter>(router: T) {
   router.get('/dashboard/users/total', async (ctx, next) => {
     const { count: totalUserCount } = await countUsers();
     ctx.body = { totalUserCount };
+
+    return next();
+  });
+
+  router.get('/dashboard/users/new', async (ctx, next) => {
+    const today = dayjs();
+
+    const thirteenDaysAgo = today.subtract(13, 'day');
+    const tomorrow = today.add(1, 'day');
+    const dailyNewUserCounts = await getDailyNewUserCountsByTimeInterval(
+      thirteenDaysAgo.valueOf(),
+      tomorrow.valueOf()
+    );
+
+    const recent14DaysDailyNewUserCounts = new Map(
+      dailyNewUserCounts.map(({ date, count }) => [date, count])
+    );
+
+    const todayNewUserCount = recent14DaysDailyNewUserCounts.get(getDateString(today)) ?? 0;
+    const yesterday = today.subtract(1, 'day');
+    const yesterdayNewUserCount = recent14DaysDailyNewUserCounts.get(getDateString(yesterday)) ?? 0;
+    // If yesterdayNewUserCount is 0, todayUpPercent will be not applicable.
+    const todayUpPercent =
+      yesterdayNewUserCount > 0
+        ? Math.round((todayNewUserCount / yesterdayNewUserCount) * 100 - 100)
+        : undefined;
+
+    const recent7DaysNewUserCount = [...Array.from({ length: 7 }).keys()]
+      .map((index) => getDateString(today.subtract(index, 'day')))
+      .reduce((sum, date) => sum + (recent14DaysDailyNewUserCounts.get(date) ?? 0), 0);
+    const newUserCountFrom13DaysAgoTo7DaysAgo = [...Array.from({ length: 7 }).keys()]
+      .map((index) => getDateString(today.subtract(7 + index, 'day')))
+      .reduce((sum, date) => sum + (recent14DaysDailyNewUserCounts.get(date) ?? 0), 0);
+    // If newUserCountFrom13DaysAgoTo7DaysAgo is 0, past7DaysUpPercent will be not applicable.
+    const past7DaysUpPercent =
+      newUserCountFrom13DaysAgoTo7DaysAgo > 0
+        ? Math.round((recent7DaysNewUserCount / newUserCountFrom13DaysAgoTo7DaysAgo) * 100 - 100)
+        : undefined;
+
+    ctx.body = {
+      today: {
+        count: todayNewUserCount,
+        upPercent: todayUpPercent,
+      },
+      past7Days: {
+        count: recent7DaysNewUserCount,
+        upPercent: past7DaysUpPercent,
+      },
+    };
 
     return next();
   });

--- a/packages/core/src/routes/dashboard.ts
+++ b/packages/core/src/routes/dashboard.ts
@@ -7,6 +7,8 @@ import { AuthedRouter } from './types';
 
 const getDateString = (day: Dayjs) => day.format('YYYY-MM-DD');
 
+const indicesFrom0To6 = [...Array.from({ length: 7 }).keys()];
+
 export default function dashboardRoutes<T extends AuthedRouter>(router: T) {
   router.get('/dashboard/users/total', async (ctx, next) => {
     const { count: totalUserCount } = await countUsers();
@@ -24,31 +26,31 @@ export default function dashboardRoutes<T extends AuthedRouter>(router: T) {
       today.endOf('day').valueOf()
     );
 
-    const recent14DaysNewUserCounts = new Map(
+    const last14DaysNewUserCounts = new Map(
       dailyNewUserCounts.map(({ date, count }) => [date, count])
     );
 
-    const todayNewUserCount = recent14DaysNewUserCounts.get(getDateString(today)) ?? 0;
+    const todayNewUserCount = last14DaysNewUserCounts.get(getDateString(today)) ?? 0;
     const yesterday = today.subtract(1, 'day');
-    const yesterdayNewUserCount = recent14DaysNewUserCounts.get(getDateString(yesterday)) ?? 0;
+    const yesterdayNewUserCount = last14DaysNewUserCounts.get(getDateString(yesterday)) ?? 0;
     const todayDelta = todayNewUserCount - yesterdayNewUserCount;
 
-    const recent7DaysNewUserCount = [...Array.from({ length: 7 }).keys()]
+    const last7DaysNewUserCount = indicesFrom0To6
       .map((index) => getDateString(today.subtract(index, 'day')))
-      .reduce((sum, date) => sum + (recent14DaysNewUserCounts.get(date) ?? 0), 0);
-    const newUserCountFrom13DaysAgoTo7DaysAgo = [...Array.from({ length: 7 }).keys()]
+      .reduce((sum, date) => sum + (last14DaysNewUserCounts.get(date) ?? 0), 0);
+    const newUserCountFrom13DaysAgoTo7DaysAgo = indicesFrom0To6
       .map((index) => getDateString(today.subtract(7 + index, 'day')))
-      .reduce((sum, date) => sum + (recent14DaysNewUserCounts.get(date) ?? 0), 0);
-    const recent7DaysDelta = recent7DaysNewUserCount - newUserCountFrom13DaysAgoTo7DaysAgo;
+      .reduce((sum, date) => sum + (last14DaysNewUserCounts.get(date) ?? 0), 0);
+    const last7DaysDelta = last7DaysNewUserCount - newUserCountFrom13DaysAgoTo7DaysAgo;
 
     ctx.body = {
       today: {
         count: todayNewUserCount,
         delta: todayDelta,
       },
-      recent7Days: {
-        count: recent7DaysNewUserCount,
-        delta: recent7DaysDelta,
+      last7Days: {
+        count: last7DaysNewUserCount,
+        delta: last7DaysDelta,
       },
     };
 

--- a/packages/core/src/routes/dashboard.ts
+++ b/packages/core/src/routes/dashboard.ts
@@ -31,7 +31,7 @@ export default function dashboardRoutes<T extends AuthedRouter>(router: T) {
     const todayNewUserCount = recent14DaysNewUserCounts.get(getDateString(today)) ?? 0;
     const yesterday = today.subtract(1, 'day');
     const yesterdayNewUserCount = recent14DaysNewUserCounts.get(getDateString(yesterday)) ?? 0;
-    const todayDifference = todayNewUserCount - yesterdayNewUserCount;
+    const todayDelta = todayNewUserCount - yesterdayNewUserCount;
 
     const recent7DaysNewUserCount = [...Array.from({ length: 7 }).keys()]
       .map((index) => getDateString(today.subtract(index, 'day')))
@@ -39,16 +39,16 @@ export default function dashboardRoutes<T extends AuthedRouter>(router: T) {
     const newUserCountFrom13DaysAgoTo7DaysAgo = [...Array.from({ length: 7 }).keys()]
       .map((index) => getDateString(today.subtract(7 + index, 'day')))
       .reduce((sum, date) => sum + (recent14DaysNewUserCounts.get(date) ?? 0), 0);
-    const recent7DaysDifference = recent7DaysNewUserCount - newUserCountFrom13DaysAgoTo7DaysAgo;
+    const recent7DaysDelta = recent7DaysNewUserCount - newUserCountFrom13DaysAgoTo7DaysAgo;
 
     ctx.body = {
       today: {
         count: todayNewUserCount,
-        difference: todayDifference,
+        delta: todayDelta,
       },
       recent7Days: {
         count: recent7DaysNewUserCount,
-        difference: recent7DaysDifference,
+        delta: recent7DaysDelta,
       },
     };
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add GET /dashboard/users/new

Input: none
Output:

```json
{
  "today": {
    "count": 111, // today new user count
    "delta": 11 // today new user count - yesterday new user count
  },
  "recent7Days": {
    "count": 500, // last 7 days new user count
    "delta": 25 // last 7 days new user count - previous 7 days new user count
  }
}
```

- e.g. assumed `today` is 5.14, the `last 7 days` is [5.8, 5.14] and `previous 7 days` is [5.1, 5.7]


<!--

- ~`today up percent` = ((`today new user count` / `yesterday new user count`) - 1) * 100%~
- ~`last 7 days up percent` = ((`last 7 days new user count` / `another previous 7 days new user count`) - 1）* 100%~

-->

See Notion [doc](https://www.notion.so/silverhand/Dashboard-API-956dadaf287c428ea79a7018b39948b0)

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-942
LOG-2482

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
![image](https://user-images.githubusercontent.com/10594507/170056455-213cc4a3-2cdc-4117-a272-61eaf3c779f5.png)
![image](https://user-images.githubusercontent.com/10594507/170299376-9925d18b-7f5c-44f8-bf86-72bf91c16e4e.png)

---

FIXME:

- [x] when `yesterday new user count` or `another previous 7 days new user count` is 0, how to deal with `up percent`? (**since we should not do division by 0.**) Maybe assign them null, and hide the up percent on the dashboard? wait for @guamain
    - Conclusion: `up percent` is replaced by `delta`
        - e.g. the delta between `today new user count` and `yesterday new user count`
        - See the Slack thread [discussion](https://silverhand-io.slack.com/archives/C0243P3E4KS/p1653449049214669)