### PR TITLE
fix(console): axis calculations in use-position hook

### DIFF
--- a/packages/console/src/hooks/use-position.ts
+++ b/packages/console/src/hooks/use-position.ts
@@ -196,12 +196,11 @@ export default function usePosition({
 
     const anchorRect = anchorRef.current.getBoundingClientRect();
     const overlayRect = overlayRef.current.getBoundingClientRect();
-    const { scrollTop, scrollLeft } = document.documentElement;
 
-    const verticalTop = anchorRect.y - overlayRect.height + scrollTop - offset.vertical;
+    const verticalTop = anchorRect.y - overlayRect.height - offset.vertical;
     const verticalCenter =
-      anchorRect.y - anchorRect.height / 2 - overlayRect.height / 2 + scrollTop + offset.vertical;
-    const verticalBottom = anchorRect.y + anchorRect.height + scrollTop + offset.vertical;
+      anchorRect.y - anchorRect.height / 2 - overlayRect.height / 2 + offset.vertical;
+    const verticalBottom = anchorRect.y + anchorRect.height + offset.vertical;
 
     const verticalPositionMap = {
       top: verticalTop,
@@ -209,11 +208,10 @@ export default function usePosition({
       bottom: verticalBottom,
     };
 
-    const horizontalStart = anchorRect.x + scrollLeft + offset.horizontal;
+    const horizontalStart = anchorRect.x + offset.horizontal;
     const horizontalCenter =
-      anchorRect.x + anchorRect.width / 2 - overlayRect.width / 2 + scrollLeft + offset.horizontal;
-    const horizontalEnd =
-      anchorRect.x + anchorRect.width - overlayRect.width + scrollLeft + offset.horizontal;
+      anchorRect.x + anchorRect.width / 2 - overlayRect.width / 2 + offset.horizontal;
+    const horizontalEnd = anchorRect.x + anchorRect.width - overlayRect.width + offset.horizontal;
 
     const horizontalPositionMap = {
       start: horizontalStart,


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fix axis calculations in `use-position` hook. Previously, the dropdown position is incorrect when the page element has been scrolled.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally
