### PR TITLE
fix(console): dashboard chart yaxis width

### DIFF
--- a/packages/console/src/pages/Dashboard/index.tsx
+++ b/packages/console/src/pages/Dashboard/index.tsx
@@ -110,7 +110,13 @@ const Dashboard = () => {
                     fill="var(--color-hover-variant)"
                   />
                   <XAxis dataKey="date" tickLine={false} tick={tickStyle} />
-                  <YAxis orientation="right" axisLine={false} tickLine={false} tick={tickStyle} />
+                  <YAxis
+                    orientation="right"
+                    width={30}
+                    axisLine={false}
+                    tickLine={false}
+                    tick={tickStyle}
+                  />
                   <Tooltip content={<ChartTooltip />} cursor={{ stroke: 'var(--color-primary' }} />
                 </AreaChart>
               </ResponsiveContainer>


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

In dashboard, fix chart padding by setting width to "YAxis".

There is still some space remained, incase number grows (with more digits).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="1214" alt="截屏2022-07-06 下午1 39 45" src="https://user-images.githubusercontent.com/5717882/177477078-ed73f9b3-6504-483e-bc6f-1872826b0b92.png">

