### PR TITLE
refactor(console): display full contents in language edit section

### DIFF
--- a/packages/console/src/components/Textarea/index.module.scss
+++ b/packages/console/src/components/Textarea/index.module.scss
@@ -1,0 +1,29 @@
+@use '@/scss/underscore' as _;
+
+.container {
+  border-radius: 6px;
+  border: 1px solid var(--color-border);
+  outline: 3px solid transparent;
+  padding: _.unit(2) _.unit(3);
+
+  &:focus-within {
+    border-color: var(--color-primary);
+    outline-color: var(--color-focused-variant);
+  }
+
+  textarea {
+    width: 100%;
+    height: 100%;
+    color: var(--color-text);
+    font: var(--font-body-medium);
+    background: transparent;
+    border: none;
+    outline: none;
+    resize: none;
+    padding: 0;
+
+    &::placeholder {
+      color: var(--color-caption);
+    }
+  }
+}

--- a/packages/console/src/components/Textarea/index.tsx
+++ b/packages/console/src/components/Textarea/index.tsx
@@ -1,0 +1,18 @@
+import classNames from 'classnames';
+import { ForwardedRef, forwardRef, HTMLProps } from 'react';
+
+import * as styles from './index.module.scss';
+
+type Props = HTMLProps<HTMLTextAreaElement> & {
+  className?: string;
+};
+
+const Textarea = ({ className, ...rest }: Props, reference: ForwardedRef<HTMLTextAreaElement>) => {
+  return (
+    <div className={classNames(styles.container, className)}>
+      <textarea {...rest} ref={reference} />
+    </div>
+  );
+};
+
+export default forwardRef(Textarea);

