### PR TITLE
style(ui): fix sign-in page top space after initial render

### DIFF
--- a/packages/ui/src/containers/AppContent/index.module.scss
+++ b/packages/ui/src/containers/AppContent/index.module.scss
@@ -36,6 +36,7 @@ body {
 .content {
   @include _.flex_column;
   background-color: var(--color-surface);
+  position: relative;
 }
 
 .placeHolder {

--- a/packages/ui/src/containers/AppContent/index.tsx
+++ b/packages/ui/src/containers/AppContent/index.tsx
@@ -1,5 +1,13 @@
 import { conditionalString } from '@silverhand/essentials';
-import { ReactNode, useEffect, useCallback, useContext } from 'react';
+import {
+  ReactNode,
+  useEffect,
+  useState,
+  useCallback,
+  useContext,
+  useLayoutEffect,
+  useRef,
+} from 'react';
 
 import Toast from '@/components/Toast';
 import useColorTheme from '@/hooks/use-color-theme';
@@ -15,6 +23,17 @@ export type Props = {
 const AppContent = ({ children }: Props) => {
   const theme = useTheme();
   const { toast, platform, setToast, experienceSettings } = useContext(PageContext);
+  const [topSpace, setTopSpace] = useState(0);
+  const topPlaceHolderRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    setTimeout(() => {
+      if (!topPlaceHolderRef.current) {
+        return;
+      }
+      setTopSpace(topPlaceHolderRef.current.offsetHeight);
+    });
+  }, [topPlaceHolderRef]);
 
   // Prevent internal eventListener rebind
   const hideToast = useCallback(() => {
@@ -38,7 +57,13 @@ const AppContent = ({ children }: Props) => {
 
   return (
     <div className={styles.container}>
-      {platform === 'web' && <div className={styles.placeHolder} />}
+      {platform === 'web' && (
+        <div
+          ref={topPlaceHolderRef}
+          className={styles.placeHolder}
+          style={{ height: `${topSpace}px`, flex: `${topSpace === 0 ? 1 : 'none'}` }}
+        />
+      )}
       <main className={styles.content}>{children}</main>
       {platform === 'web' && <div className={styles.placeHolder} />}
       <Toast message={toast} isVisible={Boolean(toast)} callback={hideToast} />

--- a/packages/ui/src/pages/SignIn/index.module.scss
+++ b/packages/ui/src/pages/SignIn/index.module.scss
@@ -59,6 +59,10 @@
     margin-bottom: _.unit(6);
   }
 
+  .wrapper {
+    transition: height 10s ease-in;
+  }
+
   .primarySocial {
     margin-bottom: _.unit(12);
   }

--- a/packages/ui/src/pages/SignIn/index.tsx
+++ b/packages/ui/src/pages/SignIn/index.tsx
@@ -1,6 +1,6 @@
 import { BrandingStyle, SignInMode } from '@logto/schemas';
 import classNames from 'classnames';
-import { useContext } from 'react';
+import { useContext, useLayoutEffect, useRef, useState } from 'react';
 
 import BrandingHeader from '@/components/BrandingHeader';
 import AppNotification from '@/containers/AppNotification';
@@ -11,6 +11,18 @@ import { PrimarySection, SecondarySection, CreateAccountLink } from './registry'
 
 const SignIn = () => {
   const { experienceSettings, theme, platform } = useContext(PageContext);
+  const [topSpace, setTopSpace] = useState(0);
+
+  const topPlaceHolderRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    setTimeout(() => {
+      if (!topPlaceHolderRef.current) {
+        return;
+      }
+      setTopSpace(topPlaceHolderRef.current.offsetHeight);
+    });
+  }, [topPlaceHolderRef]);
 
   if (!experienceSettings) {
     return null;
@@ -20,7 +32,13 @@ const SignIn = () => {
 
   return (
     <>
-      {platform === 'web' && <div className={styles.placeholderTop} />}
+      {platform === 'web' && (
+        <div
+          ref={topPlaceHolderRef}
+          className={styles.placeholderTop}
+          style={{ height: `${topSpace}px`, flex: `${topSpace === 0 ? 3 : 'none'}` }}
+        />
+      )}
       <div className={classNames(styles.wrapper)}>
         <BrandingHeader
           className={styles.header}


### PR DESCRIPTION


<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
fix sign-in page top space after the initial render. 

Error messages may change the original form height. Wich causes a container visual jumpping transform under the align-center flexbox layout. 

Expected behavior, the top space of both inner and outer cards should be static after the initial render. Extra content should keep the card's top position still at the same time extent the card height. 

| state | outer card space | inner card space |
| ----- | ----------------- | ----------------- |
| initial | <img width="759" alt="image" src="https://user-images.githubusercontent.com/36393111/180363928-cdcc1331-d2c9-493f-85d6-32b38bd42985.png"> | <img width="756" alt="image" src="https://user-images.githubusercontent.com/36393111/180363993-66df1af0-3c29-40d2-9e1e-7f2893123e66.png"> |
| before fix | <img width="887" alt="image" src="https://user-images.githubusercontent.com/36393111/180363549-08a19159-ebbf-4570-a03f-fab699365216.png"> | <img width="722" alt="image" src="https://user-images.githubusercontent.com/36393111/180363583-b3d6e719-daee-4b03-8e38-984d1ce46f77.png"> |
| after fix | <img width="978" alt="image" src="https://user-images.githubusercontent.com/36393111/180363264-383e8802-8e24-4d15-8b83-46877e9c9436.png"> | <img width="716" alt="image" src="https://user-images.githubusercontent.com/36393111/180363305-8b2fe1cf-add7-472a-9062-12af772edede.png"> |


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
@logto-io/eng 
