### PR TITLE
feat(core,phrases): add re-authentication check function for protected access

### DIFF
--- a/packages/phrases/src/locales/de/errors.ts
+++ b/packages/phrases/src/locales/de/errors.ts
@@ -7,6 +7,7 @@ const errors = {
     expected_role_not_found:
       'Erwartete Rolle nicht gefunden. Bitte überprüfe deine Rollen und Berechtigungen.',
     jwt_sub_missing: '`sub` fehlt in JWT.',
+    require_re_authentication: 'Re-authentication is required to perform a protected action.', // UNTRANSLATED
   },
   guard: {
     invalid_input: 'Die Anfrage {{type}} ist ungültig.',

--- a/packages/phrases/src/locales/en/errors.ts
+++ b/packages/phrases/src/locales/en/errors.ts
@@ -7,6 +7,7 @@ const errors = {
     expected_role_not_found:
       'Expected role not found. Please check your user roles and permissions.',
     jwt_sub_missing: 'Missing `sub` in JWT.',
+    require_re_authentication: 'Re-authentication is required to perform a protected action.',
   },
   guard: {
     invalid_input: 'The request {{type}} is invalid.',

--- a/packages/phrases/src/locales/fr/errors.ts
+++ b/packages/phrases/src/locales/fr/errors.ts
@@ -8,6 +8,7 @@ const errors = {
     expected_role_not_found:
       'Expected role not found. Please check your user roles and permissions.',
     jwt_sub_missing: '`sub` manquant dans JWT.',
+    require_re_authentication: 'Re-authentication is required to perform a protected action.', // UNTRANSLATED
   },
   guard: {
     invalid_input: "La requête {{type}} n'est pas valide.",

--- a/packages/phrases/src/locales/ko/errors.ts
+++ b/packages/phrases/src/locales/ko/errors.ts
@@ -7,6 +7,7 @@ const errors = {
     expected_role_not_found:
       'Expected role not found. Please check your user roles and permissions.',
     jwt_sub_missing: 'JWT에서 `sub`를 찾을 수 없어요.',
+    require_re_authentication: 'Re-authentication is required to perform a protected action.', // UNTRANSLATED
   },
   guard: {
     invalid_input: '{{type}} 요청 타입은 유효하지 않아요.',

--- a/packages/phrases/src/locales/pt-pt/errors.ts
+++ b/packages/phrases/src/locales/pt-pt/errors.ts
@@ -6,6 +6,7 @@ const errors = {
     forbidden: 'Proibido. Verifique os seus cargos e permissões.',
     expected_role_not_found: 'Role esperado não encontrado. Verifique os seus cargos e permissões.',
     jwt_sub_missing: 'Campo `sub` está ausente no JWT.',
+    require_re_authentication: 'Re-authentication is required to perform a protected action.', // UNTRANSLATED
   },
   guard: {
     invalid_input: 'O pedido {{type}} é inválido.',

--- a/packages/phrases/src/locales/tr-tr/errors.ts
+++ b/packages/phrases/src/locales/tr-tr/errors.ts
@@ -7,6 +7,7 @@ const errors = {
     expected_role_not_found:
       'Expected role not found. Please check your user roles and permissions.',
     jwt_sub_missing: 'JWTde `sub` eksik.',
+    require_re_authentication: 'Re-authentication is required to perform a protected action.', // UNTRANSLATED
   },
   guard: {
     invalid_input: 'İstek {{type}} geçersiz.',

--- a/packages/phrases/src/locales/zh-cn/errors.ts
+++ b/packages/phrases/src/locales/zh-cn/errors.ts
@@ -6,6 +6,7 @@ const errors = {
     forbidden: '禁止访问。请检查用户 role 与权限。',
     expected_role_not_found: '未找到期望的 role。请检查用户 role 与权限。',
     jwt_sub_missing: 'JWT 缺失 `sub`',
+    require_re_authentication: '需要重新认证以进行受保护操作。',
   },
   guard: {
     invalid_input: '请求中 {{type}} 无效',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Originally introduced in #1927 

Add a function to check if current session have the access to perform a protected action (sign in within a period of time), if not, throw an error with code auth.require_re_authentication. And the front-end(@simeng-li) will guide the user to re-authentice to get the access.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] locally tested
