### PR TITLE
fix(console): add sandbox attribute to iframe

### DIFF
--- a/packages/console/src/pages/SignInExperience/components/Preview.tsx
+++ b/packages/console/src/pages/SignInExperience/components/Preview.tsx
@@ -1,5 +1,3 @@
-// FIXME: @sijie
-/* eslint-disable react/iframe-missing-sandbox */
 import { languageOptions } from '@logto/phrases-ui';
 import {
   AppearanceMode,
@@ -197,7 +195,12 @@ const Preview = ({ signInExperience, className }: Props) => {
                 <PhoneInfo />
               </div>
             )}
+            {
+              // The missing of attribute "sandbox" is intended since the source is trusted
+              /* eslint-disable react/iframe-missing-sandbox */
+            }
             <iframe ref={previewRef} src="/sign-in?preview=true" tabIndex={-1} />
+            {/* eslint-enable react/iframe-missing-sandbox */}
           </div>
         </div>
       </div>
@@ -206,4 +209,3 @@ const Preview = ({ signInExperience, className }: Props) => {
 };
 
 export default Preview;
-/* eslint-enable react/iframe-missing-sandbox */


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Add [sandbox](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox) attribute to iframe in SIE preview.

Have to disable the lint rule, for we need to set both "allow-scripts" and "allow-same-origin" to allow communication between the iframe and parent.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested.