### PR TITLE
fix(console): connector guide setup content should scroll in the whole container

### DIFF
--- a/packages/console/src/pages/Connectors/components/Guide/index.module.scss
+++ b/packages/console/src/pages/Connectors/components/Guide/index.module.scss
@@ -32,11 +32,9 @@
     flex: 1;
     display: flex;
     overflow: hidden;
-    padding: _.unit(6) _.unit(15);
 
     > * {
       flex: 1;
-      margin: 0 12px;
       overflow-y: auto;
     }
 
@@ -44,6 +42,11 @@
       background-color: var(--color-layer-1);
       border-radius: 16px;
       padding: 0 _.unit(6);
+      margin: _.unit(6) _.unit(10) _.unit(6) _.unit(18);
+    }
+
+    .setup {
+      padding: _.unit(6) _.unit(18) _.unit(6) 0;
     }
 
     form + div {

--- a/packages/console/src/pages/Connectors/components/Guide/index.tsx
+++ b/packages/console/src/pages/Connectors/components/Guide/index.tsx
@@ -92,7 +92,7 @@ const Guide = ({ connector, onClose }: Props) => {
       </div>
       <div className={styles.content}>
         <Markdown className={styles.readme}>{readme}</Markdown>
-        <div>
+        <div className={styles.setup}>
           <FormProvider {...methods}>
             <form onSubmit={onSubmit}>
               <Step


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Design in Figma:
<img width="581" alt="image" src="https://user-images.githubusercontent.com/10806653/176589495-6a76f1a7-491d-4f22-b005-f63cf32c2c38.png">
<img width="589" alt="image" src="https://user-images.githubusercontent.com/10806653/176589533-7cf1fadf-3a1c-4012-95af-cc36ec1c8c5d.png">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
![fix-connector-scroll](https://user-images.githubusercontent.com/10806653/176589758-db726c68-70ec-4de6-97cd-8abc8ff2e5db.gif)

