### PR TITLE
style(console): plain button

### DIFF
--- a/packages/console/src/components/Button/index.module.scss
+++ b/packages/console/src/components/Button/index.module.scss
@@ -207,12 +207,8 @@
       outline: 2px solid var(--color-focused-variant);
     }
 
-    &:active {
-      background: var(--color-pressed-variant);
-    }
-
-    &:not(:disabled):not(:active):hover {
-      background: var(--color-hover-variant);
+    &:not(:disabled):hover {
+      text-decoration: underline;
     }
   }
 }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Plain button is now looks like "link button", change hover state from background effect to underline decoration.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

<img width="676" alt="截屏2022-07-05 下午7 16 07" src="https://user-images.githubusercontent.com/5717882/177316065-7945fadb-800a-4196-8259-d7cf02b8afe1.png">

<img width="434" alt="截屏2022-07-05 下午7 16 11" src="https://user-images.githubusercontent.com/5717882/177316084-103771c9-881e-4445-bc96-c149f4908c26.png">

<img width="422" alt="截屏2022-07-05 下午7 16 14" src="https://user-images.githubusercontent.com/5717882/177316104-20057456-e7fe-4d42-a6f0-bb22657868c7.png">

