### PR TITLE
refactor(core): update sign-in-settings api path

### DIFF
--- a/packages/core/src/routes/init.ts
+++ b/packages/core/src/routes/init.ts
@@ -15,9 +15,9 @@ import sessionRoutes from '@/routes/session/session';
 import sessionSocialRoutes from '@/routes/session/social';
 import settingRoutes from '@/routes/setting';
 import signInExperiencesRoutes from '@/routes/sign-in-experience';
-import signInSettingsRoutes from '@/routes/sign-in-settings';
 import statusRoutes from '@/routes/status';
 import swaggerRoutes from '@/routes/swagger';
+import wellKnownRoutes from '@/routes/well-known';
 
 import adminUserRoutes from './admin-user';
 import logRoutes from './log';
@@ -49,7 +49,7 @@ const createRouters = (provider: Provider) => {
   meRoutes(meRouter);
 
   const anonymousRouter: AnonymousRouter = new Router();
-  signInSettingsRoutes(anonymousRouter, provider);
+  wellKnownRoutes(anonymousRouter, provider);
   statusRoutes(anonymousRouter);
   // The swagger.json should contain all API routers.
   swaggerRoutes(anonymousRouter, [sessionRouter, managementRouter, meRouter, anonymousRouter]);

--- a/packages/core/src/routes/well-known.test.ts
+++ b/packages/core/src/routes/well-known.test.ts
@@ -15,7 +15,7 @@ import {
 import { getConnectorInstanceById } from '@/connectors';
 import RequestError from '@/errors/RequestError';
 import * as signInExperienceQueries from '@/queries/sign-in-experience';
-import signInSettingsRoutes from '@/routes/sign-in-settings';
+import wellKnownRoutes from '@/routes/well-known';
 import { createRequester } from '@/utils/test-utils';
 
 const getConnectorInstances = jest.fn(async () => [
@@ -58,13 +58,13 @@ jest.mock('oidc-provider', () => ({
   })),
 }));
 
-describe('GET /sign-in-settings', () => {
+describe('GET /.well-known/sign-in-exp', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   const sessionRequest = createRequester({
-    anonymousRoutes: signInSettingsRoutes,
+    anonymousRoutes: wellKnownRoutes,
     provider: new Provider(''),
     middlewares: [
       async (ctx, next) => {
@@ -81,7 +81,7 @@ describe('GET /sign-in-settings', () => {
     .mockResolvedValue(mockSignInExperience);
 
   it('should return github and facebook connector instances', async () => {
-    const response = await sessionRequest.get('/sign-in-settings');
+    const response = await sessionRequest.get('/.well-known/sign-in-exp');
     expect(signInExperienceQuerySpyOn).toHaveBeenCalledTimes(1);
     expect(response.status).toEqual(200);
     expect(response.body).toMatchObject(
@@ -111,7 +111,7 @@ describe('GET /sign-in-settings', () => {
 
   it('should return admin console settings', async () => {
     interactionDetails.mockResolvedValue({ params: { client_id: adminConsoleApplicationId } });
-    const response = await sessionRequest.get('/sign-in-settings');
+    const response = await sessionRequest.get('/.well-known/sign-in-exp');
     expect(signInExperienceQuerySpyOn).toHaveBeenCalledTimes(1);
     expect(response.status).toEqual(200);
 

--- a/packages/core/src/routes/well-known.ts
+++ b/packages/core/src/routes/well-known.ts
@@ -15,12 +15,9 @@ import { hasActiveUsers } from '@/queries/user';
 
 import { AnonymousRouter } from './types';
 
-export default function signInSettingsRoutes<T extends AnonymousRouter>(
-  router: T,
-  provider: Provider
-) {
+export default function wellKnownRoutes<T extends AnonymousRouter>(router: T, provider: Provider) {
   router.get(
-    '/sign-in-settings',
+    '/.well-known/sign-in-exp',
     async (ctx, next) => {
       const [signInExperience, connectorInstances, interaction] = await Promise.all([
         findDefaultSignInExperience(),

--- a/packages/ui/src/apis/settings.ts
+++ b/packages/ui/src/apis/settings.ts
@@ -7,5 +7,5 @@ import { SignInExperience } from '@logto/schemas';
 import ky from 'ky';
 
 export const getSignInExperience = async <T extends SignInExperience>(): Promise<T> => {
-  return ky.get('/api/sign-in-settings').json<T>();
+  return ky.get('/api/.well-known/sign-in-exp').json<T>();
 };


### PR DESCRIPTION


<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Update sign-in-settings api path.

The original path name is confusing, introduce the /.well-known path accordingly. All open configs API should lies under this subpath.




<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
ut passed, test locally
@logto-io/eng 
