### PR TITLE
fix(console): sign in exp layout

### DIFF
--- a/packages/console/src/pages/SignInExperience/components/Preview.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/Preview.module.scss
@@ -4,8 +4,8 @@
   width: 480px;
   padding: 0;
   overflow: hidden;
-  box-shadow: var(--shadow-1);
-  border: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
 
   .header {
     display: flex;
@@ -43,59 +43,6 @@
       border: none;
     }
 
-    &.mobile {
-      padding: _.unit(10) 0;
-
-      .device {
-        width: 390px;
-        margin: 0 auto;
-        border-radius: 26px;
-        overflow: hidden;
-
-        .topBar {
-          display: flex;
-          align-items: center;
-          padding: _.unit(3) _.unit(6);
-
-          .time {
-            flex: 1;
-            font: var(--font-subhead-2);
-          }
-        }
-
-        &.dark {
-          // Sync with iframe's UI color
-          background: #1a1c1d;
-
-          .topBar {
-            color: #fff;
-          }
-        }
-
-        &.light {
-          // Sync with iframe's UI color
-          background: #fff;
-
-          .topBar {
-            color: #000;
-          }
-        }
-
-        iframe {
-          width: 390px;
-          height: 808px;
-        }
-      }
-
-      .description {
-        margin-top: _.unit(6);
-        width: 100%;
-        text-align: center;
-        color: var(--color-caption);
-        font: var(--font-body-small);
-      }
-    }
-
     &.web {
       .device {
         width: 480px;
@@ -110,6 +57,77 @@
           position: absolute;
           top: -190px;
           left: -240px;
+        }
+      }
+    }
+
+    &.mobile {
+      padding: _.unit(10) 0;
+      height: 500px;
+      position: relative;
+
+      .deviceWrapper {
+        width: 390px;
+        height: 450px;
+        margin: 0 auto;
+        transform: scale(0.5);
+        transform-origin: top center;
+
+        .device {
+          border-radius: 26px;
+          overflow: hidden;
+
+          .topBar {
+            display: flex;
+            align-items: center;
+            padding: _.unit(3) _.unit(6);
+
+            .time {
+              flex: 1;
+              font: var(--font-subhead-2);
+            }
+          }
+
+          &.dark {
+            // Sync with iframe's UI color
+            background: #1a1c1d;
+
+            .topBar {
+              color: #fff;
+            }
+          }
+
+          &.light {
+            // Sync with iframe's UI color
+            background: #fff;
+
+            .topBar {
+              color: #000;
+            }
+          }
+
+          iframe {
+            width: 390px;
+            height: 808px;
+          }
+        }
+
+        @media screen and (min-height: 1100px) {
+          transform: unset;
+          height: 900px;
+        }
+
+        @media screen and (min-height: 900px) and (max-height: 1100px) {
+          transform: scale(0.75);
+          height: 675px;
+        }
+
+        .description {
+          margin-top: _.unit(6);
+          width: 100%;
+          text-align: center;
+          color: var(--color-caption);
+          font: var(--font-body-small);
         }
       }
     }

