### PR TITLE
refactor(core): replace deprecated .nonempty() with .min(1) for ZodString

### DIFF
--- a/packages/core/src/routes/session/session.ts
+++ b/packages/core/src/routes/session/session.ts
@@ -41,8 +41,8 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
     '/session/sign-in/username-password',
     koaGuard({
       body: object({
-        username: string().nonempty(),
-        password: string().nonempty(),
+        username: string().min(1),
+        password: string().min(1),
       }),
     }),
     async (ctx, next) => {

--- a/packages/core/src/utils/zod.test.ts
+++ b/packages/core/src/utils/zod.test.ts
@@ -17,7 +17,7 @@ describe('zodTypeToSwagger', () => {
     const notStartingWithDigitRegex = /^\D/;
 
     it('nonempty check', () => {
-      expect(zodTypeToSwagger(string().nonempty())).toEqual({
+      expect(zodTypeToSwagger(string().min(1))).toEqual({
         type: 'string',
         minLength: 1,
       });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Replace deprecated `.nonempty()` with `.min(1)` for `ZodString`

<img width="366" alt="image" src="https://user-images.githubusercontent.com/10594507/182546145-390bb0ad-5ef2-4360-abe8-498c07527031.png">

Reference: https://github.com/colinhacks/zod#strings

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Pass existing UTs.
