### PR TITLE
fix(console): read-only text field background color should use color-layer-2

### DIFF
--- a/packages/console/src/components/TextInput/index.module.scss
+++ b/packages/console/src/components/TextInput/index.module.scss
@@ -54,7 +54,7 @@
   }
 
   &.readOnly {
-    background: var(--color-inverse-on-surface);
+    background: var(--color-layer-2);
     color: var(--color-text);
     border-color: var(--color-border);
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
fix(console): read-only text field background color should use color-layer-2

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
* LOG-3049

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Before
<img width="708" alt="image" src="https://user-images.githubusercontent.com/10806653/174516197-a523d949-e6ed-42e4-8216-c51110fceee2.png">

### After
<img width="673" alt="image" src="https://user-images.githubusercontent.com/10806653/174516140-d78fe91d-ec30-4c5e-9653-13eed827c6fe.png">

