### PR TITLE
feat(core)!: use comma separated values as a string array in the env file

### DIFF
--- a/packages/core/jest.setup.ts
+++ b/packages/core/jest.setup.ts
@@ -6,10 +6,11 @@ import envSet from '@/env-set';
 
 import { privateKeyPath } from './jest.global-setup';
 
+// eslint-disable-next-line unicorn/prefer-top-level-await
 (async () => {
   process.env = {
     ...process.env,
-    OIDC_PRIVATE_KEY_PATHS: `["${privateKeyPath}"]`,
+    OIDC_PRIVATE_KEY_PATHS: privateKeyPath,
     OIDC_COOKIE_KEYS: '["LOGTOSEKRIT1"]',
   };
   await envSet.load();

--- a/packages/core/src/connectors/consts.ts
+++ b/packages/core/src/connectors/consts.ts
@@ -1,6 +1,4 @@
-import { getEnv } from '@silverhand/essentials';
-
-const defaultPackages = [
+export const defaultConnectorPackages = [
   '@logto/connector-alipay-web',
   '@logto/connector-alipay-native',
   '@logto/connector-aliyun-dm',
@@ -16,9 +14,3 @@ const defaultPackages = [
   '@logto/connector-wechat-web',
   '@logto/connector-wechat-native',
 ];
-
-const additionalConnectorPackages = getEnv('ADDITIONAL_CONNECTOR_PACKAGES', '')
-  .split(',')
-  .filter(Boolean);
-
-export const connectorPackages = [...defaultPackages, ...additionalConnectorPackages];

--- a/packages/core/src/connectors/index.ts
+++ b/packages/core/src/connectors/index.ts
@@ -4,10 +4,11 @@ import path from 'path';
 import { ConnectorInstance, SocialConnectorInstance } from '@logto/connector-types';
 import resolvePackagePath from 'resolve-package-path';
 
+import envSet from '@/env-set';
 import RequestError from '@/errors/RequestError';
 import { findAllConnectors, insertConnector } from '@/queries/connector';
 
-import { connectorPackages } from './consts';
+import { defaultConnectorPackages } from './consts';
 import { ConnectorType } from './types';
 import { getConnectorConfig } from './utilities';
 
@@ -18,6 +19,12 @@ const loadConnectors = async () => {
   if (cachedConnectors) {
     return cachedConnectors;
   }
+
+  const {
+    values: { additionalConnectorPackages },
+  } = envSet;
+
+  const connectorPackages = [...defaultConnectorPackages, ...additionalConnectorPackages];
 
   // eslint-disable-next-line @silverhand/fp/no-mutation
   cachedConnectors = await Promise.all(

--- a/packages/core/src/env-set/index.ts
+++ b/packages/core/src/env-set/index.ts
@@ -6,6 +6,7 @@ import { appendPath } from '@/utils/url';
 import createPoolByEnv from './create-pool-by-env';
 import loadOidcValues from './oidc';
 import { isTrue } from './parameters';
+import { getEnvAsStringArray } from './utils';
 
 export enum MountedApps {
   Api = 'api',
@@ -23,6 +24,7 @@ const loadEnvValues = async () => {
   const port = Number(getEnv('PORT', '3001'));
   const localhostUrl = `${isHttpsEnabled ? 'https' : 'http'}://localhost:${port}`;
   const endpoint = getEnv('ENDPOINT', localhostUrl);
+  const additionalConnectorPackages = getEnvAsStringArray('ADDITIONAL_CONNECTOR_PACKAGES', []);
 
   return Object.freeze({
     isTest,
@@ -34,6 +36,7 @@ const loadEnvValues = async () => {
     port,
     localhostUrl,
     endpoint,
+    additionalConnectorPackages,
     developmentUserId: getEnv('DEVELOPMENT_USER_ID'),
     trustProxyHeader: isTrue(getEnv('TRUST_PROXY_HEADER')),
     oidc: await loadOidcValues(appendPath(endpoint, '/oidc').toString()),

--- a/packages/core/src/env-set/oidc.test.ts
+++ b/packages/core/src/env-set/oidc.test.ts
@@ -4,7 +4,6 @@ import fs, { PathOrFileDescriptor } from 'fs';
 import inquirer from 'inquirer';
 
 import { readCookieKeys, readPrivateKeys } from './oidc';
-import { getEnvAsStringArray } from './utils';
 
 describe('oidc env-set', () => {
   const envBackup = process.env;
@@ -77,15 +76,12 @@ describe('oidc env-set', () => {
   });
 
   it('should throw if private keys configured in `OIDC_PRIVATE_KEY_PATHS` are not found', async () => {
-    process.env.OIDC_PRIVATE_KEY_PATHS = 'foo.pem, bar.pem';
+    process.env.OIDC_PRIVATE_KEY_PATHS = 'foo.pem, bar.pem, baz.pem';
     const existsSyncSpy = jest.spyOn(fs, 'existsSync').mockReturnValue(false);
-    const privateKeyPaths = getEnvAsStringArray('OIDC_PRIVATE_KEY_PATHS');
 
     await expect(readPrivateKeys()).rejects.toMatchError(
       new Error(
-        `Private keys ${privateKeyPaths.join(
-          ' and '
-        )} configured in env \`OIDC_PRIVATE_KEY_PATHS\` not found.`
+        `Private keys foo.pem, bar.pem, and baz.pem configured in env \`OIDC_PRIVATE_KEY_PATHS\` not found.`
       )
     );
 

--- a/packages/core/src/env-set/oidc.test.ts
+++ b/packages/core/src/env-set/oidc.test.ts
@@ -76,29 +76,6 @@ describe('oidc env-set', () => {
     writeFileSyncSpy.mockRestore();
   });
 
-  it('should throw if the deprecated `OIDC_PRIVATE_KEY` is provided', async () => {
-    process.env.OIDC_PRIVATE_KEY = 'foo';
-
-    await expect(readPrivateKeys()).rejects.toMatchError(
-      new Error(
-        `The env \`OIDC_PRIVATE_KEY\` is deprecated, please use \`OIDC_PRIVATE_KEYS\` instead.\nE.g.OIDC_PRIVATE_KEYS=key or OIDC_PRIVATE_KEYS=key1,key2`
-      )
-    );
-  });
-
-  it('should throw if the deprecated `OIDC_PRIVATE_KEY_PATH` is provided', async () => {
-    // Unset the `OIDC_PRIVATE_KEY_PATHS` environment variable config by jest.setup.ts.
-    process.env.OIDC_PRIVATE_KEY_PATHS = '';
-
-    process.env.OIDC_PRIVATE_KEY_PATH = 'foo.pem';
-
-    await expect(readPrivateKeys()).rejects.toMatchError(
-      new Error(
-        `The env \`OIDC_PRIVATE_KEY_PATH\` is deprecated, please use \`OIDC_PRIVATE_KEY_PATHS\` instead.\nE.g.OIDC_PRIVATE_KEY_PATHS=path or OIDC_PRIVATE_KEY_PATHS=path1,path2`
-      )
-    );
-  });
-
   it('should throw if private keys configured in `OIDC_PRIVATE_KEY_PATHS` are not found', async () => {
     process.env.OIDC_PRIVATE_KEY_PATHS = 'foo.pem, bar.pem';
     const existsSyncSpy = jest.spyOn(fs, 'existsSync').mockReturnValue(false);

--- a/packages/core/src/env-set/oidc.test.ts
+++ b/packages/core/src/env-set/oidc.test.ts
@@ -53,7 +53,7 @@ describe('oidc env-set', () => {
     process.env.OIDC_PRIVATE_KEY_PATHS = '';
 
     const readFileSyncSpy = jest.spyOn(fs, 'readFileSync').mockImplementation(() => {
-      throw new Error('Intent read file error');
+      throw new Error('Dummy read file error');
     });
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/packages/core/src/env-set/oidc.test.ts
+++ b/packages/core/src/env-set/oidc.test.ts
@@ -48,7 +48,7 @@ describe('oidc env-set', () => {
     readFileSyncSpy.mockRestore();
   });
 
-  it('should generate a default OIDC private key if `OIDC_PRIVATE_KEY_PATHS` and `OIDC_PRIVATE_KEYS` are not provided', async () => {
+  it('should generate a default OIDC private key if neither `OIDC_PRIVATE_KEY_PATHS` nor `OIDC_PRIVATE_KEYS` is provided', async () => {
     process.env.OIDC_PRIVATE_KEYS = '';
     process.env.OIDC_PRIVATE_KEY_PATHS = '';
 

--- a/packages/core/src/env-set/oidc.test.ts
+++ b/packages/core/src/env-set/oidc.test.ts
@@ -3,7 +3,8 @@ import fs, { PathOrFileDescriptor } from 'fs';
 
 import inquirer from 'inquirer';
 
-import { readPrivateKeys } from './oidc';
+import { readCookieKeys, readPrivateKeys } from './oidc';
+import { getEnvAsStringArray } from './utils';
 
 describe('oidc env-set', () => {
   const envBackup = process.env;
@@ -17,24 +18,24 @@ describe('oidc env-set', () => {
     jest.resetModules();
   });
 
-  it('should read private keys if `OIDC_PRIVATE_KEYS` is provided', async () => {
-    process.env.OIDC_PRIVATE_KEYS = '["foo","bar"]';
+  it('should read OIDC private keys if `OIDC_PRIVATE_KEYS` is provided', async () => {
+    process.env.OIDC_PRIVATE_KEYS = 'foo, bar';
 
     const privateKeys = await readPrivateKeys();
 
     expect(privateKeys).toEqual(['foo', 'bar']);
   });
 
-  it('should read private keys if `OIDC_PRIVATE_KEY` is provided - [compatibility]', async () => {
-    process.env.OIDC_PRIVATE_KEY = 'foo';
+  it('should read OIDC private keys if provided `OIDC_PRIVATE_KEYS` contain newline characters', async () => {
+    process.env.OIDC_PRIVATE_KEYS = 'foo\nbar, bob\noop';
 
     const privateKeys = await readPrivateKeys();
 
-    expect(privateKeys).toEqual(['foo']);
+    expect(privateKeys).toEqual(['foo\nbar', 'bob\noop']);
   });
 
-  it('should read private keys if `OIDC_PRIVATE_KEY_PATHS` is provided', async () => {
-    process.env.OIDC_PRIVATE_KEY_PATHS = '["foo.pem", "bar.pem"]';
+  it('should read OIDC private keys if `OIDC_PRIVATE_KEY_PATHS` is provided', async () => {
+    process.env.OIDC_PRIVATE_KEY_PATHS = 'foo.pem, bar.pem';
     const existsSyncSpy = jest.spyOn(fs, 'existsSync').mockReturnValue(true);
     const readFileSyncSpy = jest
       .spyOn(fs, 'readFileSync')
@@ -48,40 +49,7 @@ describe('oidc env-set', () => {
     readFileSyncSpy.mockRestore();
   });
 
-  it('should read private keys if `OIDC_PRIVATE_KEY_PATH` is provided - [compatibility]', async () => {
-    // Unset the `OIDC_PRIVATE_KEY_PATHS` environment variable config by jest.setup.ts.
-    process.env.OIDC_PRIVATE_KEY_PATHS = '';
-
-    process.env.OIDC_PRIVATE_KEY_PATH = 'foo.pem';
-
-    const existsSyncSpy = jest.spyOn(fs, 'existsSync').mockReturnValue(true);
-
-    const readFileSyncSpy = jest
-      .spyOn(fs, 'readFileSync')
-      .mockImplementation((path: PathOrFileDescriptor) => path.toString());
-
-    const privateKeys = await readPrivateKeys();
-
-    expect(privateKeys).toEqual(['foo.pem']);
-
-    existsSyncSpy.mockRestore();
-    readFileSyncSpy.mockRestore();
-  });
-
-  it('should throw if private keys configured in `OIDC_PRIVATE_KEY_PATHS` are not found', async () => {
-    process.env.OIDC_PRIVATE_KEY_PATHS = '["foo.pem","bar.pem"]';
-    const existsSyncSpy = jest.spyOn(fs, 'existsSync').mockReturnValue(false);
-
-    await expect(readPrivateKeys).rejects.toMatchError(
-      new Error(
-        `Private keys ${process.env.OIDC_PRIVATE_KEY_PATHS} configured in env \`OIDC_PRIVATE_KEY_PATHS\` not found.`
-      )
-    );
-
-    existsSyncSpy.mockRestore();
-  });
-
-  it('should generate a default private key if `OIDC_PRIVATE_KEY_PATHS` and `OIDC_PRIVATE_KEYS` are not provided', async () => {
+  it('should generate a default OIDC private key if `OIDC_PRIVATE_KEY_PATHS` and `OIDC_PRIVATE_KEYS` are not provided', async () => {
     process.env.OIDC_PRIVATE_KEYS = '';
     process.env.OIDC_PRIVATE_KEY_PATHS = '';
 
@@ -106,5 +74,69 @@ describe('oidc env-set', () => {
     promptMock.mockRestore();
     generateKeyPairSyncSpy.mockRestore();
     writeFileSyncSpy.mockRestore();
+  });
+
+  it('should throw if the deprecated `OIDC_PRIVATE_KEY` is provided', async () => {
+    process.env.OIDC_PRIVATE_KEY = 'foo';
+
+    await expect(readPrivateKeys()).rejects.toMatchError(
+      new Error(
+        `The env \`OIDC_PRIVATE_KEY\` is deprecated, please use \`OIDC_PRIVATE_KEYS\` instead.\nE.g.OIDC_PRIVATE_KEYS=key or OIDC_PRIVATE_KEYS=key1,key2`
+      )
+    );
+  });
+
+  it('should throw if the deprecated `OIDC_PRIVATE_KEY_PATH` is provided', async () => {
+    // Unset the `OIDC_PRIVATE_KEY_PATHS` environment variable config by jest.setup.ts.
+    process.env.OIDC_PRIVATE_KEY_PATHS = '';
+
+    process.env.OIDC_PRIVATE_KEY_PATH = 'foo.pem';
+
+    await expect(readPrivateKeys()).rejects.toMatchError(
+      new Error(
+        `The env \`OIDC_PRIVATE_KEY_PATH\` is deprecated, please use \`OIDC_PRIVATE_KEY_PATHS\` instead.\nE.g.OIDC_PRIVATE_KEY_PATHS=path or OIDC_PRIVATE_KEY_PATHS=path1,path2`
+      )
+    );
+  });
+
+  it('should throw if private keys configured in `OIDC_PRIVATE_KEY_PATHS` are not found', async () => {
+    process.env.OIDC_PRIVATE_KEY_PATHS = 'foo.pem, bar.pem';
+    const existsSyncSpy = jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+    const privateKeyPaths = getEnvAsStringArray('OIDC_PRIVATE_KEY_PATHS');
+
+    await expect(readPrivateKeys()).rejects.toMatchError(
+      new Error(
+        `Private keys ${privateKeyPaths.join(
+          ' and '
+        )} configured in env \`OIDC_PRIVATE_KEY_PATHS\` not found.`
+      )
+    );
+
+    existsSyncSpy.mockRestore();
+  });
+
+  it('should read OIDC cookie keys if `OIDC_COOKIE_KEYS` is provided', async () => {
+    process.env.OIDC_COOKIE_KEYS = 'foo, bar';
+
+    const cookieKeys = await readCookieKeys();
+
+    expect(cookieKeys).toEqual(['foo', 'bar']);
+  });
+
+  it('should generate a default OIDC cookie key if `OIDC_COOKIE_KEYS` is not provided', async () => {
+    process.env.OIDC_COOKIE_KEYS = '';
+
+    const promptMock = jest.spyOn(inquirer, 'prompt').mockResolvedValue({ confirm: true });
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    const appendFileSyncSpy = jest.spyOn(fs, 'appendFileSync').mockImplementation(() => {});
+
+    const cookieKeys = await readCookieKeys();
+
+    expect(cookieKeys.length).toBe(1);
+    expect(appendFileSyncSpy).toHaveBeenCalled();
+
+    promptMock.mockRestore();
+    appendFileSyncSpy.mockRestore();
   });
 });

--- a/packages/core/src/env-set/oidc.ts
+++ b/packages/core/src/env-set/oidc.ts
@@ -89,7 +89,7 @@ export const readPrivateKeys = async (): Promise<string[]> => {
   } catch {
     throw new Error(
       `Failed to read private keys ${listFormatter.format(
-        ' and '
+        privateKeyPaths
       )} from env \`OIDC_PRIVATE_KEY_PATHS\`.`
     );
   }

--- a/packages/core/src/env-set/oidc.ts
+++ b/packages/core/src/env-set/oidc.ts
@@ -10,7 +10,7 @@ import { exportJWK } from '@/utils/jwks';
 
 import { appendDotEnv } from './dot-env';
 import { allYes, noInquiry } from './parameters';
-import { checkDeprecatedEnv, getEnvAsStringArray } from './utils';
+import { getEnvAsStringArray } from './utils';
 
 const defaultLogtoOidcPrivateKey = './oidc-private-key.pem';
 
@@ -26,18 +26,6 @@ const defaultLogtoOidcPrivateKey = './oidc-private-key.pem';
  * @throws An error when failed to read a private key.
  */
 export const readPrivateKeys = async (): Promise<string[]> => {
-  checkDeprecatedEnv(
-    'OIDC_PRIVATE_KEY',
-    'OIDC_PRIVATE_KEYS',
-    'OIDC_PRIVATE_KEYS=key or OIDC_PRIVATE_KEYS=key1,key2'
-  );
-
-  checkDeprecatedEnv(
-    'OIDC_PRIVATE_KEY_PATH',
-    'OIDC_PRIVATE_KEY_PATHS',
-    'OIDC_PRIVATE_KEY_PATHS=path or OIDC_PRIVATE_KEY_PATHS=path1,path2'
-  );
-
   const privateKeys = getEnvAsStringArray('OIDC_PRIVATE_KEYS');
 
   if (privateKeys.length > 0) {

--- a/packages/core/src/env-set/oidc.ts
+++ b/packages/core/src/env-set/oidc.ts
@@ -109,7 +109,7 @@ export const readCookieKeys = async (): Promise<string[]> => {
   }
 
   const cookieKeysMissingError = new Error(
-    `The OIDC cookie keys are not found, Please check the value of env \`${envKey}\`.`
+    `The OIDC cookie keys are not found. Please check the value of env \`${envKey}\`.`
   );
 
   if (noInquiry) {

--- a/packages/core/src/env-set/oidc.ts
+++ b/packages/core/src/env-set/oidc.ts
@@ -14,6 +14,8 @@ import { getEnvAsStringArray } from './utils';
 
 const defaultLogtoOidcPrivateKey = './oidc-private-key.pem';
 
+const listFormatter = new Intl.ListFormat('en', { style: 'long', type: 'conjunction' });
+
 /**
  * Try to read private keys with the following order:
  *
@@ -76,8 +78,8 @@ export const readPrivateKeys = async (): Promise<string[]> => {
 
   if (notExistPrivateKeys.length > 0) {
     throw new Error(
-      `Private keys ${notExistPrivateKeys.join(
-        ' and '
+      `Private keys ${listFormatter.format(
+        notExistPrivateKeys
       )} configured in env \`OIDC_PRIVATE_KEY_PATHS\` not found.`
     );
   }
@@ -86,7 +88,7 @@ export const readPrivateKeys = async (): Promise<string[]> => {
     return privateKeyPaths.map((path): string => readFileSync(path, 'utf8'));
   } catch {
     throw new Error(
-      `Failed to read private keys ${privateKeyPaths.join(
+      `Failed to read private keys ${listFormatter.format(
         ' and '
       )} from env \`OIDC_PRIVATE_KEY_PATHS\`.`
     );

--- a/packages/core/src/env-set/utils.ts
+++ b/packages/core/src/env-set/utils.ts
@@ -1,16 +1,5 @@
 import { getEnv } from '@silverhand/essentials';
 
-class EnvParseError extends Error {
-  constructor(envKey: string, errorMessage: string) {
-    super(`Failed to parse env \`${envKey}\`: ${errorMessage}`);
-  }
-}
-
-class InvalidStringArrayValueError extends Error {
-  message = 'the value should be an array of strings.';
-}
-
-// TODO: LOG-3870 - Add `getEnvAsStringArray` to `@silverhand/essentials`
 export const getEnvAsStringArray = (envKey: string, fallback: string[] = []): string[] => {
   const rawValue = getEnv(envKey);
 
@@ -18,33 +7,16 @@ export const getEnvAsStringArray = (envKey: string, fallback: string[] = []): st
     return fallback;
   }
 
-  try {
-    return convertEnvToStringArray(rawValue);
-  } catch (error: unknown) {
-    if (error instanceof InvalidStringArrayValueError) {
-      throw new EnvParseError(envKey, error.message);
-    }
-    throw error;
-  }
+  return rawValue
+    .split(',')
+    .filter(Boolean)
+    .map((value) => value.trim());
 };
 
-const convertEnvToStringArray = (value: string): string[] => {
-  // eslint-disable-next-line @silverhand/fp/no-let
-  let values: unknown;
-
-  try {
-    // eslint-disable-next-line @silverhand/fp/no-mutation
-    values = JSON.parse(value);
-  } catch {
-    throw new InvalidStringArrayValueError();
+export const checkDeprecatedEnv = (deprecatedEnv: string, newEnv: string, example: string) => {
+  if (getEnv(deprecatedEnv)) {
+    throw new Error(
+      `The env \`${deprecatedEnv}\` is deprecated, please use \`${newEnv}\` instead.\nE.g.${example}`
+    );
   }
-
-  if (
-    !Array.isArray(values) ||
-    !values.every((value): value is string => typeof value === 'string')
-  ) {
-    throw new InvalidStringArrayValueError();
-  }
-
-  return values;
 };

--- a/packages/core/src/env-set/utils.ts
+++ b/packages/core/src/env-set/utils.ts
@@ -12,11 +12,3 @@ export const getEnvAsStringArray = (envKey: string, fallback: string[] = []): st
     .map((value) => value.trim())
     .filter(Boolean);
 };
-
-export const checkDeprecatedEnv = (deprecatedEnv: string, newEnv: string, example: string) => {
-  if (getEnv(deprecatedEnv)) {
-    throw new Error(
-      `The env \`${deprecatedEnv}\` is deprecated, please use \`${newEnv}\` instead.\nE.g.${example}`
-    );
-  }
-};

--- a/packages/core/src/env-set/utils.ts
+++ b/packages/core/src/env-set/utils.ts
@@ -9,8 +9,8 @@ export const getEnvAsStringArray = (envKey: string, fallback: string[] = []): st
 
   return rawValue
     .split(',')
-    .filter(Boolean)
-    .map((value) => value.trim());
+    .map((value) => value.trim())
+    .filter(Boolean);
 };
 
 export const checkDeprecatedEnv = (deprecatedEnv: string, newEnv: string, example: string) => {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- use comma separated values as a string array in the env file
- use `getEnvAsStringArray` to read `additionalConnectorPackages` from env
- add `additionalConnectorPackages` to the `env-set` and read `additionalConnectorPackages` after the `env-set` is loaded.
- update oidc private keys config and treat old envs (`OIDC_PRIVATE_KEY` and `OIDC_PRIVATE_KEY_PATHS`) as deprecated.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test Locally & UT passed.
