### PR TITLE
fix(console): connector card item style

### DIFF
--- a/packages/console/src/components/RadioGroup/index.module.scss
+++ b/packages/console/src/components/RadioGroup/index.module.scss
@@ -33,6 +33,8 @@
     &.disabled {
       cursor: not-allowed;
       background-color: var(--color-layer-2);
+      border-color: var(--color-layer-2);
+      outline: unset;
     }
 
     &:not(.disabled):focus {

--- a/packages/console/src/pages/Connectors/components/CreateForm/index.module.scss
+++ b/packages/console/src/pages/Connectors/components/CreateForm/index.module.scss
@@ -9,12 +9,17 @@
 
     .logo {
       margin: _.unit(2);
-      width: 32px;
-      height: 32px;
+      width: 48px;
+      height: 48px;
+      border-radius: 8px;
+      background-color: var(--color-hover);
+      display: flex;
+      align-items: center;
+      justify-content: center;
 
       img {
-        width: 32px;
-        height: 32px;
+        width: 34px;
+        height: 34px;
       }
     }
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- Instead of removing the border from the disabled radio item, we change the border color to the background color to ensure the disabled radio item will have the same size as the enabled item.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
LOG-3027

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="785" alt="image" src="https://user-images.githubusercontent.com/10806653/174915483-54daf805-3a73-4d9b-9545-816e8e10482c.png">

