### PR TITLE
fix(console): remove dashboard tip time range

### DIFF
--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -453,20 +453,17 @@ const translation = {
       total_users: 'Total users',
       total_users_tip: 'Total users',
       new_users_today: 'New users today',
-      new_users_today_tip:
-        'The number of new users registered on your apps today (from {{today}} to {{now}})',
+      new_users_today_tip: 'The number of new users registered on your apps today',
       new_users_7_days: 'New users past 7 days',
-      new_users_7_days_tip:
-        'The number of new users registered on your apps in the past 7 days (from {{daysAgo}} to {{now}})',
+      new_users_7_days_tip: 'The number of new users registered on your apps in the past 7 days',
       daily_active_users: 'Daily active users',
-      daily_active_users_tip:
-        'The number of unique users exchanged tokens on your apps today (from {{today}} to {{now}})',
+      daily_active_users_tip: 'The number of unique users exchanged tokens on your apps today',
       weekly_active_users: 'Weekly active users',
       weekly_active_users_tip:
-        'The number of unique users exchanged tokens on your apps in the past 7 days (from {{daysAgo}} to {{now}})',
+        'The number of unique users exchanged tokens on your apps in the past 7 days',
       monthly_active_users: 'Monthly active users',
       monthly_active_users_tip:
-        'The number of unique users exchanged tokens on your apps in the past 30 days (from {{daysAgo}} to {{now}})',
+        'The number of unique users exchanged tokens on your apps in the past 30 days',
     },
     logs: {
       title: 'Audit Logs',

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -437,18 +437,15 @@ const translation = {
       total_users: '总用户',
       total_users_tip: '总用户',
       new_users_today: '今日新增',
-      new_users_today_tip: '今日注册到你应用上的新用户数（从 {{today}} 到 {{now}} 期间）',
+      new_users_today_tip: '今日注册到你应用上的新用户数',
       new_users_7_days: '7日新增',
-      new_users_7_days_tip: '最近7日注册到你应用上的新用户数（从 {{daysAgo}} 到 {{now}} 期间）',
+      new_users_7_days_tip: '最近7日注册到你应用上的新用户数',
       daily_active_users: '日活用户',
-      daily_active_users_tip:
-        '今日在你的应用上交换过 token 的唯一身份用户数（从 {{today}} 到 {{now}} 期间）',
+      daily_active_users_tip: '今日在你的应用上交换过 token 的唯一身份用户数',
       weekly_active_users: '周活用户',
-      weekly_active_users_tip:
-        '最近7日在你的应用上交换过 token 的唯一身份用户数（从 {{daysAgo}} 到 {{now}} 期间）',
+      weekly_active_users_tip: '最近7日在你的应用上交换过 token 的唯一身份用户数',
       monthly_active_users: '月活用户',
-      monthly_active_users_tip:
-        '最近30日在你的应用上交换过 token 的唯一身份用户数（从 {{daysAgo}} 到 {{now}} 期间）',
+      monthly_active_users_tip: '最近30日在你的应用上交换过 token 的唯一身份用户数',
     },
     logs: {
       title: '审计日志',


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Due to the complexity of handing timezone issue, remove the specific time range label from dashboard tooltips.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
No need to test.
