### PR TITLE
fix(console): button loading spinner position

### DIFF
--- a/packages/console/src/components/Button/index.module.scss
+++ b/packages/console/src/components/Button/index.module.scss
@@ -23,8 +23,6 @@
 
     .spinner {
       position: absolute;
-      left: 50%;
-      transform: translateX(-50%);
     }
 
     .spinner ~ span {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fix button loading spinner position, since we now using flex layout in button component.
Previously, the spinner was slightly shifted to the right. Now it's right in the middle

<img width="229" alt="image" src="https://user-images.githubusercontent.com/12833674/174778802-6a488751-340f-4b9d-b0a2-fe6252f60c5a.png">

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Switch to slow 3G network and submit any form, the spinner shows up right in the middle of the submit button
