### PR TITLE
ci: set integration test env to staging

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -99,4 +99,5 @@ jobs:
           cd /tmp/integration-tests
           npm start
         env:
+          NODE_ENV: staging
           LOGTO_URL: http://localhost:3001


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Set the integration test `NODE_ENV` to staging to allow visiting the management API as an admin role in integration tests.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested in the integration test process.
