### PR TITLE
feat(console): toggle tip

### DIFF
--- a/packages/console/src/components/ToggleTip/index.module.scss
+++ b/packages/console/src/components/ToggleTip/index.module.scss
@@ -1,0 +1,16 @@
+@use '@/scss/underscore' as _;
+
+.content {
+  box-shadow: var(--shadow-2);
+  position: absolute;
+
+  &:focus {
+    outline: none;
+  }
+}
+
+.overlay {
+  background: transparent;
+  position: fixed;
+  inset: 0;
+}

--- a/packages/console/src/components/ToggleTip/index.tsx
+++ b/packages/console/src/components/ToggleTip/index.tsx
@@ -1,0 +1,78 @@
+import type { HTMLProps, ReactNode, RefObject } from 'react';
+import { useRef } from 'react';
+import ReactModal from 'react-modal';
+
+import type { HorizontalAlignment } from '@/hooks/use-position';
+import usePosition from '@/hooks/use-position';
+
+import type { TipBubblePosition } from '../TipBubble';
+import TipBubble from '../TipBubble';
+import {
+  getVerticalAlignment,
+  getHorizontalAlignment,
+  getVerticalOffset,
+  getHorizontalOffset,
+} from '../TipBubble/utils';
+import * as styles from './index.module.scss';
+
+type Props = HTMLProps<HTMLDivElement> & {
+  children: ReactNode;
+  isOpen: boolean;
+  onClose: () => void;
+  anchorRef: RefObject<HTMLElement>;
+  position?: TipBubblePosition;
+  horizontalAlign?: HorizontalAlignment;
+};
+
+const ToggleTip = ({
+  children,
+  isOpen,
+  onClose,
+  anchorRef,
+  position = 'top',
+  horizontalAlign = 'start',
+}: Props) => {
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  const {
+    position: layoutPosition,
+    positionState,
+    mutate,
+  } = usePosition({
+    verticalAlign: getVerticalAlignment(position),
+    horizontalAlign: getHorizontalAlignment(position, horizontalAlign),
+    offset: {
+      vertical: getVerticalOffset(position),
+      horizontal: getHorizontalOffset(position, horizontalAlign),
+    },
+    anchorRef,
+    overlayRef,
+  });
+
+  return (
+    <ReactModal
+      shouldCloseOnOverlayClick
+      shouldCloseOnEsc
+      isOpen={isOpen}
+      style={{
+        content: {
+          ...layoutPosition,
+        },
+      }}
+      className={styles.content}
+      overlayClassName={styles.overlay}
+      onRequestClose={onClose}
+      onAfterOpen={mutate}
+    >
+      <TipBubble
+        ref={overlayRef}
+        position={position}
+        horizontalAlignment={positionState.horizontalAlign}
+      >
+        {children}
+      </TipBubble>
+    </ReactModal>
+  );
+};
+
+export default ToggleTip;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
feat(console): toggle tip
<img width="358" alt="image" src="https://user-images.githubusercontent.com/10806653/199780095-ded71c23-4a6f-454c-bfcb-e38ee42f4049.png">

### Behaviors:

#### States

The toggletip component has two states—active and inactive. By default, the toggletip is hidden and inactive. Toggletips are displayed on `Click` and `Enter`.

### Interactions

#### Mouse

Toggletips are triggered on `Click` and is dismissed by clicking anywhere outside the toggletip’s active popover or UI trigger.

#### Keyboard

Users can trigger a toggletip by pressing `Enter` or `Space` while the trigger element has focus. Users can dismiss a toggletip by pressing `Escape`. For additional keyboard interactions, see the accessibility tab.

DS: https://www.notion.so/silverhand/Web-Toggletips-c573fdb1fdb34fbc8c2f3901b307aca0

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="383" alt="image" src="https://user-images.githubusercontent.com/10806653/199778984-4ba3ca37-5dba-4d3d-b4b0-db3f75c1e200.png">

