### PR TITLE
fix(console): language auto detection

### DIFF
--- a/packages/console/src/i18n/init.ts
+++ b/packages/console/src/i18n/init.ts
@@ -1,4 +1,5 @@
 import resources, { Language } from '@logto/phrases';
+import { conditional } from '@silverhand/essentials';
 import i18next from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
@@ -13,11 +14,11 @@ const initI18n = async (language?: Language) =>
       interpolation: {
         escapeValue: false,
       },
-      lng: language,
       detection: {
         lookupLocalStorage: 'i18nextLogtoAcLng',
         lookupSessionStorage: 'i18nextLogtoAcLng',
       },
+      ...conditional(language && { lng: language }),
     });
 
 export default initI18n;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
The admin console failed to detect user language on initial run, and user always gets English language.

We suspect it is the `undefined` language param passed in to the i18next initializer that causes this problem.

Thus try to set react-i18next language only when language param is not empty

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [ ] To be tested in gitpod
