### PR TITLE
feat(ui): add passwordless switch

### DIFF
--- a/packages/core/src/middleware/koa-spa-session-guard.ts
+++ b/packages/core/src/middleware/koa-spa-session-guard.ts
@@ -7,7 +7,13 @@ import { appendPath } from '@/utils/url';
 
 // Need To Align With UI
 export const sessionNotFoundPath = '/unknown-session';
-export const guardedPath = ['/sign-in', '/register', '/social-register'];
+export const guardedPath = [
+  '/sign-in',
+  '/register',
+  '/social/register',
+  '/reset-password',
+  '/forgot-password',
+];
 
 export default function koaSpaSessionGuard<
   StateT,

--- a/packages/phrases-ui/src/locales/en.ts
+++ b/packages/phrases-ui/src/locales/en.ts
@@ -26,6 +26,7 @@ const translation = {
     got_it: 'Got it',
     sign_in_with: 'Sign in with {{name}}',
     forgot_password: 'Forgot Password?',
+    switch_to: 'Switch to {{method}}',
   },
   description: {
     email: 'email',

--- a/packages/phrases-ui/src/locales/fr.ts
+++ b/packages/phrases-ui/src/locales/fr.ts
@@ -28,6 +28,7 @@ const translation = {
     got_it: 'Compris',
     sign_in_with: 'Connexion avec {{name}}',
     forgot_password: 'Mot de passe oublié ?',
+    switch_to: 'Passer au {{method}}',
   },
   description: {
     email: 'email',

--- a/packages/phrases-ui/src/locales/ko-kr.ts
+++ b/packages/phrases-ui/src/locales/ko-kr.ts
@@ -28,6 +28,7 @@ const translation = {
     got_it: '알겠습니다',
     sign_in_with: '{{name}} 로그인',
     forgot_password: '비밀번호를 잊어버리셨나요?',
+    switch_to: 'Switch to {{method}}', // TODO: untranslated
   },
   description: {
     email: '이메일',

--- a/packages/phrases-ui/src/locales/pt-pt.ts
+++ b/packages/phrases-ui/src/locales/pt-pt.ts
@@ -28,6 +28,7 @@ const translation = {
     got_it: 'Entendi',
     sign_in_with: 'Entrar com {{name}}',
     forgot_password: 'Esqueceu a password?',
+    switch_to: 'Mudar para {{method}}',
   },
   description: {
     email: 'email',

--- a/packages/phrases-ui/src/locales/tr-tr.ts
+++ b/packages/phrases-ui/src/locales/tr-tr.ts
@@ -28,6 +28,7 @@ const translation = {
     got_it: 'Anladım',
     sign_in_with: '{{name}} ile giriş yap',
     forgot_password: 'Şifremi Unuttum?',
+    switch_to: 'Switch to {{method}}', // TODO: not translated
   },
   description: {
     email: 'e-posta adresi',

--- a/packages/phrases-ui/src/locales/zh-cn.ts
+++ b/packages/phrases-ui/src/locales/zh-cn.ts
@@ -28,6 +28,7 @@ const translation = {
     got_it: '知道了',
     sign_in_with: '通过 {{name}} 登录',
     forgot_password: '忘记密码？',
+    switch_to: '切换到{{method}}',
   },
   description: {
     email: '邮箱',

--- a/packages/ui/src/containers/CreateAccount/index.module.scss
+++ b/packages/ui/src/containers/CreateAccount/index.module.scss
@@ -11,7 +11,17 @@
     margin-bottom: _.unit(4);
   }
 
+  .formFields {
+    margin-bottom: _.unit(8);
+  }
+
   .terms {
-    margin: _.unit(8) 0 _.unit(4);
+    margin-bottom: _.unit(4);
+  }
+}
+
+:global(body.desktop) {
+  .formFields {
+    margin-bottom: _.unit(2);
   }
 }

--- a/packages/ui/src/containers/CreateAccount/index.tsx
+++ b/packages/ui/src/containers/CreateAccount/index.tsx
@@ -85,41 +85,44 @@ const CreateAccount = ({ className, autoFocus }: Props) => {
 
   return (
     <form className={classNames(styles.form, className)} onSubmit={onSubmitHandler}>
-      <Input
-        autoFocus={autoFocus}
-        className={styles.inputField}
-        name="new-username"
-        placeholder={t('input.username')}
-        {...fieldRegister('username', usernameValidation)}
-        onClear={() => {
-          setFieldValue((state) => ({ ...state, username: '' }));
-        }}
-      />
-      <Input
-        className={styles.inputField}
-        name="new-password"
-        type="password"
-        autoComplete="new-password"
-        placeholder={t('input.password')}
-        {...fieldRegister('password', passwordValidation)}
-        onClear={() => {
-          setFieldValue((state) => ({ ...state, password: '' }));
-        }}
-      />
-      <Input
-        className={styles.inputField}
-        name="confirm-new-password"
-        type="password"
-        autoComplete="new-password"
-        placeholder={t('input.confirm_password')}
-        {...fieldRegister('confirmPassword', (confirmPassword) =>
-          confirmPasswordValidation(fieldValue.password, confirmPassword)
-        )}
-        errorStyling={false}
-        onClear={() => {
-          setFieldValue((state) => ({ ...state, confirmPassword: '' }));
-        }}
-      />
+      <div className={styles.formFields}>
+        <Input
+          autoFocus={autoFocus}
+          className={styles.inputField}
+          name="new-username"
+          placeholder={t('input.username')}
+          {...fieldRegister('username', usernameValidation)}
+          onClear={() => {
+            setFieldValue((state) => ({ ...state, username: '' }));
+          }}
+        />
+        <Input
+          className={styles.inputField}
+          name="new-password"
+          type="password"
+          autoComplete="new-password"
+          placeholder={t('input.password')}
+          {...fieldRegister('password', passwordValidation)}
+          onClear={() => {
+            setFieldValue((state) => ({ ...state, password: '' }));
+          }}
+        />
+        <Input
+          className={styles.inputField}
+          name="confirm-new-password"
+          type="password"
+          autoComplete="new-password"
+          placeholder={t('input.confirm_password')}
+          {...fieldRegister('confirmPassword', (confirmPassword) =>
+            confirmPasswordValidation(fieldValue.password, confirmPassword)
+          )}
+          errorStyling={false}
+          onClear={() => {
+            setFieldValue((state) => ({ ...state, confirmPassword: '' }));
+          }}
+        />
+      </div>
+
       <TermsOfUse className={styles.terms} />
 
       <Button title="action.create" onClick={async () => onSubmitHandler()} />

--- a/packages/ui/src/containers/Passwordless/PasswordlessSwitch.test.tsx
+++ b/packages/ui/src/containers/Passwordless/PasswordlessSwitch.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import renderWithPageContext from '@/__mocks__/RenderWithPageContext';
+import SettingsProvider from '@/__mocks__/RenderWithPageContext/SettingsProvider';
+import { mockSignInExperienceSettings } from '@/__mocks__/logto';
+
+import PasswordlessSwitch from './PasswordlessSwitch';
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedNavigate,
+}));
+
+describe('<PasswordlessSwitch />', () => {
+  afterEach(() => {
+    mockedNavigate.mockClear();
+  });
+
+  test('render sms passwordless switch', () => {
+    const { queryByText, getByText } = renderWithPageContext(
+      <MemoryRouter initialEntries={['/forgot-password/sms']}>
+        <SettingsProvider>
+          <PasswordlessSwitch target="email" />
+        </SettingsProvider>
+      </MemoryRouter>
+    );
+
+    expect(queryByText('action.switch_to')).not.toBeNull();
+
+    const link = getByText('action.switch_to');
+    fireEvent.click(link);
+
+    expect(mockedNavigate).toBeCalledWith({ pathname: '/forgot-password/email' });
+  });
+
+  test('render email passwordless switch', () => {
+    const { queryByText, getByText } = renderWithPageContext(
+      <MemoryRouter initialEntries={['/forgot-password/email']}>
+        <SettingsProvider>
+          <PasswordlessSwitch target="sms" />
+        </SettingsProvider>
+      </MemoryRouter>
+    );
+
+    expect(queryByText('action.switch_to')).not.toBeNull();
+
+    const link = getByText('action.switch_to');
+    fireEvent.click(link);
+
+    expect(mockedNavigate).toBeCalledWith({ pathname: '/forgot-password/sms' });
+  });
+
+  test('should not render the switch if SIE setting does not has the supported sign in method', () => {
+    const { queryByText, getByText } = renderWithPageContext(
+      <MemoryRouter initialEntries={['/forgot-password/email']}>
+        <SettingsProvider
+          settings={{
+            ...mockSignInExperienceSettings,
+            primarySignInMethod: 'username',
+            secondarySignInMethods: ['email', 'social'],
+          }}
+        >
+          <PasswordlessSwitch target="sms" />
+        </SettingsProvider>
+      </MemoryRouter>
+    );
+
+    expect(queryByText('action.switch_to')).toBeNull();
+  });
+});

--- a/packages/ui/src/containers/Passwordless/PasswordlessSwitch.tsx
+++ b/packages/ui/src/containers/Passwordless/PasswordlessSwitch.tsx
@@ -1,0 +1,48 @@
+import { useContext } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate, useLocation } from 'react-router-dom';
+
+import TextLink from '@/components/TextLink';
+import { PageContext } from '@/hooks/use-page-context';
+
+type Props = {
+  target: 'sms' | 'email';
+  className?: string;
+};
+
+const PasswordlessSwitch = ({ target, className }: Props) => {
+  const { t } = useTranslation();
+  const { experienceSettings } = useContext(PageContext);
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+
+  if (!experienceSettings) {
+    return null;
+  }
+
+  if (
+    experienceSettings.primarySignInMethod !== target &&
+    !experienceSettings.secondarySignInMethods.includes(target)
+  ) {
+    return null;
+  }
+
+  const targetPathname = pathname.replace(target === 'email' ? 'sms' : 'email', target);
+
+  return (
+    <TextLink
+      className={className}
+      onClick={() => {
+        navigate({
+          pathname: targetPathname,
+        });
+      }}
+    >
+      {t('action.switch_to', {
+        method: t(`description.${target === 'email' ? 'email' : 'phone_number'}`),
+      })}
+    </TextLink>
+  );
+};
+
+export default PasswordlessSwitch;

--- a/packages/ui/src/containers/Passwordless/index.module.scss
+++ b/packages/ui/src/containers/Passwordless/index.module.scss
@@ -7,11 +7,24 @@
     width: 100%;
   }
 
-  .inputField {
-    margin-bottom: _.unit(12);
+  .inputField,
+  .terms,
+  .switch {
+    margin-bottom: _.unit(4);
   }
 
-  .childWrapper {
-    margin-bottom: _.unit(4);
+  .switch {
+    margin-top: _.unit(-1);
+    display: block;
+  }
+
+  .formFields {
+    margin-bottom: _.unit(8);
+  }
+}
+
+:global(body.desktop) {
+  .formFields {
+    margin-bottom: _.unit(2);
   }
 }

--- a/packages/ui/src/containers/SocialSignIn/PrimarySocialSignIn/index.module.scss
+++ b/packages/ui/src/containers/SocialSignIn/PrimarySocialSignIn/index.module.scss
@@ -1,0 +1,5 @@
+@use '@/scss/underscore' as _;
+
+.terms {
+  margin-bottom: _.unit(4);
+}

--- a/packages/ui/src/containers/SocialSignIn/PrimarySocialSignIn/index.tsx
+++ b/packages/ui/src/containers/SocialSignIn/PrimarySocialSignIn/index.tsx
@@ -1,7 +1,9 @@
+import TermsOfUse from '@/containers/TermsOfUse';
 import useNativeMessageListener from '@/hooks/use-native-message-listener';
 import useSocial from '@/hooks/use-social';
 
 import SocialSignInList from '../SocialSignInList';
+import * as styles from './index.module.scss';
 
 export const defaultSize = 3;
 
@@ -13,7 +15,12 @@ const PrimarySocialSignIn = ({ className }: Props) => {
   const { socialConnectors } = useSocial();
   useNativeMessageListener();
 
-  return <SocialSignInList className={className} socialConnectors={socialConnectors} />;
+  return (
+    <>
+      <TermsOfUse className={styles.terms} />
+      <SocialSignInList className={className} socialConnectors={socialConnectors} />
+    </>
+  );
 };
 
 export default PrimarySocialSignIn;

--- a/packages/ui/src/containers/UsernameSignIn/index.module.scss
+++ b/packages/ui/src/containers/UsernameSignIn/index.module.scss
@@ -11,16 +11,22 @@
     margin-bottom: _.unit(4);
   }
 
+  .formFields {
+    margin-bottom: _.unit(8);
+  }
+
   .terms {
-    margin: _.unit(8) 0 _.unit(4);
+    margin-bottom: _.unit(4);
   }
 
   .formErrors {
     margin-top: _.unit(-2);
     margin-bottom: _.unit(4);
+  }
+}
 
