### PR TITLE
feat(console): allow to disable create account

### DIFF
--- a/packages/console/src/pages/SignInExperience/components/AuthenticationForm.tsx
+++ b/packages/console/src/pages/SignInExperience/components/AuthenticationForm.tsx
@@ -1,0 +1,28 @@
+import { SignInMode } from '@logto/schemas';
+import { useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+
+import FormField from '@/components/FormField';
+import Switch from '@/components/Switch';
+
+import { SignInExperienceForm } from '../types';
+import * as styles from './index.module.scss';
+
+const AuthenticationForm = () => {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const { register } = useFormContext<SignInExperienceForm>();
+
+  return (
+    <>
+      <div className={styles.title}>{t('sign_in_exp.others.authentication.title')}</div>
+      <FormField title="sign_in_exp.others.authentication.enable_create_account">
+        <Switch
+          {...register('createAccountEnabled')}
+          label={t('sign_in_exp.others.authentication.enable_create_account_description')}
+        />
+      </FormField>
+    </>
+  );
+};
+
+export default AuthenticationForm;

--- a/packages/console/src/pages/SignInExperience/tabs/OthersTab.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/OthersTab.tsx
@@ -3,6 +3,7 @@ import { useFormContext } from 'react-hook-form';
 
 import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
 
+import AuthenticationForm from '../components/AuthenticationForm';
 import LanguagesForm from '../components/LanguagesForm';
 import TermsForm from '../components/TermsForm';
 import { SignInExperienceForm } from '../types';
@@ -25,6 +26,7 @@ const OthersTab = ({ defaultData, isDataDirty }: Props) => {
     <>
       <TermsForm />
       <LanguagesForm />
+      <AuthenticationForm />
       <UnsavedChangesAlertModal hasUnsavedChanges={isDataDirty} />
     </>
   );

--- a/packages/console/src/pages/SignInExperience/types.ts
+++ b/packages/console/src/pages/SignInExperience/types.ts
@@ -20,4 +20,5 @@ export type SignInExperienceForm = Omit<SignInExperience, 'signInMethods' | 'lan
     fixedLanguage: Language;
     fallbackLanguage: Language;
   };
+  createAccountEnabled: boolean;
 };

--- a/packages/console/src/pages/SignInExperience/utilities.ts
+++ b/packages/console/src/pages/SignInExperience/utilities.ts
@@ -3,6 +3,7 @@ import {
   SignInMethodKey,
   SignInMethods,
   SignInMethodState,
+  SignInMode,
 } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
 
@@ -41,6 +42,7 @@ export const signInExperienceParser = {
 
     const {
       languageInfo: { autoDetect, fallbackLanguage, fixedLanguage },
+      signInMode,
     } = signInExperience;
 
     return {
@@ -58,12 +60,14 @@ export const signInExperienceParser = {
         fallbackLanguage,
         fixedLanguage,
       },
+      createAccountEnabled: signInMode !== SignInMode.SignIn,
     };
   },
   toRemoteModel: (setup: SignInExperienceForm): SignInExperience => {
     const {
       branding,
       languageInfo: { mode, fallbackLanguage, fixedLanguage },
+      createAccountEnabled,
     } = setup;
 
     return {
@@ -85,6 +89,7 @@ export const signInExperienceParser = {
         fallbackLanguage,
         fixedLanguage,
       },
+      signInMode: createAccountEnabled ? SignInMode.SignInAndRegister : SignInMode.SignIn,
     };
   },
 };

--- a/packages/phrases/src/locales/en/translation/admin-console/sign-in-exp.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/sign-in-exp.ts
@@ -79,6 +79,12 @@ const sign_in_exp = {
         'Which language to fall back if Logto finds no proper language phrase-set.',
       fixed_language: 'Fixed language',
     },
+    authentication: {
+      title: 'AUTHENTICATION',
+      enable_create_account: 'Enable create account',
+      enable_create_account_description:
+        'Enable or disable create account (sign-up). Once disabled, your customers can’t create accounts through the sign-in UI, but you can still add users in Admin Console.',
+    },
   },
   setup_warning: {
     no_connector: '',

--- a/packages/phrases/src/locales/fr/translation/admin-console/sign-in-exp.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/sign-in-exp.ts
@@ -81,6 +81,12 @@ const sign_in_exp = {
         'La langue de repli si Logto ne trouve pas de jeu de phrases dans la langue appropriée.',
       fixed_language: 'Langue fixe',
     },
+    authentication: {
+      title: 'AUTHENTICATION',
+      enable_create_account: 'Enable create account',
+      enable_create_account_description:
+        'Enable or disable create account (sign-up). Once disabled, your customers can’t create accounts through the sign-in UI, but you can still add users in Admin Console.',
+    },
   },
   setup_warning: {
     no_connector: '',

--- a/packages/phrases/src/locales/ko-kr/translation/admin-console/sign-in-exp.ts
+++ b/packages/phrases/src/locales/ko-kr/translation/admin-console/sign-in-exp.ts
@@ -75,6 +75,12 @@ const sign_in_exp = {
       fallback_language_tip: '적절한 언어를 찾을 수 없을 때 백업 언어를 사용해요.',
       fixed_language: '언어 고정',
     },
+    authentication: {
+      title: 'AUTHENTICATION',
+      enable_create_account: 'Enable create account',
+      enable_create_account_description:
+        'Enable or disable create account (sign-up). Once disabled, your customers can’t create accounts through the sign-in UI, but you can still add users in Admin Console.',
+    },
   },
   setup_warning: {
     no_connector: '',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/sign-in-exp.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/sign-in-exp.ts
@@ -80,6 +80,12 @@ const sign_in_exp = {
         'Logto uygun bir dil ifade kümesi bulamazsa hangi dilden vazgeçilecek?',
       fixed_language: 'Sabitlenmiş dil',
     },
+    authentication: {
+      title: 'AUTHENTICATION',
+      enable_create_account: 'Enable create account',
+      enable_create_account_description:
+        'Enable or disable create account (sign-up). Once disabled, your customers can’t create accounts through the sign-in UI, but you can still add users in Admin Console.',
+    },
   },
   setup_warning: {
     no_connector: '',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/sign-in-exp.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/sign-in-exp.ts
@@ -75,6 +75,12 @@ const sign_in_exp = {
       fallback_language_tip: '如果 Logto 找不到合适的语言包，将回退至哪种语言。',
       fixed_language: '固定语言',
     },
+    authentication: {
+      title: '身份验证',
+      enable_create_account: '启用创建帐号',
+      enable_create_account_description:
+        '启用或禁用创建帐号（注册）。一旦禁用，你的用户将无法通过登录 UI 来创建帐户，但你仍可以通过「管理面板」添加用户。',
+    },
   },
   setup_warning: {
     no_connector: '',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

- allow to disable account in Admin Console, resolves #1716 
- still have a follow up issue for API guarding LOG-3981

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

- toggle off the switch, see no "create account" in preview, either in the real SIE