### PR TITLE
fix(console): save generated password in session storage

### DIFF
--- a/packages/console/src/consts/index.ts
+++ b/packages/console/src/consts/index.ts
@@ -5,3 +5,4 @@ export * from './logs';
 
 export const themeStorageKey = 'logto:admin_console:theme';
 export const requestTimeout = 20_000;
+export const generatedPasswordStorageKey = 'logto:admin_console:generated_password';

--- a/packages/console/src/pages/UserDetails/index.tsx
+++ b/packages/console/src/pages/UserDetails/index.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import ReactModal from 'react-modal';
-import { useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import useSWR from 'swr';
 
 import ActionMenu, { ActionMenuItem } from '@/components/ActionMenu';
@@ -14,6 +14,7 @@ import DeleteConfirmModal from '@/components/DeleteConfirmModal';
 import DetailsSkeleton from '@/components/DetailsSkeleton';
 import LinkButton from '@/components/LinkButton';
 import TabNav, { TabNavItem } from '@/components/TabNav';
+import { generatedPasswordStorageKey } from '@/consts';
 import { generateAvatarPlaceHolderById } from '@/consts/avatars';
 import useApi, { RequestError } from '@/hooks/use-api';
 import Back from '@/icons/Back';
@@ -33,15 +34,13 @@ const UserDetails = () => {
   const location = useLocation();
   const isLogs = location.pathname.endsWith('/logs');
   const { userId } = useParams();
-  const [searchParameters, setSearchParameters] = useSearchParams();
-  const passwordEncoded = searchParameters.get('password');
-  const password = passwordEncoded && atob(passwordEncoded);
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const [isDeleteFormOpen, setIsDeleteFormOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isDeleted, setIsDeleted] = useState(false);
   const [isResetPasswordFormOpen, setIsResetPasswordFormOpen] = useState(false);
   const [resetResult, setResetResult] = useState<string>();
+  const [password, setPassword] = useState(sessionStorage.getItem(generatedPasswordStorageKey));
 
   const { data, error, mutate } = useSWR<User, RequestError>(userId && `/api/users/${userId}`);
   const isLoading = !data && !error;
@@ -192,7 +191,8 @@ const UserDetails = () => {
           username={data.username ?? '-'}
           password={password}
           onClose={() => {
-            setSearchParameters({});
+            setPassword(null);
+            sessionStorage.removeItem(generatedPasswordStorageKey);
           }}
         />
       )}

--- a/packages/console/src/pages/Users/components/CreateForm/index.tsx
+++ b/packages/console/src/pages/Users/components/CreateForm/index.tsx
@@ -37,7 +37,7 @@ const CreateForm = ({ onClose }: Props) => {
     const password = nanoid(8);
 
     const createdUser = await api.post('/api/users', { json: { ...data, password } }).json<User>();
-    onClose?.(createdUser, btoa(password));
+    onClose?.(createdUser, password);
   });
 
   return (

--- a/packages/console/src/pages/Users/index.tsx
+++ b/packages/console/src/pages/Users/index.tsx
@@ -18,6 +18,7 @@ import Search from '@/components/Search';
 import TableEmpty from '@/components/Table/TableEmpty';
 import TableError from '@/components/Table/TableError';
 import TableLoading from '@/components/Table/TableLoading';
+import { generatedPasswordStorageKey } from '@/consts';
 import { generateAvatarPlaceHolderById } from '@/consts/avatars';
 import { RequestError } from '@/hooks/use-api';
 import Plus from '@/icons/Plus';
@@ -67,7 +68,8 @@ const Users = () => {
               setIsCreateFormOpen(false);
 
               if (createdUser && password) {
-                navigate(`/users/${createdUser.id}?password=${password}`);
+                sessionStorage.setItem(generatedPasswordStorageKey, password);
+                navigate(`/users/${createdUser.id}`);
               }
             }}
           />


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Previously, in order to pass generated password from "Users Page" to "User Detail Page", the password is attached to url's query, this may become a security issue. Now save it in sessionStorage.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested:

<img width="394" alt="截屏2022-10-11 下午3 22 38" src="https://user-images.githubusercontent.com/5717882/195022757-8ea8d4df-2754-48b9-b9b8-20e8b094e1c3.png">

<img width="662" alt="截屏2022-10-11 下午3 22 41" src="https://user-images.githubusercontent.com/5717882/195022782-be8c2c16-2985-442d-b656-83a4267e255d.png">

