### PR TITLE
refactor(schemas): auto update next alteration scripts

### DIFF
--- a/packages/core/src/alteration/index.ts
+++ b/packages/core/src/alteration/index.ts
@@ -154,4 +154,6 @@ export const deployAlterations = async (pool: DatabasePool) => {
     // eslint-disable-next-line no-await-in-loop
     await deployAlteration(pool, alteration);
   }
+
+  console.log(`${chalk.blue('[alteration]')} ✓ done`);
 };

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -48,7 +48,17 @@
     "extends": "@silverhand",
     "rules": {
       "@typescript-eslint/ban-types": "off"
-    }
+    },
+    "overrides": [
+      {
+        "files": [
+          "alterations/*.ts"
+        ],
+        "rules": {
+          "unicorn/filename-case": "off"
+        }
+      }
+    ]
   },
   "prettier": "@silverhand/eslint-config/.prettierrc",
   "dependencies": {

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -11,6 +11,7 @@
   "private": true,
   "scripts": {
     "precommit": "lint-staged",
+    "version": "./update-next.sh && git add alterations/",
     "generate": "rm -rf src/db-entries && ts-node src/gen/index.ts && eslint \"src/db-entries/**\" --fix",
     "build:alterations": "rm -rf alterations/*.d.ts alterations/*.js && tsc -p tsconfig.build.alterations.json",
     "build": "pnpm generate && rm -rf lib/ && tsc -p tsconfig.build.json && pnpm build:alterations",

--- a/packages/schemas/update-next.sh
+++ b/packages/schemas/update-next.sh
@@ -1,0 +1,7 @@
+CURRENT_VERSION=$(node -p "require('./package.json').version.replaceAll('-', '_')")
+
+cd alterations
+
+for x in next-*.ts;
+  do mv $x $CURRENT_VERSION$(echo ${x#next});
+done


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- when versioning, update `@logto-io/schemas/alteration/next-*.ts` to `$version-*.ts`
- print log when alteration is done

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

**Execute `pnpm lerna version --no-push` in the project root**

- [x] `next-1663923211-machine-to-machine-app.ts` -> `1.0.0_beta.10-1663923211-machine-to-machine-app.ts`

**Execute `pnpm alteration deploy`**

<img width="566" alt="image" src="https://user-images.githubusercontent.com/14722250/192440576-fb1ec77e-791d-435e-94a6-e34384ba028f.png">
