### PR TITLE
refactor(console,schemas,shared): extract dark mode color generator

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -42,7 +42,6 @@
     "@types/react-modal": "^3.13.1",
     "@types/react-syntax-highlighter": "^15.5.1",
     "classnames": "^2.3.1",
-    "color": "^4.2.3",
     "cross-env": "^7.0.3",
     "csstype": "^3.0.11",
     "dayjs": "^1.10.5",

--- a/packages/console/src/pages/SignInExperience/components/ColorForm.tsx
+++ b/packages/console/src/pages/SignInExperience/components/ColorForm.tsx
@@ -1,5 +1,4 @@
-import { absoluteLighten } from '@logto/shared';
-import color from 'color';
+import { generateDarkColor } from '@logto/shared';
 import React, { useCallback, useEffect, useMemo } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -27,7 +26,7 @@ const ColorForm = () => {
   const darkPrimaryColor = watch('color.darkPrimaryColor');
 
   const calculatedDarkPrimaryColor = useMemo(() => {
-    return absoluteLighten(color(primaryColor), 10).hex();
+    return generateDarkColor(primaryColor);
   }, [primaryColor]);
 
   const handleResetColor = useCallback(() => {

--- a/packages/schemas/src/seeds/sign-in-experience.ts
+++ b/packages/schemas/src/seeds/sign-in-experience.ts
@@ -1,14 +1,17 @@
 import { Language } from '@logto/phrases-ui';
+import { generateDarkColor } from '@logto/shared';
 
 import { CreateSignInExperience, SignInMode } from '../db-entries';
 import { BrandingStyle, SignInMethodState } from '../foundations';
 
+const defaultPrimaryColor = '#6139F6';
+
 export const defaultSignInExperience: Readonly<CreateSignInExperience> = {
   id: 'default',
   color: {
-    primaryColor: '#6139F6',
+    primaryColor: defaultPrimaryColor,
     isDarkModeEnabled: false,
-    darkPrimaryColor: '#8768F8',
+    darkPrimaryColor: generateDarkColor(defaultPrimaryColor),
   },
   branding: {
     style: BrandingStyle.Logo,

--- a/packages/shared/src/utilities/color.ts
+++ b/packages/shared/src/utilities/color.ts
@@ -12,3 +12,6 @@ export const absoluteDarken = (baseColor: color, delta: number) => {
 
   return color([hslArray[0], hslArray[1], hslArray[2] - delta], 'hsl');
 };
+
+export const generateDarkColor = (lightColor: string) =>
+  absoluteLighten(color(lightColor), 10).hex();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -691,7 +691,6 @@ importers:
       '@types/react-modal': ^3.13.1
       '@types/react-syntax-highlighter': ^15.5.1
       classnames: ^2.3.1
-      color: ^4.2.3
       cross-env: ^7.0.3
       csstype: ^3.0.11
       dayjs: ^1.10.5
@@ -755,7 +754,6 @@ importers:
       '@types/react-modal': 3.13.1
       '@types/react-syntax-highlighter': 15.5.1
       classnames: 2.3.1
-      color: 4.2.3
       cross-env: 7.0.3
       csstype: 3.0.11
       dayjs: 1.10.7


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

extract dark mode color generator to `shared`, and use it in seed.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

pass existing UTs, and UI looks fine in local test.
