### PR TITLE
fix(cli): `chooseAlterationsByVersion` should contain the last `next` version alteration script

### DIFF
--- a/packages/cli/src/commands/database/alteration/index.test.ts
+++ b/packages/cli/src/commands/database/alteration/index.test.ts
@@ -75,7 +75,7 @@ describe('chooseAlterationsByVersion()', () => {
       ),
       expect(chooseAlterationsByVersion(files, 'v1.1.0')).resolves.toEqual(files.slice(0, 8)),
       expect(chooseAlterationsByVersion(files, 'v1.2.0')).resolves.toEqual(files.slice(0, 9)),
-      expect(chooseAlterationsByVersion(files, 'next')).resolves.toEqual(files.slice(0, 11)),
+      expect(chooseAlterationsByVersion(files, 'next')).resolves.toEqual(files.slice(0, 12)),
     ]);
   });
 });

--- a/packages/cli/src/commands/database/alteration/version.ts
+++ b/packages/cli/src/commands/database/alteration/version.ts
@@ -32,7 +32,7 @@ export const chooseAlterationsByVersion = async (
 
     log.info(`Deploy target ${chalk.green(nextTag)}`);
 
-    return alterations.slice(0, endIndex);
+    return alterations.slice(0, endIndex + 1);
   }
 
   const versions = alterations


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
The `end` param in `Array.prototype.slice(start, end)` will not include the end index element, so we will miss the last alteration script when choosing alteration scripts with version `next`.

Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT
