### PR TITLE
fix(console): fix dark mode char tooltip background

### DIFF
--- a/packages/console/src/pages/Dashboard/components/ChartTooltip/index.module.scss
+++ b/packages/console/src/pages/Dashboard/components/ChartTooltip/index.module.scss
@@ -1,7 +1,7 @@
 @use '@/scss/underscore' as _;
 
 .chartTooltip {
-  background: var(--color-on-primary);
+  background: var(--color-float);
   border: 1px solid var(--color-divider);
   box-shadow: var(--shadow-2);
   border-radius: 4px;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

fix dark mode char tooltip background

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="250" alt="截屏2022-07-01 下午3 08 53" src="https://user-images.githubusercontent.com/5717882/176843165-c5c3e813-ef97-42ed-a240-4ffec73e76c5.png">

