### PR TITLE
chore: run dev mode in gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,14 +1,37 @@
 tasks:
-  - name: Start Logto
+  - name: DB Server
+    init: docker pull postgres:14-alpine
+    command: docker run -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=p0stgr3s postgres:14-alpine
+  - name: Logto Dev Mode
     init: |
-      docker-compose pull
+      pnpm i
+      pnpm prepack
     command: |
-      ENDPOINT=$(gp url 3001) docker compose -p logto up
+      ENDPOINT=$(gp url 3001) pnpm dev
     env:
-      TAG: prerelease
+      ALL_YES: 1
+      NO_INQUIRY: 0
+      TRUST_PROXY_HEADER: 1
+      DB_URL_DEFAULT: postgres://postgres:p0stgr3s@127.0.0.1:5432
 
 ports:
   - name: Logto
     description: The Logto core service
     port: 3001
     visibility: public
+  - name: Postgres
+    port: 5432
+    visibility: public
+    onOpen: ignore
+  - port: 5001
+    onOpen: ignore
+  - port: 5002
+    onOpen: ignore
+  - port: 5003
+    onOpen: ignore
+  - port: 6001
+    onOpen: ignore
+  - port: 6002
+    onOpen: ignore
+  - port: 6003
+    onOpen: ignore


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Previously, our demo in GitPod is running in production mode with a prebuild docker image. 
But running in dev mode would be better, the user can then preview the latest code in any branch, and can even change code and get preview in real time.

This will be helpful for the new users.

With the help of the feature [prebuilds](https://www.gitpod.io/docs/prebuilds), we don't need to wait for something like `pnpm i`, so this is almost as quick as the docker image.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Open this link: https://gitpod.io/#https://github.com/logto-io/logto/pull/1878
