### PR TITLE
refactor: get-started task corresponding keys in DB

### DIFF
--- a/packages/console/src/components/AppContent/components/Sidebar/hook.tsx
+++ b/packages/console/src/components/AppContent/components/Sidebar/hook.tsx
@@ -43,7 +43,7 @@ export const useSidebarMenuItems = (): {
   firstItem: Optional<SidebarItem>;
 } => {
   const {
-    data: { hideGetStarted },
+    data: { getStartedHidden },
   } = useUserPreferences();
 
   const sections: SidebarSection[] = [
@@ -53,7 +53,7 @@ export const useSidebarMenuItems = (): {
         {
           Icon: Bolt,
           title: 'get_started',
-          isHidden: hideGetStarted,
+          isHidden: getStartedHidden,
         },
         {
           Icon: BarGraph,

--- a/packages/console/src/hooks/use-user-preferences.ts
+++ b/packages/console/src/hooks/use-user-preferences.ts
@@ -14,7 +14,7 @@ const userPreferencesGuard = z.object({
   language: z.nativeEnum(Language),
   appearanceMode: z.nativeEnum(AppearanceMode),
   experienceNoticeConfirmed: z.boolean().optional(),
-  hideGetStarted: z.boolean().optional(),
+  getStartedHidden: z.boolean().optional(),
 });
 
 export type UserPreferences = z.infer<typeof userPreferencesGuard>;

--- a/packages/console/src/pages/Applications/components/CreateForm/index.tsx
+++ b/packages/console/src/pages/Applications/components/CreateForm/index.tsx
@@ -57,7 +57,7 @@ const CreateForm = ({ onClose }: Props) => {
     const createdApp = await api.post('/api/applications', { json: data }).json<Application>();
     setCreatedApp(createdApp);
     setIsGetStartedModalOpen(true);
-    void updateSettings({ createApplication: true });
+    void updateSettings({ applicationCreated: true });
   });
 
   return (

--- a/packages/console/src/pages/Connectors/components/Guide/index.tsx
+++ b/packages/console/src/pages/Connectors/components/Guide/index.tsx
@@ -64,8 +64,8 @@ const Guide = ({ connector, onClose }: Props) => {
         .json<ConnectorDTO>();
 
       await updateSettings({
-        ...conditional(!isSocialConnector && { configurePasswordless: true }),
-        ...conditional(isSocialConnector && { configureSocialSignIn: true }),
+        ...conditional(!isSocialConnector && { passwordlessConfigured: true }),
+        ...conditional(isSocialConnector && { socialSignInConfigured: true }),
       });
 
       onClose();

--- a/packages/console/src/pages/GetStarted/components/GetStartedProgress/index.tsx
+++ b/packages/console/src/pages/GetStarted/components/GetStartedProgress/index.tsx
@@ -16,7 +16,7 @@ import * as styles from './index.module.scss';
 const GetStartedProgress = () => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const {
-    data: { hideGetStarted },
+    data: { getStartedHidden },
   } = useUserPreferences();
   const theme = useTheme();
   const Icon = theme === AppearanceMode.LightMode ? Tada : TadaDark;
@@ -24,7 +24,7 @@ const GetStartedProgress = () => {
   const [showDropDown, setShowDropdown] = useState(false);
   const { data, completedCount, totalCount } = useGetStartedMetadata({ checkDemoAppExists: false });
 
-  if (hideGetStarted) {
+  if (getStartedHidden) {
     return null;
   }
 

--- a/packages/console/src/pages/GetStarted/hook.ts
+++ b/packages/console/src/pages/GetStarted/hook.ts
@@ -61,10 +61,10 @@ const useGetStartedMetadata = ({ checkDemoAppExists }: Props) => {
       subtitle: 'get_started.card1_subtitle',
       icon: isLightMode ? CheckDemo : CheckDemoDark,
       buttonText: 'admin_console.general.check_out',
-      isComplete: settings?.checkDemo,
+      isComplete: settings?.demoChecked,
       isHidden: hideDemo,
       onClick: async () => {
-        void updateSettings({ checkDemo: true });
+        void updateSettings({ demoChecked: true });
         window.open('/demo-app', '_blank');
       },
     },
@@ -74,7 +74,7 @@ const useGetStartedMetadata = ({ checkDemoAppExists }: Props) => {
       subtitle: 'get_started.card2_subtitle',
       icon: isLightMode ? CreateApp : CreateAppDark,
       buttonText: 'admin_console.general.create',
-      isComplete: settings?.createApplication,
+      isComplete: settings?.applicationCreated,
       onClick: () => {
         navigate('/applications/create');
       },
@@ -85,7 +85,7 @@ const useGetStartedMetadata = ({ checkDemoAppExists }: Props) => {
       subtitle: 'get_started.card3_subtitle',
       icon: isLightMode ? Customize : CustomizeDark,
       buttonText: 'admin_console.general.customize',
-      isComplete: settings?.customizeSignInExperience,
+      isComplete: settings?.signInExperienceCustomized,
       onClick: () => {
         navigate('/sign-in-experience');
       },
@@ -96,7 +96,7 @@ const useGetStartedMetadata = ({ checkDemoAppExists }: Props) => {
       subtitle: 'get_started.card4_subtitle',
       icon: isLightMode ? Passwordless : PasswordlessDark,
       buttonText: 'admin_console.general.enable',
-      isComplete: settings?.configurePasswordless,
+      isComplete: settings?.passwordlessConfigured,
       onClick: () => {
         navigate('/connectors');
       },
@@ -107,7 +107,7 @@ const useGetStartedMetadata = ({ checkDemoAppExists }: Props) => {
       subtitle: 'get_started.card5_subtitle',
       icon: isLightMode ? OneClick : OneClickDark,
       buttonText: 'admin_console.general.set_up',
-      isComplete: settings?.configureSocialSignIn,
+      isComplete: settings?.socialSignInConfigured,
       onClick: () => {
         navigate('/connectors/social');
       },
@@ -118,9 +118,9 @@ const useGetStartedMetadata = ({ checkDemoAppExists }: Props) => {
       subtitle: 'get_started.card6_subtitle',
       icon: isLightMode ? FurtherReadings : FurtherReadingsDark,
       buttonText: 'admin_console.general.check_out',
-      isComplete: settings?.checkFurtherReadings,
+      isComplete: settings?.furtherReadingsChecked,
       onClick: () => {
-        void updateSettings({ checkFurtherReadings: true });
+        void updateSettings({ furtherReadingsChecked: true });
         window.open('https://docs.logto.io/', '_blank');
       },
     },

--- a/packages/console/src/pages/GetStarted/index.tsx
+++ b/packages/console/src/pages/GetStarted/index.tsx
@@ -21,7 +21,7 @@ const GetStarted = () => {
   const [showConfirmModal, setShowConfirmModal] = useState(false);
 
   const hideGetStarted = () => {
-    void update({ hideGetStarted: true });
+    void update({ getStartedHidden: true });
     // Navigate to next menu item
     navigate('/dashboard');
   };

--- a/packages/console/src/pages/SignInExperience/components/GuideModal.tsx
+++ b/packages/console/src/pages/SignInExperience/components/GuideModal.tsx
@@ -68,7 +68,7 @@ const GuideModal = ({ isOpen, onClose }: Props) => {
       api.patch('/api/sign-in-exp', {
         json: signInExperienceParser.toRemoteModel(formData),
       }),
-      updateSettings({ customizeSignInExperience: true }),
+      updateSettings({ signInExperienceCustomized: true }),
     ]);
 
     onClose();
@@ -76,7 +76,7 @@ const GuideModal = ({ isOpen, onClose }: Props) => {
 
   const onSkip = async () => {
     setIsLoading(true);
-    await updateSettings({ customizeSignInExperience: true });
+    await updateSettings({ signInExperienceCustomized: true });
     setIsLoading(false);
     onClose();
   };

--- a/packages/console/src/pages/SignInExperience/index.tsx
+++ b/packages/console/src/pages/SignInExperience/index.tsx
@@ -62,7 +62,7 @@ const SignInExperience = () => {
       })
       .json<SignInExperienceType>();
     void mutate(updatedData);
-    await updateSettings({ customizeSignInExperience: true });
+    await updateSettings({ signInExperienceCustomized: true });
     toast.success(t('general.saved'));
   };
 
@@ -91,7 +91,7 @@ const SignInExperience = () => {
     return <div>{settingsError.body?.message ?? settingsError.message}</div>;
   }
 
-  if (!settings?.customizeSignInExperience) {
+  if (!settings?.signInExperienceCustomized) {
     return <Welcome mutate={mutateSettings} />;
   }
 

--- a/packages/core/src/__mocks__/index.ts
+++ b/packages/core/src/__mocks__/index.ts
@@ -44,12 +44,12 @@ export const mockRole: Role = {
 export const mockSetting: Setting = {
   id: 'foo setting',
   adminConsole: {
-    checkDemo: false,
-    createApplication: false,
-    configurePasswordless: false,
-    configureSocialSignIn: false,
-    customizeSignInExperience: false,
-    checkFurtherReadings: false,
+    demoChecked: false,
+    applicationCreated: false,
+    signInExperienceCustomized: false,
+    passwordlessConfigured: false,
+    socialSignInConfigured: false,
+    furtherReadingsChecked: false,
   },
 };
 

--- a/packages/schemas/src/foundations/jsonb-types.ts
+++ b/packages/schemas/src/foundations/jsonb-types.ts
@@ -147,12 +147,12 @@ export enum AppearanceMode {
 
 export const adminConsoleConfigGuard = z.object({
   // Get started challenges
-  checkDemo: z.boolean(),
-  createApplication: z.boolean(),
-  configurePasswordless: z.boolean(),
-  configureSocialSignIn: z.boolean(),
-  customizeSignInExperience: z.boolean(),
-  checkFurtherReadings: z.boolean(),
+  demoChecked: z.boolean(),
+  applicationCreated: z.boolean(),
+  signInExperienceCustomized: z.boolean(),
+  passwordlessConfigured: z.boolean(),
+  socialSignInConfigured: z.boolean(),
+  furtherReadingsChecked: z.boolean(),
 });
 
 export type AdminConsoleConfig = z.infer<typeof adminConsoleConfigGuard>;

--- a/packages/schemas/src/seeds/setting.ts
+++ b/packages/schemas/src/seeds/setting.ts
@@ -11,11 +11,11 @@ export const createDefaultSetting = (): Readonly<CreateSetting> =>
     adminConsole: {
       language: Language.English,
       appearanceMode: AppearanceMode.SyncWithSystem,
-      checkDemo: false,
-      createApplication: false,
-      configurePasswordless: false,
-      configureSocialSignIn: false,
-      customizeSignInExperience: false,
-      checkFurtherReadings: false,
+      demoChecked: false,
+      applicationCreated: false,
+      signInExperienceCustomized: false,
+      passwordlessConfigured: false,
+      socialSignInConfigured: false,
+      furtherReadingsChecked: false,
     },
   });


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Improve get-started task corresponding keys in DB. Use past tense, e.g.:

e.g. 
createApplication => applicationCreated
checkFurtherReadings => furtherReadingsChecked

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Modified jsonb value in DB, and everything works well on the client. All saved progress restored.
<img width="1261" alt="image" src="https://user-images.githubusercontent.com/12833674/176982363-8f5f70c2-7e92-4e68-9e01-2bca035c891a.png">
