### PR TITLE
feat(core): require set a password

### DIFF
--- a/packages/core/src/__mocks__/user.ts
+++ b/packages/core/src/__mocks__/user.ts
@@ -8,8 +8,8 @@ export const mockUser: User = {
   primaryEmail: 'foo@logto.io',
   primaryPhone: '111111',
   roleNames: ['admin'],
-  passwordEncrypted: null,
-  passwordEncryptionMethod: null,
+  passwordEncrypted: 'password',
+  passwordEncryptionMethod: UsersPasswordEncryptionMethod.Argon2i,
   name: null,
   avatar: null,
   identities: {

--- a/packages/core/src/routes/session/consts.ts
+++ b/packages/core/src/routes/session/consts.ts
@@ -1,1 +1,2 @@
 export const verificationTimeout = 10 * 60; // 10 mins.
+export const continueSignInTimeout = 10 * 60; // 10 mins.

--- a/packages/core/src/routes/session/continue.test.ts
+++ b/packages/core/src/routes/session/continue.test.ts
@@ -1,0 +1,113 @@
+import dayjs from 'dayjs';
+import { Provider } from 'oidc-provider';
+
+import { mockUser } from '@/__mocks__';
+import { createRequester } from '@/utils/test-utils';
+
+import continueRoutes, { continueRoute } from './continue';
+
+const checkRequiredProfile = jest.fn();
+jest.mock('./utils', () => ({
+  ...jest.requireActual('./utils'),
+  checkRequiredProfile: () => checkRequiredProfile(),
+}));
+
+jest.mock('@/queries/sign-in-experience', () => ({
+  findDefaultSignInExperience: jest.fn(),
+}));
+
+const updateUserById = jest.fn(async (..._args: unknown[]) => mockUser);
+const findUserById = jest.fn(async (..._args: unknown[]) => mockUser);
+
+jest.mock('@/queries/user', () => ({
+  updateUserById: async (...args: unknown[]) => updateUserById(...args),
+  findUserById: async () => findUserById(),
+}));
+
+const interactionResult = jest.fn(async () => 'redirectTo');
+const interactionDetails: jest.MockedFunction<() => Promise<unknown>> = jest.fn(async () => ({}));
+
+jest.mock('oidc-provider', () => ({
+  Provider: jest.fn(() => ({
+    interactionDetails,
+    interactionResult,
+  })),
+}));
+
+afterEach(() => {
+  interactionResult.mockClear();
+});
+
+describe('session -> continueRoutes', () => {
+  const sessionRequest = createRequester({
+    anonymousRoutes: continueRoutes,
+    provider: new Provider(''),
+    middlewares: [
+      async (ctx, next) => {
+        ctx.addLogContext = jest.fn();
+        ctx.log = jest.fn();
+
+        return next();
+      },
+    ],
+  });
+
+  describe('POST /session/sign-in/continue/password', () => {
+    it('updates user password, checks required profile, and sign in', async () => {
+      interactionDetails.mockResolvedValueOnce({
+        jti: 'jti',
+        result: {
+          continueSignIn: {
+            userId: mockUser.id,
+            expiresAt: dayjs().add(1, 'day').toISOString(),
+          },
+        },
+      });
+      findUserById.mockResolvedValueOnce({
+        ...mockUser,
+        passwordEncrypted: null,
+        identities: {},
+      });
+      const response = await sessionRequest.post(`${continueRoute}/password`).send({
+        password: 'password',
+      });
+      expect(response.statusCode).toEqual(200);
+      expect(checkRequiredProfile).toHaveBeenCalled();
+      expect(updateUserById).toHaveBeenCalledWith(mockUser.id, expect.anything());
+      expect(response.body).toHaveProperty('redirectTo');
+      expect(interactionResult).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ login: { accountId: mockUser.id } }),
+        expect.anything()
+      );
+    });
+
+    it('throws on empty continue sign in storage', async () => {
+      interactionDetails.mockResolvedValueOnce({
+        jti: 'jti',
+        result: {},
+      });
+      const response = await sessionRequest.post(`${continueRoute}/password`).send({
+        password: 'password',
+      });
+      expect(response.statusCode).toEqual(401);
+    });
+
+    it('throws on expired continue sign in storage', async () => {
+      interactionDetails.mockResolvedValueOnce({
+        jti: 'jti',
+        result: {
+          continueSignIn: {
+            userId: mockUser.id,
+            expiresAt: dayjs().subtract(1, 'second').toISOString(),
+          },
+        },
+      });
+      const response = await sessionRequest.post(`${continueRoute}/password`).send({
+        password: 'password',
+      });
+      expect(response.statusCode).toEqual(401);
+    });
+  });
+});

