### PR TITLE
fix(core): remove name regex

### DIFF
--- a/packages/core/src/routes/admin-user.ts
+++ b/packages/core/src/routes/admin-user.ts
@@ -1,5 +1,5 @@
 import { arbitraryObjectGuard, userInfoSelectFields } from '@logto/schemas';
-import { nameRegEx, passwordRegEx, usernameRegEx } from '@logto/shared';
+import { passwordRegEx, usernameRegEx } from '@logto/shared';
 import { has } from '@silverhand/essentials';
 import pick from 'lodash.pick';
 import { InvalidInputError } from 'slonik';
@@ -73,7 +73,7 @@ export default function adminUserRoutes<T extends AuthedRouter>(router: T) {
       body: object({
         username: string().regex(usernameRegEx),
         password: string().regex(passwordRegEx),
-        name: string().regex(nameRegEx),
+        name: string(),
       }),
     }),
     async (ctx, next) => {
@@ -109,7 +109,7 @@ export default function adminUserRoutes<T extends AuthedRouter>(router: T) {
     koaGuard({
       params: object({ userId: string() }),
       body: object({
-        name: string().regex(nameRegEx).optional(),
+        name: string().nullable().optional(),
         avatar: string().url().nullable().optional(),
         customData: arbitraryObjectGuard.optional(),
         roleNames: string().array().optional(),

--- a/packages/shared/src/regex.ts
+++ b/packages/shared/src/regex.ts
@@ -1,7 +1,6 @@
 export const emailRegEx = /^\S+@\S+\.\S+$/;
 export const phoneRegEx = /^\d+$/;
 export const usernameRegEx = /^[A-Z_a-z-][\w-]*$/;
-export const nameRegEx = /^.+$/;
 export const passwordRegEx = /^.{6,}$/;
 export const redirectUriRegEx = /^https?:\/\//;
 export const hexColorRegEx = /^#[\da-f]{3}([\da-f]{3})?$/i;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Remove `nameRegEx` since is no longer necessary, `name` is user's nickname, and have no limitation.

When users in AC remove name string in form input, the formdata's `name` will become an empty string, this is an issue before. Is now fixed by this PR.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2601

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested.
