### PR TITLE
refactor(core): add profile verification

### DIFF
--- a/packages/core/src/routes/interaction/types/index.ts
+++ b/packages/core/src/routes/interaction/types/index.ts
@@ -13,9 +13,9 @@ export type Identifier =
 
 export type AccountIdIdentifier = { key: 'accountId'; value: string };
 
-export type VerifiedEmailIdentifier = { key: 'verifiedEmail'; value: string };
+export type VerifiedEmailIdentifier = { key: 'emailVerified'; value: string };
 
-export type VerifiedPhoneIdentifier = { key: 'verifiedPhone'; value: string };
+export type VerifiedPhoneIdentifier = { key: 'phoneVerified'; value: string };
 
 export type SocialIdentifier = { key: 'social'; connectorId: string; value: UseInfo };
 

--- a/packages/core/src/routes/interaction/utils/index.ts
+++ b/packages/core/src/routes/interaction/utils/index.ts
@@ -1,4 +1,4 @@
-import type { Profile, SocialConnectorPayload } from '@logto/schemas';
+import type { Profile, SocialConnectorPayload, User } from '@logto/schemas';
 
 import type {
   PasscodeIdentifierPayload,
@@ -31,4 +31,12 @@ export const isProfileIdentifier = (
   }
 
   return profile?.connectorId === identifier.connectorId;
+};
+
+// Social identities can take place the role of password
+export const isUserPasswordSet = ({
+  passwordEncrypted,
+  identities,
+}: Pick<User, 'passwordEncrypted' | 'identities'>): boolean => {
+  return Boolean(passwordEncrypted) || Object.keys(identities).length > 0;
 };

--- a/packages/core/src/routes/interaction/utils/interaction.ts
+++ b/packages/core/src/routes/interaction/utils/interaction.ts
@@ -9,5 +9,5 @@ export const assignIdentifierVerificationResult = async (
   ctx: Context,
   provider: Provider
 ) => {
-  await provider.interactionResult(ctx.req, ctx.res, payload);
+  await provider.interactionResult(ctx.req, ctx.res, payload, { mergeWithLastSubmission: true });
 };

--- a/packages/core/src/routes/interaction/verifications/identifier-verification.test.ts
+++ b/packages/core/src/routes/interaction/verifications/identifier-verification.test.ts
@@ -150,7 +150,7 @@ describe('identifier verification', () => {
 
     expect(result).toEqual([
       { key: 'accountId', value: 'foo' },
-      { key: 'verifiedEmail', value: 'email' },
+      { key: 'emailVerified', value: 'email' },
     ]);
   });
 
