### PR TITLE
feat: expose zod error

### DIFF
--- a/packages/connector-apple/src/index.ts
+++ b/packages/connector-apple/src/index.ts
@@ -23,7 +23,7 @@ export default class AppleConnector implements SocialConnector {
     const result = appleConfigGuard.safeParse(config);
 
     if (!result.success) {
-      throw new ConnectorError(ConnectorErrorCodes.InvalidConfig, result.error.message);
+      throw new ConnectorError(ConnectorErrorCodes.InvalidConfig, result.error);
     }
   };
 

--- a/packages/connector-types/src/index.ts
+++ b/packages/connector-types/src/index.ts
@@ -41,10 +41,13 @@ export enum ConnectorErrorCodes {
 
 export class ConnectorError extends Error {
   public code: ConnectorErrorCodes;
+  public data: unknown;
 
-  constructor(code: ConnectorErrorCodes, message?: string) {
+  constructor(code: ConnectorErrorCodes, data?: unknown) {
+    const message = typeof data === 'string' ? data : 'Connector error occurred.';
     super(message);
     this.code = code;
+    this.data = typeof data === 'string' ? { message: data } : data;
   }
 }
 

--- a/packages/console/src/components/Toast/index.module.scss
+++ b/packages/console/src/components/Toast/index.module.scss
@@ -31,5 +31,6 @@ div.toast {
   &.error {
     border: 1px solid var(--color-error);
     background-color: var(--color-danger-toast-background);
+    white-space: pre-line;
   }
 }

--- a/packages/console/src/hooks/use-api.ts
+++ b/packages/console/src/hooks/use-api.ts
@@ -20,7 +20,9 @@ export class RequestError extends Error {
 const toastError = async (response: Response) => {
   try {
     const data = await response.json<RequestErrorBody>();
-    toast.error(data.message || t('admin_console.errors.unknown_server_error'));
+    toast.error(
+      [data.message, data.details].join('\n') || t('admin_console.errors.unknown_server_error')
+    );
   } catch {
     toast.error(t('admin_console.errors.unknown_server_error'));
   }

--- a/packages/core/src/errors/RequestError/index.ts
+++ b/packages/core/src/errors/RequestError/index.ts
@@ -1,8 +1,22 @@
 import { LogtoErrorCode, LogtoErrorI18nKey } from '@logto/phrases';
 import { RequestErrorBody, RequestErrorMetadata } from '@logto/schemas';
+import { conditional, Optional } from '@silverhand/essentials';
 import i18next from 'i18next';
 import pick from 'lodash.pick';
+import { ZodError } from 'zod';
 
+const formatZodError = ({ issues }: ZodError): string[] =>
+  issues.map((issue) => {
+    const base = `Error in key path "${issue.path.map((node) => String(node)).join('.')}": (${
+      issue.code
+    }) `;
+
+    if (issue.code === 'invalid_type') {
+      return base + `Expected ${issue.expected} but received ${issue.received}.`;
+    }
+
+    return base + issue.message;
+  });
 export default class RequestError extends Error {
   code: LogtoErrorCode;
   status: number;
@@ -27,6 +41,10 @@ export default class RequestError extends Error {
   }
 
   get body(): RequestErrorBody {
-    return pick(this, 'message', 'code', 'data');
+    return pick(this, 'message', 'code', 'data', 'details');
+  }
+
+  get details(): Optional<string> {
+    return conditional(this.data instanceof ZodError && formatZodError(this.data).join('\n'));
   }
 }

--- a/packages/core/src/middleware/koa-connector-error-handler.ts
+++ b/packages/core/src/middleware/koa-connector-error-handler.ts
@@ -12,10 +12,7 @@ export default function koaConnectorErrorHandler<StateT, ContextT>(): Middleware
         throw error;
       }
 
-      const { code, message } = error;
-
-      // Original OIDCProvider Error description and details are provided in the data field
-      const data = { message };
+      const { code, data } = error;
 
       switch (code) {
         case ConnectorErrorCodes.InsufficientRequestParameters:

--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -546,7 +546,7 @@ const errors = {
     jwt_sub_missing: 'Missing `sub` in JWT.',
   },
   guard: {
-    invalid_input: 'The request input is invalid.',
+    invalid_input: 'The request {{type}} is invalid.',
     invalid_pagination: 'The request pagination value is invalid.',
   },
   oidc: {

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -524,7 +524,7 @@ const errors = {
     jwt_sub_missing: 'JWT 缺失 `sub`',
   },
   guard: {
-    invalid_input: '请求输入无效',
+    invalid_input: '请求中 {{type}} 无效',
     invalid_pagination: '分页参数无效',
   },
   oidc: {

--- a/packages/schemas/src/api/error.ts
+++ b/packages/schemas/src/api/error.ts
@@ -6,4 +6,9 @@ export type RequestErrorMetadata = Record<string, unknown> & {
   expose?: boolean;
 };
 
-export type RequestErrorBody = { message: string; data: unknown; code: LogtoErrorCode };
+export type RequestErrorBody = {
+  message: string;
+  data: unknown;
+  code: LogtoErrorCode;
+  details?: string;
+};


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- support multiline toast display
- expose data for connector errors
- format `invalid_type` zod errors
- provide `details` prop for detailed error message
- specify which part of request data is invalid (params, body, or query)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Save API Resource without TTL
![image](https://user-images.githubusercontent.com/14722250/177934719-8eb400c6-4d03-43b2-817d-700d79365e41.png)

Save Apple connector config without Client ID
<img width="456" alt="image" src="https://user-images.githubusercontent.com/14722250/177934761-b8474092-5208-4d24-8537-bcbc0b4c91e9.png">

Request test API with multiple errors

<img width="1230" alt="image" src="https://user-images.githubusercontent.com/14722250/177934967-a5220fb6-2b71-437a-99d4-a5fcf3c5ce69.png">
