### PR TITLE
refactor: connector-core types

### DIFF
--- a/packages/connector-alipay-native/src/constant.ts
+++ b/packages/connector-alipay-native/src/constant.ts
@@ -18,7 +18,6 @@ export const invalidAccessTokenSubCode = ['isv.code-invalid'];
 export const defaultMetadata: ConnectorMetadata = {
   id: 'alipay-native',
   target: 'alipay',
-  type: ConnectorType.Social,
   platform: ConnectorPlatform.Native,
   name: {
     en: 'Alipay',

--- a/packages/connector-alipay-native/src/constant.ts
+++ b/packages/connector-alipay-native/src/constant.ts
@@ -1,4 +1,4 @@
-import { ConnectorType, ConnectorMetadata, ConnectorPlatform } from '@logto/connector-core';
+import { ConnectorMetadata, ConnectorPlatform } from '@logto/connector-core';
 
 export const authorizationEndpoint = 'alipay://'; // This is used to arouse the native Alipay App
 export const alipayEndpoint = 'https://openapi.alipay.com/gateway.do';

--- a/packages/connector-alipay-native/src/index.ts
+++ b/packages/connector-alipay-native/src/index.ts
@@ -16,6 +16,7 @@ import {
   CreateConnector,
   SocialConnector,
   validateConfig,
+  ConnectorType,
 } from '@logto/connector-core';
 import { assert } from '@silverhand/essentials';
 import dayjs from 'dayjs';
@@ -182,6 +183,7 @@ const authorizationCallbackHandler = async (parameterObject: unknown) => {
 const createAlipayNativeConnector: CreateConnector<SocialConnector> = async ({ getConfig }) => {
   return {
     metadata: defaultMetadata,
+    type: ConnectorType.Social,
     configGuard: alipayNativeConfigGuard,
     getAuthorizationUri: getAuthorizationUri(getConfig),
     getUserInfo: getUserInfo(getConfig),

--- a/packages/connector-alipay-web/src/constant.ts
+++ b/packages/connector-alipay-web/src/constant.ts
@@ -21,7 +21,6 @@ export const invalidAccessTokenSubCode = ['isv.code-invalid'];
 export const defaultMetadata: ConnectorMetadata = {
   id: 'alipay-web',
   target: 'alipay',
-  type: ConnectorType.Social,
   platform: ConnectorPlatform.Web,
   name: {
     en: 'Alipay',

--- a/packages/connector-alipay-web/src/index.ts
+++ b/packages/connector-alipay-web/src/index.ts
@@ -14,6 +14,7 @@ import {
   CreateConnector,
   SocialConnector,
   validateConfig,
+  ConnectorType,
 } from '@logto/connector-core';
 import { assert } from '@silverhand/essentials';
 import dayjs from 'dayjs';
@@ -192,6 +193,7 @@ const authorizationCallbackHandler = async (parameterObject: unknown) => {
 const createAlipayConnector: CreateConnector<SocialConnector> = async ({ getConfig }) => {
   return {
     metadata: defaultMetadata,
+    type: ConnectorType.Social,
     configGuard: alipayConfigGuard,
     getAuthorizationUri: getAuthorizationUri(getConfig),
     getUserInfo: getUserInfo(getConfig),

--- a/packages/connector-aliyun-dm/src/constant.ts
+++ b/packages/connector-aliyun-dm/src/constant.ts
@@ -12,7 +12,6 @@ export const staticConfigs = {
 export const defaultMetadata: ConnectorMetadata = {
   id: 'aliyun-direct-mail',
   target: 'aliyun-dm',
-  type: ConnectorType.Email,
   platform: null,
   name: {
     en: 'Aliyun Direct Mail',

--- a/packages/connector-aliyun-dm/src/index.ts
+++ b/packages/connector-aliyun-dm/src/index.ts
@@ -1,6 +1,7 @@
 import {
   ConnectorError,
   ConnectorErrorCodes,
+  ConnectorType,
   CreateConnector,
   EmailConnector,
   GetConnectorConfig,
@@ -95,6 +96,7 @@ const errorHandler = (errorResponseBody: string) => {
 const createAliyunDmConnector: CreateConnector<EmailConnector> = async ({ getConfig }) => {
   return {
     metadata: defaultMetadata,
+    type: ConnectorType.Email,
     configGuard: aliyunDmConfigGuard,
     sendMessage: sendMessage(getConfig),
   };

--- a/packages/connector-aliyun-sms/src/constant.ts
+++ b/packages/connector-aliyun-sms/src/constant.ts
@@ -28,7 +28,6 @@ export enum SmsTemplateType {
 export const defaultMetadata: ConnectorMetadata = {
   id: 'aliyun-short-message-service',
   target: 'aliyun-sms',
-  type: ConnectorType.SMS,
   platform: null,
   name: {
     en: 'Aliyun Short Message Service',

--- a/packages/connector-aliyun-sms/src/index.test.ts
+++ b/packages/connector-aliyun-sms/src/index.test.ts
@@ -1,7 +1,7 @@
 import { MessageTypes } from '@logto/connector-core';
 
 import createConnector from '.';
-import { mockedConnectorConfig, mockedValidConnectorConfig, phoneTest, codeTest } from './mock';
+import { mockedConnectorConfig, phoneTest, codeTest } from './mock';
 import { sendSms } from './single-send-text';
 
 const getConfig = jest.fn().mockResolvedValue(mockedConnectorConfig);

--- a/packages/connector-aliyun-sms/src/index.ts
+++ b/packages/connector-aliyun-sms/src/index.ts
@@ -6,6 +6,7 @@ import {
   SmsConnector,
   CreateConnector,
   validateConfig,
+  ConnectorType,
 } from '@logto/connector-core';
 import { assert } from '@silverhand/essentials';
 import { HTTPError } from 'got';
@@ -87,6 +88,7 @@ const parseResponseString = (response: string) => {
 const createAliyunSmsConnector: CreateConnector<SmsConnector> = async ({ getConfig }) => {
   return {
     metadata: defaultMetadata,
+    type: ConnectorType.Sms,
     configGuard: aliyunSmsConfigGuard,
     sendMessage: sendMessage(getConfig),
   };

--- a/packages/connector-aliyun-sms/src/mock.ts
+++ b/packages/connector-aliyun-sms/src/mock.ts
@@ -11,13 +11,6 @@ export const mockedConnectorConfig = {
   ],
 };
 
-export const mockedValidConnectorConfig = {
-  accessKeyId: 'accessKeyId',
-  accessKeySecret: 'accessKeySecret',
-  signName: 'signName',
-  templates: [],
-};
-
 export const phoneTest = '13012345678';
 export const codeTest = '1234';
 

--- a/packages/connector-apple/src/constant.ts
+++ b/packages/connector-apple/src/constant.ts
@@ -12,7 +12,6 @@ export const scope = ''; // Note: `openid` is required when adding more scope(s)
 export const defaultMetadata: ConnectorMetadata = {
   id: 'apple-universal',
   target: 'apple',
-  type: ConnectorType.Social,
   platform: ConnectorPlatform.Universal,
   name: {
     en: 'Apple',

--- a/packages/connector-apple/src/index.ts
+++ b/packages/connector-apple/src/index.ts
@@ -7,6 +7,7 @@ import {
   validateConfig,
   CreateConnector,
   SocialConnector,
+  ConnectorType,
 } from '@logto/connector-core';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
 
@@ -80,6 +81,7 @@ const authorizationCallbackHandler = async (parameterObject: unknown) => {
 const createAppleConnector: CreateConnector<SocialConnector> = async ({ getConfig }) => {
   return {
     metadata: defaultMetadata,
+    type: ConnectorType.Social,
     configGuard: appleConfigGuard,
     getAuthorizationUri: getAuthorizationUri(getConfig),
     getUserInfo: getUserInfo(getConfig),

--- a/packages/connector-azuread/src/constant.ts
+++ b/packages/connector-azuread/src/constant.ts
@@ -6,7 +6,6 @@ export const scopes = ['User.Read'];
 export const defaultMetadata: ConnectorMetadata = {
   id: 'azuread-universal',
   target: 'azuread',
-  type: ConnectorType.Social,
   platform: ConnectorPlatform.Universal,
   name: {
     en: 'Azure Active Directory',

--- a/packages/connector-azuread/src/index.ts
+++ b/packages/connector-azuread/src/index.ts
@@ -15,6 +15,7 @@ import {
   validateConfig,
   CreateConnector,
   SocialConnector,
+  ConnectorType,
 } from '@logto/connector-core';
 import { assert, conditional } from '@silverhand/essentials';
 import got, { HTTPError } from 'got';
@@ -152,6 +153,7 @@ const authorizationCallbackHandler = async (parameterObject: unknown) => {
 const createAzureAdConnector: CreateConnector<SocialConnector> = async ({ getConfig }) => {
   return {
     metadata: defaultMetadata,
+    type: ConnectorType.Social,
     configGuard: azureADConfigGuard,
     getAuthorizationUri: getAuthorizationUri(getConfig),
     getUserInfo: getUserInfo(getConfig),

--- a/packages/connector-core/src/types.ts
+++ b/packages/connector-core/src/types.ts
@@ -22,7 +22,7 @@ type I18nPhrases = { en: string } & {
 export enum ConnectorErrorCodes {
   General = 'general',
   InvalidMetadata = 'invalid_metadata',
-  InvalidType = 'invalid_type',
+  UnexpectedType = 'unexpected_type',
   InvalidConfigGuard = 'invalid_config_guard',
   InsufficientRequestParameters = 'insufficient_request_parameters',
   InvalidConfig = 'invalid_config',

--- a/packages/connector-core/src/types.ts
+++ b/packages/connector-core/src/types.ts
@@ -22,6 +22,7 @@ type I18nPhrases = { en: string } & {
 export enum ConnectorErrorCodes {
   General = 'general',
   InvalidMetadata = 'invalid_metadata',
+  InvalidType = 'invalid_type',
   InvalidConfigGuard = 'invalid_config_guard',
   InsufficientRequestParameters = 'insufficient_request_parameters',
   InvalidConfig = 'invalid_config',
@@ -109,8 +110,3 @@ export type GetAuthorizationUri = (payload: {
 export type GetUserInfo = (
   data: unknown
 ) => Promise<{ id: string } & Record<string, string | undefined>>;
-
-export type GeneralConnector =
-  | BaseConnector<ConnectorType.Email>
-  | BaseConnector<ConnectorType.Sms>
-  | BaseConnector<ConnectorType.Social>;

--- a/packages/connector-facebook/src/constant.ts
+++ b/packages/connector-facebook/src/constant.ts
@@ -17,7 +17,6 @@ export const scope = 'email,public_profile';
 export const defaultMetadata: ConnectorMetadata = {
   id: 'facebook-universal',
   target: 'facebook',
-  type: ConnectorType.Social,
   platform: ConnectorPlatform.Universal,
   name: {
     en: 'Facebook',

--- a/packages/connector-facebook/src/index.ts
+++ b/packages/connector-facebook/src/index.ts
@@ -12,6 +12,7 @@ import {
   GetUserInfo,
   GetConnectorConfig,
   validateConfig,
+  ConnectorType,
 } from '@logto/connector-core';
 import { assert } from '@silverhand/essentials';
 import got, { HTTPError } from 'got';
@@ -160,6 +161,7 @@ const authorizationCallbackHandler = async (parameterObject: unknown) => {
 const createFacebookConnector: CreateConnector<SocialConnector> = async ({ getConfig }) => {
   return {
     metadata: defaultMetadata,
+    type: ConnectorType.Social,
     configGuard: facebookConfigGuard,
     getAuthorizationUri: getAuthorizationUri(getConfig),
     getUserInfo: getUserInfo(getConfig),

--- a/packages/connector-github/src/constant.ts
+++ b/packages/connector-github/src/constant.ts
@@ -8,7 +8,6 @@ export const userInfoEndpoint = 'https://api.github.com/user';
 export const defaultMetadata: ConnectorMetadata = {
   id: 'github-universal',
   target: 'github',
-  type: ConnectorType.Social,
   platform: ConnectorPlatform.Universal,
   name: {
     en: 'GitHub',

--- a/packages/connector-github/src/index.ts
+++ b/packages/connector-github/src/index.ts
@@ -7,6 +7,7 @@ import {
   CreateConnector,
   GetConnectorConfig,
   validateConfig,
+  ConnectorType,
 } from '@logto/connector-core';
 import { assert, conditional } from '@silverhand/essentials';
 import got, { HTTPError } from 'got';
@@ -145,6 +146,7 @@ const getUserInfo =
 const createGithubConnector: CreateConnector<SocialConnector> = async ({ getConfig }) => {
   return {
     metadata: defaultMetadata,
+    type: ConnectorType.Social,
     configGuard: githubConfigGuard,
     getAuthorizationUri: getAuthorizationUri(getConfig),
     getUserInfo: getUserInfo(getConfig),

--- a/packages/connector-google/src/constant.ts
+++ b/packages/connector-google/src/constant.ts
@@ -8,7 +8,6 @@ export const scope = 'openid profile email';
 export const defaultMetadata: ConnectorMetadata = {
   id: 'google-universal',
   target: 'google',
-  type: ConnectorType.Social,
   platform: ConnectorPlatform.Universal,
   name: {
     en: 'Google',

--- a/packages/connector-google/src/index.ts
+++ b/packages/connector-google/src/index.ts
@@ -11,6 +11,7 @@ import {
   validateConfig,
   CreateConnector,
   SocialConnector,
+  ConnectorType,
 } from '@logto/connector-core';
 import { conditional, assert } from '@silverhand/essentials';
 import got, { HTTPError } from 'got';
@@ -143,6 +144,7 @@ const getUserInfoErrorHandler = (error: unknown) => {
 const createGoogleConnector: CreateConnector<SocialConnector> = async ({ getConfig }) => {
   return {
     metadata: defaultMetadata,
+    type: ConnectorType.Social,
     configGuard: googleConfigGuard,
     getAuthorizationUri: getAuthorizationUri(getConfig),
     getUserInfo: getUserInfo(getConfig),

--- a/packages/connector-kakao/src/constant.ts
+++ b/packages/connector-kakao/src/constant.ts
@@ -1,4 +1,4 @@
-import { ConnectorMetadata, ConnectorPlatform, ConnectorType } from '@logto/connector-core';
+import { ConnectorMetadata, ConnectorPlatform } from '@logto/connector-core';
 
 export const authorizationEndpoint = 'https://kauth.kakao.com/oauth/authorize';
 export const accessTokenEndpoint = 'https://kauth.kakao.com/oauth/token';
@@ -7,7 +7,6 @@ export const userInfoEndpoint = 'https://kapi.kakao.com/v2/user/me';
 export const defaultMetadata: ConnectorMetadata = {
   id: 'kakao-universal',
   target: 'kakao',
-  type: ConnectorType.Social,
   platform: ConnectorPlatform.Universal,
   name: {
     en: 'Kakao',

--- a/packages/connector-kakao/src/index.ts
+++ b/packages/connector-kakao/src/index.ts
@@ -5,6 +5,7 @@
 import {
   ConnectorError,
   ConnectorErrorCodes,
+  ConnectorType,
   CreateConnector,
   GetAuthorizationUri,
   GetConnectorConfig,
@@ -147,6 +148,7 @@ const getUserInfoErrorHandler = (error: unknown) => {
 const createKakaoConnector: CreateConnector<SocialConnector> = async ({ getConfig }) => {
   return {
     metadata: defaultMetadata,
+    type: ConnectorType.Social,
     configGuard: kakaoConfigGuard,
     getAuthorizationUri: getAuthorizationUri(getConfig),
     getUserInfo: getUserInfo(getConfig),

--- a/packages/connector-mock-email/src/constant.ts
+++ b/packages/connector-mock-email/src/constant.ts
@@ -3,7 +3,6 @@ import { ConnectorType, ConnectorMetadata } from '@logto/connector-core';
 export const defaultMetadata: ConnectorMetadata = {
   id: 'mock-email-service',
   target: 'mock-mail',
-  type: ConnectorType.Email,
   platform: null,
   name: {
     en: 'Mock Mail Service',

--- a/packages/connector-mock-email/src/index.ts
+++ b/packages/connector-mock-email/src/index.ts
@@ -9,6 +9,7 @@ import {
   CreateConnector,
   EmailConnector,
   validateConfig,
+  ConnectorType,
 } from '@logto/connector-core';
 import { assert } from '@silverhand/essentials';
 
@@ -43,6 +44,7 @@ const sendMessage =
 const createMockEmailConnector: CreateConnector<EmailConnector> = async ({ getConfig }) => {
   return {
     metadata: defaultMetadata,
+    type: ConnectorType.Email,
     configGuard: mockMailConfigGuard,
     sendMessage: sendMessage(getConfig),
   };

--- a/packages/connector-mock-sms/src/constant.ts
+++ b/packages/connector-mock-sms/src/constant.ts
@@ -3,7 +3,6 @@ import { ConnectorType, ConnectorMetadata } from '@logto/connector-core';
 export const defaultMetadata: ConnectorMetadata = {
   id: 'mock-short-message-service',
   target: 'mock-sms',
-  type: ConnectorType.SMS,
   platform: null,
   name: {
     en: 'Mock SMS Service',

--- a/packages/connector-mock-sms/src/index.ts
+++ b/packages/connector-mock-sms/src/index.ts
@@ -9,6 +9,7 @@ import {
   validateConfig,
   CreateConnector,
   SmsConnector,
+  ConnectorType,
 } from '@logto/connector-core';
 import { assert } from '@silverhand/essentials';
 
@@ -43,6 +44,7 @@ const sendMessage =
 const createMockSmsConnector: CreateConnector<SmsConnector> = async ({ getConfig }) => {
   return {
     metadata: defaultMetadata,
+    type: ConnectorType.Sms,
     configGuard: mockSmsConfigGuard,
     sendMessage: sendMessage(getConfig),
   };

--- a/packages/connector-mock-social/src/constant.ts
+++ b/packages/connector-mock-social/src/constant.ts
@@ -3,7 +3,6 @@ import { ConnectorMetadata, ConnectorType, ConnectorPlatform } from '@logto/conn
 export const defaultMetadata: ConnectorMetadata = {
   id: 'mock-social-connector',
   target: 'mock-social',
-  type: ConnectorType.Social,
   platform: ConnectorPlatform.Universal,
   name: {
     en: 'Mock Social',

--- a/packages/connector-mock-social/src/index.ts
+++ b/packages/connector-mock-social/src/index.ts
@@ -7,6 +7,7 @@ import {
   GetUserInfo,
   CreateConnector,
   SocialConnector,
+  ConnectorType,
 } from '@logto/connector-core';
 import { z } from 'zod';
 
@@ -36,6 +37,7 @@ const getUserInfo: GetUserInfo = async (data) => {
 const createMockSocialConnector: CreateConnector<SocialConnector> = async ({ getConfig }) => {
   return {
     metadata: defaultMetadata,
+    type: ConnectorType.Social,
     configGuard: mockSocialConfigGuard,
     getAuthorizationUri,
     getUserInfo,

--- a/packages/connector-sendgrid-mail/src/constant.ts
+++ b/packages/connector-sendgrid-mail/src/constant.ts
@@ -5,7 +5,6 @@ export const endpoint = 'https://api.sendgrid.com/v3/mail/send';
 export const defaultMetadata: ConnectorMetadata = {
   id: 'sendgrid-email-service',
   target: 'sendgrid-mail',
-  type: ConnectorType.Email,
   platform: null,
   name: {
     en: 'SendGrid Mail Service',

--- a/packages/connector-sendgrid-mail/src/index.ts
+++ b/packages/connector-sendgrid-mail/src/index.ts
@@ -6,6 +6,7 @@ import {
   validateConfig,
   CreateConnector,
   EmailConnector,
+  ConnectorType,
 } from '@logto/connector-core';
 import { assert } from '@silverhand/essentials';
 import got, { HTTPError } from 'got';
@@ -87,6 +88,7 @@ const sendMessage =
 const createSendGridMailConnector: CreateConnector<EmailConnector> = async ({ getConfig }) => {
   return {
     metadata: defaultMetadata,
+    type: ConnectorType.Email,
     configGuard: sendGridMailConfigGuard,
     sendMessage: sendMessage(getConfig),
   };

--- a/packages/connector-smtp/src/constant.ts
+++ b/packages/connector-smtp/src/constant.ts
@@ -3,7 +3,6 @@ import { ConnectorType, ConnectorMetadata } from '@logto/connector-core';
 export const defaultMetadata: ConnectorMetadata = {
   id: 'simple-mail-transfer-protocol',
   target: 'smtp',
-  type: ConnectorType.Email,
   platform: null,
   name: {
     en: 'SMTP',

--- a/packages/connector-smtp/src/index.ts
+++ b/packages/connector-smtp/src/index.ts
@@ -6,6 +6,7 @@ import {
   EmailConnector,
   SendMessageFunction,
   validateConfig,
+  ConnectorType,
 } from '@logto/connector-core';
 import { assert } from '@silverhand/essentials';
 import nodemailer from 'nodemailer';
@@ -89,6 +90,7 @@ const parseContents = (contents: string, contentType: ContextType) => {
 const createSmtpConnector: CreateConnector<EmailConnector> = async ({ getConfig }) => {
   return {
     metadata: defaultMetadata,
+    type: ConnectorType.Email,
     configGuard: smtpConfigGuard,
     sendMessage: sendMessage(getConfig),
   };

--- a/packages/connector-twilio-sms/src/constant.ts
+++ b/packages/connector-twilio-sms/src/constant.ts
@@ -5,7 +5,6 @@ export const endpoint = 'https://api.twilio.com/2010-04-01/Accounts/{{accountSID
 export const defaultMetadata: ConnectorMetadata = {
   id: 'twilio-short-message-service',
   target: 'twilio-sms',
-  type: ConnectorType.SMS,
   platform: null,
   name: {
     en: 'Twilio SMS Service',

--- a/packages/connector-twilio-sms/src/index.ts
+++ b/packages/connector-twilio-sms/src/index.ts
@@ -6,6 +6,7 @@ import {
   validateConfig,
   CreateConnector,
   SmsConnector,
+  ConnectorType,
 } from '@logto/connector-core';
 import { assert } from '@silverhand/essentials';
 import got, { HTTPError } from 'got';
@@ -68,6 +69,7 @@ const sendMessage =
 const createTwilioSmsConnector: CreateConnector<SmsConnector> = async ({ getConfig }) => {
   return {
     metadata: defaultMetadata,
+    type: ConnectorType.Sms,
     configGuard: twilioSmsConfigGuard,
     sendMessage: sendMessage(getConfig),
   };

--- a/packages/connector-wechat-native/src/constant.ts
+++ b/packages/connector-wechat-native/src/constant.ts
@@ -13,7 +13,6 @@ export const invalidAccessTokenErrcode = [40_001, 40_014];
 export const defaultMetadata: ConnectorMetadata = {
   id: 'wechat-native',
   target: 'wechat',
-  type: ConnectorType.Social,
   platform: ConnectorPlatform.Native,
   name: {
     en: 'WeChat',

--- a/packages/connector-wechat-native/src/index.ts
+++ b/packages/connector-wechat-native/src/index.ts
@@ -12,6 +12,7 @@ import {
   validateConfig,
   CreateConnector,
   SocialConnector,
+  ConnectorType,
 } from '@logto/connector-core';
 import { assert } from '@silverhand/essentials';
 import got, { HTTPError } from 'got';
@@ -167,6 +168,7 @@ const authorizationCallbackHandler = async (parameterObject: unknown) => {
 const createWechatNativeConnector: CreateConnector<SocialConnector> = async ({ getConfig }) => {
   return {
     metadata: defaultMetadata,
+    type: ConnectorType.Social,
     configGuard: wechatNativeConfigGuard,
     getAuthorizationUri: getAuthorizationUri(getConfig),
     getUserInfo: getUserInfo(getConfig),

--- a/packages/connector-wechat-web/src/constant.ts
+++ b/packages/connector-wechat-web/src/constant.ts
@@ -13,7 +13,6 @@ export const invalidAccessTokenErrcode = [40_001, 40_014];
 export const defaultMetadata: ConnectorMetadata = {
   id: 'wechat-web',
   target: 'wechat',
-  type: ConnectorType.Social,
   platform: ConnectorPlatform.Web,
   name: {
     en: 'WeChat',

--- a/packages/connector-wechat-web/src/index.ts
+++ b/packages/connector-wechat-web/src/index.ts
@@ -12,6 +12,7 @@ import {
   validateConfig,
   CreateConnector,
   SocialConnector,
+  ConnectorType,
 } from '@logto/connector-core';
 import { assert } from '@silverhand/essentials';
 import got, { HTTPError } from 'got';
@@ -168,6 +169,7 @@ const authorizationCallbackHandler = async (parameterObject: unknown) => {
 const createWechatConnector: CreateConnector<SocialConnector> = async ({ getConfig }) => {
   return {
     metadata: defaultMetadata,
+    type: ConnectorType.Social,
     configGuard: wechatConfigGuard,
     getAuthorizationUri: getAuthorizationUri(getConfig),
     getUserInfo: getUserInfo(getConfig),

--- a/packages/console/src/consts/connectors.ts
+++ b/packages/console/src/consts/connectors.ts
@@ -9,7 +9,7 @@ type TitlePlaceHolder = {
 };
 
 export const connectorTitlePlaceHolder: TitlePlaceHolder = Object.freeze({
-  [ConnectorType.SMS]: 'connectors.type.sms',
+  [ConnectorType.Sms]: 'connectors.type.sms',
   [ConnectorType.Email]: 'connectors.type.email',
   [ConnectorType.Social]: 'connectors.type.social',
 });
@@ -29,6 +29,6 @@ type ConnectorPlaceholderIcon = {
 };
 
 export const connectorPlaceholderIcon: ConnectorPlaceholderIcon = Object.freeze({
-  [ConnectorType.SMS]: SmsConnectorIcon,
+  [ConnectorType.Sms]: SmsConnectorIcon,
   [ConnectorType.Email]: EmailConnector,
 } as const);

--- a/packages/console/src/hooks/use-connector-in-use.ts
+++ b/packages/console/src/hooks/use-connector-in-use.ts
@@ -14,7 +14,7 @@ const useConnectorInUse = (type?: ConnectorType, target?: string): boolean | und
     return data.signInMethods.email !== SignInMethodState.Disabled;
   }
 
-  if (type === ConnectorType.SMS) {
+  if (type === ConnectorType.Sms) {
     return data.signInMethods.sms !== SignInMethodState.Disabled;
   }
 

--- a/packages/console/src/pages/ConnectorDetails/components/ConnectorContent.tsx
+++ b/packages/console/src/pages/ConnectorDetails/components/ConnectorContent.tsx
@@ -56,7 +56,7 @@ const ConnectorContent = ({ isDeleted, connectorData, onConnectorUpdated }: Prop
 
     const { metadata, ...rest } = await api
       .patch(`/api/connectors/${connectorData.id}`, { json: { config: result.data } })
-      .json<Connector & { metadata: ConnectorMetadata }>();
+      .json<Connector & { metadata: ConnectorMetadata; type: ConnectorType }>();
 
     onConnectorUpdated({ ...rest, ...metadata });
     reset({ configJson: JSON.stringify(result.data, null, 2) });

--- a/packages/console/src/pages/ConnectorDetails/components/ConnectorTypeName/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/components/ConnectorTypeName/index.tsx
@@ -13,7 +13,7 @@ const ConnectorTypeName = ({ type }: Props) => {
   return (
     <div className={styles.connectorType}>
       {type === ConnectorType.Email && t('connector_details.type_email')}
-      {type === ConnectorType.SMS && t('connector_details.type_sms')}
+      {type === ConnectorType.Sms && t('connector_details.type_sms')}
       {type === ConnectorType.Social && t('connector_details.type_social')}
     </div>
   );

--- a/packages/console/src/pages/ConnectorDetails/components/SenderTester/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/components/SenderTester/index.tsx
@@ -39,7 +39,7 @@ const SenderTester = ({ connectorId, connectorType, config, className }: Props) 
   } = useForm<FormData>();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const api = useApi();
-  const isSms = connectorType === ConnectorType.SMS;
+  const isSms = connectorType === ConnectorType.Sms;
 
   useEffect(() => {
     if (!showTooltip) {

--- a/packages/console/src/pages/ConnectorDetails/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/index.tsx
@@ -143,7 +143,7 @@ const ConnectorDetails = () => {
                   }}
                 >
                   {t(
-                    data.type === ConnectorType.SMS
+                    data.type === ConnectorType.Sms
                       ? 'connector_details.options_change_sms'
                       : 'connector_details.options_change_email'
                   )}

--- a/packages/console/src/pages/Connectors/components/CreateForm/index.tsx
+++ b/packages/console/src/pages/Connectors/components/CreateForm/index.tsx
@@ -46,7 +46,7 @@ const CreateForm = ({ onClose, isOpen: isFormOpen, type }: Props) => {
       return 'connectors.setup_title.email';
     }
 
-    if (type === ConnectorType.SMS) {
+    if (type === ConnectorType.Sms) {
       return 'connectors.setup_title.sms';
     }
 

--- a/packages/console/src/pages/Connectors/components/Guide/index.tsx
+++ b/packages/console/src/pages/Connectors/components/Guide/index.tsx
@@ -37,7 +37,7 @@ const Guide = ({ connector, onClose }: Props) => {
   const connectorName = result.success ? name[result.data] : name.en;
 
   const isSocialConnector =
-    connectorType !== ConnectorType.SMS && connectorType !== ConnectorType.Email;
+    connectorType !== ConnectorType.Sms && connectorType !== ConnectorType.Email;
   const methods = useForm<GuideForm>({ reValidateMode: 'onBlur' });
   const {
     control,

--- a/packages/console/src/pages/Connectors/index.tsx
+++ b/packages/console/src/pages/Connectors/index.tsx
@@ -42,7 +42,7 @@ const Connectors = () => {
 
   const smsConnector = useMemo(() => {
     const smsConnectorGroup = data?.find(
-      ({ enabled, type }) => enabled && type === ConnectorType.SMS
+      ({ enabled, type }) => enabled && type === ConnectorType.Sms
     );
 
     return smsConnectorGroup?.connectors[0];
@@ -119,9 +119,9 @@ const Connectors = () => {
               {!isLoading && !isSocial && (
                 <ConnectorRow
                   connectors={smsConnector ? [smsConnector] : []}
-                  type={ConnectorType.SMS}
+                  type={ConnectorType.Sms}
                   onClickSetup={() => {
-                    setCreateType(ConnectorType.SMS);
+                    setCreateType(ConnectorType.Sms);
                   }}
                 />
               )}

--- a/packages/console/src/pages/SignInExperience/components/ConnectorSetupWarning.tsx
+++ b/packages/console/src/pages/SignInExperience/components/ConnectorSetupWarning.tsx
@@ -19,8 +19,8 @@ const ConnectorSetupWarning = ({ method }: Props) => {
       return;
     }
 
-    if (method === SignInMethodKey.SMS) {
-      return ConnectorType.SMS;
+    if (method === SignInMethodKey.Sms) {
+      return ConnectorType.Sms;
     }
 
     if (method === SignInMethodKey.Email) {

--- a/packages/console/src/pages/SignInExperience/components/SignInMethodsForm.tsx
+++ b/packages/console/src/pages/SignInExperience/components/SignInMethodsForm.tsx
@@ -55,7 +55,7 @@ const SignInMethodsForm = () => {
 
         const enabled =
           (method === SignInMethodKey.Email && email) ||
-          (method === SignInMethodKey.SMS && sms) ||
+          (method === SignInMethodKey.Sms && sms) ||
           (method === SignInMethodKey.Social && social);
 
         return (

--- a/packages/console/src/pages/SignInExperience/utilities.ts
+++ b/packages/console/src/pages/SignInExperience/utilities.ts
@@ -51,7 +51,7 @@ export const signInExperienceParser = {
         primary: primaryMethod,
         enableSecondary: secondaryMethods.length > 0,
         username: secondaryMethods.includes(SignInMethodKey.Username),
-        sms: secondaryMethods.includes(SignInMethodKey.SMS),
+        sms: secondaryMethods.includes(SignInMethodKey.Sms),
         email: secondaryMethods.includes(SignInMethodKey.Email),
         social: secondaryMethods.includes(SignInMethodKey.Social),
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logto/core",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "The open source identity solution.",
   "main": "build/index.js",
   "author": "Silverhand Inc. <contact@silverhand.io>",

--- a/packages/core/src/__mocks__/connector.ts
+++ b/packages/core/src/__mocks__/connector.ts
@@ -7,7 +7,6 @@ import { LogtoConnector } from '@/connectors/types';
 export const mockMetadata: ConnectorMetadata = {
   id: 'id',
   target: 'connector',
-  type: ConnectorType.Email,
   platform: null,
   name: {
     en: 'Connector',
@@ -34,7 +33,7 @@ export const mockConnector: Connector = {
   createdAt: 1_234_567_890_123,
 };
 
-export const mockLogtoConnector: Omit<LogtoConnector, 'metadata' | 'dbEntry'> = {
+export const mockLogtoConnector = {
   getAuthorizationUri: jest.fn(),
   getUserInfo: jest.fn(),
   sendMessage: jest.fn(),
@@ -46,7 +45,6 @@ const mockMetadata0: ConnectorMetadata = {
   ...mockMetadata,
   id: 'id0',
   target: 'connector_0',
-  type: ConnectorType.Email,
   platform: ConnectorPlatform.Universal,
 };
 
@@ -54,7 +52,6 @@ const mockMetadata1: ConnectorMetadata = {
   ...mockMetadata,
   id: 'id1',
   target: 'connector_1',
-  type: ConnectorType.SMS,
   platform: ConnectorPlatform.Universal,
 };
 
@@ -62,7 +59,6 @@ const mockMetadata2: ConnectorMetadata = {
   ...mockMetadata,
   id: 'id2',
   target: 'connector_2',
-  type: ConnectorType.Social,
   platform: ConnectorPlatform.Universal,
 };
 
@@ -70,7 +66,6 @@ const mockMetadata3: ConnectorMetadata = {
   ...mockMetadata,
   id: 'id3',
   target: 'connector_3',
-  type: ConnectorType.Social,
   platform: ConnectorPlatform.Universal,
 };
 
@@ -78,7 +73,6 @@ const mockMetadata4: ConnectorMetadata = {
   ...mockMetadata,
   id: 'id4',
   target: 'connector_4',
-  type: ConnectorType.Social,
   platform: ConnectorPlatform.Universal,
 };
 
@@ -86,7 +80,6 @@ const mockMetadata5: ConnectorMetadata = {
   ...mockMetadata,
   id: 'id5',
   target: 'connector_5',
-  type: ConnectorType.Social,
   platform: ConnectorPlatform.Universal,
 };
 
@@ -94,7 +87,6 @@ const mockMetadata6: ConnectorMetadata = {
   ...mockMetadata,
   id: 'id6',
   target: 'connector_6',
-  type: ConnectorType.Social,
   platform: ConnectorPlatform.Universal,
 };
 
@@ -160,37 +152,44 @@ export const mockConnectorList: Connector[] = [
 export const mockLogtoConnectorList: LogtoConnector[] = [
   {
     dbEntry: mockConnector0,
-    metadata: { ...mockMetadata0, type: ConnectorType.Social },
+    metadata: { ...mockMetadata0 },
+    type: ConnectorType.Social,
     ...mockLogtoConnector,
   },
   {
     dbEntry: mockConnector1,
     metadata: mockMetadata1,
+    type: ConnectorType.Sms,
     ...mockLogtoConnector,
   },
   {
     dbEntry: mockConnector2,
     metadata: mockMetadata2,
+    type: ConnectorType.Social,
     ...mockLogtoConnector,
   },
   {
     dbEntry: mockConnector3,
     metadata: mockMetadata3,
+    type: ConnectorType.Social,
     ...mockLogtoConnector,
   },
   {
     dbEntry: mockConnector4,
-    metadata: { ...mockMetadata4, type: ConnectorType.Email, platform: null },
+    metadata: { ...mockMetadata4, platform: null },
+    type: ConnectorType.Email,
     ...mockLogtoConnector,
   },
   {
     dbEntry: mockConnector5,
-    metadata: { ...mockMetadata5, type: ConnectorType.SMS, platform: null },
+    metadata: { ...mockMetadata5, platform: null },
+    type: ConnectorType.Sms,
     ...mockLogtoConnector,
   },
   {
     dbEntry: mockConnector6,
-    metadata: { ...mockMetadata6, type: ConnectorType.Email, platform: null },
+    metadata: { ...mockMetadata6, platform: null },
+    type: ConnectorType.Email,
     ...mockLogtoConnector,
   },
 ];
@@ -204,9 +203,9 @@ export const mockAliyunDmConnector: LogtoConnector = {
     ...mockMetadata,
     id: 'aliyun-dm',
     target: 'aliyun-dm',
-    type: ConnectorType.Email,
     platform: null,
   },
+  type: ConnectorType.Email,
   ...mockLogtoConnector,
 };
 
@@ -219,9 +218,9 @@ export const mockAliyunSmsConnector: LogtoConnector = {
     ...mockMetadata,
     id: 'aliyun-sms',
     target: 'aliyun-sms',
-    type: ConnectorType.SMS,
     platform: null,
   },
+  type: ConnectorType.Sms,
   ...mockLogtoConnector,
 };
 
@@ -234,9 +233,9 @@ export const mockFacebookConnector: LogtoConnector = {
     ...mockMetadata,
     id: 'facebook',
     target: 'facebook',
-    type: ConnectorType.Social,
     platform: ConnectorPlatform.Web,
   },
+  type: ConnectorType.Social,
   ...mockLogtoConnector,
 };
 
@@ -249,9 +248,9 @@ export const mockGithubConnector: LogtoConnector = {
     ...mockMetadata,
     id: 'github',
     target: 'github',
-    type: ConnectorType.Social,
     platform: ConnectorPlatform.Web,
   },
+  type: ConnectorType.Social,
   ...mockLogtoConnector,
 };
 
@@ -264,9 +263,9 @@ export const mockWechatConnector: LogtoConnector = {
     ...mockMetadata,
     id: 'wechat-web',
     target: 'wechat',
-    type: ConnectorType.Social,
     platform: ConnectorPlatform.Web,
   },
+  type: ConnectorType.Social,
   ...mockLogtoConnector,
 };
 
@@ -279,9 +278,9 @@ export const mockWechatNativeConnector: LogtoConnector = {
     ...mockMetadata,
     id: 'wechat-native',
     target: 'wechat',
-    type: ConnectorType.Social,
     platform: ConnectorPlatform.Native,
   },
+  type: ConnectorType.Social,
   ...mockLogtoConnector,
 };
 
@@ -295,9 +294,9 @@ export const mockGoogleConnector: LogtoConnector = {
     ...mockMetadata,
     id: 'google',
     target: 'google',
-    type: ConnectorType.Social,
     platform: ConnectorPlatform.Web,
   },
+  type: ConnectorType.Social,
   ...mockLogtoConnector,
 };
 

--- a/packages/core/src/connectors/consts.ts
+++ b/packages/core/src/connectors/consts.ts
@@ -1,6 +1,4 @@
-import { ConnectorError, ConnectorErrorCodes, GeneralConnector } from '@logto/connector-core';
-
-import { LogtoConnector } from './types';
+import { ConnectorError, ConnectorErrorCodes } from '@logto/connector-core';
 
 export const defaultConnectorPackages = [
   '@logto/connector-alipay-web',

--- a/packages/core/src/connectors/consts.ts
+++ b/packages/core/src/connectors/consts.ts
@@ -24,10 +24,9 @@ const notImplemented = () => {
   throw new ConnectorError(ConnectorErrorCodes.NotImplemented);
 };
 
-export const defaultConnectorMethods: Omit<LogtoConnector, 'metadata' | 'configGuard' | 'dbEntry'> =
-  {
-    getAuthorizationUri: notImplemented,
-    getUserInfo: notImplemented,
-    sendMessage: notImplemented,
-    validateConfig: notImplemented,
-  };
+export const defaultConnectorMethods = {
+  getAuthorizationUri: notImplemented,
+  getUserInfo: notImplemented,
+  sendMessage: notImplemented,
+  validateConfig: notImplemented,
+};

--- a/packages/core/src/connectors/types.ts
+++ b/packages/core/src/connectors/types.ts
@@ -16,15 +16,6 @@ export const socialUserInfoGuard = z.object({
 
 export type SocialUserInfo = z.infer<typeof socialUserInfoGuard>;
 
-export type GeneralConnector =
-  | BaseConnector<ConnectorType.Email>
-  | BaseConnector<ConnectorType.Sms>
-  | BaseConnector<ConnectorType.Social>;
-
-type ExtractConnectorType<T extends GeneralConnector> = T extends BaseConnector<infer R>
-  ? R
-  : never;
-
 export type LoadConnector<T extends AllConnector = AllConnector> = T & {
   validateConfig: (config: unknown) => void;
 };

--- a/packages/core/src/connectors/types.ts
+++ b/packages/core/src/connectors/types.ts
@@ -16,10 +16,16 @@ export const socialUserInfoGuard = z.object({
 
 export type SocialUserInfo = z.infer<typeof socialUserInfoGuard>;
 
+/**
+ * Dynamic loaded connector type.
+ */
 export type LoadConnector<T extends AllConnector = AllConnector> = T & {
   validateConfig: (config: unknown) => void;
 };
 
+/**
+ * The connector type with full context.
+ */
 export type LogtoConnector<T extends AllConnector = AllConnector> = LoadConnector<T> & {
   dbEntry: Connector;
 };

--- a/packages/core/src/connectors/types.ts
+++ b/packages/core/src/connectors/types.ts
@@ -1,4 +1,4 @@
-import { AllConnector, BaseConnector, ConnectorType, EmailConnector } from '@logto/connector-core';
+import { AllConnector } from '@logto/connector-core';
 import { Connector, PasscodeType } from '@logto/schemas';
 import { z } from 'zod';
 

--- a/packages/core/src/connectors/types.ts
+++ b/packages/core/src/connectors/types.ts
@@ -1,4 +1,4 @@
-import { GeneralConnector } from '@logto/connector-core';
+import { AllConnector, BaseConnector, ConnectorType, EmailConnector } from '@logto/connector-core';
 import { Connector, PasscodeType } from '@logto/schemas';
 import { z } from 'zod';
 
@@ -16,7 +16,19 @@ export const socialUserInfoGuard = z.object({
 
 export type SocialUserInfo = z.infer<typeof socialUserInfoGuard>;
 
-export type LogtoConnector = Required<GeneralConnector> & {
-  dbEntry: Connector;
+export type GeneralConnector =
+  | BaseConnector<ConnectorType.Email>
+  | BaseConnector<ConnectorType.Sms>
+  | BaseConnector<ConnectorType.Social>;
+
+type ExtractConnectorType<T extends GeneralConnector> = T extends BaseConnector<infer R>
+  ? R
+  : never;
+
+export type LoadConnector<T extends AllConnector = AllConnector> = T & {
   validateConfig: (config: unknown) => void;
+};
+
+export type LogtoConnector<T extends AllConnector = AllConnector> = LoadConnector<T> & {
+  dbEntry: Connector;
 };

--- a/packages/core/src/connectors/utilities/index.ts
+++ b/packages/core/src/connectors/utilities/index.ts
@@ -1,4 +1,9 @@
-import { ConnectorError, ConnectorErrorCodes, GeneralConnector } from '@logto/connector-core';
+import {
+  BaseConnector,
+  ConnectorError,
+  ConnectorErrorCodes,
+  ConnectorType,
+} from '@logto/connector-core';
 
 import RequestError from '@/errors/RequestError';
 import { findAllConnectors } from '@/queries/connector';
@@ -14,13 +19,17 @@ export const getConnectorConfig = async (id: string): Promise<unknown> => {
 };
 
 export function validateConnectorModule(
-  connector: Partial<GeneralConnector>
-): asserts connector is GeneralConnector {
+  connector: Partial<BaseConnector<ConnectorType>>
+): asserts connector is BaseConnector<ConnectorType> {
   if (!connector.metadata) {
     throw new ConnectorError(ConnectorErrorCodes.InvalidMetadata);
   }
 
   if (!connector.configGuard) {
     throw new ConnectorError(ConnectorErrorCodes.InvalidConfigGuard);
+  }
+
+  if (!connector.type || Object.values(ConnectorType).includes(connector.type)) {
+    throw new ConnectorError(ConnectorErrorCodes.InvalidType);
   }
 }

--- a/packages/core/src/connectors/utilities/index.ts
+++ b/packages/core/src/connectors/utilities/index.ts
@@ -29,7 +29,7 @@ export function validateConnectorModule(
     throw new ConnectorError(ConnectorErrorCodes.InvalidConfigGuard);
   }
 
-  if (!connector.type || Object.values(ConnectorType).includes(connector.type)) {
-    throw new ConnectorError(ConnectorErrorCodes.InvalidType);
+  if (!connector.type || !Object.values(ConnectorType).includes(connector.type)) {
+    throw new ConnectorError(ConnectorErrorCodes.UnexpectedType);
   }
 }

--- a/packages/core/src/lib/passcode.test.ts
+++ b/packages/core/src/lib/passcode.test.ts
@@ -135,9 +135,10 @@ describe('sendPasscode', () => {
         },
         metadata: {
           ...mockMetadata,
-          type: ConnectorType.Email,
           platform: null,
         },
+        type: ConnectorType.Email,
+        sendMessage: jest.fn(),
         configGuard: any(),
       },
     ]);
@@ -155,7 +156,7 @@ describe('sendPasscode', () => {
     await expect(sendPasscode(passcode)).rejects.toThrowError(
       new RequestError({
         code: 'connector.not_found',
-        type: ConnectorType.SMS,
+        type: ConnectorType.Sms,
       })
     );
   });
@@ -172,9 +173,9 @@ describe('sendPasscode', () => {
         },
         metadata: {
           ...mockMetadata,
-          type: ConnectorType.SMS,
           platform: null,
         },
+        type: ConnectorType.Sms,
         sendMessage,
       },
       {
@@ -186,9 +187,9 @@ describe('sendPasscode', () => {
         },
         metadata: {
           ...mockMetadata,
-          type: ConnectorType.Email,
           platform: null,
         },
+        type: ConnectorType.Email,
         sendMessage,
       },
     ]);

--- a/packages/core/src/lib/passcode.ts
+++ b/packages/core/src/lib/passcode.ts
@@ -64,7 +64,7 @@ export const sendPasscode = async (passcode: Passcode) => {
     connector,
     new RequestError({
       code: 'connector.not_found',
-      type: passcode.email ? ConnectorType.Email : ConnectorType.Sms,
+      type: expectType,
     })
   );
 

--- a/packages/core/src/lib/passcode.ts
+++ b/packages/core/src/lib/passcode.ts
@@ -1,9 +1,15 @@
-import { messageTypesGuard, ConnectorError, ConnectorErrorCodes } from '@logto/connector-core';
+import {
+  messageTypesGuard,
+  ConnectorError,
+  ConnectorErrorCodes,
+  EmailConnector,
+  SmsConnector,
+} from '@logto/connector-core';
 import { Passcode, PasscodeType } from '@logto/schemas';
 import { customAlphabet, nanoid } from 'nanoid';
 
 import { getLogtoConnectors } from '@/connectors';
-import { ConnectorType } from '@/connectors/types';
+import { ConnectorType, LogtoConnector } from '@/connectors/types';
 import RequestError from '@/errors/RequestError';
 import {
   consumePasscode,
@@ -46,22 +52,19 @@ export const sendPasscode = async (passcode: Passcode) => {
     throw new RequestError('passcode.phone_email_empty');
   }
 
+  const expectType = passcode.phone ? ConnectorType.Sms : ConnectorType.Email;
   const connectors = await getLogtoConnectors();
 
-  const emailConnector = connectors.find(
-    (connector) => connector.dbEntry.enabled && connector.metadata.type === ConnectorType.Email
+  const connector = connectors.find(
+    (connector): connector is LogtoConnector<SmsConnector | EmailConnector> =>
+      connector.dbEntry.enabled && connector.type === expectType
   );
-  const smsConnector = connectors.find(
-    (connector) => connector.dbEntry.enabled && connector.metadata.type === ConnectorType.SMS
-  );
-
-  const connector = passcode.email ? emailConnector : smsConnector;
 
   assertThat(
     connector,
     new RequestError({
       code: 'connector.not_found',
-      type: passcode.email ? ConnectorType.Email : ConnectorType.SMS,
+      type: passcode.email ? ConnectorType.Email : ConnectorType.Sms,
     })
   );
 

--- a/packages/core/src/lib/sign-in-experience.test.ts
+++ b/packages/core/src/lib/sign-in-experience.test.ts
@@ -132,7 +132,7 @@ describe('validate sign-in methods', () => {
       }).toMatchError(
         new RequestError({
           code: 'sign_in_experiences.enabled_connector_not_found',
-          type: ConnectorType.SMS,
+          type: ConnectorType.Sms,
         })
       );
     });

--- a/packages/core/src/lib/sign-in-experience.ts
+++ b/packages/core/src/lib/sign-in-experience.ts
@@ -41,7 +41,7 @@ export const validateSignInMethods = (
 
   if (isEnabled(signInMethods.email)) {
     assertThat(
-      enabledConnectors.some((item) => item.metadata.type === ConnectorType.Email),
+      enabledConnectors.some((item) => item.type === ConnectorType.Email),
       new RequestError({
         code: 'sign_in_experiences.enabled_connector_not_found',
         type: ConnectorType.Email,
@@ -51,17 +51,17 @@ export const validateSignInMethods = (
 
   if (isEnabled(signInMethods.sms)) {
     assertThat(
-      enabledConnectors.some((item) => item.metadata.type === ConnectorType.SMS),
+      enabledConnectors.some((item) => item.type === ConnectorType.Sms),
       new RequestError({
         code: 'sign_in_experiences.enabled_connector_not_found',
-        type: ConnectorType.SMS,
+        type: ConnectorType.Sms,
       })
     );
   }
 
   if (isEnabled(signInMethods.social)) {
     assertThat(
-      enabledConnectors.some((item) => item.metadata.type === ConnectorType.Social),
+      enabledConnectors.some((item) => item.type === ConnectorType.Social),
       new RequestError({
         code: 'sign_in_experiences.enabled_connector_not_found',
         type: ConnectorType.Social,

--- a/packages/core/src/lib/social.ts
+++ b/packages/core/src/lib/social.ts
@@ -1,4 +1,4 @@
-import { User } from '@logto/schemas';
+import { ConnectorType, User } from '@logto/schemas';
 import { Nullable } from '@silverhand/essentials';
 import { InteractionResults } from 'oidc-provider';
 import { z } from 'zod';
@@ -40,6 +40,15 @@ export const getUserInfoByAuthCode = async (
   data: unknown
 ): Promise<SocialUserInfo> => {
   const connector = await getConnector(connectorId);
+
+  assertThat(
+    connector.type === ConnectorType.Social,
+    new RequestError({
+      code: 'session.invalid_connector_id',
+      status: 422,
+      connectorId,
+    })
+  );
 
   return connector.getUserInfo(data);
 };

--- a/packages/core/src/routes/connector.test.ts
+++ b/packages/core/src/routes/connector.test.ts
@@ -1,4 +1,4 @@
-import { MessageTypes } from '@logto/connector-core';
+import { EmailConnector, MessageTypes, SmsConnector } from '@logto/connector-core';
 import { Connector, ConnectorType } from '@logto/schemas';
 import { any } from 'zod';
 
@@ -49,9 +49,7 @@ describe('connector route', () => {
 
     it('throws if more than one SMS connector is enabled', async () => {
       getLogtoConnectorsPlaceHolder.mockResolvedValueOnce(
-        mockLogtoConnectorList.filter(
-          (connector) => connector.metadata.type !== ConnectorType.Email
-        )
+        mockLogtoConnectorList.filter((connector) => connector.type !== ConnectorType.Email)
       );
       const response = await connectorRequest.get('/connectors').send({});
       expect(response).toHaveProperty('statusCode', 400);
@@ -59,9 +57,7 @@ describe('connector route', () => {
 
     it('shows all connectors', async () => {
       getLogtoConnectorsPlaceHolder.mockResolvedValueOnce(
-        mockLogtoConnectorList.filter(
-          (connector) => connector.metadata.type === ConnectorType.Social
-        )
+        mockLogtoConnectorList.filter((connector) => connector.type === ConnectorType.Social)
       );
       const response = await connectorRequest.get('/connectors').send({});
       expect(response).toHaveProperty('statusCode', 200);
@@ -100,12 +96,12 @@ describe('connector route', () => {
     it('should get SMS connector and send test message', async () => {
       const mockedMetadata = {
         ...mockMetadata,
-        type: ConnectorType.SMS,
       };
       const sendMessage = jest.fn();
-      const mockedSmsConnector: LogtoConnector = {
+      const mockedSmsConnector: LogtoConnector<SmsConnector> = {
         dbEntry: mockConnector,
         metadata: mockedMetadata,
+        type: ConnectorType.Sms,
         configGuard: any(),
         ...defaultConnectorMethods,
         sendMessage,
@@ -130,9 +126,10 @@ describe('connector route', () => {
 
     it('should get email connector and send test message', async () => {
       const sendMessage = jest.fn();
-      const mockedEmailConnector: LogtoConnector = {
+      const mockedEmailConnector: LogtoConnector<EmailConnector> = {
         dbEntry: mockConnector,
         metadata: mockMetadata,
+        type: ConnectorType.Email,
         configGuard: any(),
         ...defaultConnectorMethods,
         sendMessage,

--- a/packages/core/src/routes/connector.update.test.ts
+++ b/packages/core/src/routes/connector.update.test.ts
@@ -75,7 +75,8 @@ describe('connector PATCH routes', () => {
       getLogtoConnectorsPlaceholder.mockResolvedValueOnce([
         {
           dbEntry: mockConnector,
-          metadata: { ...mockMetadata, type: ConnectorType.Social },
+          metadata: mockMetadata,
+          type: ConnectorType.Social,
           ...mockLogtoConnector,
         },
       ]);
@@ -90,7 +91,8 @@ describe('connector PATCH routes', () => {
         })
       );
       expect(response.body).toMatchObject({
-        metadata: { ...mockMetadata, type: ConnectorType.Social },
+        metadata: mockMetadata,
+        type: ConnectorType.Social,
       });
       expect(response).toHaveProperty('statusCode', 200);
     });
@@ -100,6 +102,7 @@ describe('connector PATCH routes', () => {
         {
           dbEntry: mockConnector,
           metadata: mockMetadata,
+          type: ConnectorType.Social,
           ...mockLogtoConnector,
           validateConfig: () => {
             throw new ConnectorError(ConnectorErrorCodes.InvalidConfig);
@@ -117,6 +120,7 @@ describe('connector PATCH routes', () => {
         {
           dbEntry: mockConnector,
           metadata: mockMetadata,
+          type: ConnectorType.Social,
           ...mockLogtoConnector,
         },
       ]);
@@ -141,7 +145,6 @@ describe('connector PATCH routes', () => {
       const mockedMetadata = {
         ...mockMetadata,
         id: 'id1',
-        type: ConnectorType.SMS,
       };
       const mockedConnector = {
         ...mockConnector,
@@ -150,6 +153,7 @@ describe('connector PATCH routes', () => {
       getLogtoConnectorByIdPlaceholder.mockResolvedValueOnce({
         dbEntry: mockedConnector,
         metadata: mockedMetadata,
+        type: ConnectorType.Sms,
         ...mockLogtoConnector,
       });
       const response = await connectorRequest
@@ -189,10 +193,8 @@ describe('connector PATCH routes', () => {
       getLogtoConnectorsPlaceholder.mockResolvedValueOnce([
         {
           dbEntry: mockConnector,
-          metadata: {
-            ...mockMetadata,
-            type: ConnectorType.SMS,
-          },
+          metadata: mockMetadata,
+          type: ConnectorType.Sms,
           ...mockLogtoConnector,
           validateConfig: () => {
             throw new ConnectorError(ConnectorErrorCodes.InvalidConfig);
@@ -210,6 +212,7 @@ describe('connector PATCH routes', () => {
         {
           dbEntry: mockConnector,
           metadata: mockMetadata,
+          type: ConnectorType.Sms,
           ...mockLogtoConnector,
         },
       ]);
@@ -252,6 +255,7 @@ describe('connector PATCH routes', () => {
         {
           dbEntry: mockConnector,
           metadata: mockMetadata,
+          type: ConnectorType.Sms,
           ...mockLogtoConnector,
           validateConfig: () => {
             throw new ConnectorError(ConnectorErrorCodes.InvalidConfig);
@@ -269,6 +273,7 @@ describe('connector PATCH routes', () => {
         {
           dbEntry: mockConnector,
           metadata: mockMetadata,
+          type: ConnectorType.Sms,
           ...mockLogtoConnector,
         },
       ]);

--- a/packages/core/src/routes/session/social.test.ts
+++ b/packages/core/src/routes/session/social.test.ts
@@ -61,10 +61,14 @@ const getLogtoConnectorByIdHelper = jest.fn(async (connectorId: string) => {
         : connectorId === 'social_disabled'
         ? 'social_disabled'
         : 'others',
-    type: connectorId.startsWith('social') ? ConnectorType.Social : ConnectorType.SMS,
   };
 
-  return { dbEntry: database, metadata, getAuthorizationUri: jest.fn(async () => '') };
+  return {
+    dbEntry: database,
+    metadata,
+    type: connectorId.startsWith('social') ? ConnectorType.Social : ConnectorType.Sms,
+    getAuthorizationUri: jest.fn(async () => ''),
+  };
 });
 
 jest.mock('@/connectors', () => ({
@@ -72,7 +76,7 @@ jest.mock('@/connectors', () => ({
   getLogtoConnectorById: jest.fn(async (connectorId: string) => {
     const connector = await getLogtoConnectorByIdHelper(connectorId);
 
-    if (connector.metadata.type !== ConnectorType.Social) {
+    if (connector.type !== ConnectorType.Social) {
       throw new RequestError({
         code: 'entity.not_found',
         status: 404,

--- a/packages/core/src/routes/session/social.ts
+++ b/packages/core/src/routes/session/social.ts
@@ -1,4 +1,4 @@
-import { userInfoSelectFields } from '@logto/schemas';
+import { ConnectorType, userInfoSelectFields } from '@logto/schemas';
 import { redirectUriRegEx } from '@logto/shared';
 import pick from 'lodash.pick';
 import { Provider } from 'oidc-provider';
@@ -45,6 +45,7 @@ export default function socialRoutes<T extends AnonymousRouter>(router: T, provi
       assertThat(state && redirectUri, 'session.insufficient_info');
       const connector = await getLogtoConnectorById(connectorId);
       assertThat(connector.dbEntry.enabled, 'connector.not_enabled');
+      assertThat(connector.type === ConnectorType.Social, 'connector.unexpected_type');
       const redirectTo = await connector.getAuthorizationUri({ state, redirectUri });
       ctx.body = { redirectTo };
 

--- a/packages/core/src/routes/sign-in-experience.ts
+++ b/packages/core/src/routes/sign-in-experience.ts
@@ -50,7 +50,7 @@ export default function signInExperiencesRoutes<T extends AuthedRouter>(router: 
       const filteredSocialSignInConnectorTargets = socialSignInConnectorTargets?.filter((target) =>
         enabledConnectors.some(
           (connector) =>
-            connector.metadata.target === target && connector.metadata.type === ConnectorType.Social
+            connector.metadata.target === target && connector.type === ConnectorType.Social
         )
       );
 

--- a/packages/core/src/routes/well-known.ts
+++ b/packages/core/src/routes/well-known.ts
@@ -1,4 +1,4 @@
-import { ConnectorMetadata, ConnectorType } from '@logto/connector-core';
+import { ConnectorMetadata } from '@logto/connector-core';
 import { SignInMode } from '@logto/schemas';
 import {
   adminConsoleApplicationId,

--- a/packages/core/src/routes/well-known.ts
+++ b/packages/core/src/routes/well-known.ts
@@ -1,4 +1,4 @@
-import { ConnectorMetadata } from '@logto/connector-core';
+import { ConnectorMetadata, ConnectorType } from '@logto/connector-core';
 import { SignInMode } from '@logto/schemas';
 import {
   adminConsoleApplicationId,

--- a/packages/integration-tests/tests/api/connector.test.ts
+++ b/packages/integration-tests/tests/api/connector.test.ts
@@ -67,7 +67,7 @@ test('connector set-up flow', async () => {
    */
   await Promise.all(
     [
-      { id: mockSmsConnectorId, config: mockSmsConnectorConfig, type: ConnectorType.SMS },
+      { id: mockSmsConnectorId, config: mockSmsConnectorConfig, type: ConnectorType.Sms },
       { id: mockEmailConnectorId, config: mockEmailConnectorConfig, type: ConnectorType.Email },
     ].map(async ({ id, config, type }) => {
       const updatedConnector = await updateConnectorConfig(id, config);

--- a/packages/phrases/src/locales/en/errors.ts
+++ b/packages/phrases/src/locales/en/errors.ts
@@ -64,6 +64,7 @@ const errors = {
     not_enabled: 'The connector is not enabled.',
     invalid_metadata: "The connector's metadata is invalid.",
     invalid_config_guard: "The connector's config guard is invalid.",
+    unexpected_type: "The connector's type is unexpected.",
     insufficient_request_parameters: 'The request might miss some input parameters.',
     invalid_config: "The connector's config is invalid.",
     invalid_response: "The connector's response is invalid.",

--- a/packages/phrases/src/locales/fr/errors.ts
+++ b/packages/phrases/src/locales/fr/errors.ts
@@ -69,6 +69,7 @@ const errors = {
     not_enabled: "Le connecteur n'est pas activé.",
     invalid_metadata: "The connector's metadata is invalid.", // UNTRANSLATED
     invalid_config_guard: "The connector's config guard is invalid.", // UNTRANSLATED
+    unexpected_type: "The connector's type is unexpected.", // UNTRANSLATED
     insufficient_request_parameters: 'Certains paramètres peuvent manquer dans la requête.',
     invalid_config: "La configuration du connecteur n'est pas valide.",
     invalid_response: "La réponse du connecteur n'est pas valide.",

--- a/packages/phrases/src/locales/ko-kr/errors.ts
+++ b/packages/phrases/src/locales/ko-kr/errors.ts
@@ -63,6 +63,7 @@ const errors = {
     not_enabled: '연동이 활성화 되지 않았어요.',
     invalid_metadata: "The connector's metadata is invalid.", // UNTRANSLATED
     invalid_config_guard: "The connector's config guard is invalid.", // UNTRANSLATED
+    unexpected_type: "The connector's type is unexpected.", // UNTRANSLATED
     insufficient_request_parameters: '요청 데이터에서 일부 정보가 없어요.',
     invalid_config: '연동 설정이 유효하지 않아요.',
     invalid_response: '연동 응답이 유효하지 않아요.',

--- a/packages/phrases/src/locales/tr-tr/errors.ts
+++ b/packages/phrases/src/locales/tr-tr/errors.ts
@@ -65,6 +65,7 @@ const errors = {
     not_enabled: 'Bağlayıcı etkin değil.',
     invalid_metadata: "The connector's metadata is invalid.", // UNTRANSLATED
     invalid_config_guard: "The connector's config guard is invalid.", // UNTRANSLATED
+    unexpected_type: "The connector's type is unexpected.", // UNTRANSLATED
     insufficient_request_parameters: 'İstek, bazı input parametrelerini atlayabilir.',
     invalid_config: 'Bağlayıcının ayarları geçersiz.',
     invalid_response: 'Bağlayıcının yanıtı geçersiz.',

--- a/packages/phrases/src/locales/zh-cn/errors.ts
+++ b/packages/phrases/src/locales/zh-cn/errors.ts
@@ -63,6 +63,7 @@ const errors = {
     not_enabled: '连接器尚未启用',
     invalid_metadata: '连接器 metadata 参数错误',
     invalid_config_guard: '连接器配置 guard 错误',
+    unexpected_type: '连接器类型错误',
     insufficient_request_parameters: '请求参数缺失',
     invalid_config: '连接器配置错误',
     invalid_response: '连接器错误响应',

--- a/packages/schemas/src/foundations/jsonb-types.ts
+++ b/packages/schemas/src/foundations/jsonb-types.ts
@@ -111,7 +111,7 @@ export type LanguageInfo = z.infer<typeof languageInfoGuard>;
 export enum SignInMethodKey {
   Username = 'username',
   Email = 'email',
-  SMS = 'sms',
+  Sms = 'sms',
   Social = 'social',
 }
 
@@ -124,7 +124,7 @@ export enum SignInMethodState {
 export const signInMethodsGuard = z.object({
   [SignInMethodKey.Username]: z.nativeEnum(SignInMethodState),
   [SignInMethodKey.Email]: z.nativeEnum(SignInMethodState),
-  [SignInMethodKey.SMS]: z.nativeEnum(SignInMethodState),
+  [SignInMethodKey.Sms]: z.nativeEnum(SignInMethodState),
   [SignInMethodKey.Social]: z.nativeEnum(SignInMethodState),
 });
 

--- a/packages/schemas/src/types/connector.ts
+++ b/packages/schemas/src/types/connector.ts
@@ -1,8 +1,10 @@
-import { ConnectorMetadata } from '@logto/connector-core';
+import { BaseConnector, ConnectorMetadata, ConnectorType } from '@logto/connector-core';
 
 import { Connector } from '../db-entries';
 
 export type { ConnectorMetadata } from '@logto/connector-core';
 export { ConnectorType, ConnectorPlatform } from '@logto/connector-core';
 
-export type ConnectorDto = Connector & ConnectorMetadata;
+export type ConnectorDto = Connector &
+  Omit<BaseConnector<ConnectorType>, 'configGuard' | 'metadata'> &
+  ConnectorMetadata;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -403,6 +403,7 @@ importers:
     specifiers:
       '@jest/types': ^28.1.3
       '@logto/connector-core': ^1.0.0-beta.6
+<<<<<<< HEAD
       '@silverhand/eslint-config': 1.0.0-rc.2
       '@silverhand/essentials': ^1.2.0
       '@silverhand/jest-config': 1.0.0-rc.3
@@ -1416,6 +1417,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/trace-mapping': 0.3.4
+    dev: true
 
   /@azure/msal-common/7.2.0:
     resolution: {integrity: sha512-+Oz8LKTOACDHqDmv+MZy/z+DZRH8RZbMjhadmvp0scQ0R75OrzZro+HkxifWhtDG8l1ViYkvV9NHb4pEZyajAQ==}
@@ -1440,6 +1442,7 @@ packages:
   /@babel/compat-data/7.17.7:
     resolution: {integrity: sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ==}
     engines: {node: '>=6.9.0'}
+    dev: true
 
   /@babel/core/7.12.9:
     resolution: {integrity: sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==}
@@ -1486,6 +1489,7 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/generator/7.17.9:
     resolution: {integrity: sha512-rAdDousTwxbIxbz5I7GEQ3lUip+xVCXooZNbsydCWs3xA7ZsYOv+CFRdzGxRX78BmQHu9B1Eso59AOZQOJDEdQ==}
@@ -1494,6 +1498,7 @@ packages:
       '@babel/types': 7.18.2
       jsesc: 2.5.2
       source-map: 0.5.7
+    dev: true
 
   /@babel/helper-compilation-targets/7.17.7_@babel+core@7.17.9:
     resolution: {integrity: sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==}
@@ -1506,12 +1511,14 @@ packages:
       '@babel/helper-validator-option': 7.16.7
       browserslist: 4.20.3
       semver: 6.3.0
+    dev: true
 
   /@babel/helper-environment-visitor/7.16.7:
     resolution: {integrity: sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.18.2
+    dev: true
 
   /@babel/helper-function-name/7.17.9:
     resolution: {integrity: sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==}
@@ -1519,18 +1526,21 @@ packages:
     dependencies:
       '@babel/template': 7.16.7
       '@babel/types': 7.18.2
+    dev: true
 
   /@babel/helper-hoist-variables/7.16.7:
     resolution: {integrity: sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.18.2
+    dev: true
 
   /@babel/helper-module-imports/7.16.7:
     resolution: {integrity: sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.18.2
+    dev: true
 
   /@babel/helper-module-transforms/7.17.7:
     resolution: {integrity: sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==}
@@ -1546,6 +1556,7 @@ packages:
       '@babel/types': 7.18.2
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/helper-plugin-utils/7.10.4:
     resolution: {integrity: sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==}
@@ -1554,18 +1565,21 @@ packages:
   /@babel/helper-plugin-utils/7.17.12:
     resolution: {integrity: sha512-JDkf04mqtN3y4iAbO1hv9U2ARpPyPL1zqyWs/2WG1pgSq9llHFjStX5jdxb84himgJm+8Ng+x0oiWF/nw/XQKA==}
     engines: {node: '>=6.9.0'}
+    dev: true
 
   /@babel/helper-simple-access/7.17.7:
     resolution: {integrity: sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.18.2
+    dev: true
 
   /@babel/helper-split-export-declaration/7.16.7:
     resolution: {integrity: sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.18.2
+    dev: true
 
   /@babel/helper-validator-identifier/7.16.7:
     resolution: {integrity: sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==}
@@ -1574,10 +1588,12 @@ packages:
   /@babel/helper-validator-identifier/7.18.6:
     resolution: {integrity: sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==}
     engines: {node: '>=6.9.0'}
+    dev: true
 
   /@babel/helper-validator-option/7.16.7:
     resolution: {integrity: sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==}
     engines: {node: '>=6.9.0'}
+    dev: true
 
   /@babel/helpers/7.17.9:
     resolution: {integrity: sha512-cPCt915ShDWUEzEp3+UNRktO2n6v49l5RSnG9M5pS24hA+2FAc5si+Pn1i4VVbQQ+jh+bIZhPFQOJOzbrOYY1Q==}
@@ -1588,6 +1604,7 @@ packages:
       '@babel/types': 7.18.2
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/highlight/7.16.10:
     resolution: {integrity: sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==}
@@ -1603,6 +1620,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.18.2
+    dev: true
 
   /@babel/plugin-proposal-object-rest-spread/7.12.1_@babel+core@7.12.9:
     resolution: {integrity: sha512-s6SowJIjzlhx8o7lsFx5zmY4At6CTtDvgNQDdPzkBQucle58A6b/TTeEBYtyDgmcXjUTM+vE8YOGHZzzbc/ioA==}
@@ -1622,6 +1640,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.9
       '@babel/helper-plugin-utils': 7.17.12
+    dev: true
 
   /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.17.9:
     resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
@@ -1630,6 +1649,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.9
       '@babel/helper-plugin-utils': 7.17.12
+    dev: true
 
   /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.17.9:
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
@@ -1638,6 +1658,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.9
       '@babel/helper-plugin-utils': 7.17.12
+    dev: true
 
   /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.17.9:
     resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
@@ -1646,6 +1667,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.9
       '@babel/helper-plugin-utils': 7.17.12
+    dev: true
 
   /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.17.9:
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
@@ -1654,6 +1676,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.9
       '@babel/helper-plugin-utils': 7.17.12
+    dev: true
 
   /@babel/plugin-syntax-jsx/7.12.1_@babel+core@7.12.9:
     resolution: {integrity: sha512-1yRi7yAtB0ETgxdY9ti/p2TivUxJkTdhu/ZbF9MshVGqOx1TdB3b7xCXs49Fupgg50N45KcAsRP/ZqWjs9SRjg==}
@@ -1671,6 +1694,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.9
       '@babel/helper-plugin-utils': 7.17.12
+    dev: true
 
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.17.9:
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
@@ -1679,6 +1703,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.9
       '@babel/helper-plugin-utils': 7.17.12
+    dev: true
 
   /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.17.9:
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
@@ -1687,6 +1712,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.9
       '@babel/helper-plugin-utils': 7.17.12
+    dev: true
 
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.12.9:
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
@@ -1704,6 +1730,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.9
       '@babel/helper-plugin-utils': 7.17.12
+    dev: true
 
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.17.9:
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
@@ -1712,6 +1739,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.9
       '@babel/helper-plugin-utils': 7.17.12
+    dev: true
 
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.17.9:
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
@@ -1720,6 +1748,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.9
       '@babel/helper-plugin-utils': 7.17.12
+    dev: true
 
   /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.17.9:
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
@@ -1729,6 +1758,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.9
       '@babel/helper-plugin-utils': 7.17.12
+    dev: true
 
   /@babel/plugin-syntax-typescript/7.16.7_@babel+core@7.17.9:
     resolution: {integrity: sha512-YhUIJHHGkqPgEcMYkPCKTyGUdoGKWtopIycQyjJH8OjvRgOYsXsaKehLVPScKJWAULPxMa4N1vCe6szREFlZ7A==}
@@ -1738,6 +1768,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.9
       '@babel/helper-plugin-utils': 7.17.12
+    dev: true
 
   /@babel/plugin-transform-parameters/7.16.7_@babel+core@7.12.9:
     resolution: {integrity: sha512-AT3MufQ7zZEhU2hwOA11axBnExW0Lszu4RL/tAlUJBuNoRak+wehQW8h6KcXOcgjY42fHtDxswuMhMjFEuv/aw==}
@@ -1768,6 +1799,7 @@ packages:
       '@babel/code-frame': 7.16.7
       '@babel/parser': 7.18.3
       '@babel/types': 7.18.2
+    dev: true
 
   /@babel/traverse/7.17.9:
     resolution: {integrity: sha512-PQO8sDIJ8SIwipTPiR71kJQCKQYB5NGImbOviK8K+kg5xkNSYXLBupuX9QhatFowrsvo9Hj8WgArg3W7ijNAQw==}
@@ -1785,6 +1817,7 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/types/7.17.0:
     resolution: {integrity: sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==}
@@ -1800,9 +1833,11 @@ packages:
     dependencies:
       '@babel/helper-validator-identifier': 7.18.6
       to-fast-properties: 2.0.0
+    dev: true
 
   /@bcoe/v8-coverage/0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+    dev: true
 
   /@commitlint/cli/17.0.0:
     resolution: {integrity: sha512-Np6slCdVVG1XwMvwbZrXIzS1INPAD5QmN4L6al04AmCd4nAPU63gxgxC5Mz0Fmx7va23Uvb0S7yEFV1JPhvPUQ==}
@@ -2065,10 +2100,12 @@ packages:
       get-package-type: 0.1.0
       js-yaml: 3.14.1
       resolve-from: 5.0.0
+    dev: true
 
   /@istanbuljs/schema/0.1.3:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
+    dev: true
 
   /@jest/console/28.1.3:
     resolution: {integrity: sha512-QPAkP5EwKdK/bxIr6C1I4Vs0rm2nHiANzj/Z5X2JQkrZo6IqvC4ldZ9K95tF0HdidhA8Bo6egxSzUFPYKcEXLw==}
@@ -2080,6 +2117,7 @@ packages:
       jest-message-util: 28.1.3
       jest-util: 28.1.3
       slash: 3.0.0
+    dev: true
 
   /@jest/core/28.1.3:
     resolution: {integrity: sha512-CIKBrlaKOzA7YG19BEqCw3SLIsEwjZkeJzf5bdooVnW4bH5cktqe3JX+G2YV1aK5vP8N9na1IGWFzYaTp6k6NA==}
@@ -2122,6 +2160,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - ts-node
+    dev: true
 
   /@jest/core/28.1.3_ts-node@10.9.1:
     resolution: {integrity: sha512-CIKBrlaKOzA7YG19BEqCw3SLIsEwjZkeJzf5bdooVnW4bH5cktqe3JX+G2YV1aK5vP8N9na1IGWFzYaTp6k6NA==}
@@ -2184,12 +2223,14 @@ packages:
       '@jest/types': 28.1.3
       '@types/node': 17.0.23
       jest-mock: 28.1.3
+    dev: true
 
   /@jest/expect-utils/28.1.3:
     resolution: {integrity: sha512-wvbi9LUrHJLn3NlDW6wF2hvIMtd4JUl2QNVrjq+IBSHirgfrR3o9RnVtxzdEGO2n9JyIWwHnLfby5KzqBGg2YA==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       jest-get-type: 28.0.2
+    dev: true
 
   /@jest/expect/28.1.3:
     resolution: {integrity: sha512-lzc8CpUbSoE4dqT0U+g1qODQjBRHPpCPXissXD4mS9+sWQdmmpeJ9zSH1rS1HEkrsMN0fb7nKrJ9giAR1d3wBw==}
@@ -2199,6 +2240,7 @@ packages:
       jest-snapshot: 28.1.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@jest/fake-timers/27.5.1:
     resolution: {integrity: sha512-/aPowoolwa07k7/oM3aASneNeBGCmGQsc3ugN4u6s4C/+s5M64MFo/+djTdiwcbQlRfFElGuDXWzaWj6QgKObQ==}
@@ -2222,6 +2264,7 @@ packages:
       jest-message-util: 28.1.3
       jest-mock: 28.1.3
       jest-util: 28.1.3
+    dev: true
 
   /@jest/globals/28.1.3:
     resolution: {integrity: sha512-XFU4P4phyryCXu1pbcqMO0GSQcYe1IsalYCDzRNyhetyeyxMcIxa11qPNDpVNLeretItNqEmYYQn1UYz/5x1NA==}
@@ -2232,6 +2275,7 @@ packages:
       '@jest/types': 28.1.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@jest/reporters/28.1.3:
     resolution: {integrity: sha512-JuAy7wkxQZVNU/V6g9xKzCGC5LVXx9FDcABKsSXp5MiKPEE2144a/vXTEDoyzjUpZKfVwp08Wqg5A4WfTMAzjg==}
@@ -2269,6 +2313,7 @@ packages:
       v8-to-istanbul: 9.0.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@jest/schemas/28.1.3:
     resolution: {integrity: sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==}
@@ -2283,6 +2328,7 @@ packages:
       '@jridgewell/trace-mapping': 0.3.14
       callsites: 3.1.0
       graceful-fs: 4.2.9
+    dev: true
 
   /@jest/test-result/28.1.3:
     resolution: {integrity: sha512-kZAkxnSE+FqE8YjW8gNuoVkkC9I7S1qmenl8sGcDOLropASP+BkcGKwhXoyqQuGOGeYY0y/ixjrd/iERpEXHNg==}
@@ -2292,6 +2338,7 @@ packages:
       '@jest/types': 28.1.3
       '@types/istanbul-lib-coverage': 2.0.3
       collect-v8-coverage: 1.0.1
+    dev: true
 
   /@jest/test-sequencer/28.1.3:
     resolution: {integrity: sha512-NIMPEqqa59MWnDi1kvXXpYbqsfQmSJsIbnd85mdVGkiDfQ9WQQTXOLsvISUfonmnBT+w85WEgneCigEEdHDFxw==}
@@ -2301,6 +2348,7 @@ packages:
       graceful-fs: 4.2.9
       jest-haste-map: 28.1.3
       slash: 3.0.0
+    dev: true
 
   /@jest/transform/28.1.3:
     resolution: {integrity: sha512-u5dT5di+oFI6hfcLOHGTAfmUxFRrjK+vnaP0kkVow9Md/M7V/MxqQMOz/VV25UZO8pzeA9PjfTpOu6BDuwSPQA==}
@@ -2323,6 +2371,7 @@ packages:
       write-file-atomic: 4.0.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@jest/types/27.5.1:
     resolution: {integrity: sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==}
@@ -2349,21 +2398,25 @@ packages:
   /@jridgewell/resolve-uri/3.0.5:
     resolution: {integrity: sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==}
     engines: {node: '>=6.0.0'}
+    dev: true
 
   /@jridgewell/sourcemap-codec/1.4.11:
     resolution: {integrity: sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==}
+    dev: true
 
   /@jridgewell/trace-mapping/0.3.14:
     resolution: {integrity: sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==}
     dependencies:
       '@jridgewell/resolve-uri': 3.0.5
       '@jridgewell/sourcemap-codec': 1.4.11
+    dev: true
 
   /@jridgewell/trace-mapping/0.3.4:
     resolution: {integrity: sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==}
     dependencies:
       '@jridgewell/resolve-uri': 3.0.5
       '@jridgewell/sourcemap-codec': 1.4.11
+    dev: true
 
   /@jridgewell/trace-mapping/0.3.9:
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -4483,7 +4536,6 @@ packages:
       stylelint-config-xo-scss: 0.15.0_eqpuutlgonckfyjzwkrpusdvaa
     transitivePeerDependencies:
       - eslint
-      - eslint-import-resolver-webpack
       - postcss
       - prettier
       - supports-color
@@ -4504,7 +4556,6 @@ packages:
       stylelint-config-xo-scss: 0.15.0_uyk3cwxn3favstz4untq233szu
     transitivePeerDependencies:
       - eslint
-      - eslint-import-resolver-webpack
       - postcss
       - prettier
       - supports-color
@@ -4528,7 +4579,7 @@ packages:
       eslint-import-resolver-typescript: 3.4.0_jatgrcxl4x7ywe7ak6cnjca2ae
       eslint-plugin-consistent-default-export-name: 0.0.15
       eslint-plugin-eslint-comments: 3.2.0_eslint@8.21.0
-      eslint-plugin-import: 2.26.0_klqlxqqxnpnfpttri4irupweri
+      eslint-plugin-import: 2.26.0_eslint@8.21.0
       eslint-plugin-no-use-extend-native: 0.5.0
       eslint-plugin-node: 11.1.0_eslint@8.21.0
       eslint-plugin-prettier: 4.2.1_h62lvancfh4b7r6zn2dgodrh5e
@@ -4537,7 +4588,6 @@ packages:
       eslint-plugin-unicorn: 43.0.2_eslint@8.21.0
       prettier: 2.7.1
     transitivePeerDependencies:
-      - eslint-import-resolver-webpack
       - supports-color
       - typescript
     dev: true
@@ -4611,6 +4661,7 @@ packages:
     resolution: {integrity: sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==}
     dependencies:
       type-detect: 4.0.8
+    dev: true
 
   /@sinonjs/fake-timers/8.1.0:
     resolution: {integrity: sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==}
@@ -4622,6 +4673,7 @@ packages:
     resolution: {integrity: sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==}
     dependencies:
       '@sinonjs/commons': 1.8.3
+    dev: true
 
   /@svgr/babel-plugin-add-jsx-attribute/6.0.0_@babel+core@7.17.9:
     resolution: {integrity: sha512-MdPdhdWLtQsjd29Wa4pABdhWbaRMACdM1h31BY+c6FghTZqNGT7pEYdBoaGeKtdTOBC/XNFQaKVj+r/Ei2ryWA==}
@@ -4855,22 +4907,26 @@ packages:
       '@types/babel__generator': 7.6.3
       '@types/babel__template': 7.4.1
       '@types/babel__traverse': 7.14.2
+    dev: true
 
   /@types/babel__generator/7.6.3:
     resolution: {integrity: sha512-/GWCmzJWqV7diQW54smJZzWbSFf4QYtF71WCKhcx6Ru/tFyQIY2eiiITcCAeuPbNSvT9YCGkVMqqvSk2Z0mXiA==}
     dependencies:
       '@babel/types': 7.18.2
+    dev: true
 
   /@types/babel__template/7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
       '@babel/parser': 7.18.3
       '@babel/types': 7.18.2
+    dev: true
 
   /@types/babel__traverse/7.14.2:
     resolution: {integrity: sha512-K2waXdXBi2302XUdcHcR1jCeU0LL4TD9HRs/gk0N2Xvrht+G/BfJa4QObBQZfhMdxiCpV3COl5Nfq4uKTeTnJA==}
     dependencies:
       '@babel/types': 7.18.2
+    dev: true
 
   /@types/body-parser/1.19.2:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
@@ -4965,6 +5021,7 @@ packages:
     resolution: {integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==}
     dependencies:
       '@types/node': 17.0.23
+    dev: true
 
   /@types/hast/2.3.4:
     resolution: {integrity: sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==}
@@ -5152,6 +5209,7 @@ packages:
 
   /@types/node/16.11.12:
     resolution: {integrity: sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==}
+    dev: true
 
   /@types/node/17.0.23:
     resolution: {integrity: sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==}
@@ -5189,6 +5247,7 @@ packages:
 
   /@types/prettier/2.4.2:
     resolution: {integrity: sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==}
+    dev: true
 
   /@types/prop-types/15.7.4:
     resolution: {integrity: sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==}
@@ -5271,6 +5330,7 @@ packages:
 
   /@types/stack-utils/2.0.1:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
+    dev: true
 
   /@types/superagent/4.1.15:
     resolution: {integrity: sha512-mu/N4uvfDN2zVQQ5AYJI/g4qxn2bHB6521t1UuH09ShNWjebTqN0ZFuYK9uYjcgmI0dTQEs+Owi1EO6U0OkOZQ==}
@@ -5634,6 +5694,7 @@ packages:
   /ansi-styles/5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+    dev: true
 
   /ansi-styles/6.1.0:
     resolution: {integrity: sha512-VbqNsoz55SYGczauuup0MFUyXNQviSpFTj1RQtFzmQLk18qbVSpTFFGMT293rmDaQuKCT6InmbuEyUne4mTuxQ==}
@@ -5646,6 +5707,7 @@ packages:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+    dev: true
 
   /aproba/1.2.0:
     resolution: {integrity: sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==}
@@ -5678,6 +5740,7 @@ packages:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
     dependencies:
       sprintf-js: 1.0.3
+    dev: true
 
   /argparse/2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -5815,6 +5878,7 @@ packages:
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /babel-plugin-apply-mdx-type-prop/1.6.22_@babel+core@7.12.9:
     resolution: {integrity: sha512-VefL+8o+F/DfK24lPZMtJctrCVOfgbqLAGZSkxwhazQv4VxPg3Za/i40fu22KR2m8eEda+IfSOlPLUSIiLcnCQ==}
@@ -5843,6 +5907,7 @@ packages:
       test-exclude: 6.0.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /babel-plugin-jest-hoist/28.1.3:
     resolution: {integrity: sha512-Ys3tUKAmfnkRUpPdpa98eYrAR0nV+sSFUZZEGuQ2EbFd1y4SOLtD5QDNHAq+bb9a+bbXvYQC4b+ID/THIMcU6Q==}
@@ -5852,6 +5917,7 @@ packages:
       '@babel/types': 7.18.2
       '@types/babel__core': 7.1.17
       '@types/babel__traverse': 7.14.2
+    dev: true
 
   /babel-plugin-macros/2.8.0:
     resolution: {integrity: sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==}
@@ -5879,6 +5945,7 @@ packages:
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.17.9
       '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.17.9
       '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.17.9
+    dev: true
 
   /babel-preset-jest/28.1.3_@babel+core@7.17.9:
     resolution: {integrity: sha512-L+fupJvlWAHbQfn74coNX3zf60LXMJsezNvvx8eIh7iOR1luJ1poxYgQk1F8PYtNq/6QODDHCqsSnTFSWC491A==}
@@ -5889,6 +5956,7 @@ packages:
       '@babel/core': 7.17.9
       babel-plugin-jest-hoist: 28.1.3
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.17.9
+    dev: true
 
   /bail/1.0.5:
     resolution: {integrity: sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==}
@@ -5971,6 +6039,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.0.1
+    dev: true
 
   /browser-process-hrtime/1.0.0:
     resolution: {integrity: sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==}
@@ -5986,6 +6055,7 @@ packages:
       escalade: 3.1.1
       node-releases: 2.0.5
       picocolors: 1.0.0
+    dev: true
 
   /bs-logger/0.2.6:
     resolution: {integrity: sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==}
@@ -5997,6 +6067,7 @@ packages:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
     dependencies:
       node-int64: 0.4.0
+    dev: true
 
   /buffer-crc32/0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
@@ -6172,6 +6243,7 @@ packages:
   /camelcase/5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
+    dev: true
 
   /camelcase/6.2.1:
     resolution: {integrity: sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==}
@@ -6184,6 +6256,7 @@ packages:
 
   /caniuse-lite/1.0.30001344:
     resolution: {integrity: sha512-0ZFjnlCaXNOAYcV7i+TtdKBp0L/3XEU2MF/x6Du1lrh+SRX4IfzIVL4HNJg5pB2PmFb8rszIGyOvsZnqqRoc2g==}
+    dev: true
 
   /ccount/1.1.0:
     resolution: {integrity: sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==}
@@ -6211,6 +6284,7 @@ packages:
   /char-regex/1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
+    dev: true
 
   /character-entities-legacy/1.1.4:
     resolution: {integrity: sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==}
@@ -6269,6 +6343,7 @@ packages:
 
   /cjs-module-lexer/1.2.2:
     resolution: {integrity: sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==}
+    dev: true
 
   /classnames/2.3.1:
     resolution: {integrity: sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==}
@@ -6403,6 +6478,7 @@ packages:
 
   /collect-v8-coverage/1.0.1:
     resolution: {integrity: sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==}
+    dev: true
 
   /color-convert/1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -6638,6 +6714,7 @@ packages:
     resolution: {integrity: sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==}
     dependencies:
       safe-buffer: 5.1.2
+    dev: true
 
   /cookiejar/2.1.3:
     resolution: {integrity: sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==}
@@ -6749,6 +6826,7 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+    dev: true
 
   /css-functions-list/3.1.0:
     resolution: {integrity: sha512-/9lCvYZaUbBGvYUgYGFJ4dcYiyqdhSjG7IPVluoV8A1ILjkF7ilmhp1OGUz8n+nmBcu0RNrQAzgD8B6FJbrt2w==}
@@ -6900,11 +6978,6 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
     dependencies:
       ms: 2.0.0
     dev: true
@@ -6918,18 +6991,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.3
-    dev: true
-
-  /debug/3.2.7_supports-color@5.5.0:
-    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.3
-      supports-color: 5.5.0
     dev: true
 
   /debug/4.3.3:
@@ -7003,6 +7064,7 @@ packages:
 
   /dedent/0.7.0:
     resolution: {integrity: sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=}
+    dev: true
 
   /deep-equal/1.0.1:
     resolution: {integrity: sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=}
@@ -7092,6 +7154,7 @@ packages:
   /detect-newline/3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
+    dev: true
 
   /detect-node/2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
@@ -7110,6 +7173,7 @@ packages:
   /diff-sequences/28.1.1:
     resolution: {integrity: sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    dev: true
 
   /diff/4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
@@ -7255,10 +7319,12 @@ packages:
 
   /electron-to-chromium/1.4.141:
     resolution: {integrity: sha512-mfBcbqc0qc6RlxrsIgLG2wCqkiPAjEezHxGTu7p3dHHFOurH4EjS9rFZndX5axC8264rI1Pcbw8uQP39oZckeA==}
+    dev: true
 
   /emittery/0.10.2:
     resolution: {integrity: sha512-aITqOwnLanpHLNXZJENbOgjUBeHocD+xsSJmNrjovKBW5HbSpW3d1pEls7GFQPUWXiwG9+0P4GtHfEqC/4M0Iw==}
     engines: {node: '>=12'}
+    dev: true
 
   /emoji-regex/7.0.3:
     resolution: {integrity: sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==}
@@ -7378,6 +7444,7 @@ packages:
   /escape-string-regexp/2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
     engines: {node: '>=8'}
+    dev: true
 
   /escape-string-regexp/4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -7476,7 +7543,7 @@ packages:
       debug: 4.3.4
       enhanced-resolve: 5.10.0
       eslint: 8.21.0
-      eslint-plugin-import: 2.26.0_klqlxqqxnpnfpttri4irupweri
+      eslint-plugin-import: 2.26.0_eslint@8.21.0
       get-tsconfig: 4.2.0
       globby: 13.1.2
       is-core-module: 2.9.0
@@ -7486,23 +7553,9 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils/2.7.3_dirjbmf3bsnpt3git34hjh5rju:
+  /eslint-module-utils/2.7.3:
     resolution: {integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==}
     engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
     dependencies:
       '@typescript-eslint/parser': 5.32.0_qugx7qdu5zevzvxaiqyxfiwquq
       debug: 3.2.7
@@ -7511,6 +7564,8 @@ packages:
       find-up: 2.1.0
     transitivePeerDependencies:
       - supports-color
+      debug: 3.2.7
+      find-up: 2.1.0
     dev: true
 
   /eslint-plugin-consistent-default-export-name/0.0.15:
@@ -7543,24 +7598,19 @@ packages:
       ignore: 5.2.0
     dev: true
 
-  /eslint-plugin-import/2.26.0_klqlxqqxnpnfpttri4irupweri:
+  /eslint-plugin-import/2.26.0_eslint@8.21.0:
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
-      '@typescript-eslint/parser': '*'
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.32.0_qugx7qdu5zevzvxaiqyxfiwquq
       array-includes: 3.1.4
       array.prototype.flat: 1.2.5
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 8.21.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.3_dirjbmf3bsnpt3git34hjh5rju
+      eslint-module-utils: 2.7.3
       has: 1.0.3
       is-core-module: 2.9.0
       is-glob: 4.0.3
@@ -7568,10 +7618,6 @@ packages:
       object.values: 1.1.5
       resolve: 1.22.0
       tsconfig-paths: 3.14.1
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
     dev: true
 
   /eslint-plugin-no-use-extend-native/0.5.0:
@@ -7805,6 +7851,7 @@ packages:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+    dev: true
 
   /esquery/1.4.0:
     resolution: {integrity: sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==}
@@ -7856,6 +7903,7 @@ packages:
       onetime: 5.1.2
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
+    dev: true
 
   /execa/6.1.0:
     resolution: {integrity: sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==}
@@ -7886,6 +7934,7 @@ packages:
   /exit/0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
+    dev: true
 
   /expand-tilde/1.2.2:
     resolution: {integrity: sha512-rtmc+cjLZqnu9dSYosX9EWmSJhTwpACgJQTfj4hgg2JjOD/6SIQalZrt4a3aQeh++oNxkazcaxrhPUj6+g5G/Q==}
@@ -7907,6 +7956,7 @@ packages:
       jest-matcher-utils: 28.1.3
       jest-message-util: 28.1.3
       jest-util: 28.1.3
+    dev: true
 
   /extend/3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -8003,6 +8053,7 @@ packages:
     resolution: {integrity: sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==}
     dependencies:
       bser: 2.1.1
+    dev: true
 
   /fd-slicer/1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
@@ -8034,6 +8085,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       to-regex-range: 5.0.1
+    dev: true
 
   /filter-obj/1.1.0:
     resolution: {integrity: sha1-mzERErxsYSehbgFsbF1/GeCAXFs=}
@@ -8078,6 +8130,7 @@ packages:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
+    dev: true
 
   /find-up/5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -8199,12 +8252,14 @@ packages:
 
   /fs.realpath/1.0.0:
     resolution: {integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=}
+    dev: true
 
   /fsevents/2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /function-bind/1.1.1:
@@ -8250,6 +8305,7 @@ packages:
   /gensync/1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+    dev: true
 
   /get-caller-file/2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -8265,6 +8321,7 @@ packages:
   /get-package-type/0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
     engines: {node: '>=8.0.0'}
+    dev: true
 
   /get-pkg-repo/4.2.1:
     resolution: {integrity: sha512-2+QbHjFRfGB74v/pYWjd5OhU3TDIC2Gv/YKUTk/tCvAz0pkn/Mz6P3uByuBimLOcPvN2jYdScl3xGFSrx0jEcA==}
@@ -8314,6 +8371,7 @@ packages:
   /get-stream/6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
+    dev: true
 
   /get-symbol-description/1.0.0:
     resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
@@ -8398,6 +8456,7 @@ packages:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
+    dev: true
 
   /glob/8.0.3:
     resolution: {integrity: sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==}
@@ -8454,6 +8513,7 @@ packages:
   /globals/11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
+    dev: true
 
   /globals/13.16.0:
     resolution: {integrity: sha512-A1lrQfpNF+McdPOnnFqY3kSN0AFTy485bTi1bkLk4mVPODIUEcSfhHgRqA+QdXPksrSTTztYXx37NFV+GpGk3Q==}
@@ -8712,6 +8772,7 @@ packages:
 
   /html-escaper/2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+    dev: true
 
   /html-parse-stringify/3.0.1:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
@@ -8921,6 +8982,7 @@ packages:
   /human-signals/2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+    dev: true
 
   /human-signals/3.0.1:
     resolution: {integrity: sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==}
@@ -9040,6 +9102,7 @@ packages:
     dependencies:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
+    dev: true
 
   /import-modules/2.1.0:
     resolution: {integrity: sha512-8HEWcnkbGpovH9yInoisxaSoIg9Brbul+Ju3Kqe2UsYDUBJD/iQjSgEj0zPcTDPKfPp2fs5xlv1i+JSye/m1/A==}
@@ -9049,6 +9112,7 @@ packages:
   /imurmurhash/0.1.4:
     resolution: {integrity: sha1-khi5srkoojixPcT7a21XbyMUU+o=}
     engines: {node: '>=0.8.19'}
+    dev: true
 
   /indent-string/4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
@@ -9069,6 +9133,7 @@ packages:
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
+    dev: true
 
   /inherits/2.0.1:
     resolution: {integrity: sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=}
@@ -9298,6 +9363,7 @@ packages:
   /is-generator-fn/2.1.0:
     resolution: {integrity: sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==}
     engines: {node: '>=6'}
+    dev: true
 
   /is-generator-function/1.0.10:
     resolution: {integrity: sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==}
@@ -9357,6 +9423,7 @@ packages:
   /is-number/7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+    dev: true
 
   /is-obj-prop/1.0.0:
     resolution: {integrity: sha512-5Idb61slRlJlsAzi0Wsfwbp+zZY+9LXKUAZpvT/1ySw+NxKLRWfa0Bzj+wXI3fX5O9hiddm5c3DAaRSNP/yl2w==}
@@ -9433,6 +9500,7 @@ packages:
   /is-stream/2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
+    dev: true
 
   /is-stream/3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
@@ -9504,6 +9572,7 @@ packages:
 
   /isexe/2.0.0:
     resolution: {integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=}
+    dev: true
 
   /iso8601-duration/1.3.0:
     resolution: {integrity: sha512-K4CiUBzo3YeWk76FuET/dQPH03WE04R94feo5TSKQCXpoXQt9E4yx2CnY737QZnSAI3PI4WlKo/zfqizGx52QQ==}
@@ -9517,6 +9586,7 @@ packages:
   /istanbul-lib-coverage/3.2.0:
     resolution: {integrity: sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==}
     engines: {node: '>=8'}
+    dev: true
 
   /istanbul-lib-instrument/5.1.0:
     resolution: {integrity: sha512-czwUz525rkOFDJxfKK6mYfIs9zBKILyrZQxjz3ABhjQXhbhFsSbo1HW/BFcsDnfJYJWA6thRR5/TUY2qs5W99Q==}
@@ -9529,6 +9599,7 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /istanbul-lib-report/3.0.0:
     resolution: {integrity: sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==}
@@ -9537,6 +9608,7 @@ packages:
       istanbul-lib-coverage: 3.2.0
       make-dir: 3.1.0
       supports-color: 7.2.0
+    dev: true
 
   /istanbul-lib-source-maps/4.0.1:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
@@ -9547,6 +9619,7 @@ packages:
       source-map: 0.6.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /istanbul-reports/3.1.4:
     resolution: {integrity: sha512-r1/DshN4KSE7xWEknZLLLLDn5CJybV3nw01VTkp6D5jzLuELlcbudfj/eSQFvrKsJuTVCGnePO7ho82Nw9zzfw==}
@@ -9554,6 +9627,7 @@ packages:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.0
+    dev: true
 
   /jake/10.8.2:
     resolution: {integrity: sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==}
@@ -9571,6 +9645,7 @@ packages:
     dependencies:
       execa: 5.1.1
       p-limit: 3.1.0
+    dev: true
 
   /jest-circus/28.1.3:
     resolution: {integrity: sha512-cZ+eS5zc79MBwt+IhQhiEp0OeBddpc1n8MBo1nMB8A7oPMKEO+Sre+wHaLJexQUj9Ya/8NOBY0RESUgYjB6fow==}
@@ -9597,6 +9672,7 @@ packages:
       stack-utils: 2.0.5
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /jest-cli/28.1.3:
     resolution: {integrity: sha512-roY3kvrv57Azn1yPgdTebPAXvdR2xfezaKKYzVxZ6It/5NCxzJym6tUI5P1zkdWhfUYkxEI9uZWcQdaFLo8mJQ==}
@@ -9652,6 +9728,7 @@ packages:
       - '@types/node'
       - supports-color
       - ts-node
+    dev: true
 
   /jest-cli/28.1.3_k5ytkvaprncdyzidqqws5bqksq:
     resolution: {integrity: sha512-roY3kvrv57Azn1yPgdTebPAXvdR2xfezaKKYzVxZ6It/5NCxzJym6tUI5P1zkdWhfUYkxEI9uZWcQdaFLo8mJQ==}
@@ -9756,6 +9833,7 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /jest-config/28.1.3_@types+node@17.0.23:
     resolution: {integrity: sha512-MG3INjByJ0J4AsNBm7T3hsuxKQqFIiRo/AUqb1q9LRKI5UU6Aar9JHbr9Ivn1TVwfUD9KirRoM/T6u8XlcQPHQ==}
@@ -9794,6 +9872,7 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /jest-config/28.1.3_hvivgrlmkyd4vgu6rkkmg6acly:
     resolution: {integrity: sha512-MG3INjByJ0J4AsNBm7T3hsuxKQqFIiRo/AUqb1q9LRKI5UU6Aar9JHbr9Ivn1TVwfUD9KirRoM/T6u8XlcQPHQ==}
@@ -9898,12 +9977,14 @@ packages:
       diff-sequences: 28.1.1
       jest-get-type: 28.0.2
       pretty-format: 28.1.3
+    dev: true
 
   /jest-docblock/28.1.1:
     resolution: {integrity: sha512-3wayBVNiOYx0cwAbl9rwm5kKFP8yHH3d/fkEaL02NPTkDojPtheGB7HZSFY4wzX+DxyrvhXz0KSCVksmCknCuA==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       detect-newline: 3.1.0
+    dev: true
 
   /jest-each/28.1.3:
     resolution: {integrity: sha512-arT1z4sg2yABU5uogObVPvSlSMQlDA48owx07BDPAiasW0yYpYHYOo4HHLz9q0BVzDVU4hILFjzJw0So9aCL/g==}
@@ -9914,6 +9995,7 @@ packages:
       jest-get-type: 28.0.2
       jest-util: 28.1.3
       pretty-format: 28.1.3
+    dev: true
 
   /jest-environment-jsdom/28.1.3:
     resolution: {integrity: sha512-HnlGUmZRdxfCByd3GM2F100DgQOajUBzEitjGqIREcb45kGjZvRrKUdlaF6escXBdcXNl0OBh+1ZrfeZT3GnAg==}
@@ -9956,6 +10038,7 @@ packages:
       '@types/node': 17.0.23
       jest-mock: 28.1.3
       jest-util: 28.1.3
+    dev: true
 
   /jest-environment-puppeteer/6.1.1:
     resolution: {integrity: sha512-Ces37g8Gdj7QaVxszeoXlvmsZxcEJN9EPUdJt8fGMLA+6ARVFKyVmFgP9xVeGyjTvzsXdtIiJdeOKMLMeD8r2A==}
@@ -9973,6 +10056,7 @@ packages:
   /jest-get-type/28.0.2:
     resolution: {integrity: sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    dev: true
 
   /jest-haste-map/28.1.3:
     resolution: {integrity: sha512-3S+RQWDXccXDKSWnkHa/dPwt+2qwA8CJzR61w3FoYCvoo3Pn8tvGcysmMF0Bj0EX5RYvAI2EIvC57OmotfdtKA==}
@@ -9991,6 +10075,7 @@ packages:
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
 
   /jest-leak-detector/28.1.3:
     resolution: {integrity: sha512-WFVJhnQsiKtDEo5lG2mM0v40QWnBM+zMdHHyJs8AWZ7J0QZJS59MsyKeJHWhpBZBH32S48FOVvGyOFT1h0DlqA==}
@@ -9998,6 +10083,7 @@ packages:
     dependencies:
       jest-get-type: 28.0.2
       pretty-format: 28.1.3
+    dev: true
 
   /jest-matcher-specific-error/1.0.0:
     resolution: {integrity: sha512-thJdy9ibhDo8k+0arFalNCQBJ0u7eqTfpTzS2MzL3iCLmbRCkI+yhhKSiAxEi55e5ZUyf01ySa0fMqzF+sblAw==}
@@ -10010,6 +10096,7 @@ packages:
       jest-diff: 28.1.3
       jest-get-type: 28.0.2
       pretty-format: 28.1.3
+    dev: true
 
   /jest-message-util/27.5.1:
     resolution: {integrity: sha512-rMyFe1+jnyAAf+NHwTclDz0eAaLkVDdKVHHBFWsBWHnnh5YeJMNWWsv7AbFYXfK3oTqvL7VTWkhNLu1jX24D+g==}
@@ -10039,6 +10126,7 @@ packages:
       pretty-format: 28.1.3
       slash: 3.0.0
       stack-utils: 2.0.5
+    dev: true
 
   /jest-mock/27.5.1:
     resolution: {integrity: sha512-K4jKbY1d4ENhbrG2zuPWaQBvDly+iZ2yAW+T1fATN78hc0sInwn7wZB8XtlNnvHug5RMwV897Xm4LqmPM4e2Og==}
@@ -10054,6 +10142,7 @@ packages:
     dependencies:
       '@jest/types': 28.1.3
       '@types/node': 17.0.23
+    dev: true
 
   /jest-pnp-resolver/1.2.2_jest-resolve@28.1.3:
     resolution: {integrity: sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==}
@@ -10065,6 +10154,7 @@ packages:
         optional: true
     dependencies:
       jest-resolve: 28.1.3
+    dev: true
 
   /jest-puppeteer/6.1.1_puppeteer@16.1.0:
     resolution: {integrity: sha512-cBOszleUpyipDMNYmcmH3x+687x03ZvOVz7W8X5y5TgD+j4MK+BcumwGdE1YwVS21kPLjJUu1pIdEzEDuFEBfA==}
@@ -10082,6 +10172,7 @@ packages:
   /jest-regex-util/28.0.2:
     resolution: {integrity: sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    dev: true
 
   /jest-resolve-dependencies/28.1.3:
     resolution: {integrity: sha512-qa0QO2Q0XzQoNPouMbCc7Bvtsem8eQgVPNkwn9LnS+R2n8DaVDPL/U1gngC0LTl1RYXJU0uJa2BMC2DbTfFrHA==}
@@ -10091,6 +10182,7 @@ packages:
       jest-snapshot: 28.1.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /jest-resolve/28.1.3:
     resolution: {integrity: sha512-Z1W3tTjE6QaNI90qo/BJpfnvpxtaFTFw5CDgwpyE/Kz8U/06N1Hjf4ia9quUhCh39qIGWF1ZuxFiBiJQwSEYKQ==}
@@ -10105,6 +10197,7 @@ packages:
       resolve: 1.22.0
       resolve.exports: 1.1.0
       slash: 3.0.0
+    dev: true
 
   /jest-runner/28.1.3:
     resolution: {integrity: sha512-GkMw4D/0USd62OVO0oEgjn23TM+YJa2U2Wu5zz9xsQB1MxWKDOlrnykPxnMsN0tnJllfLPinHTka61u0QhaxBA==}
@@ -10133,6 +10226,7 @@ packages:
       source-map-support: 0.5.13
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /jest-runtime/28.1.3:
     resolution: {integrity: sha512-NU+881ScBQQLc1JHG5eJGU7Ui3kLKrmwCPPtYsJtBykixrM2OhVQlpMmFWJjMyDfdkGgBMNjXCGB/ebzsgNGQw==}
@@ -10162,6 +10256,7 @@ packages:
       strip-bom: 4.0.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /jest-snapshot/28.1.3:
     resolution: {integrity: sha512-4lzMgtiNlc3DU/8lZfmqxN3AYD6GGLbl+72rdBpXvcV+whX7mDrREzkPdp2RnmfIiWBg1YbuFSkXduF2JcafJg==}
@@ -10192,6 +10287,7 @@ packages:
       semver: 7.3.7
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /jest-transform-stub/2.0.0:
     resolution: {integrity: sha512-lspHaCRx/mBbnm3h4uMMS3R5aZzMwyNpNIJLXj4cEsV0mIUtS4IjYJLSoyjRCtnxb6RIGJ4NL2quZzfIeNhbkg==}
@@ -10239,6 +10335,7 @@ packages:
       jest-get-type: 28.0.2
       leven: 3.1.0
       pretty-format: 28.1.3
+    dev: true
 
   /jest-watcher/28.1.3:
     resolution: {integrity: sha512-t4qcqj9hze+jviFPUN3YAtAEeFnr/azITXQEMARf5cMwKY2SMBRnCQTXLixTl20OR6mLh9KLMrgVJgJISym+1g==}
@@ -10252,6 +10349,7 @@ packages:
       emittery: 0.10.2
       jest-util: 28.1.3
       string-length: 4.0.2
+    dev: true
 
   /jest-worker/28.1.3:
     resolution: {integrity: sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==}
@@ -10260,6 +10358,7 @@ packages:
       '@types/node': 17.0.23
       merge-stream: 2.0.0
       supports-color: 8.1.1
+    dev: true
 
   /jest/28.1.3:
     resolution: {integrity: sha512-N4GT5on8UkZgH0O5LUavMRV1EDEhNTL0KEfRmDIeZHSV7p2XgLoY9t9VDUgL6o+yfdgYHVxuz81G8oB9VG5uyA==}
@@ -10299,6 +10398,7 @@ packages:
       - '@types/node'
       - supports-color
       - ts-node
+    dev: true
 
   /jest/28.1.3_k5ytkvaprncdyzidqqws5bqksq:
     resolution: {integrity: sha512-N4GT5on8UkZgH0O5LUavMRV1EDEhNTL0KEfRmDIeZHSV7p2XgLoY9t9VDUgL6o+yfdgYHVxuz81G8oB9VG5uyA==}
@@ -10351,6 +10451,7 @@ packages:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
+    dev: true
 
   /js-yaml/4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -10404,6 +10505,7 @@ packages:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
     engines: {node: '>=4'}
     hasBin: true
+    dev: true
 
   /jsesc/3.0.2:
     resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
@@ -10544,6 +10646,7 @@ packages:
   /kleur/3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
+    dev: true
 
   /kleur/4.1.4:
     resolution: {integrity: sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==}
@@ -10702,6 +10805,7 @@ packages:
   /leven/3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
+    dev: true
 
   /levn/0.3.0:
     resolution: {integrity: sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==}
@@ -10856,6 +10960,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-locate: 4.1.0
+    dev: true
 
   /locate-path/6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -11040,6 +11145,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       semver: 6.3.0
+    dev: true
 
   /make-error/1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
@@ -11122,6 +11228,7 @@ packages:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
     dependencies:
       tmpl: 1.0.5
+    dev: true
 
   /map-obj/1.0.1:
     resolution: {integrity: sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=}
@@ -11345,6 +11452,7 @@ packages:
 
   /merge-stream/2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+    dev: true
 
   /merge2/1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -11609,6 +11717,7 @@ packages:
     dependencies:
       braces: 3.0.2
       picomatch: 2.3.1
+    dev: true
 
   /mime-db/1.51.0:
     resolution: {integrity: sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==}
@@ -11922,6 +12031,7 @@ packages:
 
   /natural-compare/1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+    dev: true
 
   /negotiator/0.6.2:
     resolution: {integrity: sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==}
@@ -12013,6 +12123,7 @@ packages:
 
   /node-int64/0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
+    dev: true
 
   /node-mocks-http/1.11.0:
     resolution: {integrity: sha512-jS/WzSOcKbOeGrcgKbenZeNhxUNnP36Yw11+hL4TTxQXErGfqYZ+MaYNNvhaTiGIJlzNSqgQkk9j8dSu1YWSuw==}
@@ -12032,6 +12143,7 @@ packages:
 
   /node-releases/2.0.5:
     resolution: {integrity: sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==}
+    dev: true
 
   /nodemailer/6.7.5:
     resolution: {integrity: sha512-6VtMpwhsrixq1HDYSBBHvW0GwiWawE75dS3oal48VqRhUvKJNnKnJo2RI/bCVQubj1vgrgscMNW4DHaD6xtMCg==}
@@ -12045,7 +12157,7 @@ packages:
     requiresBuild: true
     dependencies:
       chokidar: 3.5.3
-      debug: 3.2.7_supports-color@5.5.0
+      debug: 3.2.7
       ignore-by-default: 1.0.1
       minimatch: 3.1.2
       pstree.remy: 1.1.8
@@ -12110,6 +12222,7 @@ packages:
   /normalize-path/3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /normalize-url/6.1.0:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
@@ -12235,6 +12348,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       path-key: 3.1.1
+    dev: true
 
   /npm-run-path/5.1.0:
     resolution: {integrity: sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==}
@@ -12508,12 +12622,14 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       p-try: 2.2.0
+    dev: true
 
   /p-limit/3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
     dependencies:
       yocto-queue: 0.1.0
+    dev: true
 
   /p-locate/2.0.0:
     resolution: {integrity: sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==}
@@ -12527,6 +12643,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-limit: 2.3.0
+    dev: true
 
   /p-locate/5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
@@ -12588,6 +12705,7 @@ packages:
   /p-try/2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
+    dev: true
 
   /p-waterfall/2.1.1:
     resolution: {integrity: sha512-RRTnDb2TBG/epPRI2yYXsimO0v3BXC8Yd3ogr1545IaqKK17VGhbWVeGGN+XfCm/08OK8635nH31c8bATkHuSw==}
@@ -12798,6 +12916,7 @@ packages:
   /path-exists/4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+    dev: true
 
   /path-is-absolute/1.0.1:
     resolution: {integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18=}
@@ -12806,6 +12925,7 @@ packages:
   /path-key/3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+    dev: true
 
   /path-key/4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
@@ -12986,6 +13106,7 @@ packages:
 
   /picocolors/1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
+    dev: true
 
   /picomatch/2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
@@ -13020,12 +13141,14 @@ packages:
   /pirates/4.0.4:
     resolution: {integrity: sha512-ZIrVPH+A52Dw84R0L3/VS9Op04PuQ2SEoJL6bkshmiTic/HldyW9Tf7oH5mhJZBK7NmDx27vSMrYEXPXclpDKw==}
     engines: {node: '>= 6'}
+    dev: true
 
   /pkg-dir/4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
     dependencies:
       find-up: 4.1.0
+    dev: true
 
   /pkg-dir/5.0.0:
     resolution: {integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==}
@@ -13308,6 +13431,7 @@ packages:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 18.2.0
+    dev: true
 
   /pretty-ms/6.0.1:
     resolution: {integrity: sha512-ke4njoVmlotekHlHyCZ3wI/c5AMT8peuHs8rKJqekj/oR5G8lND2dVpicFlUz5cbZgE290vvkMuDwfj/OcW1kw==}
@@ -13378,6 +13502,7 @@ packages:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
+    dev: true
 
   /promzard/0.3.0:
     resolution: {integrity: sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=}
@@ -13668,6 +13793,7 @@ packages:
 
   /react-is/18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
+    dev: true
 
   /react-lifecycles-compat/3.0.4:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
@@ -14169,6 +14295,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       resolve-from: 5.0.0
+    dev: true
 
   /resolve-dir/0.1.1:
     resolution: {integrity: sha512-QxMPqI6le2u0dCLyiGzgy92kjkkL6zO0XyvHzjdTNH3zM6e5Hz3BwG6+aEyNgiQ5Xz6PwTwgQEj3U50dByPKIA==}
@@ -14185,6 +14312,7 @@ packages:
   /resolve-from/5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+    dev: true
 
   /resolve-global/1.0.0:
     resolution: {integrity: sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==}
@@ -14211,6 +14339,7 @@ packages:
   /resolve.exports/1.1.0:
     resolution: {integrity: sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==}
     engines: {node: '>=10'}
+    dev: true
 
   /resolve/1.22.0:
     resolution: {integrity: sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==}
@@ -14262,6 +14391,7 @@ packages:
     hasBin: true
     dependencies:
       glob: 7.2.0
+    dev: true
 
   /roarr/2.15.4:
     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
@@ -14318,6 +14448,7 @@ packages:
 
   /safe-buffer/5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+    dev: true
 
   /safe-buffer/5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -14365,6 +14496,7 @@ packages:
   /semver/6.3.0:
     resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
     hasBin: true
+    dev: true
 
   /semver/7.0.0:
     resolution: {integrity: sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==}
@@ -14433,10 +14565,12 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       shebang-regex: 3.0.0
+    dev: true
 
   /shebang-regex/3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+    dev: true
 
   /shell-quote/1.7.3:
     resolution: {integrity: sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==}
@@ -14465,10 +14599,12 @@ packages:
 
   /sisteransi/1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+    dev: true
 
   /slash/3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+    dev: true
 
   /slash/4.0.0:
     resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
@@ -14712,6 +14848,7 @@ packages:
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
+    dev: true
 
   /source-map-support/0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
@@ -14723,10 +14860,12 @@ packages:
   /source-map/0.5.7:
     resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /source-map/0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /source-map/0.7.3:
     resolution: {integrity: sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==}
@@ -14795,6 +14934,7 @@ packages:
 
   /sprintf-js/1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+    dev: true
 
   /sprintf-js/1.1.2:
     resolution: {integrity: sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==}
@@ -14829,6 +14969,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       escape-string-regexp: 2.0.0
+    dev: true
 
   /state-toggle/1.0.3:
     resolution: {integrity: sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==}
@@ -14862,6 +15003,7 @@ packages:
     dependencies:
       char-regex: 1.0.2
       strip-ansi: 6.0.1
+    dev: true
 
   /string-similarity/4.0.4:
     resolution: {integrity: sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==}
@@ -14979,10 +15121,12 @@ packages:
   /strip-bom/4.0.0:
     resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
     engines: {node: '>=8'}
+    dev: true
 
   /strip-final-newline/2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
+    dev: true
 
   /strip-final-newline/3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
@@ -14999,6 +15143,7 @@ packages:
   /strip-json-comments/3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+    dev: true
 
   /strong-log-transformer/2.1.0:
     resolution: {integrity: sha512-B3Hgul+z0L9a236FAUC9iZsL+nVHgoCJnqCbN588DjYxvGXaXaaFbfmQ/JhvKjZwsOukuR72XbHv71Qkug0HxA==}
@@ -15190,6 +15335,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       has-flag: 4.0.0
+    dev: true
 
   /supports-hyperlinks/2.2.0:
     resolution: {integrity: sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==}
@@ -15197,6 +15343,7 @@ packages:
     dependencies:
       has-flag: 4.0.0
       supports-color: 7.2.0
+    dev: true
 
   /supports-preserve-symlinks-flag/1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -15318,6 +15465,7 @@ packages:
     dependencies:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.2.0
+    dev: true
 
   /terser/5.12.0:
     resolution: {integrity: sha512-R3AUhNBGWiFc77HXag+1fXpAxTAFRQTJemlJKjAgD9r8xXTpjNKqIXwHM/o7Rh+O0kUJtS3WQVdBeMKFk5sw9A==}
@@ -15337,6 +15485,7 @@ packages:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.0
       minimatch: 3.1.2
+    dev: true
 
   /text-encoder/0.0.4:
     resolution: {integrity: sha512-12gllbNnC0Zdh9r+LCpEwpUdvncaE9hfUmCVm2ryCH1LEVUZbS6NdRq8omEgJI0zKgaGFTjwQVHbglGDCIbmNA==}
@@ -15392,6 +15541,7 @@ packages:
 
   /tmpl/1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
+    dev: true
 
   /to-fast-properties/2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
@@ -15402,6 +15552,7 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
+    dev: true
 
   /toidentifier/1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -15623,6 +15774,7 @@ packages:
   /type-detect/4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
     engines: {node: '>=4'}
+    dev: true
 
   /type-fest/0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
@@ -15687,6 +15839,7 @@ packages:
     resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
     engines: {node: '>=4.2.0'}
     hasBin: true
+    dev: true
 
   /ua-parser-js/1.0.2:
     resolution: {integrity: sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg==}
@@ -15955,6 +16108,7 @@ packages:
       '@jridgewell/trace-mapping': 0.3.14
       '@types/istanbul-lib-coverage': 2.0.3
       convert-source-map: 1.8.0
+    dev: true
 
   /validate-npm-package-license/3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -16056,6 +16210,7 @@ packages:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
     dependencies:
       makeerror: 1.0.12
+    dev: true
 
   /warning/4.0.3:
     resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
@@ -16179,6 +16334,7 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
+    dev: true
 
   /wide-align/1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
@@ -16237,6 +16393,7 @@ packages:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
+    dev: true
 
   /write-json-file/3.2.0:
     resolution: {integrity: sha512-3xZqT7Byc2uORAatYiP3DHUUAVEkNOswEWNs9H5KXiicRTvzYzYqKjYc4G7p+8pltvAw641lVByKVtMpf+4sYQ==}
@@ -16375,6 +16532,7 @@ packages:
   /yocto-queue/0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+    dev: true
 
   /zod/3.14.3:
     resolution: {integrity: sha512-OzwRCSXB1+/8F6w6HkYHdbuWysYWnAF4fkRgKDcSFc54CE+Sv0rHXKfeNUReGCrHukm1LNpi6AYeXotznhYJbQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -403,7 +403,6 @@ importers:
     specifiers:
       '@jest/types': ^28.1.3
       '@logto/connector-core': ^1.0.0-beta.6
-<<<<<<< HEAD
       '@silverhand/eslint-config': 1.0.0-rc.2
       '@silverhand/essentials': ^1.2.0
       '@silverhand/jest-config': 1.0.0-rc.3
@@ -7564,8 +7563,6 @@ packages:
       find-up: 2.1.0
     transitivePeerDependencies:
       - supports-color
-      debug: 3.2.7
-      find-up: 2.1.0
     dev: true
 
   /eslint-plugin-consistent-default-export-name/0.0.15:


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- move out `connector.metadata.type` to `connector.type` for discriminated unions
- define `BaseConnector<T>` for better and more flexible narrowing
- rename `.SMS` -> `.Sms`
- add `LoadConnector` and `LogtoConnector` in `@logto/core` to enable type narrowing

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

- [x] CI
- [x] type inference
- [ ] admin console connector CRUD
- [ ] main flow sms connector
- [ ] main flow email connector
- [ ] main flow social connector

### Narrowing `LogtoConnector<AllConnector>`

**Case 1**

<img width="497" alt="image" src="https://user-images.githubusercontent.com/14722250/187718624-531e2558-c3d7-4517-91cc-bacb01bcae08.png">

<img width="653" alt="image" src="https://user-images.githubusercontent.com/14722250/187718689-8e7bbca8-ae32-4ca2-a025-191aeae2c5a6.png">

**Case 2**

<img width="429" alt="image" src="https://user-images.githubusercontent.com/14722250/187719064-1da683f9-dd8f-4fd9-a4c5-392c59a9c2bf.png">

<img width="523" alt="image" src="https://user-images.githubusercontent.com/14722250/187719092-ca6ab452-238b-42cb-889a-f1456d067e05.png">

### Narrowing `AllConnector`

**First `connector`**
<img width="250" alt="image" src="https://user-images.githubusercontent.com/14722250/187719274-3ce35024-2ed7-4871-9dd4-396da9a3da5b.png">

**Second `connector`**
<img width="394" alt="image" src="https://user-images.githubusercontent.com/14722250/187719302-e09e7717-a7de-4e7a-a444-918395f30b47.png">
