### PR TITLE
fix(console): reduce refresh frequency in preview

### DIFF
--- a/packages/console/src/pages/SignInExperience/components/GuideModal.tsx
+++ b/packages/console/src/pages/SignInExperience/components/GuideModal.tsx
@@ -1,5 +1,5 @@
 import { SignInExperience } from '@logto/schemas';
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import Modal from 'react-modal';
@@ -15,6 +15,7 @@ import useAdminConsoleConfigs from '@/hooks/use-configs';
 import Close from '@/icons/Close';
 import * as modalStyles from '@/scss/modal.module.scss';
 
+import usePreviewConfigs from '../hooks';
 import { SignInExperienceForm } from '../types';
 import { signInExperienceParser } from '../utilities';
 import BrandingForm from './BrandingForm';
@@ -43,13 +44,7 @@ const GuideModal = ({ isOpen, onClose }: Props) => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const formData = watch();
 
-  const previewConfigs = useMemo(() => {
-    if (!isDirty) {
-      return data;
-    }
-
-    return signInExperienceParser.toRemoteModel(formData);
-  }, [formData, isDirty, data]);
+  const previewConfigs = usePreviewConfigs(formData, isDirty, data);
 
   useEffect(() => {
     if (data && !isDirty) {

--- a/packages/console/src/pages/SignInExperience/components/GuideModal.tsx
+++ b/packages/console/src/pages/SignInExperience/components/GuideModal.tsx
@@ -1,5 +1,5 @@
 import { SignInExperience } from '@logto/schemas';
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import Modal from 'react-modal';
@@ -36,12 +36,20 @@ const GuideModal = ({ isOpen, onClose }: Props) => {
   const {
     reset,
     handleSubmit,
-    formState: { isSubmitting },
+    formState: { isSubmitting, isDirty },
     watch,
   } = methods;
   const api = useApi();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const formData = watch();
+
+  const previewConfigs = useMemo(() => {
+    if (!isDirty) {
+      return data;
+    }
+
+    return signInExperienceParser.toRemoteModel(formData);
+  }, [formData, isDirty, data]);
 
   useEffect(() => {
     if (data) {
@@ -114,10 +122,7 @@ const GuideModal = ({ isOpen, onClose }: Props) => {
                   </div>
                 </div>
                 {formData.id && (
-                  <Preview
-                    signInExperience={signInExperienceParser.toRemoteModel(formData)}
-                    className={styles.preview}
-                  />
+                  <Preview signInExperience={previewConfigs} className={styles.preview} />
                 )}
               </div>
               <div className={styles.footer}>

--- a/packages/console/src/pages/SignInExperience/components/GuideModal.tsx
+++ b/packages/console/src/pages/SignInExperience/components/GuideModal.tsx
@@ -52,10 +52,10 @@ const GuideModal = ({ isOpen, onClose }: Props) => {
   }, [formData, isDirty, data]);
 
   useEffect(() => {
-    if (data) {
+    if (data && !isDirty) {
       reset(signInExperienceParser.toLocalForm(data));
     }
-  }, [data, reset]);
+  }, [data, reset, isDirty]);
 
   const onGotIt = async () => {
     if (!configs) {

--- a/packages/console/src/pages/SignInExperience/components/Preview.tsx
+++ b/packages/console/src/pages/SignInExperience/components/Preview.tsx
@@ -15,7 +15,7 @@ import { RequestError } from '@/hooks/use-api';
 import * as styles from './Preview.module.scss';
 
 type Props = {
-  signInExperience: SignInExperience;
+  signInExperience?: SignInExperience;
   className?: string;
 };
 
@@ -28,7 +28,7 @@ const Preview = ({ signInExperience, className }: Props) => {
   const previewRef = useRef<HTMLIFrameElement>(null);
 
   const config = useMemo(() => {
-    if (!allConnectors) {
+    if (!allConnectors || !signInExperience) {
       return;
     }
 

--- a/packages/console/src/pages/SignInExperience/hooks.ts
+++ b/packages/console/src/pages/SignInExperience/hooks.ts
@@ -1,0 +1,21 @@
+import { SignInExperience } from '@logto/schemas';
+import { useMemo } from 'react';
+
+import { SignInExperienceForm } from './types';
+import { signInExperienceParser } from './utilities';
+
+const usePreviewConfigs = (
+  formData: SignInExperienceForm,
+  isDirty: boolean,
+  data?: SignInExperience
+) => {
+  return useMemo(() => {
+    if (!isDirty) {
+      return data;
+    }
+
+    return signInExperienceParser.toRemoteModel(formData);
+  }, [formData, isDirty, data]);
+};
+
+export default usePreviewConfigs;

--- a/packages/console/src/pages/SignInExperience/index.tsx
+++ b/packages/console/src/pages/SignInExperience/index.tsx
@@ -1,6 +1,6 @@
 import { SignInExperience as SignInExperienceType } from '@logto/schemas';
 import classNames from 'classnames';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
@@ -41,10 +41,18 @@ const SignInExperience = () => {
     handleSubmit,
     getValues,
     watch,
-    formState: { isSubmitting },
+    formState: { isSubmitting, isDirty },
   } = methods;
   const api = useApi();
   const formData = watch();
+
+  const previewConfigs = useMemo(() => {
+    if (!isDirty) {
+      return data;
+    }
+
+    return signInExperienceParser.toRemoteModel(formData);
+  }, [formData, isDirty, data]);
 
   useEffect(() => {
     if (data) {
@@ -138,7 +146,7 @@ const SignInExperience = () => {
           )}
         </Card>
       </div>
-      {formData.id && <Preview signInExperience={signInExperienceParser.toRemoteModel(formData)} />}
+      {formData.id && <Preview signInExperience={previewConfigs} />}
       {data && (
         <ReactModal
           isOpen={Boolean(dataToCompare)}

--- a/packages/console/src/pages/SignInExperience/index.tsx
+++ b/packages/console/src/pages/SignInExperience/index.tsx
@@ -1,6 +1,6 @@
 import { SignInExperience as SignInExperienceType } from '@logto/schemas';
 import classNames from 'classnames';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
@@ -24,6 +24,7 @@ import SaveAlert from './components/SaveAlert';
 import SignInMethodsForm from './components/SignInMethodsForm';
 import TermsForm from './components/TermsForm';
 import Welcome from './components/Welcome';
+import usePreviewConfigs from './hooks';
 import * as styles from './index.module.scss';
 import { SignInExperienceForm } from './types';
 import { compareSignInMethods, signInExperienceParser } from './utilities';
@@ -46,13 +47,7 @@ const SignInExperience = () => {
   const api = useApi();
   const formData = watch();
 
-  const previewConfigs = useMemo(() => {
-    if (!isDirty) {
-      return data;
-    }
-
-    return signInExperienceParser.toRemoteModel(formData);
-  }, [formData, isDirty, data]);
+  const previewConfigs = usePreviewConfigs(formData, isDirty, data);
 
   useEffect(() => {
     if (data && !isDirty) {

--- a/packages/console/src/pages/SignInExperience/index.tsx
+++ b/packages/console/src/pages/SignInExperience/index.tsx
@@ -55,10 +55,10 @@ const SignInExperience = () => {
   }, [formData, isDirty, data]);
 
   useEffect(() => {
-    if (data) {
+    if (data && !isDirty) {
       reset(signInExperienceParser.toLocalForm(data));
     }
-  }, [data, reset]);
+  }, [data, reset, isDirty]);
 
   const saveData = async () => {
     const updatedData = await api


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Pass form data to preview box only when form is dirty, otherwise, use remote data directly.

This can reduce "postMessage" frequency to avoid unexpected refresh.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested, change one form value, and count postMessage calls:

before:

<img width="304" alt="截屏2022-05-25 下午5 40 27" src="https://user-images.githubusercontent.com/5717882/170232600-d749b877-57b2-41d8-91a6-200425fff8fa.png">

after reduce:

<img width="233" alt="image" src="https://user-images.githubusercontent.com/5717882/170230640-39353a4f-265a-4e30-a796-0708c5567624.png">
