### PR TITLE
feat(schemas): add logto configs table

### DIFF
--- a/packages/schemas/tables/logto_configs.sql
+++ b/packages/schemas/tables/logto_configs.sql
@@ -1,0 +1,5 @@
+create table _logto_configs (
+  key varchar(256) not null,
+  value jsonb /* @use ArbitraryObject */ not null default '{}'::jsonb,
+  primary key (key)
+);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add `_logto_configs` table to store "metadata", a usage is to store "dbVersion" that will be used to implement database migration.

Notice that in our schema, table name should be countable noun, so "logto" and "logto_info" are not valid.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested in local DB engine.
