### PR TITLE
refactor(console): audit log details page

### DIFF
--- a/packages/console/src/pages/AuditLogDetails/index.module.scss
+++ b/packages/console/src/pages/AuditLogDetails/index.module.scss
@@ -46,6 +46,8 @@
 }
 
 .body {
+  margin-bottom: _.unit(6);
+
   > :not(:first-child) {
     margin-top: _.unit(4);
   }

--- a/packages/console/src/pages/AuditLogDetails/index.tsx
+++ b/packages/console/src/pages/AuditLogDetails/index.tsx
@@ -95,12 +95,12 @@ const AuditLogDetails = () => {
               </div>
             </div>
           </Card>
+          <TabNav>
+            <TabNavItem href={`/audit-logs/${logId ?? ''}`}>
+              {t('log_details.tab_details')}
+            </TabNavItem>
+          </TabNav>
           <Card className={classNames(styles.body, detailsStyles.body)}>
-            <TabNav>
-              <TabNavItem href={`/audit-logs/${logId ?? ''}`}>
-                {t('log_details.tab_details')}
-              </TabNavItem>
-            </TabNav>
             <div className={styles.main}>
               <FormField title="log_details.raw_data">
                 <CodeEditor language="json" value={JSON.stringify(data.payload, null, 2)} />


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
refactor(console): audit log details page

- add margin-bottom to the page body
- move out nav tabs from the body card

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Before
<img width="1215" alt="image" src="https://user-images.githubusercontent.com/10806653/203496926-49b0e762-958a-476b-ac45-521c915d9c18.png">

### After
<img width="1204" alt="image" src="https://user-images.githubusercontent.com/10806653/203497029-c9f5ae9d-d627-4cc6-8506-5315d72709f1.png">
<img width="1703" alt="image" src="https://user-images.githubusercontent.com/10806653/203497085-e4367a52-7f0f-4d4c-930c-1c46ab46df53.png">

