### PR TITLE
fix(ui): should clear prev passcode input when click on backspace

### DIFF
--- a/packages/ui/src/components/Passcode/index.tsx
+++ b/packages/ui/src/components/Passcode/index.tsx
@@ -141,12 +141,16 @@ const Passcode = ({ name, className, value, length = defaultLength, error, onCha
         case 'Backspace':
           event.preventDefault();
 
-          if (!value) {
-            previousTarget?.focus();
+          if (value) {
+            onChange(Object.assign([], codes, { [targetId]: '' }));
             break;
           }
 
-          onChange(Object.assign([], codes, { [targetId]: '' }));
+          if (previousTarget) {
+            previousTarget.focus();
+            onChange(Object.assign([], codes, { [targetId - 1]: '' }));
+          }
+
           break;
         case 'ArrowLeft':
           event.preventDefault();


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
 should clear prev passcode input when clicking on backspace btn

Prev: need to click twice to clear the value

https://user-images.githubusercontent.com/36393111/180394014-37a9f7b9-bda5-4ac1-8c16-03b5e2a53c83.mp4


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
@logto-io/eng 
