### PR TITLE
refactor(ui): rename create account form name

### DIFF
--- a/packages/ui/src/containers/CreateAccount/index.test.tsx
+++ b/packages/ui/src/containers/CreateAccount/index.test.tsx
@@ -12,9 +12,9 @@ jest.mock('@/apis/register', () => ({ register: jest.fn(async () => Promise.reso
 describe('<CreateAccount/>', () => {
   test('default render', () => {
     const { queryByText, container } = renderWithPageContext(<CreateAccount />);
-    expect(container.querySelector('input[name="username"]')).not.toBeNull();
-    expect(container.querySelector('input[name="password"]')).not.toBeNull();
-    expect(container.querySelector('input[name="confirm_password"]')).not.toBeNull();
+    expect(container.querySelector('input[name="new-username"]')).not.toBeNull();
+    expect(container.querySelector('input[name="new-password"]')).not.toBeNull();
+    expect(container.querySelector('input[name="confirm-new-password"]')).not.toBeNull();
     expect(queryByText('action.create')).not.toBeNull();
   });
 
@@ -42,7 +42,7 @@ describe('<CreateAccount/>', () => {
     const { queryByText, getByText, container } = renderWithPageContext(<CreateAccount />);
     const submitButton = getByText('action.create');
 
-    const usernameInput = container.querySelector('input[name="username"]');
+    const usernameInput = container.querySelector('input[name="new-username"]');
 
     if (usernameInput) {
       fireEvent.change(usernameInput, { target: { value: '1username' } });
@@ -65,7 +65,7 @@ describe('<CreateAccount/>', () => {
   test('username with special character should throw', () => {
     const { queryByText, getByText, container } = renderWithPageContext(<CreateAccount />);
     const submitButton = getByText('action.create');
-    const usernameInput = container.querySelector('input[name="username"]');
+    const usernameInput = container.querySelector('input[name="new-username"]');
 
     if (usernameInput) {
       fireEvent.change(usernameInput, { target: { value: '@username' } });
@@ -88,7 +88,7 @@ describe('<CreateAccount/>', () => {
   test('password less than 6 chars should throw', () => {
     const { queryByText, getByText, container } = renderWithPageContext(<CreateAccount />);
     const submitButton = getByText('action.create');
-    const passwordInput = container.querySelector('input[name="password"]');
+    const passwordInput = container.querySelector('input[name="new-password"]');
 
     if (passwordInput) {
       fireEvent.change(passwordInput, { target: { value: '12345' } });
@@ -111,8 +111,8 @@ describe('<CreateAccount/>', () => {
   test('password mismatch with confirmPassword should throw', () => {
     const { queryByText, getByText, container } = renderWithPageContext(<CreateAccount />);
     const submitButton = getByText('action.create');
-    const passwordInput = container.querySelector('input[name="password"]');
-    const confirmPasswordInput = container.querySelector('input[name="confirm_password"]');
+    const passwordInput = container.querySelector('input[name="new-password"]');
+    const confirmPasswordInput = container.querySelector('input[name="confirm-new-password"]');
     const usernameInput = container.querySelector('input[name="username"]');
 
     if (usernameInput) {
@@ -148,9 +148,9 @@ describe('<CreateAccount/>', () => {
       </SettingsProvider>
     );
     const submitButton = getByText('action.create');
-    const passwordInput = container.querySelector('input[name="password"]');
-    const confirmPasswordInput = container.querySelector('input[name="confirm_password"]');
-    const usernameInput = container.querySelector('input[name="username"]');
+    const passwordInput = container.querySelector('input[name="new-password"]');
+    const confirmPasswordInput = container.querySelector('input[name="confirm-new-password"]');
+    const usernameInput = container.querySelector('input[name="new-username"]');
 
     if (usernameInput) {
       fireEvent.change(usernameInput, { target: { value: 'username' } });

--- a/packages/ui/src/containers/CreateAccount/index.tsx
+++ b/packages/ui/src/containers/CreateAccount/index.tsx
@@ -83,7 +83,7 @@ const CreateAccount = ({ className, autoFocus }: Props) => {
       <Input
         autoFocus={autoFocus}
         className={styles.inputField}
-        name="username"
+        name="new-username"
         placeholder={t('input.username')}
         {...fieldRegister('username', usernameValidation)}
         onClear={() => {
@@ -92,7 +92,7 @@ const CreateAccount = ({ className, autoFocus }: Props) => {
       />
       <Input
         className={styles.inputField}
-        name="password"
+        name="new-password"
         type="password"
         autoComplete="new-password"
         placeholder={t('input.password')}
@@ -103,7 +103,7 @@ const CreateAccount = ({ className, autoFocus }: Props) => {
       />
       <Input
         className={styles.inputField}
-        name="confirm_password"
+        name="confirm-new-password"
         type="password"
         autoComplete="new-password"
         placeholder={t('input.confirm_password')}


### PR DESCRIPTION


<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Rename create account form name

chrome uses the input name only to determine whether an auto-fill data is fitted in.  So have to use a different name for the creation forms 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test case updated
@logto-io/eng 
