### PR TITLE
feat(schemas): make users.avatar URL length 2048

### DIFF
--- a/packages/schemas/tables/users.sql
+++ b/packages/schemas/tables/users.sql
@@ -8,7 +8,7 @@ create table users (
   password_encrypted varchar(128),
   password_encryption_method users_password_encryption_method,
   name varchar(128),
-  avatar varchar(256),
+  avatar varchar(2048),
   application_id varchar(21),
   role_names jsonb /* @use RoleNames */ not null default '[]'::jsonb,
   identities jsonb /* @use Identities */ not null default '{}'::jsonb,


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Make the DB field `users.avatar` URL length 2048 to contain the extreme long avatar URL, e.g. length 304 from Facebook

See Slack discussion [thread](https://silverhand-io.slack.com/archives/C02A8G4HVAM/p1655450692387249)

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-3100

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
No need.
