### PR TITLE
refactor(console): connector details page

### DIFF
--- a/packages/console/src/pages/ConnectorDetails/components/SenderTester/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/components/SenderTester/index.tsx
@@ -57,6 +57,7 @@ const SenderTester = ({ connectorId, connectorType, config, className }: Props) 
 
   const onSubmit = handleSubmit(async (formData) => {
     const { sendTo } = formData;
+
     const result = safeParseJson(config);
 
     if (!result.success) {
@@ -73,7 +74,7 @@ const SenderTester = ({ connectorId, connectorType, config, className }: Props) 
   });
 
   return (
-    <form className={className}>
+    <div className={className}>
       <div className={styles.fields}>
         <FormField
           isRequired
@@ -120,7 +121,7 @@ const SenderTester = ({ connectorId, connectorType, config, className }: Props) 
       <div className={classNames(inputError?.message ? styles.error : styles.description)}>
         {inputError?.message ?? t('connector_details.test_sender_description')}
       </div>
-    </form>
+    </div>
   );
 };
 

--- a/packages/console/src/pages/ConnectorDetails/index.module.scss
+++ b/packages/console/src/pages/ConnectorDetails/index.module.scss
@@ -76,18 +76,12 @@
   }
 }
 
-.body {
-  > :not(:first-child) {
-    margin-top: _.unit(4);
-  }
+.codeEditor {
+  margin-bottom: _.unit(6);
+}
 
-  .main {
-    flex: 1;
-
-    .codeEditor {
-      margin-bottom: _.unit(6);
-    }
-  }
+.senderTest {
+  margin-top: _.unit(6);
 }
 
 .resetIcon {

--- a/packages/console/src/pages/ConnectorDetails/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/index.tsx
@@ -1,6 +1,5 @@
 import type { ConnectorResponse } from '@logto/schemas';
 import { AppearanceMode, ConnectorType } from '@logto/schemas';
-import classNames from 'classnames';
 import { useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { Trans, useTranslation } from 'react-i18next';
@@ -73,10 +72,11 @@ const ConnectorDetails = () => {
         json: { enabled: false },
       })
       .json<ConnectorResponse>();
-    toast.success(t('connector_details.connector_deleted'));
 
-    await mutateGlobal('/api/connectors');
     setIsDeleted(true);
+
+    toast.success(t('connector_details.connector_deleted'));
+    await mutateGlobal('/api/connectors');
 
     if (isSocial) {
       navigate(`/connectors/social`, { replace: true });
@@ -178,21 +178,19 @@ const ConnectorDetails = () => {
           </div>
         </Card>
       )}
+      <TabNav>
+        <TabNavItem href={`/connectors/${connectorId ?? ''}`}>
+          {t('general.settings_nav')}
+        </TabNavItem>
+      </TabNav>
       {data && (
-        <Card className={classNames(styles.body, detailsStyles.body)}>
-          <TabNav>
-            <TabNavItem href={`/connectors/${connectorId ?? ''}`}>
-              {t('general.settings_nav')}
-            </TabNavItem>
-          </TabNav>
-          <ConnectorContent
-            isDeleted={isDeleted}
-            connectorData={data}
-            onConnectorUpdated={(connector) => {
-              void mutate(connector);
-            }}
-          />
-        </Card>
+        <ConnectorContent
+          isDeleted={isDeleted}
+          connectorData={data}
+          onConnectorUpdated={(connector) => {
+            void mutate(connector);
+          }}
+        />
       )}
       {data && (
         <ConfirmModal

--- a/packages/console/src/scss/resources.module.scss
+++ b/packages/console/src/scss/resources.module.scss
@@ -2,6 +2,7 @@
 
 .container {
   width: 100%;
+  padding-bottom: _.unit(6);
   @include _.flex-column;
 
   .headline {

--- a/packages/phrases/src/locales/de/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/connector-details.ts
@@ -1,6 +1,9 @@
 const connector_details = {
   back_to_connectors: 'Zurück zu Connectoren',
   check_readme: 'Zur README',
+  settings: 'Settings', // UNTRANSLATED
+  settings_description:
+    'It real sent your at. Amounted all shy set why followed declared. Repeated of endeavor mr position kindness offering ignorant so up. Simplicity are melancholy preference considered saw companions.', // UNTRANSLATED
   save_error_empty_config: 'Bitte fülle die Konfiguration aus',
   send: 'Senden',
   send_error_invalid_format: 'Ungültige Eingabe',

--- a/packages/phrases/src/locales/en/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/connector-details.ts
@@ -1,6 +1,9 @@
 const connector_details = {
   back_to_connectors: 'Back to Connectors',
   check_readme: 'Check README',
+  settings: 'Settings',
+  settings_description:
+    'It real sent your at. Amounted all shy set why followed declared. Repeated of endeavor mr position kindness offering ignorant so up. Simplicity are melancholy preference considered saw companions.', // UNTRANSLATED
   save_error_empty_config: 'Please enter config',
   send: 'Send',
   send_error_invalid_format: 'Invalid input',

--- a/packages/phrases/src/locales/fr/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/connector-details.ts
@@ -1,6 +1,9 @@
 const connector_details = {
   back_to_connectors: 'Retour à Connecteurs',
   check_readme: 'Vérifier le README',
+  settings: 'Settings', // UNTRANSLATED
+  settings_description:
+    'It real sent your at. Amounted all shy set why followed declared. Repeated of endeavor mr position kindness offering ignorant so up. Simplicity are melancholy preference considered saw companions.', // UNTRANSLATED
   save_error_empty_config: 'Veuillez entrer la configuration',
   send: 'Envoyer',
   send_error_invalid_format: 'Entrée non valide',

--- a/packages/phrases/src/locales/ko/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/connector-details.ts
@@ -1,6 +1,9 @@
 const connector_details = {
   back_to_connectors: '연동으로 돌아가기',
   check_readme: 'README 확인',
+  settings: 'Settings', // UNTRANSLATED
+  settings_description:
+    'It real sent your at. Amounted all shy set why followed declared. Repeated of endeavor mr position kindness offering ignorant so up. Simplicity are melancholy preference considered saw companions.', // UNTRANSLATED
   save_error_empty_config: '설정을 입력해주세요.',
   send: '보내기',
   send_error_invalid_format: '유효하지 않은 입력',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/connector-details.ts
@@ -1,6 +1,9 @@
 const connector_details = {
   back_to_connectors: 'Voltar para Conectores',
   check_readme: 'Verifique o README',
+  settings: 'Settings', // UNTRANSLATED
+  settings_description:
+    'It real sent your at. Amounted all shy set why followed declared. Repeated of endeavor mr position kindness offering ignorant so up. Simplicity are melancholy preference considered saw companions.', // UNTRANSLATED
   save_error_empty_config: 'Por favor, insira a configuração',
   send: 'Enviar',
   send_error_invalid_format: 'Entrada inválida',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/connector-details.ts
@@ -1,6 +1,9 @@
 const connector_details = {
   back_to_connectors: 'Connectorlara dön',
   check_readme: 'READMEye göz at',
+  settings: 'Settings', // UNTRANSLATED
+  settings_description:
+    'It real sent your at. Amounted all shy set why followed declared. Repeated of endeavor mr position kindness offering ignorant so up. Simplicity are melancholy preference considered saw companions.', // UNTRANSLATED
   save_error_empty_config: 'Lütfen yapılandırmayı girin',
   send: 'Gönder',
   send_error_invalid_format: 'Geçersiz input',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/connector-details.ts
@@ -1,6 +1,9 @@
 const connector_details = {
   back_to_connectors: '返回连接器',
   check_readme: '查看 README',
+  settings: '设置',
+  settings_description:
+    'It real sent your at. Amounted all shy set why followed declared. Repeated of endeavor mr position kindness offering ignorant so up. Simplicity are melancholy preference considered saw companions.', // UNTRANSLATED
   save_error_empty_config: '请输入配置内容',
   send: '发送',
   send_error_invalid_format: '无效输入',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate) and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- refactor(console): connector details page
- wrap the `<SenderTester />` with `div` instead of `<form />` to make it possible to be placed into a form.
- reset connector data when the connector switches between different types without saving unsaved changes.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Before

<img width="1206" alt="image" src="https://user-images.githubusercontent.com/10806653/202608386-4541fa69-0790-4d0b-8ebe-3671c13e1663.png">

### After
<img width="1168" alt="image" src="https://user-images.githubusercontent.com/10806653/202608780-f0880898-a973-4d32-b4d8-cdb5bae26b2f.png">

