### PR TITLE
feat(core): make GET /api/swagger.json contain all api routes

### DIFF
--- a/packages/core/src/routes/init.ts
+++ b/packages/core/src/routes/init.ts
@@ -26,11 +26,6 @@ const createRouters = (provider: Provider) => {
   sessionRouter.use(koaLogSession(provider));
   sessionRoutes(sessionRouter, provider);
 
-  const anonymousRouter: AnonymousRouter = new Router();
-  signInSettingsRoutes(anonymousRouter);
-  statusRoutes(anonymousRouter);
-  swaggerRoutes(anonymousRouter);
-
   const authedRouter: AuthedRouter = new Router();
   authedRouter.use(koaAuth());
   applicationRoutes(authedRouter);
@@ -42,6 +37,12 @@ const createRouters = (provider: Provider) => {
   logRoutes(authedRouter);
   roleRoutes(authedRouter);
   dashboardRoutes(authedRouter);
+
+  const anonymousRouter: AnonymousRouter = new Router();
+  signInSettingsRoutes(anonymousRouter);
+  statusRoutes(anonymousRouter);
+  // The swagger.json should contain all API routers.
+  swaggerRoutes(anonymousRouter, [sessionRouter, authedRouter]);
 
   return [sessionRouter, anonymousRouter, authedRouter];
 };

--- a/packages/core/src/routes/init.ts
+++ b/packages/core/src/routes/init.ts
@@ -42,7 +42,7 @@ const createRouters = (provider: Provider) => {
   signInSettingsRoutes(anonymousRouter);
   statusRoutes(anonymousRouter);
   // The swagger.json should contain all API routers.
-  swaggerRoutes(anonymousRouter, [sessionRouter, authedRouter]);
+  swaggerRoutes(anonymousRouter, [sessionRouter, authedRouter, anonymousRouter]);
 
   return [sessionRouter, anonymousRouter, authedRouter];
 };

--- a/packages/core/src/routes/swagger.test.ts
+++ b/packages/core/src/routes/swagger.test.ts
@@ -7,22 +7,55 @@ import { AnonymousRouter, AuthedRouter } from '@/routes/types';
 import swaggerRoutes from './swagger';
 
 describe('swagger api', () => {
+  const authedRouter: AuthedRouter = new Router();
+  authedRouter.get('/mock', () => ({}));
+
   const anonymousRouter: AnonymousRouter = new Router();
-  const anotherRouter: AuthedRouter = new Router();
-  swaggerRoutes(anonymousRouter, [anotherRouter]);
+  swaggerRoutes(anonymousRouter, [authedRouter]);
 
   const app = new Koa();
   app.use(anonymousRouter.routes()).use(anonymousRouter.allowedMethods());
 
   const swaggerRequest = request(app.callback());
 
-  it('GET /swagger.json', async () => {
-    const response = await swaggerRequest.get('/swagger.json');
-    expect(response.status).toEqual(200);
-    expect(response.body).toHaveProperty('openapi');
-    expect(response.body).toHaveProperty('info');
+  describe('GET /swagger.json', () => {
+    it('should contain standard fields', async () => {
+      const response = await swaggerRequest.get('/swagger.json');
+      expect(response.status).toEqual(200);
+      expect(response.body).toMatchObject(
+        expect.objectContaining({
+          /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+          openapi: expect.any(String),
+          info: expect.objectContaining({
+            title: expect.any(String),
+            version: expect.any(String),
+          }),
+          paths: expect.any(Object),
+          /* eslint-enable @typescript-eslint/no-unsafe-assignment */
+        })
+      );
+    });
 
-    // TODO: find a better way to test the paths details should contain api list
-    expect(response.body).toHaveProperty('paths');
+    it('should contain specific paths', async () => {
+      const response = await swaggerRequest.get('/swagger.json');
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const { paths } = response.body;
+
+      expect(Object.entries(paths)).toHaveLength(2);
+      expect(paths).toMatchObject(
+        expect.objectContaining({
+          /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+          '/api/mock': expect.objectContaining({
+            head: expect.anything(),
+            get: expect.anything(),
+          }),
+          '/api/swagger.json': expect.objectContaining({
+            head: expect.anything(),
+            get: expect.anything(),
+          }),
+          /* eslint-enable @typescript-eslint/no-unsafe-assignment */
+        })
+      );
+    });
   });
 });

--- a/packages/core/src/routes/swagger.test.ts
+++ b/packages/core/src/routes/swagger.test.ts
@@ -9,9 +9,12 @@ import swaggerRoutes from './swagger';
 describe('swagger api', () => {
   const authedRouter: AuthedRouter = new Router();
   authedRouter.get('/mock', () => ({}));
+  authedRouter.patch('/mock', () => ({}));
+  authedRouter.post('/mock', () => ({}));
+  authedRouter.delete('/mock', () => ({}));
 
   const anonymousRouter: AnonymousRouter = new Router();
-  swaggerRoutes(anonymousRouter, [authedRouter]);
+  swaggerRoutes(anonymousRouter, [authedRouter, anonymousRouter]);
 
   const app = new Koa();
   app.use(anonymousRouter.routes()).use(anonymousRouter.allowedMethods());
@@ -46,11 +49,12 @@ describe('swagger api', () => {
         expect.objectContaining({
           /* eslint-disable @typescript-eslint/no-unsafe-assignment */
           '/api/mock': expect.objectContaining({
-            head: expect.anything(),
             get: expect.anything(),
+            patch: expect.anything(),
+            post: expect.anything(),
+            delete: expect.anything(),
           }),
           '/api/swagger.json': expect.objectContaining({
-            head: expect.anything(),
             get: expect.anything(),
           }),
           /* eslint-enable @typescript-eslint/no-unsafe-assignment */

--- a/packages/core/src/routes/swagger.test.ts
+++ b/packages/core/src/routes/swagger.test.ts
@@ -1,12 +1,22 @@
-import { createRequester } from '@/utils/test-utils';
+import Koa from 'koa';
+import Router from 'koa-router';
+import request from 'supertest';
 
-import statusRoutes from './status';
+import { AnonymousRouter, AuthedRouter } from '@/routes/types';
+
 import swaggerRoutes from './swagger';
 
 describe('swagger api', () => {
-  const swaggerRequest = createRequester({ anonymousRoutes: [swaggerRoutes, statusRoutes] });
+  const anonymousRouter: AnonymousRouter = new Router();
+  const anotherRouter: AuthedRouter = new Router();
+  swaggerRoutes(anonymousRouter, [anotherRouter]);
 
-  it('GET /swagger', async () => {
+  const app = new Koa();
+  app.use(anonymousRouter.routes()).use(anonymousRouter.allowedMethods());
+
+  const swaggerRequest = request(app.callback());
+
+  it('GET /swagger.json', async () => {
     const response = await swaggerRequest.get('/swagger.json');
     expect(response.status).toEqual(200);
     expect(response.body).toHaveProperty('openapi');

--- a/packages/core/src/routes/swagger.ts
+++ b/packages/core/src/routes/swagger.ts
@@ -12,14 +12,14 @@ type HttpMethod = 'get' | 'head' | 'patch' | 'post' | 'delete';
 type RouteObject = {
   path: string;
   method: HttpMethod;
-  operationObject: OpenAPIV3.OperationObject;
+  operation: OpenAPIV3.OperationObject;
 };
 
 type MethodsObject = Partial<Record<HttpMethod, OpenAPIV3.OperationObject>>;
 
 type PathsObject = Record<string, MethodsObject>;
 
-const buildOperationObject = (stack: IMiddleware[], path: string): OpenAPIV3.OperationObject => {
+const buildOperation = (stack: IMiddleware[], path: string): OpenAPIV3.OperationObject => {
   const guard = stack.find((function_): function_ is WithGuardConfig<IMiddleware> =>
     isGuardMiddleware(function_)
   );
@@ -56,7 +56,7 @@ export default function swaggerRoutes<T extends AnonymousRouter, R extends Route
           .map((method) => ({
             path: `/api${path}`,
             method: method.toLowerCase() as HttpMethod,
-            operationObject: buildOperationObject(stack, path),
+            operation: buildOperation(stack, path),
           }))
       )
     );
@@ -64,14 +64,14 @@ export default function swaggerRoutes<T extends AnonymousRouter, R extends Route
     // Group routes by path
     // eslint-disable-next-line unicorn/prefer-object-from-entries
     const paths = routes.reduce<PathsObject>(
-      (pathsObject, { path, method, operationObject }: RouteObject) => {
+      (pathsObject, { path, method, operation }: RouteObject) => {
         const methodObject = pathsObject[path];
 
         /* eslint-disable @silverhand/fp/no-mutation */
         if (methodObject) {
-          methodObject[method] = operationObject;
+          methodObject[method] = operation;
         } else {
-          pathsObject[path] = { [method]: operationObject };
+          pathsObject[path] = { [method]: operation };
         }
         /* eslint-enable @silverhand/fp/no-mutation */
 

--- a/packages/core/src/routes/swagger.ts
+++ b/packages/core/src/routes/swagger.ts
@@ -7,17 +7,14 @@ import { zodTypeToSwagger } from '@/utils/zod';
 
 import { AnonymousRouter } from './types';
 
-// According to the HTTP methods that are declared in the koa-router.
-type HttpMethod = 'get' | 'post' | 'put' | 'link' | 'unlink' | 'delete' | 'options';
-
 type RouteObject = {
   path: string;
-  method: HttpMethod;
+  method: OpenAPIV3.HttpMethods;
   operation: OpenAPIV3.OperationObject;
 };
 
 type MethodMap = {
-  [key in HttpMethod]?: OpenAPIV3.OperationObject;
+  [key in OpenAPIV3.HttpMethods]?: OpenAPIV3.OperationObject;
 };
 
 const buildOperation = (stack: IMiddleware[], path: string): OpenAPIV3.OperationObject => {
@@ -56,7 +53,7 @@ export default function swaggerRoutes<T extends AnonymousRouter, R extends Route
           .filter((method) => method !== 'HEAD')
           .map((method) => ({
             path: `/api${path}`,
-            method: method.toLowerCase() as HttpMethod,
+            method: method.toLowerCase() as OpenAPIV3.HttpMethods,
             operation: buildOperation(stack, path),
           }))
       )

--- a/packages/core/src/routes/swagger.ts
+++ b/packages/core/src/routes/swagger.ts
@@ -19,7 +19,7 @@ type MethodsObject = Partial<Record<HttpMethod, OpenAPIV3.OperationObject>>;
 
 type PathsObject = Record<string, MethodsObject>;
 
-const buildOperationObject = (stack: IMiddleware[], path: string) => {
+const buildOperationObject = (stack: IMiddleware[], path: string): OpenAPIV3.OperationObject => {
   const guard = stack.find((function_): function_ is WithGuardConfig<IMiddleware> =>
     isGuardMiddleware(function_)
   );

--- a/packages/core/src/utils/zod.test.ts
+++ b/packages/core/src/utils/zod.test.ts
@@ -1,4 +1,5 @@
-import { string, boolean, number, object } from 'zod';
+import { ApplicationType } from '@logto/schemas';
+import { string, boolean, number, object, nativeEnum } from 'zod';
 
 import RequestError from '@/errors/RequestError';
 
@@ -45,7 +46,28 @@ describe('zodTypeToSwagger', () => {
     expect(zodTypeToSwagger(string().optional())).toEqual({ type: 'string' });
   });
 
-  it('unknow type', () => {
+  it('nullable type', () => {
+    expect(zodTypeToSwagger(string().nullable())).toEqual({ type: 'string', nullable: true });
+  });
+
+  it('unknown type', () => {
+    expect(zodTypeToSwagger(string().nullable())).toEqual({ type: 'string', nullable: true });
+  });
+
+  it('nullable type', () => {
+    expect(zodTypeToSwagger(string().nullable())).toEqual({ type: 'string', nullable: true });
+  });
+
+  it('native enum type', () => {
+    expect(zodTypeToSwagger(nativeEnum(ApplicationType))).toEqual({
+      type: 'string',
+      enum: Object.values(ApplicationType),
+    });
+  });
+
+  // TODO: ZodUnion, ZodUnknown, and etc.
+
+  it('unexpected type', () => {
     expect(() => zodTypeToSwagger('test')).toMatchError(
       new RequestError('swagger.invalid_zod_type', 'test')
     );

--- a/packages/core/src/utils/zod.test.ts
+++ b/packages/core/src/utils/zod.test.ts
@@ -54,10 +54,6 @@ describe('zodTypeToSwagger', () => {
     expect(zodTypeToSwagger(string().nullable())).toEqual({ type: 'string', nullable: true });
   });
 
-  it('nullable type', () => {
-    expect(zodTypeToSwagger(string().nullable())).toEqual({ type: 'string', nullable: true });
-  });
-
   it('native enum type', () => {
     expect(zodTypeToSwagger(nativeEnum(ApplicationType))).toEqual({
       type: 'string',

--- a/packages/core/src/utils/zod.ts
+++ b/packages/core/src/utils/zod.ts
@@ -29,7 +29,6 @@ export const zodTypeToSwagger = (config: unknown): OpenAPIV3.SchemaObject => {
 
   if (config instanceof ZodNativeEnum) {
     return {
-      description: 'enum',
       type: 'string',
       enum: Object.values(config.enum),
     };

--- a/packages/core/src/utils/zod.ts
+++ b/packages/core/src/utils/zod.ts
@@ -1,12 +1,48 @@
 import { conditional } from '@silverhand/essentials';
 import { OpenAPIV3 } from 'openapi-types';
-import { ZodArray, ZodBoolean, ZodNumber, ZodObject, ZodOptional, ZodString } from 'zod';
+import {
+  ZodArray,
+  ZodBoolean,
+  ZodNativeEnum,
+  ZodNullable,
+  ZodNumber,
+  ZodObject,
+  ZodOptional,
+  ZodString,
+  ZodUnion,
+  ZodUnknown,
+} from 'zod';
 
 import RequestError from '@/errors/RequestError';
 
 export const zodTypeToSwagger = (config: unknown): OpenAPIV3.SchemaObject => {
   if (config instanceof ZodOptional) {
     return zodTypeToSwagger(config._def.innerType);
+  }
+
+  if (config instanceof ZodNullable) {
+    return {
+      nullable: true,
+      ...zodTypeToSwagger(config._def.innerType),
+    };
+  }
+
+  if (config instanceof ZodNativeEnum) {
+    return {
+      description: 'enum',
+      type: 'string',
+      enum: Object.values(config.enum),
+    };
+  }
+
+  if (config instanceof ZodUnion) {
+    return {
+      description: 'union',
+    };
+  }
+
+  if (config instanceof ZodUnknown) {
+    return { description: 'unknown' };
   }
 
   if (config instanceof ZodObject) {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Make GET /api/swagger.json contain all `/api/*` routes

( Next PR: LOG-2809 Convert the Zod types (`ZodUnion`, `ZodUnknown` and etc.) to OpenAPI schemas )

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2609
LOG-2811

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="287" alt="image" src="https://user-images.githubusercontent.com/10594507/171402601-155ef45b-c0b0-4026-89d5-711e534810a3.png">

<img width="191" alt="image" src="https://user-images.githubusercontent.com/10594507/171402531-d5a68799-51d0-47dc-b01d-132975cae32d.png">

<img width="785" alt="image" src="https://user-images.githubusercontent.com/10594507/171152519-bbb919b9-b73a-45f5-a82e-d495c24c1077.png">

TODO:

- [x] missing some routes
- [x] test swaggerRoutes
- [x] test zodTypeToSwagger
- [x] refactor `GET /api/swagger.json` (easy to understand)