### PR TITLE
refactor(phrases,console): move terms_of_use translations

### DIFF
--- a/packages/console/src/pages/SignInExperience/components/TermsForm.tsx
+++ b/packages/console/src/pages/SignInExperience/components/TermsForm.tsx
@@ -20,18 +20,18 @@ const TermsForm = () => {
 
   return (
     <>
-      <div className={styles.title}>{t('sign_in_exp.terms_of_use.title')}</div>
-      <FormField title="sign_in_exp.terms_of_use.enable">
+      <div className={styles.title}>{t('sign_in_exp.others.terms_of_use.title')}</div>
+      <FormField title="sign_in_exp.others.terms_of_use.enable">
         <Switch
           {...register('termsOfUse.enabled')}
-          label={t('sign_in_exp.terms_of_use.description')}
+          label={t('sign_in_exp.others.terms_of_use.description')}
         />
       </FormField>
       {enabled && (
         <FormField
           isRequired
-          title="sign_in_exp.terms_of_use.terms_of_use"
-          tooltip="sign_in_exp.terms_of_use.terms_of_use_tip"
+          title="sign_in_exp.others.terms_of_use.terms_of_use"
+          tooltip="sign_in_exp.others.terms_of_use.terms_of_use_tip"
         >
           <TextInput
             {...register('termsOfUse.contentUrl', {
@@ -40,7 +40,7 @@ const TermsForm = () => {
             })}
             hasError={Boolean(errors.termsOfUse)}
             errorMessage={errors.termsOfUse?.contentUrl?.message}
-            placeholder={t('sign_in_exp.terms_of_use.terms_of_use_placeholder')}
+            placeholder={t('sign_in_exp.others.terms_of_use.terms_of_use_placeholder')}
           />
         </FormField>
       )}

--- a/packages/phrases/src/locales/en/translation/admin-console/sign-in-exp.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/sign-in-exp.ts
@@ -38,14 +38,6 @@ const sign_in_exp = {
     slogan: 'Slogan',
     slogan_placeholder: 'Unleash your creativity',
   },
-  terms_of_use: {
-    title: 'TERMS OF USE',
-    enable: 'Enable terms of use',
-    description: 'Add the legal agreements for the use of your product',
-    terms_of_use: 'Terms of use',
-    terms_of_use_placeholder: 'https://your.terms.of.use/',
-    terms_of_use_tip: 'Terms of use URL',
-  },
   sign_in_methods: {
     title: 'SIGN-IN METHODS',
     primary: 'Primary sign-in method',
@@ -69,6 +61,14 @@ const sign_in_exp = {
     },
   },
   others: {
+    terms_of_use: {
+      title: 'TERMS OF USE',
+      enable: 'Enable terms of use',
+      description: 'Add the legal agreements for the use of your product',
+      terms_of_use: 'Terms of use',
+      terms_of_use_placeholder: 'https://your.terms.of.use/',
+      terms_of_use_tip: 'Terms of use URL',
+    },
     languages: {
       title: 'LANGUAGES',
       mode: 'Language mode',

--- a/packages/phrases/src/locales/fr/translation/admin-console/sign-in-exp.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/sign-in-exp.ts
@@ -40,14 +40,6 @@ const sign_in_exp = {
     slogan: 'Slogan',
     slogan_placeholder: 'Libérez votre créativité',
   },
-  terms_of_use: {
-    title: "CONDITIONS D'UTILISATION",
-    enable: "Activer les conditions d'utilisation",
-    description: "Ajouter les accords juridiques pour l'utilisation de votre produit",
-    terms_of_use: "Conditions d'utilisation",
-    terms_of_use_placeholder: 'https://vos.conditions.utilisation/',
-    terms_of_use_tip: "Conditions d'utilisation URL",
-  },
   sign_in_methods: {
     title: 'METHODES DE CONNEXION',
     primary: 'Méthode de connexion principale',
@@ -71,6 +63,14 @@ const sign_in_exp = {
     },
   },
   others: {
+    terms_of_use: {
+      title: "CONDITIONS D'UTILISATION",
+      enable: "Activer les conditions d'utilisation",
+      description: "Ajouter les accords juridiques pour l'utilisation de votre produit",
+      terms_of_use: "Conditions d'utilisation",
+      terms_of_use_placeholder: 'https://vos.conditions.utilisation/',
+      terms_of_use_tip: "Conditions d'utilisation URL",
+    },
     languages: {
       title: 'LANGAGES',
       mode: 'Mode langue',

--- a/packages/phrases/src/locales/ko-kr/translation/admin-console/sign-in-exp.ts
+++ b/packages/phrases/src/locales/ko-kr/translation/admin-console/sign-in-exp.ts
@@ -35,14 +35,6 @@ const sign_in_exp = {
     slogan: '슬로건',
     slogan_placeholder: 'Unleash your creativity',
   },
-  terms_of_use: {
-    title: '이용 약관',
-    enable: '이용 약관 활성화',
-    description: '서비스 사용을 위한 이용 약관을 추가해보세요.',
-    terms_of_use: '이용 약관',
-    terms_of_use_placeholder: 'https://your.terms.of.use/',
-    terms_of_use_tip: '이용 약관 URL',
-  },
   sign_in_methods: {
     title: '로그인 방법',
     primary: '메인 로그인 방법',
@@ -66,6 +58,14 @@ const sign_in_exp = {
     },
   },
   others: {
+    terms_of_use: {
+      title: '이용 약관',
+      enable: '이용 약관 활성화',
+      description: '서비스 사용을 위한 이용 약관을 추가해보세요.',
+      terms_of_use: '이용 약관',
+      terms_of_use_placeholder: 'https://your.terms.of.use/',
+      terms_of_use_tip: '이용 약관 URL',
+    },
     languages: {
       title: '언어',
       mode: '언어 모드',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/sign-in-exp.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/sign-in-exp.ts
@@ -39,14 +39,6 @@ const sign_in_exp = {
     slogan: 'Slogan',
     slogan_placeholder: 'Yaratıcılığınızı açığa çıkarın',
   },
-  terms_of_use: {
-    title: 'KULLANIM KOŞULLARI',
-    enable: 'Kullanım koşullarını etkinleştir',
-    description: 'Ürününüzün kullanımına ilişkin yasal anlaşmaları ekleyin',
-    terms_of_use: 'Kullanım koşulları',
-    terms_of_use_placeholder: 'https://your.terms.of.use/',
-    terms_of_use_tip: 'Kullanım koşulları URLi',
-  },
   sign_in_methods: {
     title: 'OTURUM AÇMA YÖNTEMLERİ',
     primary: 'Birincil oturum açma yöntemi',
@@ -70,6 +62,14 @@ const sign_in_exp = {
     },
   },
   others: {
+    terms_of_use: {
+      title: 'KULLANIM KOŞULLARI',
+      enable: 'Kullanım koşullarını etkinleştir',
+      description: 'Ürününüzün kullanımına ilişkin yasal anlaşmaları ekleyin',
+      terms_of_use: 'Kullanım koşulları',
+      terms_of_use_placeholder: 'https://your.terms.of.use/',
+      terms_of_use_tip: 'Kullanım koşulları URLi',
+    },
     languages: {
       title: 'DİLLER',
       mode: 'Dil modu',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/sign-in-exp.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/sign-in-exp.ts
@@ -36,14 +36,6 @@ const sign_in_exp = {
     slogan: '标语',
     slogan_placeholder: '释放你的创意',
   },
-  terms_of_use: {
-    title: '使用条款',
-    enable: '开启使用条款',
-    description: '添加使用产品的法律协议。',
-    terms_of_use: '使用条款',
-    terms_of_use_placeholder: 'https://your.terms.of.use/',
-    terms_of_use_tip: '使用条款 URL',
-  },
   sign_in_methods: {
     title: '登录方式',
     primary: '主要登录方式',
@@ -66,6 +58,14 @@ const sign_in_exp = {
     },
   },
   others: {
+    terms_of_use: {
+      title: '使用条款',
+      enable: '开启使用条款',
+      description: '添加使用产品的法律协议。',
+      terms_of_use: '使用条款',
+      terms_of_use_placeholder: 'https://your.terms.of.use/',
+      terms_of_use_tip: '使用条款 URL',
+    },
     languages: {
       title: '语言',
       mode: '语言模式',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Move terms_of_use translations from `sign_in_exp.terms_of_use` to `sign_in_exp.others.terms_of_use`
(to align with the frontend page form hierarchy.)

<img width="653" alt="image" src="https://user-images.githubusercontent.com/10594507/186836038-6faa85f8-69e7-4808-89de-f7ded702ce12.png">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested.
