### PR TITLE
feat(core): register with admin role

### DIFF
--- a/packages/core/src/routes/session/session.test.ts
+++ b/packages/core/src/routes/session/session.test.ts
@@ -189,10 +189,6 @@ describe('sessionRoutes', () => {
 
       expect(insertUser).toHaveBeenCalledWith(
         expect.objectContaining({
-          id: 'user1',
-          username: 'username',
-          passwordEncrypted: 'password_user1',
-          passwordEncryptionMethod: 'Argon2i',
           roleNames: ['admin'],
         })
       );
@@ -209,10 +205,6 @@ describe('sessionRoutes', () => {
 
       expect(insertUser).toHaveBeenCalledWith(
         expect.objectContaining({
-          id: 'user1',
-          username: 'username',
-          passwordEncrypted: 'password_user1',
-          passwordEncryptionMethod: 'Argon2i',
           roleNames: [],
         })
       );

--- a/packages/core/src/routes/session/session.test.ts
+++ b/packages/core/src/routes/session/session.test.ts
@@ -1,4 +1,5 @@
 import { User } from '@logto/schemas';
+import { adminConsoleApplicationId } from '@logto/schemas/lib/seeds';
 import { Provider } from 'oidc-provider';
 
 import { mockUser } from '@/__mocks__';
@@ -29,6 +30,8 @@ jest.mock('@/lib/user', () => ({
 const insertUser = jest.fn(async (..._args: unknown[]) => ({ id: 'id' }));
 const findUserById = jest.fn(async (): Promise<User> => mockUser);
 const updateUserById = jest.fn(async (..._args: unknown[]) => ({ id: 'id' }));
+const hasActiveUsers = jest.fn(async () => true);
+
 jest.mock('@/queries/user', () => ({
   findUserById: async () => findUserById(),
   findUserByIdentity: async () => ({ id: 'id', identities: {} }),
@@ -41,6 +44,7 @@ jest.mock('@/queries/user', () => ({
     connectorId === 'connectorId' && userId === 'id',
   hasUserWithPhone: async (phone: string) => phone === '13000000000',
   hasUserWithEmail: async (email: string) => email === 'a@a.com',
+  hasActiveUsers: async () => hasActiveUsers(),
 }));
 
 const grantSave = jest.fn(async () => 'finalGrantId');
@@ -149,6 +153,8 @@ describe('sessionRoutes', () => {
 
   describe('POST /session/register/username-password', () => {
     it('assign result and redirect', async () => {
+      interactionDetails.mockResolvedValueOnce({ params: {} });
+
       const response = await sessionRequest
         .post('/session/register/username-password')
         .send({ username: 'username', password: 'password' });
@@ -158,6 +164,7 @@ describe('sessionRoutes', () => {
           username: 'username',
           passwordEncrypted: 'password_user1',
           passwordEncryptionMethod: 'Argon2i',
+          roleNames: [],
         })
       );
       expect(response.body).toHaveProperty('redirectTo');
@@ -166,6 +173,48 @@ describe('sessionRoutes', () => {
         expect.anything(),
         expect.objectContaining({ login: { accountId: 'user1' } }),
         expect.anything()
+      );
+    });
+
+    it('register user with admin role for admin console if no active user found', async () => {
+      interactionDetails.mockResolvedValueOnce({
+        params: { client_id: adminConsoleApplicationId },
+      });
+
+      hasActiveUsers.mockResolvedValueOnce(false);
+
+      await sessionRequest
+        .post('/session/register/username-password')
+        .send({ username: 'username', password: 'password' });
+
+      expect(insertUser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'user1',
+          username: 'username',
+          passwordEncrypted: 'password_user1',
+          passwordEncryptionMethod: 'Argon2i',
+          roleNames: ['admin'],
+        })
+      );
+    });
+
+    it('should not register user with admin role for admin console if any active user found', async () => {
+      interactionDetails.mockResolvedValueOnce({
+        params: { client_id: adminConsoleApplicationId },
+      });
+
+      await sessionRequest
+        .post('/session/register/username-password')
+        .send({ username: 'username', password: 'password' });
+
+      expect(insertUser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'user1',
+          username: 'username',
+          passwordEncrypted: 'password_user1',
+          passwordEncryptionMethod: 'Argon2i',
+          roleNames: [],
+        })
       );
     });
 

--- a/packages/core/src/routes/session/session.ts
+++ b/packages/core/src/routes/session/session.ts
@@ -128,10 +128,11 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
 
       const createAdminUser =
         String(client_id) === adminConsoleApplicationId && !(await hasActiveUsers());
+      const roleNames = createAdminUser ? [UserRole.Admin] : [];
 
       const id = await generateUserId();
 
-      ctx.log(type, { userId: id });
+      ctx.log(type, { userId: id, roleNames });
 
       const { passwordEncrypted, passwordEncryptionMethod } = await encryptUserPassword(password);
 
@@ -140,7 +141,7 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
         username,
         passwordEncrypted,
         passwordEncryptionMethod,
-        roleNames: createAdminUser ? [UserRole.Admin] : [],
+        roleNames,
       });
       await updateLastSignInAt(id);
       await assignInteractionResults(ctx, provider, { login: { accountId: id } });

--- a/packages/core/src/routes/session/session.ts
+++ b/packages/core/src/routes/session/session.ts
@@ -1,6 +1,8 @@
 import path from 'path';
 
 import { LogtoErrorCode } from '@logto/phrases';
+import { UserRole } from '@logto/schemas';
+import { adminConsoleApplicationId } from '@logto/schemas/lib/seeds';
 import { passwordRegEx, usernameRegEx } from '@logto/shared';
 import { conditional } from '@silverhand/essentials';
 import { Provider } from 'oidc-provider';
@@ -15,7 +17,7 @@ import {
   updateLastSignInAt,
 } from '@/lib/user';
 import koaGuard from '@/middleware/koa-guard';
-import { hasUser, insertUser } from '@/queries/user';
+import { hasUser, insertUser, hasActiveUsers } from '@/queries/user';
 import assertThat from '@/utils/assert-that';
 
 import { AnonymousRouter } from '../types';
@@ -120,7 +122,15 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
         })
       );
 
+      const {
+        params: { client_id },
+      } = await provider.interactionDetails(ctx.req, ctx.res);
+
+      const createAdminUser =
+        String(client_id) === adminConsoleApplicationId && !(await hasActiveUsers());
+
       const id = await generateUserId();
+
       ctx.log(type, { userId: id });
 
       const { passwordEncrypted, passwordEncryptionMethod } = await encryptUserPassword(password);
@@ -130,6 +140,7 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
         username,
         passwordEncrypted,
         passwordEncryptionMethod,
+        roleNames: createAdminUser ? [UserRole.Admin] : [],
       });
       await updateLastSignInAt(id);
       await assignInteractionResults(ctx, provider, { login: { accountId: id } });


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Add the register user with the admin role feature for the `session/register/username-password` API


Check if target client_id is admin role, and has no active users, our Logto very first user should be created as admin. 


<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
log-3099

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
ut case added
@logto-io/eng 
