### PR TITLE
feat(console): support dark logo for connectors

### DIFF
--- a/packages/console/src/pages/ConnectorDetails/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/index.tsx
@@ -1,4 +1,4 @@
-import { ConnectorDTO, ConnectorType } from '@logto/schemas';
+import { AppearanceMode, ConnectorDTO, ConnectorType } from '@logto/schemas';
 import classNames from 'classnames';
 import React, { useEffect, useState } from 'react';
 import { toast } from 'react-hot-toast';
@@ -21,6 +21,7 @@ import TabNav, { TabNavItem } from '@/components/TabNav';
 import UnnamedTrans from '@/components/UnnamedTrans';
 import useApi, { RequestError } from '@/hooks/use-api';
 import useConnectorInUse from '@/hooks/use-connector-in-use';
+import { useTheme } from '@/hooks/use-theme';
 import Back from '@/icons/Back';
 import Delete from '@/icons/Delete';
 import More from '@/icons/More';
@@ -48,6 +49,7 @@ const ConnectorDetails = () => {
   const isLoading = !data && !error;
   const api = useApi();
   const navigate = useNavigate();
+  const theme = useTheme();
 
   useEffect(() => {
     if (data) {
@@ -120,7 +122,10 @@ const ConnectorDetails = () => {
       {data && (
         <Card className={styles.header}>
           <div className={styles.logoContainer}>
-            <img src={data.logo} className={styles.logo} />
+            <img
+              src={theme === AppearanceMode.DarkMode && data.logoDark ? data.logoDark : data.logo}
+              className={styles.logo}
+            />
           </div>
           <div className={styles.metadata}>
             <div>

--- a/packages/console/src/pages/Connectors/components/ConnectorName/index.tsx
+++ b/packages/console/src/pages/Connectors/components/ConnectorName/index.tsx
@@ -1,4 +1,4 @@
-import { ConnectorDTO, ConnectorType } from '@logto/schemas';
+import { AppearanceMode, ConnectorDTO, ConnectorType } from '@logto/schemas';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
@@ -7,6 +7,7 @@ import Button from '@/components/Button';
 import ItemPreview from '@/components/ItemPreview';
 import UnnamedTrans from '@/components/UnnamedTrans';
 import { connectorPlatformLabel, connectorTitlePlaceHolder } from '@/consts/connectors';
+import { useTheme } from '@/hooks/use-theme';
 import ConnectorPlatformIcon from '@/icons/ConnectorPlatformIcon';
 
 import ConnectorPlaceholderIcon from '../ConnectorPlaceholderIcon';
@@ -22,6 +23,7 @@ const ConnectorName = ({ type, connectors, onClickSetup }: Props) => {
   const { t } = useTranslation(undefined);
   const enabledConnectors = connectors.filter(({ enabled }) => enabled);
   const connector = enabledConnectors[0];
+  const theme = useTheme();
 
   if (!connector) {
     return (
@@ -67,7 +69,14 @@ const ConnectorName = ({ type, connectors, onClickSetup }: Props) => {
         }
         icon={
           <div className={styles.logoContainer}>
-            <img className={styles.logo} src={connector.logo} />
+            <img
+              className={styles.logo}
+              src={
+                theme === AppearanceMode.DarkMode && connector.logoDark
+                  ? connector.logoDark
+                  : connector.logo
+              }
+            />
           </div>
         }
       />


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

support dark logo for connectors

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="420" alt="截屏2022-06-24 上午11 22 58" src="https://user-images.githubusercontent.com/5717882/175456070-d9a1d07f-edc9-4f08-9c50-f51f002e0587.png">

<img width="357" alt="截屏2022-06-24 上午11 23 59" src="https://user-images.githubusercontent.com/5717882/175456083-c3d955eb-0d65-4e96-b4bc-28e233105961.png">

<img width="273" alt="截屏2022-06-24 上午11 24 07" src="https://user-images.githubusercontent.com/5717882/175456085-a9a2c850-baf7-4f56-9450-0b7de4ad9910.png">

<img width="288" alt="截屏2022-06-24 上午11 24 09" src="https://user-images.githubusercontent.com/5717882/175456089-8e99a7c2-8a2d-4a52-ae1c-d600f199301c.png">

