### PR TITLE
fix(core,console): delete specific user identity by target

### DIFF
--- a/packages/console/src/pages/UserDetails/components/UserConnectors.tsx
+++ b/packages/console/src/pages/UserDetails/components/UserConnectors.tsx
@@ -33,7 +33,7 @@ const UserConnectors = ({ userId, connectors, onDelete }: Props) => {
   const isLoading = !connectorGroups && !error;
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const handleDelete = async (connectorId: string) => {
+  const handleDelete = async (target: string) => {
     if (isSubmitting) {
       return;
     }
@@ -41,8 +41,8 @@ const UserConnectors = ({ userId, connectors, onDelete }: Props) => {
     setIsSubmitting(true);
 
     try {
-      await api.delete(`/api/users/${userId}/identities/${connectorId}`);
-      onDelete?.(connectorId);
+      await api.delete(`/api/users/${userId}/identities/${target}`);
+      onDelete?.(target);
     } finally {
       setIsSubmitting(false);
     }

--- a/packages/core/src/routes/admin-user.ts
+++ b/packages/core/src/routes/admin-user.ts
@@ -5,7 +5,6 @@ import pick from 'lodash.pick';
 import { InvalidInputError } from 'slonik';
 import { object, string } from 'zod';
 
-import { getConnectorInstanceById } from '@/connectors';
 import RequestError from '@/errors/RequestError';
 import { encryptUserPassword, generateUserId } from '@/lib/user';
 import koaGuard from '@/middleware/koa-guard';
@@ -199,17 +198,14 @@ export default function adminUserRoutes<T extends AuthedRouter>(router: T) {
   );
 
   router.delete(
-    '/users/:userId/identities/:connectorId',
-    koaGuard({ params: object({ userId: string(), connectorId: string() }) }),
+    '/users/:userId/identities/:target',
+    koaGuard({ params: object({ userId: string(), target: string() }) }),
     async (ctx, next) => {
       const {
-        params: { userId, connectorId },
+        params: { userId, target },
       } = ctx.guard;
 
       const { identities } = await findUserById(userId);
-      const {
-        metadata: { target },
-      } = await getConnectorInstanceById(connectorId);
 
       if (!has(identities, target)) {
         throw new RequestError({ code: 'user.identity_not_exists', status: 404 });


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
1. In Admin Console UserDetails page, the deletion of user identities info should be indexed by `target` instead of `connectorId`.
2. Fix backend API and UTs as well.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-3133

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Passed UTs and tested locally.
