### PR TITLE
fix(ui): add mandatory profile missing error handle logic

### DIFF
--- a/packages/ui/src/containers/PasscodeValidation/use-register-with-email-passcode-validation.ts
+++ b/packages/ui/src/containers/PasscodeValidation/use-register-with-email-passcode-validation.ts
@@ -23,15 +23,15 @@ const useRegisterWithEmailPasscodeValidation = (email: string, errorCallback?: (
 
   const { signInMode } = useSieMethods();
 
-  const { run: signInWithEmailAsync } = useApi(signInWithEmail);
+  const requiredProfileErrorHandlers = useRequiredProfileErrorHandler(true);
+
+  const { run: signInWithEmailAsync } = useApi(signInWithEmail, requiredProfileErrorHandlers);
 
   const identifierExistErrorHandler = useIdentifierErrorAlert(
     UserFlow.register,
     SignInIdentifier.Email,
     email
   );
-
-  const requiredProfileErrorHandlers = useRequiredProfileErrorHandler(true);
 
   const emailExistSignInErrorHandler = useCallback(async () => {
     const [confirm] = await show({

--- a/packages/ui/src/containers/PasscodeValidation/use-register-with-sms-passcode-validation.ts
+++ b/packages/ui/src/containers/PasscodeValidation/use-register-with-sms-passcode-validation.ts
@@ -23,15 +23,15 @@ const useRegisterWithSmsPasscodeValidation = (phone: string, errorCallback?: () 
   const { errorMessage, clearErrorMessage, sharedErrorHandlers } = useSharedErrorHandler();
   const { signInMode } = useSieMethods();
 
-  const { run: signInWithSmsAsync } = useApi(signInWithSms);
+  const requiredProfileErrorHandlers = useRequiredProfileErrorHandler(true);
+
+  const { run: signInWithSmsAsync } = useApi(signInWithSms, requiredProfileErrorHandlers);
 
   const identifierExistErrorHandler = useIdentifierErrorAlert(
     UserFlow.register,
     SignInIdentifier.Sms,
     formatPhoneNumberWithCountryCallingCode(phone)
   );
-
-  const requiredProfileErrorHandlers = useRequiredProfileErrorHandler(true);
 
   const phoneExistSignInErrorHandler = useCallback(async () => {
     const [confirm] = await show({

--- a/packages/ui/src/containers/PasscodeValidation/use-sign-in-with-email-passcode-validation.ts
+++ b/packages/ui/src/containers/PasscodeValidation/use-sign-in-with-email-passcode-validation.ts
@@ -24,7 +24,9 @@ const useSignInWithEmailPasscodeValidation = (email: string, errorCallback?: () 
 
   const { signInMode } = useSieMethods();
 
-  const { run: registerWithEmailAsync } = useApi(registerWithEmail);
+  const requiredProfileErrorHandlers = useRequiredProfileErrorHandler(true);
+
+  const { run: registerWithEmailAsync } = useApi(registerWithEmail, requiredProfileErrorHandlers);
 
   const socialToBind = getSearchParameters(location.search, SearchParameters.bindWithSocial);
 
@@ -33,8 +35,6 @@ const useSignInWithEmailPasscodeValidation = (email: string, errorCallback?: () 
     SignInIdentifier.Email,
     email
   );
-
-  const requiredProfileErrorHandlers = useRequiredProfileErrorHandler(true);
 
   const emailNotExistRegisterErrorHandler = useCallback(async () => {
     const [confirm] = await show({

--- a/packages/ui/src/containers/PasscodeValidation/use-sign-in-with-sms-passcode-validation.ts
+++ b/packages/ui/src/containers/PasscodeValidation/use-sign-in-with-sms-passcode-validation.ts
@@ -24,7 +24,9 @@ const useSignInWithSmsPasscodeValidation = (phone: string, errorCallback?: () =>
 
   const { signInMode } = useSieMethods();
 
-  const { run: registerWithSmsAsync } = useApi(registerWithSms);
+  const requiredProfileErrorHandlers = useRequiredProfileErrorHandler(true);
+
+  const { run: registerWithSmsAsync } = useApi(registerWithSms, requiredProfileErrorHandlers);
 
   const socialToBind = getSearchParameters(location.search, SearchParameters.bindWithSocial);
 
@@ -33,8 +35,6 @@ const useSignInWithSmsPasscodeValidation = (phone: string, errorCallback?: () =>
     SignInIdentifier.Sms,
     phone
   );
-
-  const requiredProfileErrorHandlers = useRequiredProfileErrorHandler(true);
 
   const phoneNotExistRegisterErrorHandler = useCallback(async () => {
     const [confirm] = await show({


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add mandatory profile missing error handle logic.

For all the passwordless sign-in and register flow. Missing the secondary profile missing error handling logic. 
- sign-in flow account not exsit error -> switch to register -> handle required profile error -> jump to continue page
-  register flow account exsit error -> switch to sign-in -> handle required profile error -> jump to continue page


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

