### PR TITLE
fix(console): sign-up identifier translation

### DIFF
--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignUpAndSignInDiffSection/SignUpDiffSection.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignInTab/components/SignUpAndSignInDiffSection/SignUpDiffSection.tsx
@@ -2,6 +2,7 @@ import type { SignUp } from '@logto/schemas';
 import { diff } from 'deep-object-diff';
 import get from 'lodash.get';
 import { useTranslation } from 'react-i18next';
+import { snakeCase } from 'snake-case';
 
 import DiffSegment from './DiffSegment';
 import * as styles from './index.module.scss';
@@ -29,7 +30,7 @@ const SignUpDiffSection = ({ before, after, isAfter = false }: Props) => {
         <li>
           <DiffSegment hasChanged={hasChanged('identifier')} isAfter={isAfter}>
             {t('sign_in_exp.sign_up_and_sign_in.identifiers', {
-              context: identifier.toLowerCase(),
+              context: snakeCase(identifier),
             })}
           </DiffSegment>
           {hasAuthentication && ' ('}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Sign-up identifier translation context should be snake case of the identifier definition.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="584" alt="image" src="https://user-images.githubusercontent.com/10806653/201323265-d759e589-41cd-4dee-865d-67c0a9d0899a.png">

