### PR TITLE
chore: integrate Uffizzi PR Environments

### DIFF
--- a/docker-compose.uffizzi.yml
+++ b/docker-compose.uffizzi.yml
@@ -1,0 +1,44 @@
+# This compose file is for demonstration only, do not use in prod.
+version: "3.9"
+
+x-uffizzi:
+  ingress:
+    service: app
+    port: 3001
+  continuous_previews:
+    deploy_preview_when_pull_request_is_opened: true
+    delete_preview_when_pull_request_is_closed: true
+    share_to_github: true
+
+services:
+  app:
+    depends_on:
+      - "postgres"
+    build:
+      context: ./
+      dockerfile: ./Dockerfile
+    ports:
+      - 3001:3001
+    environment:
+      TRUST_PROXY_HEADER: 1
+      DB_URL: postgres://postgres:p0stgr3s@localhost:5432/logto
+    deploy:
+      resources:
+        limits:
+          memory: 2000M
+    entrypoint: /bin/sh
+    command:
+      - "-c"
+      - "npm run cli db seed -- --swe && ENDPOINT=$$UFFIZZI_URL npm start"
+
+  postgres:
+    image: postgres:14-alpine
+    user: postgres
+    environment:
+      POSTGRES_USER: "postgres"
+      POSTGRES_PASSWORD: "p0stgr3s"
+    deploy:
+      resources:
+        limits:
+          memory: 500M
+


### PR DESCRIPTION
## Summary
<!-- Provide detail PR description below -->
Add support for creating pull request environment on every PR using Uffizzi.
- Build an image for every PR build in github actions
- Uffizzi deploy github action which uses the built image to deploy the PR Environment
- Docker compose template with uses postgres instance for every PR environment

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested this PR locally and on my fork of the repo https://github.com/waveywaves/logto/pull/2

## Additional information for maintainers
I want to invite the maintainers of Logto to the Uffizzi project created for them. The PR setups up PR Environments for Logto to ease development and reviews. Reviewers should be able to see a preview of the PR as a hosted service. The URL of the service will be provided in a comment on the PR itself. I want to invite the maintainers of Logto to the uffizzi project to get an idea of what the platform looks like. Uffizzi is free for Logto.
