### PR TITLE
refactor: email/sms connector test API

### DIFF
--- a/packages/console/src/pages/ConnectorDetails/components/SenderTester/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/components/SenderTester/index.tsx
@@ -14,6 +14,7 @@ import useApi from '@/hooks/use-api';
 import * as styles from './index.module.scss';
 
 type Props = {
+  connectorId: string;
   connectorType: Exclude<ConnectorType, ConnectorType.Social>;
   config?: string;
   className?: string;
@@ -23,7 +24,7 @@ type FormData = {
   sendTo: string;
 };
 
-const SenderTester = ({ connectorType, config, className }: Props) => {
+const SenderTester = ({ connectorId, connectorType, config, className }: Props) => {
   const buttonPosReference = useRef(null);
   const [showTooltip, setShowTooltip] = useState(false);
   const [isSubmitting, seIsSubmitting] = useState(false);
@@ -62,7 +63,7 @@ const SenderTester = ({ connectorType, config, className }: Props) => {
 
     try {
       await api
-        .post(`/api/connectors/test/${connectorType.toLowerCase()}`, {
+        .post(`/api/connectors/${connectorId}/test`, {
           json: data,
         })
         .json();

--- a/packages/console/src/pages/ConnectorDetails/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/index.tsx
@@ -213,7 +213,7 @@ const ConnectorDetails = () => {
               />
             </FormField>
             {data.type !== ConnectorType.Social && (
-              <SenderTester connectorType={data.type} config={config} />
+              <SenderTester connectorId={data.id} connectorType={data.type} config={config} />
             )}
             {saveError && <div>{saveError}</div>}
           </div>

--- a/packages/console/src/pages/Connectors/components/Guide/index.tsx
+++ b/packages/console/src/pages/Connectors/components/Guide/index.tsx
@@ -120,6 +120,7 @@ const Guide = ({ connector, onClose }: Props) => {
                 {!isSocialConnector && (
                   <SenderTester
                     className={styles.tester}
+                    connectorId={connectorId}
                     connectorType={connectorType}
                     config={watch('connectorConfigJson')}
                   />

--- a/packages/core/src/routes/connector.test.ts
+++ b/packages/core/src/routes/connector.test.ts
@@ -101,51 +101,7 @@ describe('connector route', () => {
     });
   });
 
-  describe('POST /connectors/test/email', () => {
-    afterEach(() => {
-      jest.clearAllMocks();
-    });
-
-    it('should get email connector and send message', async () => {
-      const mockedEmailConnector: EmailConnectorInstance = {
-        connector: mockConnector,
-        metadata: mockMetadata,
-        validateConfig: jest.fn(),
-        getConfig: jest.fn(),
-        sendMessage: async (
-          address: string,
-          type: keyof EmailMessageTypes,
-          _payload: EmailMessageTypes[typeof type]
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
-        ): Promise<any> => {},
-      };
-      getConnectorInstancesPlaceHolder.mockResolvedValueOnce([mockedEmailConnector]);
-      const sendMessageSpy = jest.spyOn(mockedEmailConnector, 'sendMessage');
-      const response = await connectorRequest
-        .post('/connectors/test/email')
-        .send({ email: 'test@email.com', config: { test: 123 } });
-      expect(sendMessageSpy).toHaveBeenCalledTimes(1);
-      expect(sendMessageSpy).toHaveBeenCalledWith(
-        'test@email.com',
-        'Test',
-        {
-          code: 'email-test',
-        },
-        { test: 123 }
-      );
-      expect(response).toHaveProperty('statusCode', 204);
-    });
-
-    it('should throw when email connector is not found', async () => {
-      getConnectorInstancesPlaceHolder.mockResolvedValueOnce([]);
-      const response = await connectorRequest
-        .post('/connectors/test/email')
-        .send({ email: 'test@email.com' });
-      expect(response).toHaveProperty('statusCode', 400);
-    });
-  });
-
-  describe('POST /connectors/test/sms', () => {
+  describe('POST /connectors/:id/test', () => {
     afterEach(() => {
       jest.clearAllMocks();
     });
@@ -170,7 +126,7 @@ describe('connector route', () => {
       getConnectorInstancesPlaceHolder.mockResolvedValueOnce([mockedSmsConnectorInstance]);
       const sendMessageSpy = jest.spyOn(mockedSmsConnectorInstance, 'sendMessage');
       const response = await connectorRequest
-        .post('/connectors/test/sms')
+        .post('/connectors/id/test')
         .send({ phone: '12345678901', config: { test: 123 } });
       expect(sendMessageSpy).toHaveBeenCalledTimes(1);
       expect(sendMessageSpy).toHaveBeenCalledWith(
@@ -184,11 +140,54 @@ describe('connector route', () => {
       expect(response).toHaveProperty('statusCode', 204);
     });
 
+    it('should get email connector and send message', async () => {
+      const mockedEmailConnector: EmailConnectorInstance = {
+        connector: mockConnector,
+        metadata: mockMetadata,
+        validateConfig: jest.fn(),
+        getConfig: jest.fn(),
+        sendMessage: async (
+          address: string,
+          type: keyof EmailMessageTypes,
+          _payload: EmailMessageTypes[typeof type]
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+        ): Promise<any> => {},
+      };
+      getConnectorInstancesPlaceHolder.mockResolvedValueOnce([mockedEmailConnector]);
+      const sendMessageSpy = jest.spyOn(mockedEmailConnector, 'sendMessage');
+      const response = await connectorRequest
+        .post('/connectors/id/test')
+        .send({ email: 'test@email.com', config: { test: 123 } });
+      expect(sendMessageSpy).toHaveBeenCalledTimes(1);
+      expect(sendMessageSpy).toHaveBeenCalledWith(
+        'test@email.com',
+        'Test',
+        {
+          code: 'email-test',
+        },
+        { test: 123 }
+      );
+      expect(response).toHaveProperty('statusCode', 204);
+    });
+
+    it('should throw when neither phone nor email is provided', async () => {
+      const response = await connectorRequest.post('/connectors/id/test').send({});
+      expect(response).toHaveProperty('statusCode', 400);
+    });
+
     it('should throw when sms connector is not found', async () => {
       getConnectorInstancesPlaceHolder.mockResolvedValueOnce([]);
       const response = await connectorRequest
-        .post('/connectors/test/sms')
+        .post('/connectors/id/test')
         .send({ phone: '12345678901' });
+      expect(response).toHaveProperty('statusCode', 400);
+    });
+
+    it('should throw when email connector is not found', async () => {
+      getConnectorInstancesPlaceHolder.mockResolvedValueOnce([]);
+      const response = await connectorRequest
+        .post('/connectors/id/test')
+        .send({ email: 'test@email.com' });
       expect(response).toHaveProperty('statusCode', 400);
     });
   });


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
* pass connectorId to email/sms test API => `/connectors/:id/test`
* combine `/connectors/test/email` and `/connectors/test/sms` APIs into one

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Aliyun DM send email test works. Received test email
- [x] Aliyun SMS send message test works. Received test message
