### PR TITLE
fix(console): should display user avatar through google connector

### DIFF
--- a/packages/console/src/pages/UserDetails/index.tsx
+++ b/packages/console/src/pages/UserDetails/index.tsx
@@ -67,9 +67,15 @@ const UserDetails = () => {
       {userId && data && (
         <>
           <Card className={styles.header}>
+            {/**
+             * Some social connectors like Google will block the references to its image resource,
+             * without specifying the referrerPolicy attribute. Reference:
+             * https://stackoverflow.com/questions/40570117/http403-forbidden-error-when-trying-to-load-img-src-with-google-profile-pic
+             */}
             <img
               className={styles.avatar}
               src={data.avatar || generateAvatarPlaceHolderById(userId)}
+              referrerPolicy="no-referrer"
             />
             <div className={styles.metadata}>
               <div className={styles.name}>{data.name ?? '-'}</div>


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fix user avatar failure from google connector social sign-in.

Bug description:
![image](https://user-images.githubusercontent.com/12833674/178452637-7c6689bc-afed-4fdb-a0e1-7eebdb0f0acb.png)

There was a 403 error in browser console, but the link worked fine if you open it in new browser tab
![image](https://user-images.githubusercontent.com/12833674/178452931-b9abaf71-f328-4719-98b4-dc2bed5caf36.png)


Solution:
Need to add `referrer-policy="no-referrer"` attribute
https://stackoverflow.com/questions/40570117/http403-forbidden-error-when-trying-to-load-img-src-with-google-profile-pic

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally
