### PR TITLE
fix(console): error callstack content should not overflow container

### DIFF
--- a/packages/console/src/components/AppError/index.module.scss
+++ b/packages/console/src/components/AppError/index.module.scss
@@ -54,5 +54,6 @@
     font: var(--font-body-medium);
     padding: _.unit(6);
     white-space: pre-wrap;
+    word-break: break-all;
   }
 }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fix the issue that long text content in error callstack would overflow the container width.

Before:
<img width="596" alt="image" src="https://user-images.githubusercontent.com/12833674/170833797-909d5eb4-75f7-4b2d-9dc4-0bc9f87fa6bf.png">

After:
<img width="551" alt="image" src="https://user-images.githubusercontent.com/12833674/170833813-f2d3ef5a-86de-44ff-a718-bb312a5ff4a6.png">


<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x]: screenshot attached
