### PR TITLE
fix(console): return to user-details page from user-log-details page

### DIFF
--- a/packages/console/src/App.tsx
+++ b/packages/console/src/App.tsx
@@ -70,6 +70,7 @@ const Main = () => {
                 <Route index element={<Users />} />
                 <Route path=":id" element={<UserDetails />} />
                 <Route path=":id/logs" element={<UserDetails />} />
+                <Route path=":id/logs/:logId" element={<AuditLogDetails />} />
               </Route>
               <Route path="sign-in-experience">
                 <Route index element={<Navigate to="experience" />} />

--- a/packages/console/src/App.tsx
+++ b/packages/console/src/App.tsx
@@ -68,9 +68,9 @@ const Main = () => {
               </Route>
               <Route path="users">
                 <Route index element={<Users />} />
-                <Route path=":id" element={<UserDetails />} />
-                <Route path=":id/logs" element={<UserDetails />} />
-                <Route path=":id/logs/:logId" element={<AuditLogDetails />} />
+                <Route path=":userId" element={<UserDetails />} />
+                <Route path=":userId/logs" element={<UserDetails />} />
+                <Route path=":userId/logs/:logId" element={<AuditLogDetails />} />
               </Route>
               <Route path="sign-in-experience">
                 <Route index element={<Navigate to="experience" />} />

--- a/packages/console/src/components/AuditLogTable/index.tsx
+++ b/packages/console/src/components/AuditLogTable/index.tsx
@@ -3,7 +3,7 @@ import { conditionalString } from '@silverhand/essentials';
 import classNames from 'classnames';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import useSWR from 'swr';
 
 import ApplicationName from '@/components/ApplicationName';
@@ -23,12 +23,12 @@ import * as styles from './index.module.scss';
 const pageSize = 20;
 
 type Props = {
-  detailBaseUrl: string;
   userId?: string;
 };
 
-const AuditLogTable = ({ userId, detailBaseUrl }: Props) => {
+const AuditLogTable = ({ userId }: Props) => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const { pathname } = useLocation();
   const [query, setQuery] = useSearchParams();
   const pageIndex = Number(query.get('page') ?? '1');
   const event = query.get('event');
@@ -115,7 +115,7 @@ const AuditLogTable = ({ userId, detailBaseUrl }: Props) => {
                 key={id}
                 className={tableStyles.clickable}
                 onClick={() => {
-                  navigate(`${detailBaseUrl}/${id}`);
+                  navigate(`${pathname}/${id}`);
                 }}
               >
                 <td>

--- a/packages/console/src/components/AuditLogTable/index.tsx
+++ b/packages/console/src/components/AuditLogTable/index.tsx
@@ -23,10 +23,11 @@ import * as styles from './index.module.scss';
 const pageSize = 20;
 
 type Props = {
+  detailBaseUrl: string;
   userId?: string;
 };
 
-const AuditLogTable = ({ userId }: Props) => {
+const AuditLogTable = ({ userId, detailBaseUrl }: Props) => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const [query, setQuery] = useSearchParams();
   const pageIndex = Number(query.get('page') ?? '1');
@@ -114,7 +115,7 @@ const AuditLogTable = ({ userId }: Props) => {
                 key={id}
                 className={tableStyles.clickable}
                 onClick={() => {
-                  navigate(`/audit-logs/${id}`);
+                  navigate(`${detailBaseUrl}/${id}`);
                 }}
               >
                 <td>

--- a/packages/console/src/pages/AuditLogDetails/index.tsx
+++ b/packages/console/src/pages/AuditLogDetails/index.tsx
@@ -30,7 +30,7 @@ const AuditLogDetails = () => {
 
   const isLoading = !data && !error;
 
-  const backLink = userId ? `/users/${userId}` : '/audit-logs';
+  const backLink = userId ? `/users/${userId}/logs` : '/audit-logs';
   const backLinkTitle = userId ? (
     <DangerousRaw>{t('log_details.back_to_user', { name: userData?.name ?? '-' })}</DangerousRaw>
   ) : (

--- a/packages/console/src/pages/AuditLogDetails/index.tsx
+++ b/packages/console/src/pages/AuditLogDetails/index.tsx
@@ -1,4 +1,4 @@
-import { LogDTO } from '@logto/schemas';
+import { LogDTO, User } from '@logto/schemas';
 import classNames from 'classnames';
 import dayjs from 'dayjs';
 import React from 'react';
@@ -9,6 +9,7 @@ import useSWR from 'swr';
 import ApplicationName from '@/components/ApplicationName';
 import Card from '@/components/Card';
 import CodeEditor from '@/components/CodeEditor';
+import DangerousRaw from '@/components/DangerousRaw';
 import DetailsSkeleton from '@/components/DetailsSkeleton';
 import LinkButton from '@/components/LinkButton';
 import TabNav, { TabNavItem } from '@/components/TabNav';
@@ -22,19 +23,23 @@ import EventIcon from './components/EventIcon';
 import * as styles from './index.module.scss';
 
 const AuditLogDetails = () => {
-  const { logId } = useParams();
+  const { id: userId, logId } = useParams();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { data, error } = useSWR<LogDTO, RequestError>(logId && `/api/logs/${logId}`);
+  const { data: userData } = useSWR<User, RequestError>(userId && `/api/users/${userId}`);
+
   const isLoading = !data && !error;
+
+  const backLink = userId ? `/users/${userId}` : '/audit-logs';
+  const backLinkTitle = userId ? (
+    <DangerousRaw>{t('log_details.back_to_user', { name: userData?.name ?? '-' })}</DangerousRaw>
+  ) : (
+    'admin_console.log_details.back_to_logs'
+  );
 
   return (
     <div className={detailsStyles.container}>
-      <LinkButton
-        to="/audit-logs"
-        icon={<Back />}
-        title="admin_console.log_details.back_to_logs"
-        className={styles.backLink}
-      />
+      <LinkButton to={backLink} icon={<Back />} title={backLinkTitle} className={styles.backLink} />
       {isLoading && <DetailsSkeleton />}
       {!data && error && <div>{`error occurred: ${error.body?.message ?? error.message}`}</div>}
       {data && (

--- a/packages/console/src/pages/AuditLogDetails/index.tsx
+++ b/packages/console/src/pages/AuditLogDetails/index.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import dayjs from 'dayjs';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import useSWR from 'swr';
 
 import ApplicationName from '@/components/ApplicationName';
@@ -24,13 +24,14 @@ import * as styles from './index.module.scss';
 
 const AuditLogDetails = () => {
   const { userId, logId } = useParams();
+  const { pathname } = useLocation();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { data, error } = useSWR<LogDTO, RequestError>(logId && `/api/logs/${logId}`);
   const { data: userData } = useSWR<User, RequestError>(userId && `/api/users/${userId}`);
 
   const isLoading = !data && !error;
 
-  const backLink = userId ? `/users/${userId}/logs` : '/audit-logs';
+  const backLink = `/${pathname.slice(0, pathname.lastIndexOf('/'))}`;
   const backLinkTitle = userId ? (
     <DangerousRaw>{t('log_details.back_to_user', { name: userData?.name ?? '-' })}</DangerousRaw>
   ) : (

--- a/packages/console/src/pages/AuditLogDetails/index.tsx
+++ b/packages/console/src/pages/AuditLogDetails/index.tsx
@@ -22,6 +22,9 @@ import * as detailsStyles from '@/scss/details.module.scss';
 import EventIcon from './components/EventIcon';
 import * as styles from './index.module.scss';
 
+const getAuditLogDetailsRelatedResourceLink = (pathname: string) =>
+  `/${pathname.slice(0, pathname.lastIndexOf('/'))}`;
+
 const AuditLogDetails = () => {
   const { userId, logId } = useParams();
   const { pathname } = useLocation();
@@ -31,7 +34,7 @@ const AuditLogDetails = () => {
 
   const isLoading = !data && !error;
 
-  const backLink = `/${pathname.slice(0, pathname.lastIndexOf('/'))}`;
+  const backLink = getAuditLogDetailsRelatedResourceLink(pathname);
   const backLinkTitle = userId ? (
     <DangerousRaw>{t('log_details.back_to_user', { name: userData?.name ?? '-' })}</DangerousRaw>
   ) : (

--- a/packages/console/src/pages/AuditLogDetails/index.tsx
+++ b/packages/console/src/pages/AuditLogDetails/index.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import dayjs from 'dayjs';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import useSWR from 'swr';
 
 import ApplicationName from '@/components/ApplicationName';
@@ -23,16 +23,14 @@ import EventIcon from './components/EventIcon';
 import * as styles from './index.module.scss';
 
 const AuditLogDetails = () => {
-  const { id: userId, logId } = useParams();
-  const { pathname } = useLocation();
+  const { userId, logId } = useParams();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { data, error } = useSWR<LogDTO, RequestError>(logId && `/api/logs/${logId}`);
   const { data: userData } = useSWR<User, RequestError>(userId && `/api/users/${userId}`);
 
   const isLoading = !data && !error;
 
-  const backLink =
-    pathname.startsWith('/users') && userId ? `/users/${userId}/logs` : '/audit-logs';
+  const backLink = userId ? `/users/${userId}/logs` : '/audit-logs';
   const backLinkTitle = userId ? (
     <DangerousRaw>{t('log_details.back_to_user', { name: userData?.name ?? '-' })}</DangerousRaw>
   ) : (

--- a/packages/console/src/pages/AuditLogDetails/index.tsx
+++ b/packages/console/src/pages/AuditLogDetails/index.tsx
@@ -36,7 +36,9 @@ const AuditLogDetails = () => {
 
   const backLink = getAuditLogDetailsRelatedResourceLink(pathname);
   const backLinkTitle = userId ? (
-    <DangerousRaw>{t('log_details.back_to_user', { name: userData?.name ?? '-' })}</DangerousRaw>
+    <DangerousRaw>
+      {t('log_details.back_to_user', { name: userData?.name ?? t('users.unnamed') })}
+    </DangerousRaw>
   ) : (
     'admin_console.log_details.back_to_logs'
   );

--- a/packages/console/src/pages/AuditLogDetails/index.tsx
+++ b/packages/console/src/pages/AuditLogDetails/index.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import dayjs from 'dayjs';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import useSWR from 'swr';
 
 import ApplicationName from '@/components/ApplicationName';
@@ -24,13 +24,15 @@ import * as styles from './index.module.scss';
 
 const AuditLogDetails = () => {
   const { id: userId, logId } = useParams();
+  const { pathname } = useLocation();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { data, error } = useSWR<LogDTO, RequestError>(logId && `/api/logs/${logId}`);
   const { data: userData } = useSWR<User, RequestError>(userId && `/api/users/${userId}`);
 
   const isLoading = !data && !error;
 
-  const backLink = userId ? `/users/${userId}/logs` : '/audit-logs';
+  const backLink =
+    pathname.startsWith('/users') && userId ? `/users/${userId}/logs` : '/audit-logs';
   const backLinkTitle = userId ? (
     <DangerousRaw>{t('log_details.back_to_user', { name: userData?.name ?? '-' })}</DangerousRaw>
   ) : (

--- a/packages/console/src/pages/AuditLogs/index.tsx
+++ b/packages/console/src/pages/AuditLogs/index.tsx
@@ -12,7 +12,7 @@ const AuditLogs = () => {
       <div className={styles.headline}>
         <CardTitle title="logs.title" subtitle="logs.subtitle" />
       </div>
-      <AuditLogTable detailBaseUrl="/audit-logs" />
+      <AuditLogTable />
     </Card>
   );
 };

--- a/packages/console/src/pages/AuditLogs/index.tsx
+++ b/packages/console/src/pages/AuditLogs/index.tsx
@@ -12,7 +12,7 @@ const AuditLogs = () => {
       <div className={styles.headline}>
         <CardTitle title="logs.title" subtitle="logs.subtitle" />
       </div>
-      <AuditLogTable />
+      <AuditLogTable detailBaseUrl="/audit-logs" />
     </Card>
   );
 };

--- a/packages/console/src/pages/UserDetails/index.tsx
+++ b/packages/console/src/pages/UserDetails/index.tsx
@@ -51,12 +51,12 @@ type FormData = {
 const UserDetails = () => {
   const location = useLocation();
   const isLogs = location.pathname.endsWith('/logs');
-  const { id } = useParams();
+  const { userId } = useParams();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const [isDeleteFormOpen, setIsDeleteFormOpen] = useState(false);
   const [isResetPasswordFormOpen, setIsResetPasswordFormOpen] = useState(false);
 
-  const { data, error, mutate } = useSWR<User, RequestError>(id && `/api/users/${id}`);
+  const { data, error, mutate } = useSWR<User, RequestError>(userId && `/api/users/${userId}`);
   const isLoading = !data && !error;
 
   const {
@@ -118,10 +118,10 @@ const UserDetails = () => {
       />
       {isLoading && <DetailsSkeleton />}
       {!data && error && <div>{`error occurred: ${error.body?.message ?? error.message}`}</div>}
-      {id && data && (
+      {userId && data && (
         <>
           <Card className={styles.header}>
-            <img className={styles.avatar} src={data.avatar ?? getAvatarById(id)} />
+            <img className={styles.avatar} src={data.avatar ?? getAvatarById(userId)} />
             <div className={styles.metadata}>
               <div className={styles.name}>{data.name ?? '-'}</div>
               <div>
@@ -186,8 +186,8 @@ const UserDetails = () => {
           </Card>
           <Card className={classNames(styles.body, detailsStyles.body)}>
             <TabNav>
-              <TabNavItem href={`/users/${id}`}>{t('user_details.tab_settings')}</TabNavItem>
-              <TabNavItem href={`/users/${id}/logs`}>{t('user_details.tab_logs')}</TabNavItem>
+              <TabNavItem href={`/users/${userId}`}>{t('user_details.tab_settings')}</TabNavItem>
+              <TabNavItem href={`/users/${userId}/logs`}>{t('user_details.tab_logs')}</TabNavItem>
             </TabNav>
             {isLogs ? (
               <div className={styles.logs}>

--- a/packages/console/src/pages/UserDetails/index.tsx
+++ b/packages/console/src/pages/UserDetails/index.tsx
@@ -191,7 +191,7 @@ const UserDetails = () => {
             </TabNav>
             {isLogs ? (
               <div className={styles.logs}>
-                <AuditLogTable userId={data.id} />
+                <AuditLogTable userId={data.id} detailBaseUrl={`/users/${id}/logs`} />
               </div>
             ) : (
               <form className={styles.form} onSubmit={onSubmit}>

--- a/packages/console/src/pages/UserDetails/index.tsx
+++ b/packages/console/src/pages/UserDetails/index.tsx
@@ -191,7 +191,7 @@ const UserDetails = () => {
             </TabNav>
             {isLogs ? (
               <div className={styles.logs}>
-                <AuditLogTable userId={data.id} detailBaseUrl={`/users/${id}/logs`} />
+                <AuditLogTable userId={data.id} />
               </div>
             ) : (
               <form className={styles.form} onSubmit={onSubmit}>

--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -551,6 +551,7 @@ const translation = {
     },
     log_details: {
       back_to_logs: 'Back to Audit Logs',
+      back_to_user: 'Back to {{name}}',
       success: 'Success',
       failed: 'Failed',
       event_type: 'Event Type',

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -535,7 +535,7 @@ const translation = {
     },
     log_details: {
       back_to_logs: '返回审计日志',
-      back_to_user: '返回{{name}}',
+      back_to_user: '返回 {{name}}',
       success: '成功',
       failed: '失败',
       event_type: '事件类型',

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -535,6 +535,7 @@ const translation = {
     },
     log_details: {
       back_to_logs: '返回审计日志',
+      back_to_user: '返回{{name}}',
       success: '成功',
       failed: '失败',
       event_type: '事件类型',


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
* Rename the `id` param name under the `/user` route to `userId` for clarity.
* Per AC design, we should be able to nav back to user-details page from user-log-details page:
<img width="1339" alt="image" src="https://user-images.githubusercontent.com/10806653/174038736-16490ca9-3d45-462e-9975-7ee6a03f7eee.png">

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
* LOG-3096

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
![navback](https://user-images.githubusercontent.com/10806653/174202629-90b71c53-d55b-47d5-8bb1-069592b3e198.gif)


