### PR TITLE
fix(connector-github): convert `null` value to `undefined` in user info response

### DIFF
--- a/packages/connector-github/src/index.ts
+++ b/packages/connector-github/src/index.ts
@@ -9,7 +9,7 @@ import {
   SocialConnector,
   GetConnectorConfig,
 } from '@logto/connector-types';
-import { assert } from '@silverhand/essentials';
+import { assert, conditional } from '@silverhand/essentials';
 import got, { RequestError as GotRequestError } from 'got';
 
 import {
@@ -90,9 +90,9 @@ export default class GithubConnector implements SocialConnector {
 
       return {
         id: String(id),
-        avatar,
-        email,
-        name,
+        avatar: conditional(avatar),
+        email: conditional(email),
+        name: conditional(name),
       };
     } catch (error: unknown) {
       if (error instanceof GotRequestError && error.response?.statusCode === 401) {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Our GitHub universal sign-in flow will be failed when the user info response contains a `null` value.
<img width="1114" alt="image" src="https://user-images.githubusercontent.com/10806653/170171407-272de073-4a98-4fd2-9f52-a0235f848ff4.png">

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
N/A

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT
