### PR TITLE
fix(console): leave page button should be a danger button

### DIFF
--- a/packages/console/src/components/ConfirmModal/index.tsx
+++ b/packages/console/src/components/ConfirmModal/index.tsx
@@ -19,7 +19,6 @@ export type ConfirmModalProps = {
   isOpen: boolean;
   onCancel: () => void;
   onConfirm: () => void;
-  onClose?: () => void;
 };
 
 const ConfirmModal = ({
@@ -32,7 +31,6 @@ const ConfirmModal = ({
   isOpen,
   onCancel,
   onConfirm,
-  onClose = onCancel,
 }: ConfirmModalProps) => {
   return (
     <ReactModal
@@ -49,7 +47,7 @@ const ConfirmModal = ({
           </>
         }
         className={classNames(styles.content, className)}
-        onClose={onClose}
+        onClose={onCancel}
       >
         {children}
       </ModalLayout>

--- a/packages/console/src/components/UnsavedChangesAlertModal/index.tsx
+++ b/packages/console/src/components/UnsavedChangesAlertModal/index.tsx
@@ -68,12 +68,10 @@ const UnsavedChangesAlertModal = ({ hasUnsavedChanges }: Props) => {
   return (
     <ConfirmModal
       isOpen={displayAlert}
-      confirmButtonType="primary"
-      confirmButtonText="admin_console.general.stay_on_page"
-      cancelButtonText="admin_console.general.leave_page"
-      onCancel={leavePage}
-      onConfirm={stayOnPage}
-      onClose={stayOnPage}
+      confirmButtonText="admin_console.general.leave_page"
+      cancelButtonText="admin_console.general.stay_on_page"
+      onCancel={stayOnPage}
+      onConfirm={leavePage}
     >
       {t('general.unsaved_changes_warning')}
     </ConfirmModal>


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
leave page button should be a danger button and on the right of the unsaved changes alert modal

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="610" alt="image" src="https://user-images.githubusercontent.com/10806653/177294568-2fc92a28-858a-408b-bbe0-5216739b8dd2.png">

