### PR TITLE
style(console): `CardTitle` should not be shrunk in the flex layout

### DIFF
--- a/packages/console/src/components/CardTitle/index.module.scss
+++ b/packages/console/src/components/CardTitle/index.module.scss
@@ -2,6 +2,7 @@
 
 .container {
   overflow: hidden;
+  flex-shrink: 0;
 
   .title {
     color: var(--color-text);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
style(console): `CardTitle` should not be shrunk in the flex layout

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Before
<img width="1111" alt="image" src="https://user-images.githubusercontent.com/10806653/203003123-be11aa79-db03-4a0b-af97-9aa38ceee0f2.png">

### After
<img width="1238" alt="image" src="https://user-images.githubusercontent.com/10806653/203003360-380b3242-288e-400c-a6b7-bc6110db618f.png">


