### PR TITLE
fix(console): show i18n content of "errors.unknown_server_error"

### DIFF
--- a/packages/console/src/hooks/use-api.ts
+++ b/packages/console/src/hooks/use-api.ts
@@ -21,11 +21,13 @@ export class RequestError extends Error {
 }
 
 const toastError = async (response: Response) => {
+  const fallbackErrorMessage = t('admin_console.errors.unknown_server_error');
+
   try {
     const data = await response.json<RequestErrorBody>();
-    toast.error([data.message, data.details].join('\n') || t('errors.unknown_server_error'));
+    toast.error([data.message, data.details].join('\n') || fallbackErrorMessage);
   } catch {
-    toast.error(t('errors.unknown_server_error'));
+    toast.error(fallbackErrorMessage);
   }
 };
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fixed an issue that admin console failed to display i18n content for the error key  "error.unknown_server_error"

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Locally tested

<img width="248" alt="image" src="https://user-images.githubusercontent.com/12833674/196643608-5a3f0f94-72f5-4e44-9f8a-dc94dbd42ed1.png">
