### PR TITLE
fix(worklow): add master codecov report job

### DIFF
--- a/.github/workflows/master-codecov-report.yml
+++ b/.github/workflows/master-codecov-report.yml
@@ -1,0 +1,35 @@
+name: Master Codecov Report
+
+on:
+  push:
+    branches: [master]
+
+concurrency: master-codecov-report
+
+jobs:
+  report-coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node and pnpm
+        uses: silverhand-io/actions-node-pnpm-run-steps@v1.2.2
+
+      - name: Prepack
+        run: pnpm prepack
+
+      - name: Test
+        run: pnpm ci:test
+
+      - name: Codecov Core
+        uses: codecov/codecov-action@v3
+        with:
+          flags: core
+          directory: ./packages/core
+
+      - name: Codecov ui
+        uses: codecov/codecov-action@v3
+        with:
+          flags: ui
+          directory: ./packages/ui

--- a/.github/workflows/master-codecov-report.yml
+++ b/.github/workflows/master-codecov-report.yml
@@ -28,7 +28,7 @@ jobs:
           flags: core
           directory: ./packages/core
 
-      - name: Codecov ui
+      - name: Codecov UI
         uses: codecov/codecov-action@v3
         with:
           flags: ui


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add master codecov report job.

We have observed that the master base branch codecov report hasn't been updated since PR #1123 
We need to upload the report to codecov on each master push. So create an individual workflow job for that. 


<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
@logto-io/eng 
