### PR TITLE
fix(console): secondary "cancel" button should use default border style

### DIFF
--- a/packages/console/src/components/ConfirmModal/index.tsx
+++ b/packages/console/src/components/ConfirmModal/index.tsx
@@ -47,7 +47,7 @@ const ConfirmModal = ({
         title={title}
         footer={
           <>
-            <Button type="outline" title={cancelButtonText} onClick={onCancel} />
+            <Button title={cancelButtonText} onClick={onCancel} />
             <Button
               type={confirmButtonType}
               title={confirmButtonText}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Secondary "Cancel" buttons in confirm modal dialogs should use the default gray style border color, instead of the light purple one.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Before:

<img width="618" alt="image" src="https://user-images.githubusercontent.com/12833674/203018987-0fc55ac9-eeb1-4edc-90dd-9799e9450a7c.png">

After:

<img width="621" alt="image" src="https://user-images.githubusercontent.com/12833674/203018932-efa3bf33-d102-4656-809b-a805bac76e06.png">
