### PR TITLE
Revert "feat(console): checked if sign in method is primary"

### DIFF
--- a/packages/console/src/pages/SignInExperience/components/SignInMethodsForm.tsx
+++ b/packages/console/src/pages/SignInExperience/components/SignInMethodsForm.tsx
@@ -67,7 +67,7 @@ const SignInMethodsForm = () => {
                 <Checkbox
                   label={label}
                   disabled={primaryMethod === method}
-                  value={value || primaryMethod === method}
+                  value={value}
                   onChange={onChange}
                 />
               )}


### PR DESCRIPTION
Reverts logto-io/logto#1706

@pemassi we had an internal discussion, your feedback is very valid.

the checkbox is for “secondary sign-in”, so keep it unchecked is logically correct. thus I’ll revert this. but we’re trying to figure out a way to reduce the confusion - thank you for the PR and feedback!