### PR TITLE
feat(core): log error body

### DIFF
--- a/packages/core/src/middleware/koa-log.test.ts
+++ b/packages/core/src/middleware/koa-log.test.ts
@@ -103,10 +103,11 @@ describe('koaLog middleware', () => {
       };
       ctx.request.ip = ip;
 
-      const errorMessage = 'Error message';
-      jest.spyOn(i18next, 't').mockReturnValueOnce(errorMessage); // Used in
-      const errorCode = 'connector.general';
-      const error = new RequestError(errorCode, { foo: 'bar', num: 123 });
+      const message = 'Error message';
+      jest.spyOn(i18next, 't').mockReturnValueOnce(message); // Used in
+      const code = 'connector.general';
+      const data = { foo: 'bar', num: 123 };
+      const error = new RequestError(code, data);
 
       const next = async () => {
         ctx.log(type, mockPayload);
@@ -120,7 +121,7 @@ describe('koaLog middleware', () => {
         payload: {
           ...mockPayload,
           result: LogResult.Error,
-          error: `{"message":"${errorMessage}","code":"${errorCode}","data":{"foo":"bar","num":123}}`,
+          error: { message, code, data },
           ip,
           userAgent,
         },

--- a/packages/core/src/middleware/koa-log.test.ts
+++ b/packages/core/src/middleware/koa-log.test.ts
@@ -105,11 +105,8 @@ describe('koaLog middleware', () => {
 
       const errorMessage = 'Error message';
       jest.spyOn(i18next, 't').mockReturnValue(errorMessage);
-
-      const error = new RequestError('connector.general', {
-        foo: 'bar',
-        num: 123,
-      });
+      const errorCode = 'connector.general';
+      const error = new RequestError(errorCode, { foo: 'bar', num: 123 });
 
       const next = async () => {
         ctx.log(type, payload);
@@ -123,7 +120,7 @@ describe('koaLog middleware', () => {
         payload: {
           ...payload,
           result: LogResult.Error,
-          error: `{"message":"${errorMessage}","code":"connector.general","data":{"foo":"bar","num":123}}`,
+          error: `{"message":"${errorMessage}","code":"${errorMessage}","data":{"foo":"bar","num":123}}`,
           ip,
           userAgent,
         },

--- a/packages/core/src/middleware/koa-log.test.ts
+++ b/packages/core/src/middleware/koa-log.test.ts
@@ -23,7 +23,7 @@ jest.mock('nanoid', () => ({
 describe('koaLog middleware', () => {
   const insertLogMock = insertLog as jest.Mock;
   const type = 'SignInUsernamePassword';
-  const payload: LogPayload = {
+  const mockPayload: LogPayload = {
     userId: 'foo',
     username: 'Bar',
   };
@@ -46,7 +46,7 @@ describe('koaLog middleware', () => {
     ctx.request.ip = ip;
 
     const next = async () => {
-      ctx.log(type, payload);
+      ctx.log(type, mockPayload);
     };
     await koaLog()(ctx, next);
 
@@ -54,7 +54,7 @@ describe('koaLog middleware', () => {
       id: nanoIdMock,
       type,
       payload: {
-        ...payload,
+        ...mockPayload,
         result: LogResult.Success,
         ip,
         userAgent,
@@ -76,7 +76,7 @@ describe('koaLog middleware', () => {
       const error = new Error(message);
 
       const next = async () => {
-        ctx.log(type, payload);
+        ctx.log(type, mockPayload);
         throw error;
       };
       await expect(koaLog()(ctx, next)).rejects.toMatchError(error);
@@ -85,7 +85,7 @@ describe('koaLog middleware', () => {
         id: nanoIdMock,
         type,
         payload: {
-          ...payload,
+          ...mockPayload,
           result: LogResult.Error,
           error: `Error: ${message}`,
           ip,
@@ -104,12 +104,12 @@ describe('koaLog middleware', () => {
       ctx.request.ip = ip;
 
       const errorMessage = 'Error message';
-      jest.spyOn(i18next, 't').mockReturnValue(errorMessage);
+      jest.spyOn(i18next, 't').mockReturnValueOnce(errorMessage); // Used in
       const errorCode = 'connector.general';
       const error = new RequestError(errorCode, { foo: 'bar', num: 123 });
 
       const next = async () => {
-        ctx.log(type, payload);
+        ctx.log(type, mockPayload);
         throw error;
       };
       await expect(koaLog()(ctx, next)).rejects.toMatchError(error);
@@ -118,9 +118,9 @@ describe('koaLog middleware', () => {
         id: nanoIdMock,
         type,
         payload: {
-          ...payload,
+          ...mockPayload,
           result: LogResult.Error,
-          error: `{"message":"${errorMessage}","code":"${errorMessage}","data":{"foo":"bar","num":123}}`,
+          error: `{"message":"${errorMessage}","code":"${errorCode}","data":{"foo":"bar","num":123}}`,
           ip,
           userAgent,
         },

--- a/packages/core/src/middleware/koa-log.test.ts
+++ b/packages/core/src/middleware/koa-log.test.ts
@@ -1,5 +1,7 @@
 import { LogPayload, LogResult } from '@logto/schemas';
+import i18next from 'i18next';
 
+import RequestError from '@/errors/RequestError';
 import { insertLog } from '@/queries/log';
 import { createContextWithRouteParameters } from '@/utils/test-utils';
 
@@ -34,7 +36,7 @@ describe('koaLog middleware', () => {
     jest.clearAllMocks();
   });
 
-  it('insert log with success response', async () => {
+  it('should insert a success log when next() does not throw an error', async () => {
     const ctx: WithLogContext<ReturnType<typeof createContextWithRouteParameters>> = {
       ...createContextWithRouteParameters({ headers: { 'user-agent': userAgent } }),
       // Bypass middleware context type assert
@@ -60,33 +62,72 @@ describe('koaLog middleware', () => {
     });
   });
 
-  it('should insert log with failed result if next throws error', async () => {
-    const ctx: WithLogContext<ReturnType<typeof createContextWithRouteParameters>> = {
-      ...createContextWithRouteParameters({ headers: { 'user-agent': userAgent } }),
-      // Bypass middleware context type assert
-      addLogContext,
-      log,
-    };
-    ctx.request.ip = ip;
+  describe('should insert an error log with the error message when next() throws an error', () => {
+    it('should log with error message when next throws a normal Error', async () => {
+      const ctx: WithLogContext<ReturnType<typeof createContextWithRouteParameters>> = {
+        ...createContextWithRouteParameters({ headers: { 'user-agent': userAgent } }),
+        // Bypass middleware context type assert
+        addLogContext,
+        log,
+      };
+      ctx.request.ip = ip;
 
-    const error = new Error('next error');
+      const message = 'normal error';
+      const error = new Error(message);
 
-    const next = async () => {
-      ctx.log(type, payload);
-      throw error;
-    };
-    await expect(koaLog()(ctx, next)).rejects.toMatchError(error);
+      const next = async () => {
+        ctx.log(type, payload);
+        throw error;
+      };
+      await expect(koaLog()(ctx, next)).rejects.toMatchError(error);
 
-    expect(insertLogMock).toBeCalledWith({
-      id: nanoIdMock,
-      type,
-      payload: {
-        ...payload,
-        result: LogResult.Error,
-        error: String(error),
-        ip,
-        userAgent,
-      },
+      expect(insertLogMock).toBeCalledWith({
+        id: nanoIdMock,
+        type,
+        payload: {
+          ...payload,
+          result: LogResult.Error,
+          error: `Error: ${message}`,
+          ip,
+          userAgent,
+        },
+      });
+    });
+
+    it('should insert an error log with the error body when next() throws a RequestError', async () => {
+      const ctx: WithLogContext<ReturnType<typeof createContextWithRouteParameters>> = {
+        ...createContextWithRouteParameters({ headers: { 'user-agent': userAgent } }),
+        // Bypass middleware context type assert
+        addLogContext,
+        log,
+      };
+      ctx.request.ip = ip;
+
+      const errorMessage = 'Error message';
+      jest.spyOn(i18next, 't').mockReturnValue(errorMessage);
+
+      const error = new RequestError('connector.general', {
+        foo: 'bar',
+        num: 123,
+      });
+
+      const next = async () => {
+        ctx.log(type, payload);
+        throw error;
+      };
+      await expect(koaLog()(ctx, next)).rejects.toMatchError(error);
+
+      expect(insertLogMock).toBeCalledWith({
+        id: nanoIdMock,
+        type,
+        payload: {
+          ...payload,
+          result: LogResult.Error,
+          error: `{"message":"${errorMessage}","code":"connector.general","data":{"foo":"bar","num":123}}`,
+          ip,
+          userAgent,
+        },
+      });
     });
   });
 });

--- a/packages/core/src/middleware/koa-log.test.ts
+++ b/packages/core/src/middleware/koa-log.test.ts
@@ -72,7 +72,7 @@ describe('koaLog middleware', () => {
       };
       ctx.request.ip = ip;
 
-      const message = 'normal error';
+      const message = 'Normal error';
       const error = new Error(message);
 
       const next = async () => {
@@ -87,7 +87,7 @@ describe('koaLog middleware', () => {
         payload: {
           ...mockPayload,
           result: LogResult.Error,
-          error: `Error: ${message}`,
+          error: { message: `Error: ${message}` },
           ip,
           userAgent,
         },

--- a/packages/core/src/middleware/koa-log.ts
+++ b/packages/core/src/middleware/koa-log.ts
@@ -4,6 +4,7 @@ import { MiddlewareType } from 'koa';
 import { IRouterParamContext } from 'koa-router';
 import { nanoid } from 'nanoid';
 
+import RequestError from '@/errors/RequestError';
 import { insertLog } from '@/queries/log';
 
 type MergeLog = <T extends LogType>(type: T, payload: LogPayloads[T]) => void;
@@ -90,7 +91,11 @@ export default function koaLog<
     try {
       await next();
     } catch (error: unknown) {
-      logger.set({ result: LogResult.Error, error: String(error) });
+      const errorInfo = error instanceof RequestError ? JSON.stringify(error.body) : String(error);
+      logger.set({
+        result: LogResult.Error,
+        error: errorInfo,
+      });
       throw error;
     } finally {
       await logger.save();

--- a/packages/core/src/middleware/koa-log.ts
+++ b/packages/core/src/middleware/koa-log.ts
@@ -2,6 +2,7 @@ import { BaseLogPayload, LogPayload, LogPayloads, LogResult, LogType } from '@lo
 import deepmerge from 'deepmerge';
 import { MiddlewareType } from 'koa';
 import { IRouterParamContext } from 'koa-router';
+import pick from 'lodash.pick';
 import { nanoid } from 'nanoid';
 
 import RequestError from '@/errors/RequestError';
@@ -91,7 +92,10 @@ export default function koaLog<
     try {
       await next();
     } catch (error: unknown) {
-      const errorInfo = error instanceof RequestError ? JSON.stringify(error.body) : String(error);
+      const errorInfo =
+        error instanceof RequestError
+          ? pick(error, 'message', 'code', 'data')
+          : { message: String(error) };
       logger.set({
         result: LogResult.Error,
         error: errorInfo,

--- a/packages/core/src/middleware/koa-log.ts
+++ b/packages/core/src/middleware/koa-log.ts
@@ -92,13 +92,12 @@ export default function koaLog<
     try {
       await next();
     } catch (error: unknown) {
-      const errorInfo =
-        error instanceof RequestError
-          ? pick(error, 'message', 'code', 'data')
-          : { message: String(error) };
       logger.set({
         result: LogResult.Error,
-        error: errorInfo,
+        error:
+          error instanceof RequestError
+            ? pick(error, 'message', 'code', 'data')
+            : { message: String(error) },
       });
       throw error;
     } finally {

--- a/packages/schemas/src/types/log.ts
+++ b/packages/schemas/src/types/log.ts
@@ -7,7 +7,7 @@ export enum LogResult {
 
 export interface BaseLogPayload {
   result?: LogResult;
-  error?: string;
+  error?: Record<string, unknown>;
   ip?: string;
   userAgent?: string;
   applicationId?: string;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Save the error context from `RequestError.body` in logs

See Slack thread [discussion](https://silverhand-io.slack.com/archives/C02A8G4HVAM/p1654570553888139)

- [LOG-2875 : Save RequestError.data in the logs](https://linear.app/silverhand/issue/LOG-2875/save-requesterrordata-in-the-logs)

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2875

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="586" alt="image" src="https://user-images.githubusercontent.com/10594507/172316392-a68b3e0d-154e-4049-99fc-9a190c281f8e.png">
