### PR TITLE
chore: bump toolkit version and update color tokens

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@fontsource/roboto-mono": "^4.5.7",
-    "@logto/core-kit": "1.0.0-beta.16",
+    "@logto/core-kit": "1.0.0-beta.18",
     "@logto/language-kit": "1.0.0-beta.16",
     "@logto/phrases": "workspace:1.0.0-beta.10",
     "@logto/phrases-ui": "workspace:1.0.0-beta.10",

--- a/packages/console/src/components/Alert/index.module.scss
+++ b/packages/console/src/components/Alert/index.module.scss
@@ -16,7 +16,7 @@
   .icon {
     width: 20px;
     height: 20px;
-    color: var(--color-icon);
+    color: var(--color-text-secondary);
   }
 
   .content {

--- a/packages/console/src/components/AppContent/components/Sidebar/components/Contact/index.module.scss
+++ b/packages/console/src/components/AppContent/components/Sidebar/components/Contact/index.module.scss
@@ -26,7 +26,7 @@
 
       .description {
         font: var(--font-body-medium);
-        color: var(--color-caption);
+        color: var(--color-text-secondary);
       }
     }
 

--- a/packages/console/src/components/AppContent/components/UserInfo/index.module.scss
+++ b/packages/console/src/components/AppContent/components/UserInfo/index.module.scss
@@ -36,7 +36,7 @@
 
     .role {
       font: var(--font-body-small);
-      color: var(--color-caption);
+      color: var(--color-text-secondary);
     }
   }
 }
@@ -58,7 +58,7 @@
   }
 
   .signOutIcon {
-    color: var(--color-icon);
+    color: var(--color-text-secondary);
   }
 
   .spinner {

--- a/packages/console/src/components/AuditLogTable/index.module.scss
+++ b/packages/console/src/components/AuditLogTable/index.module.scss
@@ -6,7 +6,7 @@
   align-items: center;
 
   .title {
-    color: var(--color-caption);
+    color: var(--color-text-secondary);
     font: var(--font-body-medium);
   }
 

--- a/packages/console/src/components/CardTitle/index.module.scss
+++ b/packages/console/src/components/CardTitle/index.module.scss
@@ -10,7 +10,7 @@
 
   .subtitle {
     margin-top: _.unit(1);
-    color: var(--color-caption);
+    color: var(--color-text-secondary);
   }
 
   &.large {

--- a/packages/console/src/components/FormField/index.module.scss
+++ b/packages/console/src/components/FormField/index.module.scss
@@ -20,11 +20,11 @@
     margin-left: _.unit(1);
     width: 16px;
     height: 16px;
-    color: var(--color-caption);
+    color: var(--color-text-secondary);
   }
 
   .required {
     font: var(--font-body-medium);
-    color: var(--color-caption);
+    color: var(--color-text-secondary);
   }
 }

--- a/packages/console/src/components/IconButton/index.module.scss
+++ b/packages/console/src/components/IconButton/index.module.scss
@@ -15,7 +15,7 @@
   align-items: center;
 
   > svg {
-    color: var(--color-caption);
+    color: var(--color-text-secondary);
   }
 
   &:disabled {

--- a/packages/console/src/components/ItemPreview/index.module.scss
+++ b/packages/console/src/components/ItemPreview/index.module.scss
@@ -21,7 +21,7 @@
 
     .subtitle {
       font: var(--font-body-small);
-      color: var(--color-outline);
+      color: var(--color-text-secondary);
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;

--- a/packages/console/src/components/Markdown/index.module.scss
+++ b/packages/console/src/components/Markdown/index.module.scss
@@ -47,7 +47,7 @@
 
   h2 {
     font: var(--font-title-medium);
-    color: var(--color-caption);
+    color: var(--color-text-secondary);
     margin: _.unit(6) 0 _.unit(3);
   }
 

--- a/packages/console/src/components/ModalLayout/index.module.scss
+++ b/packages/console/src/components/ModalLayout/index.module.scss
@@ -19,7 +19,7 @@
     margin-bottom: _.unit(6);
 
     .closeIcon {
-      color: var(--color-icon);
+      color: var(--color-text-secondary);
     }
   }
 

--- a/packages/console/src/components/MultiTextInput/index.module.scss
+++ b/packages/console/src/components/MultiTextInput/index.module.scss
@@ -17,7 +17,7 @@
   }
 
   .minusIcon {
-    color: var(--color-icon);
+    color: var(--color-text-secondary);
   }
 
   .addAnother {

--- a/packages/console/src/components/Search/index.module.scss
+++ b/packages/console/src/components/Search/index.module.scss
@@ -13,6 +13,6 @@
   }
 
   .searchIcon {
-    color: var(--color-icon);
+    color: var(--color-text-secondary);
   }
 }

