### PR TITLE
refactor(console): update table styles

### DIFF
--- a/packages/console/src/components/CopyToClipboard/index.module.scss
+++ b/packages/console/src/components/CopyToClipboard/index.module.scss
@@ -33,6 +33,11 @@
 
     .copyIcon {
       margin-left: _.unit(3);
+
+      svg {
+        width: 16px;
+        height: 16px;
+      }
     }
   }
 }

--- a/packages/console/src/scss/normalized.scss
+++ b/packages/console/src/scss/normalized.scss
@@ -21,8 +21,7 @@ input {
 }
 
 table {
-  border: 1px solid var(--color-neutral-90);
-  border-radius: _.unit(2);
+  border: 1px solid var(--color-divider);
   border-spacing: 0;
   width: 100%;
   table-layout: fixed;
@@ -30,14 +29,14 @@ table {
   thead {
     th {
       font: var(--font-subhead-2);
-      color: var(--color-caption);
-      padding: _.unit(2);
-      border-bottom: 1px solid var(--color-neutral-90);
+      color: var(--color-text);
+      padding: _.unit(3);
+      border-bottom: 1px solid var(--color-divider);
       text-align: left;
 
       &:first-child,
       &:last-child {
-        padding: _.unit(2) _.unit(8);
+        padding: _.unit(3) _.unit(8);
       }
     }
   }
@@ -45,7 +44,7 @@ table {
   tbody {
     td {
       font: var(--font-body-medium);
-      border-bottom: 1px solid var(--color-neutral-90);
+      border-bottom: 1px solid var(--color-divider);
       padding: _.unit(3) _.unit(2);
 
       &:first-child,
@@ -68,7 +67,7 @@ table {
   background: var(--color-neutral-variant-80);
   background-clip: content-box;
   border: 4px solid transparent;
-  border-radius: 8px;
+  border-radius: 12px;
 }
 
 ::-webkit-scrollbar-track {

--- a/packages/console/src/scss/table.module.scss
+++ b/packages/console/src/scss/table.module.scss
@@ -14,8 +14,8 @@ tr.clickable {
 
 .scrollable {
   overflow-y: auto;
-  border: 1px solid var(--color-neutral-90);
-  border-radius: _.unit(2);
+  border: 1px solid var(--color-divider);
+  border-radius: 12px;
 
   table {
     border: none;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Update styles for table components per [latest design system updates](https://www.figma.com/file/RFBSbreIEYfaxJLdsb1KX1/%F0%9F%98%84-DS-components-updates?node-id=0%3A59)
* Table column text color updated to `--color-text` (darker)
* Table radius increase from 8px to 12px
* Copy icon size shrinked to 16px x 16px

<img width="289" alt="image" src="https://user-images.githubusercontent.com/12833674/195323965-ce7a865c-4ffc-408f-acc6-f63f113e790d.png">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Locally tested OK
