### PR TITLE
feat(core): check migration state before app start

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prepack": "lerna run --stream prepack",
     "dev": "lerna run --stream prepack -- --incremental && lerna --ignore=@logto/integration-test run --parallel dev",
     "start": "cd packages/core && NODE_ENV=production node . --from-root",
+    "migration-deploy": "cd packages/core && pnpm migration-deploy",
     "ci:build": "lerna run --stream build",
     "ci:lint": "lerna run --parallel lint",
     "ci:stylelint": "lerna run --parallel stylelint",

--- a/packages/core/src/env-set/check-migration-state.ts
+++ b/packages/core/src/env-set/check-migration-state.ts
@@ -1,0 +1,34 @@
+import inquirer from 'inquirer';
+import { DatabasePool } from 'slonik';
+
+import { getUndeployedMigrations, runMigrations } from '@/migration';
+
+import { allYes } from './parameters';
+
+export const checkMigrationState = async (pool: DatabasePool) => {
+  const migrations = await getUndeployedMigrations(pool);
+
+  if (migrations.length === 0) {
+    return;
+  }
+
+  const error = new Error(
+    `Found undeployed migrations, you must deploy them first by "pnpm migration-deploy" command, reference: https://docs.logto.io/docs/recipes/deployment/#migration`
+  );
+
+  if (allYes) {
+    throw error;
+  }
+
+  const deploy = await inquirer.prompt({
+    type: 'confirm',
+    name: 'value',
+    message: `Found undeployed migrations, would you like to deploy now?`,
+  });
+
+  if (!deploy.value) {
+    throw error;
+  }
+
+  await runMigrations(pool);
+};

--- a/packages/core/src/env-set/index.ts
+++ b/packages/core/src/env-set/index.ts
@@ -6,6 +6,7 @@ import { DatabasePool } from 'slonik';
 import { appendPath } from '@/utils/url';
 
 import { addConnectors } from './add-connectors';
+import { checkMigrationState } from './check-migration-state';
 import createPoolByEnv from './create-pool-by-env';
 import loadOidcValues from './oidc';
 import { isTrue } from './parameters';
@@ -80,6 +81,10 @@ function createEnvSet() {
       values = await loadEnvValues();
       pool = await createPoolByEnv(values.isTest);
       await addConnectors(values.connectorDirectory);
+
+      if (pool) {
+        await checkMigrationState(pool);
+      }
     },
   };
 }

--- a/packages/core/src/migration/index.test.ts
+++ b/packages/core/src/migration/index.test.ts
@@ -22,17 +22,6 @@ const pool = createMockPool({
   },
 });
 const { table, fields } = convertToIdentifiers(LogtoConfigs);
-const existsSync = jest.fn();
-const readdir = jest.fn();
-
-jest.mock('fs', () => ({
-  existsSync: () => existsSync(),
-}));
-
-jest.mock('fs/promises', () => ({
-  ...jest.requireActual('fs/promises'),
-  readdir: async () => readdir(),
-}));
 
 describe('isLogtoConfigsTableExists()', () => {
   it('generates "select exists" sql and query for result', async () => {
@@ -168,20 +157,6 @@ describe('updateDatabaseVersion()', () => {
     jest.spyOn(functions, 'isLogtoConfigsTableExists').mockResolvedValueOnce(true);
 
     await updateDatabaseVersion(pool, version);
-  });
-});
-
-describe('getMigrationFiles()', () => {
-  it('returns [] if directory does not exist', async () => {
-    existsSync.mockReturnValueOnce(false);
-    await expect(getMigrationFiles()).resolves.toEqual([]);
-  });
-
-  it('returns files without "next"', async () => {
-    existsSync.mockReturnValueOnce(true);
-    readdir.mockResolvedValueOnce(['next.js', '1.0.0.js', '1.0.2.js', '1.0.1.js']);
-
-    await expect(getMigrationFiles()).resolves.toEqual(['1.0.0.js', '1.0.2.js', '1.0.1.js']);
   });
 });
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Before app start, we must ensure that there is no undeployed migration.

Add migration state checking in `envSet.load()`:
1. for "all-yes", throw an error and stop the app from starting
2. for normal environment, prompt the user to confirm the migration deploy, if no, throw and stop.

The reference link is not available now, see LOG-4203

Also, remove tests for "getMigrationFiles" since is hard to mock the "fs" module. That is because our "jest.setup" will import this file, see https://stackoverflow.com/questions/70566676/jest-mock-doesnt-work-inside-tests-only-outside-tests

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

<img width="1415" alt="截屏2022-09-22 下午2 24 01" src="https://user-images.githubusercontent.com/5717882/191674599-8658fb11-ca49-44c7-a20c-351538da9653.png">

