### PR TITLE
fix(console): avoid unexpected data reset in sign-up and sign-in tab

### DIFF
--- a/packages/console/src/pages/SignInExperience/index.tsx
+++ b/packages/console/src/pages/SignInExperience/index.tsx
@@ -60,10 +60,10 @@ const SignInExperience = () => {
   }, [data]);
 
   useEffect(() => {
-    if (defaultFormData && !isDirty) {
+    if (defaultFormData) {
       reset(defaultFormData);
     }
-  }, [reset, isDirty, defaultFormData]);
+  }, [reset, defaultFormData, tab]);
 
   const saveData = async () => {
     const updatedData = await api
@@ -138,15 +138,9 @@ const SignInExperience = () => {
             <FormProvider {...methods}>
               <form className={styles.formWrapper} onSubmit={onSubmit}>
                 <div className={classNames(detailsStyles.body, styles.form)}>
-                  {tab === 'branding' && (
-                    <BrandingTab defaultData={defaultFormData} isDataDirty={isDirty} />
-                  )}
-                  {tab === 'sign-up-and-sign-in' && (
-                    <SignUpAndSignInTab defaultData={defaultFormData} isDataDirty={isDirty} />
-                  )}
-                  {tab === 'others' && (
-                    <OthersTab defaultData={defaultFormData} isDataDirty={isDirty} />
-                  )}
+                  {tab === 'branding' && <BrandingTab />}
+                  {tab === 'sign-up-and-sign-in' && <SignUpAndSignInTab />}
+                  {tab === 'others' && <OthersTab />}
                 </div>
                 <div className={detailsStyles.footer}>
                   <div className={detailsStyles.footerMain}>

--- a/packages/console/src/pages/SignInExperience/index.tsx
+++ b/packages/console/src/pages/SignInExperience/index.tsx
@@ -12,6 +12,7 @@ import Card from '@/components/Card';
 import CardTitle from '@/components/CardTitle';
 import ConfirmModal from '@/components/ConfirmModal';
 import TabNav, { TabNavItem } from '@/components/TabNav';
+import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
 import type { RequestError } from '@/hooks/use-api';
 import useApi from '@/hooks/use-api';
 import useSettings from '@/hooks/use-settings';
@@ -172,6 +173,7 @@ const SignInExperience = () => {
           {dataToCompare && <SignInMethodsChangePreview before={data} after={dataToCompare} />}
         </ConfirmModal>
       )}
+      <UnsavedChangesAlertModal hasUnsavedChanges={isDirty} />
     </div>
   );
 };

--- a/packages/console/src/pages/SignInExperience/tabs/BrandingTab.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/BrandingTab.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
@@ -7,25 +6,16 @@ import BrandingForm from '../components/BrandingForm';
 import ColorForm from '../components/ColorForm';
 import type { SignInExperienceForm } from '../types';
 
