### PR TITLE
fix: support capital letter "Y" in command line prompt

### DIFF
--- a/install.js
+++ b/install.js
@@ -19,7 +19,7 @@ const question = async (query) => new Promise((resolve) => {
 
 const confirm = async (query) => {
   const answer = await question(`${query} (Y/n) `);
-  return answer === '' || ['y', 'yes', 'yep', 'yeah'].includes(answer);
+  return answer === '' || ['y', 'yes', 'yep', 'yeah'].includes(answer.toLowerCase());
 };
 
 const safeExecSync = (command) => {

--- a/packages/core/src/env-set/parameters.ts
+++ b/packages/core/src/env-set/parameters.ts
@@ -1,6 +1,7 @@
 import { getEnv } from '@silverhand/essentials';
 
-export const isTrue = (value: string) => ['1', 'true', 'y', 'yes', 'yep', 'yeah'].includes(value);
+export const isTrue = (value: string) =>
+  ['1', 'true', 'y', 'yes', 'yep', 'yeah'].includes(value.toLowerCase());
 
 const parameters = new Set(process.argv.slice(2));
 export const noInquiry = parameters.has('--no-inquiry') || isTrue(getEnv('NO_INQUIRY'));


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Support capital letter "Y" in logto command line prompt.

Previously when prompt (Y/n) in command line, if user inputs "Y", it will be considered as negative answer and the command line tool will be terminated.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally
