### PR TITLE
feat(core): save empty string as null value in DB

### DIFF
--- a/packages/core/src/database/utils.test.ts
+++ b/packages/core/src/database/utils.test.ts
@@ -53,6 +53,10 @@ describe('convertToPrimitiveOrSql()', () => {
     expect(convertToPrimitiveOrSql(normalKey, ['bar'])).toEqual('["bar"]');
   });
 
+  it('converts empty string to null value', () => {
+    expect(convertToPrimitiveOrSql(normalKey, '')).toEqual(null);
+  });
+
   it('converts value to sql when key ends with special set and value is number', () => {
     for (const value of timestampKeyEndings) {
       expect(convertToPrimitiveOrSql(`${normalKey}${value}`, 12_341_234)).toEqual({

--- a/packages/core/src/database/utils.ts
+++ b/packages/core/src/database/utils.ts
@@ -47,7 +47,15 @@ export const convertToPrimitiveOrSql = (
     return sql`to_timestamp(${value}::double precision / 1000)`;
   }
 
-  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    if (value === '') {
+      return null;
+    }
+
     return value;
   }
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Per offline discussion, the empty string is meaningless in our database, so we save `''` as `null` value in our database.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT & Testlocally.