-type Props = {
-  defaultData: SignInExperienceForm;
-  isDataDirty: boolean;
-};
-
-const BrandingTab = ({ defaultData, isDataDirty }: Props) => {
-  const { reset } = useFormContext<SignInExperienceForm>();
-
-  useEffect(() => {
-    return () => {
-      reset(defaultData);
-    };
-  }, [reset, defaultData]);
+const BrandingTab = () => {
+  const {
+    formState: { isDirty },
+  } = useFormContext<SignInExperienceForm>();
 
   return (
     <>
       <ColorForm />
       <BrandingForm />
-      <UnsavedChangesAlertModal hasUnsavedChanges={isDataDirty} />
+      <UnsavedChangesAlertModal hasUnsavedChanges={isDirty} />
     </>
   );
 };

--- a/packages/console/src/pages/SignInExperience/tabs/BrandingTab.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/BrandingTab.tsx
@@ -1,23 +1,11 @@
-import { useFormContext } from 'react-hook-form';
-
-import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
-
 import BrandingForm from '../components/BrandingForm';
 import ColorForm from '../components/ColorForm';
-import type { SignInExperienceForm } from '../types';
 
-const BrandingTab = () => {
-  const {
-    formState: { isDirty },
-  } = useFormContext<SignInExperienceForm>();
-
-  return (
-    <>
-      <ColorForm />
-      <BrandingForm />
-      <UnsavedChangesAlertModal hasUnsavedChanges={isDirty} />
-    </>
-  );
-};
+const BrandingTab = () => (
+  <>
+    <ColorForm />
+    <BrandingForm />
+  </>
+);
 
 export default BrandingTab;

--- a/packages/console/src/pages/SignInExperience/tabs/OthersTab.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/OthersTab.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
@@ -8,26 +7,17 @@ import LanguagesForm from '../components/LanguagesForm';
 import TermsForm from '../components/TermsForm';
 import type { SignInExperienceForm } from '../types';
 
-type Props = {
-  defaultData: SignInExperienceForm;
-  isDataDirty: boolean;
-};
-
-const OthersTab = ({ defaultData, isDataDirty }: Props) => {
-  const { reset } = useFormContext<SignInExperienceForm>();
-
-  useEffect(() => {
-    return () => {
-      reset(defaultData);
-    };
-  }, [reset, defaultData]);
+const OthersTab = () => {
+  const {
+    formState: { isDirty },
+  } = useFormContext<SignInExperienceForm>();
 
   return (
     <>
       <TermsForm />
       <LanguagesForm isManageLanguageVisible />
       <AuthenticationForm />
-      <UnsavedChangesAlertModal hasUnsavedChanges={isDataDirty} />
+      <UnsavedChangesAlertModal hasUnsavedChanges={isDirty} />
     </>
   );
 };

--- a/packages/console/src/pages/SignInExperience/tabs/OthersTab.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/OthersTab.tsx
@@ -1,25 +1,13 @@
-import { useFormContext } from 'react-hook-form';
-
-import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
-
 import AuthenticationForm from '../components/AuthenticationForm';
 import LanguagesForm from '../components/LanguagesForm';
 import TermsForm from '../components/TermsForm';
-import type { SignInExperienceForm } from '../types';
 
-const OthersTab = () => {
-  const {
-    formState: { isDirty },
-  } = useFormContext<SignInExperienceForm>();
-
-  return (
-    <>
-      <TermsForm />
-      <LanguagesForm isManageLanguageVisible />
-      <AuthenticationForm />
-      <UnsavedChangesAlertModal hasUnsavedChanges={isDirty} />
-    </>
-  );
-};
+const OthersTab = () => (
+  <>
+    <TermsForm />
+    <LanguagesForm isManageLanguageVisible />
+    <AuthenticationForm />
+  </>
+);
 
 export default OthersTab;

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/index.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/index.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
@@ -8,26 +7,17 @@ import SignInForm from './SignInForm';
 import SignUpForm from './SignUpForm';
 import SocialSignInForm from './SocialSignInForm';
 
-type Props = {
-  defaultData: SignInExperienceForm;
-  isDataDirty: boolean;
-};
-
-const SignUpAndSignInTab = ({ defaultData, isDataDirty }: Props) => {
-  const { reset } = useFormContext<SignInExperienceForm>();
-
-  useEffect(() => {
-    return () => {
-      reset(defaultData);
-    };
-  }, [reset, defaultData]);
+const SignUpAndSignInTab = () => {
+  const {
+    formState: { isDirty },
+  } = useFormContext<SignInExperienceForm>();
 
   return (
     <>
       <SignUpForm />
       <SignInForm />
       <SocialSignInForm />
-      <UnsavedChangesAlertModal hasUnsavedChanges={isDataDirty} />
+      <UnsavedChangesAlertModal hasUnsavedChanges={isDirty} />
     </>
   );
 };

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/index.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/index.tsx
@@ -1,25 +1,13 @@
-import { useFormContext } from 'react-hook-form';
-
-import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
-
-import type { SignInExperienceForm } from '../../types';
 import SignInForm from './SignInForm';
 import SignUpForm from './SignUpForm';
 import SocialSignInForm from './SocialSignInForm';
 
-const SignUpAndSignInTab = () => {
-  const {
-    formState: { isDirty },
-  } = useFormContext<SignInExperienceForm>();
-
-  return (
-    <>
-      <SignUpForm />
-      <SignInForm />
-      <SocialSignInForm />
-      <UnsavedChangesAlertModal hasUnsavedChanges={isDirty} />
-    </>
-  );
-};
+const SignUpAndSignInTab = () => (
+  <>
+    <SignUpForm />
+    <SignInForm />
+    <SocialSignInForm />
+  </>
+);
 
 export default SignUpAndSignInTab;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The old reset logic under the sie tabs will cause the form to reset data with old values when the tab is destroyed to reconstruct. This will cause some unexpected behaviors on the SIE page.

- remove the old reset logic under the SIE tabs
- unsaved changes alert now can be placed on the SIE index page for now we use the `tab` URL param to trigger the unsaved alert.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.
