### PR TITLE
feat(core): add sign-in timestamp in session interaction

### DIFF
--- a/packages/core/src/routes/session/continue.test.ts
+++ b/packages/core/src/routes/session/continue.test.ts
@@ -89,7 +89,8 @@ describe('session -> continueRoutes', () => {
       expect(interactionResult).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
-        expect.objectContaining({ login: { accountId: mockUser.id } }),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        expect.objectContaining({ login: { accountId: mockUser.id, ts: expect.any(Number) } }),
         expect.anything()
       );
     });
@@ -121,7 +122,8 @@ describe('session -> continueRoutes', () => {
       expect(interactionResult).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
-        expect.objectContaining({ login: { accountId: mockUser.id } }),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        expect.objectContaining({ login: { accountId: mockUser.id, ts: expect.any(Number) } }),
         expect.anything()
       );
     });
@@ -156,7 +158,8 @@ describe('session -> continueRoutes', () => {
       expect(interactionResult).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
-        expect.objectContaining({ login: { accountId: mockUser.id } }),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        expect.objectContaining({ login: { accountId: mockUser.id, ts: expect.any(Number) } }),
         expect.anything()
       );
     });
@@ -188,7 +191,8 @@ describe('session -> continueRoutes', () => {
       expect(interactionResult).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
-        expect.objectContaining({ login: { accountId: mockUser.id } }),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        expect.objectContaining({ login: { accountId: mockUser.id, ts: expect.any(Number) } }),
         expect.anything()
       );
     });

--- a/packages/core/src/routes/session/password.test.ts
+++ b/packages/core/src/routes/session/password.test.ts
@@ -111,7 +111,8 @@ describe('session -> password routes', () => {
     expect(interactionResult).toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),
-      expect.objectContaining({ login: { accountId: 'id' } }),
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      expect.objectContaining({ login: { accountId: 'id', ts: expect.any(Number) } }),
       expect.anything()
     );
   });
@@ -127,7 +128,8 @@ describe('session -> password routes', () => {
     expect(interactionResult).toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),
-      expect.objectContaining({ login: { accountId: 'id' } }),
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      expect.objectContaining({ login: { accountId: 'id', ts: expect.any(Number) } }),
       expect.anything()
     );
   });
@@ -143,7 +145,8 @@ describe('session -> password routes', () => {
     expect(interactionResult).toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),
-      expect.objectContaining({ login: { accountId: 'id' } }),
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      expect.objectContaining({ login: { accountId: 'id', ts: expect.any(Number) } }),
       expect.anything()
     );
   });
