### PR TITLE
fix(console): text input autofill styles

### DIFF
--- a/packages/console/src/components/TextInput/index.module.scss
+++ b/packages/console/src/components/TextInput/index.module.scss
@@ -41,9 +41,9 @@
 
     // Overwrite webkit auto-fill style
     &:-webkit-autofill {
-      box-shadow: 0 0 0 30px transparent inset;
-      transition: background-color 5000s ease-in-out 0s;
+      box-shadow: 0 0 0 30px var(--color-layer-1) inset;
       -webkit-text-fill-color: var(--color-text);
+      caret-color: var(--color-text);
     }
 
     &[type='date'] {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fix text input autofill styles

Before:
<img width="656" alt="image" src="https://user-images.githubusercontent.com/12833674/175273662-116c9085-bc2d-45cc-a92b-9f2fd9e7b599.png">

After:
<img width="651" alt="image" src="https://user-images.githubusercontent.com/12833674/175273381-319483ad-3266-4f4f-a8b8-a1df96e91b3d.png">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] See screenshots for comparison
