### PR TITLE
fix(console): pagination color should be color-text-link

### DIFF
--- a/packages/console/src/components/Pagination/index.module.scss
+++ b/packages/console/src/components/Pagination/index.module.scss
@@ -25,8 +25,8 @@
       }
 
       &.active {
-        border-color: var(--color-primary);
-        color: var(--color-primary);
+        border-color: var(--color-text-link);
+        color: var(--color-text-link);
       }
     }
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
pagination active color should be `var(--color-text-link)`

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="395" alt="image" src="https://user-images.githubusercontent.com/10806653/177827812-f70d69e4-0a6a-445a-9831-4579f49f5fbe.png">

