### PR TITLE
feat(core): cannot delete custom phrase used as default language in sign-in exp

### DIFF
--- a/packages/core/src/routes/custom-phrase.test.ts
+++ b/packages/core/src/routes/custom-phrase.test.ts
@@ -1,5 +1,6 @@
 import { CustomPhrase } from '@logto/schemas';
 
+import { mockSignInExperience } from '@/__mocks__';
 import RequestError from '@/errors/RequestError';
 import customPhraseRoutes from '@/routes/custom-phrase';
 import { createRequester } from '@/utils/test-utils';
@@ -46,6 +47,12 @@ jest.mock('@/queries/custom-phrase', () => ({
   findAllCustomPhrases: async () => findAllCustomPhrases(),
   findCustomPhraseByLanguageKey: async (key: string) => findCustomPhraseByLanguageKey(key),
   upsertCustomPhrase: async (customPhrase: CustomPhrase) => upsertCustomPhrase(customPhrase),
+}));
+
+const findDefaultSignInExperience = jest.fn(async () => mockSignInExperience);
+
+jest.mock('@/queries/sign-in-experience', () => ({
+  findDefaultSignInExperience: async () => findDefaultSignInExperience(),
 }));
 
 describe('customPhraseRoutes', () => {
@@ -122,8 +129,13 @@ describe('customPhraseRoutes', () => {
     });
 
     it('should return 404 status code when the specified custom phrase does not exist before deleting', async () => {
-      const response = await customPhraseRequest.delete(`/custom-phrases/en-UK`);
+      const response = await customPhraseRequest.delete('/custom-phrases/en-UK');
       expect(response.status).toEqual(404);
+    });
+
+    it('should return 400 status code when the specified custom phrase is used as default language in sign-in experience', async () => {
+      const response = await customPhraseRequest.delete('/custom-phrases/en');
+      expect(response.status).toEqual(400);
     });
   });
 });

--- a/packages/core/src/routes/custom-phrase.ts
+++ b/packages/core/src/routes/custom-phrase.ts
@@ -1,5 +1,6 @@
 import { CustomPhrases, translationGuard } from '@logto/schemas';
 
