### PR TITLE
fix(console): hide split line when username is empty

### DIFF
--- a/packages/console/src/pages/UserDetails/index.module.scss
+++ b/packages/console/src/pages/UserDetails/index.module.scss
@@ -29,8 +29,8 @@
       display: flex;
       align-items: center;
 
-      > *:not(:first-child) {
-        margin-left: _.unit(2);
+      > *:not(:last-child) {
+        margin-right: _.unit(2);
       }
     }
 

--- a/packages/console/src/pages/UserDetails/index.tsx
+++ b/packages/console/src/pages/UserDetails/index.tsx
@@ -121,8 +121,12 @@ const UserDetails = () => {
             <div className={styles.metadata}>
               <div className={styles.name}>{data.name ?? '-'}</div>
               <div>
-                <div className={styles.username}>{data.username}</div>
-                <div className={styles.verticalBar} />
+                {data.username && (
+                  <>
+                    <div className={styles.username}>{data.username}</div>
+                    <div className={styles.verticalBar} />
+                  </>
+                )}
                 <div className={styles.text}>User ID</div>
                 <CopyToClipboard value={data.id} className={styles.copy} />
               </div>


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

User Details: hide split line when username is empty, and fix paddings.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2530

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

<img width="473" alt="截屏2022-05-25 下午3 47 28" src="https://user-images.githubusercontent.com/5717882/170209608-e838301d-5b0b-4683-bd50-511c881e9934.png">

<img width="482" alt="截屏2022-05-25 下午3 47 36" src="https://user-images.githubusercontent.com/5717882/170209632-408f9c80-62e4-461e-a0bb-567fc2436adc.png">

