### PR TITLE
fix(console): item preview alignment

### DIFF
--- a/packages/console/src/components/ItemPreview/index.module.scss
+++ b/packages/console/src/components/ItemPreview/index.module.scss
@@ -6,18 +6,13 @@
   white-space: nowrap;
 
   > div:not(:first-child) {
-    margin-left: _.unit(4);
-  }
-
-  .icon {
-    flex-shrink: 0;
+    margin-left: _.unit(3);
   }
 
   .title {
     font: var(--font-body-medium);
     color: var(--color-text-link);
     text-decoration: none;
-    margin-bottom: _.unit(1);
   }
 
   .subtitle {

--- a/packages/console/src/components/ItemPreview/index.tsx
+++ b/packages/console/src/components/ItemPreview/index.tsx
@@ -15,7 +15,7 @@ type Props = {
 const ItemPreview = ({ title, subtitle, icon, to, size = 'default' }: Props) => {
   return (
     <div className={classNames(styles.item, styles[size])}>
-      {icon && <div className={styles.icon}>{icon}</div>}
+      {icon}
       <div className={styles.content}>
         {to && (
           <Link


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fix the item preview aligment.
Related PR: https://github.com/logto-io/logto/pull/1152

### Notes
* For the `<ItemPreview />` is used in tables that have a min-width limit, so the icon will not be shrunk anymore.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
N / A

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested in the Admin Console.
