### PR TITLE
fix(console): treat null value as empty in the user details form

### DIFF
--- a/packages/console/src/pages/UserDetails/components/UserSettings.tsx
+++ b/packages/console/src/pages/UserDetails/components/UserSettings.tsx
@@ -16,16 +16,16 @@ import { safeParseJson } from '@/utilities/json';
 import { uriValidator } from '@/utilities/validator';
 
 import type { UserDetailsForm } from '../types';
-import { userDetailsParser } from '../utils';
 import UserConnectors from './UserConnectors';
 
 type Props = {
-  data: User;
+  userData: User;
+  userFormData: UserDetailsForm;
   onUserUpdated: (user?: User) => void;
   isDeleted: boolean;
 };
 
-const UserSettings = ({ data, isDeleted, onUserUpdated }: Props) => {
+const UserSettings = ({ userData, userFormData, isDeleted, onUserUpdated }: Props) => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
   const {
@@ -44,8 +44,8 @@ const UserSettings = ({ data, isDeleted, onUserUpdated }: Props) => {
   const api = useApi();
 
   useEffect(() => {
-    reset(userDetailsParser.toLocalForm(data));
-  }, [reset, data]);
+    reset(userFormData);
+  }, [reset, userFormData]);
 
   const onSubmit = handleSubmit(async (formData) => {
     if (isSubmitting) {
@@ -77,7 +77,9 @@ const UserSettings = ({ data, isDeleted, onUserUpdated }: Props) => {
       customData: guardResult.data,
     };
 
-    const updatedUser = await api.patch(`/api/users/${data.id}`, { json: payload }).json<User>();
+    const updatedUser = await api
+      .patch(`/api/users/${userData.id}`, { json: payload })
+      .json<User>();
     onUserUpdated(updatedUser);
     toast.success(t('general.saved'));
   });
@@ -126,8 +128,8 @@ const UserSettings = ({ data, isDeleted, onUserUpdated }: Props) => {
           </FormField>
           <FormField title="user_details.field_connectors">
             <UserConnectors
-              userId={data.id}
-              connectors={data.identities}
+              userId={userData.id}
+              connectors={userData.identities}
               onDelete={() => {
                 onUserUpdated();
               }}

--- a/packages/console/src/pages/UserDetails/components/UserSettings.tsx
+++ b/packages/console/src/pages/UserDetails/components/UserSettings.tsx
@@ -1,6 +1,5 @@
 import type { User } from '@logto/schemas';
 import { arbitraryObjectGuard } from '@logto/schemas';
-import type { Nullable } from '@silverhand/essentials';
 import { useEffect } from 'react';
 import { useForm, useController } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
@@ -16,26 +15,17 @@ import useApi from '@/hooks/use-api';
 import { safeParseJson } from '@/utilities/json';
 import { uriValidator } from '@/utilities/validator';
 
+import type { UserDetailsForm } from '../types';
+import { userDetailsParser } from '../utils';
 import UserConnectors from './UserConnectors';
 
-type FormData = {
-  primaryEmail: Nullable<string>;
-  primaryPhone: Nullable<string>;
-  username: Nullable<string>;
-  name: Nullable<string>;
-  avatar: Nullable<string>;
-  roleNames: string[];
-  customData: string;
-};
-
 type Props = {
-  userData: User;
-  userFormData: FormData;
+  data: User;
   onUserUpdated: (user?: User) => void;
   isDeleted: boolean;
 };
 
-const UserSettings = ({ userData, userFormData, isDeleted, onUserUpdated }: Props) => {
+const UserSettings = ({ data, isDeleted, onUserUpdated }: Props) => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
   const {
@@ -45,7 +35,7 @@ const UserSettings = ({ userData, userFormData, isDeleted, onUserUpdated }: Prop
     reset,
     formState: { isSubmitting, errors, isDirty },
     getValues,
-  } = useForm<FormData>();
+  } = useForm<UserDetailsForm>();
 
   const {
     field: { onChange, value },
@@ -54,8 +44,8 @@ const UserSettings = ({ userData, userFormData, isDeleted, onUserUpdated }: Prop
   const api = useApi();
 
   useEffect(() => {
-    reset(userFormData);
-  }, [reset, userFormData]);
+    reset(userDetailsParser.toLocalForm(data));
+  }, [reset, data]);
 
   const onSubmit = handleSubmit(async (formData) => {
     if (isSubmitting) {
@@ -87,9 +77,7 @@ const UserSettings = ({ userData, userFormData, isDeleted, onUserUpdated }: Prop
       customData: guardResult.data,
     };
 
-    const updatedUser = await api
-      .patch(`/api/users/${userData.id}`, { json: payload })
-      .json<User>();
+    const updatedUser = await api.patch(`/api/users/${data.id}`, { json: payload }).json<User>();
     onUserUpdated(updatedUser);
     toast.success(t('general.saved'));
   });
@@ -138,8 +126,8 @@ const UserSettings = ({ userData, userFormData, isDeleted, onUserUpdated }: Prop
           </FormField>
           <FormField title="user_details.field_connectors">
             <UserConnectors
-              userId={userData.id}
-              connectors={userData.identities}
+              userId={data.id}
+              connectors={data.identities}
               onDelete={() => {
                 onUserUpdated();
               }}

--- a/packages/console/src/pages/UserDetails/index.tsx
+++ b/packages/console/src/pages/UserDetails/index.tsx
@@ -1,5 +1,5 @@
 import type { User } from '@logto/schemas';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import ReactModal from 'react-modal';
@@ -29,6 +29,7 @@ import ResetPasswordForm from './components/ResetPasswordForm';
 import UserLogs from './components/UserLogs';
 import UserSettings from './components/UserSettings';
 import * as styles from './index.module.scss';
+import { userDetailsParser } from './utils';
 
 const UserDetails = () => {
   const location = useLocation();
@@ -46,6 +47,14 @@ const UserDetails = () => {
   const isLoading = !data && !error;
   const api = useApi();
   const navigate = useNavigate();
+
+  const userFormData = useMemo(() => {
+    if (!data) {
+      return;
+    }
+
+    return userDetailsParser.toLocalForm(data);
+  }, [data]);
 
   const onDelete = async () => {
     if (!data || isDeleting) {
@@ -163,9 +172,10 @@ const UserDetails = () => {
             <TabNavItem href={`/users/${userId}/logs`}>{t('user_details.tab_logs')}</TabNavItem>
           </TabNav>
           {isLogs && <UserLogs userId={data.id} />}
-          {!isLogs && (
+          {!isLogs && userFormData && (
             <UserSettings
-              data={data}
+              userData={data}
+              userFormData={userFormData}
               isDeleted={isDeleted}
               onUserUpdated={(user) => {
                 void mutate(user);

--- a/packages/console/src/pages/UserDetails/index.tsx
+++ b/packages/console/src/pages/UserDetails/index.tsx
@@ -1,5 +1,5 @@
 import type { User } from '@logto/schemas';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import ReactModal from 'react-modal';
@@ -46,17 +46,6 @@ const UserDetails = () => {
   const isLoading = !data && !error;
   const api = useApi();
   const navigate = useNavigate();
-
-  const userFormData = useMemo(() => {
-    if (!data) {
-      return;
-    }
-
-    return {
-      ...data,
-      customData: JSON.stringify(data.customData, null, 2),
-    };
-  }, [data]);
 
   const onDelete = async () => {
     if (!data || isDeleting) {
@@ -174,10 +163,9 @@ const UserDetails = () => {
             <TabNavItem href={`/users/${userId}/logs`}>{t('user_details.tab_logs')}</TabNavItem>
           </TabNav>
           {isLogs && <UserLogs userId={data.id} />}
-          {!isLogs && userFormData && (
+          {!isLogs && (
             <UserSettings
-              userData={data}
-              userFormData={userFormData}
+              data={data}
               isDeleted={isDeleted}
               onUserUpdated={(user) => {
                 void mutate(user);

--- a/packages/console/src/pages/UserDetails/types.ts
+++ b/packages/console/src/pages/UserDetails/types.ts
@@ -1,0 +1,9 @@
+export type UserDetailsForm = {
+  primaryEmail: string;
+  primaryPhone: string;
+  username: string;
+  name: string;
+  avatar: string;
+  roleNames: string[];
+  customData: string;
+};

--- a/packages/console/src/pages/UserDetails/utils.ts
+++ b/packages/console/src/pages/UserDetails/utils.ts
@@ -1,0 +1,19 @@
+import type { User } from '@logto/schemas';
+
+import type { UserDetailsForm } from './types';
+
+export const userDetailsParser = {
+  toLocalForm: (data: User): UserDetailsForm => {
+    const { primaryEmail, primaryPhone, username, name, avatar, roleNames, customData } = data;
+
+    return {
+      primaryEmail: primaryEmail ?? '',
+      primaryPhone: primaryPhone ?? '',
+      username: username ?? '',
+      name: name ?? '',
+      avatar: avatar ?? '',
+      roleNames,
+      customData: JSON.stringify(customData, null, 2),
+    };
+  },
+};


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

We have an unsaved changes bug on the user details page:
when the user's `name` is a `null` value, after we edit the name field and delete all our inputs, the `name` value in the form data will be `''`, and the form compares the `''` value with the raw `null` value, which will cause the form 'dirty'.

so we need to treat the `null` value as `''` in the user details form to avoid this bug. 

### Todo
- refactor: remove the redundant `userFormData` prop from the `<UserSettings />` component.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
![user-details](https://user-images.githubusercontent.com/10806653/203686348-e957ca18-2e95-44e0-8c27-07f48c133e8b.gif)

