### PR TITLE
fix(console): connector name in user detials

### DIFF
--- a/packages/console/src/pages/UserDetails/components/UserConnectors.tsx
+++ b/packages/console/src/pages/UserDetails/components/UserConnectors.tsx
@@ -54,7 +54,7 @@ const UserConnectors = ({ userId, connectors, onDelete }: Props) => {
     }
 
     return Object.keys(connectors).map((key) => {
-      const connector = connectorGroups.find(({ target }) => target === key);
+      const connector = connectorGroups.find(({ id }) => id === key);
 
       if (!connector) {
         return {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
fix(console): connector name in user details
We store the `connectorId` in the user table, so we should use `connectorId` to retrieve the connector information here.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
N / A

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
before:
<img width="592" alt="image" src="https://user-images.githubusercontent.com/10806653/174302916-aacd567f-2440-4f2e-b1b3-7d39094b5400.png">

after:
<img width="617" alt="image" src="https://user-images.githubusercontent.com/10806653/174302961-1b5419fb-3839-4d23-9e40-231d3f8d3ec7.png">

