### PR TITLE
fix(console): save sie when secondary method is disabled

### DIFF
--- a/packages/console/src/pages/SignInExperience/components/SignInMethodsForm.tsx
+++ b/packages/console/src/pages/SignInExperience/components/SignInMethodsForm.tsx
@@ -76,7 +76,7 @@ const SignInMethodsForm = () => {
           </div>
         );
       }),
-    [primaryMethod, register, t, email, social, sms]
+    [t, primaryMethod, email, sms, social, control]
   );
 
   return (
@@ -116,7 +116,11 @@ const SignInMethodsForm = () => {
       )}
       <FormField title="admin_console.sign_in_exp.sign_in_methods.enable_secondary">
         <Switch
-          {...register('signInMethods.enableSecondary', { required: true })}
+          /**
+           * DO NOT SET THIS FIELD TO REQUIRED UNLESS YOU KNOW WHAT YOU ARE DOING.
+           * https://github.com/react-hook-form/react-hook-form/issues/2323
+           */
+          {...register('signInMethods.enableSecondary')}
           label={t('sign_in_exp.sign_in_methods.enable_secondary_description')}
         />
       </FormField>


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
fix sie cannot save when secondary sign-in methods are disabled

![image](https://user-images.githubusercontent.com/14722250/177176007-997fd6cb-8407-41d1-bb19-1e288c3c5aef.png)

the required rule will fail if `checked` is false

ref https://github.com/react-hook-form/react-hook-form/issues/2323

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

save successfully when secondary sign-in methods are disabled