### PR TITLE
fix(console): correct sign-in method item state

### DIFF
--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/SignInMethodItem.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/SignInMethodItem.tsx
@@ -14,8 +14,8 @@ import type { SignInMethod } from './types';
 
 type Props = {
   signInMethod: SignInMethod;
-  isPasswordDisabled: boolean;
-  isVerificationDisabled: boolean;
+  isPasswordCheckboxEnabled: boolean;
+  isVerificationCheckboxEnabled: boolean;
   isDeletable: boolean;
   onVerificationStateChange: (
     identifier: SignInIdentifier,
@@ -28,8 +28,8 @@ type Props = {
 
 const SignInMethodItem = ({
   signInMethod: { identifier, password, verificationCode, isPasswordPrimary },
-  isPasswordDisabled,
-  isVerificationDisabled,
+  isPasswordCheckboxEnabled,
+  isVerificationCheckboxEnabled,
   isDeletable,
   onVerificationStateChange,
   onToggleVerificationPrimary,
@@ -55,7 +55,7 @@ const SignInMethodItem = ({
           <Checkbox
             label={t('sign_in_exp.sign_up_and_sign_in.sign_in.password_auth')}
             value={password}
-            disabled={isPasswordDisabled}
+            disabled={!isPasswordCheckboxEnabled}
             onChange={(checked) => {
               onVerificationStateChange(identifier, 'password', checked);
             }}
@@ -73,7 +73,7 @@ const SignInMethodItem = ({
               <Checkbox
                 label={t('sign_in_exp.sign_up_and_sign_in.sign_in.verification_code_auth')}
                 value={verificationCode}
-                disabled={isVerificationDisabled}
+                disabled={!isVerificationCheckboxEnabled}
                 onChange={(checked) => {
                   onVerificationStateChange(identifier, 'verificationCode', checked);
                 }}
@@ -83,7 +83,7 @@ const SignInMethodItem = ({
         </div>
       </div>
       <IconButton
-        disabled={isDeletable}
+        disabled={!isDeletable}
         onClick={() => {
           onDelete(identifier);
         }}

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/SignInMethodItem.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/SignInMethodItem.tsx
@@ -14,8 +14,8 @@ import type { SignInMethod } from './types';
 
 type Props = {
   signInMethod: SignInMethod;
-  isPasswordEnabled: boolean;
-  isVerificationEnabled: boolean;
+  isPasswordCheckable: boolean;
+  isVerificationCodeCheckable: boolean;
   isDeletable: boolean;
   onVerificationStateChange: (
     identifier: SignInIdentifier,
@@ -28,8 +28,8 @@ type Props = {
 
 const SignInMethodItem = ({
   signInMethod: { identifier, password, verificationCode, isPasswordPrimary },
-  isPasswordEnabled,
-  isVerificationEnabled,
+  isPasswordCheckable,
+  isVerificationCodeCheckable,
   isDeletable,
   onVerificationStateChange,
   onToggleVerificationPrimary,
@@ -55,7 +55,7 @@ const SignInMethodItem = ({
           <Checkbox
             label={t('sign_in_exp.sign_up_and_sign_in.sign_in.password_auth')}
             value={password}
-            disabled={!isPasswordEnabled}
+            disabled={!isPasswordCheckable}
             onChange={(checked) => {
               onVerificationStateChange(identifier, 'password', checked);
             }}
@@ -73,7 +73,7 @@ const SignInMethodItem = ({
               <Checkbox
                 label={t('sign_in_exp.sign_up_and_sign_in.sign_in.verification_code_auth')}
                 value={verificationCode}
-                disabled={!isVerificationEnabled}
+                disabled={!isVerificationCodeCheckable}
                 onChange={(checked) => {
                   onVerificationStateChange(identifier, 'verificationCode', checked);
                 }}

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/SignInMethodItem.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/SignInMethodItem.tsx
@@ -14,8 +14,8 @@ import type { SignInMethod } from './types';
 
 type Props = {
   signInMethod: SignInMethod;
-  isPasswordCheckboxEnabled: boolean;
-  isVerificationCheckboxEnabled: boolean;
+  isPasswordEnabled: boolean;
+  isVerificationEnabled: boolean;
   isDeletable: boolean;
   onVerificationStateChange: (
     identifier: SignInIdentifier,
@@ -28,8 +28,8 @@ type Props = {
 
 const SignInMethodItem = ({
   signInMethod: { identifier, password, verificationCode, isPasswordPrimary },
-  isPasswordCheckboxEnabled,
-  isVerificationCheckboxEnabled,
+  isPasswordEnabled,
+  isVerificationEnabled,
   isDeletable,
   onVerificationStateChange,
   onToggleVerificationPrimary,
@@ -55,7 +55,7 @@ const SignInMethodItem = ({
           <Checkbox
             label={t('sign_in_exp.sign_up_and_sign_in.sign_in.password_auth')}
             value={password}
-            disabled={!isPasswordCheckboxEnabled}
+            disabled={!isPasswordEnabled}
             onChange={(checked) => {
               onVerificationStateChange(identifier, 'password', checked);
             }}
@@ -73,7 +73,7 @@ const SignInMethodItem = ({
               <Checkbox
                 label={t('sign_in_exp.sign_up_and_sign_in.sign_in.verification_code_auth')}
                 value={verificationCode}
-                disabled={!isVerificationCheckboxEnabled}
+                disabled={!isVerificationEnabled}
                 onChange={(checked) => {
                   onVerificationStateChange(identifier, 'verificationCode', checked);
                 }}

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/index.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/index.tsx
@@ -128,10 +128,10 @@ const SignInMethodEditBox = ({
           >
             <SignInMethodItem
               signInMethod={signInMethod}
-              isPasswordCheckboxEnabled={
+              isPasswordEnabled={
                 signInMethod.identifier !== SignInIdentifier.Username && !isSignUpPasswordRequired
               }
-              isVerificationCheckboxEnabled={
+              isVerificationEnabled={
                 (isSignUpPasswordRequired && isSignUpVerificationRequired) ||
                 // Note: the next line is used to handle the case when the sign-up identifier is `Username`
                 (isSignUpPasswordRequired && signInMethod.identifier !== SignInIdentifier.Username)

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/index.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/index.tsx
@@ -55,15 +55,12 @@ const SignInMethodEditBox = ({
         computeOnSignInMethodAppended(value, {
           identifier,
           password: getSignInMethodPasswordCheckState(identifier, isSignUpPasswordRequired),
-          verificationCode: getSignInMethodVerificationCodeCheckState(
-            identifier,
-            isSignUpVerificationRequired
-          ),
+          verificationCode: getSignInMethodVerificationCodeCheckState(identifier),
           isPasswordPrimary: true,
         })
       );
     },
-    [handleChange, value, isSignUpPasswordRequired, isSignUpVerificationRequired]
+    [handleChange, value, isSignUpPasswordRequired]
   );
 
   useEffect(() => {
@@ -72,10 +69,7 @@ const SignInMethodEditBox = ({
         computeOnSignInMethodAppended(previous, {
           identifier: current,
           password: getSignInMethodPasswordCheckState(current, isSignUpPasswordRequired),
-          verificationCode: getSignInMethodVerificationCodeCheckState(
-            current,
-            isSignUpVerificationRequired
-          ),
+          verificationCode: getSignInMethodVerificationCodeCheckState(current),
           isPasswordPrimary: true,
         }),
       signInMethods.current
@@ -89,11 +83,7 @@ const SignInMethodEditBox = ({
           isSignUpPasswordRequired,
           method.password
         ),
-        verificationCode: getSignInMethodVerificationCodeCheckState(
-          method.identifier,
-          isSignUpVerificationRequired,
-          method.verificationCode
-        ),
+        verificationCode: getSignInMethodVerificationCodeCheckState(method.identifier),
       }))
     );
   }, [
@@ -138,11 +128,15 @@ const SignInMethodEditBox = ({
           >
             <SignInMethodItem
               signInMethod={signInMethod}
-              isPasswordDisabled={
-                signInMethod.identifier === SignInIdentifier.Username || isSignUpPasswordRequired
+              isPasswordCheckboxEnabled={
+                signInMethod.identifier !== SignInIdentifier.Username && !isSignUpPasswordRequired
               }
-              isVerificationDisabled={isSignUpVerificationRequired && !isSignUpPasswordRequired}
-              isDeletable={requiredSignInIdentifiers.includes(signInMethod.identifier)}
+              isVerificationCheckboxEnabled={
+                (isSignUpPasswordRequired && isSignUpVerificationRequired) ||
+                // Note: the next line is used to handle the case when the sign-up identifier is `Username`
+                (isSignUpPasswordRequired && signInMethod.identifier !== SignInIdentifier.Username)
+              }
+              isDeletable={!requiredSignInIdentifiers.includes(signInMethod.identifier)}
               onVerificationStateChange={(identifier, verification, checked) => {
                 handleChange(
                   computeOnVerificationStateChanged(value, identifier, verification, checked)

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/index.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/index.tsx
@@ -128,10 +128,10 @@ const SignInMethodEditBox = ({
           >
             <SignInMethodItem
               signInMethod={signInMethod}
-              isPasswordEnabled={
+              isPasswordCheckable={
                 signInMethod.identifier !== SignInIdentifier.Username && !isSignUpPasswordRequired
               }
-              isVerificationEnabled={
+              isVerificationCodeCheckable={
                 (isSignUpPasswordRequired && isSignUpVerificationRequired) ||
                 // Note: the next line is used to handle the case when the sign-up identifier is `Username`
                 (isSignUpPasswordRequired && signInMethod.identifier !== SignInIdentifier.Username)

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/utilities.ts
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignInMethodEditBox/utilities.ts
@@ -55,14 +55,6 @@ export const getSignInMethodPasswordCheckState = (
   return isSignUpPasswordRequired || originCheckState;
 };
 
-export const getSignInMethodVerificationCodeCheckState = (
-  signInIdentifier: SignInIdentifier,
-  isSignUpVerificationRequired: boolean,
-  originCheckState = false
-) => {
-  if (signInIdentifier === SignInIdentifier.Username) {
-    return false;
-  }
-
-  return isSignUpVerificationRequired || originCheckState;
+export const getSignInMethodVerificationCodeCheckState = (signInIdentifier: SignInIdentifier) => {
+  return signInIdentifier !== SignInIdentifier.Username;
 };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- the `verificationCode` prop of SMS and Email sign-in methods should be true by default.
- the password checkbox should be enabled only when the sign-in method is not `username` and `set a password` is not required in the sign-up config.
- the verification code checkbox should be enabled when the `set a password` and the `verify at sign up` are both required in the sign-up config or the `set a password` is required and the sign-in method is SMS or Email. (the latter case will occur when we set `Username` to the `Sign Up Identifier`)
- refactor the props of `<SignInMethod />` for clarification.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.
