### PR TITLE
feat(core): update migration state after db init

### DIFF
--- a/packages/core/src/database/seed.ts
+++ b/packages/core/src/database/seed.ts
@@ -8,6 +8,7 @@ import { createPool, parseDsn, sql, stringifyDsn } from 'slonik';
 import { createInterceptors } from 'slonik-interceptor-preset';
 import { raw } from 'slonik-sql-tag-raw';
 
+import { updateDatabaseTimestamp } from '@/migration';
 import { buildApplicationSecret } from '@/utils/id';
 
 import { convertToPrimitiveOrSql } from './utils';
@@ -79,6 +80,9 @@ export const createDatabaseCli = async (dsn: string) => {
       await pool.query(sql`${raw(query)}`);
       console.log(`${chalk.blue('[create-tables]')} Run ${file} succeeded.`);
     }
+
+    await updateDatabaseTimestamp(pool);
+    console.log(`${chalk.blue('[create-tables]')} Update migration state succeeded.`);
   };
 
   const seedTables = async () => {

--- a/packages/core/src/env-set/index.ts
+++ b/packages/core/src/env-set/index.ts
@@ -82,8 +82,7 @@ function createEnvSet() {
       pool = await createPoolByEnv(values.isTest);
       await addConnectors(values.connectorDirectory);
 
-      // FIXME: @sijie temparaly disable migration for integration test
-      if (pool && !values.isIntegrationTest) {
+      if (pool) {
         await checkMigrationState(pool);
       }
     },


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
After database init (`createTables()`), update migration state to latest migration file. Then the database is ready for the next migration.

notice: the word "migration" will be changed later.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="403" alt="截屏2022-09-26 下午12 02 23" src="https://user-images.githubusercontent.com/5717882/192191554-3d461e64-94ce-40d9-83f2-7e603c4b4f5a.png">

<img width="220" alt="截屏2022-09-26 下午12 00 48" src="https://user-images.githubusercontent.com/5717882/192191597-ecd1997a-d7ba-416e-99f3-eef924d55bc8.png">
