### PR TITLE
feat(core): refresh token rotation reuse interval

### DIFF
--- a/packages/core/src/env-set/oidc.ts
+++ b/packages/core/src/env-set/oidc.ts
@@ -112,12 +112,19 @@ const loadOidcValues = async (issuer: string) => {
   const cookieKeys = await readCookieKeys();
   const privateKey = crypto.createPrivateKey(await readPrivateKey());
   const publicKey = crypto.createPublicKey(privateKey);
+  /*
+   * This interval helps to avoid concurrency issues when exchanging the rotating refresh token multiple times within a given timeframe.
+   * During the leeway window (in seconds), the consumed refresh token will be considered as valid.
+   * This is useful for distributed apps and serverless apps like Next.js, in which there is no shared memory.
+   */
+  const refreshTokenReuseInterval = getEnv('OIDC_REFRESH_TOKEN_REUSE_INTERVAL', '3');
 
   return Object.freeze({
     cookieKeys,
     privateKey,
     publicKey,
     issuer,
+    refreshTokenReuseInterval: Number(refreshTokenReuseInterval),
     defaultIdTokenTtl: 60 * 60,
     defaultRefreshTokenTtl: 14 * 24 * 60 * 60,
   });

--- a/packages/core/src/env-set/oidc.ts
+++ b/packages/core/src/env-set/oidc.ts
@@ -112,7 +112,7 @@ const loadOidcValues = async (issuer: string) => {
   const cookieKeys = await readCookieKeys();
   const privateKey = crypto.createPrivateKey(await readPrivateKey());
   const publicKey = crypto.createPublicKey(privateKey);
-  /*
+  /**
    * This interval helps to avoid concurrency issues when exchanging the rotating refresh token multiple times within a given timeframe.
    * During the leeway window (in seconds), the consumed refresh token will be considered as valid.
    * This is useful for distributed apps and serverless apps like Next.js, in which there is no shared memory.


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Add refresh token rotation reuse interval, to avoid concurrency issues.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested, a refresh token that is consumed, can be reuse during the interval seconds.

- [x] send a grant request, reply it after 1s, succeeded.
- [x] send a grant request, reply it after 3s, failed.
