### PR TITLE
fix(console): input invalid format content in multitextinput will not crash the app

### DIFF
--- a/packages/console/src/components/MultiTextInput/types.ts
+++ b/packages/console/src/components/MultiTextInput/types.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const multiTextInputErrorGuard = z.object({
   required: z.string().optional(),
-  inputs: z.record(z.number(), z.string().optional()).optional(),
+  inputs: z.record(z.number().or(z.string()), z.string().optional()).optional(),
 });
 
 export type MultiTextInputError = z.infer<typeof multiTextInputErrorGuard>;

--- a/packages/console/src/components/MultiTextInput/utils.ts
+++ b/packages/console/src/components/MultiTextInput/utils.ts
@@ -1,5 +1,7 @@
 import { t } from 'i18next';
 
+import { safeParseJson } from '@/utilities/json';
+
 import { MultiTextInputError, multiTextInputErrorGuard, MultiTextInputRule } from './types';
 
 export const validate = (
@@ -57,7 +59,13 @@ export const convertRhfErrorMessage = (errorMessage?: string): MultiTextInputErr
     return;
   }
 
-  const result = multiTextInputErrorGuard.safeParse(errorMessage);
+  const jsonParseResult = safeParseJson(errorMessage);
+
+  if (!jsonParseResult.success) {
+    throw new Error(t('admin_console.errors.invalid_error_message_format'));
+  }
+
+  const result = multiTextInputErrorGuard.safeParse(jsonParseResult.data);
 
   if (!result.success) {
     throw new Error(t('admin_console.errors.invalid_error_message_format'));


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fixed the bug that inputting invalid format content in MultiTextInput component will end up with app crash and showing exception message in ErrorBoundary, instead of showing the message under the field.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] In application details, input invalid URL format in "Redirect Uris" field, and click save button, error message is now displayed under the field, instead of an app crash and showing the error message in the fullscreen ErrorBoundary display.

![image](https://user-images.githubusercontent.com/12833674/188853038-c34bf00d-c619-4379-9fea-8765942324c3.png)

Instead of 

![image](https://user-images.githubusercontent.com/12833674/188852981-904dca3b-5b2b-4c60-9849-64b50a883523.png)

