### PR TITLE
fix(console): correct tab nav link on the audit-logs details page

### DIFF
--- a/packages/console/src/pages/AuditLogDetails/index.tsx
+++ b/packages/console/src/pages/AuditLogDetails/index.tsx
@@ -24,6 +24,9 @@ import * as styles from './index.module.scss';
 const getAuditLogDetailsRelatedResourceLink = (pathname: string) =>
   `/${pathname.slice(0, pathname.lastIndexOf('/'))}`;
 
+const getDetailsTabNavLink = (logId: string, userId?: string) =>
+  userId ? `/users/${userId}/logs/${logId}` : `/audit-logs/${logId}`;
+
 const AuditLogDetails = () => {
   const { userId, logId } = useParams();
   const { pathname } = useLocation();
@@ -41,6 +44,10 @@ const AuditLogDetails = () => {
   ) : (
     'log_details.back_to_logs'
   );
+
+  if (!logId) {
+    return null;
+  }
 
   return (
     <div className={detailsStyles.container}>
@@ -96,7 +103,7 @@ const AuditLogDetails = () => {
             </div>
           </Card>
           <TabNav>
-            <TabNavItem href={`/audit-logs/${logId ?? ''}`}>
+            <TabNavItem href={getDetailsTabNavLink(logId, userId)}>
               {t('log_details.tab_details')}
             </TabNavItem>
           </TabNav>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
The tab nav link should be different when we visit the audit-logs details page from the user details pages.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Before
<img width="1174" alt="image" src="https://user-images.githubusercontent.com/10806653/204200612-8922de5f-3ec3-4972-b977-bfd744ea2328.png">

### After
<img width="1232" alt="image" src="https://user-images.githubusercontent.com/10806653/204200664-4c12118b-c6ba-403e-9a13-d068f3406317.png">

