### PR TITLE
fix(ui,core): fix i18n issue

### DIFF
--- a/packages/core/src/routes/well-known.ts
+++ b/packages/core/src/routes/well-known.ts
@@ -65,9 +65,13 @@ export default function wellKnownRoutes<T extends AnonymousRouter>(router: T, pr
         ];
       }, []);
 
+      const {
+        languageInfo: { autoDetect, fixedLanguage },
+      } = signInExperience;
+
       const notification =
         interaction?.params.client_id === demoAppApplicationId
-          ? i18next.t('demo_app.notification')
+          ? i18next.t('demo_app.notification', autoDetect ? undefined : { lng: fixedLanguage })
           : undefined;
 
       ctx.body = { ...signInExperience, socialConnectors, notification };

--- a/packages/core/src/routes/well-known.ts
+++ b/packages/core/src/routes/well-known.ts
@@ -65,16 +65,25 @@ export default function wellKnownRoutes<T extends AnonymousRouter>(router: T, pr
         ];
       }, []);
 
-      const {
-        languageInfo: { autoDetect, fixedLanguage },
-      } = signInExperience;
+      // Insert Demo App Notification
+      if (interaction?.params.client_id === demoAppApplicationId) {
+        const {
+          languageInfo: { autoDetect, fixedLanguage },
+        } = signInExperience;
 
-      const notification =
-        interaction?.params.client_id === demoAppApplicationId
-          ? i18next.t('demo_app.notification', autoDetect ? undefined : { lng: fixedLanguage })
-          : undefined;
+        ctx.body = {
+          ...signInExperience,
+          socialConnectors,
+          notification: i18next.t(
+            'demo_app.notification',
+            autoDetect ? undefined : { lng: fixedLanguage }
+          ),
+        };
 
-      ctx.body = { ...signInExperience, socialConnectors, notification };
+        return next();
+      }
+
+      ctx.body = { ...signInExperience, socialConnectors };
 
       return next();
     },

--- a/packages/ui/src/hooks/use-preview.ts
+++ b/packages/ui/src/hooks/use-preview.ts
@@ -33,7 +33,7 @@ const usePreview = (context: Context): [boolean, PreviewConfig?] => {
     }
 
     // Init i18n
-    void initI18n();
+    void initI18n(undefined, isPreview);
 
     // Block pointer event
     document.body.classList.add(conditionalString(styles.preview));

--- a/packages/ui/src/i18n/init.ts
+++ b/packages/ui/src/i18n/init.ts
@@ -4,25 +4,30 @@ import i18next, { InitOptions } from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
 
-const initI18n = async (languageSettings?: LanguageInfo) => {
-  const baseOptions: InitOptions = {
+const storageKey = 'i18nextLogtoUiLng';
+
+const initI18n = async (languageSettings?: LanguageInfo, isPreview = false) => {
+  const options: InitOptions = {
     resources,
     fallbackLng: languageSettings?.fallbackLanguage ?? 'en',
+    lng: languageSettings?.autoDetect === false ? languageSettings.fixedLanguage : undefined,
     interpolation: {
       escapeValue: false,
     },
     detection: {
-      lookupLocalStorage: 'i18nextLogtoUiLng',
-      lookupSessionStorage: 'i18nextLogtoUiLng',
+      lookupLocalStorage: storageKey,
+      lookupSessionStorage: storageKey,
     },
   };
 
-  const options: InitOptions =
-    languageSettings?.autoDetect === false
-      ? { ...baseOptions, lng: languageSettings.fixedLanguage }
-      : baseOptions;
+  i18next.use(initReactI18next);
 
-  const i18n = i18next.use(initReactI18next).use(LanguageDetector).init(options);
+  // Should not apply auto detect if is preview or fix
+  if (!isPreview && !(languageSettings?.autoDetect === false)) {
+    i18next.use(LanguageDetector);
+  }
+
+  const i18n = i18next.init(options);
 
   // @ts-expect-error - i18next doesn't have a type definition for this. called after i18next is initialized
   i18next.services.formatter.add('zhOrSpaces', (value: string, lng) => {


### PR DESCRIPTION


<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
fix some of the i18n issues

1. AC preview settings &  fixed language sign-in-exp should not affect the i18n localStorage value. 
- previously i18n `LanguageDetector` plugin initialize regardless of the preview or  fixed language settings
- previously AC preview language settings may affect the local i18n LNG storage as well
- previously when switching fixed language to auto-detect settings. UI i18n does not update properly since the local storage was set to the previous fixed language settings

fix: should not init `LanguageDetector` if is a preview or is fixed language.


2.  App notifications in sign-in exp should pick up the sign-in-ex language settings properly. If it is set to fixed LNG, should use the specified language instead of detecting from the header. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
@logto-io/eng 
