### PR TITLE
fix: handle versioning when no `next-*.ts` found

### DIFF
--- a/packages/schemas/update-next.sh
+++ b/packages/schemas/update-next.sh
@@ -3,5 +3,7 @@ CURRENT_VERSION=$(node -p "require('./package.json').version.replaceAll('-', '_'
 cd alterations
 
 for x in next-*.ts;
-  do mv $x $CURRENT_VERSION$(echo ${x#next});
+do
+  [ -e "$x" ] || continue; # Skip when no file found (will still loop $x with "next-*.ts")
+  mv $x $CURRENT_VERSION$(echo ${x#next});
 done


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
https://superuser.com/questions/519374/how-to-handle-bash-matching-when-there-are-no-matches

<img width="852" alt="image" src="https://user-images.githubusercontent.com/14722250/196632136-eafe3b04-fd57-46f6-89b9-d1afc0601ff1.png">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

- [x] no error when no file found
- [x] update filename when files found