### PR TITLE
chore(core,locale): fix error messages of signing in with non-existing username

### DIFF
--- a/packages/core/src/lib/user.ts
+++ b/packages/core/src/lib/user.ts
@@ -44,6 +44,7 @@ export const findUserByUsernameAndPassword = async (
   password: string
 ): Promise<User> => {
   const user = await findUserByUsername(username);
+  assertThat(user, 'user.username_not_exists');
   const { passwordEncrypted, passwordEncryptionMethod } = user;
 
   assertThat(passwordEncrypted && passwordEncryptionMethod, 'session.invalid_sign_in_method');

--- a/packages/core/src/queries/user.ts
+++ b/packages/core/src/queries/user.ts
@@ -10,7 +10,7 @@ import { DeletionError, UpdateError } from '@/errors/SlonikError';
 const { table, fields } = convertToIdentifiers(Users);
 
 export const findUserByUsername = async (username: string) =>
-  envSet.pool.one<User>(sql`
+  envSet.pool.maybeOne<User>(sql`
     select ${sql.join(Object.values(fields), sql`,`)}
     from ${table}
     where ${fields.username}=${username}

--- a/packages/core/src/routes/session.ts
+++ b/packages/core/src/routes/session.ts
@@ -68,14 +68,13 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
     koaGuard({
       body: object({
         username: string(),
-        password: string(),
+        password: string().nonempty(),
       }),
     }),
     async (ctx, next) => {
       const { username, password } = ctx.guard.body;
       const type = 'SignInUsernamePassword';
       ctx.log(type, { username });
-      assertThat(password, 'session.insufficient_info');
 
       const { id } = await findUserByUsernameAndPassword(username, password);
       ctx.log(type, { userId: id });

--- a/packages/core/src/routes/session.ts
+++ b/packages/core/src/routes/session.ts
@@ -67,7 +67,7 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
     '/session/sign-in/username-password',
     koaGuard({
       body: object({
-        username: string(),
+        username: string().nonempty(),
         password: string().nonempty(),
       }),
     }),

--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -89,7 +89,7 @@ const translation = {
       invalid_passcode: 'The passcode is invalid.',
       invalid_connector_auth: 'The authorization is invalid.',
       invalid_connector_request: 'The connector data is invalid.',
-      request: 'Request error {{message}}',
+      request: 'Request error: {{message}}',
       unknown: 'Unknown error, please try again later.',
       invalid_session: 'Session not found. Please go back and sign in again.',
     },
@@ -584,6 +584,7 @@ const errors = {
     phone_exists_register: 'The phone number has been registered.',
     invalid_email: 'Invalid email address.',
     invalid_phone: 'Invalid phone number.',
+    username_not_exists: 'The username has not been registered yet.',
     email_not_exists: 'The email address has not been registered yet.',
     phone_not_exists: 'The phone number has not been registered yet.',
     identity_not_exists: 'The social account has not been registered yet.',
@@ -602,7 +603,7 @@ const errors = {
     connector_id_mismatch: 'The connectorId is mismatched with session record.',
     connector_session_not_found: 'Connector session not found. Please go back and sign in again.',
     unauthorized: 'Please sign in first.',
-    unsupported_prompt_name: 'Unsupported prompt name',
+    unsupported_prompt_name: 'Unsupported prompt name.',
   },
   connector: {
     general: 'An unexpected error occurred in connector.',
@@ -645,7 +646,7 @@ const errors = {
     create_failed: 'Failed to create {{name}}.',
     not_exists: 'The {{name}} does not exist.',
     not_exists_with_id: 'The {{name}} with ID `{{id}}` does not exist.',
-    not_found: 'The resource does not exist',
+    not_found: 'The resource does not exist.',
   },
 };
 

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -89,7 +89,7 @@ const translation = {
       invalid_passcode: '无效的验证码。',
       invalid_connector_auth: '登录失败。',
       invalid_connector_request: '无效的登录请求。',
-      request: '请求错误：{{ message }}。',
+      request: '请求错误：{{ message }}', // All error messages are end with '。'.
       unknown: '未知错误，请稍后重试。',
       invalid_session: '未找到有效的会话，请重新登录。',
     },
@@ -578,6 +578,7 @@ const errors = {
     phone_exists_register: '手机号码已被注册。',
     invalid_email: '邮箱地址不正确。',
     invalid_phone: '手机号码不正确。',
+    username_not_exists: '用户名尚未注册。',
     email_not_exists: '邮箱地址尚未注册。',
     phone_not_exists: '手机号码尚未注册。',
     identity_not_exists: '该社交账号尚未注册。',
@@ -637,7 +638,7 @@ const errors = {
     create_failed: '创建 {{name}} 失败。',
     not_exists: '该 {{name}} 不存在。',
     not_exists_with_id: 'ID 为 `{{id}}` 的 {{name}} 不存在。',
-    not_found: '该资源不存在',
+    not_found: '该资源不存在。',
   },
 };
 

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -89,7 +89,7 @@ const translation = {
       invalid_passcode: '无效的验证码。',
       invalid_connector_auth: '登录失败。',
       invalid_connector_request: '无效的登录请求。',
-      request: '请求错误：{{ message }}', // All error messages are end with '。'.
+      request: '请求错误：{{ message }}', // All error messages end with '。'.
       unknown: '未知错误，请稍后重试。',
       invalid_session: '未找到有效的会话，请重新登录。',
     },


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Elaborate error message of signing in with username and password.
Ensure all English/Chinese error messages end with './。'.
Remove duplicated tailing '。's.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2825

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UTs.
