### PR TITLE
fix(console): user management search result

### DIFF
--- a/packages/console/src/pages/Users/index.tsx
+++ b/packages/console/src/pages/Users/index.tsx
@@ -1,5 +1,5 @@
 import { User } from '@logto/schemas';
-import { conditionalString } from '@silverhand/essentials';
+import { conditional, conditionalString } from '@silverhand/essentials';
 import classNames from 'classnames';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -147,7 +147,7 @@ const Users = () => {
             pageCount={Math.ceil(totalCount / pageSize)}
             pageIndex={pageIndex}
             onChange={(page) => {
-              setQuery({ page: String(page) });
+              setQuery({ page: String(page), ...conditional(keyword && { search: keyword }) });
             }}
           />
         )}


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
### Steps to reproduce
- Search users with a keyword that matches more than the page-size count results.
- Click page 2 in the pagination
- You will see the items displayed on page 2 are not search results.

### Solution
- Add the missing query `search` on the page number changed.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
* LOG-3081

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="1600" alt="image" src="https://user-images.githubusercontent.com/10806653/173997489-9f034f43-366a-4deb-8b5c-e640a79f2ea1.png">

