### PR TITLE
fix(console): update terms of use

### DIFF
--- a/packages/console/src/pages/SignInExperience/components/TermsForm.tsx
+++ b/packages/console/src/pages/SignInExperience/components/TermsForm.tsx
@@ -24,7 +24,7 @@ const TermsForm = () => {
       <div className={styles.title}>{t('sign_in_exp.terms_of_use.title')}</div>
       <FormField title="admin_console.sign_in_exp.terms_of_use.enable">
         <Switch
-          {...register('termsOfUse.enabled', { required: true })}
+          {...register('termsOfUse.enabled')}
           label={t('sign_in_exp.terms_of_use.description')}
         />
       </FormField>

--- a/packages/core/src/routes/sign-in-experience.guard.test.ts
+++ b/packages/core/src/routes/sign-in-experience.guard.test.ts
@@ -72,11 +72,18 @@ describe('terms of use', () => {
       await expectPatchResponseStatus(signInExperience, 400);
     });
 
-    test('should allow empty contentUrl', async () => {
+    test('should allow empty contentUrl if termsOfUse is disabled', async () => {
       const signInExperience = {
         termsOfUse: { ...mockTermsOfUse, enabled: false, contentUrl: '' },
       };
       await expectPatchResponseStatus(signInExperience, 200);
+    });
+
+    test('should not allow empty contentUrl if termsOfUse is enabled', async () => {
+      const signInExperience = {
+        termsOfUse: { ...mockTermsOfUse, enabled: true, contentUrl: '' },
+      };
+      await expectPatchResponseStatus(signInExperience, 400);
     });
   });
 });

--- a/packages/core/src/routes/sign-in-experience.guard.test.ts
+++ b/packages/core/src/routes/sign-in-experience.guard.test.ts
@@ -67,9 +67,16 @@ describe('terms of use', () => {
       }
     );
 
-    test.each([null, '', ' \t\n\r', 'non-url'])('%p should fail', async (contentUrl) => {
+    test.each([null, ' \t\n\r', 'non-url'])('%p should fail', async (contentUrl) => {
       const signInExperience = { termsOfUse: { ...mockTermsOfUse, enabled: false, contentUrl } };
       await expectPatchResponseStatus(signInExperience, 400);
+    });
+
+    test('should allow empty contentUrl', async () => {
+      const signInExperience = {
+        termsOfUse: { ...mockTermsOfUse, enabled: false, contentUrl: '' },
+      };
+      await expectPatchResponseStatus(signInExperience, 200);
     });
   });
 });

--- a/packages/schemas/src/foundations/jsonb-types.ts
+++ b/packages/schemas/src/foundations/jsonb-types.ts
@@ -91,7 +91,7 @@ export type Branding = z.infer<typeof brandingGuard>;
 
 export const termsOfUseGuard = z.object({
   enabled: z.boolean(),
-  contentUrl: z.string().url().optional(),
+  contentUrl: z.string().url().optional().or(z.literal('')),
 });
 
 export type TermsOfUse = z.infer<typeof termsOfUseGuard>;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
This pr fix these issues:
- The `<Switch />` component treats the uncheck value as `""`, which will cause the `required` rule to fail.
- The Zod rule `string().url().optional()` does not allow `""`, but the text input will generate `""` by default without any input.
- If we convert the `contentUrl` from `""` to `undefined`, then the back end will ignore this partial update.

## Todo
* LOG-3059: Return `false` When The Switch is Unchecked

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
* LOG-2868

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT & Test in the admin console.
