### PR TITLE
refactor(console): sync input URI values in code samples in guide

### DIFF
--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/android.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/android.mdx
@@ -140,21 +140,25 @@ Go back to your IDE/editor, use the following code to implement sign-in:
 
 <TabItem value="kotlin" label="Kotlin">
 
-```kotlin
-logtoClient.signIn(this, "<your-redirect-uri>") { logtoException: LogtoException? ->
-    // User signed in successfully if `logtoException` is null.
-}
-```
+<pre>
+<code className="language-kotlin">
+{`logtoClient.signIn(this, "${props.redirectUris[0] ?? '<your-redirect-uri>'}") { logtoException: LogtoException? ->
+    // User signed in successfully if \`logtoException\` is null.
+}`}
+</code>
+</pre>
 
 </TabItem>
 
 <TabItem value="java" label="Java">
 
-```java
-logtoClient.signIn(this, "<your-redirect-uri>", logtoException -> {
-    // User signed in successfully if `logtoException` is null.
-});
-```
+<pre>
+<code className="language-java">
+{`logtoClient.signIn(this, "${props.redirectUris[0] ?? '<your-redirect-uri>'}", logtoException -> {
+    // User signed in successfully if \`logtoException\` is null.
+});`}
+</code>
+</pre>
 
 </TabItem>
 

