### PR TITLE
style(console): fix border style copy field padding

### DIFF
--- a/packages/console/src/components/CopyToClipboard/index.module.scss
+++ b/packages/console/src/components/CopyToClipboard/index.module.scss
@@ -14,7 +14,7 @@
   }
 
   &.border {
-    padding: _.unit(2) _.unit(3);
+    padding: _.unit(1) _.unit(3);
     background: var(--color-layer-2);
     border: 1px solid var(--color-border);
   }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
fix border style `CopyToClipboard` padding

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
The new height is 36px
<img width="656" alt="image" src="https://user-images.githubusercontent.com/5717882/186623509-dda2afae-996f-4a96-a3be-33451179997f.png">

