### PR TITLE
fix(console): display dark mode color setting only when dark mode is enabled

### DIFF
--- a/packages/console/src/pages/SignInExperience/components/BrandingForm.tsx
+++ b/packages/console/src/pages/SignInExperience/components/BrandingForm.tsx
@@ -38,18 +38,20 @@ const BrandingForm = () => {
           {...register('branding.isDarkModeEnabled')}
         />
       </FormField>
-      <FormField
-        isRequired={isDarkModeEnabled}
-        title="admin_console.sign_in_exp.branding.dark_primary_color"
-      >
-        <Controller
-          name="branding.darkPrimaryColor"
-          control={control}
-          render={({ field: { onChange, value } }) => (
-            <ColorPicker value={value} onChange={onChange} />
-          )}
-        />
-      </FormField>
+      {isDarkModeEnabled && (
+        <FormField
+          isRequired={isDarkModeEnabled}
+          title="admin_console.sign_in_exp.branding.dark_primary_color"
+        >
+          <Controller
+            name="branding.darkPrimaryColor"
+            control={control}
+            render={({ field: { onChange, value } }) => (
+              <ColorPicker value={value} onChange={onChange} />
+            )}
+          />
+        </FormField>
+      )}
       <FormField isRequired title="admin_console.sign_in_exp.branding.ui_style">
         <Controller
           name="branding.style"


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
fix(console): display dark mode color setting only when dark mode is enabled.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
* LOG-2789

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="458" alt="Snipaste_2022-06-02_12-40-05" src="https://user-images.githubusercontent.com/10806653/171554459-2e903809-7059-4d34-a140-beeb4c52bdf2.png">
<img width="473" alt="image" src="https://user-images.githubusercontent.com/10806653/171554485-32061954-a3ce-45b3-bca8-0044604f4374.png">