@@ -178,7 +178,7 @@ describe('identifier verification', () => {
     expect(assignIdentifierVerificationResult).toBeCalledWith(
       {
         event: Event.SignIn,
-        identifiers: [{ key: 'verifiedEmail', value: 'email' }],
+        identifiers: [{ key: 'emailVerified', value: 'email' }],
       },
       ctx,
       provider
@@ -231,7 +231,7 @@ describe('identifier verification', () => {
     );
     expect(findUserByIdentifierMock).not.toBeCalled();
 
-    expect(result).toEqual([{ key: 'verifiedEmail', value: 'email' }]);
+    expect(result).toEqual([{ key: 'emailVerified', value: 'email' }]);
   });
 
   it('phone passcode with no profile', async () => {
@@ -256,7 +256,7 @@ describe('identifier verification', () => {
 
     expect(result).toEqual([
       { key: 'accountId', value: 'foo' },
-      { key: 'verifiedPhone', value: 'phone' },
+      { key: 'phoneVerified', value: 'phone' },
     ]);
   });
 
@@ -282,6 +282,6 @@ describe('identifier verification', () => {
     );
     expect(findUserByIdentifierMock).not.toBeCalled();
 
-    expect(result).toEqual([{ key: 'verifiedPhone', value: 'phone' }]);
+    expect(result).toEqual([{ key: 'phoneVerified', value: 'phone' }]);
   });
 });

--- a/packages/core/src/routes/interaction/verifications/identifier-verification.ts
+++ b/packages/core/src/routes/interaction/verifications/identifier-verification.ts
@@ -42,8 +42,8 @@ const passcodeIdentifierVerification = async (
 
   const verifiedPasscodeIdentifier: Identifier =
     'email' in identifier
-      ? { key: 'verifiedEmail', value: identifier.email }
-      : { key: 'verifiedPhone', value: identifier.phone };
+      ? { key: 'emailVerified', value: identifier.email }
+      : { key: 'phoneVerified', value: identifier.phone };
 
   // Return the verified identity directly if it is for new profile identity verification
   if (isProfileIdentifier(identifier, profile)) {

--- a/packages/core/src/routes/interaction/verifications/profile-verification-profile-exist.test.ts
+++ b/packages/core/src/routes/interaction/verifications/profile-verification-profile-exist.test.ts
@@ -1,0 +1,113 @@
+import { Event } from '@logto/schemas';
+
+import RequestError from '#src/errors/RequestError/index.js';
+import { findUserById } from '#src/queries/user.js';
+import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
+
+import type { Identifier, InteractionContext } from '../types/index.js';
+import profileVerification from './profile-verification.js';
+
+jest.mock('#src/queries/user.js', () => ({
+  findUserById: jest.fn().mockResolvedValue({ id: 'foo' }),
+  hasUserWithEmail: jest.fn().mockResolvedValue(false),
+  hasUserWithPhone: jest.fn().mockResolvedValue(false),
+  hasUserWithIdentity: jest.fn().mockResolvedValue(false),
+}));
+
+jest.mock('../utils/index.js', () => ({
+  isUserPasswordSet: jest.fn().mockResolvedValueOnce(true),
+}));
+
+describe('Existed profile should throw', () => {
+  const baseCtx = createContextWithRouteParameters();
+  const identifiers: Identifier[] = [
+    { key: 'accountId', value: 'foo' },
+    { key: 'verifiedEmail', value: 'email' },
+    { key: 'verifiedPhone', value: 'phone' },
+    { key: 'social', connectorId: 'connectorId', value: { id: 'foo' } },
+  ];
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('username exist', async () => {
+    (findUserById as jest.Mock).mockResolvedValueOnce({ id: 'foo', username: 'foo' });
+
+    const ctx: InteractionContext = {
+      ...baseCtx,
+      interactionPayload: {
+        event: Event.SignIn,
+        profile: {
+          username: 'username',
+        },
+      },
+    };
+
+    await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+      new RequestError({
+        code: 'user.username_exists',
+      })
+    );
+  });
+
+  it('email exist', async () => {
+    (findUserById as jest.Mock).mockResolvedValueOnce({ id: 'foo', primaryEmail: 'email' });
+
+    const ctx: InteractionContext = {
+      ...baseCtx,
+      interactionPayload: {
+        event: Event.SignIn,
+        profile: {
+          email: 'email',
+        },
+      },
+    };
+
+    await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+      new RequestError({
+        code: 'user.email_exists',
+      })
+    );
+  });
+
+  it('phone exist', async () => {
+    (findUserById as jest.Mock).mockResolvedValueOnce({ id: 'foo', primaryPhone: 'phone' });
+
+    const ctx: InteractionContext = {
+      ...baseCtx,
+      interactionPayload: {
+        event: Event.SignIn,
+        profile: {
+          phone: 'phone',
+        },
+      },
+    };
+
+    await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+      new RequestError({
+        code: 'user.sms_exists',
+      })
+    );
+  });
+
+  it('password exist', async () => {
+    (findUserById as jest.Mock).mockResolvedValueOnce({ id: 'foo' });
+
+    const ctx: InteractionContext = {
+      ...baseCtx,
+      interactionPayload: {
+        event: Event.SignIn,
+        profile: {
+          password: 'password',
+        },
+      },
+    };
+
+    await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+      new RequestError({
+        code: 'user.password_exists',
+      })
+    );
+  });
+});

