### PR TITLE
ci: update publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: master
           fetch-depth: 0
           token: ${{ secrets.BOT_PAT }}
           
@@ -48,18 +49,18 @@ jobs:
             --conventional-commits \
             --preid=${{ github.event.inputs.preid }} \
             --no-verify-access \
-            --create-release=github \
             --sign-git-commit \
             --sign-git-tag \
+            --no-push \
             --yes \
             ${{ github.event.inputs.semver }} ${{ github.event.inputs.append }}
         env:
           GH_TOKEN: ${{ secrets.BOT_PAT }}
 
-      - name: Package
-        run: ./package.sh
-
-      - name: Upload tar to GitHub release
-        uses: softprops/action-gh-release@v1
+      - name: Push to protected branch
+        uses: CasperWA/push-protected@v2
         with:
-          files: /tmp/logto.tar.gz
+          token: ${{ secrets.BOT_PAT }}
+          branch: master
+          tags: true
+          timeout: 20

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Dockerize
+name: Release
 
 on:
   push:
@@ -16,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Docker meta
         id: meta
@@ -27,7 +29,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=dev
+            type=edge
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -55,3 +57,20 @@ jobs:
       
       - name: Health check
         run: curl http://localhost:3001/api/status -If
+
+  create-github-release:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Package
+        run: ./package.sh
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: /tmp/logto.tar.gz

--- a/.github/workflows/update-pr-metadata.yml
+++ b/.github/workflows/update-pr-metadata.yml
@@ -21,7 +21,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Add assignees
-        if: ${{ github.event_name == 'pull_request' }}
+        if: github.event_name == 'pull_request'
         uses: actions-ecosystem/action-add-assignees@v1
         with:
           github_token: ${{ github.token }}


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

github can only bypass pull request to push, but not status check

<img width="767" alt="image" src="https://user-images.githubusercontent.com/14722250/176985697-ea6b58ed-75e4-4853-85da-dc90fc16bea2.png">

we don't want to bypass status check, so use 

refactored publish flow:
1. dispatch
2. push to temp branch
3. wait status check
4. push and tag master
5. create release and push docker

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

commit works as expected
https://github.com/logto-io/logto/runs/7155623671?check_suite_focus=true

wait for a real test