### PR TITLE
refactor(core): should not use login to store session info

### DIFF
--- a/packages/core/src/routes/session/forgot-password.test.ts
+++ b/packages/core/src/routes/session/forgot-password.test.ts
@@ -97,8 +97,7 @@ describe('session -> forgotPasswordRoutes', () => {
       const response = await sessionRequest
         .post(`${forgotPasswordRoute}/sms/verify-passcode`)
         .send({ phone: '13000000000', code: '1234' });
-      expect(response.statusCode).toEqual(200);
-      expect(response.body).toHaveProperty('redirectTo');
+      expect(response.statusCode).toEqual(204);
       expect(interactionResult).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
@@ -109,8 +108,7 @@ describe('session -> forgotPasswordRoutes', () => {
               .add(forgotPasswordVerificationTimeout, 'second')
               .toISOString(),
           },
-        }),
-        expect.anything()
+        })
       );
       jest.useRealTimers();
     });
@@ -150,8 +148,7 @@ describe('session -> forgotPasswordRoutes', () => {
       const response = await sessionRequest
         .post(`${forgotPasswordRoute}/email/verify-passcode`)
         .send({ email: 'a@a.com', code: '1234' });
-      expect(response.statusCode).toEqual(200);
-      expect(response.body).toHaveProperty('redirectTo');
+      expect(response.statusCode).toEqual(204);
       expect(interactionResult).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
@@ -162,8 +159,7 @@ describe('session -> forgotPasswordRoutes', () => {
               .add(forgotPasswordVerificationTimeout, 'second')
               .toISOString(),
           },
-        }),
-        expect.anything()
+        })
       );
       jest.useRealTimers();
     });

--- a/packages/core/src/routes/session/forgot-password.test.ts
+++ b/packages/core/src/routes/session/forgot-password.test.ts
@@ -103,8 +103,8 @@ describe('session -> forgotPasswordRoutes', () => {
         expect.anything(),
         expect.anything(),
         expect.objectContaining({
-          login: { accountId: 'id' },
           forgotPassword: {
+            userId: 'id',
             expiresAt: dayjs(fakeTime)
               .add(forgotPasswordVerificationTimeout, 'second')
               .toISOString(),
@@ -156,8 +156,8 @@ describe('session -> forgotPasswordRoutes', () => {
         expect.anything(),
         expect.anything(),
         expect.objectContaining({
-          login: { accountId: 'id' },
           forgotPassword: {
+            userId: 'id',
             expiresAt: dayjs(fakeTime)
               .add(forgotPasswordVerificationTimeout, 'second')
               .toISOString(),
@@ -188,8 +188,7 @@ describe('session -> forgotPasswordRoutes', () => {
     it('assign result and redirect', async () => {
       interactionDetails.mockResolvedValueOnce({
         result: {
-          login: { accountId: 'id' },
-          forgotPassword: { expiresAt: dayjs().add(1, 'day').toISOString() },
+          forgotPassword: { userId: 'id', expiresAt: dayjs().add(1, 'day').toISOString() },
         },
       });
       const response = await sessionRequest
@@ -219,8 +218,7 @@ describe('session -> forgotPasswordRoutes', () => {
     it('should throw when `forgotPassword.expiresAt` is not string', async () => {
       interactionDetails.mockResolvedValueOnce({
         result: {
-          login: { accountId: 'id' },
-          forgotPassword: { expiresAt: 0 },
+          forgotPassword: { userId: 'id', expiresAt: 0 },
         },
       });
       const response = await sessionRequest
@@ -232,8 +230,7 @@ describe('session -> forgotPasswordRoutes', () => {
     it('should throw when `expiresAt` is not a valid date string', async () => {
       interactionDetails.mockResolvedValueOnce({
         result: {
-          login: { accountId: 'id' },
-          forgotPassword: { expiresAt: 'invalid date string' },
+          forgotPassword: { userId: 'id', expiresAt: 'invalid date string' },
         },
       });
       const response = await sessionRequest
@@ -245,8 +242,7 @@ describe('session -> forgotPasswordRoutes', () => {
     it('should throw when verification expires', async () => {
       interactionDetails.mockResolvedValueOnce({
         result: {
-          login: { accountId: 'id' },
-          forgotPassword: { expiresAt: dayjs().subtract(1, 'day').toISOString() },
+          forgotPassword: { userId: 'id', expiresAt: dayjs().subtract(1, 'day').toISOString() },
         },
       });
       const response = await sessionRequest
@@ -258,8 +254,7 @@ describe('session -> forgotPasswordRoutes', () => {
     it('should throw when new password is the same as old one', async () => {
       interactionDetails.mockResolvedValueOnce({
         result: {
-          login: { accountId: 'id' },
-          forgotPassword: { expiresAt: dayjs().add(1, 'day').toISOString() },
+          forgotPassword: { userId: 'id', expiresAt: dayjs().add(1, 'day').toISOString() },
         },
       });
       mockArgon2Verify.mockResolvedValueOnce(true);
@@ -272,8 +267,7 @@ describe('session -> forgotPasswordRoutes', () => {
     it('should redirect when there was no old password', async () => {
       interactionDetails.mockResolvedValueOnce({
         result: {
-          login: { accountId: 'id' },
-          forgotPassword: { expiresAt: dayjs().add(1, 'day').toISOString() },
+          forgotPassword: { userId: 'id', expiresAt: dayjs().add(1, 'day').toISOString() },
         },
       });
       findUserById.mockResolvedValueOnce({

--- a/packages/core/src/routes/session/forgot-password.ts
+++ b/packages/core/src/routes/session/forgot-password.ts
@@ -7,7 +7,6 @@ import { z } from 'zod';
 
 import RequestError from '@/errors/RequestError';
 import { createPasscode, sendPasscode, verifyPasscode } from '@/lib/passcode';
-import { assignInteractionResults } from '@/lib/session';
 import { encryptUserPassword } from '@/lib/user';
 import koaGuard from '@/middleware/koa-guard';
 import {
@@ -70,12 +69,13 @@ export default function forgotPasswordRoutes<T extends AnonymousRouter>(
       const { id } = await findUserByPhone(phone);
       ctx.log(type, { userId: id });
 
-      await assignInteractionResults(ctx, provider, {
+      await provider.interactionResult(ctx.req, ctx.res, {
         forgotPassword: {
           userId: id,
           expiresAt: dayjs().add(forgotPasswordVerificationTimeout, 'second').toISOString(),
         },
       });
+      ctx.status = 204;
 
       return next();
     }
@@ -115,12 +115,13 @@ export default function forgotPasswordRoutes<T extends AnonymousRouter>(
 
       await verifyPasscode(jti, PasscodeType.ForgotPassword, code, { email });
       const { id } = await findUserByEmail(email);
-      await assignInteractionResults(ctx, provider, {
+      await provider.interactionResult(ctx.req, ctx.res, {
         forgotPassword: {
           userId: id,
           expiresAt: dayjs().add(forgotPasswordVerificationTimeout, 'second').toISOString(),
         },
       });
+      ctx.status = 204;
 
       return next();
     }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Should not use the `login` field as it is a build-in field for oidc-provider interactions and will trigger auto sign-in which is not desired.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Passed UTs and tested locally.
