### PR TITLE
refactor(console): increase the color picker interaction area

### DIFF
--- a/packages/console/src/components/ColorPicker/index.module.scss
+++ b/packages/console/src/components/ColorPicker/index.module.scss
@@ -47,9 +47,7 @@
   }
 
   label {
-    display: flex;
-    align-items: center;
-    position: relative;
+    flex: 1;
     margin-left: _.unit(2);
   }
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Increase the `ColorPicker` interaction area for a better UX and remove redundant styles in the `label`.

Currently, we can only click the color square to open the color picker.
<img width="568" alt="image" src="https://user-images.githubusercontent.com/10806653/205289610-03ffcb07-51fb-419f-acb6-3f1f30dd4e76.png">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Click the whole input content, the color picker will pop up.
<img width="564" alt="image" src="https://user-images.githubusercontent.com/10806653/205279864-20e23118-c8a1-4b18-8c91-3566e291f6b0.png">

