### PR TITLE
fix(console): admin console language detection

### DIFF
--- a/packages/console/src/hooks/use-user-preferences.ts
+++ b/packages/console/src/hooks/use-user-preferences.ts
@@ -11,7 +11,7 @@ import { themeStorageKey } from '@/consts';
 import useApi, { RequestError } from './use-api';
 
 const userPreferencesGuard = z.object({
-  language: z.nativeEnum(Language),
+  language: z.nativeEnum(Language).optional(),
   appearanceMode: z.nativeEnum(AppearanceMode),
   experienceNoticeConfirmed: z.boolean().optional(),
   getStartedHidden: z.boolean().optional(),
@@ -39,7 +39,6 @@ const useUserPreferences = () => {
       return z.object({ [key]: userPreferencesGuard }).parse(data).adminConsolePreferences;
     } catch {
       return {
-        language: Language.English,
         appearanceMode:
           getEnumFromArray(Object.values(AppearanceMode), localStorage.getItem(themeStorageKey)) ??
           AppearanceMode.SyncWithSystem,

--- a/packages/console/src/i18n/init.ts
+++ b/packages/console/src/i18n/init.ts
@@ -1,5 +1,4 @@
 import resources, { Language } from '@logto/phrases';
-import { conditional } from '@silverhand/essentials';
 import i18next from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
@@ -14,11 +13,11 @@ const initI18n = async (language?: Language) =>
       interpolation: {
         escapeValue: false,
       },
+      lng: language,
       detection: {
         lookupLocalStorage: 'i18nextLogtoAcLng',
         lookupSessionStorage: 'i18nextLogtoAcLng',
       },
-      ...conditional(language && { lng: language }),
     });
 
 export default initI18n;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
* Revert the previous fix #1456 for it didn't work
* Re-fix the language auto detection problem in admin console


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally and it could detect zh-CN if Chinese is set as first language in chrome
