### PR TITLE
refactor: by default allow redirect URIs for CORS access

### DIFF
--- a/packages/console/src/pages/ApplicationDetails/components/Settings.tsx
+++ b/packages/console/src/pages/ApplicationDetails/components/Settings.tsx
@@ -117,6 +117,7 @@ const Settings = ({ applicationType, oidcConfig }: Props) => {
       <FormField
         title="admin_console.application_details.cors_allowed_origins"
         className={styles.textField}
+        tooltip="admin_console.application_details.cors_allowed_origins_tip"
       >
         <Controller
           name="customClientMetadata.corsAllowedOrigins"

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -95,7 +95,8 @@ export default async function initOidc(app: Koa): Promise<Provider> {
     },
     // https://github.com/panva/node-oidc-provider/blob/main/recipes/client_based_origins.md
     clientBasedCORS: (ctx, origin, client) =>
-      ctx.request.origin === origin || isOriginAllowed(origin, client.metadata()),
+      ctx.request.origin === origin ||
+      isOriginAllowed(origin, client.metadata(), client.redirectUris),
     // https://github.com/panva/node-oidc-provider/blob/main/recipes/claim_configuration.md
     claims: {
       profile: ['username', 'name', 'avatar', 'role_names'],

--- a/packages/core/src/oidc/utils.test.ts
+++ b/packages/core/src/oidc/utils.test.ts
@@ -88,4 +88,16 @@ describe('isOriginAllowed', () => {
       })
     ).toBeTruthy();
   });
+
+  it('should return true if redirectUris include the origin', () => {
+    expect(
+      isOriginAllowed(
+        'https://logto.dev',
+        {
+          [CustomClientMetadataKey.CorsAllowedOrigins]: [],
+        },
+        ['https://logto.dev/callback']
+      )
+    ).toBeTruthy();
+  });
 });

--- a/packages/core/src/oidc/utils.ts
+++ b/packages/core/src/oidc/utils.ts
@@ -23,5 +23,13 @@ export const validateCustomClientMetadata = (key: string, value: unknown) => {
   }
 };
 
-export const isOriginAllowed = (origin: string, customClientMetadata: CustomClientMetadata) =>
-  Boolean(customClientMetadata.corsAllowedOrigins?.includes(origin));
+export const isOriginAllowed = (
+  origin: string,
+  customClientMetadata: CustomClientMetadata,
+  redirectUris: string[] = []
+) => {
+  const { corsAllowedOrigins = [] } = customClientMetadata;
+  const redirectUriOrigins = redirectUris.map((uri) => new URL(uri).origin);
+
+  return [...corsAllowedOrigins, ...redirectUriOrigins].includes(origin);
+};

--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -132,6 +132,7 @@ const translation = {
       post_sign_out_redirect_uri_placeholder: 'https://your.website.com/home',
       cors_allowed_origins: 'CORS allowed origins',
       cors_allowed_origins_placeholder: 'https://your.website.com',
+      cors_allowed_origins_tip: 'By default, all your redirect URIs will be allowed.',
       add_another: 'Add Another',
       id_token_expiration: 'ID Token expiration',
       refresh_token_expiration: 'Refresh Token expiration',

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -129,6 +129,7 @@ const translation = {
       post_sign_out_redirect_uri_placeholder: 'https://your.website.com/home',
       cors_allowed_origins: 'CORS Allowed Origins',
       cors_allowed_origins_placeholder: 'https://your.website.com',
+      cors_allowed_origins_tip: '所有 Redirect URI 默认为 CORS 所允许。',
       add_another: '新增',
       id_token_expiration: 'ID Token 过期时间',
       refresh_token_expiration: 'Refresh Token 过期时间',


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Allow all redirect URIs for CORS access by default.

<img width="597" alt="image" src="https://user-images.githubusercontent.com/12833674/177287460-e48d8229-4701-4ab4-9015-f56ae23724db.png">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] UT passed.
- [ ] Deploy to test on `logto.dev`
