### PR TITLE
fix(core): fix preview session not found bug

### DIFF
--- a/packages/core/src/middleware/koa-proxy-guard.ts
+++ b/packages/core/src/middleware/koa-proxy-guard.ts
@@ -24,10 +24,10 @@ export default function koaSpaSessionGuard<
     }
 
     // Session guard
-    if (
-      guardedPath.some((path) => requestPath.startsWith(path)) &&
-      !ctx.request.URL.searchParams.get('preview')
-    ) {
+    const isPreview = ctx.request.URL.searchParams.get('preview');
+    const isSessionRequiredPath = guardedPath.some((path) => requestPath.startsWith(path));
+
+    if (isSessionRequiredPath && !isPreview) {
       try {
         await provider.interactionDetails(ctx.req, ctx.res);
       } catch {

--- a/packages/core/src/middleware/koa-proxy-guard.ts
+++ b/packages/core/src/middleware/koa-proxy-guard.ts
@@ -24,7 +24,10 @@ export default function koaSpaSessionGuard<
     }
 
     // Session guard
-    if (guardedPath.some((path) => requestPath.startsWith(path))) {
+    if (
+      guardedPath.some((path) => requestPath.startsWith(path)) &&
+      !ctx.request.URL.searchParams.get('preview')
+    ) {
       try {
         await provider.interactionDetails(ctx.req, ctx.res);
       } catch {


### PR DESCRIPTION


<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
fix preview session not found bug
<img width="493" alt="image" src="https://user-images.githubusercontent.com/36393111/170646284-4bac8af5-951e-4590-98c2-2f943d75169e.png">

preview query string filter is mistakenly removed on the session guard refactor PR

add it back

<img width="988" alt="image" src="https://user-images.githubusercontent.com/36393111/170646374-26d8c69f-5a08-4b8c-8ca7-7e7f80339863.png">

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
@logto-io/eng 
