### PR TITLE
fix(console): change account password modal margin

### DIFF
--- a/packages/console/src/pages/Settings/components/ChangePassword.module.scss
+++ b/packages/console/src/pages/Settings/components/ChangePassword.module.scss
@@ -14,11 +14,3 @@
     margin-right: _.unit(4);
   }
 }
-
-.modal {
-  .description {
-    font: var(--font-body-medium);
-    color: var(--color-caption);
-    margin-bottom: _.unit(4);
-  }
-}

--- a/packages/console/src/pages/Settings/components/ChangePassword.tsx
+++ b/packages/console/src/pages/Settings/components/ChangePassword.tsx
@@ -58,6 +58,7 @@ const ChangePassword = () => {
       >
         <ModalLayout
           title="settings.change_modal_title"
+          subtitle="settings.change_modal_description"
           footer={
             <Button
               type="primary"
@@ -70,8 +71,7 @@ const ChangePassword = () => {
             setIsOpen(false);
           }}
         >
-          <div className={styles.modal}>
-            <div className={styles.description}>{t('settings.change_modal_description')}</div>
+          <div>
             <FormField title="admin_console.settings.new_password">
               <TextInput {...register('password', { required: true })} type="password" />
             </FormField>


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Fix change account password modal margin by moving "description" to "subTitle".

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="677" alt="image" src="https://user-images.githubusercontent.com/5717882/176840300-6f5f4c5c-96ff-46ad-b42a-045ab299e487.png">

