### PR TITLE
feat(core): add response guard

### DIFF
--- a/packages/core/src/errors/ServerError/index.ts
+++ b/packages/core/src/errors/ServerError/index.ts
@@ -1,0 +1,3 @@
+// Needs to standardize
+
+export default class ServerError extends Error {}

--- a/packages/core/src/middleware/koa-error-handler.test.ts
+++ b/packages/core/src/middleware/koa-error-handler.test.ts
@@ -38,8 +38,9 @@ describe('koaErrorHandler middleware', () => {
     expect(ctx.body).toEqual(mockBody);
   });
 
-  it('expect to throw if error type is not RequestError', async () => {
+  it('expect status 500 if error type is not RequestError', async () => {
     next.mockRejectedValueOnce(new Error('err'));
-    await expect(koaErrorHandler()(ctx, next)).rejects.toThrow();
+    await koaErrorHandler()(ctx, next);
+    expect(ctx.status).toEqual(500);
   });
 });

--- a/packages/core/src/middleware/koa-error-handler.ts
+++ b/packages/core/src/middleware/koa-error-handler.ts
@@ -6,7 +6,7 @@ import RequestError from '@/errors/RequestError';
 export default function koaErrorHandler<StateT, ContextT, BodyT>(): Middleware<
   StateT,
   ContextT,
-  BodyT | RequestErrorBody
+  BodyT | RequestErrorBody | { message: string }
 > {
   return async (ctx, next) => {
     try {
@@ -19,7 +19,8 @@ export default function koaErrorHandler<StateT, ContextT, BodyT>(): Middleware<
         return;
       }
 
-      throw error;
+      ctx.status = 500;
+      ctx.body = { message: 'Internal server error.' };
     }
   };
 }

--- a/packages/core/src/middleware/koa-error-handler.ts
+++ b/packages/core/src/middleware/koa-error-handler.ts
@@ -1,6 +1,7 @@
 import { RequestErrorBody } from '@logto/schemas';
 import { Middleware } from 'koa';
 
+import envSet from '@/env-set';
 import RequestError from '@/errors/RequestError';
 
 export default function koaErrorHandler<StateT, ContextT, BodyT>(): Middleware<
@@ -12,6 +13,10 @@ export default function koaErrorHandler<StateT, ContextT, BodyT>(): Middleware<
     try {
       await next();
     } catch (error: unknown) {
+      if (!envSet.values.isProduction) {
+        console.error(error);
+      }
+
       if (error instanceof RequestError) {
         ctx.status = error.status;
         ctx.body = error.body;

--- a/packages/core/src/routes/log.test.ts
+++ b/packages/core/src/routes/log.test.ts
@@ -2,8 +2,9 @@ import { LogCondition } from '@/queries/log';
 import logRoutes from '@/routes/log';
 import { createRequester } from '@/utils/test-utils';
 
-const mockLog = { id: 1 };
-const mockLogs = [mockLog, { id: 2 }];
+const mockBody = { type: 'a', payload: {}, createdAt: 123 };
+const mockLog = { id: '1', ...mockBody };
+const mockLogs = [mockLog, { id: '2', ...mockBody }];
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 const countLogs = jest.fn(async (condition: LogCondition) => ({

--- a/packages/core/src/routes/log.ts
+++ b/packages/core/src/routes/log.ts
@@ -1,3 +1,4 @@
+import { Logs } from '@logto/schemas';
 import { object, string } from 'zod';
 
 import koaGuard from '@/middleware/koa-guard';
@@ -38,7 +39,7 @@ export default function logRoutes<T extends AuthedRouter>(router: T) {
 
   router.get(
     '/logs/:id',
-    koaGuard({ params: object({ id: string().min(1) }) }),
+    koaGuard({ params: object({ id: string().min(1) }), response: Logs.guard }),
     async (ctx, next) => {
       const {
         params: { id },

--- a/packages/core/src/routes/status.ts
+++ b/packages/core/src/routes/status.ts
@@ -1,7 +1,9 @@
+import koaGuard from '@/middleware/koa-guard';
+
 import { AnonymousRouter } from './types';
 
 export default function statusRoutes<T extends AnonymousRouter>(router: T) {
-  router.get('/status', async (ctx, next) => {
+  router.get('/status', koaGuard({ status: 204 }), async (ctx, next) => {
     ctx.status = 204;
 
     return next();

--- a/packages/schemas/src/foundations/schemas.ts
+++ b/packages/schemas/src/foundations/schemas.ts
@@ -4,8 +4,12 @@ type ParseOptional<K> = undefined extends K
   ? ZodOptional<ZodType<Exclude<K, undefined>>>
   : ZodType<K>;
 
-export type Guard<T extends Record<string, unknown>> = ZodObject<{
+export type CreateGuard<T extends Record<string, unknown>> = ZodObject<{
   [key in keyof T]-?: ParseOptional<T[key]>;
+}>;
+
+export type Guard<T extends Record<string, unknown>> = ZodObject<{
+  [key in keyof T]: ZodType<T[key]>;
 }>;
 
 export type SchemaValuePrimitive = string | number | boolean | undefined;
@@ -22,6 +26,7 @@ export type GeneratedSchema<Schema extends SchemaLike> = keyof Schema extends st
         [key in keyof Schema]: string;
       };
       fieldKeys: ReadonlyArray<keyof Schema>;
-      createGuard: Guard<Schema>;
+      createGuard: CreateGuard<Schema>;
+      guard: Guard<Schema>;
     }>
   : never;

--- a/packages/schemas/src/gen/index.ts
+++ b/packages/schemas/src/gen/index.ts
@@ -174,7 +174,7 @@ const generate = async () => {
       }));
 
       if (tableWithTypes.length > 0) {
-        tsTypes.push('GeneratedSchema', 'Guard');
+        tsTypes.push('GeneratedSchema', 'Guard', 'CreateGuard');
       }
       /* eslint-enable @silverhand/fp/no-mutating-methods */
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- add response and status guard to `koaGuard()`
- guard `/api/status` status 204
- guard `/api/logs/:id` body
- auto generate DB schema zod guard

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

- [x] local admin console works
- [x] `/api/status` with wrong status responds 500
- [x] `/api/logs/:id` with wrong response responds 500
- [x] unit tests