### PR TITLE
docs(console): use "appId" instead of "clientId" in React SDK guide

### DIFF
--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/react.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/react.mdx
@@ -52,7 +52,7 @@ Import and use `LogtoProvider` to provide a Logto context:
 
 const config: LogtoConfig = {
   endpoint: '${props.endpoint}',
-  clientId: '${props.appId}',
+  appId: '${props.appId}',
 };
 
 const App = () => (

--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/react_zh-cn.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/react_zh-cn.mdx
@@ -52,7 +52,7 @@ Import 并使用 `LogtoProvider` 来提供 Logto context:
 
 const config: LogtoConfig = {
   endpoint: '${props.endpoint}',
-  clientId: '${props.appId}',
+  appId: '${props.appId}',
 };
 
 const App = () => (


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Amend last commit

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A
