### PR TITLE
refactor(console): the sign-up and sign-in form interactions

### DIFF
--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/SignInForm.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/SignInForm.tsx
@@ -22,8 +22,12 @@ const SignInForm = () => {
     name: 'signUp.identifier',
     defaultValue: SignUpIdentifier.Username,
   });
-  const requirePassword = useWatch({ control, name: 'signUp.password', defaultValue: false });
-  const requireVerificationCode = useWatch({ control, name: 'signUp.verify', defaultValue: false });
+  const setupPasswordAtSignUp = useWatch({ control, name: 'signUp.password', defaultValue: false });
+  const setupVerificationAtSignUp = useWatch({
+    control,
+    name: 'signUp.verify',
+    defaultValue: false,
+  });
 
   return (
     <>
@@ -41,8 +45,8 @@ const SignInForm = () => {
               <SignInMethodEditBox
                 value={value}
                 requiredSignInIdentifiers={signUpToSignInIdentifierMapping[signUpIdentifier]}
-                isPasswordRequired={requirePassword}
-                isVerificationRequired={requireVerificationCode}
+                isSignUpPasswordRequired={setupPasswordAtSignUp}
+                isSignUpVerificationRequired={setupVerificationAtSignUp}
                 onChange={onChange}
               />
             );

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/SignUpForm.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/SignUpForm.tsx
@@ -1,6 +1,5 @@
 import { SignUpIdentifier } from '@logto/schemas';
-import { useEffect } from 'react';
-import { Controller, useFormContext } from 'react-hook-form';
+import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { snakeCase } from 'snake-case';
 
@@ -19,10 +18,14 @@ import * as styles from './index.module.scss';
 
 const SignUpForm = () => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
-  const { control, setValue, resetField, watch } = useFormContext<SignInExperienceForm>();
-  const signUpIdentifier = watch('signUp.identifier');
+  const { control, setValue } = useFormContext<SignInExperienceForm>();
 
-  useEffect(() => {
+  const signUpIdentifier = useWatch({
+    control,
+    name: 'signUp.identifier',
+  });
+
+  const postSignUpIdentifierChange = (signUpIdentifier: SignUpIdentifier) => {
     if (signUpIdentifier === SignUpIdentifier.Username) {
       setValue('signUp.password', true);
       setValue('signUp.verify', false);
@@ -38,10 +41,9 @@ const SignUpForm = () => {
     }
 
     if (requiredVerifySignUpIdentifiers.includes(signUpIdentifier)) {
-      resetField('signUp.password');
       setValue('signUp.verify', true);
     }
-  }, [resetField, setValue, signUpIdentifier]);
+  };
 
   return (
     <>
@@ -71,7 +73,11 @@ const SignUpForm = () => {
                 ),
               }))}
               onChange={(value) => {
+                if (!value) {
+                  return;
+                }
                 onChange(value);
+                postSignUpIdentifierChange(value);
               }}
             />
           )}

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/SignUpForm.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/SignUpForm.tsx
@@ -1,5 +1,5 @@
 import { SignUpIdentifier } from '@logto/schemas';
