### PR TITLE
fix(console): adding social connector should complete corresponding get-started task

### DIFF
--- a/packages/console/src/pages/GetStarted/hook.ts
+++ b/packages/console/src/pages/GetStarted/hook.ts
@@ -107,6 +107,7 @@ const useGetStartedMetadata = ({ checkDemoAppExists }: Props) => {
       subtitle: 'get_started.card5_subtitle',
       icon: isLightMode ? OneClick : OneClickDark,
       buttonText: 'admin_console.general.set_up',
+      isComplete: settings?.configureSocialSignIn,
       onClick: () => {
         navigate('/connectors/social');
       },


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Bug:
Get-started task "Add a social connector" is never completed even if we have successfully added a social connector.

Now all get-started tasks can be completed (6/6).

<img width="1511" alt="image" src="https://user-images.githubusercontent.com/12833674/176390881-adb5daa0-11c5-448e-abe0-72b71ec20ea0.png">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] All get-started tasks can be completed now (6/6)
