### PR TITLE
refactor(console): unnamed translation

### DIFF
--- a/packages/console/src/components/UnnamedTrans/index.tsx
+++ b/packages/console/src/components/UnnamedTrans/index.tsx
@@ -1,22 +1,14 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
+
+import { translateUnnamed } from '@/utilities/translation';
 
 type Props = {
   resource: Record<string, string>;
   className?: string;
 };
 
-const UnnamedTrans = ({ resource, className }: Props) => {
-  const {
-    i18n: { languages },
-  } = useTranslation();
-  const matchedLanguage = languages.find((language) => resource[language]);
-
-  if (!matchedLanguage) {
-    return null;
-  }
-
-  return <span className={className}>{resource[matchedLanguage]}</span>;
-};
+const UnnamedTrans = ({ resource, className }: Props) => (
+  <span className={className}>{translateUnnamed(resource)}</span>
+);
 
 export default UnnamedTrans;

--- a/packages/console/src/components/UnnamedTrans/index.tsx
+++ b/packages/console/src/components/UnnamedTrans/index.tsx
@@ -7,8 +7,14 @@ type Props = {
   className?: string;
 };
 
-const UnnamedTrans = ({ resource, className }: Props) => (
-  <span className={className}>{translateUnnamed(resource)}</span>
-);
+const UnnamedTrans = ({ resource, className }: Props) => {
+  const translation = translateUnnamed(resource);
+
+  if (!translation) {
+    return null;
+  }
+
+  return <span className={className}>{translation}</span>;
+};
 
 export default UnnamedTrans;

--- a/packages/console/src/utilities/translation.ts
+++ b/packages/console/src/utilities/translation.ts
@@ -1,0 +1,9 @@
+import i18next from 'i18next';
+
+export const translateUnnamed = (resource: Record<string, string>) => {
+  const { languages } = i18next;
+  const matchedLanguage = languages.find((language) => resource[language]);
+
+  // Note: the `Unknown` string will not be returned in theory.
+  return (matchedLanguage && resource[matchedLanguage]) ?? 'Unknown';
+};

--- a/packages/console/src/utilities/translation.ts
+++ b/packages/console/src/utilities/translation.ts
@@ -2,8 +2,7 @@ import i18next from 'i18next';
 
 export const translateUnnamed = (resource: Record<string, string>) => {
   const { languages } = i18next;
-  const matchedLanguage = languages.find((language) => resource[language]);
+  const matchedTranslation = languages.find((language) => resource[language]);
 
-  // Note: the `Unknown` string will not be returned in theory.
-  return (matchedLanguage && resource[matchedLanguage]) ?? 'Unknown';
+  return matchedTranslation && resource[matchedTranslation];
 };


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Extract the `UnnamedTrans` component logic into util, for this functionality will not be only used as react component.
e.g. display the connector name in the confirm modal. Future feature: LOG-3073:
<img width="1057" alt="image" src="https://user-images.githubusercontent.com/10806653/174301030-6b1d9719-5609-43c1-9c22-de26387f79c4.png">


<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
N/A

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested in the Admin Console.