--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/android_zh-cn.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/android_zh-cn.mdx
@@ -140,21 +140,25 @@ public class MainActivity extends AppCompatActivity {
 
 <TabItem value="kotlin" label="Kotlin">
 
-```kotlin
-logtoClient.signIn(this, "<your-redirect-uri>") { logtoException: LogtoException? ->
-    // 当 `logtoException` 为 null 时，则登录成功。
-}
-```
+<pre>
+<code className="language-kotlin">
+{`logtoClient.signIn(this, "${props.redirectUris[0] ?? '<your-redirect-uri>'}") { logtoException: LogtoException? ->
+    // 当 \`logtoException\` 为 null 时，则登录成功。
+}`}
+</code>
+</pre>
 
 </TabItem>
 
 <TabItem value="java" label="Java">
 
-```java
-logtoClient.signIn(this, "<your-redirect-uri>", logtoException -> {
-    // 当 `logtoException` 为 null 时，则登录成功。
-});
-```
+<pre>
+<code className="language-java">
+{`logtoClient.signIn(this, "${props.redirectUris[0] ?? '<your-redirect-uri>'}", logtoException -> {
+    // 当 \`logtoException\` 为 null 时，则登录成功。
+});`}
+</code>
+</pre>
 
 </TabItem>
 

--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/express.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/express.mdx
@@ -80,12 +80,12 @@ app.use(
 >
 
 <Alert>
-  In the following steps, we assume your app is running on <code>http://localhost:3000</code>.
+  In the following steps, we assume your app is running on <code>http://localhost:1234</code>.
 </Alert>
 
 ### Configure Redirect URI
 
-First, let’s enter your redirect URI. E.g. `http://localhost:3000/callback`.
+First, let’s enter your redirect URI. E.g. `http://localhost:1234/callback`.
 
 <UriInputField appId={props.appId} isSingle={!props.isCompact} name="redirectUris" title="Redirect URI" />
 
@@ -118,7 +118,7 @@ const { fromUint8Array } = require('js-base64');
 const config = {
   endpoint: '${props.endpoint}',
   appId: '${props.appId}',
-  redirectUri: 'http://localhost:3000/callback', // Configured in the previous step
+  redirectUri: '${props.redirectUris[0] ?? 'http://localhost:1234/callback'}', // Configured in the previous step
   scopes: withReservedScopes().split(' '),
 };
 

--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/express_zh-cn.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/express_zh-cn.mdx
@@ -116,7 +116,7 @@ const { fromUint8Array } = require('js-base64');
 const config = {
   endpoint: '${props.endpoint}',
   appId: '${props.appId}',
-  redirectUri: 'http://localhost:3000/callback', // 上一步配置过的 Redirect URI
+  redirectUri: '${props.redirectUris[0] ?? 'http://localhost:1234/callback'}', // 上一步配置过的 Redirect URI
   scopes: withReservedScopes().split(' '),
 };
 

--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/ios.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/ios.mdx
@@ -83,7 +83,7 @@ let config = try? LogtoConfig(
 
 ### Configure Redirect URI
 
-First, let’s configure your redirect URI scheme. E.g. `logto://callback`
+First, let’s configure your redirect URI scheme. E.g. `io.logto://callback`
 
 <UriInputField appId={props.appId} isSingle={!props.isCompact} name="redirectUris" title="Redirect URI" />
 
@@ -93,14 +93,16 @@ First, let’s configure your redirect URI scheme. E.g. `logto://callback`
 
 Go back to Xcode, use the following code to implement sign-in:
 
-```swift
-do {
-  try await client.signInWithBrowser(redirectUri: "logto://callback")
+<pre>
+<code className="language-swift">
+{`do {
+  try await client.signInWithBrowser(redirectUri: "${props.redirectUris[0] ?? 'io.logto://callback'}")
   print(client.isAuthenticated) // true
 } catch let error as LogtoClientErrors.SignIn {
   // error occured during sign in
-}
-```
+}`}
+</code>
+</pre>
 
 </Step>
 

--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/ios_zh-cn.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/ios_zh-cn.mdx
@@ -82,7 +82,7 @@ let config = try? LogtoConfig(
 
 ### 配置 Redirect URI
 
-首先，我们来配置你的 redirect URI scheme。例如 `logto://callback`
+首先，我们来配置你的 redirect URI scheme。例如 `io.logto://callback`
 
 <UriInputField appId={props.appId} isSingle={!props.isCompact} name="redirectUris" title="Redirect URI" />
 
@@ -92,14 +92,16 @@ let config = try? LogtoConfig(
 
 回到 Xcode，使用如下代码实现登录：
 
-```swift
-do {
-  try await client.signInWithBrowser(redirectUri: "logto://callback")
+<pre>
+<code className="language-swift">
+{`do {
+  try await client.signInWithBrowser(redirectUri: "${props.redirectUris[0] ?? 'io.logto://callback'}")
   print(client.isAuthenticated) // true
 } catch let error as LogtoClientErrors.SignIn {
   // 登录过程中有错误发生
-}
-```
+}`}
+</code>
+</pre>
 
 </Step>
 

--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/react.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/react.mdx
@@ -89,8 +89,9 @@ We provide two hooks `useHandleSignInCallback()` and `useLogto()` which can help
 
 Go back to your IDE/editor, use the following code to implement the sign-in button:
 
-```tsx
-import { useLogto } from '@logto/react';
+<pre>
+<code className="language-tsx">
+{`import { useLogto } from '@logto/react';
 
 const SignIn = () => {
   const { signIn, isAuthenticated } = useLogto();
@@ -100,12 +101,13 @@ const SignIn = () => {
   }
 
   return (
-    <button onClick={() => signIn('http://localhost:1234/callback')}>
+    <button onClick={() => signIn('${props.redirectUris[0] ?? 'http://localhost:1234/callback'}')}>
       Sign In
     </button>
   );
-};
-```
+};`}
+</code>
+</pre>
 
 ### Handle redirect
 
@@ -153,17 +155,19 @@ After signing out, it'll be great to redirect user back to your website. Let's a
 
 ### Implement a sign-out button
 
-```tsx
-const SignOut = () => {
+<pre>
+<code className="language-tsx">
+{`const SignOut = () => {
   const { signOut } = useLogto();
 
   return (
-    <button onClick={() => signOut('http://localhost:1234')}>
+    <button onClick={() => signOut('${props.postLogoutRedirectUris[0] ?? 'http://localhost:1234'}')}>
       Sign out
     </button>
   );
-};
-```
+};`}
+</code>
+</pre>
 
 </Step>
 

--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/react_zh-cn.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/react_zh-cn.mdx
@@ -89,8 +89,9 @@ const App = () => (
 
 返回你的 IDE 或编辑器，使用如下代码来实现一个登录按钮：
 
-```tsx
-import { useLogto } from '@logto/react';
+<pre>
+<code className="language-tsx">
+{`import { useLogto } from '@logto/react';
 
 const SignIn = () => {
   const { signIn, isAuthenticated } = useLogto();
@@ -100,12 +101,13 @@ const SignIn = () => {
   }
 
   return (
-    <button onClick={() => signIn('http://localhost:1234/callback')}>
+    <button onClick={() => signIn('${props.redirectUris[0] ?? 'http://localhost:1234/callback'}')}>
       登录
     </button>
   );
-};
-```
+};`}
+</code>
+</pre>
 
 ### 处理重定向
 
@@ -153,17 +155,19 @@ const Callback = () => {
 
 ### 实现退出登录按钮
 
-```tsx
-const SignOut = () => {
+<pre>
+<code className="language-tsx">
+{`const SignOut = () => {
   const { signOut } = useLogto();
 
   return (
-    <button onClick={() => signOut('http://localhost:1234')}>
+    <button onClick={() => signOut('${props.postLogoutRedirectUris[0] ?? 'http://localhost:1234'}')}>
       退出登录
     </button>
   );
-};
-```
+};`}
+</code>
+</pre>
 
 </Step>
 

--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/vanilla.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/vanilla.mdx
@@ -81,11 +81,13 @@ First, let’s enter your redirect URI. E.g. `http://localhost:1234/callback`.
 
 Go back to your IDE/editor, use the following code to implement the sign-in button:
 
-```html
-<button onclick="logtoClient.signIn('http://localhost:1234/callback')">
+<pre>
+<code className="language-html">
+{`<button onclick="logtoClient.signIn('${props.redirectUris[0] ?? 'http://localhost:1234/callback'}')">
   Sign In
-</button>
-```
+</button>`}
+</code>
+</pre>
 
 ### Handle redirect
 
@@ -122,11 +124,13 @@ After signing out, it'll be great to redirect user back to your website. Let's a
 
 ### Implement a sign-out button
 
-```html
-<button onclick="logtoClient.signOut('http://localhost:1234')">
+<pre>
+<code className="language-html">
+{`<button onclick="logtoClient.signOut('${props.postLogoutRedirectUris[0] ?? 'http://localhost:1234'}')">
   Sign Out
-</button>
-```
+</button>`}
+</code>
+</pre>
 
 </Step>
 

--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/vanilla_zh-cn.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/vanilla_zh-cn.mdx
@@ -81,11 +81,13 @@ const logtoClient = new LogtoClient({
 
 返回你的 IDE 或编辑器，使用如下代码来实现一个登录按钮：
 
-```html
-<button onclick="logtoClient.signIn('http://localhost:1234/callback')">
+<pre>
+<code className="language-html">
+{`<button onclick="logtoClient.signIn('${props.redirectUris[0] ?? 'http://localhost:1234/callback'}')">
   登录
-</button>
-```
+</button>`}
+</code>
+</pre>
 
 ### 处理重定向
 
@@ -122,11 +124,13 @@ try {
 
 ### 实现退出登录按钮
 
-```html
-<button onclick="logtoClient.signOut('http://localhost:1234')">
+<pre>
+<code className="language-html">
+{`<button onclick="logtoClient.signOut('${props.postLogoutRedirectUris[0] ?? 'http://localhost:1234'}')">
   退出登录
-</button>
-```
+</button>`}
+</code>
+</pre>
 
 </Step>
 

--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/vue.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/vue.mdx
@@ -92,12 +92,14 @@ We provide two composables `useHandleSignInCallback()` and `useLogto()`, which c
 
 Go back to your IDE/editor, use the following code to implement the sign-in button:
 
-```ts
-import { useLogto } from "@logto/vue";
+<pre>
+<code className="language-ts">
+{`import { useLogto } from "@logto/vue";
 
 const { signIn, isAuthenticated } = useLogto();
-const onClickSignIn = () => signIn('http://localhost:1234/callback');
-```
+const onClickSignIn = () => signIn('${props.redirectUris[0] ?? 'http://localhost:1234/callback'}');`}
+</code>
+</pre>
 
 ```html
 <div v-if="isAuthenticated">
@@ -162,12 +164,14 @@ After signing out, it'll be great to redirect user back to your website. Let's a
 
 ### Implement a sign-out button
 
-```ts
-import { useLogto } from "@logto/vue";
+<pre>
+<code className="language-ts">
+{`import { useLogto } from "@logto/vue";
 
 const { signOut } = useLogto();
-const onClickSignOut = () => signOut('http://localhost:1234');
-```
+const onClickSignOut = () => signOut('${props.postLogoutRedirectUris[0] ?? 'http://localhost:1234'}');`}
+</code>
+</pre>
 
 ```html
 <button @click="onClickSignOut">Sign Out</button>

--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/vue_zh-cn.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/vue_zh-cn.mdx
@@ -92,12 +92,14 @@ app.mount("#app");`}
 
 返回你的 IDE 或编辑器，使用如下代码来实现一个登录按钮：
 
-```ts
-import { useLogto } from "@logto/vue";
+<pre>
+<code className="language-ts">
+{`import { useLogto } from "@logto/vue";
 
 const { signIn, isAuthenticated } = useLogto();
-const onClickSignIn = () => signIn('http://localhost:1234/callback');
-```
+const onClickSignIn = () => signIn('${props.redirectUris[0] ?? 'http://localhost:1234/callback'}');`}
+</code>
+</pre>
 
 ```html
 <div v-if="isAuthenticated">
@@ -162,12 +164,14 @@ const router = createRouter({
 
 ### 实现退出登录按钮
 
-```ts
-import { useLogto } from "@logto/vue";
+<pre>
+<code className="language-ts">
+{`import { useLogto } from "@logto/vue";
 
 const { signOut } = useLogto();
-const onClickSignOut = () => signOut('http://localhost:1234');
-```
+const onClickSignOut = () => signOut('${props.postLogoutRedirectUris[0] ?? 'http://localhost:1234'}');`}
+</code>
+</pre>
 
 ```html
 <button @click="onClickSignOut">退出登录</button>

--- a/packages/console/src/pages/Applications/components/Guide/index.tsx
+++ b/packages/console/src/pages/Applications/components/Guide/index.tsx
@@ -41,7 +41,7 @@ const Guides: Record<string, LazyExoticComponent<(props: MDXProps) => JSX.Elemen
 };
 
 const Guide = ({ app, isCompact, onClose }: Props) => {
-  const { id: appId, name: appName, type: appType } = app;
+  const { id: appId, name: appName, type: appType, oidcClientMetadata } = app;
   const sdks = applicationTypeAndSdkTypeMappings[appType];
   const [selectedSdk, setSelectedSdk] = useState<SupportedSdk>(sdks[0]);
   const [activeStepIndex, setActiveStepIndex] = useState(-1);
@@ -91,6 +91,8 @@ const Guide = ({ app, isCompact, onClose }: Props) => {
               <GuideComponent
                 appId={appId}
                 endpoint={window.location.origin}
+                redirectUris={oidcClientMetadata.redirectUris}
+                postLogoutRedirectUris={oidcClientMetadata.postLogoutRedirectUris}
                 activeStepIndex={activeStepIndex}
                 isCompact={isCompact}
                 onNext={(nextIndex: number) => {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Sync user input `Redirect URIs` and `Post Sign-out Redirect URIs` in the provided code samples as well in each guide.

<img width="699" alt="image" src="https://user-images.githubusercontent.com/12833674/177755215-c02b8046-144a-48c1-a7ce-822efb39c204.png">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally and it works fine
