### PR TITLE
refactor(console): add dedicated route path for create app popup dialog

### DIFF
--- a/packages/console/src/App.tsx
+++ b/packages/console/src/App.tsx
@@ -50,6 +50,7 @@ const Main = () => {
               <Route path="get-started" element={<GetStarted />} />
               <Route path="applications">
                 <Route index element={<Applications />} />
+                <Route path="create" element={<Applications />} />
                 <Route path=":id">
                   <Route index element={<Navigate to="settings" />} />
                   <Route path="settings" element={<ApplicationDetails />} />

--- a/packages/console/src/pages/Applications/index.tsx
+++ b/packages/console/src/pages/Applications/index.tsx
@@ -1,10 +1,10 @@
 import { Application } from '@logto/schemas';
 import classNames from 'classnames';
-import React, { useState } from 'react';
+import React from 'react';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import Modal from 'react-modal';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import useSWR from 'swr';
 
 import Button from '@/components/Button';
@@ -29,7 +29,9 @@ import * as styles from './index.module.scss';
 const pageSize = 20;
 
 const Applications = () => {
-  const [isCreateFormOpen, setIsCreateFormOpen] = useState(false);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const isCreateNew = location.pathname.endsWith('/create');
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const [query, setQuery] = useSearchParams();
   const pageIndex = Number(query.get('page') ?? '1');
@@ -37,7 +39,6 @@ const Applications = () => {
     `/api/applications?page=${pageIndex}&page_size=${pageSize}`
   );
   const isLoading = !data && !error;
-  const navigate = useNavigate();
   const [applications, totalCount] = data ?? [];
 
   return (
@@ -49,17 +50,17 @@ const Applications = () => {
           title="admin_console.applications.create"
           type="primary"
           onClick={() => {
-            setIsCreateFormOpen(true);
+            navigate('/applications/create');
           }}
         />
         <Modal
-          isOpen={isCreateFormOpen}
+          isOpen={isCreateNew}
           className={modalStyles.content}
           overlayClassName={modalStyles.overlay}
         >
           <CreateForm
             onClose={(createdApp) => {
-              setIsCreateFormOpen(false);
+              navigate('/applications');
 
               if (createdApp) {
                 toast.success(t('applications.application_created', { name: createdApp.name }));
@@ -96,7 +97,7 @@ const Applications = () => {
                   title="admin_console.applications.create"
                   type="outline"
                   onClick={() => {
-                    setIsCreateFormOpen(true);
+                    navigate('/applications/create');
                   }}
                 />
               </TableEmpty>

--- a/packages/console/src/pages/GetStarted/hook.ts
+++ b/packages/console/src/pages/GetStarted/hook.ts
@@ -67,7 +67,7 @@ const useGetStartedMetadata = ({ checkDemoAppExists }: Props) => {
       buttonText: 'general.create',
       isComplete: settings?.createApplication,
       onClick: () => {
-        navigate('/applications');
+        navigate('/applications/create');
       },
     },
     {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add dedicated route path for create application popup dialog, so that clicking "create application" button from get-started page will open create app popup directly

![Jun-10-2022 20-44-51](https://user-images.githubusercontent.com/12833674/173066999-0d1c13c2-af19-4af7-97ad-98dd97493b8f.gif)

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] On "get-started" page, click "create application" button (2nd card), page will be navigated to applications list, and the create application popup dialog will show up automatically
