### PR TITLE
refactor(ui): add SmsRegister Container

### DIFF
--- a/packages/ui/src/containers/EmailForm/EmailForm.tsx
+++ b/packages/ui/src/containers/EmailForm/EmailForm.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import Button from '@/components/Button';
@@ -44,20 +44,6 @@ const EmailForm = ({
   const { termsValidation } = useTerms();
   const { fieldValue, setFieldValue, register, validateForm } = useForm(defaultState);
 
-  /*  Clear the form error when input field is updated */
-  const errorMessageRef = useRef(errorMessage);
-
-  useEffect(() => {
-    // eslint-disable-next-line @silverhand/fp/no-mutation
-    errorMessageRef.current = errorMessage;
-  }, [errorMessage]);
-
-  useEffect(() => {
-    if (errorMessageRef.current) {
-      clearErrorMessage?.();
-    }
-  }, [clearErrorMessage, errorMessageRef, fieldValue.email]);
-
   const onSubmitHandler = useCallback(
     async (event?: React.FormEvent<HTMLFormElement>) => {
       event?.preventDefault();
@@ -75,6 +61,8 @@ const EmailForm = ({
     [validateForm, hasTerms, termsValidation, onSubmit, fieldValue.email]
   );
 
+  const { onChange, ...rest } = register('email', emailValidation);
+
   return (
     <form className={classNames(styles.form, className)} onSubmit={onSubmitHandler}>
       <Input
@@ -86,16 +74,17 @@ const EmailForm = ({
         // eslint-disable-next-line jsx-a11y/no-autofocus
         autoFocus={autoFocus}
         className={styles.inputField}
-        {...register('email', emailValidation)}
+        onChange={(event) => {
+          onChange(event);
+          clearErrorMessage?.();
+        }}
+        {...rest}
         onClear={() => {
           setFieldValue((state) => ({ ...state, email: '' }));
         }}
       />
-
       {errorMessage && <ErrorMessage className={styles.formErrors}>{errorMessage}</ErrorMessage>}
-
       {hasSwitch && <PasswordlessSwitch target="sms" className={styles.switch} />}
-
       {hasTerms && <TermsOfUse className={styles.terms} />}
       <Button title="action.continue" onClick={async () => onSubmitHandler()} />
 

--- a/packages/ui/src/containers/PhoneForm/PhoneForm.test.tsx
+++ b/packages/ui/src/containers/PhoneForm/PhoneForm.test.tsx
@@ -3,24 +3,32 @@ import { MemoryRouter } from 'react-router-dom';
 
 import renderWithPageContext from '@/__mocks__/RenderWithPageContext';
 import SettingsProvider from '@/__mocks__/RenderWithPageContext/SettingsProvider';
+import { getDefaultCountryCallingCode } from '@/utils/country-code';
 
-import EmailForm from './EmailForm';
+import PhoneForm from './PhoneForm';
 
 const onSubmit = jest.fn();
 const clearErrorMessage = jest.fn();
 
-describe('<EmailForm/>', () => {
+jest.mock('i18next', () => ({
+  language: 'en',
+}));
+
+describe('<PhonePasswordless/>', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
+  const phoneNumber = '8573333333';
+  const defaultCountryCallingCode = getDefaultCountryCallingCode();
+
   test('render', () => {
     const { queryByText, container } = renderWithPageContext(
       <MemoryRouter>
-        <EmailForm onSubmit={onSubmit} />
+        <PhoneForm onSubmit={onSubmit} />
       </MemoryRouter>
     );
-    expect(container.querySelector('input[name="email"]')).not.toBeNull();
+    expect(container.querySelector('input[name="phone"]')).not.toBeNull();
     expect(queryByText('action.continue')).not.toBeNull();
   });
 
@@ -28,7 +36,7 @@ describe('<EmailForm/>', () => {
     const { queryByText } = renderWithPageContext(
       <MemoryRouter>
         <SettingsProvider>
-          <EmailForm onSubmit={onSubmit} />
+          <PhoneForm onSubmit={onSubmit} />
         </SettingsProvider>
       </MemoryRouter>
     );
@@ -39,40 +47,40 @@ describe('<EmailForm/>', () => {
     const { queryByText } = renderWithPageContext(
       <MemoryRouter>
         <SettingsProvider>
-          <EmailForm hasTerms={false} onSubmit={onSubmit} />
+          <PhoneForm hasTerms={false} onSubmit={onSubmit} />
         </SettingsProvider>
       </MemoryRouter>
     );
     expect(queryByText('description.terms_of_use')).toBeNull();
   });
 
-  test('required email with error message', () => {
+  test('required phone with error message', () => {
     const { queryByText, container, getByText } = renderWithPageContext(
       <MemoryRouter>
-        <EmailForm onSubmit={onSubmit} />
+        <PhoneForm onSubmit={onSubmit} />
       </MemoryRouter>
     );
     const submitButton = getByText('action.continue');
 
     fireEvent.click(submitButton);
-    expect(queryByText('invalid_email')).not.toBeNull();
+    expect(queryByText('invalid_phone')).not.toBeNull();
     expect(onSubmit).not.toBeCalled();
 
-    const emailInput = container.querySelector('input[name="email"]');
+    const phoneInput = container.querySelector('input[name="phone"]');
 
-    if (emailInput) {
-      fireEvent.change(emailInput, { target: { value: 'foo' } });
-      expect(queryByText('invalid_email')).not.toBeNull();
+    if (phoneInput) {
+      fireEvent.change(phoneInput, { target: { value: '1113' } });
+      expect(queryByText('invalid_phone')).not.toBeNull();
 
-      fireEvent.change(emailInput, { target: { value: 'foo@logto.io' } });
-      expect(queryByText('invalid_email')).toBeNull();
+      fireEvent.change(phoneInput, { target: { value: phoneNumber } });
+      expect(queryByText('invalid_phone')).toBeNull();
     }
   });
 
   test('should display and clear the form error message as expected', () => {
     const { queryByText, container } = renderWithPageContext(
       <MemoryRouter>
-        <EmailForm
+        <PhoneForm
           errorMessage="form error"
           clearErrorMessage={clearErrorMessage}
           onSubmit={onSubmit}
@@ -82,10 +90,10 @@ describe('<EmailForm/>', () => {
 
     expect(queryByText('form error')).not.toBeNull();
 
-    const emailInput = container.querySelector('input[name="email"]');
+    const phoneInput = container.querySelector('input[name="phone"]');
 
-    if (emailInput) {
-      fireEvent.change(emailInput, { target: { value: 'foo' } });
+    if (phoneInput) {
+      fireEvent.change(phoneInput, { target: { value: phoneNumber } });
       expect(clearErrorMessage).toBeCalled();
     }
   });
@@ -94,15 +102,14 @@ describe('<EmailForm/>', () => {
     const { container, getByText } = renderWithPageContext(
       <MemoryRouter>
         <SettingsProvider>
-          <EmailForm onSubmit={onSubmit} />
+          <PhoneForm onSubmit={onSubmit} />
         </SettingsProvider>
       </MemoryRouter>
     );
+    const phoneInput = container.querySelector('input[name="phone"]');
 
-    const emailInput = container.querySelector('input[name="email"]');
-
-    if (emailInput) {
-      fireEvent.change(emailInput, { target: { value: 'foo@logto.io' } });
+    if (phoneInput) {
+      fireEvent.change(phoneInput, { target: { value: phoneNumber } });
     }
 
     const submitButton = getByText('action.continue');
@@ -116,19 +123,18 @@ describe('<EmailForm/>', () => {
     });
   });
 
-  test('should call onSubmit properly with terms settings enabled but hasTerms param set to false', async () => {
+  test('should call submit method properly with terms settings enabled but hasTerms param set to false', async () => {
     const { container, getByText } = renderWithPageContext(
       <MemoryRouter>
         <SettingsProvider>
-          <EmailForm hasTerms={false} onSubmit={onSubmit} />
+          <PhoneForm hasTerms={false} onSubmit={onSubmit} />
         </SettingsProvider>
       </MemoryRouter>
     );
+    const phoneInput = container.querySelector('input[name="phone"]');
 
-    const emailInput = container.querySelector('input[name="email"]');
-
-    if (emailInput) {
-      fireEvent.change(emailInput, { target: { value: 'foo@logto.io' } });
+    if (phoneInput) {
+      fireEvent.change(phoneInput, { target: { value: phoneNumber } });
     }
 
     const submitButton = getByText('action.continue');
@@ -138,22 +144,22 @@ describe('<EmailForm/>', () => {
     });
 
     await waitFor(() => {
-      expect(onSubmit).toBeCalledWith('foo@logto.io');
+      expect(onSubmit).toBeCalledWith(`${defaultCountryCallingCode}${phoneNumber}`);
     });
   });
 
-  test('should call onSubmit method properly with terms settings enabled and checked', async () => {
+  test('should call submit method properly with terms settings enabled and checked', async () => {
     const { container, getByText } = renderWithPageContext(
       <MemoryRouter>
         <SettingsProvider>
-          <EmailForm onSubmit={onSubmit} />
+          <PhoneForm onSubmit={onSubmit} />
         </SettingsProvider>
       </MemoryRouter>
     );
-    const emailInput = container.querySelector('input[name="email"]');
+    const phoneInput = container.querySelector('input[name="phone"]');
 
-    if (emailInput) {
-      fireEvent.change(emailInput, { target: { value: 'foo@logto.io' } });
+    if (phoneInput) {
+      fireEvent.change(phoneInput, { target: { value: phoneNumber } });
     }
 
     const termsButton = getByText('description.agree_with_terms');
@@ -166,7 +172,7 @@ describe('<EmailForm/>', () => {
     });
 
     await waitFor(() => {
-      expect(onSubmit).toBeCalledWith('foo@logto.io');
+      expect(onSubmit).toBeCalledWith(`${defaultCountryCallingCode}${phoneNumber}`);
     });
   });
 });

--- a/packages/ui/src/containers/PhoneForm/PhoneForm.tsx
+++ b/packages/ui/src/containers/PhoneForm/PhoneForm.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import Button from '@/components/Button';
@@ -45,20 +45,6 @@ const PhoneForm = ({
   const { countryList, phoneNumber, setPhoneNumber, isValidPhoneNumber } = usePhoneNumber();
 
   const { fieldValue, setFieldValue, validateForm, register } = useForm(defaultState);
-
-  /*  Clear the form error when input field is updated */
-  const errorMessageRef = useRef(errorMessage);
-
-  useEffect(() => {
-    // eslint-disable-next-line @silverhand/fp/no-mutation
-    errorMessageRef.current = errorMessage;
-  }, [errorMessage]);
-
-  useEffect(() => {
-    if (errorMessageRef.current) {
-      clearErrorMessage?.();
-    }
-  }, [clearErrorMessage, errorMessageRef, fieldValue.phone]);
 
   // Validate phoneNumber with given country code
   const phoneNumberValidation = useCallback(
@@ -109,6 +95,7 @@ const PhoneForm = ({
         {...register('phone', phoneNumberValidation)}
         onChange={(data) => {
           setPhoneNumber((previous) => ({ ...previous, ...data }));
+          clearErrorMessage?.();
         }}
       />
 

--- a/packages/ui/src/containers/PhoneForm/SmsRegister.tsx
+++ b/packages/ui/src/containers/PhoneForm/SmsRegister.tsx
@@ -1,0 +1,23 @@
+import PhoneForm from './PhoneForm';
+import useSmsRegister from './use-sms-register';
+
+type Props = {
+  className?: string;
+  // eslint-disable-next-line react/boolean-prop-naming
+  autoFocus?: boolean;
+};
+
+const SmsRegister = (props: Props) => {
+  const { onSubmit, errorMessage, clearErrorMessage } = useSmsRegister();
+
+  return (
+    <PhoneForm
+      onSubmit={onSubmit}
+      {...props}
+      errorMessage={errorMessage}
+      clearErrorMessage={clearErrorMessage}
+    />
+  );
+};
+
+export default SmsRegister;

--- a/packages/ui/src/containers/PhoneForm/index.module.scss
+++ b/packages/ui/src/containers/PhoneForm/index.module.scss
@@ -1,0 +1,24 @@
+@use '@/scss/underscore' as _;
+
+.form {
+  @include _.flex-column;
+
+  > * {
+    width: 100%;
+  }
+
+  .inputField,
+  .terms,
+  .switch {
+    margin-bottom: _.unit(4);
+  }
+
+  .switch {
+    display: block;
+  }
+
+  .formErrors {
+    margin-top: _.unit(-2);
+    margin-bottom: _.unit(4);
+  }
+}

--- a/packages/ui/src/containers/PhoneForm/index.tsx
+++ b/packages/ui/src/containers/PhoneForm/index.tsx
@@ -1,0 +1,1 @@
+export { default as SmsRegister } from './SmsRegister';

--- a/packages/ui/src/containers/PhoneForm/use-sms-register.ts
+++ b/packages/ui/src/containers/PhoneForm/use-sms-register.ts
@@ -1,0 +1,55 @@
+import { SignInIdentifier } from '@logto/schemas';
+import { useState, useMemo, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { sendRegisterSmsPasscode } from '@/apis/register';
+import type { ErrorHandlers } from '@/hooks/use-api';
+import useApi from '@/hooks/use-api';
+import { UserFlow } from '@/types';
+
+const useSmsRegister = () => {
+  const [errorMessage, setErrorMessage] = useState<string>();
+  const navigate = useNavigate();
+
+  const errorHandlers: ErrorHandlers = useMemo(
+    () => ({
+      'guard.invalid_input': () => {
+        setErrorMessage('invalid_phone');
+      },
+    }),
+    [setErrorMessage]
+  );
+
+  const clearErrorMessage = useCallback(() => {
+    setErrorMessage('');
+  }, []);
+
+  const { run: asyncSendRegisterSmsPasscode } = useApi(sendRegisterSmsPasscode, errorHandlers);
+
+  const onSubmit = useCallback(
+    async (phone: string) => {
+      const result = await asyncSendRegisterSmsPasscode(phone);
+
+      if (!result) {
+        return;
+      }
+
+      navigate(
+        {
+          pathname: `/${UserFlow.register}/${SignInIdentifier.Sms}/passcode-validation`,
+          search: location.search,
+        },
+        { state: { phone } }
+      );
+    },
+    [asyncSendRegisterSmsPasscode, navigate]
+  );
+
+  return {
+    errorMessage,
+    clearErrorMessage,
+    onSubmit,
+  };
+};
+
+export default useSmsRegister;

--- a/packages/ui/src/hooks/use-sie.ts
+++ b/packages/ui/src/hooks/use-sie.ts
@@ -4,9 +4,11 @@ import { PageContext } from './use-page-context';
 
 export const useSieMethods = () => {
   const { experienceSettings } = useContext(PageContext);
+  const { methods, password, verify } = experienceSettings?.signUp ?? {};
 
   return {
-    signUpMethods: experienceSettings?.signUp.methods ?? [],
+    signUpMethods: methods ?? [],
+    signUpSettings: { password, verify },
     signInMethods: experienceSettings?.signIn.methods ?? [],
     socialConnectors: experienceSettings?.socialConnectors ?? [],
   };

--- a/packages/ui/src/pages/Register/Main.tsx
+++ b/packages/ui/src/pages/Register/Main.tsx
@@ -1,10 +1,9 @@
 import type { SignInIdentifier, ConnectorMetadata } from '@logto/schemas';
 
 import { EmailRegister } from '@/containers/EmailForm';
-import { PhonePasswordless } from '@/containers/Passwordless';
+import { SmsRegister } from '@/containers/PhoneForm';
 import SocialSignIn from '@/containers/SocialSignIn';
 import UsernameRegister from '@/containers/UsernameRegister';
-import { UserFlow } from '@/types';
 
 import * as styles from './index.module.scss';
 
@@ -19,7 +18,7 @@ const Main = ({ signUpMethod, socialConnectors }: Props) => {
       return <EmailRegister className={styles.main} />;
 
     case 'sms':
-      return <PhonePasswordless type={UserFlow.register} className={styles.main} />;
+      return <SmsRegister className={styles.main} />;
 
     case 'username':
       return <UsernameRegister className={styles.main} />;

--- a/packages/ui/src/pages/SecondaryRegister/index.tsx
+++ b/packages/ui/src/pages/SecondaryRegister/index.tsx
@@ -1,35 +1,48 @@
+import { SignInIdentifier } from '@logto/schemas';
 import { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
+import { is } from 'superstruct';
 
 import SecondaryPageWrapper from '@/components/SecondaryPageWrapper';
 import CreateAccount from '@/containers/CreateAccount';
-import { PhonePasswordless, EmailPasswordless } from '@/containers/Passwordless';
+import { EmailRegister } from '@/containers/EmailForm';
+import { SmsRegister } from '@/containers/PhoneForm';
+import { useSieMethods } from '@/hooks/use-sie';
 import ErrorPage from '@/pages/ErrorPage';
-import { UserFlow } from '@/types';
+import { SignInMethodGuard, passcodeMethodGuard } from '@/types/guard';
 
 type Parameters = {
   method?: string;
 };
 
 const SecondaryRegister = () => {
-  const { method = 'username' } = useParams<Parameters>();
+  const { method = '' } = useParams<Parameters>();
+  const { signUpMethods, signUpSettings } = useSieMethods();
 
   const registerForm = useMemo(() => {
-    if (method === 'sms') {
+    if (method === SignInIdentifier.Sms) {
       // eslint-disable-next-line jsx-a11y/no-autofocus
-      return <PhonePasswordless autoFocus type={UserFlow.register} />;
+      return <SmsRegister autoFocus />;
     }
 
-    if (method === 'email') {
+    if (method === SignInIdentifier.Email) {
       // eslint-disable-next-line jsx-a11y/no-autofocus
-      return <EmailPasswordless autoFocus type={UserFlow.register} />;
+      return <EmailRegister autoFocus />;
     }
 
-    // eslint-disable-next-line jsx-a11y/no-autofocus
-    return <CreateAccount autoFocus />;
+    if (method === SignInIdentifier.Username) {
+      // eslint-disable-next-line jsx-a11y/no-autofocus
+      return <CreateAccount autoFocus />;
+    }
   }, [method]);
 
-  if (!['email', 'sms', 'username'].includes(method)) {
+  // Validate the signUp method
+  if (!is(method, SignInMethodGuard) || !signUpMethods.includes(method)) {
+    return <ErrorPage />;
+  }
+
+  // Validate the verify settings
+  if (is(method, passcodeMethodGuard) && !signUpSettings.verify) {
     return <ErrorPage />;
   }
 

--- a/packages/ui/src/types/guard.ts
+++ b/packages/ui/src/types/guard.ts
@@ -15,6 +15,12 @@ export const passcodeMethodGuard = s.union([
   s.literal(SignInIdentifier.Sms),
 ]);
 
+export const SignInMethodGuard = s.union([
+  s.literal(SignInIdentifier.Email),
+  s.literal(SignInIdentifier.Sms),
+  s.literal(SignInIdentifier.Username),
+]);
+
 export const userFlowGuard = s.union([
   s.literal('sign-in'),
   s.literal('register'),


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Following the previous PR. Add `SmsRegister` container.

- new `PhoneForm` container
- new `useSmsRegister` hook
- new `SmsRegister` container with the integration of PhoneForm` container and `useSmsRegister` hook
- Update the Primary Register page and Secondary Register page to pick up the latest `SmsRegister`  and `EmailRegister`  instead of the old `Passwordless` container. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT added
