### PR TITLE
fix(core): require connector when verification code is enabled

### DIFF
--- a/packages/core/src/lib/sign-in-experience/sign-in.test.ts
+++ b/packages/core/src/lib/sign-in-experience/sign-in.test.ts
@@ -66,7 +66,7 @@ describe('validate sign-in', () => {
   });
 
   describe('There must be at least one enabled connector for the specific identifier.', () => {
-    it('throws when there is no enabled email connector and identifiers includes email', () => {
+    it('throws when there is no enabled email connector and identifiers includes email with verification code checked', () => {
       expect(() => {
         validateSignIn(
           {
@@ -74,6 +74,7 @@ describe('validate sign-in', () => {
               {
                 ...mockSignInMethod,
                 identifier: SignInIdentifier.Email,
+                verificationCode: true,
               },
             ],
           },
@@ -88,7 +89,7 @@ describe('validate sign-in', () => {
       );
     });
 
-    it('throws when there is no enabled sms connector and identifiers includes phone', () => {
+    it('throws when there is no enabled sms connector and identifiers includes phone with verification code checked', () => {
       expect(() => {
         validateSignIn(
           {
@@ -96,6 +97,7 @@ describe('validate sign-in', () => {
               {
                 ...mockSignInMethod,
                 identifier: SignInIdentifier.Sms,
+                verificationCode: true,
               },
             ],
           },

--- a/packages/core/src/lib/sign-in-experience/sign-in.ts
+++ b/packages/core/src/lib/sign-in-experience/sign-in.ts
@@ -11,7 +11,12 @@ export const validateSignIn = (
   signUp: SignUp,
   enabledConnectors: LogtoConnector[]
 ) => {
-  if (signIn.methods.some(({ identifier }) => identifier === SignInIdentifier.Email)) {
+  if (
+    signIn.methods.some(
+      ({ identifier, verificationCode }) =>
+        verificationCode && identifier === SignInIdentifier.Email
+    )
+  ) {
     assertThat(
       enabledConnectors.some((item) => item.type === ConnectorType.Email),
       new RequestError({
@@ -21,7 +26,11 @@ export const validateSignIn = (
     );
   }
 
-  if (signIn.methods.some(({ identifier }) => identifier === SignInIdentifier.Sms)) {
+  if (
+    signIn.methods.some(
+      ({ identifier, verificationCode }) => verificationCode && identifier === SignInIdentifier.Sms
+    )
+  ) {
     assertThat(
       enabledConnectors.some((item) => item.type === ConnectorType.Sms),
       new RequestError({


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Require connector to setup before add a sms/email sign in method with "verification code".

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UTs
