### PR TITLE
refactor(console): add support to image display in connector readme

### DIFF
--- a/packages/console/src/components/Markdown/components/GithubRawImage/index.tsx
+++ b/packages/console/src/components/Markdown/components/GithubRawImage/index.tsx
@@ -1,0 +1,34 @@
+import React, { HTMLProps, useRef, useState } from 'react';
+
+const githubRawUrlPrefix = 'https://raw.githubusercontent.com/logto-io/logto/master';
+
+const GithubRawImage = ({ src, alt }: HTMLProps<HTMLImageElement>) => {
+  const imgRef = useRef<HTMLImageElement>(null);
+  const [width, setWidth] = useState(0);
+
+  const onLoad = () => {
+    if (imgRef.current) {
+      const { naturalWidth, parentElement } = imgRef.current;
+      const parentClientWidth = parentElement?.clientWidth ?? 0;
+      const preferredWidth = Math.min(parentClientWidth, naturalWidth / 2);
+
+      setWidth(preferredWidth);
+    }
+  };
+
+  if (!src) {
+    return null;
+  }
+
+  return (
+    <img
+      ref={imgRef}
+      src={`${githubRawUrlPrefix}${src}`}
+      alt={alt}
+      width={`${width}px`}
+      onLoad={onLoad}
+    />
+  );
+};
+
+export default GithubRawImage;

--- a/packages/console/src/components/Markdown/index.tsx
+++ b/packages/console/src/components/Markdown/index.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
 import CodeEditor from '../CodeEditor';
+import GithubRawImage from './components/GithubRawImage';
 import * as styles from './index.module.scss';
 
 type Props = {
@@ -26,6 +27,9 @@ const Markdown = ({ className, children }: Props) => (
         ) : (
           <CodeEditor isReadonly language={codeBlockType} value={String(children)} />
         );
+      },
+      img: ({ src, alt }) => {
+        return <GithubRawImage src={src} alt={alt} />;
       },
     }}
   >


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add support to image display in connector readme in admin console.

<img width="1511" alt="image" src="https://user-images.githubusercontent.com/12833674/176235797-aa1a87ef-2c32-4907-b1ef-71e786af5c5b.png">

<img width="766" alt="image" src="https://user-images.githubusercontent.com/12833674/176235865-e3e3bd58-a90b-4349-a1f8-209ca4715532.png">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Locally tested using connector-wechat-native
