### PR TITLE
feat(console,core): hide admin user

### DIFF
--- a/packages/console/src/components/ApplicationName/index.tsx
+++ b/packages/console/src/components/ApplicationName/index.tsx
@@ -1,6 +1,7 @@
 import { Application } from '@logto/schemas';
 import { adminConsoleApplicationId } from '@logto/schemas/lib/seeds';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import useSWR from 'swr';
 
@@ -15,8 +16,9 @@ const ApplicationName = ({ applicationId, isLink = false }: Props) => {
   const isAdminConsole = applicationId === adminConsoleApplicationId;
 
   const { data } = useSWR<Application>(!isAdminConsole && `/api/applications/${applicationId}`);
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
-  const name = (isAdminConsole ? 'Admin Console' : data?.name) || '-';
+  const name = (isAdminConsole ? <>Admin Console ({t('system_app')})</> : data?.name) || '-';
 
   if (isLink && !isAdminConsole) {
     return (

--- a/packages/console/src/components/UserName/index.tsx
+++ b/packages/console/src/components/UserName/index.tsx
@@ -1,4 +1,4 @@
-import { User } from '@logto/schemas';
+import { User, UserRole } from '@logto/schemas';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
@@ -20,18 +20,23 @@ const UserName = ({ userId, isLink = false }: Props) => {
   const isLoading = !data && !error;
   const name = data?.name || t('users.unnamed');
 
+  const isAdmin = data?.roleNames.includes(UserRole.Admin);
+
   if (isLoading) {
     return null;
   }
 
   return (
     <div className={styles.userName}>
-      {isLink ? (
+      {isLink && !isAdmin ? (
         <Link to={`/users/${userId}`} target="_blank" className={styles.link}>
           {name}
         </Link>
       ) : (
-        <span>{name}</span>
+        <span>
+          {name}
+          {isAdmin && <> ({t('admin_user')})</>}
+        </span>
       )}
       <span className={styles.userId}>{userId}</span>
     </div>

--- a/packages/console/src/pages/Users/index.tsx
+++ b/packages/console/src/pages/Users/index.tsx
@@ -36,7 +36,7 @@ const Users = () => {
   const pageIndex = Number(query.get('page') ?? '1');
   const keyword = query.get('search') ?? '';
   const { data, error, mutate } = useSWR<[User[], number], RequestError>(
-    `/api/users?page=${pageIndex}&page_size=${pageSize}${conditionalString(
+    `/api/users?page=${pageIndex}&page_size=${pageSize}&hideAdminUser=true${conditionalString(
       keyword && `&search=${keyword}`
     )}`
   );

--- a/packages/core/src/queries/user.ts
+++ b/packages/core/src/queries/user.ts
@@ -94,21 +94,37 @@ const buildUserSearchConditionSql = (search: string) => {
   return sql`${sql.join(conditions, sql` or `)}`;
 };
 
-export const countUsers = async (search?: string) =>
+const buildUserConditions = (search?: string, hideAdminUser?: boolean) => {
+  if (hideAdminUser) {
+    return sql`
+      where not (${fields.roleNames}::jsonb?${UserRole.Admin})
+      ${conditionalSql(search, (search) => sql`and (${buildUserSearchConditionSql(search)})`)}
+    `;
+  }
+
+  return sql`
+    ${conditionalSql(search, (search) => sql`where ${buildUserSearchConditionSql(search)}`)}
+  `;
+};
+
+export const countUsers = async (search?: string, hideAdminUser?: boolean) =>
   envSet.pool.one<{ count: number }>(sql`
     select count(*)
     from ${table}
-    where not (${fields.roleNames}::jsonb?${UserRole.Admin})
-    ${conditionalSql(search, (search) => sql`and ${buildUserSearchConditionSql(search)}`)}
+    ${buildUserConditions(search, hideAdminUser)}
   `);
 
-export const findUsers = async (limit: number, offset: number, search?: string) =>
+export const findUsers = async (
+  limit: number,
+  offset: number,
+  search?: string,
+  hideAdminUser?: boolean
+) =>
   envSet.pool.any<User>(
     sql`
       select ${sql.join(Object.values(fields), sql`,`)}
       from ${table}
-      where not (${fields.roleNames}::jsonb?${UserRole.Admin})
-      ${conditionalSql(search, (search) => sql`and ${buildUserSearchConditionSql(search)}`)}
+      ${buildUserConditions(search, hideAdminUser)}
       limit ${limit}
       offset ${offset}
     `

--- a/packages/core/src/queries/user.ts
+++ b/packages/core/src/queries/user.ts
@@ -1,4 +1,4 @@
-import { User, CreateUser, Users } from '@logto/schemas';
+import { User, CreateUser, Users, UserRole } from '@logto/schemas';
 import { sql } from 'slonik';
 
 import { buildInsertInto } from '@/database/insert-into';
@@ -98,7 +98,8 @@ export const countUsers = async (search?: string) =>
   envSet.pool.one<{ count: number }>(sql`
     select count(*)
     from ${table}
-    ${conditionalSql(search, (search) => sql`where ${buildUserSearchConditionSql(search)}`)}
+    where not (${fields.roleNames}::jsonb?${UserRole.Admin})
+    ${conditionalSql(search, (search) => sql`and ${buildUserSearchConditionSql(search)}`)}
   `);
 
 export const findUsers = async (limit: number, offset: number, search?: string) =>
@@ -106,7 +107,8 @@ export const findUsers = async (limit: number, offset: number, search?: string) 
     sql`
       select ${sql.join(Object.values(fields), sql`,`)}
       from ${table}
-      ${conditionalSql(search, (search) => sql`where ${buildUserSearchConditionSql(search)}`)}
+      where not (${fields.roleNames}::jsonb?${UserRole.Admin})
+      ${conditionalSql(search, (search) => sql`and ${buildUserSearchConditionSql(search)}`)}
       limit ${limit}
       offset ${offset}
     `

--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -96,6 +96,8 @@ const translation = {
     title: 'Admin Console',
     sign_out: 'Sign out',
     profile: 'Profile',
+    admin_user: 'Admin',
+    system_app: 'System',
     copy: {
       pending: 'Copy',
       copying: 'Copying',

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -96,6 +96,8 @@ const translation = {
     title: '管理面板',
     sign_out: '登出',
     profile: '账户管理',
+    admin_user: '管理员',
+    system_app: '系统应用',
     copy: {
       pending: '拷贝',
       copying: '拷贝中',


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Hide admin user in AC:

1. In user management table list, admin users are filtered.
2. In audit log detail, if is admin user, the "user" link is removed and a tag is added.
3. Add a tag on special "Admin Console" app.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-3041

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="390" alt="截屏2022-06-21 下午4 13 58" src="https://user-images.githubusercontent.com/5717882/174752154-b602ca5e-97d2-4918-93e3-8b5fc580cc25.png">

<img width="318" alt="截屏2022-06-21 下午4 18 11" src="https://user-images.githubusercontent.com/5717882/174752180-830f679f-2d15-4ef2-8e63-80bbb85d00ee.png">

