### PR TITLE
fix(core): filter out connector-kit

### DIFF
--- a/packages/core/src/connectors/add-connectors.ts
+++ b/packages/core/src/connectors/add-connectors.ts
@@ -13,12 +13,18 @@ import { npmPackResultGuard } from './types';
 
 const execPromise = promisify(exec);
 const npmConnectorFilter = '@logto/connector-';
+const excludedPackages = new Set([
+  '@logto/connector-kit',
+  '@logto/connector-mock-sms',
+  '@logto/connector-mock-social',
+  '@logto/connector-mock-email',
+]);
 
 const fetchOfficialConnectorList = async () => {
   const { stdout } = await execPromise(`npm search ${npmConnectorFilter} --json`);
   const packages = z.object({ name: z.string() }).array().parse(JSON.parse(stdout));
 
-  return packages.filter(({ name }) => !name.includes('mock') && !name.includes('core'));
+  return packages.filter(({ name }) => !excludedPackages.has(name));
 };
 
 export const addConnector = async (packageName: string, cwd: string) => {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
We renamed "connector-core" to "connector-kit" some days before, this breaks the filter of "add-official-connectors". Change to package name match to fix it.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="570" alt="image" src="https://user-images.githubusercontent.com/5717882/191910988-b15ebddd-8f65-4dd9-8e1e-edb76b475900.png">

