### PR TITLE
fix(console): change checkbox to controlled comp

### DIFF
--- a/packages/console/src/components/Checkbox/index.tsx
+++ b/packages/console/src/components/Checkbox/index.tsx
@@ -1,23 +1,36 @@
 import { nanoid } from 'nanoid';
-import React, { forwardRef, InputHTMLAttributes, ReactNode, Ref, useState } from 'react';
+import React, { ReactNode, useState } from 'react';
 
 import Icon from './Icon';
 import * as styles from './index.module.scss';
 
-type Props = Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> & {
+type Props = {
+  // eslint-disable-next-line react/boolean-prop-naming
+  value: boolean;
+  onChange: (value: boolean) => void;
   label?: ReactNode;
+  // eslint-disable-next-line react/boolean-prop-naming
+  disabled: boolean;
 };
 
-const Checkbox = ({ label, disabled, ...rest }: Props, ref: Ref<HTMLInputElement>) => {
+const Checkbox = ({ value, onChange, label, disabled }: Props) => {
   const [id] = useState(nanoid());
 
   return (
     <div className={styles.checkbox}>
-      <input id={id} type="checkbox" disabled={disabled} {...rest} ref={ref} />
+      <input
+        id={id}
+        type="checkbox"
+        checked={value}
+        disabled={disabled}
+        onChange={(event) => {
+          onChange(event.target.checked);
+        }}
+      />
       <Icon className={styles.icon} />
       {label && <label htmlFor={id}>{label}</label>}
     </div>
   );
 };
 
-export default forwardRef<HTMLInputElement, Props>(Checkbox);
+export default Checkbox;

--- a/packages/console/src/pages/SignInExperience/components/SignInMethodsForm.tsx
+++ b/packages/console/src/pages/SignInExperience/components/SignInMethodsForm.tsx
@@ -60,10 +60,17 @@ const SignInMethodsForm = () => {
 
         return (
           <div key={method} className={styles.method}>
-            <Checkbox
-              label={label}
-              disabled={primaryMethod === method}
-              {...register(`signInMethods.${method}`)}
+            <Controller
+              name={`signInMethods.${method}`}
+              control={control}
+              render={({ field: { value, onChange } }) => (
+                <Checkbox
+                  label={label}
+                  disabled={primaryMethod === method}
+                  value={value}
+                  onChange={onChange}
+                />
+              )}
             />
             {enabled && <ConnectorSetupWarning method={method} />}
           </div>


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Change `<Checkbox />` from ref component to controlled component. This will fix the bug: 

change value from `true` to `false`, then change back to `true`, and then, continue to change the checkbox state won't cause form value change, even won't trigger react render.

You can see LOG-3167 for more details.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested in SIE, now checkbox value change will map to "Preview" immediatly.