### PR TITLE
fix(ui): revert color token changes in ui as it uses different design system

### DIFF
--- a/packages/ui/src/components/Button/IconButton.module.scss
+++ b/packages/ui/src/components/Button/IconButton.module.scss
@@ -11,7 +11,7 @@
   cursor: pointer;
 
   > svg {
-    color: var(--color-text-secondary);
+    color: var(--color-icon);
   }
 }
 

--- a/packages/ui/src/components/Checkbox/index.module.scss
+++ b/packages/ui/src/components/Checkbox/index.module.scss
@@ -12,7 +12,7 @@
       display: none;
 
       &:nth-child(1) {
-        color: var(--color-text-secondary);
+        color: var(--color-icon);
       }
 
       &:nth-child(2) {

--- a/packages/ui/src/components/Divider/index.module.scss
+++ b/packages/ui/src/components/Divider/index.module.scss
@@ -4,7 +4,7 @@
 .divider {
   @include _.flex-row;
   font: var(--font-body);
-  color: var(--color-text-secondary);
+  color: var(--color-caption);
 
   .line {
     flex: 1;

--- a/packages/ui/src/components/Drawer/index.module.scss
+++ b/packages/ui/src/components/Drawer/index.module.scss
@@ -25,7 +25,7 @@
   margin-bottom: _.unit(4);
 
   svg {
-    color: var(--color-text-secondary);
+    color: var(--color-icon);
     width: 20px;
     height: 20px;
   }

--- a/packages/ui/src/components/Input/index.module.scss
+++ b/packages/ui/src/components/Input/index.module.scss
@@ -19,7 +19,7 @@
     top: 50%;
     transform: translateY(-50%);
     display: none;
-    color: var(--color-text-secondary);
+    color: var(--color-icon);
     width: 24px;
     height: 24px;
   }
@@ -34,7 +34,7 @@
     align-self: stretch;
 
     &::placeholder {
-      color: var(--color-placeholder);
+      color: var(--color-caption);
     }
 
     // Overwrite webkit auto-fill style

--- a/packages/ui/src/components/Input/phoneInput.module.scss
+++ b/packages/ui/src/components/Input/phoneInput.module.scss
@@ -45,7 +45,7 @@
 :global(body.desktop) {
   .countryCodeSelector {
     > svg {
-      color: var(--color-text-secondary);
+      color: var(--color-icon);
       margin-left: _.unit(2);
       width: 20px;
       height: 20px;

--- a/packages/ui/src/components/Notification/index.module.scss
+++ b/packages/ui/src/components/Notification/index.module.scss
@@ -17,7 +17,7 @@
 }
 
 .icon {
-  color: var(--color-text-secondary);
+  color: var(--color-outline);
   width: 20px;
   height: 20px;
   margin-right: _.unit(3);

--- a/packages/ui/src/components/Passcode/index.module.scss
+++ b/packages/ui/src/components/Passcode/index.module.scss
@@ -20,7 +20,7 @@
     }
 
     &::placeholder {
-      color: var(--color-placeholder);
+      color: var(--color-caption);
     }
   }
 }

--- a/packages/ui/src/components/TermsOfUse/index.module.scss
+++ b/packages/ui/src/components/TermsOfUse/index.module.scss
@@ -8,7 +8,7 @@
 
 .checkBox {
   margin-right: _.unit(2);
-  fill: var(--color-text-secondary);
+  fill: var(--color-icon);
 }
 
 .content {

--- a/packages/ui/src/components/TextLink/index.module.scss
+++ b/packages/ui/src/components/TextLink/index.module.scss
@@ -12,7 +12,7 @@
   }
 
   &.secondary {
-    color: var(--color-text-secondary);
+    color: var(--color-caption);
     font: var(--font-body);
     text-decoration: underline;
   }

--- a/packages/ui/src/containers/PasscodeValidation/index.module.scss
+++ b/packages/ui/src/containers/PasscodeValidation/index.module.scss
@@ -36,6 +36,6 @@
 
 :global(body.desktop) {
   .message {
-    color: var(--color-text-secondary);
+    color: var(--color-caption);
   }
 }

--- a/packages/ui/src/containers/SocialLanding/index.module.scss
+++ b/packages/ui/src/containers/SocialLanding/index.module.scss
@@ -19,5 +19,5 @@
 .message {
   text-align: center;
   font: var(--font-caption);
-  color: var(--color-text-secondary);
+  color: var(--color-caption);
 }

--- a/packages/ui/src/pages/ForgotPassword/index.module.scss
+++ b/packages/ui/src/pages/ForgotPassword/index.module.scss
@@ -15,7 +15,7 @@
 
 .description {
   margin-bottom: _.unit(6);
-  color: var(--color-text-secondary);
+  color: var(--color-caption);
 }
 
 :global(body.mobile) {

--- a/packages/ui/src/pages/Passcode/index.module.scss
+++ b/packages/ui/src/pages/Passcode/index.module.scss
@@ -16,7 +16,7 @@
 
 .detail {
   margin-bottom: _.unit(6);
-  color: var(--color-text-secondary);
+  color: var(--color-caption);
 }
 
 :global(body.mobile) {

--- a/packages/ui/src/scss/_underscore.scss
+++ b/packages/ui/src/scss/_underscore.scss
@@ -21,7 +21,7 @@
 
 @mixin text-hint {
   font: var(--font-caption);
-  color: var(--color-text-secondary);
+  color: var(--color-caption);
 }
 
 @mixin title {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Revert recent changes to color tokens in `ui` package, as it is by design using a different design system from `console`. And @simeng-li will update it later based on the new design.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally

<img width="647" alt="image" src="https://user-images.githubusercontent.com/12833674/196409809-812188fa-e76d-4d4c-a155-5c76ae6dbc70.png">

