### PR TITLE
refactor(core,schemas): use identifier array in sign-up settings

### DIFF
--- a/packages/core/src/__mocks__/sign-in-experience.ts
+++ b/packages/core/src/__mocks__/sign-in-experience.ts
@@ -7,7 +7,7 @@ import type {
   SignUp,
   SignIn,
 } from '@logto/schemas';
-import { BrandingStyle, SignInMode, SignUpIdentifier, SignInIdentifier } from '@logto/schemas';
+import { BrandingStyle, SignInMode, SignInExperienceIdentifier } from '@logto/schemas';
 
 export const mockSignInExperience: SignInExperience = {
   id: 'foo',
@@ -29,26 +29,26 @@ export const mockSignInExperience: SignInExperience = {
     fallbackLanguage: 'en',
   },
   signUp: {
-    identifier: SignUpIdentifier.Username,
+    identifiers: [SignInExperienceIdentifier.Username],
     password: true,
     verify: false,
   },
   signIn: {
     methods: [
       {
-        identifier: SignInIdentifier.Username,
+        identifier: SignInExperienceIdentifier.Username,
         password: true,
         isPasswordPrimary: true,
         verificationCode: true,
       },
       {
-        identifier: SignInIdentifier.Email,
+        identifier: SignInExperienceIdentifier.Email,
         password: true,
         verificationCode: true,
         isPasswordPrimary: true,
       },
       {
-        identifier: SignInIdentifier.Sms,
+        identifier: SignInExperienceIdentifier.Sms,
         password: true,
         verificationCode: true,
         isPasswordPrimary: true,
@@ -82,13 +82,13 @@ export const mockLanguageInfo: LanguageInfo = {
 };
 
 export const mockSignUp: SignUp = {
-  identifier: SignUpIdentifier.Username,
+  identifiers: [SignInExperienceIdentifier.Username],
   password: true,
   verify: false,
 };
 
 export const mockSignInMethod: SignIn['methods'][0] = {
-  identifier: SignInIdentifier.Username,
+  identifier: SignInExperienceIdentifier.Username,
   password: true,
   verificationCode: false,
   isPasswordPrimary: true,

--- a/packages/core/src/lib/sign-in-experience/sign-in.test.ts
+++ b/packages/core/src/lib/sign-in-experience/sign-in.test.ts
@@ -1,4 +1,4 @@
-import { ConnectorType, SignInIdentifier, SignUpIdentifier } from '@logto/schemas';
+import { ConnectorType, SignInExperienceIdentifier } from '@logto/schemas';
 
 import {
   mockAliyunDmConnector,
@@ -21,19 +21,19 @@ describe('validate sign-in', () => {
             methods: [
               {
                 ...mockSignInMethod,
-                identifier: SignInIdentifier.Email,
+                identifier: SignInExperienceIdentifier.Email,
                 verificationCode: true,
               },
               {
                 ...mockSignInMethod,
-                identifier: SignInIdentifier.Sms,
+                identifier: SignInExperienceIdentifier.Sms,
                 verificationCode: true,
               },
             ],
           },
           {
             ...mockSignUp,
-            identifier: SignUpIdentifier.EmailOrSms,
+            identifiers: [SignInExperienceIdentifier.Email, SignInExperienceIdentifier.Sms],
             password: false,
             verify: true,
           },
@@ -49,14 +49,14 @@ describe('validate sign-in', () => {
             methods: [
               {
                 ...mockSignInMethod,
-                identifier: SignInIdentifier.Username,
+                identifier: SignInExperienceIdentifier.Username,
                 password: true,
               },
             ],
           },
           {
             ...mockSignUp,
-            identifier: SignUpIdentifier.Username,
+            identifiers: [SignInExperienceIdentifier.Username],
             password: true,
           },
           []
@@ -73,7 +73,7 @@ describe('validate sign-in', () => {
             methods: [
               {
                 ...mockSignInMethod,
-                identifier: SignInIdentifier.Email,
+                identifier: SignInExperienceIdentifier.Email,
                 verificationCode: true,
               },
             ],
@@ -96,7 +96,7 @@ describe('validate sign-in', () => {
             methods: [
               {
                 ...mockSignInMethod,
-                identifier: SignInIdentifier.Sms,
+                identifier: SignInExperienceIdentifier.Sms,
                 verificationCode: true,
               },
             ],
@@ -121,13 +121,13 @@ describe('validate sign-in', () => {
             methods: [
               {
                 ...mockSignInMethod,
-                identifier: SignInIdentifier.Sms,
+                identifier: SignInExperienceIdentifier.Sms,
               },
             ],
           },
           {
             ...mockSignUp,
-            identifier: SignUpIdentifier.Username,
+            identifiers: [SignInExperienceIdentifier.Username],
           },
           enabledConnectors
         );
@@ -145,13 +145,13 @@ describe('validate sign-in', () => {
             methods: [
               {
                 ...mockSignInMethod,
-                identifier: SignInIdentifier.Username,
+                identifier: SignInExperienceIdentifier.Username,
               },
             ],
           },
           {
             ...mockSignUp,
-            identifier: SignUpIdentifier.Email,
+            identifiers: [SignInExperienceIdentifier.Email],
           },
           enabledConnectors
         );
@@ -169,13 +169,13 @@ describe('validate sign-in', () => {
             methods: [
               {
                 ...mockSignInMethod,
-                identifier: SignInIdentifier.Username,
+                identifier: SignInExperienceIdentifier.Username,
               },
             ],
           },
           {
             ...mockSignUp,
-            identifier: SignUpIdentifier.Sms,
+            identifiers: [SignInExperienceIdentifier.Sms],
           },
           enabledConnectors
         );
@@ -193,13 +193,13 @@ describe('validate sign-in', () => {
             methods: [
               {
                 ...mockSignInMethod,
-                identifier: SignInIdentifier.Email,
+                identifier: SignInExperienceIdentifier.Email,
               },
             ],
           },
           {
             ...mockSignUp,
-            identifier: SignUpIdentifier.EmailOrSms,
+            identifiers: [SignInExperienceIdentifier.Email, SignInExperienceIdentifier.Sms],
           },
           enabledConnectors
         );
@@ -218,7 +218,7 @@ describe('validate sign-in', () => {
           methods: [
             {
               ...mockSignInMethod,
-              identifier: SignInIdentifier.Email,
+              identifier: SignInExperienceIdentifier.Email,
               password: false,
               verificationCode: true,
             },
@@ -226,7 +226,7 @@ describe('validate sign-in', () => {
         },
         {
           ...mockSignUp,
-          identifier: SignUpIdentifier.Email,
+          identifiers: [SignInExperienceIdentifier.Email],
           password: true,
         },
         enabledConnectors
@@ -245,14 +245,14 @@ describe('validate sign-in', () => {
           methods: [
             {
               ...mockSignInMethod,
-              identifier: SignInIdentifier.Email,
+              identifier: SignInExperienceIdentifier.Email,
               verificationCode: false,
             },
           ],
         },
         {
           ...mockSignUp,
-          identifier: SignUpIdentifier.Email,
+          identifiers: [SignInExperienceIdentifier.Email],
           password: false,
           verify: true,
         },
@@ -272,13 +272,13 @@ describe('validate sign-in', () => {
           methods: [
             {
               ...mockSignInMethod,
-              identifier: SignInIdentifier.Email,
+              identifier: SignInExperienceIdentifier.Email,
               verificationCode: false,
               password: false,
             },
             {
               ...mockSignInMethod,
-              identifier: SignInIdentifier.Sms,
+              identifier: SignInExperienceIdentifier.Sms,
               verificationCode: true,
               password: false,
             },
@@ -286,7 +286,7 @@ describe('validate sign-in', () => {
         },
         {
           ...mockSignUp,
-          identifier: SignUpIdentifier.Sms,
+          identifiers: [SignInExperienceIdentifier.Sms],
           password: false,
           verify: true,
         },

--- a/packages/core/src/lib/sign-in-experience/sign-in.ts
+++ b/packages/core/src/lib/sign-in-experience/sign-in.ts
@@ -1,5 +1,5 @@
 import type { SignIn, SignUp } from '@logto/schemas';
-import { ConnectorType, SignInIdentifier, SignUpIdentifier } from '@logto/schemas';
+import { ConnectorType, SignInExperienceIdentifier } from '@logto/schemas';
 
 import type { LogtoConnector } from '#src/connectors/types.js';
 import RequestError from '#src/errors/RequestError/index.js';
@@ -14,7 +14,7 @@ export const validateSignIn = (
   if (
     signIn.methods.some(
       ({ identifier, verificationCode }) =>
-        verificationCode && identifier === SignInIdentifier.Email
+        verificationCode && identifier === SignInExperienceIdentifier.Email
     )
   ) {
     assertThat(
@@ -28,7 +28,8 @@ export const validateSignIn = (
 
   if (
     signIn.methods.some(
-      ({ identifier, verificationCode }) => verificationCode && identifier === SignInIdentifier.Sms
+      ({ identifier, verificationCode }) =>
+        verificationCode && identifier === SignInExperienceIdentifier.Sms
     )
   ) {
     assertThat(
@@ -47,56 +48,31 @@ export const validateSignIn = (
     })
   );
 
-  switch (signUp.identifier) {
-    case SignUpIdentifier.Username: {
-      assertThat(
-        signIn.methods.some(({ identifier }) => identifier === SignInIdentifier.Username),
-        new RequestError({
-          code: 'sign_in_experiences.miss_sign_up_identifier_in_sign_in',
-        })
-      );
+  if (signUp.identifiers.includes(SignInExperienceIdentifier.Username)) {
+    assertThat(
+      signIn.methods.some(({ identifier }) => identifier === SignInExperienceIdentifier.Username),
+      new RequestError({
+        code: 'sign_in_experiences.miss_sign_up_identifier_in_sign_in',
+      })
+    );
+  }
 
-      break;
-    }
+  if (signUp.identifiers.includes(SignInExperienceIdentifier.Email)) {
+    assertThat(
+      signIn.methods.some(({ identifier }) => identifier === SignInExperienceIdentifier.Email),
+      new RequestError({
+        code: 'sign_in_experiences.miss_sign_up_identifier_in_sign_in',
+      })
+    );
+  }
 
-    case SignUpIdentifier.Email: {
-      assertThat(
-        signIn.methods.some(({ identifier }) => identifier === SignInIdentifier.Email),
-        new RequestError({
-          code: 'sign_in_experiences.miss_sign_up_identifier_in_sign_in',
-        })
-      );
-
-      break;
-    }
-
-    case SignUpIdentifier.Sms: {
-      assertThat(
-        signIn.methods.some(({ identifier }) => identifier === SignInIdentifier.Sms),
-        new RequestError({
-          code: 'sign_in_experiences.miss_sign_up_identifier_in_sign_in',
-        })
-      );
-
-      break;
-    }
-
-    case SignUpIdentifier.EmailOrSms: {
-      assertThat(
-        signIn.methods.some(({ identifier }) => identifier === SignInIdentifier.Email) &&
-          signIn.methods.some(({ identifier }) => identifier === SignInIdentifier.Sms),
-        new RequestError({
-          code: 'sign_in_experiences.miss_sign_up_identifier_in_sign_in',
-        })
-      );
-
-      break;
-    }
-
-    case SignUpIdentifier.None: {
-      // No requirement
-    }
-    // No default
+  if (signUp.identifiers.includes(SignInExperienceIdentifier.Sms)) {
+    assertThat(
+      signIn.methods.some(({ identifier }) => identifier === SignInExperienceIdentifier.Sms),
+      new RequestError({
+        code: 'sign_in_experiences.miss_sign_up_identifier_in_sign_in',
+      })
+    );
   }
 
   if (signUp.password) {
@@ -112,7 +88,7 @@ export const validateSignIn = (
     assertThat(
       signIn.methods.every(
         ({ verificationCode, identifier }) =>
-          verificationCode || identifier === SignInIdentifier.Username
+          verificationCode || identifier === SignInExperienceIdentifier.Username
       ),
       new RequestError({
         code: 'sign_in_experiences.code_sign_in_must_be_enabled',

--- a/packages/core/src/lib/sign-in-experience/sign-up.test.ts
+++ b/packages/core/src/lib/sign-in-experience/sign-up.test.ts
@@ -1,4 +1,4 @@
-import { ConnectorType, SignUpIdentifier } from '@logto/schemas';
+import { ConnectorType, SignInExperienceIdentifier } from '@logto/schemas';
 
 import { mockAliyunDmConnector, mockAliyunSmsConnector, mockSignUp } from '#src/__mocks__/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
@@ -16,7 +16,7 @@ describe('validate sign-up', () => {
   describe('There must be at least one enabled connector for the specific identifier.', () => {
     test('should throw when there is no enabled email connector and identifier is email', async () => {
       expect(() => {
-        validateSignUp({ ...mockSignUp, identifier: SignUpIdentifier.Email }, []);
+        validateSignUp({ ...mockSignUp, identifiers: [SignInExperienceIdentifier.Email] }, []);
       }).toMatchError(
         new RequestError({
           code: 'sign_in_experiences.enabled_connector_not_found',
@@ -27,7 +27,13 @@ describe('validate sign-up', () => {
 
     test('should throw when there is no enabled email connector and identifier is email or phone', async () => {
       expect(() => {
-        validateSignUp({ ...mockSignUp, identifier: SignUpIdentifier.EmailOrSms }, []);
+        validateSignUp(
+          {
+            ...mockSignUp,
+            identifiers: [SignInExperienceIdentifier.Email, SignInExperienceIdentifier.Sms],
+          },
+          []
+        );
       }).toMatchError(
         new RequestError({
           code: 'sign_in_experiences.enabled_connector_not_found',
@@ -38,7 +44,7 @@ describe('validate sign-up', () => {
 
     test('should throw when there is no enabled sms connector and identifier is phone', async () => {
       expect(() => {
-        validateSignUp({ ...mockSignUp, identifier: SignUpIdentifier.Sms }, []);
+        validateSignUp({ ...mockSignUp, identifiers: [SignInExperienceIdentifier.Sms] }, []);
       }).toMatchError(
         new RequestError({
           code: 'sign_in_experiences.enabled_connector_not_found',
@@ -49,9 +55,13 @@ describe('validate sign-up', () => {
 
     test('should throw when there is no enabled email connector and identifier is email or phone', async () => {
       expect(() => {
-        validateSignUp({ ...mockSignUp, identifier: SignUpIdentifier.EmailOrSms }, [
-          mockAliyunDmConnector,
-        ]);
+        validateSignUp(
+          {
+            ...mockSignUp,
+            identifiers: [SignInExperienceIdentifier.Email, SignInExperienceIdentifier.Sms],
+          },
+          [mockAliyunDmConnector]
+        );
       }).toMatchError(
         new RequestError({
           code: 'sign_in_experiences.enabled_connector_not_found',
@@ -64,7 +74,7 @@ describe('validate sign-up', () => {
   test('should throw when identifier is username and password is false', async () => {
     expect(() => {
       validateSignUp(
-        { ...mockSignUp, identifier: SignUpIdentifier.Username, password: false },
+        { ...mockSignUp, identifiers: [SignInExperienceIdentifier.Username], password: false },
         enabledConnectors
       );
     }).toMatchError(
@@ -78,7 +88,7 @@ describe('validate sign-up', () => {
     test('should throw when identifier is email', async () => {
       expect(() => {
         validateSignUp(
-          { ...mockSignUp, identifier: SignUpIdentifier.Email, verify: false },
+          { ...mockSignUp, identifiers: [SignInExperienceIdentifier.Email], verify: false },
           enabledConnectors
         );
       }).toMatchError(
@@ -91,7 +101,7 @@ describe('validate sign-up', () => {
     test('should throw when identifier is phone', async () => {
       expect(() => {
         validateSignUp(
-          { ...mockSignUp, identifier: SignUpIdentifier.Email, verify: false },
+          { ...mockSignUp, identifiers: [SignInExperienceIdentifier.Email], verify: false },
           enabledConnectors
         );
       }).toMatchError(
@@ -104,7 +114,11 @@ describe('validate sign-up', () => {
     test('should throw when identifier is email or phone', async () => {
       expect(() => {
         validateSignUp(
-          { ...mockSignUp, identifier: SignUpIdentifier.EmailOrSms, verify: false },
+          {
+            ...mockSignUp,
+            identifiers: [SignInExperienceIdentifier.Email, SignInExperienceIdentifier.Sms],
+            verify: false,
+          },
           enabledConnectors
         );
       }).toMatchError(

--- a/packages/core/src/lib/sign-in-experience/sign-up.ts
+++ b/packages/core/src/lib/sign-in-experience/sign-up.ts
@@ -1,15 +1,12 @@
 import type { SignUp } from '@logto/schemas';
-import { ConnectorType, SignUpIdentifier } from '@logto/schemas';
+import { SignInExperienceIdentifier, ConnectorType } from '@logto/schemas';
 
 import type { LogtoConnector } from '#src/connectors/types.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import assertThat from '#src/utils/assert-that.js';
 
 export const validateSignUp = (signUp: SignUp, enabledConnectors: LogtoConnector[]) => {
-  if (
-    signUp.identifier === SignUpIdentifier.Email ||
-    signUp.identifier === SignUpIdentifier.EmailOrSms
-  ) {
+  if (signUp.identifiers.includes(SignInExperienceIdentifier.Email)) {
     assertThat(
       enabledConnectors.some((item) => item.type === ConnectorType.Email),
       new RequestError({
@@ -19,10 +16,7 @@ export const validateSignUp = (signUp: SignUp, enabledConnectors: LogtoConnector
     );
   }
 
-  if (
-    signUp.identifier === SignUpIdentifier.Sms ||
-    signUp.identifier === SignUpIdentifier.EmailOrSms
-  ) {
+  if (signUp.identifiers.includes(SignInExperienceIdentifier.Sms)) {
     assertThat(
       enabledConnectors.some((item) => item.type === ConnectorType.Sms),
       new RequestError({
@@ -32,7 +26,7 @@ export const validateSignUp = (signUp: SignUp, enabledConnectors: LogtoConnector
     );
   }
 
-  if (signUp.identifier === SignUpIdentifier.Username) {
+  if (signUp.identifiers.includes(SignInExperienceIdentifier.Username)) {
     assertThat(
       signUp.password,
       new RequestError({
@@ -42,9 +36,8 @@ export const validateSignUp = (signUp: SignUp, enabledConnectors: LogtoConnector
   }
 
   if (
-    [SignUpIdentifier.Sms, SignUpIdentifier.Email, SignUpIdentifier.EmailOrSms].includes(
-      signUp.identifier
-    )
+    signUp.identifiers.includes(SignInExperienceIdentifier.Email) ||
+    signUp.identifiers.includes(SignInExperienceIdentifier.Sms)
   ) {
     assertThat(
       signUp.verify,

--- a/packages/core/src/routes/admin-user.test.ts
+++ b/packages/core/src/routes/admin-user.test.ts
@@ -1,5 +1,5 @@
 import type { CreateUser, Role, User } from '@logto/schemas';
-import { SignUpIdentifier, userInfoSelectFields } from '@logto/schemas';
+import { userInfoSelectFields } from '@logto/schemas';
 import pick from 'lodash.pick';
 
 import {
@@ -30,7 +30,7 @@ const filterUsersWithSearch = (users: User[], search: string) =>
 
 const mockFindDefaultSignInExperience = jest.fn(async () => ({
   signUp: {
-    identifier: SignUpIdentifier.None,
+    identifiers: [],
     password: false,
     verify: false,
   },

--- a/packages/core/src/routes/interaction/utils/sign-in-experience-valiation.test.ts
+++ b/packages/core/src/routes/interaction/utils/sign-in-experience-valiation.test.ts
@@ -1,5 +1,5 @@
 import type { SignInExperience } from '@logto/schemas';
-import { SignUpIdentifier, SignInIdentifier, SignInMode } from '@logto/schemas';
+import { SignInExperienceIdentifier, SignInMode } from '@logto/schemas';
 
 import { mockSignInExperience } from '#src/__mocks__/sign-in-experience.js';
 
@@ -66,7 +66,7 @@ describe('identifier validation', () => {
         ...mockSignInExperience,
         signIn: {
           methods: mockSignInExperience.signIn.methods.filter(
-            ({ identifier }) => identifier !== SignInIdentifier.Username
+            ({ identifier }) => identifier !== SignInExperienceIdentifier.Username
           ),
         },
       });
@@ -85,7 +85,7 @@ describe('identifier validation', () => {
         ...mockSignInExperience,
         signIn: {
           methods: mockSignInExperience.signIn.methods.filter(
-            ({ identifier }) => identifier !== SignInIdentifier.Email
+            ({ identifier }) => identifier !== SignInExperienceIdentifier.Email
           ),
         },
       });
@@ -97,7 +97,7 @@ describe('identifier validation', () => {
         signIn: {
           methods: [
             {
-              identifier: SignInIdentifier.Email,
+              identifier: SignInExperienceIdentifier.Email,
               password: false,
               verificationCode: true,
               isPasswordPrimary: true,
@@ -120,7 +120,7 @@ describe('identifier validation', () => {
         ...mockSignInExperience,
         signIn: {
           methods: mockSignInExperience.signIn.methods.filter(
-            ({ identifier }) => identifier !== SignInIdentifier.Email
+            ({ identifier }) => identifier !== SignInExperienceIdentifier.Email
           ),
         },
       });
@@ -132,7 +132,7 @@ describe('identifier validation', () => {
         signIn: {
           methods: [
             {
-              identifier: SignInIdentifier.Email,
+              identifier: SignInExperienceIdentifier.Email,
               password: true,
               verificationCode: false,
               isPasswordPrimary: true,
@@ -146,14 +146,14 @@ describe('identifier validation', () => {
       identifierValidation(identifier, {
         ...mockSignInExperience,
         signUp: {
-          identifier: SignUpIdentifier.Email,
+          identifiers: [SignInExperienceIdentifier.Email],
           password: false,
           verify: true,
         },
         signIn: {
           methods: [
             {
-              identifier: SignInIdentifier.Email,
+              identifier: SignInExperienceIdentifier.Email,
               password: true,
               verificationCode: false,
               isPasswordPrimary: true,
@@ -176,7 +176,7 @@ describe('identifier validation', () => {
         ...mockSignInExperience,
         signIn: {
           methods: mockSignInExperience.signIn.methods.filter(
-            ({ identifier }) => identifier !== SignInIdentifier.Sms
+            ({ identifier }) => identifier !== SignInExperienceIdentifier.Sms
           ),
         },
       });
@@ -188,7 +188,7 @@ describe('identifier validation', () => {
         signIn: {
           methods: [
             {
-              identifier: SignInIdentifier.Sms,
+              identifier: SignInExperienceIdentifier.Sms,
               password: false,
               verificationCode: true,
               isPasswordPrimary: true,
@@ -211,7 +211,7 @@ describe('identifier validation', () => {
         ...mockSignInExperience,
         signIn: {
           methods: mockSignInExperience.signIn.methods.filter(
-            ({ identifier }) => identifier !== SignInIdentifier.Sms
+            ({ identifier }) => identifier !== SignInExperienceIdentifier.Sms
           ),
         },
       });
@@ -223,7 +223,7 @@ describe('identifier validation', () => {
         signIn: {
           methods: [
             {
-              identifier: SignInIdentifier.Sms,
+              identifier: SignInExperienceIdentifier.Sms,
               password: true,
               verificationCode: false,
               isPasswordPrimary: true,
@@ -237,14 +237,14 @@ describe('identifier validation', () => {
       identifierValidation(identifier, {
         ...mockSignInExperience,
         signUp: {
-          identifier: SignUpIdentifier.Sms,
+          identifiers: [SignInExperienceIdentifier.Sms],
           password: false,
           verify: true,
         },
         signIn: {
           methods: [
             {
-              identifier: SignInIdentifier.Sms,
+              identifier: SignInExperienceIdentifier.Sms,
               password: true,
               verificationCode: false,
               isPasswordPrimary: true,

--- a/packages/core/src/routes/interaction/utils/sign-in-experience-validation.ts
+++ b/packages/core/src/routes/interaction/utils/sign-in-experience-validation.ts
@@ -1,5 +1,5 @@
 import type { Event, SignInExperience, Profile } from '@logto/schemas';
-import { SignUpIdentifier, SignInMode, SignInIdentifier } from '@logto/schemas';
+import { SignInMode, SignInExperienceIdentifier } from '@logto/schemas';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import assertThat from '#src/utils/assert-that.js';
@@ -33,7 +33,8 @@ export const identifierValidation = (
   if ('username' in identifier) {
     assertThat(
       signIn.methods.some(
-        ({ identifier: method, password }) => method === SignInIdentifier.Username && password
+        ({ identifier: method, password }) =>
+          method === SignInExperienceIdentifier.Username && password
       ),
       forbiddenIdentifierError
     );
@@ -46,7 +47,7 @@ export const identifierValidation = (
     assertThat(
       // eslint-disable-next-line complexity
       signIn.methods.some(({ identifier: method, password, verificationCode }) => {
-        if (method !== SignInIdentifier.Email) {
+        if (method !== SignInExperienceIdentifier.Email) {
           return false;
         }
 
@@ -59,7 +60,7 @@ export const identifierValidation = (
         if (
           'passcode' in identifier &&
           !verificationCode &&
-          ![SignUpIdentifier.Email, SignUpIdentifier.EmailOrSms].includes(signUp.identifier) &&
+          !signUp.identifiers.includes(SignInExperienceIdentifier.Email) &&
           !signUp.verify
         ) {
           return false;
@@ -78,7 +79,7 @@ export const identifierValidation = (
     assertThat(
       // eslint-disable-next-line complexity
       signIn.methods.some(({ identifier: method, password, verificationCode }) => {
-        if (method !== SignInIdentifier.Sms) {
+        if (method !== SignInExperienceIdentifier.Sms) {
           return false;
         }
 
@@ -91,7 +92,7 @@ export const identifierValidation = (
         if (
           'passcode' in identifier &&
           !verificationCode &&
-          ![SignUpIdentifier.Sms, SignUpIdentifier.EmailOrSms].includes(signUp.identifier) &&
+          !signUp.identifiers.includes(SignInExperienceIdentifier.Sms) &&
           !signUp.verify
         ) {
           return false;
@@ -109,22 +110,23 @@ export const identifierValidation = (
 export const profileValidation = (profile: Profile, { signUp }: SignInExperience) => {
   if (profile.phone) {
     assertThat(
-      signUp.identifier === SignUpIdentifier.Sms ||
-        signUp.identifier === SignUpIdentifier.EmailOrSms,
+      signUp.identifiers.includes(SignInExperienceIdentifier.Sms),
       forbiddenIdentifierError
     );
   }
 
   if (profile.email) {
     assertThat(
-      signUp.identifier === SignUpIdentifier.Email ||
-        signUp.identifier === SignUpIdentifier.EmailOrSms,
+      signUp.identifiers.includes(SignInExperienceIdentifier.Email),
       forbiddenIdentifierError
     );
   }
 
   if (profile.username) {
-    assertThat(signUp.identifier === SignUpIdentifier.Username, forbiddenIdentifierError);
+    assertThat(
+      signUp.identifiers.includes(SignInExperienceIdentifier.Username),
+      forbiddenIdentifierError
+    );
   }
 
   if (profile.password) {

--- a/packages/core/src/routes/session/middleware/passwordless-action.ts
+++ b/packages/core/src/routes/session/middleware/passwordless-action.ts
@@ -1,4 +1,4 @@
-import { PasscodeType, SignInIdentifier, SignUpIdentifier } from '@logto/schemas';
+import { PasscodeType, SignInExperienceIdentifier } from '@logto/schemas';
 import type { MiddlewareType } from 'koa';
 import type { Provider } from 'oidc-provider';
 
@@ -34,7 +34,7 @@ export const smsSignInAction = <StateT, ContextT extends WithLogContext, Respons
     assertThat(
       signInExperience.signIn.methods.some(
         ({ identifier, verificationCode }) =>
-          identifier === SignInIdentifier.Sms && verificationCode
+          identifier === SignInExperienceIdentifier.Sms && verificationCode
       ),
       new RequestError({
         code: 'user.sign_in_method_not_enabled',
@@ -79,7 +79,7 @@ export const emailSignInAction = <StateT, ContextT extends WithLogContext, Respo
     assertThat(
       signInExperience.signIn.methods.some(
         ({ identifier, verificationCode }) =>
-          identifier === SignInIdentifier.Email && verificationCode
+          identifier === SignInExperienceIdentifier.Email && verificationCode
       ),
       new RequestError({
         code: 'user.sign_in_method_not_enabled',
@@ -121,9 +121,9 @@ export const smsRegisterAction = <StateT, ContextT extends WithLogContext, Respo
     const signInExperience = await getSignInExperienceForApplication(
       await getApplicationIdFromInteraction(ctx, provider)
     );
+
     assertThat(
-      signInExperience.signUp.identifier === SignUpIdentifier.Sms ||
-        signInExperience.signUp.identifier === SignUpIdentifier.EmailOrSms,
+      signInExperience.signUp.identifiers.includes(SignInExperienceIdentifier.Sms),
       new RequestError({
         code: 'user.sign_up_method_not_enabled',
         status: 422,
@@ -165,9 +165,9 @@ export const emailRegisterAction = <StateT, ContextT extends WithLogContext, Res
     const signInExperience = await getSignInExperienceForApplication(
       await getApplicationIdFromInteraction(ctx, provider)
     );
+
     assertThat(
-      signInExperience.signUp.identifier === SignUpIdentifier.Email ||
-        signInExperience.signUp.identifier === SignUpIdentifier.EmailOrSms,
+      signInExperience.signUp.identifiers.includes(SignInExperienceIdentifier.Email),
       new RequestError({
         code: 'user.sign_up_method_not_enabled',
         status: 422,

--- a/packages/core/src/routes/session/password.test.ts
+++ b/packages/core/src/routes/session/password.test.ts
@@ -1,5 +1,5 @@
 import type { User } from '@logto/schemas';
-import { UserRole, SignUpIdentifier } from '@logto/schemas';
+import { UserRole, SignInExperienceIdentifier } from '@logto/schemas';
 import { adminConsoleApplicationId } from '@logto/schemas/lib/seeds/index.js';
 import { Provider } from 'oidc-provider';
 
@@ -239,7 +239,7 @@ describe('session -> password routes', () => {
         ...mockSignInExperience,
         signUp: {
           ...mockSignInExperience.signUp,
-          identifier: SignUpIdentifier.Email,
+          identifiers: [SignInExperienceIdentifier.Email],
         },
       });
 
@@ -283,7 +283,7 @@ describe('session -> password routes', () => {
         ...mockSignInExperience,
         signUp: {
           ...mockSignInExperience.signUp,
-          identifier: SignUpIdentifier.Email,
+          identifiers: [SignInExperienceIdentifier.Email],
         },
       });
 

--- a/packages/core/src/routes/session/password.ts
+++ b/packages/core/src/routes/session/password.ts
@@ -1,5 +1,5 @@
 import { passwordRegEx, usernameRegEx } from '@logto/core-kit';
-import { SignInIdentifier, SignUpIdentifier, UserRole } from '@logto/schemas';
+import { SignInExperienceIdentifier, UserRole } from '@logto/schemas';
 import { adminConsoleApplicationId } from '@logto/schemas/lib/seeds/index.js';
 import type { Provider } from 'oidc-provider';
 import { object, string } from 'zod';
@@ -37,7 +37,7 @@ export default function passwordRoutes<T extends AnonymousRouter>(router: T, pro
       const { username, password } = ctx.guard.body;
       const type = 'SignInUsernamePassword';
       await signInWithPassword(ctx, provider, {
-        identifier: SignInIdentifier.Username,
+        identifier: SignInExperienceIdentifier.Username,
         password,
         logType: type,
         logPayload: { username },
@@ -60,7 +60,7 @@ export default function passwordRoutes<T extends AnonymousRouter>(router: T, pro
       const { email, password } = ctx.guard.body;
       const type = 'SignInEmailPassword';
       await signInWithPassword(ctx, provider, {
-        identifier: SignInIdentifier.Email,
+        identifier: SignInExperienceIdentifier.Email,
         password,
         logType: type,
         logPayload: { email },
@@ -83,7 +83,7 @@ export default function passwordRoutes<T extends AnonymousRouter>(router: T, pro
       const { phone, password } = ctx.guard.body;
       const type = 'SignInSmsPassword';
       await signInWithPassword(ctx, provider, {
-        identifier: SignInIdentifier.Sms,
+        identifier: SignInExperienceIdentifier.Sms,
         password,
         logType: type,
         logPayload: { phone },
@@ -108,7 +108,7 @@ export default function passwordRoutes<T extends AnonymousRouter>(router: T, pro
         await getApplicationIdFromInteraction(ctx, provider)
       );
       assertThat(
-        signInExperience.signUp.identifier === SignUpIdentifier.Username,
+        signInExperience.signUp.identifiers.includes(SignInExperienceIdentifier.Username),
         new RequestError({
           code: 'user.sign_up_method_not_enabled',
           status: 422,
@@ -146,7 +146,7 @@ export default function passwordRoutes<T extends AnonymousRouter>(router: T, pro
         await getApplicationIdFromInteraction(ctx, provider)
       );
       assertThat(
-        signInExperience.signUp.identifier === SignUpIdentifier.Username,
+        signInExperience.signUp.identifiers.includes(SignInExperienceIdentifier.Username),
         new RequestError({
           code: 'user.sign_up_method_not_enabled',
           status: 422,

--- a/packages/core/src/routes/session/passwordless.test.ts
+++ b/packages/core/src/routes/session/passwordless.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 import type { User } from '@logto/schemas';
-import { PasscodeType, SignInIdentifier, SignUpIdentifier } from '@logto/schemas';
+import { PasscodeType, SignInExperienceIdentifier } from '@logto/schemas';
 import type { Nullable } from '@silverhand/essentials';
 import { addDays, addSeconds, subDays } from 'date-fns';
 import { Provider } from 'oidc-provider';
@@ -22,7 +22,7 @@ const findDefaultSignInExperience = jest.fn(async () => ({
   ...mockSignInExperience,
   signUp: {
     ...mockSignInExperience.signUp,
-    identifier: SignUpIdentifier.Username,
+    identifiers: [SignInExperienceIdentifier.Username],
     password: false,
     verify: true,
   },
@@ -538,7 +538,7 @@ describe('session -> passwordlessRoutes', () => {
           methods: [
             {
               ...mockSignInMethod,
-              identifier: SignInIdentifier.Username,
+              identifier: SignInExperienceIdentifier.Username,
             },
           ],
         },
@@ -554,7 +554,7 @@ describe('session -> passwordlessRoutes', () => {
         ...mockSignInExperience,
         signUp: {
           ...mockSignInExperience.signUp,
-          identifier: SignUpIdentifier.Email,
+          identifiers: [SignInExperienceIdentifier.Email],
           password: false,
           verify: true,
         },
@@ -693,7 +693,7 @@ describe('session -> passwordlessRoutes', () => {
           methods: [
             {
               ...mockSignInMethod,
-              identifier: SignInIdentifier.Username,
+              identifier: SignInExperienceIdentifier.Username,
             },
           ],
         },
@@ -709,7 +709,7 @@ describe('session -> passwordlessRoutes', () => {
         ...mockSignInExperience,
         signUp: {
           ...mockSignInExperience.signUp,
-          identifier: SignUpIdentifier.Sms,
+          identifiers: [SignInExperienceIdentifier.Sms],
           password: false,
         },
       });
@@ -822,7 +822,7 @@ describe('session -> passwordlessRoutes', () => {
         ...mockSignInExperience,
         signUp: {
           ...mockSignInExperience.signUp,
-          identifier: SignUpIdentifier.Email,
+          identifiers: [SignInExperienceIdentifier.Email],
         },
       });
 
@@ -837,7 +837,7 @@ describe('session -> passwordlessRoutes', () => {
         ...mockSignInExperience,
         signUp: {
           ...mockSignInExperience.signUp,
-          identifier: SignUpIdentifier.Email,
+          identifiers: [SignInExperienceIdentifier.Email],
           password: false,
         },
       });
@@ -950,7 +950,7 @@ describe('session -> passwordlessRoutes', () => {
         ...mockSignInExperience,
         signUp: {
           ...mockSignInExperience.signUp,
-          identifier: SignUpIdentifier.Sms,
+          identifiers: [SignInExperienceIdentifier.Sms],
         },
       });
 

--- a/packages/core/src/routes/session/profile.test.ts
+++ b/packages/core/src/routes/session/profile.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 import type { CreateUser, User } from '@logto/schemas';
-import { ConnectorType, SignUpIdentifier } from '@logto/schemas';
+import { ConnectorType } from '@logto/schemas';
 import { getUnixTime } from 'date-fns';
 import { Provider } from 'oidc-provider';
 
@@ -80,7 +80,7 @@ jest.mock('#src/queries/user.js', () => ({
 
 const mockFindDefaultSignInExperience = jest.fn(async () => ({
   signUp: {
-    identifier: SignUpIdentifier.None,
+    identifier: [],
     password: false,
     verify: false,
   },

--- a/packages/core/src/routes/session/social.bind-social.test.ts
+++ b/packages/core/src/routes/session/social.bind-social.test.ts
@@ -1,6 +1,5 @@
 import { ConnectorType } from '@logto/connector-kit';
 import type { User } from '@logto/schemas';
-import { SignUpIdentifier } from '@logto/schemas';
 import { Provider } from 'oidc-provider';
 
 import { mockLogtoConnectorList, mockSignInExperience, mockUser } from '#src/__mocks__/index.js';
@@ -58,7 +57,7 @@ jest.mock('#src/queries/sign-in-experience.js', () => ({
     ...mockSignInExperience,
     signUp: {
       ...mockSignInExperience.signUp,
-      identifier: SignUpIdentifier.None,
+      identifiers: [],
     },
   }),
 }));

--- a/packages/core/src/routes/session/social.test.ts
+++ b/packages/core/src/routes/session/social.test.ts
@@ -1,6 +1,5 @@
 import { ConnectorType } from '@logto/connector-kit';
 import type { User } from '@logto/schemas';
-import { SignUpIdentifier } from '@logto/schemas';
 import { Provider } from 'oidc-provider';
 
 import { mockLogtoConnectorList, mockSignInExperience, mockUser } from '#src/__mocks__/index.js';
@@ -65,7 +64,7 @@ jest.mock('#src/queries/sign-in-experience.js', () => ({
     ...mockSignInExperience,
     signUp: {
       ...mockSignInExperience.signUp,
-      identifier: SignUpIdentifier.None,
+      identifiers: [],
     },
   }),
 }));

--- a/packages/core/src/routes/session/utils.test.ts
+++ b/packages/core/src/routes/session/utils.test.ts
@@ -1,5 +1,5 @@
 import type { User } from '@logto/schemas';
-import { UserRole, SignInIdentifier, SignUpIdentifier } from '@logto/schemas';
+import { UserRole, SignInExperienceIdentifier } from '@logto/schemas';
 import { createMockContext } from '@shopify/jest-koa-mocks';
 import type { Nullable } from '@silverhand/essentials';
 import { Provider } from 'oidc-provider';
@@ -17,7 +17,7 @@ const findDefaultSignInExperience = jest.fn(async () => ({
   ...mockSignInExperience,
   signUp: {
     ...mockSignInExperience.signUp,
-    identifier: SignUpIdentifier.Username,
+    identifiers: [SignInExperienceIdentifier.Username],
   },
 }));
 
@@ -112,7 +112,7 @@ describe('signInWithPassword()', () => {
   it('assign result', async () => {
     interactionDetails.mockResolvedValueOnce({ params: {} });
     await signInWithPassword(createContext(), createProvider(), {
-      identifier: SignInIdentifier.Username,
+      identifier: SignInExperienceIdentifier.Username,
       password: 'password',
       findUser: jest.fn(async () => mockUser),
       logType: 'SignInUsernamePassword',
@@ -130,7 +130,7 @@ describe('signInWithPassword()', () => {
     interactionDetails.mockResolvedValueOnce({ params: {} });
     await expect(
       signInWithPassword(createContext(), createProvider(), {
-        identifier: SignInIdentifier.Username,
+        identifier: SignInExperienceIdentifier.Username,
         password: 'password',
         findUser: jest.fn(async () => null),
         logType: 'SignInUsernamePassword',
@@ -143,7 +143,7 @@ describe('signInWithPassword()', () => {
     interactionDetails.mockResolvedValueOnce({ params: {} });
     await expect(
       signInWithPassword(createContext(), createProvider(), {
-        identifier: SignInIdentifier.Username,
+        identifier: SignInExperienceIdentifier.Username,
         password: '_password',
         findUser: jest.fn(async () => mockUser),
         logType: 'SignInUsernamePassword',
@@ -156,7 +156,7 @@ describe('signInWithPassword()', () => {
     interactionDetails.mockResolvedValueOnce({ params: {} });
     await expect(
       signInWithPassword(createContext(), createProvider(), {
-        identifier: SignInIdentifier.Username,
+        identifier: SignInExperienceIdentifier.Username,
         password: 'password',
         findUser: jest.fn(async () => ({
           ...mockUser,
@@ -175,7 +175,7 @@ describe('signInWithPassword()', () => {
         methods: [
           {
             ...mockSignInMethod,
-            identifier: SignInIdentifier.Sms,
+            identifier: SignInExperienceIdentifier.Sms,
             password: false,
           },
         ],
@@ -184,7 +184,7 @@ describe('signInWithPassword()', () => {
     interactionDetails.mockResolvedValueOnce({ params: {} });
     await expect(
       signInWithPassword(createContext(), createProvider(), {
-        identifier: SignInIdentifier.Username,
+        identifier: SignInExperienceIdentifier.Username,
         password: 'password',
         findUser: jest.fn(async () => mockUser),
         logType: 'SignInUsernamePassword',

--- a/packages/core/src/routes/session/utils.ts
+++ b/packages/core/src/routes/session/utils.ts
@@ -1,12 +1,5 @@
-import type {
-  LogPayload,
-  LogType,
-  PasscodeType,
-  SignInExperience,
-  SignInIdentifier,
-  User,
-} from '@logto/schemas';
-import { SignUpIdentifier, logTypeGuard } from '@logto/schemas';
+import type { LogPayload, LogType, PasscodeType, SignInExperience, User } from '@logto/schemas';
+import { SignInExperienceIdentifier, logTypeGuard } from '@logto/schemas';
 import type { Nullable, Truthy } from '@silverhand/essentials';
 import { addSeconds, isAfter, isValid } from 'date-fns';
 import type { Context } from 'koa';
@@ -176,24 +169,29 @@ export const checkRequiredProfile = async (
     throw new RequestError({ code: 'user.require_password', status: 422 });
   }
 
-  if (signUp.identifier === SignUpIdentifier.Username && !username) {
+  if (signUp.identifiers.includes(SignInExperienceIdentifier.Username) && !username) {
     await assignContinueSignInResult(ctx, provider, { userId: id });
     throw new RequestError({ code: 'user.require_username', status: 422 });
   }
 
-  if (signUp.identifier === SignUpIdentifier.Email && !primaryEmail) {
+  if (
+    signUp.identifiers.includes(SignInExperienceIdentifier.Email) &&
+    signUp.identifiers.includes(SignInExperienceIdentifier.Sms) &&
+    !primaryEmail &&
+    !primaryPhone
+  ) {
+    await assignContinueSignInResult(ctx, provider, { userId: id });
+    throw new RequestError({ code: 'user.require_email_or_sms', status: 422 });
+  }
+
+  if (signUp.identifiers.includes(SignInExperienceIdentifier.Email) && !primaryEmail) {
     await assignContinueSignInResult(ctx, provider, { userId: id });
     throw new RequestError({ code: 'user.require_email', status: 422 });
   }
 
-  if (signUp.identifier === SignUpIdentifier.Sms && !primaryPhone) {
+  if (signUp.identifiers.includes(SignInExperienceIdentifier.Sms) && !primaryPhone) {
     await assignContinueSignInResult(ctx, provider, { userId: id });
     throw new RequestError({ code: 'user.require_sms', status: 422 });
-  }
-
-  if (signUp.identifier === SignUpIdentifier.EmailOrSms && !primaryEmail && !primaryPhone) {
-    await assignContinueSignInResult(ctx, provider, { userId: id });
-    throw new RequestError({ code: 'user.require_email_or_sms', status: 422 });
   }
 };
 
@@ -206,16 +204,21 @@ export const checkMissingRequiredSignUpIdentifiers = async (identifiers: {
 
   const { signUp } = await getSignInExperienceForApplication();
 
-  if (signUp.identifier === SignUpIdentifier.Email && !primaryEmail) {
+  if (
+    signUp.identifiers.includes(SignInExperienceIdentifier.Email) &&
+    signUp.identifiers.includes(SignInExperienceIdentifier.Sms) &&
+    !primaryEmail &&
+    !primaryPhone
+  ) {
+    throw new RequestError({ code: 'user.require_email_or_sms', status: 422 });
+  }
+
+  if (signUp.identifiers.includes(SignInExperienceIdentifier.Email) && !primaryEmail) {
     throw new RequestError({ code: 'user.require_email', status: 422 });
   }
 
-  if (signUp.identifier === SignUpIdentifier.Sms && !primaryPhone) {
+  if (signUp.identifiers.includes(SignInExperienceIdentifier.Sms) && !primaryPhone) {
     throw new RequestError({ code: 'user.require_sms', status: 422 });
-  }
-
-  if (signUp.identifier === SignUpIdentifier.EmailOrSms && !primaryEmail && !primaryPhone) {
-    throw new RequestError({ code: 'user.require_email_or_sms', status: 422 });
   }
 };
 /* eslint-enable complexity */
@@ -244,7 +247,7 @@ export const checkSignUpIdentifierCollision = async (
 };
 
 type SignInWithPasswordParameter = {
-  identifier: SignInIdentifier;
+  identifier: SignInExperienceIdentifier;
   password: string;
   logType: LogType;
   logPayload: LogPayload;

--- a/packages/schemas/alterations/next-1669702299-sign-up.ts
+++ b/packages/schemas/alterations/next-1669702299-sign-up.ts
@@ -1,0 +1,129 @@
+import { isSameArray } from '@silverhand/essentials';
+import type { DatabaseTransactionConnection } from 'slonik';
+import { sql } from 'slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+enum DeprecatedSignUpIdentifier {
+  Email = 'email',
+  Sms = 'sms',
+  Username = 'username',
+  EmailOrSms = 'emailOrSms',
+  None = 'none',
+}
+
+type DeprecatedSignUp = {
+  identifier: DeprecatedSignUpIdentifier;
+  password: boolean;
+  verify: boolean;
+};
+
+type DeprecatedSignInExperience = {
+  id: string;
+  signUp: DeprecatedSignUp;
+};
+
+enum SignInExperienceIdentifier {
+  Username = 'username',
+  Email = 'email',
+  Sms = 'sms',
+}
+
+type SignUp = {
+  identifiers: SignInExperienceIdentifier[];
+  password: boolean;
+  verify: boolean;
+};
+
+type SignInExperience = {
+  id: string;
+  signUp: SignUp;
+};
+
+const signUpIdentifierMapping: {
+  [key in DeprecatedSignUpIdentifier]: SignInExperienceIdentifier[];
+} = {
+  [DeprecatedSignUpIdentifier.Email]: [SignInExperienceIdentifier.Email],
+  [DeprecatedSignUpIdentifier.Sms]: [SignInExperienceIdentifier.Sms],
+  [DeprecatedSignUpIdentifier.Username]: [SignInExperienceIdentifier.Username],
+  [DeprecatedSignUpIdentifier.EmailOrSms]: [
+    SignInExperienceIdentifier.Email,
+    SignInExperienceIdentifier.Sms,
+  ],
+  [DeprecatedSignUpIdentifier.None]: [],
+};
+
+const mapDeprecatedSignUpIdentifierToIdentifiers = (signUpIdentifier: DeprecatedSignUpIdentifier) =>
+  signUpIdentifierMapping[signUpIdentifier];
+
+const alterSignUp = async (
+  signInExperience: DeprecatedSignInExperience,
+  pool: DatabaseTransactionConnection
+) => {
+  const {
+    id,
+    signUp: { identifier, password, verify },
+  } = signInExperience;
+
+  const signUpIdentifiers = mapDeprecatedSignUpIdentifierToIdentifiers(identifier);
+
+  const signUp: SignUp = {
+    identifiers: signUpIdentifiers,
+    password,
+    verify,
+  };
+
+  await pool.query(
+    sql`update sign_in_experiences set sign_up = ${JSON.stringify(signUp)} where id = ${id}`
+  );
+};
+
+const mapIdentifiersToDeprecatedSignUpIdentifier = (
+  identifiers: SignInExperienceIdentifier[]
+): DeprecatedSignUpIdentifier => {
+  for (const [key, mappedIdentifiers] of Object.entries(signUpIdentifierMapping)) {
+    if (isSameArray(identifiers, mappedIdentifiers)) {
+      // eslint-disable-next-line no-restricted-syntax
+      return key as DeprecatedSignUpIdentifier;
+    }
+  }
+
+  throw new Error('Invalid identifiers in the sign up settings.');
+};
+
+const rollbackSignUp = async (
+  signInExperience: SignInExperience,
+  pool: DatabaseTransactionConnection
+) => {
+  const {
+    id,
+    signUp: { identifiers, password, verify },
+  } = signInExperience;
+
+  const signUpIdentifier = mapIdentifiersToDeprecatedSignUpIdentifier(identifiers);
+
+  const signUp: DeprecatedSignUp = {
+    identifier: signUpIdentifier,
+    password,
+    verify,
+  };
+
+  await pool.query(
+    sql`update sign_in_experiences set sign_up = ${JSON.stringify(signUp)} where id = ${id}`
+  );
+};
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    const rows = await pool.many<DeprecatedSignInExperience>(
+      sql`select * from sign_in_experiences`
+    );
+    await Promise.all(rows.map(async (row) => alterSignUp(row, pool)));
+  },
+  down: async (pool) => {
+    const rows = await pool.many<SignInExperience>(sql`select * from sign_in_experiences`);
+    await Promise.all(rows.map(async (row) => rollbackSignUp(row, pool)));
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/foundations/jsonb-types.ts
+++ b/packages/schemas/src/foundations/jsonb-types.ts
@@ -133,6 +133,13 @@ export const languageInfoGuard = z.object({
 
 export type LanguageInfo = z.infer<typeof languageInfoGuard>;
 
+export enum SignInExperienceIdentifier {
+  Username = 'username',
+  Email = 'email',
+  Sms = 'sms',
+}
+
+// Todo: @xiaoyijun deprecate this type
 export enum SignUpIdentifier {
   Email = 'email',
   Sms = 'sms',
@@ -141,24 +148,25 @@ export enum SignUpIdentifier {
   None = 'none',
 }
 
-export const signUpGuard = z.object({
-  identifier: z.nativeEnum(SignUpIdentifier),
-  password: z.boolean(),
-  verify: z.boolean(),
-});
-
-export type SignUp = z.infer<typeof signUpGuard>;
-
+// Todo: @xiaoyijun deprecate this type
 export enum SignInIdentifier {
   Email = 'email',
   Sms = 'sms',
   Username = 'username',
 }
 
+export const signUpGuard = z.object({
+  identifiers: z.nativeEnum(SignInExperienceIdentifier).array(),
+  password: z.boolean(),
+  verify: z.boolean(),
+});
+
+export type SignUp = z.infer<typeof signUpGuard>;
+
 export const signInGuard = z.object({
   methods: z
     .object({
-      identifier: z.nativeEnum(SignInIdentifier),
+      identifier: z.nativeEnum(SignInExperienceIdentifier),
       password: z.boolean(),
       verificationCode: z.boolean(),
       isPasswordPrimary: z.boolean(),

--- a/packages/schemas/src/seeds/sign-in-experience.ts
+++ b/packages/schemas/src/seeds/sign-in-experience.ts
@@ -2,7 +2,7 @@ import { generateDarkColor } from '@logto/core-kit';
 
 import type { CreateSignInExperience } from '../db-entries/index.js';
 import { SignInMode } from '../db-entries/index.js';
-import { BrandingStyle, SignInIdentifier, SignUpIdentifier } from '../foundations/index.js';
+import { BrandingStyle, SignInExperienceIdentifier } from '../foundations/index.js';
 
 const defaultPrimaryColor = '#6139F6';
 
@@ -26,14 +26,14 @@ export const defaultSignInExperience: Readonly<CreateSignInExperience> = {
     enabled: false,
   },
   signUp: {
-    identifier: SignUpIdentifier.Username,
+    identifiers: [SignInExperienceIdentifier.Username],
     password: true,
     verify: false,
   },
   signIn: {
     methods: [
       {
-        identifier: SignInIdentifier.Username,
+        identifier: SignInExperienceIdentifier.Username,
         password: true,
         verificationCode: false,
         isPasswordPrimary: true,


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- Replace `SignUpIdentifier` and `SignInIdentifier` with `SignInExperienceIdentifier` in `packages/core`

Note that this branch will be merged into the `xiaoyijun-log-4472-redesign-schema-signin-methods` branch, and when the `UI` and `AC` is refactored, they will be merged into the `master` branch together.

### Todo
- Remove deprecated `SignUpIdentifier` & `SignInIdentifier` once the `AC` & `UI` project is refactored.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT passed.
