### PR TITLE
refactor(console): user logs

### DIFF
--- a/packages/console/src/components/AuditLogTable/index.module.scss
+++ b/packages/console/src/components/AuditLogTable/index.module.scss
@@ -1,5 +1,11 @@
 @use '@/scss/underscore' as _;
 
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
 .filter {
   display: flex;
   justify-content: flex-end;
@@ -28,6 +34,9 @@
 .tableLayout {
   display: flex;
   flex-direction: column;
+  max-height: 100%;
+  overflow-y: auto;
+  flex: 1;
 
   .tableContainer {
     border-top-left-radius: 0;

--- a/packages/console/src/components/AuditLogTable/index.tsx
+++ b/packages/console/src/components/AuditLogTable/index.tsx
@@ -69,7 +69,7 @@ const AuditLogTable = ({ userId }: Props) => {
 
   return (
     <div className={styles.container}>
-      <div className={classNames(styles.tableLayout)}>
+      <div className={styles.tableLayout}>
         <div className={styles.filter}>
           <div className={styles.title}>{t('logs.filter_by')}</div>
           <div className={styles.eventSelector}>

--- a/packages/console/src/components/AuditLogTable/index.tsx
+++ b/packages/console/src/components/AuditLogTable/index.tsx
@@ -13,7 +13,6 @@ import TableError from '@/components/Table/TableError';
 import TableLoading from '@/components/Table/TableLoading';
 import UserName from '@/components/UserName';
 import type { RequestError } from '@/hooks/use-api';
-import * as resourcesStyles from '@/scss/resources.module.scss';
 import * as tableStyles from '@/scss/table.module.scss';
 
 import ApplicationSelector from './components/ApplicationSelector';
@@ -69,8 +68,8 @@ const AuditLogTable = ({ userId }: Props) => {
   };
 
   return (
-    <>
-      <div className={classNames(resourcesStyles.table, styles.tableLayout)}>
+    <div className={styles.container}>
+      <div className={classNames(styles.tableLayout)}>
         <div className={styles.filter}>
           <div className={styles.title}>{t('logs.filter_by')}</div>
           <div className={styles.eventSelector}>
@@ -153,7 +152,7 @@ const AuditLogTable = ({ userId }: Props) => {
           updateQuery('page', String(page));
         }}
       />
-    </>
+    </div>
   );
 };
 

--- a/packages/console/src/pages/AuditLogs/index.tsx
+++ b/packages/console/src/pages/AuditLogs/index.tsx
@@ -8,7 +8,9 @@ const AuditLogs = () => {
       <div className={resourcesStyles.headline}>
         <CardTitle title="logs.title" subtitle="logs.subtitle" />
       </div>
-      <AuditLogTable />
+      <div className={resourcesStyles.table}>
+        <AuditLogTable />
+      </div>
     </div>
   );
 };

--- a/packages/console/src/pages/UserDetails/components/UserLogs.module.scss
+++ b/packages/console/src/pages/UserDetails/components/UserLogs.module.scss
@@ -1,9 +1,7 @@
 @use '@/scss/underscore' as _;
 
 .logs {
+  flex: 1;
   margin-bottom: _.unit(6);
-
-  >:not(:first-child) {
-    margin-top: _.unit(3);
-  }
+  overflow-y: auto;
 }

--- a/packages/console/src/pages/UserDetails/components/UserLogs.tsx
+++ b/packages/console/src/pages/UserDetails/components/UserLogs.tsx
@@ -1,5 +1,4 @@
 import AuditLogTable from '@/components/AuditLogTable';
-import Card from '@/components/Card';
 
 import * as styles from './UserLogs.module.scss';
 
@@ -9,9 +8,9 @@ type Props = {
 
 const UserLogs = ({ userId }: Props) => {
   return (
-    <Card className={styles.logs}>
+    <div className={styles.logs}>
       <AuditLogTable userId={userId} />
-    </Card>
+    </div>
   );
 };
 

--- a/packages/console/src/pages/UserDetails/index.module.scss
+++ b/packages/console/src/pages/UserDetails/index.module.scss
@@ -4,6 +4,10 @@
   margin: _.unit(1) 0 0 _.unit(1);
 }
 
+.resourceLayout {
+  height: 100%;
+}
+
 .header {
   padding: _.unit(6);
   display: flex;

--- a/packages/console/src/pages/UserDetails/index.tsx
+++ b/packages/console/src/pages/UserDetails/index.tsx
@@ -1,4 +1,5 @@
 import type { User } from '@logto/schemas';
+import classNames from 'classnames';
 import { useMemo, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
@@ -78,7 +79,7 @@ const UserDetails = () => {
   };
 
   return (
-    <div className={detailsStyles.container}>
+    <div className={classNames(detailsStyles.container, isLogs && styles.resourceLayout)}>
       <LinkButton
         to="/users"
         icon={<Back />}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

refactor(console): user logs

- remove page-related layout styles from `<AuditLogTable />`
- wrap `<AuditLogTable />` with a `div` tag for better reusability on different pages.
- when switching to the user logs tab on the user-details page, change the main content's height to `100%` to avoid scrolling.
- add `flex:1` to the `<AuditLogTable />` table section, for we want to keep the pagination on the bottom of the page.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Before
<img width="1198" alt="image" src="https://user-images.githubusercontent.com/10806653/203494445-ebf59135-60c1-4027-b126-a73e17b95c32.png">

### After

<img width="1361" alt="image" src="https://user-images.githubusercontent.com/10806653/203494060-75753805-1fc7-4b38-9b7f-ebefbe7a35cc.png">
<img width="1198" alt="image" src="https://user-images.githubusercontent.com/10806653/203494189-db381182-087d-48f8-88da-99877a12972c.png">
<img width="1200" alt="image" src="https://user-images.githubusercontent.com/10806653/203494302-71a50ba0-e561-43dd-b28a-493c58d316ab.png">



