### PR TITLE
fix(console): should not display unsaved alert on settings updated

### DIFF
--- a/packages/console/src/pages/Settings/index.tsx
+++ b/packages/console/src/pages/Settings/index.tsx
@@ -1,7 +1,7 @@
 import { Language } from '@logto/phrases';
 import { AppearanceMode } from '@logto/schemas';
 import classNames from 'classnames';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
@@ -28,8 +28,15 @@ const Settings = () => {
   const {
     handleSubmit,
     control,
+    reset,
     formState: { isSubmitting, isDirty },
-  } = useForm<UserPreferences>({ defaultValues: data });
+  } = useForm<UserPreferences>();
+
+  useEffect(() => {
+    if (isLoaded) {
+      reset(data);
+    }
+  }, [isLoaded, data, reset]);
 
   const onSubmit = handleSubmit(async (formData) => {
     if (isSubmitting) {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- reset form data state on settings page on settings updated

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested in the admin console