--- a/packages/core/src/routes/interaction/verifications/profile-verification-profile-exist.test.ts
+++ b/packages/core/src/routes/interaction/verifications/profile-verification-profile-exist.test.ts
@@ -22,8 +22,8 @@ describe('Existed profile should throw', () => {
   const baseCtx = createContextWithRouteParameters();
   const identifiers: Identifier[] = [
     { key: 'accountId', value: 'foo' },
-    { key: 'verifiedEmail', value: 'email' },
-    { key: 'verifiedPhone', value: 'phone' },
+    { key: 'emailVerified', value: 'email' },
+    { key: 'phoneVerified', value: 'phone' },
     { key: 'social', connectorId: 'connectorId', value: { id: 'foo' } },
   ];
 

--- a/packages/core/src/routes/interaction/verifications/profile-verification-profile-registered.test.ts
+++ b/packages/core/src/routes/interaction/verifications/profile-verification-profile-registered.test.ts
@@ -29,8 +29,8 @@ jest.mock('#src/connectors/index.js', () => ({
 const baseCtx = createContextWithRouteParameters();
 const identifiers: Identifier[] = [
   { key: 'accountId', value: 'foo' },
-  { key: 'verifiedEmail', value: 'email@logto.io' },
-  { key: 'verifiedPhone', value: '123456' },
+  { key: 'emailVerified', value: 'email@logto.io' },
+  { key: 'phoneVerified', value: '123456' },
   { key: 'social', connectorId: 'connectorId', value: { id: 'foo' } },
 ];
 

--- a/packages/core/src/routes/interaction/verifications/profile-verification-profile-registered.test.ts
+++ b/packages/core/src/routes/interaction/verifications/profile-verification-profile-registered.test.ts
@@ -1,0 +1,197 @@
+import { Event } from '@logto/schemas';
+
+import RequestError from '#src/errors/RequestError/index.js';
+import {
+  hasUser,
+  hasUserWithEmail,
+  hasUserWithPhone,
+  hasUserWithIdentity,
+} from '#src/queries/user.js';
+import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
+
+import type { Identifier, InteractionContext } from '../types/index.js';
+import profileVerification from './profile-verification.js';
+
+jest.mock('#src/queries/user.js', () => ({
+  hasUser: jest.fn().mockResolvedValue(false),
+  findUserById: jest.fn().mockResolvedValue({ id: 'foo' }),
+  hasUserWithEmail: jest.fn().mockResolvedValue(false),
+  hasUserWithPhone: jest.fn().mockResolvedValue(false),
+  hasUserWithIdentity: jest.fn().mockResolvedValue(false),
+}));
+
+jest.mock('#src/connectors/index.js', () => ({
+  getLogtoConnectorById: jest.fn().mockResolvedValue({
+    metadata: { target: 'logto' },
+  }),
+}));
+
+const baseCtx = createContextWithRouteParameters();
+const identifiers: Identifier[] = [
+  { key: 'accountId', value: 'foo' },
+  { key: 'verifiedEmail', value: 'email@logto.io' },
+  { key: 'verifiedPhone', value: '123456' },
+  { key: 'social', connectorId: 'connectorId', value: { id: 'foo' } },
+];
+
+describe('register payload guard', () => {
+  it('username only should throw', async () => {
+    const ctx: InteractionContext = {
+      ...baseCtx,
+      interactionPayload: {
+        event: Event.Register,
+        profile: {
+          username: 'username',
+        },
+      },
+    };
+
+    await expect(profileVerification(ctx, identifiers)).rejects.toThrow();
+  });
+
+  it('password only should throw', async () => {
+    const ctx: InteractionContext = {
+      ...baseCtx,
+      interactionPayload: {
+        event: Event.Register,
+        profile: {
+          password: 'password',
+        },
+      },
+    };
+
+    await expect(profileVerification(ctx, identifiers)).rejects.toThrow();
+  });
+
+  it('username password is valid', async () => {
+    const ctx: InteractionContext = {
+      ...baseCtx,
+      interactionPayload: {
+        event: Event.Register,
+        profile: {
+          username: 'username',
+          password: 'password',
+        },
+      },
+    };
+
+    await expect(profileVerification(ctx, identifiers)).resolves.not.toThrow();
+  });
+
+  it('username with a given email is valid', async () => {
+    const ctx: InteractionContext = {
+      ...baseCtx,
+      interactionPayload: {
+        event: Event.Register,
+        profile: {
+          username: 'username',
+          email: 'email@logto.io',
+        },
+      },
+    };
+
+    await expect(profileVerification(ctx, identifiers)).resolves.not.toThrow();
+  });
+
+  it('password with a given email is valid', async () => {
+    const ctx: InteractionContext = {
+      ...baseCtx,
+      interactionPayload: {
+        event: Event.Register,
+        profile: {
+          password: 'password',
+          email: 'email@logto.io',
+        },
+      },
+    };
+
+    await expect(profileVerification(ctx, identifiers)).resolves.not.toThrow();
+  });
+});
+
+describe('profile registered validation', () => {
+  it('username is registered', async () => {
+    (hasUser as jest.Mock).mockResolvedValueOnce(true);
+
+    const ctx: InteractionContext = {
+      ...baseCtx,
+      interactionPayload: {
+        event: Event.Register,
+        profile: {
+          username: 'username',
+          password: 'password',
+        },
+      },
+    };
+
+    await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+      new RequestError({
+        code: 'user.username_exists_register',
+        status: 422,
+      })
+    );
+  });
+
+  it('email is registered', async () => {
+    (hasUserWithEmail as jest.Mock).mockResolvedValueOnce(true);
+
+    const ctx: InteractionContext = {
+      ...baseCtx,
+      interactionPayload: {
+        event: Event.Register,
+        profile: {
+          email: 'email@logto.io',
+        },
+      },
+    };
+
+    await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+      new RequestError({
+        code: 'user.email_exists_register',
+        status: 422,
+      })
+    );
+  });
+
+  it('phone is registered', async () => {
+    (hasUserWithPhone as jest.Mock).mockResolvedValueOnce(true);
+
+    const ctx: InteractionContext = {
+      ...baseCtx,
+      interactionPayload: {
+        event: Event.Register,
+        profile: {
+          phone: '123456',
+        },
+      },
+    };
+
+    await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+      new RequestError({
+        code: 'user.phone_exists_register',
+        status: 422,
+      })
+    );
+  });
+
+  it('connector identity exist', async () => {
+    (hasUserWithIdentity as jest.Mock).mockResolvedValueOnce(true);
+
+    const ctx: InteractionContext = {
+      ...baseCtx,
+      interactionPayload: {
+        event: Event.Register,
+        profile: {
+          connectorId: 'connectorId',
+        },
+      },
+    };
+
+    await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+      new RequestError({
+        code: 'user.identity_exists',
+        status: 422,
+      })
+    );
+  });
+});

--- a/packages/core/src/routes/interaction/verifications/profile-verification-protected-identifier.test.ts
+++ b/packages/core/src/routes/interaction/verifications/profile-verification-protected-identifier.test.ts
@@ -1,0 +1,199 @@
+import { Event } from '@logto/schemas';
+
+import RequestError from '#src/errors/RequestError/index.js';
+import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
+
+import type { Identifier, InteractionContext } from '../types/index.js';
+import profileVerification from './profile-verification.js';
+
+jest.mock('#src/queries/user.js', () => ({
+  findUserById: jest.fn().mockResolvedValue({ id: 'foo' }),
+  hasUserWithEmail: jest.fn().mockResolvedValue(false),
+  hasUserWithPhone: jest.fn().mockResolvedValue(false),
+  hasUserWithIdentity: jest.fn().mockResolvedValue(false),
+}));
+
+jest.mock('#src/connectors/index.js', () => ({
+  getLogtoConnectorById: jest.fn().mockResolvedValue({
+    metadata: { target: 'logto' },
+  }),
+}));
+
+describe('profile protected identifier verification', () => {
+  const baseCtx = createContextWithRouteParameters();
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('email, phone and social identifier must be verified', () => {
+    it('email without a verified identifier should throw', async () => {
+      const ctx: InteractionContext = {
+        ...baseCtx,
+        interactionPayload: {
+          event: Event.SignIn,
+          profile: {
+            email: 'email',
+          },
+        },
+      };
+
+      const identifiers: Identifier[] = [{ key: 'accountId', value: 'foo' }];
+
+      await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+        new RequestError({ code: 'session.verification_session_not_found', status: 404 })
+      );
+    });
+
+    it('email with unmatched identifier should throw', async () => {
+      const ctx: InteractionContext = {
+        ...baseCtx,
+        interactionPayload: {
+          event: Event.SignIn,
+          profile: {
+            email: 'email',
+          },
+        },
+      };
+
+      const identifiers: Identifier[] = [
+        { key: 'accountId', value: 'foo' },
+        { key: 'verifiedEmail', value: 'phone' },
+      ];
+      await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+        new RequestError({ code: 'session.verification_session_not_found', status: 404 })
+      );
+    });
+
+    it('email with proper identifier should not throw', async () => {
+      const ctx: InteractionContext = {
+        ...baseCtx,
+        interactionPayload: {
+          event: Event.SignIn,
+          profile: {
+            email: 'email',
+          },
+        },
+      };
+
+      const identifiers: Identifier[] = [
+        { key: 'accountId', value: 'foo' },
+        { key: 'verifiedEmail', value: 'email' },
+      ];
+      await expect(profileVerification(ctx, identifiers)).resolves.not.toThrow();
+    });
+
+    it('phone without a verified identifier should throw', async () => {
+      const ctx: InteractionContext = {
+        ...baseCtx,
+        interactionPayload: {
+          event: Event.SignIn,
+          profile: {
+            phone: 'phone',
+          },
+        },
+      };
+
+      const identifiers: Identifier[] = [{ key: 'accountId', value: 'foo' }];
+
+      await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+        new RequestError({ code: 'session.verification_session_not_found', status: 404 })
+      );
+    });
+
+    it('phone with unmatched identifier should throw', async () => {
+      const ctx: InteractionContext = {
+        ...baseCtx,
+        interactionPayload: {
+          event: Event.SignIn,
+          profile: {
+            phone: 'phone',
+          },
+        },
+      };
+
+      const identifiers: Identifier[] = [
+        { key: 'accountId', value: 'foo' },
+        { key: 'verifiedPhone', value: 'email' },
+      ];
+      await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+        new RequestError({ code: 'session.verification_session_not_found', status: 404 })
+      );
+    });
+
+    it('phone with proper identifier should not throw', async () => {
+      const ctx: InteractionContext = {
+        ...baseCtx,
+        interactionPayload: {
+          event: Event.SignIn,
+          profile: {
+            phone: 'phone',
+          },
+        },
+      };
+
+      const identifiers: Identifier[] = [
+        { key: 'accountId', value: 'foo' },
+        { key: 'verifiedPhone', value: 'phone' },
+      ];
+      await expect(profileVerification(ctx, identifiers)).resolves.not.toThrow();
+    });
+
+    it('connectorId without a verified identifier should throw', async () => {
+      const ctx: InteractionContext = {
+        ...baseCtx,
+        interactionPayload: {
+          event: Event.SignIn,
+          profile: {
+            connectorId: 'connectorId',
+          },
+        },
+      };
+
+      const identifiers: Identifier[] = [{ key: 'accountId', value: 'foo' }];
+
+      await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+        new RequestError({ code: 'session.connector_session_not_found', status: 404 })
+      );
+    });
+
+    it('connectorId with unmatched identifier should throw', async () => {
+      const ctx: InteractionContext = {
+        ...baseCtx,
+        interactionPayload: {
+          event: Event.SignIn,
+          profile: {
+            connectorId: 'logto',
+          },
+        },
+      };
+
+      const identifiers: Identifier[] = [
+        { key: 'accountId', value: 'foo' },
+        { key: 'social', connectorId: 'connectorId', value: { id: 'foo' } },
+      ];
+      await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+        new RequestError({ code: 'session.connector_session_not_found', status: 404 })
+      );
+    });
+
+    it('connectorId with proper identifier should not throw', async () => {
+      const ctx: InteractionContext = {
+        ...baseCtx,
+        interactionPayload: {
+          event: Event.SignIn,
+          profile: {
+            connectorId: 'logto',
+          },
+        },
+      };
+
+      const identifiers: Identifier[] = [
+        { key: 'accountId', value: 'foo' },
+        { key: 'social', connectorId: 'logto', value: { id: 'foo' } },
+      ];
+
+      await expect(profileVerification(ctx, identifiers)).resolves.not.toThrow();
+    });
+  });
+});