--- a/packages/console/src/pages/SignInExperience/components/Preview.tsx
+++ b/packages/console/src/pages/SignInExperience/components/Preview.tsx
@@ -111,14 +111,6 @@ const Preview = ({ signInExperience, className }: Props) => {
       </div>
       <TabNav className={styles.nav}>
         <TabNavItem
-          isActive={platform === 'web'}
-          onClick={() => {
-            setPlatform('web');
-          }}
-        >
-          {t('sign_in_exp.preview.web')}
-        </TabNavItem>
-        <TabNavItem
           isActive={platform === 'mobile'}
           onClick={() => {
             setPlatform('mobile');
@@ -126,20 +118,30 @@ const Preview = ({ signInExperience, className }: Props) => {
         >
           {t('sign_in_exp.preview.mobile')}
         </TabNavItem>
+        <TabNavItem
+          isActive={platform === 'web'}
+          onClick={() => {
+            setPlatform('web');
+          }}
+        >
+          {t('sign_in_exp.preview.web')}
+        </TabNavItem>
       </TabNav>
       <div className={classNames(styles.body, styles[platform])}>
-        <div className={classNames(styles.device, styles[mode])}>
+        <div className={styles.deviceWrapper}>
+          <div className={classNames(styles.device, styles[mode])}>
+            {platform === 'mobile' && (
+              <div className={styles.topBar}>
+                <div className={styles.time}>{dayjs().format('HH:mm')}</div>
+                <PhoneInfo />
+              </div>
+            )}
+            <iframe ref={previewRef} src="/sign-in?preview=true" tabIndex={-1} />
+          </div>
           {platform === 'mobile' && (
-            <div className={styles.topBar}>
-              <div className={styles.time}>{dayjs().format('HH:mm')}</div>
-              <PhoneInfo />
-            </div>
+            <div className={styles.description}>{t('sign_in_exp.preview.mobile_description')}</div>
           )}
-          <iframe ref={previewRef} src="/sign-in?preview=true" tabIndex={-1} />
         </div>
-        {platform === 'mobile' && (
-          <div className={styles.description}>{t('sign_in_exp.preview.mobile_description')}</div>
-        )}
       </div>
     </Card>
   );

--- a/packages/console/src/pages/SignInExperience/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/index.module.scss
@@ -2,9 +2,9 @@
 
 .wrapper {
   display: flex;
-  align-items: flex-start;
-  height: 100%;
+  align-items: stretch;
   min-width: 950px;
+  height: 100%;
 
   .setup {
     flex: 1;

--- a/packages/console/src/pages/SignInExperience/index.tsx
+++ b/packages/console/src/pages/SignInExperience/index.tsx
@@ -14,7 +14,6 @@ import CardTitle from '@/components/CardTitle';
 import TabNav, { TabNavItem } from '@/components/TabNav';
 import useApi, { RequestError } from '@/hooks/use-api';
 import useSettings from '@/hooks/use-settings';
-import useUserPreferences from '@/hooks/use-user-preferences';
 import * as detailsStyles from '@/scss/details.module.scss';
 import * as modalStyles from '@/scss/modal.module.scss';
 
@@ -35,9 +34,6 @@ const SignInExperience = () => {
   const { tab } = useParams();
   const { data, error, mutate } = useSWR<SignInExperienceType, RequestError>('/api/sign-in-exp');
   const { settings, error: settingsError, updateSettings } = useSettings();
-  const {
-    data: { experienceNoticeConfirmed },
-  } = useUserPreferences();
   const [dataToCompare, setDataToCompare] = useState<SignInExperienceType>();
 
   const methods = useForm<SignInExperienceForm>();
@@ -95,7 +91,7 @@ const SignInExperience = () => {
     return <div>{settingsError.body?.message ?? settingsError.message}</div>;
   }
 
-  if (!experienceNoticeConfirmed) {
+  if (!settings?.customizeSignInExperience) {
     return <Welcome />;
   }
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Make changes on sign in experience (with preview) layout:

1. Form card can scroll inside
2. Mobile tab comes first
3. Mobile preview support 3 scales (100%, 75%, 50%) depending on device height, make sure that users can see the whole "phone" without scrolling.
4. Fix: use `settings.customizeSignInExperience` to control guide visibility.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-2794

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="1309" alt="截屏2022-06-17 下午3 35 02" src="https://user-images.githubusercontent.com/5717882/174252908-f72eaf58-304d-4dc1-953d-dc732dd55dd7.png">

<img width="1145" alt="截屏2022-06-17 下午3 35 10" src="https://user-images.githubusercontent.com/5717882/174252933-16ab7645-0d30-4fe8-86c8-d36904e02667.png">

<img width="952" alt="截屏2022-06-17 下午3 35 44" src="https://user-images.githubusercontent.com/5717882/174252955-91c3217f-fdb9-4ec2-b0d9-ce1b99919b54.png">

