### PR TITLE
fix(console): provide fallback value for language field in settings

### DIFF
--- a/packages/console/src/pages/Settings/index.tsx
+++ b/packages/console/src/pages/Settings/index.tsx
@@ -19,7 +19,10 @@ import ChangePassword from './components/ChangePassword';
 import * as styles from './index.module.scss';
 
 const Settings = () => {
-  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const {
+    t,
+    i18n: { language },
+  } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { data, error, update, isLoading, isLoaded } = useUserPreferences();
   const {
     handleSubmit,
@@ -53,7 +56,7 @@ const Settings = () => {
                 control={control}
                 render={({ field: { value, onChange } }) => (
                   <Select
-                    value={value}
+                    value={value ?? language}
                     options={[
                       {
                         value: Language.English,


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Provide fallback language value for language selection field in settings.

Previously if user never selected language, there would be no language setting in user preferences, thus the field would be empty.
![image](https://user-images.githubusercontent.com/12833674/177963505-61589fe9-862c-46ec-b789-ece3be292fa3.png)


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally and the language field was no longer empty