--- a/packages/core/src/routes/session/continue.ts
+++ b/packages/core/src/routes/session/continue.ts
@@ -1,0 +1,51 @@
+import { passwordRegEx } from '@logto/core-kit';
+import type { Provider } from 'oidc-provider';
+import { object, string } from 'zod';
+
+import RequestError from '@/errors/RequestError';
+import { assignInteractionResults } from '@/lib/session';
+import { encryptUserPassword } from '@/lib/user';
+import koaGuard from '@/middleware/koa-guard';
+import { findDefaultSignInExperience } from '@/queries/sign-in-experience';
+import { findUserById, updateUserById } from '@/queries/user';
+import assertThat from '@/utils/assert-that';
+
+import type { AnonymousRouter } from '../types';
+import { checkRequiredProfile, getContinueSignInResult, getRoutePrefix } from './utils';
+
+export const continueRoute = getRoutePrefix('sign-in', 'continue');
+
+export default function continueRoutes<T extends AnonymousRouter>(router: T, provider: Provider) {
+  router.post(
+    `${continueRoute}/password`,
+    koaGuard({
+      body: object({
+        password: string().regex(passwordRegEx),
+      }),
+    }),
+    async (ctx, next) => {
+      const { password } = ctx.guard.body;
+      const { userId } = await getContinueSignInResult(ctx, provider);
+      const user = await findUserById(userId);
+
+      // Social identities can take place the role of password
+      assertThat(
+        !user.passwordEncrypted && Object.keys(user.identities).length === 0,
+        new RequestError({
+          code: 'user.password_exists',
+        })
+      );
+
+      const { passwordEncrypted, passwordEncryptionMethod } = await encryptUserPassword(password);
+      const updatedUser = await updateUserById(userId, {
+        passwordEncrypted,
+        passwordEncryptionMethod,
+      });
+      const signInExperience = await findDefaultSignInExperience();
+      await checkRequiredProfile(ctx, provider, updatedUser, signInExperience);
+      await assignInteractionResults(ctx, provider, { login: { accountId: updatedUser.id } });
+
+      return next();
+    }
+  );
+}

--- a/packages/core/src/routes/session/index.ts
+++ b/packages/core/src/routes/session/index.ts
@@ -13,6 +13,7 @@ import { findUserById } from '@/queries/user';
 import assertThat from '@/utils/assert-that';
 
 import type { AnonymousRouter } from '../types';
+import continueRoutes from './continue';
 import forgotPasswordRoutes from './forgot-password';
 import koaGuardSessionAction from './middleware/koa-guard-session-action';
 import passwordRoutes from './password';
@@ -103,6 +104,7 @@ export default function sessionRoutes<T extends AnonymousRouter>(router: T, prov
   passwordRoutes(router, provider);
   passwordlessRoutes(router, provider);
   socialRoutes(router, provider);
+  continueRoutes(router, provider);
 
   forgotPasswordRoutes(router, provider);
 }

--- a/packages/core/src/routes/session/passwordless.test.ts
+++ b/packages/core/src/routes/session/passwordless.test.ts
@@ -12,14 +12,17 @@ import { verificationTimeout } from './consts';
 import * as passwordlessActions from './middleware/passwordless-action';
 import passwordlessRoutes, { registerRoute, signInRoute } from './passwordless';
 
-const insertUser = jest.fn(async (..._args: unknown[]) => ({ id: 'id' }));
+const insertUser = jest.fn(async (..._args: unknown[]) => ({ id: 'foo' }));
 const findUserById = jest.fn(async (): Promise<User> => mockUser);
