### PR TITLE
feat: add users_roles table and remove role_names

### DIFF
--- a/packages/console/src/components/UserName/index.tsx
+++ b/packages/console/src/components/UserName/index.tsx
@@ -1,4 +1,4 @@
-import type { User } from '@logto/schemas';
+import type { UserWithRoleNames } from '@logto/schemas';
 import { UserRole } from '@logto/schemas';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
@@ -14,7 +14,7 @@ type Props = {
 };
 
 const UserName = ({ userId, isLink = false }: Props) => {
-  const { data, error } = useSWR<User, RequestError>(`/api/users/${userId}`);
+  const { data, error } = useSWR<UserWithRoleNames, RequestError>(`/api/users/${userId}`);
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
   const isLoading = !data && !error;

--- a/packages/console/src/pages/UserDetails/components/UserSettings.tsx
+++ b/packages/console/src/pages/UserDetails/components/UserSettings.tsx
@@ -52,7 +52,7 @@ const UserSettings = ({ userData, userFormData, isDeleted, onUserUpdated }: Prop
       return;
     }
 
-    const { customData: inputCustomData, name, avatar, roleNames } = formData;
+    const { customData: inputCustomData, name, avatar } = formData;
 
     const parseResult = safeParseJson(inputCustomData);
 
@@ -73,7 +73,6 @@ const UserSettings = ({ userData, userFormData, isDeleted, onUserUpdated }: Prop
     const payload: Partial<User> = {
       name,
       avatar,
-      roleNames,
       customData: guardResult.data,
     };
 

--- a/packages/console/src/pages/UserDetails/types.ts
+++ b/packages/console/src/pages/UserDetails/types.ts
@@ -4,6 +4,5 @@ export type UserDetailsForm = {
   username: string;
   name: string;
   avatar: string;
-  roleNames: string[];
   customData: string;
 };

--- a/packages/console/src/pages/UserDetails/utils.ts
+++ b/packages/console/src/pages/UserDetails/utils.ts
@@ -4,7 +4,7 @@ import type { UserDetailsForm } from './types';
 
 export const userDetailsParser = {
   toLocalForm: (data: User): UserDetailsForm => {
-    const { primaryEmail, primaryPhone, username, name, avatar, roleNames, customData } = data;
+    const { primaryEmail, primaryPhone, username, name, avatar, customData } = data;
 
     return {
       primaryEmail: primaryEmail ?? '',
@@ -12,7 +12,6 @@ export const userDetailsParser = {
       username: username ?? '',
       name: name ?? '',
       avatar: avatar ?? '',
-      roleNames,
       customData: JSON.stringify(customData, null, 2),
     };
   },

--- a/packages/core/src/__mocks__/user.ts
+++ b/packages/core/src/__mocks__/user.ts
@@ -1,8 +1,8 @@
-import type { User } from '@logto/schemas';
+import type { UserWithRoleNames } from '@logto/schemas';
 import { userInfoSelectFields, UsersPasswordEncryptionMethod } from '@logto/schemas';
 import { pick } from '@silverhand/essentials';
 
-export const mockUser: User = {
+export const mockUser: UserWithRoleNames = {
   id: 'foo',
   username: 'foo',
   primaryEmail: 'foo@logto.io',
@@ -25,7 +25,7 @@ export const mockUser: User = {
 export const mockUserResponse = pick(mockUser, ...userInfoSelectFields);
 
 export const mockPasswordEncrypted = 'a1b2c3';
-export const mockUserWithPassword: User = {
+export const mockUserWithPassword: UserWithRoleNames = {
   id: 'id',
   username: 'username',
   primaryEmail: 'foo@logto.io',
@@ -45,7 +45,7 @@ export const mockUserWithPassword: User = {
   isSuspended: false,
 };
 
-export const mockUserList: User[] = [
+export const mockUserList: UserWithRoleNames[] = [
   {
     id: '1',
     username: 'foo1',

--- a/packages/core/src/oidc/scope.ts
+++ b/packages/core/src/oidc/scope.ts
@@ -1,10 +1,10 @@
 import type { UserClaim } from '@logto/core-kit';
 import { idTokenClaims, userinfoClaims, UserScope } from '@logto/core-kit';
-import type { User } from '@logto/schemas';
+import type { UserWithRoleNames } from '@logto/schemas';
 import type { Nullable } from '@silverhand/essentials';
 import type { ClaimsParameterMember } from 'oidc-provider';
 
-export const claimToUserKey: Readonly<Record<UserClaim, keyof User>> = Object.freeze({
+export const claimToUserKey: Readonly<Record<UserClaim, keyof UserWithRoleNames>> = Object.freeze({
   name: 'name',
   picture: 'avatar',
   username: 'username',

--- a/packages/core/src/queries/roles.ts
+++ b/packages/core/src/queries/roles.ts
@@ -12,6 +12,14 @@ export const findAllRoles = async () =>
     select ${sql.join(Object.values(fields), sql`, `)}
     from ${table}
   `);
+export const findRolesByRoleIds = async (roleIds: string[]) =>
+  roleIds.length > 0
+    ? envSet.pool.any<Role>(sql`
+      select ${sql.join(Object.values(fields), sql`, `)}
+      from ${table}
+      where ${fields.id} in (${sql.join(roleIds, sql`, `)})
+    `)
+    : [];
 
 export const findRolesByRoleNames = async (roleNames: string[]) =>
   envSet.pool.any<Role>(sql`
@@ -20,11 +28,18 @@ export const findRolesByRoleNames = async (roleNames: string[]) =>
     where ${fields.name} in (${sql.join(roleNames, sql`, `)})
   `);
 
+export const findRoleByRoleName = async (roleName: string) =>
+  envSet.pool.maybeOne<Role>(sql`
+    select ${sql.join(Object.values(fields), sql`, `)}
+    from ${table}
+    where ${fields.name} = ${roleName}
+  `);
+
 export const insertRoles = async (roles: Role[]) =>
   envSet.pool.query(sql`
-    insert into ${table} (${fields.name}, ${fields.description}) values
+    insert into ${table} (${fields.id}, ${fields.name}, ${fields.description}) values
     ${sql.join(
-      roles.map(({ name, description }) => sql`(${name}, ${description})`),
+      roles.map(({ id, name, description }) => sql`(${id}, ${name}, ${description})`),
       sql`, `
     )}
   `);

--- a/packages/core/src/queries/user.test.ts
+++ b/packages/core/src/queries/user.test.ts
@@ -1,4 +1,4 @@
-import { Users } from '@logto/schemas';
+import { Roles, Users, UsersRoles } from '@logto/schemas';
 import { convertToIdentifiers } from '@logto/shared';
 import { createMockPool, createMockQueryResult, sql } from 'slonik';
 
@@ -12,7 +12,6 @@ import {
   findUserByUsername,
   findUserByEmail,
   findUserByPhone,
-  findUserById,
   findUserByIdentity,
   hasUser,
   hasUserWithId,
@@ -38,6 +37,8 @@ jest.spyOn(envSet, 'pool', 'get').mockReturnValue(
 
 describe('user query', () => {
   const { table, fields } = convertToIdentifiers(Users);
+  const { fields: rolesFields, table: rolesTable } = convertToIdentifiers(Roles);
+  const { fields: usersRolesFields, table: usersRolesTable } = convertToIdentifiers(UsersRoles);
   const dbvalue = {
     ...mockUser,
     roleNames: JSON.stringify(mockUser.roleNames),
@@ -97,23 +98,6 @@ describe('user query', () => {
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await expect(findUserByPhone(mockUser.primaryPhone!)).resolves.toEqual(dbvalue);
-  });
-
-  it('findUserById', async () => {
-    const expectSql = sql`
-      select ${sql.join(Object.values(fields), sql`,`)}
-      from ${table}
-      where ${fields.id}=$1
-    `;
-
-    mockQuery.mockImplementationOnce(async (sql, values) => {
-      expectSqlAssert(sql, expectSql.sql);
-      expect(values).toEqual([mockUser.id]);
-
-      return createMockQueryResult([dbvalue]);
-    });
-
-    await expect(findUserById(mockUser.id)).resolves.toEqual(dbvalue);
   });
 
   it('findUserByIdentity', async () => {

--- a/packages/core/src/queries/users-roles.ts
+++ b/packages/core/src/queries/users-roles.ts
@@ -1,0 +1,38 @@
+import type { UsersRole } from '@logto/schemas';
+import { UsersRoles } from '@logto/schemas';
+import { convertToIdentifiers } from '@logto/shared';
+import { sql } from 'slonik';
+
+import envSet from '#src/env-set/index.js';
+
+const { table, fields } = convertToIdentifiers(UsersRoles);
+
+export const findUsersRolesByUserId = async (userId: string) =>
+  envSet.pool.any<UsersRole>(sql`
+    select ${sql.join(Object.values(fields), sql`,`)}
+    from ${table}
+    where ${fields.userId}=${userId}
+  `);
+
+export const findUsersRolesByRoleId = async (roleId: string) =>
+  envSet.pool.any<UsersRole>(sql`
+    select ${sql.join(Object.values(fields), sql`,`)}
+    from ${table}
+    where ${fields.roleId}=${roleId}
+  `);
+
+export const insertUsersRoles = async (usersRoles: UsersRole[]) =>
+  envSet.pool.query(sql`
+    insert into ${table} (${fields.userId}, ${fields.roleId}) values
+    ${sql.join(
+      usersRoles.map(({ userId, roleId }) => sql`(${userId}, ${roleId})`),
+      sql`, `
+    )}
+  `);
+
+export const deleteUsersRolesByUserIdAndRoleId = async (userId: string, roleId: string) => {
+  await envSet.pool.query(sql`
+    delete from ${table}
+    where ${fields.userId} = ${userId} and ${fields.roleId} = ${roleId}
+  `);
+};

--- a/packages/core/src/routes/admin-user.test.ts
+++ b/packages/core/src/routes/admin-user.test.ts
@@ -171,14 +171,17 @@ describe('adminUserRoutes', () => {
       .send({ username, name, avatar, primaryEmail, primaryPhone });
 
     expect(response.status).toEqual(200);
-    expect(response.body).toEqual({
-      ...mockUserResponse,
-      primaryEmail,
-      primaryPhone,
-      username,
-      name,
-      avatar,
-    });
+    expect(updateUserById).toHaveBeenCalledWith(
+      'foo',
+      {
+        primaryEmail,
+        primaryPhone,
+        username,
+        name,
+        avatar,
+      },
+      expect.anything()
+    );
   });
 
   it('PATCH /users/:userId should allow empty string for clearable fields', async () => {
@@ -186,12 +189,15 @@ describe('adminUserRoutes', () => {
       .patch('/users/foo')
       .send({ name: '', avatar: '', primaryEmail: '' });
     expect(response.status).toEqual(200);
-    expect(response.body).toEqual({
-      ...mockUserResponse,
-      name: '',
-      avatar: '',
-      primaryEmail: '',
-    });
+    expect(updateUserById).toHaveBeenCalledWith(
+      'foo',
+      {
+        name: '',
+        avatar: '',
+        primaryEmail: '',
+      },
+      expect.anything()
+    );
   });
 
   it('PATCH /users/:userId should allow null values for clearable fields', async () => {
@@ -199,12 +205,15 @@ describe('adminUserRoutes', () => {
       .patch('/users/foo')
       .send({ name: null, username: null, primaryPhone: null });
     expect(response.status).toEqual(200);
-    expect(response.body).toEqual({
-      ...mockUserResponse,
-      name: null,
-      username: null,
-      primaryPhone: null,
-    });
+    expect(updateUserById).toHaveBeenCalledWith(
+      'foo',
+      {
+        name: null,
+        username: null,
+        primaryPhone: null,
+      },
+      expect.anything()
+    );
   });
 
   it('PATCH /users/:userId should allow partial update', async () => {
@@ -212,18 +221,24 @@ describe('adminUserRoutes', () => {
 
     const updateNameResponse = await userRequest.patch('/users/foo').send({ name });
     expect(updateNameResponse.status).toEqual(200);
-    expect(updateNameResponse.body).toEqual({
-      ...mockUserResponse,
-      name,
-    });
+    expect(updateUserById).toHaveBeenCalledWith(
+      'foo',
+      {
+        name,
+      },
+      expect.anything()
+    );
 
     const avatar = 'https://www.michael.png';
     const updateAvatarResponse = await userRequest.patch('/users/foo').send({ avatar });
     expect(updateAvatarResponse.status).toEqual(200);
-    expect(updateAvatarResponse.body).toEqual({
-      ...mockUserResponse,
-      avatar,
-    });
+    expect(updateUserById).toHaveBeenCalledWith(
+      'foo',
+      {
+        avatar,
+      },
+      expect.anything()
+    );
   });
 
   it('PATCH /users/:userId should throw when avatar URL is invalid', async () => {
@@ -289,7 +304,7 @@ describe('adminUserRoutes', () => {
       ]
     );
     await expect(
-      userRequest.patch('/users/foo').send({ roleNames: ['admin'] })
+      userRequest.patch('/users/foo').send({ roleNames: ['superadmin'] })
     ).resolves.toHaveProperty('status', 400);
     expect(findUserById).toHaveBeenCalledTimes(1);
     expect(updateUserById).not.toHaveBeenCalled();
@@ -300,10 +315,7 @@ describe('adminUserRoutes', () => {
 
     const response = await userRequest.patch('/users/foo').send({ roleNames });
     expect(response.status).toEqual(200);
-    expect(response.body).toEqual({
-      ...mockUserResponse,
-      roleNames,
-    });
+    expect(response.body).toEqual(mockUserResponse);
   });
 
   it('PATCH /users/:userId/password', async () => {

--- a/packages/integration-tests/src/tests/api/admin-user.test.ts
+++ b/packages/integration-tests/src/tests/api/admin-user.test.ts
@@ -42,7 +42,6 @@ describe('admin console user management', () => {
       customData: {
         level: 1,
       },
-      roleNames: ['admin'],
     };
 
     const updatedUser = await updateUser(user.id, newUserData);

--- a/packages/schemas/alterations/next-1672815959-user-roles.ts
+++ b/packages/schemas/alterations/next-1672815959-user-roles.ts
@@ -1,0 +1,75 @@
+import { sql } from 'slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      create table users_roles (
+        user_id varchar(21) not null references users (id) on update cascade on delete cascade,
+        role_id varchar(21) not null references roles (id) on update cascade on delete cascade,
+        primary key (user_id, role_id)
+      );
+    `);
+    const users = await pool.any<{ id: string; roleNames: string[] }>(sql`
+      select * from users where jsonb_array_length(role_names) > 0
+    `);
+    const roles = await pool.any<{ id: string; name: string }>(sql`
+      select * from roles
+    `);
+
+    for (const user of users) {
+      for (const roleName of user.roleNames) {
+        if (!roleName) {
+          continue;
+        }
+
+        const role = roles.find(({ name }) => name === roleName);
+
+        if (!role) {
+          throw new Error(`Unable to find role: ${roleName}`);
+        }
+
+        // eslint-disable-next-line no-await-in-loop
+        await pool.query(sql`
+          insert into users_roles (user_id, role_id) values (${user.id}, ${role.id})
+        `);
+      }
+    }
+
+    await pool.query(sql`
+      alter table users drop column role_names
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      alter table users add column role_names jsonb not null default '[]'::jsonb
+    `);
+
+    const relations = await pool.any<{ userId: string; roleId: string }>(sql`
+      select * from users_roles
+    `);
+    const roles = await pool.any<{ id: string; name: string }>(sql`
+      select * from roles
+    `);
+
+    for (const relation of relations) {
+      const role = roles.find(({ id }) => id === relation.roleId);
+
+      if (!role) {
+        continue;
+      }
+
+      // eslint-disable-next-line no-await-in-loop
+      await pool.query(sql`
+        update users set role_names = role_names || '[${role.name}]'::jsonb where id = ${relation.userId}
+      `);
+    }
+
+    await pool.query(sql`
+      drop table users_roles;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/seeds/roles.ts
+++ b/packages/schemas/src/seeds/roles.ts
@@ -1,11 +1,13 @@
 import type { CreateRole } from '../db-entries/index.js';
 import { UserRole } from '../types/index.js';
 
+export const adminConsoleAdminRoleId = 'ac-admin-id';
+
 /**
  * Default Admin Role for Admin Console.
  */
 export const defaultRole: Readonly<CreateRole> = {
-  id: 'ac-admin-id',
+  id: adminConsoleAdminRoleId,
   name: UserRole.Admin,
   description: 'Admin role for Logto.',
 };

--- a/packages/schemas/src/types/user.ts
+++ b/packages/schemas/src/types/user.ts
@@ -1,4 +1,4 @@
-import type { CreateUser } from '../db-entries/index.js';
+import type { CreateUser, User } from '../db-entries/index.js';
 
 export const userInfoSelectFields = Object.freeze([
   'id',
@@ -7,7 +7,6 @@ export const userInfoSelectFields = Object.freeze([
   'primaryPhone',
   'name',
   'avatar',
-  'roleNames',
   'customData',
   'identities',
   'lastSignInAt',
@@ -26,3 +25,6 @@ export type UserProfileResponse = UserInfo & { hasPasswordSet: boolean };
 export enum UserRole {
   Admin = 'admin',
 }
+
+// FIXME @sijie remove this after RBAC is completed.
+export type UserWithRoleNames = User & { roleNames: string[] };

--- a/packages/schemas/tables/users.sql
+++ b/packages/schemas/tables/users.sql
@@ -10,7 +10,6 @@ create table users (
   name varchar(128),
   avatar varchar(2048),
   application_id varchar(21),
-  role_names jsonb /* @use RoleNames */ not null default '[]'::jsonb,
   identities jsonb /* @use Identities */ not null default '{}'::jsonb,
   custom_data jsonb /* @use ArbitraryObject */ not null default '{}'::jsonb,
   is_suspended boolean not null default false,

--- a/packages/schemas/tables/usersroles.sql
+++ b/packages/schemas/tables/usersroles.sql
@@ -1,0 +1,5 @@
+create table users_roles (
+  user_id varchar(21) not null references users (id) on update cascade on delete cascade,
+  role_id varchar(21) not null references roles (id) on update cascade on delete cascade,
+  primary key (user_id, role_id)
+);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

1. create table `users_roles` to store user->role relations
2. remove old `user.role_names`
3. create an alteration to migrate old data

The "roleNames" is still available in many place, it is selected from new table "users_roles".

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

pass all tests.

and local tested with the alter script.
