### PR TITLE
refactor(core): migrate social/sign-in

### DIFF
--- a/packages/core/src/routes/interaction/index.test.ts
+++ b/packages/core/src/routes/interaction/index.test.ts
@@ -85,8 +85,8 @@ describe('session -> interactionRoutes', () => {
     });
   });
 
-  describe('POST /verification/social/authorization_uri', () => {
-    const path = `${verificationPrefix}/social/authorization_uri`;
+  describe('POST /verification/social/authorization-uri', () => {
+    const path = `${verificationPrefix}/social/authorization-uri`;
 
     it('should throw when redirectURI is invalid', async () => {
       const response = await sessionRequest.post(path).send({
@@ -97,7 +97,7 @@ describe('session -> interactionRoutes', () => {
       expect(response.statusCode).toEqual(400);
     });
 
-    it('should return the authorization_uri properly', async () => {
+    it('should return the authorization-uri properly', async () => {
       const response = await sessionRequest.post(path).send({
         connectorId: 'social_enabled',
         state: 'state',

--- a/packages/core/src/routes/interaction/index.test.ts
+++ b/packages/core/src/routes/interaction/index.test.ts
@@ -1,0 +1,145 @@
+import { ConnectorType } from '@logto/connector-kit';
+import { Provider } from 'oidc-provider';
+
+import RequestError from '#src/errors/RequestError/index.js';
+import { createRequester } from '#src/utils/test-utils.js';
+
+import interactionRoutes, { verificationPrefix } from './index.js';
+import { sendPasscodeToIdentifier } from './utils/passcode-validation.js';
+
+const getLogtoConnectorByIdHelper = jest.fn(async (connectorId: string) => {
+  const database = {
+    enabled: connectorId === 'social_enabled',
+  };
+  const metadata = {
+    id:
+      connectorId === 'social_enabled'
+        ? 'social_enabled'
+        : connectorId === 'social_disabled'
+        ? 'social_disabled'
+        : 'others',
+  };
+
+  return {
+    dbEntry: database,
+    metadata,
+    type: connectorId.startsWith('social') ? ConnectorType.Social : ConnectorType.Sms,
+    getAuthorizationUri: jest.fn(async () => ''),
+  };
+});
+
+jest.mock('#src/connectors.js', () => ({
+  getLogtoConnectorById: jest.fn(async (connectorId: string) => {
+    const connector = await getLogtoConnectorByIdHelper(connectorId);
+
+    if (connector.type !== ConnectorType.Social) {
+      throw new RequestError({
+        code: 'entity.not_found',
+        status: 404,
+      });
+    }
+
+    return connector;
+  }),
+}));
+
+jest.mock('./utils/passcode-validation.js', () => ({
+  sendPasscodeToIdentifier: jest.fn(),
+}));
+
+jest.mock('oidc-provider', () => ({
+  Provider: jest.fn(() => ({
+    interactionDetails: jest.fn().mockResolvedValue({
+      jti: 'jti',
+    }),
+  })),
+}));
+
+const log = jest.fn();
+
+describe('session -> interactionRoutes', () => {
+  const sessionRequest = createRequester({
+    anonymousRoutes: interactionRoutes,
+    provider: new Provider(''),
+    middlewares: [
+      async (ctx, next) => {
+        ctx.addLogContext = jest.fn();
+        ctx.log = log;
+
+        return next();
+      },
+    ],
+  });
+
+  describe('POST /verification/passcode', () => {
+    const path = `${verificationPrefix}/passcode`;
+    it('should call send passcode properly', async () => {
+      const body = {
+        event: 'sign-in',
+        email: 'email@logto.io',
+      };
+
+      const response = await sessionRequest.post(path).send(body);
+      expect(sendPasscodeToIdentifier).toBeCalledWith(body, 'jti', log);
+      expect(response.status).toEqual(204);
+    });
+  });
+
+  describe('POST /verification/social/authorization_uri', () => {
+    const path = `${verificationPrefix}/social/authorization_uri`;
+
+    it('should throw when redirectURI is invalid', async () => {
+      const response = await sessionRequest.post(path).send({
+        connectorId: 'social_enabled',
+        state: 'state',
+        redirectUri: 'logto.dev',
+      });
+      expect(response.statusCode).toEqual(400);
+    });
+
+    it('should return the authorization_uri properly', async () => {
+      const response = await sessionRequest.post(path).send({
+        connectorId: 'social_enabled',
+        state: 'state',
+        redirectUri: 'https://logto.dev',
+      });
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.body).toHaveProperty('redirectTo', '');
+    });
+
+    it('throw error when sign-in with social but miss state', async () => {
+      const response = await sessionRequest.post(path).send({
+        connectorId: 'social_enabled',
+        redirectUri: 'https://logto.dev',
+      });
+      expect(response.statusCode).toEqual(400);
+    });
+
+    it('throw error when sign-in with social but miss redirectUri', async () => {
+      const response = await sessionRequest.post(path).send({
+        connectorId: 'social_enabled',
+        state: 'state',
+      });
+      expect(response.statusCode).toEqual(400);
+    });
+
+    it('throw error when connector is disabled', async () => {
+      const response = await sessionRequest.post(path).send({
+        connectorId: 'social_disabled',
+        state: 'state',
+        redirectUri: 'https://logto.dev',
+      });
+      expect(response.statusCode).toEqual(400);
+    });
+
+    it('throw error when no social connector is found', async () => {
+      const response = await sessionRequest.post(path).send({
+        connectorId: 'others',
+        state: 'state',
+        redirectUri: 'https://logto.dev',
+      });
+      expect(response.statusCode).toEqual(404);
+    });
+  });
+});

--- a/packages/core/src/routes/interaction/index.ts
+++ b/packages/core/src/routes/interaction/index.ts
@@ -39,7 +39,7 @@ export default function interactionRoutes<T extends AnonymousRouter>(
   );
 
   router.post(
-    `${verificationPrefix}/social/authorization_uri`,
+    `${verificationPrefix}/social/authorization-uri`,
     koaGuard({ body: getSocialAuthorizationUrlPayloadGuard }),
     async (ctx, next) => {
       // Check interaction session

--- a/packages/core/src/routes/interaction/types/guard.ts
+++ b/packages/core/src/routes/interaction/types/guard.ts
@@ -5,7 +5,6 @@ import type {
   EmailPasscodePayload,
   PhonePasswordPayload,
   PhonePasscodePayload,
-  SocialConnectorPayload,
 } from '@logto/schemas';
 import { eventGuard, profileGuard, identifierGuard } from '@logto/schemas';
 import { z } from 'zod';
@@ -26,12 +25,6 @@ export type PasswordIdentifierPayload =
   | PhonePasswordPayload;
 
 export type PasscodeIdentifierPayload = EmailPasscodePayload | PhonePasscodePayload;
-
-export type UserIdentity =
-  | Omit<UsernamePasswordPayload, 'password'>
-  | Omit<EmailPasswordPayload, 'password'>
-  | Omit<PhonePasswordPayload, 'password'>
-  | Omit<SocialConnectorPayload, 'data'>;
 
 // Passcode Send Route Guard
 export const sendPasscodePayloadGuard = z.union([

--- a/packages/core/src/routes/interaction/types/guard.ts
+++ b/packages/core/src/routes/interaction/types/guard.ts
@@ -53,3 +53,5 @@ export const getSocialAuthorizationUrlPayloadGuard = z.object({
   state: z.string(),
   redirectUri: z.string().refine((url) => validateRedirectUrl(url, 'web')),
 });
+
+export type SocialAuthorizationUrlPayload = z.infer<typeof getSocialAuthorizationUrlPayloadGuard>;

--- a/packages/core/src/routes/interaction/types/guard.ts
+++ b/packages/core/src/routes/interaction/types/guard.ts
@@ -1,4 +1,4 @@
-import { emailRegEx, phoneRegEx } from '@logto/core-kit';
+import { emailRegEx, phoneRegEx, validateRedirectUrl } from '@logto/core-kit';
 import type {
   UsernamePasswordPayload,
   EmailPasswordPayload,
@@ -10,6 +10,7 @@ import type {
 import { eventGuard, profileGuard, identifierGuard } from '@logto/schemas';
 import { z } from 'zod';
 
+// Interaction Route Guard
 export const interactionPayloadGuard = z.object({
   event: eventGuard.optional(),
   identifier: identifierGuard.optional(),
@@ -18,19 +19,6 @@ export const interactionPayloadGuard = z.object({
 
 export type InteractionPayload = z.infer<typeof interactionPayloadGuard>;
 export type IdentifierPayload = z.infer<typeof identifierGuard>;
-
-export const sendPasscodePayloadGuard = z.union([
-  z.object({
-    event: eventGuard,
-    email: z.string().regex(emailRegEx),
-  }),
-  z.object({
-    event: eventGuard,
-    phone: z.string().regex(phoneRegEx),
-  }),
-]);
-
-export type SendPasscodePayload = z.infer<typeof sendPasscodePayloadGuard>;
 
 export type PasswordIdentifierPayload =
   | UsernamePasswordPayload
@@ -45,10 +33,23 @@ export type UserIdentity =
   | Omit<PhonePasswordPayload, 'password'>
   | Omit<SocialConnectorPayload, 'data'>;
 
-export const isPasswordIdentifier = (
-  identifier: IdentifierPayload
-): identifier is PasswordIdentifierPayload => 'password' in identifier;
+// Passcode Send Route Guard
+export const sendPasscodePayloadGuard = z.union([
+  z.object({
+    event: eventGuard,
+    email: z.string().regex(emailRegEx),
+  }),
+  z.object({
+    event: eventGuard,
+    phone: z.string().regex(phoneRegEx),
+  }),
+]);
 
-export const isPasscodeIdentifier = (
-  identifier: IdentifierPayload
-): identifier is PasscodeIdentifierPayload => 'passcode' in identifier;
+export type SendPasscodePayload = z.infer<typeof sendPasscodePayloadGuard>;
+
+// Social Authorization Uri Route Guard
+export const getSocialAuthorizationUrlPayloadGuard = z.object({
+  connectorId: z.string(),
+  state: z.string(),
+  redirectUri: z.string().refine((url) => validateRedirectUrl(url, 'web')),
+});

--- a/packages/core/src/routes/interaction/types/index.ts
+++ b/packages/core/src/routes/interaction/types/index.ts
@@ -1,6 +1,8 @@
 import type { Context } from 'koa';
 import type { IRouterParamContext } from 'koa-router';
 
+import type { SocialUserInfo } from '#src/connectors/types.js';
+
 import type { WithGuardedIdentifierPayloadContext } from '../middleware/koa-interaction-body-guard.js';
 
 export type Identifier =
@@ -26,3 +28,9 @@ type UseInfo = {
 };
 
 export type InteractionContext = WithGuardedIdentifierPayloadContext<IRouterParamContext & Context>;
+
+export type UserIdentity =
+  | { username: string }
+  | { email: string }
+  | { phone: string }
+  | { connectorId: string; userInfo: SocialUserInfo };

--- a/packages/core/src/routes/interaction/utils/find-user-by-identity.ts
+++ b/packages/core/src/routes/interaction/utils/find-user-by-identity.ts
@@ -1,6 +1,12 @@
-import { findUserByEmail, findUserByUsername, findUserByPhone } from '#src/queries/user.js';
+import { getLogtoConnectorById } from '#src/connectors/index.js';
+import {
+  findUserByEmail,
+  findUserByUsername,
+  findUserByPhone,
+  findUserByIdentity as findUserBySocialIdentity,
+} from '#src/queries/user.js';
 
-import type { UserIdentity } from '../types/guard.js';
+import type { UserIdentity } from '../types/index.js';
 
 export default async function findUserByIdentity(identity: UserIdentity) {
   if ('username' in identity) {
@@ -13,6 +19,14 @@ export default async function findUserByIdentity(identity: UserIdentity) {
 
   if ('phone' in identity) {
     return findUserByPhone(identity.phone);
+  }
+
+  if ('connectorId' in identity) {
+    const {
+      metadata: { target },
+    } = await getLogtoConnectorById(identity.connectorId);
+
+    return findUserBySocialIdentity(target, identity.userInfo.id);
   }
 
   return null;

--- a/packages/core/src/routes/interaction/utils/index.ts.ts
+++ b/packages/core/src/routes/interaction/utils/index.ts.ts
@@ -14,6 +14,10 @@ export const isPasscodeIdentifier = (
   identifier: IdentifierPayload
 ): identifier is PasscodeIdentifierPayload => 'passcode' in identifier;
 
+export const isSocialIdentifier = (
+  identifier: IdentifierPayload
+): identifier is SocialConnectorPayload => 'connectorId' in identifier;
+
 export const isProfileIdentifier = (
   identifier: PasscodeIdentifierPayload | SocialConnectorPayload,
   profile?: Profile

--- a/packages/core/src/routes/interaction/utils/social-verification.test.ts
+++ b/packages/core/src/routes/interaction/utils/social-verification.test.ts
@@ -1,0 +1,35 @@
+import { ConnectorType } from '@logto/connector-kit';
+
+import { getUserInfoByAuthCode } from '#src/lib/social.js';
+
+import { verifySocialIdentity } from './social-verification.js';
+
+jest.mock('#src/lib/social.js', () => ({
+  getUserInfoByAuthCode: jest.fn().mockResolvedValue({ id: 'foo' }),
+}));
+
+jest.mock('#src/connectors.js', () => ({
+  getLogtoConnectorById: jest.fn().mockResolvedValue({
+    dbEntry: {
+      enabled: true,
+    },
+    metadata: {
+      id: 'social',
+    },
+    type: ConnectorType.Social,
+    getAuthorizationUri: jest.fn(async () => ''),
+  }),
+}));
+
+const log = jest.fn();
+
+describe('social-verification', () => {
+  it('verifySocialIdentity', async () => {
+    const connectorId = 'connector';
+    const connectorData = { authCode: 'code' };
+    const userInfo = await verifySocialIdentity({ connectorId, connectorData }, log);
+
+    expect(getUserInfoByAuthCode).toBeCalledWith(connectorId, connectorData);
+    expect(userInfo).toEqual({ id: 'foo' });
+  });
+});

--- a/packages/core/src/routes/interaction/utils/social-verification.ts
+++ b/packages/core/src/routes/interaction/utils/social-verification.ts
@@ -1,6 +1,10 @@
+import type { SocialConnectorPayload, LogType } from '@logto/schemas';
 import { ConnectorType } from '@logto/schemas';
 
 import { getLogtoConnectorById } from '#src/connectors/index.js';
+import type { SocialUserInfo } from '#src/connectors/types.js';
+import { getUserInfoByAuthCode } from '#src/lib/social.js';
+import type { LogContext } from '#src/middleware/koa-log.js';
 import assertThat from '#src/utils/assert-that.js';
 
 import type { SocialAuthorizationUrlPayload } from '../types/guard.js';
@@ -15,4 +19,18 @@ export const createSocialAuthorizationUrl = async (payload: SocialAuthorizationU
   assertThat(connector.type === ConnectorType.Social, 'connector.unexpected_type');
 
   return connector.getAuthorizationUri({ state, redirectUri });
+};
+
+export const verifySocialIdentity = async (
+  { connectorId, connectorData }: SocialConnectorPayload,
+  log: LogContext['log']
+): Promise<SocialUserInfo> => {
+  const logType: LogType = 'SignInSocial';
+  log(logType, { connectorId, connectorData });
+
+  const userInfo = await getUserInfoByAuthCode(connectorId, connectorData);
+
+  log(logType, userInfo);
+
+  return userInfo;
 };

--- a/packages/core/src/routes/interaction/utils/social-verification.ts
+++ b/packages/core/src/routes/interaction/utils/social-verification.ts
@@ -1,0 +1,18 @@
+import { ConnectorType } from '@logto/schemas';
+
+import { getLogtoConnectorById } from '#src/connectors/index.js';
+import assertThat from '#src/utils/assert-that.js';
+
+import type { SocialAuthorizationUrlPayload } from '../types/guard.js';
+
+export const createSocialAuthorizationUrl = async (payload: SocialAuthorizationUrlPayload) => {
+  const { connectorId, state, redirectUri } = payload;
+  assertThat(state && redirectUri, 'session.insufficient_info');
+
+  const connector = await getLogtoConnectorById(connectorId);
+
+  assertThat(connector.dbEntry.enabled, 'connector.not_enabled');
+  assertThat(connector.type === ConnectorType.Social, 'connector.unexpected_type');
+
+  return connector.getAuthorizationUri({ state, redirectUri });
+};

--- a/packages/core/src/routes/interaction/utils/verify-user.ts
+++ b/packages/core/src/routes/interaction/utils/verify-user.ts
@@ -1,8 +1,10 @@
+import type { SocialUserInfo } from '#src/connectors/types.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { verifyUserPassword } from '#src/lib/user.js';
 import assertThat from '#src/utils/assert-that.js';
 
-import type { PasswordIdentifierPayload, UserIdentity } from '../types/guard.js';
+import type { PasswordIdentifierPayload } from '../types/guard.js';
+import type { UserIdentity } from '../types/index.js';
 import findUserByIdentity from './find-user-by-identity.js';
 
 export const verifyUserByVerifiedPasscodeIdentity = async (identifier: UserIdentity) => {
@@ -23,6 +25,16 @@ export const verifyUserByIdentityAndPassword = async ({
   const verifiedUser = await verifyUserPassword(user, password);
 
   const { isSuspended, id } = verifiedUser;
+  assertThat(!isSuspended, new RequestError({ code: 'user.suspended', status: 401 }));
+
+  return id;
+};
+
+export const verifyUserBySocialIdentity = async (connectorId: string, userInfo: SocialUserInfo) => {
+  const user = await findUserByIdentity({ connectorId, userInfo });
+  assertThat(user, new RequestError({ code: 'user.user_not_exist', status: 404 }));
+
+  const { id, isSuspended } = user;
   assertThat(!isSuspended, new RequestError({ code: 'user.suspended', status: 401 }));
 
   return id;


### PR DESCRIPTION


<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Migrate original `social/sign-in ` API to `/verification/social/authorization_uri`;

Also renamed the passcode API, current router naming:

PUT/PATCH `/interaction`: routes that manage the interaction details

POST `/verification/:method`: initiate a new verification entity like passcode or social authorization. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT case added
