### PR TITLE
refactor(core)!: use case insensitive search for emails

### DIFF
--- a/packages/core/src/queries/user.test.ts
+++ b/packages/core/src/queries/user.test.ts
@@ -67,7 +67,7 @@ describe('user query', () => {
     const expectSql = sql`
       select ${sql.join(Object.values(fields), sql`,`)}
       from ${table}
-      where ${fields.primaryEmail}=$1
+      where lower(${fields.primaryEmail})=lower($1)
     `;
 
     mockQuery.mockImplementationOnce(async (sql, values) => {
@@ -179,7 +179,7 @@ describe('user query', () => {
       SELECT EXISTS(
         select ${fields.primaryEmail}
         from ${table}
-        where ${fields.primaryEmail}=$1
+        where lower(${fields.primaryEmail})=lower($1)
       )
     `;
 

--- a/packages/core/src/queries/user.ts
+++ b/packages/core/src/queries/user.ts
@@ -21,7 +21,7 @@ export const findUserByEmail = async (email: string) =>
   envSet.pool.one<User>(sql`
     select ${sql.join(Object.values(fields), sql`,`)}
     from ${table}
-    where ${fields.primaryEmail}=${email}
+    where lower(${fields.primaryEmail})=lower(${email})
   `);
 
 export const findUserByPhone = async (phone: string) =>
@@ -65,7 +65,7 @@ export const hasUserWithEmail = async (email: string) =>
   envSet.pool.exists(sql`
     select ${fields.primaryEmail}
     from ${table}
-    where ${fields.primaryEmail}=${email}
+    where lower(${fields.primaryEmail})=lower(${email})
   `);
 
 export const hasUserWithPhone = async (phone: string) =>

--- a/packages/core/src/routes/admin-user.test.ts
+++ b/packages/core/src/routes/admin-user.test.ts
@@ -117,8 +117,11 @@ describe('adminUserRoutes', () => {
     const username = 'MJAtLogto';
     const password = 'PASSWORD';
     const name = 'Michael';
+    const primaryEmail = 'foo@logto.io';
 
-    const response = await userRequest.post('/users').send({ username, password, name });
+    const response = await userRequest
+      .post('/users')
+      .send({ primaryEmail, username, password, name });
     expect(response.status).toEqual(200);
     expect(response.body).toEqual({
       ...mockUserResponse,
@@ -132,21 +135,6 @@ describe('adminUserRoutes', () => {
     const username = 'MJAtLogto';
     const password = 'PASSWORD';
     const name = 'Michael';
-
-    // Missing input
-    await expect(userRequest.post('/users').send({})).resolves.toHaveProperty('status', 400);
-    await expect(userRequest.post('/users').send({ username, password })).resolves.toHaveProperty(
-      'status',
-      400
-    );
-    await expect(userRequest.post('/users').send({ username, name })).resolves.toHaveProperty(
-      'status',
-      400
-    );
-    await expect(userRequest.post('/users').send({ password, name })).resolves.toHaveProperty(
-      'status',
-      400
-    );
 
     // Invalid input format
     await expect(

--- a/packages/core/src/routes/admin-user.ts
+++ b/packages/core/src/routes/admin-user.ts
@@ -125,7 +125,7 @@ export default function adminUserRoutes<T extends AuthedRouter>(router: T) {
         primaryEmail: string().regex(emailRegEx).optional(),
         username: string().regex(usernameRegEx).optional(),
         password: string().regex(passwordRegEx),
-        name: string(),
+        name: string().optional(),
       }),
     }),
     async (ctx, next) => {

--- a/packages/core/src/routes/admin-user.ts
+++ b/packages/core/src/routes/admin-user.ts
@@ -141,7 +141,7 @@ export default function adminUserRoutes<T extends AuthedRouter>(router: T) {
       assertThat(
         !primaryEmail || !(await hasUserWithEmail(primaryEmail)),
         new RequestError({
-          code: 'user.username_exists_register',
+          code: 'user.email_exists_register',
           status: 422,
         })
       );

--- a/packages/integration-tests/src/api/admin-user.ts
+++ b/packages/integration-tests/src/api/admin-user.ts
@@ -3,6 +3,7 @@ import type { User } from '@logto/schemas';
 import { authedAdminApi } from './api';
 
 type CreateUserPayload = {
+  primaryEmail?: string;
   username: string;
   password: string;
   name: string;

--- a/packages/integration-tests/src/api/session.ts
+++ b/packages/integration-tests/src/api/session.ts
@@ -52,24 +52,6 @@ export const signInWithPassword = async ({
     })
     .json<RedirectResponse>();
 
-export const signInWithEmailAndPassword = async (
-  email: string,
-  password: string,
-  interactionCookie: string
-) =>
-  api
-    .post('session/sign-in/email/username', {
-      headers: {
-        cookie: interactionCookie,
-      },
-      json: {
-        email,
-        password,
-      },
-      followRedirect: false,
-    })
-    .json<RedirectResponse>();
-
 export const consent = async (interactionCookie: string) =>
   api
     .post('session/consent', {

--- a/packages/integration-tests/src/api/session.ts
+++ b/packages/integration-tests/src/api/session.ts
@@ -24,18 +24,46 @@ export const registerUserWithUsernameAndPassword = async (
     })
     .json<RedirectResponse>();
 
-export const signInWithUsernameAndPassword = async (
-  username: string,
-  password: string,
-  interactionCookie: string
-) =>
+export type SignInWithPassword = {
+  username?: string;
+  email?: string;
+  password: string;
+  interactionCookie: string;
+};
+
+export const signInWithPassword = async ({
+  email,
+  username,
+  password,
+  interactionCookie,
+}: SignInWithPassword) =>
   api
-    .post('session/sign-in/password/username', {
+    // This route in core needs to be refactored
+    .post('session/sign-in/password/' + (username ? 'username' : 'email'), {
       headers: {
         cookie: interactionCookie,
       },
       json: {
+        email,
         username,
+        password,
+      },
+      followRedirect: false,
+    })
+    .json<RedirectResponse>();
+
+export const signInWithEmailAndPassword = async (
+  email: string,
+  password: string,
+  interactionCookie: string
+) =>
+  api
+    .post('session/sign-in/email/username', {
+      headers: {
+        cookie: interactionCookie,
+      },
+      json: {
+        email,
         password,
       },
       followRedirect: false,

--- a/packages/integration-tests/src/utils.ts
+++ b/packages/integration-tests/src/utils.ts
@@ -11,7 +11,7 @@ export const generatePassword = () => `pwd_${crypto.randomUUID()}`;
 
 export const generateResourceName = () => `res_${crypto.randomUUID()}`;
 export const generateResourceIndicator = () => `https://${crypto.randomUUID()}.logto.io`;
-export const generateEmail = () => `${crypto.randomUUID()}@logto.io`;
+export const generateEmail = () => `${crypto.randomUUID().toLowerCase()}@logto.io`;
 
 export const generatePhone = () => {
   const array = new Uint32Array(1);

--- a/packages/integration-tests/tests/api/dashboard.test.ts
+++ b/packages/integration-tests/tests/api/dashboard.test.ts
@@ -44,7 +44,7 @@ describe('admin console dashboard', () => {
     const username = generateUsername();
     await createUserByAdmin(username, password);
 
-    await signIn(username, password);
+    await signIn({ username, password });
 
     const newActiveUserStatistics = await getActiveUsersData();
 

--- a/packages/integration-tests/tests/api/get-access-token.test.ts
+++ b/packages/integration-tests/tests/api/get-access-token.test.ts
@@ -5,7 +5,7 @@ import { managementResource } from '@logto/schemas/lib/seeds';
 import { assert } from '@silverhand/essentials';
 import fetch from 'node-fetch';
 
-import { signInWithUsernameAndPassword } from '@/api';
+import { signInWithPassword } from '@/api';
 import MockClient, { defaultConfig } from '@/client';
 import { logtoUrl } from '@/constants';
 import { createUserByAdmin } from '@/helpers';
@@ -24,11 +24,11 @@ describe('get access token', () => {
     await client.initSession();
     assert(client.interactionCookie, new Error('Session not found'));
 
-    const { redirectTo } = await signInWithUsernameAndPassword(
+    const { redirectTo } = await signInWithPassword({
       username,
       password,
-      client.interactionCookie
-    );
+      interactionCookie: client.interactionCookie,
+    });
 
     await client.processSession(redirectTo);
 
@@ -47,11 +47,11 @@ describe('get access token', () => {
     await client.initSession();
     assert(client.interactionCookie, new Error('Session not found'));
 
-    const { redirectTo } = await signInWithUsernameAndPassword(
+    const { redirectTo } = await signInWithPassword({
       username,
       password,
-      client.interactionCookie
-    );
+      interactionCookie: client.interactionCookie,
+    });
 
     await client.processSession(redirectTo);
     assert(client.isAuthenticated, new Error('Sign in get get access token failed'));

--- a/packages/integration-tests/tests/api/session.test.ts
+++ b/packages/integration-tests/tests/api/session.test.ts
@@ -1,6 +1,6 @@
-import assert from 'assert';
-
+import { SignInIdentifier, SignUpIdentifier } from '@logto/schemas';
 import { adminConsoleApplicationId } from '@logto/schemas/lib/seeds';
+import { assert } from '@silverhand/essentials';
 
 import {
   mockEmailConnectorId,
@@ -9,27 +9,27 @@ import {
   mockSmsConnectorConfig,
 } from '@/__mocks__/connectors-mock';
 import {
-  createUser,
-  disableConnector,
   sendRegisterUserWithEmailPasscode,
-  sendRegisterUserWithSmsPasscode,
-  sendSignInUserWithEmailPasscode,
-  sendSignInUserWithSmsPasscode,
-  signInWithPassword,
   verifyRegisterUserWithEmailPasscode,
-  verifyRegisterUserWithSmsPasscode,
+  sendSignInUserWithEmailPasscode,
   verifySignInUserWithEmailPasscode,
+  sendRegisterUserWithSmsPasscode,
+  verifyRegisterUserWithSmsPasscode,
+  sendSignInUserWithSmsPasscode,
   verifySignInUserWithSmsPasscode,
+  disableConnector,
+  signInWithPassword,
+  createUser,
 } from '@/api';
 import MockClient from '@/client';
 import {
-  createUserByAdmin,
-  readPasscode,
   registerNewUser,
-  setSignInMethod,
-  setSignUpIdentifier,
-  setUpConnector,
   signIn,
+  setUpConnector,
+  readPasscode,
+  createUserByAdmin,
+  setSignUpIdentifier,
+  setSignInMethod,
 } from '@/helpers';
 import { generateUsername, generatePassword, generateEmail, generatePhone } from '@/utils';
 
@@ -48,7 +48,7 @@ describe('email and password flow', () => {
   const [localPart, domain] = email.split('@');
   const password = generatePassword();
 
-  assert(localPart && domain);
+  assert(localPart && domain, new Error('Email address local part or domain is empty'));
 
   beforeAll(async () => {
     await setSignInMethod([

--- a/packages/integration-tests/tests/api/session.test.ts
+++ b/packages/integration-tests/tests/api/session.test.ts
@@ -37,6 +37,18 @@ describe('username and password flow', () => {
   const username = generateUsername();
   const password = generatePassword();
 
+  beforeAll(async () => {
+    await setSignUpIdentifier(SignUpIdentifier.Username, true);
+    await setSignInMethod([
+      {
+        identifier: SignInIdentifier.Username,
+        password: true,
+        verificationCode: false,
+        isPasswordPrimary: false,
+      },
+    ]);
+  });
+
   it('register and sign in with username & password', async () => {
     await expect(registerNewUser(username, password)).resolves.not.toThrow();
     await expect(signIn({ username, password })).resolves.not.toThrow();
@@ -51,6 +63,8 @@ describe('email and password flow', () => {
   assert(localPart && domain, new Error('Email address local part or domain is empty'));
 
   beforeAll(async () => {
+    await setUpConnector(mockEmailConnectorId, mockEmailConnectorConfig);
+    await setSignUpIdentifier(SignUpIdentifier.Email, true);
     await setSignInMethod([
       {
         identifier: SignInIdentifier.Email,

--- a/packages/integration-tests/tests/api/social-session.test.ts
+++ b/packages/integration-tests/tests/api/social-session.test.ts
@@ -12,7 +12,7 @@ import {
   getAuthWithSocial,
   registerWithSocial,
   bindWithSocial,
-  signInWithUsernameAndPassword,
+  signInWithPassword,
   getUser,
 } from '@/api';
 import MockClient from '@/client';
@@ -126,11 +126,11 @@ describe('social bind account', () => {
     // User with social does not exist
     expect(response instanceof HTTPError && response.response.statusCode === 422).toBe(true);
 
-    const { redirectTo } = await signInWithUsernameAndPassword(
+    const { redirectTo } = await signInWithPassword({
       username,
       password,
-      client.interactionCookie
-    );
+      interactionCookie: client.interactionCookie,
+    });
 
     await expect(
       bindWithSocial(mockSocialConnectorId, client.interactionCookie)


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Adopt our [new strategy](https://www.notion.so/silverhand/Email-Address-Resolution-99ee44b471c2409884e4ea4d86815b19): store email in case-sensitive, search in case-insensitive

- use `lower()` to check email existency
- enable admin user API to create user with email, and make username optional
- add integration tests of email and password sign-in

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] sign in demo app with random uppercase or lowercase in the address local part
- [x] integration test
