### PR TITLE
feat(core): append page and page_size to the query parameters in swagger.json

### DIFF
--- a/packages/core/src/middleware/koa-pagination.ts
+++ b/packages/core/src/middleware/koa-pagination.ts
@@ -30,6 +30,7 @@ export default function koaPagination<StateT, ContextT, ResponseBodyT>({
   defaultPageSize = fallbackDefaultPageSize,
   maxPageSize = 100,
 }: PaginationConfig = {}): MiddlewareType<StateT, WithPaginationContext<ContextT>, ResponseBodyT> {
+  // Name this anonymous function for the utility function `isPaginationMiddleware` to identify it
   const paginationMiddleware: MiddlewareType<
     StateT,
     WithPaginationContext<ContextT>,

--- a/packages/core/src/middleware/koa-pagination.ts
+++ b/packages/core/src/middleware/koa-pagination.ts
@@ -1,4 +1,5 @@
 import { MiddlewareType } from 'koa';
+import { IMiddleware } from 'koa-router';
 import { number } from 'zod';
 
 import RequestError from '@/errors/RequestError';
@@ -19,11 +20,21 @@ export interface PaginationConfig {
   maxPageSize?: number;
 }
 
+export const isPaginationMiddleware = <Type extends IMiddleware>(
+  function_: Type
+): function_ is WithPaginationContext<Type> => function_.name === 'paginationMiddleware';
+
+export const fallbackDefaultPageSize = 20;
+
 export default function koaPagination<StateT, ContextT, ResponseBodyT>({
-  defaultPageSize = 20,
+  defaultPageSize = fallbackDefaultPageSize,
   maxPageSize = 100,
 }: PaginationConfig = {}): MiddlewareType<StateT, WithPaginationContext<ContextT>, ResponseBodyT> {
-  return async (ctx, next) => {
+  const paginationMiddleware: MiddlewareType<
+    StateT,
+    WithPaginationContext<ContextT>,
+    ResponseBodyT
+  > = async (ctx, next) => {
     try {
       const {
         request: {
@@ -67,4 +78,6 @@ export default function koaPagination<StateT, ContextT, ResponseBodyT>({
       ctx.append('Link', buildLink(ctx.request, page + 1, 'next'));
     }
   };
+
+  return paginationMiddleware;
 }

--- a/packages/core/src/routes/swagger.ts
+++ b/packages/core/src/routes/swagger.ts
@@ -66,7 +66,7 @@ const buildOperation = (stack: IMiddleware[], path: string): OpenAPIV3.Operation
   const guard = stack.find((function_): function_ is WithGuardConfig<IMiddleware> =>
     isGuardMiddleware(function_)
   );
-  const hasPagination = Boolean(stack.some((function_) => isPaginationMiddleware(function_)));
+  const hasPagination = stack.some((function_) => isPaginationMiddleware(function_));
 
   const body = guard?.config.body;
   const requestBody = body && {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Append the `page` and `page_size` to the query parameters in the `swagger.json` when the routes use `pagination`

---

Check the pagination middleware like the guard middleware:

- `isPaginationMiddleware`:

    <img width="670" alt="image" src="https://user-images.githubusercontent.com/10594507/173545412-a1a14160-2891-468a-85cf-fa126e142b50.png">

- `isGuardMiddleware`:

    <img width="905" alt="image" src="https://user-images.githubusercontent.com/10594507/173545732-5efc1bb5-faff-4cec-9beb-4f096fec41e7.png">

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2856

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- UTs

    <img width="656" alt="image" src="https://user-images.githubusercontent.com/10594507/173544364-9a2bf65d-e740-49ba-80cd-6fe33945c8fd.png">

- GET /api/swagger.json

    <img width="1104" alt="image" src="https://user-images.githubusercontent.com/10594507/173544925-27a349cc-efb0-4e2f-9348-7ecad5d60d82.png">

- API Reference page

    <img width="1493" alt="image" src="https://user-images.githubusercontent.com/10594507/173544837-4188ca17-a22f-4d71-932d-d4f2fdf4d888.png">
