### PR TITLE
refactor(core): remove redundant `isBuffer('base64url')`

### DIFF
--- a/packages/core/src/utils/jwks.ts
+++ b/packages/core/src/utils/jwks.ts
@@ -1,25 +1,11 @@
 /**
  * Theses codes comes from [node-oidc-provider](https://github.com/panva/node-oidc-provider):
  * - [initialize_keystore.js](https://github.com/panva/node-oidc-provider/blob/9da61e9c9dc6152cd1140d42ea06abe1d812c286/lib/helpers/initialize_keystore.js#L13-L36)
- * - [base64url.js](https://github.com/panva/node-oidc-provider/blob/9da61e9c9dc6152cd1140d42ea06abe1d812c286/lib/helpers/base64url.js)
  */
 
 import { createHash } from 'crypto';
 
 import { JWK, KeyLike, exportJWK as joseExportJWK } from 'jose';
-
-const fromBase64 = (base64: string) =>
-  base64.replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
-
-const encodeBuffer = (buf: Buffer) => {
-  const base64url = buf.toString('base64url');
-
-  if (Buffer.isEncoding('base64url')) {
-    return base64url;
-  }
-
-  return fromBase64(base64url);
-};
 
 const getCalculateKidComponents = (jwk: JWK) => {
   switch (jwk.kty) {
@@ -49,7 +35,7 @@ const getCalculateKidComponents = (jwk: JWK) => {
 const calculateKid = (jwk: JWK) => {
   const components = getCalculateKidComponents(jwk);
 
-  return encodeBuffer(createHash('sha256').update(JSON.stringify(components)).digest());
+  return createHash('sha256').update(JSON.stringify(components)).digest().toString('base64url');
 };
 
 export const exportJWK = async (key: KeyLike | Uint8Array): Promise<JWK> => {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
remove redundant `isBuffer('base64url')` for the min NODE version of Logto is 16 which support `base64url` encoding by default.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.
