### PR TITLE
chore(schemas): add db alteration script to repair user created_at column by user logs

### DIFF
--- a/packages/schemas/alterations/next-1664462389-correct-user-created-at-column-by-user-logs.ts
+++ b/packages/schemas/alterations/next-1664462389-correct-user-created-at-column-by-user-logs.ts
@@ -1,0 +1,25 @@
+import { sql } from 'slonik';
+
+import { AlterationScript } from '../lib/types/alteration';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      update users
+      set created_at = user_logs.registered_at
+      from (
+        select logs.payload ->> 'userId' as user_id, max(logs.created_at) as registered_at
+        from logs
+        where logs.type in ('RegisterUsernamePassword', 'RegisterEmail', 'RegisterSms', 'RegisterSocial')
+        and logs.payload ->> 'result' = 'Success'
+        group by logs.payload ->> 'userId'
+      ) as user_logs
+      where users.id = user_logs.user_id;
+    `);
+  },
+  down: async (pool) => {
+    // It cannot be reverted automatically.
+  },
+};
+
+export default alteration;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add a database alteration script to repair user `created_at` column by user logs

References: Related PR #2027 [comment](https://github.com/logto-io/logto/pull/2027#discussion_r983166717) & related Slack thread [discussion](https://silverhand-io.slack.com/archives/C02A8G4HVAM/p1664436981148519)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

### Locally tested

The test data is dumped from logto.dev database instance:

- user count = 251
- log count = 14677

Import the test data and test SQL in the local database instance:

<img width="904" alt="image" src="https://user-images.githubusercontent.com/10594507/193066914-fb9e209e-fec1-4ddc-a75e-9cf823317ac6.png">

<img width="1243" alt="image" src="https://user-images.githubusercontent.com/10594507/193067843-47c01b85-b0d3-4975-835d-ee59dc655216.png">
