### PR TITLE
refactor(core): db seed question

### DIFF
--- a/packages/core/src/env-set/create-pool-by-env.ts
+++ b/packages/core/src/env-set/create-pool-by-env.ts
@@ -1,15 +1,10 @@
-import {
-  assertEnv,
-  conditional,
-  conditionalString,
-  getEnv,
-  Optional,
-} from '@silverhand/essentials';
+import { assertEnv, conditional, getEnv, Optional } from '@silverhand/essentials';
 import inquirer from 'inquirer';
 import { createPool } from 'slonik';
 import { createInterceptors } from 'slonik-interceptor-preset';
+import { z } from 'zod';
 
-import { createDatabase, createDatabaseCli } from '@/database/seed';
+import { createDatabase, createDatabaseCli, replaceDsnDatabase } from '@/database/seed';
 
 import { appendDotEnv } from './dot-env';
 import { allYes, noInquiry } from './parameters';
@@ -17,9 +12,37 @@ import { allYes, noInquiry } from './parameters';
 const defaultDatabaseUrl = getEnv('DB_URL_DEFAULT', 'postgres://@localhost:5432');
 const defaultDatabaseName = 'logto';
 
+const createDatabaseIfNotExists = async (dsn: string): Promise<[string, boolean]> => {
+  try {
+    return [await createDatabase(dsn, defaultDatabaseName), true];
+  } catch (error: unknown) {
+    const result = z.object({ code: z.string() }).safeParse(error);
+
+    // https://www.postgresql.org/docs/12/errcodes-appendix.html
+    // Database already exists
+    if (result.success && result.data.code === '42P04') {
+      if (allYes) {
+        return [replaceDsnDatabase(dsn, defaultDatabaseName), false];
+      }
+
+      const useCurrent = await inquirer.prompt({
+        type: 'confirm',
+        name: 'value',
+        message: `A database named "${defaultDatabaseName}" already exists. Would you like to use it without seeding?`,
+      });
+
+      if (useCurrent.value) {
+        return [replaceDsnDatabase(dsn, defaultDatabaseName), false];
+      }
+    }
+
+    throw error;
+  }
+};
+
 const inquireForLogtoDsn = async (key: string): Promise<[Optional<string>, boolean]> => {
   if (allYes) {
-    return [await createDatabase(defaultDatabaseUrl, defaultDatabaseName), true];
+    return createDatabaseIfNotExists(defaultDatabaseUrl);
   }
 
   const setUp = await inquirer.prompt({
@@ -38,19 +61,10 @@ const inquireForLogtoDsn = async (key: string): Promise<[Optional<string>, boole
     return [conditional<string>(dsn.value && String(dsn.value)), false];
   }
 
-  const hasEmptyDatabase = await inquirer.prompt({
-    type: 'confirm',
-    name: 'value',
-    default: false,
-    message: 'Do you have an empty database for Logto?',
-  });
-
   const dsnAnswer = await inquirer.prompt({
     name: 'value',
-    default: new URL(hasEmptyDatabase.value ? defaultDatabaseName : '', defaultDatabaseUrl).href,
-    message: `Please input the DSN _WITH${conditionalString(
-      !hasEmptyDatabase.value && 'OUT'
-    )}_ database name:`,
+    default: new URL(defaultDatabaseUrl).href,
+    message: `Please input the DSN _WITHOUT_ database name:`,
   });
   const dsn = conditional<string>(dsnAnswer.value && String(dsnAnswer.value));
 
@@ -58,11 +72,7 @@ const inquireForLogtoDsn = async (key: string): Promise<[Optional<string>, boole
     return [dsn, false];
   }
 
-  if (!hasEmptyDatabase.value) {
-    return [await createDatabase(dsn, defaultDatabaseName), true];
-  }
-
-  return [dsn, true];
+  return createDatabaseIfNotExists(dsn);
 };
 
 const createPoolByEnv = async (isTest: boolean, demoAppUrl: string) => {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

### Background
if user is pull a new logto image without resetting postgres, it's likely to encounter the error below:

<img width="694" alt="image" src="https://user-images.githubusercontent.com/14722250/177039604-bed900ad-6fdf-4ae0-8df5-2b3c8398c06a.png">

because for a new logto image with `--all-yes` specified, it will try to create a new database which will cause 42P04 (duplicate_database) error.

also, the original question "Do you have an empty database for Logto?" is confusing when it comes with "Would you like to set up a new Logto database?".

### Solution

1. remove the confusing question
2. ask user if we can go with the existing database without seed if logto database exists.

then we can use `--all-yes` even if there's an existing logto database

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

with local logto database created:

1. remove env `DB_URL`, the question shows; choose `y` then the app runs, and the correct `DB_URL` will be appended to `.env`
2. remove env `DB_URL`, the question shows; choose `n` then it throws an error
3. remove env and run with `--all-yes`, the app runs, and the correct `DB_URL` will be appended to `.env`