@@ -172,7 +175,8 @@ describe('session -> password routes', () => {
       expect(interactionResult).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
-        expect.objectContaining({ login: { accountId: 'user1' } }),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        expect.objectContaining({ login: { accountId: 'user1', ts: expect.any(Number) } }),
         expect.anything()
       );
       jest.useRealTimers();

--- a/packages/core/src/routes/session/passwordless.test.ts
+++ b/packages/core/src/routes/session/passwordless.test.ts
@@ -392,7 +392,8 @@ describe('session -> passwordlessRoutes', () => {
         expect.anything(),
         expect.anything(),
         expect.objectContaining({
-          login: { accountId: mockUser.id },
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          login: { accountId: mockUser.id, ts: expect.any(Number) },
         }),
         expect.anything()
       );
@@ -414,7 +415,8 @@ describe('session -> passwordlessRoutes', () => {
         expect.anything(),
         expect.anything(),
         expect.objectContaining({
-          login: { accountId: mockUser.id },
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          login: { accountId: mockUser.id, ts: expect.any(Number) },
         }),
         expect.anything()
       );
@@ -555,7 +557,8 @@ describe('session -> passwordlessRoutes', () => {
         expect.anything(),
         expect.anything(),
         expect.objectContaining({
-          login: { accountId: mockUser.id },
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          login: { accountId: mockUser.id, ts: expect.any(Number) },
         }),
         expect.anything()
       );
@@ -579,7 +582,8 @@ describe('session -> passwordlessRoutes', () => {
         expect.anything(),
         expect.anything(),
         expect.objectContaining({
-          login: { accountId: mockUser.id },
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          login: { accountId: mockUser.id, ts: expect.any(Number) },
         }),
         expect.anything()
       );
@@ -688,7 +692,8 @@ describe('session -> passwordlessRoutes', () => {
         expect.anything(),
         expect.anything(),
         expect.objectContaining({
-          login: { accountId: 'user1' },
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          login: { accountId: 'user1', ts: expect.any(Number) },
         }),
         expect.anything()
       );
@@ -710,7 +715,8 @@ describe('session -> passwordlessRoutes', () => {
         expect.anything(),
         expect.anything(),
         expect.objectContaining({
-          login: { accountId: 'user1' },
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          login: { accountId: 'user1', ts: expect.any(Number) },
         }),
         expect.anything()
       );
@@ -816,7 +822,8 @@ describe('session -> passwordlessRoutes', () => {
         expect.anything(),
         expect.anything(),
         expect.objectContaining({
-          login: { accountId: 'user1' },
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          login: { accountId: 'user1', ts: expect.any(Number) },
         }),
         expect.anything()
       );
@@ -838,7 +845,8 @@ describe('session -> passwordlessRoutes', () => {
         expect.anything(),
         expect.anything(),
         expect.objectContaining({
-          login: { accountId: 'user1' },
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          login: { accountId: 'user1', ts: expect.any(Number) },
         }),
         expect.anything()
       );

--- a/packages/core/src/routes/session/social.test.ts
+++ b/packages/core/src/routes/session/social.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { ConnectorType } from '@logto/connector-kit';
 import type { User } from '@logto/schemas';
 import { SignUpIdentifier } from '@logto/schemas';
@@ -233,7 +234,8 @@ describe('session -> socialRoutes', () => {
       expect(interactionResult).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
-        expect.objectContaining({ login: { accountId: mockUser.id } }),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        expect.objectContaining({ login: { accountId: mockUser.id, ts: expect.any(Number) } }),
         expect.anything()
       );
     });
@@ -316,7 +318,8 @@ describe('session -> socialRoutes', () => {
       expect(interactionResult).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
-        expect.objectContaining({ login: { accountId: 'user1' } }),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        expect.objectContaining({ login: { accountId: 'user1', ts: expect.any(Number) } }),
         expect.anything()
       );
     });
@@ -350,7 +353,8 @@ describe('session -> socialRoutes', () => {
       expect(interactionResult).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
-        expect.objectContaining({ login: { accountId: 'user1' } }),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        expect.objectContaining({ login: { accountId: 'user1', ts: expect.any(Number) } }),
         expect.anything()
       );
     });
@@ -364,7 +368,10 @@ describe('session -> socialRoutes', () => {
     });
 
     it('throw error if result parsing fails', async () => {
-      interactionDetails.mockResolvedValueOnce({ result: { login: { accountId: mockUser.id } } });
+      interactionDetails.mockResolvedValueOnce({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        result: { login: { accountId: mockUser.id, ts: expect.any(Number) } },
+      });
       const response = await sessionRequest
         .post(`${registerRoute}`)
         .send({ connectorId: 'connectorId' });
@@ -436,3 +443,4 @@ describe('session -> socialRoutes', () => {
     });
   });
 });
+/* eslint-enable max-lines */

--- a/packages/core/src/routes/session/utils.test.ts
+++ b/packages/core/src/routes/session/utils.test.ts
@@ -121,7 +121,8 @@ describe('signInWithPassword()', () => {
     expect(interactionResult).toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),
-      expect.objectContaining({ login: { accountId: mockUser.id } }),
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      expect.objectContaining({ login: { accountId: mockUser.id, ts: expect.any(Number) } }),
       expect.anything()
     );
   });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add sign-in timestamp to session interaction. Originally introduced in #1917 but got reverted for we didn't think it clearly enough back in the day.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] UT
