### PR TITLE
refactor(ui): refactor ui i18n

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -18,7 +18,7 @@ import SignIn from './pages/SignIn';
 import SocialLanding from './pages/SocialLanding';
 import SocialRegister from './pages/SocialRegister';
 import SocialSignIn from './pages/SocialSignInCallback';
-import getSignInExperienceSettings from './utils/sign-in-experience';
+import { getSignInExperienceSettings } from './utils/sign-in-experience';
 
 import './scss/normalized.scss';
 
@@ -35,9 +35,10 @@ const App = () => {
     (async () => {
       const settings = await getSignInExperienceSettings();
 
-      // Note: i18n must be initialized ahead of global experience settings
+      // Note: i18n must be initialized ahead of page render
       await initI18n(settings.languageInfo);
 
+      // Init the page settings and render
       setExperienceSettings(settings);
     })();
   }, [isPreview, setExperienceSettings, setLoading]);

--- a/packages/ui/src/apis/settings.ts
+++ b/packages/ui/src/apis/settings.ts
@@ -9,3 +9,18 @@ import ky from 'ky';
 export const getSignInExperience = async <T extends SignInExperience>(): Promise<T> => {
   return ky.get('/api/.well-known/sign-in-exp').json<T>();
 };
+
+export const getPhrases = async (lng?: string) =>
+  ky
+    .extend({
+      hooks: {
+        beforeRequest: [
+          (request) => {
+            if (lng) {
+              request.headers.set('Accept-Language', lng);
+            }
+          },
+        ],
+      },
+    })
+    .get('/api/phrase');

--- a/packages/ui/src/hooks/use-preview.ts
+++ b/packages/ui/src/hooks/use-preview.ts
@@ -1,11 +1,11 @@
 import { ConnectorPlatform } from '@logto/schemas';
 import { conditionalString } from '@silverhand/essentials';
-import i18next from 'i18next';
 import { useEffect, useState } from 'react';
 
 import * as styles from '@/App.module.scss';
 import { Context } from '@/hooks/use-page-context';
 import initI18n from '@/i18n/init';
+import { changeLanguage } from '@/i18n/utils';
 import { SignInExperienceSettings, PreviewConfig } from '@/types';
 import { parseQueryParameters } from '@/utils';
 import { getPrimarySignInMethod, getSecondarySignInMethods } from '@/utils/sign-in-experience';
@@ -24,7 +24,7 @@ const usePreview = (context: Context): [boolean, PreviewConfig?] => {
     }
 
     // Init i18n
-    void initI18n(undefined, isPreview);
+    void initI18n();
 
     // Block pointer event
     document.body.classList.add(conditionalString(styles.preview));
@@ -75,13 +75,15 @@ const usePreview = (context: Context): [boolean, PreviewConfig?] => {
       ),
     };
 
-    void i18next.changeLanguage(language);
+    (async () => {
+      await changeLanguage(language);
 
-    setTheme(mode);
+      setTheme(mode);
 
-    setPlatform(platform);
+      setPlatform(platform);
 
-    setExperienceSettings(experienceSettings);
+      setExperienceSettings(experienceSettings);
+    })();
   }, [isPreview, previewConfig, setExperienceSettings, setPlatform, setTheme]);
 
   return [isPreview, previewConfig];

--- a/packages/ui/src/i18n/init.ts
+++ b/packages/ui/src/i18n/init.ts
@@ -1,35 +1,30 @@
-import resources from '@logto/phrases-ui';
 import { LanguageInfo } from '@logto/schemas';
 import i18next, { InitOptions } from 'i18next';
-import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
+
+import { getI18nResource, detectLanguage } from '@/i18n/utils';
 
 const storageKey = 'i18nextLogtoUiLng';
 
