### PR TITLE
feat(core,phrases): add check protected access function

### DIFF
--- a/packages/core/src/utils/format.ts
+++ b/packages/core/src/utils/format.ts
@@ -1,10 +1,20 @@
-export const maskUserInfo = ({ type, value }: { type: 'email' | 'phone'; value: string }) => {
+export const maskUserInfo = ({
+  type,
+  value,
+}: {
+  type: 'email' | 'phone' | 'username';
+  value: string;
+}) => {
   if (!value) {
     return value;
   }
 
   if (type === 'phone') {
     return `****${value.slice(-4)}`;
+  }
+
+  if (type === 'username') {
+    return `****${value.slice(-2)}`;
   }
 
   const [name = '', domain = ''] = value.split('@');

--- a/packages/phrases/src/locales/en/errors.ts
+++ b/packages/phrases/src/locales/en/errors.ts
@@ -7,6 +7,7 @@ const errors = {
     expected_role_not_found:
       'Expected role not found. Please check your user roles and permissions.',
     jwt_sub_missing: 'Missing `sub` in JWT.',
+    require_re_authentication: 'Re-authentication is required to perform a protected action.',
   },
   guard: {
     invalid_input: 'The request {{type}} is invalid.',

--- a/packages/phrases/src/locales/fr/errors.ts
+++ b/packages/phrases/src/locales/fr/errors.ts
@@ -8,6 +8,7 @@ const errors = {
     expected_role_not_found:
       'Expected role not found. Please check your user roles and permissions.',
     jwt_sub_missing: '`sub` manquant dans JWT.',
+    require_re_authentication: 'Re-authentication is required to perform a protected action.', // UNTRANSLATED
   },
   guard: {
     invalid_input: "La requête {{type}} n'est pas valide.",

--- a/packages/phrases/src/locales/ko-kr/errors.ts
+++ b/packages/phrases/src/locales/ko-kr/errors.ts
@@ -7,6 +7,7 @@ const errors = {
     expected_role_not_found:
       'Expected role not found. Please check your user roles and permissions.',
     jwt_sub_missing: 'JWT에서 `sub`를 찾을 수 없어요.',
+    require_re_authentication: 'Re-authentication is required to perform a protected action.', // UNTRANSLATED
   },
   guard: {
     invalid_input: '{{type}} 요청 타입은 유효하지 않아요.',

--- a/packages/phrases/src/locales/pt-pt/errors.ts
+++ b/packages/phrases/src/locales/pt-pt/errors.ts
@@ -6,6 +6,7 @@ const errors = {
     forbidden: 'Proibido. Verifique os seus cargos e permissões.',
     expected_role_not_found: 'Role esperado não encontrado. Verifique os seus cargos e permissões.',
     jwt_sub_missing: 'Campo `sub` está ausente no JWT.',
+    require_re_authentication: 'Re-authentication is required to perform a protected action.', // UNTRANSLATED
   },
   guard: {
     invalid_input: 'O pedido {{type}} é inválido.',

--- a/packages/phrases/src/locales/tr-tr/errors.ts
+++ b/packages/phrases/src/locales/tr-tr/errors.ts
@@ -7,6 +7,7 @@ const errors = {
     expected_role_not_found:
       'Expected role not found. Please check your user roles and permissions.',
     jwt_sub_missing: 'JWTde `sub` eksik.',
+    require_re_authentication: 'Re-authentication is required to perform a protected action.', // UNTRANSLATED
   },
   guard: {
     invalid_input: 'İstek {{type}} geçersiz.',

--- a/packages/phrases/src/locales/zh-cn/errors.ts
+++ b/packages/phrases/src/locales/zh-cn/errors.ts
@@ -6,6 +6,7 @@ const errors = {
     forbidden: '禁止访问。请检查用户 role 与权限。',
     expected_role_not_found: '未找到期望的 role。请检查用户 role 与权限。',
     jwt_sub_missing: 'JWT 缺失 `sub`',
+    require_re_authentication: '需要重新认证以进行受保护操作。',
   },
   guard: {
     invalid_input: '请求中 {{type}} 无效',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add a function to check if current session have the access to perform a protected action (sign in within a period of time), if not, throw an error with code `auth.require_re_authentication`. And the front-end(@simeng-li) will guide the user to re-authentice to get the access.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested with the following code:

<img width="522" alt="截屏2022-09-14 下午2 24 39" src="https://user-images.githubusercontent.com/5717882/190076711-0b88fec4-8e2b-4fe3-a084-5a30c6aab9df.png">

And the error payload structure is:

<img width="709" alt="image" src="https://user-images.githubusercontent.com/5717882/190079325-deab7737-056a-4f1a-ac2f-7d7bda59881d.png">

