### PR TITLE
feat(cli): rotate keys

### DIFF
--- a/.changeset/unlucky-lizards-agree.md
+++ b/.changeset/unlucky-lizards-agree.md
@@ -1,0 +1,13 @@
+---
+"@logto/cli": minor
+---
+
+## CLI
+
+### Rotate your private or secret key
+
+Add a new command `db config rotate <key>` to support key rotation via CLI.
+
+When rotating, the CLI will generate a new key and prepend to the corresponding key array. Thus the old key is still valid and the serivce will use the new key for signing.
+
+Run `logto db config rotate help` for detailed usage.

--- a/packages/cli/src/commands/database/config.ts
+++ b/packages/cli/src/commands/database/config.ts
@@ -137,15 +137,13 @@ const rotateConfig: CommandModule<unknown, { key: string }> = {
       const parsed = logtoConfigGuards[key].safeParse(rows[0]?.value);
       const original = parsed.success ? parsed.data : [];
 
+      // No need for default. It's already exhaustive
+      // eslint-disable-next-line default-case
       switch (key) {
         case LogtoOidcConfigKey.PrivateKeys:
           return [await generateOidcPrivateKey(), ...original];
         case LogtoOidcConfigKey.CookieKeys:
           return [generateOidcCookieKey(), ...original];
-        default:
-          log.warn('No proper handler found, use empty array');
-
-          return [];
       }
     };
     const rotated = await getValue();

--- a/packages/cli/src/commands/database/utilities.ts
+++ b/packages/cli/src/commands/database/utilities.ts
@@ -1,0 +1,22 @@
+import { generateKeyPair } from 'crypto';
+import { promisify } from 'util';
+
+import { nanoid } from 'nanoid';
+
+export const generateOidcPrivateKey = async () => {
+  const { privateKey } = await promisify(generateKeyPair)('rsa', {
+    modulusLength: 4096,
+    publicKeyEncoding: {
+      type: 'spki',
+      format: 'pem',
+    },
+    privateKeyEncoding: {
+      type: 'pkcs8',
+      format: 'pem',
+    },
+  });
+
+  return privateKey;
+};
+
+export const generateOidcCookieKey = () => nanoid();


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
`logto db config rotate <key>` to rotate OIDC private and cookie keys

### Known limit
there's no timestamp when key created, thus user need to manually remove the old keys. perhaps to provide a command to remove outdated keys.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

<img width="438" alt="image" src="https://user-images.githubusercontent.com/14722250/200222781-3a6795e2-355c-4fc3-8a12-09e53e4979fd.png">

<img width="438" alt="image" src="https://user-images.githubusercontent.com/14722250/200222793-40aeb0b6-c442-4150-87f8-f69db751a7ef.png">

checked database, works as expected