### PR TITLE
style(ui): remove outline button style

### DIFF
--- a/packages/ui/src/components/Button/index.module.scss
+++ b/packages/ui/src/components/Button/index.module.scss
@@ -55,21 +55,6 @@
   }
 }
 
-.outline {
-  border: _.border(var(--color-brand-default));
-  background: transparent;
-  color: var(--color-type-link);
-
-  &.disabled,
-  &:disabled {
-    border-color: var(--color-type-disable);
-    color: var(--color-type-disable);
-  }
-
-  &:active {
-    background: var(--color-overlay-brand-pressed);
-  }
-}
 
 :global(body.desktop) {
   .primary {
@@ -89,16 +74,6 @@
 
     &:not(:disabled):not(:active):hover {
       background: var(--color-overlay-neutral-hover);
-    }
-  }
-
-  .outline {
-    &:focus-visible {
-      outline: 3px solid var(--color-overlay-brand-focused);
-    }
-
-    &:not(:disabled):not(:active):hover {
-      background: var(--color-overlay-brand-hover);
     }
   }
 }

--- a/packages/ui/src/components/Button/index.tsx
+++ b/packages/ui/src/components/Button/index.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 import * as styles from './index.module.scss';
 
-export type ButtonType = 'primary' | 'secondary' | 'outline';
+export type ButtonType = 'primary' | 'secondary';
 
 type BaseProps = Omit<HTMLProps<HTMLButtonElement>, 'type' | 'size' | 'title'> & {
   htmlType?: 'button' | 'submit' | 'reset';

--- a/packages/ui/src/components/ConfirmModal/AcModal.tsx
+++ b/packages/ui/src/components/ConfirmModal/AcModal.tsx
@@ -37,7 +37,7 @@ const AcModal = ({
         </div>
         <div className={styles.content}>{children}</div>
         <div className={styles.footer}>
-          <Button title={cancelText} type="outline" size="small" onClick={onClose} />
+          <Button title={cancelText} type="secondary" size="small" onClick={onClose} />
           {onConfirm && <Button title={confirmText} size="small" onClick={onConfirm} />}
         </div>
       </div>


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
use the basic button style to replace old outline button style

Before:
<img width="622" alt="image" src="https://user-images.githubusercontent.com/36393111/198011187-c6a6b86e-84dc-4bed-a6be-40ff9e2c5724.png">

After:
<img width="626" alt="image" src="https://user-images.githubusercontent.com/36393111/198011292-7d006bc9-9149-4a8a-b183-7758179ce45b.png">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
