### PR TITLE
feat(console): show userinfo endpoint information

### DIFF
--- a/packages/console/src/pages/ApplicationDetails/components/AdvancedSettings.tsx
+++ b/packages/console/src/pages/ApplicationDetails/components/AdvancedSettings.tsx
@@ -54,6 +54,13 @@ const AdvancedSettings = ({ applicationType, oidcConfig, defaultData, isDeleted 
           variant="border"
         />
       </FormField>
+      <FormField title="application_details.user_info_endpoint">
+        <CopyToClipboard
+          className={styles.textField}
+          value={oidcConfig.userinfo_endpoint}
+          variant="border"
+        />
+      </FormField>
       {applicationType === ApplicationType.MachineToMachine && (
         <FormField title="application_details.enable_admin_access">
           <Controller


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary

This PR adds the userinfo endpoint information when viewing the "Advanced settings" pages of an application.

![image](https://user-images.githubusercontent.com/911605/197425366-c1878d72-d21d-4743-a33f-034f168d8eb7.png)


<!-- MANDATORY -->
## Testing
1. Created a new application in console
2. Navigated to "Advanced settings" tab
3. Verified userinfo endpoint information is in a field

