### PR TITLE
feat(core): add ts to interaction result

### DIFF
--- a/packages/core/src/lib/session.ts
+++ b/packages/core/src/lib/session.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import { Context } from 'koa';
 import { InteractionResults, Provider } from 'oidc-provider';
 
@@ -14,20 +15,31 @@ export const assignInteractionResults = async (
   // have to do it manually
   // refer to: https://github.com/panva/node-oidc-provider/blob/c243bf6b6663c41ff3e75c09b95fb978eba87381/lib/actions/authorization/interactions.js#L106
   const details = merge ? await provider.interactionDetails(ctx.req, ctx.res) : undefined;
+  const ts = dayjs().unix();
+  const mergedResult = {
+    // Merge with current result
+    ...details?.result,
+    ...result,
+  };
 
   const redirectTo = await provider.interactionResult(
     ctx.req,
     ctx.res,
     {
-      // Merge with current result
-      ...details?.result,
-      ...result,
+      ...mergedResult,
+      login: mergedResult.login
+        ? {
+            ...mergedResult.login,
+            // Update ts(timestamp) if the accountId is been set in result
+            ts: result.login?.accountId ? ts : mergedResult.login.ts,
+          }
+        : undefined,
     },
     {
       mergeWithLastSubmission: merge,
     }
   );
-  ctx.body = { redirectTo };
+  ctx.body = { redirectTo, ts };
 };
 
 export const saveUserFirstConsentedAppId = async (userId: string, applicationId: string) => {

--- a/packages/core/src/routes/session/passwordless.test.ts
+++ b/packages/core/src/routes/session/passwordless.test.ts
@@ -97,7 +97,8 @@ describe('session -> passwordlessRoutes', () => {
       expect(interactionResult).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
-        expect.objectContaining({ login: { accountId: 'id' } }),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        expect.objectContaining({ login: expect.objectContaining({ accountId: 'id' }) }),
         expect.anything()
       );
     });
@@ -146,7 +147,8 @@ describe('session -> passwordlessRoutes', () => {
       expect(interactionResult).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
-        expect.objectContaining({ login: { accountId: 'id' } }),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        expect.objectContaining({ login: expect.objectContaining({ accountId: 'id' }) }),
         expect.anything()
       );
     });
@@ -214,7 +216,8 @@ describe('session -> passwordlessRoutes', () => {
       expect(interactionResult).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
-        expect.objectContaining({ login: { accountId: 'user1' } }),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        expect.objectContaining({ login: expect.objectContaining({ accountId: 'user1' }) }),
         expect.anything()
       );
     });
@@ -291,7 +294,8 @@ describe('session -> passwordlessRoutes', () => {
       expect(interactionResult).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
-        expect.objectContaining({ login: { accountId: 'user1' } }),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        expect.objectContaining({ login: expect.objectContaining({ accountId: 'user1' }) }),
         expect.anything()
       );
     });

--- a/packages/core/src/routes/session/social.test.ts
+++ b/packages/core/src/routes/session/social.test.ts
@@ -223,7 +223,8 @@ describe('session -> socialRoutes', () => {
       expect(interactionResult).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
-        expect.objectContaining({ login: { accountId: 'id' } }),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        expect.objectContaining({ login: expect.objectContaining({ accountId: 'id' }) }),
         expect.anything()
       );
     });
@@ -309,7 +310,8 @@ describe('session -> socialRoutes', () => {
       expect(interactionResult).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
-        expect.objectContaining({ login: { accountId: 'user1' } }),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        expect.objectContaining({ login: expect.objectContaining({ accountId: 'user1' }) }),
         expect.anything()
       );
     });
@@ -346,7 +348,8 @@ describe('session -> socialRoutes', () => {
       expect(interactionResult).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
-        expect.objectContaining({ login: { accountId: 'user1' } }),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        expect.objectContaining({ login: expect.objectContaining({ accountId: 'user1' }) }),
         expect.anything()
       );
     });

--- a/packages/core/src/routes/session/username-password.test.ts
+++ b/packages/core/src/routes/session/username-password.test.ts
@@ -111,7 +111,8 @@ describe('sessionRoutes', () => {
       expect(interactionResult).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
-        expect.objectContaining({ login: { accountId: 'user1' } }),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        expect.objectContaining({ login: expect.objectContaining({ accountId: 'user1' }) }),
         expect.anything()
       );
     });
@@ -180,7 +181,8 @@ describe('sessionRoutes', () => {
       expect(interactionResult).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
-        expect.objectContaining({ login: { accountId: 'user1' } }),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        expect.objectContaining({ login: expect.objectContaining({ accountId: 'user1' }) }),
         expect.anything()
       );
     });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Record sign in time, and save to interaction session as `ts`, also this will be exposed in every sign in API along with `redirectTo`.

<img width="490" alt="截屏2022-09-13 下午4 44 05" src="https://user-images.githubusercontent.com/5717882/189856689-938ff4b0-4c16-49e4-bef0-1cf4bacdd89f.png">

This is used to verify if the user can modify sensitive profile info. If the `ts` is within a short period of time, the user can continue, and if it is exceeded, the user will be redirect to "sign in again" to refresh `ts`.

`ts` is the recommended key name in `node-oidc-provider`:

<img width="808" alt="image" src="https://user-images.githubusercontent.com/5717882/189856488-3fa4a7e8-2b15-4b48-b17b-888549758138.png">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested, the key `ts` can be found in session:

<img width="480" alt="截屏2022-09-13 下午4 44 25" src="https://user-images.githubusercontent.com/5717882/189859831-2f65e38a-56ec-4975-a341-f5f8785d2667.png">

