### PR TITLE
chore: ignore fly.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ cache
 .idea/
 *.pem
 .history
+fly.toml
 
 # connectors
 /packages/core/connectors


### PR DESCRIPTION
Should ignore `fly.toml`, which is a configuration file of fly.io