### PR TITLE
fix(console): fix platform label prefix caused by merge

### DIFF
--- a/packages/console/src/pages/Connectors/components/ConnectorName/index.tsx
+++ b/packages/console/src/pages/Connectors/components/ConnectorName/index.tsx
@@ -55,7 +55,7 @@ const ConnectorName = ({ type, connectors, onClickSetup }: Props) => {
                     platform && (
                       <div key={id} className={styles.platform}>
                         <ConnectorPlatformIcon platform={platform} />
-                        {t(connectorPlatformLabel[platform])}
+                        {t(`admin_console.${connectorPlatformLabel[platform]}`)}
                       </div>
                     )
                 )}


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Fix k18n key prefix for `connectorPlatformLabel`, this issue is caused by uncorrect merge conflict pick.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local testd.