### PR TITLE
refactor(test): use random name and indicator in create resource integration test

### DIFF
--- a/packages/integration-tests/tests/api-resources.test.ts
+++ b/packages/integration-tests/tests/api-resources.test.ts
@@ -24,8 +24,8 @@ describe('admin console api resources', () => {
   });
 
   it('should create api resource successfully', async () => {
-    const resourceName = 'gallery';
-    const resourceIndicator = 'https://gallery.logto.io';
+    const resourceName = generateResourceName();
+    const resourceIndicator = generateResourceIndicator();
 
     const createdResource = await createResource(resourceName, resourceIndicator);
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Use random names and indicators in the create-resource integration test to avoid `resourceIndicator` conflict when developing in the local env.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
None.
