### PR TITLE
fix(ui): connector name  should fallback to en

### DIFF
--- a/packages/ui/src/components/Button/SocialLinkButton.tsx
+++ b/packages/ui/src/components/Button/SocialLinkButton.tsx
@@ -1,3 +1,4 @@
+import { Language } from '@logto/phrases-ui';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 
@@ -19,7 +20,7 @@ const SocialLinkButton = ({ isDisabled, className, target, name, logo, onClick }
     i18n: { language },
   } = useTranslation();
 
-  const localName = name[language] ?? target;
+  const localName = name[language] ?? name[Language.English];
 
   return (
     <button


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
connector name should fall back to en not target.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
@logto-io/eng 
