### PR TITLE
refactor(console): hide check demo button if demo app is deleted

### DIFF
--- a/packages/console/src/hooks/use-swr-fetcher.ts
+++ b/packages/console/src/hooks/use-swr-fetcher.ts
@@ -41,7 +41,7 @@ const useSwrFetcher: useSwrFetcherHook = <T>() => {
         if (error instanceof HTTPError) {
           const { response } = error;
           const metadata = await response.json<RequestErrorBody>();
-          throw new RequestError(metadata);
+          throw new RequestError(response.status, metadata);
         }
         throw error;
       }

--- a/packages/console/src/pages/GetStarted/components/Skeleton/index.module.scss
+++ b/packages/console/src/pages/GetStarted/components/Skeleton/index.module.scss
@@ -1,0 +1,44 @@
+@use '@/scss/underscore' as _;
+
+.card {
+  display: flex;
+  padding: _.unit(6) _.unit(8);
+  background-color: var(--color-layer-1);
+  border-radius: 16px;
+
+  .icon {
+    @include _.shimmering-animation;
+    width: 48px;
+    height: 48px;
+    margin-right: _.unit(6);
+  }
+
+  .wrapper {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+
+    .title {
+      @include _.shimmering-animation;
+      width: 113px;
+      height: 20px;
+    }
+
+    .subtitle {
+      @include _.shimmering-animation;
+      width: 453px;
+      height: 20px;
+      margin-top: _.unit(1);
+    }
+  }
+
+  .button {
+    @include _.shimmering-animation;
+    width: 129px;
+    height: 44px;
+  }
+}
+
+.card + .card {
+  margin-top: _.unit(4);
+}

--- a/packages/console/src/pages/GetStarted/components/Skeleton/index.tsx
+++ b/packages/console/src/pages/GetStarted/components/Skeleton/index.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import * as styles from './index.module.scss';
+
+const Skeleton = () => (
+  <>
+    {[...Array.from({ length: 5 }).keys()].map((key) => (
+      <div key={key} className={styles.card}>
+        <div className={styles.icon} />
+        <div className={styles.wrapper}>
+          <div className={styles.title} />
+          <div className={styles.subtitle} />
+        </div>
+      </div>
+    ))}
+  </>
+);
+
+export default Skeleton;

--- a/packages/console/src/pages/GetStarted/index.tsx
+++ b/packages/console/src/pages/GetStarted/index.tsx
@@ -9,13 +9,14 @@ import ConfirmModal from '@/components/ConfirmModal';
 import Spacer from '@/components/Spacer';
 import useUserPreferences from '@/hooks/use-user-preferences';
 
+import Skeleton from './components/Skeleton';
 import useGetStartedMetadata from './hook';
 import * as styles from './index.module.scss';
 
 const GetStarted = () => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const navigate = useNavigate();
-  const { data } = useGetStartedMetadata();
+  const { data, isLoading } = useGetStartedMetadata();
   const { update } = useUserPreferences();
   const [showConfirmModal, setShowConfirmModal] = useState(false);
 
@@ -45,23 +46,28 @@ const GetStarted = () => {
           </span>
         </div>
       </div>
-      {data.map(({ id, title, subtitle, icon, isComplete, buttonText, onClick }) => (
-        <Card key={id} className={styles.card}>
-          <img className={styles.icon} src={icon} />
-          {isComplete && <img className={styles.completeIndicator} src={completeIndicator} />}
-          <div className={styles.wrapper}>
-            <div className={styles.title}>{t(title)}</div>
-            <div className={styles.subtitle}>{t(subtitle)}</div>
-          </div>
-          <Button
-            className={styles.button}
-            type="outline"
-            size="large"
-            title={buttonText}
-            onClick={onClick}
-          />
-        </Card>
-      ))}
+      {isLoading && <Skeleton />}
+      {!isLoading &&
+        data.map(
+          ({ id, title, subtitle, icon, isComplete, isHidden, buttonText, onClick }) =>
+            !isHidden && (
+              <Card key={id} className={styles.card}>
+                <img className={styles.icon} src={icon} />
+                {isComplete && <img className={styles.completeIndicator} src={completeIndicator} />}
+                <div className={styles.wrapper}>
+                  <div className={styles.title}>{t(title)}</div>
+                  <div className={styles.subtitle}>{t(subtitle)}</div>
+                </div>
+                <Button
+                  className={styles.button}
+                  type="outline"
+                  size="large"
+                  title={buttonText}
+                  onClick={onClick}
+                />
+              </Card>
+            )
+        )}
       <ConfirmModal
         title="get_started.confirm"
         isOpen={showConfirmModal}


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Hide "check demo" from get-started page if demo app is deleted from applications list

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] remove `demo_app` from applications table, there was no `check demo` card in get-started page
- [x] add `demo_app` back in applications table, `check demo` card was back in get-started page
