### PR TITLE
fix(console): application icon size

### DIFF
--- a/packages/console/src/components/ApplicationIcon/index.tsx
+++ b/packages/console/src/components/ApplicationIcon/index.tsx
@@ -1,32 +1,20 @@
 import { AppearanceMode, ApplicationType } from '@logto/schemas';
 import React from 'react';
 
-import NativeAppDark from '@/assets/images/native-app-dark.svg';
-import NativeApp from '@/assets/images/native-app.svg';
-import SinglePageAppDark from '@/assets/images/single-page-app-dark.svg';
-import SinglePageApp from '@/assets/images/single-page-app.svg';
-import TraditionalWebAppDark from '@/assets/images/traditional-web-app-dark.svg';
-import TraditionalWebApp from '@/assets/images/traditional-web-app.svg';
+import { darkModeApplicationIconMap, lightModeApplicationIconMap } from '@/consts';
 import { useTheme } from '@/hooks/use-theme';
 
 type Props = {
   type: ApplicationType;
+  className?: string;
 };
 
-const ApplicationIcon = ({ type }: Props) => {
+const ApplicationIcon = ({ type, className }: Props) => {
   const theme = useTheme();
   const isLightMode = theme === AppearanceMode.LightMode;
+  const Icon = isLightMode ? lightModeApplicationIconMap[type] : darkModeApplicationIconMap[type];
 
-  switch (type) {
-    case ApplicationType.Native:
-      return isLightMode ? <NativeApp /> : <NativeAppDark />;
-    case ApplicationType.SPA:
-      return isLightMode ? <SinglePageApp /> : <SinglePageAppDark />;
-    case ApplicationType.Traditional:
-      return isLightMode ? <TraditionalWebApp /> : <TraditionalWebAppDark />;
-    default:
-      return null;
-  }
+  return <Icon className={className} />;
 };
 
 export default ApplicationIcon;

--- a/packages/console/src/consts/applications.ts
+++ b/packages/console/src/consts/applications.ts
@@ -1,7 +1,30 @@
 import { ApplicationType } from '@logto/schemas';
 
+import NativeAppDark from '@/assets/images/native-app-dark.svg';
+import NativeApp from '@/assets/images/native-app.svg';
+import SinglePageAppDark from '@/assets/images/single-page-app-dark.svg';
+import SinglePageApp from '@/assets/images/single-page-app.svg';
+import TraditionalWebAppDark from '@/assets/images/traditional-web-app-dark.svg';
+import TraditionalWebApp from '@/assets/images/traditional-web-app.svg';
+
 export const applicationTypeI18nKey = Object.freeze({
   [ApplicationType.Native]: 'applications.type.native',
   [ApplicationType.SPA]: 'applications.type.spa',
   [ApplicationType.Traditional]: 'applications.type.traditional',
+} as const);
+
+type ApplicationIconMap = {
+  [key in ApplicationType]: SvgComponent;
+};
+
+export const lightModeApplicationIconMap: ApplicationIconMap = Object.freeze({
+  [ApplicationType.Native]: NativeApp,
+  [ApplicationType.SPA]: SinglePageApp,
+  [ApplicationType.Traditional]: TraditionalWebApp,
+} as const);
+
+export const darkModeApplicationIconMap: ApplicationIconMap = Object.freeze({
+  [ApplicationType.Native]: NativeAppDark,
+  [ApplicationType.SPA]: SinglePageAppDark,
+  [ApplicationType.Traditional]: TraditionalWebAppDark,
 } as const);

--- a/packages/console/src/pages/ApplicationDetails/index.module.scss
+++ b/packages/console/src/pages/ApplicationDetails/index.module.scss
@@ -38,7 +38,6 @@
     margin-left: _.unit(2);
     width: 60px;
     height: 60px;
-    object-fit: cover;
   }
 
   .operations {

--- a/packages/console/src/pages/ApplicationDetails/index.module.scss
+++ b/packages/console/src/pages/ApplicationDetails/index.module.scss
@@ -34,6 +34,13 @@
     margin-left: _.unit(6);
   }
 
+  .icon {
+    margin-left: _.unit(2);
+    width: 60px;
+    height: 60px;
+    object-fit: cover;
+  }
+
   .operations {
     display: flex;
     align-items: center;

--- a/packages/console/src/pages/ApplicationDetails/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/index.tsx
@@ -115,7 +115,7 @@ const ApplicationDetails = () => {
       {data && oidcConfig && (
         <>
           <Card className={styles.header}>
-            <ApplicationIcon type={data.type} />
+            <ApplicationIcon type={data.type} className={styles.icon} />
             <div className={styles.metadata}>
               <div className={styles.name}>{data.name}</div>
               <div className={styles.details}>


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
* Refactor the `<ApplicationIcon />` to support style settings.
* Fix the application icon size on the details page.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Before
<img width="565" alt="image" src="https://user-images.githubusercontent.com/10806653/175555804-8409e98b-fbf9-44c3-bc0b-e41a7cc5d6d9.png">

### After
<img width="573" alt="image" src="https://user-images.githubusercontent.com/10806653/175555863-47dbdff5-68f1-44c4-810e-0f609bd8d030.png">