-import { Controller, useFormContext, useWatch } from 'react-hook-form';
+import { Controller, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { snakeCase } from 'snake-case';
 
@@ -18,12 +18,9 @@ import * as styles from './index.module.scss';
 
 const SignUpForm = () => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
-  const { control, setValue } = useFormContext<SignInExperienceForm>();
+  const { control, setValue, getValues } = useFormContext<SignInExperienceForm>();
 
-  const signUpIdentifier = useWatch({
-    control,
-    name: 'signUp.identifier',
-  });
+  const signUpIdentifier = getValues('signUp.identifier');
 
   const postSignUpIdentifierChange = (signUpIdentifier: SignUpIdentifier) => {
     if (signUpIdentifier === SignUpIdentifier.Username) {

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/SignInMethodItem.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/SignInMethodItem.tsx
@@ -14,8 +14,8 @@ import type { SignInMethod } from './types';
 
 type Props = {
   signInMethod: SignInMethod;
-  isPasswordRequired: boolean;
-  isVerificationRequired: boolean;
+  isPasswordDisabled: boolean;
+  isVerificationDisabled: boolean;
   isDeletable: boolean;
   onVerificationStateChange: (
     identifier: SignInIdentifier,
@@ -28,8 +28,8 @@ type Props = {
 
 const SignInMethodItem = ({
   signInMethod: { identifier, password, verificationCode, isPasswordPrimary },
-  isPasswordRequired,
-  isVerificationRequired,
+  isPasswordDisabled,
+  isVerificationDisabled,
   isDeletable,
   onVerificationStateChange,
   onToggleVerificationPrimary,
@@ -55,7 +55,7 @@ const SignInMethodItem = ({
           <Checkbox
             label={t('sign_in_exp.sign_up_and_sign_in.sign_in.password_auth')}
             value={password}
-            disabled={isPasswordRequired}
+            disabled={isPasswordDisabled}
             onChange={(checked) => {
               onVerificationStateChange(identifier, 'password', checked);
             }}
@@ -73,7 +73,7 @@ const SignInMethodItem = ({
               <Checkbox
                 label={t('sign_in_exp.sign_up_and_sign_in.sign_in.verification_code_auth')}
                 value={verificationCode}
-                disabled={isVerificationRequired && !isPasswordRequired}
+                disabled={isVerificationDisabled}
                 onChange={(checked) => {
                   onVerificationStateChange(identifier, 'verificationCode', checked);
                 }}

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/index.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/index.tsx
@@ -67,7 +67,7 @@ const SignInMethodEditBox = ({
   );
 
   useEffect(() => {
-    const requiredSignInMethods = requiredSignInIdentifiers.reduce(
+    const allSignInMethods = requiredSignInIdentifiers.reduce(
       (previous, current) =>
         computeOnSignInMethodAppended(previous, {
           identifier: current,
@@ -82,7 +82,7 @@ const SignInMethodEditBox = ({
     );
 
     handleChange(
-      requiredSignInMethods.map((method) => ({
+      allSignInMethods.map((method) => ({
         ...method,
         password: getSignInMethodPasswordCheckState(
           method.identifier,

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/index.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/index.tsx
@@ -14,7 +14,8 @@ import {
   computeOnSignInMethodAppended,
   computeOnVerificationStateChanged,
   computeOnPasswordPrimaryFlagToggled,
-  getSignInMethodAuthValue,
+  getSignInMethodPasswordCheckState,
+  getSignInMethodVerificationCodeCheckState,
 } from './utilities';
 
 type Props = {
@@ -53,8 +54,11 @@ const SignInMethodEditBox = ({
       handleChange(
         computeOnSignInMethodAppended(value, {
           identifier,
-          password: getSignInMethodAuthValue(identifier, isSignUpPasswordRequired),
-          verificationCode: getSignInMethodAuthValue(identifier, isSignUpVerificationRequired),
+          password: getSignInMethodPasswordCheckState(identifier, isSignUpPasswordRequired),
+          verificationCode: getSignInMethodVerificationCodeCheckState(
+            identifier,
+            isSignUpVerificationRequired
+          ),
           isPasswordPrimary: true,
         })
       );
@@ -67,8 +71,11 @@ const SignInMethodEditBox = ({
       (previous, current) =>
         computeOnSignInMethodAppended(previous, {
           identifier: current,
-          password: getSignInMethodAuthValue(current, isSignUpPasswordRequired),
-          verificationCode: getSignInMethodAuthValue(current, isSignUpVerificationRequired),
+          password: getSignInMethodPasswordCheckState(current, isSignUpPasswordRequired),
+          verificationCode: getSignInMethodVerificationCodeCheckState(
+            current,
+            isSignUpVerificationRequired
+          ),
           isPasswordPrimary: true,
         }),
       signInMethods.current
@@ -77,12 +84,12 @@ const SignInMethodEditBox = ({
     handleChange(
       requiredSignInMethods.map((method) => ({
         ...method,
-        password: getSignInMethodAuthValue(
+        password: getSignInMethodPasswordCheckState(
           method.identifier,
           isSignUpPasswordRequired,
           method.password
         ),
-        verificationCode: getSignInMethodAuthValue(
+        verificationCode: getSignInMethodVerificationCodeCheckState(
           method.identifier,
           isSignUpVerificationRequired,
           method.verificationCode

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/index.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/index.tsx
@@ -1,4 +1,5 @@
-import type { ConnectorType, SignInIdentifier } from '@logto/schemas';
+import type { ConnectorType } from '@logto/schemas';
+import { SignInIdentifier } from '@logto/schemas';
 import { useCallback, useEffect, useRef } from 'react';
 
 import DragDropProvider from '@/components/Transfer/DragDropProvider';
@@ -10,25 +11,26 @@ import AddSignInMethodButton from './AddSignInMethodButton';
 import SignInMethodItem from './SignInMethodItem';
 import type { SignInMethod } from './types';
 import {
-  computeOnSignInMethodAppended as appendSignInMethodIfNotExist,
+  computeOnSignInMethodAppended,
   computeOnVerificationStateChanged,
   computeOnPasswordPrimaryFlagToggled,
+  getSignInMethodAuthValue,
 } from './utilities';
 
 type Props = {
   value: SignInMethod[];
   onChange: (value: SignInMethod[]) => void;
   requiredSignInIdentifiers: SignInIdentifier[];
-  isPasswordRequired: boolean;
-  isVerificationRequired: boolean;
+  isSignUpPasswordRequired: boolean;
+  isSignUpVerificationRequired: boolean;
 };
 
 const SignInMethodEditBox = ({
   value,
   onChange,
   requiredSignInIdentifiers,
-  isPasswordRequired,
-  isVerificationRequired,
+  isSignUpPasswordRequired,
+  isSignUpVerificationRequired,
 }: Props) => {
   const signInIdentifierOptions = signInIdentifiers.filter((candidateIdentifier) =>
     value.every(({ identifier }) => identifier !== candidateIdentifier)
@@ -49,27 +51,50 @@ const SignInMethodEditBox = ({
   const addSignInMethod = useCallback(
     (identifier: SignInIdentifier) => {
       handleChange(
-        appendSignInMethodIfNotExist(value, identifier, isPasswordRequired, isVerificationRequired)
+        computeOnSignInMethodAppended(value, {
+          identifier,
+          password: getSignInMethodAuthValue(identifier, isSignUpPasswordRequired),
+          verificationCode: getSignInMethodAuthValue(identifier, isSignUpVerificationRequired),
+          isPasswordPrimary: true,
+        })
       );
     },
-    [handleChange, value, isPasswordRequired, isVerificationRequired]
+    [handleChange, value, isSignUpPasswordRequired, isSignUpVerificationRequired]
   );
 
   useEffect(() => {
     const requiredSignInMethods = requiredSignInIdentifiers.reduce(
       (previous, current) =>
-        appendSignInMethodIfNotExist(previous, current, isPasswordRequired, isVerificationRequired),
+        computeOnSignInMethodAppended(previous, {
+          identifier: current,
+          password: getSignInMethodAuthValue(current, isSignUpPasswordRequired),
+          verificationCode: getSignInMethodAuthValue(current, isSignUpVerificationRequired),
+          isPasswordPrimary: true,
+        }),
       signInMethods.current
     );
 
     handleChange(
       requiredSignInMethods.map((method) => ({
         ...method,
-        password: isPasswordRequired,
-        verificationCode: isVerificationRequired,
+        password: getSignInMethodAuthValue(
+          method.identifier,
+          isSignUpPasswordRequired,
+          method.password
+        ),
+        verificationCode: getSignInMethodAuthValue(
+          method.identifier,
+          isSignUpVerificationRequired,
+          method.verificationCode
+        ),
       }))
     );
-  }, [handleChange, isPasswordRequired, isVerificationRequired, requiredSignInIdentifiers]);
+  }, [
+    handleChange,
+    isSignUpPasswordRequired,
+    isSignUpVerificationRequired,
+    requiredSignInIdentifiers,
+  ]);
 
   const onMoveItem = (dragIndex: number, hoverIndex: number) => {
     const dragItem = value[dragIndex];
@@ -106,8 +131,10 @@ const SignInMethodEditBox = ({
           >
             <SignInMethodItem
               signInMethod={signInMethod}
-              isPasswordRequired={isPasswordRequired}
-              isVerificationRequired={isVerificationRequired}
+              isPasswordDisabled={
+                signInMethod.identifier === SignInIdentifier.Username || isSignUpPasswordRequired
+              }
+              isVerificationDisabled={isSignUpVerificationRequired && !isSignUpPasswordRequired}
               isDeletable={requiredSignInIdentifiers.includes(signInMethod.identifier)}
               onVerificationStateChange={(identifier, verification, checked) => {
                 handleChange(

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/utilities.ts
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/utilities.ts
@@ -46,23 +46,23 @@ export const computeOnPasswordPrimaryFlagToggled = (
 export const getSignInMethodPasswordCheckState = (
   signInIdentifier: SignInIdentifier,
   isSignUpPasswordRequired: boolean,
-  originCheckState?: boolean
+  originCheckState = false
 ) => {
   if (signInIdentifier === SignInIdentifier.Username) {
     return true;
   }
 
-  return isSignUpPasswordRequired || (originCheckState ?? isSignUpPasswordRequired);
+  return isSignUpPasswordRequired || originCheckState;
 };
 
 export const getSignInMethodVerificationCodeCheckState = (
   signInIdentifier: SignInIdentifier,
   isSignUpVerificationRequired: boolean,
-  originCheckState?: boolean
+  originCheckState = false
 ) => {
   if (signInIdentifier === SignInIdentifier.Username) {
     return false;
   }
 
-  return isSignUpVerificationRequired || (originCheckState ?? isSignUpVerificationRequired);
+  return isSignUpVerificationRequired || originCheckState;
 };

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/utilities.ts
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/utilities.ts
@@ -43,14 +43,26 @@ export const computeOnPasswordPrimaryFlagToggled = (
       : method
   );
 
-export const getSignInMethodAuthValue = (
+export const getSignInMethodPasswordCheckState = (
   signInIdentifier: SignInIdentifier,
-  isSignUpAuthRequired: boolean,
-  originValue?: boolean
+  isSignUpPasswordRequired: boolean,
+  originCheckState?: boolean
 ) => {
   if (signInIdentifier === SignInIdentifier.Username) {
     return true;
   }
 
-  return isSignUpAuthRequired || (originValue ?? isSignUpAuthRequired);
+  return isSignUpPasswordRequired || (originCheckState ?? isSignUpPasswordRequired);
+};
+
+export const getSignInMethodVerificationCodeCheckState = (
+  signInIdentifier: SignInIdentifier,
+  isSignUpVerificationRequired: boolean,
+  originCheckState?: boolean
+) => {
+  if (signInIdentifier === SignInIdentifier.Username) {
+    return false;
+  }
+
+  return isSignUpVerificationRequired || (originCheckState ?? isSignUpVerificationRequired);
 };

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/utilities.ts
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/utilities.ts
@@ -1,4 +1,4 @@
-import type { SignInIdentifier } from '@logto/schemas';
+import { SignInIdentifier } from '@logto/schemas';
 
 import type { SignInMethod } from './types';
 
@@ -18,24 +18,16 @@ export const computeOnVerificationStateChanged = (
   );
 
 export const computeOnSignInMethodAppended = (
-  oldValue: SignInMethod[],
-  signInIdentifier: SignInIdentifier,
-  requirePassword: boolean,
-  requireVerificationCode: boolean
-) => {
-  if (oldValue.some((method) => method.identifier === signInIdentifier)) {
-    return oldValue;
+  appendTo: SignInMethod[],
+  appended: SignInMethod
+): SignInMethod[] => {
+  const { identifier: signInIdentifier } = appended;
+
+  if (appendTo.some((method) => method.identifier === signInIdentifier)) {
+    return appendTo;
   }
 
-  return [
-    ...oldValue,
-    {
-      identifier: signInIdentifier,
-      password: requirePassword,
-      verificationCode: requireVerificationCode,
-      isPasswordPrimary: true,
-    },
-  ];
+  return [...appendTo, appended];
 };
 
 export const computeOnPasswordPrimaryFlagToggled = (
@@ -50,3 +42,15 @@ export const computeOnPasswordPrimaryFlagToggled = (
         }
       : method
   );
+
+export const getSignInMethodAuthValue = (
+  signInIdentifier: SignInIdentifier,
+  isSignUpAuthRequired: boolean,
+  originValue?: boolean
+) => {
+  if (signInIdentifier === SignInIdentifier.Username) {
+    return true;
+  }
+
+  return isSignUpAuthRequired || (originValue ?? isSignUpAuthRequired);
+};


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
refactor(console): the sign-up and sign-in form interactions
- should not reset the `signUp.pasword` value on the sign-up method change. (keep user's choice)
- refactor the `computeOnSignInMethodAppended` parameters to make this method more meaningful.
- add a `getSignInMethodAuthValue` to get the correct authentication check state when modifying the sign-up identifier and authentications.
- refactor related components to make the logic simple.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
![sign-up-sign-in-interactions](https://user-images.githubusercontent.com/10806653/198962995-548eb6ae-15e2-404e-92ec-d468eaff6345.gif)

