### PR TITLE
refactor(cli): add skip when exists option

### DIFF
--- a/packages/cli/src/queries/logto-config.ts
+++ b/packages/cli/src/queries/logto-config.ts
@@ -7,10 +7,19 @@ import {
   AlterationStateKey,
 } from '@logto/schemas';
 import { convertToIdentifiers } from '@logto/shared';
+import { Nullable } from '@silverhand/essentials';
 import { DatabasePool, DatabaseTransactionConnection, sql } from 'slonik';
 import { z } from 'zod';
 
 const { table, fields } = convertToIdentifiers(LogtoConfigs);
+
+export const isConfigsTableExists = async (pool: DatabasePool) => {
+  const { rows } = await pool.query<Nullable<string>>(
+    sql`select to_regclass(${LogtoConfigs.table})`
+  );
+
+  return Boolean(rows[0]);
+};
 
 export const getRowsByKeys = async (
   pool: DatabasePool | DatabaseTransactionConnection,


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
since we removed init process in `core` (to keep the core service clean), hence we need to manually add the seed command to our `docker-compose.yml`.

in the CLI database seed command, add `--skip-when-exists` option to skip seeding if Logto configs table exists. helpful for demo purpose.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

### with the option
<img width="487" alt="image" src="https://user-images.githubusercontent.com/14722250/196181532-bbb754bf-6015-4b1a-999c-61a493be9319.png">

### without the option (default)
<img width="497" alt="image" src="https://user-images.githubusercontent.com/14722250/196181584-e9f288aa-cb43-4f77-9a7c-00f6b1a210bb.png">
