### PR TITLE
fix(core): koaAuth should return 403 instead of 401 on non-admin role

### DIFF
--- a/packages/core/src/middleware/koa-auth.ts
+++ b/packages/core/src/middleware/koa-auth.ts
@@ -70,12 +70,15 @@ export default function koaAuth<StateT, ContextT extends IRouterParamContext, Re
       if (forRole) {
         assertThat(
           roleNames?.includes(forRole),
-          new RequestError({ code: 'auth.unauthorized', status: 401 })
+          new RequestError({ code: 'auth.forbidden', status: 403 })
         );
       }
 
       ctx.auth = sub;
-    } catch {
+    } catch (error: unknown) {
+      if (error instanceof RequestError) {
+        throw error;
+      }
       throw new RequestError({ code: 'auth.unauthorized', status: 401 });
     }
 

--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -571,6 +571,7 @@ const errors = {
     authorization_header_missing: 'Authorization header is missing.',
     authorization_token_type_not_supported: 'Authorization type is not supported.',
     unauthorized: 'Unauthorized. Please check credentials and its scope.',
+    forbidden: 'Forbidden. Please check your user roles and permissions.',
     jwt_sub_missing: 'Missing `sub` in JWT.',
   },
   guard: {

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -554,6 +554,7 @@ const errors = {
     authorization_header_missing: 'Authorization 请求 header 遗漏。',
     authorization_token_type_not_supported: '不支持的 authorization 类型。',
     unauthorized: '未授权。请检查相关 credentials 和 scope。',
+    forbidden: '禁止访问。请检查用户权限。',
     jwt_sub_missing: 'JWT 中找不到 `sub`。',
   },
   guard: {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
KoaAuth should return 403 status code instead of 401, when user does not have admin role.

<img width="514" alt="image" src="https://user-images.githubusercontent.com/12833674/172354241-50ecec0e-4e9f-4b60-9a45-92918cb631ef.png">


<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally with a non-admin user. APIs protected by admin role threw 403 errors
