### PR TITLE
feat(core): add DELETE /custom-phrases/:languageKey route

### DIFF
--- a/packages/core/src/queries/custom-phrase.ts
+++ b/packages/core/src/queries/custom-phrase.ts
@@ -3,6 +3,7 @@ import { sql } from 'slonik';
 
 import { convertToIdentifiers } from '@/database/utils';
 import envSet from '@/env-set';
+import { DeletionError } from '@/errors/SlonikError';
 
 const { table, fields } = convertToIdentifiers(CustomPhrases);
 
@@ -12,3 +13,14 @@ export const findCustomPhraseByLanguageKey = async (languageKey: string): Promis
     from ${table}
     where ${fields.languageKey} = ${languageKey}
   `);
+
+export const deleteCustomPhraseByLanguageKey = async (languageKey: string) => {
+  const { rowCount } = await envSet.pool.query(sql`
+    delete from ${table}
+    where ${fields.languageKey}=${languageKey}
+  `);
+
+  if (rowCount < 1) {
+    throw new DeletionError(CustomPhrases.table, languageKey);
+  }
+};

--- a/packages/core/src/routes/custom-phrase.test.ts
+++ b/packages/core/src/routes/custom-phrase.test.ts
@@ -1,7 +1,7 @@
 import { CustomPhrase } from '@logto/schemas';
 
 import RequestError from '@/errors/RequestError';
-import phraseRoutes from '@/routes/custom-phrase';
+import customPhraseRoutes from '@/routes/custom-phrase';
 import { createRequester } from '@/utils/test-utils';
 
 const mockLanguageKey = 'en-US';
@@ -21,6 +21,12 @@ const mockCustomPhrases: Record<string, CustomPhrase> = {
   },
 };
 
+const deleteCustomPhraseByLanguageKey = jest.fn(async (languageKey: string) => {
+  if (!mockCustomPhrases[languageKey]) {
+    throw new RequestError({ code: 'entity.not_found', status: 404 });
+  }
+});
+
 const findCustomPhraseByLanguageKey = jest.fn(async (languageKey: string) => {
   const mockCustomPhrase = mockCustomPhrases[languageKey];
 
@@ -32,11 +38,12 @@ const findCustomPhraseByLanguageKey = jest.fn(async (languageKey: string) => {
 });
 
 jest.mock('@/queries/custom-phrase', () => ({
+  deleteCustomPhraseByLanguageKey: async (key: string) => deleteCustomPhraseByLanguageKey(key),
   findCustomPhraseByLanguageKey: async (key: string) => findCustomPhraseByLanguageKey(key),
 }));
 
 describe('customPhraseRoutes', () => {
-  const phraseRequest = createRequester({ authedRoutes: phraseRoutes });
+  const customPhraseRequest = createRequester({ authedRoutes: customPhraseRoutes });
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -44,18 +51,35 @@ describe('customPhraseRoutes', () => {
 
   describe('GET /custom-phrases/:languageKey', () => {
     it('should call findCustomPhraseByLanguageKey once', async () => {
-      await phraseRequest.get(`/custom-phrases/${mockLanguageKey}`);
+      await customPhraseRequest.get(`/custom-phrases/${mockLanguageKey}`);
       expect(findCustomPhraseByLanguageKey).toBeCalledTimes(1);
     });
 
     it('should return the specified custom phrase existing in the database', async () => {
-      const response = await phraseRequest.get(`/custom-phrases/${mockLanguageKey}`);
+      const response = await customPhraseRequest.get(`/custom-phrases/${mockLanguageKey}`);
       expect(response.status).toEqual(200);
       expect(response.body).toEqual(mockCustomPhrases[mockLanguageKey]);
     });
 
     it('should return 404 status code when there is no specified custom phrase in the database', async () => {
-      const response = await phraseRequest.get('/custom-phrases/en-UK');
+      const response = await customPhraseRequest.get('/custom-phrases/en-UK');
+      expect(response.status).toEqual(404);
+    });
+  });
+
+  describe('DELETE /custom-phrases/:languageKey', () => {
+    it('should call deleteCustomPhraseByLanguageKey', async () => {
+      await customPhraseRequest.delete(`/custom-phrases/${mockLanguageKey}`);
+      expect(deleteCustomPhraseByLanguageKey).toBeCalledWith(mockLanguageKey);
+    });
+
+    it('should return 204 status code after deleting the specified custom phrase', async () => {
+      const response = await customPhraseRequest.delete(`/custom-phrases/${mockLanguageKey}`);
+      expect(response.status).toEqual(204);
+    });
+
+    it('should return 404 status code when the specified custom phrase does not exist before deleting', async () => {
+      const response = await customPhraseRequest.delete(`/custom-phrases/en-UK`);
       expect(response.status).toEqual(404);
     });
   });

--- a/packages/core/src/routes/custom-phrase.ts
+++ b/packages/core/src/routes/custom-phrase.ts
@@ -1,11 +1,14 @@
 import { CustomPhrases } from '@logto/schemas';
 
 import koaGuard from '@/middleware/koa-guard';
-import { findCustomPhraseByLanguageKey } from '@/queries/custom-phrase';
+import {
+  deleteCustomPhraseByLanguageKey,
+  findCustomPhraseByLanguageKey,
+} from '@/queries/custom-phrase';
 
 import { AuthedRouter } from './types';
 
-export default function phraseRoutes<T extends AuthedRouter>(router: T) {
+export default function customPhraseRoutes<T extends AuthedRouter>(router: T) {
   router.get(
     '/custom-phrases/:languageKey',
     koaGuard({
@@ -19,6 +22,23 @@ export default function phraseRoutes<T extends AuthedRouter>(router: T) {
       } = ctx.guard;
 
       ctx.body = await findCustomPhraseByLanguageKey(languageKey);
+
+      return next();
+    }
+  );
+
+  router.delete(
+    '/custom-phrases/:languageKey',
+    koaGuard({
+      params: CustomPhrases.createGuard.pick({ languageKey: true }),
+    }),
+    async (ctx, next) => {
+      const {
+        params: { languageKey },
+      } = ctx.guard;
+
+      await deleteCustomPhraseByLanguageKey(languageKey);
+      ctx.status = 204;
 
       return next();
     }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- Add `DELETE /custom-phrases/:languageKey` route
    - If the specified custom phrase does not exist before deleting, it will return 404 status.
    - If the specified custom phrase exists before deleting, it will return 204 status when the process succeeds.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Locally tested.

![image](https://user-images.githubusercontent.com/10594507/189879159-9b840777-67ed-407e-8c05-beedab7dc804.png)

First deletion (the specified custom phrase exists before deleting)

![image](https://user-images.githubusercontent.com/10594507/189879203-9ed8fd68-0cc7-4093-8354-5fd99ef4458c.png)

Second deletion (the specified custom phrase does not exist before deleting)

![image](https://user-images.githubusercontent.com/10594507/189879460-8be71eb6-8634-4fd8-9a61-057fdb7655ff.png)

