### PR TITLE
fix(console): unset compare data on the sie data updated

### DIFF
--- a/packages/console/src/pages/SignInExperience/index.tsx
+++ b/packages/console/src/pages/SignInExperience/index.tsx
@@ -72,6 +72,7 @@ const SignInExperience = () => {
       })
       .json<SignInExperienceType>();
     void mutate(updatedData);
+    setDataToCompare(undefined);
     await updateSettings({ signInExperienceCustomized: true });
     toast.success(t('general.saved'));
   };
@@ -172,7 +173,6 @@ const SignInExperience = () => {
           }}
           onConfirm={async () => {
             await saveData();
-            setDataToCompare(undefined);
           }}
         >
           {dataToCompare && <SignInMethodsChangePreview before={data} after={dataToCompare} />}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Unset compare data on the sie data updated to avoid the sign-up and sign-in change alert modal splashing with empty data.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- Once the SIE data is updated, the change alert modal is closed immediately.
