### PR TITLE
feat(core): add GET /custom-phrases route

### DIFF
--- a/packages/core/src/queries/custom-phrase.ts
+++ b/packages/core/src/queries/custom-phrase.ts
@@ -2,11 +2,20 @@ import { CreateCustomPhrase, CustomPhrase, CustomPhrases } from '@logto/schemas'
 import { sql } from 'slonik';
 
 import { buildInsertInto } from '@/database/insert-into';
-import { convertToIdentifiers } from '@/database/utils';
+import { convertToIdentifiers, manyRows } from '@/database/utils';
 import envSet from '@/env-set';
 import { DeletionError } from '@/errors/SlonikError';
 
 const { table, fields } = convertToIdentifiers(CustomPhrases);
+
+export const findAllCustomPhrases = async () =>
+  manyRows(
+    envSet.pool.query<CustomPhrase>(sql`
+      select ${sql.join(Object.values(fields), sql`,`)}
+      from ${table}
+      order by ${fields.languageKey}
+    `)
+  );
 
 export const findCustomPhraseByLanguageKey = async (languageKey: string): Promise<CustomPhrase> =>
   envSet.pool.one<CustomPhrase>(sql`

--- a/packages/core/src/routes/custom-phrase.test.ts
+++ b/packages/core/src/routes/custom-phrase.test.ts
@@ -37,10 +37,13 @@ const findCustomPhraseByLanguageKey = jest.fn(async (languageKey: string) => {
   return mockCustomPhrase;
 });
 
+const findAllCustomPhrases = jest.fn(async (): Promise<CustomPhrase[]> => []);
+
 const upsertCustomPhrase = jest.fn(async (customPhrase: CustomPhrase) => customPhrase);
 
 jest.mock('@/queries/custom-phrase', () => ({
   deleteCustomPhraseByLanguageKey: async (key: string) => deleteCustomPhraseByLanguageKey(key),
+  findAllCustomPhrases: async () => findAllCustomPhrases(),
   findCustomPhraseByLanguageKey: async (key: string) => findCustomPhraseByLanguageKey(key),
   upsertCustomPhrase: async (customPhrase: CustomPhrase) => upsertCustomPhrase(customPhrase),
 }));
@@ -50,6 +53,26 @@ describe('customPhraseRoutes', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('GET /custom-phrases', () => {
+    it('should call findAllCustomPhrases', async () => {
+      await customPhraseRequest.get('/custom-phrases');
+      expect(findAllCustomPhrases).toBeCalledTimes(1);
+    });
+
+    it('should return all custom phrases', async () => {
+      const mockCustomPhrase = {
+        languageKey: 'zh-HK',
+        translation: {
+          input: { username: '用戶名', password: '密碼' },
+        },
+      };
+      findAllCustomPhrases.mockImplementationOnce(async () => [mockCustomPhrase]);
+      const response = await customPhraseRequest.get('/custom-phrases');
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual([mockCustomPhrase]);
+    });
   });
 
   describe('GET /custom-phrases/:languageKey', () => {

--- a/packages/core/src/routes/custom-phrase.ts
+++ b/packages/core/src/routes/custom-phrase.ts
@@ -3,6 +3,7 @@ import { CustomPhrases, translationGuard } from '@logto/schemas';
 import koaGuard from '@/middleware/koa-guard';
 import {
   deleteCustomPhraseByLanguageKey,
+  findAllCustomPhrases,
   findCustomPhraseByLanguageKey,
   upsertCustomPhrase,
 } from '@/queries/custom-phrase';
@@ -10,6 +11,18 @@ import {
 import { AuthedRouter } from './types';
 
 export default function customPhraseRoutes<T extends AuthedRouter>(router: T) {
+  router.get(
+    '/custom-phrases',
+    koaGuard({
+      response: CustomPhrases.guard.array(),
+    }),
+    async (ctx, next) => {
+      ctx.body = await findAllCustomPhrases();
+
+      return next();
+    }
+  );
+
   router.get(
     '/custom-phrases/:languageKey',
     koaGuard({


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Get all custom phrases in the database.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested.

- UTs

<img width="337" alt="image" src="https://user-images.githubusercontent.com/10594507/190315360-898fe99e-ae8a-48d2-be08-43c2dd4d1a06.png">

- HTTP request

<img width="726" alt="image" src="https://user-images.githubusercontent.com/10594507/190315314-fe0472e1-1f51-441c-b4a6-b0c4f1d51c9b.png">