-const updateUserById = jest.fn(async (..._args: unknown[]) => ({ id: 'id' }));
+const findUserByEmail = jest.fn(async (): Promise<User> => mockUser);
+const updateUserById = jest.fn(async (..._args: unknown[]) => ({ id: 'foo' }));
 const findDefaultSignInExperience = jest.fn(async () => ({
   ...mockSignInExperience,
   signUp: {
     ...mockSignInExperience.signUp,
     identifier: SignUpIdentifier.Username,
+    password: false,
+    verify: true,
   },
 }));
 
@@ -30,8 +33,8 @@ jest.mock('@/lib/user', () => ({
 
 jest.mock('@/queries/user', () => ({
   findUserById: async () => findUserById(),
-  findUserByPhone: async () => ({ id: 'id' }),
-  findUserByEmail: async () => ({ id: 'id' }),
+  findUserByPhone: async () => ({ id: 'foo' }),
+  findUserByEmail: async () => findUserByEmail(),
   updateUserById: async (...args: unknown[]) => updateUserById(...args),
   hasUser: async (username: string) => username === 'username1',
   hasUserWithPhone: async (phone: string) => phone === '13000000000',
@@ -247,7 +250,7 @@ describe('session -> passwordlessRoutes', () => {
         expect.anything(),
         expect.objectContaining({
           verification: {
-            userId: 'id',
+            userId: 'foo',
             expiresAt: dayjs(fakeTime).add(verificationTimeout, 'second').toISOString(),
             flow: PasscodeType.ForgotPassword,
           },
@@ -343,7 +346,7 @@ describe('session -> passwordlessRoutes', () => {
         expect.anything(),
         expect.objectContaining({
           verification: {
-            userId: 'id',
+            userId: 'foo',
             expiresAt: dayjs(fakeTime).add(verificationTimeout, 'second').toISOString(),
             flow: PasscodeType.ForgotPassword,
           },
@@ -388,7 +391,7 @@ describe('session -> passwordlessRoutes', () => {
         expect.anything(),
         expect.anything(),
         expect.objectContaining({
-          login: { accountId: 'id' },
+          login: { accountId: 'foo' },
         }),
         expect.anything()
       );
@@ -410,7 +413,7 @@ describe('session -> passwordlessRoutes', () => {
         expect.anything(),
         expect.anything(),
         expect.objectContaining({
-          login: { accountId: 'id' },
+          login: { accountId: 'foo' },
         }),
         expect.anything()
       );
@@ -523,6 +526,8 @@ describe('session -> passwordlessRoutes', () => {
         signUp: {
           ...mockSignInExperience.signUp,
           identifier: SignUpIdentifier.Email,
+          password: false,
+          verify: true,
         },
       });
     });
@@ -549,7 +554,7 @@ describe('session -> passwordlessRoutes', () => {
         expect.anything(),
         expect.anything(),
         expect.objectContaining({
-          login: { accountId: 'id' },
+          login: { accountId: 'foo' },
         }),
         expect.anything()
       );
@@ -573,7 +578,7 @@ describe('session -> passwordlessRoutes', () => {
         expect.anything(),
         expect.anything(),
         expect.objectContaining({
-          login: { accountId: 'id' },
+          login: { accountId: 'foo' },
         }),
         expect.anything()
       );
@@ -657,6 +662,7 @@ describe('session -> passwordlessRoutes', () => {
         signUp: {
           ...mockSignInExperience.signUp,
           identifier: SignUpIdentifier.Sms,
+          password: false,
         },
       });
     });
@@ -784,6 +790,7 @@ describe('session -> passwordlessRoutes', () => {
         signUp: {
           ...mockSignInExperience.signUp,
           identifier: SignUpIdentifier.Email,
+          password: false,
         },
       });
     });

--- a/packages/core/src/routes/session/types.ts
+++ b/packages/core/src/routes/session/types.ts
@@ -51,3 +51,10 @@ export type VerificationStorage =
   | ForgotPasswordSessionStorage;
 
 export type VerificationResult<T = VerificationStorage> = { verification: T };
+
+export const continueSignInStorageGuard = z.object({
+  userId: z.string(),
+  expiresAt: z.string(),
+});
+
+export type ContinueSignInStorage = z.infer<typeof continueSignInStorageGuard>;

--- a/packages/phrases/src/locales/en/errors.ts
+++ b/packages/phrases/src/locales/en/errors.ts
@@ -45,6 +45,8 @@ const errors = {
     sign_up_method_not_enabled: 'This sign up method is not enabled.',
     sign_in_method_not_enabled: 'This sign in method is not enabled.',
     same_password: 'Your new password can’t be the same as your current password.',
+    require_password: 'You need to set a password before sign in.',
+    password_exists: 'Your password has been set.',
   },
   password: {
     unsupported_encryption_method: 'The encryption method {{name}} is not supported.',

--- a/packages/phrases/src/locales/fr/errors.ts
+++ b/packages/phrases/src/locales/fr/errors.ts
@@ -46,6 +46,8 @@ const errors = {
     sign_up_method_not_enabled: 'This sign up method is not enabled.', // UNTRANSLATED
     sign_in_method_not_enabled: 'This sign in method is not enabled.', // UNTRANSLATED
     same_password: 'Your new password can’t be the same as your current password.', // UNTRANSLATED
+    require_password: 'You need to set a password before sign in.', // UNTRANSLATED
+    password_exists: 'Your password has been set.', // UNTRANSLATED
   },
   password: {
     unsupported_encryption_method: "La méthode de cryptage {{name}} n'est pas prise en charge.",

--- a/packages/phrases/src/locales/ko/errors.ts
+++ b/packages/phrases/src/locales/ko/errors.ts
@@ -44,6 +44,8 @@ const errors = {
     sign_up_method_not_enabled: 'This sign up method is not enabled.', // UNTRANSLATED
     sign_in_method_not_enabled: 'This sign in method is not enabled.', // UNTRANSLATED
     same_password: 'Your new password can’t be the same as your current password.', // UNTRANSLATED
+    require_password: 'You need to set a password before sign in.', // UNTRANSLATED
+    password_exists: 'Your password has been set.', // UNTRANSLATED
   },
   password: {
     unsupported_encryption_method: '{{name}} 암호화 방법을 지원하지 않아요.',

--- a/packages/phrases/src/locales/pt-pt/errors.ts
+++ b/packages/phrases/src/locales/pt-pt/errors.ts
@@ -44,6 +44,8 @@ const errors = {
     sign_up_method_not_enabled: 'This sign up method is not enabled.', // UNTRANSLATED
     sign_in_method_not_enabled: 'This sign in method is not enabled.', // UNTRANSLATED
     same_password: 'Your new password can’t be the same as your current password.', // UNTRANSLATED
+    require_password: 'You need to set a password before sign in.', // UNTRANSLATED
+    password_exists: 'Your password has been set.', // UNTRANSLATED
   },
   password: {
     unsupported_encryption_method: 'O método de enncriptação {{name}} não é suportado.',

--- a/packages/phrases/src/locales/tr-tr/errors.ts
+++ b/packages/phrases/src/locales/tr-tr/errors.ts
@@ -45,6 +45,8 @@ const errors = {
     sign_up_method_not_enabled: 'This sign up method is not enabled.', // UNTRANSLATED
     sign_in_method_not_enabled: 'This sign in method is not enabled.', // UNTRANSLATED
     same_password: 'Your new password can’t be the same as your current password.', // UNTRANSLATED
+    require_password: 'You need to set a password before sign in.', // UNTRANSLATED
+    password_exists: 'Your password has been set.', // UNTRANSLATED
   },
   password: {
     unsupported_encryption_method: '{{name}} şifreleme metodu desteklenmiyor.',

--- a/packages/phrases/src/locales/zh-cn/errors.ts
+++ b/packages/phrases/src/locales/zh-cn/errors.ts
@@ -44,6 +44,8 @@ const errors = {
     sign_up_method_not_enabled: '注册方式尚未启用',
     sign_in_method_not_enabled: '登录方式尚未启用',
     same_password: '为确保你的账户安全，新密码不能与旧密码一致',
+    require_password: '请设置密码',
+    password_exists: '密码已设置过',
   },
   password: {
     unsupported_encryption_method: '不支持的加密方法 {{name}}',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

If check "set a password" on SIE configs, then users sign in or register through verification code will get an error `user.require_password`, and need to call the new route `/session/sign-in/continue/password` to set a password, then will auto sign in with last verification state.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UTs
