### PR TITLE
fix(console): connector can be dragged upwards to reorder

### DIFF
--- a/packages/console/src/components/Transfer/DraggableItem.tsx
+++ b/packages/console/src/components/Transfer/DraggableItem.tsx
@@ -52,7 +52,7 @@ const DraggableItem = ({ id, children, sortIndex, moveItem }: Props) => {
       const clientOffset = monitor.getClientOffset();
 
       // Get pixels to the top
-      const hoverClientY = clientOffset?.y ?? 0 - hoverBoundingRect.top;
+      const hoverClientY = (clientOffset?.y ?? 0) - hoverBoundingRect.top;
 
       // Only perform the move when the mouse has crossed half of the items height
       // When dragging downwards, only move when the cursor is below 50%


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fixed the issue that social connector can only be dragged downwards when re-ordering in sign-in experience page. Now user can drag connector upwards or downwards freely to re-order them.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally and the dragging worked properly
