### PR TITLE
style(ui): add short screen notification style

### DIFF
--- a/packages/ui/src/containers/AppNotification/index.module.scss
+++ b/packages/ui/src/containers/AppNotification/index.module.scss
@@ -2,9 +2,7 @@
 
 .appNotification {
   position: absolute;
-  top: _.unit(6);
-  left: 50%;
-  transform: translateX(-50%);
+  max-width: 520px;
 }
 
 :global(body.mobile) {
@@ -12,15 +10,23 @@
     top: _.unit(6);
     left: _.unit(5);
     right: _.unit(5);
-    transform: none;
   }
 }
 
 :global(body.desktop) {
   .appNotification {
     top: _.unit(-6);
+    left: 50%;
     transform: translate(-50%, -100%);
     width: fit-content;
-    max-width: 520px;
+  }
+}
+
+@media screen and (max-height: 820px) {
+  :global(body.desktop) {
+    .appNotification {
+      top: _.unit(6);
+      transform: translate(-50%);
+    }
   }
 }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
fix app notification position under short screen

Before:
![image](https://user-images.githubusercontent.com/36393111/176984408-cfbcb454-e1bf-4121-94ef-d43ca7fc6f93.png)

After:
<img width="672" alt="image" src="https://user-images.githubusercontent.com/36393111/176984394-636f605d-ec0f-4ecf-b24e-fe03364647f4.png">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
@logto-io/eng 

