### PR TITLE
refactor(console): add padding-bottom to the scrollable table

### DIFF
--- a/packages/console/src/scss/table.module.scss
+++ b/packages/console/src/scss/table.module.scss
@@ -17,6 +17,7 @@ tr.clickable {
   background-color: var(--color-layer-1);
   border-radius: 12px;
   overflow-y: auto;
+  padding-bottom: _.unit(2);
 
   table {
     border: none;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
add padding-bottom to the scrollable table to avoid hover state fading in the background

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Before
<img width="1274" alt="image" src="https://user-images.githubusercontent.com/10806653/203911962-70095f7c-e5f3-4a5b-9a9c-ee949cbdd22d.png">


### After
<img width="1260" alt="image" src="https://user-images.githubusercontent.com/10806653/203911927-86246716-68e3-41f8-9921-790af2f9ebdc.png">
