### PR TITLE
refactor(console): handle user navigates to 'callback' after authenticated

### DIFF
--- a/packages/console/src/pages/Callback/index.tsx
+++ b/packages/console/src/pages/Callback/index.tsx
@@ -1,12 +1,24 @@
 import { LogtoError, OidcError, useHandleSignInCallback } from '@logto/react';
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import AppError from '@/components/AppError';
 import LogtoLoading from '@/components/LogtoLoading';
 import { getBasename } from '@/utilities/app';
 
 const Callback = () => {
-  const { error } = useHandleSignInCallback(getBasename());
+  const { error, isAuthenticated } = useHandleSignInCallback(getBasename());
+  const navigate = useNavigate();
+
+  /**
+   * Redirect back to the home page if the user is already authenticated.
+   * Corner case when user mistakenly navigate to `/callback` route after a successful authentication.
+   */
+  useEffect(() => {
+    if (isAuthenticated) {
+      navigate('/');
+    }
+  }, [isAuthenticated, navigate]);
 
   if (error) {
     const errorCode =


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
In Admin Console, if the user mistakenly / manually navigates to `/callback` route after a successful authentication, we should navigate the user back to home page, instead of stuck in `Navigating…` state.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Manually navigated to `/callback` route after authenticated, I was navigated back to `/console/get-started` page
