### PR TITLE
feat(core): set user default roles from env

### DIFF
--- a/packages/core/src/env-set/index.ts
+++ b/packages/core/src/env-set/index.ts
@@ -23,7 +23,6 @@ const loadEnvValues = async () => {
   const port = Number(getEnv('PORT', '3001'));
   const localhostUrl = `${isHttpsEnabled ? 'https' : 'http'}://localhost:${port}`;
   const endpoint = getEnv('ENDPOINT', localhostUrl);
-  const additionalConnectorPackages = getEnvAsStringArray('ADDITIONAL_CONNECTOR_PACKAGES', []);
 
   return Object.freeze({
     isTest,
@@ -35,7 +34,8 @@ const loadEnvValues = async () => {
     port,
     localhostUrl,
     endpoint,
-    additionalConnectorPackages,
+    additionalConnectorPackages: getEnvAsStringArray('ADDITIONAL_CONNECTOR_PACKAGES'),
+    userDefaultRoleNames: getEnvAsStringArray('USER_DEFAULT_ROLE_NAMES'),
     developmentUserId: getEnv('DEVELOPMENT_USER_ID'),
     trustProxyHeader: isTrue(getEnv('TRUST_PROXY_HEADER')),
     oidc: await loadOidcValues(appendPath(endpoint, '/oidc').toString()),

--- a/packages/core/src/lib/user.ts
+++ b/packages/core/src/lib/user.ts
@@ -1,11 +1,4 @@
-import {
-  User,
-  UsersPasswordEncryptionMethod,
-  CreateUser,
-  User,
-  Users,
-  UsersPasswordEncryptionMethod,
-} from '@logto/schemas';
+import { User, CreateUser, Users, UsersPasswordEncryptionMethod } from '@logto/schemas';
 import { argon2Verify } from 'hash-wasm';
 import pRetry from 'p-retry';
 
@@ -73,6 +66,8 @@ const insertUserQuery = buildInsertInto<CreateUser, User>(Users, {
   returning: true,
 });
 
+// Temp solution since Hasura requires a role to proceed authn.
+// The source of default roles should be guarded and moved to database once we implement RBAC.
 export const insertUser: typeof insertUserQuery = async ({ roleNames, ...rest }) => {
   const computedRoleNames = [
     ...new Set((roleNames ?? []).concat(envSet.values.userDefaultRoleNames)),

--- a/packages/core/src/queries/roles.ts
+++ b/packages/core/src/queries/roles.ts
@@ -18,3 +18,12 @@ export const findRolesByRoleNames = async (roleNames: string[]) =>
     from ${table}
     where ${fields.name} in (${sql.join(roleNames, sql`, `)})
   `);
+
+export const insertRoles = async (roles: Role[]) =>
+  envSet.pool.query(sql`
+    insert into ${table} (${fields.name}, ${fields.description}) values
+    ${sql.join(
+      roles.map(({ name, description }) => sql`(${name}, ${description})`),
+      sql`, `
+    )}
+  `);

--- a/packages/core/src/queries/user.test.ts
+++ b/packages/core/src/queries/user.test.ts
@@ -18,7 +18,6 @@ import {
   hasUserWithEmail,
   hasUserWithIdentity,
   hasUserWithPhone,
-  insertUser,
   countUsers,
   findUsers,
   updateUserById,
@@ -233,33 +232,6 @@ describe('user query', () => {
     });
 
     await expect(hasUserWithIdentity(target, mockUser.id)).resolves.toEqual(true);
-  });
-
-  it('insertUser', async () => {
-    const expectSql = sql`
-      insert into ${table} (${sql.join(Object.values(fields), sql`, `)})
-      values (${sql.join(
-        Object.values(fields)
-          .slice(0, -1)
-          .map((_, index) => `$${index + 1}`),
-        sql`, `
-      )}, to_timestamp(${Object.values(fields).length}::double precision / 1000))
-      returning *
-    `;
-
-    mockQuery.mockImplementationOnce(async (sql, values) => {
-      expectSqlAssert(sql, expectSql.sql);
-
-      expect(values).toEqual(
-        Users.fieldKeys.map((k) =>
-          k === 'lastSignInAt' ? mockUser[k] : convertToPrimitiveOrSql(k, mockUser[k])
-        )
-      );
-
-      return createMockQueryResult([dbvalue]);
-    });
-
-    await expect(insertUser(mockUser)).resolves.toEqual(dbvalue);
   });
 
   it('countUsers', async () => {

--- a/packages/core/src/queries/user.ts
+++ b/packages/core/src/queries/user.ts
@@ -83,10 +83,6 @@ export const hasUserWithIdentity = async (target: string, userId: string) =>
     `
   );
 
-export const insertUser = buildInsertInto<CreateUser, User>(Users, {
-  returning: true,
-});
-
 const buildUserSearchConditionSql = (search: string) => {
   const searchFields = [fields.primaryEmail, fields.primaryPhone, fields.username, fields.name];
   const conditions = searchFields.map((filedName) => sql`${filedName} like ${'%' + search + '%'}`);

--- a/packages/core/src/routes/admin-user.test.ts
+++ b/packages/core/src/routes/admin-user.test.ts
@@ -39,12 +39,6 @@ jest.mock('@/queries/user', () => ({
     })
   ),
   deleteUserById: jest.fn(),
-  insertUser: jest.fn(
-    async (user: CreateUser): Promise<User> => ({
-      ...mockUser,
-      ...user,
-    })
-  ),
   deleteUserIdentity: jest.fn(),
 }));
 
@@ -54,6 +48,12 @@ jest.mock('@/lib/user', () => ({
     passwordEncrypted: 'password',
     passwordEncryptionMethod: 'Argon2i',
   })),
+  insertUser: jest.fn(
+    async (user: CreateUser): Promise<User> => ({
+      ...mockUser,
+      ...user,
+    })
+  ),
 }));
 
 jest.mock('@/queries/roles', () => ({

--- a/packages/core/src/routes/admin-user.ts
+++ b/packages/core/src/routes/admin-user.ts
@@ -5,7 +5,7 @@ import pick from 'lodash.pick';
 import { literal, object, string } from 'zod';
 
 import RequestError from '@/errors/RequestError';
-import { encryptUserPassword, generateUserId } from '@/lib/user';
+import { encryptUserPassword, generateUserId, insertUser } from '@/lib/user';
 import koaGuard from '@/middleware/koa-guard';
 import koaPagination from '@/middleware/koa-pagination';
 import { findRolesByRoleNames } from '@/queries/roles';
@@ -16,7 +16,6 @@ import {
   countUsers,
   findUserById,
   hasUser,
-  insertUser,
   updateUserById,
 } from '@/queries/user';
 import assertThat from '@/utils/assert-that';

--- a/packages/core/src/routes/session/passwordless.test.ts
+++ b/packages/core/src/routes/session/passwordless.test.ts
@@ -7,23 +7,26 @@ import { createRequester } from '@/utils/test-utils';
 
 import sessionPasswordlessRoutes from './passwordless';
 
-jest.mock('@/lib/user', () => ({
-  generateUserId: () => 'user1',
-  updateLastSignInAt: async (...args: unknown[]) => updateUserById(...args),
-}));
 const insertUser = jest.fn(async (..._args: unknown[]) => ({ id: 'id' }));
 const findUserById = jest.fn(async (): Promise<User> => mockUser);
 const updateUserById = jest.fn(async (..._args: unknown[]) => ({ id: 'id' }));
+
+jest.mock('@/lib/user', () => ({
+  generateUserId: () => 'user1',
+  updateLastSignInAt: async (...args: unknown[]) => updateUserById(...args),
+  insertUser: async (...args: unknown[]) => insertUser(...args),
+}));
+
 jest.mock('@/queries/user', () => ({
   findUserById: async () => findUserById(),
   findUserByPhone: async () => ({ id: 'id' }),
   findUserByEmail: async () => ({ id: 'id' }),
-  insertUser: async (...args: unknown[]) => insertUser(...args),
   updateUserById: async (...args: unknown[]) => updateUserById(...args),
   hasUser: async (username: string) => username === 'username1',
   hasUserWithPhone: async (phone: string) => phone === '13000000000',
   hasUserWithEmail: async (email: string) => email === 'a@a.com',
 }));
+
 const sendPasscode = jest.fn(async () => ({ connector: { id: 'connectorIdValue' } }));
 jest.mock('@/lib/passcode', () => ({
   createPasscode: async () => ({ id: 'id' }),

--- a/packages/core/src/routes/session/passwordless.ts
+++ b/packages/core/src/routes/session/passwordless.ts
@@ -6,12 +6,11 @@ import { object, string } from 'zod';
 import RequestError from '@/errors/RequestError';
 import { createPasscode, sendPasscode, verifyPasscode } from '@/lib/passcode';
 import { assignInteractionResults } from '@/lib/session';
-import { generateUserId, updateLastSignInAt } from '@/lib/user';
+import { generateUserId, insertUser, updateLastSignInAt } from '@/lib/user';
 import koaGuard from '@/middleware/koa-guard';
 import {
   hasUserWithEmail,
   hasUserWithPhone,
-  insertUser,
   findUserByEmail,
   findUserByPhone,
 } from '@/queries/user';

--- a/packages/core/src/routes/session/session.test.ts
+++ b/packages/core/src/routes/session/session.test.ts
@@ -8,6 +8,25 @@ import { createRequester } from '@/utils/test-utils';
 
 import sessionRoutes from './session';
 
+const insertUser = jest.fn(async (..._args: unknown[]) => ({ id: 'id' }));
+const findUserById = jest.fn(async (): Promise<User> => mockUser);
+const updateUserById = jest.fn(async (..._args: unknown[]) => ({ id: 'id' }));
+const hasActiveUsers = jest.fn(async () => true);
+
+jest.mock('@/queries/user', () => ({
+  findUserById: async () => findUserById(),
+  findUserByIdentity: async () => ({ id: 'id', identities: {} }),
+  findUserByPhone: async () => ({ id: 'id' }),
+  findUserByEmail: async () => ({ id: 'id' }),
+  updateUserById: async (...args: unknown[]) => updateUserById(...args),
+  hasUser: async (username: string) => username === 'username1',
+  hasUserWithIdentity: async (connectorId: string, userId: string) =>
+    connectorId === 'connectorId' && userId === 'id',
+  hasUserWithPhone: async (phone: string) => phone === '13000000000',
+  hasUserWithEmail: async (email: string) => email === 'a@a.com',
+  hasActiveUsers: async () => hasActiveUsers(),
+}));
+
 jest.mock('@/lib/user', () => ({
   async findUserByUsernameAndPassword(username: string, password: string) {
     if (username !== 'username' && username !== 'admin') {
@@ -28,25 +47,7 @@ jest.mock('@/lib/user', () => ({
     passwordEncryptionMethod: 'Argon2i',
   }),
   updateLastSignInAt: async (...args: unknown[]) => updateUserById(...args),
-}));
-const insertUser = jest.fn(async (..._args: unknown[]) => ({ id: 'id' }));
-const findUserById = jest.fn(async (): Promise<User> => mockUser);
-const updateUserById = jest.fn(async (..._args: unknown[]) => ({ id: 'id' }));
-const hasActiveUsers = jest.fn(async () => true);
-
-jest.mock('@/queries/user', () => ({
-  findUserById: async () => findUserById(),
-  findUserByIdentity: async () => ({ id: 'id', identities: {} }),
-  findUserByPhone: async () => ({ id: 'id' }),
-  findUserByEmail: async () => ({ id: 'id' }),
   insertUser: async (...args: unknown[]) => insertUser(...args),
-  updateUserById: async (...args: unknown[]) => updateUserById(...args),
-  hasUser: async (username: string) => username === 'username1',
-  hasUserWithIdentity: async (connectorId: string, userId: string) =>
-    connectorId === 'connectorId' && userId === 'id',
-  hasUserWithPhone: async (phone: string) => phone === '13000000000',
-  hasUserWithEmail: async (email: string) => email === 'a@a.com',
-  hasActiveUsers: async () => hasActiveUsers(),
 }));
 
 const grantSave = jest.fn(async () => 'finalGrantId');

--- a/packages/core/src/routes/session/session.ts
+++ b/packages/core/src/routes/session/session.ts
@@ -15,9 +15,10 @@ import {
   generateUserId,
   findUserByUsernameAndPassword,
   updateLastSignInAt,
+  insertUser,
 } from '@/lib/user';
 import koaGuard from '@/middleware/koa-guard';
-import { hasUser, insertUser, hasActiveUsers } from '@/queries/user';
+import { hasUser, hasActiveUsers } from '@/queries/user';
 import assertThat from '@/utils/assert-that';
 
 import { AnonymousRouter } from '../types';

--- a/packages/core/src/routes/session/social.test.ts
+++ b/packages/core/src/routes/session/social.test.ts
@@ -9,10 +9,6 @@ import { createRequester } from '@/utils/test-utils';
 
 import sessionSocialRoutes from './social';
 
-jest.mock('@/lib/user', () => ({
-  generateUserId: () => 'user1',
-  updateLastSignInAt: async (...args: unknown[]) => updateUserById(...args),
-}));
 jest.mock('@/lib/social', () => ({
   ...jest.requireActual('@/lib/social'),
   async findSocialRelatedUser() {
@@ -39,14 +35,21 @@ jest.mock('@/lib/social', () => ({
 const insertUser = jest.fn(async (..._args: unknown[]) => ({ id: 'id' }));
 const findUserById = jest.fn(async (): Promise<User> => mockUser);
 const updateUserById = jest.fn(async (..._args: unknown[]) => ({ id: 'id' }));
+
 jest.mock('@/queries/user', () => ({
   findUserById: async () => findUserById(),
   findUserByIdentity: async () => ({ id: 'id', identities: {} }),
-  insertUser: async (...args: unknown[]) => insertUser(...args),
   updateUserById: async (...args: unknown[]) => updateUserById(...args),
   hasUserWithIdentity: async (target: string, userId: string) =>
     target === 'connectorTarget' && userId === 'id',
 }));
+
+jest.mock('@/lib/user', () => ({
+  generateUserId: () => 'user1',
+  updateLastSignInAt: async (...args: unknown[]) => updateUserById(...args),
+  insertUser: async (...args: unknown[]) => insertUser(...args),
+}));
+
 const getConnectorInstanceByIdHelper = jest.fn(async (connectorId: string) => {
   const connector = {
     enabled: connectorId === 'social_enabled',

--- a/packages/core/src/routes/session/social.ts
+++ b/packages/core/src/routes/session/social.ts
@@ -12,11 +12,10 @@ import {
   getUserInfoByAuthCode,
   getUserInfoFromInteractionResult,
 } from '@/lib/social';
-import { generateUserId, updateLastSignInAt } from '@/lib/user';
+import { generateUserId, insertUser, updateLastSignInAt } from '@/lib/user';
 import koaGuard from '@/middleware/koa-guard';
 import {
   hasUserWithIdentity,
-  insertUser,
   findUserById,
   updateUserById,
   findUserByIdentity,


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- set env `USER_DEFAULT_ROLE_NAMES` to add default roles when inserting a new user
- remove original `insertUser` query, replace with `insertUser` lib function

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

- [x] no `USER_DEFAULT_ROLE_NAMES`, no role name for new users
- [x] `USER_DEFAULT_ROLE_NAMES=user,good_user`, user has role names `["user", "good_user"]` with new roles created
<img width="411" alt="image" src="https://user-images.githubusercontent.com/14722250/185432274-5932fbcb-1393-47e1-b92a-8f2038ae357f.png">
