### PR TITLE
test: increase request timeout in integration tests

### DIFF
--- a/packages/integration-tests/src/api/api.ts
+++ b/packages/integration-tests/src/api/api.ts
@@ -2,11 +2,14 @@ import got from 'got';
 
 import { logtoUrl } from '@/constants';
 
-export default got.extend({ prefixUrl: new URL('/api', logtoUrl) });
+const requestTimeout = 10_000;
+
+export default got.extend({ prefixUrl: new URL('/api', logtoUrl), timeout: requestTimeout });
 
 export const authedAdminApi = got.extend({
   prefixUrl: new URL('/api', logtoUrl),
   headers: {
     'development-user-id': 'integration-test-admin-user',
   },
+  timeout: requestTimeout,
 });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Increasing request timeout in integration tests to 10s to avoid integration tests failing on low macOS machines.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
None.
