### PR TITLE
feat(core): revoke tokens when user is suspended

### DIFF
--- a/packages/core/src/queries/oidc-model-instance.ts
+++ b/packages/core/src/queries/oidc-model-instance.ts
@@ -108,3 +108,11 @@ export const revokeInstanceByGrantId = async (modelName: string, grantId: string
     and ${fields.payload}->>'grantId'=${grantId}
   `);
 };
+
+export const revokeInstanceByUserId = async (modelName: string, userId: string) => {
+  await envSet.pool.query(sql`
+    delete from ${table}
+    where ${fields.modelName}=${modelName}
+    and ${fields.payload}->>'accountId'=${userId}
+  `);
+};

--- a/packages/core/src/routes/admin-user.test.ts
+++ b/packages/core/src/routes/admin-user.test.ts
@@ -80,6 +80,12 @@ jest.mock('@/queries/roles', () => ({
   ),
 }));
 
+const revokeInstanceByUserId = jest.fn();
+jest.mock('@/queries/oidc-model-instance', () => ({
+  revokeInstanceByUserId: async (modelName: string, userId: string) =>
+    revokeInstanceByUserId(modelName, userId),
+}));
+
 describe('adminUserRoutes', () => {
   const userRequest = createRequester({ authedRoutes: adminUserRoutes });
 
@@ -324,6 +330,7 @@ describe('adminUserRoutes', () => {
       .patch(`/users/${mockedUserId}/is-suspended`)
       .send({ isSuspended: true });
     expect(updateUserById).toHaveBeenCalledWith(mockedUserId, { isSuspended: true });
+    expect(revokeInstanceByUserId).toHaveBeenCalledWith('refreshToken', mockedUserId);
     expect(response.status).toEqual(200);
     expect(response.body).toEqual({
       ...mockUserResponse,

--- a/packages/core/src/routes/admin-user.ts
+++ b/packages/core/src/routes/admin-user.ts
@@ -9,6 +9,7 @@ import RequestError from '@/errors/RequestError';
 import { encryptUserPassword, generateUserId, insertUser } from '@/lib/user';
 import koaGuard from '@/middleware/koa-guard';
 import koaPagination from '@/middleware/koa-pagination';
+import { revokeInstanceByUserId } from '@/queries/oidc-model-instance';
 import { findRolesByRoleNames } from '@/queries/roles';
 import {
   deleteUserById,
@@ -259,6 +260,10 @@ export default function adminUserRoutes<T extends AuthedRouter>(router: T) {
       const user = await updateUserById(userId, {
         isSuspended,
       });
+
+      if (isSuspended) {
+        await revokeInstanceByUserId('refreshToken', user.id);
+      }
 
       ctx.body = pick(user, ...userInfoSelectFields);
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Revoke tokens (refresh token) when user is suspended by calling management API.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

UTs