### PR TITLE
style(console): split the sie settings and the preview content equally

### DIFF
--- a/packages/console/src/pages/SignInExperience/components/Preview/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/Preview/index.module.scss
@@ -1,7 +1,7 @@
 @use '@/scss/underscore' as _;
 
 .preview {
-  width: 100%;
+  min-width: 480px;
   overflow: hidden;
   display: flex;
   flex-direction: column;

--- a/packages/console/src/pages/SignInExperience/components/Preview/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/Preview/index.module.scss
@@ -1,7 +1,7 @@
 @use '@/scss/underscore' as _;
 
 .preview {
-  width: 480px;
+  width: 100%;
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -51,6 +51,7 @@
         height: 380px;
         position: relative;
         background: var(--color-surface-1);
+        margin: 0 auto;
 
         iframe {
           width: 960px;

--- a/packages/console/src/pages/SignInExperience/components/Welcome/GuideModal.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/Welcome/GuideModal.module.scss
@@ -44,7 +44,7 @@
       position: relative;
       padding: _.unit(6) _.unit(17);
       // Space for footer
-      padding-bottom: 112px;
+      padding-bottom: 108px;
     }
   }
 
@@ -54,16 +54,10 @@
     @include _.main-content-width;
 
     .form {
-      flex: 1;
+      width: 100%;
 
-      .card {
-        background: var(--color-layer-1);
-        padding: _.unit(2) _.unit(6) _.unit(6);
-        border-radius: 16px;
-
-        &:not(:last-child) {
-          margin-bottom: _.unit(6);
-        }
+      > :not(:first-child) {
+        margin-top: _.unit(3);
       }
     }
 

--- a/packages/console/src/pages/SignInExperience/components/Welcome/GuideModal.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/Welcome/GuideModal.module.scss
@@ -54,7 +54,7 @@
     @include _.main-content-width;
 
     .form {
-      width: 100%;
+      flex: 1;
 
       > :not(:first-child) {
         margin-top: _.unit(3);
@@ -62,6 +62,7 @@
     }
 
     .preview {
+      flex: 1;
       margin-left: _.unit(8);
       position: sticky;
       top: _.unit(4);

--- a/packages/console/src/pages/SignInExperience/components/Welcome/GuideModal.tsx
+++ b/packages/console/src/pages/SignInExperience/components/Welcome/GuideModal.tsx
@@ -111,18 +111,10 @@ const GuideModal = ({ isOpen, onClose }: Props) => {
               )}
               <div className={styles.main}>
                 <div className={styles.form}>
-                  <div className={styles.card}>
-                    <ColorForm />
-                  </div>
-                  <div className={styles.card}>
-                    <BrandingForm />
-                  </div>
-                  <div className={styles.card}>
-                    <TermsForm />
-                  </div>
-                  <div className={styles.card}>
-                    <LanguagesForm />
-                  </div>
+                  <ColorForm />
+                  <BrandingForm />
+                  <TermsForm />
+                  <LanguagesForm />
                 </div>
                 {formData.id && (
                   <Preview signInExperience={previewConfigs} className={styles.preview} />

--- a/packages/console/src/pages/SignInExperience/components/Welcome/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/Welcome/index.module.scss
@@ -2,6 +2,7 @@
 
 .container {
   height: 100%;
+  min-height: 528px;
   padding-bottom: _.unit(6);
 }
 

--- a/packages/console/src/pages/SignInExperience/components/Welcome/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/components/Welcome/index.module.scss
@@ -1,9 +1,18 @@
 @use '@/scss/underscore' as _;
 
+.container {
+  height: 100%;
+  padding-bottom: _.unit(6);
+}
+
 .welcome {
   height: 100%;
   display: flex;
   flex-direction: column;
+
+  .cardTitle {
+    flex-shrink: 0;
+  }
 
   .content {
     flex: 1;

--- a/packages/console/src/pages/SignInExperience/components/Welcome/index.tsx
+++ b/packages/console/src/pages/SignInExperience/components/Welcome/index.tsx
@@ -22,9 +22,13 @@ const Welcome = ({ mutate }: Props) => {
   const theme = useTheme();
 
   return (
-    <>
+    <div className={styles.container}>
       <Card className={styles.welcome}>
-        <CardTitle title="sign_in_exp.title" subtitle="sign_in_exp.description" />
+        <CardTitle
+          title="sign_in_exp.title"
+          subtitle="sign_in_exp.description"
+          className={styles.cardTitle}
+        />
         <div className={styles.content}>
           {theme === AppearanceMode.LightMode ? <WelcomeImage /> : <WelcomeImageDark />}
           <div className={styles.text}>{t('sign_in_exp.welcome.title')}</div>
@@ -44,7 +48,7 @@ const Welcome = ({ mutate }: Props) => {
           mutate();
         }}
       />
-    </>
+    </div>
   );
 };
 

--- a/packages/console/src/pages/SignInExperience/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/index.module.scss
@@ -28,7 +28,7 @@
       }
 
       .form {
-        width: 100%;
+        flex: 1;
         margin-right: _.unit(3);
 
         > :not(:first-child) {
@@ -37,6 +37,7 @@
       }
 
       .preview {
+        flex: 1;
         position: sticky;
         top: _.unit(4);
         align-self: flex-start;

--- a/packages/console/src/pages/SignInExperience/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/index.module.scss
@@ -28,7 +28,7 @@
       }
 
       .form {
-        flex: 1;
+        width: 100%;
         margin-right: _.unit(3);
 
         > :not(:first-child) {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Split the SIE settings and the preview content equally, also the SIE setup guide modal.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Before(SIE Guide)
<img width="775" alt="image" src="https://user-images.githubusercontent.com/10806653/204256711-97818c90-7e91-4f5d-ac92-3b6016792a5b.png">

### After(SIE Guide)
<img width="1488" alt="image" src="https://user-images.githubusercontent.com/10806653/204257550-0988f100-598a-4c5f-9797-5ae3a523e209.png">

### Before(SIE)
<img width="1316" alt="image" src="https://user-images.githubusercontent.com/10806653/204198145-df424f1a-b704-4951-8b85-9ad402928a8f.png">

### After(SIE)
<img width="1255" alt="image" src="https://user-images.githubusercontent.com/10806653/204198185-658bd6e0-e326-43a6-8d31-47ea0006d2e0.png">


