### PR TITLE
style(console): notification text in demo-app should not wrap on desktop

### DIFF
--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -505,7 +505,7 @@ const translation = {
     },
   },
   demo_app: {
-    notification: 'Use the username and password to sign in this demo.',
+    notification: 'Use your admin console account to sign in to this demo app.',
     title: "You've successfully signed in the demo app!",
     subtitle: 'Here is your log in information:',
     username: 'Username: ',

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -486,7 +486,7 @@ const translation = {
     },
   },
   demo_app: {
-    notification: '请使用管理员帐号密码登录本示例应用',
+    notification: '请使用你的管理控制台帐号来登录本示例应用',
     title: '恭喜！你已成功登录到示例应用！',
     subtitle: '以下是你本次登录的用户信息：',
     username: '用户名：',

--- a/packages/ui/src/containers/AppNotification/index.module.scss
+++ b/packages/ui/src/containers/AppNotification/index.module.scss
@@ -20,6 +20,7 @@
   .appNotification {
     top: _.unit(-6);
     transform: translate(-50%, -100%);
+    width: fit-content;
     max-width: 520px;
   }
 }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
* In desktop mode, notification text in demo-app should not wrap.
* Update wording

<img width="694" alt="image" src="https://user-images.githubusercontent.com/12833674/176948542-f25add99-d9a8-42e6-8316-92510f1863d9.png">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally in demo-app, with both English and Chinese versions
