### PR TITLE
refactor(core,phrases,schemas): validate fallback language before updating sign-in experience

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,8 +23,8 @@
   },
   "dependencies": {
     "@logto/connector-kit": "^1.0.0-beta.13",
-    "@logto/core-kit": "1.0.0-beta.16",
-    "@logto/language-kit": "1.0.0-beta.16",
+    "@logto/core-kit": "^1.0.0-beta.16",
+    "@logto/language-kit": "^1.0.0-beta.16",
     "@logto/phrases": "^1.0.0-beta.9",
     "@logto/phrases-ui": "^1.0.0-beta.9",
     "@logto/schemas": "^1.0.0-beta.9",

--- a/packages/core/src/lib/sign-in-experience.ts
+++ b/packages/core/src/lib/sign-in-experience.ts
@@ -1,6 +1,8 @@
+import { builtInLanguages } from '@logto/phrases-ui';
 import {
   Branding,
   BrandingStyle,
+  LanguageInfo,
   SignInMethods,
   SignInMethodState,
   TermsOfUse,
@@ -9,6 +11,7 @@ import { Optional } from '@silverhand/essentials';
 
 import { ConnectorType, LogtoConnector } from '@/connectors/types';
 import RequestError from '@/errors/RequestError';
+import { findAllCustomLanguageKeys } from '@/queries/custom-phrase';
 import assertThat from '@/utils/assert-that';
 
 export const validateBranding = (branding: Branding) => {
@@ -17,6 +20,18 @@ export const validateBranding = (branding: Branding) => {
   }
 
   assertThat(branding.logoUrl.trim(), 'sign_in_experiences.empty_logo');
+};
+
+export const validateLanguageInfo = async (languageInfo: LanguageInfo) => {
+  const supportedLanguages = [...builtInLanguages, ...(await findAllCustomLanguageKeys())];
+
+  assertThat(
+    supportedLanguages.includes(languageInfo.fallbackLanguage),
+    new RequestError({
+      code: 'sign_in_experiences.unsupported_default_language',
+      language: languageInfo.fallbackLanguage,
+    })
+  );
 };
 
 export const validateTermsOfUse = (termsOfUse: TermsOfUse) => {

--- a/packages/core/src/routes/sign-in-experience.test.ts
+++ b/packages/core/src/routes/sign-in-experience.test.ts
@@ -14,6 +14,7 @@ import {
   mockSignInMethods,
   mockWechatConnector,
   mockColor,
+  mockLanguageInfo,
 } from '@/__mocks__';
 import * as signInExpLib from '@/lib/sign-in-experience';
 import { createRequester } from '@/utils/test-utils';
@@ -49,6 +50,10 @@ jest.mock('@/queries/sign-in-experience', () => ({
 }));
 
 const signInExperienceRequester = createRequester({ authedRoutes: signInExperiencesRoutes });
+
+jest.mock('@/queries/custom-phrase', () => ({
+  findAllCustomLanguageKeys: async () => [],
+}));
 
 describe('GET /sign-in-exp', () => {
   afterAll(() => {
@@ -138,18 +143,21 @@ describe('PATCH /sign-in-exp', () => {
     const socialSignInConnectorTargets = ['github', 'facebook', 'wechat'];
 
     const validateBranding = jest.spyOn(signInExpLib, 'validateBranding');
+    const validateLanguageInfo = jest.spyOn(signInExpLib, 'validateLanguageInfo');
     const validateTermsOfUse = jest.spyOn(signInExpLib, 'validateTermsOfUse');
     const validateSignInMethods = jest.spyOn(signInExpLib, 'validateSignInMethods');
 
     const response = await signInExperienceRequester.patch('/sign-in-exp').send({
       color: mockColor,
       branding: mockBranding,
+      languageInfo: mockLanguageInfo,
       termsOfUse,
       signInMethods: mockSignInMethods,
       socialSignInConnectorTargets,
     });
 
     expect(validateBranding).toHaveBeenCalledWith(mockBranding);
+    expect(validateLanguageInfo).toHaveBeenCalledWith(mockLanguageInfo);
     expect(validateTermsOfUse).toHaveBeenCalledWith(termsOfUse);
     expect(validateSignInMethods).toHaveBeenCalledWith(
       mockSignInMethods,

--- a/packages/core/src/routes/sign-in-experience.ts
+++ b/packages/core/src/routes/sign-in-experience.ts
@@ -3,6 +3,7 @@ import { ConnectorType, SignInExperiences } from '@logto/schemas';
 import { getLogtoConnectors } from '@/connectors';
 import {
   validateBranding,
+  validateLanguageInfo,
   validateTermsOfUse,
   validateSignInMethods,
   isEnabled,
@@ -33,10 +34,14 @@ export default function signInExperiencesRoutes<T extends AuthedRouter>(router: 
     }),
     async (ctx, next) => {
       const { socialSignInConnectorTargets, ...rest } = ctx.guard.body;
-      const { branding, termsOfUse, signInMethods } = rest;
+      const { branding, languageInfo, termsOfUse, signInMethods } = rest;
 
       if (branding) {
         validateBranding(branding);
+      }
+
+      if (languageInfo) {
+        await validateLanguageInfo(languageInfo);
       }
 
       if (termsOfUse) {

--- a/packages/core/src/utils/zod.test.ts
+++ b/packages/core/src/utils/zod.test.ts
@@ -1,3 +1,4 @@
+import { languages, languageTagGuard } from '@logto/language-kit';
 import { ApplicationType, arbitraryObjectGuard, translationGuard } from '@logto/schemas';
 import { string, boolean, number, object, nativeEnum, unknown, literal, union } from 'zod';
 
@@ -16,6 +17,13 @@ describe('zodTypeToSwagger', () => {
   it('translation object guard', () => {
     expect(zodTypeToSwagger(translationGuard)).toEqual({
       $ref: '#/components/schemas/TranslationObject',
+    });
+  });
+
+  it('language tag guard', () => {
+    expect(zodTypeToSwagger(languageTagGuard)).toEqual({
+      type: 'string',
+      enum: Object.keys(languages),
     });
   });
 

--- a/packages/core/src/utils/zod.ts
+++ b/packages/core/src/utils/zod.ts
@@ -1,3 +1,4 @@
+import { languages, languageTagGuard } from '@logto/language-kit';
 import { arbitraryObjectGuard, translationGuard } from '@logto/schemas';
 import { conditional, ValuesOf } from '@silverhand/essentials';
 import { OpenAPIV3 } from 'openapi-types';
@@ -137,6 +138,13 @@ export const zodTypeToSwagger = (
   if (config === translationGuard) {
     return {
       $ref: '#/components/schemas/TranslationObject',
+    };
+  }
+
+  if (config === languageTagGuard) {
+    return {
+      type: 'string',
+      enum: Object.keys(languages),
     };
   }
 

--- a/packages/phrases/src/locales/en/errors.ts
+++ b/packages/phrases/src/locales/en/errors.ts
@@ -105,6 +105,7 @@ const errors = {
     enabled_connector_not_found: 'Enabled {{type}} connector not found.',
     not_one_and_only_one_primary_sign_in_method:
       'There must be one and only one primary sign-in method. Please check your input.',
+    unsupported_default_language: 'Default language {{language}} is unsupported.', // UNTRANSLATED
   },
   localization: {
     cannot_delete_default_language:

--- a/packages/phrases/src/locales/fr/errors.ts
+++ b/packages/phrases/src/locales/fr/errors.ts
@@ -113,6 +113,7 @@ const errors = {
     enabled_connector_not_found: 'Le connecteur {{type}} activé est introuvable.',
     not_one_and_only_one_primary_sign_in_method:
       'Il doit y avoir une et une seule méthode de connexion primaire. Veuillez vérifier votre saisie.',
+    unsupported_default_language: 'Default language {{language}} is unsupported.', // UNTRANSLATED
   },
   localization: {
     cannot_delete_default_language:

--- a/packages/phrases/src/locales/ko-kr/errors.ts
+++ b/packages/phrases/src/locales/ko-kr/errors.ts
@@ -102,6 +102,7 @@ const errors = {
     enabled_connector_not_found: '활성된 {{type}} 연동을 찾을 수 없어요.',
     not_one_and_only_one_primary_sign_in_method:
       '반드시 하나의 메인 로그인 방법이 설정되어야 해요. 입력된 값을 확인해주세요.',
+    unsupported_default_language: 'Default language {{language}} is unsupported.', // UNTRANSLATED
   },
   localization: {
     cannot_delete_default_language:

--- a/packages/phrases/src/locales/pt-pt/errors.ts
+++ b/packages/phrases/src/locales/pt-pt/errors.ts
@@ -108,6 +108,7 @@ const errors = {
     enabled_connector_not_found: 'Conector {{type}} ativado não encontrado.',
     not_one_and_only_one_primary_sign_in_method:
       'Deve haver um e apenas um método de login principal. Por favor, verifique sua entrada.',
+    unsupported_default_language: 'Default language {{language}} is unsupported.', // UNTRANSLATED
   },
   localization: {
     cannot_delete_default_language:

--- a/packages/phrases/src/locales/tr-tr/errors.ts
+++ b/packages/phrases/src/locales/tr-tr/errors.ts
@@ -106,6 +106,7 @@ const errors = {
     enabled_connector_not_found: 'Etkin {{type}} bağlayıcı bulunamadı.',
     not_one_and_only_one_primary_sign_in_method:
       'Yalnızca bir tane birincil oturum açma yöntemi olmalıdır. Lütfen inputu kontrol ediniz.',
+    unsupported_default_language: 'Default language {{language}} is unsupported.', // UNTRANSLATED
   },
   localization: {
     cannot_delete_default_language:

--- a/packages/phrases/src/locales/zh-cn/errors.ts
+++ b/packages/phrases/src/locales/zh-cn/errors.ts
@@ -98,6 +98,7 @@ const errors = {
     empty_social_connectors: '你启用了社交登录的方式。请至少选择一个社交连接器。',
     enabled_connector_not_found: '未找到已启用的 {{type}} 连接器',
     not_one_and_only_one_primary_sign_in_method: '主要的登录方式必须有且仅有一个，请检查你的输入。',
+    unsupported_default_language: '不支持默认语言 {{language}}。', // UNTRANSLATED
   },
   localization: {
     cannot_delete_default_language: '不能删除「登录体验」正在使用的默认语言 {{languageKey}}。', // UNTRANSLATED

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -53,6 +53,7 @@
   "dependencies": {
     "@logto/connector-kit": "^1.0.0-beta.13",
     "@logto/core-kit": "^1.0.0-beta.13",
+    "@logto/language-kit": "^1.0.0-beta.16",
     "@logto/phrases": "^1.0.0-beta.9",
     "@logto/phrases-ui": "^1.0.0-beta.9",
     "zod": "^3.18.0"

--- a/packages/schemas/src/foundations/jsonb-types.ts
+++ b/packages/schemas/src/foundations/jsonb-types.ts
@@ -1,4 +1,5 @@
 import { hexColorRegEx, languageKeys } from '@logto/core-kit';
+import { languageTagGuard } from '@logto/language-kit';
 import { z } from 'zod';
 
 /**
@@ -102,7 +103,8 @@ export type TermsOfUse = z.infer<typeof termsOfUseGuard>;
 
 export const languageInfoGuard = z.object({
   autoDetect: z.boolean(),
-  fallbackLanguage: z.enum(languageKeys),
+  fallbackLanguage: languageTagGuard,
+  /** @deprecated */
   fixedLanguage: z.enum(languageKeys),
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,8 +155,8 @@ importers:
   packages/core:
     specifiers:
       '@logto/connector-kit': ^1.0.0-beta.13
-      '@logto/core-kit': 1.0.0-beta.16
-      '@logto/language-kit': 1.0.0-beta.16
+      '@logto/core-kit': ^1.0.0-beta.16
+      '@logto/language-kit': ^1.0.0-beta.16
       '@logto/phrases': ^1.0.0-beta.9
       '@logto/phrases-ui': ^1.0.0-beta.9
       '@logto/schemas': ^1.0.0-beta.9
@@ -471,6 +471,7 @@ importers:
     specifiers:
       '@logto/connector-kit': ^1.0.0-beta.13
       '@logto/core-kit': ^1.0.0-beta.13
+      '@logto/language-kit': ^1.0.0-beta.16
       '@logto/phrases': ^1.0.0-beta.9
       '@logto/phrases-ui': ^1.0.0-beta.9
       '@silverhand/eslint-config': 1.0.0
@@ -495,6 +496,7 @@ importers:
     dependencies:
       '@logto/connector-kit': 1.0.0-beta.13
       '@logto/core-kit': 1.0.0-beta.13
+      '@logto/language-kit': 1.0.0-beta.16
       '@logto/phrases': link:../phrases
       '@logto/phrases-ui': link:../phrases-ui
       zod: 3.18.0


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Validate fallback language before updating sign-in experience

---

Related:

- _Fixed language_ will be deprecated and replaced by _default language_ according to the new sign-in experience configuration designed by @fleuraly.
- _Default language_ shown on the page is _fallback language_ stored in `SignInExperience.LanguageInfo.fallbackLanguage`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

UTs

- src/routes/sign-in-experience.guard.test.ts

    <img width="328" alt="image" src="https://user-images.githubusercontent.com/10594507/192923882-4205706a-2b36-4752-9b81-d0ec6dc5858a.png">

- src/lib/sign-in-experience.test.ts

    <img width="452" alt="image" src="https://user-images.githubusercontent.com/10594507/192923578-6ca249d8-74f6-43d2-bc90-85677fa4953d.png">

HTTP requests

- Invalid language tag

    <img width="747" alt="image" src="https://user-images.githubusercontent.com/10594507/192689308-d68c21b8-357c-4a28-8ed9-f898d984722d.png">

- Unsupported language

    <img width="722" alt="image" src="https://user-images.githubusercontent.com/10594507/192689250-3015268b-6904-480c-b2c8-b16fe39fd57c.png">

- Supported language

    <img width="716" alt="image" src="https://user-images.githubusercontent.com/10594507/192689414-5578260e-d577-42bc-acdc-8c748558123f.png">

API reference generated by swagger.json

<img width="1630" alt="image" src="https://user-images.githubusercontent.com/10594507/192704636-e6d59a94-1870-4e21-986e-5c63cda5508b.png">
