### PR TITLE
fix(demo-app): username should not overflow info card

### DIFF
--- a/packages/demo-app/src/App.module.scss
+++ b/packages/demo-app/src/App.module.scss
@@ -46,6 +46,12 @@
       border-radius: 8px;
       width: 400px;
 
+      div {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
       span {
         font: var(--font-label-large);
       }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Long username will no longer overflow the outer card

<img width="487" alt="image" src="https://user-images.githubusercontent.com/12833674/178020385-42fa26db-b135-4887-8dd7-71bad71fe4a9.png">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally
