### PR TITLE
fix(console): clear select state on close modal

### DIFF
--- a/packages/console/src/pages/Connectors/components/CreateForm/index.tsx
+++ b/packages/console/src/pages/Connectors/components/CreateForm/index.tsx
@@ -74,6 +74,8 @@ const CreateForm = ({ onClose, isOpen: isFormOpen, type }: Props) => {
   const closeModal = () => {
     setIsGetStartedModalOpen(false);
     onClose?.(activeConnectorId);
+    setActiveGroupId(undefined);
+    setActiveConnectorId(undefined);
   };
 
   return (


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
For add connector modal: clear select state on close modal.

This can prevent "select" on last "added" connector which should be unselectable.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested.
