### PR TITLE
refactor(connector,core): add config param to email/sms connector test API

### DIFF
--- a/packages/connector-aliyun-dm/src/index.ts
+++ b/packages/connector-aliyun-dm/src/index.ts
@@ -32,10 +32,12 @@ export default class AliyunDmConnector implements EmailConnector {
     }
   };
 
-  public sendMessage: EmailSendMessageFunction = async (address, type, data) => {
-    const config = await this.getConfig(this.metadata.id);
-    await this.validateConfig(config);
-    const { accessKeyId, accessKeySecret, accountName, fromAlias, templates } = config;
+  // eslint-disable-next-line complexity
+  public sendMessage: EmailSendMessageFunction = async (address, type, data, config) => {
+    const emailConfig =
+      (config as AliyunDmConfig | undefined) ?? (await this.getConfig(this.metadata.id));
+    await this.validateConfig(emailConfig);
+    const { accessKeyId, accessKeySecret, accountName, fromAlias, templates } = emailConfig;
     const template = templates.find((template) => template.usageType === type);
 
     assert(

--- a/packages/connector-aliyun-sms/src/index.ts
+++ b/packages/connector-aliyun-sms/src/index.ts
@@ -26,10 +26,11 @@ export default class AliyunSmsConnector implements SmsConnector {
     }
   };
 
-  public sendMessage: SmsSendMessageFunction = async (phone, type, { code }) => {
-    const config = await this.getConfig(this.metadata.id);
-    await this.validateConfig(config);
-    const { accessKeyId, accessKeySecret, signName, templates } = config;
+  public sendMessage: SmsSendMessageFunction = async (phone, type, { code }, config) => {
+    const smsConfig =
+      (config as AliyunSmsConfig | undefined) ?? (await this.getConfig(this.metadata.id));
+    await this.validateConfig(smsConfig);
+    const { accessKeyId, accessKeySecret, signName, templates } = smsConfig;
     const template = templates.find(({ usageType }) => usageType === type);
 
     assert(

--- a/packages/connector-types/src/index.ts
+++ b/packages/connector-types/src/index.ts
@@ -64,13 +64,15 @@ export type SmsMessageTypes = EmailMessageTypes;
 export type EmailSendMessageFunction<T = unknown> = (
   address: string,
   type: keyof EmailMessageTypes,
-  payload: EmailMessageTypes[typeof type]
+  payload: EmailMessageTypes[typeof type],
+  config?: Record<string, unknown>
 ) => Promise<T>;
 
 export type SmsSendMessageFunction<T = unknown> = (
   phone: string,
   type: keyof SmsMessageTypes,
-  payload: SmsMessageTypes[typeof type]
+  payload: SmsMessageTypes[typeof type],
+  config?: Record<string, unknown>
 ) => Promise<T>;
 
 export interface BaseConnector {

--- a/packages/console/src/pages/ConnectorDetails/index.module.scss
+++ b/packages/console/src/pages/ConnectorDetails/index.module.scss
@@ -93,3 +93,7 @@
 .resetIcon {
   color: var(--color-icon);
 }
+
+.readme {
+  margin-top: _.unit(-6);
+}

--- a/packages/console/src/pages/ConnectorDetails/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/index.tsx
@@ -210,7 +210,9 @@ const ConnectorDetails = () => {
                 }}
               />
             </FormField>
-            {data.type !== ConnectorType.Social && <SenderTester connectorType={data.type} />}
+            {data.type !== ConnectorType.Social && (
+              <SenderTester connectorType={data.type} config={config} />
+            )}
             {saveError && <div>{saveError}</div>}
           </div>
           <div className={detailsStyles.footer}>

--- a/packages/core/src/routes/connector.test.ts
+++ b/packages/core/src/routes/connector.test.ts
@@ -123,11 +123,16 @@ describe('connector route', () => {
       const sendMessageSpy = jest.spyOn(mockedEmailConnector, 'sendMessage');
       const response = await connectorRequest
         .post('/connectors/test/email')
-        .send({ email: 'test@email.com' });
+        .send({ email: 'test@email.com', config: { test: 123 } });
       expect(sendMessageSpy).toHaveBeenCalledTimes(1);
-      expect(sendMessageSpy).toHaveBeenCalledWith('test@email.com', 'Test', {
-        code: 'email-test',
-      });
+      expect(sendMessageSpy).toHaveBeenCalledWith(
+        'test@email.com',
+        'Test',
+        {
+          code: 'email-test',
+        },
+        { test: 123 }
+      );
       expect(response).toHaveProperty('statusCode', 204);
     });
 
@@ -166,11 +171,16 @@ describe('connector route', () => {
       const sendMessageSpy = jest.spyOn(mockedSmsConnectorInstance, 'sendMessage');
       const response = await connectorRequest
         .post('/connectors/test/sms')
-        .send({ phone: '12345678901' });
+        .send({ phone: '12345678901', config: { test: 123 } });
       expect(sendMessageSpy).toHaveBeenCalledTimes(1);
-      expect(sendMessageSpy).toHaveBeenCalledWith('12345678901', 'Test', {
-        code: '123456',
-      });
+      expect(sendMessageSpy).toHaveBeenCalledWith(
+        '12345678901',
+        'Test',
+        {
+          code: '123456',
+        },
+        { test: 123 }
+      );
       expect(response).toHaveProperty('statusCode', 204);
     });
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add `config` param to email/sms connector test API, in order to allow testing the email/sms connector on the fly, without having to save the configs first.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Update email connector config without saving, send test. Received email with new config
- [x] Update SMS connector config without saving, send test. Received SMS on mobile with new config
