### PR TITLE
fix(core): do not titlize tags of .well-known APIs

### DIFF
--- a/packages/core/src/routes/swagger.test.ts
+++ b/packages/core/src/routes/swagger.test.ts
@@ -68,15 +68,20 @@ describe('GET /swagger.json', () => {
   });
 
   it('should generate the tags', async () => {
-    const response = await mockSwaggerRequest.get('/swagger.json');
+    const testTagRouter = new Router();
+    testTagRouter.get('/mock', () => ({}));
+    testTagRouter.put('/.well-known', () => ({}));
+    const swaggerRequest = createSwaggerRequest([testTagRouter]);
+
+    const response = await swaggerRequest.get('/swagger.json');
     expect(response.body.paths).toMatchObject(
       expect.objectContaining({
         /* eslint-disable @typescript-eslint/no-unsafe-assignment */
         '/api/mock': expect.objectContaining({
           get: expect.objectContaining({ tags: ['Mock'] }),
         }),
-        '/api/test': expect.objectContaining({
-          put: expect.objectContaining({ tags: ['Test'] }),
+        '/api/.well-known': expect.objectContaining({
+          put: expect.objectContaining({ tags: ['.well-known'] }),
         }),
         /* eslint-enable @typescript-eslint/no-unsafe-assignment */
       })

--- a/packages/core/src/routes/swagger.ts
+++ b/packages/core/src/routes/swagger.ts
@@ -62,6 +62,16 @@ const buildParameters = (
   }));
 };
 
+function buildTag(path: string) {
+  const part = path.split('/')[1];
+
+  if (part?.startsWith('.')) {
+    return part;
+  }
+
+  return toTitle(part ?? 'General');
+}
+
 const buildOperation = (stack: IMiddleware[], path: string): OpenAPIV3.OperationObject => {
   const guard = stack.find((function_): function_ is WithGuardConfig<IMiddleware> =>
     isGuardMiddleware(function_)
@@ -85,7 +95,7 @@ const buildOperation = (stack: IMiddleware[], path: string): OpenAPIV3.Operation
   ];
 
   return {
-    tags: [toTitle(path.split('/')[1] ?? 'General')],
+    tags: [buildTag(path)],
     parameters: [...pathParameters, ...queryParameters],
     requestBody,
     responses: {

--- a/packages/core/src/routes/swagger.ts
+++ b/packages/core/src/routes/swagger.ts
@@ -63,13 +63,13 @@ const buildParameters = (
 };
 
 function buildTag(path: string) {
-  const part = path.split('/')[1];
+  const root = path.split('/')[1];
 
-  if (part?.startsWith('.')) {
-    return part;
+  if (root?.startsWith('.')) {
+    return root;
   }
 
-  return toTitle(part ?? 'General');
+  return toTitle(root ?? 'General');
 }
 
 const buildOperation = (stack: IMiddleware[], path: string): OpenAPIV3.OperationObject => {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
DO NOT titlize the tags of .well-known APIs

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

![image](https://user-images.githubusercontent.com/10594507/177195135-79ac94f7-53bd-416d-a5bf-e1f9f1472f69.png)

![image](https://user-images.githubusercontent.com/10594507/177195220-d8b09fee-9947-4d77-aaea-2972bd9fd6ed.png)

![image](https://user-images.githubusercontent.com/10594507/177195163-92e1cbf1-77be-45c4-a1e7-3f6d12374c0e.png)
