### PR TITLE
fix(console): markdown toc links that contain special characters should work

### DIFF
--- a/packages/console/src/components/Markdown/index.tsx
+++ b/packages/console/src/components/Markdown/index.tsx
@@ -29,7 +29,11 @@ const Markdown = ({ className, children }: Props) => {
       return resolveIdCollision(kebabCaseString, index + 1);
     };
 
-    const initialKebabCaseString = text.replace(/\s/g, '-').toLowerCase();
+    const initialKebabCaseString = text
+      // Remove all symbols and punctuations except for dash and underscore. https://javascript.info/regexp-unicode
+      .replace(/\p{S}|\p{Pi}|\p{Pf}|\p{Ps}|\p{Pe}|\p{Po}/gu, '')
+      .replace(/\s+/g, '-')
+      .toLowerCase();
 
     return resolveIdCollision(initialKebabCaseString);
   };


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Markdown TOC links that contain special characters should be supported.

ID generating rule:
* Added new regex to strip special characters when generating the internal link (element id)
* Dashes `-` and underscores `_` are kept
* Whitespaces are converted to dash `-`

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] `添加「测试用户」（仅「User Type」设置为「外部」时需要）` outputs: `添加测试用户仅user-type设置为外部时需要`
- [x] ``` `\@#$%^&*()\=\+\~[]{}\|;:\'",./<>?Add test users (External [user] type only)``` outputs: `add-test-users-external-user-type-only`
- [x] Tested in Apple connector README in admin console, clicking the TOC links that contains Chinese block quotes can navigate to linked paragraph