### PR TITLE
fix(console): navigate to new connector details page after switching connector

### DIFF
--- a/packages/console/src/pages/ConnectorDetails/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/index.tsx
@@ -156,8 +156,9 @@ const ConnectorDetails = () => {
             <CreateForm
               isOpen={isSetupOpen}
               type={data.type}
-              onClose={() => {
+              onClose={(connectorId?: string) => {
                 setIsSetupOpen(false);
+                navigate(`/connectors/${connectorId ?? ''}`);
               }}
             />
           </div>

--- a/packages/console/src/pages/Connectors/components/CreateForm/index.tsx
+++ b/packages/console/src/pages/Connectors/components/CreateForm/index.tsx
@@ -16,7 +16,7 @@ import * as styles from './index.module.scss';
 type Props = {
   isOpen: boolean;
   type?: ConnectorType;
-  onClose?: () => void;
+  onClose?: (connectorId?: string) => void;
 };
 
 const CreateForm = ({ onClose, isOpen: isFormOpen, type }: Props) => {
@@ -73,7 +73,7 @@ const CreateForm = ({ onClose, isOpen: isFormOpen, type }: Props) => {
 
   const closeModal = () => {
     setIsGetStartedModalOpen(false);
-    onClose?.();
+    onClose?.(activeConnectorId);
   };
 
   return (


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fixed a bug that in connectors, if we switch to another connector provider (e.g. Aliyun DM => Sendgrid), after saving the new connector config, the page is still navigated back to the old connector details.

The fix now will navigate users to the new connector details.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally and it worked as expected
