### PR TITLE
fix(console): set undefined value to empty string in custom phrases

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -48,6 +48,7 @@
     "cross-env": "^7.0.3",
     "csstype": "^3.0.11",
     "dayjs": "^1.10.5",
+    "deepmerge": "^4.2.2",
     "dnd-core": "^16.0.0",
     "eslint": "^8.21.0",
     "history": "^5.3.0",

--- a/packages/console/src/pages/SignInExperience/components/ManageLanguageModal/LanguageEditor.tsx
+++ b/packages/console/src/pages/SignInExperience/components/ManageLanguageModal/LanguageEditor.tsx
@@ -3,6 +3,7 @@ import resource, { isBuiltInLanguageTag } from '@logto/phrases-ui';
 import en from '@logto/phrases-ui/lib/locales/en';
 import { SignInExperience, Translation } from '@logto/schemas';
 import cleanDeep from 'clean-deep';
+import deepmerge from 'deepmerge';
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
@@ -56,10 +57,7 @@ const LanguageEditor = () => {
   );
 
   const defaultFormValues = useMemo(
-    () =>
-      customPhrase && Object.keys(customPhrase.translation).length > 0
-        ? customPhrase.translation
-        : emptyUiTranslation,
+    () => deepmerge(emptyUiTranslation, customPhrase?.translation ?? {}),
     [customPhrase]
   );
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,7 @@ importers:
       cross-env: ^7.0.3
       csstype: ^3.0.11
       dayjs: ^1.10.5
+      deepmerge: ^4.2.2
       dnd-core: ^16.0.0
       eslint: ^8.21.0
       history: ^5.3.0
@@ -117,6 +118,7 @@ importers:
       cross-env: 7.0.3
       csstype: 3.0.11
       dayjs: 1.10.7
+      deepmerge: 4.2.2
       dnd-core: 16.0.0
       eslint: 8.21.0
       history: 5.3.0


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
When we switching between custom phrases with some undefined values, the form won't work correctly with undefined values:
![bug](https://user-images.githubusercontent.com/10806653/194744689-b545a091-6890-4ec9-a0d8-d6361df565aa.gif)

So, we convert all undefined values to empty string by merge it with the `emptyUiTranslation`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
![fixed](https://user-images.githubusercontent.com/10806653/194744729-2412053d-7786-4f54-8bbf-fad6ead75fc3.gif)

