### PR TITLE
fix(console): set background color for preview iframe

### DIFF
--- a/packages/console/src/pages/SignInExperience/components/Preview.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/Preview.module.scss
@@ -58,6 +58,7 @@
           position: absolute;
           top: -190px;
           left: -240px;
+          background: var(--color-surface-1);
         }
       }
     }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
set background color for preview iframe, useful when the web page is loading slowly.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested, no color difference when swiching tabs.
