### PR TITLE
refactor(console): use non-i18n raw string in language select box

### DIFF
--- a/packages/console/src/pages/Settings/index.tsx
+++ b/packages/console/src/pages/Settings/index.tsx
@@ -1,4 +1,4 @@
-import { Language } from '@logto/phrases';
+import { languageOptions } from '@logto/phrases';
 import { AppearanceMode } from '@logto/schemas';
 import classNames from 'classnames';
 import { Controller, useForm } from 'react-hook-form';
@@ -58,16 +58,7 @@ const Settings = () => {
                 render={({ field: { value, onChange } }) => (
                   <Select
                     value={value ?? defaultLanguage}
-                    options={[
-                      {
-                        value: Language.English,
-                        title: t('settings.language_english'),
-                      },
-                      {
-                        value: Language.Chinese,
-                        title: t('settings.language_chinese'),
-                      },
-                    ]}
+                    options={languageOptions}
                     onChange={onChange}
                   />
                 )}

--- a/packages/console/src/pages/SignInExperience/components/LanguagesForm.tsx
+++ b/packages/console/src/pages/SignInExperience/components/LanguagesForm.tsx
@@ -1,5 +1,4 @@
-import { Language } from '@logto/phrases';
-import { useMemo } from 'react';
+import { languageOptions } from '@logto/phrases';
 import { Controller, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -14,20 +13,6 @@ const LanguagesForm = () => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { watch, control } = useFormContext<SignInExperienceForm>();
   const mode = watch('languageInfo.mode');
-
-  const languageOptions = useMemo(
-    () => [
-      {
-        value: Language.English,
-        title: t('sign_in_exp.others.languages.languages.english'),
-      },
-      {
-        value: Language.Chinese,
-        title: t('sign_in_exp.others.languages.languages.chinese'),
-      },
-    ],
-    [t]
-  );
 
   return (
     <>

--- a/packages/phrases/src/index.ts
+++ b/packages/phrases/src/index.ts
@@ -4,7 +4,7 @@ import en from './locales/en';
 import zhCN from './locales/zh-cn';
 import { Resource, Language } from './types';
 
-export { Language } from './types';
+export { Language, languageOptions } from './types';
 export type Translation = typeof en.translation;
 export type Errors = typeof en.errors;
 export type LogtoErrorCode = NormalizeKeyPaths<Errors>;

--- a/packages/phrases/src/locales/en/translation/admin-console/settings.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/settings.ts
@@ -6,8 +6,6 @@ const settings = {
   },
   custom_domain: 'Custom domain',
   language: 'Language',
-  language_english: 'English',
-  language_chinese: 'Chinese',
   appearance: 'Appearance',
   appearance_system: 'Sync with system',
   appearance_light: 'Light mode',

--- a/packages/phrases/src/locales/en/translation/admin-console/sign-in-exp.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/sign-in-exp.ts
@@ -78,10 +78,6 @@ const sign_in_exp = {
       fallback_language_tip:
         'Which language to fall back if Logto finds no proper language phrase-set.',
       fixed_language: 'Fixed language',
-      languages: {
-        english: 'English',
-        chinese: 'Chinese',
-      },
     },
   },
   setup_warning: {

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/settings.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/settings.ts
@@ -6,8 +6,6 @@ const settings = {
   },
   custom_domain: '自定义域名',
   language: '语言',
-  language_english: '英语',
-  language_chinese: '中文',
   appearance: '外观',
   appearance_system: '跟随系统',
   appearance_light: '浅色模式',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/sign-in-exp.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/sign-in-exp.ts
@@ -74,10 +74,6 @@ const sign_in_exp = {
       fallback_language: '备用语言',
       fallback_language_tip: '如果 Logto 找不到合适的语言包，将回退至哪种语言。',
       fixed_language: '固定语言',
-      languages: {
-        english: '英文',
-        chinese: '中文',
-      },
     },
   },
   setup_warning: {

--- a/packages/phrases/src/types.ts
+++ b/packages/phrases/src/types.ts
@@ -14,4 +14,9 @@ export enum Language {
   Chinese = 'zh-CN',
 }
 
+export const languageOptions = [
+  { value: Language.English, title: 'English' },
+  { value: Language.Chinese, title: '中文' },
+];
+
 /* eslint-enable @typescript-eslint/consistent-indexed-object-style */


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Use non-i18n raw string as language names in language select box.

Settings:
<img width="583" alt="image" src="https://user-images.githubusercontent.com/12833674/179807246-f58df456-ec72-466b-9d6a-39e80221c0e8.png">

Sign-in Experience:
<img width="629" alt="image" src="https://user-images.githubusercontent.com/12833674/179943340-79560f3d-2e6c-478c-bd22-f6a2bb441b55.png">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally and it shows language name in its own language
