### PR TITLE
fix(console): language editor form should be dirty on clear button clicked

### DIFF
--- a/packages/console/src/pages/SignInExperience/components/ManageLanguageModal/LanguageEditor.tsx
+++ b/packages/console/src/pages/SignInExperience/components/ManageLanguageModal/LanguageEditor.tsx
@@ -66,6 +66,7 @@ const LanguageEditor = () => {
   const {
     handleSubmit,
     reset,
+    setValue,
     formState: { isSubmitting, isDirty, dirtyFields },
   } = formMethods;
 
@@ -159,7 +160,11 @@ const LanguageEditor = () => {
                       className={style.clearButton}
                       icon={<Delete />}
                       onClick={() => {
-                        reset(emptyUiTranslation);
+                        for (const [key, value] of Object.entries(
+                          flattenTranslation(emptyUiTranslation)
+                        )) {
+                          setValue(key, value, { shouldDirty: true });
+                        }
                       }}
                     />
                   </span>

--- a/packages/console/src/pages/SignInExperience/utilities.ts
+++ b/packages/console/src/pages/SignInExperience/utilities.ts
@@ -110,14 +110,14 @@ export const flattenTranslation = (
     const unwrappedKey = `${prefix}${key}`;
     const unwrapped = translation[key];
 
-    return unwrapped
-      ? {
+    return unwrapped === undefined
+      ? result
+      : {
           ...result,
           ...(typeof unwrapped === 'string'
             ? { [unwrappedKey]: unwrapped }
             : flattenTranslation(unwrapped, unwrappedKey)),
-        }
-      : result;
+        };
   }, {});
 
 const emptyTranslation = (translation: Translation): Translation =>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
The react hook form `reset` function will set the form `isDirty` state to `false` even if the value passed to `reset` function is not equal to the form default value. So we call `setValue` to get a correct `isDirty` state.

- fix: language editor form should be dirty on clear button clicked
- fix: flattenTranslation should not skip `''` string


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.
