### PR TITLE
refactor(core, connector): fix code to fit new ESlint rule

### DIFF
--- a/packages/connector-wechat-native/src/index.test.ts
+++ b/packages/connector-wechat-native/src/index.test.ts
@@ -108,6 +108,17 @@ describe('getUserInfo', () => {
     });
   });
 
+  it('throws error if `openid` is missing', async () => {
+    nock(userInfoEndpointUrl.origin).get(userInfoEndpointUrl.pathname).query(parameters).reply(0, {
+      unionid: 'this_is_an_arbitrary_wechat_union_id',
+      headimgurl: 'https://github.com/images/error/octocat_happy.gif',
+      nickname: 'wechat bot',
+    });
+    await expect(
+      weChatNativeMethods.getUserInfo({ accessToken: 'accessToken' })
+    ).rejects.toMatchError(new Error('`openid` is required for WeChat API.'));
+  });
+
   it('throws SocialAccessTokenInvalid error if errcode is 40001', async () => {
     nock(userInfoEndpointUrl.origin)
       .get(userInfoEndpointUrl.pathname)
@@ -138,10 +149,10 @@ describe('getUserInfo', () => {
   it('throws SocialAccessTokenInvalid error if response code is 401', async () => {
     nock(userInfoEndpointUrl.origin)
       .get(userInfoEndpointUrl.pathname)
-      .query(new URLSearchParams({ access_token: 'accessToken' }))
+      .query(new URLSearchParams({ access_token: 'wrongAccessToken', openid: 'openid' }))
       .reply(401);
     await expect(
-      weChatNativeMethods.getUserInfo({ accessToken: 'accessToken' })
+      weChatNativeMethods.getUserInfo({ accessToken: 'wrongAccessToken', openid: 'openid' })
     ).rejects.toMatchError(new ConnectorError(ConnectorErrorCodes.SocialAccessTokenInvalid));
   });
 });

--- a/packages/connector-wechat-native/src/index.test.ts
+++ b/packages/connector-wechat-native/src/index.test.ts
@@ -116,7 +116,7 @@ describe('getUserInfo', () => {
     });
     await expect(
       weChatNativeMethods.getUserInfo({ accessToken: 'accessToken' })
-    ).rejects.toMatchError(new Error('`openid` is required for WeChat API.'));
+    ).rejects.toMatchError(new Error('`openid` is required by WeChat API.'));
   });
 
   it('throws SocialAccessTokenInvalid error if errcode is 40001', async () => {

--- a/packages/connector-wechat-native/src/index.ts
+++ b/packages/connector-wechat-native/src/index.ts
@@ -102,15 +102,16 @@ export default class WeChatNativeConnector implements SocialConnector {
       // These two groups are mutually exclusive: if group (1) is not empty, group (2) should be empty and vice versa.
       // 'errmsg' and 'errcode' turn to be non-empty values or empty values at the same time. Hence, if 'errmsg' is non-empty then 'errcode' should be non-empty.
 
-      assert(errcode === 40_001, new ConnectorError(ConnectorErrorCodes.SocialAccessTokenInvalid));
+      assert(errcode !== 40_001, new ConnectorError(ConnectorErrorCodes.SocialAccessTokenInvalid));
       assert(!errcode, new Error(errmsg));
       assert(openid, new Error(errmsg));
 
       return { id: unionid ?? openid, avatar: headimgurl, name: nickname };
     } catch (error: unknown) {
-      if (error instanceof GotRequestError && error.response?.statusCode === 401) {
-        throw new ConnectorError(ConnectorErrorCodes.SocialAccessTokenInvalid);
-      }
+      assert(
+        !(error instanceof GotRequestError && error.response?.statusCode === 401),
+        new ConnectorError(ConnectorErrorCodes.SocialAccessTokenInvalid)
+      );
 
       throw error;
     }

--- a/packages/connector-wechat-native/src/index.ts
+++ b/packages/connector-wechat-native/src/index.ts
@@ -80,8 +80,6 @@ export default class WeChatNativeConnector implements SocialConnector {
     return { accessToken, openid };
   };
 
-  // FIXME:
-  // eslint-disable-next-line complexity
   public getUserInfo: GetUserInfo = async (accessTokenObject) => {
     const { accessToken, openid } = accessTokenObject;
 
@@ -93,19 +91,20 @@ export default class WeChatNativeConnector implements SocialConnector {
         })
         .json<UserInfoResponse>();
 
-      if (!openid || errcode || errmsg) {
-        // 'openid' is defined as a required input argument in WeChat API doc, but it does not necessarily to
-        // be the return value from getAccessToken per testing.
-        // In another word, 'openid' is required but the response of getUserInfo is consistent as long as
-        // access_token is valid.
-        // We are expecting to get 41009 'missing openid' response according to the developers doc, but the
-        // fact is that we still got 40001 'invalid credentials' response.
-        if (errcode === 40_001) {
-          throw new ConnectorError(ConnectorErrorCodes.SocialAccessTokenInvalid);
-        }
+      // 'openid' is defined as a required input argument in WeChat API doc, but it does not necessarily to
+      // be the return value from getAccessToken per testing.
+      // In another word, 'openid' is required but the response of getUserInfo is consistent as long as
+      // access_token is valid.
+      // We are expecting to get 41009 'missing openid' response according to the developers doc, but the
+      // fact is that we still got 40001 'invalid credentials' response.
 
-        throw new Error(errmsg);
-      }
+      // Response properties of user info can be separated into two groups: (1) {unionid, headimgurl, nickname}, (2) {errcode, errmsg}.
+      // These two groups are mutually exclusive: if group (1) is not empty, group (2) should be empty and vice versa.
+      // 'errmsg' and 'errcode' turn to be non-empty values or empty values at the same time. Hence, if 'errmsg' is non-empty then 'errcode' should be non-empty.
+
+      assert(errcode === 40_001, new ConnectorError(ConnectorErrorCodes.SocialAccessTokenInvalid));
+      assert(!errcode, new Error(errmsg));
+      assert(openid, new Error(errmsg));
 
       return { id: unionid ?? openid, avatar: headimgurl, name: nickname };
     } catch (error: unknown) {

--- a/packages/connector-wechat-native/src/index.ts
+++ b/packages/connector-wechat-native/src/index.ts
@@ -82,6 +82,7 @@ export default class WeChatNativeConnector implements SocialConnector {
 
   public getUserInfo: GetUserInfo = async (accessTokenObject) => {
     const { accessToken, openid } = accessTokenObject;
+    assert(openid, new Error('`openid` is required for WeChat API.'));
 
     try {
       const { unionid, headimgurl, nickname, errcode, errmsg } = await got
@@ -104,7 +105,6 @@ export default class WeChatNativeConnector implements SocialConnector {
 
       assert(errcode !== 40_001, new ConnectorError(ConnectorErrorCodes.SocialAccessTokenInvalid));
       assert(!errcode, new Error(errmsg));
-      assert(openid, new Error(errmsg));
 
       return { id: unionid ?? openid, avatar: headimgurl, name: nickname };
     } catch (error: unknown) {

--- a/packages/connector-wechat-native/src/index.ts
+++ b/packages/connector-wechat-native/src/index.ts
@@ -82,7 +82,14 @@ export default class WeChatNativeConnector implements SocialConnector {
 
   public getUserInfo: GetUserInfo = async (accessTokenObject) => {
     const { accessToken, openid } = accessTokenObject;
-    assert(openid, new Error('`openid` is required for WeChat API.'));
+
+    // 'openid' is defined as a required input argument in WeChat API doc, but it does not necessarily have to
+    // be the return value from getAccessToken per testing.
+    // In other words, 'openid' is required but the response of getUserInfo is consistent as long as
+    // access_token is valid.
+    // We are expecting to get 41009 'missing openid' response according to the developers doc, but the
+    // fact is that we still got 40001 'invalid credentials' response.
+    assert(openid, new Error('`openid` is required by WeChat API.'));
 
     try {
       const { unionid, headimgurl, nickname, errcode, errmsg } = await got
@@ -92,16 +99,9 @@ export default class WeChatNativeConnector implements SocialConnector {
         })
         .json<UserInfoResponse>();
 
-      // 'openid' is defined as a required input argument in WeChat API doc, but it does not necessarily to
-      // be the return value from getAccessToken per testing.
-      // In another word, 'openid' is required but the response of getUserInfo is consistent as long as
-      // access_token is valid.
-      // We are expecting to get 41009 'missing openid' response according to the developers doc, but the
-      // fact is that we still got 40001 'invalid credentials' response.
-
       // Response properties of user info can be separated into two groups: (1) {unionid, headimgurl, nickname}, (2) {errcode, errmsg}.
       // These two groups are mutually exclusive: if group (1) is not empty, group (2) should be empty and vice versa.
-      // 'errmsg' and 'errcode' turn to be non-empty values or empty values at the same time. Hence, if 'errmsg' is non-empty then 'errcode' should be non-empty.
+      // 'errmsg' and 'errcode' turn to non-empty values or empty values at the same time. Hence, if 'errmsg' is non-empty then 'errcode' should be non-empty.
 
       assert(errcode !== 40_001, new ConnectorError(ConnectorErrorCodes.SocialAccessTokenInvalid));
       assert(!errcode, new Error(errmsg));

--- a/packages/connector-wechat/src/index.test.ts
+++ b/packages/connector-wechat/src/index.test.ts
@@ -115,7 +115,7 @@ describe('getUserInfo', () => {
       nickname: 'wechat bot',
     });
     await expect(weChatMethods.getUserInfo({ accessToken: 'accessToken' })).rejects.toMatchError(
-      new Error('`openid` is required for WeChat API.')
+      new Error('`openid` is required by WeChat API.')
     );
   });
 

--- a/packages/connector-wechat/src/index.test.ts
+++ b/packages/connector-wechat/src/index.test.ts
@@ -108,6 +108,17 @@ describe('getUserInfo', () => {
     });
   });
 
+  it('throws error if `openid` is missing', async () => {
+    nock(userInfoEndpointUrl.origin).get(userInfoEndpointUrl.pathname).query(parameters).reply(0, {
+      unionid: 'this_is_an_arbitrary_wechat_union_id',
+      headimgurl: 'https://github.com/images/error/octocat_happy.gif',
+      nickname: 'wechat bot',
+    });
+    await expect(weChatMethods.getUserInfo({ accessToken: 'accessToken' })).rejects.toMatchError(
+      new Error('`openid` is required for WeChat API.')
+    );
+  });
+
   it('throws SocialAccessTokenInvalid error if errcode is 40001', async () => {
     nock(userInfoEndpointUrl.origin)
       .get(userInfoEndpointUrl.pathname)
@@ -138,10 +149,10 @@ describe('getUserInfo', () => {
   it('throws SocialAccessTokenInvalid error if response code is 401', async () => {
     nock(userInfoEndpointUrl.origin)
       .get(userInfoEndpointUrl.pathname)
-      .query(new URLSearchParams({ access_token: 'accessToken' }))
+      .query(new URLSearchParams({ access_token: 'wrongAccessToken', openid: 'openid' }))
       .reply(401);
-    await expect(weChatMethods.getUserInfo({ accessToken: 'accessToken' })).rejects.toMatchError(
-      new ConnectorError(ConnectorErrorCodes.SocialAccessTokenInvalid)
-    );
+    await expect(
+      weChatMethods.getUserInfo({ accessToken: 'wrongAccessToken', openid: 'openid' })
+    ).rejects.toMatchError(new ConnectorError(ConnectorErrorCodes.SocialAccessTokenInvalid));
   });
 });

--- a/packages/connector-wechat/src/index.ts
+++ b/packages/connector-wechat/src/index.ts
@@ -79,8 +79,6 @@ export default class WeChatConnector implements SocialConnector {
     return { accessToken, openid };
   };
 
-  // FIXME:
-  // eslint-disable-next-line complexity
   public getUserInfo: GetUserInfo = async (accessTokenObject) => {
     const { accessToken, openid } = accessTokenObject;
 
@@ -92,25 +90,27 @@ export default class WeChatConnector implements SocialConnector {
         })
         .json<UserInfoResponse>();
 
-      if (!openid || errcode || errmsg) {
-        // 'openid' is defined as a required input argument in WeChat API doc, but it does not necessarily to
-        // be the return value from getAccessToken per testing.
-        // In another word, 'openid' is required but the response of getUserInfo is consistent as long as
-        // access_token is valid.
-        // We are expecting to get 41009 'missing openid' response according to the developers doc, but the
-        // fact is that we still got 40001 'invalid credentials' response.
-        if (errcode === 40_001) {
-          throw new ConnectorError(ConnectorErrorCodes.SocialAccessTokenInvalid);
-        }
+      // 'openid' is defined as a required input argument in WeChat API doc, but it does not necessarily to
+      // be the return value from getAccessToken per testing.
+      // In another word, 'openid' is required but the response of getUserInfo is consistent as long as
+      // access_token is valid.
+      // We are expecting to get 41009 'missing openid' response according to the developers doc, but the
+      // fact is that we still got 40001 'invalid credentials' response.
 
-        throw new Error(errmsg);
-      }
+      // Response properties of user info can be separated into two groups: (1) {unionid, headimgurl, nickname}, (2) {errcode, errmsg}.
+      // These two groups are mutually exclusive: if group (1) is not empty, group (2) should be empty and vice versa.
+      // 'errmsg' and 'errcode' turn to be non-empty values or empty values at the same time. Hence, if 'errmsg' is non-empty then 'errcode' should be non-empty.
+
+      assert(errcode === 40_001, new ConnectorError(ConnectorErrorCodes.SocialAccessTokenInvalid));
+      assert(!errcode, new Error(errmsg));
+      assert(openid, new Error(errmsg));
 
       return { id: unionid ?? openid, avatar: headimgurl, name: nickname };
     } catch (error: unknown) {
-      if (error instanceof GotRequestError && error.response?.statusCode === 401) {
-        throw new ConnectorError(ConnectorErrorCodes.SocialAccessTokenInvalid);
-      }
+      assert(
+        error instanceof GotRequestError && error.response?.statusCode === 401,
+        new ConnectorError(ConnectorErrorCodes.SocialAccessTokenInvalid)
+      );
 
       throw error;
     }

--- a/packages/connector-wechat/src/index.ts
+++ b/packages/connector-wechat/src/index.ts
@@ -101,14 +101,14 @@ export default class WeChatConnector implements SocialConnector {
       // These two groups are mutually exclusive: if group (1) is not empty, group (2) should be empty and vice versa.
       // 'errmsg' and 'errcode' turn to be non-empty values or empty values at the same time. Hence, if 'errmsg' is non-empty then 'errcode' should be non-empty.
 
-      assert(errcode === 40_001, new ConnectorError(ConnectorErrorCodes.SocialAccessTokenInvalid));
+      assert(errcode !== 40_001, new ConnectorError(ConnectorErrorCodes.SocialAccessTokenInvalid));
       assert(!errcode, new Error(errmsg));
       assert(openid, new Error(errmsg));
 
       return { id: unionid ?? openid, avatar: headimgurl, name: nickname };
     } catch (error: unknown) {
       assert(
-        error instanceof GotRequestError && error.response?.statusCode === 401,
+        !(error instanceof GotRequestError && error.response?.statusCode === 401),
         new ConnectorError(ConnectorErrorCodes.SocialAccessTokenInvalid)
       );
 

--- a/packages/connector-wechat/src/index.ts
+++ b/packages/connector-wechat/src/index.ts
@@ -81,6 +81,7 @@ export default class WeChatConnector implements SocialConnector {
 
   public getUserInfo: GetUserInfo = async (accessTokenObject) => {
     const { accessToken, openid } = accessTokenObject;
+    assert(openid, new Error('`openid` is required for WeChat API.'));
 
     try {
       const { unionid, headimgurl, nickname, errcode, errmsg } = await got
@@ -103,7 +104,6 @@ export default class WeChatConnector implements SocialConnector {
 
       assert(errcode !== 40_001, new ConnectorError(ConnectorErrorCodes.SocialAccessTokenInvalid));
       assert(!errcode, new Error(errmsg));
-      assert(openid, new Error(errmsg));
 
       return { id: unionid ?? openid, avatar: headimgurl, name: nickname };
     } catch (error: unknown) {

--- a/packages/core/src/routes/connector.ts
+++ b/packages/core/src/routes/connector.ts
@@ -124,9 +124,7 @@ export default function connectorRoutes<T extends AuthedRouter>(router: T) {
     '/connectors/:id',
     koaGuard({
       params: object({ id: string().min(1) }),
-      body: Connectors.createGuard
-        .omit({ id: true, type: true, enabled: true, createdAt: true })
-        .partial(),
+      body: Connectors.createGuard.omit({ id: true, enabled: true, createdAt: true }).partial(),
     }),
     async (ctx, next) => {
       const {

--- a/packages/core/src/routes/connector.update.test.ts
+++ b/packages/core/src/routes/connector.update.test.ts
@@ -1,0 +1,281 @@
+import { ConnectorError, ConnectorErrorCodes, ValidateConfig } from '@logto/connector-types';
+import { Connector, ConnectorType } from '@logto/schemas';
+
+import { mockConnectorInstanceList, mockMetadata, mockConnector } from '@/__mocks__';
+import { ConnectorMetadata } from '@/connectors/types';
+import RequestError from '@/errors/RequestError';
+import { updateConnector } from '@/queries/connector';
+import assertThat from '@/utils/assert-that';
+import { createRequester } from '@/utils/test-utils';
+
+import connectorRoutes from './connector';
+
+type ConnectorInstance = {
+  connector: Connector;
+  metadata: ConnectorMetadata;
+  validateConfig?: ValidateConfig;
+  sendMessage?: unknown;
+};
+
+const getConnectorInstancesPlaceHolder = jest.fn() as jest.MockedFunction<
+  () => Promise<ConnectorInstance[]>
+>;
+const getConnectorInstanceByIdPlaceHolder = jest.fn(async (connectorId: string) => {
+  const connectorInstances = await getConnectorInstancesPlaceHolder();
+  const connector = connectorInstances.find(({ connector }) => connector.id === connectorId);
+  assertThat(
+    connector,
+    new RequestError({
+      code: 'entity.not_found',
+      connectorId,
+      status: 404,
+    })
+  );
+
+  return {
+    ...connector,
+    validateConfig: validateConfigPlaceHolder,
+    sendMessage: sendMessagePlaceHolder,
+  };
+});
+const validateConfigPlaceHolder = jest.fn();
+const sendMessagePlaceHolder = jest.fn();
+
+jest.mock('@/queries/connector', () => ({
+  updateConnector: jest.fn(),
+}));
+jest.mock('@/connectors', () => ({
+  getConnectorInstances: async () => getConnectorInstancesPlaceHolder(),
+  getConnectorInstanceById: async (connectorId: string) =>
+    getConnectorInstanceByIdPlaceHolder(connectorId),
+}));
+
+describe('connector PATCH routes', () => {
+  const connectorRequest = createRequester({ authedRoutes: connectorRoutes });
+
+  describe('PATCH /connectors/:id/enabled', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('throws if connector can not be found (locally)', async () => {
+      getConnectorInstancesPlaceHolder.mockResolvedValueOnce(mockConnectorInstanceList.slice(1));
+      const response = await connectorRequest
+        .patch('/connectors/findConnector/enabled')
+        .send({ enabled: true });
+      expect(response).toHaveProperty('statusCode', 404);
+    });
+
+    it('throws if connector can not be found (remotely)', async () => {
+      getConnectorInstancesPlaceHolder.mockResolvedValueOnce([]);
+      const response = await connectorRequest
+        .patch('/connectors/id0/enabled')
+        .send({ enabled: true });
+      expect(response).toHaveProperty('statusCode', 404);
+    });
+
+    it('enables one of the social connectors (with valid config)', async () => {
+      getConnectorInstancesPlaceHolder.mockResolvedValueOnce([
+        {
+          connector: mockConnector,
+          metadata: { ...mockMetadata, type: ConnectorType.Social },
+        },
+      ]);
+      const response = await connectorRequest
+        .patch('/connectors/id/enabled')
+        .send({ enabled: true });
+      expect(updateConnector).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'id' },
+          set: { enabled: true },
+        })
+      );
+      expect(response.body).toMatchObject({
+        metadata: { ...mockMetadata, type: ConnectorType.Social },
+      });
+      expect(response).toHaveProperty('statusCode', 200);
+    });
+
+    it('enables one of the social connectors (with invalid config)', async () => {
+      validateConfigPlaceHolder.mockImplementationOnce(async () => {
+        throw new ConnectorError(ConnectorErrorCodes.InvalidConfig);
+      });
+      getConnectorInstancesPlaceHolder.mockResolvedValueOnce([
+        {
+          connector: mockConnector,
+          metadata: mockMetadata,
+        },
+      ]);
+      const response = await connectorRequest
+        .patch('/connectors/id/enabled')
+        .send({ enabled: true });
+      expect(response).toHaveProperty('statusCode', 500);
+    });
+
+    it('disables one of the social connectors', async () => {
+      getConnectorInstancesPlaceHolder.mockResolvedValueOnce([
+        {
+          connector: mockConnector,
+          metadata: mockMetadata,
+        },
+      ]);
+      const response = await connectorRequest
+        .patch('/connectors/id/enabled')
+        .send({ enabled: false });
+      expect(updateConnector).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'id' },
+          set: { enabled: false },
+        })
+      );
+      expect(response.body).toMatchObject({
+        metadata: mockMetadata,
+      });
+      expect(response).toHaveProperty('statusCode', 200);
+    });
+
+    it('enables one of the email/sms connectors (with valid config)', async () => {
+      getConnectorInstancesPlaceHolder.mockResolvedValueOnce(mockConnectorInstanceList);
+      const mockedMetadata = {
+        ...mockMetadata,
+        id: 'id1',
+        type: ConnectorType.SMS,
+      };
+      const mockedConnector = {
+        ...mockConnector,
+        id: 'id1',
+      };
+      getConnectorInstanceByIdPlaceHolder.mockResolvedValueOnce({
+        connector: mockedConnector,
+        metadata: mockedMetadata,
+        validateConfig: jest.fn(),
+        sendMessage: jest.fn(),
+      });
+      const response = await connectorRequest
+        .patch('/connectors/id1/enabled')
+        .send({ enabled: true });
+      expect(response).toHaveProperty('statusCode', 200);
+      expect(updateConnector).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          where: { id: 'id1' },
+          set: { enabled: false },
+        })
+      );
+      expect(updateConnector).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          where: { id: 'id5' },
+          set: { enabled: false },
+        })
+      );
+      expect(updateConnector).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({
+          where: { id: 'id1' },
+          set: { enabled: true },
+        })
+      );
+      expect(response.body).toMatchObject({
+        metadata: mockedMetadata,
+      });
+    });
+
+    it('enables one of the email/sms connectors (with invalid config)', async () => {
+      validateConfigPlaceHolder.mockImplementationOnce(async () => {
+        throw new ConnectorError(ConnectorErrorCodes.InvalidConfig);
+      });
+      getConnectorInstancesPlaceHolder.mockResolvedValueOnce([
+        {
+          connector: mockConnector,
+          metadata: {
+            ...mockMetadata,
+            type: ConnectorType.SMS,
+          },
+        },
+      ]);
+      const response = await connectorRequest
+        .patch('/connectors/id/enabled')
+        .send({ enabled: true });
+      expect(response).toHaveProperty('statusCode', 500);
+    });
+
+    it('disables one of the email/sms connectors', async () => {
+      getConnectorInstancesPlaceHolder.mockResolvedValueOnce([
+        {
+          connector: mockConnector,
+          metadata: mockMetadata,
+        },
+      ]);
+      const response = await connectorRequest
+        .patch('/connectors/id/enabled')
+        .send({ enabled: false });
+      expect(updateConnector).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'id' },
+          set: { enabled: false },
+        })
+      );
+      expect(response.body).toMatchObject({
+        metadata: mockMetadata,
+      });
+      expect(response).toHaveProperty('statusCode', 200);
+    });
+  });
+
+  describe('PATCH /connectors/:id', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('throws when connector can not be found by given connectorId (locally)', async () => {
+      getConnectorInstancesPlaceHolder.mockResolvedValueOnce(mockConnectorInstanceList.slice(0, 1));
+      const response = await connectorRequest.patch('/connectors/findConnector').send({});
+      expect(response).toHaveProperty('statusCode', 404);
+    });
+
+    it('throws when connector can not be found by given connectorId (remotely)', async () => {
+      getConnectorInstancesPlaceHolder.mockResolvedValueOnce([]);
+      const response = await connectorRequest.patch('/connectors/id0').send({});
+      expect(response).toHaveProperty('statusCode', 404);
+    });
+
+    it('config validation fails', async () => {
+      validateConfigPlaceHolder.mockImplementationOnce(async () => {
+        throw new ConnectorError(ConnectorErrorCodes.InvalidConfig);
+      });
+      getConnectorInstancesPlaceHolder.mockResolvedValueOnce([
+        {
+          connector: mockConnector,
+          metadata: mockMetadata,
+        },
+      ]);
+      const response = await connectorRequest
+        .patch('/connectors/id')
+        .send({ config: { cliend_id: 'client_id', client_secret: 'client_secret' } });
+      expect(response).toHaveProperty('statusCode', 500);
+    });
+
+    it('successfully updates connector configs', async () => {
+      getConnectorInstancesPlaceHolder.mockResolvedValueOnce([
+        {
+          connector: mockConnector,
+          metadata: mockMetadata,
+        },
+      ]);
+      const response = await connectorRequest
+        .patch('/connectors/id')
+        .send({ config: { cliend_id: 'client_id', client_secret: 'client_secret' } });
+      expect(updateConnector).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'id' },
+          set: { config: { cliend_id: 'client_id', client_secret: 'client_secret' } },
+        })
+      );
+      expect(response.body).toMatchObject({
+        metadata: mockMetadata,
+      });
+      expect(response).toHaveProperty('statusCode', 200);
+    });
+  });
+});


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
1. Separate connector route UTs to make each testing file under 300 lines.
2. Fix WeChat Web and WeChat Native connector error handler of getUserInfo() to fit the max-complexity of 5 for each code block.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2405

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Passed UTs.
