### PR TITLE
style(console): improve link and bullet styles in guide and readme

### DIFF
--- a/packages/console/src/components/Markdown/index.module.scss
+++ b/packages/console/src/components/Markdown/index.module.scss
@@ -33,6 +33,7 @@
   a {
     font: var(--font-body-medium);
     color: var(--color-text-link);
+    text-decoration: none;
   }
 
   h1 {

--- a/packages/console/src/mdx-components/Step/index.module.scss
+++ b/packages/console/src/mdx-components/Step/index.module.scss
@@ -38,19 +38,39 @@
     }
   }
 
-  ul {
-    padding-inline-start: 1ch;
+  li {
+    font: var(--font-body-medium);
+
+    ul,
+    ol {
+      padding-inline-start: 1ch;
+    }
   }
 
-  li {
-    list-style-type: '-';
-    margin-block-end: _.unit(6);
-    padding-inline-start: _.unit(1.5);
+  ul {
+    padding-inline-start: 4ch;
+
+    > li {
+      margin-block-start: _.unit(2);
+      margin-block-end: _.unit(2);
+      padding-inline-start: _.unit(1);
+    }
+  }
+
+  ol {
+    padding-inline-start: 2ch;
+
+    > li {
+      margin-block-start: _.unit(3);
+      margin-block-end: _.unit(3);
+      padding-inline-start: _.unit(1);
+    }
   }
 
   a {
     font: var(--font-body-medium);
     color: var(--color-text-link);
+    text-decoration: none;
   }
 
   h3 {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Improve bullet list and link styles in application guide
* Remove underline style from hyperlinks
* Use bullet instead of hyphen in unordered lists

<img width="757" alt="image" src="https://user-images.githubusercontent.com/12833674/176338910-2771e394-9fa5-4686-a3ef-ac86c7b2d1ad.png">

<img width="1511" alt="image" src="https://user-images.githubusercontent.com/12833674/176339028-63c32eee-539d-4afd-ad26-512a171bd593.png">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Bullet and link styles looked as expected in app sdk guide
- [x] Bullet and link styles looked as expected in facebook connector readme
