### PR TITLE
fix(connector): use unsaved config first when testing with passwordless connector

### DIFF
--- a/packages/connector-aliyun-dm/src/index.ts
+++ b/packages/connector-aliyun-dm/src/index.ts
@@ -37,7 +37,7 @@ export default class AliyunDmConnector implements EmailConnector {
     const emailConfig = await this.getConfig(this.metadata.id);
     await this.validateConfig(emailConfig);
 
-    return this.sendMessageCore(address, type, data, emailConfig);
+    return this.sendMessageBy(emailConfig, address, type, data);
   };
 
   public sendTestMessage: EmailSendMessageFunction = async (address, type, data, config) => {
@@ -47,14 +47,14 @@ export default class AliyunDmConnector implements EmailConnector {
 
     await this.validateConfig(config);
 
-    return this.sendMessageCore(address, type, data, config as AliyunDmConfig);
+    return this.sendMessageBy(config as AliyunDmConfig, address, type, data);
   };
 
-  private readonly sendMessageCore = async (
+  private readonly sendMessageBy = async (
+    config: AliyunDmConfig,
     address: string,
     type: keyof EmailMessageTypes,
-    data: EmailMessageTypes[typeof type],
-    config: AliyunDmConfig
+    data: EmailMessageTypes[typeof type]
   ) => {
     const { accessKeyId, accessKeySecret, accountName, fromAlias, templates } = config;
     const template = templates.find((template) => template.usageType === type);

--- a/packages/connector-aliyun-dm/src/index.ts
+++ b/packages/connector-aliyun-dm/src/index.ts
@@ -4,6 +4,7 @@ import {
   ConnectorMetadata,
   EmailMessageTypes,
   EmailSendMessageFunction,
+  EmailSendTestMessageFunction,
   ValidateConfig,
   EmailConnector,
   GetConnectorConfig,
@@ -40,11 +41,7 @@ export default class AliyunDmConnector implements EmailConnector {
     return this.sendMessageBy(emailConfig, address, type, data);
   };
 
-  public sendTestMessage: EmailSendMessageFunction = async (address, type, data, config) => {
-    if (!config) {
-      throw new ConnectorError(ConnectorErrorCodes.InsufficientRequestParameters);
-    }
-
+  public sendTestMessage: EmailSendTestMessageFunction = async (address, type, data, config) => {
     await this.validateConfig(config);
 
     return this.sendMessageBy(config as AliyunDmConfig, address, type, data);

--- a/packages/connector-aliyun-sms/src/index.ts
+++ b/packages/connector-aliyun-sms/src/index.ts
@@ -4,6 +4,7 @@ import {
   ConnectorMetadata,
   SmsMessageTypes,
   SmsSendMessageFunction,
+  SmsSendTestMessageFunction,
   ValidateConfig,
   SmsConnector,
   GetConnectorConfig,
@@ -35,14 +36,10 @@ export default class AliyunSmsConnector implements SmsConnector {
     return this.sendMessageBy(smsConfig, phone, type, { code });
   };
 
-  public sendTestMessage: SmsSendMessageFunction = async (phone, type, { code }, config) => {
-    if (!config) {
-      throw new ConnectorError(ConnectorErrorCodes.InsufficientRequestParameters);
-    }
-
+  public sendTestMessage: SmsSendTestMessageFunction = async (phone, type, data, config) => {
     await this.validateConfig(config);
 
-    return this.sendMessageBy(config as AliyunSmsConfig, phone, type, { code });
+    return this.sendMessageBy(config as AliyunSmsConfig, phone, type, data);
   };
 
   private readonly sendMessageBy = async (

--- a/packages/connector-aliyun-sms/src/index.ts
+++ b/packages/connector-aliyun-sms/src/index.ts
@@ -32,7 +32,7 @@ export default class AliyunSmsConnector implements SmsConnector {
     const smsConfig = await this.getConfig(this.metadata.id);
     await this.validateConfig(smsConfig);
 
-    return this.sendMessageCore(phone, type, { code }, smsConfig);
+    return this.sendMessageBy(smsConfig, phone, type, { code });
   };
 
   public sendTestMessage: SmsSendMessageFunction = async (phone, type, { code }, config) => {
@@ -42,14 +42,14 @@ export default class AliyunSmsConnector implements SmsConnector {
 
     await this.validateConfig(config);
 
-    return this.sendMessageCore(phone, type, { code }, config as AliyunSmsConfig);
+    return this.sendMessageBy(config as AliyunSmsConfig, phone, type, { code });
   };
 
-  private readonly sendMessageCore = async (
+  private readonly sendMessageBy = async (
+    config: AliyunSmsConfig,
     phone: string,
     type: keyof SmsMessageTypes,
-    data: SmsMessageTypes[typeof type],
-    config: AliyunSmsConfig
+    data: SmsMessageTypes[typeof type]
   ) => {
     const { accessKeyId, accessKeySecret, signName, templates } = config;
     const template = templates.find(({ usageType }) => usageType === type);

--- a/packages/connector-sendgrid-mail/src/index.ts
+++ b/packages/connector-sendgrid-mail/src/index.ts
@@ -4,6 +4,7 @@ import {
   ConnectorMetadata,
   EmailMessageTypes,
   EmailSendMessageFunction,
+  EmailSendTestMessageFunction,
   ValidateConfig,
   EmailConnector,
   GetConnectorConfig,
@@ -41,11 +42,7 @@ export default class SendGridMailConnector implements EmailConnector {
     return this.sendMessageBy(emailConfig, address, type, data);
   };
 
-  public sendTestMessage: EmailSendMessageFunction = async (address, type, data, config) => {
-    if (!config) {
-      throw new ConnectorError(ConnectorErrorCodes.InsufficientRequestParameters);
-    }
-
+  public sendTestMessage: EmailSendTestMessageFunction = async (address, type, data, config) => {
     await this.validateConfig(config);
 
     return this.sendMessageBy(config as SendGridMailConfig, address, type, data);

--- a/packages/connector-sendgrid-mail/src/index.ts
+++ b/packages/connector-sendgrid-mail/src/index.ts
@@ -33,10 +33,12 @@ export default class SendGridMailConnector implements EmailConnector {
     }
   };
 
-  public sendMessage: EmailSendMessageFunction = async (address, type, data) => {
-    const config = await this.getConfig(this.metadata.id);
-    await this.validateConfig(config);
-    const { apiKey, fromEmail, fromName, templates } = config;
+  // eslint-disable-next-line complexity
+  public sendMessage: EmailSendMessageFunction = async (address, type, data, config) => {
+    const emailConfig =
+      (config as SendGridMailConfig | undefined) ?? (await this.getConfig(this.metadata.id));
+    await this.validateConfig(emailConfig);
+    const { apiKey, fromEmail, fromName, templates } = emailConfig;
     const template = templates.find((template) => template.usageType === type);
 
     assert(

--- a/packages/connector-sendgrid-mail/src/index.ts
+++ b/packages/connector-sendgrid-mail/src/index.ts
@@ -38,7 +38,7 @@ export default class SendGridMailConnector implements EmailConnector {
     const emailConfig = await this.getConfig(this.metadata.id);
     await this.validateConfig(emailConfig);
 
-    return this.sendMessageCore(address, type, data, emailConfig);
+    return this.sendMessageBy(emailConfig, address, type, data);
   };
 
   public sendTestMessage: EmailSendMessageFunction = async (address, type, data, config) => {
@@ -48,14 +48,14 @@ export default class SendGridMailConnector implements EmailConnector {
 
     await this.validateConfig(config);
 
-    return this.sendMessageCore(address, type, data, config as SendGridMailConfig);
+    return this.sendMessageBy(config as SendGridMailConfig, address, type, data);
   };
 
-  private readonly sendMessageCore = async (
+  private readonly sendMessageBy = async (
+    config: SendGridMailConfig,
     address: string,
     type: keyof EmailMessageTypes,
-    data: EmailMessageTypes[typeof type],
-    config: SendGridMailConfig
+    data: EmailMessageTypes[typeof type]
   ) => {
     const { apiKey, fromEmail, fromName, templates } = config;
     const template = templates.find((template) => template.usageType === type);

--- a/packages/connector-smtp/src/index.ts
+++ b/packages/connector-smtp/src/index.ts
@@ -32,7 +32,7 @@ export default class SmtpConnector implements EmailConnector {
     const emailConfig = await this.getConfig(this.metadata.id);
     await this.validateConfig(emailConfig);
 
-    return this.sendMessageCore(address, type, data, emailConfig);
+    return this.sendMessageBy(emailConfig, address, type, data);
   };
 
   public sendTestMessage: EmailSendMessageFunction = async (address, type, data, config) => {
@@ -42,14 +42,14 @@ export default class SmtpConnector implements EmailConnector {
 
     await this.validateConfig(config);
 
-    return this.sendMessageCore(address, type, data, config as SmtpConfig);
+    return this.sendMessageBy(config as SmtpConfig, address, type, data);
   };
 
-  private readonly sendMessageCore = async (
+  private readonly sendMessageBy = async (
+    config: SmtpConfig,
     address: string,
     type: keyof EmailMessageTypes,
-    data: EmailMessageTypes[typeof type],
-    config: SmtpConfig
+    data: EmailMessageTypes[typeof type]
   ) => {
     const { host, port, username, password, fromEmail, replyTo, templates } = config;
     const template = templates.find((template) => template.usageType === type);

--- a/packages/connector-smtp/src/index.ts
+++ b/packages/connector-smtp/src/index.ts
@@ -76,10 +76,9 @@ export default class SmtpConnector implements EmailConnector {
     try {
       return await transporter.sendMail(mailOptions);
     } catch (error: unknown) {
-      throw new ConnectorError(
-        ConnectorErrorCodes.General,
-        error instanceof Error ? error.message : ''
-      );
+      throw new ConnectorError(ConnectorErrorCodes.General, {
+        errorDescription: error instanceof Error ? error.message : undefined,
+      });
     }
   };
 

--- a/packages/connector-smtp/src/index.ts
+++ b/packages/connector-smtp/src/index.ts
@@ -27,10 +27,11 @@ export default class SmtpConnector implements EmailConnector {
     }
   };
 
-  public sendMessage: EmailSendMessageFunction = async (address, type, data) => {
-    const config = await this.getConfig(this.metadata.id);
-    await this.validateConfig(config);
-    const { host, port, username, password, fromEmail, replyTo, templates } = config;
+  public sendMessage: EmailSendMessageFunction = async (address, type, data, config) => {
+    const emailConfig =
+      (config as SmtpConfig | undefined) ?? (await this.getConfig(this.metadata.id));
+    await this.validateConfig(emailConfig);
+    const { host, port, username, password, fromEmail, replyTo, templates } = emailConfig;
     const template = templates.find((template) => template.usageType === type);
 
     assert(

--- a/packages/connector-smtp/src/index.ts
+++ b/packages/connector-smtp/src/index.ts
@@ -4,6 +4,7 @@ import {
   ConnectorMetadata,
   EmailMessageTypes,
   EmailSendMessageFunction,
+  EmailSendTestMessageFunction,
   ValidateConfig,
   EmailConnector,
   GetConnectorConfig,
@@ -35,11 +36,7 @@ export default class SmtpConnector implements EmailConnector {
     return this.sendMessageBy(emailConfig, address, type, data);
   };
 
-  public sendTestMessage: EmailSendMessageFunction = async (address, type, data, config) => {
-    if (!config) {
-      throw new ConnectorError(ConnectorErrorCodes.InsufficientRequestParameters);
-    }
-
+  public sendTestMessage: EmailSendTestMessageFunction = async (address, type, data, config) => {
     await this.validateConfig(config);
 
     return this.sendMessageBy(config as SmtpConfig, address, type, data);

--- a/packages/connector-twilio-sms/src/index.ts
+++ b/packages/connector-twilio-sms/src/index.ts
@@ -4,6 +4,7 @@ import {
   ConnectorMetadata,
   SmsMessageTypes,
   SmsSendMessageFunction,
+  SmsSendTestMessageFunction,
   ValidateConfig,
   SmsConnector,
   GetConnectorConfig,
@@ -34,14 +35,10 @@ export default class TwilioSmsConnector implements SmsConnector {
     return this.sendMessageBy(smsConfig, address, type, data);
   };
 
-  public sendTestMessage: SmsSendMessageFunction = async (address, type, data, config) => {
-    if (!config) {
-      throw new ConnectorError(ConnectorErrorCodes.InsufficientRequestParameters);
-    }
-
+  public sendTestMessage: SmsSendTestMessageFunction = async (phone, type, data, config) => {
     await this.validateConfig(config);
 
-    return this.sendMessageBy(config as TwilioSmsConfig, address, type, data);
+    return this.sendMessageBy(config as TwilioSmsConfig, phone, type, data);
   };
 
   private readonly sendMessageBy = async (

--- a/packages/connector-twilio-sms/src/index.ts
+++ b/packages/connector-twilio-sms/src/index.ts
@@ -2,7 +2,7 @@ import {
   ConnectorError,
   ConnectorErrorCodes,
   ConnectorMetadata,
-  EmailSendMessageFunction,
+  SmsSendMessageFunction,
   ValidateConfig,
   SmsConnector,
   GetConnectorConfig,
@@ -26,10 +26,11 @@ export default class TwilioSmsConnector implements SmsConnector {
     }
   };
 
-  public sendMessage: EmailSendMessageFunction = async (address, type, data) => {
-    const config = await this.getConfig(this.metadata.id);
-    await this.validateConfig(config);
-    const { accountSID, authToken, fromMessagingServiceSID, templates } = config;
+  public sendMessage: SmsSendMessageFunction = async (address, type, data, config) => {
+    const smsConfig =
+      (config as TwilioSmsConfig | undefined) ?? (await this.getConfig(this.metadata.id));
+    await this.validateConfig(smsConfig);
+    const { accountSID, authToken, fromMessagingServiceSID, templates } = smsConfig;
     const template = templates.find((template) => template.usageType === type);
 
     assert(

--- a/packages/connector-twilio-sms/src/index.ts
+++ b/packages/connector-twilio-sms/src/index.ts
@@ -31,7 +31,7 @@ export default class TwilioSmsConnector implements SmsConnector {
     const smsConfig = await this.getConfig(this.metadata.id);
     await this.validateConfig(smsConfig);
 
-    return this.sendMessageCore(address, type, data, smsConfig);
+    return this.sendMessageBy(smsConfig, address, type, data);
   };
 
   public sendTestMessage: SmsSendMessageFunction = async (address, type, data, config) => {
@@ -41,14 +41,14 @@ export default class TwilioSmsConnector implements SmsConnector {
 
     await this.validateConfig(config);
 
-    return this.sendMessageCore(address, type, data, config as TwilioSmsConfig);
+    return this.sendMessageBy(config as TwilioSmsConfig, address, type, data);
   };
 
-  private readonly sendMessageCore = async (
+  private readonly sendMessageBy = async (
+    config: TwilioSmsConfig,
     phone: string,
     type: keyof SmsMessageTypes,
-    data: SmsMessageTypes[typeof type],
-    config: TwilioSmsConfig
+    data: SmsMessageTypes[typeof type]
   ) => {
     const { accountSID, authToken, fromMessagingServiceSID, templates } = config;
     const template = templates.find((template) => template.usageType === type);

--- a/packages/connector-types/src/index.ts
+++ b/packages/connector-types/src/index.ts
@@ -33,6 +33,7 @@ export enum ConnectorErrorCodes {
   InvalidConfig,
   InvalidResponse,
   TemplateNotFound,
+  NotImplemented,
   SocialAuthCodeInvalid,
   SocialAccessTokenInvalid,
   SocialIdTokenInvalid,
@@ -69,15 +70,27 @@ export type SmsMessageTypes = EmailMessageTypes;
 export type EmailSendMessageFunction<T = unknown> = (
   address: string,
   type: keyof EmailMessageTypes,
+  payload: EmailMessageTypes[typeof type]
+) => Promise<T>;
+
+export type EmailSendTestMessageFunction<T = unknown> = (
+  address: string,
+  type: keyof EmailMessageTypes,
   payload: EmailMessageTypes[typeof type],
-  config?: Record<string, unknown>
+  config: Record<string, unknown>
 ) => Promise<T>;
 
 export type SmsSendMessageFunction<T = unknown> = (
   phone: string,
   type: keyof SmsMessageTypes,
+  payload: SmsMessageTypes[typeof type]
+) => Promise<T>;
+
+export type SmsSendTestMessageFunction<T = unknown> = (
+  phone: string,
+  type: keyof SmsMessageTypes,
   payload: SmsMessageTypes[typeof type],
-  config?: Record<string, unknown>
+  config: Record<string, unknown>
 ) => Promise<T>;
 
 export interface BaseConnector {
@@ -88,12 +101,12 @@ export interface BaseConnector {
 
 export interface SmsConnector extends BaseConnector {
   sendMessage: SmsSendMessageFunction;
-  sendTestMessage: SmsSendMessageFunction;
+  sendTestMessage?: SmsSendTestMessageFunction;
 }
 
 export interface EmailConnector extends BaseConnector {
   sendMessage: EmailSendMessageFunction;
-  sendTestMessage: EmailSendMessageFunction;
+  sendTestMessage?: EmailSendTestMessageFunction;
 }
 
 export interface SocialConnector extends BaseConnector {

--- a/packages/connector-types/src/index.ts
+++ b/packages/connector-types/src/index.ts
@@ -66,19 +66,19 @@ export type EmailMessageTypes = {
 
 export type SmsMessageTypes = EmailMessageTypes;
 
-export type EmailSendMessageFunction<T = Record<string, unknown>, U = unknown> = (
+export type EmailSendMessageFunction<T = unknown> = (
   address: string,
   type: keyof EmailMessageTypes,
   payload: EmailMessageTypes[typeof type],
-  config?: T
-) => Promise<U>;
+  config?: Record<string, unknown>
+) => Promise<T>;
 
-export type SmsSendMessageFunction<T = Record<string, unknown>, U = unknown> = (
+export type SmsSendMessageFunction<T = unknown> = (
   phone: string,
   type: keyof SmsMessageTypes,
   payload: SmsMessageTypes[typeof type],
-  config?: T
-) => Promise<U>;
+  config?: Record<string, unknown>
+) => Promise<T>;
 
 export interface BaseConnector {
   metadata: ConnectorMetadata;

--- a/packages/connector-types/src/index.ts
+++ b/packages/connector-types/src/index.ts
@@ -66,19 +66,19 @@ export type EmailMessageTypes = {
 
 export type SmsMessageTypes = EmailMessageTypes;
 
-export type EmailSendMessageFunction<T = unknown> = (
+export type EmailSendMessageFunction<T = Record<string, unknown>, U = unknown> = (
   address: string,
   type: keyof EmailMessageTypes,
   payload: EmailMessageTypes[typeof type],
-  config?: Record<string, unknown>
-) => Promise<T>;
+  config?: T
+) => Promise<U>;
 
-export type SmsSendMessageFunction<T = unknown> = (
+export type SmsSendMessageFunction<T = Record<string, unknown>, U = unknown> = (
   phone: string,
   type: keyof SmsMessageTypes,
   payload: SmsMessageTypes[typeof type],
-  config?: Record<string, unknown>
-) => Promise<T>;
+  config?: T
+) => Promise<U>;
 
 export interface BaseConnector {
   metadata: ConnectorMetadata;
@@ -88,10 +88,12 @@ export interface BaseConnector {
 
 export interface SmsConnector extends BaseConnector {
   sendMessage: SmsSendMessageFunction;
+  sendTestMessage: SmsSendMessageFunction;
 }
 
 export interface EmailConnector extends BaseConnector {
   sendMessage: EmailSendMessageFunction;
+  sendTestMessage: EmailSendMessageFunction;
 }
 
 export interface SocialConnector extends BaseConnector {

--- a/packages/core/src/lib/passcode.test.ts
+++ b/packages/core/src/lib/passcode.test.ts
@@ -119,6 +119,7 @@ describe('sendPasscode', () => {
 
   it('should throw error when email or sms connector can not be found', async () => {
     const sendMessage = jest.fn();
+    const sendTestMessage = jest.fn();
     const validateConfig = jest.fn();
     const getConfig = jest.fn();
     mockedGetConnectorInstances.mockResolvedValueOnce([
@@ -133,6 +134,7 @@ describe('sendPasscode', () => {
           platform: null,
         },
         sendMessage,
+        sendTestMessage,
         validateConfig,
         getConfig,
       },
@@ -158,6 +160,7 @@ describe('sendPasscode', () => {
 
   it('should call sendPasscode with params matching', async () => {
     const sendMessage = jest.fn();
+    const sendTestMessage = jest.fn();
     const validateConfig = jest.fn();
     const getConfig = jest.fn();
     mockedGetConnectorInstances.mockResolvedValueOnce([
@@ -172,6 +175,7 @@ describe('sendPasscode', () => {
           platform: null,
         },
         sendMessage,
+        sendTestMessage,
         validateConfig,
         getConfig,
       },
@@ -186,6 +190,7 @@ describe('sendPasscode', () => {
           platform: null,
         },
         sendMessage,
+        sendTestMessage,
         validateConfig,
         getConfig,
       },

--- a/packages/core/src/middleware/koa-connector-error-handler.ts
+++ b/packages/core/src/middleware/koa-connector-error-handler.ts
@@ -53,6 +53,14 @@ export default function koaConnectorErrorHandler<StateT, ContextT>(): Middleware
             },
             data
           );
+        case ConnectorErrorCodes.NotImplemented:
+          throw new RequestError(
+            {
+              code: 'connector.not_implemented',
+              status: 500,
+            },
+            data
+          );
         case ConnectorErrorCodes.SocialAuthCodeInvalid:
           throw new RequestError(
             {

--- a/packages/core/src/routes/connector.test.ts
+++ b/packages/core/src/routes/connector.test.ts
@@ -116,15 +116,16 @@ describe('connector route', () => {
         metadata: mockedMetadata,
         validateConfig: jest.fn(),
         getConfig: jest.fn(),
-        sendMessage: async (
+        sendTestMessage: async (
           address: string,
           type: keyof EmailMessageTypes,
           _payload: EmailMessageTypes[typeof type]
           // eslint-disable-next-line @typescript-eslint/no-empty-function
         ): Promise<any> => {},
+        sendMessage: jest.fn(),
       };
       getConnectorInstancesPlaceHolder.mockResolvedValueOnce([mockedSmsConnectorInstance]);
-      const sendMessageSpy = jest.spyOn(mockedSmsConnectorInstance, 'sendMessage');
+      const sendMessageSpy = jest.spyOn(mockedSmsConnectorInstance, 'sendTestMessage');
       const response = await connectorRequest
         .post('/connectors/id/test')
         .send({ phone: '12345678901', config: { test: 123 } });
@@ -146,15 +147,16 @@ describe('connector route', () => {
         metadata: mockMetadata,
         validateConfig: jest.fn(),
         getConfig: jest.fn(),
-        sendMessage: async (
+        sendTestMessage: async (
           address: string,
           type: keyof EmailMessageTypes,
           _payload: EmailMessageTypes[typeof type]
           // eslint-disable-next-line @typescript-eslint/no-empty-function
         ): Promise<any> => {},
+        sendMessage: jest.fn(),
       };
       getConnectorInstancesPlaceHolder.mockResolvedValueOnce([mockedEmailConnector]);
-      const sendMessageSpy = jest.spyOn(mockedEmailConnector, 'sendMessage');
+      const sendMessageSpy = jest.spyOn(mockedEmailConnector, 'sendTestMessage');
       const response = await connectorRequest
         .post('/connectors/id/test')
         .send({ email: 'test@email.com', config: { test: 123 } });

--- a/packages/core/src/routes/connector.ts
+++ b/packages/core/src/routes/connector.ts
@@ -191,7 +191,7 @@ export default function connectorRoutes<T extends AuthedRouter>(router: T) {
         await connector.validateConfig(config);
       }
 
-      await connector.sendMessage(
+      await connector.sendTestMessage(
         subject,
         'Test',
         {

--- a/packages/core/src/routes/connector.ts
+++ b/packages/core/src/routes/connector.ts
@@ -187,17 +187,16 @@ export default function connectorRoutes<T extends AuthedRouter>(router: T) {
         })
       );
 
-      if (config) {
-        await connector.validateConfig(config);
-      }
+      const { sendTestMessage } = connector;
+      assertThat(sendTestMessage, new RequestError('connector.not_implemented'));
 
-      await connector.sendTestMessage(
+      await sendTestMessage(
         subject,
         'Test',
         {
           code: phone ? '123456' : 'email-test',
         },
-        config
+        config as Record<string, unknown>
       );
 
       ctx.status = 204;

--- a/packages/phrases/src/locales/en.ts
+++ b/packages/phrases/src/locales/en.ts
@@ -606,6 +606,7 @@ const errors = {
     invalid_config: "The connector's config is invalid.",
     invalid_response: "The connector's response is invalid.",
     template_not_found: 'Unable to find correct template in connector config.',
+    not_implemented: 'The method has not been implemented.',
     invalid_access_token: "The connector's access token is invalid.",
     invalid_auth_code: "The connector's auth code is invalid.",
     invalid_id_token: "The connector's id token is invalid.",

--- a/packages/phrases/src/locales/zh-cn.ts
+++ b/packages/phrases/src/locales/zh-cn.ts
@@ -584,6 +584,7 @@ const errors = {
     invalid_config: '连接器配置错误',
     invalid_response: '连接器错误响应',
     template_not_found: '无法从连接器配置中找到对应的模板',
+    not_implemented: '该方法尚未实现',
     invalid_access_token: '当前连接器的 access_token 无效',
     invalid_auth_code: '当前连接器的授权码无效',
     invalid_id_token: '当前连接器的 id_token 无效',


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Use unsaved config first when testing with passwordless connectors.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A
