### PR TITLE
fix(console): show correct password after reset

### DIFF
--- a/packages/console/src/pages/UserDetails/components/ResetPasswordForm.tsx
+++ b/packages/console/src/pages/UserDetails/components/ResetPasswordForm.tsx
@@ -19,7 +19,7 @@ const ResetPasswordForm = ({ onClose, userId }: Props) => {
   const onSubmit = async () => {
     const password = nanoid(8);
     await api.patch(`/api/users/${userId}/password`, { json: { password } }).json<User>();
-    onClose?.(btoa(password));
+    onClose?.(password);
   };
 
   return (


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

show correct password after reset, remove the original "btoa"

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

local tested, sign in with the new password
