### PR TITLE
refactor(console): fix undesired appearance for popup and tooltip

### DIFF
--- a/packages/console/src/components/Dropdown/index.tsx
+++ b/packages/console/src/components/Dropdown/index.tsx
@@ -54,6 +54,7 @@ const Dropdown = ({
             isFullWidth && anchorRef.current
               ? anchorRef.current.getBoundingClientRect().width
               : undefined,
+          ...(!position && { opacity: 0 }),
           ...position,
         },
       }}

--- a/packages/console/src/components/ToggleTip/index.tsx
+++ b/packages/console/src/components/ToggleTip/index.tsx
@@ -56,6 +56,7 @@ const ToggleTip = ({
       isOpen={isOpen}
       style={{
         content: {
+          ...(!layoutPosition && { opacity: 0 }),
           ...layoutPosition,
         },
       }}

--- a/packages/console/src/components/Tooltip/index.tsx
+++ b/packages/console/src/components/Tooltip/index.tsx
@@ -130,7 +130,7 @@ const Tooltip = ({
       <TipBubble
         ref={tooltipRef}
         className={className}
-        style={{ ...layoutPosition }}
+        style={{ ...(!layoutPosition && { opacity: 0 }), ...layoutPosition }}
         position={position}
         horizontalAlignment={positionState.horizontalAlign}
       >


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Popup and tooltip will show in the top-left corner in the first rendering since there is no position returned in `usePosition()`.

Set the opacity to 0 when no position returns to fix the issue.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Tested locally, not improper appearance for these components.