-const initI18n = async (languageSettings?: LanguageInfo, isPreview = false) => {
+const initI18n = async (languageSettings?: LanguageInfo) => {
+  // Get language settings from the SIE
+  const locale = detectLanguage(languageSettings);
+
+  const { resources, lng } = await getI18nResource(locale);
+
   const options: InitOptions = {
     resources,
-    fallbackLng: languageSettings?.fallbackLanguage ?? 'en',
-    lng: languageSettings?.autoDetect === false ? languageSettings.fixedLanguage : undefined,
+    lng,
     interpolation: {
       escapeValue: false,
-    },
-    detection: {
-      lookupLocalStorage: storageKey,
-      lookupSessionStorage: storageKey,
     },
   };
 
   i18next.use(initReactI18next);
 
-  // Should not apply auto detect if is preview or fix
-  if (!isPreview && !(languageSettings?.autoDetect === false)) {
-    i18next.use(LanguageDetector);
-  }
-
   const i18n = i18next.init(options);
 
-  // @ts-expect-error - i18next doesn't have a type definition for this. called after i18next is initialized
+  // @ts-expect-error - i18next doesn't have a type definition for this. Must called after i18next is initialized
   i18next.services.formatter.add('zhOrSpaces', (value: string, lng) => {
     if (lng !== 'zh-CN') {
       return value;

--- a/packages/ui/src/i18n/utils.ts
+++ b/packages/ui/src/i18n/utils.ts
@@ -53,7 +53,6 @@ export const detectLanguage = (languageSettings?: LanguageInfo) => {
 // Must be called after i18n's initialization
 export const changeLanguage = async (targetLanguage: string) => {
   const { resources, lng } = await getI18nResource(targetLanguage);
-  console.log(resources, lng);
 
   for (const [namespace, resource] of Object.entries(resources[lng] ?? {})) {
     i18next.addResourceBundle(lng, namespace, resource);

--- a/packages/ui/src/i18n/utils.ts
+++ b/packages/ui/src/i18n/utils.ts
@@ -1,0 +1,63 @@
+import resource, { LocalePhrase } from '@logto/phrases-ui';
+import { LanguageInfo } from '@logto/schemas';
+import i18next, { Resource } from 'i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+
+import { getPhrases } from '@/apis/settings';
+
+export const getI18nResource = async (
+  locale?: string | string[]
+): Promise<{ resources: Resource; lng: string }> => {
+  try {
+    const response = await getPhrases(Array.isArray(locale) ? locale.join(' ') : locale);
+    const phrases = await response.json<LocalePhrase>();
+    const lng = response.headers.get('Content-Language');
+
+    if (!lng) {
+      throw new Error('lng not found');
+    }
+
+    return {
+      resources: { [lng]: phrases },
+      lng,
+    };
+  } catch {
+    // Fallback to build in en
+    return {
+      resources: { en: resource.en },
+      lng: 'en',
+    };
+  }
+};
+
+const storageKey = 'i18nextLogtoUiLng';
+
+export const detectLanguage = (languageSettings?: LanguageInfo) => {
+  if (languageSettings?.autoDetect === false) {
+    return languageSettings.fallbackLanguage;
+  }
+
+  const languageDetector = new LanguageDetector();
+  languageDetector.init(
+    // Pass in a empty i18n languageUtils server instance to bypass the [languageDetector detection](https://github.com/i18next/i18next-browser-languageDetector/blob/master/src/index.js#L70)
+    { languageUtils: {} },
+    {
+      lookupLocalStorage: storageKey,
+      lookupSessionStorage: storageKey,
+    }
+  );
+
+  return languageDetector.detect();
+};
+
+// Must be called after i18n's initialization
+export const changeLanguage = async (targetLanguage: string) => {
+  const { resources, lng } = await getI18nResource(targetLanguage);
+  console.log(resources, lng);
+
+  for (const [namespace, resource] of Object.entries(resources[lng] ?? {})) {
+    i18next.addResourceBundle(lng, namespace, resource);
+  }
+
+  await i18next.changeLanguage(lng);
+};

--- a/packages/ui/src/types/index.ts
+++ b/packages/ui/src/types/index.ts
@@ -1,4 +1,3 @@
-import type { LanguageKey } from '@logto/core-kit';
 import { SignInExperience, ConnectorMetadata, AppearanceMode } from '@logto/schemas';
 
 export type UserFlow = 'sign-in' | 'register' | 'forgot-password';
@@ -34,7 +33,7 @@ export enum ConfirmModalMessage {
 
 export type PreviewConfig = {
   signInExperience: SignInExperienceSettingsResponse;
-  language: LanguageKey;
+  language: string;
   mode: AppearanceMode.LightMode | AppearanceMode.DarkMode;
   platform: Platform;
   isNative: boolean;

--- a/packages/ui/src/utils/sign-in-experience.test.ts
+++ b/packages/ui/src/utils/sign-in-experience.test.ts
@@ -1,7 +1,7 @@
 import { mockSignInExperience } from '@/__mocks__/logto';
 import { getSignInExperience } from '@/apis/settings';
 
-import getSignInExperienceSettings from './sign-in-experience';
+import { getSignInExperienceSettings } from './sign-in-experience';
 
 jest.mock('@/apis/settings', () => ({
   getSignInExperience: jest.fn(),

--- a/packages/ui/src/utils/sign-in-experience.ts
+++ b/packages/ui/src/utils/sign-in-experience.ts
@@ -30,7 +30,7 @@ export const getSecondarySignInMethods = (signInMethods: SignInMethods) =>
     return methods;
   }, []);
 
-const getSignInExperienceSettings = async (): Promise<SignInExperienceSettings> => {
+export const getSignInExperienceSettings = async (): Promise<SignInExperienceSettings> => {
   const { signInMethods, socialConnectors, ...rest } =
     await getSignInExperience<SignInExperienceSettingsResponse>();
 
@@ -41,5 +41,3 @@ const getSignInExperienceSettings = async (): Promise<SignInExperienceSettings> 
     socialConnectors: filterSocialConnectors(socialConnectors),
   };
 };
-
-export default getSignInExperienceSettings;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Refactor ui i18n logic to pick up the latest i18n design

- add new API `/getPhrase`
- remove the UI's build in resource loading logic, using the resource and language returned from the phrase api
- use build-in en as default fallback language
-  update the preview logic to load resource dynamically from the api


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
@xiaoyijun @IceHe 