### PR TITLE
fix(console): update user data

### DIFF
--- a/packages/console/src/pages/UserDetails/index.tsx
+++ b/packages/console/src/pages/UserDetails/index.tsx
@@ -69,7 +69,7 @@ const UserDetails = () => {
 
   const {
     field: { onChange, value },
-  } = useController({ name: 'customData', control, rules: { required: true } });
+  } = useController({ name: 'customData', control });
   const api = useApi();
 
   useEffect(() => {
@@ -87,7 +87,9 @@ const UserDetails = () => {
       return;
     }
 
-    const customData = safeParseJson(formData.customData);
+    const { customData: inputCustomData, name, avatar, roleNames } = formData;
+
+    const customData = inputCustomData ? safeParseJson(inputCustomData) : {};
 
     if (!customData) {
       toast.error(t('user_details.custom_data_invalid'));
@@ -96,9 +98,9 @@ const UserDetails = () => {
     }
 
     const payload: Partial<User> = {
-      name: formData.name,
-      avatar: formData.avatar,
-      roleNames: formData.roleNames,
+      name,
+      avatar,
+      roleNames,
       customData,
     };
 

--- a/packages/console/src/pages/UserDetails/index.tsx
+++ b/packages/console/src/pages/UserDetails/index.tsx
@@ -87,9 +87,9 @@ const UserDetails = () => {
       return;
     }
 
-    const { customData: inputCustomData, name, avatar, roleNames } = formData;
+    const { customData: inputtedCustomData, name, avatar, roleNames } = formData;
 
-    const customData = inputCustomData ? safeParseJson(inputCustomData) : {};
+    const customData = inputtedCustomData ? safeParseJson(inputtedCustomData) : {};
 
     if (!customData) {
       toast.error(t('user_details.custom_data_invalid'));

--- a/packages/core/src/routes/admin-user.test.ts
+++ b/packages/core/src/routes/admin-user.test.ts
@@ -162,6 +162,19 @@ describe('adminUserRoutes', () => {
     });
   });
 
+  it('PATCH /users/:userId should allow updated with empty avatar', async () => {
+    const name = 'Micheal';
+    const avatar = '';
+
+    const response = await userRequest.patch('/users/foo').send({ name, avatar });
+    expect(response.status).toEqual(200);
+    expect(response.body).toEqual({
+      ...mockUserResponse,
+      name,
+      avatar,
+    });
+  });
+
   it('PATCH /users/:userId should updated with one field if the other is undefined', async () => {
     const name = 'Micheal';
 

--- a/packages/core/src/routes/admin-user.ts
+++ b/packages/core/src/routes/admin-user.ts
@@ -112,7 +112,7 @@ export default function adminUserRoutes<T extends AuthedRouter>(router: T) {
       params: object({ userId: string() }),
       body: object({
         name: string().nullable().optional(),
-        avatar: string().url().nullable().optional(),
+        avatar: string().url().or(literal('')).nullable().optional(),
         customData: arbitraryObjectGuard.optional(),
         roleNames: string().array().optional(),
       }),


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
* Allow update user data with empty avatar string.
* Remove required rule from `customData` field, for the JSON syntax check will guard this situation.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
* LOG-2596

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test in the Admin Console.
