### PR TITLE
fix(console): app error illustration height should not be shrunk

### DIFF
--- a/packages/console/src/components/AppError/index.module.scss
+++ b/packages/console/src/components/AppError/index.module.scss
@@ -18,6 +18,7 @@
     height: 256px;
     width: 256px;
     margin-top: _.unit(30);
+    flex-shrink: 0;
   }
 
   label {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fixed the illustration size issue when the browser height is low.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally, and the illustration size didn't change when decreasing the browser height
