### PR TITLE
fix(core): get per app sie

### DIFF
--- a/packages/core/src/lib/sign-in-experience/sign-up.test.ts
+++ b/packages/core/src/lib/sign-in-experience/sign-up.test.ts
@@ -7,6 +7,11 @@ import { validateSignUp } from './sign-up';
 
 const enabledConnectors = [mockAliyunDmConnector, mockAliyunSmsConnector];
 
+jest.mock('@/lib/session', () => ({
+  ...jest.requireActual('@/lib/session'),
+  getApplicationIdFromInteraction: jest.fn(),
+}));
+
 describe('validate sign-up', () => {
   describe('There must be at least one enabled connector for the specific identifier.', () => {
     test('should throw when there is no enabled email connector and identifier is email', async () => {

--- a/packages/core/src/routes/session/continue.ts
+++ b/packages/core/src/routes/session/continue.ts
@@ -3,10 +3,10 @@ import type { Provider } from 'oidc-provider';
 import { object, string } from 'zod';
 
 import RequestError from '@/errors/RequestError';
-import { assignInteractionResults } from '@/lib/session';
+import { assignInteractionResults, getApplicationIdFromInteraction } from '@/lib/session';
+import { getSignInExperienceForApplication } from '@/lib/sign-in-experience';
 import { encryptUserPassword } from '@/lib/user';
 import koaGuard from '@/middleware/koa-guard';
-import { findDefaultSignInExperience } from '@/queries/sign-in-experience';
 import {
   findUserById,
   hasUser,
@@ -54,7 +54,9 @@ export default function continueRoutes<T extends AnonymousRouter>(router: T, pro
         passwordEncrypted,
         passwordEncryptionMethod,
       });
-      const signInExperience = await findDefaultSignInExperience();
+      const signInExperience = await getSignInExperienceForApplication(
+        await getApplicationIdFromInteraction(ctx, provider)
+      );
       await checkRequiredProfile(ctx, provider, updatedUser, signInExperience);
       await assignInteractionResults(ctx, provider, { login: { accountId: updatedUser.id } });
 
@@ -92,7 +94,9 @@ export default function continueRoutes<T extends AnonymousRouter>(router: T, pro
       const updatedUser = await updateUserById(userId, {
         username,
       });
-      const signInExperience = await findDefaultSignInExperience();
+      const signInExperience = await getSignInExperienceForApplication(
+        await getApplicationIdFromInteraction(ctx, provider)
+      );
       await checkRequiredProfile(ctx, provider, updatedUser, signInExperience);
       await assignInteractionResults(ctx, provider, { login: { accountId: updatedUser.id } });
 
@@ -127,7 +131,9 @@ export default function continueRoutes<T extends AnonymousRouter>(router: T, pro
     const updatedUser = await updateUserById(userId, {
       primaryEmail: email,
     });
-    const signInExperience = await findDefaultSignInExperience();
+    const signInExperience = await getSignInExperienceForApplication(
+      await getApplicationIdFromInteraction(ctx, provider)
+    );
     await checkRequiredProfile(ctx, provider, updatedUser, signInExperience);
     await assignInteractionResults(ctx, provider, { login: { accountId: updatedUser.id } });
 
@@ -161,7 +167,9 @@ export default function continueRoutes<T extends AnonymousRouter>(router: T, pro
     const updatedUser = await updateUserById(userId, {
       primaryPhone: phone,
     });
-    const signInExperience = await findDefaultSignInExperience();
+    const signInExperience = await getSignInExperienceForApplication(
+      await getApplicationIdFromInteraction(ctx, provider)
+    );
     await checkRequiredProfile(ctx, provider, updatedUser, signInExperience);
     await assignInteractionResults(ctx, provider, { login: { accountId: updatedUser.id } });
 

--- a/packages/core/src/routes/session/middleware/koa-guard-session-action.ts
+++ b/packages/core/src/routes/session/middleware/koa-guard-session-action.ts
@@ -5,7 +5,8 @@ import type { Provider } from 'oidc-provider';
 import { errors } from 'oidc-provider';
 
 import RequestError from '@/errors/RequestError';
-import { findDefaultSignInExperience } from '@/queries/sign-in-experience';
+import { getApplicationIdFromInteraction } from '@/lib/session';
+import { getSignInExperienceForApplication } from '@/lib/sign-in-experience';
 import assertThat from '@/utils/assert-that';
 
 export default function koaGuardSessionAction<StateT, ContextT, ResponseBodyT>(
@@ -34,7 +35,9 @@ export default function koaGuardSessionAction<StateT, ContextT, ResponseBodyT>(
       return next();
     }
 
-    const { signInMode } = await findDefaultSignInExperience();
+    const { signInMode } = await getSignInExperienceForApplication(
+      await getApplicationIdFromInteraction(ctx, provider)
+    );
 
     if (forType === 'sign-in') {
       assertThat(signInMode !== SignInMode.Register, forbiddenError);

--- a/packages/core/src/routes/session/middleware/passwordless-action.ts
+++ b/packages/core/src/routes/session/middleware/passwordless-action.ts
@@ -3,10 +3,10 @@ import type { MiddlewareType } from 'koa';
 import type { Provider } from 'oidc-provider';
 
 import RequestError from '@/errors/RequestError';
-import { assignInteractionResults } from '@/lib/session';
+import { assignInteractionResults, getApplicationIdFromInteraction } from '@/lib/session';
+import { getSignInExperienceForApplication } from '@/lib/sign-in-experience';
 import { generateUserId, insertUser } from '@/lib/user';
 import type { WithLogContext } from '@/middleware/koa-log';
-import { findDefaultSignInExperience } from '@/queries/sign-in-experience';
 import {
   hasUserWithPhone,
   hasUserWithEmail,
@@ -28,7 +28,9 @@ export const smsSignInAction = <StateT, ContextT extends WithLogContext, Respons
   provider: Provider
 ): MiddlewareType<StateT, ContextT, ResponseBodyT> => {
   return async (ctx, next) => {
-    const signInExperience = await findDefaultSignInExperience();
+    const signInExperience = await getSignInExperienceForApplication(
+      await getApplicationIdFromInteraction(ctx, provider)
+    );
     assertThat(
       signInExperience.signIn.methods.some(
         ({ identifier, verificationCode }) =>
@@ -71,7 +73,9 @@ export const emailSignInAction = <StateT, ContextT extends WithLogContext, Respo
   provider: Provider
 ): MiddlewareType<StateT, ContextT, ResponseBodyT> => {
   return async (ctx, next) => {
-    const signInExperience = await findDefaultSignInExperience();
+    const signInExperience = await getSignInExperienceForApplication(
+      await getApplicationIdFromInteraction(ctx, provider)
+    );
     assertThat(
       signInExperience.signIn.methods.some(
         ({ identifier, verificationCode }) =>
@@ -114,7 +118,9 @@ export const smsRegisterAction = <StateT, ContextT extends WithLogContext, Respo
   provider: Provider
 ): MiddlewareType<StateT, ContextT, ResponseBodyT> => {
   return async (ctx, next) => {
-    const signInExperience = await findDefaultSignInExperience();
+    const signInExperience = await getSignInExperienceForApplication(
+      await getApplicationIdFromInteraction(ctx, provider)
+    );
     assertThat(
       signInExperience.signUp.identifier === SignUpIdentifier.Sms ||
         signInExperience.signUp.identifier === SignUpIdentifier.EmailOrSms,
@@ -156,7 +162,9 @@ export const emailRegisterAction = <StateT, ContextT extends WithLogContext, Res
   provider: Provider
 ): MiddlewareType<StateT, ContextT, ResponseBodyT> => {
   return async (ctx, next) => {
-    const signInExperience = await findDefaultSignInExperience();
+    const signInExperience = await getSignInExperienceForApplication(
+      await getApplicationIdFromInteraction(ctx, provider)
+    );
     assertThat(
       signInExperience.signUp.identifier === SignUpIdentifier.Email ||
         signInExperience.signUp.identifier === SignUpIdentifier.EmailOrSms,

--- a/packages/core/src/routes/session/password.test.ts
+++ b/packages/core/src/routes/session/password.test.ts
@@ -51,6 +51,11 @@ jest.mock('@/lib/user', () => ({
   insertUser: async (...args: unknown[]) => insertUser(...args),
 }));
 
+jest.mock('@/lib/session', () => ({
+  ...jest.requireActual('@/lib/session'),
+  getApplicationIdFromInteraction: jest.fn(),
+}));
+
 const grantSave = jest.fn(async () => 'finalGrantId');
 const grantAddOIDCScope = jest.fn();
 const grantAddResourceScope = jest.fn();

--- a/packages/core/src/routes/session/password.ts
+++ b/packages/core/src/routes/session/password.ts
@@ -5,10 +5,10 @@ import type { Provider } from 'oidc-provider';
 import { object, string } from 'zod';
 
 import RequestError from '@/errors/RequestError';
-import { assignInteractionResults } from '@/lib/session';
+import { assignInteractionResults, getApplicationIdFromInteraction } from '@/lib/session';
+import { getSignInExperienceForApplication } from '@/lib/sign-in-experience';
 import { encryptUserPassword, generateUserId, insertUser } from '@/lib/user';
 import koaGuard from '@/middleware/koa-guard';
-import { findDefaultSignInExperience } from '@/queries/sign-in-experience';
 import {
   findUserByEmail,
   findUserByPhone,
@@ -104,7 +104,9 @@ export default function passwordRoutes<T extends AnonymousRouter>(router: T, pro
     async (ctx, next) => {
       const { username } = ctx.guard.body;
 
-      const signInExperience = await findDefaultSignInExperience();
+      const signInExperience = await getSignInExperienceForApplication(
+        await getApplicationIdFromInteraction(ctx, provider)
+      );
       assertThat(
         signInExperience.signUp.identifier === SignUpIdentifier.Username,
         new RequestError({
@@ -140,7 +142,9 @@ export default function passwordRoutes<T extends AnonymousRouter>(router: T, pro
       const type = 'RegisterUsernamePassword';
       ctx.log(type, { username });
 
-      const signInExperience = await findDefaultSignInExperience();
+      const signInExperience = await getSignInExperienceForApplication(
+        await getApplicationIdFromInteraction(ctx, provider)
+      );
       assertThat(
         signInExperience.signUp.identifier === SignUpIdentifier.Username,
         new RequestError({

--- a/packages/core/src/routes/session/passwordless.test.ts
+++ b/packages/core/src/routes/session/passwordless.test.ts
@@ -34,6 +34,11 @@ jest.mock('@/lib/user', () => ({
   insertUser: async (...args: unknown[]) => insertUser(...args),
 }));
 
+jest.mock('@/lib/session', () => ({
+  ...jest.requireActual('@/lib/session'),
+  getApplicationIdFromInteraction: jest.fn(),
+}));
+
 jest.mock('@/queries/user', () => ({
   findUserById: async () => findUserById(),
   findUserByPhone: async () => findUserByPhone(),

--- a/packages/core/src/routes/session/social.ts
+++ b/packages/core/src/routes/session/social.ts
@@ -6,7 +6,8 @@ import { object, string, unknown } from 'zod';
 
 import { getLogtoConnectorById } from '@/connectors';
 import RequestError from '@/errors/RequestError';
-import { assignInteractionResults } from '@/lib/session';
+import { assignInteractionResults, getApplicationIdFromInteraction } from '@/lib/session';
+import { getSignInExperienceForApplication } from '@/lib/sign-in-experience';
 import {
   findSocialRelatedUser,
   getUserInfoByAuthCode,
@@ -14,7 +15,6 @@ import {
 } from '@/lib/social';
 import { generateUserId, insertUser } from '@/lib/user';
 import koaGuard from '@/middleware/koa-guard';
-import { findDefaultSignInExperience } from '@/queries/sign-in-experience';
 import {
   hasUserWithIdentity,
   findUserById,
@@ -104,7 +104,9 @@ export default function socialRoutes<T extends AnonymousRouter>(router: T, provi
         lastSignInAt: Date.now(),
       });
 
-      const signInExperience = await findDefaultSignInExperience();
+      const signInExperience = await getSignInExperienceForApplication(
+        await getApplicationIdFromInteraction(ctx, provider)
+      );
       await checkRequiredProfile(ctx, provider, user, signInExperience);
       await assignInteractionResults(ctx, provider, { login: { accountId: id } });
 
@@ -143,7 +145,9 @@ export default function socialRoutes<T extends AnonymousRouter>(router: T, provi
         lastSignInAt: Date.now(),
       });
 
-      const signInExperience = await findDefaultSignInExperience();
+      const signInExperience = await getSignInExperienceForApplication(
+        await getApplicationIdFromInteraction(ctx, provider)
+      );
       await checkRequiredProfile(ctx, provider, user, signInExperience);
       await assignInteractionResults(ctx, provider, { login: { accountId: id } });
 
@@ -191,7 +195,9 @@ export default function socialRoutes<T extends AnonymousRouter>(router: T, provi
       });
       ctx.log(type, { userId: id });
 
-      const signInExperience = await findDefaultSignInExperience();
+      const signInExperience = await getSignInExperienceForApplication(
+        await getApplicationIdFromInteraction(ctx, provider)
+      );
       await checkRequiredProfile(ctx, provider, user, signInExperience);
       await assignInteractionResults(ctx, provider, { login: { accountId: id } });
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Create a function to get sign in experience configs according to `applicationId`, then session routes and UI are based on the same SIE configs.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UTs
