### PR TITLE
chore(core): function naming should stick to camel case

### DIFF
--- a/packages/core/src/routes/session/middleware/koa-guard-session-action.ts
+++ b/packages/core/src/routes/session/middleware/koa-guard-session-action.ts
@@ -7,7 +7,7 @@ import RequestError from '@/errors/RequestError';
 import { findDefaultSignInExperience } from '@/queries/sign-in-experience';
 import assertThat from '@/utils/assert-that';
 
-export default function KoaGuardSessionAction<StateT, ContextT, ResponseBodyT>(
+export default function koaGuardSessionAction<StateT, ContextT, ResponseBodyT>(
   provider: Provider,
   forType: 'sign-in' | 'register'
 ): MiddlewareType<StateT, ContextT, ResponseBodyT> {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
`koaGuardSessionAction` function's naming should stick to camel-case.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A
