### PR TITLE
fix: exclude mock connectors

### DIFF
--- a/packages/core/src/connectors/add-connectors.ts
+++ b/packages/core/src/connectors/add-connectors.ts
@@ -14,12 +14,13 @@ import { npmPackResultGuard } from './types';
 const execPromise = promisify(exec);
 
 const fetchOfficialConnectorList = async () => {
-  // Will change to "logto-io/connectors" once the new repo is ready.
   const directories = await got
     .get('https://api.github.com/repos/logto-io/connectors/contents/packages')
     .json<Array<{ name: string }>>();
 
-  return directories.map(({ name }) => `@logto/${name}`);
+  return directories
+    .filter(({ name }) => !name.includes('mock-'))
+    .map(({ name }) => `@logto/${name}`);
 };
 
 export const addConnector = async (packageName: string, cwd: string) => {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Exclude 3 mock connectors when fetching official connectors list.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Ran `pnpm add-official-connectors` in local.