--- a/packages/console/src/components/Select/index.module.scss
+++ b/packages/console/src/components/Select/index.module.scss
@@ -42,7 +42,7 @@
   .icon {
     display: flex;
     margin-left: _.unit(3);
-    color: var(--color-icon);
+    color: var(--color-text-secondary);
   }
 
   .clear {

--- a/packages/console/src/components/TabNav/TabNavItem.module.scss
+++ b/packages/console/src/components/TabNav/TabNavItem.module.scss
@@ -9,7 +9,7 @@
 
   a {
     display: inline-block;
-    color: var(--color-caption);
+    color: var(--color-text-secondary);
     text-decoration: none;
     cursor: pointer;
     padding-bottom: _.unit(1);

--- a/packages/console/src/components/TextInput/index.module.scss
+++ b/packages/console/src/components/TextInput/index.module.scss
@@ -36,7 +36,7 @@
     padding: 0;
 
     &::placeholder {
-      color: var(--color-caption);
+      color: var(--color-placeholder);
     }
 
     // Overwrite webkit auto-fill style
@@ -51,7 +51,7 @@
 
       &::-webkit-calendar-picker-indicator {
         background-image: none;
-        background-color: var(--color-icon);
+        background-color: var(--color-text-secondary);
         mask-image: url('../../assets/images/calendar.png');
         mask-size: 20px 20px;
         width: 16px;
@@ -62,7 +62,7 @@
 
   &.disabled {
     background: var(--color-inverse-on-surface);
-    color: var(--color-caption);
+    color: var(--color-text-secondary);
     border-color: var(--color-border);
   }
 

--- a/packages/console/src/components/Transfer/index.module.scss
+++ b/packages/console/src/components/Transfer/index.module.scss
@@ -33,7 +33,7 @@
             cursor: move;
 
             .draggableIcon {
-              color: var(--color-icon);
+              color: var(--color-text-secondary);
             }
           }
 
@@ -64,7 +64,7 @@
 
   .footer {
     font: var(--font-body-medium);
-    color: var(--color-caption);
+    color: var(--color-text-secondary);
     margin-top: _.unit(2);
 
     a {

--- a/packages/console/src/components/UserName/index.module.scss
+++ b/packages/console/src/components/UserName/index.module.scss
@@ -6,7 +6,7 @@
 
   .userId {
     font: var(--body-small);
-    color: var(--color-caption);
+    color: var(--color-text-secondary);
     margin-left: _.unit(1);
   }
 

--- a/packages/console/src/mdx-components/DetailsSummary/index.module.scss
+++ b/packages/console/src/mdx-components/DetailsSummary/index.module.scss
@@ -11,7 +11,7 @@
     display: flex;
     align-items: center;
     padding: _.unit(4);
-    color: var(--color-caption);
+    color: var(--color-text-secondary);
     font: var(--font-subhead-2);
     user-select: none;
     cursor: pointer;

--- a/packages/console/src/mdx-components/Step/index.module.scss
+++ b/packages/console/src/mdx-components/Step/index.module.scss
@@ -13,7 +13,7 @@
     cursor: pointer;
 
     > svg {
-      color: var(--color-icon);
+      color: var(--color-text-secondary);
     }
 
     .index {
@@ -83,7 +83,7 @@
 
   h3 {
     font: var(--font-title-medium);
-    color: var(--color-caption);
+    color: var(--color-text-secondary);
     margin: _.unit(6) 0 _.unit(3);
   }
 

--- a/packages/console/src/mdx-components/Tabs/index.module.scss
+++ b/packages/console/src/mdx-components/Tabs/index.module.scss
@@ -15,7 +15,7 @@
       margin-right: _.unit(6);
       padding-bottom: _.unit(1);
       font: var(--font-subhead-2);
-      color: var(--color-caption);
+      color: var(--color-text-secondary);
       margin-block-end: unset;
       padding-inline-start: unset;
       cursor: pointer;

--- a/packages/console/src/pages/ApiResourceDetails/index.module.scss
+++ b/packages/console/src/pages/ApiResourceDetails/index.module.scss
@@ -51,7 +51,7 @@
     align-items: center;
 
     .moreIcon {
-      color: var(--color-icon);
+      color: var(--color-text-secondary);
     }
 
     > *:not(:first-child) {

--- a/packages/console/src/pages/ApplicationDetails/index.module.scss
+++ b/packages/console/src/pages/ApplicationDetails/index.module.scss
@@ -59,7 +59,7 @@
     align-items: center;
 
     .moreIcon {
-      color: var(--color-icon);
+      color: var(--color-text-secondary);
     }
 
     > :not(:first-child) {
@@ -96,7 +96,7 @@
 
       .text {
         font: var(--font-subhead-2);
-        color: var(--color-caption);
+        color: var(--color-text-secondary);
       }
 
       .verticalBar {

--- a/packages/console/src/pages/Applications/components/GuideHeader/index.module.scss
+++ b/packages/console/src/pages/Applications/components/GuideHeader/index.module.scss
@@ -14,7 +14,7 @@
   }
 
   .closeIcon {
-    color: var(--color-icon);
+    color: var(--color-text-secondary);
   }
 
   .githubIcon {

--- a/packages/console/src/pages/Applications/components/TypeDescription/index.module.scss
+++ b/packages/console/src/pages/Applications/components/TypeDescription/index.module.scss
@@ -19,5 +19,5 @@
 
 .description {
   font: var(--font-body-medium);
-  color: var(--color-caption);
+  color: var(--color-text-secondary);
 }

--- a/packages/console/src/pages/AuditLogDetails/components/EventIcon/index.module.scss
+++ b/packages/console/src/pages/AuditLogDetails/components/EventIcon/index.module.scss
@@ -12,7 +12,7 @@
 }
 
 .label {
-  color: var(--color-icon);
+  color: var(--color-text-secondary);
   font: var(--font-body-medium);
   text-align: center;
 }

--- a/packages/console/src/pages/AuditLogDetails/index.module.scss
+++ b/packages/console/src/pages/AuditLogDetails/index.module.scss
@@ -37,7 +37,7 @@
       font: var(--font-body-medium);
 
       .label {
-        color: var(--color-caption);
+        color: var(--color-text-secondary);
         font: var(--font-subhead-2);
         margin-bottom: _.unit(2);
       }

--- a/packages/console/src/pages/ConnectorDetails/components/SenderTester/index.module.scss
+++ b/packages/console/src/pages/ConnectorDetails/components/SenderTester/index.module.scss
@@ -22,7 +22,7 @@
 
 .description {
   font: var(--font-body-medium);
-  color: var(--color-caption);
+  color: var(--color-text-secondary);
 }
 
 .successfulTooltip {

--- a/packages/console/src/pages/ConnectorDetails/index.module.scss
+++ b/packages/console/src/pages/ConnectorDetails/index.module.scss
@@ -35,7 +35,7 @@
     align-items: center;
 
     .moreIcon {
-      color: var(--color-icon);
+      color: var(--color-text-secondary);
     }
 
     > *:not(:first-child) {
@@ -66,7 +66,7 @@
 
     .text {
       font: var(--font-subhead-2);
-      color: var(--color-caption);
+      color: var(--color-text-secondary);
     }
 
     .verticalBar {
@@ -91,7 +91,7 @@
 }
 
 .resetIcon {
-  color: var(--color-icon);
+  color: var(--color-text-secondary);
 }
 
 .readme {

--- a/packages/console/src/pages/Connectors/components/CreateForm/index.module.scss
+++ b/packages/console/src/pages/Connectors/components/CreateForm/index.module.scss
@@ -38,12 +38,12 @@
         .connectorId {
           margin-top: _.unit(1);
           font: var(--font-body-small);
-          color: var(--color-caption);
+          color: var(--color-text-secondary);
         }
 
         .description {
           font: var(--font-body-small);
-          color: var(--color-caption);
+          color: var(--color-text-secondary);
           margin-top: _.unit(1);
           @include _.multi-line-ellipsis(3);
         }

--- a/packages/console/src/pages/Connectors/components/Guide/index.module.scss
+++ b/packages/console/src/pages/Connectors/components/Guide/index.module.scss
@@ -24,7 +24,7 @@
     }
 
     .closeIcon {
-      color: var(--color-icon);
+      color: var(--color-text-secondary);
     }
   }
 

--- a/packages/console/src/pages/Dashboard/components/Block.module.scss
+++ b/packages/console/src/pages/Dashboard/components/Block.module.scss
@@ -38,7 +38,7 @@
       margin-left: _.unit(1);
       width: 16px;
       height: 16px;
-      color: var(--color-caption);
+      color: var(--color-text-secondary);
 
       > svg {
         display: block;

--- a/packages/console/src/pages/Dashboard/components/ChartTooltip/index.module.scss
+++ b/packages/console/src/pages/Dashboard/components/ChartTooltip/index.module.scss
@@ -15,6 +15,6 @@
 
   .label {
     font: var(--font-body-small);
-    color: var(--color-icon);
+    color: var(--color-text-secondary);
   }
 }

--- a/packages/console/src/pages/Dashboard/index.module.scss
+++ b/packages/console/src/pages/Dashboard/index.module.scss
@@ -18,7 +18,7 @@
     margin-top: _.unit(1);
     padding-right: _.unit(6);
     font: var(--font-body-medium);
-    color: var(--color-caption);
+    color: var(--color-text-secondary);
   }
 }
 

--- a/packages/console/src/pages/Dashboard/index.tsx
+++ b/packages/console/src/pages/Dashboard/index.tsx
@@ -24,7 +24,7 @@ import * as styles from './index.module.scss';
 import { ActiveUsersResponse, NewUsersResponse, TotalUsersResponse } from './types';
 
 const tickStyle = {
-  fill: 'var(--color-caption)',
+  fill: 'var(--color-text-secondary)',
   fontSize: 11,
   fontFamily: 'var(--font-family)',
 };

--- a/packages/console/src/pages/GetStarted/index.module.scss
+++ b/packages/console/src/pages/GetStarted/index.module.scss
@@ -20,7 +20,7 @@
     margin-top: _.unit(1);
     padding-right: _.unit(6);
     font: var(--font-body-medium);
-    color: var(--color-caption);
+    color: var(--color-text-secondary);
 
     .hideButton {
       color: var(--color-text-link);
@@ -56,7 +56,7 @@
 
     .subtitle {
       font: var(--font-body-medium);
-      color: var(--color-caption);
+      color: var(--color-text-secondary);
     }
   }
 

--- a/packages/console/src/pages/SignInExperience/components/ConnectorsTransfer.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/ConnectorsTransfer.module.scss
@@ -20,6 +20,6 @@
     height: 16px;
     object-fit: cover;
     margin-left: _.unit(1);
-    color: var(--color-icon);
+    color: var(--color-text-secondary);
   }
 }

--- a/packages/console/src/pages/SignInExperience/components/GuideModal.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/GuideModal.module.scss
@@ -25,7 +25,7 @@
     }
 
     .closeIcon {
-      color: var(--color-icon);
+      color: var(--color-text-secondary);
     }
   }
 

--- a/packages/console/src/pages/SignInExperience/components/ManageLanguage/LanguageEditor/AddLanguageSelector.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/ManageLanguage/LanguageEditor/AddLanguageSelector.module.scss
@@ -10,7 +10,7 @@
     }
 
     .buttonIcon {
-      color: var(--color-outline);
+      color: var(--color-text-secondary);
     }
   }
 
