### PR TITLE
fix(ui): align mobile input outline

### DIFF
--- a/packages/ui/src/components/Passcode/index.module.scss
+++ b/packages/ui/src/components/Passcode/index.module.scss
@@ -16,6 +16,7 @@
 
     &:focus {
       border: _.border(var(--color-primary));
+      outline: none;
     }
 
     &::placeholder {


### PR DESCRIPTION


<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Align passcode input with text field input styles.

on mobile view, input field does not show outline. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
@logto-io/eng 
@logto-io/mandatory-reviewers 
