### PR TITLE
feat(core): add sign-in-mode

### DIFF
--- a/packages/core/src/__mocks__/sign-in-experience.ts
+++ b/packages/core/src/__mocks__/sign-in-experience.ts
@@ -7,6 +7,7 @@ import {
   SignInMethods,
   SignInMethodState,
   TermsOfUse,
+  SignInMode,
 } from '@logto/schemas';
 
 export const mockSignInExperience: SignInExperience = {
@@ -34,6 +35,7 @@ export const mockSignInExperience: SignInExperience = {
     social: SignInMethodState.Secondary,
   },
   socialSignInConnectorTargets: ['github', 'facebook', 'wechat'],
+  signInMode: SignInMode.SignInAndRegister,
 };
 
 export const mockBranding: Branding = {

--- a/packages/core/src/queries/sign-in-experience.test.ts
+++ b/packages/core/src/queries/sign-in-experience.test.ts
@@ -31,7 +31,7 @@ describe('sign-in-experience query', () => {
   it('findDefaultSignInExperience', async () => {
     /* eslint-disable sql/no-unsafe-query */
     const expectSql = `
-      select "id", "branding", "language_info", "terms_of_use", "sign_in_methods", "social_sign_in_connector_targets"
+      select "id", "branding", "language_info", "terms_of_use", "sign_in_methods", "social_sign_in_connector_targets", "sign_in_mode"
       from "sign_in_experiences"
       where "id" = $1
     `;

--- a/packages/core/src/routes/init.ts
+++ b/packages/core/src/routes/init.ts
@@ -49,7 +49,7 @@ const createRouters = (provider: Provider) => {
   meRoutes(meRouter);
 
   const anonymousRouter: AnonymousRouter = new Router();
-  signInSettingsRoutes(anonymousRouter);
+  signInSettingsRoutes(anonymousRouter, provider);
   statusRoutes(anonymousRouter);
   // The swagger.json should contain all API routers.
   swaggerRoutes(anonymousRouter, [sessionRouter, managementRouter, meRouter, anonymousRouter]);

--- a/packages/core/src/routes/sign-in-settings.ts
+++ b/packages/core/src/routes/sign-in-settings.ts
@@ -17,7 +17,7 @@ export default function signInSettingsRoutes<T extends AnonymousRouter>(
   router.get(
     '/sign-in-settings',
     async (ctx, next) => {
-      const [signInExperience, connectorInstances, interactions] = await Promise.all([
+      const [signInExperience, connectorInstances, interaction] = await Promise.all([
         findDefaultSignInExperience(),
         getConnectorInstances(),
         provider.interactionDetails(ctx.req, ctx.res),
@@ -39,7 +39,7 @@ export default function signInSettingsRoutes<T extends AnonymousRouter>(
 
       const {
         params: { client_id },
-      } = interactions;
+      } = interaction;
 
       // Hard code AdminConsole sign-in methods settings.
       if (client_id === adminConsoleApplicationId) {

--- a/packages/core/src/routes/sign-in-settings.ts
+++ b/packages/core/src/routes/sign-in-settings.ts
@@ -50,8 +50,6 @@ export default function signInSettingsRoutes<T extends AnonymousRouter>(
           socialConnectors: [],
         };
 
-        console.log(ctx.body);
-
         return next();
       }
 

--- a/packages/schemas/src/seeds/sign-in-experience.ts
+++ b/packages/schemas/src/seeds/sign-in-experience.ts
@@ -1,6 +1,6 @@
 import { Language } from '@logto/phrases';
 
-import { CreateSignInExperience } from '../db-entries';
+import { CreateSignInExperience, SignInMode } from '../db-entries';
 import { BrandingStyle, SignInMethodState } from '../foundations';
 
 export const defaultSignInExperience: Readonly<CreateSignInExperience> = {
@@ -28,4 +28,12 @@ export const defaultSignInExperience: Readonly<CreateSignInExperience> = {
     social: SignInMethodState.Disabled,
   },
   socialSignInConnectorTargets: [],
+  signInMode: SignInMode.SignInAndRegister,
+};
+
+export const adminConsoleSignInMethods = {
+  username: SignInMethodState.Primary,
+  email: SignInMethodState.Disabled,
+  sms: SignInMethodState.Disabled,
+  social: SignInMethodState.Disabled,
 };

--- a/packages/schemas/tables/sign_in_experiences.sql
+++ b/packages/schemas/tables/sign_in_experiences.sql
@@ -1,3 +1,6 @@
+create type sign_in_mode as enum ('SignIn', 'Register', 'SignInAndRegister');
+
+
 create table sign_in_experiences (
   id varchar(21) not null,
   branding jsonb /* @use Branding */ not null,
@@ -5,5 +8,6 @@ create table sign_in_experiences (
   terms_of_use jsonb /* @use TermsOfUse */ not null,
   sign_in_methods jsonb /* @use SignInMethods */ not null,
   social_sign_in_connector_targets jsonb /* @use ConnectorTargets */ not null default '[]'::jsonb,
+  sign_in_mode sign_in_mode not null default 'SignInAndRegister',
   primary key (id)
 );

--- a/packages/schemas/tables/sign_in_experiences.sql
+++ b/packages/schemas/tables/sign_in_experiences.sql
@@ -1,6 +1,5 @@
 create type sign_in_mode as enum ('SignIn', 'Register', 'SignInAndRegister');
 
-
 create table sign_in_experiences (
   id varchar(21) not null,
   branding jsonb /* @use Branding */ not null,

--- a/packages/ui/src/__mocks__/logto.tsx
+++ b/packages/ui/src/__mocks__/logto.tsx
@@ -5,6 +5,7 @@ import {
   ConnectorType,
   SignInExperience,
   SignInMethodState,
+  SignInMode,
 } from '@logto/schemas';
 
 import { SignInExperienceSettings } from '@/types';
@@ -140,6 +141,7 @@ export const mockSignInExperience: SignInExperience = {
     social: SignInMethodState.Secondary,
   },
   socialSignInConnectorTargets: ['BE8QXN0VsrOH7xdWFDJZ9', 'lcXT4o2GSjbV9kg2shZC7'],
+  signInMode: SignInMode.SignInAndRegister,
 };
 
 export const mockSignInExperienceSettings: SignInExperienceSettings = {
@@ -149,4 +151,5 @@ export const mockSignInExperienceSettings: SignInExperienceSettings = {
   primarySignInMethod: 'username',
   secondarySignInMethods: ['email', 'sms', 'social'],
   socialConnectors,
+  signInMode: SignInMode.SignInAndRegister,
 };

--- a/packages/ui/src/pages/SignIn/index.tsx
+++ b/packages/ui/src/pages/SignIn/index.tsx
@@ -1,4 +1,4 @@
-import { BrandingStyle } from '@logto/schemas';
+import { BrandingStyle, SignInMode } from '@logto/schemas';
 import classNames from 'classnames';
 import React, { useContext } from 'react';
 
@@ -29,13 +29,17 @@ const SignIn = () => {
       <PrimarySection
         signInMethod={experienceSettings.primarySignInMethod}
         socialConnectors={experienceSettings.socialConnectors}
+        signInMode={experienceSettings.signInMode}
       />
       <SecondarySection
         primarySignInMethod={experienceSettings.primarySignInMethod}
         secondarySignInMethods={experienceSettings.secondarySignInMethods}
         socialConnectors={experienceSettings.socialConnectors}
       />
-      <CreateAccountLink primarySignInMethod={experienceSettings.primarySignInMethod} />
+      {experienceSettings.signInMode === SignInMode.SignInAndRegister && (
+        <CreateAccountLink primarySignInMethod={experienceSettings.primarySignInMethod} />
+      )}
+
       <AppNotification />
     </div>
   );

--- a/packages/ui/src/pages/SignIn/index.tsx
+++ b/packages/ui/src/pages/SignIn/index.tsx
@@ -31,11 +31,15 @@ const SignIn = () => {
         socialConnectors={experienceSettings.socialConnectors}
         signInMode={experienceSettings.signInMode}
       />
-      <SecondarySection
-        primarySignInMethod={experienceSettings.primarySignInMethod}
-        secondarySignInMethods={experienceSettings.secondarySignInMethods}
-        socialConnectors={experienceSettings.socialConnectors}
-      />
+
+      {experienceSettings.signInMode !== SignInMode.Register && (
+        <SecondarySection
+          primarySignInMethod={experienceSettings.primarySignInMethod}
+          secondarySignInMethods={experienceSettings.secondarySignInMethods}
+          socialConnectors={experienceSettings.socialConnectors}
+        />
+      )}
+
       {experienceSettings.signInMode === SignInMode.SignInAndRegister && (
         <CreateAccountLink primarySignInMethod={experienceSettings.primarySignInMethod} />
       )}

--- a/packages/ui/src/pages/SignIn/registry.tsx
+++ b/packages/ui/src/pages/SignIn/registry.tsx
@@ -1,7 +1,9 @@
+import { SignInMode } from '@logto/schemas';
 import React from 'react';
 
 import Divider from '@/components/Divider';
 import TextLink from '@/components/TextLink';
+import CreateAccount from '@/containers/CreateAccount';
 import { EmailPasswordless, PhonePasswordless } from '@/containers/Passwordless';
 import SignInMethodsLink from '@/containers/SignInMethodsLink';
 import { PrimarySocialSignIn, SecondarySocialSignIn } from '@/containers/SocialSignIn';
@@ -14,17 +16,33 @@ import * as styles from './index.module.scss';
 export const PrimarySection = ({
   signInMethod,
   socialConnectors = [],
+  signInMode,
 }: {
   signInMethod?: SignInMethod;
   socialConnectors?: ConnectorData[];
+  signInMode?: SignInMode;
 }) => {
   switch (signInMethod) {
     case 'email':
-      return <EmailPasswordless type="sign-in" className={styles.primarySignIn} />;
+      return (
+        <EmailPasswordless
+          type={signInMode === SignInMode.Register ? 'register' : 'sign-in'}
+          className={styles.primarySignIn}
+        />
+      );
     case 'sms':
-      return <PhonePasswordless type="sign-in" className={styles.primarySignIn} />;
+      return (
+        <PhonePasswordless
+          type={signInMode === SignInMode.Register ? 'register' : 'sign-in'}
+          className={styles.primarySignIn}
+        />
+      );
     case 'username':
-      return <UsernameSignin className={styles.primarySignIn} />;
+      return signInMode === SignInMode.Register ? (
+        <CreateAccount />
+      ) : (
+        <UsernameSignin className={styles.primarySignIn} />
+      );
     case 'social':
       return socialConnectors.length > 0 ? (
         <>

--- a/packages/ui/src/types/index.ts
+++ b/packages/ui/src/types/index.ts
@@ -4,6 +4,7 @@ import {
   TermsOfUse,
   SignInExperience,
   ConnectorMetadata,
+  SignInMode,
 } from '@logto/schemas';
 
 export type UserFlow = 'sign-in' | 'register';
@@ -35,4 +36,5 @@ export type SignInExperienceSettings = {
   primarySignInMethod: SignInMethod;
   secondarySignInMethods: SignInMethod[];
   socialConnectors: ConnectorData[];
+  signInMode: SignInMode;
 };


### PR DESCRIPTION

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add sign-in-mode to sign-in-experience settings.

1. Introduce sign-in-mode to the sign-in-experience settings.  `SignIn`, `Register` and `SignInAndRegister`
2. Update SignInSettings API, for admin console, always set signInMethods to `username`. If no user is found set sign-in mode to Register, else set to SignIn. 
3. Update UI signin page settings to reflect the updates
<img width="816" alt="image" src="https://user-images.githubusercontent.com/36393111/174025308-5786712e-abe9-4dba-961f-f96b5b9fedb5.png">


<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
log-2870

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
ut case update
@logto-io/eng 