--- a/packages/core/src/routes/interaction/verifications/profile-verification-protected-identifier.test.ts
+++ b/packages/core/src/routes/interaction/verifications/profile-verification-protected-identifier.test.ts
@@ -58,7 +58,7 @@ describe('profile protected identifier verification', () => {
 
       const identifiers: Identifier[] = [
         { key: 'accountId', value: 'foo' },
-        { key: 'verifiedEmail', value: 'phone' },
+        { key: 'emailVerified', value: 'phone' },
       ];
       await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
         new RequestError({ code: 'session.verification_session_not_found', status: 404 })
@@ -78,7 +78,7 @@ describe('profile protected identifier verification', () => {
 
       const identifiers: Identifier[] = [
         { key: 'accountId', value: 'foo' },
-        { key: 'verifiedEmail', value: 'email' },
+        { key: 'emailVerified', value: 'email' },
       ];
       await expect(profileVerification(ctx, identifiers)).resolves.not.toThrow();
     });
@@ -114,7 +114,7 @@ describe('profile protected identifier verification', () => {
 
       const identifiers: Identifier[] = [
         { key: 'accountId', value: 'foo' },
-        { key: 'verifiedPhone', value: 'email' },
+        { key: 'phoneVerified', value: 'email' },
       ];
       await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
         new RequestError({ code: 'session.verification_session_not_found', status: 404 })
@@ -134,7 +134,7 @@ describe('profile protected identifier verification', () => {
 
       const identifiers: Identifier[] = [
         { key: 'accountId', value: 'foo' },
-        { key: 'verifiedPhone', value: 'phone' },
+        { key: 'phoneVerified', value: 'phone' },
       ];
       await expect(profileVerification(ctx, identifiers)).resolves.not.toThrow();
     });

--- a/packages/core/src/routes/interaction/verifications/profile-verification.ts
+++ b/packages/core/src/routes/interaction/verifications/profile-verification.ts
@@ -1,0 +1,219 @@
+import type { Profile, User } from '@logto/schemas';
+import { Event } from '@logto/schemas';
+import { argon2Verify } from 'hash-wasm';
+
+import { getLogtoConnectorById } from '#src/connectors/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
+import {
+  findUserById,
+  hasUser,
+  hasUserWithEmail,
+  hasUserWithPhone,
+  hasUserWithIdentity,
+} from '#src/queries/user.js';
+import assertThat from '#src/utils/assert-that.js';
+
+import { registerProfileSafeGuard } from '../types/guard.js';
+import type {
+  InteractionContext,
+  Identifier,
+  AccountIdIdentifier,
+  SocialIdentifier,
+} from '../types/index.js';
+import { isUserPasswordSet } from '../utils/index.js';
+
+const findUserByIdentifier = async (identifiers: Identifier[]) => {
+  const accountIdentifier = identifiers.find(
+    (identifier): identifier is AccountIdIdentifier => identifier.key === 'accountId'
+  );
+
+  assertThat(
+    accountIdentifier,
+    new RequestError({
+      code: 'session.unauthorized',
+      status: 401,
+    })
+  );
+
+  return findUserById(accountIdentifier.value);
+};
+
+const protectedIdentifierVerification = (
+  { email, phone, connectorId }: Profile,
+  identifiers: Identifier[]
+) => {
+  if (email) {
+    assertThat(
+      identifiers.some(({ key, value }) => key === 'verifiedEmail' && value === email),
+      new RequestError({
+        code: 'session.verification_session_not_found',
+        status: 404,
+      })
+    );
+  }
+
+  if (phone) {
+    assertThat(
+      identifiers.some(({ key, value }) => key === 'verifiedPhone' && value === phone),
+      new RequestError({
+        code: 'session.verification_session_not_found',
+        status: 404,
+      })
+    );
+  }
+
+  if (connectorId) {
+    assertThat(
+      identifiers.some(
+        (identifier) => identifier.key === 'social' && identifier.connectorId === connectorId
+      ),
+      new RequestError({
+        code: 'session.connector_session_not_found',
+        status: 404,
+      })
+    );
+  }
+};
+
+const profileRegisteredValidation = async (
+  { username, email, phone, connectorId }: Profile,
+  identifiers: Identifier[]
+) => {
+  if (username) {
+    assertThat(
+      !(await hasUser(username)),
+      new RequestError({
+        code: 'user.username_exists_register',
+        status: 422,
+      })
+    );
+  }
+
+  if (email) {
+    assertThat(
+      !(await hasUserWithEmail(email)),
+      new RequestError({
+        code: 'user.email_exists_register',
+        status: 422,
+      })
+    );
+  }
+
+  if (phone) {
+    assertThat(
+      !(await hasUserWithPhone(phone)),
+      new RequestError({
+        code: 'user.phone_exists_register',
+        status: 422,
+      })
+    );
+  }
+
+  if (connectorId) {
+    const {
+      metadata: { target },
+    } = await getLogtoConnectorById(connectorId);
+
+    const socialIdentifier = identifiers.find(
+      (identifier): identifier is SocialIdentifier => identifier.key === 'social'
+    );
+
+    // Social identifier session should be verified by protectedIdentifierVerification
+    if (!socialIdentifier) {
+      return;
+    }
+
+    assertThat(
+      !(await hasUserWithIdentity(target, socialIdentifier.value.id)),
+      new RequestError({
+        code: 'user.identity_exists',
+        status: 422,
+      })
+    );
+  }
+};
+
+const profileExistValidation = async (
+  { username, email, phone, password }: Profile,
+  user: User
+) => {
+  if (username) {
+    assertThat(
+      !user.username,
+      new RequestError({
+        code: 'user.username_exists',
+      })
+    );
+  }
+
+  if (email) {
+    assertThat(
+      !user.primaryEmail,
+      new RequestError({
+        code: 'user.email_exists',
+      })
+    );
+  }
+
+  if (phone) {
+    assertThat(
+      !user.primaryPhone,
+      new RequestError({
+        code: 'user.sms_exists',
+      })
+    );
+  }
+
+  if (password) {
+    assertThat(
+      !isUserPasswordSet(user),
+      new RequestError({
+        code: 'user.password_exists',
+      })
+    );
+  }
+};
+
+export default async function profileVerification(
+  ctx: InteractionContext,
+  identifiers: Identifier[]
+) {
+  const { profile, event } = ctx.interactionPayload;
+
+  if (!profile) {
+    return;
+  }
+
+  protectedIdentifierVerification(profile, identifiers);
+
+  if (event === Event.SignIn) {
+    // Find exist account
+    const user = await findUserByIdentifier(identifiers);
+
+    await profileExistValidation(profile, user);
+    await profileRegisteredValidation(profile, identifiers);
+
+    return;
+  }
+
+  if (event === Event.Register) {
+    // Verify the profile includes sufficient identifiers to register a new account
+    try {
+      registerProfileSafeGuard.parse(profile);
+    } catch (error: unknown) {
+      throw new RequestError({ code: 'guard.invalid_input' }, error);
+    }
+
+    await profileRegisteredValidation(profile, identifiers);
+
+    return;
+  }
+
+  // ForgotPassword
+  const { password } = profile;
+  const { passwordEncrypted: oldPasswordEncrypted } = await findUserByIdentifier(identifiers);
+  assertThat(
+    !oldPasswordEncrypted || !(await argon2Verify({ password, hash: oldPasswordEncrypted })),
+    new RequestError({ code: 'user.same_password', status: 422 })
+  );
+}

--- a/packages/core/src/routes/interaction/verifications/profile-verification.ts
+++ b/packages/core/src/routes/interaction/verifications/profile-verification.ts
@@ -38,7 +38,7 @@ const findUserByIdentifier = async (identifiers: Identifier[]) => {
   return findUserById(accountIdentifier.value);
 };
 
-const verifiyProtectedIdentifiers = (
+const verifyProtectedIdentifiers = (
   { email, phone, connectorId }: Profile,
   identifiers: Identifier[]
 ) => {
@@ -118,7 +118,7 @@ const profileRegisteredValidation = async (
       (identifier): identifier is SocialIdentifier => identifier.key === 'social'
     );
 
-    // Social identifier session should be verified by verifiyProtectedIdentifiers
+    // Social identifier session should be verified by verifyProtectedIdentifiers
     if (!socialIdentifier) {
       return;
     }
@@ -184,7 +184,7 @@ export default async function profileVerification(
     return;
   }
 
-  verifiyProtectedIdentifiers(profile, identifiers);
+  verifyProtectedIdentifiers(profile, identifiers);
 
   if (event === Event.SignIn) {
     // Find existing account

--- a/packages/core/src/routes/interaction/verifications/profile-verification.ts
+++ b/packages/core/src/routes/interaction/verifications/profile-verification.ts
@@ -38,13 +38,13 @@ const findUserByIdentifier = async (identifiers: Identifier[]) => {
   return findUserById(accountIdentifier.value);
 };
 
-const protectedIdentifierVerification = (
+const verifiyProtectedIdentifiers = (
   { email, phone, connectorId }: Profile,
   identifiers: Identifier[]
 ) => {
   if (email) {
     assertThat(
-      identifiers.some(({ key, value }) => key === 'verifiedEmail' && value === email),
+      identifiers.some(({ key, value }) => key === 'emailVerified' && value === email),
       new RequestError({
         code: 'session.verification_session_not_found',
         status: 404,
@@ -54,7 +54,7 @@ const protectedIdentifierVerification = (
 
   if (phone) {
     assertThat(
-      identifiers.some(({ key, value }) => key === 'verifiedPhone' && value === phone),
+      identifiers.some(({ key, value }) => key === 'phoneVerified' && value === phone),
       new RequestError({
         code: 'session.verification_session_not_found',
         status: 404,
@@ -118,7 +118,7 @@ const profileRegisteredValidation = async (
       (identifier): identifier is SocialIdentifier => identifier.key === 'social'
     );
 
-    // Social identifier session should be verified by protectedIdentifierVerification
+    // Social identifier session should be verified by verifiyProtectedIdentifiers
     if (!socialIdentifier) {
       return;
     }
@@ -184,10 +184,10 @@ export default async function profileVerification(
     return;
   }
 
-  protectedIdentifierVerification(profile, identifiers);
+  verifiyProtectedIdentifiers(profile, identifiers);
 
   if (event === Event.SignIn) {
-    // Find exist account
+    // Find existing account
     const user = await findUserByIdentifier(identifiers);
 
     await profileExistValidation(profile, user);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add profile verification method to verify the provided profile payload:

1. For all the protected identifiers, email, phone, and social, a verified identifier record must present
2. Profile fulfilling, a valid user account must be present in the identifier record.
3. Profile fulfilling, all the field must not exist
4. New register profile payload must contain valid identifiers to create a new account.  i.e. (a single username is invalid)
5. New registered and profile-fulfilling fields must not be registered by other user accounts.
6. ForgotPassord profile, new password must not equal the old one.

Please ignore the huge PR size, mostly are test cases. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT case added
