### PR TITLE
fix(console): should return to previous page when on sign-in-experience and app details page

### DIFF
--- a/packages/console/src/App.tsx
+++ b/packages/console/src/App.tsx
@@ -52,7 +52,7 @@ const Main = () => {
                 <Route index element={<Applications />} />
                 <Route path="create" element={<Applications />} />
                 <Route path=":id">
-                  <Route index element={<Navigate to="settings" />} />
+                  <Route index element={<Navigate replace to="settings" />} />
                   <Route path="settings" element={<ApplicationDetails />} />
                   <Route path="advanced-settings" element={<ApplicationDetails />} />
                 </Route>
@@ -73,7 +73,7 @@ const Main = () => {
                 <Route path=":userId/logs/:logId" element={<AuditLogDetails />} />
               </Route>
               <Route path="sign-in-experience">
-                <Route index element={<Navigate to="experience" />} />
+                <Route index element={<Navigate replace to="experience" />} />
                 <Route path=":tab" element={<SignInExperience />} />
               </Route>
               <Route path="settings" element={<Settings />} />


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
We can not navigate back to the previous page on the sign-in-experience and app details page for the react-router's redirect action.
Now use `replace` when redirecting these two pages.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
* LOG-3098

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested in the Admin Console.
