### PR TITLE
fix(console): fix info icon vertical alignment

### DIFF
--- a/packages/console/src/pages/Dashboard/components/Block.module.scss
+++ b/packages/console/src/pages/Dashboard/components/Block.module.scss
@@ -39,6 +39,10 @@
       width: 16px;
       height: 16px;
       color: var(--color-caption);
+
+      > svg {
+        display: block;
+      }
     }
   }
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Fix info icon vertical position, now is in center position.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2926

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="251" alt="截屏2022-06-13 下午2 27 53" src="https://user-images.githubusercontent.com/5717882/173292980-79d96613-1e09-4875-86ce-c7b253b856f8.png">

