### PR TITLE
fix(core): add check required profile to password routes

### DIFF
--- a/packages/core/src/routes/session/password.test.ts
+++ b/packages/core/src/routes/session/password.test.ts
@@ -8,29 +8,29 @@ import { createRequester } from '@/utils/test-utils';
 
 import passwordRoutes, { registerRoute, signInRoute } from './password';
 
-const insertUser = jest.fn(async (..._args: unknown[]) => ({ id: 'id' }));
+const insertUser = jest.fn(async (..._args: unknown[]) => mockUser);
 const hasUser = jest.fn(async (username: string) => username === 'username1');
 const findUserById = jest.fn(async (): Promise<User> => mockUser);
-const updateUserById = jest.fn(async (..._args: unknown[]) => ({ id: 'id' }));
+const updateUserById = jest.fn(async (..._args: unknown[]) => mockUser);
 const hasActiveUsers = jest.fn(async () => true);
 const findDefaultSignInExperience = jest.fn(async () => mockSignInExperience);
 
 jest.mock('@/queries/user', () => ({
   findUserById: async () => findUserById(),
-  findUserByIdentity: async () => ({ id: 'id', identities: {} }),
-  findUserByPhone: async () => ({ id: 'id' }),
-  findUserByEmail: async () => ({ id: 'id' }),
+  findUserByIdentity: async () => ({ id: mockUser.id, identities: {} }),
+  findUserByPhone: async () => mockUser,
+  findUserByEmail: async () => mockUser,
   updateUserById: async (...args: unknown[]) => updateUserById(...args),
   hasUser: async (username: string) => hasUser(username),
   hasUserWithIdentity: async (connectorId: string, userId: string) =>
-    connectorId === 'connectorId' && userId === 'id',
+    connectorId === 'connectorId' && userId === mockUser.id,
   hasUserWithPhone: async (phone: string) => phone === '13000000000',
   hasUserWithEmail: async (email: string) => email === 'a@a.com',
   hasActiveUsers: async () => hasActiveUsers(),
   async findUserByUsername(username: string) {
     const roleNames = username === 'admin' ? [UserRole.Admin] : [];
 
-    return { id: 'id', username, roleNames };
+    return { ...mockUser, username, roleNames };
   },
 }));
 
@@ -112,7 +112,7 @@ describe('session -> password routes', () => {
       expect.anything(),
       expect.anything(),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      expect.objectContaining({ login: { accountId: 'id', ts: expect.any(Number) } }),
+      expect.objectContaining({ login: { accountId: mockUser.id, ts: expect.any(Number) } }),
       expect.anything()
     );
   });
@@ -129,7 +129,7 @@ describe('session -> password routes', () => {
       expect.anything(),
       expect.anything(),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      expect.objectContaining({ login: { accountId: 'id', ts: expect.any(Number) } }),
+      expect.objectContaining({ login: { accountId: mockUser.id, ts: expect.any(Number) } }),
       expect.anything()
     );
   });
@@ -146,7 +146,7 @@ describe('session -> password routes', () => {
       expect.anything(),
       expect.anything(),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      expect.objectContaining({ login: { accountId: 'id', ts: expect.any(Number) } }),
+      expect.objectContaining({ login: { accountId: mockUser.id, ts: expect.any(Number) } }),
       expect.anything()
     );
   });

--- a/packages/core/src/routes/session/password.ts
+++ b/packages/core/src/routes/session/password.ts
@@ -19,7 +19,7 @@ import {
 import assertThat from '@/utils/assert-that';
 
 import type { AnonymousRouter } from '../types';
-import { getRoutePrefix, signInWithPassword } from './utils';
+import { checkRequiredProfile, getRoutePrefix, signInWithPassword } from './utils';
 
 export const registerRoute = getRoutePrefix('register', 'password');
 export const signInRoute = getRoutePrefix('sign-in', 'password');
@@ -171,7 +171,7 @@ export default function passwordRoutes<T extends AnonymousRouter>(router: T, pro
 
       const { passwordEncrypted, passwordEncryptionMethod } = await encryptUserPassword(password);
 
-      await insertUser({
+      const user = await insertUser({
         id,
         username,
         passwordEncrypted,
@@ -179,6 +179,7 @@ export default function passwordRoutes<T extends AnonymousRouter>(router: T, pro
         roleNames,
         lastSignInAt: Date.now(),
       });
+      await checkRequiredProfile(ctx, provider, user, signInExperience);
       await assignInteractionResults(ctx, provider, { login: { accountId: id } });
 
       return next();

--- a/packages/core/src/routes/session/utils.ts
+++ b/packages/core/src/routes/session/utils.ts
@@ -219,9 +219,11 @@ export const signInWithPassword = async (
   ctx.log(logType, logPayload);
 
   const user = await findUser();
-  const { id } = await verifyUserPassword(user, password);
+  const verifiedUser = await verifyUserPassword(user, password);
+  const { id } = verifiedUser;
 
   ctx.log(logType, { userId: id });
   await updateUserById(id, { lastSignInAt: Date.now() });
+  await checkRequiredProfile(ctx, provider, verifiedUser, signInExperience);
   await assignInteractionResults(ctx, provider, { login: { accountId: id } }, true);
 };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
add `checkRequiredProfile` to password routes, other sign-in/register routes were added before.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UTs
