### PR TITLE
fix(core): signing in with a non-existing username should throw invalid credentials

### DIFF
--- a/packages/core/src/lib/user.ts
+++ b/packages/core/src/lib/user.ts
@@ -44,7 +44,7 @@ export const findUserByUsernameAndPassword = async (
   password: string
 ): Promise<User> => {
   const user = await findUserByUsername(username);
-  assertThat(user, 'user.username_not_exists');
+  assertThat(user, 'session.invalid_credentials');
   const { passwordEncrypted, passwordEncryptionMethod } = user;
 
   assertThat(passwordEncrypted && passwordEncryptionMethod, 'session.invalid_sign_in_method');

--- a/packages/core/src/routes/session/session.test.ts
+++ b/packages/core/src/routes/session/session.test.ts
@@ -11,7 +11,7 @@ import sessionRoutes from './session';
 jest.mock('@/lib/user', () => ({
   async findUserByUsernameAndPassword(username: string, password: string) {
     if (username !== 'username') {
-      throw new RequestError({ code: 'entity.not_found', status: 404 });
+      throw new RequestError('session.invalid_credentials');
     }
 
     if (password !== 'password') {
@@ -139,7 +139,7 @@ describe('sessionRoutes', () => {
         username: 'notexistuser',
         password: 'password',
       });
-      expect(response.statusCode).toEqual(404);
+      expect(response.statusCode).toEqual(400);
     });
 
     it('throw if user found but wrong password', async () => {

--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -634,7 +634,6 @@ const errors = {
     phone_exists_register: 'The phone number has been registered.',
     invalid_email: 'Invalid email address.',
     invalid_phone: 'Invalid phone number.',
-    username_not_exists: 'The username has not been registered yet.',
     email_not_exists: 'The email address has not been registered yet.',
     phone_not_exists: 'The phone number has not been registered yet.',
     identity_not_exists: 'The social account has not been registered yet.',

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -615,7 +615,6 @@ const errors = {
     phone_exists_register: '手机号码已被注册。',
     invalid_email: '邮箱地址不正确。',
     invalid_phone: '手机号码不正确。',
-    username_not_exists: '用户名尚未注册。',
     email_not_exists: '邮箱地址尚未注册。',
     phone_not_exists: '手机号码尚未注册。',
     identity_not_exists: '该社交账号尚未注册。',


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Signing in with a non-existing username should throw invalid credentials.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UTs.
