### PR TITLE
fix(ui): fix some firefox standout bug

### DIFF
--- a/packages/ui/src/components/Input/phoneInput.module.scss
+++ b/packages/ui/src/components/Input/phoneInput.module.scss
@@ -20,6 +20,10 @@
     width: 100%;
     height: 100%;
     font-size: 0;
+
+    option {
+      font: var(--font-body);
+    }
   }
 
   + input {

--- a/packages/ui/src/components/Passcode/index.module.scss
+++ b/packages/ui/src/components/Passcode/index.module.scss
@@ -14,12 +14,6 @@
     color: var(--color-text);
     caret-color: var(--color-primary);
 
-    &::-webkit-outer-spin-button,
-    &::-webkit-inner-spin-button {
-      -webkit-appearance: none;
-      margin: 0;
-    }
-
     &:focus {
       border: _.border(var(--color-primary));
     }

--- a/packages/ui/src/scss/normalized.scss
+++ b/packages/ui/src/scss/normalized.scss
@@ -16,3 +16,14 @@ input {
   padding: 0;
   margin: 0;
 }
+
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+/* Firefox */
+input[type='number'] {
+  -moz-appearance: textfield;
+}


### PR DESCRIPTION

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
fix some firefox standout bug

1. Number input field should hide arrow icon

Before:
Before:
<img width="737" alt="image" src="https://user-images.githubusercontent.com/36393111/179883929-28aa4851-c3d0-49eb-bd18-6c098a71689b.png">


After:
<img width="677" alt="image" src="https://user-images.githubusercontent.com/36393111/179883729-9c94710e-6c9f-4463-9754-b5d6c93fc53e.png">

3. Select font size 
Before:
<img width="714" alt="image" src="https://user-images.githubusercontent.com/36393111/179883866-e217bf02-bd0a-4c56-af59-294cf3b2b9fc.png">

After:
<img width="699" alt="image" src="https://user-images.githubusercontent.com/36393111/179883775-142eda57-6e33-4e52-98c0-558e8aa0c82a.png">

## Issue related

#1612 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
@logto-io/eng @demonzoo 
