### PR TITLE
fix(console): remove redundant `forwardRef` from `DetailsForm`

### DIFF
--- a/packages/console/src/components/DetailsForm/index.tsx
+++ b/packages/console/src/components/DetailsForm/index.tsx
@@ -1,4 +1,3 @@
-import { forwardRef } from 'react';
 import type { ReactNode } from 'react';
 
 import SubmitFormChangesActionBar from '../SubmitFormChangesActionBar';
@@ -26,4 +25,4 @@ const DetailsForm = ({ isDirty, isSubmitting, onSubmit, onDiscard, children }: P
   );
 };
 
-export default forwardRef(DetailsForm);
+export default DetailsForm;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- remove redundant `forwardRef` from `DetailsForm`

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Before
<img width="1466" alt="image" src="https://user-images.githubusercontent.com/10806653/203733715-ccedc03e-8574-4583-9601-f80558ecd46f.png">

### After
<img width="1239" alt="image" src="https://user-images.githubusercontent.com/10806653/203733660-590b3681-958e-451d-90af-1d1baa3fb666.png">

