### PR TITLE
refactor(core): use fallback language as default in demo app

### DIFF
--- a/packages/core/src/routes/well-known.ts
+++ b/packages/core/src/routes/well-known.ts
@@ -67,7 +67,7 @@ export default function wellKnownRoutes<T extends AnonymousRouter>(router: T, pr
       // Insert Demo App Notification
       if (interaction?.params.client_id === demoAppApplicationId) {
         const {
-          languageInfo: { autoDetect, fixedLanguage },
+          languageInfo: { autoDetect, fallbackLanguage },
         } = signInExperience;
 
         ctx.body = {
@@ -75,7 +75,7 @@ export default function wellKnownRoutes<T extends AnonymousRouter>(router: T, pr
           socialConnectors,
           notification: i18next.t(
             'demo_app.notification',
-            autoDetect ? undefined : { lng: fixedLanguage }
+            autoDetect ? undefined : { lng: fallbackLanguage }
           ),
         };
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
The `fixedLanguage` is deprecated, we now use the `fallbackLangauge` as the default language.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested in the demo app.
