### PR TITLE
fix(core,schemas): move alteration types into schemas src

### DIFF
--- a/packages/core/src/alteration/index.ts
+++ b/packages/core/src/alteration/index.ts
@@ -7,7 +7,7 @@ import {
   AlterationScript,
   AlterationState,
   alterationStateGuard,
-} from '@logto/schemas/alterations/types';
+} from '@logto/schemas/lib/types/alteration';
 import { conditionalString } from '@silverhand/essentials';
 import chalk from 'chalk';
 import { DatabasePool, sql } from 'slonik';

--- a/packages/schemas/src/types/alteration.ts
+++ b/packages/schemas/src/types/alteration.ts
@@ -1,4 +1,4 @@
-import { DatabaseTransactionConnection } from 'slonik';
+import type { DatabaseTransactionConnection } from 'slonik';
 import { z } from 'zod';
 
 export const alterationStateGuard = z.object({


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Move alteration types into schemas's `src` folder.

Previously, alteration types are in `@logto/schemas/alterations/types`, this is out of `src` folder, causing problems for `pnpm dev`:

![image](https://user-images.githubusercontent.com/5717882/192236068-aab961bb-24b9-48a7-906b-4e6ba7561865.png)

The reason is that, `lerna` can not handle the dependencies order properly, and the "build" order for packages is wrong, the `core` does not wait for `schemas`'s `build:alterations`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

`pnpm dev` works fine.