@@ -44,7 +44,7 @@
       }
 
       .languageTag {
-        color: var(--color-caption);
+        color: var(--color-text-secondary);
       }
     }
   }

--- a/packages/console/src/pages/SignInExperience/components/ManageLanguage/LanguageEditor/LanguageDetails.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/ManageLanguage/LanguageEditor/LanguageDetails.module.scss
@@ -17,7 +17,7 @@
       > span {
         margin-left: _.unit(2);
         font: var(--font-body-medium);
-        color: var(--color-caption);
+        color: var(--color-text-secondary);
       }
 
       .builtInFlag {

--- a/packages/console/src/pages/SignInExperience/components/ManageLanguage/LanguageEditor/LanguageItem.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/ManageLanguage/LanguageEditor/LanguageItem.module.scss
@@ -12,7 +12,7 @@
   }
 
   .languageTag {
-    color: var(--color-caption);
+    color: var(--color-text-secondary);
     font: var(--font-body-medium);
   }
 

--- a/packages/console/src/pages/SignInExperience/components/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/index.module.scss
@@ -11,7 +11,7 @@
 }
 
 .primaryTag {
-  color: var(--color-caption);
+  color: var(--color-text-secondary);
 }
 
 .method {
@@ -26,11 +26,11 @@
   display: flex;
   align-items: baseline;
   font: var(--font-body-medium);
-  color: var(--color-caption);
+  color: var(--color-text-secondary);
 }
 
 .defaultLanguageDescription {
   padding-top: _.unit(2);
   font: var(--font-body-medium);
-  color: var(--color-caption);
+  color: var(--color-text-secondary);
 }

