### PR TITLE
fix(core): throw invalid credentials for empty password users

### DIFF
--- a/packages/core/src/lib/user.ts
+++ b/packages/core/src/lib/user.ts
@@ -48,7 +48,7 @@ export const verifyUserPassword = async (user: Nullable<User>, password: string)
   assertThat(user, 'session.invalid_credentials');
   const { passwordEncrypted, passwordEncryptionMethod } = user;
 
-  assertThat(passwordEncrypted && passwordEncryptionMethod, 'session.invalid_sign_in_method');
+  assertThat(passwordEncrypted && passwordEncryptionMethod, 'session.invalid_credentials');
 
   const result = await argon2Verify({ password, hash: passwordEncrypted });
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Throw "invalid credentials" when a user is tring to sign in but has no password in DB.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

UTs