### PR TITLE
refactor: watch all packages when dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "bootstrap": "lerna bootstrap",
     "prepare": "if test \"$NODE_ENV\" != \"production\" && test \"$CI\" != \"true\" ; then husky install ; fi",
     "prepack": "lerna run --stream prepack",
-    "dev": "lerna run --stream prepack && lerna --scope=@logto/{core,ui,console,demo-app} exec -- pnpm dev",
+    "dev": "lerna run --stream prepack -- --incremental && lerna --ignore=@logto/integration-test run --parallel dev",
     "start": "cd packages/core && NODE_ENV=production node . --from-root",
     "ci:build": "lerna run --stream build",
     "ci:lint": "lerna run --parallel lint",

--- a/packages/connector-alipay-native/package.json
+++ b/packages/connector-alipay-native/package.json
@@ -16,9 +16,9 @@
   "scripts": {
     "precommit": "lint-staged",
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput --incremental",
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
-    "dev": "rm -rf lib/ && tsc-watch -p tsconfig.build.json --preserveWatchOutput --onSuccess \"node ./lib/index.js\"",
     "test": "jest",
     "test:coverage": "jest --coverage --silent",
     "prepack": "pnpm build"
@@ -50,7 +50,6 @@
     "nock": "^13.2.2",
     "prettier": "^2.7.1",
     "supertest": "^6.2.2",
-    "tsc-watch": "^5.0.0",
     "typescript": "^4.7.4"
   },
   "engines": {

--- a/packages/connector-alipay-web/package.json
+++ b/packages/connector-alipay-web/package.json
@@ -16,9 +16,9 @@
   "scripts": {
     "precommit": "lint-staged",
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput --incremental",
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
-    "dev": "rm -rf lib/ && tsc-watch -p tsconfig.build.json --preserveWatchOutput --onSuccess \"node ./lib/index.js\"",
     "test": "jest",
     "test:coverage": "jest --coverage --silent",
     "prepack": "pnpm build"
@@ -50,7 +50,6 @@
     "nock": "^13.2.2",
     "prettier": "^2.7.1",
     "supertest": "^6.2.2",
-    "tsc-watch": "^5.0.0",
     "typescript": "^4.7.4"
   },
   "engines": {

--- a/packages/connector-aliyun-dm/package.json
+++ b/packages/connector-aliyun-dm/package.json
@@ -16,9 +16,9 @@
   "scripts": {
     "precommit": "lint-staged",
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput --incremental",
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
-    "dev": "rm -rf lib/ && tsc-watch -p tsconfig.build.json --preserveWatchOutput --onSuccess \"node ./lib/index.js\"",
     "test": "jest",
     "test:coverage": "jest --coverage --silent",
     "prepack": "pnpm build"
@@ -41,7 +41,6 @@
     "jest": "^28.1.3",
     "lint-staged": "^13.0.0",
     "prettier": "^2.7.1",
-    "tsc-watch": "^5.0.0",
     "typescript": "^4.7.4"
   },
   "engines": {

--- a/packages/connector-aliyun-sms/package.json
+++ b/packages/connector-aliyun-sms/package.json
@@ -16,9 +16,9 @@
   "scripts": {
     "precommit": "lint-staged",
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput --incremental",
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
-    "dev": "rm -rf lib/ && tsc-watch -p tsconfig.build.json --preserveWatchOutput --onSuccess \"node ./lib/index.js\"",
     "test": "jest",
     "test:coverage": "jest --coverage --silent",
     "prepack": "pnpm build"
@@ -42,7 +42,6 @@
     "jest": "^28.1.3",
     "lint-staged": "^13.0.0",
     "prettier": "^2.7.1",
-    "tsc-watch": "^5.0.0",
     "typescript": "^4.7.4"
   },
   "engines": {

--- a/packages/connector-apple/package.json
+++ b/packages/connector-apple/package.json
@@ -17,9 +17,9 @@
   "scripts": {
     "precommit": "lint-staged",
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput --incremental",
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
-    "dev": "rm -rf lib/ && tsc-watch -p tsconfig.build.json --preserveWatchOutput --onSuccess \"node ./lib/index.js\"",
     "test": "jest",
     "test:coverage": "jest --coverage --silent",
     "prepack": "pnpm build"
@@ -46,7 +46,6 @@
     "lint-staged": "^13.0.0",
     "nock": "^13.2.2",
     "prettier": "^2.7.1",
-    "tsc-watch": "^5.0.0",
     "typescript": "^4.7.4"
   },
   "engines": {

--- a/packages/connector-azuread/package.json
+++ b/packages/connector-azuread/package.json
@@ -16,9 +16,9 @@
   "scripts": {
     "precommit": "lint-staged",
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput --incremental",
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
-    "dev": "rm -rf lib/ && tsc-watch -p tsconfig.build.json --preserveWatchOutput --onSuccess \"node ./lib/index.js\"",
     "test": "jest",
     "test:coverage": "jest --coverage --silent",
     "prepack": "pnpm build"
@@ -46,7 +46,6 @@
     "lint-staged": "^13.0.0",
     "nock": "^13.2.2",
     "prettier": "^2.7.1",
-    "tsc-watch": "^5.0.0",
     "typescript": "^4.7.4"
   },
   "engines": {

--- a/packages/connector-facebook/package.json
+++ b/packages/connector-facebook/package.json
@@ -16,9 +16,9 @@
   "scripts": {
     "precommit": "lint-staged",
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput --incremental",
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
-    "dev": "rm -rf lib/ && tsc-watch -p tsconfig.build.json --preserveWatchOutput --onSuccess \"node ./lib/index.js\"",
     "test": "jest",
     "test:coverage": "jest --coverage --silent",
     "prepack": "pnpm build"
@@ -44,7 +44,6 @@
     "lint-staged": "^13.0.0",
     "nock": "^13.2.2",
     "prettier": "^2.7.1",
-    "tsc-watch": "^5.0.0",
     "typescript": "^4.7.4"
   },
   "engines": {

--- a/packages/connector-github/package.json
+++ b/packages/connector-github/package.json
@@ -17,9 +17,9 @@
   "scripts": {
     "precommit": "lint-staged",
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput --incremental",
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
-    "dev": "rm -rf lib/ && tsc-watch -p tsconfig.build.json --preserveWatchOutput --onSuccess \"node ./lib/index.js\"",
     "test": "jest",
     "test:coverage": "jest --coverage --silent",
     "prepack": "pnpm build"
@@ -46,7 +46,6 @@
     "lint-staged": "^13.0.0",
     "nock": "^13.2.2",
     "prettier": "^2.7.1",
-    "tsc-watch": "^5.0.0",
     "typescript": "^4.7.4"
   },
   "engines": {

--- a/packages/connector-google/package.json
+++ b/packages/connector-google/package.json
@@ -16,9 +16,9 @@
   "scripts": {
     "precommit": "lint-staged",
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput --incremental",
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
-    "dev": "rm -rf lib/ && tsc-watch -p tsconfig.build.json --preserveWatchOutput --onSuccess \"node ./lib/index.js\"",
     "test": "jest",
     "test:coverage": "jest --coverage --silent",
     "prepack": "pnpm build"
@@ -44,7 +44,6 @@
     "lint-staged": "^13.0.0",
     "nock": "^13.2.2",
     "prettier": "^2.7.1",
-    "tsc-watch": "^5.0.0",
     "typescript": "^4.7.4"
   },
   "engines": {

--- a/packages/connector-mock-email/package.json
+++ b/packages/connector-mock-email/package.json
@@ -16,9 +16,9 @@
   "scripts": {
     "precommit": "lint-staged",
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput --incremental",
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
-    "dev": "rm -rf lib/ && tsc-watch -p tsconfig.build.json --preserveWatchOutput --onSuccess \"node ./lib/index.js\"",
     "prepack": "pnpm build"
   },
   "dependencies": {
@@ -34,7 +34,6 @@
     "eslint": "^8.21.0",
     "lint-staged": "^13.0.0",
     "prettier": "^2.7.1",
-    "tsc-watch": "^5.0.0",
     "typescript": "^4.7.4"
   },
   "engines": {

--- a/packages/connector-mock-sms/package.json
+++ b/packages/connector-mock-sms/package.json
@@ -16,9 +16,9 @@
   "scripts": {
     "precommit": "lint-staged",
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput --incremental",
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
-    "dev": "rm -rf lib/ && tsc-watch -p tsconfig.build.json --preserveWatchOutput --onSuccess \"node ./lib/index.js\"",
     "prepack": "pnpm build"
   },
   "dependencies": {
@@ -34,7 +34,6 @@
     "eslint": "^8.21.0",
     "lint-staged": "^13.0.0",
     "prettier": "^2.7.1",
-    "tsc-watch": "^5.0.0",
     "typescript": "^4.7.4"
   },
   "engines": {

--- a/packages/connector-mock-social/package.json
+++ b/packages/connector-mock-social/package.json
@@ -16,9 +16,9 @@
   "scripts": {
     "precommit": "lint-staged",
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput --incremental",
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
-    "dev": "rm -rf lib/ && tsc-watch -p tsconfig.build.json --preserveWatchOutput --onSuccess \"node ./lib/index.js\"",
     "prepack": "pnpm build"
   },
   "dependencies": {
@@ -35,7 +35,6 @@
     "eslint": "^8.21.0",
     "lint-staged": "^13.0.0",
     "prettier": "^2.7.1",
-    "tsc-watch": "^5.0.0",
     "typescript": "^4.7.4"
   },
   "engines": {

--- a/packages/connector-sendgrid-mail/package.json
+++ b/packages/connector-sendgrid-mail/package.json
@@ -16,9 +16,9 @@
   "scripts": {
     "precommit": "lint-staged",
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput --incremental",
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
-    "dev": "rm -rf lib/ && tsc-watch -p tsconfig.build.json --preserveWatchOutput --onSuccess \"node ./lib/index.js\"",
     "test": "jest",
     "test:coverage": "jest --coverage --silent",
     "prepack": "pnpm build"
@@ -41,7 +41,6 @@
     "jest": "^28.1.3",
     "lint-staged": "^13.0.0",
     "prettier": "^2.7.1",
-    "tsc-watch": "^5.0.0",
     "typescript": "^4.7.4"
   },
   "engines": {

--- a/packages/connector-smtp/package.json
+++ b/packages/connector-smtp/package.json
@@ -16,9 +16,9 @@
   "scripts": {
     "precommit": "lint-staged",
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput --incremental",
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
-    "dev": "rm -rf lib/ && tsc-watch -p tsconfig.build.json --preserveWatchOutput --onSuccess \"node ./lib/index.js\"",
     "test": "jest",
     "test:coverage": "jest --coverage --silent",
     "prepack": "pnpm build"
@@ -42,7 +42,6 @@
     "jest": "^28.1.3",
     "lint-staged": "^13.0.0",
     "prettier": "^2.7.1",
-    "tsc-watch": "^5.0.0",
     "typescript": "^4.7.4"
   },
   "engines": {

--- a/packages/connector-twilio-sms/package.json
+++ b/packages/connector-twilio-sms/package.json
@@ -16,9 +16,9 @@
   "scripts": {
     "precommit": "lint-staged",
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput --incremental",
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
-    "dev": "rm -rf lib/ && tsc-watch -p tsconfig.build.json --preserveWatchOutput --onSuccess \"node ./lib/index.js\"",
     "test": "jest",
     "test:coverage": "jest --coverage --silent",
     "prepack": "pnpm build"
@@ -41,7 +41,6 @@
     "jest": "^28.1.3",
     "lint-staged": "^13.0.0",
     "prettier": "^2.7.1",
-    "tsc-watch": "^5.0.0",
     "typescript": "^4.7.4"
   },
   "engines": {

--- a/packages/connector-types/package.json
+++ b/packages/connector-types/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "precommit": "lint-staged",
     "build": "rm -rf lib/ && tsc --p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput --incremental",
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "prepack": "pnpm build"

--- a/packages/connector-wechat-native/package.json
+++ b/packages/connector-wechat-native/package.json
@@ -16,9 +16,9 @@
   "scripts": {
     "precommit": "lint-staged",
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput --incremental",
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
-    "dev": "rm -rf lib/ && tsc-watch -p tsconfig.build.json --preserveWatchOutput --onSuccess \"node ./lib/index.js\"",
     "test": "jest",
     "test:coverage": "jest --coverage --silent",
     "prepack": "pnpm build"
@@ -44,7 +44,6 @@
     "lint-staged": "^13.0.0",
     "nock": "^13.2.2",
     "prettier": "^2.7.1",
-    "tsc-watch": "^5.0.0",
     "typescript": "^4.7.4"
   },
   "engines": {

--- a/packages/connector-wechat-web/package.json
+++ b/packages/connector-wechat-web/package.json
@@ -16,9 +16,9 @@
   "scripts": {
     "precommit": "lint-staged",
     "build": "rm -rf lib/ && tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput --incremental",
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
-    "dev": "rm -rf lib/ && tsc-watch -p tsconfig.build.json --preserveWatchOutput --onSuccess \"node ./lib/index.js\"",
     "test": "jest",
     "test:coverage": "jest --coverage --silent",
     "prepack": "pnpm build"
@@ -44,7 +44,6 @@
     "lint-staged": "^13.0.0",
     "nock": "^13.2.2",
     "prettier": "^2.7.1",
-    "tsc-watch": "^5.0.0",
     "typescript": "^4.7.4"
   },
   "engines": {

--- a/packages/core/nodemon.json
+++ b/packages/core/nodemon.json
@@ -1,0 +1,14 @@
+{
+  "exec": "tsc -p tsconfig.build.json --incremental && node ./build/index.js",
+  "ignore": [
+    "node_modules/**/node_modules"
+  ],
+  "watch": [
+    "../*/lib/",
+    "../core/src/",
+    "../core/node_modules/",
+    ".env"
+  ],
+  "ext": "json,js,jsx,ts,tsx",
+  "delay": 500
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,7 @@
     "build": "rm -rf build/ && tsc -p tsconfig.build.json && pnpm run copyfiles",
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
-    "dev": "rm -rf build/ && pnpm run copyfiles && tsc-watch -p tsconfig.build.json --preserveWatchOutput --onSuccess \"node ./build/index.js\"",
+    "dev": "rm -rf build/ && pnpm run copyfiles && nodemon",
     "start": "NODE_ENV=production node build/index.js",
     "test": "jest",
     "test:coverage": "jest --coverage --silent",
@@ -100,10 +100,10 @@
     "jest-matcher-specific-error": "^1.0.0",
     "lint-staged": "^13.0.0",
     "nock": "^13.2.2",
+    "nodemon": "^2.0.19",
     "openapi-types": "^12.0.0",
     "prettier": "^2.7.1",
     "supertest": "^6.2.2",
-    "tsc-watch": "^5.0.0",
     "typescript": "^4.7.4"
   },
   "engines": {

--- a/packages/core/src/routes/authn.ts
+++ b/packages/core/src/routes/authn.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 import RequestError from '@/errors/RequestError';
-import koaAuth, { verifyBearerTokenFromRequest } from '@/middleware/koa-auth';
+import { verifyBearerTokenFromRequest } from '@/middleware/koa-auth';
 import koaGuard from '@/middleware/koa-guard';
 import assertThat from '@/utils/assert-that';
 

--- a/packages/phrases-ui/package.json
+++ b/packages/phrases-ui/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "precommit": "lint-staged",
     "build": "rm -rf lib/ && tsc",
+    "dev": "tsc --watch --preserveWatchOutput --incremental",
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "prepack": "pnpm build"

--- a/packages/phrases/package.json
+++ b/packages/phrases/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "precommit": "lint-staged",
     "build": "rm -rf lib/ && tsc",
+    "dev": "tsc --watch --preserveWatchOutput --incremental",
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "prepack": "pnpm build"

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "precommit": "lint-staged",
     "generate": "rm -rf src/db-entries && ts-node src/gen/index.ts && eslint \"src/db-entries/**\" --fix",
-    "build": "pnpm generate && rm -rf lib/ && tsc --p tsconfig.build.json",
+    "build": "pnpm generate && rm -rf lib/ && tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput --incremental",
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "prepack": "pnpm build",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,7 +12,8 @@
   "private": true,
   "scripts": {
     "precommit": "lint-staged",
-    "build": "rm -rf lib/ && tsc --p tsconfig.build.json",
+    "build": "rm -rf lib/ && tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput --incremental",
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "prepack": "pnpm build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,6 @@ importers:
       prettier: ^2.7.1
       snakecase-keys: ^5.1.0
       supertest: ^6.2.2
-      tsc-watch: ^5.0.0
       typescript: ^4.7.4
       zod: ^3.14.3
     dependencies:
@@ -72,7 +71,6 @@ importers:
       nock: 13.2.2
       prettier: 2.7.1
       supertest: 6.2.2
-      tsc-watch: 5.0.3_typescript@4.7.4
       typescript: 4.7.4
 
   packages/connector-alipay-web:
@@ -100,7 +98,6 @@ importers:
       prettier: ^2.7.1
       snakecase-keys: ^5.1.0
       supertest: ^6.2.2
-      tsc-watch: ^5.0.0
       typescript: ^4.7.4
       zod: ^3.14.3
     dependencies:
@@ -129,7 +126,6 @@ importers:
       nock: 13.2.2
       prettier: 2.7.1
       supertest: 6.2.2
-      tsc-watch: 5.0.3_typescript@4.7.4
       typescript: 4.7.4
 
   packages/connector-aliyun-dm:
@@ -148,7 +144,6 @@ importers:
       jest: ^28.1.3
       lint-staged: ^13.0.0
       prettier: ^2.7.1
-      tsc-watch: ^5.0.0
       typescript: ^4.7.4
       zod: ^3.14.3
     dependencies:
@@ -168,7 +163,6 @@ importers:
       jest: 28.1.3_@types+node@16.11.12
       lint-staged: 13.0.0
       prettier: 2.7.1
-      tsc-watch: 5.0.3_typescript@4.7.4
       typescript: 4.7.4
 
   packages/connector-aliyun-sms:
@@ -188,7 +182,6 @@ importers:
       jest: ^28.1.3
       lint-staged: ^13.0.0
       prettier: ^2.7.1
-      tsc-watch: ^5.0.0
       typescript: ^4.7.4
       zod: ^3.14.3
     dependencies:
@@ -209,7 +202,6 @@ importers:
       jest: 28.1.3_@types+node@16.11.12
       lint-staged: 13.0.0
       prettier: 2.7.1
-      tsc-watch: 5.0.3_typescript@4.7.4
       typescript: 4.7.4
 
   packages/connector-apple:
@@ -232,7 +224,6 @@ importers:
       lint-staged: ^13.0.0
       nock: ^13.2.2
       prettier: ^2.7.1
-      tsc-watch: ^5.0.0
       typescript: ^4.7.4
       zod: ^3.14.3
     dependencies:
@@ -256,7 +247,6 @@ importers:
       lint-staged: 13.0.0
       nock: 13.2.2
       prettier: 2.7.1
-      tsc-watch: 5.0.3_typescript@4.7.4
       typescript: 4.7.4
 
   packages/connector-azuread:
@@ -280,7 +270,6 @@ importers:
       lint-staged: ^13.0.0
       nock: ^13.2.2
       prettier: ^2.7.1
-      tsc-watch: ^5.0.0
       typescript: ^4.7.4
       zod: ^3.14.3
     dependencies:
@@ -305,7 +294,6 @@ importers:
       lint-staged: 13.0.0
       nock: 13.2.2
       prettier: 2.7.1
-      tsc-watch: 5.0.3_typescript@4.7.4
       typescript: 4.7.4
 
   packages/connector-facebook:
@@ -327,7 +315,6 @@ importers:
       lint-staged: ^13.0.0
       nock: ^13.2.2
       prettier: ^2.7.1
-      tsc-watch: ^5.0.0
       typescript: ^4.7.4
       zod: ^3.14.3
     dependencies:
@@ -350,7 +337,6 @@ importers:
       lint-staged: 13.0.0
       nock: 13.2.2
       prettier: 2.7.1
-      tsc-watch: 5.0.3_typescript@4.7.4
       typescript: 4.7.4
 
   packages/connector-github:
@@ -373,7 +359,6 @@ importers:
       nock: ^13.2.2
       prettier: ^2.7.1
       query-string: ^7.0.1
-      tsc-watch: ^5.0.0
       typescript: ^4.7.4
       zod: ^3.14.3
     dependencies:
@@ -397,7 +382,6 @@ importers:
       lint-staged: 13.0.0
       nock: 13.2.2
       prettier: 2.7.1
-      tsc-watch: 5.0.3_typescript@4.7.4
       typescript: 4.7.4
 
   packages/connector-google:
@@ -419,7 +403,6 @@ importers:
       lint-staged: ^13.0.0
       nock: ^13.2.2
       prettier: ^2.7.1
-      tsc-watch: ^5.0.0
       typescript: ^4.7.4
       zod: ^3.14.3
     dependencies:
@@ -442,7 +425,6 @@ importers:
       lint-staged: 13.0.0
       nock: 13.2.2
       prettier: 2.7.1
-      tsc-watch: 5.0.3_typescript@4.7.4
       typescript: 4.7.4
 
   packages/connector-mock-email:
@@ -456,7 +438,6 @@ importers:
       eslint: ^8.21.0
       lint-staged: ^13.0.0
       prettier: ^2.7.1
-      tsc-watch: ^5.0.0
       typescript: ^4.7.4
       zod: ^3.14.3
     dependencies:
@@ -471,7 +452,6 @@ importers:
       eslint: 8.21.0
       lint-staged: 13.0.0
       prettier: 2.7.1
-      tsc-watch: 5.0.3_typescript@4.7.4
       typescript: 4.7.4
 
   packages/connector-mock-sms:
@@ -485,7 +465,6 @@ importers:
       eslint: ^8.21.0
       lint-staged: ^13.0.0
       prettier: ^2.7.1
-      tsc-watch: ^5.0.0
       typescript: ^4.7.4
       zod: ^3.14.3
     dependencies:
@@ -500,7 +479,6 @@ importers:
       eslint: 8.21.0
       lint-staged: 13.0.0
       prettier: 2.7.1
-      tsc-watch: 5.0.3_typescript@4.7.4
       typescript: 4.7.4
 
   packages/connector-mock-social:
@@ -515,7 +493,6 @@ importers:
       eslint: ^8.21.0
       lint-staged: ^13.0.0
       prettier: ^2.7.1
-      tsc-watch: ^5.0.0
       typescript: ^4.7.4
       zod: ^3.14.3
     dependencies:
@@ -531,7 +508,6 @@ importers:
       eslint: 8.21.0
       lint-staged: 13.0.0
       prettier: 2.7.1
-      tsc-watch: 5.0.3_typescript@4.7.4
       typescript: 4.7.4
 
   packages/connector-sendgrid-mail:
@@ -550,7 +526,6 @@ importers:
       jest: ^28.1.3
       lint-staged: ^13.0.0
       prettier: ^2.7.1
-      tsc-watch: ^5.0.0
       typescript: ^4.7.4
       zod: ^3.14.3
     dependencies:
@@ -570,7 +545,6 @@ importers:
       jest: 28.1.3_@types+node@16.11.12
       lint-staged: 13.0.0
       prettier: 2.7.1
-      tsc-watch: 5.0.3_typescript@4.7.4
       typescript: 4.7.4
 
   packages/connector-smtp:
@@ -590,7 +564,6 @@ importers:
       lint-staged: ^13.0.0
       nodemailer: ^6.7.5
       prettier: ^2.7.1
-      tsc-watch: ^5.0.0
       typescript: ^4.7.4
       zod: ^3.14.3
     dependencies:
@@ -611,7 +584,6 @@ importers:
       jest: 28.1.3_@types+node@16.11.12
       lint-staged: 13.0.0
       prettier: 2.7.1
-      tsc-watch: 5.0.3_typescript@4.7.4
       typescript: 4.7.4
 
   packages/connector-twilio-sms:
@@ -630,7 +602,6 @@ importers:
       jest: ^28.1.3
       lint-staged: ^13.0.0
       prettier: ^2.7.1
-      tsc-watch: ^5.0.0
       typescript: ^4.7.4
       zod: ^3.14.3
     dependencies:
@@ -650,7 +621,6 @@ importers:
       jest: 28.1.3_@types+node@16.11.12
       lint-staged: 13.0.0
       prettier: 2.7.1
-      tsc-watch: 5.0.3_typescript@4.7.4
       typescript: 4.7.4
 
   packages/connector-types:
@@ -703,7 +673,6 @@ importers:
       lint-staged: ^13.0.0
       nock: ^13.2.2
       prettier: ^2.7.1
-      tsc-watch: ^5.0.0
       typescript: ^4.7.4
       zod: ^3.14.3
     dependencies:
@@ -726,7 +695,6 @@ importers:
       lint-staged: 13.0.0
       nock: 13.2.2
       prettier: 2.7.1
-      tsc-watch: 5.0.3_typescript@4.7.4
       typescript: 4.7.4
 
   packages/connector-wechat-web:
@@ -748,7 +716,6 @@ importers:
       lint-staged: ^13.0.0
       nock: ^13.2.2
       prettier: ^2.7.1
-      tsc-watch: ^5.0.0
       typescript: ^4.7.4
       zod: ^3.14.3
     dependencies:
@@ -771,7 +738,6 @@ importers:
       lint-staged: 13.0.0
       nock: 13.2.2
       prettier: 2.7.1
-      tsc-watch: 5.0.3_typescript@4.7.4
       typescript: 4.7.4
 
   packages/console:
@@ -974,6 +940,7 @@ importers:
       module-alias: ^2.2.2
       nanoid: ^3.1.23
       nock: ^13.2.2
+      nodemon: ^2.0.19
       oidc-provider: ^7.11.3
       openapi-types: ^12.0.0
       p-retry: ^4.6.1
@@ -987,7 +954,6 @@ importers:
       snake-case: ^3.0.4
       snakecase-keys: ^5.1.0
       supertest: ^6.2.2
-      tsc-watch: ^5.0.0
       typescript: ^4.7.4
       zod: ^3.14.3
     dependencies:
@@ -1071,10 +1037,10 @@ importers:
       jest-matcher-specific-error: 1.0.0
       lint-staged: 13.0.0
       nock: 13.2.2
+      nodemon: 2.0.19
       openapi-types: 12.0.0
       prettier: 2.7.1
       supertest: 6.2.2
-      tsc-watch: 5.0.3_typescript@4.7.4
       typescript: 4.7.4
 
   packages/demo-app:
@@ -6922,6 +6888,18 @@ packages:
       ms: 2.1.3
     dev: true
 
+  /debug/3.2.7_supports-color@5.5.0:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+      supports-color: 5.5.0
+    dev: true
+
   /debug/4.3.3:
     resolution: {integrity: sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==}
     engines: {node: '>=6.0'}
@@ -7830,18 +7808,6 @@ packages:
     engines: {node: '>= 0.6'}
     dev: false
 
-  /event-stream/3.3.4:
-    resolution: {integrity: sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=}
-    dependencies:
-      duplexer: 0.1.2
-      from: 0.1.7
-      map-stream: 0.1.0
-      pause-stream: 0.0.11
-      split: 0.3.3
-      stream-combiner: 0.0.4
-      through: 2.3.8
-    dev: true
-
   /eventemitter3/4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
@@ -8163,10 +8129,6 @@ packages:
   /fresh/0.5.2:
     resolution: {integrity: sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=}
     engines: {node: '>= 0.6'}
-
-  /from/0.1.7:
-    resolution: {integrity: sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=}
-    dev: true
 
   /fs-constants/1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -9000,6 +8962,10 @@ packages:
 
   /ieee754/1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  /ignore-by-default/1.0.1:
+    resolution: {integrity: sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==}
+    dev: true
 
   /ignore-walk/3.0.4:
     resolution: {integrity: sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==}
@@ -11134,10 +11100,6 @@ packages:
     resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
     engines: {node: '>=8'}
 
-  /map-stream/0.1.0:
-    resolution: {integrity: sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=}
-    dev: true
-
   /markdown-escapes/1.0.4:
     resolution: {integrity: sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==}
     dev: true
@@ -11969,10 +11931,6 @@ packages:
     resolution: {integrity: sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==}
     dev: true
 
-  /node-cleanup/2.1.2:
-    resolution: {integrity: sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=}
-    dev: true
-
   /node-fetch/2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
     engines: {node: 4.x || >=6.0.0}
@@ -12048,11 +12006,36 @@ packages:
     engines: {node: '>=6.0.0'}
     dev: false
 
+  /nodemon/2.0.19:
+    resolution: {integrity: sha512-4pv1f2bMDj0Eeg/MhGqxrtveeQ5/G/UVe9iO6uTZzjnRluSA4PVWf8CW99LUPwGB3eNIA7zUFoP77YuI7hOc0A==}
+    engines: {node: '>=8.10.0'}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      chokidar: 3.5.3
+      debug: 3.2.7_supports-color@5.5.0
+      ignore-by-default: 1.0.1
+      minimatch: 3.1.2
+      pstree.remy: 1.1.8
+      semver: 5.7.1
+      simple-update-notifier: 1.0.7
+      supports-color: 5.5.0
+      touch: 3.1.0
+      undefsafe: 2.0.5
+    dev: true
+
   /noms/0.0.0:
     resolution: {integrity: sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=}
     dependencies:
       inherits: 2.0.4
       readable-stream: 1.0.34
+    dev: true
+
+  /nopt/1.0.10:
+    resolution: {integrity: sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==}
+    hasBin: true
+    dependencies:
+      abbrev: 1.1.1
     dev: true
 
   /nopt/5.0.0:
@@ -12840,12 +12823,6 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
-  /pause-stream/0.0.11:
-    resolution: {integrity: sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=}
-    dependencies:
-      through: 2.3.8
-    dev: true
-
   /pend/1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
     dev: true
@@ -13416,16 +13393,12 @@ packages:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
     dev: true
 
-  /ps-tree/1.2.0:
-    resolution: {integrity: sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==}
-    engines: {node: '>= 0.10'}
-    hasBin: true
-    dependencies:
-      event-stream: 3.3.4
-    dev: true
-
   /psl/1.9.0:
     resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
+    dev: true
+
+  /pstree.remy/1.1.8:
+    resolution: {integrity: sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==}
     dev: true
 
   /pump/3.0.0:
@@ -14361,6 +14334,11 @@ packages:
     resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
     hasBin: true
 
+  /semver/7.0.0:
+    resolution: {integrity: sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==}
+    hasBin: true
+    dev: true
+
   /semver/7.3.5:
     resolution: {integrity: sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==}
     engines: {node: '>=10'}
@@ -14445,6 +14423,13 @@ packages:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
     dependencies:
       is-arrayish: 0.3.2
+
+  /simple-update-notifier/1.0.7:
+    resolution: {integrity: sha512-BBKgR84BJQJm6WjWFMHgLVuo61FBDSj1z/xSFUIozqO6wO7ii0JxCqlIud7Enr/+LhlbNI0whErq96P2qHNWew==}
+    engines: {node: '>=8.10.0'}
+    dependencies:
+      semver: 7.0.0
+    dev: true
 
   /sisteransi/1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -14765,12 +14750,6 @@ packages:
     resolution: {integrity: sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==}
     engines: {node: '>=6'}
 
-  /split/0.3.3:
-    resolution: {integrity: sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=}
-    dependencies:
-      through: 2.3.8
-    dev: true
-
   /split/1.0.1:
     resolution: {integrity: sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==}
     dependencies:
@@ -14832,20 +14811,9 @@ packages:
     engines: {node: '>= 0.8'}
     dev: false
 
-  /stream-combiner/0.0.4:
-    resolution: {integrity: sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=}
-    dependencies:
-      duplexer: 0.1.2
-    dev: true
-
   /strict-uri-encode/2.0.0:
     resolution: {integrity: sha1-ucczDHBChi9rFC3CdLvMWGbONUY=}
     engines: {node: '>=4'}
-
-  /string-argv/0.1.2:
-    resolution: {integrity: sha512-mBqPGEOMNJKXRo7z0keX0wlAhbBAjilUdPW13nN0PecVryZxdHIeM7TqbsSUA7VYuS00HGC6mojP7DlQzfa9ZA==}
-    engines: {node: '>=0.6.19'}
-    dev: true
 
   /string-argv/0.3.1:
     resolution: {integrity: sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==}
@@ -15407,6 +15375,13 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  /touch/3.1.0:
+    resolution: {integrity: sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==}
+    hasBin: true
+    dependencies:
+      nopt: 1.0.10
+    dev: true
+
   /tough-cookie/4.0.0:
     resolution: {integrity: sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==}
     engines: {node: '>=6'}
@@ -15566,21 +15541,6 @@ packages:
       yn: 3.1.1
     dev: true
 
-  /tsc-watch/5.0.3_typescript@4.7.4:
-    resolution: {integrity: sha512-Hz2UawwELMSLOf0xHvAFc7anLeMw62cMVXr1flYmhRuOhOyOljwmb1l/O60ZwRyy1k7N1iC1mrn1QYM2zITfuw==}
-    engines: {node: '>=8.17.0'}
-    hasBin: true
-    peerDependencies:
-      typescript: '*'
-    dependencies:
-      cross-spawn: 7.0.3
-      node-cleanup: 2.1.2
-      ps-tree: 1.2.0
-      string-argv: 0.1.2
-      strip-ansi: 6.0.1
-      typescript: 4.7.4
-    dev: true
-
   /tsconfig-paths/3.14.1:
     resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}
     dependencies:
@@ -15727,6 +15687,10 @@ packages:
     dependencies:
       buffer: 5.7.1
       through: 2.3.8
+    dev: true
+
+  /undefsafe/2.0.5:
+    resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
     dev: true
 
   /unherit/1.1.3:


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

- remove `tsc-watch` in all packages
- watch and incrementally build lib packages
- watch all `core` source files and dependencies using `nodemon`, rebuild and restart core if needed
- watch all frontend project using `parcel`

note the watch scripts are all independent. thus only necessary rebuilds/restarts will be triggered.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Run `pnpm dev` to execute the actions in order:

- [x] all necessary packages start incremental build
- [x] frontend packages and core start to build; other packages start to watch without rebuild
- [x] frontend packages and core start to watch

Then change some source code in `packages/connectors-apple`:

<img width="709" alt="image" src="https://user-images.githubusercontent.com/14722250/185659453-840fdb44-9d0c-4a35-8cca-e39c34ebc520.png">

Then change some source code in `packages/console`:

<img width="414" alt="image" src="https://user-images.githubusercontent.com/14722250/185659549-af7349e5-3f60-4310-9bf9-201245d273a4.png">

All jobs are executed as expected in a very neat way. Looks good for dev.