### PR TITLE
feat(console): hide added connectors in modal

### DIFF
--- a/packages/console/src/pages/Connectors/components/CreateForm/index.module.scss
+++ b/packages/console/src/pages/Connectors/components/CreateForm/index.module.scss
@@ -62,10 +62,6 @@
         .name {
           font: var(--font-subhead-2);
           @include _.multi-line-ellipsis(1);
-
-          &.nameWithRightPadding {
-            padding-right: _.unit(12); /* For check mark and added label */
-          }
         }
 
         .connectorId {

--- a/packages/console/src/pages/Connectors/components/CreateForm/index.tsx
+++ b/packages/console/src/pages/Connectors/components/CreateForm/index.tsx
@@ -46,15 +46,17 @@ const CreateForm = ({ onClose, isOpen: isFormOpen, type }: Props) => {
       factories.filter(({ type: factoryType }) => factoryType === type)
     );
 
-    return allGroups.map((group) => ({
-      ...group,
-      connectors: group.connectors.map((connector) => ({
-        ...connector,
-        added: group.isStandard
-          ? false
-          : existingConnectors.some(({ connectorId }) => connector.id === connectorId),
-      })),
-    }));
+    return allGroups
+      .map((group) => ({
+        ...group,
+        connectors: group.connectors.map((connector) => ({
+          ...connector,
+          added:
+            !group.isStandard &&
+            existingConnectors.some(({ connectorId }) => connector.id === connectorId),
+        })),
+      }))
+      .filter(({ connectors }) => !connectors.every(({ added }) => added));
   }, [factories, type, existingConnectors]);
 
   const activeGroup = useMemo(
@@ -143,29 +145,23 @@ const CreateForm = ({ onClose, isOpen: isFormOpen, type }: Props) => {
           className={classNames(styles.connectorGroup, styles[modalSize])}
           onChange={handleGroupChange}
         >
-          {groups.map(({ id, name, logo, description, connectors }) => {
-            const isDisabled = connectors.every(({ added }) => added);
-
-            return (
-              <Radio key={id} value={id} isDisabled={isDisabled} disabledLabel="general.added">
-                <div className={styles.connector}>
-                  <div className={styles.logo}>
-                    <img src={logo} alt="logo" />
+          {groups.map(({ id, name, logo, description }) => (
+            <Radio key={id} value={id}>
+              <div className={styles.connector}>
+                <div className={styles.logo}>
+                  <img src={logo} alt="logo" />
+                </div>
+                <div className={styles.content}>
+                  <div className={classNames(styles.name)}>
+                    <UnnamedTrans resource={name} />
                   </div>
-                  <div className={styles.content}>
-                    <div
-                      className={classNames(styles.name, isDisabled && styles.nameWithRightPadding)}
-                    >
-                      <UnnamedTrans resource={name} />
-                    </div>
-                    <div className={styles.description}>
-                      <UnnamedTrans resource={description} />
-                    </div>
+                  <div className={styles.description}>
+                    <UnnamedTrans resource={description} />
                   </div>
                 </div>
-              </Radio>
-            );
-          })}
+              </div>
+            </Radio>
+          ))}
         </RadioGroup>
         {activeGroup && (
           <PlatformSelector


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Hide added connectors in "Create Connector Modal", previously, they are marked as "added" and disabled.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested

<img width="1287" alt="截屏2022-12-01 下午3 21 52" src="https://user-images.githubusercontent.com/5717882/204991291-89c05420-5913-472e-a39a-043a80a8034e.png">

<img width="1404" alt="截屏2022-12-01 下午3 21 56" src="https://user-images.githubusercontent.com/5717882/204991316-940cc86f-2966-4650-9df7-0b8e3f3fc162.png">

