### PR TITLE
refactor(core): refactor admin user auth check logic

### DIFF
--- a/packages/core/src/lib/session.ts
+++ b/packages/core/src/lib/session.ts
@@ -9,7 +9,7 @@ export const assignInteractionResults = async (
   result: InteractionResults,
   merge = false
 ) => {
-  // The "mergeWithLastSubmission" will only merge current request's interfaction results,
+  // The "mergeWithLastSubmission" will only merge current request's interaction results,
   // which is stored in ctx.oidc, we need to merge interaction results in two requests,
   // have to do it manually
   // refer to: https://github.com/panva/node-oidc-provider/blob/c243bf6b6663c41ff3e75c09b95fb978eba87381/lib/actions/authorization/interactions.js#L106

--- a/packages/core/src/routes/session/index.ts
+++ b/packages/core/src/routes/session/index.ts
@@ -51,12 +51,13 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
     const { accountId } = session;
 
     // Temp solution before migrating to RBAC.  Block non-admin user from consent to admin console
-    const { roleNames } = await findUserById(accountId);
 
     if (String(client_id) === adminConsoleApplicationId) {
+      const { roleNames } = await findUserById(accountId);
+
       assertThat(
         roleNames.includes(UserRole.Admin),
-        new RequestError({ code: 'auth.forbidden', status: 403 })
+        new RequestError({ code: 'auth.forbidden', status: 401 })
       );
     }
 

--- a/packages/core/src/routes/session/index.ts
+++ b/packages/core/src/routes/session/index.ts
@@ -1,12 +1,15 @@
 import path from 'path';
 
 import { LogtoErrorCode } from '@logto/phrases';
+import { UserRole } from '@logto/schemas';
+import { adminConsoleApplicationId } from '@logto/schemas/lib/seeds';
 import { conditional } from '@silverhand/essentials';
 import { Provider } from 'oidc-provider';
 import { object, string } from 'zod';
 
 import RequestError from '@/errors/RequestError';
 import { assignInteractionResults, saveUserFirstConsentedAppId } from '@/lib/session';
+import { findUserById } from '@/queries/user';
 import assertThat from '@/utils/assert-that';
 
 import { AnonymousRouter } from '../types';
@@ -46,6 +49,17 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
     assertThat(session, 'session.not_found');
 
     const { accountId } = session;
+
+    // Temp solution before migrating to RBAC.  Block non-admin user from consent to admin console
+    const { roleNames } = await findUserById(accountId);
+
+    if (String(client_id) === adminConsoleApplicationId) {
+      assertThat(
+        roleNames.includes(UserRole.Admin),
+        new RequestError({ code: 'auth.forbidden', status: 403 })
+      );
+    }
+
     const grant =
       conditional(grantId && (await provider.Grant.find(grantId))) ??
       new provider.Grant({ accountId, clientId: String(client_id) });

--- a/packages/core/src/routes/session/username-password.test.ts
+++ b/packages/core/src/routes/session/username-password.test.ts
@@ -133,31 +133,6 @@ describe('sessionRoutes', () => {
       });
       expect(response.statusCode).toEqual(400);
     });
-
-    it('throw if non-admin user sign in to AC', async () => {
-      interactionDetails.mockResolvedValueOnce({
-        params: { client_id: adminConsoleApplicationId },
-      });
-      const response = await sessionRequest.post(signInRoute).send({
-        username: 'username',
-        password: 'password',
-      });
-
-      expect(response.statusCode).toEqual(403);
-      console.log(response);
-    });
-
-    it('should not throw if admin user sign in to AC', async () => {
-      interactionDetails.mockResolvedValueOnce({
-        params: { client_id: adminConsoleApplicationId },
-      });
-      const response = await sessionRequest.post(signInRoute).send({
-        username: 'admin',
-        password: 'password',
-      });
-
-      expect(response.statusCode).toEqual(200);
-    });
   });
 
   describe('POST /session/register/username-password', () => {

--- a/packages/core/src/routes/session/username-password.ts
+++ b/packages/core/src/routes/session/username-password.ts
@@ -43,15 +43,7 @@ export default function usernamePasswordRoutes<T extends AnonymousRouter>(
       const type = 'SignInUsernamePassword';
       ctx.log(type, { username });
 
-      const { id, roleNames } = await findUserByUsernameAndPassword(username, password);
-
-      // Temp solution before migrating to RBAC. As AC sign-in exp currently hardcoded to username password only.
-      if (String(client_id) === adminConsoleApplicationId) {
-        assertThat(
-          roleNames.includes(UserRole.Admin),
-          new RequestError({ code: 'auth.forbidden', status: 403 })
-        );
-      }
+      const { id } = await findUserByUsernameAndPassword(username, password);
 
       ctx.log(type, { userId: id });
       await updateLastSignInAt(id);

--- a/packages/integration-tests/src/client/index.ts
+++ b/packages/integration-tests/src/client/index.ts
@@ -99,6 +99,10 @@ export default class MockClient {
     return this.logto.getIdTokenClaims();
   }
 
+  public assignCookie(cookie: string) {
+    this.interactionCookie = cookie;
+  }
+
   private readonly consent = async () => {
     // Note: If sign in action completed successfully, we will get `_session.sig` in the cookie.
     assert(this.interactionCookie, new Error('Session not found'));

--- a/packages/integration-tests/tests/api/session.test.ts
+++ b/packages/integration-tests/tests/api/session.test.ts
@@ -247,6 +247,6 @@ describe('sign-in to demo app and revisit Admin Console', () => {
 
     acClient.assignCookie(interactionCookie);
 
-    await expect(client.initSession()).rejects.toThrow();
+    await expect(acClient.initSession()).rejects.toThrow();
   });
 });


### PR DESCRIPTION


<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
LOG-4214

refactor admin user auth check logic. Previously we only have blockers on the username-password sign-in route which won't block the consent flow of an authenticated user. Move the blocker to the consent route.  


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

@logto-io/eng 
@logto-io/mandatory-reviewers 
@charIeszhao 
