### PR TITLE
fix(console): external links in readme should be opened in new tab

### DIFF
--- a/packages/console/src/components/Markdown/index.tsx
+++ b/packages/console/src/components/Markdown/index.tsx
@@ -57,6 +57,15 @@ const Markdown = ({ className, children }: Props) => {
         img: ({ src, alt }) => {
           return <GithubRawImage src={src} alt={alt} />;
         },
+        a: ({ href, children }) => {
+          const isExternalLink = href?.startsWith('http');
+
+          return (
+            <a href={href} target={isExternalLink ? '_blank' : '_self'} rel="noopener">
+              {children}
+            </a>
+          );
+        },
         h1: ({ children }) => <h1 id={generateTocId(String(children))}>{children}</h1>,
         h2: ({ children }) => <h2 id={generateTocId(String(children))}>{children}</h2>,
         h3: ({ children }) => <h3 id={generateTocId(String(children))}>{children}</h3>,


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
External links in connector README should be opened in new tab.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested in connectors, external links are opened in new browser tab, while links in TOC still remains on the same page
