### PR TITLE
fix(console): set preview desktop background color

### DIFF
--- a/packages/console/src/pages/SignInExperience/components/Preview.tsx
+++ b/packages/console/src/pages/SignInExperience/components/Preview.tsx
@@ -1,5 +1,6 @@
 import { Language } from '@logto/phrases';
 import { AppearanceMode, ConnectorDTO, ConnectorMetadata, SignInExperience } from '@logto/schemas';
+import { conditional } from '@silverhand/essentials';
 import classNames from 'classnames';
 import dayjs from 'dayjs';
 import React, { useEffect, useMemo, useState, useRef, useCallback } from 'react';
@@ -176,6 +177,12 @@ const Preview = ({ signInExperience, className }: Props) => {
       </TabNav>
       <div
         className={classNames(styles.body, platform === 'desktopWeb' ? styles.web : styles.mobile)}
+        style={conditional(
+          platform === 'desktopWeb' && {
+            // Set background color to match iframe's background color on both dark and light mode.
+            backgroundColor: mode === AppearanceMode.DarkMode ? '#2A2C31' : '#e5e1ec',
+          }
+        )}
       >
         <div className={styles.deviceWrapper}>
           <div className={classNames(styles.device, styles[mode])}>


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Set preview background color for "Desktop Web", according to selected appearence mode.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="551" alt="截屏2022-06-29 下午12 05 10" src="https://user-images.githubusercontent.com/5717882/176349337-b680c482-9334-4173-b422-f99ee319fdfd.png">

<img width="533" alt="截屏2022-06-29 下午12 05 15" src="https://user-images.githubusercontent.com/5717882/176349355-803c932b-701c-448a-a7fa-1da030d2f59f.png">

