### PR TITLE
fix(console): sdk selector content in the guide should be left-aligned

### DIFF
--- a/packages/console/src/pages/Applications/components/SdkSelector/index.module.scss
+++ b/packages/console/src/pages/Applications/components/SdkSelector/index.module.scss
@@ -13,6 +13,10 @@
     margin: _.unit(1) auto _.unit(8);
   }
 
+  .congratsText {
+    width: 100%;
+  }
+
   .title {
     font: var(--font-title-large);
   }
@@ -24,7 +28,9 @@
   }
 
   .radioGroup {
+    width: 100%;
     margin-top: _.unit(6);
+    margin-right: 0;
   }
 
   .radio {

--- a/packages/console/src/pages/Applications/components/SdkSelector/index.tsx
+++ b/packages/console/src/pages/Applications/components/SdkSelector/index.tsx
@@ -63,7 +63,7 @@ const SdkSelector = ({
   return (
     <Card className={classNames(styles.card, className)}>
       <CongratsIcon className={styles.congrats} />
-      <div>
+      <div className={styles.congratsText}>
         <div className={styles.title}>{t('applications.guide.title')}</div>
         <div className={styles.subtitle}>{t('applications.guide.subtitle')}</div>
       </div>


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
sdk selector content in the guide should be left-aligned
### Solution
- apply `width:100%` to the congrats and radioGroup to adjust their size to fit the card content
- add `margin-right: 0;` to **override** the default radioGroup style.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Before
<img width="818" alt="image" src="https://user-images.githubusercontent.com/10806653/176592979-45259074-f3c3-4250-ad2c-ca8a6e29b32e.png">

### After
<img width="1003" alt="image" src="https://user-images.githubusercontent.com/10806653/176593040-0bb43b9b-70b8-4923-b476-e148a5c7a80d.png">

