### PR TITLE
feat(schemas): add roles and permissions

### DIFF
--- a/packages/core/src/__mocks__/index.ts
+++ b/packages/core/src/__mocks__/index.ts
@@ -32,6 +32,7 @@ export const mockResource: Resource = {
 };
 
 export const mockRole: Role = {
+  id: 'role_id',
   name: 'admin',
   description: 'admin',
 };

--- a/packages/core/src/lib/user.ts
+++ b/packages/core/src/lib/user.ts
@@ -13,6 +13,7 @@ import assertThat from '#src/utils/assert-that.js';
 import { encryptPassword } from '#src/utils/password.js';
 
 const userId = buildIdGenerator(12);
+const roleId = buildIdGenerator(21);
 
 export const generateUserId = async (retries = 500) =>
   pRetry(
@@ -76,7 +77,11 @@ export const insertUser: typeof insertUserQuery = async ({ roleNames, ...rest })
 
     if (missingRoleNames.length > 0) {
       await insertRoles(
-        missingRoleNames.map((name) => ({ name, description: 'User default role.' }))
+        missingRoleNames.map((name) => ({
+          id: roleId(),
+          name,
+          description: 'User default role.',
+        }))
       );
     }
   }

--- a/packages/core/src/routes/admin-user.test.ts
+++ b/packages/core/src/routes/admin-user.test.ts
@@ -81,7 +81,7 @@ jest.mock('#src/lib/user.js', () => ({
 
 jest.mock('#src/queries/roles.js', () => ({
   findRolesByRoleNames: jest.fn(
-    async (): Promise<Role[]> => [{ name: 'admin', description: 'none' }]
+    async (): Promise<Role[]> => [{ id: 'role_id', name: 'admin', description: 'none' }]
   ),
 }));
 
@@ -291,8 +291,8 @@ describe('adminUserRoutes', () => {
     const mockedFindRolesByRoleNames = findRolesByRoleNames as jest.Mock;
     mockedFindRolesByRoleNames.mockImplementationOnce(
       async (): Promise<Role[]> => [
-        { name: 'worker', description: 'none' },
-        { name: 'cleaner', description: 'none' },
+        { id: 'role_id1', name: 'worker', description: 'none' },
+        { id: 'role_id2', name: 'cleaner', description: 'none' },
       ]
     );
     await expect(

--- a/packages/schemas/alterations/next-1669091623-roles-and-scopes.ts
+++ b/packages/schemas/alterations/next-1669091623-roles-and-scopes.ts
@@ -1,0 +1,43 @@
+import { sql } from 'slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      -- scopes
+      create table scopes (
+        id varchar(21) not null,
+        resource_id varchar(21) references resources (id) on update cascade on delete cascade,
+        name varchar(256) not null,
+        description text,
+        created_at timestamptz not null default(now()),
+        primary key (id)
+      );
+      -- update table roles, add id and replace pkey
+      alter table roles add column id varchar(21);
+      update roles set id = name;
+      alter table roles alter column id set not null;
+      alter table roles drop constraint roles_pkey;
+      create unique index roles_pkey on roles using btree(id);
+      create unique index roles__name on roles (name);
+      -- roles_scopes
+      create table roles_scopes (
+        role_id varchar(21) references roles (id) on update cascade on delete cascade,
+        scope_id varchar(21) references scopes (id) on update cascade on delete cascade,
+        constraint roles_permissison_pkey primary key (role_id, scope_id)
+      );
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      drop table permissions;
+      alter index roles_pkey rename to roles_pkey_1;
+      create unique index roles_pkey on roles using btree(name)
+      drop index roles_pkey_1;
+      alter table roles drop column id;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/seeds/roles.ts
+++ b/packages/schemas/src/seeds/roles.ts
@@ -5,6 +5,7 @@ import { UserRole } from '../types/index.js';
  * Default Admin Role for Admin Console.
  */
 export const defaultRole: Readonly<CreateRole> = {
+  id: 'ac-admin-id',
   name: UserRole.Admin,
   description: 'Admin role for Logto.',
 };

--- a/packages/schemas/tables/roles.sql
+++ b/packages/schemas/tables/roles.sql
@@ -1,5 +1,11 @@
 create table roles (
-    name varchar(128) not null,
-    description varchar(128) not null,
-    primary key (name)
+  id varchar(21) not null,
+  name varchar(128) not null,
+  description varchar(128) not null,
+  primary key (id)
+);
+
+create unique index roles__name
+on roles (
+  name
 );

--- a/packages/schemas/tables/scopes.sql
+++ b/packages/schemas/tables/scopes.sql
@@ -1,0 +1,8 @@
+create table scopes (
+  id varchar(21) not null,
+  resource_id varchar(21) references resources (id) on update cascade on delete cascade,
+  name varchar(256) not null,
+  description text,
+  created_at timestamptz not null default(now()),
+  primary key (id)
+);

--- a/packages/schemas/tables/scopesroles.sql
+++ b/packages/schemas/tables/scopesroles.sql
@@ -1,0 +1,5 @@
+create table roles_scopes (
+  role_id varchar(21) references roles (id) on update cascade on delete cascade,
+  scope_id varchar(21) references scopes (id) on update cascade on delete cascade,
+  primary key (role_id, scope_id)
+);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

Add RBAC related tables:

1. Add table `scopes`, with a foreign key pointing to `resources`
2. Add `id` to `roles`, because we have a display name now, and judge access by `role_name` is deperecated.
3. Add table `roles_scopes` to implement many-to-many relations.

After consideration and research, instead of `jsonb`, use the traditional foreign key constraints and a "relation" table, that would be more flexable and efficency: https://dba.stackexchange.com/questions/82009/postgres-json-field-for-many-to-many-relationships

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

/