### PR TITLE
refactor(core): refactor passwordless route

### DIFF
--- a/packages/core/src/routes/session/forgot-password.test.ts
+++ b/packages/core/src/routes/session/forgot-password.test.ts
@@ -13,7 +13,7 @@ const encryptUserPassword = jest.fn(async (password: string) => ({
   passwordEncryptionMethod: 'Argon2i',
 }));
 const findUserById = jest.fn(async (): Promise<User> => mockUserWithPassword);
-const updateUserById = jest.fn(async (..._args: unknown[]) => ({ id: 'id' }));
+const updateUserById = jest.fn(async (..._args: unknown[]) => ({ userId: 'id' }));
 
 jest.mock('@/lib/user', () => ({
   ...jest.requireActual('@/lib/user'),
@@ -23,16 +23,16 @@ jest.mock('@/lib/user', () => ({
 jest.mock('@/queries/user', () => ({
   ...jest.requireActual('@/queries/user'),
   hasUserWithPhone: async (phone: string) => phone === '13000000000',
-  findUserByPhone: async () => ({ id: 'id' }),
+  findUserByPhone: async () => ({ userId: 'id' }),
   hasUserWithEmail: async (email: string) => email === 'a@a.com',
-  findUserByEmail: async () => ({ id: 'id' }),
+  findUserByEmail: async () => ({ userId: 'id' }),
   findUserById: async () => findUserById(),
   updateUserById: async (...args: unknown[]) => updateUserById(...args),
 }));
 
 const sendPasscode = jest.fn(async () => ({ dbEntry: { id: 'connectorIdValue' } }));
 jest.mock('@/lib/passcode', () => ({
-  createPasscode: async () => ({ id: 'id' }),
+  createPasscode: async () => ({ userId: 'id' }),
   sendPasscode: async () => sendPasscode(),
   verifyPasscode: async (_a: unknown, _b: unknown, code: string) => {
     if (code !== '1234') {
@@ -82,7 +82,7 @@ describe('session -> forgotPasswordRoutes', () => {
       interactionDetails.mockResolvedValueOnce({
         result: {
           verification: {
-            id: 'id',
+            userId: 'id',
             expiresAt: dayjs().add(1, 'day').toISOString(),
             flow: PasscodeType.ForgotPassword,
           },
@@ -119,7 +119,7 @@ describe('session -> forgotPasswordRoutes', () => {
       interactionDetails.mockResolvedValueOnce({
         result: {
           verification: {
-            id: 'id',
+            userId: 'id',
             expiresAt: dayjs().add(1, 'day').toISOString(),
             flow: PasscodeType.SignIn,
           },
@@ -134,7 +134,7 @@ describe('session -> forgotPasswordRoutes', () => {
     it('should throw when `verification.expiresAt` is not string', async () => {
       interactionDetails.mockResolvedValueOnce({
         result: {
-          verification: { id: 'id', expiresAt: 0, flow: PasscodeType.ForgotPassword },
+          verification: { userId: 'id', expiresAt: 0, flow: PasscodeType.ForgotPassword },
         },
       });
       const response = await sessionRequest
@@ -147,7 +147,7 @@ describe('session -> forgotPasswordRoutes', () => {
       interactionDetails.mockResolvedValueOnce({
         result: {
           verification: {
-            id: 'id',
+            userId: 'id',
             expiresAt: 'invalid date string',
             flow: PasscodeType.ForgotPassword,
           },
@@ -163,7 +163,7 @@ describe('session -> forgotPasswordRoutes', () => {
       interactionDetails.mockResolvedValueOnce({
         result: {
           verification: {
-            id: 'id',
+            userId: 'id',
             expiresAt: dayjs().subtract(1, 'day').toISOString(),
             flow: PasscodeType.ForgotPassword,
           },
@@ -179,7 +179,7 @@ describe('session -> forgotPasswordRoutes', () => {
       interactionDetails.mockResolvedValueOnce({
         result: {
           verification: {
-            id: 'id',
+            userId: 'id',
             expiresAt: dayjs().add(1, 'day').toISOString(),
             flow: PasscodeType.ForgotPassword,
           },
@@ -196,7 +196,7 @@ describe('session -> forgotPasswordRoutes', () => {
       interactionDetails.mockResolvedValueOnce({
         result: {
           verification: {
-            id: 'id',
+            userId: 'id',
             expiresAt: dayjs().add(1, 'day').toISOString(),
             flow: PasscodeType.ForgotPassword,
           },

--- a/packages/core/src/routes/session/forgot-password.ts
+++ b/packages/core/src/routes/session/forgot-password.ts
@@ -39,11 +39,11 @@ export default function forgotPasswordRoutes<T extends AnonymousRouter>(
       const type = 'ForgotPasswordReset';
       ctx.log(type, verificationStorage);
 
-      const { id, expiresAt } = verificationStorage;
+      const { userId, expiresAt } = verificationStorage;
 
       checkValidateExpiration(expiresAt);
 
-      const { passwordEncrypted: oldPasswordEncrypted } = await findUserById(id);
+      const { passwordEncrypted: oldPasswordEncrypted } = await findUserById(userId);
 
       assertThat(
         !oldPasswordEncrypted ||
@@ -53,9 +53,9 @@ export default function forgotPasswordRoutes<T extends AnonymousRouter>(
 
       const { passwordEncrypted, passwordEncryptionMethod } = await encryptUserPassword(password);
 
-      ctx.log(type, { userId: id });
+      ctx.log(type, { userId });
 
-      await updateUserById(id, { passwordEncrypted, passwordEncryptionMethod });
+      await updateUserById(userId, { passwordEncrypted, passwordEncryptionMethod });
       await clearVerificationResult(ctx, provider);
       ctx.status = 204;
 

--- a/packages/core/src/routes/session/middleware/passwordless-action.ts
+++ b/packages/core/src/routes/session/middleware/passwordless-action.ts
@@ -1,0 +1,149 @@
+import { PasscodeType } from '@logto/schemas';
+import { MiddlewareType } from 'koa';
+import { Provider } from 'oidc-provider';
+
+import RequestError from '@/errors/RequestError';
+import { assignInteractionResults } from '@/lib/session';
+import { generateUserId, insertUser } from '@/lib/user';
+import { WithLogContext } from '@/middleware/koa-log';
+import {
+  hasUserWithPhone,
+  hasUserWithEmail,
+  findUserByPhone,
+  findUserByEmail,
+  updateUserById,
+} from '@/queries/user';
+import assertThat from '@/utils/assert-that';
+
+import { smsSessionResultGuard, emailSessionResultGuard } from '../types';
+import {
+  getVerificationStorageFromInteraction,
+  getPasswordlessRelatedLogType,
+  checkValidateExpiration,
+} from '../utils';
+
+export const smsSignInAction = <StateT, ContextT extends WithLogContext, ResponseBodyT>(
+  provider: Provider
+): MiddlewareType<StateT, ContextT, ResponseBodyT> => {
+  return async (ctx, next) => {
+    const verificationStorage = await getVerificationStorageFromInteraction(
+      ctx,
+      provider,
+      smsSessionResultGuard
+    );
+
+    const type = getPasswordlessRelatedLogType(PasscodeType.SignIn, 'sms');
+    ctx.log(type, verificationStorage);
+
+    const { phone, expiresAt } = verificationStorage;
+
+    checkValidateExpiration(expiresAt);
+
+    assertThat(
+      await hasUserWithPhone(phone),
+      new RequestError({ code: 'user.phone_not_exists', status: 404 })
+    );
+
+    const { id } = await findUserByPhone(phone);
+    ctx.log(type, { userId: id });
+
+    await updateUserById(id, { lastSignInAt: Date.now() });
+    await assignInteractionResults(ctx, provider, { login: { accountId: id } });
+
+    return next();
+  };
+};
+
+export const emailSignInAction = <StateT, ContextT extends WithLogContext, ResponseBodyT>(
+  provider: Provider
+): MiddlewareType<StateT, ContextT, ResponseBodyT> => {
+  return async (ctx, next) => {
+    const verificationStorage = await getVerificationStorageFromInteraction(
+      ctx,
+      provider,
+      emailSessionResultGuard
+    );
+
+    const type = getPasswordlessRelatedLogType(PasscodeType.SignIn, 'email');
+    ctx.log(type, verificationStorage);
+
+    const { email, expiresAt } = verificationStorage;
+
+    checkValidateExpiration(expiresAt);
+
+    assertThat(
+      await hasUserWithEmail(email),
+      new RequestError({ code: 'user.phone_not_exists', status: 404 })
+    );
+
+    const { id } = await findUserByEmail(email);
+    ctx.log(type, { userId: id });
+
+    await updateUserById(id, { lastSignInAt: Date.now() });
+    await assignInteractionResults(ctx, provider, { login: { accountId: id } });
+
+    return next();
+  };
+};
+
+export const smsRegisterAction = <StateT, ContextT extends WithLogContext, ResponseBodyT>(
+  provider: Provider
+): MiddlewareType<StateT, ContextT, ResponseBodyT> => {
+  return async (ctx, next) => {
+    const verificationStorage = await getVerificationStorageFromInteraction(
+      ctx,
+      provider,
+      smsSessionResultGuard
+    );
+
+    const type = getPasswordlessRelatedLogType(PasscodeType.Register, 'sms');
+    ctx.log(type, verificationStorage);
+
+    const { phone, expiresAt } = verificationStorage;
+
+    checkValidateExpiration(expiresAt);
+
+    assertThat(
+      !(await hasUserWithPhone(phone)),
+      new RequestError({ code: 'user.phone_exists_register', status: 422 })
+    );
+    const id = await generateUserId();
+    ctx.log(type, { userId: id });
+
+    await insertUser({ id, primaryPhone: phone, lastSignInAt: Date.now() });
+    await assignInteractionResults(ctx, provider, { login: { accountId: id } });
+
+    return next();
+  };
+};
+
+export const emailRegisterAction = <StateT, ContextT extends WithLogContext, ResponseBodyT>(
+  provider: Provider
+): MiddlewareType<StateT, ContextT, ResponseBodyT> => {
+  return async (ctx, next) => {
+    const verificationStorage = await getVerificationStorageFromInteraction(
+      ctx,
+      provider,
+      emailSessionResultGuard
+    );
+
+    const type = getPasswordlessRelatedLogType(PasscodeType.Register, 'email');
+    ctx.log(type, verificationStorage);
+
+    const { email, expiresAt } = verificationStorage;
+
+    checkValidateExpiration(expiresAt);
+
+    assertThat(
+      !(await hasUserWithEmail(email)),
+      new RequestError({ code: 'user.email_exists_register', status: 422 })
+    );
+    const id = await generateUserId();
+    ctx.log(type, { userId: id });
+
+    await insertUser({ id, primaryEmail: email, lastSignInAt: Date.now() });
+    await assignInteractionResults(ctx, provider, { login: { accountId: id } });
+
+    return next();
+  };
+};

--- a/packages/core/src/routes/session/types.ts
+++ b/packages/core/src/routes/session/types.ts
@@ -11,15 +11,6 @@ export const operationGuard = z.enum(['send', 'verify']);
 
 export type Operation = z.infer<typeof operationGuard>;
 
-export type VerifiedIdentity = { email: string } | { phone: string } | { id: string };
-
-export type VerificationStorage =
-  | SmsSessionStorage
-  | EmailSessionStorage
-  | ForgotPasswordSessionStorage;
-
-export type VerificationResult<T = VerificationStorage> = { verification: T };
-
 const smsSessionStorageGuard = z.object({
   flow: z.literal(PasscodeType.SignIn).or(z.literal(PasscodeType.Register)),
   expiresAt: z.string(),
@@ -45,7 +36,7 @@ export const emailSessionResultGuard = z.object({
 const forgotPasswordSessionStorageGuard = z.object({
   flow: z.literal(PasscodeType.ForgotPassword),
   expiresAt: z.string(),
-  id: z.string(),
+  userId: z.string(),
 });
 
 export type ForgotPasswordSessionStorage = z.infer<typeof forgotPasswordSessionStorageGuard>;
@@ -53,3 +44,10 @@ export type ForgotPasswordSessionStorage = z.infer<typeof forgotPasswordSessionS
 export const forgotPasswordSessionResultGuard = z.object({
   verification: forgotPasswordSessionStorageGuard,
 });
+
+export type VerificationStorage =
+  | SmsSessionStorage
+  | EmailSessionStorage
+  | ForgotPasswordSessionStorage;
+
+export type VerificationResult<T = VerificationStorage> = { verification: T };

--- a/packages/core/src/routes/session/utils.ts
+++ b/packages/core/src/routes/session/utils.ts
@@ -9,16 +9,7 @@ import RequestError from '@/errors/RequestError';
 import assertThat from '@/utils/assert-that';
 
 import { verificationTimeout } from './consts';
-import {
-  emailSessionResultGuard,
-  smsSessionResultGuard,
-  forgotPasswordSessionResultGuard,
-  Method,
-  Operation,
-  VerificationResult,
-  VerificationStorage,
-  VerifiedIdentity,
-} from './types';
+import { Method, Operation, VerificationResult, VerificationStorage } from './types';
 
 export const getRoutePrefix = (
   type: 'sign-in' | 'register' | 'forgot-password',
@@ -44,11 +35,16 @@ export const getPasswordlessRelatedLogType = (
   return result.data;
 };
 
-const parseVerificationStorage = <T = VerificationStorage>(
-  data: unknown,
+export const getVerificationStorageFromInteraction = async <T = VerificationStorage>(
+  ctx: Context,
+  provider: Provider,
   resultGuard: ZodType<VerificationResult<T>>
-): T => {
-  const verificationResult = resultGuard.safeParse(data);
+): Promise<T> => {
+  const { result } = await provider.interactionDetails(ctx.req, ctx.res);
+
+  const verificationResult = resultGuard.safeParse(result);
+
+  console.log(result);
 
   if (!verificationResult.success) {
     throw new RequestError(
@@ -63,16 +59,6 @@ const parseVerificationStorage = <T = VerificationStorage>(
   return verificationResult.data.verification;
 };
 
-export const getVerificationStorageFromInteraction = async <T = VerificationStorage>(
-  ctx: Context,
-  provider: Provider,
-  resultGuard: ZodType<VerificationResult<T>>
-): Promise<T> => {
-  const { result } = await provider.interactionDetails(ctx.req, ctx.res);
-
-  return parseVerificationStorage<T>(result, resultGuard);
-};
-
 export const checkValidateExpiration = (expiresAt: string) => {
   assertThat(
     dayjs(expiresAt).isValid() && dayjs(expiresAt).isAfter(dayjs()),
@@ -80,28 +66,21 @@ export const checkValidateExpiration = (expiresAt: string) => {
   );
 };
 
+type DistributiveOmit<T, K extends keyof T> = T extends unknown ? Omit<T, K> : never;
+
 export const assignVerificationResult = async (
   ctx: Context,
   provider: Provider,
-  flow: PasscodeType,
-  identity: VerifiedIdentity
+  verificationData: DistributiveOmit<VerificationStorage, 'expiresAt'>
 ) => {
-  const verificationResult = {
-    verification: {
-      flow,
-      expiresAt: dayjs().add(verificationTimeout, 'second').toISOString(),
-      ...identity,
-    },
+  const verification: VerificationStorage = {
+    ...verificationData,
+    expiresAt: dayjs().add(verificationTimeout, 'second').toISOString(),
   };
 
-  assertThat(
-    emailSessionResultGuard.safeParse(verificationResult).success ||
-      smsSessionResultGuard.safeParse(verificationResult).success ||
-      forgotPasswordSessionResultGuard.safeParse(verificationResult).success,
-    new RequestError({ code: 'session.invalid_verification' })
-  );
-
-  await provider.interactionResult(ctx.req, ctx.res, verificationResult);
+  await provider.interactionResult(ctx.req, ctx.res, {
+    verification,
+  });
 };
 
 export const clearVerificationResult = async (ctx: Context, provider: Provider) => {

--- a/packages/core/src/routes/session/utils.ts
+++ b/packages/core/src/routes/session/utils.ts
@@ -44,8 +44,6 @@ export const getVerificationStorageFromInteraction = async <T = VerificationStor
 
   const verificationResult = resultGuard.safeParse(result);
 
-  console.log(result);
-
   if (!verificationResult.success) {
     throw new RequestError(
       {

--- a/packages/integration-tests/src/api/session.ts
+++ b/packages/integration-tests/src/api/session.ts
@@ -68,16 +68,18 @@ export const verifyRegisterUserWithEmailPasscode = (
   code: string,
   interactionCookie: string
 ) =>
-  api.post('session/passwordless/email/verify', {
-    headers: {
-      cookie: interactionCookie,
-    },
-    json: {
-      email,
-      code,
-      flow: PasscodeType.Register,
-    },
-  });
+  api
+    .post('session/passwordless/email/verify', {
+      headers: {
+        cookie: interactionCookie,
+      },
+      json: {
+        email,
+        code,
+        flow: PasscodeType.Register,
+      },
+    })
+    .json<RedirectResponse>();
 
 export const checkVerificationSessionAndRegisterWithEmail = (interactionCookie: string) =>
   api
@@ -104,16 +106,18 @@ export const verifySignInUserWithEmailPasscode = (
   code: string,
   interactionCookie: string
 ) =>
-  api.post('session/passwordless/email/verify', {
-    headers: {
-      cookie: interactionCookie,
-    },
-    json: {
-      email,
-      code,
-      flow: PasscodeType.SignIn,
-    },
-  });
+  api
+    .post('session/passwordless/email/verify', {
+      headers: {
+        cookie: interactionCookie,
+      },
+      json: {
+        email,
+        code,
+        flow: PasscodeType.SignIn,
+      },
+    })
+    .json<RedirectResponse>();
 
 export const checkVerificationSessionAndSignInWithEmail = (interactionCookie: string) =>
   api
@@ -140,16 +144,18 @@ export const verifyRegisterUserWithSmsPasscode = (
   code: string,
   interactionCookie: string
 ) =>
-  api.post('session/passwordless/sms/verify', {
-    headers: {
-      cookie: interactionCookie,
-    },
-    json: {
-      phone,
-      code,
-      flow: PasscodeType.Register,
-    },
-  });
+  api
+    .post('session/passwordless/sms/verify', {
+      headers: {
+        cookie: interactionCookie,
+      },
+      json: {
+        phone,
+        code,
+        flow: PasscodeType.Register,
+      },
+    })
+    .json<RedirectResponse>();
 
 export const checkVerificationSessionAndRegisterWithSms = (interactionCookie: string) =>
   api
@@ -176,16 +182,18 @@ export const verifySignInUserWithSmsPasscode = (
   code: string,
   interactionCookie: string
 ) =>
-  api.post('session/passwordless/sms/verify', {
-    headers: {
-      cookie: interactionCookie,
-    },
-    json: {
-      phone,
-      code,
-      flow: PasscodeType.SignIn,
-    },
-  });
+  api
+    .post('session/passwordless/sms/verify', {
+      headers: {
+        cookie: interactionCookie,
+      },
+      json: {
+        phone,
+        code,
+        flow: PasscodeType.SignIn,
+      },
+    })
+    .json<RedirectResponse>();
 
 export const checkVerificationSessionAndSignInWithSms = (interactionCookie: string) =>
   api

--- a/packages/integration-tests/tests/api/session.test.ts
+++ b/packages/integration-tests/tests/api/session.test.ts
@@ -10,16 +10,12 @@ import {
 import {
   sendRegisterUserWithEmailPasscode,
   verifyRegisterUserWithEmailPasscode,
-  checkVerificationSessionAndRegisterWithEmail,
   sendSignInUserWithEmailPasscode,
   verifySignInUserWithEmailPasscode,
-  checkVerificationSessionAndSignInWithEmail,
   sendRegisterUserWithSmsPasscode,
   verifyRegisterUserWithSmsPasscode,
-  checkVerificationSessionAndRegisterWithSms,
   sendSignInUserWithSmsPasscode,
   verifySignInUserWithSmsPasscode,
-  checkVerificationSessionAndSignInWithSms,
   disableConnector,
   signInWithUsernameAndPassword,
 } from '@/api';
@@ -73,11 +69,9 @@ describe('email passwordless flow', () => {
 
     const { code } = passcodeRecord;
 
-    await expect(
-      verifyRegisterUserWithEmailPasscode(email, code, client.interactionCookie)
-    ).resolves.not.toThrow();
-
-    const { redirectTo } = await checkVerificationSessionAndRegisterWithEmail(
+    const { redirectTo } = await verifyRegisterUserWithEmailPasscode(
+      email,
+      code,
       client.interactionCookie
     );
 
@@ -105,11 +99,9 @@ describe('email passwordless flow', () => {
 
     const { code } = passcodeRecord;
 
-    await expect(
-      verifySignInUserWithEmailPasscode(email, code, client.interactionCookie)
-    ).resolves.not.toThrow();
-
-    const { redirectTo } = await checkVerificationSessionAndSignInWithEmail(
+    const { redirectTo } = await verifySignInUserWithEmailPasscode(
+      email,
+      code,
       client.interactionCookie
     );
 
@@ -150,11 +142,9 @@ describe('sms passwordless flow', () => {
 
     const { code } = passcodeRecord;
 
-    await expect(
-      verifyRegisterUserWithSmsPasscode(phone, code, client.interactionCookie)
-    ).resolves.not.toThrow();
-
-    const { redirectTo } = await checkVerificationSessionAndRegisterWithSms(
+    const { redirectTo } = await verifyRegisterUserWithSmsPasscode(
+      phone,
+      code,
       client.interactionCookie
     );
 
@@ -182,11 +172,11 @@ describe('sms passwordless flow', () => {
 
     const { code } = passcodeRecord;
 
-    await expect(
-      verifySignInUserWithSmsPasscode(phone, code, client.interactionCookie)
-    ).resolves.not.toThrow();
-
-    const { redirectTo } = await checkVerificationSessionAndSignInWithSms(client.interactionCookie);
+    const { redirectTo } = await verifySignInUserWithSmsPasscode(
+      phone,
+      code,
+      client.interactionCookie
+    );
 
     await client.processSession(redirectTo);
 


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
refactor passwordless route

- rename the forgot password identity name `id` to `userId` to be more precise. 
- remove the `VerifiedIdentity` type as it is useless. Could infer the type from StorageType directly
- remove the `parseVerificationStorage` method, as the logic is simple put it directly under `getVerificationStorageFromInteraction`;
- refactor the `assignVerificationResult`. As it is an internal method, we should use type to guard the inputs instead of using zod guard. 
- extract `smsSignIn`,`smsRegister`, `emailSignIn`, `emailRegister` actions as middlewares. So passwordless verify API could directly run the following actions without extra API call. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
ut case update
@darcyYe @wangsijie 
