### PR TITLE
chore: sync signin page theme with console dashboard

### DIFF
--- a/packages/ui/src/hooks/use-theme.ts
+++ b/packages/ui/src/hooks/use-theme.ts
@@ -10,13 +10,18 @@ const getThemeBySystemConfiguration = (): Theme => (darkThemeWatchMedia.matches 
 export default function useTheme(): Theme {
   const { experienceSettings, theme, setTheme } = useContext(PageContext);
 
+  const consoleThemeFromLocalStorage = window.localStorage.getItem('logto:admin_console:theme');
   useEffect(() => {
-    if (!experienceSettings?.color.isDarkModeEnabled) {
-      return;
-    }
-
+    /**
+     * If Theme set in console dashboard, then based on localStorage we need update use-theme
+     * elseif no key found then will consider theme from system configuration
+     */
     const changeTheme = () => {
-      setTheme(getThemeBySystemConfiguration());
+      if (consoleThemeFromLocalStorage === 'light' || consoleThemeFromLocalStorage === 'dark') {
+        setTheme(consoleThemeFromLocalStorage);
+      } else {
+        setTheme(getThemeBySystemConfiguration);
+      }
     };
 
     changeTheme();
@@ -26,7 +31,7 @@ export default function useTheme(): Theme {
     return () => {
       darkThemeWatchMedia.removeEventListener('change', changeTheme);
     };
-  }, [experienceSettings, setTheme]);
+  }, [experienceSettings, setTheme, consoleThemeFromLocalStorage]);
 
   return theme;
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The SignIn Page theme is not syncing with the console dashboard, so using the localStorage value set from the console dashboard, changing the sign in page theme

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally by setting up a theme in the console dashboard.
