### PR TITLE
feat(console): go back to previous list page from details

### DIFF
--- a/packages/console/src/App.tsx
+++ b/packages/console/src/App.tsx
@@ -52,7 +52,7 @@ const Main = () => {
                 <Route index element={<Applications />} />
                 <Route path="create" element={<Applications />} />
                 <Route path=":id">
-                  <Route index element={<Navigate to="settings" />} />
+                  <Route index element={<ApplicationDetails />} />
                   <Route path="settings" element={<ApplicationDetails />} />
                   <Route path="advanced-settings" element={<ApplicationDetails />} />
                 </Route>

--- a/packages/console/src/components/ItemPreview/index.tsx
+++ b/packages/console/src/components/ItemPreview/index.tsx
@@ -9,10 +9,11 @@ type Props = {
   subtitle?: ReactNode;
   icon?: ReactNode;
   to?: To;
+  locationState?: any;
   size?: 'default' | 'compact';
 };
 
-const ItemPreview = ({ title, subtitle, icon, to, size = 'default' }: Props) => {
+const ItemPreview = ({ title, subtitle, icon, to, locationState, size = 'default' }: Props) => {
   return (
     <div className={classNames(styles.item, styles[size])}>
       {icon && <div className={styles.icon}>{icon}</div>}
@@ -21,6 +22,8 @@ const ItemPreview = ({ title, subtitle, icon, to, size = 'default' }: Props) => 
           <Link
             className={styles.title}
             to={to}
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            state={locationState}
             onClick={(event) => {
               event.stopPropagation();
             }}

--- a/packages/console/src/components/TabNav/TabNavItem.tsx
+++ b/packages/console/src/components/TabNav/TabNavItem.tsx
@@ -6,18 +6,26 @@ import * as styles from './TabNavItem.module.scss';
 
 type Props = {
   href?: string;
+  locationState?: any;
   isActive?: boolean;
   onClick?: () => void;
   children: React.ReactNode;
 };
 
-const TabNavItem = ({ children, href, isActive, onClick }: Props) => {
+const TabNavItem = ({ children, href, locationState, isActive, onClick }: Props) => {
   const location = useLocation();
   const selected = href ? location.pathname === href : isActive;
 
   return (
     <div className={classNames(styles.link, selected && styles.selected)}>
-      {href ? <Link to={href}>{children}</Link> : <a onClick={onClick}>{children}</a>}
+      {href ? (
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        <Link to={href} state={locationState}>
+          {children}
+        </Link>
+      ) : (
+        <a onClick={onClick}>{children}</a>
+      )}
     </div>
   );
 };

--- a/packages/console/src/pages/ApiResourceDetails/index.tsx
+++ b/packages/console/src/pages/ApiResourceDetails/index.tsx
@@ -1,4 +1,5 @@
 import { Resource } from '@logto/schemas';
+import { conditionalString } from '@silverhand/essentials';
 import classNames from 'classnames';
 import React, { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -25,6 +26,7 @@ import Delete from '@/icons/Delete';
 import More from '@/icons/More';
 import * as detailsStyles from '@/scss/details.module.scss';
 import * as modalStyles from '@/scss/modal.module.scss';
+import { queryStringify } from '@/utilities/query-stringify';
 
 import DeleteForm from './components/DeleteForm';
 import * as styles from './index.module.scss';
@@ -35,9 +37,13 @@ type FormData = {
 };
 
 const ApiResourceDetails = () => {
-  const location = useLocation();
+  const { pathname, state: locationState } = useLocation();
   const { id } = useParams();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+
+  const backLink = `/api-resources${conditionalString(
+    locationState && `?${queryStringify(locationState as Record<string, string>)}`
+  )}`;
 
   const { data, error, mutate } = useSWR<Resource, RequestError>(id && `/api/resources/${id}`);
   const isLoading = !data && !error;
@@ -78,7 +84,7 @@ const ApiResourceDetails = () => {
   return (
     <div className={detailsStyles.container}>
       <LinkButton
-        to="/api-resources"
+        to={backLink}
         icon={<Back />}
         title="admin_console.api_resource_details.back_to_api_resources"
         className={styles.backLink}
@@ -143,7 +149,7 @@ const ApiResourceDetails = () => {
           </Card>
           <Card className={classNames(styles.body, detailsStyles.body)}>
             <TabNav>
-              <TabNavItem href={location.pathname}>{t('api_resource_details.settings')}</TabNavItem>
+              <TabNavItem href={pathname}>{t('api_resource_details.settings')}</TabNavItem>
             </TabNav>
             <form className={classNames(styles.form, detailsStyles.body)} onSubmit={onSubmit}>
               <div className={styles.fields}>

--- a/packages/console/src/pages/ApiResources/index.tsx
+++ b/packages/console/src/pages/ApiResources/index.tsx
@@ -34,6 +34,7 @@ const ApiResources = () => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const [query, setQuery] = useSearchParams();
   const pageIndex = Number(query.get('page') ?? '1');
+  const locationState = { page: `${pageIndex}` };
   const { data, error, mutate } = useSWR<[Resource[], number], RequestError>(
     `/api/resources?page=${pageIndex}&page_size=${pageSize}`
   );
@@ -110,7 +111,7 @@ const ApiResources = () => {
                 key={id}
                 className={tableStyles.clickable}
                 onClick={() => {
-                  navigate(buildDetailsLink(id));
+                  navigate(buildDetailsLink(id), { state: locationState });
                 }}
               >
                 <td>
@@ -118,6 +119,7 @@ const ApiResources = () => {
                     title={name}
                     icon={<img src={apiResourceIcon} />}
                     to={buildDetailsLink(id)}
+                    locationState={locationState}
                   />
                 </td>
                 <td>

--- a/packages/console/src/pages/ApplicationDetails/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/index.tsx
@@ -1,4 +1,5 @@
 import { Application, SnakeCaseOidcConfig } from '@logto/schemas';
+import { conditionalString } from '@silverhand/essentials';
 import classNames from 'classnames';
 import React, { useEffect, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
@@ -24,6 +25,7 @@ import More from '@/icons/More';
 import * as detailsStyles from '@/scss/details.module.scss';
 import * as modalStyles from '@/scss/modal.module.scss';
 import { applicationTypeI18nKey } from '@/types/applications';
+import { queryStringify } from '@/utilities/query-stringify';
 
 import AdvancedSettings from './components/AdvancedSettings';
 import DeleteForm from './components/DeleteForm';
@@ -38,11 +40,16 @@ const mapToUriOriginFormatArrays = (value?: string[]) =>
 
 const ApplicationDetails = () => {
   const { id } = useParams();
-  const location = useLocation();
+  const { pathname, state: locationState } = useLocation();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { data, error, mutate } = useSWR<Application, RequestError>(
     id && `/api/applications/${id}`
   );
+
+  const backLink = `/applications${conditionalString(
+    locationState && `?${queryStringify(locationState as Record<string, string>)}`
+  )}`;
+
   const { data: oidcConfig, error: fetchOidcConfigError } = useSWR<
     SnakeCaseOidcConfig,
     RequestError
@@ -96,12 +103,12 @@ const ApplicationDetails = () => {
     toast.success(t('application_details.save_success'));
   });
 
-  const isAdvancedSettings = location.pathname.includes('advanced-settings');
+  const isAdvancedSettings = pathname.includes('advanced-settings');
 
   return (
     <div className={detailsStyles.container}>
       <LinkButton
-        to="/applications"
+        to={backLink}
         icon={<Back />}
         title="admin_console.application_details.back_to_applications"
         className={styles.backLink}
@@ -168,10 +175,13 @@ const ApplicationDetails = () => {
           </Card>
           <Card className={classNames(styles.body, detailsStyles.body)}>
             <TabNav>
-              <TabNavItem href={`/applications/${data.id}/settings`}>
+              <TabNavItem href={`/applications/${data.id}`} locationState={locationState}>
                 {t('application_details.settings')}
               </TabNavItem>
-              <TabNavItem href={`/applications/${data.id}/advanced-settings`}>
+              <TabNavItem
+                href={`/applications/${data.id}/advanced-settings`}
+                locationState={locationState}
+              >
                 {t('application_details.advanced_settings')}
               </TabNavItem>
             </TabNav>

--- a/packages/console/src/pages/Applications/index.tsx
+++ b/packages/console/src/pages/Applications/index.tsx
@@ -35,6 +35,8 @@ const Applications = () => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const [query, setQuery] = useSearchParams();
   const pageIndex = Number(query.get('page') ?? '1');
+  const locationState = { page: `${pageIndex}` };
+
   const { data, error, mutate } = useSWR<[Application[], number], RequestError>(
     `/api/applications?page=${pageIndex}&page_size=${pageSize}`
   );
@@ -108,7 +110,7 @@ const Applications = () => {
                 key={id}
                 className={tableStyles.clickable}
                 onClick={() => {
-                  navigate(`/applications/${id}`);
+                  navigate(`/applications/${id}`, { state: locationState });
                 }}
               >
                 <td>
@@ -117,6 +119,7 @@ const Applications = () => {
                     subtitle={t(`${applicationTypeI18nKey[type]}.title`)}
                     icon={<img src={ApplicationIcon[type]} />}
                     to={`/applications/${id}`}
+                    locationState={locationState}
                   />
                 </td>
                 <td>

--- a/packages/console/src/pages/AuditLogDetails/index.tsx
+++ b/packages/console/src/pages/AuditLogDetails/index.tsx
@@ -1,9 +1,10 @@
 import { LogDTO } from '@logto/schemas';
+import { conditionalString } from '@silverhand/essentials';
 import classNames from 'classnames';
 import dayjs from 'dayjs';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import useSWR from 'swr';
 
 import ApplicationName from '@/components/ApplicationName';
@@ -17,11 +18,16 @@ import { logEventTitle } from '@/consts/logs';
 import { RequestError } from '@/hooks/use-api';
 import Back from '@/icons/Back';
 import * as detailsStyles from '@/scss/details.module.scss';
+import { queryStringify } from '@/utilities/query-stringify';
 
 import EventIcon from './components/EventIcon';
 import * as styles from './index.module.scss';
 
 const AuditLogDetails = () => {
+  const { state: locationState } = useLocation();
+  const backLink = `/audit-logs${conditionalString(
+    locationState && `?${queryStringify(locationState as Record<string, string>)}`
+  )}`;
   const { logId } = useParams();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { data, error } = useSWR<LogDTO, RequestError>(logId && `/api/logs/${logId}`);
@@ -30,7 +36,7 @@ const AuditLogDetails = () => {
   return (
     <div className={detailsStyles.container}>
       <LinkButton
-        to="/audit-logs"
+        to={backLink}
         icon={<Back />}
         title="admin_console.log_details.back_to_logs"
         className={styles.backLink}
@@ -87,7 +93,7 @@ const AuditLogDetails = () => {
           </Card>
           <Card className={classNames(styles.body, detailsStyles.body)}>
             <TabNav>
-              <TabNavItem href={`/audit-logs/${logId ?? ''}`}>
+              <TabNavItem href={`/audit-logs/${logId ?? ''}`} locationState={locationState}>
                 {t('log_details.tab_details')}
               </TabNavItem>
             </TabNav>

--- a/packages/console/src/pages/Users/index.tsx
+++ b/packages/console/src/pages/Users/index.tsx
@@ -1,5 +1,5 @@
 import { User } from '@logto/schemas';
-import { conditionalString } from '@silverhand/essentials';
+import { conditional, conditionalString } from '@silverhand/essentials';
 import classNames from 'classnames';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -35,11 +35,13 @@ const Users = () => {
   const [query, setQuery] = useSearchParams();
   const pageIndex = Number(query.get('page') ?? '1');
   const keyword = query.get('search') ?? '';
+  const locationState = { page: `${pageIndex}`, ...conditional(keyword && { search: keyword }) };
   const { data, error, mutate } = useSWR<[User[], number], RequestError>(
     `/api/users?page=${pageIndex}&page_size=${pageSize}${conditionalString(
       keyword && `&search=${keyword}`
     )}`
   );
+
   const isLoading = !data && !error;
   const navigate = useNavigate();
   const [users, totalCount] = data ?? [];
@@ -120,7 +122,7 @@ const Users = () => {
                 key={id}
                 className={tableStyles.clickable}
                 onClick={() => {
-                  navigate(`/users/${id}`);
+                  navigate(`/users/${id}`, { state: locationState });
                 }}
               >
                 <td>
@@ -129,6 +131,7 @@ const Users = () => {
                     subtitle={conditionalString(username)}
                     icon={<img className={styles.avatar} src={avatar ?? getAvatarById(id)} />}
                     to={`/users/${id}`}
+                    locationState={locationState}
                     size="compact"
                   />
                 </td>

--- a/packages/console/src/utilities/query-stringify.ts
+++ b/packages/console/src/utilities/query-stringify.ts
@@ -1,0 +1,7 @@
+// TODO - shared with ui/utilities/query-stringify.ts
+export const queryStringify = (parameters: URLSearchParams | Record<string, string>) => {
+  const searchParameters =
+    parameters instanceof URLSearchParams ? parameters : new URLSearchParams(parameters);
+
+  return searchParameters.toString();
+};


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Original Issue: LOG-3036

Navigate back to the list page from any detail page should keep its original search & page pagination status. 

1. Use location state to store the list page's filter status before jumping to the detail page
2. Load all the prev page filter status from the location state and applied to the backlink as query parameters in a detail page.
 

Note:
* Modify the `ApplicationDetails` redirect route to avoid the location state missing on redirect.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
* 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
* Test in all details pages
* Test in all details pages without location state
