### PR TITLE
refactor(cli): add official connectors during init

### DIFF
--- a/packages/cli/src/commands/connector/add.ts
+++ b/packages/cli/src/commands/connector/add.ts
@@ -1,5 +1,6 @@
 import { CommandModule } from 'yargs';
 
+import { log } from '../../utilities';
 import { addConnectors, addOfficialConnectors, inquireInstancePath } from './utils';
 
 const add: CommandModule<unknown, { packages: string[]; path?: string; official: boolean }> = {
@@ -26,10 +27,12 @@ const add: CommandModule<unknown, { packages: string[]; path?: string; official:
     const instancePath = await inquireInstancePath(path);
 
     if (official) {
-      return addOfficialConnectors(instancePath);
+      await addOfficialConnectors(instancePath);
     }
 
-    return addConnectors(instancePath, packageNames);
+    await addConnectors(instancePath, packageNames);
+
+    log.info('Restart your Logto instance to get the changes reflected.');
   },
 };
 

--- a/packages/cli/src/commands/connector/add.ts
+++ b/packages/cli/src/commands/connector/add.ts
@@ -1,13 +1,6 @@
-import chalk from 'chalk';
 import { CommandModule } from 'yargs';
 
-import { oraPromise } from '../../utilities';
-import {
-  addConnectors,
-  fetchOfficialConnectorList,
-  inquireInstancePath,
-  normalizePackageName,
-} from './utils';
+import { addConnectors, addOfficialConnectors, inquireInstancePath } from './utils';
 
 const add: CommandModule<unknown, { packages: string[]; path?: string; official: boolean }> = {
   command: ['add [packages...]', 'a', 'install', 'i'],
@@ -32,14 +25,11 @@ const add: CommandModule<unknown, { packages: string[]; path?: string; official:
   handler: async ({ packages: packageNames, path, official }) => {
     const instancePath = await inquireInstancePath(path);
 
-    const packages = official
-      ? await oraPromise(fetchOfficialConnectorList(), {
-          text: 'Fetch official connector list',
-          prefixText: chalk.blue('[info]'),
-        })
-      : packageNames.map((name) => normalizePackageName(name));
+    if (official) {
+      return addOfficialConnectors(instancePath);
+    }
 
-    await addConnectors(instancePath, packages);
+    return addConnectors(instancePath, packageNames);
   },
 };
 

--- a/packages/cli/src/commands/install/index.ts
+++ b/packages/cli/src/commands/install/index.ts
@@ -81,7 +81,7 @@ const install: CommandModule<unknown, InstallArgs> = {
       },
       officialConnectors: {
         alias: 'oc',
-        describe: 'Install official connectors after downloading Logto',
+        describe: 'Add official connectors after downloading Logto',
         type: 'boolean',
       },
     }),

--- a/packages/cli/src/commands/install/index.ts
+++ b/packages/cli/src/commands/install/index.ts
@@ -37,7 +37,11 @@ const installLogto = async ({ path, skipSeed, officialConnectors }: InstallArgs)
 
   // Seed database
   if (skipSeed) {
-    log.info(`You can use ${chalk.green('db seed')} command to seed database when ready.`);
+    log.info(
+      `Skipped database seeding.\n\n' + '  You can use the ${chalk.green(
+        'db seed'
+      )} command to seed database when ready.\n`
+    );
   } else {
     await seedDatabase(instancePath);
   }
@@ -48,6 +52,11 @@ const installLogto = async ({ path, skipSeed, officialConnectors }: InstallArgs)
   // Add official connectors
   if (await inquireOfficialConnectors(officialConnectors)) {
     await addOfficialConnectors(instancePath);
+  } else {
+    log.info(
+      'Skipped adding official connectors.\n\n' +
+        `  You can use the ${chalk.green('connector add')} command to add connectors at any time.\n`
+    );
   }
 
   // Finale

--- a/packages/cli/src/commands/install/utils.ts
+++ b/packages/cli/src/commands/install/utils.ts
@@ -157,7 +157,7 @@ export const inquireOfficialConnectors = async (initialAnswer?: boolean) => {
   const { value } = await inquirer.prompt<{ value: boolean }>(
     {
       name: 'value',
-      message: 'Do you want to install official connectors?',
+      message: 'Do you want to add official connectors?',
       type: 'confirm',
       default: true,
     },

--- a/packages/cli/src/commands/install/utils.ts
+++ b/packages/cli/src/commands/install/utils.ts
@@ -152,3 +152,17 @@ export const logFinale = (instancePath: string) => {
     `Use the command below to start Logto. Happy hacking!\n\n  ${chalk.green(startCommand)}`
   );
 };
+
+export const inquireOfficialConnectors = async (initialAnswer?: boolean) => {
+  const { value } = await inquirer.prompt<{ value: boolean }>(
+    {
+      name: 'value',
+      message: 'Do you want to install official connectors?',
+      type: 'confirm',
+      default: true,
+    },
+    { value: initialAnswer }
+  );
+
+  return value;
+};


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- add `--oc` option for adding connectors during init
- ask user to init if no option found

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

### With no option provided
<img width="472" alt="image" src="https://user-images.githubusercontent.com/14722250/195275283-e9c18182-bf9e-4bd3-9415-bd254e5991aa.png">

### With all options provided
<img width="571" alt="image" src="https://user-images.githubusercontent.com/14722250/195275397-4cc83338-e387-4a51-8603-4ae7c5cb5a72.png">

- [x] start Logto, connectors can be found in console
