### PR TITLE
refactor(core,phrases): rm empty strings and check structure in PUT /custom-phrase

### DIFF
--- a/packages/core/src/utils/translation.test.ts
+++ b/packages/core/src/utils/translation.test.ts
@@ -1,0 +1,42 @@
+import en from '@logto/phrases-ui/lib/locales/en';
+import fr from '@logto/phrases-ui/lib/locales/fr';
+
+import { isValidStructure } from '@/utils/translation';
+
+const customizedFrTranslation = {
+  secondary: {
+    sign_in_with: 'Customized value A',
+    social_bind_with: 'Customized value B',
+  },
+};
+
+describe('isValidStructure', () => {
+  it('should be true when its structure is valid', () => {
+    expect(isValidStructure(en.translation, fr.translation)).toBeTruthy();
+    expect(isValidStructure(en.translation, customizedFrTranslation)).toBeTruthy();
+  });
+
+  it('should be true when the structure is partial and the existing key-value pairs are correct', () => {
+    expect(
+      isValidStructure(en.translation, {
+        secondary: {
+          sign_in_with: 'Se connecter avec {{methods, list(type: disjunction;)}}',
+          // Missing 'secondary.social_bind_with' key-value pair
+        },
+      })
+    ).toBeTruthy();
+  });
+
+  it('should be false when there is an unexpected key-value pair', () => {
+    expect(
+      isValidStructure(en.translation, {
+        secondary: {
+          sign_in_with: 'Se connecter avec {{methods, list(type: disjunction;)}}',
+          social_bind_with:
+            'Vous avez déjà un compte ? Connectez-vous pour lier {{methods, list(type: disjunction;)}} avec votre identité sociale.',
+          foo: 'bar', // Unexpected key-value pair
+        },
+      })
+    ).toBeFalsy();
+  });
+});

--- a/packages/core/src/utils/translation.ts
+++ b/packages/core/src/utils/translation.ts
@@ -1,0 +1,36 @@
+import { Translation } from '@logto/schemas';
+
+export const isValidStructure = (fullTranslation: Translation, partialTranslation: Translation) => {
+  const fullKeys = new Set(Object.keys(fullTranslation));
+  const partialKeys = Object.keys(partialTranslation);
+
+  if (fullKeys.size === 0 || partialKeys.length === 0) {
+    return true;
+  }
+
+  if (partialKeys.some((key) => !fullKeys.has(key))) {
+    return false;
+  }
+
+  for (const [key, value] of Object.entries(fullTranslation)) {
+    const targetValue = partialTranslation[key];
+
+    if (targetValue === undefined) {
+      continue;
+    }
+
+    if (typeof value === 'string') {
+      if (typeof targetValue === 'string') {
+        continue;
+      }
+
+      return false;
+    }
+
+    if (typeof targetValue === 'string' || !isValidStructure(value, targetValue)) {
+      return false;
+    }
+  }
+
+  return true;
+};

--- a/packages/phrases/src/locales/en/errors.ts
+++ b/packages/phrases/src/locales/en/errors.ts
@@ -109,6 +109,8 @@ const errors = {
   localization: {
     cannot_delete_default_language:
       'You cannot delete {{languageKey}} language since it is used as default language in sign-in experience.', // UNTRANSLATED
+    invalid_translation_structure:
+      'Invalid translation structure. Please check the input translation.', // UNTRANSLATED
   },
   swagger: {
     invalid_zod_type: 'Invalid Zod type. Please check route guard config.',

--- a/packages/phrases/src/locales/fr/errors.ts
+++ b/packages/phrases/src/locales/fr/errors.ts
@@ -117,6 +117,8 @@ const errors = {
   localization: {
     cannot_delete_default_language:
       'You cannot delete {{languageKey}} language since it is used as default language in sign-in experience.', // UNTRANSLATED
+    invalid_translation_structure:
+      'Invalid translation structure. Please check the input translation.', // UNTRANSLATED
   },
   swagger: {
     invalid_zod_type: 'Type Zod non valide. Veuillez vérifier la configuration du garde-route.',

--- a/packages/phrases/src/locales/ko-kr/errors.ts
+++ b/packages/phrases/src/locales/ko-kr/errors.ts
@@ -106,6 +106,8 @@ const errors = {
   localization: {
     cannot_delete_default_language:
       'You cannot delete {{languageKey}} language since it is used as default language in sign-in experience.', // UNTRANSLATED
+    invalid_translation_structure:
+      'Invalid translation structure. Please check the input translation.', // UNTRANSLATED
   },
   swagger: {
     invalid_zod_type: '유요하지 않은 Zod 종류에요. Route Guard 설정을 확인해주세요.',

--- a/packages/phrases/src/locales/pt-pt/errors.ts
+++ b/packages/phrases/src/locales/pt-pt/errors.ts
@@ -112,6 +112,8 @@ const errors = {
   localization: {
     cannot_delete_default_language:
       'You cannot delete {{languageKey}} language since it is used as default language in sign-in experience.', // UNTRANSLATED
+    invalid_translation_structure:
+      'Invalid translation structure. Please check the input translation.', // UNTRANSLATED
   },
   swagger: {
     invalid_zod_type: 'Tipo de Zod inválido. Verifique a configuração do protetor de rota.',

--- a/packages/phrases/src/locales/tr-tr/errors.ts
+++ b/packages/phrases/src/locales/tr-tr/errors.ts
@@ -110,6 +110,8 @@ const errors = {
   localization: {
     cannot_delete_default_language:
       'You cannot delete {{languageKey}} language since it is used as default language in sign-in experience.', // UNTRANSLATED
+    invalid_translation_structure:
+      'Invalid translation structure. Please check the input translation.', // UNTRANSLATED
   },
   swagger: {
     invalid_zod_type:

--- a/packages/phrases/src/locales/zh-cn/errors.ts
+++ b/packages/phrases/src/locales/zh-cn/errors.ts
@@ -101,6 +101,7 @@ const errors = {
   },
   localization: {
     cannot_delete_default_language: '不能删除「登录体验」正在使用的默认语言 {{languageKey}}。', // UNTRANSLATED
+    invalid_translation_structure: '无效的 translation 结构。请检查输入的 translation。', // UNTRANSLATED
   },
   swagger: {
     invalid_zod_type: '无效的 Zod 类型，请检查路由 guard 配置。',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
`PUT /custom-phrase` route

- Remove empty string values in the input translation.
- If the input translation structure is invalid, it will fail.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

- UTs

<img width="592" alt="image" src="https://user-images.githubusercontent.com/10594507/192556233-4586265e-365e-48b5-8c9d-d4ec62b53851.png">

- HTTP requests

<img width="797" alt="image" src="https://user-images.githubusercontent.com/10594507/192556746-75e85221-4320-497a-8c44-0881c3f3145a.png">

<img width="796" alt="image" src="https://user-images.githubusercontent.com/10594507/192556907-53e147cf-e0c6-43db-9dc2-51300b4706fa.png">
