### PR TITLE
style(console): use small size button for clear button

### DIFF
--- a/packages/console/src/pages/SignInExperience/components/ManageLanguage/LanguageEditor/LanguageDetails.tsx
+++ b/packages/console/src/pages/SignInExperience/components/ManageLanguage/LanguageEditor/LanguageDetails.tsx
@@ -186,6 +186,7 @@ const LanguageDetails = () => {
                   <span className={style.customValuesColumn}>
                     {t('sign_in_exp.others.manage_language.custom_values')}
                     <IconButton
+                      size="small"
                       className={style.clearButton}
                       tooltip="sign_in_exp.others.manage_language.clear_all_tip"
                       onClick={() => {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
the clear button should be a small-size button for the hover-state background area is 24 x 24.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="285" alt="image" src="https://user-images.githubusercontent.com/10806653/196080033-748f603b-fe10-4bc9-bd10-0a309c41acfc.png">

