### PR TITLE
fix(console): page content should not jump on scrollbar present

### DIFF
--- a/packages/console/src/components/AppContent/index.module.scss
+++ b/packages/console/src/components/AppContent/index.module.scss
@@ -18,7 +18,7 @@
 .main {
   flex-grow: 1;
   padding-right: _.unit(6);
-  overflow-y: auto;
+  overflow-y: scroll;
 
   > * {
     @include _.main-content-width;

--- a/packages/console/src/pages/SignInExperience/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/index.module.scss
@@ -10,7 +10,7 @@
     flex: 1;
     margin-right: _.unit(3);
     height: 100%;
-    overflow-y: auto;
+    overflow-y: scroll;
 
     .tabs {
       padding-top: _.unit(2);


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
The page content size will change when the scrollbar is present.

### Solution
Change the related page's style from `overflow-y: auto` to `overflow-y: scroll`, then the page content's size will always contain the scrollbar size.
When switching to the page without a scrollbar, the page will not jump.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Before
![before-fix-jump](https://user-images.githubusercontent.com/10806653/176464353-b003ae1e-1f9f-4c15-be44-da116ddf05c7.gif)

### After
![fix-jump](https://user-images.githubusercontent.com/10806653/176406678-3d43a3a3-1fcf-40b7-a352-fc7d20448cb1.gif)

