### PR TITLE
fix(core): update proxy guard middleware

### DIFF
--- a/packages/core/src/middleware/koa-proxy-guard.ts
+++ b/packages/core/src/middleware/koa-proxy-guard.ts
@@ -1,14 +1,12 @@
-import fs from 'fs/promises';
-import path from 'path';
-
 import { MiddlewareType } from 'koa';
 import { IRouterParamContext } from 'koa-router';
 import { Provider } from 'oidc-provider';
 
 import { MountedApps } from '@/env-set';
-import { fromRoot } from '@/env-set/parameters';
 
+// Need To Align With UI
 export const sessionNotFoundPath = '/unknown-session';
+export const guardedPath = ['/sign-in', '/register', '/social-register'];
 
 export default function koaSpaSessionGuard<
   StateT,
@@ -17,8 +15,6 @@ export default function koaSpaSessionGuard<
 >(provider: Provider): MiddlewareType<StateT, ContextT, ResponseBodyT> {
   return async (ctx, next) => {
     const requestPath = ctx.request.path;
-    const packagesPath = fromRoot ? 'packages/' : '..';
-    const clientPath = path.join(packagesPath, 'ui', 'dist');
 
     // Empty path Redirect
     if (requestPath === '/') {
@@ -27,22 +23,11 @@ export default function koaSpaSessionGuard<
       return next();
     }
 
-    // Check client routes session status only
-    if (Object.values(MountedApps).some((app) => requestPath.startsWith(`/${app}`))) {
-      return next();
-    }
-
-    // Client session guard
-    try {
-      await provider.interactionDetails(ctx.req, ctx.res);
-    } catch {
-      const spaDistFiles = await fs.readdir(clientPath);
-
-      if (
-        !spaDistFiles.some((file) => requestPath.startsWith('/' + file)) &&
-        !ctx.request.path.endsWith(sessionNotFoundPath) &&
-        !ctx.request.URL.searchParams.get('preview') // Should not check session on preview mode
-      ) {
+    // Session guard
+    if (guardedPath.some((path) => requestPath.startsWith(path))) {
+      try {
+        await provider.interactionDetails(ctx.req, ctx.res);
+      } catch {
         ctx.redirect(sessionNotFoundPath);
       }
     }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Update proxy guard middleware. As we continuously find edge cases for session guard route requests:

1. social callback page
2. static files request

Instead of by default guarding all incoming routes excluding provided exceptions, only protect the provided paths.


<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
ut case updated

@logto-io/eng 
