### PR TITLE
ci: refine add assignees trigger

### DIFF
--- a/.github/workflows/update-pr-metadata.yml
+++ b/.github/workflows/update-pr-metadata.yml
@@ -24,11 +24,14 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Add assignees
-        if: github.event_name == 'pull_request'
+        if: |
+          github.event_name == 'pull_request' &&
+          contains(fromJson('["opened", "reopened"]'), github.event.action) &&
+          !endsWith(github.event.pull_request.user.login, '[bot]')
         uses: actions-ecosystem/action-add-assignees@v1
         with:
           github_token: ${{ github.token }}
-          assignees: ${{ github.actor }}
+          assignees: ${{ github.event.pull_request.user.login }}
 
   pr-size-diff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
for job "add assignees":
- only trigger when the PR (re)opens
- filter out bot user
- add PR creator as the assignee instead of actor

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

reopen PR, assignee added

https://github.com/logto-io/logto/runs/7429497160?check_suite_focus=true

other events "add assignee" is skipped
