### PR TITLE
fix(ui): social bind account should back to sign-in page

### DIFF
--- a/packages/ui/src/hooks/use-social.ts
+++ b/packages/ui/src/hooks/use-social.ts
@@ -29,6 +29,7 @@ const useSocial = () => {
       'user.identity_not_exists': (error) => {
         if (parameters.connector) {
           navigate(`/social-register/${parameters.connector}`, {
+            replace: true,
             state: {
               ...(error.data as Record<string, unknown> | undefined),
             },
@@ -129,8 +130,11 @@ const useSocial = () => {
     const { platform, callbackLink } = decodedState;
 
     if (platform === 'web') {
-      window.location.assign(
-        new URL(`${location.origin}/sign-in/callback/${connectorId}/${window.location.search}`)
+      navigate(
+        new URL(`${location.origin}/sign-in/callback/${connectorId}/${window.location.search}`),
+        {
+          replace: true,
+        }
       );
 
       return;
@@ -142,7 +146,7 @@ const useSocial = () => {
     }
 
     window.location.assign(new URL(`${callbackLink}${window.location.search}`));
-  }, [parameters.connector, setToast, t]);
+  }, [navigate, parameters.connector, setToast, t]);
 
   // Social Sign-In Callback Handler
   useEffect(() => {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Social bind account should back to sign-in page

Fix the social nav flow:

Before:
web/moweb:   `sign-in` -push-> `social` -replace-> `callback` -push-> `sign-in/callback` -push-> `bind-social`
native: `sign-in` -push-> `social` -> `SDK`  -push->   `sign-in/callback` -push-> `bind-social`

After:
web/moweb: `sign-in` -push-> `social` -replace-> `callback` -replace-> `sign-in/callback` -replace-> `bind-social`
native: `sign-in` -push-> `social` -> `SDK`  -push->   `sign-in/callback` -replace-> `bind-social`

Always keep the history stack only have `sign-in` and the current page. 


<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
@logto-io/eng 
