### PR TITLE
refactor(core): remove SIE identifier check from user management API

### DIFF
--- a/packages/core/src/routes/admin-user.test.ts
+++ b/packages/core/src/routes/admin-user.test.ts
@@ -251,64 +251,6 @@ describe('adminUserRoutes', () => {
     expect(updateUserById).not.toBeCalled();
   });
 
-  it('PATCH /users/:userId should throw if required sign-up identifier username is missing', async () => {
-    mockFindDefaultSignInExperience.mockImplementationOnce(async () => ({
-      signUp: {
-        identifier: SignUpIdentifier.Username,
-        password: false,
-        verify: false,
-      },
-    }));
-
-    await expect(
-      userRequest
-        .patch('/users/foo')
-        .send({ primaryEmail: 'test@abc.com', primaryPhone: '18688886666' })
-    ).resolves.toHaveProperty('status', 422);
-  });
-
-  it('PATCH /users/:userId should throw if required sign-up identifier email is missing', async () => {
-    mockFindDefaultSignInExperience.mockImplementationOnce(async () => ({
-      signUp: {
-        identifier: SignUpIdentifier.Email,
-        password: false,
-        verify: false,
-      },
-    }));
-
-    await expect(
-      userRequest.patch('/users/foo').send({ username: 'test', primaryPhone: '18688886666' })
-    ).resolves.toHaveProperty('status', 422);
-  });
-
-  it('PATCH /users/:userId should throw if required sign-up identifier phone is missing', async () => {
-    mockFindDefaultSignInExperience.mockImplementationOnce(async () => ({
-      signUp: {
-        identifier: SignUpIdentifier.Sms,
-        password: false,
-        verify: false,
-      },
-    }));
-
-    await expect(
-      userRequest.patch('/users/foo').send({ username: 'test', primaryEmail: 'test@abc.com' })
-    ).resolves.toHaveProperty('status', 422);
-  });
-
-  it('PATCH /users/:userId should throw if required sign-up identifiers email and phone are both missing', async () => {
-    mockFindDefaultSignInExperience.mockImplementationOnce(async () => ({
-      signUp: {
-        identifier: SignUpIdentifier.EmailOrSms,
-        password: false,
-        verify: false,
-      },
-    }));
-
-    await expect(
-      userRequest.patch('/users/foo').send({ username: 'test' })
-    ).resolves.toHaveProperty('status', 422);
-  });
-
   it('PATCH /users/:userId should throw if new username is already in use', async () => {
     mockHasUser.mockImplementationOnce(async () => true);
 

--- a/packages/core/src/routes/admin-user.ts
+++ b/packages/core/src/routes/admin-user.ts
@@ -21,7 +21,7 @@ import {
 } from '@/queries/user';
 import assertThat from '@/utils/assert-that';
 
-import { checkExistingSignUpIdentifiers, checkRequiredSignUpIdentifiers } from './session/utils';
+import { checkExistingSignUpIdentifiers } from './session/utils';
 import type { AuthedRouter } from './types';
 
 export default function adminUserRoutes<T extends AuthedRouter>(router: T) {
@@ -175,7 +175,6 @@ export default function adminUserRoutes<T extends AuthedRouter>(router: T) {
       } = ctx.guard;
 
       await findUserById(userId);
-      await checkRequiredSignUpIdentifiers(body);
       await checkExistingSignUpIdentifiers(body);
 
       // Temp solution to validate the existence of input roleNames


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Remove SIE identifier check from user management API, as this is management API it shouldn't bind too much business logic into it

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] UT
