### PR TITLE
feat(core): password sign in with phone or email

### DIFF
--- a/packages/core/src/routes/session/utils.test.ts
+++ b/packages/core/src/routes/session/utils.test.ts
@@ -1,0 +1,184 @@
+import type { User } from '@logto/schemas';
+import { UserRole, SignInIdentifier, SignUpIdentifier } from '@logto/schemas';
+import { createMockContext } from '@shopify/jest-koa-mocks';
+import type { Nullable } from '@silverhand/essentials';
+import { Provider } from 'oidc-provider';
+
+import { mockSignInExperience, mockSignInMethod, mockUser } from '@/__mocks__';
+import RequestError from '@/errors/RequestError';
+
+import { signInWithPassword } from './utils';
+
+const insertUser = jest.fn(async (..._args: unknown[]) => ({ id: 'id' }));
+const findUserById = jest.fn(async (): Promise<User> => mockUser);
+const updateUserById = jest.fn(async (..._args: unknown[]) => ({ id: 'id' }));
+const hasActiveUsers = jest.fn(async () => true);
+const findDefaultSignInExperience = jest.fn(async () => ({
+  ...mockSignInExperience,
+  signUp: {
+    ...mockSignInExperience.signUp,
+    identifier: SignUpIdentifier.Username,
+  },
+}));
+
+jest.mock('@/queries/user', () => ({
+  findUserById: async () => findUserById(),
+  findUserByIdentity: async () => ({ id: 'id', identities: {} }),
+  findUserByPhone: async () => ({ id: 'id' }),
+  findUserByEmail: async () => ({ id: 'id' }),
+  updateUserById: async (...args: unknown[]) => updateUserById(...args),
+  hasUser: async (username: string) => username === 'username1',
+  hasUserWithIdentity: async (connectorId: string, userId: string) =>
+    connectorId === 'connectorId' && userId === 'id',
+  hasUserWithPhone: async (phone: string) => phone === '13000000000',
+  hasUserWithEmail: async (email: string) => email === 'a@a.com',
+  hasActiveUsers: async () => hasActiveUsers(),
+  async findUserByUsername(username: string) {
+    const roleNames = username === 'admin' ? [UserRole.Admin] : [];
+
+    return { id: 'user1', username, roleNames };
+  },
+}));
+
+jest.mock('@/queries/sign-in-experience', () => ({
+  findDefaultSignInExperience: async () => findDefaultSignInExperience(),
+}));
+
+jest.mock('@/lib/user', () => ({
+  async verifyUserPassword(user: Nullable<User>, password: string) {
+    if (!user) {
+      throw new RequestError('session.invalid_credentials');
+    }
+
+    if (password !== 'password') {
+      throw new RequestError('session.invalid_credentials');
+    }
+
+    return user;
+  },
+  generateUserId: () => 'user1',
+  encryptUserPassword: (password: string) => ({
+    passwordEncrypted: password + '_user1',
+    passwordEncryptionMethod: 'Argon2i',
+  }),
+  updateLastSignInAt: async (...args: unknown[]) => updateUserById(...args),
+  insertUser: async (...args: unknown[]) => insertUser(...args),
+}));
+
+const grantSave = jest.fn(async () => 'finalGrantId');
+const grantAddOIDCScope = jest.fn();
+const grantAddResourceScope = jest.fn();
+const interactionResult = jest.fn(async () => 'redirectTo');
+const interactionDetails: jest.MockedFunction<() => Promise<unknown>> = jest.fn(async () => ({}));
+
+class Grant {
+  static async find(id: string) {
+    return id === 'exists' ? new Grant() : undefined;
+  }
+
+  save: typeof grantSave;
+  addOIDCScope: typeof grantAddOIDCScope;
+  addResourceScope: typeof grantAddResourceScope;
+
+  constructor() {
+    this.save = grantSave;
+    this.addOIDCScope = grantAddOIDCScope;
+    this.addResourceScope = grantAddResourceScope;
+  }
+}
+
+const createContext = () => ({
+  ...createMockContext(),
+  addLogContext: jest.fn(),
+  log: jest.fn(),
+});
+
+const createProvider = () => new Provider('');
+
+jest.mock('oidc-provider', () => ({
+  Provider: jest.fn(() => ({
+    Grant,
+    interactionDetails,
+    interactionResult,
+  })),
+}));
+
+afterEach(() => {
+  grantSave.mockClear();
+  interactionResult.mockClear();
+});
+
+describe('signInWithPassword()', () => {
+  it('assign result', async () => {
+    interactionDetails.mockResolvedValueOnce({ params: {} });
+    await signInWithPassword(createContext(), createProvider(), {
+      identifier: SignInIdentifier.Username,
+      password: 'password',
+      findUser: jest.fn(async () => mockUser),
+      logType: 'SignInUsernamePassword',
+      logPayload: { username: 'username' },
+    });
+    expect(interactionResult).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ login: { accountId: mockUser.id } }),
+      expect.anything()
+    );
+  });
+
+  it('throw if user not found', async () => {
+    interactionDetails.mockResolvedValueOnce({ params: {} });
+    await expect(
+      signInWithPassword(createContext(), createProvider(), {
+        identifier: SignInIdentifier.Username,
+        password: 'password',
+        findUser: jest.fn(async () => null),
+        logType: 'SignInUsernamePassword',
+        logPayload: { username: 'username' },
+      })
+    ).rejects.toThrowError(new RequestError('session.invalid_credentials'));
+  });
+
+  it('throw if user found but wrong password', async () => {
+    interactionDetails.mockResolvedValueOnce({ params: {} });
+    await expect(
+      signInWithPassword(createContext(), createProvider(), {
+        identifier: SignInIdentifier.Username,
+        password: '_password',
+        findUser: jest.fn(async () => mockUser),
+        logType: 'SignInUsernamePassword',
+        logPayload: { username: 'username' },
+      })
+    ).rejects.toThrowError(new RequestError('session.invalid_credentials'));
+  });
+
+  it('throw if sign in method is not enabled', async () => {
+    findDefaultSignInExperience.mockResolvedValueOnce({
+      ...mockSignInExperience,
+      signIn: {
+        methods: [
+          {
+            ...mockSignInMethod,
+            identifier: SignInIdentifier.Sms,
+            password: false,
+          },
+        ],
+      },
+    });
+    interactionDetails.mockResolvedValueOnce({ params: {} });
+    await expect(
+      signInWithPassword(createContext(), createProvider(), {
+        identifier: SignInIdentifier.Username,
+        password: 'password',
+        findUser: jest.fn(async () => mockUser),
+        logType: 'SignInUsernamePassword',
+        logPayload: { username: 'username' },
+      })
+    ).rejects.toThrowError(
+      new RequestError({
+        code: 'user.sign_in_method_not_enabled',
+        status: 422,
+      })
+    );
+  });
+});

