### PR TITLE
chore: use `cz-git` as commitizen adapter

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -9,7 +9,7 @@ const scopeComplete = execSync('git status --porcelain || true')
   .find((r) => ~r.indexOf('M  packages'))
   ?.replace(/(\/)/g, '%%')
   ?.match(/packages%%((\w|-)*)/)?.[1]
-  ?.replace(/^connector(\w|-)*/g, 'connector')
+  ?.replace(/^connector(\w|-)*/g, 'connector');
 
 /** @type {import('cz-git').UserConfig} */
 module.exports = {

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,10 +1,30 @@
 const { rules } = require('@commitlint/config-conventional');
+const { execSync } = require('child_process');
 
-/** @type {import('@commitlint/types').UserConfig} **/
+// precomputed scope
+const scopeComplete = execSync('git status --porcelain || true')
+  .toString()
+  .trim()
+  .split('\n')
+  .find((r) => ~r.indexOf('M  packages'))
+  ?.replace(/(\/)/g, '%%')
+  ?.match(/packages%%((\w|-)*)/)?.[1]
+  ?.replace(/^connector(\w|-)*/g, 'connector')
+
+/** @type {import('cz-git').UserConfig} */
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
     'type-enum': [2, 'always', [...rules['type-enum'][2], 'api', 'release']],
     'scope-enum': [2, 'always', ['connector', 'console', 'core', 'demo-app', 'test', 'phrases', 'schemas', 'shared', 'ui', 'deps']]
   },
+  prompt: {
+    typesAppend: [
+      { value: 'api', name: 'api:      Api aspect modify' },
+    ],
+    customScopesAlign: !scopeComplete ? 'top' : 'bottom',
+    defaultScope: scopeComplete,
+    allowEmptyIssuePrefixs: false,
+    allowCustomIssuePrefixs: false,
+  }
 };

--- a/package.json
+++ b/package.json
@@ -16,10 +16,15 @@
     "ci:stylelint": "lerna run --parallel stylelint",
     "ci:test": "lerna run --parallel test:coverage"
   },
+  "config": {
+    "commitizen": {
+      "path": "node_modules/cz-git"
+    }
+  },
   "devDependencies": {
     "@commitlint/cli": "^17.0.0",
     "@commitlint/config-conventional": "^17.0.0",
-    "@commitlint/types": "^17.0.0",
+    "cz-git": "^1.3.9",
     "husky": "^8.0.0",
     "lerna": "^5.0.0",
     "typescript": "^4.6.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ importers:
       '@commitlint/cli': ^17.0.0
       '@commitlint/config-conventional': ^17.0.0
       '@commitlint/types': ^17.0.0
+      cz-git: ^1.3.9
       husky: ^8.0.0
       lerna: ^5.0.0
       typescript: ^4.6.2
@@ -14,6 +15,7 @@ importers:
       '@commitlint/cli': 17.0.0
       '@commitlint/config-conventional': 17.0.0
       '@commitlint/types': 17.0.0
+      cz-git: 1.3.9
       husky: 8.0.1
       lerna: 5.0.0
       typescript: 4.6.2
@@ -4548,6 +4550,7 @@ packages:
       - babel-jest
       - esbuild
       - typescript
+    dev: false
 
   /@silverhand/jest-config/0.17.0_u4suh3umvg724wu2nufptihvny:
     resolution: {integrity: sha512-Syb9S2Hqbg3UcuGq+qByv+SJKWC6jrFSQp6JeGbsqLWlGTDjXX3QpHMaq5p9XYldlns6ZT6QQ7Q19CtbqUFU+A==}
@@ -4568,6 +4571,7 @@ packages:
       - babel-jest
       - esbuild
       - typescript
+    dev: false
 
   /@silverhand/ts-config-react/0.17.0_typescript@4.6.2:
     resolution: {integrity: sha512-vsZMcWVzaQT2Qb2b46jbmbcXPHxEKz3snQzQhHHV4IRJbLWnTtswOnNwfPRdXsW7/xcYfF+EM9Bw4Q7Cmib2nA==}
@@ -7053,6 +7057,10 @@ packages:
 
   /csstype/3.0.11:
     resolution: {integrity: sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==}
+    dev: true
+
+  /cz-git/1.3.9:
+    resolution: {integrity: sha512-S7XpI+XtJ/foh9MYB1pBB+YGsQyzhQpUzmNaN3Y17KeYf0EvRQt0OR7GVf3xZ5clLEdQh2nY5TjdGZ4ctXUTuA==}
     dev: true
 
   /d3-array/2.12.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,6 @@ importers:
     specifiers:
       '@commitlint/cli': ^17.0.0
       '@commitlint/config-conventional': ^17.0.0
-      '@commitlint/types': ^17.0.0
       cz-git: ^1.3.9
       husky: ^8.0.0
       lerna: ^5.0.0
@@ -14,7 +13,6 @@ importers:
     devDependencies:
       '@commitlint/cli': 17.0.0
       '@commitlint/config-conventional': 17.0.0
-      '@commitlint/types': 17.0.0
       cz-git: 1.3.9
       husky: 8.0.1
       lerna: 5.0.0
@@ -4550,7 +4548,6 @@ packages:
       - babel-jest
       - esbuild
       - typescript
-    dev: false
 
   /@silverhand/jest-config/0.17.0_u4suh3umvg724wu2nufptihvny:
     resolution: {integrity: sha512-Syb9S2Hqbg3UcuGq+qByv+SJKWC6jrFSQp6JeGbsqLWlGTDjXX3QpHMaq5p9XYldlns6ZT6QQ7Q19CtbqUFU+A==}
@@ -4571,7 +4568,6 @@ packages:
       - babel-jest
       - esbuild
       - typescript
-    dev: false
 
   /@silverhand/ts-config-react/0.17.0_typescript@4.6.2:
     resolution: {integrity: sha512-vsZMcWVzaQT2Qb2b46jbmbcXPHxEKz3snQzQhHHV4IRJbLWnTtswOnNwfPRdXsW7/xcYfF+EM9Bw4Q7Cmib2nA==}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Hi, I am the author of `cz-git`, I observed the commiti message and project structure of the project, I think my `cz-git` commitizen adapter can be very helpful for maintainers **who use commitizen cli**

github: https://github.com/Zhengqbbb/cz-git
website | guide: https://cz-git.qbb.sh/
中文文档： https://cz-git.qbb.sh/zh/

- **Friendly**： Supports **search and selection** on the command line, reducing spelling errors
- **Highly Customizable and better with Commitlint**: The behavior of the CLI can be customized as project needed.
- **Lightweight** zero dependencies, 1.5MB

### Demo:
![demo](https://user-images.githubusercontent.com/40693636/180369502-71f0d151-6530-471b-ada9-3eaab4bb69c5.gif)

### Features:
Automatically match the scope name of packages in staging through `git status` **pin top of list**, and use it directly <kbd>Enter</kbd>
![demo](https://user-images.githubusercontent.com/40693636/180370205-ec199944-fb2f-465e-9d52-2c908e518845.gif)
![demo](https://user-images.githubusercontent.com/40693636/180370594-7d042763-fcb3-4b9e-8697-944b3c0b4c2d.gif)

Hope it can be liked and used, if you have other questions please tell me

