### PR TITLE
feat(core): hasura authn

### DIFF
--- a/packages/core/src/middleware/koa-auth.test.ts
+++ b/packages/core/src/middleware/koa-auth.test.ts
@@ -185,6 +185,8 @@ describe('koaAuth middleware', () => {
       },
     };
 
-    await expect(koaAuth()(ctx, next)).rejects.toMatchError(unauthorizedError);
+    await expect(koaAuth()(ctx, next)).rejects.toMatchError(
+      new RequestError({ code: 'auth.unauthorized', status: 401 }, new Error('unknown error'))
+    );
   });
 });

--- a/packages/core/src/routes/authn.ts
+++ b/packages/core/src/routes/authn.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+
+import RequestError from '@/errors/RequestError';
+import koaAuth, { verifyBearerTokenFromRequest } from '@/middleware/koa-auth';
+import koaGuard from '@/middleware/koa-guard';
+import assertThat from '@/utils/assert-that';
+
+import { AnonymousRouter } from './types';
+
+/**
+ * Authn stands for authentication.
+ * This router will have a route `/authn` to authenticate tokens with a general manner.
+ * For now, we only implement the API for Hasura authentication.
+ */
+export default function authnRoutes<T extends AnonymousRouter>(router: T) {
+  router.get(
+    '/authn/hasura',
+    koaGuard({
+      query: z.object({ resource: z.string().min(1) }),
+      status: [200, 401],
+    }),
+    async (ctx, next) => {
+      const expectedRole = ctx.headers['expected-role']?.toString();
+      const { sub, roleNames } = await verifyBearerTokenFromRequest(
+        ctx.request,
+        ctx.guard.query.resource
+      );
+
+      if (expectedRole) {
+        assertThat(
+          roleNames?.includes(expectedRole),
+          new RequestError({ code: 'auth.expected_role_not_found', status: 401 })
+        );
+      }
+
+      ctx.body = {
+        'X-Hasura-User-Id': sub,
+        'X-Hasura-Role': expectedRole,
+      };
+      ctx.status = 200;
+
+      return next();
+    }
+  );
+}

--- a/packages/core/src/routes/init.ts
+++ b/packages/core/src/routes/init.ts
@@ -8,6 +8,7 @@ import koaAuth from '@/middleware/koa-auth';
 import koaLogSession from '@/middleware/koa-log-session';
 import adminUserRoutes from '@/routes/admin-user';
 import applicationRoutes from '@/routes/application';
+import authnRoutes from '@/routes/authn';
 import connectorRoutes from '@/routes/connector';
 import dashboardRoutes from '@/routes/dashboard';
 import logRoutes from '@/routes/log';
