### PR TITLE
feat(core): convert route guards to swagger.json

### DIFF
--- a/packages/core/src/routes/swagger.test.ts
+++ b/packages/core/src/routes/swagger.test.ts
@@ -1,65 +1,210 @@
 import Koa from 'koa';
 import Router from 'koa-router';
 import request from 'supertest';
+import { number, object, string } from 'zod';
 
-import { AnonymousRouter, AuthedRouter } from '@/routes/types';
+import koaGuard from '@/middleware/koa-guard';
+import { AnonymousRouter } from '@/routes/types';
 
 import swaggerRoutes from './swagger';
 
-describe('swagger api', () => {
-  const authedRouter: AuthedRouter = new Router();
-  authedRouter.get('/mock', () => ({}));
-  authedRouter.patch('/mock', () => ({}));
-  authedRouter.post('/mock', () => ({}));
-  authedRouter.delete('/mock', () => ({}));
-
-  const anonymousRouter: AnonymousRouter = new Router();
-  swaggerRoutes(anonymousRouter, [authedRouter, anonymousRouter]);
-
+const createSwaggerRequest = (
+  allRouters: Array<Router<unknown, any>>,
+  swaggerRouter: AnonymousRouter = new Router()
+) => {
+  swaggerRoutes(swaggerRouter, allRouters);
   const app = new Koa();
-  app.use(anonymousRouter.routes()).use(anonymousRouter.allowedMethods());
+  app.use(swaggerRouter.routes()).use(swaggerRouter.allowedMethods());
 
-  const swaggerRequest = request(app.callback());
+  return request(app.callback());
+};
 
-  describe('GET /swagger.json', () => {
-    it('should contain standard fields', async () => {
-      const response = await swaggerRequest.get('/swagger.json');
-      expect(response.status).toEqual(200);
-      expect(response.body).toMatchObject(
-        expect.objectContaining({
-          /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-          openapi: expect.any(String),
-          info: expect.objectContaining({
-            title: expect.any(String),
-            version: expect.any(String),
-          }),
-          paths: expect.any(Object),
-          /* eslint-enable @typescript-eslint/no-unsafe-assignment */
-        })
-      );
+describe('GET /swagger.json', () => {
+  const mockRouter = new Router();
+  mockRouter.get('/mock', () => ({}));
+  mockRouter.patch('/mock', () => ({}));
+  mockRouter.post('/mock', () => ({}));
+  mockRouter.delete('/mock', () => ({}));
+
+  const testRouter = new Router();
+  testRouter.options('/test', () => ({}));
+  testRouter.put('/test', () => ({}));
+
+  const mockSwaggerRequest = createSwaggerRequest([mockRouter, testRouter]);
+
+  it('should contain the standard fields', async () => {
+    const response = await mockSwaggerRequest.get('/swagger.json');
+    expect(response.status).toEqual(200);
+    expect(response.body).toMatchObject({
+      /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+      openapi: expect.any(String),
+      info: expect.objectContaining({
+        title: expect.any(String),
+        version: expect.any(String),
+      }),
+      paths: expect.any(Object),
+      /* eslint-enable @typescript-eslint/no-unsafe-assignment */
     });
+  });
 
-    it('should contain specific paths', async () => {
-      const response = await swaggerRequest.get('/swagger.json');
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const { paths } = response.body;
-
-      expect(Object.entries(paths)).toHaveLength(2);
-      expect(paths).toMatchObject(
-        expect.objectContaining({
-          /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-          '/api/mock': expect.objectContaining({
-            get: expect.anything(),
-            patch: expect.anything(),
-            post: expect.anything(),
-            delete: expect.anything(),
-          }),
-          '/api/swagger.json': expect.objectContaining({
-            get: expect.anything(),
-          }),
-          /* eslint-enable @typescript-eslint/no-unsafe-assignment */
-        })
-      );
+  it('should contain the specific paths', async () => {
+    const response = await mockSwaggerRequest.get('/swagger.json');
+    expect(Object.entries(response.body.paths)).toHaveLength(2);
+    expect(response.body.paths).toMatchObject({
+      /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+      '/api/mock': {
+        get: expect.anything(),
+        patch: expect.anything(),
+        post: expect.anything(),
+        delete: expect.anything(),
+      },
+      '/api/test': {
+        options: expect.anything(),
+        put: expect.anything(),
+      },
+      /* eslint-enable @typescript-eslint/no-unsafe-assignment */
     });
+  });
+
+  it('should generate the tags', async () => {
+    const response = await mockSwaggerRequest.get('/swagger.json');
+    expect(response.body.paths).toMatchObject(
+      expect.objectContaining({
+        /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+        '/api/mock': expect.objectContaining({
+          get: expect.objectContaining({ tags: ['Mock'] }),
+        }),
+        '/api/test': expect.objectContaining({
+          put: expect.objectContaining({ tags: ['Test'] }),
+        }),
+        /* eslint-enable @typescript-eslint/no-unsafe-assignment */
+      })
+    );
+  });
+
+  it('should parse the path parameters', async () => {
+    const queryParametersRouter = new Router();
+    queryParametersRouter.get(
+      '/mock/:id/:field',
+      koaGuard({
+        params: object({
+          id: number(),
+          field: string(),
+        }),
+      }),
+      () => ({})
+    );
+    const swaggerRequest = createSwaggerRequest([queryParametersRouter]);
+
+    const response = await swaggerRequest.get('/swagger.json');
+    expect(response.body.paths).toMatchObject(
+      expect.objectContaining({
+        /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+        '/api/mock/:id/:field': {
+          get: expect.objectContaining({
+            parameters: [
+              {
+                name: 'id',
+                in: 'path',
+                required: true,
+                schema: { type: 'number' },
+              },
+              {
+                name: 'field',
+                in: 'path',
+                required: true,
+                schema: { type: 'string' },
+              },
+            ],
+          }),
+        },
+        /* eslint-enable @typescript-eslint/no-unsafe-assignment */
+      })
+    );
+  });
+
+  it('should parse the query parameters', async () => {
+    const queryParametersRouter = new Router();
+    queryParametersRouter.get(
+      '/mock',
+      koaGuard({
+        query: object({
+          id: number(),
+          name: string().optional(),
+        }),
+      }),
+      () => ({})
+    );
+    const swaggerRequest = createSwaggerRequest([queryParametersRouter]);
+    const response = await swaggerRequest.get('/swagger.json');
+    expect(response.body.paths).toMatchObject(
+      expect.objectContaining({
+        /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+        '/api/mock': {
+          get: expect.objectContaining({
+            parameters: [
+              {
+                name: 'id',
+                in: 'query',
+                required: true,
+                schema: {
+                  type: 'number',
+                },
+              },
+              {
+                name: 'name',
+                in: 'query',
+                required: false,
+                schema: {
+                  type: 'string',
+                },
+              },
+            ],
+          }),
+        },
+        /* eslint-enable @typescript-eslint/no-unsafe-assignment */
+      })
+    );
+  });
+
+  it('should parse the request body', async () => {
+    const queryParametersRouter = new Router();
+    queryParametersRouter.post(
+      '/mock',
+      koaGuard({
+        body: object({
+          name: string(),
+        }),
+      }),
+      () => ({})
+    );
+    const swaggerRequest = createSwaggerRequest([queryParametersRouter]);
+    const response = await swaggerRequest.get('/swagger.json');
+    expect(response.body.paths).toMatchObject(
+      expect.objectContaining({
+        /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+        '/api/mock': {
+          post: expect.objectContaining({
+            requestBody: {
+              required: true,
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    required: ['name'],
+                    properties: {
+                      name: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          }),
+        },
+        /* eslint-enable @typescript-eslint/no-unsafe-assignment */
+      })
+    );
   });
 });

--- a/packages/core/src/routes/swagger.ts
+++ b/packages/core/src/routes/swagger.ts
@@ -21,24 +21,19 @@ type MethodMap = {
 
 // Parameter serialization: https://swagger.io/docs/specification/serialization
 const buildParameters = (
-  parameters: unknown,
+  zodParameters: unknown,
   inWhere: 'path' | 'query'
 ): OpenAPIV3.ParameterObject[] => {
-  if (!parameters) {
+  if (!zodParameters) {
     return [];
   }
 
-  assertThat(parameters instanceof ZodObject, 'swagger.not_supported_zod_type_for_params');
+  assertThat(zodParameters instanceof ZodObject, 'swagger.not_supported_zod_type_for_params');
 
-  const entries = Object.entries(parameters.shape);
-  const requiredKeys = new Set(
-    entries.filter(([, value]) => !(value instanceof ZodOptional)).map(([key]) => key)
-  );
-
-  return entries.map(([key, value]) => ({
+  return Object.entries(zodParameters.shape).map(([key, value]) => ({
     name: key,
     in: inWhere,
-    required: requiredKeys.has(key),
+    required: !(value instanceof ZodOptional),
     schema: zodTypeToSwagger(value),
   }));
 };

--- a/packages/core/src/routes/swagger.ts
+++ b/packages/core/src/routes/swagger.ts
@@ -1,8 +1,10 @@
 import { toTitle } from '@silverhand/essentials';
 import Router, { IMiddleware } from 'koa-router';
 import { OpenAPIV3 } from 'openapi-types';
+import { ZodObject, ZodOptional } from 'zod';
 
 import { isGuardMiddleware, WithGuardConfig } from '@/middleware/koa-guard';
+import assertThat from '@/utils/assert-that';
 import { zodTypeToSwagger } from '@/utils/zod';
 
 import { AnonymousRouter } from './types';
@@ -17,22 +19,52 @@ type MethodMap = {
   [key in OpenAPIV3.HttpMethods]?: OpenAPIV3.OperationObject;
 };
 
+// Parameter serialization: https://swagger.io/docs/specification/serialization
+const buildParameters = (
+  parameters: unknown,
+  inWhere: 'path' | 'query'
+): OpenAPIV3.ParameterObject[] => {
+  if (!parameters) {
+    return [];
+  }
+
+  assertThat(parameters instanceof ZodObject, 'swagger.not_supported_zod_type_for_params');
+
+  const entries = Object.entries(parameters.shape);
+  const requiredKeys = new Set(
+    entries.filter(([, value]) => !(value instanceof ZodOptional)).map(([key]) => key)
+  );
+
+  return entries.map(([key, value]) => ({
+    name: key,
+    in: inWhere,
+    required: requiredKeys.has(key),
+    schema: zodTypeToSwagger(value),
+  }));
+};
+
 const buildOperation = (stack: IMiddleware[], path: string): OpenAPIV3.OperationObject => {
   const guard = stack.find((function_): function_ is WithGuardConfig<IMiddleware> =>
     isGuardMiddleware(function_)
   );
+
   const body = guard?.config.body;
+  const requestBody = body && {
+    required: true,
+    content: {
+      'application/json': {
+        schema: zodTypeToSwagger(body),
+      },
+    },
+  };
+
+  const pathParameters = buildParameters(guard?.config.params, 'path');
+  const queryParameters = buildParameters(guard?.config.query, 'query');
 
   return {
     tags: [toTitle(path.split('/')[1] ?? 'General')],
-    requestBody: body && {
-      required: true,
-      content: {
-        'application/json': {
-          schema: zodTypeToSwagger(body),
-        },
-      },
-    },
+    parameters: [...pathParameters, ...queryParameters],
+    requestBody,
     responses: {
       '200': {
         description: 'OK',

--- a/packages/core/src/utils/zod.test.ts
+++ b/packages/core/src/utils/zod.test.ts
@@ -1,11 +1,18 @@
-import { ApplicationType } from '@logto/schemas';
-import { string, boolean, number, object, nativeEnum } from 'zod';
+import { ApplicationType, arbitraryObjectGuard } from '@logto/schemas';
+import { string, boolean, number, object, nativeEnum, unknown } from 'zod';
 
 import RequestError from '@/errors/RequestError';
 
 import { zodTypeToSwagger } from './zod';
 
 describe('zodTypeToSwagger', () => {
+  it('arbitrary object guard', () => {
+    expect(zodTypeToSwagger(arbitraryObjectGuard)).toEqual({
+      type: 'object',
+      description: 'arbitrary',
+    });
+  });
+
   it('string type', () => {
     expect(zodTypeToSwagger(string())).toEqual({ type: 'string' });
   });
@@ -51,7 +58,7 @@ describe('zodTypeToSwagger', () => {
   });
 
   it('unknown type', () => {
-    expect(zodTypeToSwagger(string().nullable())).toEqual({ type: 'string', nullable: true });
+    expect(zodTypeToSwagger(unknown())).toEqual({});
   });
 
   it('native enum type', () => {
@@ -60,8 +67,6 @@ describe('zodTypeToSwagger', () => {
       enum: Object.values(ApplicationType),
     });
   });
-
-  // TODO: ZodUnion, ZodUnknown, and etc.
 
   it('unexpected type', () => {
     expect(() => zodTypeToSwagger('test')).toMatchError(

--- a/packages/core/src/utils/zod.ts
+++ b/packages/core/src/utils/zod.ts
@@ -42,7 +42,7 @@ export const zodTypeToSwagger = (config: unknown): OpenAPIV3.SchemaObject => {
   }
 
   if (config instanceof ZodUnknown) {
-    return {}; // I.e. any data type
+    return {}; // Any data type
   }
 
   if (config instanceof ZodObject) {

--- a/packages/core/src/utils/zod.ts
+++ b/packages/core/src/utils/zod.ts
@@ -42,7 +42,7 @@ export const zodTypeToSwagger = (config: unknown): OpenAPIV3.SchemaObject => {
   }
 
   if (config instanceof ZodUnknown) {
-    return {};
+    return {}; // I.e. any data type
   }
 
   if (config instanceof ZodObject) {

--- a/packages/core/src/utils/zod.ts
+++ b/packages/core/src/utils/zod.ts
@@ -1,3 +1,4 @@
+import { arbitraryObjectGuard } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
 import { OpenAPIV3 } from 'openapi-types';
 import {
@@ -9,13 +10,19 @@ import {
   ZodObject,
   ZodOptional,
   ZodString,
-  ZodUnion,
   ZodUnknown,
 } from 'zod';
 
 import RequestError from '@/errors/RequestError';
 
 export const zodTypeToSwagger = (config: unknown): OpenAPIV3.SchemaObject => {
+  if (config === arbitraryObjectGuard) {
+    return {
+      type: 'object',
+      description: 'arbitrary',
+    };
+  }
+
   if (config instanceof ZodOptional) {
     return zodTypeToSwagger(config._def.innerType);
   }
@@ -34,14 +41,8 @@ export const zodTypeToSwagger = (config: unknown): OpenAPIV3.SchemaObject => {
     };
   }
 
-  if (config instanceof ZodUnion) {
-    return {
-      description: 'union',
-    };
-  }
-
   if (config instanceof ZodUnknown) {
-    return { description: 'unknown' };
+    return {};
   }
 
   if (config instanceof ZodObject) {

--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -641,7 +641,9 @@ const errors = {
       'There must be one and only one primary sign-in method. Please check your input.',
   },
   swagger: {
-    invalid_zod_type: 'Invalid Zod type, please check route guard config.',
+    invalid_zod_type: 'Invalid Zod type. Please check route guard config.',
+    not_supported_zod_type_for_params:
+      'Not supported Zod type for the parameters. Please check route guard config.',
   },
   entity: {
     create_failed: 'Failed to create {{name}}.',

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -623,6 +623,7 @@ const errors = {
   },
   swagger: {
     invalid_zod_type: '无效的 Zod 类型，请检查路由 guard 配置。',
+    not_supported_zod_type_for_params: '请求参数不支持的 Zod 类型，请检查路由 guard 配置。',
   },
   entity: {
     create_failed: '创建 {{name}} 失败。',


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Convert the koa guards of `params`, `query` and `body` to the swagger.json

- Convert the used Zod types and `arbitraryObjectGuard` to `OpenAPIV3.SchemaObject`
- Convert the parameters of `path` and `query` to `OpenAPIV3.ParameterObject[]`.
    - path parameter: e.g. `id` in `GET /connectors/:id` 
    - query parameter: e.g. `target` in `GET /connectors?target=github`

References:

- Parameter serialization: https://swagger.io/docs/specification/serialization/
- Data types: https://swagger.io/docs/specification/data-models/data-types/

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2609
LOG-2809

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="204" alt="image" src="https://user-images.githubusercontent.com/10594507/172042258-be2fe18b-b431-424d-a2ee-59e9ca66fbbc.png">

<img width="291" alt="image" src="https://user-images.githubusercontent.com/10594507/172042268-4252fdd2-0cbf-4345-b59b-6873e5dabaf6.png">
