### PR TITLE
fix(console,core): only show enabled connectors in sign in methods

### DIFF
--- a/packages/console/src/pages/SignInExperience/components/ConnectorsTransfer.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/ConnectorsTransfer.module.scss
@@ -1,9 +1,5 @@
 @use '@/scss/underscore' as _;
 
-.disabled {
-  color: var(--color-disabled);
-}
-
 .title {
   display: flex;
   align-items: center;

--- a/packages/console/src/pages/SignInExperience/components/ConnectorsTransfer.tsx
+++ b/packages/console/src/pages/SignInExperience/components/ConnectorsTransfer.tsx
@@ -1,5 +1,4 @@
 import { ConnectorType } from '@logto/schemas';
-import { conditionalString } from '@silverhand/essentials';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
@@ -33,17 +32,15 @@ const ConnectorsTransfer = ({ value, onChange }: Props) => {
   const datasource = data
     ? data
         .filter(({ type }) => type === ConnectorType.Social)
-        .map(({ target, name, enabled, connectors, logo }) => ({
+        .filter(({ enabled }) => enabled)
+        .map(({ target, name, connectors, logo }) => ({
           value: target,
           title: (
             <div className={styles.title}>
               <div className={styles.logo}>
                 <img src={logo} alt={target} />
               </div>
-              <UnnamedTrans
-                resource={name}
-                className={conditionalString(!enabled && styles.disabled)}
-              />
+              <UnnamedTrans resource={name} />
               {connectors.length > 1 &&
                 connectors
                   .filter(({ enabled }) => enabled)

--- a/packages/core/src/routes/sign-in-settings.ts
+++ b/packages/core/src/routes/sign-in-settings.ts
@@ -15,7 +15,7 @@ export default function signInSettingsRoutes<T extends AnonymousRouter>(router: 
       Array<ConnectorMetadata & { id: string }>
     >((previous, connectorTarget) => {
       const connectors = connectorInstances.filter(
-        ({ metadata: { target } }) => target === connectorTarget
+        ({ metadata: { target }, connector: { enabled } }) => target === connectorTarget && enabled
       );
 
       return [


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Only show enabled(configured) connector targets in sign in methods.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2733

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested.
