### PR TITLE
fix(ui): add sandbox props to iframe

### DIFF
--- a/packages/ui/src/components/ConfirmModal/IframeConfirmModal.tsx
+++ b/packages/ui/src/components/ConfirmModal/IframeConfirmModal.tsx
@@ -1,5 +1,3 @@
-// FIXME: @simeng
-/* eslint-disable react/iframe-missing-sandbox */
 import classNames from 'classnames';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -38,6 +36,7 @@ const IframeConfirmModal = ({
         <div className={styles.content}>
           {isLoading && <LoadingIcon />}
           <iframe
+            sandbox={undefined}
             className={isLoading ? styles.hidden : undefined}
             role="iframe"
             src={url}
@@ -65,4 +64,3 @@ const IframeConfirmModal = ({
 };
 
 export default IframeConfirmModal;
-/* eslint-enable react/iframe-missing-sandbox */

--- a/packages/ui/src/include.d/dom.d.ts
+++ b/packages/ui/src/include.d/dom.d.ts
@@ -73,7 +73,7 @@ type AutoCompleteType =
   | 'tel-country-code'
   | 'tel-national';
 
-// TODO: @simeng remove me
+// LOG-2893 should remove this once we have API response guard
 interface Body {
   json<T>(): Promise<T>;
 }


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add sandbox props to the iframe. Set undefined to allow all restrictions.
Also add the related issue for API response guard, inorder to remove the JSON response type assert. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
@logto-io/eng 
