### PR TITLE
fix(console): connector guide should not have sub title

### DIFF
--- a/packages/console/src/pages/Connectors/components/Guide/index.tsx
+++ b/packages/console/src/pages/Connectors/components/Guide/index.tsx
@@ -96,8 +96,7 @@ const Guide = ({ connector, onClose }: Props) => {
           <FormProvider {...methods}>
             <form onSubmit={onSubmit}>
               <Step
-                title="Enter your json here"
-                subtitle="Lorem ipsum dolor sit amet, consectetuer adipiscing elit."
+                title={t('connector_details.edit_config_label')}
                 index={0}
                 activeIndex={0}
                 buttonText="admin_console.connectors.save_and_done"


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- remove sub title from connector guide
- apply i18n to the connector guide title

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="909" alt="image" src="https://user-images.githubusercontent.com/10806653/177911214-41e61d34-bf2e-4f04-ab9f-a142bfbc0aee.png">

