### PR TITLE
fix(console): language select box initial value should not be empty

### DIFF
--- a/packages/console/src/pages/Settings/index.tsx
+++ b/packages/console/src/pages/Settings/index.tsx
@@ -41,6 +41,10 @@ const Settings = () => {
     toast.success(t('general.saved'));
   });
 
+  const defaultLanguage = Object.values<string>(Language).includes(language)
+    ? language
+    : Language.English;
+
   return (
     <Card className={classNames(detailsStyles.container, styles.container)}>
       <CardTitle title="settings.title" subtitle="settings.description" />
@@ -58,7 +62,7 @@ const Settings = () => {
                 control={control}
                 render={({ field: { value, onChange } }) => (
                   <Select
-                    value={value ?? language}
+                    value={value ?? defaultLanguage}
                     options={[
                       {
                         value: Language.English,


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Second fix for the "empty value in language selection box" issue

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Cleared language selection from DB user preference table, and change system locale to `en-US`. The language select box has initial value `English` after page refresh. Works fine
- [ ] To be tested in GitPod
