### PR TITLE
refactor(ui): refactor ac signin exp

### DIFF
--- a/packages/core/src/routes/well-known.test.ts
+++ b/packages/core/src/routes/well-known.test.ts
@@ -1,5 +1,5 @@
 import { ConnectorType, SignInMode } from '@logto/schemas';
-import { adminConsoleApplicationId, adminConsoleSignInMethods } from '@logto/schemas/lib/seeds';
+import { adminConsoleApplicationId, adminConsoleSignInExperience } from '@logto/schemas/lib/seeds';
 import { Provider } from 'oidc-provider';
 
 import {
@@ -58,6 +58,10 @@ jest.mock('oidc-provider', () => ({
   })),
 }));
 
+jest.mock('i18next', () => ({
+  t: (key: string) => key,
+}));
+
 describe('GET /.well-known/sign-in-exp', () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -112,13 +116,16 @@ describe('GET /.well-known/sign-in-exp', () => {
   it('should return admin console settings', async () => {
     interactionDetails.mockResolvedValue({ params: { client_id: adminConsoleApplicationId } });
     const response = await sessionRequest.get('/.well-known/sign-in-exp');
-    expect(signInExperienceQuerySpyOn).toHaveBeenCalledTimes(1);
+    expect(signInExperienceQuerySpyOn).not.toBeCalled();
     expect(response.status).toEqual(200);
 
     expect(response.body).toMatchObject(
       expect.objectContaining({
-        ...mockSignInExperience,
-        signInMethods: adminConsoleSignInMethods,
+        ...adminConsoleSignInExperience,
+        branding: {
+          ...adminConsoleSignInExperience.branding,
+          slogan: 'admin_console.welcome.title',
+        },
         socialConnectors: [],
         signInMode: SignInMode.SignIn,
       })

--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -498,7 +498,7 @@ const translation = {
       button: 'Sign in again',
     },
     welcome: {
-      title: 'Welcome to Logto Admin Console',
+      title: 'Welcome to Admin Console',
       description:
         'Admin console is a web app to manage Logto without coding requirements. Let’s first create an account. With this account, you can manage Logto by yourself or on behalf of your company.',
       create_account: 'Create Account',

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -479,7 +479,7 @@ const translation = {
       button: '重新登录',
     },
     welcome: {
-      title: '欢迎使用管理控制台',
+      title: '欢迎来到管理控制台',
       description:
         '管理控制台是一个无需代码操作的应用。你可以用它来管理登录体验。让我们首先创建一个帐号。你可以用它以个人或公司的身份管理 Logto。',
       create_account: '创建帐号',

--- a/packages/schemas/src/seeds/sign-in-experience.ts
+++ b/packages/schemas/src/seeds/sign-in-experience.ts
@@ -33,9 +33,11 @@ export const defaultSignInExperience: Readonly<CreateSignInExperience> = {
   signInMode: SignInMode.SignInAndRegister,
 };
 
-export const adminConsoleSignInMethods = {
-  username: SignInMethodState.Primary,
-  email: SignInMethodState.Disabled,
-  sms: SignInMethodState.Disabled,
-  social: SignInMethodState.Disabled,
+export const adminConsoleSignInExperience: CreateSignInExperience = {
+  ...defaultSignInExperience,
+  branding: {
+    style: BrandingStyle.Logo_Slogan,
+    logoUrl: '',
+    darkLogoUrl: '',
+  },
 };

--- a/packages/ui/src/pages/SignIn/index.module.scss
+++ b/packages/ui/src/pages/SignIn/index.module.scss
@@ -27,11 +27,11 @@
   }
 }
 
-.placeHolderTop {
+.placeholderTop {
   flex: 3;
 }
 
-.placeHolderBottom {
+.placeholderBottom {
   flex: 5;
 }
 

--- a/packages/ui/src/pages/SignIn/index.module.scss
+++ b/packages/ui/src/pages/SignIn/index.module.scss
@@ -27,6 +27,14 @@
   }
 }
 
+.placeHolderTop {
+  flex: 2;
+}
+
+.placeHolderBottom {
+  flex: 3;
+}
+
 :global(body.mobile) {
   .header {
     margin-top: _.unit(3);
@@ -48,7 +56,6 @@
 
 :global(body.desktop) {
   .header {
-    margin-top: _.unit(6);
     margin-bottom: _.unit(6);
   }
 

--- a/packages/ui/src/pages/SignIn/index.module.scss
+++ b/packages/ui/src/pages/SignIn/index.module.scss
@@ -28,11 +28,11 @@
 }
 
 .placeHolderTop {
-  flex: 2;
+  flex: 3;
 }
 
 .placeHolderBottom {
-  flex: 3;
+  flex: 5;
 }
 
 :global(body.mobile) {

--- a/packages/ui/src/pages/SignIn/index.tsx
+++ b/packages/ui/src/pages/SignIn/index.tsx
@@ -12,7 +12,7 @@ import * as styles from './index.module.scss';
 import { PrimarySection, SecondarySection, CreateAccountLink } from './registry';
 
 const SignIn = () => {
-  const { experienceSettings, theme } = useContext(PageContext);
+  const { experienceSettings, theme, platform } = useContext(PageContext);
 
   if (!experienceSettings) {
     return null;
@@ -29,32 +29,36 @@ const SignIn = () => {
   };
 
   return (
-    <div className={classNames(styles.wrapper)}>
-      <BrandingHeader
-        className={styles.header}
-        headline={style === BrandingStyle.Logo_Slogan ? slogan : undefined}
-        logo={getLogto()}
-      />
-      <PrimarySection
-        signInMethod={experienceSettings.primarySignInMethod}
-        socialConnectors={experienceSettings.socialConnectors}
-        signInMode={experienceSettings.signInMode}
-      />
-
-      {experienceSettings.signInMode !== SignInMode.Register && (
-        <SecondarySection
-          primarySignInMethod={experienceSettings.primarySignInMethod}
-          secondarySignInMethods={experienceSettings.secondarySignInMethods}
-          socialConnectors={experienceSettings.socialConnectors}
+    <>
+      {platform === 'web' && <div className={styles.placeHolderTop} />}
+      <div className={classNames(styles.wrapper)}>
+        <BrandingHeader
+          className={styles.header}
+          headline={style === BrandingStyle.Logo_Slogan ? slogan : undefined}
+          logo={getLogto()}
         />
-      )}
+        <PrimarySection
+          signInMethod={experienceSettings.primarySignInMethod}
+          socialConnectors={experienceSettings.socialConnectors}
+          signInMode={experienceSettings.signInMode}
+        />
 
-      {experienceSettings.signInMode === SignInMode.SignInAndRegister && (
-        <CreateAccountLink primarySignInMethod={experienceSettings.primarySignInMethod} />
-      )}
+        {experienceSettings.signInMode !== SignInMode.Register && (
+          <SecondarySection
+            primarySignInMethod={experienceSettings.primarySignInMethod}
+            secondarySignInMethods={experienceSettings.secondarySignInMethods}
+            socialConnectors={experienceSettings.socialConnectors}
+          />
+        )}
 
-      <AppNotification />
-    </div>
+        {experienceSettings.signInMode === SignInMode.SignInAndRegister && (
+          <CreateAccountLink primarySignInMethod={experienceSettings.primarySignInMethod} />
+        )}
+
+        <AppNotification />
+      </div>
+      {platform === 'web' && <div className={styles.placeHolderBottom} />}
+    </>
   );
 };
 

--- a/packages/ui/src/pages/SignIn/index.tsx
+++ b/packages/ui/src/pages/SignIn/index.tsx
@@ -30,7 +30,7 @@ const SignIn = () => {
 
   return (
     <>
-      {platform === 'web' && <div className={styles.placeHolderTop} />}
+      {platform === 'web' && <div className={styles.placeholderTop} />}
       <div className={classNames(styles.wrapper)}>
         <BrandingHeader
           className={styles.header}
@@ -57,7 +57,7 @@ const SignIn = () => {
 
         <AppNotification />
       </div>
-      {platform === 'web' && <div className={styles.placeHolderBottom} />}
+      {platform === 'web' && <div className={styles.placeholderBottom} />}
     </>
   );
 };


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Refactor ac signin exp

1. Refactor the sign-exp API. Should not query user sign-in-exp data for AC app. Use hardcoded AC experience settings instead.
2. Add a slogan to AC sign-in-exp
3. Adjust the web sign-in page layout according to the latest design
<img width="464" alt="image" src="https://user-images.githubusercontent.com/36393111/176986238-28551f22-97dd-4f3d-8f51-74701d16bfff.png">


Updates:
AC:
<img width="662" alt="image" src="https://user-images.githubusercontent.com/36393111/176986247-9d394b61-e605-476b-b6ef-c0ce6a12df4d.png">
Rest:
<img width="670" alt="image" src="https://user-images.githubusercontent.com/36393111/176986251-a745cbfe-d8f7-47ec-891e-638fc5a33a4e.png">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
@logto-io/eng 
