### PR TITLE
fix(console): only check demo app existence on get-started page

### DIFF
--- a/packages/console/src/pages/GetStarted/components/GetStartedProgress/index.tsx
+++ b/packages/console/src/pages/GetStarted/components/GetStartedProgress/index.tsx
@@ -17,7 +17,7 @@ const GetStartedProgress = () => {
   } = useUserPreferences();
   const anchorRef = useRef<HTMLDivElement>(null);
   const [showDropDown, setShowDropdown] = useState(false);
-  const { data, completedCount, totalCount } = useGetStartedMetadata();
+  const { data, completedCount, totalCount } = useGetStartedMetadata({ checkDemoAppExists: false });
 
   if (hideGetStarted) {
     return null;

--- a/packages/console/src/pages/GetStarted/hook.ts
+++ b/packages/console/src/pages/GetStarted/hook.ts
@@ -23,17 +23,24 @@ type GetStartedMetadata = {
   onClick: () => void;
 };
 
-const useGetStartedMetadata = () => {
-  const { settings, updateSettings } = useSettings();
-  const { data: demoApp, error } = useSWR<Application, RequestError>('/api/applications/demo_app', {
-    shouldRetryOnError: (error: unknown) => {
-      if (error instanceof RequestError) {
-        return error.status !== 404;
-      }
+type Props = {
+  checkDemoAppExists: boolean;
+};
 
-      return true;
-    },
-  });
+const useGetStartedMetadata = ({ checkDemoAppExists }: Props) => {
+  const { settings, updateSettings } = useSettings();
+  const { data: demoApp, error } = useSWR<Application, RequestError>(
+    checkDemoAppExists && '/api/applications/demo_app',
+    {
+      shouldRetryOnError: (error: unknown) => {
+        if (error instanceof RequestError) {
+          return error.status !== 404;
+        }
+
+        return true;
+      },
+    }
+  );
   const navigate = useNavigate();
   const isLoadingDemoApp = !demoApp && !error;
   const hideDemo = error?.status === 404;

--- a/packages/console/src/pages/GetStarted/index.tsx
+++ b/packages/console/src/pages/GetStarted/index.tsx
@@ -16,7 +16,7 @@ import * as styles from './index.module.scss';
 const GetStarted = () => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const navigate = useNavigate();
-  const { data, isLoading } = useGetStartedMetadata();
+  const { data, isLoading } = useGetStartedMetadata({ checkDemoAppExists: true });
   const { update } = useUserPreferences();
   const [showConfirmModal, setShowConfirmModal] = useState(false);
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
We check if demo app exists in the `useGetStartedMetadata` hook. However, the hook is used in two different places, one in get-started page, another one in the get-started progress indicator on top bar.

We only want to check demo app existence when user is on get-started page, because if it does not exist, we should hide "Check Demo" button from that page.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Navigating to get-started page, can see a check demo_app request sent to the server
- [x] Navigating to other pages, cannot see check demo_app request
