### PR TITLE
fix(console): code editor content should be editable on firefox

### DIFF
--- a/packages/console/src/components/CodeEditor/index.module.scss
+++ b/packages/console/src/components/CodeEditor/index.module.scss
@@ -30,6 +30,8 @@
     position: relative;
 
     textarea {
+      width: 100%;
+      height: 100%;
       margin: 0;
       padding: 0;
       border: none;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fixed the issue that content in code editor is not editable on Firefox

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested on Firefox, Chrome and Safari, works well
