### PR TITLE
fix(console): use box shadow on radio group item hovered

### DIFF
--- a/packages/console/src/components/RadioGroup/index.module.scss
+++ b/packages/console/src/components/RadioGroup/index.module.scss
@@ -43,7 +43,7 @@
     }
 
     &:not(.disabled):hover {
-      background-color: var(--color-layer-2);
+      box-shadow: var(--shadow-2);
     }
 
     svg {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
fix(console): use box shadow on radio group item hovered

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Before
<img width="848" alt="image" src="https://user-images.githubusercontent.com/10806653/176624428-32f64d0a-95e9-4553-a04d-c132405ab0b7.png">

### After
<img width="753" alt="image" src="https://user-images.githubusercontent.com/10806653/176624304-a899c02e-7dc0-4436-b812-853e72a980bf.png">

