### PR TITLE
fix(console): show enabled platforms in detail tab

### DIFF
--- a/packages/console/src/pages/ConnectorDetails/components/ConnectorTabs/index.module.scss
+++ b/packages/console/src/pages/ConnectorDetails/components/ConnectorTabs/index.module.scss
@@ -31,11 +31,5 @@
       margin-right: _.unit(1);
       color: var(--color-text-link);
     }
-
-    .notSet {
-      color: var(--color-caption);
-      font: var(--font-body-medium);
-      margin-left: _.unit(2);
-    }
   }
 }

--- a/packages/console/src/pages/ConnectorDetails/components/ConnectorTabs/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/components/ConnectorTabs/index.tsx
@@ -1,7 +1,6 @@
 import { ConnectorDTO } from '@logto/schemas';
 import classNames from 'classnames';
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import useSWR from 'swr';
 
@@ -16,7 +15,6 @@ type Props = {
 
 const ConnectorTabs = ({ target, connectorId }: Props) => {
   const { data } = useSWR<ConnectorDTO[]>(`/api/connectors?target=${target}`);
-  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
   if (!data) {
     return null;
@@ -24,23 +22,22 @@ const ConnectorTabs = ({ target, connectorId }: Props) => {
 
   return (
     <div className={styles.tabs}>
-      {data.map((connector) => (
-        <Link
-          key={connector.id}
-          to={`/connectors/${connector.id}`}
-          className={classNames(styles.tab, connector.id === connectorId && styles.active)}
-        >
-          {connector.platform && (
-            <div className={styles.icon}>
-              <ConnectorPlatformIcon platform={connector.platform} />
-            </div>
-          )}
-          {connector.platform}
-          {!connector.enabled && (
-            <div className={styles.notSet}>{t('connector_details.not_set')}</div>
-          )}
-        </Link>
-      ))}
+      {data
+        .filter(({ enabled }) => enabled)
+        .map((connector) => (
+          <Link
+            key={connector.id}
+            to={`/connectors/${connector.id}`}
+            className={classNames(styles.tab, connector.id === connectorId && styles.active)}
+          >
+            {connector.platform && (
+              <div className={styles.icon}>
+                <ConnectorPlatformIcon platform={connector.platform} />
+              </div>
+            )}
+            {connector.platform}
+          </Link>
+        ))}
     </div>
   );
 };

--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -283,7 +283,6 @@ const translation = {
       options_change_sms: 'Change SMS connector',
       more_options: 'MORE OPTIONS',
       connector_deleted: 'The connector has been deleted.',
-      not_set: '(Not set)',
       type_email: 'Email connector',
       type_sms: 'SMS connector',
       type_social: 'Social connector',

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -281,7 +281,6 @@ const translation = {
       options_change_sms: '更换短信服务商',
       more_options: '更多选项',
       connector_deleted: '成功删除连接器。',
-      not_set: '（未设置）',
       type_email: '邮件连接器',
       type_sms: '短信连接器',
       type_social: '社交连接器',


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Now only show enabled platforms in connector details tabs(in top).

And remove old "not set" tag.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2770

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested.
