### PR TITLE
feat(core): add GET /custom-language-keys route

### DIFF
--- a/packages/core/src/queries/custom-phrase.ts
+++ b/packages/core/src/queries/custom-phrase.ts
@@ -24,3 +24,13 @@ export const deleteCustomPhraseByLanguageKey = async (languageKey: string) => {
     throw new DeletionError(CustomPhrases.table, languageKey);
   }
 };
+
+export const getCustomLanguageKeys = async (): Promise<string[]> => {
+  const rows = await envSet.pool.many<{ languageKey: string }>(sql`
+    select ${fields.languageKey} 
+    from ${table}
+    order by ${fields.languageKey}
+  `);
+
+  return rows.map((row) => row.languageKey);
+};

--- a/packages/core/src/routes/custom-phrase.test.ts
+++ b/packages/core/src/routes/custom-phrase.test.ts
@@ -37,9 +37,12 @@ const findCustomPhraseByLanguageKey = jest.fn(async (languageKey: string) => {
   return mockCustomPhrase;
 });
 
+const getCustomLanguageKeys = jest.fn(async () => [mockLanguageKey]);
+
 jest.mock('@/queries/custom-phrase', () => ({
   deleteCustomPhraseByLanguageKey: async (key: string) => deleteCustomPhraseByLanguageKey(key),
   findCustomPhraseByLanguageKey: async (key: string) => findCustomPhraseByLanguageKey(key),
+  getCustomLanguageKeys: async () => getCustomLanguageKeys(),
 }));
 
 describe('customPhraseRoutes', () => {
@@ -81,6 +84,21 @@ describe('customPhraseRoutes', () => {
     it('should return 404 status code when the specified custom phrase does not exist before deleting', async () => {
       const response = await customPhraseRequest.delete(`/custom-phrases/en-UK`);
       expect(response.status).toEqual(404);
+    });
+  });
+
+  describe('GET /custom-language-keys', () => {
+    it('should call getCustomLanguageKeys', async () => {
+      await customPhraseRequest.get('/custom-language-keys');
+      expect(getCustomLanguageKeys).toBeCalledTimes(1);
+    });
+
+    it('should return the language keys of the existing custom phrases', async () => {
+      const mockCustomLanguageKeys = ['en-UK', mockLanguageKey];
+      getCustomLanguageKeys.mockImplementationOnce(async () => mockCustomLanguageKeys);
+      const response = await customPhraseRequest.get('/custom-language-keys');
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual(mockCustomLanguageKeys);
     });
   });
 });

--- a/packages/core/src/routes/custom-phrase.ts
+++ b/packages/core/src/routes/custom-phrase.ts
@@ -1,9 +1,11 @@
 import { CustomPhrases } from '@logto/schemas';
+import { z } from 'zod';
 
 import koaGuard from '@/middleware/koa-guard';
 import {
   deleteCustomPhraseByLanguageKey,
   findCustomPhraseByLanguageKey,
+  getCustomLanguageKeys,
 } from '@/queries/custom-phrase';
 
 import { AuthedRouter } from './types';
@@ -39,6 +41,18 @@ export default function customPhraseRoutes<T extends AuthedRouter>(router: T) {
 
       await deleteCustomPhraseByLanguageKey(languageKey);
       ctx.status = 204;
+
+      return next();
+    }
+  );
+
+  router.get(
+    '/custom-language-keys',
+    koaGuard({
+      response: z.string().array(),
+    }),
+    async (ctx, next) => {
+      ctx.body = await getCustomLanguageKeys();
 
       return next();
     }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Get the language keys of the existing custom phrases.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Locally tested.

- UTs

<img width="525" alt="image" src="https://user-images.githubusercontent.com/10594507/190128979-20a18ea1-58a5-4b81-99a7-aafc3714fe04.png">

- HTTP request

<img width="720" alt="image" src="https://user-images.githubusercontent.com/10594507/190129122-ba4367fb-4f1a-4338-bf50-21bfa8acabee.png">