### PR TITLE
feat(core): any-type parameter shows empty object in swagger example

### DIFF
--- a/packages/core/src/utils/zod.test.ts
+++ b/packages/core/src/utils/zod.test.ts
@@ -58,7 +58,7 @@ describe('zodTypeToSwagger', () => {
   });
 
   it('unknown type', () => {
-    expect(zodTypeToSwagger(unknown())).toEqual({});
+    expect(zodTypeToSwagger(unknown())).toEqual({ example: {} });
   });
 
   it('native enum type', () => {

--- a/packages/core/src/utils/zod.ts
+++ b/packages/core/src/utils/zod.ts
@@ -42,7 +42,7 @@ export const zodTypeToSwagger = (config: unknown): OpenAPIV3.SchemaObject => {
   }
 
   if (config instanceof ZodUnknown) {
-    return {}; // Any data type
+    return { example: {} }; // Any data type
   }
 
   if (config instanceof ZodObject) {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
The any-type parameter shows an empty object in the APi request example.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2994

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UTs

<img width="250" alt="image" src="https://user-images.githubusercontent.com/10594507/173325538-8dce862e-6a7a-4a88-bd30-78f5b3eb8a64.png">

API reference page

<img width="1223" alt="image" src="https://user-images.githubusercontent.com/10594507/173325529-e1e590a9-f4c0-46ef-9463-13cf72904db3.png">

GET /api/swagger.json response

<img width="594" alt="image" src="https://user-images.githubusercontent.com/10594507/173325756-2feb2caa-a484-4b78-8c6c-8104b833484e.png">
