### PR TITLE
fix: integration test should build project and set logto env to integration-test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -55,11 +55,11 @@ jobs:
           run-install: false
 
       # Setup integration test
-      - name: Install dependencies
+      - name: Install dependencies and build
         run: |
           mv tests /tmp/tests
           cd /tmp/tests
-          pnpm i
+          pnpm i && pnpm ci:build
 
       # Setup environment
       - name: Start Postgres (Linux)
@@ -89,7 +89,7 @@ jobs:
         run: node . --from-root --all-yes &
         working-directory: logto/packages/core
         env:
-          NODE_ENV: production
+          NODE_ENV: integration-test
           DB_URL_DEFAULT: postgres://postgres:postgres@localhost:5432
 
       - name: Sleep for 5 seconds
@@ -101,5 +101,4 @@ jobs:
           cd /tmp/tests/packages/integration-tests
           pnpm start
         env:
-          NODE_ENV: integration-test
           LOGTO_URL: http://localhost:3001

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -55,11 +55,11 @@ jobs:
           run-install: false
 
       # Setup integration test
-      - name: Install dependencies and build
+      - name: Install dependencies
         run: |
           mv tests /tmp/tests
           cd /tmp/tests
-          pnpm i && pnpm ci:build
+          pnpm i
 
       # Setup environment
       - name: Start Postgres (Linux)
@@ -89,7 +89,7 @@ jobs:
         run: node . --from-root --all-yes &
         working-directory: logto/packages/core
         env:
-          # NODE_ENV: integration-test
+          NODE_ENV: integration-test
           DB_URL_DEFAULT: postgres://postgres:postgres@localhost:5432
 
       - name: Sleep for 5 seconds

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -89,7 +89,7 @@ jobs:
         run: node . --from-root --all-yes &
         working-directory: logto/packages/core
         env:
-          NODE_ENV: integration-test
+          # NODE_ENV: integration-test
           DB_URL_DEFAULT: postgres://postgres:postgres@localhost:5432
 
       - name: Sleep for 5 seconds


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- Add build process to integration test otherwise the libs of `schema`, `phrases` and `shared` will missing.
- Set up the logto's env to `integration-test` rather than the test project.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested in ci.