### PR TITLE
fix(console): unexpected spacing under item-preview icon

### DIFF
--- a/packages/console/src/pages/ApiResources/index.module.scss
+++ b/packages/console/src/pages/ApiResources/index.module.scss
@@ -14,6 +14,10 @@
   flex: 1;
 }
 
+.icon {
+  @include _.image-block;
+}
+
 .pagination {
   margin-top: _.unit(4);
   min-height: 32px;

--- a/packages/console/src/pages/ApiResources/index.module.scss
+++ b/packages/console/src/pages/ApiResources/index.module.scss
@@ -15,7 +15,7 @@
 }
 
 .icon {
-  @include _.image-block;
+  display: block;
 }
 
 .pagination {

--- a/packages/console/src/pages/ApiResources/index.tsx
+++ b/packages/console/src/pages/ApiResources/index.tsx
@@ -116,7 +116,7 @@ const ApiResources = () => {
                 <td>
                   <ItemPreview
                     title={name}
-                    icon={<img src={apiResourceIcon} />}
+                    icon={<img className={styles.icon} src={apiResourceIcon} />}
                     to={buildDetailsLink(id)}
                   />
                 </td>

--- a/packages/console/src/pages/Applications/index.module.scss
+++ b/packages/console/src/pages/Applications/index.module.scss
@@ -14,6 +14,10 @@
   flex: 1;
 }
 
+.icon {
+  @include _.image-block;
+}
+
 .pagination {
   margin-top: _.unit(4);
   min-height: 32px;

--- a/packages/console/src/pages/Applications/index.module.scss
+++ b/packages/console/src/pages/Applications/index.module.scss
@@ -15,7 +15,7 @@
 }
 
 .icon {
-  @include _.image-block;
+  display: block;
 }
 
 .pagination {

--- a/packages/console/src/pages/Applications/index.tsx
+++ b/packages/console/src/pages/Applications/index.tsx
@@ -115,7 +115,7 @@ const Applications = () => {
                   <ItemPreview
                     title={name}
                     subtitle={t(`${applicationTypeI18nKey[type]}.title`)}
-                    icon={<img src={ApplicationIcon[type]} />}
+                    icon={<img className={styles.icon} src={ApplicationIcon[type]} />}
                     to={`/applications/${id}`}
                   />
                 </td>

--- a/packages/console/src/pages/Connectors/components/ConnectorName/index.module.scss
+++ b/packages/console/src/pages/Connectors/components/ConnectorName/index.module.scss
@@ -9,7 +9,7 @@ a.link {
   width: 40px;
   height: 40px;
   border-radius: 5px;
-  @include _.image-block;
+  display: block;
 }
 
 .previewTitle {

--- a/packages/console/src/pages/Connectors/components/ConnectorName/index.module.scss
+++ b/packages/console/src/pages/Connectors/components/ConnectorName/index.module.scss
@@ -9,6 +9,7 @@ a.link {
   width: 40px;
   height: 40px;
   border-radius: 5px;
+  @include _.image-block;
 }
 
 .previewTitle {

--- a/packages/console/src/pages/Connectors/components/ConnectorName/index.tsx
+++ b/packages/console/src/pages/Connectors/components/ConnectorName/index.tsx
@@ -36,7 +36,7 @@ const ConnectorName = ({ type, connectors, onClickSetup }: Props) => {
             )}
           </div>
         }
-        icon={<img src={connectorIconPlaceHolder[type]} />}
+        icon={<img className={styles.logo} src={connectorIconPlaceHolder[type]} />}
       />
     );
   }

--- a/packages/console/src/pages/Users/index.module.scss
+++ b/packages/console/src/pages/Users/index.module.scss
@@ -38,7 +38,7 @@
   height: 28px;
   border-radius: 6px;
   object-fit: cover;
-  @include _.image-block;
+  display: block;
 }
 
 .userName {

--- a/packages/console/src/pages/Users/index.module.scss
+++ b/packages/console/src/pages/Users/index.module.scss
@@ -38,6 +38,7 @@
   height: 28px;
   border-radius: 6px;
   object-fit: cover;
+  @include _.image-block;
 }
 
 .userName {

--- a/packages/console/src/scss/_underscore.scss
+++ b/packages/console/src/scss/_underscore.scss
@@ -38,10 +38,6 @@
   font: var(--font-subhead-cap-small);
 }
 
-@mixin image-block {
-  display: block;
-}
-
 @mixin rotating-animation {
   animation: rotating 1s ease-in-out infinite;
 }

--- a/packages/console/src/scss/_underscore.scss
+++ b/packages/console/src/scss/_underscore.scss
@@ -38,6 +38,10 @@
   font: var(--font-subhead-cap-small);
 }
 
+@mixin image-block {
+  display: block;
+}
+
 @mixin rotating-animation {
   animation: rotating 1s ease-in-out infinite;
 }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
When an `<img />` is contained by a `<div />`, the `<img />` will align to the text baseline inside the `<div />` for the default display behavior of `<img />` is `inline`.

<!-- Provide detail PR description below -->
<img width="1429" alt="unexpected-spacing" src="https://user-images.githubusercontent.com/10806653/174515246-409930a3-ceef-4919-8f5f-999ceea7e8f9.png">


### Solution
Change the display behavior of the `<img />` tag inside `<ItemPreview />` from 'inline` to `bock`.

Refer to: https://stackoverflow.com/questions/21726898/div-with-image-has-a-bigger-height-than-expected

<img width="1122" alt="unexpected-spacing-fixed" src="https://user-images.githubusercontent.com/10806653/174515257-a7d42d1a-54e2-4604-ab79-da0f22a2c86c.png">


<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
* LOG-3112

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested in the Admin Console.
