### PR TITLE
refactor(core): split sign in experience lib

### DIFF
--- a/packages/core/src/__mocks__/sign-in-experience.ts
+++ b/packages/core/src/__mocks__/sign-in-experience.ts
@@ -10,6 +10,7 @@ import {
   Color,
   SignUpIdentifier,
   SignInIdentifier,
+  SignUp,
 } from '@logto/schemas';
 
 export const mockSignInExperience: SignInExperience = {
@@ -86,4 +87,10 @@ export const mockSignInMethods: SignInMethods = {
   email: SignInMethodState.Disabled,
   sms: SignInMethodState.Disabled,
   social: SignInMethodState.Disabled,
+};
+
+export const mockSignUp: SignUp = {
+  identifier: SignUpIdentifier.Username,
+  password: true,
+  verify: false,
 };

--- a/packages/core/src/lib/sign-in-experience/index.test.ts
+++ b/packages/core/src/lib/sign-in-experience/index.test.ts
@@ -1,0 +1,57 @@
+import { BrandingStyle } from '@logto/schemas';
+
+import { mockBranding } from '@/__mocks__';
+import RequestError from '@/errors/RequestError';
+import { validateBranding, validateTermsOfUse } from '@/lib/sign-in-experience';
+
+describe('validate branding', () => {
+  test('should throw when the UI style contains the slogan and slogan is empty', () => {
+    expect(() => {
+      validateBranding({
+        ...mockBranding,
+        style: BrandingStyle.Logo_Slogan,
+        slogan: '',
+      });
+    }).toMatchError(new RequestError('sign_in_experiences.empty_slogan'));
+  });
+
+  test('should throw when the logo is empty', () => {
+    expect(() => {
+      validateBranding({
+        ...mockBranding,
+        style: BrandingStyle.Logo,
+        logoUrl: ' ',
+        slogan: '',
+      });
+    }).toMatchError(new RequestError('sign_in_experiences.empty_logo'));
+  });
+
+  test('should throw when the UI style contains the slogan and slogan is blank', () => {
+    expect(() => {
+      validateBranding({
+        ...mockBranding,
+        style: BrandingStyle.Logo_Slogan,
+        slogan: ' \t\n',
+      });
+    }).toMatchError(new RequestError('sign_in_experiences.empty_slogan'));
+  });
+
+  test('should not throw when the UI style does not contain the slogan and slogan is empty', () => {
+    expect(() => {
+      validateBranding({
+        ...mockBranding,
+        style: BrandingStyle.Logo,
+      });
+    }).not.toThrow();
+  });
+});
+
+describe('validate terms of use', () => {
+  test('should throw when terms of use is enabled and content URL is empty', () => {
+    expect(() => {
+      validateTermsOfUse({
+        enabled: true,
+      });
+    }).toMatchError(new RequestError('sign_in_experiences.empty_content_url_of_terms_of_use'));
+  });
+});

--- a/packages/core/src/lib/sign-in-experience/index.ts
+++ b/packages/core/src/lib/sign-in-experience/index.ts
@@ -3,6 +3,7 @@ import { Branding, BrandingStyle, TermsOfUse } from '@logto/schemas';
 import assertThat from '@/utils/assert-that';
 
 export * from './sign-in-methods';
+export * from './sign-up';
 
 export const validateBranding = (branding: Branding) => {
   if (branding.style === BrandingStyle.Logo_Slogan) {

--- a/packages/core/src/lib/sign-in-experience/index.ts
+++ b/packages/core/src/lib/sign-in-experience/index.ts
@@ -1,0 +1,20 @@
+import { Branding, BrandingStyle, TermsOfUse } from '@logto/schemas';
+
+import assertThat from '@/utils/assert-that';
+
+export * from './sign-in-methods';
+
+export const validateBranding = (branding: Branding) => {
+  if (branding.style === BrandingStyle.Logo_Slogan) {
+    assertThat(branding.slogan?.trim(), 'sign_in_experiences.empty_slogan');
+  }
+
+  assertThat(branding.logoUrl.trim(), 'sign_in_experiences.empty_logo');
+};
+
+export const validateTermsOfUse = (termsOfUse: TermsOfUse) => {
+  assertThat(
+    !termsOfUse.enabled || termsOfUse.contentUrl,
+    'sign_in_experiences.empty_content_url_of_terms_of_use'
+  );
+};

--- a/packages/core/src/lib/sign-in-experience/sign-in-methods.test.ts
+++ b/packages/core/src/lib/sign-in-experience/sign-in-methods.test.ts
@@ -1,73 +1,15 @@
-import { BrandingStyle, SignInMethodState, ConnectorType } from '@logto/schemas';
+import { SignInMethodState, ConnectorType } from '@logto/schemas';
 
 import {
   mockAliyunDmConnector,
   mockFacebookConnector,
   mockGithubConnector,
-  mockBranding,
   mockSignInMethods,
 } from '@/__mocks__';
 import RequestError from '@/errors/RequestError';
-import {
-  isEnabled,
-  validateBranding,
-  validateSignInMethods,
-  validateTermsOfUse,
-} from '@/lib/sign-in-experience';
+import { isEnabled, validateSignInMethods } from '@/lib/sign-in-experience';
 
 const enabledConnectors = [mockFacebookConnector, mockGithubConnector];
-
-describe('validate branding', () => {
-  test('should throw when the UI style contains the slogan and slogan is empty', () => {
-    expect(() => {
-      validateBranding({
-        ...mockBranding,
-        style: BrandingStyle.Logo_Slogan,
-        slogan: '',
-      });
-    }).toMatchError(new RequestError('sign_in_experiences.empty_slogan'));
-  });
-
-  test('should throw when the logo is empty', () => {
-    expect(() => {
-      validateBranding({
-        ...mockBranding,
-        style: BrandingStyle.Logo,
-        logoUrl: ' ',
-        slogan: '',
-      });
-    }).toMatchError(new RequestError('sign_in_experiences.empty_logo'));
-  });
-
-  test('should throw when the UI style contains the slogan and slogan is blank', () => {
-    expect(() => {
-      validateBranding({
-        ...mockBranding,
-        style: BrandingStyle.Logo_Slogan,
-        slogan: ' \t\n',
-      });
-    }).toMatchError(new RequestError('sign_in_experiences.empty_slogan'));
-  });
-
-  test('should not throw when the UI style does not contain the slogan and slogan is empty', () => {
-    expect(() => {
-      validateBranding({
-        ...mockBranding,
-        style: BrandingStyle.Logo,
-      });
-    }).not.toThrow();
-  });
-});
-
-describe('validate terms of use', () => {
-  test('should throw when terms of use is enabled and content URL is empty', () => {
-    expect(() => {
-      validateTermsOfUse({
-        enabled: true,
-      });
-    }).toMatchError(new RequestError('sign_in_experiences.empty_content_url_of_terms_of_use'));
-  });
-});
 
 describe('check whether the social sign-in method state is enabled', () => {
   it('should be truthy when sign-in method state is primary', () => {

--- a/packages/core/src/lib/sign-in-experience/sign-in-methods.ts
+++ b/packages/core/src/lib/sign-in-experience/sign-in-methods.ts
@@ -1,30 +1,9 @@
-import {
-  Branding,
-  BrandingStyle,
-  SignInMethods,
-  SignInMethodState,
-  TermsOfUse,
-} from '@logto/schemas';
+import { ConnectorType, SignInMethods, SignInMethodState } from '@logto/schemas';
 import { Optional } from '@silverhand/essentials';
 
-import { ConnectorType, LogtoConnector } from '@/connectors/types';
+import { LogtoConnector } from '@/connectors/types';
 import RequestError from '@/errors/RequestError';
 import assertThat from '@/utils/assert-that';
-
-export const validateBranding = (branding: Branding) => {
-  if (branding.style === BrandingStyle.Logo_Slogan) {
-    assertThat(branding.slogan?.trim(), 'sign_in_experiences.empty_slogan');
-  }
-
-  assertThat(branding.logoUrl.trim(), 'sign_in_experiences.empty_logo');
-};
-
-export const validateTermsOfUse = (termsOfUse: TermsOfUse) => {
-  assertThat(
-    !termsOfUse.enabled || termsOfUse.contentUrl,
-    'sign_in_experiences.empty_content_url_of_terms_of_use'
-  );
-};
 
 export const isEnabled = (state: SignInMethodState) => state !== SignInMethodState.Disabled;
 

--- a/packages/core/src/lib/sign-in-experience/sign-up.test.ts
+++ b/packages/core/src/lib/sign-in-experience/sign-up.test.ts
@@ -1,0 +1,112 @@
+import { ConnectorType, SignUpIdentifier } from '@logto/schemas';
+
+import { mockAliyunDmConnector, mockAliyunSmsConnector, mockSignUp } from '@/__mocks__';
+import RequestError from '@/errors/RequestError';
+
+import { validateSignUp } from './sign-up';
+
+const enabledConnectors = [mockAliyunDmConnector, mockAliyunSmsConnector];
+
+describe('validate sign-up', () => {
+  describe('There must be at least one enabled connector for the specific identifier.', () => {
+    test('should throw when there is no enabled email connector and identifier is email', async () => {
+      expect(() => {
+        validateSignUp({ ...mockSignUp, identifier: SignUpIdentifier.Email }, []);
+      }).toMatchError(
+        new RequestError({
+          code: 'sign_in_experiences.enabled_connector_not_found',
+          type: ConnectorType.Email,
+        })
+      );
+    });
+
+    test('should throw when there is no enabled email connector and identifier is email or phone', async () => {
+      expect(() => {
+        validateSignUp({ ...mockSignUp, identifier: SignUpIdentifier.EmailOrPhone }, []);
+      }).toMatchError(
+        new RequestError({
+          code: 'sign_in_experiences.enabled_connector_not_found',
+          type: ConnectorType.Email,
+        })
+      );
+    });
+
+    test('should throw when there is no enabled sms connector and identifier is phone', async () => {
+      expect(() => {
+        validateSignUp({ ...mockSignUp, identifier: SignUpIdentifier.Phone }, []);
+      }).toMatchError(
+        new RequestError({
+          code: 'sign_in_experiences.enabled_connector_not_found',
+          type: ConnectorType.Sms,
+        })
+      );
+    });
+
+    test('should throw when there is no enabled email connector and identifier is email or phone', async () => {
+      expect(() => {
+        validateSignUp({ ...mockSignUp, identifier: SignUpIdentifier.EmailOrPhone }, [
+          mockAliyunDmConnector,
+        ]);
+      }).toMatchError(
+        new RequestError({
+          code: 'sign_in_experiences.enabled_connector_not_found',
+          type: ConnectorType.Sms,
+        })
+      );
+    });
+  });
+
+  test('should throw when identifier is username and password is false', async () => {
+    expect(() => {
+      validateSignUp(
+        { ...mockSignUp, identifier: SignUpIdentifier.Username, password: false },
+        enabledConnectors
+      );
+    }).toMatchError(
+      new RequestError({
+        code: 'sign_in_experiences.username_requires_password',
+      })
+    );
+  });
+
+  describe('verify should be true for passwordless identifier', () => {
+    test('should throw when identifier is email', async () => {
+      expect(() => {
+        validateSignUp(
+          { ...mockSignUp, identifier: SignUpIdentifier.Email, verify: false },
+          enabledConnectors
+        );
+      }).toMatchError(
+        new RequestError({
+          code: 'sign_in_experiences.passwordless_requires_verify',
+        })
+      );
+    });
+
+    test('should throw when identifier is phone', async () => {
+      expect(() => {
+        validateSignUp(
+          { ...mockSignUp, identifier: SignUpIdentifier.Email, verify: false },
+          enabledConnectors
+        );
+      }).toMatchError(
+        new RequestError({
+          code: 'sign_in_experiences.passwordless_requires_verify',
+        })
+      );
+    });
+
+    test('should throw when identifier is email or phone', async () => {
+      expect(() => {
+        validateSignUp(
+          { ...mockSignUp, identifier: SignUpIdentifier.EmailOrPhone, verify: false },
+          enabledConnectors
+        );
+      }).toMatchError(
+        new RequestError({
+          code: 'sign_in_experiences.passwordless_requires_verify',
+        })
+      );
+    });
+  });
+});

--- a/packages/core/src/lib/sign-in-experience/sign-up.ts
+++ b/packages/core/src/lib/sign-in-experience/sign-up.ts
@@ -1,0 +1,55 @@
+import { ConnectorType, SignUp, SignUpIdentifier } from '@logto/schemas';
+
+import { LogtoConnector } from '@/connectors/types';
+import RequestError from '@/errors/RequestError';
+import assertThat from '@/utils/assert-that';
+
+export const validateSignUp = (signUp: SignUp, enabledConnectors: LogtoConnector[]) => {
+  if (
+    signUp.identifier === SignUpIdentifier.Email ||
+    signUp.identifier === SignUpIdentifier.EmailOrPhone
+  ) {
+    assertThat(
+      enabledConnectors.some((item) => item.type === ConnectorType.Email),
+      new RequestError({
+        code: 'sign_in_experiences.enabled_connector_not_found',
+        type: ConnectorType.Email,
+      })
+    );
+  }
+
+  if (
+    signUp.identifier === SignUpIdentifier.Phone ||
+    signUp.identifier === SignUpIdentifier.EmailOrPhone
+  ) {
+    assertThat(
+      enabledConnectors.some((item) => item.type === ConnectorType.Sms),
+      new RequestError({
+        code: 'sign_in_experiences.enabled_connector_not_found',
+        type: ConnectorType.Sms,
+      })
+    );
+  }
+
+  if (signUp.identifier === SignUpIdentifier.Username) {
+    assertThat(
+      signUp.password,
+      new RequestError({
+        code: 'sign_in_experiences.username_requires_password',
+      })
+    );
+  }
+
+  if (
+    [SignUpIdentifier.Phone, SignUpIdentifier.Email, SignUpIdentifier.EmailOrPhone].includes(
+      signUp.identifier
+    )
+  ) {
+    assertThat(
+      signUp.verify,
+      new RequestError({
+        code: 'sign_in_experiences.passwordless_requires_verify',
+      })
+    );
+  }
+};

--- a/packages/core/src/routes/sign-in-experience.test.ts
+++ b/packages/core/src/routes/sign-in-experience.test.ts
@@ -16,6 +16,7 @@ import {
   mockColor,
 } from '@/__mocks__';
 import * as signInExpLib from '@/lib/sign-in-experience';
+import * as signInMethodsLib from '@/lib/sign-in-experience/sign-in-methods';
 import { createRequester } from '@/utils/test-utils';
 
 import signInExperiencesRoutes from './sign-in-experience';
@@ -139,7 +140,7 @@ describe('PATCH /sign-in-exp', () => {
 
     const validateBranding = jest.spyOn(signInExpLib, 'validateBranding');
     const validateTermsOfUse = jest.spyOn(signInExpLib, 'validateTermsOfUse');
-    const validateSignInMethods = jest.spyOn(signInExpLib, 'validateSignInMethods');
+    const validateSignInMethods = jest.spyOn(signInMethodsLib, 'validateSignInMethods');
 
     const response = await signInExperienceRequester.patch('/sign-in-exp').send({
       color: mockColor,

--- a/packages/core/src/routes/sign-in-experience.ts
+++ b/packages/core/src/routes/sign-in-experience.ts
@@ -6,6 +6,7 @@ import {
   validateTermsOfUse,
   validateSignInMethods,
   isEnabled,
+  validateSignUp,
 } from '@/lib/sign-in-experience';
 import koaGuard from '@/middleware/koa-guard';
 import {
@@ -33,7 +34,7 @@ export default function signInExperiencesRoutes<T extends AuthedRouter>(router: 
     }),
     async (ctx, next) => {
       const { socialSignInConnectorTargets, ...rest } = ctx.guard.body;
-      const { branding, termsOfUse, signInMethods } = rest;
+      const { branding, termsOfUse, signInMethods, signUp } = rest;
 
       if (branding) {
         validateBranding(branding);
@@ -60,6 +61,10 @@ export default function signInExperiencesRoutes<T extends AuthedRouter>(router: 
           filteredSocialSignInConnectorTargets,
           enabledConnectors
         );
+      }
+
+      if (signUp) {
+        validateSignUp(signUp, enabledConnectors);
       }
 
       // Update socialSignInConnectorTargets only when social sign-in is enabled.

--- a/packages/phrases/src/locales/en/errors.ts
+++ b/packages/phrases/src/locales/en/errors.ts
@@ -105,6 +105,8 @@ const errors = {
     enabled_connector_not_found: 'Enabled {{type}} connector not found.',
     not_one_and_only_one_primary_sign_in_method:
       'There must be one and only one primary sign-in method. Please check your input.',
+    username_requires_password: 'Must enable set a password for username sign up identifier.',
+    passwordless_requires_verify: 'Must enable verify for email/phone sign up identifier.',
   },
   localization: {
     cannot_delete_default_language:

--- a/packages/phrases/src/locales/fr/errors.ts
+++ b/packages/phrases/src/locales/fr/errors.ts
@@ -113,6 +113,8 @@ const errors = {
     enabled_connector_not_found: 'Le connecteur {{type}} activé est introuvable.',
     not_one_and_only_one_primary_sign_in_method:
       'Il doit y avoir une et une seule méthode de connexion primaire. Veuillez vérifier votre saisie.',
+    username_requires_password: 'Must enable set a password for username sign up identifier.', // UNTRANSLATED
+    passwordless_requires_verify: 'Must enable verify for email/phone sign up identifier.', // UNTRANSLATED
   },
   localization: {
     cannot_delete_default_language:

--- a/packages/phrases/src/locales/ko-kr/errors.ts
+++ b/packages/phrases/src/locales/ko-kr/errors.ts
@@ -102,6 +102,8 @@ const errors = {
     enabled_connector_not_found: '활성된 {{type}} 연동을 찾을 수 없어요.',
     not_one_and_only_one_primary_sign_in_method:
       '반드시 하나의 메인 로그인 방법이 설정되어야 해요. 입력된 값을 확인해주세요.',
+    username_requires_password: 'Must enable set a password for username sign up identifier.', // UNTRANSLATED
+    passwordless_requires_verify: 'Must enable verify for email/phone sign up identifier.', // UNTRANSLATED
   },
   localization: {
     cannot_delete_default_language:

--- a/packages/phrases/src/locales/pt-pt/errors.ts
+++ b/packages/phrases/src/locales/pt-pt/errors.ts
@@ -108,6 +108,8 @@ const errors = {
     enabled_connector_not_found: 'Conector {{type}} ativado não encontrado.',
     not_one_and_only_one_primary_sign_in_method:
       'Deve haver um e apenas um método de login principal. Por favor, verifique sua entrada.',
+    username_requires_password: 'Must enable set a password for username sign up identifier.', // UNTRANSLATED
+    passwordless_requires_verify: 'Must enable verify for email/phone sign up identifier.', // UNTRANSLATED
   },
   localization: {
     cannot_delete_default_language:

--- a/packages/phrases/src/locales/tr-tr/errors.ts
+++ b/packages/phrases/src/locales/tr-tr/errors.ts
@@ -106,6 +106,8 @@ const errors = {
     enabled_connector_not_found: 'Etkin {{type}} bağlayıcı bulunamadı.',
     not_one_and_only_one_primary_sign_in_method:
       'Yalnızca bir tane birincil oturum açma yöntemi olmalıdır. Lütfen inputu kontrol ediniz.',
+    username_requires_password: 'Must enable set a password for username sign up identifier.', // UNTRANSLATED
+    passwordless_requires_verify: 'Must enable verify for email/phone sign up identifier.', // UNTRANSLATED
   },
   localization: {
     cannot_delete_default_language:

--- a/packages/phrases/src/locales/zh-cn/errors.ts
+++ b/packages/phrases/src/locales/zh-cn/errors.ts
@@ -98,6 +98,8 @@ const errors = {
     empty_social_connectors: '你启用了社交登录的方式。请至少选择一个社交连接器。',
     enabled_connector_not_found: '未找到已启用的 {{type}} 连接器',
     not_one_and_only_one_primary_sign_in_method: '主要的登录方式必须有且仅有一个，请检查你的输入。',
+    username_requires_password: 'Must enable set a password for username sign up identifier.', // UNTRANSLATED
+    passwordless_requires_verify: 'Must enable verify for email/phone sign up identifier.', // UNTRANSLATED
   },
   localization: {
     cannot_delete_default_language: '不能删除「登录体验」正在使用的默认语言 {{languageKey}}。', // UNTRANSLATED


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Split `lib/sign-in-experience.ts` into files, preparing for the complex new rules.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

UTs
