### PR TITLE
fix(console): last button in guide should be primary

### DIFF
--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/android.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/android.mdx
@@ -271,6 +271,7 @@ Notes:
   index={4}
   activeIndex={props.activeStepIndex}
   buttonText="admin_console.general.done"
+  buttonType="primary"
   onButtonClick={props.onComplete}
 >
 

--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/android_zh-cn.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/android_zh-cn.mdx
@@ -271,6 +271,7 @@ logtoClient.signOut(logtoException -> {
   index={4}
   activeIndex={props.activeStepIndex}
   buttonText="admin_console.general.done"
+  buttonType="primary"
   onButtonClick={props.onComplete}
 >
 

--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/ios.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/ios.mdx
@@ -105,6 +105,7 @@ await client.signOut()
   index={4}
   activeIndex={props.activeStepIndex}
   buttonText="admin_console.general.done"
+  buttonType="primary"
   onButtonClick={props.onComplete}
 >
 

--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/react.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/react.mdx
@@ -184,6 +184,7 @@ export default SignOutButton;
   index={4}
   activeIndex={props.activeStepIndex}
   buttonText="admin_console.general.done"
+  buttonType="primary"
   onButtonClick={props.onComplete}
 >
 

--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/react_zh-cn.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/react_zh-cn.mdx
@@ -183,6 +183,8 @@ export default SignOutButton;
   subtitle="3 steps"
   index={4}
   activeIndex={props.activeStepIndex}
+  buttonText="admin_console.general.done"
+  buttonType="primary"
   onButtonClick={props.onComplete}
 >
 

--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/vue.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/vue.mdx
@@ -179,6 +179,7 @@ const onClickSignOut = () => signOut('http://localhost:1234');
   index={4}
   activeIndex={props.activeStepIndex}
   buttonText="admin_console.general.done"
+  buttonType="primary"
   onButtonClick={props.onComplete}
 >
 

--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/vue_zh-cn.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/vue_zh-cn.mdx
@@ -152,6 +152,8 @@ const { isAuthenticated } = useLogto();
   subtitle="1 step"
   index={3}
   activeIndex={props.activeStepIndex}
+  buttonText="admin_console.general.done"
+  buttonType="primary"
   onButtonClick={() => props.onNext(4)}
 >
 

--- a/packages/console/src/mdx-components/Step/index.tsx
+++ b/packages/console/src/mdx-components/Step/index.tsx
@@ -20,6 +20,7 @@ type Props = PropsWithChildren<{
   activeIndex: number;
   buttonText?: I18nKey;
   buttonHtmlType?: 'submit' | 'button';
+  buttonType?: 'primary' | 'outline';
   isLoading?: boolean;
   onButtonClick?: () => void;
 }>;
@@ -32,6 +33,7 @@ const Step = ({
   activeIndex,
   buttonText = 'admin_console.general.next',
   buttonHtmlType = 'button',
+  buttonType = 'outline',
   isLoading,
   onButtonClick,
 }: Props) => {
@@ -78,7 +80,7 @@ const Step = ({
         {children}
         <div className={styles.buttonWrapper}>
           <Button
-            type="outline"
+            type={buttonType}
             size="large"
             isLoading={isLoading}
             htmlType={buttonHtmlType}

--- a/packages/console/src/pages/Connectors/components/Guide/index.tsx
+++ b/packages/console/src/pages/Connectors/components/Guide/index.tsx
@@ -102,6 +102,7 @@ const Guide = ({ connector, onClose }: Props) => {
                 activeIndex={0}
                 buttonText="admin_console.connectors.save_and_done"
                 buttonHtmlType="submit"
+                buttonType="primary"
                 isLoading={isSubmitting}
               >
                 <Controller


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
* `Done` button in last step in guide should be primary
* `Save and done` button in connector guide should be primary

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Last step in guide
<img width="757" alt="image" src="https://user-images.githubusercontent.com/12833674/176340540-e3870587-3247-4c72-8b21-915bd714eefa.png">

- [x] Connector guide
<img width="1511" alt="image" src="https://user-images.githubusercontent.com/12833674/176340593-06cfed2a-d74f-4795-a4e3-df26838dd0f6.png">