--- a/packages/console/src/pages/UserDetails/components/CreateSuccess.module.scss
+++ b/packages/console/src/pages/UserDetails/components/CreateSuccess.module.scss
@@ -27,7 +27,7 @@
       }
 
       .eyeIcon {
-        color: var(--color-icon);
+        color: var(--color-text-secondary);
       }
     }
   }

--- a/packages/console/src/pages/UserDetails/components/UserConnectors.module.scss
+++ b/packages/console/src/pages/UserDetails/components/UserConnectors.module.scss
@@ -1,7 +1,7 @@
 @use '@/scss/underscore' as _;
 
 .empty {
-  color: var(--color-caption);
+  color: var(--color-text-secondary);
   font: var(--font-body-medium);
 }
 

--- a/packages/console/src/pages/UserDetails/index.module.scss
+++ b/packages/console/src/pages/UserDetails/index.module.scss
@@ -40,13 +40,13 @@
     }
 
     .username {
-      color: var(--color-caption);
+      color: var(--color-text-secondary);
       font: var(--font-subhead-2);
     }
 
     .text {
       font: var(--font-subhead-2);
-      color: var(--color-caption);
+      color: var(--color-text-secondary);
     }
 
     .verticalBar {
@@ -56,7 +56,7 @@
   }
 
   .moreIcon {
-    color: var(--color-icon);
+    color: var(--color-text-secondary);
   }
 }
 
@@ -87,5 +87,5 @@
 }
 
 .resetIcon {
-  color: var(--color-icon);
+  color: var(--color-text-secondary);
 }

