### PR TITLE
feat: add vertical center support

### DIFF
--- a/packages/console/src/components/Tooltip/index.module.scss
+++ b/packages/console/src/components/Tooltip/index.module.scss
@@ -34,7 +34,7 @@
 
   &.arrowLeft::after {
     top: 50%;
-    left: 0% !important;
+    left: 0%;
   }
 
   &.start::after {

--- a/packages/console/src/components/Tooltip/index.module.scss
+++ b/packages/console/src/components/Tooltip/index.module.scss
@@ -27,6 +27,16 @@
     top: 0%;
   }
 
+  &.arrowRight::after {
+    top: 50%;
+    left: 100%;
+  }
+
+  &.arrowLeft::after {
+    top: 50%;
+    left: 0% !important;
+  }
+
   &.start::after {
     left: _.unit(10);
   }

--- a/packages/console/src/components/Tooltip/index.tsx
+++ b/packages/console/src/components/Tooltip/index.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import { ReactNode, RefObject, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
-import usePosition, { HorizontalAlignment } from '@/hooks/use-position';
+import usePosition, { VerticalAlignment, HorizontalAlignment } from '@/hooks/use-position';
 
 import * as styles from './index.module.scss';
 
@@ -11,15 +11,17 @@ type Props = {
   anchorRef: RefObject<Element>;
   className?: string;
   isKeepOpen?: boolean;
+  verticalAlign?: VerticalAlignment;
   horizontalAlign?: HorizontalAlignment;
+  flip?: 'right' | 'left' 
 };
 
-const getHorizontalOffset = (alignment: HorizontalAlignment): number => {
+const getHorizontalOffset = (alignment: HorizontalAlignment, flipped: string): number => {
   switch (alignment) {
     case 'start':
-      return -32;
+      return flipped === 'right' ? 32 : -32;
     case 'end':
-      return 32;
+      return flipped === 'left' ? -32 : 32;
     default:
       return 0;
   }
@@ -30,15 +32,17 @@ const Tooltip = ({
   anchorRef,
   className,
   isKeepOpen = false,
+  verticalAlign= 'top',
   horizontalAlign = 'start',
+  flip
 }: Props) => {
   const [tooltipDom, setTooltipDom] = useState<HTMLDivElement>();
   const tooltipRef = useRef<HTMLDivElement>(null);
 
   const { position, positionState, mutate } = usePosition({
-    verticalAlign: 'top',
+    verticalAlign,
     horizontalAlign,
-    offset: { vertical: 16, horizontal: getHorizontalOffset(horizontalAlign) },
+    offset: { vertical: 16, horizontal: getHorizontalOffset(horizontalAlign, flip ?? '') },
     anchorRef,
     overlayRef: tooltipRef,
   });
@@ -119,6 +123,8 @@ const Tooltip = ({
   }
 
   const isArrowUp = positionState.verticalAlign === 'bottom';
+  const isArrowRight = flip === 'left' && positionState.horizontalAlign === 'end';
+  const isArrowLeft = flip === 'right' && positionState.horizontalAlign === 'start';
 
   return createPortal(
     <div
@@ -126,6 +132,8 @@ const Tooltip = ({
       className={classNames(
         styles.tooltip,
         isArrowUp && styles.arrowUp,
+        isArrowRight && styles.arrowRight,
+        isArrowLeft && styles.arrowLeft,
         styles[horizontalAlign],
         className
       )}

--- a/packages/console/src/components/Tooltip/index.tsx
+++ b/packages/console/src/components/Tooltip/index.tsx
@@ -13,7 +13,7 @@ type Props = {
   isKeepOpen?: boolean;
   verticalAlign?: VerticalAlignment;
   horizontalAlign?: HorizontalAlignment;
-  flip?: 'right' | 'left' 
+  flip?: 'right' | 'left';
 };
 
 const getHorizontalOffset = (alignment: HorizontalAlignment, flipped: string): number => {
@@ -32,9 +32,9 @@ const Tooltip = ({
   anchorRef,
   className,
   isKeepOpen = false,
-  verticalAlign= 'top',
+  verticalAlign = 'top',
   horizontalAlign = 'start',
-  flip
+  flip,
 }: Props) => {
   const [tooltipDom, setTooltipDom] = useState<HTMLDivElement>();
   const tooltipRef = useRef<HTMLDivElement>(null);

--- a/packages/console/src/components/Tooltip/index.tsx
+++ b/packages/console/src/components/Tooltip/index.tsx
@@ -134,7 +134,7 @@ const Tooltip = ({
         isArrowUp && styles.arrowUp,
         isArrowRight && styles.arrowRight,
         isArrowLeft && styles.arrowLeft,
-        styles[horizontalAlign],
+        !flip && styles[horizontalAlign],
         className
       )}
       style={{ ...position }}

--- a/packages/console/src/hooks/use-position.ts
+++ b/packages/console/src/hooks/use-position.ts
@@ -1,6 +1,6 @@
 import { RefObject, useCallback, useEffect, useState } from 'react';
 
-export type VerticalAlignment = 'top' | 'bottom';
+export type VerticalAlignment = 'top' | 'center' | 'bottom';
 
 export type HorizontalAlignment = 'start' | 'center' | 'end';
 
@@ -28,11 +28,13 @@ const windowSafePadding = 12;
 const selectVerticalAlignment = ({
   verticalAlign,
   verticalTop,
+  verticalCenter,
   verticalBottom,
   overlayHeight,
 }: {
   verticalAlign: VerticalAlignment;
   verticalTop: number;
+  verticalCenter: number;
   verticalBottom: number;
   overlayHeight: number;
 }) => {
@@ -40,10 +42,32 @@ const selectVerticalAlignment = ({
   const maxY = window.innerHeight - windowSafePadding;
 
   const isTopAllowed = verticalTop >= minY;
+  const isCenterAllowed =
+    verticalCenter - overlayHeight / 2 >= minY && verticalCenter + overlayHeight / 2 <= maxY;
   const isBottomAllowed = verticalBottom + overlayHeight <= maxY;
 
   switch (verticalAlign) {
     case 'top': {
+      if (isTopAllowed) {
+        return 'top';
+      }
+
+      if (isBottomAllowed) {
+        return 'bottom';
+      }
+
+      if (isCenterAllowed) {
+        return 'center';
+      }
+
+      return verticalAlign;
+    }
+
+    case 'center': {
+      if (isCenterAllowed) {
+        return 'center';
+      }
+
       if (isTopAllowed) {
         return 'top';
       }
@@ -62,6 +86,10 @@ const selectVerticalAlignment = ({
 
       if (isTopAllowed) {
         return 'top';
+      }
+
+      if (isCenterAllowed) {
+        return 'center';
       }
 
       return verticalAlign;
@@ -170,9 +198,10 @@ export default function usePosition({
     const { scrollTop, scrollLeft } = document.documentElement;
 
     const verticalTop = anchorRect.y - overlayRect.height + scrollTop - offset.vertical;
+    const verticalCenter = anchorRect.y - anchorRect.height / 2 - overlayRect.height / 2 + scrollTop + offset.vertical;
     const verticalBottom = anchorRect.y + anchorRect.height + scrollTop + offset.vertical;
 
-    const verticalPositionMap = { top: verticalTop, bottom: verticalBottom };
+    const verticalPositionMap = { top: verticalTop, center: verticalCenter, bottom: verticalBottom };
 
     const horizontalStart = anchorRect.x + scrollLeft + offset.horizontal;
     const horizontalCenter =
@@ -189,6 +218,7 @@ export default function usePosition({
     const selectedVerticalAlign = selectVerticalAlignment({
       verticalAlign,
       verticalTop,
+      verticalCenter,
       verticalBottom,
       overlayHeight: overlayRect.height,
     });

--- a/packages/console/src/hooks/use-position.ts
+++ b/packages/console/src/hooks/use-position.ts
@@ -198,10 +198,15 @@ export default function usePosition({
     const { scrollTop, scrollLeft } = document.documentElement;
 
     const verticalTop = anchorRect.y - overlayRect.height + scrollTop - offset.vertical;
-    const verticalCenter = anchorRect.y - anchorRect.height / 2 - overlayRect.height / 2 + scrollTop + offset.vertical;
+    const verticalCenter =
+      anchorRect.y - anchorRect.height / 2 - overlayRect.height / 2 + scrollTop + offset.vertical;
     const verticalBottom = anchorRect.y + anchorRect.height + scrollTop + offset.vertical;
 
-    const verticalPositionMap = { top: verticalTop, center: verticalCenter, bottom: verticalBottom };
+    const verticalPositionMap = {
+      top: verticalTop,
+      center: verticalCenter,
+      bottom: verticalBottom,
+    };
 
     const horizontalStart = anchorRect.x + scrollLeft + offset.horizontal;
     const horizontalCenter =


### PR DESCRIPTION
## Summary
This PR adds vertical center support in usePosition hook (#1852)

The tooltip can be flipped to `'right' | 'left'` and the tail points correctly.

See the following examples
#### Left Tooltip
 - `<Tooltip verticalAlign='center' horizontalAlign='end' flip='left' anchorRef={tipRef} content={t(tooltip)} />`
 
#### Right Tooltip
 - `<Tooltip verticalAlign='center' horizontalAlign='start' flip='right' anchorRef={tipRef} content={t(tooltip)} />`

#### I think I got it correct, let me know if I did smth wrong, UI is not my best. Also, sorry for the huge delay, been busy and my dev environment on windows was a little buggy.

## Testing
Locally Tested
![logto-tail-left](https://user-images.githubusercontent.com/47457170/193224596-71f65e52-2fee-418f-affe-9519d154f4ae.png)
![logto-tail-right](https://user-images.githubusercontent.com/47457170/193224601-7a0dcdfb-4f3f-45b7-9891-591ab6987fcc.png)



