### PR TITLE
style(console): improve styles in guides

### DIFF
--- a/packages/console/src/components/Markdown/index.module.scss
+++ b/packages/console/src/components/Markdown/index.module.scss
@@ -34,6 +34,10 @@
     font: var(--font-body-medium);
     color: var(--color-text-link);
     text-decoration: none;
+
+    &:hover {
+      border-bottom: 1px solid var(--color-text-link);
+    }
   }
 
   h1 {

--- a/packages/console/src/mdx-components/DetailsSummary/index.module.scss
+++ b/packages/console/src/mdx-components/DetailsSummary/index.module.scss
@@ -4,6 +4,7 @@
   display: flex;
   flex-direction: column;
   background-color: var(--color-layer-light);
+  margin: _.unit(6) 0;
   border-radius: 8px;
 
   .summary {
@@ -40,8 +41,4 @@
       }
     }
   }
-}
-
-.container + .container {
-  margin-top: _.unit(6);
 }

--- a/packages/console/src/mdx-components/Step/index.module.scss
+++ b/packages/console/src/mdx-components/Step/index.module.scss
@@ -36,6 +36,10 @@
       height: auto;
       overflow: unset;
     }
+
+    > *:first-child {
+      margin-top: _.unit(6);
+    }
   }
 
   li {
@@ -71,17 +75,29 @@
     font: var(--font-body-medium);
     color: var(--color-text-link);
     text-decoration: none;
+
+    &:hover {
+      border-bottom: 1px solid var(--color-text-link);
+    }
   }
 
   h3 {
     font: var(--font-title-medium);
     color: var(--color-caption);
-    margin: _.unit(6) 0;
+    margin: _.unit(6) 0 _.unit(3);
   }
 
   p {
     font: var(--font-body-medium);
-    margin: _.unit(6) 0;
+    margin: _.unit(3) 0;
+  }
+
+  strong {
+    font: var(--font-label-large);
+  }
+
+  pre {
+    margin: _.unit(3) 0;
   }
 
   code:not(pre > code) {

--- a/packages/console/src/mdx-components/Tabs/index.module.scss
+++ b/packages/console/src/mdx-components/Tabs/index.module.scss
@@ -2,7 +2,7 @@
 
 .container {
   width: 100%;
-  margin-top: _.unit(6);
+  margin-top: _.unit(3);
 
   ul {
     border-bottom: 1px solid var(--color-divider);


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
* Adjust paragraph margins in AC guide: inner 12px, outer 24px
* Improve `<strong>` element font styles
* Improve `<a>` element hover styles, add underline text decoration

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] paragraph margins
<img width="754" alt="image" src="https://user-images.githubusercontent.com/12833674/176944439-2361ffb5-634a-4051-b0c3-58b4c610d4c5.png">

- [x] <strong> element uses `label-large` font
<img width="745" alt="image" src="https://user-images.githubusercontent.com/12833674/176944558-b17f5e14-fcf3-4cc1-9c61-b007e19775e8.png">

- [x] <a> element hover has underline
<img width="352" alt="image" src="https://user-images.githubusercontent.com/12833674/176944671-8af849de-e50a-4201-979f-54105fa2cb2b.png">