+import RequestError from '@/errors/RequestError';
 import koaGuard from '@/middleware/koa-guard';
 import {
   deleteCustomPhraseByLanguageKey,
@@ -7,6 +8,7 @@ import {
   findCustomPhraseByLanguageKey,
   upsertCustomPhrase,
 } from '@/queries/custom-phrase';
+import { findDefaultSignInExperience } from '@/queries/sign-in-experience';
 
 import { AuthedRouter } from './types';
 
@@ -69,6 +71,14 @@ export default function customPhraseRoutes<T extends AuthedRouter>(router: T) {
       const {
         params: { languageKey },
       } = ctx.guard;
+
+      const {
+        languageInfo: { fallbackLanguage },
+      } = await findDefaultSignInExperience();
+
+      if (fallbackLanguage === languageKey) {
+        throw new RequestError({ code: 'localization.not_allowed_to_delete', languageKey });
+      }
 
       await deleteCustomPhraseByLanguageKey(languageKey);
       ctx.status = 204;

--- a/packages/core/src/routes/custom-phrase.ts
+++ b/packages/core/src/routes/custom-phrase.ts
@@ -77,7 +77,10 @@ export default function customPhraseRoutes<T extends AuthedRouter>(router: T) {
       } = await findDefaultSignInExperience();
 
       if (fallbackLanguage === languageKey) {
-        throw new RequestError({ code: 'localization.not_allowed_to_delete', languageKey });
+        throw new RequestError({
+          code: 'localization.cannot_delete_default_language',
+          languageKey,
+        });
       }
 
       await deleteCustomPhraseByLanguageKey(languageKey);

--- a/packages/phrases/src/locales/en/errors.ts
+++ b/packages/phrases/src/locales/en/errors.ts
@@ -101,6 +101,10 @@ const errors = {
     not_one_and_only_one_primary_sign_in_method:
       'There must be one and only one primary sign-in method. Please check your input.',
   },
+  localization: {
+    not_allowed_to_delete:
+      'You are not allowed to delete the {{languageKey}} language since it is used as default language of the sign-in experience.',
+  },
   swagger: {
     invalid_zod_type: 'Invalid Zod type. Please check route guard config.',
     not_supported_zod_type_for_params:

--- a/packages/phrases/src/locales/en/errors.ts
+++ b/packages/phrases/src/locales/en/errors.ts
@@ -102,8 +102,8 @@ const errors = {
       'There must be one and only one primary sign-in method. Please check your input.',
   },
   localization: {
-    cannot_delete:
-      'You can not delete the {{languageKey}} language since it is used as default language in the sign-in experience.',
+    cannot_delete_default_language:
+      'You cannot delete {{languageKey}} language since it is used as default language in sign-in experience.', // UNTRANSLATED
   },
   swagger: {
     invalid_zod_type: 'Invalid Zod type. Please check route guard config.',

--- a/packages/phrases/src/locales/en/errors.ts
+++ b/packages/phrases/src/locales/en/errors.ts
@@ -102,8 +102,8 @@ const errors = {
       'There must be one and only one primary sign-in method. Please check your input.',
   },
   localization: {
-    not_allowed_to_delete:
-      'You are not allowed to delete the {{languageKey}} language since it is used as default language of the sign-in experience.',
+    cannot_delete:
+      'You can not delete the {{languageKey}} language since it is used as default language in the sign-in experience.',
   },
   swagger: {
     invalid_zod_type: 'Invalid Zod type. Please check route guard config.',

--- a/packages/phrases/src/locales/fr/errors.ts
+++ b/packages/phrases/src/locales/fr/errors.ts
@@ -110,8 +110,8 @@ const errors = {
       'Il doit y avoir une et une seule méthode de connexion primaire. Veuillez vérifier votre saisie.',
   },
   localization: {
-    cannot_delete:
-      'You can not delete the {{languageKey}} language since it is used as default language in the sign-in experience.', // UNTRANSLATED
+    cannot_delete_default_language:
+      'You cannot delete {{languageKey}} language since it is used as default language in sign-in experience.', // UNTRANSLATED
   },
   swagger: {
     invalid_zod_type: 'Type Zod non valide. Veuillez vérifier la configuration du garde-route.',

--- a/packages/phrases/src/locales/fr/errors.ts
+++ b/packages/phrases/src/locales/fr/errors.ts
@@ -109,6 +109,10 @@ const errors = {
     not_one_and_only_one_primary_sign_in_method:
       'Il doit y avoir une et une seule méthode de connexion primaire. Veuillez vérifier votre saisie.',
   },
+  localization: {
+    not_allowed_to_delete:
+      'You are not allowed to delete the language {{languageKey}} since it is used as default language of the sign-in experience.', // UNTRANSLATED
+  },
   swagger: {
     invalid_zod_type: 'Type Zod non valide. Veuillez vérifier la configuration du garde-route.',
     not_supported_zod_type_for_params:

--- a/packages/phrases/src/locales/fr/errors.ts
+++ b/packages/phrases/src/locales/fr/errors.ts
@@ -110,8 +110,8 @@ const errors = {
       'Il doit y avoir une et une seule méthode de connexion primaire. Veuillez vérifier votre saisie.',
   },
   localization: {
-    not_allowed_to_delete:
-      'You are not allowed to delete the language {{languageKey}} since it is used as default language of the sign-in experience.', // UNTRANSLATED
+    cannot_delete:
+      'You can not delete the {{languageKey}} language since it is used as default language in the sign-in experience.', // UNTRANSLATED
   },
   swagger: {
     invalid_zod_type: 'Type Zod non valide. Veuillez vérifier la configuration du garde-route.',

--- a/packages/phrases/src/locales/ko-kr/errors.ts
+++ b/packages/phrases/src/locales/ko-kr/errors.ts
@@ -98,6 +98,10 @@ const errors = {
     not_one_and_only_one_primary_sign_in_method:
       '반드시 하나의 메인 로그인 방법이 설정되어야 해요. 입력된 값을 확인해주세요.',
   },
+  localization: {
+    not_allowed_to_delete:
+      'You are not allowed to delete the language {{languageKey}} since it is used as default language of the sign-in experience.', // UNTRANSLATED
+  },
   swagger: {
     invalid_zod_type: '유요하지 않은 Zod 종류에요. Route Guard 설정을 확인해주세요.',
     not_supported_zod_type_for_params:

--- a/packages/phrases/src/locales/ko-kr/errors.ts
+++ b/packages/phrases/src/locales/ko-kr/errors.ts
@@ -99,8 +99,8 @@ const errors = {
       '반드시 하나의 메인 로그인 방법이 설정되어야 해요. 입력된 값을 확인해주세요.',
   },
   localization: {
-    cannot_delete:
-      'You can not delete the {{languageKey}} language since it is used as default language in the sign-in experience.', // UNTRANSLATED
+    cannot_delete_default_language:
+      'You cannot delete {{languageKey}} language since it is used as default language in sign-in experience.', // UNTRANSLATED
   },
   swagger: {
     invalid_zod_type: '유요하지 않은 Zod 종류에요. Route Guard 설정을 확인해주세요.',

--- a/packages/phrases/src/locales/ko-kr/errors.ts
+++ b/packages/phrases/src/locales/ko-kr/errors.ts
@@ -99,8 +99,8 @@ const errors = {
       '반드시 하나의 메인 로그인 방법이 설정되어야 해요. 입력된 값을 확인해주세요.',
   },
   localization: {
-    not_allowed_to_delete:
-      'You are not allowed to delete the language {{languageKey}} since it is used as default language of the sign-in experience.', // UNTRANSLATED
+    cannot_delete:
+      'You can not delete the {{languageKey}} language since it is used as default language in the sign-in experience.', // UNTRANSLATED
   },
   swagger: {
     invalid_zod_type: '유요하지 않은 Zod 종류에요. Route Guard 설정을 확인해주세요.',

--- a/packages/phrases/src/locales/pt-pt/errors.ts
+++ b/packages/phrases/src/locales/pt-pt/errors.ts
@@ -104,6 +104,10 @@ const errors = {
     not_one_and_only_one_primary_sign_in_method:
       'Deve haver um e apenas um método de login principal. Por favor, verifique sua entrada.',
   },
+  localization: {
+    not_allowed_to_delete:
+      'You are not allowed to delete the language {{languageKey}} since it is used as default language of the sign-in experience.', // UNTRANSLATED
+  },
   swagger: {
     invalid_zod_type: 'Tipo de Zod inválido. Verifique a configuração do protetor de rota.',
     not_supported_zod_type_for_params:

--- a/packages/phrases/src/locales/pt-pt/errors.ts
+++ b/packages/phrases/src/locales/pt-pt/errors.ts
@@ -105,8 +105,8 @@ const errors = {
       'Deve haver um e apenas um método de login principal. Por favor, verifique sua entrada.',
   },
   localization: {
-    not_allowed_to_delete:
-      'You are not allowed to delete the language {{languageKey}} since it is used as default language of the sign-in experience.', // UNTRANSLATED
+    cannot_delete:
+      'You can not delete the {{languageKey}} language since it is used as default language in the sign-in experience.', // UNTRANSLATED
   },
   swagger: {
     invalid_zod_type: 'Tipo de Zod inválido. Verifique a configuração do protetor de rota.',

--- a/packages/phrases/src/locales/pt-pt/errors.ts
+++ b/packages/phrases/src/locales/pt-pt/errors.ts
@@ -105,8 +105,8 @@ const errors = {
       'Deve haver um e apenas um método de login principal. Por favor, verifique sua entrada.',
   },
   localization: {
-    cannot_delete:
-      'You can not delete the {{languageKey}} language since it is used as default language in the sign-in experience.', // UNTRANSLATED
+    cannot_delete_default_language:
+      'You cannot delete {{languageKey}} language since it is used as default language in sign-in experience.', // UNTRANSLATED
   },
   swagger: {
     invalid_zod_type: 'Tipo de Zod inválido. Verifique a configuração do protetor de rota.',

--- a/packages/phrases/src/locales/tr-tr/errors.ts
+++ b/packages/phrases/src/locales/tr-tr/errors.ts
@@ -103,7 +103,7 @@ const errors = {
       'Yalnızca bir tane birincil oturum açma yöntemi olmalıdır. Lütfen inputu kontrol ediniz.',
   },
   localization: {
-    not_allowed_to_delete:
+    cannot_delete:
       'You are not allowed to delete the language {{languageKey}} since it is used as default language of the sign-in experience.', // UNTRANSLATED
   },
   swagger: {

--- a/packages/phrases/src/locales/tr-tr/errors.ts
+++ b/packages/phrases/src/locales/tr-tr/errors.ts
@@ -102,6 +102,10 @@ const errors = {
     not_one_and_only_one_primary_sign_in_method:
       'Yalnızca bir tane birincil oturum açma yöntemi olmalıdır. Lütfen inputu kontrol ediniz.',
   },
+  localization: {
+    not_allowed_to_delete:
+      'You are not allowed to delete the language {{languageKey}} since it is used as default language of the sign-in experience.', // UNTRANSLATED
+  },
   swagger: {
     invalid_zod_type:
       'Geçersiz Zod tipi. Lütfen yönlendirici koruma yapılandırmasını kontrol ediniz.',

--- a/packages/phrases/src/locales/tr-tr/errors.ts
+++ b/packages/phrases/src/locales/tr-tr/errors.ts
@@ -103,8 +103,8 @@ const errors = {
       'Yalnızca bir tane birincil oturum açma yöntemi olmalıdır. Lütfen inputu kontrol ediniz.',
   },
   localization: {
-    cannot_delete:
-      'You are not allowed to delete the language {{languageKey}} since it is used as default language of the sign-in experience.', // UNTRANSLATED
+    cannot_delete_default_language:
+      'You cannot delete {{languageKey}} language since it is used as default language in sign-in experience.', // UNTRANSLATED
   },
   swagger: {
     invalid_zod_type:

--- a/packages/phrases/src/locales/zh-cn/errors.ts
+++ b/packages/phrases/src/locales/zh-cn/errors.ts
@@ -97,7 +97,7 @@ const errors = {
     not_one_and_only_one_primary_sign_in_method: '主要的登录方式必须有且仅有一个，请检查你的输入。',
   },
   localization: {
-    cannot_delete: '不能删除登录体验正在使用的默认语言 {{languageKey}}。',
+    cannot_delete_default_language: '不能删除登录体验正在使用的默认语言 {{languageKey}}。',
   },
   swagger: {
     invalid_zod_type: '无效的 Zod 类型，请检查路由 guard 配置。',

--- a/packages/phrases/src/locales/zh-cn/errors.ts
+++ b/packages/phrases/src/locales/zh-cn/errors.ts
@@ -97,8 +97,7 @@ const errors = {
     not_one_and_only_one_primary_sign_in_method: '主要的登录方式必须有且仅有一个，请检查你的输入。',
   },
   localization: {
-    not_allowed_to_delete:
-      '因为 {{languageKey}} 在登录体验中正在作为默认语言使用，你不能删除该语言。',
+    cannot_delete: '不能删除登录体验正在使用的默认语言 {{languageKey}}。',
   },
   swagger: {
     invalid_zod_type: '无效的 Zod 类型，请检查路由 guard 配置。',

--- a/packages/phrases/src/locales/zh-cn/errors.ts
+++ b/packages/phrases/src/locales/zh-cn/errors.ts
@@ -97,7 +97,7 @@ const errors = {
     not_one_and_only_one_primary_sign_in_method: '主要的登录方式必须有且仅有一个，请检查你的输入。',
   },
   localization: {
-    cannot_delete_default_language: '不能删除登录体验正在使用的默认语言 {{languageKey}}。',
+    cannot_delete_default_language: '不能删除「登录体验」正在使用的默认语言 {{languageKey}}。', // UNTRANSLATED
   },
   swagger: {
     invalid_zod_type: '无效的 Zod 类型，请检查路由 guard 配置。',

--- a/packages/phrases/src/locales/zh-cn/errors.ts
+++ b/packages/phrases/src/locales/zh-cn/errors.ts
@@ -96,6 +96,10 @@ const errors = {
     enabled_connector_not_found: '未找到已启用的 {{type}} 连接器',
     not_one_and_only_one_primary_sign_in_method: '主要的登录方式必须有且仅有一个，请检查你的输入。',
   },
+  localization: {
+    not_allowed_to_delete:
+      '因为 {{languageKey}} 在登录体验中正在作为默认语言使用，你不能删除该语言。',
+  },
   swagger: {
     invalid_zod_type: '无效的 Zod 类型，请检查路由 guard 配置。',
     not_supported_zod_type_for_params: '请求参数不支持的 Zod 类型，请检查路由 guard 配置。',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Cannot delete the specified custom phrase used as default language in sign-in experience.

- Add translations of a new error message in `@logto/phrases` (marked by `// UNTRANSLATED` comments) that should be determined by @fleuraly @BTX26 later.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested.

- UTs

<img width="876" alt="image" src="https://user-images.githubusercontent.com/10594507/190613893-0c0bba36-e53d-44b8-8e7f-53f5f568b246.png">

- HTTP request

<img width="798" alt="image" src="https://user-images.githubusercontent.com/10594507/190980736-26f842a6-f5f4-408a-9c9c-089f4859c78e.png">
