### PR TITLE
refactor(console): change language editor table header height to 36px

### DIFF
--- a/packages/console/src/pages/SignInExperience/components/ManageLanguage/LanguageEditor/LanguageDetails.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/ManageLanguage/LanguageEditor/LanguageDetails.module.scss
@@ -41,6 +41,8 @@
 
       > thead > tr {
         > th {
+          height: 36px;
+          padding: 0 _.unit(2);
           font: var(--font-label-large);
           color: var(--color-text);
           background-color: var(--color-layer-1);
@@ -48,7 +50,11 @@
 
         > th:first-child {
           width: 300px;
-          padding: _.unit(1) _.unit(5);
+          padding: 0 _.unit(5);
+        }
+
+        > th:last-child {
+          padding: 0 _.unit(8);
         }
       }
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Change the language editor table header height to 36px.

The style of the `th` tag has been set by the normalized CSS with `padding-top` and `padding-bottom` equals to`8px`,
So overwrite them to `0px` by add a padding style.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="1017" alt="image" src="https://user-images.githubusercontent.com/10806653/195017718-bfea4855-d059-4607-bc1e-187050ac7a1f.png">

