### PR TITLE
fix(console): fix forgotpassword not shown on preview

### DIFF
--- a/packages/console/src/pages/SignInExperience/components/Preview.tsx
+++ b/packages/console/src/pages/SignInExperience/components/Preview.tsx
@@ -106,15 +106,15 @@ const Preview = ({ signInExperience, className }: Props) => {
       signInExperience: {
         ...signInExperience,
         socialConnectors,
+        forgotPassword: {
+          email: hasEmailConnector,
+          sms: hasSmsConnector,
+        },
       },
       language,
       mode,
       platform: platform === 'desktopWeb' ? 'web' : 'mobile',
       isNative: platform === 'mobile',
-      forgotPassword: {
-        email: hasEmailConnector,
-        sms: hasSmsConnector,
-      },
     };
   }, [allConnectors, language, mode, platform, signInExperience]);
 


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix forgot password not shown on preview bug

root cause: forgot password settings were attached to the wrong position under preview configs instead of signInExperiences. 

related PR: https://github.com/logto-io/logto/pull/2358

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

test locally
<img width="1138" alt="image" src="https://user-images.githubusercontent.com/36393111/201848361-820b698a-290b-4c47-b834-dbac8808949c.png">
