### PR TITLE
feat(console): update dashboard chart y-axis tick format

### DIFF
--- a/packages/console/src/pages/Dashboard/index.tsx
+++ b/packages/console/src/pages/Dashboard/index.tsx
@@ -29,6 +29,11 @@ const tickStyle = {
   fontFamily: 'var(--font-family)',
 };
 
+const tickFormatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 1,
+  notation: 'compact',
+});
+
 const Dashboard = () => {
   const [date, setDate] = useState<string>(dayjs().format('YYYY-MM-DD'));
   const { data: totalData, error: totalError } = useSWR<TotalUsersResponse, RequestError>(
@@ -111,11 +116,11 @@ const Dashboard = () => {
                   />
                   <XAxis dataKey="date" tickLine={false} tick={tickStyle} />
                   <YAxis
-                    orientation="right"
                     width={30}
                     axisLine={false}
                     tickLine={false}
                     tick={tickStyle}
+                    tickFormatter={(tick) => tickFormatter.format(tick).toLowerCase()}
                   />
                   <Tooltip content={<ChartTooltip />} cursor={{ stroke: 'var(--color-primary' }} />
                 </AreaChart>

--- a/packages/console/src/pages/Dashboard/index.tsx
+++ b/packages/console/src/pages/Dashboard/index.tsx
@@ -116,7 +116,7 @@ const Dashboard = () => {
                   />
                   <XAxis dataKey="date" tickLine={false} tick={tickStyle} />
                   <YAxis
-                    width={30}
+                    width={35}
                     axisLine={false}
                     tickLine={false}
                     tick={tickStyle}


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Per discussion with @fleuraly , we need to put the Y-Axis on the left and compact the tick number when it is a huge number and increase the Y-Axis width to fit the max width of the tick number.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

<img width="226" alt="image" src="https://user-images.githubusercontent.com/10806653/179493833-6c21ff72-0d3a-4b29-8887-252a803b2fad.png">

<img width="103" alt="image" src="https://user-images.githubusercontent.com/10806653/179493887-2cb98617-9e1e-47d1-ace7-4b4e402bd72e.png">

<img width="91" alt="image" src="https://user-images.githubusercontent.com/10806653/179494070-ba07828e-997f-495f-927c-cc58cf45952e.png">

