### PR TITLE
refactor(console): add language button height should be the same with search input

### DIFF
--- a/packages/console/src/pages/SignInExperience/components/ManageLanguage/LanguageEditor/AddLanguageSelector.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/ManageLanguage/LanguageEditor/AddLanguageSelector.module.scss
@@ -6,6 +6,7 @@
 
     .addLanguageButton {
       width: 100%;
+      height: 38px;
       background: unset;
     }
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
refactor(console): add language button height should be the same with search input

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.
