### PR TITLE
refactor(console): recover the main content size limitations

### DIFF
--- a/packages/console/src/scss/_underscore.scss
+++ b/packages/console/src/scss/_underscore.scss
@@ -5,7 +5,9 @@
 }
 
 @mixin main-content-width {
+  max-width: 1168px;
   min-width: 604px;
+  margin: 0 auto;
 }
 
 @mixin flex-column {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Per discussion with @fleuraly, we should not remove the main content size limitations in [this PR](https://github.com/logto-io/logto/pull/2453/files#diff-94ba094bf16f4eb6b8d36f593c65bccf57e499efed80df34ee5561901e25e817), so we add the limitations back.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Before
<img width="1915" alt="image" src="https://user-images.githubusercontent.com/10806653/202951998-9e4ed135-d6bf-4d60-bc50-0d713e3a06d3.png">

### After
<img width="1904" alt="image" src="https://user-images.githubusercontent.com/10806653/202952024-2c2d6925-b543-4c78-b53f-ac15e0822766.png">