--- a/packages/console/src/pages/Welcome/index.module.scss
+++ b/packages/console/src/pages/Welcome/index.module.scss
@@ -64,7 +64,7 @@ main {
 
 .description {
   font: var(--font-body-large);
-  color: var(--color-caption);
+  color: var(--color-text-secondary);
   margin-bottom: _.unit(8);
 }
 

--- a/packages/console/src/scss/_underscore.scss
+++ b/packages/console/src/scss/_underscore.scss
@@ -33,7 +33,7 @@
 }
 
 @mixin subhead-cap {
-  color: var(--color-caption);
+  color: var(--color-text-secondary);
   font: var(--font-subhead-cap);
   letter-spacing: 0.1em;
   text-transform: uppercase;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,8 +24,8 @@
   },
   "dependencies": {
     "@logto/cli": "workspace:1.0.0-beta.10",
-    "@logto/connector-kit": "^1.0.0-beta.13",
-    "@logto/core-kit": "^1.0.0-beta.16",
+    "@logto/connector-kit": "^1.0.0-beta.18",
+    "@logto/core-kit": "^1.0.0-beta.18",
     "@logto/language-kit": "^1.0.0-beta.16",
     "@logto/phrases": "workspace:1.0.0-beta.10",
     "@logto/phrases-ui": "workspace:1.0.0-beta.10",

--- a/packages/core/src/routes/session/social.ts
+++ b/packages/core/src/routes/session/social.ts
@@ -1,4 +1,4 @@
-import { redirectUriRegEx } from '@logto/core-kit';
+import { validateRedirectUrl } from '@logto/core-kit';
 import { ConnectorType, userInfoSelectFields } from '@logto/schemas';
 import pick from 'lodash.pick';
 import { Provider } from 'oidc-provider';
@@ -36,7 +36,7 @@ export default function socialRoutes<T extends AnonymousRouter>(router: T, provi
       body: object({
         connectorId: string(),
         state: string(),
-        redirectUri: string().regex(redirectUriRegEx),
+        redirectUri: string().refine((url) => validateRedirectUrl(url, 'web')),
       }),
     }),
     async (ctx, next) => {

--- a/packages/demo-app/package.json
+++ b/packages/demo-app/package.json
@@ -17,7 +17,7 @@
     "stylelint": "stylelint \"src/**/*.scss\""
   },
   "devDependencies": {
-    "@logto/core-kit": "^1.0.0-beta.13",
+    "@logto/core-kit": "1.0.0-beta.18",
     "@logto/language-kit": "1.0.0-beta.16",
     "@logto/phrases": "workspace:1.0.0-beta.10",
     "@logto/react": "1.0.0-beta.8",

--- a/packages/demo-app/src/App.module.scss
+++ b/packages/demo-app/src/App.module.scss
@@ -34,7 +34,7 @@
     .text {
       margin-top: _.unit(1);
       font: var(--font-body-medium);
-      color: var(--color-caption);
+      color: var(--color-text-secondary);
     }
 
     .infoCard {
@@ -86,7 +86,7 @@
       display: flex;
       align-items: center;
       column-gap: _.unit(4);
-      color: var(--color-caption);
+      color: var(--color-text-secondary);
 
       .hr {
         width: 110px;

--- a/packages/phrases-ui/package.json
+++ b/packages/phrases-ui/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/logto-io/logto/issues"
   },
   "dependencies": {
-    "@logto/core-kit": "1.0.0-beta.16",
+    "@logto/core-kit": "1.0.0-beta.18",
     "@logto/language-kit": "1.0.0-beta.16",
     "@silverhand/essentials": "^1.3.0",
     "zod": "^3.18.0"

--- a/packages/phrases/package.json
+++ b/packages/phrases/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/logto-io/logto/issues"
   },
   "dependencies": {
-    "@logto/core-kit": "1.0.0-beta.16",
+    "@logto/core-kit": "1.0.0-beta.18",
     "@logto/language-kit": "1.0.0-beta.15",
     "@silverhand/essentials": "^1.3.0",
     "zod": "^3.18.0"

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -63,8 +63,8 @@
   },
   "prettier": "@silverhand/eslint-config/.prettierrc",
   "dependencies": {
-    "@logto/connector-kit": "^1.0.0-beta.13",
-    "@logto/core-kit": "^1.0.0-beta.13",
+    "@logto/connector-kit": "1.0.0-beta.18",
+    "@logto/core-kit": "1.0.0-beta.18",
     "@logto/language-kit": "^1.0.0-beta.16",
     "@logto/phrases": "workspace:1.0.0-beta.10",
     "@logto/phrases-ui": "workspace:1.0.0-beta.10",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,6 +15,9 @@
     "test:ci": "jest --coverage --silent",
     "test": "jest"
   },
+  "dependencies": {
+    "@logto/core-kit": "1.0.0-beta.18"
+  },
   "devDependencies": {
     "@logto/phrases": "workspace:1.0.0-beta.10",
     "@logto/phrases-ui": "workspace:1.0.0-beta.10",
@@ -80,8 +83,5 @@
   "stylelint": {
     "extends": "@silverhand/eslint-config-react/.stylelintrc"
   },
-  "prettier": "@silverhand/eslint-config/.prettierrc",
-  "dependencies": {
-    "@logto/core-kit": "^1.0.0-beta.13"
-  }
+  "prettier": "@silverhand/eslint-config/.prettierrc"
 }

--- a/packages/ui/src/components/Button/IconButton.module.scss
+++ b/packages/ui/src/components/Button/IconButton.module.scss
@@ -11,7 +11,7 @@
   cursor: pointer;
 
   > svg {
-    color: var(--color-icon);
+    color: var(--color-text-secondary);
   }
 }
 

--- a/packages/ui/src/components/Checkbox/index.module.scss
+++ b/packages/ui/src/components/Checkbox/index.module.scss
@@ -12,7 +12,7 @@
       display: none;
 
       &:nth-child(1) {
-        color: var(--color-icon);
+        color: var(--color-text-secondary);
       }
 
       &:nth-child(2) {

--- a/packages/ui/src/components/Divider/index.module.scss
+++ b/packages/ui/src/components/Divider/index.module.scss
@@ -4,7 +4,7 @@
 .divider {
   @include _.flex-row;
   font: var(--font-body);
-  color: var(--color-caption);
+  color: var(--color-text-secondary);
 
   .line {
     flex: 1;

--- a/packages/ui/src/components/Drawer/index.module.scss
+++ b/packages/ui/src/components/Drawer/index.module.scss
@@ -25,7 +25,7 @@
   margin-bottom: _.unit(4);
 
   svg {
-    color: var(--color-icon);
+    color: var(--color-text-secondary);
     width: 20px;
     height: 20px;
   }

--- a/packages/ui/src/components/Input/index.module.scss
+++ b/packages/ui/src/components/Input/index.module.scss
@@ -19,7 +19,7 @@
     top: 50%;
     transform: translateY(-50%);
     display: none;
-    color: var(--color-icon);
+    color: var(--color-text-secondary);
     width: 24px;
     height: 24px;
   }
@@ -34,7 +34,7 @@
     align-self: stretch;
 
     &::placeholder {
-      color: var(--color-caption);
+      color: var(--color-placeholder);
     }
 
     // Overwrite webkit auto-fill style

--- a/packages/ui/src/components/Input/phoneInput.module.scss
+++ b/packages/ui/src/components/Input/phoneInput.module.scss
@@ -45,7 +45,7 @@
 :global(body.desktop) {
   .countryCodeSelector {
     > svg {
-      color: var(--color-icon);
+      color: var(--color-text-secondary);
       margin-left: _.unit(2);
       width: 20px;
       height: 20px;

--- a/packages/ui/src/components/Notification/index.module.scss
+++ b/packages/ui/src/components/Notification/index.module.scss
@@ -17,7 +17,7 @@
 }
 
 .icon {
-  color: var(--color-outline);
+  color: var(--color-text-secondary);
   width: 20px;
   height: 20px;
   margin-right: _.unit(3);

--- a/packages/ui/src/components/Passcode/index.module.scss
+++ b/packages/ui/src/components/Passcode/index.module.scss
@@ -20,7 +20,7 @@
     }
 
     &::placeholder {
-      color: var(--color-caption);
+      color: var(--color-placeholder);
     }
   }
 }

--- a/packages/ui/src/components/TermsOfUse/index.module.scss
+++ b/packages/ui/src/components/TermsOfUse/index.module.scss
@@ -8,7 +8,7 @@
 
 .checkBox {
   margin-right: _.unit(2);
-  fill: var(--color-icon);
+  fill: var(--color-text-secondary);
 }
 
 .content {

--- a/packages/ui/src/components/TextLink/index.module.scss
+++ b/packages/ui/src/components/TextLink/index.module.scss
@@ -12,7 +12,7 @@
   }
 
   &.secondary {
-    color: var(--color-caption);
+    color: var(--color-text-secondary);
     font: var(--font-body);
     text-decoration: underline;
   }

--- a/packages/ui/src/containers/PasscodeValidation/index.module.scss
+++ b/packages/ui/src/containers/PasscodeValidation/index.module.scss
@@ -36,6 +36,6 @@
 
 :global(body.desktop) {
   .message {
-    color: var(--color-caption);
+    color: var(--color-text-secondary);
   }
 }

--- a/packages/ui/src/containers/SocialLanding/index.module.scss
+++ b/packages/ui/src/containers/SocialLanding/index.module.scss
@@ -19,5 +19,5 @@
 .message {
   text-align: center;
   font: var(--font-caption);
-  color: var(--color-caption);
+  color: var(--color-text-secondary);
 }

--- a/packages/ui/src/pages/ForgotPassword/index.module.scss
+++ b/packages/ui/src/pages/ForgotPassword/index.module.scss
@@ -15,7 +15,7 @@
 
 .description {
   margin-bottom: _.unit(6);
-  color: var(--color-caption);
+  color: var(--color-text-secondary);
 }
 
 :global(body.mobile) {

--- a/packages/ui/src/pages/Passcode/index.module.scss
+++ b/packages/ui/src/pages/Passcode/index.module.scss
@@ -16,7 +16,7 @@
 
 .detail {
   margin-bottom: _.unit(6);
-  color: var(--color-caption);
+  color: var(--color-text-secondary);
 }
 
 :global(body.mobile) {

--- a/packages/ui/src/scss/_underscore.scss
+++ b/packages/ui/src/scss/_underscore.scss
@@ -21,7 +21,7 @@
 
 @mixin text-hint {
   font: var(--font-caption);
-  color: var(--color-caption);
+  color: var(--color-text-secondary);
 }
 
 @mixin title {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,7 +102,7 @@ importers:
   packages/console:
     specifiers:
       '@fontsource/roboto-mono': ^4.5.7
-      '@logto/core-kit': 1.0.0-beta.16
+      '@logto/core-kit': 1.0.0-beta.18
       '@logto/language-kit': 1.0.0-beta.16
       '@logto/phrases': workspace:1.0.0-beta.10
       '@logto/phrases-ui': workspace:1.0.0-beta.10
@@ -169,7 +169,7 @@ importers:
       zod: ^3.18.0
     devDependencies:
       '@fontsource/roboto-mono': 4.5.7
-      '@logto/core-kit': 1.0.0-beta.16
+      '@logto/core-kit': 1.0.0-beta.18
       '@logto/language-kit': 1.0.0-beta.16
       '@logto/phrases': link:../phrases
       '@logto/phrases-ui': link:../phrases-ui
@@ -238,8 +238,8 @@ importers:
   packages/core:
     specifiers:
       '@logto/cli': workspace:1.0.0-beta.10
-      '@logto/connector-kit': ^1.0.0-beta.13
-      '@logto/core-kit': ^1.0.0-beta.16
+      '@logto/connector-kit': ^1.0.0-beta.18
+      '@logto/core-kit': ^1.0.0-beta.18
       '@logto/language-kit': ^1.0.0-beta.16
       '@logto/phrases': workspace:1.0.0-beta.10
       '@logto/phrases-ui': workspace:1.0.0-beta.10
@@ -316,8 +316,8 @@ importers:
       zod: ^3.18.0
     dependencies:
       '@logto/cli': link:../cli
-      '@logto/connector-kit': 1.0.0-beta.13
-      '@logto/core-kit': 1.0.0-beta.16
+      '@logto/connector-kit': 1.0.0-beta.18
+      '@logto/core-kit': 1.0.0-beta.18
       '@logto/language-kit': 1.0.0-beta.16
       '@logto/phrases': link:../phrases
       '@logto/phrases-ui': link:../phrases-ui
@@ -402,7 +402,7 @@ importers:
 
   packages/demo-app:
     specifiers:
-      '@logto/core-kit': ^1.0.0-beta.13
+      '@logto/core-kit': 1.0.0-beta.18
       '@logto/language-kit': 1.0.0-beta.16
       '@logto/phrases': workspace:1.0.0-beta.10
       '@logto/react': 1.0.0-beta.8
@@ -429,7 +429,7 @@ importers:
       stylelint: ^14.9.1
       typescript: ^4.7.4
     devDependencies:
-      '@logto/core-kit': 1.0.0-beta.13
+      '@logto/core-kit': 1.0.0-beta.18
       '@logto/language-kit': 1.0.0-beta.16
       '@logto/phrases': link:../phrases
       '@logto/react': 1.0.0-beta.8_react@18.2.0
@@ -510,7 +510,7 @@ importers:
 
   packages/phrases:
     specifiers:
-      '@logto/core-kit': 1.0.0-beta.16
+      '@logto/core-kit': 1.0.0-beta.18
       '@logto/language-kit': 1.0.0-beta.15
       '@silverhand/eslint-config': 1.0.0
       '@silverhand/essentials': ^1.3.0
@@ -521,7 +521,7 @@ importers:
       typescript: ^4.7.4
       zod: ^3.18.0
     dependencies:
-      '@logto/core-kit': 1.0.0-beta.16
+      '@logto/core-kit': 1.0.0-beta.18
       '@logto/language-kit': 1.0.0-beta.15
       '@silverhand/essentials': 1.3.0
       zod: 3.18.0
@@ -535,7 +535,7 @@ importers:
 
   packages/phrases-ui:
     specifiers:
-      '@logto/core-kit': 1.0.0-beta.16
+      '@logto/core-kit': 1.0.0-beta.18
       '@logto/language-kit': 1.0.0-beta.16
       '@silverhand/eslint-config': 1.0.0
       '@silverhand/essentials': ^1.3.0
@@ -546,7 +546,7 @@ importers:
       typescript: ^4.7.4
       zod: ^3.18.0
     dependencies:
-      '@logto/core-kit': 1.0.0-beta.16
+      '@logto/core-kit': 1.0.0-beta.18
       '@logto/language-kit': 1.0.0-beta.16
       '@silverhand/essentials': 1.3.0
       zod: 3.18.0
@@ -560,8 +560,8 @@ importers:
 
   packages/schemas:
     specifiers:
-      '@logto/connector-kit': ^1.0.0-beta.13
-      '@logto/core-kit': ^1.0.0-beta.13
+      '@logto/connector-kit': 1.0.0-beta.18
+      '@logto/core-kit': 1.0.0-beta.18
       '@logto/language-kit': ^1.0.0-beta.16
       '@logto/phrases': workspace:1.0.0-beta.10
       '@logto/phrases-ui': workspace:1.0.0-beta.10
@@ -585,8 +585,8 @@ importers:
       typescript: ^4.7.4
       zod: ^3.18.0
     dependencies:
-      '@logto/connector-kit': 1.0.0-beta.13
-      '@logto/core-kit': 1.0.0-beta.13
+      '@logto/connector-kit': 1.0.0-beta.18
+      '@logto/core-kit': 1.0.0-beta.18
       '@logto/language-kit': 1.0.0-beta.16
       '@logto/phrases': link:../phrases
       '@logto/phrases-ui': link:../phrases-ui
@@ -648,7 +648,7 @@ importers:
 
   packages/ui:
     specifiers:
-      '@logto/core-kit': ^1.0.0-beta.13
+      '@logto/core-kit': 1.0.0-beta.18
       '@logto/phrases': workspace:1.0.0-beta.10
       '@logto/phrases-ui': workspace:1.0.0-beta.10
       '@logto/schemas': workspace:1.0.0-beta.10
@@ -701,7 +701,7 @@ importers:
       typescript: ^4.7.4
       use-debounced-loader: ^0.1.1
     dependencies:
-      '@logto/core-kit': 1.0.0-beta.13
+      '@logto/core-kit': 1.0.0-beta.18
     devDependencies:
       '@logto/phrases': link:../phrases
       '@logto/phrases-ui': link:../phrases-ui
@@ -2592,22 +2592,15 @@ packages:
       lodash.once: 4.1.1
     dev: true
 
-  /@logto/connector-kit/1.0.0-beta.13:
-    resolution: {integrity: sha512-bUgAaba1RkYIjHMPrcefLTJAf0d1uVhr864Gh/4JO7/du3xmbFbAWzDyfOhwzt1YZoG4NaMmjVXicfSh/zF/YQ==}
+  /@logto/connector-kit/1.0.0-beta.18:
+    resolution: {integrity: sha512-V3QxKE2gjs5FpLBihHA4YLC0RFK8gW56qZkBKk0uWt2gxcs5eGJvBxV1rgskn6W/3Z8ohnK5FJRv6fIOsUWSKw==}
     engines: {node: ^16.0.0}
     dependencies:
-      '@logto/core-kit': 1.0.0-beta.16
+      '@logto/core-kit': 1.0.0-beta.18
+      '@logto/language-kit': 1.0.0-beta.16
       '@silverhand/essentials': 1.3.0
       zod: 3.18.0
     dev: false
-
-  /@logto/core-kit/1.0.0-beta.13:
-    resolution: {integrity: sha512-3Ugvpu2VHfBziEOZ07v+JpwQSoU71pO60dIeN2w3SHVgr0G6TV0FC/0NxJqEOGEEh6rEvcikVocwZJBJ+P6CoA==}
-    engines: {node: ^16.0.0}
-    dependencies:
-      color: 4.2.3
-      nanoid: 3.3.4
-      zod: 3.18.0
 
   /@logto/core-kit/1.0.0-beta.14:
     resolution: {integrity: sha512-nyRlOU92k65TRHA7WaeM2ktiy0OmCooD8OXW9XxEOx4d6tJUReuFisPmNEh8bV3wK41fSy3zRwo93SAF6nSlRQ==}
@@ -2618,8 +2611,8 @@ packages:
       zod: 3.18.0
     dev: true
 
-  /@logto/core-kit/1.0.0-beta.16:
-    resolution: {integrity: sha512-6f03W+FczXOusWPB9PiMz8mIMIaylYEyPSmICmN8YmIUJgD7jN1tHRJSZjnuo/8h2L6szm/8oNGqcxgIpBjeWg==}
+  /@logto/core-kit/1.0.0-beta.18:
+    resolution: {integrity: sha512-VgSBWbPeFHgSOiOoYiE+TQF8byImxfd2xGTjA37RtFHMeUfT8CNTQWESUYuP7JWrKNm1N2ua7DTZZAJAKH9qMg==}
     engines: {node: ^16.0.0}
     dependencies:
       '@logto/language-kit': 1.0.0-beta.16


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
* Bump `core-kit` and `connector-kit` to beta.17
* Update color tokens:
  - Replace `--color-caption` and `--color-icon` with `--color-text-secondary`
  - Replace placeholder text color to the new `--color-placeholder` token
  - Replace several `--color-outline` text to `--color-text-secondary`

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [ ] Locally tested
