### PR TITLE
fix(console): show platform icons in connector table

### DIFF
--- a/packages/console/src/pages/Connectors/components/ConnectorName/index.tsx
+++ b/packages/console/src/pages/Connectors/components/ConnectorName/index.tsx
@@ -56,7 +56,7 @@ const ConnectorName = ({ type, connectors, onClickSetup }: Props) => {
         subtitle={
           <>
             {type !== ConnectorType.Social && connector.id}
-            {type === ConnectorType.Social && enabledConnectors.length > 1 && (
+            {type === ConnectorType.Social && connectors.length > 1 && (
               <div className={styles.platforms}>
                 {enabledConnectors.map(
                   ({ id, platform }) =>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Show platform icons in connector table for multi-platform connectors, no matter how many platforms are enabled.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested.

<img width="518" alt="截屏2022-08-18 下午10 08 10" src="https://user-images.githubusercontent.com/5717882/185416004-96189a3e-c60d-4afd-a355-0b88d62aedcb.png">

