### PR TITLE
fix(console): mutate settings after SIE guide done

### DIFF
--- a/packages/console/src/hooks/use-settings.ts
+++ b/packages/console/src/hooks/use-settings.ts
@@ -31,6 +31,7 @@ const useSettings = () => {
     isLoading: !settings && !error,
     settings: settings?.adminConsole,
     error,
+    mutate,
     updateSettings,
   };
 };

--- a/packages/console/src/pages/SignInExperience/components/GuideModal.tsx
+++ b/packages/console/src/pages/SignInExperience/components/GuideModal.tsx
@@ -69,7 +69,7 @@ const GuideModal = ({ isOpen, onClose }: Props) => {
       updateSettings({ customizeSignInExperience: true }),
     ]);
 
-    location.reload();
+    onClose();
   });
 
   return (

--- a/packages/console/src/pages/SignInExperience/components/Welcome.tsx
+++ b/packages/console/src/pages/SignInExperience/components/Welcome.tsx
@@ -9,7 +9,11 @@ import CardTitle from '@/components/CardTitle';
 import GuideModal from './GuideModal';
 import * as styles from './Welcome.module.scss';
 
-const Welcome = () => {
+type Props = {
+  mutate: () => void;
+};
+
+const Welcome = ({ mutate }: Props) => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const [isOpen, setIsOpen] = useState(false);
 
@@ -33,6 +37,7 @@ const Welcome = () => {
         isOpen={isOpen}
         onClose={() => {
           setIsOpen(false);
+          mutate();
         }}
       />
     </>

--- a/packages/console/src/pages/SignInExperience/index.tsx
+++ b/packages/console/src/pages/SignInExperience/index.tsx
@@ -32,7 +32,7 @@ const SignInExperience = () => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { tab } = useParams();
   const { data, error, mutate } = useSWR<SignInExperienceType, RequestError>('/api/sign-in-exp');
-  const { settings, error: settingsError, updateSettings } = useSettings();
+  const { settings, error: settingsError, updateSettings, mutate: mutateSettings } = useSettings();
   const [dataToCompare, setDataToCompare] = useState<SignInExperienceType>();
 
   const methods = useForm<SignInExperienceForm>();
@@ -91,7 +91,7 @@ const SignInExperience = () => {
   }
 
   if (!settings?.customizeSignInExperience) {
-    return <Welcome />;
+    return <Welcome mutate={mutateSettings} />;
   }
 
   return (


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Mutate settings after SIE guide done, this will refresh the state (`settings.admin_console.customizeSignInExperience`) on whether to show welcome guide modal.

Previously, this is done by `location.reload`.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested and performed as expected.
