### PR TITLE
fix(ui): add i18n formater for zh-CN list

### DIFF
--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -29,9 +29,9 @@ const translation = {
       confirm_password: '确认密码',
     },
     secondary: {
-      sign_in_with: '通过 {{methods, list(type: disjunction;)}} 登录',
+      sign_in_with: '通过 {{methods, list(type: disjunction;), zhOrSpaces}} 登录',
       social_bind_with:
-        'Already have an account? Sign in to bind {{methods, list(type: disjunction;)}} with your social identity.',
+        '绑定到已有账户? 使用 {{methods, list(type: disjunction;), zhOrSpaces}} 登录并绑定。',
     },
     action: {
       sign_in: '登录',
@@ -66,8 +66,8 @@ const translation = {
       resend_after_seconds: '在 {{ seconds }} 秒后重发',
       resend_passcode: '重发验证码',
       continue_with: '通过以下方式继续',
-      create_account_id_exists: '{{ type }}为 {{ value }} 的账号已存在，您要登录吗？',
-      sign_in_id_does_not_exists: '{{ type }}为 {{ value }} 的账号不存在，您要创建一个新账号吗？',
+      create_account_id_exists: '{{type}}为 {{ value }} 的账号已存在，您要登录吗？',
+      sign_in_id_does_not_exists: '{{type}}为 {{ value }} 的账号不存在，您要创建一个新账号吗？',
       bind_account_title: '绑定 Logto 账号',
       social_create_account: 'No account? You can create a new account and bind.',
       social_bind_account: 'Already have an account? Sign in to bind it with your social identity.',

--- a/packages/ui/src/i18n/init.ts
+++ b/packages/ui/src/i18n/init.ts
@@ -18,7 +18,18 @@ const initI18n = async (languageSettings?: LanguageInfo) => {
       ? { ...baseOptions, lng: languageSettings.fixedLanguage }
       : baseOptions;
 
-  return i18next.use(initReactI18next).use(LanguageDetector).init(options);
+  const i18n = i18next.use(initReactI18next).use(LanguageDetector).init(options);
+
+  // @ts-expect-error - i18next doesn't have a type definition for this. called after i18next is initialized
+  i18next.services.formatter.add('zhOrSpaces', (value: string, lng) => {
+    if (lng !== 'zh-CN') {
+      return value;
+    }
+
+    return value.replaceAll(/或/g, ' 或 ');
+  });
+
+  return i18n;
 };
 
 export default initI18n;


### PR DESCRIPTION


<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add a custom i18n formattor for the zh-CN list. As i18n build-in list formattor does not have extra space between ‘或’. Need to handle it explicitly. 

Before:
<img width="388" alt="image" src="https://user-images.githubusercontent.com/36393111/171155256-d66ab5dd-68de-4eea-8bb4-f6163b58b487.png">

After:
<img width="391" alt="image" src="https://user-images.githubusercontent.com/36393111/171155288-09a9cd5a-bbf1-4fd3-aa9f-81831021e73a.png">

[reference](https://www.i18next.com/translation-function/formatting) 

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
@logto-io/eng 