--- a/packages/console/src/pages/SignInExperience/components/ManageLanguage/LanguageEditor/EditSection.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/ManageLanguage/LanguageEditor/EditSection.module.scss
@@ -14,7 +14,6 @@
 }
 
 .sectionBuiltInText {
-  width: 280px;
   padding: _.unit(2) _.unit(3);
   border-radius: 6px;
   border: 1px solid var(--color-border);
@@ -28,7 +27,7 @@
 
 .sectionInputArea {
   position: absolute;
-  inset: _.unit(3) _.unit(8);
+  inset: _.unit(2) _.unit(5);
   border-radius: 6px;
   border: 1px solid var(--color-border);
   outline: 3px solid transparent;

--- a/packages/console/src/pages/SignInExperience/components/ManageLanguage/LanguageEditor/EditSection.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/ManageLanguage/LanguageEditor/EditSection.module.scss
@@ -14,5 +14,40 @@
 }
 
 .sectionBuiltInText {
-  padding: _.unit(2) 0;
+  width: 280px;
+  padding: _.unit(2) _.unit(3);
+  border-radius: 6px;
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  background: var(--color-layer-2);
+}
+
+.inputCell {
+  position: relative;
+}
+
+.sectionInputArea {
+  position: absolute;
+  inset: _.unit(3) _.unit(8);
+  border-radius: 6px;
+  border: 1px solid var(--color-border);
+  outline: 3px solid transparent;
+  padding: _.unit(2) _.unit(3);
+
+  &:focus-within {
+    border-color: var(--color-primary);
+    outline-color: var(--color-focused-variant);
+  }
+
+  textarea {
+    color: var(--color-text);
+    font: var(--font-body-medium);
+    background: transparent;
+    border: none;
+    outline: none;
+    padding: 0;
+    width: 100%;
+    height: 100%;
+    resize: none;
+  }
 }

--- a/packages/console/src/pages/SignInExperience/components/ManageLanguage/LanguageEditor/EditSection.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/ManageLanguage/LanguageEditor/EditSection.module.scss
@@ -28,25 +28,4 @@
 .sectionInputArea {
   position: absolute;
   inset: _.unit(2) _.unit(5);
-  border-radius: 6px;
-  border: 1px solid var(--color-border);
-  outline: 3px solid transparent;
-  padding: _.unit(2) _.unit(3);
-
-  &:focus-within {
-    border-color: var(--color-primary);
-    outline-color: var(--color-focused-variant);
-  }
-
-  textarea {
-    color: var(--color-text);
-    font: var(--font-body-medium);
-    background: transparent;
-    border: none;
-    outline: none;
-    padding: 0;
-    width: 100%;
-    height: 100%;
-    resize: none;
-  }
 }

--- a/packages/console/src/pages/SignInExperience/components/ManageLanguage/LanguageEditor/EditSection.tsx
+++ b/packages/console/src/pages/SignInExperience/components/ManageLanguage/LanguageEditor/EditSection.tsx
@@ -1,6 +1,8 @@
 import { Translation } from '@logto/schemas';
 import { useFormContext } from 'react-hook-form';
 
+import Textarea from '@/components/Textarea';
+
 import * as style from './EditSection.module.scss';
 
 type EditSectionProps = {
@@ -28,9 +30,7 @@ const EditSection = ({ dataKey, data }: EditSectionProps) => {
               <div className={style.sectionBuiltInText}>{value}</div>
             </td>
             <td className={style.inputCell}>
-              <div className={style.sectionInputArea}>
-                <textarea {...register(fieldKey)} />
-              </div>
+              <Textarea className={style.sectionInputArea} {...register(fieldKey)} />
             </td>
           </tr>
         );

--- a/packages/console/src/pages/SignInExperience/components/ManageLanguage/LanguageEditor/EditSection.tsx
+++ b/packages/console/src/pages/SignInExperience/components/ManageLanguage/LanguageEditor/EditSection.tsx
@@ -1,8 +1,6 @@
 import { Translation } from '@logto/schemas';
 import { useFormContext } from 'react-hook-form';
 
-import TextInput from '@/components/TextInput';
-
 import * as style from './EditSection.module.scss';
 
 type EditSectionProps = {
@@ -27,10 +25,12 @@ const EditSection = ({ dataKey, data }: EditSectionProps) => {
           <tr key={fieldKey}>
             <td className={style.sectionDataKey}>{field}</td>
             <td>
-              <TextInput readOnly value={value} className={style.sectionBuiltInText} />
+              <div className={style.sectionBuiltInText}>{value}</div>
             </td>
-            <td>
-              <TextInput {...register(fieldKey)} />
+            <td className={style.inputCell}>
+              <div className={style.sectionInputArea}>
+                <textarea {...register(fieldKey)} />
+              </div>
             </td>
           </tr>
         );

--- a/packages/console/src/pages/SignInExperience/components/ManageLanguage/LanguageEditor/LanguageDetails.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/ManageLanguage/LanguageEditor/LanguageDetails.module.scss
@@ -46,6 +46,8 @@
           background-color: var(--color-layer-1);
           position: sticky;
           top: 0;
+          // Note: cells with `position: relative` style will overlap this sticky header, add a z-index to fix it.
+          z-index: 1;
         }
 
         > th:first-child {

--- a/packages/console/src/pages/SignInExperience/components/ManageLanguage/LanguageEditor/LanguageDetails.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/ManageLanguage/LanguageEditor/LanguageDetails.module.scss
@@ -39,31 +39,23 @@
     > table {
       border: none;
 
-      > thead > tr {
-        > th {
+      > thead {
+        position: sticky;
+        top: 0;
+        // Note: cells with `position: relative` style will overlap this sticky header, add a z-index to fix it.
+        z-index: 1;
+
+        tr > th {
+          padding: _.unit(1) _.unit(5);
           font: var(--font-label-large);
           color: var(--color-text);
           background-color: var(--color-layer-1);
-          position: sticky;
-          top: 0;
-          // Note: cells with `position: relative` style will overlap this sticky header, add a z-index to fix it.
-          z-index: 1;
-        }
-
-        > th:first-child {
-          width: 300px;
-          padding: _.unit(1) _.unit(5);
         }
       }
 
-      > tbody > tr {
-        > td {
-          border: none;
-        }
-
-        > td:first-child {
-          padding: _.unit(1) _.unit(5);
-        }
+      > tbody > tr > td {
+        padding: _.unit(2) _.unit(5);
+        border: none;
       }
     }
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- add a `Textarea` component for multiline content editing.
- display full contents in the language edit section.
- adjust the table style to fit the design doc when displaying the language content.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="1223" alt="image" src="https://user-images.githubusercontent.com/10806653/195519611-c825f22f-c335-4cf8-9fa3-e31e1dc53a1e.png">

