### PR TITLE
fix(core): prevent session lost for bind social

### DIFF
--- a/packages/core/src/lib/session.ts
+++ b/packages/core/src/lib/session.ts
@@ -9,9 +9,24 @@ export const assignInteractionResults = async (
   result: InteractionResults,
   merge = false
 ) => {
-  const redirectTo = await provider.interactionResult(ctx.req, ctx.res, result, {
-    mergeWithLastSubmission: merge,
-  });
+  // The "mergeWithLastSubmission" will only merge current request's interfaction results,
+  // which is stored in ctx.oidc, we need to merge interaction results in two requests,
+  // have to do it manually
+  // refer to: https://github.com/panva/node-oidc-provider/blob/c243bf6b6663c41ff3e75c09b95fb978eba87381/lib/actions/authorization/interactions.js#L106
+  const details = merge ? await provider.interactionDetails(ctx.req, ctx.res) : undefined;
+
+  const redirectTo = await provider.interactionResult(
+    ctx.req,
+    ctx.res,
+    {
+      // Merge with current result
+      ...details?.result,
+      ...result,
+    },
+    {
+      mergeWithLastSubmission: merge,
+    }
+  );
   ctx.body = { redirectTo };
 };
 

--- a/packages/core/src/routes/session.ts
+++ b/packages/core/src/routes/session.ts
@@ -80,7 +80,7 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
       const { id } = await findUserByUsernameAndPassword(username, password);
       ctx.log(type, { userId: id });
       await updateLastSignInAt(id);
-      await assignInteractionResults(ctx, provider, { login: { accountId: id } });
+      await assignInteractionResults(ctx, provider, { login: { accountId: id } }, true);
 
       return next();
     }
@@ -128,7 +128,7 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
       ctx.log(type, { userId: id });
 
       await updateLastSignInAt(id);
-      await assignInteractionResults(ctx, provider, { login: { accountId: id } });
+      await assignInteractionResults(ctx, provider, { login: { accountId: id } }, true);
 
       return next();
     }
@@ -176,7 +176,7 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
       ctx.log(type, { userId: id });
 
       await updateLastSignInAt(id);
-      await assignInteractionResults(ctx, provider, { login: { accountId: id } });
+      await assignInteractionResults(ctx, provider, { login: { accountId: id } }, true);
 
       return next();
     }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Flow: bind a social account to existing user (sign in with other methods).

The social info is stored in session, after signing in with other methods, those info will be overwritten, causing a "session not found" error. (Please see LOG-2685 for details)
Now change to "merge" and fixed this issue.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested with account "xyj".

@logto-io/eng 
