### PR TITLE
refactor(ui): remove all social callback page search params validation

### DIFF
--- a/packages/ui/src/containers/SocialLanding/index.tsx
+++ b/packages/ui/src/containers/SocialLanding/index.tsx
@@ -10,10 +10,9 @@ type Props = {
   className?: string;
   connectorId: string;
   isLoading?: boolean;
-  message?: string;
 };
 
-const SocialLanding = ({ className, connectorId, message, isLoading = false }: Props) => {
+const SocialLanding = ({ className, connectorId, isLoading = false }: Props) => {
   const { experienceSettings } = useContext(PageContext);
   const connector = experienceSettings?.socialConnectors.find(({ id }) => id === connectorId);
 
@@ -23,7 +22,6 @@ const SocialLanding = ({ className, connectorId, message, isLoading = false }: P
         {connector?.logo ? <img src={connector.logo} /> : connectorId}
       </div>
       {isLoading && <LoadingIcon />}
-      {!isLoading && message && <div className={styles.message}>{message}</div>}
     </div>
   );
 };

--- a/packages/ui/src/pages/Callback/index.tsx
+++ b/packages/ui/src/pages/Callback/index.tsx
@@ -13,7 +13,7 @@ type Parameters = {
 const Callback = () => {
   const { connector: connectorId } = useParams<Parameters>();
 
-  const { socialCallbackHandler, loading, errorMessage } = useSocialCallbackHandler();
+  const { socialCallbackHandler } = useSocialCallbackHandler();
 
   // SocialSignIn Callback Handler
   useEffect(() => {
@@ -29,12 +29,7 @@ const Callback = () => {
 
   return (
     <div className={styles.wrapper}>
-      <SocialLanding
-        className={styles.connectorContainer}
-        connectorId={connectorId}
-        isLoading={loading}
-        message={errorMessage}
-      />
+      <SocialLanding isLoading className={styles.connectorContainer} connectorId={connectorId} />
     </div>
   );
 };


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
To unblock PR #1166.

Remove all callback page search params validation logic. 
Instead, pass all search params as a json object to the connector server side.
Let the connector handler handle all the logic.


1. remove the message UI from social landing component. As it is no longer needed
2. remove the error,error_description, state, connectorId validation logic from the socialCallbackHandler

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT case passed
@logto-io/eng  cc: @darcyYe 

@darcyYe we can test the flow again once this is merged. 