--- a/packages/integration-tests/src/helpers.ts
+++ b/packages/integration-tests/src/helpers.ts
@@ -72,8 +72,12 @@ export const setUpConnector = async (connectorId: string, config: Record<string,
   assert(connector.enabled, new Error('Connector Setup Failed'));
 };
 
-export const setSignUpIdentifier = async (identifier: SignUpIdentifier) => {
-  await updateSignInExperience({ signUp: { identifier, password: true, verify: true } });
+export const setSignUpIdentifier = async (
+  identifier: SignUpIdentifier,
+  password = true,
+  verify = true
+) => {
+  await updateSignInExperience({ signUp: { identifier, password, verify } });
 };
 
 type PasscodeRecord = {

--- a/packages/integration-tests/tests/api/session.test.ts
+++ b/packages/integration-tests/tests/api/session.test.ts
@@ -47,7 +47,7 @@ describe('username and password flow', () => {
 describe('email passwordless flow', () => {
   beforeAll(async () => {
     await setUpConnector(mockEmailConnectorId, mockEmailConnectorConfig);
-    await setSignUpIdentifier(SignUpIdentifier.Email);
+    await setSignUpIdentifier(SignUpIdentifier.Email, false);
   });
 
   // Since we can not create a email register user throw admin. Have to run the register then sign-in concurrently.
@@ -121,7 +121,7 @@ describe('email passwordless flow', () => {
 describe('sms passwordless flow', () => {
   beforeAll(async () => {
     await setUpConnector(mockSmsConnectorId, mockSmsConnectorConfig);
-    await setSignUpIdentifier(SignUpIdentifier.Sms);
+    await setSignUpIdentifier(SignUpIdentifier.Sms, false);
   });
 
   // Since we can not create a sms register user throw admin. Have to run the register then sign-in concurrently.

--- a/packages/schemas/src/types/log.ts
+++ b/packages/schemas/src/types/log.ts
@@ -79,6 +79,20 @@ const signInUsernamePasswordLogPayloadGuard = arbitraryLogPayloadGuard.and(
   })
 );
 
+const signInEmailPasswordLogPayloadGuard = arbitraryLogPayloadGuard.and(
+  z.object({
+    userId: z.string().optional(),
+    email: z.string().optional(),
+  })
+);
+
+const signInSmsPasswordLogPayloadGuard = arbitraryLogPayloadGuard.and(
+  z.object({
+    userId: z.string().optional(),
+    sms: z.string().optional(),
+  })
+);
+
 const signInEmailSendPasscodeLogPayloadGuard = arbitraryLogPayloadGuard.and(
   z.object({
     email: z.string().optional(),
@@ -197,6 +211,8 @@ const logPayloadsGuard = z.object({
   RegisterSocialBind: registerSocialBindLogPayloadGuard,
   RegisterSocial: registerSocialLogPayloadGuard,
   SignInUsernamePassword: signInUsernamePasswordLogPayloadGuard,
+  SignInEmailPassword: signInEmailPasswordLogPayloadGuard,
+  SignInSmsPassword: signInSmsPasswordLogPayloadGuard,
   SignInEmailSendPasscode: signInEmailSendPasscodeLogPayloadGuard,
   SignInEmail: signInEmailLogPayloadGuard,
   SignInSmsSendPasscode: signInSmsSendPasscodeLogPayloadGuard,


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Add 2 APIs:

1. `/session/sign-in/password/email`
2. `/session/sign-in/password/sms`

Integration tests are not implemented yet 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UTs.
