### PR TITLE
fix(console): hide reset description on dark-mode primary color matched

### DIFF
--- a/packages/console/src/pages/SignInExperience/components/ColorForm.tsx
+++ b/packages/console/src/pages/SignInExperience/components/ColorForm.tsx
@@ -1,6 +1,6 @@
 import { absoluteLighten } from '@logto/shared';
 import color from 'color';
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -24,11 +24,16 @@ const ColorForm = () => {
 
   const isDarkModeEnabled = watch('color.isDarkModeEnabled');
   const primaryColor = watch('color.primaryColor');
+  const darkPrimaryColor = watch('color.darkPrimaryColor');
 
   const handleResetColor = useCallback(() => {
     const darkPrimaryColor = absoluteLighten(color(primaryColor), 10);
     setValue('color.darkPrimaryColor', darkPrimaryColor.hex());
   }, [primaryColor, setValue]);
+
+  const showReset = useMemo(() => {
+    return absoluteLighten(color(primaryColor), 10).hex() !== darkPrimaryColor;
+  }, [darkPrimaryColor, primaryColor]);
 
   useEffect(() => {
     if (!isDirty) {
@@ -70,15 +75,17 @@ const ColorForm = () => {
               )}
             />
           </FormField>
-          <div className={styles.darkModeTip}>
-            {t('sign_in_exp.color.dark_mode_reset_tip')}
-            <Button
-              type="plain"
-              size="small"
-              title="admin_console.sign_in_exp.color.reset"
-              onClick={handleResetColor}
-            />
-          </div>
+          {showReset && (
+            <div className={styles.darkModeTip}>
+              {t('sign_in_exp.color.dark_mode_reset_tip')}
+              <Button
+                type="plain"
+                size="small"
+                title="admin_console.sign_in_exp.color.reset"
+                onClick={handleResetColor}
+              />
+            </div>
+          )}
         </>
       )}
     </>

--- a/packages/console/src/pages/SignInExperience/components/ColorForm.tsx
+++ b/packages/console/src/pages/SignInExperience/components/ColorForm.tsx
@@ -26,14 +26,13 @@ const ColorForm = () => {
   const primaryColor = watch('color.primaryColor');
   const darkPrimaryColor = watch('color.darkPrimaryColor');
 
-  const handleResetColor = useCallback(() => {
-    const darkPrimaryColor = absoluteLighten(color(primaryColor), 10);
-    setValue('color.darkPrimaryColor', darkPrimaryColor.hex());
-  }, [primaryColor, setValue]);
+  const calculatedDarkPrimaryColor = useMemo(() => {
+    return absoluteLighten(color(primaryColor), 10).hex();
+  }, [primaryColor]);
 
-  const showReset = useMemo(() => {
-    return absoluteLighten(color(primaryColor), 10).hex() !== darkPrimaryColor;
-  }, [darkPrimaryColor, primaryColor]);
+  const handleResetColor = useCallback(() => {
+    setValue('color.darkPrimaryColor', calculatedDarkPrimaryColor);
+  }, [calculatedDarkPrimaryColor, setValue]);
 
   useEffect(() => {
     if (!isDirty) {
@@ -75,7 +74,7 @@ const ColorForm = () => {
               )}
             />
           </FormField>
-          {showReset && (
+          {calculatedDarkPrimaryColor !== darkPrimaryColor && (
             <div className={styles.darkModeTip}>
               {t('sign_in_exp.color.dark_mode_reset_tip')}
               <Button


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
fix(console): hide reset description on dark-mode primary color matched

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

### Matched
<img width="656" alt="image" src="https://user-images.githubusercontent.com/10806653/177075539-e45d9df6-6c61-4908-883f-87a31db7a475.png">

### Not Matched
<img width="679" alt="image" src="https://user-images.githubusercontent.com/10806653/177075591-108fe10b-71fe-404a-aad7-0d57cc3c3e6b.png">


