### PR TITLE
fix(console): get prefixed router basename in local dev env

### DIFF
--- a/packages/console/src/App.tsx
+++ b/packages/console/src/App.tsx
@@ -1,4 +1,4 @@
-import { getBasename, UserScope } from '@logto/core-kit';
+import { UserScope } from '@logto/core-kit';
 import { LogtoProvider } from '@logto/react';
 import { adminConsoleApplicationId, managementResource } from '@logto/schemas/lib/seeds';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
@@ -30,6 +30,8 @@ import SignInExperience from '@/pages/SignInExperience';
 import UserDetails from '@/pages/UserDetails';
 import Users from '@/pages/Users';
 import Welcome from '@/pages/Welcome';
+
+import { getBasename } from './utilities/router';
 
 void initI18n();
 

--- a/packages/console/src/utilities/router.ts
+++ b/packages/console/src/utilities/router.ts
@@ -1,0 +1,6 @@
+export const getBasename = (prefix: string, developmentPort: string): string => {
+  const isBasenameNeeded =
+    process.env.NODE_ENV !== 'development' || process.env.PORT === developmentPort;
+
+  return isBasenameNeeded ? '/' + prefix : '';
+};


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fixed a issue that caused by incorrect react router basename in console, which blocks devs from signing-in to admin console in their local dev environment.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Signing-in to logto admin console works fine
