### PR TITLE
refactor(console): show connector readme content in drawer

### DIFF
--- a/packages/console/src/components/Drawer/index.module.scss
+++ b/packages/console/src/components/Drawer/index.module.scss
@@ -9,19 +9,25 @@
   max-width: 900px;
   min-width: 770px;
   outline: none;
-  background: var(--color-layer-1);
-  overflow-y: auto;
+  background: var(--color-base);
 
-  .headline {
+  .wrapper {
     display: flex;
-    justify-content: right;
+    flex-direction: column;
+    height: 100%;
 
-    > svg {
-      cursor: pointer;
+    .header {
+      display: flex;
+      align-items: center;
+      flex-shrink: 0;
+      background-color: var(--color-layer-1);
+      height: 64px;
+      padding: 0 _.unit(6);
     }
 
-    .closeIcon {
-      color: var(--color-icon);
+    .body {
+      flex: 1;
+      overflow-y: auto;
     }
   }
 }

--- a/packages/console/src/components/Drawer/index.tsx
+++ b/packages/console/src/components/Drawer/index.tsx
@@ -1,18 +1,23 @@
+import { AdminConsoleKey } from '@logto/phrases';
 import React from 'react';
 import ReactModal from 'react-modal';
 
 import Close from '@/icons/Close';
 
+import CardTitle from '../CardTitle';
 import IconButton from '../IconButton';
+import Spacer from '../Spacer';
 import * as styles from './index.module.scss';
 
 type Props = {
+  title?: AdminConsoleKey;
+  subtitle?: AdminConsoleKey;
   isOpen: boolean;
-  onClose?: () => void;
   children: React.ReactNode;
+  onClose?: () => void;
 };
 
-const Drawer = ({ isOpen, onClose, children }: Props) => {
+const Drawer = ({ title, subtitle, isOpen, children, onClose }: Props) => {
   return (
     <ReactModal
       shouldCloseOnOverlayClick
@@ -23,14 +28,18 @@ const Drawer = ({ isOpen, onClose, children }: Props) => {
       closeTimeoutMS={300}
       onRequestClose={onClose}
     >
-      {onClose && (
-        <div className={styles.headline}>
-          <IconButton size="large" onClick={onClose}>
-            <Close className={styles.closeIcon} />
-          </IconButton>
-        </div>
-      )}
-      <div>{children}</div>
+      <div className={styles.wrapper}>
+        {title && (
+          <div className={styles.header}>
+            <CardTitle size="small" title={title} subtitle={subtitle} />
+            <Spacer />
+            <IconButton size="large" onClick={onClose}>
+              <Close />
+            </IconButton>
+          </div>
+        )}
+        <div className={styles.body}>{children}</div>
+      </div>
     </ReactModal>
   );
 };

--- a/packages/console/src/pages/ApplicationDetails/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/index.tsx
@@ -97,6 +97,10 @@ const ApplicationDetails = () => {
     toast.success(t('application_details.save_success'));
   });
 
+  const onCloseDrawer = () => {
+    setIsReadmeOpen(false);
+  };
+
   const isAdvancedSettings = location.pathname.includes('advanced-settings');
 
   return (
@@ -129,14 +133,8 @@ const ApplicationDetails = () => {
                   setIsReadmeOpen(true);
                 }}
               />
-              <Drawer isOpen={isReadmeOpen}>
-                <Guide
-                  isCompact
-                  app={data}
-                  onClose={() => {
-                    setIsReadmeOpen(false);
-                  }}
-                />
+              <Drawer isOpen={isReadmeOpen} onClose={onCloseDrawer}>
+                <Guide isCompact app={data} onClose={onCloseDrawer} />
               </Drawer>
               <ActionMenu
                 buttonProps={{ icon: <More className={styles.moreIcon} />, size: 'large' }}

--- a/packages/console/src/pages/ConnectorDetails/index.module.scss
+++ b/packages/console/src/pages/ConnectorDetails/index.module.scss
@@ -95,5 +95,5 @@
 }
 
 .readme {
-  margin-top: _.unit(-6);
+  padding: 0 _.unit(6);
 }

--- a/packages/console/src/pages/ConnectorDetails/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/index.tsx
@@ -152,6 +152,8 @@ const ConnectorDetails = () => {
               }}
             />
             <Drawer
+              title="connectors.title"
+              subtitle="connectors.subtitle"
               isOpen={isReadMeOpen}
               onClose={() => {
                 setIsReadMeOpen(false);

--- a/packages/console/src/pages/Connectors/components/ConnectorRow/index.tsx
+++ b/packages/console/src/pages/Connectors/components/ConnectorRow/index.tsx
@@ -32,7 +32,7 @@ const ConnectorRow = ({ type, connectors, onClickSetup }: Props) => {
   };
 
   return (
-    <tr className={conditional(showSetupButton && tableStyles.clickable)} onClick={handleClickRow}>
+    <tr className={conditional(!showSetupButton && tableStyles.clickable)} onClick={handleClickRow}>
       <td>
         <ConnectorName type={type} connectors={connectors} onClickSetup={onClickSetup} />
       </td>

--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -274,6 +274,8 @@ const translation = {
         native: 'Native',
       },
       add_multi_platform: ' supports multiple platform, select a platform to continue',
+      drawer_title: 'Connector Guide',
+      drawer_subtitle: 'Follow the instructions to integrate your connector',
     },
     connector_details: {
       back_to_connectors: 'Back to Connectors',

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -269,6 +269,8 @@ const translation = {
         native: '原生',
       },
       add_multi_platform: ' 支持多平台，请选择一个平台继续',
+      drawer_title: '连接器配置指南',
+      drawer_subtitle: '请参考下列连接器配置指南',
     },
     connector_details: {
       back_to_connectors: '返回连接器',


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
* Refactor drawer component by adding a fixed header on the top
* Show connector README.md content when clicking "Check README" button in connector details page.

<img width="1511" alt="image" src="https://user-images.githubusercontent.com/12833674/174998822-bd55e607-fcae-4ef3-94b6-f16c6393b1b2.png">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally in connector details. See screenshot above