-    + .terms {
-      margin-top: _.unit(4);
-    }
+:global(body.desktop) {
+  .formFields {
+    margin-bottom: _.unit(2);
   }
 }

--- a/packages/ui/src/containers/UsernameSignIn/index.tsx
+++ b/packages/ui/src/containers/UsernameSignIn/index.tsx
@@ -91,27 +91,30 @@ const UsernameSignIn = ({ className, autoFocus }: Props) => {
 
   return (
     <form className={classNames(styles.form, className)} onSubmit={onSubmitHandler}>
-      <Input
-        autoFocus={autoFocus}
-        className={styles.inputField}
-        name="username"
-        autoComplete="username"
-        placeholder={t('input.username')}
-        {...register('username', (value) => requiredValidation('username', value))}
-        onClear={() => {
-          setFieldValue((state) => ({ ...state, username: '' }));
-        }}
-      />
-      <PasswordInput
-        className={styles.inputField}
-        name="password"
-        autoComplete="current-password"
-        placeholder={t('input.password')}
-        {...register('password', (value) => requiredValidation('password', value))}
-      />
-      {formErrorMessage && (
-        <ErrorMessage className={styles.formErrors}>{formErrorMessage}</ErrorMessage>
-      )}
+      <div className={styles.formFields}>
+        <Input
+          autoFocus={autoFocus}
+          className={styles.inputField}
+          name="username"
+          autoComplete="username"
+          placeholder={t('input.username')}
+          {...register('username', (value) => requiredValidation('username', value))}
+          onClear={() => {
+            setFieldValue((state) => ({ ...state, username: '' }));
+          }}
+        />
+        <PasswordInput
+          className={styles.inputField}
+          name="password"
+          autoComplete="current-password"
+          placeholder={t('input.password')}
+          {...register('password', (value) => requiredValidation('password', value))}
+        />
+        {formErrorMessage && (
+          <ErrorMessage className={styles.formErrors}>{formErrorMessage}</ErrorMessage>
+        )}
+      </div>
+
       <TermsOfUse className={styles.terms} />
 
       <Button title="action.sign_in" onClick={async () => onSubmitHandler()} />

--- a/packages/ui/src/pages/ForgotPassword/index.tsx
+++ b/packages/ui/src/pages/ForgotPassword/index.tsx
@@ -14,16 +14,15 @@ type Props = {
 
 const ForgotPassword = () => {
   const { t } = useTranslation();
-
   const { method = '' } = useParams<Props>();
 
   const forgotPasswordForm = useMemo(() => {
     if (method === 'sms') {
-      return <PhonePasswordless autoFocus type="reset-password" />;
+      return <PhonePasswordless autoFocus hasSwitch type="reset-password" hasTerms={false} />;
     }
 
     if (method === 'email') {
-      return <EmailPasswordless autoFocus type="reset-password" />;
+      return <EmailPasswordless autoFocus hasSwitch type="reset-password" hasTerms={false} />;
     }
   }, [method]);
 

--- a/packages/ui/src/pages/Register/index.tsx
+++ b/packages/ui/src/pages/Register/index.tsx
@@ -5,8 +5,6 @@ import { useParams } from 'react-router-dom';
 import NavBar from '@/components/NavBar';
 import CreateAccount from '@/containers/CreateAccount';
 import { PhonePasswordless, EmailPasswordless } from '@/containers/Passwordless';
-import TermsOfUse from '@/containers/TermsOfUse';
-import useTerms from '@/hooks/use-terms';
 import ErrorPage from '@/pages/ErrorPage';
 
 import * as styles from './index.module.scss';
@@ -19,27 +17,17 @@ const Register = () => {
   const { t } = useTranslation();
   const { method = 'username' } = useParams<Parameters>();
 
-  const { termsValidation } = useTerms();
-
   const registerForm = useMemo(() => {
     if (method === 'sms') {
-      return (
-        <PhonePasswordless autoFocus type="register" onSubmitValidation={termsValidation}>
-          <TermsOfUse />
-        </PhonePasswordless>
-      );
+      return <PhonePasswordless autoFocus type="register" />;
     }
 
     if (method === 'email') {
-      return (
-        <EmailPasswordless autoFocus type="register" onSubmitValidation={termsValidation}>
-          <TermsOfUse />
-        </EmailPasswordless>
-      );
+      return <EmailPasswordless autoFocus type="register" />;
     }
 
     return <CreateAccount autoFocus />;
-  }, [method, termsValidation]);
+  }, [method]);
 
   if (!['email', 'sms', 'username'].includes(method)) {
     return <ErrorPage />;

--- a/packages/ui/src/pages/SecondarySignIn/index.tsx
+++ b/packages/ui/src/pages/SecondarySignIn/index.tsx
@@ -4,9 +4,7 @@ import { useParams } from 'react-router-dom';
 
 import NavBar from '@/components/NavBar';
 import { PhonePasswordless, EmailPasswordless } from '@/containers/Passwordless';
-import TermsOfUse from '@/containers/TermsOfUse';
 import UsernameSignIn from '@/containers/UsernameSignIn';
-import useTerms from '@/hooks/use-terms';
 import ErrorPage from '@/pages/ErrorPage';
 
 import * as styles from './index.module.scss';
@@ -19,27 +17,17 @@ const SecondarySignIn = () => {
   const { t } = useTranslation();
   const { method = 'username' } = useParams<Props>();
 
-  const { termsValidation } = useTerms();
-
   const signInForm = useMemo(() => {
     if (method === 'sms') {
-      return (
-        <PhonePasswordless autoFocus type="sign-in" onSubmitValidation={termsValidation}>
-          <TermsOfUse />
-        </PhonePasswordless>
-      );
+      return <PhonePasswordless autoFocus type="sign-in" />;
     }
 
     if (method === 'email') {
-      return (
-        <EmailPasswordless autoFocus type="sign-in" onSubmitValidation={termsValidation}>
-          <TermsOfUse />
-        </EmailPasswordless>
-      );
+      return <EmailPasswordless autoFocus type="sign-in" />;
     }
 
     return <UsernameSignIn autoFocus />;
-  }, [method, termsValidation]);
+  }, [method]);
 
   if (!['email', 'sms', 'username'].includes(method)) {
     return <ErrorPage />;

--- a/packages/ui/src/pages/SignIn/index.module.scss
+++ b/packages/ui/src/pages/SignIn/index.module.scss
@@ -5,10 +5,6 @@
   @include _.flex-column(normal, normal);
   @include _.full-width;
 
-  .terms {
-    margin-bottom: _.unit(4);
-  }
-
   .primarySignIn {
     margin-bottom: _.unit(5);
   }

--- a/packages/ui/src/pages/SignIn/registry.tsx
+++ b/packages/ui/src/pages/SignIn/registry.tsx
@@ -6,7 +6,6 @@ import CreateAccount from '@/containers/CreateAccount';
 import { EmailPasswordless, PhonePasswordless } from '@/containers/Passwordless';
 import SignInMethodsLink from '@/containers/SignInMethodsLink';
 import { PrimarySocialSignIn, SecondarySocialSignIn } from '@/containers/SocialSignIn';
-import TermsOfUse from '@/containers/TermsOfUse';
 import UsernameSignIn from '@/containers/UsernameSignIn';
 import { SignInMethod, LocalSignInMethod } from '@/types';
 
@@ -44,10 +43,7 @@ export const PrimarySection = ({
       );
     case 'social':
       return socialConnectors.length > 0 ? (
-        <>
-          <TermsOfUse className={styles.terms} />
-          <PrimarySocialSignIn className={styles.primarySocial} />
-        </>
+        <PrimarySocialSignIn className={styles.primarySocial} />
       ) : null;
     default:
       return null;


### PR DESCRIPTION


<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add passwordless switch.

This PR includes following updates:

1. Add the new forgot password page paths to the require session list
2. Update the overall styles of the sign-in/register form styles according to the latest design.
3. Make the Terms element and PasswordlessSwitch element configurable using the new `hasTerms` and `hasSwitch` props in the PassworldLess Containers.
4. Refactor the Sign-In page registry, Move the Terms element within PrimarySocialSignIn container. Just to align with the Passwordless containers. Do not show terms at the page level 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT added
test locally

