### PR TITLE
feat(core): add admin guard to signin

### DIFF
--- a/packages/core/src/routes/session/session.test.ts
+++ b/packages/core/src/routes/session/session.test.ts
@@ -155,7 +155,7 @@ describe('sessionRoutes', () => {
       expect(response.statusCode).toEqual(400);
     });
 
-    it('throw if non-admin user log in to AC', async () => {
+    it('throw if non-admin user sign in to AC', async () => {
       interactionDetails.mockResolvedValueOnce({
         params: { client_id: adminConsoleApplicationId },
       });
@@ -168,7 +168,7 @@ describe('sessionRoutes', () => {
       console.log(response);
     });
 
-    it('should throw if admin user log in to AC', async () => {
+    it('should throw if admin user sign in to AC', async () => {
       interactionDetails.mockResolvedValueOnce({
         params: { client_id: adminConsoleApplicationId },
       });

--- a/packages/core/src/routes/session/session.ts
+++ b/packages/core/src/routes/session/session.ts
@@ -55,6 +55,7 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
 
       const { id, roleNames } = await findUserByUsernameAndPassword(username, password);
 
+      // Temp solution before migrating to RBAC. As AC sign-in exp currently hardcoded to username password only.
       if (String(client_id) === adminConsoleApplicationId) {
         assertThat(
           roleNames.includes(UserRole.Admin),


### PR DESCRIPTION


<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
temp solution add admin guard to the username-password signin route. As we will switch to RBAD once implemented. 


<img width="763" alt="image" src="https://user-images.githubusercontent.com/36393111/178466399-d6cbf71c-0d47-4640-a5f6-dfb126ea03b8.png">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
@logto-io/eng 
