### PR TITLE
refactor(console): remove redundant reset logic on sign-in experience tabs

### DIFF
--- a/packages/console/src/pages/SignInExperience/tabs/BrandingTab.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/BrandingTab.tsx
@@ -16,8 +16,6 @@ const BrandingTab = ({ defaultData, isDataDirty }: Props) => {
   const { reset } = useFormContext<SignInExperienceForm>();
 
   useEffect(() => {
-    reset(defaultData);
-
     return () => {
       reset(defaultData);
     };

--- a/packages/console/src/pages/SignInExperience/tabs/OthersTab.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/OthersTab.tsx
@@ -16,8 +16,6 @@ const OthersTab = ({ defaultData, isDataDirty }: Props) => {
   const { reset } = useFormContext<SignInExperienceForm>();
 
   useEffect(() => {
-    reset(defaultData);
-
     return () => {
       reset(defaultData);
     };

--- a/packages/console/src/pages/SignInExperience/tabs/SignInMethodsTab.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignInMethodsTab.tsx
@@ -15,8 +15,6 @@ const SignInMethodsTab = ({ defaultData, isDataDirty }: Props) => {
   const { reset } = useFormContext<SignInExperienceForm>();
 
   useEffect(() => {
-    reset(defaultData);
-
     return () => {
       reset(defaultData);
     };


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
For the data will be reset by the logic on the sign-in experience index page, so we don't need to reset the data on tab pages.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test in the Admin Console.
