### PR TITLE
chore(core): make the i18n optional for connector metadata

### DIFF
--- a/packages/connector-alipay-native/tsconfig.test.json
+++ b/packages/connector-alipay-native/tsconfig.test.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "isolatedModules": false
+    "isolatedModules": false,
+    "allowJs": true
   }
 }

--- a/packages/connector-twilio-sms/tsconfig.test.json
+++ b/packages/connector-twilio-sms/tsconfig.test.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "isolatedModules": false
+    "isolatedModules": false,
+    "allowJs": true
   }
 }

--- a/packages/connector-types/src/index.ts
+++ b/packages/connector-types/src/index.ts
@@ -35,10 +35,10 @@ export interface ConnectorMetadata {
   target: string;
   type: ConnectorType;
   platform: Nullable<ConnectorPlatform>;
-  name: Record<Language, string>;
+  name: { [Language.English]: string } & { [key in Language]?: string };
   logo: string;
   logoDark: Nullable<string>;
-  description: Record<Language, string>;
+  description: { [Language.English]: string } & { [key in Language]?: string };
   readme: string;
   configTemplate: string;
 }

--- a/packages/connector-types/src/index.ts
+++ b/packages/connector-types/src/index.ts
@@ -30,15 +30,19 @@ export enum ConnectorPlatform {
   Web = 'Web',
 }
 
+type i18nPhrases = { [Language.English]: string } & {
+  [key in Exclude<Language, Language.English>]?: string;
+};
+
 export interface ConnectorMetadata {
   id: string;
   target: string;
   type: ConnectorType;
   platform: Nullable<ConnectorPlatform>;
-  name: { [Language.English]: string } & { [key in Language]?: string };
+  name: i18nPhrases;
   logo: string;
   logoDark: Nullable<string>;
-  description: { [Language.English]: string } & { [key in Language]?: string };
+  description: i18nPhrases;
   readme: string;
   configTemplate: string;
 }

--- a/packages/connector-types/src/index.ts
+++ b/packages/connector-types/src/index.ts
@@ -1,4 +1,4 @@
-import { Language } from '@logto/phrases';
+import type { Language } from '@logto/phrases';
 import { Nullable } from '@silverhand/essentials';
 import { z } from 'zod';
 

--- a/packages/console/src/pages/UserDetails/components/UserConnectors.tsx
+++ b/packages/console/src/pages/UserDetails/components/UserConnectors.tsx
@@ -1,5 +1,4 @@
-import { Language } from '@logto/phrases';
-import { Identities } from '@logto/schemas';
+import { Identities, ConnectorDto } from '@logto/schemas';
 import { Optional } from '@silverhand/essentials';
 import { useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
@@ -20,12 +19,7 @@ type Props = {
   onDelete?: (connectorId: string) => void;
 };
 
-type DisplayConnector = {
-  target: string;
-  userId?: string;
-  logo: string;
-  name: Record<Language, string>;
-};
+type DisplayConnector = Pick<ConnectorDto, 'target' | 'logo' | 'name'> & { userId?: string };
 
 const UserConnectors = ({ userId, connectors, onDelete }: Props) => {
   const api = useApi();

--- a/packages/console/src/pages/UserDetails/components/UserConnectors.tsx
+++ b/packages/console/src/pages/UserDetails/components/UserConnectors.tsx
@@ -1,4 +1,4 @@
-import { Identities, ConnectorDto } from '@logto/schemas';
+import type { Identities, ConnectorDto } from '@logto/schemas';
 import { Optional } from '@silverhand/essentials';
 import { useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';


### PR DESCRIPTION


<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Temp fix: make i18n optional for connector metadata

i18n translation should not block the user from providing new connectors

<img width="1140" alt="image" src="https://user-images.githubusercontent.com/36393111/182067083-0eda6901-675e-45f2-ad99-cb340f93a6b5.png">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
@logto-io/eng 
