### PR TITLE
fix(console): dashbaord chart grid color

### DIFF
--- a/packages/console/src/pages/Dashboard/index.tsx
+++ b/packages/console/src/pages/Dashboard/index.tsx
@@ -101,7 +101,7 @@ const Dashboard = () => {
                   width={1100}
                   height={168}
                 >
-                  <CartesianGrid vertical={false} />
+                  <CartesianGrid vertical={false} stroke="var(--color-divider)" />
                   <Area
                     type="monotone"
                     dataKey="count"


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Use new color for dashboard chart grid line.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="1180" alt="截屏2022-07-05 下午2 54 24" src="https://user-images.githubusercontent.com/5717882/177268161-036cc242-759e-4ff8-8b31-d133630034ed.png">