@@ -46,6 +47,7 @@ const createRouters = (provider: Provider) => {
   const anonymousRouter: AnonymousRouter = new Router();
   wellKnownRoutes(anonymousRouter, provider);
   statusRoutes(anonymousRouter);
+  authnRoutes(anonymousRouter);
   // The swagger.json should contain all API routers.
   swaggerRoutes(anonymousRouter, [sessionRouter, managementRouter, anonymousRouter]);
 

--- a/packages/phrases/src/locales/en/errors.ts
+++ b/packages/phrases/src/locales/en/errors.ts
@@ -4,6 +4,8 @@ const errors = {
     authorization_token_type_not_supported: 'Authorization type is not supported.',
     unauthorized: 'Unauthorized. Please check credentials and its scope.',
     forbidden: 'Forbidden. Please check your user roles and permissions.',
+    expected_role_not_found:
+      'Expected role not found. Please check your user roles and permissions.',
     jwt_sub_missing: 'Missing `sub` in JWT.',
   },
   guard: {

--- a/packages/phrases/src/locales/fr/errors.ts
+++ b/packages/phrases/src/locales/fr/errors.ts
@@ -5,6 +5,8 @@ const errors = {
     unauthorized:
       "Non autorisé. Veuillez vérifier les informations d'identification et son champ d'application.",
     forbidden: "Interdit. Veuillez vérifier vos rôles et autorisations d'utilisateur.",
+    expected_role_not_found:
+      'Expected role not found. Please check your user roles and permissions.',
     jwt_sub_missing: '`sub` manquant dans JWT.',
   },
   guard: {

--- a/packages/phrases/src/locales/ko-kr/errors.ts
+++ b/packages/phrases/src/locales/ko-kr/errors.ts
@@ -4,6 +4,8 @@ const errors = {
     authorization_token_type_not_supported: '해당 인증 방법을 지원하지 않아요.',
     unauthorized: '인증되지 않았어요. 로그인 정보와 범위를 확인해주세요.',
     forbidden: '접근이 금지되었어요. 로그인 권한와 직책을 확인해주세요.',
+    expected_role_not_found:
+      'Expected role not found. Please check your user roles and permissions.',
     jwt_sub_missing: 'JWT에서 `sub`를 찾을 수 없어요.',
   },
   guard: {

--- a/packages/phrases/src/locales/tr-tr/errors.ts
+++ b/packages/phrases/src/locales/tr-tr/errors.ts
@@ -4,6 +4,8 @@ const errors = {
     authorization_token_type_not_supported: 'Yetkilendirme tipi desteklenmiyor.',
     unauthorized: 'Yetki yok. Lütfen kimlik bilgilerini ve kapsamını kontrol edin.',
     forbidden: 'Yasak. Lütfen kullanıcı rollerinizi ve izinlerinizi kontrol edin.',
+    expected_role_not_found:
+      'Expected role not found. Please check your user roles and permissions.',
     jwt_sub_missing: 'JWTde `sub` eksik.',
   },
   guard: {

--- a/packages/phrases/src/locales/zh-cn/errors.ts
+++ b/packages/phrases/src/locales/zh-cn/errors.ts
@@ -3,7 +3,8 @@ const errors = {
     authorization_header_missing: '缺少权限标题',
     authorization_token_type_not_supported: '权限类型不支持',
     unauthorized: '未经授权。请检查凭据及其范围。',
-    forbidden: '禁止访问。请检查用户权限。',
+    forbidden: '禁止访问。请检查用户 role 与权限。',
+    expected_role_not_found: '未找到期望的 role。请检查用户 role 与权限。',
     jwt_sub_missing: 'JWT 缺失 `sub`',
   },
   guard: {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- add `/authn/hasura` route for [hasura authn webhook](https://hasura.io/docs/latest/auth/authentication/webhook)
  - `/authn/hasura?resource=` where `resource` stands for the resource indicator for hasura API
  - pass `authorization` header with bearer token as usual
  - pass `expected-role` with the role that to expect the user have
- `/authn` will be used as a general authn transformation API in the future

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

### Success template

<details>
<br />

Hasura env

```
HASURA_GRAPHQL_AUTH_HOOK: http://host.docker.internal:3001/api/authn/hasura?resource=https://api.logto.io
```

Hasura Request

<img width="1152" alt="image" src="https://user-images.githubusercontent.com/14722250/185157493-0c869444-2bd3-465a-9705-b72da5568fb4.png">

With JWT

<img width="448" alt="image" src="https://user-images.githubusercontent.com/14722250/185156433-9a9ebd86-67c4-4679-8f36-382860a135b1.png">

</details>

Response

<img width="489" alt="image" src="https://user-images.githubusercontent.com/14722250/185157310-d31242c2-5ecc-45a0-b988-d61697b1a374.png">

and Hasura works ✅

### Exceptions

- [x] wrong jwt signature
<img width="491" alt="image" src="https://user-images.githubusercontent.com/14722250/185160134-d9b5480d-b06c-4898-8b26-2201b65b4729.png">

- [x] wrong jwt 
<img width="373" alt="image" src="https://user-images.githubusercontent.com/14722250/185160055-2fa0ecb5-e1bb-43f9-a3c8-4b090ca50905.png">

- [x] no `expected-role` header

**In Hasura**
<img width="496" alt="image" src="https://user-images.githubusercontent.com/14722250/185160309-ed07500e-5a71-4a6f-92e1-e4e0d5087f31.png">

- [x] `expected-role` header mismatches user's `roleNames` (role not found)
<img width="297" alt="image" src="https://user-images.githubusercontent.com/14722250/185161777-a7f5ce5e-0a39-4c15-a68f-d14af132d616.png">

- [x] missing authorization header
<img width="334" alt="image" src="https://user-images.githubusercontent.com/14722250/185161997-3193e7f1-5cba-48da-8c13-9a886f3ee25a.png">


- [x] resource in jwt mismatch hasura env
<img width="449" alt="image" src="https://user-images.githubusercontent.com/14722250/185161610-32df252f-f342-4ee8-b9e5-1e25dc20a18d.png">
