### PR TITLE
refactor(console): fix language editor styles

### DIFF
--- a/packages/console/src/pages/SignInExperience/components/ManageLanguageModal/AddLanguageSelector.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/ManageLanguageModal/AddLanguageSelector.module.scss
@@ -27,6 +27,8 @@
     border-radius: 8px;
     max-height: 288px;
     overflow-y: auto;
+    box-shadow: var(--shadow-2);
+
 
     .dropDownItem {
       width: 100%;
@@ -34,18 +36,17 @@
       padding: _.unit(2);
       list-style: none;
       cursor: pointer;
+      font: var(--font-body-medium);
 
       &:hover {
         background: var(--color-hover);
       }
 
       .languageName {
-        font: var(--font-label-large);
         color: var(--color-text);
       }
 
       .languageTag {
-        font: var(--font-body-medium);
         color: var(--color-caption);
       }
     }

--- a/packages/console/src/pages/SignInExperience/components/ManageLanguageModal/AddLanguageSelector.tsx
+++ b/packages/console/src/pages/SignInExperience/components/ManageLanguageModal/AddLanguageSelector.tsx
@@ -61,7 +61,7 @@ const AddLanguageSelector = ({ options, onSelect }: Props) => {
           className={classNames(style.addLanguageButton, isDropDownOpen && style.hidden)}
           icon={<Plus className={style.buttonIcon} />}
           title="sign_in_exp.others.manage_language.add_language"
-          type="outline"
+          type="default"
           size="medium"
           onClick={() => {
             setIsDropDownOpen(true);

--- a/packages/console/src/pages/SignInExperience/components/ManageLanguageModal/EditSection.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/ManageLanguageModal/EditSection.module.scss
@@ -1,8 +1,10 @@
 @use '@/scss/underscore' as _;
 
 .sectionTitle {
-  @include _.subhead-cap;
+  @include _.subhead-cap-small;
+  color: var(--color-neutral-variant-60);
   background-color: var(--color-layer-light);
+  padding: _.unit(1) 0;
 }
 
 .sectionDataKey {

--- a/packages/console/src/pages/SignInExperience/components/ManageLanguageModal/LanguageEditor.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/ManageLanguageModal/LanguageEditor.module.scss
@@ -32,7 +32,7 @@
   }
 
   .content {
-    border-top: 1px solid var(--color-border);
+    border-top: 1px solid var(--color-divider);
     height: 481px;
     overflow-y: auto;
 
@@ -91,7 +91,7 @@
   }
 
   .footer {
-    border-top: 1px solid var(--color-border);
+    border-top: 1px solid var(--color-divider);
     display: flex;
     flex-direction: row-reverse;
     padding: _.unit(5);

--- a/packages/console/src/pages/SignInExperience/components/ManageLanguageModal/LanguageItem.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/ManageLanguageModal/LanguageItem.module.scss
@@ -5,14 +5,13 @@
   margin-bottom: _.unit(1);
   cursor: pointer;
   border-radius: 8px;
+  font: var(--font-label-large);
 
   .languageName {
-    font: var(--font-title-medium);
     color: var(--color-text);
   }
 
   .languageTag {
-    font: var(--font-label-large);
     color: var(--color-caption);
   }
 

--- a/packages/console/src/pages/SignInExperience/components/ManageLanguageModal/LanguageNav.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/ManageLanguageModal/LanguageNav.module.scss
@@ -5,7 +5,7 @@
   padding: _.unit(3) _.unit(2);
   flex-shrink: 0;
   background-color: var(--color-layer-light);
-  border-right: 1px solid var(--color-border);
+  border-right: 1px solid var(--color-divider);
 
   .languageItemList {
     margin-top: _.unit(3);

--- a/packages/console/src/pages/SignInExperience/components/ManageLanguageModal/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/ManageLanguageModal/index.module.scss
@@ -1,7 +1,7 @@
 .container {
   display: flex;
   flex-direction: row;
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--color-divider);
   border-radius: 8px;
   overflow: hidden;
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- Change the front of the language name in the drop-down item from `--font-label-large` to `--font-body-medium`
- Change the border color from `--color-border` to `--border-divider`
- Change the `AddLanguageSelector` button type to `default`
- Add shadow to the language selector drop-down menu
- Change the section header color to `--color-neutral-variant-60` and add paddings in the vertical direction.
- Change the front of the language name in the language nav area from `--font-title-medium` to `--font-label-large`

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="1228" alt="image" src="https://user-images.githubusercontent.com/10806653/195005491-574c8814-ea3c-4777-89b5-d55e570d8aa5.png">
<img width="1226" alt="image" src="https://user-images.githubusercontent.com/10806653/195005517-26a70dc9-4648-4821-a648-ee844fa7bbd7.png">
<img width="282" alt="image" src="https://user-images.githubusercontent.com/10806653/195005571-89a65b57-2e7b-4eca-8c82-906778b20e9c.png">

