### PR TITLE
refactor(console): pagination paddings

### DIFF
--- a/packages/console/src/components/AuditLogTable/index.module.scss
+++ b/packages/console/src/components/AuditLogTable/index.module.scss
@@ -46,7 +46,6 @@
 
 .pagination {
   margin-top: _.unit(4);
-  min-height: 32px;
 }
 
 .eventName {

--- a/packages/console/src/components/Pagination/index.module.scss
+++ b/packages/console/src/components/Pagination/index.module.scss
@@ -3,10 +3,10 @@
 .container {
   display: flex;
   justify-content: flex-end;
+  align-items: center;
 }
 
 .positionInfo {
-  align-self: flex-end;
   font: var(--font-body-medium);
   color: var(--color-text-secondary);
 }
@@ -15,6 +15,7 @@
   display: flex;
   justify-content: right;
   margin: 0;
+  height: 28px;
   padding-inline-start: _.unit(4);
 
   li {

--- a/packages/console/src/pages/ApiResources/index.module.scss
+++ b/packages/console/src/pages/ApiResources/index.module.scss
@@ -6,7 +6,6 @@
 
 .pagination {
   margin-top: _.unit(4);
-  min-height: 32px;
 }
 
 .apiResourceName {

--- a/packages/console/src/pages/Applications/index.module.scss
+++ b/packages/console/src/pages/Applications/index.module.scss
@@ -6,7 +6,6 @@
 
 .pagination {
   margin-top: _.unit(4);
-  min-height: 32px;
 }
 
 .applicationName {

--- a/packages/console/src/pages/Users/index.module.scss
+++ b/packages/console/src/pages/Users/index.module.scss
@@ -19,7 +19,6 @@
 
 .pagination {
   margin-top: _.unit(4);
-  min-height: 32px;
 }
 
 .avatar {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
refactor(console): pagination paddings

- set pagination height to 28px to avoid unexpected paddings in the page layout.
- align the pagination number info to the center.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Before
<img width="607" alt="image" src="https://user-images.githubusercontent.com/10806653/203917389-96060248-96ff-4c90-91b9-5d5b3cf4d552.png">

### After
<img width="579" alt="image" src="https://user-images.githubusercontent.com/10806653/203917465-d78878e9-9642-4cb9-8a5e-290293f74246.png">

