### PR TITLE
refactor(core): merge and assign interaction result

### DIFF
--- a/packages/core/src/routes/interaction/index.ts
+++ b/packages/core/src/routes/interaction/index.ts
@@ -42,9 +42,7 @@ export default function interactionRoutes<T extends AnonymousRouter>(
       const { error, verifiedIdentifiers } = await identifierVerification(ctx, provider);
 
       // Assign identifiers ahead before throwing exceptions
-      if (verifiedIdentifiers) {
-        await storeInteractionResult({ event, identifiers: verifiedIdentifiers }, ctx, provider);
-      }
+      await storeInteractionResult({ event, identifiers: verifiedIdentifiers }, ctx, provider);
 
       if (error) {
         throw error;

--- a/packages/core/src/routes/interaction/middleware/koa-interaction-body-guard.ts
+++ b/packages/core/src/routes/interaction/middleware/koa-interaction-body-guard.ts
@@ -3,8 +3,8 @@ import koaBody from 'koa-body';
 
 import RequestError from '#src/errors/RequestError/index.js';
 
-import type { InteractionPayload } from '../types/guard.js';
 import { interactionPayloadGuard } from '../types/guard.js';
+import type { InteractionPayload } from '../types/index.js';
 
 export type WithGuardedIdentifierPayloadContext<ContextT> = ContextT & {
   interactionPayload: InteractionPayload;

--- a/packages/core/src/routes/interaction/middleware/koa-session-sign-in-experience-guard.ts
+++ b/packages/core/src/routes/interaction/middleware/koa-session-sign-in-experience-guard.ts
@@ -1,3 +1,4 @@
+import type { SignInExperience } from '@logto/schemas';
 import { Event } from '@logto/schemas';
 import type { MiddlewareType } from 'koa';
 import type { IRouterParamContext } from 'koa-router';
@@ -12,11 +13,17 @@ import {
 } from '../utils/sign-in-experience-validation.js';
 import type { WithGuardedIdentifierPayloadContext } from './koa-interaction-body-guard.js';
 
+export type WithSignInExperienceContext<ContextT> = ContextT & {
+  signInExperience: SignInExperience;
+};
+
 export default function koaSessionSignInExperienceGuard<
   StateT,
   ContextT extends WithGuardedIdentifierPayloadContext<IRouterParamContext>,
   ResponseBodyT
->(provider: Provider): MiddlewareType<StateT, ContextT, ResponseBodyT> {
+>(
+  provider: Provider
+): MiddlewareType<StateT, WithSignInExperienceContext<ContextT>, ResponseBodyT> {
   return async (ctx, next) => {
     const interaction = await provider.interactionDetails(ctx.req, ctx.res);
     const { event, identifier, profile } = ctx.interactionPayload;
@@ -38,6 +45,8 @@ export default function koaSessionSignInExperienceGuard<
     if (profile) {
       profileValidation(profile, signInExperience);
     }
+
+    ctx.signInExperience = signInExperience;
 
     return next();
   };

--- a/packages/core/src/routes/interaction/middleware/koa-session-sign-inexperience-guard.test.ts
+++ b/packages/core/src/routes/interaction/middleware/koa-session-sign-inexperience-guard.test.ts
@@ -39,6 +39,7 @@ describe('koaSessionSignInExperienceGuard', () => {
         identifier: { username: 'username', password: 'password' },
         profile: { email: 'email' },
       }),
+      signInExperience: mockSignInExperience,
     };
 
     await koaSessionSignInExperienceGuard(new Provider(''))(ctx, next);

--- a/packages/core/src/routes/interaction/types/guard.ts
+++ b/packages/core/src/routes/interaction/types/guard.ts
@@ -98,7 +98,7 @@ export const identifierGuard = z.discriminatedUnion('key', [
 ]);
 
 export const customInteractionResultGuard = z.object({
-  event: eventGuard.optional(),
+  event: eventGuard,
   profile: profileGuard.optional(),
   identifiers: z.array(identifierGuard).optional(),
 });

--- a/packages/core/src/routes/interaction/types/index.ts
+++ b/packages/core/src/routes/interaction/types/index.ts
@@ -21,6 +21,7 @@ import type {
   verifiedPhoneIdentifierGuard,
   socialIdentifierGuard,
   identifierGuard,
+  customInteractionResultGuard,
 } from './guard.js';
 
 // Payload Types
@@ -47,6 +48,8 @@ export type VerifiedPhoneIdentifier = z.infer<typeof verifiedPhoneIdentifierGuar
 export type SocialIdentifier = z.infer<typeof socialIdentifierGuard>;
 
 export type Identifier = z.infer<typeof identifierGuard>;
+
+export type CustomInteractionResult = z.infer<typeof customInteractionResultGuard>;
 
 export type InteractionContext = WithGuardedIdentifierPayloadContext<IRouterParamContext & Context>;
 

--- a/packages/core/src/routes/interaction/types/index.ts
+++ b/packages/core/src/routes/interaction/types/index.ts
@@ -1,31 +1,52 @@
+import type {
+  UsernamePasswordPayload,
+  EmailPasswordPayload,
+  EmailPasscodePayload,
+  PhonePasswordPayload,
+  PhonePasscodePayload,
+} from '@logto/schemas';
 import type { Context } from 'koa';
 import type { IRouterParamContext } from 'koa-router';
+import type { z } from 'zod';
 
 import type { SocialUserInfo } from '#src/connectors/types.js';
 
 import type { WithGuardedIdentifierPayloadContext } from '../middleware/koa-interaction-body-guard.js';
+import type {
+  interactionPayloadGuard,
+  sendPasscodePayloadGuard,
+  getSocialAuthorizationUrlPayloadGuard,
+  accountIdIdentifierGuard,
+  verifiedEmailIdentifierGuard,
+  verifiedPhoneIdentifierGuard,
+  socialIdentifierGuard,
+  identifierGuard,
+} from './guard.js';
 
-export type Identifier =
-  | AccountIdIdentifier
-  | VerifiedEmailIdentifier
-  | VerifiedPhoneIdentifier
-  | SocialIdentifier;
+// Payload Types
+export type InteractionPayload = z.infer<typeof interactionPayloadGuard>;
 
-export type AccountIdIdentifier = { key: 'accountId'; value: string };
+export type PasswordIdentifierPayload =
+  | UsernamePasswordPayload
+  | EmailPasswordPayload
+  | PhonePasswordPayload;
 
-export type VerifiedEmailIdentifier = { key: 'emailVerified'; value: string };
+export type PasscodeIdentifierPayload = EmailPasscodePayload | PhonePasscodePayload;
 
-export type VerifiedPhoneIdentifier = { key: 'phoneVerified'; value: string };
+export type SendPasscodePayload = z.infer<typeof sendPasscodePayloadGuard>;
 
-export type SocialIdentifier = { key: 'social'; connectorId: string; value: UseInfo };
+export type SocialAuthorizationUrlPayload = z.infer<typeof getSocialAuthorizationUrlPayloadGuard>;
 
-type UseInfo = {
-  email?: string;
-  phone?: string;
-  name?: string;
-  avatar?: string;
-  id: string;
-};
+// Identifier Types
+export type AccountIdIdentifier = z.infer<typeof accountIdIdentifierGuard>;
+
+export type VerifiedEmailIdentifier = z.infer<typeof verifiedEmailIdentifierGuard>;
+
+export type VerifiedPhoneIdentifier = z.infer<typeof verifiedPhoneIdentifierGuard>;
+
+export type SocialIdentifier = z.infer<typeof socialIdentifierGuard>;
+
+export type Identifier = z.infer<typeof identifierGuard>;
 
 export type InteractionContext = WithGuardedIdentifierPayloadContext<IRouterParamContext & Context>;
 

--- a/packages/core/src/routes/interaction/utils/index.ts
+++ b/packages/core/src/routes/interaction/utils/index.ts
@@ -1,10 +1,6 @@
-import type { Profile, SocialConnectorPayload, User } from '@logto/schemas';
+import type { Profile, SocialConnectorPayload, User, IdentifierPayload } from '@logto/schemas';
 
-import type {
-  PasscodeIdentifierPayload,
-  IdentifierPayload,
-  PasswordIdentifierPayload,
-} from '../types/guard.js';
+import type { PasscodeIdentifierPayload, PasswordIdentifierPayload } from '../types/index.js';
 
 export const isPasswordIdentifier = (
   identifier: IdentifierPayload

--- a/packages/core/src/routes/interaction/utils/interaction.test.ts
+++ b/packages/core/src/routes/interaction/utils/interaction.test.ts
@@ -1,0 +1,45 @@
+import type { Identifier } from '../types/index.js';
+import { mergeIdentifiers } from './interaction.js';
+
+describe('interaction utils', () => {
+  const usernameIdentifier: Identifier = { key: 'accountId', value: 'foo' };
+  const emailIdentifier: Identifier = { key: 'emailVerified', value: 'foo@logto.io' };
+  const phoneIdentifier: Identifier = { key: 'phoneVerified', value: '12346' };
+
+  it('mergeIdentifiers', () => {
+    expect(mergeIdentifiers({})).toEqual(undefined);
+    expect(mergeIdentifiers({ oldIdentifiers: [usernameIdentifier] })).toEqual([
+      usernameIdentifier,
+    ]);
+    expect(mergeIdentifiers({ newIdentifiers: [usernameIdentifier] })).toEqual([
+      usernameIdentifier,
+    ]);
+    expect(
+      mergeIdentifiers({
+        oldIdentifiers: [usernameIdentifier],
+        newIdentifiers: [usernameIdentifier],
+      })
+    ).toEqual([usernameIdentifier]);
+
+    expect(
+      mergeIdentifiers({
+        oldIdentifiers: [emailIdentifier],
+        newIdentifiers: [usernameIdentifier],
+      })
+    ).toEqual([emailIdentifier, usernameIdentifier]);
+
+    expect(
+      mergeIdentifiers({
+        oldIdentifiers: [emailIdentifier, phoneIdentifier],
+        newIdentifiers: [phoneIdentifier, usernameIdentifier],
+      })
+    ).toEqual([emailIdentifier, phoneIdentifier, usernameIdentifier]);
+
+    expect(
+      mergeIdentifiers({
+        oldIdentifiers: [emailIdentifier, phoneIdentifier],
+        newIdentifiers: [usernameIdentifier],
+      })
+    ).toEqual([emailIdentifier, phoneIdentifier, usernameIdentifier]);
+  });
+});

--- a/packages/core/src/routes/interaction/utils/interaction.ts
+++ b/packages/core/src/routes/interaction/utils/interaction.ts
@@ -2,6 +2,10 @@ import type { Event } from '@logto/schemas';
 import type { Context } from 'koa';
 import type { Provider } from 'oidc-provider';
 
+import RequestError from '#src/errors/RequestError/index.js';
+import assertThat from '#src/utils/assert-that.js';
+
+import { customInteractionResultGuard } from '../types/guard.js';
 import type { Identifier, CustomInteractionResult } from '../types/index.js';
 
 // Unique identifier type is required
@@ -43,4 +47,16 @@ export const storeInteractionResult = async (
     { ...result, ...payload },
     { mergeWithLastSubmission: true }
   );
+};
+
+export const getInteractionStorage = async (ctx: Context, provider: Provider) => {
+  const result = await provider.interactionDetails(ctx.req, ctx.res);
+  const parseResult = customInteractionResultGuard.safeParse(result);
+
+  assertThat(
+    parseResult.success,
+    new RequestError({ code: 'session.verification_session_not_found' })
+  );
+
+  return parseResult.data;
 };

--- a/packages/core/src/routes/interaction/utils/interaction.ts
+++ b/packages/core/src/routes/interaction/utils/interaction.ts
@@ -2,12 +2,45 @@ import type { Event } from '@logto/schemas';
 import type { Context } from 'koa';
 import type { Provider } from 'oidc-provider';
 
-import type { Identifier } from '../types/index.js';
+import type { Identifier, CustomInteractionResult } from '../types/index.js';
 
-export const assignIdentifierVerificationResult = async (
-  payload: { event: Event; identifiers: Identifier[] },
+// Unique identifier type is required
+export const mergeIdentifiers = (pairs: {
+  newIdentifiers?: Identifier[];
+  oldIdentifiers?: Identifier[];
+}) => {
+  const { newIdentifiers, oldIdentifiers } = pairs;
+
+  if (!newIdentifiers) {
+    return oldIdentifiers;
+  }
+
+  if (!oldIdentifiers) {
+    return newIdentifiers;
+  }
+
+  const leftOvers = oldIdentifiers.filter((oldIdentifier) => {
+    return !newIdentifiers.some((newIdentifier) => newIdentifier.key === oldIdentifier.key);
+  });
+
+  return [...leftOvers, ...newIdentifiers];
+};
+
+export const storeInteractionResult = async (
+  payload: Omit<CustomInteractionResult, 'event'> & { event?: Event },
   ctx: Context,
   provider: Provider
 ) => {
-  await provider.interactionResult(ctx.req, ctx.res, payload, { mergeWithLastSubmission: true });
+  // The "mergeWithLastSubmission" will only merge current request's interaction results,
+  // manually merge with previous interaction results
+  // refer to: https://github.com/panva/node-oidc-provider/blob/c243bf6b6663c41ff3e75c09b95fb978eba87381/lib/actions/authorization/interactions.js#L106
+
+  const { result } = await provider.interactionDetails(ctx.req, ctx.res);
+
+  await provider.interactionResult(
+    ctx.req,
+    ctx.res,
+    { ...result, ...payload },
+    { mergeWithLastSubmission: true }
+  );
 };

--- a/packages/core/src/routes/interaction/utils/passcode-validation.test.ts
+++ b/packages/core/src/routes/interaction/utils/passcode-validation.test.ts
@@ -2,7 +2,7 @@ import { PasscodeType, Event } from '@logto/schemas';
 
 import { createPasscode, sendPasscode } from '#src/lib/passcode.js';
 
-import type { SendPasscodePayload } from '../types/guard.js';
+import type { SendPasscodePayload } from '../types/index.js';
 import { sendPasscodeToIdentifier } from './passcode-validation.js';
 
 jest.mock('#src/lib/passcode.js', () => ({

--- a/packages/core/src/routes/interaction/utils/passcode-validation.ts
+++ b/packages/core/src/routes/interaction/utils/passcode-validation.ts
@@ -5,7 +5,7 @@ import { createPasscode, sendPasscode, verifyPasscode } from '#src/lib/passcode.
 import type { LogContext } from '#src/middleware/koa-log.js';
 import { getPasswordlessRelatedLogType } from '#src/routes/session/utils.js';
 
-import type { SendPasscodePayload, PasscodeIdentifierPayload } from '../types/guard.js';
+import type { SendPasscodePayload, PasscodeIdentifierPayload } from '../types/index.js';
 
 /**
  * Refactor Needed:

--- a/packages/core/src/routes/interaction/utils/sign-in-experience-validation.ts
+++ b/packages/core/src/routes/interaction/utils/sign-in-experience-validation.ts
@@ -1,10 +1,8 @@
-import type { SignInExperience, Profile } from '@logto/schemas';
+import type { SignInExperience, Profile, IdentifierPayload } from '@logto/schemas';
 import { SignUpIdentifier, SignInMode, SignInIdentifier, Event } from '@logto/schemas';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import assertThat from '#src/utils/assert-that.js';
-
-import type { IdentifierPayload } from '../types/guard.js';
 
 const forbiddenEventError = new RequestError({ code: 'auth.forbidden', status: 403 });
 

--- a/packages/core/src/routes/interaction/utils/social-verification.ts
+++ b/packages/core/src/routes/interaction/utils/social-verification.ts
@@ -7,7 +7,7 @@ import { getUserInfoByAuthCode } from '#src/lib/social.js';
 import type { LogContext } from '#src/middleware/koa-log.js';
 import assertThat from '#src/utils/assert-that.js';
 
-import type { SocialAuthorizationUrlPayload } from '../types/guard.js';
+import type { SocialAuthorizationUrlPayload } from '../types/index.js';
 
 export const createSocialAuthorizationUrl = async (payload: SocialAuthorizationUrlPayload) => {
   const { connectorId, state, redirectUri } = payload;

--- a/packages/core/src/routes/interaction/verifications/identifier-verification.ts
+++ b/packages/core/src/routes/interaction/verifications/identifier-verification.ts
@@ -5,7 +5,6 @@ import type { Provider } from 'oidc-provider';
 import RequestError from '#src/errors/RequestError/index.js';
 import { findSocialRelatedUser } from '#src/lib/social.js';
 import { verifyUserPassword } from '#src/lib/user.js';
-import assertThat from '#src/utils/assert-that.js';
 import { maskUserInfo } from '#src/utils/format.js';
 
 import type {
@@ -17,29 +16,36 @@ import type {
 } from '../types/index.js';
 import findUserByIdentifier from '../utils/find-user-by-identifier.js';
 import { isPasscodeIdentifier, isPasswordIdentifier, isProfileIdentifier } from '../utils/index.js';
-import { assignIdentifierVerificationResult } from '../utils/interaction.js';
 import { verifyIdentifierByPasscode } from '../utils/passcode-validation.js';
 import { verifySocialIdentity } from '../utils/social-verification.js';
 
+type ReturnResult = {
+  error?: RequestError;
+  verifiedIdentifiers?: Identifier[];
+};
+
 const passwordIdentifierVerification = async (
   identifier: PasswordIdentifierPayload
-): Promise<Identifier[]> => {
+): Promise<ReturnResult> => {
   // TODO: Log
   const { password, ...identity } = identifier;
   const user = await findUserByIdentifier(identity);
   const verifiedUser = await verifyUserPassword(user, password);
 
   const { isSuspended, id } = verifiedUser;
-  assertThat(!isSuspended, new RequestError({ code: 'user.suspended', status: 401 }));
 
-  return [{ key: 'accountId', value: id }];
+  if (isSuspended) {
+    return { error: new RequestError({ code: 'user.suspended', status: 401 }) };
+  }
+
+  return { verifiedIdentifiers: [{ key: 'accountId', value: id }] };
 };
 
 const passcodeIdentifierVerification = async (
   payload: { event: Event; identifier: PasscodeIdentifierPayload; profile?: Profile },
   ctx: InteractionContext,
   provider: Provider
-): Promise<Identifier[]> => {
+): Promise<ReturnResult> => {
   const { identifier, event, profile } = payload;
   const { jti } = await provider.interactionDetails(ctx.req, ctx.res);
 
@@ -52,36 +58,37 @@ const passcodeIdentifierVerification = async (
 
   // Return the verified identity directly if it is for new profile identity verification
   if (isProfileIdentifier(identifier, profile)) {
-    return [verifiedPasscodeIdentifier];
+    return { verifiedIdentifiers: [verifiedPasscodeIdentifier] };
   }
 
   const user = await findUserByIdentifier(identifier);
 
   if (!user) {
-    // Throw verification exception and assign verified identifiers to the interaction
-    if (event !== Event.ForgotPassword) {
-      await assignIdentifierVerificationResult(
-        { event, identifiers: [verifiedPasscodeIdentifier] },
-        ctx,
-        provider
-      );
-    }
-
-    throw new RequestError({ code: 'user.user_not_exist', status: 404 });
+    return {
+      error: new RequestError({ code: 'user.user_not_exist', status: 404 }),
+      verifiedIdentifiers:
+        event === Event.ForgotPassword ? undefined : [verifiedPasscodeIdentifier],
+    };
   }
 
   const { id, isSuspended } = user;
-  assertThat(!isSuspended, new RequestError({ code: 'user.suspended', status: 401 }));
 
-  return [{ key: 'accountId', value: id }, verifiedPasscodeIdentifier];
+  if (isSuspended) {
+    return {
+      error: new RequestError({ code: 'user.suspended', status: 401 }),
+    };
+  }
+
+  return {
+    verifiedIdentifiers: [{ key: 'accountId', value: id }, verifiedPasscodeIdentifier],
+  };
 };
 
 const socialIdentifierVerification = async (
-  payload: { event: Event; identifier: SocialConnectorPayload; profile?: Profile },
-  ctx: InteractionContext,
-  provider: Provider
-): Promise<Identifier[]> => {
-  const { event, identifier, profile } = payload;
+  payload: { identifier: SocialConnectorPayload; profile?: Profile },
+  ctx: InteractionContext
+): Promise<ReturnResult> => {
+  const { identifier, profile } = payload;
   const userInfo = await verifySocialIdentity(identifier, ctx.log);
 
   const { connectorId } = identifier;
@@ -89,47 +96,48 @@ const socialIdentifierVerification = async (
 
   // Return the verified identity directly if it is for new profile identity verification
   if (isProfileIdentifier(identifier, profile)) {
-    return [socialIdentifier];
+    return { verifiedIdentifiers: [socialIdentifier] };
   }
 
   const user = await findUserByIdentifier({ connectorId, userInfo });
 
   if (!user) {
-    // Throw verification exception and assign verified identifiers to the interaction
-    await assignIdentifierVerificationResult(
-      { event, identifiers: [socialIdentifier] },
-      ctx,
-      provider
-    );
-
     const relatedInfo = await findSocialRelatedUser(userInfo);
 
-    throw new RequestError(
-      {
-        code: 'user.identity_not_exists',
-        status: 422,
-      },
-      relatedInfo && { relatedUser: maskUserInfo(relatedInfo[0]) }
-    );
+    return {
+      error: new RequestError(
+        {
+          code: 'user.identity_not_exists',
+          status: 422,
+        },
+        relatedInfo && { relatedUser: maskUserInfo(relatedInfo[0]) }
+      ),
+      verifiedIdentifiers: [socialIdentifier],
+    };
   }
 
   const { id, isSuspended } = user;
-  assertThat(!isSuspended, new RequestError({ code: 'user.suspended', status: 401 }));
 
-  return [
-    { key: 'accountId', value: id },
-    { key: 'social', connectorId, value: userInfo },
-  ];
+  if (isSuspended) {
+    return { error: new RequestError({ code: 'user.suspended', status: 401 }) };
+  }
+
+  return {
+    verifiedIdentifiers: [
+      { key: 'accountId', value: id },
+      { key: 'social', connectorId, value: userInfo },
+    ],
+  };
 };
 
 export default async function identifierVerification(
   ctx: InteractionContext,
   provider: Provider
-): Promise<Identifier[]> {
+): Promise<ReturnResult> {
   const { identifier, event, profile } = ctx.interactionPayload;
 
   if (!identifier) {
-    return [];
+    return {};
   }
 
   if (isPasswordIdentifier(identifier)) {
@@ -141,5 +149,5 @@ export default async function identifierVerification(
   }
 
   // Social Identifier
-  return socialIdentifierVerification({ event, identifier, profile }, ctx, provider);
+  return socialIdentifierVerification({ identifier, profile }, ctx);
 }

--- a/packages/core/src/routes/interaction/verifications/identifier-verification.ts
+++ b/packages/core/src/routes/interaction/verifications/identifier-verification.ts
@@ -8,8 +8,13 @@ import { verifyUserPassword } from '#src/lib/user.js';
 import assertThat from '#src/utils/assert-that.js';
 import { maskUserInfo } from '#src/utils/format.js';
 
-import type { PasswordIdentifierPayload, PasscodeIdentifierPayload } from '../types/guard.js';
-import type { InteractionContext, Identifier, SocialIdentifier } from '../types/index.js';
+import type {
+  PasswordIdentifierPayload,
+  PasscodeIdentifierPayload,
+  InteractionContext,
+  Identifier,
+  SocialIdentifier,
+} from '../types/index.js';
 import findUserByIdentifier from '../utils/find-user-by-identifier.js';
 import { isPasscodeIdentifier, isPasswordIdentifier, isProfileIdentifier } from '../utils/index.js';
 import { assignIdentifierVerificationResult } from '../utils/interaction.js';
@@ -53,7 +58,7 @@ const passcodeIdentifierVerification = async (
   const user = await findUserByIdentifier(identifier);
 
   if (!user) {
-    // Throw verification result and assign verified identifiers
+    // Throw verification exception and assign verified identifiers to the interaction
     if (event !== Event.ForgotPassword) {
       await assignIdentifierVerificationResult(
         { event, identifiers: [verifiedPasscodeIdentifier] },
@@ -90,7 +95,7 @@ const socialIdentifierVerification = async (
   const user = await findUserByIdentifier({ connectorId, userInfo });
 
   if (!user) {
-    // Throw verification result and assign verified identifiers
+    // Throw verification exception and assign verified identifiers to the interaction
     await assignIdentifierVerificationResult(
       { event, identifiers: [socialIdentifier] },
       ctx,

--- a/packages/core/src/routes/interaction/verifications/index.ts
+++ b/packages/core/src/routes/interaction/verifications/index.ts
@@ -1,1 +1,3 @@
 export { default as identifierVerification } from './identifier-verification.js';
+export { default as profileVerification } from './profile-verification.js';
+export { default as mandatoryUserProfileValidation } from './mandatory-user-profile-validation.js';

--- a/packages/core/src/routes/interaction/verifications/mandatory-user-profile-validation.test.ts
+++ b/packages/core/src/routes/interaction/verifications/mandatory-user-profile-validation.test.ts
@@ -1,0 +1,161 @@
+import { MissingProfile, SignUpIdentifier } from '@logto/schemas';
+
+import { mockSignInExperience } from '#src/__mocks__/sign-in-experience.js';
+import RequestError from '#src/errors/RequestError/index.js';
+import { findUserById } from '#src/queries/user.js';
+import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
+
+import type { Identifier } from '../types/index.js';
+import { isUserPasswordSet } from '../utils/index.js';
+import mandatoryUserProfileValidation from './mandatory-user-profile-validation.js';
+
+jest.mock('#src/queries/user.js', () => ({
+  findUserById: jest.fn(),
+}));
+
+jest.mock('../utils/index.js', () => ({
+  isUserPasswordSet: jest.fn(),
+}));
+
+describe('mandatoryUserProfileValidation', () => {
+  const baseCtx = createContextWithRouteParameters();
+  const identifiers: Identifier[] = [{ key: 'accountId', value: 'foo' }];
+
+  it('username and password missing but required', async () => {
+    const ctx = {
+      ...baseCtx,
+      signInExperience: mockSignInExperience,
+    };
+
+    await expect(
+      mandatoryUserProfileValidation(ctx, identifiers, { email: 'email' })
+    ).rejects.toMatchError(
+      new RequestError(
+        { code: 'user.missing_profile', status: 422 },
+        { missingProfile: [MissingProfile.password, MissingProfile.username] }
+      )
+    );
+
+    await expect(
+      mandatoryUserProfileValidation(ctx, identifiers, {
+        username: 'username',
+        password: 'password',
+      })
+    ).resolves.not.toThrow();
+  });
+
+  it('user account has username and password', async () => {
+    (findUserById as jest.Mock).mockResolvedValueOnce({
+      username: 'foo',
+    });
+    (isUserPasswordSet as jest.Mock).mockResolvedValueOnce(true);
+
+    const ctx = {
+      ...baseCtx,
+      signInExperience: mockSignInExperience,
+    };
+
+    await expect(mandatoryUserProfileValidation(ctx, identifiers, {})).resolves.not.toThrow();
+  });
+
+  it('email missing but required', async () => {
+    const ctx = {
+      ...baseCtx,
+      signInExperience: {
+        ...mockSignInExperience,
+        signUp: { identifier: SignUpIdentifier.Email, password: false, verify: true },
+      },
+    };
+
+    await expect(
+      mandatoryUserProfileValidation(ctx, identifiers, { username: 'username' })
+    ).rejects.toMatchError(
+      new RequestError(
+        { code: 'user.missing_profile', status: 422 },
+        { missingProfile: [MissingProfile.email] }
+      )
+    );
+  });
+
+  it('user account has email', async () => {
+    (findUserById as jest.Mock).mockResolvedValueOnce({
+      primaryEmail: 'email',
+    });
+
+    const ctx = {
+      ...baseCtx,
+      signInExperience: {
+        ...mockSignInExperience,
+        signUp: { identifier: SignUpIdentifier.Email, password: false, verify: true },
+      },
+    };
+
+    await expect(
+      mandatoryUserProfileValidation(ctx, identifiers, { username: 'username' })
+    ).resolves.not.toThrow();
+  });
+
+  it('phone missing but required', async () => {
+    const ctx = {
+      ...baseCtx,
+      signInExperience: {
+        ...mockSignInExperience,
+        signUp: { identifier: SignUpIdentifier.Sms, password: false, verify: true },
+      },
+    };
+
+    await expect(
+      mandatoryUserProfileValidation(ctx, identifiers, { username: 'username' })
+    ).rejects.toMatchError(
+      new RequestError(
+        { code: 'user.missing_profile', status: 422 },
+        { missingProfile: [MissingProfile.phone] }
+      )
+    );
+  });
+
+  it('user account has phone', async () => {
+    (findUserById as jest.Mock).mockResolvedValueOnce({
+      primaryPhone: 'phone',
+    });
+
+    const ctx = {
+      ...baseCtx,
+      signInExperience: {
+        ...mockSignInExperience,
+        signUp: { identifier: SignUpIdentifier.Sms, password: false, verify: true },
+      },
+    };
+
+    await expect(
+      mandatoryUserProfileValidation(ctx, identifiers, { username: 'username' })
+    ).resolves.not.toThrow();
+  });
+
+  it('email or Phone required', async () => {
+    const ctx = {
+      ...baseCtx,
+      signInExperience: {
+        ...mockSignInExperience,
+        signUp: { identifier: SignUpIdentifier.EmailOrSms, password: false, verify: true },
+      },
+    };
+
+    await expect(
+      mandatoryUserProfileValidation(ctx, identifiers, { username: 'username' })
+    ).rejects.toMatchError(
+      new RequestError(
+        { code: 'user.missing_profile', status: 422 },
+        { missingProfile: [MissingProfile.emailOrPhone] }
+      )
+    );
+
+    await expect(
+      mandatoryUserProfileValidation(ctx, identifiers, { email: 'email' })
+    ).resolves.not.toThrow();
+
+    await expect(
+      mandatoryUserProfileValidation(ctx, identifiers, { phone: 'phone' })
+    ).resolves.not.toThrow();
+  });
+});

--- a/packages/core/src/routes/interaction/verifications/mandatory-user-profile-validation.ts
+++ b/packages/core/src/routes/interaction/verifications/mandatory-user-profile-validation.ts
@@ -1,0 +1,81 @@
+import type { Profile } from '@logto/schemas';
+import { MissingProfile, SignUpIdentifier } from '@logto/schemas';
+import type { Context } from 'koa';
+
+import RequestError from '#src/errors/RequestError/index.js';
+import { findUserById } from '#src/queries/user.js';
+import assertThat from '#src/utils/assert-that.js';
+
+import type { WithSignInExperienceContext } from '../middleware/koa-session-sign-in-experience-guard.js';
+import type { Identifier, AccountIdIdentifier } from '../types/index.js';
+import { isUserPasswordSet } from '../utils/index.js';
+
+const findUserByIdentifiers = async (identifiers: Identifier[]) => {
+  const accountIdentifier = identifiers.find(
+    (identifier): identifier is AccountIdIdentifier => identifier.key === 'accountId'
+  );
+
+  if (!accountIdentifier) {
+    return null;
+  }
+
+  return findUserById(accountIdentifier.value);
+};
+
+// eslint-disable-next-line complexity
+export default async function mandatoryUserProfileValidation(
+  ctx: WithSignInExperienceContext<Context>,
+  identifiers: Identifier[],
+  profile?: Profile
+) {
+  const {
+    signInExperience: { signUp },
+  } = ctx;
+  const user = await findUserByIdentifiers(identifiers);
+  const missingProfile = new Set<MissingProfile>();
+
+  if (signUp.password && !((user && isUserPasswordSet(user)) ?? profile?.password)) {
+    missingProfile.add(MissingProfile.password);
+  }
+
+  switch (signUp.identifier) {
+    case SignUpIdentifier.Username: {
+      if (!user?.username && !profile?.username) {
+        missingProfile.add(MissingProfile.username);
+      }
+      break;
+    }
+
+    case SignUpIdentifier.Email: {
+      if (!user?.primaryEmail && !profile?.email) {
+        missingProfile.add(MissingProfile.email);
+      }
+      break;
+    }
+
+    case SignUpIdentifier.Sms: {
+      if (!user?.primaryPhone && !profile?.phone) {
+        missingProfile.add(MissingProfile.phone);
+      }
+      break;
+    }
+
+    case SignUpIdentifier.EmailOrSms: {
+      if (!user?.primaryPhone && !user?.primaryEmail && !profile?.phone && !profile?.email) {
+        missingProfile.add(MissingProfile.emailOrPhone);
+      }
+      break;
+    }
+
+    default:
+      break;
+  }
+
+  assertThat(
+    missingProfile.size === 0,
+    new RequestError(
+      { code: 'user.missing_profile', status: 422 },
+      { missingProfile: Array.from(missingProfile) }
+    )
+  );
+}

--- a/packages/core/src/routes/interaction/verifications/mandatory-user-profile-validation.ts
+++ b/packages/core/src/routes/interaction/verifications/mandatory-user-profile-validation.ts
@@ -25,7 +25,7 @@ const findUserByIdentifiers = async (identifiers: Identifier[]) => {
 // eslint-disable-next-line complexity
 export default async function mandatoryUserProfileValidation(
   ctx: WithSignInExperienceContext<Context>,
-  identifiers: Identifier[],
+  identifiers: Identifier[] = [],
   profile?: Profile
 ) {
   const {

--- a/packages/core/src/routes/interaction/verifications/profile-verification.ts
+++ b/packages/core/src/routes/interaction/verifications/profile-verification.ts
@@ -177,7 +177,7 @@ const profileExistValidation = async (
 export default async function profileVerification(
   ctx: InteractionContext,
   identifiers: Identifier[]
-) {
+): Promise<Profile | undefined> {
   const { profile, event } = ctx.interactionPayload;
 
   if (!profile) {
@@ -193,7 +193,7 @@ export default async function profileVerification(
     await profileExistValidation(profile, user);
     await profileRegisteredValidation(profile, identifiers);
 
-    return;
+    return profile;
   }
 
   if (event === Event.Register) {
@@ -206,7 +206,7 @@ export default async function profileVerification(
 
     await profileRegisteredValidation(profile, identifiers);
 
-    return;
+    return profile;
   }
 
   // ForgotPassword
@@ -216,4 +216,6 @@ export default async function profileVerification(
     !oldPasswordEncrypted || !(await argon2Verify({ password, hash: oldPasswordEncrypted })),
     new RequestError({ code: 'user.same_password', status: 422 })
   );
+
+  return profile;
 }

--- a/packages/core/src/routes/interaction/verifications/profile-verification.ts
+++ b/packages/core/src/routes/interaction/verifications/profile-verification.ts
@@ -176,7 +176,7 @@ const profileExistValidation = async (
 
 export default async function profileVerification(
   ctx: InteractionContext,
-  identifiers: Identifier[]
+  identifiers: Identifier[] = []
 ): Promise<Profile | undefined> {
   const { profile, event } = ctx.interactionPayload;
 
@@ -212,6 +212,7 @@ export default async function profileVerification(
   // ForgotPassword
   const { password } = profile;
   const { passwordEncrypted: oldPasswordEncrypted } = await findUserByIdentifier(identifiers);
+
   assertThat(
     !oldPasswordEncrypted || !(await argon2Verify({ password, hash: oldPasswordEncrypted })),
     new RequestError({ code: 'user.same_password', status: 422 })

--- a/packages/phrases/src/locales/de/errors.ts
+++ b/packages/phrases/src/locales/de/errors.ts
@@ -57,6 +57,7 @@ const errors = {
     require_email_or_sms: 'You need to add an email address or phone number before signing-in.', // UNTRANSLATED
     suspended: 'This account is suspended.', // UNTRANSLATED
     user_not_exist: 'User with {{ identity }} has not been registered yet', // UNTRANSLATED,
+    missing_profile: 'You need to provide additional info before signing-in.', // UNTRANSLATED
   },
   password: {
     unsupported_encryption_method: 'Die Verschlüsselungsmethode {{name}} wird nicht unterstützt.',

--- a/packages/phrases/src/locales/en/errors.ts
+++ b/packages/phrases/src/locales/en/errors.ts
@@ -57,6 +57,7 @@ const errors = {
     require_email_or_sms: 'You need to add an email address or phone number before signing-in.',
     suspended: 'This account is suspended.',
     user_not_exist: 'User with {{ identity }} has not been registered yet',
+    missing_profile: 'You need to provide additional info before signing-in.',
   },
   password: {
     unsupported_encryption_method: 'The encryption method {{name}} is not supported.',

--- a/packages/phrases/src/locales/fr/errors.ts
+++ b/packages/phrases/src/locales/fr/errors.ts
@@ -58,6 +58,7 @@ const errors = {
     require_email_or_sms: 'You need to add an email address or phone number before signing-in.', // UNTRANSLATED
     suspended: 'This account is suspended.', // UNTRANSLATED
     user_not_exist: 'User with {{ identity }} has not been registered yet', // UNTRANSLATED,
+    missing_profile: 'You need to provide additional info before signing-in.', // UNTRANSLATED
   },
   password: {
     unsupported_encryption_method: "La méthode de cryptage {{name}} n'est pas prise en charge.",

--- a/packages/phrases/src/locales/ko/errors.ts
+++ b/packages/phrases/src/locales/ko/errors.ts
@@ -56,6 +56,7 @@ const errors = {
     require_email_or_sms: 'You need to add an email address or phone number before signing-in.', // UNTRANSLATED
     suspended: 'This account is suspended.', // UNTRANSLATED
     user_not_exist: 'User with {{ identity }} has not been registered yet', // UNTRANSLATED,
+    missing_profile: 'You need to provide additional info before signing-in.', // UNTRANSLATED
   },
   password: {
     unsupported_encryption_method: '{{name}} 암호화 방법을 지원하지 않아요.',

--- a/packages/phrases/src/locales/pt-pt/errors.ts
+++ b/packages/phrases/src/locales/pt-pt/errors.ts
@@ -56,6 +56,7 @@ const errors = {
     require_email_or_sms: 'You need to add an email address or phone number before signing-in.', // UNTRANSLATED
     suspended: 'This account is suspended.', // UNTRANSLATED
     user_not_exist: 'User with {{ identity }} has not been registered yet', // UNTRANSLATED,
+    missing_profile: 'You need to provide additional info before signing-in.', // UNTRANSLATED
   },
   password: {
     unsupported_encryption_method: 'O método de enncriptação {{name}} não é suportado.',

--- a/packages/phrases/src/locales/tr-tr/errors.ts
+++ b/packages/phrases/src/locales/tr-tr/errors.ts
@@ -57,6 +57,7 @@ const errors = {
     require_email_or_sms: 'You need to add an email address or phone number before signing-in.', // UNTRANSLATED
     suspended: 'This account is suspended.', // UNTRANSLATED
     user_not_exist: 'User with {{ identity }} has not been registered yet', // UNTRANSLATED,
+    missing_profile: 'You need to provide additional info before signing-in.', // UNTRANSLATED
   },
   password: {
     unsupported_encryption_method: '{{name}} şifreleme metodu desteklenmiyor.',

--- a/packages/phrases/src/locales/zh-cn/errors.ts
+++ b/packages/phrases/src/locales/zh-cn/errors.ts
@@ -56,6 +56,7 @@ const errors = {
     require_email_or_sms: '请绑定邮箱地址或手机号码',
     suspended: '账号已被禁用',
     user_not_exist: 'User with {{ identity }} has not been registered yet', // UNTRANSLATED,
+    missing_profile: 'You need to provide additional info before signing-in.', // UNTRANSLATED
   },
   password: {
     unsupported_encryption_method: '不支持的加密方法 {{name}}',

--- a/packages/schemas/src/types/interactions.ts
+++ b/packages/schemas/src/types/interactions.ts
@@ -52,7 +52,7 @@ export enum Event {
 
 export const eventGuard = z.nativeEnum(Event);
 
-export const identifierGuard = z.union([
+export const identifierPayloadGuard = z.union([
   usernamePasswordPayloadGuard,
   emailPasswordPayloadGuard,
   phonePasswordPayloadGuard,
@@ -60,6 +60,14 @@ export const identifierGuard = z.union([
   phonePasscodePayloadGuard,
   socialConnectorPayloadGuard,
 ]);
+
+export type IdentifierPayload =
+  | UsernamePasswordPayload
+  | EmailPasswordPayload
+  | PhonePasswordPayload
+  | EmailPasscodePayload
+  | PhonePasscodePayload
+  | SocialConnectorPayload;
 
 export const profileGuard = z.object({
   username: z.string().regex(usernameRegEx).optional(),

--- a/packages/schemas/src/types/interactions.ts
+++ b/packages/schemas/src/types/interactions.ts
@@ -70,3 +70,11 @@ export const profileGuard = z.object({
 });
 
 export type Profile = z.infer<typeof profileGuard>;
+
+export enum MissingProfile {
+  username = 'username',
+  email = 'email',
+  phone = 'phone',
+  password = 'password',
+  emailOrPhone = 'emailOrPhone',
+}


### PR DESCRIPTION
merge and assign interaction result

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add the patch interaction API:

- update the `storeInteraction` util methods that assign the interaction results.
- add new merge identifiers util method,  as currently, our verified identifier type is unique. All merge actions should replace the original identifier having the same key type 
- refactor the `identifierVerification` method's return type. We need to store the `verified identifiers` before throwing the exceptions. return both the `error` and `verifiedIdentifiers`. 
- all the `storeInteraction` in the middle of each validation step. So the verified identifiers and profiles will be kept in record. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT case updated
