### PR TITLE
chore: skip prepack for gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,8 +6,13 @@ tasks:
     init: |
       pnpm i
       pnpm prepack
+      cd packages/core
+      pnpm build
+      pnpm add-official-connectors
+      cd -
     command: |
-      ENDPOINT=$(gp url 3001) pnpm dev
+      export ENDPOINT=$(gp url 3001)
+      pnpm lerna --ignore=@logto/integration-test run --parallel dev
     env:
       ALL_YES: 1
       NO_INQUIRY: 0


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
In gitpod, `prepack` is ensured in `init`, so we can skip this to accelerate the preparation for a dev preview.

Btw, this PR is created via Gitpod in a browser.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

https://gitpod.io/#https://github.com/logto-io/logto/pull/1883
