### PR TITLE
chore: fix and dedup workflow runs

### DIFF
--- a/.github/workflows/update-pr-metadata.yml
+++ b/.github/workflows/update-pr-metadata.yml
@@ -1,8 +1,6 @@
 name: Update Metadata
 
 on:
-  pull_request:
-    types: [opened, edited, synchronize, reopened]
   # CAREFUL! https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
@@ -14,10 +12,6 @@ concurrency:
 jobs:
   update-metadata:
     runs-on: ubuntu-latest
-    # dedup workflow runs
-    if: |
-      github.event.pull_request.head.repo.full_name != github.repository || 
-      github.event_name == 'pull_request_target'
 
     steps:
       - name: Add labels
@@ -38,10 +32,6 @@ jobs:
 
   pr-size-diff:
     runs-on: ubuntu-latest
-    # dedup workflow runs
-    if: |
-      github.event.pull_request.head.repo.full_name != github.repository || 
-      github.event_name == 'pull_request_target'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/update-pr-metadata.yml
+++ b/.github/workflows/update-pr-metadata.yml
@@ -14,6 +14,10 @@ concurrency:
 jobs:
   update-metadata:
     runs-on: ubuntu-latest
+    # dedup workflow runs
+    if: |
+      github.event.pull_request.head.repo.full_name != github.repository || 
+      github.event_name == 'pull_request_target'
 
     steps:
       - name: Add labels
@@ -34,10 +38,16 @@ jobs:
 
   pr-size-diff:
     runs-on: ubuntu-latest
+    # dedup workflow runs
+    if: |
+      github.event.pull_request.head.repo.full_name != github.repository || 
+      github.event_name == 'pull_request_target'
 
     steps:
       - uses: actions/checkout@v3
         with:
+          # https://github.com/actions/checkout/issues/518#issuecomment-890401887
+          ref: refs/pull/${{ github.event.number }}/merge
           fetch-depth: 0
           persist-credentials: false
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- use pull request ref to fix pr size diff (shows 0 in [this run](https://github.com/logto-io/logto/actions/runs/2847803408))
  - https://github.com/actions/checkout/issues/518
- only `pull_request_target` is needed for workflow run, dkw it didn't trigger in the last PR

update: i think the `pull_request_target` event has a special trigger, as the update in this PR doesn't work as well. wait for another PR workflow run to confirm this.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

pending CI