### PR TITLE
fix(console): add toast message on save uri success in guide

### DIFF
--- a/packages/console/src/mdx-components/UriInputField/index.tsx
+++ b/packages/console/src/mdx-components/UriInputField/index.tsx
@@ -2,6 +2,7 @@ import { I18nKey } from '@logto/phrases';
 import { Application } from '@logto/schemas';
 import React, { useRef, KeyboardEvent } from 'react';
 import { Controller, FormProvider, useForm } from 'react-hook-form';
+import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 
@@ -50,6 +51,7 @@ const UriInputField = ({ appId, name, title, isSingle = false }: Props) => {
       })
       .json<Application>();
     void mutate(updatedApp);
+    toast.success(t('general.saved'));
 
     // Reset form to set 'isDirty' to false
     reset(getValues());


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add toast message on save URI success in guides, including:
* Redirect URI
* Post Sign-out Redirect URI

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Go to app details, check help guide, input redirect URI and click save. 'Saved!' toast message poped up on saving succeeded
