### PR TITLE
feat(schemas): guard string max length

### DIFF
--- a/packages/schemas/jest.config.ts
+++ b/packages/schemas/jest.config.ts
@@ -1,0 +1,1 @@
+export { default } from '@silverhand/jest-config';

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -14,7 +14,8 @@
     "build": "pnpm generate && rm -rf lib/ && tsc --p tsconfig.build.json",
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
-    "prepack": "pnpm build"
+    "prepack": "pnpm build",
+    "test": "jest"
   },
   "engines": {
     "node": "^16.0.0"
@@ -22,12 +23,15 @@
   "devDependencies": {
     "@silverhand/eslint-config": "1.0.0-rc.2",
     "@silverhand/essentials": "^1.1.6",
+    "@silverhand/jest-config": "1.0.0-rc.3",
     "@silverhand/ts-config": "1.0.0-rc.2",
+    "@types/jest": "^27.4.1",
     "@types/lodash.uniq": "^4.5.6",
     "@types/node": "16",
     "@types/pluralize": "^0.0.29",
     "camelcase": "^6.2.0",
     "eslint": "^8.21.0",
+    "jest": "^28.1.3",
     "lint-staged": "^13.0.0",
     "lodash.uniq": "^4.5.0",
     "pluralize": "^8.0.0",

--- a/packages/schemas/src/gen/index.ts
+++ b/packages/schemas/src/gen/index.ts
@@ -17,7 +17,7 @@ import {
   normalizeWhitespaces,
   parseType,
   removeUnrecognizedComments,
-  splitColumnDefinitions,
+  splitTableFieldDefinitions,
 } from './utils';
 
 const directory = 'tables';
@@ -44,7 +44,7 @@ const generate = async () => {
             const name = normalizeWhitespaces(prefix).split(' ')[2];
             assert(name, 'Missing table name: ' + prefix);
 
-            const fields = splitColumnDefinitions(body)
+            const fields = splitTableFieldDefinitions(body)
               .map((value) => normalizeWhitespaces(value))
               .filter((value) =>
                 [

--- a/packages/schemas/src/gen/index.ts
+++ b/packages/schemas/src/gen/index.ts
@@ -19,7 +19,7 @@ import {
   normalizeWhitespaces,
   removeParentheses,
   removeUnrecognizedComments,
-  splitAtCommasOutsideParentheses,
+  splitColumnDefinitions,
 } from './utils';
 
 const directory = 'tables';
@@ -46,7 +46,7 @@ const generate = async () => {
             const name = normalizeWhitespaces(prefix).split(' ')[2];
             assert(name, 'Missing table name: ' + prefix);
 
-            const fields = splitAtCommasOutsideParentheses(body)
+            const fields = splitColumnDefinitions(body)
               .map((value) => normalizeWhitespaces(value))
               .filter((value) =>
                 [

--- a/packages/schemas/src/gen/index.ts
+++ b/packages/schemas/src/gen/index.ts
@@ -57,40 +57,7 @@ const generate = async () => {
                   'references',
                 ].every((constraint) => !value.toLowerCase().startsWith(constraint + ' '))
               )
-              // eslint-disable-next-line complexity
-              .map<Field>((value) => {
-                const [nameRaw, typeRaw, ...rest] = value.split(' ');
-                assert(nameRaw && typeRaw, 'Missing column name or type: ' + value);
-
-                const name = nameRaw.toLowerCase();
-                const type = typeRaw.toLowerCase();
-                const restJoined = rest.join(' ');
-                const restLowercased = restJoined.toLowerCase();
-                // CAUTION: Only works for single dimension arrays
-                const isArray = Boolean(/\[.*]/.test(type)) || restLowercased.includes('array');
-                const hasDefaultValue = restLowercased.includes('default');
-                const nullable = !restLowercased.includes('not null');
-                const { type: primitiveType, isString, maxLength } = parseType(type);
-                const tsType = /\/\* @use (.*) \*\//.exec(restJoined)?.[1];
-                assert(
-                  !(!primitiveType && tsType),
-                  `TS type can only be applied on primitive types, found ${
-                    tsType ?? 'N/A'
-                  } over ${type}`
-                );
-
-                return {
-                  name,
-                  type: primitiveType,
-                  isString,
-                  maxLength,
-                  customType: conditional(!primitiveType && type),
-                  tsType,
-                  isArray,
-                  hasDefaultValue,
-                  nullable,
-                };
-              });
+              .map<Field>((value) => parseType(value));
 
             return { name, fields };
           });

--- a/packages/schemas/src/gen/index.ts
+++ b/packages/schemas/src/gen/index.ts
@@ -16,7 +16,6 @@ import {
   findFirstParentheses,
   normalizeWhitespaces,
   parseType,
-  removeParentheses,
   removeUnrecognizedComments,
   splitColumnDefinitions,
 } from './utils';

--- a/packages/schemas/src/gen/index.ts
+++ b/packages/schemas/src/gen/index.ts
@@ -21,7 +21,7 @@ import {
 } from './utils';
 
 const directory = 'tables';
-const constrainKeywords = [
+const constrainedKeywords = [
   'primary',
   'foreign',
   'unique',

--- a/packages/schemas/src/gen/index.ts
+++ b/packages/schemas/src/gen/index.ts
@@ -21,7 +21,7 @@ import {
 } from './utils';
 
 const directory = 'tables';
-const constrainKeyWords = [
+const constrainKeywords = [
   'primary',
   'foreign',
   'unique',
@@ -61,7 +61,7 @@ const generate = async () => {
             const fields = splitTableFieldDefinitions(body)
               .map((value) => normalizeWhitespaces(value))
               .filter((value) =>
-                constrainKeyWords.every(
+                constrainedKeywords.every(
                   (constraint) => !value.toLowerCase().startsWith(constraint + ' ')
                 )
               )

--- a/packages/schemas/src/gen/index.ts
+++ b/packages/schemas/src/gen/index.ts
@@ -14,9 +14,8 @@ import { generateSchema } from './schema';
 import { FileData, Table, Field, Type, GeneratedType, TableWithType } from './types';
 import {
   findFirstParentheses,
-  getStringMaxLength,
-  getType,
   normalizeWhitespaces,
+  parseType,
   removeParentheses,
   removeUnrecognizedComments,
   splitColumnDefinitions,
@@ -72,8 +71,7 @@ const generate = async () => {
                 const isArray = Boolean(/\[.*]/.test(type)) || restLowercased.includes('array');
                 const hasDefaultValue = restLowercased.includes('default');
                 const nullable = !restLowercased.includes('not null');
-                const primitiveType = getType(removeParentheses(type));
-                const stringMaxLength = getStringMaxLength(type);
+                const { type: primitiveType, isString, maxLength } = parseType(type);
                 const tsType = /\/\* @use (.*) \*\//.exec(restJoined)?.[1];
                 assert(
                   !(!primitiveType && tsType),
@@ -85,7 +83,8 @@ const generate = async () => {
                 return {
                   name,
                   type: primitiveType,
-                  stringMaxLength,
+                  isString,
+                  maxLength,
                   customType: conditional(!primitiveType && type),
                   tsType,
                   isArray,

--- a/packages/schemas/src/gen/schema.ts
+++ b/packages/schemas/src/gen/schema.ts
@@ -33,25 +33,30 @@ export const generateSchema = ({ name, fields }: TableWithType) => {
     '};',
     '',
     `const createGuard: CreateGuard<${databaseEntryType}> = z.object({`,
-    // eslint-disable-next-line complexity
-    ...fields.map(({ name, type, isArray, isEnum, nullable, hasDefaultValue, tsType }) => {
-      if (tsType) {
-        return `  ${camelcase(name)}: ${camelcase(tsType)}Guard${conditionalString(
-          nullable && '.nullable()'
-        )}${conditionalString((nullable || hasDefaultValue) && '.optional()')},`;
-      }
 
-      return `  ${camelcase(name)}: z.${
-        isEnum ? `nativeEnum(${type})` : `${type}()`
-      }${conditionalString(isArray && '.array()')}${conditionalString(
-        nullable && '.nullable()'
-      )}${conditionalString((nullable || hasDefaultValue) && '.optional()')},`;
-    }),
+    ...fields.map(
+      // eslint-disable-next-line complexity
+      ({ name, type, isArray, isEnum, nullable, hasDefaultValue, tsType, stringMaxLength }) => {
+        if (tsType) {
+          return `  ${camelcase(name)}: ${camelcase(tsType)}Guard${conditionalString(
+            nullable && '.nullable()'
+          )}${conditionalString((nullable || hasDefaultValue) && '.optional()')},`;
+        }
+
+        return `  ${camelcase(name)}: z.${
+          isEnum ? `nativeEnum(${type})` : `${type}()`
+        }${conditionalString(stringMaxLength && `.max(${stringMaxLength})`)}${conditionalString(
+          isArray && '.array()'
+        )}${conditionalString(nullable && '.nullable()')}${conditionalString(
+          (nullable || hasDefaultValue) && '.optional()'
+        )},`;
+      }
+    ),
     '  });',
     '',
     `const guard: Guard<${modelName}> = z.object({`,
     // eslint-disable-next-line complexity
-    ...fields.map(({ name, type, isArray, isEnum, nullable, tsType }) => {
+    ...fields.map(({ name, type, isArray, isEnum, nullable, tsType, stringMaxLength }) => {
       if (tsType) {
         return `  ${camelcase(name)}: ${camelcase(tsType)}Guard${conditionalString(
           nullable && '.nullable()'
@@ -60,7 +65,9 @@ export const generateSchema = ({ name, fields }: TableWithType) => {
 
       return `  ${camelcase(name)}: z.${
         isEnum ? `nativeEnum(${type})` : `${type}()`
-      }${conditionalString(isArray && '.array()')}${conditionalString(nullable && '.nullable()')},`;
+      }${conditionalString(stringMaxLength && `.max(${stringMaxLength})`)}${conditionalString(
+        isArray && '.array()'
+      )}${conditionalString(nullable && '.nullable()')},`;
     }),
     '  });',
     '',

--- a/packages/schemas/src/gen/schema.ts
+++ b/packages/schemas/src/gen/schema.ts
@@ -36,7 +36,7 @@ export const generateSchema = ({ name, fields }: TableWithType) => {
 
     ...fields.map(
       // eslint-disable-next-line complexity
-      ({ name, type, isArray, isEnum, nullable, hasDefaultValue, tsType, stringMaxLength }) => {
+      ({ name, type, isArray, isEnum, nullable, hasDefaultValue, tsType, isString, maxLength }) => {
         if (tsType) {
           return `  ${camelcase(name)}: ${camelcase(tsType)}Guard${conditionalString(
             nullable && '.nullable()'
@@ -45,7 +45,7 @@ export const generateSchema = ({ name, fields }: TableWithType) => {
 
         return `  ${camelcase(name)}: z.${
           isEnum ? `nativeEnum(${type})` : `${type}()`
-        }${conditionalString(stringMaxLength && `.max(${stringMaxLength})`)}${conditionalString(
+        }${conditionalString(isString && maxLength && `.max(${maxLength})`)}${conditionalString(
           isArray && '.array()'
         )}${conditionalString(nullable && '.nullable()')}${conditionalString(
           (nullable || hasDefaultValue) && '.optional()'
@@ -55,8 +55,9 @@ export const generateSchema = ({ name, fields }: TableWithType) => {
     '  });',
     '',
     `const guard: Guard<${modelName}> = z.object({`,
+
     // eslint-disable-next-line complexity
-    ...fields.map(({ name, type, isArray, isEnum, nullable, tsType, stringMaxLength }) => {
+    ...fields.map(({ name, type, isArray, isEnum, nullable, tsType, isString, maxLength }) => {
       if (tsType) {
         return `  ${camelcase(name)}: ${camelcase(tsType)}Guard${conditionalString(
           nullable && '.nullable()'
@@ -65,7 +66,7 @@ export const generateSchema = ({ name, fields }: TableWithType) => {
 
       return `  ${camelcase(name)}: z.${
         isEnum ? `nativeEnum(${type})` : `${type}()`
-      }${conditionalString(stringMaxLength && `.max(${stringMaxLength})`)}${conditionalString(
+      }${conditionalString(isString && maxLength && `.max(${maxLength})`)}${conditionalString(
         isArray && '.array()'
       )}${conditionalString(nullable && '.nullable()')},`;
     }),

--- a/packages/schemas/src/gen/schema.ts
+++ b/packages/schemas/src/gen/schema.ts
@@ -36,17 +36,7 @@ export const generateSchema = ({ name, fields }: TableWithType) => {
 
     ...fields.map(
       // eslint-disable-next-line complexity
-      ({
-        name,
-        type,
-        isArray,
-        isEnum,
-        nullable,
-        hasDefaultValue,
-        tsType,
-        isString,
-        stringMaxLength,
-      }) => {
+      ({ name, type, isArray, isEnum, nullable, hasDefaultValue, tsType, isString, maxLength }) => {
         if (tsType) {
           return `  ${camelcase(name)}: ${camelcase(tsType)}Guard${conditionalString(
             nullable && '.nullable()'
@@ -55,11 +45,11 @@ export const generateSchema = ({ name, fields }: TableWithType) => {
 
         return `  ${camelcase(name)}: z.${
           isEnum ? `nativeEnum(${type})` : `${type}()`
-        }${conditionalString(
-          isString && stringMaxLength && `.max(${stringMaxLength})`
-        )}${conditionalString(isArray && '.array()')}${conditionalString(
-          nullable && '.nullable()'
-        )}${conditionalString((nullable || hasDefaultValue) && '.optional()')},`;
+        }${conditionalString(isString && maxLength && `.max(${maxLength})`)}${conditionalString(
+          isArray && '.array()'
+        )}${conditionalString(nullable && '.nullable()')}${conditionalString(
+          (nullable || hasDefaultValue) && '.optional()'
+        )},`;
       }
     ),
     '  });',
@@ -68,7 +58,7 @@ export const generateSchema = ({ name, fields }: TableWithType) => {
 
     ...fields.map(
       // eslint-disable-next-line complexity
-      ({ name, type, isArray, isEnum, nullable, tsType, isString, stringMaxLength }) => {
+      ({ name, type, isArray, isEnum, nullable, tsType, isString, maxLength }) => {
         if (tsType) {
           return `  ${camelcase(name)}: ${camelcase(tsType)}Guard${conditionalString(
             nullable && '.nullable()'
@@ -77,11 +67,9 @@ export const generateSchema = ({ name, fields }: TableWithType) => {
 
         return `  ${camelcase(name)}: z.${
           isEnum ? `nativeEnum(${type})` : `${type}()`
-        }${conditionalString(
-          isString && stringMaxLength && `.max(${stringMaxLength})`
-        )}${conditionalString(isArray && '.array()')}${conditionalString(
-          nullable && '.nullable()'
-        )},`;
+        }${conditionalString(isString && maxLength && `.max(${maxLength})`)}${conditionalString(
+          isArray && '.array()'
+        )}${conditionalString(nullable && '.nullable()')},`;
       }
     ),
     '  });',

--- a/packages/schemas/src/gen/schema.ts
+++ b/packages/schemas/src/gen/schema.ts
@@ -36,7 +36,17 @@ export const generateSchema = ({ name, fields }: TableWithType) => {
 
     ...fields.map(
       // eslint-disable-next-line complexity
-      ({ name, type, isArray, isEnum, nullable, hasDefaultValue, tsType, isString, maxLength }) => {
+      ({
+        name,
+        type,
+        isArray,
+        isEnum,
+        nullable,
+        hasDefaultValue,
+        tsType,
+        isString,
+        stringMaxLength,
+      }) => {
         if (tsType) {
           return `  ${camelcase(name)}: ${camelcase(tsType)}Guard${conditionalString(
             nullable && '.nullable()'
@@ -45,31 +55,35 @@ export const generateSchema = ({ name, fields }: TableWithType) => {
 
         return `  ${camelcase(name)}: z.${
           isEnum ? `nativeEnum(${type})` : `${type}()`
-        }${conditionalString(isString && maxLength && `.max(${maxLength})`)}${conditionalString(
-          isArray && '.array()'
-        )}${conditionalString(nullable && '.nullable()')}${conditionalString(
-          (nullable || hasDefaultValue) && '.optional()'
-        )},`;
+        }${conditionalString(
+          isString && stringMaxLength && `.max(${stringMaxLength})`
+        )}${conditionalString(isArray && '.array()')}${conditionalString(
+          nullable && '.nullable()'
+        )}${conditionalString((nullable || hasDefaultValue) && '.optional()')},`;
       }
     ),
     '  });',
     '',
     `const guard: Guard<${modelName}> = z.object({`,
 
-    // eslint-disable-next-line complexity
-    ...fields.map(({ name, type, isArray, isEnum, nullable, tsType, isString, maxLength }) => {
-      if (tsType) {
-        return `  ${camelcase(name)}: ${camelcase(tsType)}Guard${conditionalString(
+    ...fields.map(
+      // eslint-disable-next-line complexity
+      ({ name, type, isArray, isEnum, nullable, tsType, isString, stringMaxLength }) => {
+        if (tsType) {
+          return `  ${camelcase(name)}: ${camelcase(tsType)}Guard${conditionalString(
+            nullable && '.nullable()'
+          )},`;
+        }
+
+        return `  ${camelcase(name)}: z.${
+          isEnum ? `nativeEnum(${type})` : `${type}()`
+        }${conditionalString(
+          isString && stringMaxLength && `.max(${stringMaxLength})`
+        )}${conditionalString(isArray && '.array()')}${conditionalString(
           nullable && '.nullable()'
         )},`;
       }
-
-      return `  ${camelcase(name)}: z.${
-        isEnum ? `nativeEnum(${type})` : `${type}()`
-      }${conditionalString(isString && maxLength && `.max(${maxLength})`)}${conditionalString(
-        isArray && '.array()'
-      )}${conditionalString(nullable && '.nullable()')},`;
-    }),
+    ),
     '  });',
     '',
     `export const ${camelcase(name, {

--- a/packages/schemas/src/gen/types.ts
+++ b/packages/schemas/src/gen/types.ts
@@ -3,7 +3,8 @@ export type Field = {
   type?: string;
   customType?: string;
   tsType?: string;
-  stringMaxLength?: number;
+  isString: boolean;
+  maxLength?: number;
   hasDefaultValue: boolean;
   nullable: boolean;
   isArray: boolean;

--- a/packages/schemas/src/gen/types.ts
+++ b/packages/schemas/src/gen/types.ts
@@ -4,7 +4,7 @@ export type Field = {
   customType?: string;
   tsType?: string;
   isString: boolean;
-  stringMaxLength?: number;
+  maxLength?: number;
   hasDefaultValue: boolean;
   nullable: boolean;
   isArray: boolean;

--- a/packages/schemas/src/gen/types.ts
+++ b/packages/schemas/src/gen/types.ts
@@ -4,7 +4,7 @@ export type Field = {
   customType?: string;
   tsType?: string;
   isString: boolean;
-  maxLength?: number;
+  stringMaxLength?: number;
   hasDefaultValue: boolean;
   nullable: boolean;
   isArray: boolean;

--- a/packages/schemas/src/gen/types.ts
+++ b/packages/schemas/src/gen/types.ts
@@ -3,6 +3,7 @@ export type Field = {
   type?: string;
   customType?: string;
   tsType?: string;
+  stringMaxLength?: number;
   hasDefaultValue: boolean;
   nullable: boolean;
   isArray: boolean;

--- a/packages/schemas/src/gen/utils.test.ts
+++ b/packages/schemas/src/gen/utils.test.ts
@@ -34,7 +34,7 @@ describe('parseType', () => {
         type: 'string',
         isArray: false,
         isString: true,
-        stringMaxLength: length,
+        maxLength: length,
         hasDefaultValue: false,
         nullable: true,
         tsType: undefined,
@@ -55,7 +55,7 @@ describe('parseType', () => {
         name: 'foo',
         type,
         isArray: false,
-        stringMaxLength: undefined,
+        maxLength: undefined,
         hasDefaultValue: false,
         nullable: true,
         tsType: undefined,
@@ -68,14 +68,14 @@ describe('parseType', () => {
     expect(parseType(`foo varchar(${length})[]`)).toMatchObject({
       name: 'foo',
       type: 'string',
-      stringMaxLength: length,
+      maxLength: length,
       isArray: true,
     });
 
     expect(parseType(`foo varchar(${length}) array`)).toMatchObject({
       name: 'foo',
       type: 'string',
-      stringMaxLength: length,
+      maxLength: length,
       isArray: true,
     });
   });

--- a/packages/schemas/src/gen/utils.test.ts
+++ b/packages/schemas/src/gen/utils.test.ts
@@ -1,0 +1,24 @@
+import { getStringMaxLength, splitAtCommasOutsideParentheses } from './utils';
+
+test('splitAtCommasOutsideParentheses should split at each comma that is not in the parentheses', () => {
+  const segments = ['a', 'b(1)', 'c(2,3)', 'd(4,(5,6))'];
+  expect(splitAtCommasOutsideParentheses(segments.join(','))).toEqual(segments);
+});
+
+describe('getStringMaxLength', () => {
+  const length = 128;
+
+  test.each([`bpchar(${length})`, `char(${length})`, `varchar(${length})`])(
+    'should return the max length of %s',
+    (type) => {
+      expect(getStringMaxLength(type)).toEqual(length);
+    }
+  );
+
+  test.each(['text', 'time(6)', 'numeric(4,2)'])(
+    'should return undefined since %s is not the character type with length limit',
+    (type) => {
+      expect(getStringMaxLength(type)).toBeUndefined();
+    }
+  );
+});

--- a/packages/schemas/src/gen/utils.test.ts
+++ b/packages/schemas/src/gen/utils.test.ts
@@ -1,8 +1,10 @@
-import { parseType, splitColumnDefinitions } from './utils';
+import { parseType, splitTableFieldDefinitions } from './utils';
 
-test('splitColumnDefinitions should split at each comma that is not in the parentheses', () => {
+test('splitTableFieldDefinitions should split at each comma that is not in the parentheses', () => {
   const segments = ['a', 'b(1)', 'c(2,3)', 'd(4,(5,6))'];
-  expect(splitColumnDefinitions(segments.join(','))).toEqual(segments);
+  expect(splitTableFieldDefinitions(segments.join(','))).toEqual(segments);
+  const oneSegment = 'id bigint';
+  expect(splitTableFieldDefinitions(oneSegment)).toEqual([oneSegment]);
 });
 
 describe('parseType', () => {

--- a/packages/schemas/src/gen/utils.test.ts
+++ b/packages/schemas/src/gen/utils.test.ts
@@ -1,38 +1,96 @@
-import { parseType, splitTableFieldDefinitions } from './utils';
+import { parseType, getType, splitTableFieldDefinitions } from './utils';
 
-test('splitTableFieldDefinitions should split at each comma that is not in the parentheses', () => {
-  const segments = ['a', 'b(1)', 'c(2,3)', 'd(4,(5,6))'];
-  expect(splitTableFieldDefinitions(segments.join(','))).toEqual(segments);
-  const oneSegment = 'id bigint';
-  expect(splitTableFieldDefinitions(oneSegment)).toEqual([oneSegment]);
+describe('splitTableFieldDefinitions', () => {
+  it('splitTableFieldDefinitions should split at each comma that is not in the parentheses', () => {
+    const segments = ['a', 'b(1)', 'c(2,3)', 'd(4,(5,6))'];
+    expect(splitTableFieldDefinitions(segments.join(','))).toEqual(segments);
+    const oneSegment = 'id bigint';
+    expect(splitTableFieldDefinitions(oneSegment)).toEqual([oneSegment]);
+  });
+});
+
+describe('getType', () => {
+  it.each(['varchar(32)[]', 'char', 'text'])('getStringType', (type) => {
+    expect(getType(type)).toBe('string');
+  });
+
+  it.each(['int2', 'float4', 'timestamp'])('should return number', (type) => {
+    expect(getType(type)).toBe('number');
+  });
 });
 
 describe('parseType', () => {
   const length = 128;
 
-  test.each([`bpchar(${length})`, `char(${length})`, `varchar(${length})`])(
+  it('should throw without column name', () => {
+    expect(() => parseType('varchar')).toThrow();
+  });
+
+  it.each([`foo bpchar(${length})`, `foo char(${length})`, `foo varchar(${length})`])(
     'should return the string max length of %s',
     (type) => {
-      expect(parseType(type)).toEqual({
+      expect(parseType(type)).toMatchObject({
+        name: 'foo',
         type: 'string',
+        isArray: false,
         isString: true,
-        maxLength: length,
+        stringMaxLength: length,
+        hasDefaultValue: false,
+        nullable: true,
+        tsType: undefined,
+        customType: undefined,
       });
     }
   );
 
-  test.each([
-    ['text', 'string', true],
-    ['timestamp(6)', 'number', false],
-    ['numeric(4,2)', 'number', false],
-    ['jsonb', 'Record<string, unknown>', false],
+  it.each([
+    ['foo text', 'string'],
+    ['foo timestamp(6)', 'number'],
+    ['foo numeric(4,2)', 'number'],
+    ['foo jsonb', 'Record<string, unknown>'],
   ])(
     'should not return the max length since %s is not the character type with length limit',
-    (value, type, isString) => {
-      expect(parseType(value)).toEqual({
+    (value, type) => {
+      expect(parseType(value)).toMatchObject({
+        name: 'foo',
         type,
-        isString,
+        isArray: false,
+        stringMaxLength: undefined,
+        hasDefaultValue: false,
+        nullable: true,
+        tsType: undefined,
+        customType: undefined,
       });
     }
   );
+
+  it('should return isArray', () => {
+    expect(parseType(`foo varchar(${length})[]`)).toMatchObject({
+      name: 'foo',
+      type: 'string',
+      stringMaxLength: length,
+      isArray: true,
+    });
+
+    expect(parseType(`foo varchar(${length}) array`)).toMatchObject({
+      name: 'foo',
+      type: 'string',
+      stringMaxLength: length,
+      isArray: true,
+    });
+  });
+
+  it('should return tsType', () => {
+    expect(
+      parseType(
+        `custom_client_metadata jsonb /* @use CustomClientMetadata */ not null default '{}'::jsonb,`
+      )
+    ).toMatchObject({
+      name: 'custom_client_metadata',
+      type: 'Record<string, unknown>',
+      tsType: 'CustomClientMetadata',
+      nullable: false,
+      hasDefaultValue: true,
+    });
+  });
 });

--- a/packages/schemas/src/gen/utils.test.ts
+++ b/packages/schemas/src/gen/utils.test.ts
@@ -1,8 +1,8 @@
-import { getStringMaxLength, splitAtCommasOutsideParentheses } from './utils';
+import { getStringMaxLength, splitColumnDefinitions } from './utils';
 
-test('splitAtCommasOutsideParentheses should split at each comma that is not in the parentheses', () => {
+test('splitColumnDefinitions should split at each comma that is not in the parentheses', () => {
   const segments = ['a', 'b(1)', 'c(2,3)', 'd(4,(5,6))'];
-  expect(splitAtCommasOutsideParentheses(segments.join(','))).toEqual(segments);
+  expect(splitColumnDefinitions(segments.join(','))).toEqual(segments);
 });
 
 describe('getStringMaxLength', () => {

--- a/packages/schemas/src/gen/utils.test.ts
+++ b/packages/schemas/src/gen/utils.test.ts
@@ -1,24 +1,36 @@
-import { getStringMaxLength, splitColumnDefinitions } from './utils';
+import { parseType, splitColumnDefinitions } from './utils';
 
 test('splitColumnDefinitions should split at each comma that is not in the parentheses', () => {
   const segments = ['a', 'b(1)', 'c(2,3)', 'd(4,(5,6))'];
   expect(splitColumnDefinitions(segments.join(','))).toEqual(segments);
 });
 
-describe('getStringMaxLength', () => {
+describe('parseType', () => {
   const length = 128;
 
   test.each([`bpchar(${length})`, `char(${length})`, `varchar(${length})`])(
-    'should return the max length of %s',
+    'should return the string max length of %s',
     (type) => {
-      expect(getStringMaxLength(type)).toEqual(length);
+      expect(parseType(type)).toEqual({
+        type: 'string',
+        isString: true,
+        maxLength: length,
+      });
     }
   );
 
-  test.each(['text', 'time(6)', 'numeric(4,2)'])(
-    'should return undefined since %s is not the character type with length limit',
-    (type) => {
-      expect(getStringMaxLength(type)).toBeUndefined();
+  test.each([
+    ['text', 'string', true],
+    ['timestamp(6)', 'number', false],
+    ['numeric(4,2)', 'number', false],
+    ['jsonb', 'Record<string, unknown>', false],
+  ])(
+    'should not return the max length since %s is not the character type with length limit',
+    (value, type, isString) => {
+      expect(parseType(value)).toEqual({
+        type,
+        isString,
+      });
     }
   );
 });

--- a/packages/schemas/src/gen/utils.ts
+++ b/packages/schemas/src/gen/utils.ts
@@ -85,14 +85,19 @@ export const splitColumnDefinitions = (value: string) =>
       const count = previousCount + getCountDelta(current);
 
       if (count === 0 && current === ',') {
-        // eslint-disable-next-line @silverhand/fp/no-mutating-methods
-        result.push('');
-      } else {
-        // eslint-disable-next-line @silverhand/fp/no-mutation
-        result[result.length - 1] += current;
+        return {
+          result: [...result, ''],
+          count,
+        };
       }
 
-      return { result, count };
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      result[result.length - 1] += current;
+
+      return {
+        result,
+        count,
+      };
     },
     {
       result: [''],

--- a/packages/schemas/src/gen/utils.ts
+++ b/packages/schemas/src/gen/utils.ts
@@ -81,9 +81,8 @@ export const findFirstParentheses = (value: string): Optional<ParenthesesMatch> 
 // Split at each comma that is not in parentheses
 export const splitAtCommasOutsideParentheses = (value: string) =>
   Object.values(value).reduce<{ result: string[]; count: number }>(
-    (previous, current) => {
-      const { result } = previous;
-      const count = previous.count + getCountDelta(current);
+    ({ result, count: previousCount }, current) => {
+      const count = previousCount + getCountDelta(current);
 
       if (count === 0 && current === ',') {
         // eslint-disable-next-line @silverhand/fp/no-mutating-methods

--- a/packages/schemas/src/gen/utils.ts
+++ b/packages/schemas/src/gen/utils.ts
@@ -18,7 +18,7 @@ const getCountDelta = (value: string): number => {
   return 0;
 };
 
-export const removeParentheses = (value: string) =>
+const removeParentheses = (value: string) =>
   Object.values(value).reduce<{ result: string; count: number }>(
     (previous, current) => {
       const count = previous.count + getCountDelta(current);
@@ -158,7 +158,7 @@ export const parseType = (value: string) => {
 
   const isString = type === 'string';
   const parenthesesMatch = findFirstParentheses(value);
-  const maxLength = conditional(
+  const stringMaxLength = conditional(
     isString &&
       parenthesesMatch &&
       ['bpchar', 'char', 'varchar'].includes(parenthesesMatch.prefix) &&
@@ -168,6 +168,6 @@ export const parseType = (value: string) => {
   return {
     type,
     isString,
-    maxLength,
+    maxLength: stringMaxLength,
   };
 };

--- a/packages/schemas/src/gen/utils.ts
+++ b/packages/schemas/src/gen/utils.ts
@@ -192,7 +192,7 @@ export const parseType = (tableFieldDefinition: string): Field => {
     type: primitiveType,
     isString,
     isArray,
-    stringMaxLength: conditional(isString && parseStringMaxLength(type)),
+    maxLength: conditional(isString && parseStringMaxLength(type)),
     customType: conditional(!primitiveType && type),
     tsType,
     hasDefaultValue,

--- a/packages/schemas/src/gen/utils.ts
+++ b/packages/schemas/src/gen/utils.ts
@@ -159,10 +159,10 @@ const parseStringMaxLength = (rawType: string) => {
 };
 
 // eslint-disable-next-line complexity
-export const parseType = (columnStatement: string): Field => {
-  const [nameRaw, typeRaw, ...rest] = columnStatement.split(' ');
+export const parseType = (tableFieldDefinition: string): Field => {
+  const [nameRaw, typeRaw, ...rest] = tableFieldDefinition.split(' ');
 
-  assert(nameRaw && typeRaw, new Error('Missing column name or type: ' + columnStatement));
+  assert(nameRaw && typeRaw, new Error('Missing field name or type: ' + tableFieldDefinition));
 
   const name = nameRaw.toLowerCase();
   const type = typeRaw.toLowerCase();

--- a/packages/schemas/src/gen/utils.ts
+++ b/packages/schemas/src/gen/utils.ts
@@ -78,7 +78,7 @@ export const findFirstParentheses = (value: string): Optional<ParenthesesMatch> 
   return matched ? rest : undefined;
 };
 
-export const splitColumnDefinitions = (value: string) =>
+export const splitTableFieldDefinitions = (value: string) =>
   // Split at each comma that is not in parentheses
   Object.values(value).reduce<{ result: string[]; count: number }>(
     ({ result, count: previousCount }, current) => {

--- a/packages/schemas/src/gen/utils.ts
+++ b/packages/schemas/src/gen/utils.ts
@@ -78,8 +78,8 @@ export const findFirstParentheses = (value: string): Optional<ParenthesesMatch> 
   return matched ? rest : undefined;
 };
 
-// Split at each comma that is not in parentheses
-export const splitAtCommasOutsideParentheses = (value: string) =>
+export const splitColumnDefinitions = (value: string) =>
+  // Split at each comma that is not in parentheses
   Object.values(value).reduce<{ result: string[]; count: number }>(
     ({ result, count: previousCount }, current) => {
       const count = previousCount + getCountDelta(current);

--- a/packages/schemas/src/gen/utils.ts
+++ b/packages/schemas/src/gen/utils.ts
@@ -1,4 +1,4 @@
-import { conditional, conditionalString, Optional } from '@silverhand/essentials';
+import { conditional, Optional } from '@silverhand/essentials';
 
 export const normalizeWhitespaces = (string: string): string => string.replace(/\s+/g, ' ').trim();
 
@@ -91,11 +91,11 @@ export const splitColumnDefinitions = (value: string) =>
         };
       }
 
+      const rest = result.slice(0, -1);
+      const last = result.at(-1) ?? '';
+
       return {
-        result: [
-          ...result.slice(0, -1),
-          `${conditionalString(result[result.length - 1])}${current}`,
-        ],
+        result: [...rest, `${last}${current}`],
         count,
       };
     },

--- a/packages/schemas/src/gen/utils.ts
+++ b/packages/schemas/src/gen/utils.ts
@@ -1,4 +1,4 @@
-import { Optional } from '@silverhand/essentials';
+import { conditionalString, Optional } from '@silverhand/essentials';
 
 export const normalizeWhitespaces = (string: string): string => string.replace(/\s+/g, ' ').trim();
 
@@ -78,9 +78,9 @@ export const findFirstParentheses = (value: string): Optional<ParenthesesMatch> 
   return matched ? rest : undefined;
 };
 
-export const splitColumnDefinitions = (value: string) =>
+export const splitColumnDefinitions = (value: string) => {
   // Split at each comma that is not in parentheses
-  Object.values(value).reduce<{ result: string[]; count: number }>(
+  return Object.values(value).reduce<{ result: string[]; count: number }>(
     ({ result, count: previousCount }, current) => {
       const count = previousCount + getCountDelta(current);
 
@@ -91,11 +91,11 @@ export const splitColumnDefinitions = (value: string) =>
         };
       }
 
-      // eslint-disable-next-line @silverhand/fp/no-mutation
-      result[result.length - 1] += current;
-
       return {
-        result,
+        result: [
+          ...result.slice(0, -1),
+          `${conditionalString(result[result.length - 1])}${current}`,
+        ],
         count,
       };
     },
@@ -104,6 +104,7 @@ export const splitColumnDefinitions = (value: string) =>
       count: 0,
     }
   ).result;
+};
 
 const getRawType = (value: string): string => {
   const bracketIndex = value.indexOf('[');

--- a/packages/schemas/tsconfig.build.json
+++ b/packages/schemas/tsconfig.build.json
@@ -1,4 +1,5 @@
 {
   "extends": "./tsconfig",
+  "include": ["src"],
   "exclude": ["src/gen"]
 }

--- a/packages/schemas/tsconfig.json
+++ b/packages/schemas/tsconfig.json
@@ -5,6 +5,7 @@
     "declaration": true
   },
   "include": [
-    "src"
+    "src",
+    "jest.config.ts",
   ]
 }

--- a/packages/schemas/tsconfig.test.json
+++ b/packages/schemas/tsconfig.test.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./tsconfig"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1225,12 +1225,15 @@ importers:
       '@logto/shared': ^1.0.0-beta.3
       '@silverhand/eslint-config': 1.0.0-rc.2
       '@silverhand/essentials': ^1.1.6
+      '@silverhand/jest-config': 1.0.0-rc.3
       '@silverhand/ts-config': 1.0.0-rc.2
+      '@types/jest': ^27.4.1
       '@types/lodash.uniq': ^4.5.6
       '@types/node': '16'
       '@types/pluralize': ^0.0.29
       camelcase: ^6.2.0
       eslint: ^8.21.0
+      jest: ^28.1.3
       lint-staged: ^13.0.0
       lodash.uniq: ^4.5.0
       pluralize: ^8.0.0
@@ -1247,12 +1250,15 @@ importers:
     devDependencies:
       '@silverhand/eslint-config': 1.0.0-rc.2_swk2g7ygmfleszo5c33j4vooni
       '@silverhand/essentials': 1.1.7
+      '@silverhand/jest-config': 1.0.0-rc.3_bi2kohzqnxavgozw3csgny5hju
       '@silverhand/ts-config': 1.0.0-rc.2_typescript@4.7.4
+      '@types/jest': 27.5.2
       '@types/lodash.uniq': 4.5.6
       '@types/node': 16.11.12
       '@types/pluralize': 0.0.29
       camelcase: 6.2.1
       eslint: 8.21.0
+      jest: 28.1.3_k5ytkvaprncdyzidqqws5bqksq
       lint-staged: 13.0.0
       lodash.uniq: 4.5.0
       pluralize: 8.0.0
@@ -4990,6 +4996,13 @@ packages:
     dependencies:
       '@types/istanbul-lib-report': 3.0.0
 
+  /@types/jest/27.5.2:
+    resolution: {integrity: sha512-mpT8LJJ4CMeeahobofYWIjFo0xonRS/HfxnVEPMPFSQdGUt1uHCnoPT7Zhb+sjDU2wz0oKV0OLUR0WzrHNgfeA==}
+    dependencies:
+      jest-matcher-utils: 27.5.1
+      pretty-format: 27.5.1
+    dev: true
+
   /@types/jest/28.1.6:
     resolution: {integrity: sha512-0RbGAFMfcBJKOmqRazM8L98uokwuwD5F8rHrv/ZMbrZBwVOWZUyPG6VFNscjYr/vjM3Vu4fRrCPbOs42AfemaQ==}
     dependencies:
@@ -7007,6 +7020,11 @@ packages:
     dependencies:
       asap: 2.0.6
       wrappy: 1.0.2
+
+  /diff-sequences/27.5.1:
+    resolution: {integrity: sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dev: true
 
   /diff-sequences/28.1.1:
     resolution: {integrity: sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==}
@@ -9672,6 +9690,16 @@ packages:
       - supports-color
     dev: true
 
+  /jest-diff/27.5.1:
+    resolution: {integrity: sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 27.5.1
+      jest-get-type: 27.5.1
+      pretty-format: 27.5.1
+    dev: true
+
   /jest-diff/28.1.3:
     resolution: {integrity: sha512-8RqP1B/OXzjjTWkqMX67iqgwBVJRgCyKD3L9nq+6ZqJMdvjE8RgHktqZ6jNrkdMT+dJuYNI3rhQpxaz7drJHfw==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
@@ -9727,6 +9755,11 @@ packages:
       jest-mock: 28.1.3
       jest-util: 28.1.3
 
+  /jest-get-type/27.5.1:
+    resolution: {integrity: sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dev: true
+
   /jest-get-type/28.0.2:
     resolution: {integrity: sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
@@ -9758,6 +9791,16 @@ packages:
 
   /jest-matcher-specific-error/1.0.0:
     resolution: {integrity: sha512-thJdy9ibhDo8k+0arFalNCQBJ0u7eqTfpTzS2MzL3iCLmbRCkI+yhhKSiAxEi55e5ZUyf01ySa0fMqzF+sblAw==}
+
+  /jest-matcher-utils/27.5.1:
+    resolution: {integrity: sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 27.5.1
+      jest-get-type: 27.5.1
+      pretty-format: 27.5.1
+    dev: true
 
   /jest-matcher-utils/28.1.3:
     resolution: {integrity: sha512-kQeJ7qHemKfbzKoGjHHrRKH6atgxMk8Enkk2iPQ3XwO6oE/KYD8lMYOziCkeSB9G4adPM4nR1DE8Tf5JeWH6Bw==}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Append the fields' string max length limitations to `guard` and `createGuard` of the database table schemas.

- If the field in the table column definition (e.g. `field_a` in `create table examples (field_a varchar(16), …);`) is the character type with the length limit (`varchar(16)`), we will append the `.max(n)` to its `ZodString` guard to check its max length.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Diff generated `db-entries/*.ts` (just for preview):

![image](https://user-images.githubusercontent.com/10594507/182808328-8beca1a5-0ec1-4a3d-a1c5-c23a5a960973.png)

Generated `API Reference` page:

<img width="1541" alt="image" src="https://user-images.githubusercontent.com/10594507/182814291-b5d9e3a6-8c34-4d61-a03b-e40667efb0cd.png">

UTs

<img width="746" alt="image" src="https://user-images.githubusercontent.com/10594507/183825599-e7e4bba3-af33-4be9-80db-e39ff6bf2a75.png">
