### PR TITLE
fix(phrases): phrases-ui typo and types

### DIFF
--- a/packages/phrases-ui/src/locales/ko-kr.ts
+++ b/packages/phrases-ui/src/locales/ko-kr.ts
@@ -1,3 +1,5 @@
+import en from './en';
+
 const translation = {
   input: {
     username: '사용자 이름',
@@ -68,7 +70,7 @@ const translation = {
   },
 };
 
-const koKR = Object.freeze({
+const koKR: typeof en = Object.freeze({
   translation,
 });
 

--- a/packages/phrases-ui/src/locales/tr-tr.ts
+++ b/packages/phrases-ui/src/locales/tr-tr.ts
@@ -1,3 +1,5 @@
+import en from './en';
+
 const translation = {
   input: {
     username: 'Kullanıcı Adı',
@@ -69,8 +71,8 @@ const translation = {
   },
 };
 
-const en = Object.freeze({
+const trTR: typeof en = Object.freeze({
   translation,
 });
 
-export default en;
+export default trTR;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fix the typo `en` → `trTR` and add the resource type

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested.
