### PR TITLE
fix(console): user details card footer

### DIFF
--- a/packages/console/src/pages/UserDetails/index.module.scss
+++ b/packages/console/src/pages/UserDetails/index.module.scss
@@ -67,10 +67,14 @@
 
   .form {
     margin-top: _.unit(8);
+    flex: 1;
+    display: flex;
+    flex-direction: column;
   }
 
   .fields {
     padding-bottom: _.unit(10);
+    flex: 1;
   }
 
   .textField {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Fix user details card footer, auto grow form's height, to make sure "footer" is always in the bottom of page.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-3029

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="687" alt="截屏2022-06-21 下午1 42 37" src="https://user-images.githubusercontent.com/5717882/174724859-5767e45c-100d-488a-92fa-3960d07ca9d4.png">

