### PR TITLE
chore(docs): adjust sdk reference sorting order

### DIFF
--- a/packages/docs/docs/sdk/JavaScript/README.md
+++ b/packages/docs/docs/sdk/JavaScript/README.md
@@ -1,1 +1,1 @@
-# @logto-io/js
+# JavaScript

--- a/packages/docs/docs/sdk/JavaScript/browser/README.md
+++ b/packages/docs/docs/sdk/JavaScript/browser/README.md
@@ -1,4 +1,8 @@
-# Browser
+---
+sidebar_position: 2
+---
+
+# @logto/browser
 
 ## Table of contents
 

--- a/packages/docs/docs/sdk/JavaScript/js/README.md
+++ b/packages/docs/docs/sdk/JavaScript/js/README.md
@@ -1,4 +1,8 @@
-# JS Core
+---
+sidebar_position: 1
+---
+
+# @logto/js
 
 ## Table of contents
 

--- a/packages/docs/docs/sdk/JavaScript/react/README.md
+++ b/packages/docs/docs/sdk/JavaScript/react/README.md
@@ -1,4 +1,8 @@
-# React
+---
+sidebar_position: 3
+---
+
+# @logto/react
 
 ## Table of contents
 

--- a/packages/docs/docs/sdk/JavaScript/vue/README.md
+++ b/packages/docs/docs/sdk/JavaScript/vue/README.md
@@ -1,4 +1,8 @@
-# Vue
+---
+sidebar_position: 4
+---
+
+# @logto/vue
 
 ## Table of contents
 

--- a/packages/docs/i18n/zh-cn/docusaurus-plugin-content-docs/current/sdk/README.md
+++ b/packages/docs/i18n/zh-cn/docusaurus-plugin-content-docs/current/sdk/README.md
@@ -1,1 +1,5 @@
+---
+sidebar_position: 1
+---
+
 # SDK 参考概览


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
<img width="1412" alt="image" src="https://user-images.githubusercontent.com/12833674/172794482-9b005e14-703d-4400-b732-c8936e5c14f8.png">

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
[LOG-2891](https://linear.app/silverhand/issue/LOG-2891/adjust-sorting-order-of-js-sdk-references)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] sdk reference sorting order now in right order: js, browser, react and vue
