### PR TITLE
fix(console): application integrate SDK guides

### DIFF
--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/android.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/android.mdx
@@ -74,7 +74,7 @@ Notes:
 
 e.g. `io.logto.android://io.logto.sample/callback`
 
-<MultiTextInputField name="redirectUris" title="Redirect URI" />
+<MultiTextInputField appId={props.appId} name="redirectUris" title="Redirect URI" />
 
 ### Configure Logto Android SDK
 

--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/android_zh-cn.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/android_zh-cn.mdx
@@ -74,7 +74,7 @@ $(LOGTO_REDIRECT_SCHEME)://$(YOUR_APP_PACKAGE)/callback
 
 例： `io.logto.android://io.logto.sample/callback`
 
-<MultiTextInputField name="redirectUris" title="Redirect URI" />
+<MultiTextInputField appId={props.appId} name="redirectUris" title="Redirect URI" />
 
 ### 配置 Logto Android SDK
 

--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/ios.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/ios.mdx
@@ -70,7 +70,7 @@ let config = try? LogtoConfig(
 
 First, let’s configure your redirect URI
 
-<MultiTextInputField name="redirectUris" title="Redirect URI" />
+<MultiTextInputField appId={props.appId} name="redirectUris" title="Redirect URI" />
 
 ```swift
 do {

--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/react.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/react.mdx
@@ -107,11 +107,7 @@ const App = () => {
 
 The Logto React SDK provides you tools and hooks to quickly implement your own authorization flow. First, let’s enter your redirect URI
 
-<MultiTextInputField
-  appId={props.appId}
-  name="redirectUris"
-  title="Redirect URI"
-/>
+<MultiTextInputField appId={props.appId} name="redirectUris" title="Redirect URI" />
 
 Add the following code to your web app
 
@@ -161,11 +157,7 @@ const App = () => {
 
 Execute signOut() methods will redirect users to the Logto sign out page. After a success sign out, all use session data and auth status will be cleared.
 
-<MultiTextInputField
-  appId={props.appId}
-  name="postLogoutRedirectUris"
-  title="Post sign out redirect URI"
-/>
+<MultiTextInputField appId={props.appId} name="postLogoutRedirectUris" title="Post sign out redirect URI" />
 
 Add the following code to your web app
 

--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/react_zh-cn.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/react_zh-cn.mdx
@@ -108,7 +108,7 @@ const App = () => {
 
 The Logto React SDK provides you tools and hooks to quickly implement your own authorization flow. First, let’s enter your redirect URI
 
-<MultiTextInputField name="redirectUris" title="Redirect URI" />
+<MultiTextInputField appId={props.appId} name="redirectUris" title="Redirect URI" />
 
 Add the following code to your web app
 
@@ -158,7 +158,7 @@ const App = () => {
 
 Execute signOut() methods will redirect users to the Logto sign out page. After a success sign out, all use session data and auth status will be cleared.
 
-<MultiTextInputField name="postLogoutRedirectUris" title="Post sign out redirect URI" />
+<MultiTextInputField appId={props.appId} name="postLogoutRedirectUris" title="Post sign out redirect URI" />
 
 Add the following code to your web app
 

--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/vue.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/vue.mdx
@@ -83,7 +83,7 @@ In order to handle what comes from Logto, the application needs to have a dedica
 
 First, let’s enter your redirect URI. E.g. `http://localhost:1234/callback`
 
-<MultiTextInputField name="redirectUris" title="Redirect URI" />
+<MultiTextInputField appId={props.appId} name="redirectUris" title="Redirect URI" />
 
 Then let's create a callback component:
 
@@ -157,7 +157,7 @@ Calling `.signOut()` will clear all the Logto data in memory and LocalStorage, i
 To make the user come back to your application after signing out,
 it's necessary to add `http://localhost:1234` as one of the Post Sign Out URIs and use the URL as the parameter when calling `.signOut()`.
 
-<MultiTextInputField name="postLogoutRedirectUris" title="Post sign out redirect URI" />
+<MultiTextInputField appId={props.appId} name="postLogoutRedirectUris" title="Post sign out redirect URI" />
 
 ```ts
 import { useLogto } from "@logto/vue";

--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/vue_zh-cn.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/vue_zh-cn.mdx
@@ -83,7 +83,7 @@ app.mount("#app");
 
 但首先, 让我们先在下方输入 redirect URI，如：`http://localhost:1234/callback`
 
-<MultiTextInputField name="redirectUris" title="Redirect URI" />
+<MultiTextInputField appId={props.appId} name="redirectUris" title="Redirect URI" />
 
 然后，让我们来创建一个 CallbackView 组件：
 
@@ -157,7 +157,7 @@ const { isAuthenticated } = useLogto();
 
 为了确保用户登出后能够跳转回你的应用，我们需要首先在管理界面中将 `http://localhost:1234` 添加到允许登出后跳转的地址列表（Post Sign Out URIs）中。
 
-<MultiTextInputField name="postLogoutRedirectUris" title="Post sign out redirect URI" />
+<MultiTextInputField appId={props.appId} name="postLogoutRedirectUris" title="Post sign out redirect URI" />
 
 ```ts
 import { useLogto } from "@logto/vue";


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fixed errors on saving redirect URI in native SDK guide, caused by missing `appId` in mdx files

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally and the saving redirect URI works without popping errors
