### PR TITLE
refactor(ui): adjust input field auto focus logic

### DIFF
--- a/packages/console/src/pages/SignInExperience/components/Preview.tsx
+++ b/packages/console/src/pages/SignInExperience/components/Preview.tsx
@@ -135,7 +135,7 @@ const Preview = ({ signInExperience, className }: Props) => {
               <PhoneInfo />
             </div>
           )}
-          <iframe ref={previewRef} src="/sign-in?preview=true" />
+          <iframe ref={previewRef} src="/sign-in?preview=true" tabIndex={-1} />
         </div>
         {platform === 'mobile' && (
           <div className={styles.description}>{t('sign_in_exp.preview.mobile_description')}</div>

--- a/packages/ui/src/components/Input/PhoneInput.tsx
+++ b/packages/ui/src/components/Input/PhoneInput.tsx
@@ -14,6 +14,8 @@ type Value = { countryCallingCode?: CountryCallingCode; nationalNumber?: string 
 export type Props = {
   name: string;
   autoComplete?: AutoCompleteType;
+  // eslint-disable-next-line react/boolean-prop-naming
+  autoFocus?: boolean;
   className?: string;
   placeholder?: string;
   countryCallingCode?: CountryCallingCode;
@@ -26,6 +28,7 @@ export type Props = {
 const PhoneInput = ({
   name,
   autoComplete,
+  autoFocus,
   className,
   placeholder,
   countryCallingCode,
@@ -74,7 +77,7 @@ const PhoneInput = ({
         {countrySelector}
         <input
           ref={inputReference}
-          autoFocus
+          autoFocus={autoFocus}
           name={name}
           placeholder={placeholder}
           value={nationalNumber}

--- a/packages/ui/src/containers/CreateAccount/index.tsx
+++ b/packages/ui/src/containers/CreateAccount/index.tsx
@@ -17,14 +17,16 @@ import {
 
 import * as styles from './index.module.scss';
 
+type Props = {
+  className?: string;
+  // eslint-disable-next-line react/boolean-prop-naming
+  autoFocus?: boolean;
+};
+
 type FieldState = {
   username: string;
   password: string;
   confirmPassword: string;
-};
-
-type Props = {
-  className?: string;
 };
 
 const defaultState: FieldState = {
@@ -33,7 +35,7 @@ const defaultState: FieldState = {
   confirmPassword: '',
 };
 
-const CreateAccount = ({ className }: Props) => {
+const CreateAccount = ({ className, autoFocus }: Props) => {
   const { t } = useTranslation(undefined, { keyPrefix: 'main_flow' });
   const { termsValidation } = useTerms();
   const {
@@ -79,7 +81,7 @@ const CreateAccount = ({ className }: Props) => {
   return (
     <form className={classNames(styles.form, className)}>
       <Input
-        autoFocus
+        autoFocus={autoFocus}
         className={styles.inputField}
         name="username"
         placeholder={t('input.username')}

--- a/packages/ui/src/containers/Passwordless/EmailPasswordless.tsx
+++ b/packages/ui/src/containers/Passwordless/EmailPasswordless.tsx
@@ -21,6 +21,8 @@ import * as styles from './index.module.scss';
 type Props = {
   type: UserFlow;
   className?: string;
+  // eslint-disable-next-line react/boolean-prop-naming
+  autoFocus?: boolean;
 };
 
 type FieldState = {
@@ -29,7 +31,7 @@ type FieldState = {
 
 const defaultState: FieldState = { email: '' };
 
-const EmailPasswordless = ({ type, className }: Props) => {
+const EmailPasswordless = ({ type, autoFocus, className }: Props) => {
   const { setToast } = useContext(PageContext);
   const [showPasswordlessConfirmModal, setShowPasswordlessConfirmModal] = useState(false);
   const { t } = useTranslation(undefined, { keyPrefix: 'main_flow' });
@@ -97,7 +99,7 @@ const EmailPasswordless = ({ type, className }: Props) => {
     <>
       <form className={classNames(styles.form, className)}>
         <Input
-          autoFocus
+          autoFocus={autoFocus}
           className={styles.inputField}
           name="email"
           autoComplete="email"

--- a/packages/ui/src/containers/Passwordless/PhonePasswordless.tsx
+++ b/packages/ui/src/containers/Passwordless/PhonePasswordless.tsx
@@ -20,6 +20,8 @@ import * as styles from './index.module.scss';
 
 type Props = {
   type: UserFlow;
+  // eslint-disable-next-line react/boolean-prop-naming
+  autoFocus?: boolean;
   className?: string;
 };
 
@@ -29,7 +31,7 @@ type FieldState = {
 
 const defaultState: FieldState = { phone: '' };
 
-const PhonePasswordless = ({ type, className }: Props) => {
+const PhonePasswordless = ({ type, autoFocus, className }: Props) => {
   const { setToast } = useContext(PageContext);
   const [showPasswordlessConfirmModal, setShowPasswordlessConfirmModal] = useState(false);
   const { t } = useTranslation(undefined, { keyPrefix: 'main_flow' });
@@ -118,6 +120,7 @@ const PhonePasswordless = ({ type, className }: Props) => {
           placeholder={t('input.phone_number')}
           countryCallingCode={phoneNumber.countryCallingCode}
           nationalNumber={phoneNumber.nationalNumber}
+          autoFocus={autoFocus}
           countryList={countryList}
           {...register('phone', phoneNumberValidation)}
           onChange={(data) => {

--- a/packages/ui/src/containers/UsernameSignin/index.tsx
+++ b/packages/ui/src/containers/UsernameSignin/index.tsx
@@ -16,13 +16,15 @@ import { requiredValidation } from '@/utils/field-validations';
 
 import * as styles from './index.module.scss';
 
+type Props = {
+  className?: string;
+  // eslint-disable-next-line react/boolean-prop-naming
+  autoFocus?: boolean;
+};
+
 type FieldState = {
   username: string;
   password: string;
-};
-
-type Props = {
-  className?: string;
 };
 
 const defaultState: FieldState = {
@@ -30,7 +32,7 @@ const defaultState: FieldState = {
   password: '',
 };
 
-const UsernameSignin = ({ className }: Props) => {
+const UsernameSignin = ({ className, autoFocus }: Props) => {
   const { t } = useTranslation(undefined, { keyPrefix: 'main_flow' });
   const { termsValidation } = useTerms();
   const {
@@ -85,7 +87,7 @@ const UsernameSignin = ({ className }: Props) => {
   return (
     <form className={classNames(styles.form, className)}>
       <Input
-        autoFocus
+        autoFocus={autoFocus}
         className={styles.inputField}
         name="username"
         autoComplete="username"

--- a/packages/ui/src/pages/Register/index.tsx
+++ b/packages/ui/src/pages/Register/index.tsx
@@ -19,14 +19,14 @@ const Register = () => {
 
   const registerForm = useMemo(() => {
     if (method === 'sms') {
-      return <PhonePasswordless type="register" />;
+      return <PhonePasswordless autoFocus type="register" />;
     }
 
     if (method === 'email') {
-      return <EmailPasswordless type="register" />;
+      return <EmailPasswordless autoFocus type="register" />;
     }
 
-    return <CreateAccount />;
+    return <CreateAccount autoFocus />;
   }, [method]);
 
   if (!['email', 'sms', 'username'].includes(method)) {

--- a/packages/ui/src/pages/SecondarySignIn/index.tsx
+++ b/packages/ui/src/pages/SecondarySignIn/index.tsx
@@ -19,14 +19,14 @@ const SecondarySignIn = () => {
 
   const signInForm = useMemo(() => {
     if (method === 'sms') {
-      return <PhonePasswordless type="sign-in" />;
+      return <PhonePasswordless autoFocus type="sign-in" />;
     }
 
     if (method === 'email') {
-      return <EmailPasswordless type="sign-in" />;
+      return <EmailPasswordless autoFocus type="sign-in" />;
     }
 
-    return <UsernameSignin />;
+    return <UsernameSignin autoFocus />;
   }, [method]);
 
   if (!['email', 'sms', 'username'].includes(method)) {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Adjust input field auto focus logic

1. For now only apply auto focus on all secondary pages. As the default sign-in page, user may select a different sign-in method other than the primary one.

2. Add tabIndex={-1} to the console preview iframe element

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
log-2899

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
@logto-io/eng 
