### PR TITLE
refactor(core): refactor interaction verification flow

### DIFF
--- a/packages/core/src/routes/interaction/index.ts
+++ b/packages/core/src/routes/interaction/index.ts
@@ -27,20 +27,20 @@ export default function interactionRoutes<T extends AnonymousRouter>(
     koaInteractionBodyGuard(),
     koaSessionSignInExperienceGuard(provider),
     async (ctx, next) => {
+      const { event } = ctx.interactionPayload;
+
       // Check interaction session
       await provider.interactionDetails(ctx.req, ctx.res);
 
-      const verifiedIdentifiers = await identifierVerification(ctx, provider);
+      const identifierVerifiedInteraction = await identifierVerification(ctx, provider);
 
-      const profile = await profileVerification(ctx, verifiedIdentifiers);
-
-      const { event } = ctx.interactionPayload;
+      const interaction = await profileVerification(ctx, provider, identifierVerifiedInteraction);
 
       if (event !== Event.ForgotPassword) {
-        await mandatoryUserProfileValidation(ctx, verifiedIdentifiers, profile);
+        await mandatoryUserProfileValidation(ctx, interaction);
       }
 
-      // TODO: SignIn Register & ResetPassword final step
+      // TODO: SignIn Register & ResetPassword submit
 
       ctx.status = 200;
 

--- a/packages/core/src/routes/interaction/types/guard.ts
+++ b/packages/core/src/routes/interaction/types/guard.ts
@@ -87,7 +87,7 @@ export const verifiedPhoneIdentifierGuard = z.object({
 export const socialIdentifierGuard = z.object({
   key: z.literal('social'),
   connectorId: z.string(),
-  value: socialUserInfoGuard,
+  userInfo: socialUserInfoGuard,
 });
 
 export const identifierGuard = z.discriminatedUnion('key', [
@@ -98,7 +98,8 @@ export const identifierGuard = z.discriminatedUnion('key', [
 ]);
 
 export const customInteractionResultGuard = z.object({
-  event: eventGuard.optional(),
+  event: eventGuard,
   profile: profileGuard.optional(),
+  accountId: z.string().optional(),
   identifiers: z.array(identifierGuard).optional(),
 });

--- a/packages/core/src/routes/interaction/types/index.ts
+++ b/packages/core/src/routes/interaction/types/index.ts
@@ -4,6 +4,7 @@ import type {
   EmailPasscodePayload,
   PhonePasswordPayload,
   PhonePasscodePayload,
+  Event,
 } from '@logto/schemas';
 import type { Context } from 'koa';
 import type { IRouterParamContext } from 'koa-router';
@@ -21,6 +22,7 @@ import type {
   verifiedPhoneIdentifierGuard,
   socialIdentifierGuard,
   identifierGuard,
+  customInteractionResultGuard,
 } from './guard.js';
 
 // Payload Types
@@ -37,7 +39,7 @@ export type SendPasscodePayload = z.infer<typeof sendPasscodePayloadGuard>;
 
 export type SocialAuthorizationUrlPayload = z.infer<typeof getSocialAuthorizationUrlPayloadGuard>;
 
-// Identifier Types
+// Interaction Types
 export type AccountIdIdentifier = z.infer<typeof accountIdIdentifierGuard>;
 
 export type VerifiedEmailIdentifier = z.infer<typeof verifiedEmailIdentifierGuard>;
@@ -47,6 +49,31 @@ export type VerifiedPhoneIdentifier = z.infer<typeof verifiedPhoneIdentifierGuar
 export type SocialIdentifier = z.infer<typeof socialIdentifierGuard>;
 
 export type Identifier = z.infer<typeof identifierGuard>;
+
+export type AnonymousInteractionResult = z.infer<typeof customInteractionResultGuard>;
+
+export type RegisterInteractionResult = Omit<AnonymousInteractionResult, 'event'> & {
+  event: Event.Register;
+};
+
+export type PreAccountVerifiedInteractionResult = Omit<AnonymousInteractionResult, 'event'> & {
+  event: Event.SignIn | Event.ForgotPassword;
+};
+
+export type PayloadVerifiedInteractionResult =
+  | RegisterInteractionResult
+  | PreAccountVerifiedInteractionResult;
+
+export type AccountVerifiedInteractionResult = Omit<
+  PreAccountVerifiedInteractionResult,
+  'accountId'
+> & {
+  accountId: string;
+};
+
+export type IdentifierVerifiedInteractionResult =
+  | RegisterInteractionResult
+  | AccountVerifiedInteractionResult;
 
 export type InteractionContext = WithGuardedIdentifierPayloadContext<IRouterParamContext & Context>;
 

--- a/packages/core/src/routes/interaction/utils/index.ts
+++ b/packages/core/src/routes/interaction/utils/index.ts
@@ -1,6 +1,10 @@
 import type { Profile, SocialConnectorPayload, User, IdentifierPayload } from '@logto/schemas';
 
-import type { PasscodeIdentifierPayload, PasswordIdentifierPayload } from '../types/index.js';
+import type {
+  PasscodeIdentifierPayload,
+  PasswordIdentifierPayload,
+  Identifier,
+} from '../types/index.js';
 
 export const isPasswordIdentifier = (
   identifier: IdentifierPayload
@@ -14,16 +18,17 @@ export const isSocialIdentifier = (
   identifier: IdentifierPayload
 ): identifier is SocialConnectorPayload => 'connectorId' in identifier;
 
-export const isProfileIdentifier = (
-  identifier: PasscodeIdentifierPayload | SocialConnectorPayload,
-  profile?: Profile
-) => {
-  if ('email' in identifier) {
-    return profile?.email === identifier.email;
+export const isProfileIdentifier = (identifier: Identifier, profile?: Profile) => {
+  if (identifier.key === 'accountId') {
+    return false;
   }
 
-  if ('phone' in identifier) {
-    return profile?.phone === identifier.phone;
+  if (identifier.key === 'emailVerified') {
+    return profile?.email === identifier.value;
+  }
+
+  if (identifier.key === 'phoneVerified') {
+    return profile?.phone === identifier.value;
   }
 
   return profile?.connectorId === identifier.connectorId;

--- a/packages/core/src/routes/interaction/utils/interaction.test.ts
+++ b/packages/core/src/routes/interaction/utils/interaction.test.ts
@@ -1,0 +1,45 @@
+import type { Identifier } from '../types/index.js';
+import { mergeIdentifiers } from './interaction.js';
+
+describe('interaction utils', () => {
+  const usernameIdentifier: Identifier = { key: 'accountId', value: 'foo' };
+  const emailIdentifier: Identifier = { key: 'emailVerified', value: 'foo@logto.io' };
+  const phoneIdentifier: Identifier = { key: 'phoneVerified', value: '12346' };
+
+  it('mergeIdentifiers', () => {
+    expect(mergeIdentifiers({})).toEqual(undefined);
+    expect(mergeIdentifiers({ oldIdentifiers: [usernameIdentifier] })).toEqual([
+      usernameIdentifier,
+    ]);
+    expect(mergeIdentifiers({ newIdentifiers: [usernameIdentifier] })).toEqual([
+      usernameIdentifier,
+    ]);
+    expect(
+      mergeIdentifiers({
+        oldIdentifiers: [usernameIdentifier],
+        newIdentifiers: [usernameIdentifier],
+      })
+    ).toEqual([usernameIdentifier]);
+
+    expect(
+      mergeIdentifiers({
+        oldIdentifiers: [emailIdentifier],
+        newIdentifiers: [usernameIdentifier],
+      })
+    ).toEqual([emailIdentifier, usernameIdentifier]);
+
+    expect(
+      mergeIdentifiers({
+        oldIdentifiers: [emailIdentifier, phoneIdentifier],
+        newIdentifiers: [phoneIdentifier, usernameIdentifier],
+      })
+    ).toEqual([emailIdentifier, phoneIdentifier, usernameIdentifier]);
+
+    expect(
+      mergeIdentifiers({
+        oldIdentifiers: [emailIdentifier, phoneIdentifier],
+        newIdentifiers: [usernameIdentifier],
+      })
+    ).toEqual([emailIdentifier, phoneIdentifier, usernameIdentifier]);
+  });
+});

--- a/packages/core/src/routes/interaction/utils/interaction.ts
+++ b/packages/core/src/routes/interaction/utils/interaction.ts
@@ -2,12 +2,69 @@ import type { Event } from '@logto/schemas';
 import type { Context } from 'koa';
 import type { Provider } from 'oidc-provider';
 
-import type { Identifier } from '../types/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
+import assertThat from '#src/utils/assert-that.js';
 
-export const assignIdentifierVerificationResult = async (
-  payload: { event: Event; identifiers: Identifier[] },
+import { customInteractionResultGuard } from '../types/guard.js';
+import type {
+  Identifier,
+  AnonymousInteractionResult,
+  AccountVerifiedInteractionResult,
+} from '../types/index.js';
+
+// Unique identifier type is required
+export const mergeIdentifiers = (pairs: {
+  newIdentifiers?: Identifier[];
+  oldIdentifiers?: Identifier[];
+}) => {
+  const { newIdentifiers, oldIdentifiers } = pairs;
+
+  if (!newIdentifiers) {
+    return oldIdentifiers;
+  }
+
+  if (!oldIdentifiers) {
+    return newIdentifiers;
+  }
+
+  const leftOvers = oldIdentifiers.filter((oldIdentifier) => {
+    return !newIdentifiers.some((newIdentifier) => newIdentifier.key === oldIdentifier.key);
+  });
+
+  return [...leftOvers, ...newIdentifiers];
+};
+
+export const isAccountVerifiedInteractionResult = (
+  interaction: AnonymousInteractionResult
+): interaction is AccountVerifiedInteractionResult => Boolean(interaction.accountId);
+
+export const storeInteractionResult = async (
+  interaction: Omit<AnonymousInteractionResult, 'event'> & { event?: Event },
   ctx: Context,
   provider: Provider
 ) => {
-  await provider.interactionResult(ctx.req, ctx.res, payload, { mergeWithLastSubmission: true });
+  // The "mergeWithLastSubmission" will only merge current request's interaction results,
+  // manually merge with previous interaction results
+  // refer to: https://github.com/panva/node-oidc-provider/blob/c243bf6b6663c41ff3e75c09b95fb978eba87381/lib/actions/authorization/interactions.js#L106
+
+  const { result } = await provider.interactionDetails(ctx.req, ctx.res);
+
+  await provider.interactionResult(
+    ctx.req,
+    ctx.res,
+    { ...result, ...interaction },
+    { mergeWithLastSubmission: true }
+  );
+};
+
+export const getInteractionStorage = async (ctx: Context, provider: Provider) => {
+  const result = await provider.interactionDetails(ctx.req, ctx.res);
+  const parseResult = customInteractionResultGuard.safeParse(result);
+
+  assertThat(
+    parseResult.success,
+    new RequestError({ code: 'session.verification_session_not_found' })
+  );
+
+  return parseResult.data;
 };

--- a/packages/core/src/routes/interaction/verifications/identifier-payload-verification.ts
+++ b/packages/core/src/routes/interaction/verifications/identifier-payload-verification.ts
@@ -1,0 +1,107 @@
+import type { Event, SocialConnectorPayload } from '@logto/schemas';
+import type { Provider } from 'oidc-provider';
+
+import RequestError from '#src/errors/RequestError/index.js';
+import { verifyUserPassword } from '#src/lib/user.js';
+import assertThat from '#src/utils/assert-that.js';
+
+import type {
+  PasswordIdentifierPayload,
+  PasscodeIdentifierPayload,
+  InteractionContext,
+  SocialIdentifier,
+  VerifiedEmailIdentifier,
+  VerifiedPhoneIdentifier,
+  AnonymousInteractionResult,
+  PayloadVerifiedInteractionResult,
+  Identifier,
+  AccountIdIdentifier,
+} from '../types/index.js';
+import findUserByIdentifier from '../utils/find-user-by-identifier.js';
+import { isPasscodeIdentifier, isPasswordIdentifier } from '../utils/index.js';
+import { mergeIdentifiers, storeInteractionResult } from '../utils/interaction.js';
+import { verifyIdentifierByPasscode } from '../utils/passcode-validation.js';
+import { verifySocialIdentity } from '../utils/social-verification.js';
+
+const verifyPasswordIdentifier = async (
+  identifier: PasswordIdentifierPayload
+): Promise<AccountIdIdentifier> => {
+  // TODO: Log
+  const { password, ...identity } = identifier;
+  const user = await findUserByIdentifier(identity);
+  const verifiedUser = await verifyUserPassword(user, password);
+
+  const { isSuspended, id } = verifiedUser;
+
+  assertThat(!isSuspended, new RequestError({ code: 'user.suspended', status: 401 }));
+
+  return { key: 'accountId', value: id };
+};
+
+const verifyPasscodeIdentifier = async (
+  event: Event,
+  identifier: PasscodeIdentifierPayload,
+  ctx: InteractionContext,
+  provider: Provider
+): Promise<VerifiedEmailIdentifier | VerifiedPhoneIdentifier> => {
+  const { jti } = await provider.interactionDetails(ctx.req, ctx.res);
+
+  await verifyIdentifierByPasscode({ ...identifier, event }, jti, ctx.log);
+
+  return 'email' in identifier
+    ? { key: 'emailVerified', value: identifier.email }
+    : { key: 'phoneVerified', value: identifier.phone };
+};
+
+const verifySocialIdentifier = async (
+  identifier: SocialConnectorPayload,
+  ctx: InteractionContext
+): Promise<SocialIdentifier> => {
+  const userInfo = await verifySocialIdentity(identifier, ctx.log);
+
+  return { key: 'social', connectorId: identifier.connectorId, userInfo };
+};
+
+const verifyIdentifierPayload = async (
+  ctx: InteractionContext,
+  provider: Provider
+): Promise<Identifier | undefined> => {
+  const { identifier, event } = ctx.interactionPayload;
+
+  if (!identifier) {
+    return;
+  }
+
+  if (isPasswordIdentifier(identifier)) {
+    return verifyPasswordIdentifier(identifier);
+  }
+
+  if (isPasscodeIdentifier(identifier)) {
+    return verifyPasscodeIdentifier(event, identifier, ctx, provider);
+  }
+
+  return verifySocialIdentifier(identifier, ctx);
+};
+
+export default async function identifierPayloadVerification(
+  ctx: InteractionContext,
+  provider: Provider,
+  interactionRecord?: AnonymousInteractionResult
+): Promise<PayloadVerifiedInteractionResult> {
+  const { event } = ctx.interactionPayload;
+
+  const identifier = await verifyIdentifierPayload(ctx, provider);
+
+  const interaction: PayloadVerifiedInteractionResult = {
+    ...interactionRecord,
+    event,
+    identifiers: mergeIdentifiers({
+      oldIdentifiers: interactionRecord?.identifiers,
+      newIdentifiers: identifier && [identifier],
+    }),
+  };
+
+  await storeInteractionResult(interaction, ctx, provider);
+
+  return interaction;
+}

--- a/packages/core/src/routes/interaction/verifications/identifier-verification.ts
+++ b/packages/core/src/routes/interaction/verifications/identifier-verification.ts
@@ -1,145 +1,24 @@
-import type { Profile, SocialConnectorPayload } from '@logto/schemas';
 import { Event } from '@logto/schemas';
 import type { Provider } from 'oidc-provider';
 
-import RequestError from '#src/errors/RequestError/index.js';
-import { findSocialRelatedUser } from '#src/lib/social.js';
-import { verifyUserPassword } from '#src/lib/user.js';
-import assertThat from '#src/utils/assert-that.js';
-import { maskUserInfo } from '#src/utils/format.js';
-
 import type {
-  PasswordIdentifierPayload,
-  PasscodeIdentifierPayload,
   InteractionContext,
-  Identifier,
-  SocialIdentifier,
+  AnonymousInteractionResult,
+  IdentifierVerifiedInteractionResult,
 } from '../types/index.js';
-import findUserByIdentifier from '../utils/find-user-by-identifier.js';
-import { isPasscodeIdentifier, isPasswordIdentifier, isProfileIdentifier } from '../utils/index.js';
-import { assignIdentifierVerificationResult } from '../utils/interaction.js';
-import { verifyIdentifierByPasscode } from '../utils/passcode-validation.js';
-import { verifySocialIdentity } from '../utils/social-verification.js';
-
-const passwordIdentifierVerification = async (
-  identifier: PasswordIdentifierPayload
-): Promise<Identifier[]> => {
-  // TODO: Log
-  const { password, ...identity } = identifier;
-  const user = await findUserByIdentifier(identity);
-  const verifiedUser = await verifyUserPassword(user, password);
-
-  const { isSuspended, id } = verifiedUser;
-  assertThat(!isSuspended, new RequestError({ code: 'user.suspended', status: 401 }));
-
-  return [{ key: 'accountId', value: id }];
-};
-
-const passcodeIdentifierVerification = async (
-  payload: { event: Event; identifier: PasscodeIdentifierPayload; profile?: Profile },
-  ctx: InteractionContext,
-  provider: Provider
-): Promise<Identifier[]> => {
-  const { identifier, event, profile } = payload;
-  const { jti } = await provider.interactionDetails(ctx.req, ctx.res);
-
-  await verifyIdentifierByPasscode({ ...identifier, event }, jti, ctx.log);
-
-  const verifiedPasscodeIdentifier: Identifier =
-    'email' in identifier
-      ? { key: 'emailVerified', value: identifier.email }
-      : { key: 'phoneVerified', value: identifier.phone };
-
-  // Return the verified identity directly if it is for new profile identity verification
-  if (isProfileIdentifier(identifier, profile)) {
-    return [verifiedPasscodeIdentifier];
-  }
-
-  const user = await findUserByIdentifier(identifier);
-
-  if (!user) {
-    // Throw verification exception and assign verified identifiers to the interaction
-    if (event !== Event.ForgotPassword) {
-      await assignIdentifierVerificationResult(
-        { event, identifiers: [verifiedPasscodeIdentifier] },
-        ctx,
-        provider
-      );
-    }
-
-    throw new RequestError({ code: 'user.user_not_exist', status: 404 });
-  }
-
-  const { id, isSuspended } = user;
-  assertThat(!isSuspended, new RequestError({ code: 'user.suspended', status: 401 }));
-
-  return [{ key: 'accountId', value: id }, verifiedPasscodeIdentifier];
-};
-
-const socialIdentifierVerification = async (
-  payload: { event: Event; identifier: SocialConnectorPayload; profile?: Profile },
-  ctx: InteractionContext,
-  provider: Provider
-): Promise<Identifier[]> => {
-  const { event, identifier, profile } = payload;
-  const userInfo = await verifySocialIdentity(identifier, ctx.log);
-
-  const { connectorId } = identifier;
-  const socialIdentifier: SocialIdentifier = { key: 'social', connectorId, value: userInfo };
-
-  // Return the verified identity directly if it is for new profile identity verification
-  if (isProfileIdentifier(identifier, profile)) {
-    return [socialIdentifier];
-  }
-
-  const user = await findUserByIdentifier({ connectorId, userInfo });
-
-  if (!user) {
-    // Throw verification exception and assign verified identifiers to the interaction
-    await assignIdentifierVerificationResult(
-      { event, identifiers: [socialIdentifier] },
-      ctx,
-      provider
-    );
-
-    const relatedInfo = await findSocialRelatedUser(userInfo);
-
-    throw new RequestError(
-      {
-        code: 'user.identity_not_exists',
-        status: 422,
-      },
-      relatedInfo && { relatedUser: maskUserInfo(relatedInfo[0]) }
-    );
-  }
-
-  const { id, isSuspended } = user;
-  assertThat(!isSuspended, new RequestError({ code: 'user.suspended', status: 401 }));
-
-  return [
-    { key: 'accountId', value: id },
-    { key: 'social', connectorId, value: userInfo },
-  ];
-};
+import identifierPayloadVerification from './identifier-payload-verification.js';
+import userIdentityVerification from './user-identity-verification.js';
 
 export default async function identifierVerification(
   ctx: InteractionContext,
-  provider: Provider
-): Promise<Identifier[]> {
-  const { identifier, event, profile } = ctx.interactionPayload;
+  provider: Provider,
+  interactionRecord?: AnonymousInteractionResult
+): Promise<IdentifierVerifiedInteractionResult> {
+  const verifiedInteraction = await identifierPayloadVerification(ctx, provider, interactionRecord);
 
-  if (!identifier) {
-    return [];
+  if (verifiedInteraction.event === Event.Register) {
+    return verifiedInteraction;
   }
 
-  if (isPasswordIdentifier(identifier)) {
-    return passwordIdentifierVerification(identifier);
-  }
-
-  if (isPasscodeIdentifier(identifier)) {
-    return passcodeIdentifierVerification({ identifier, event, profile }, ctx, provider);
-  }
-
-  // Social Identifier
-  return socialIdentifierVerification({ event, identifier, profile }, ctx, provider);
+  return userIdentityVerification(verifiedInteraction, ctx, provider);
 }

--- a/packages/core/src/routes/interaction/verifications/index.ts
+++ b/packages/core/src/routes/interaction/verifications/index.ts
@@ -1,3 +1,3 @@
-export { default as identifierVerification } from './identifier-verification.js';
 export { default as profileVerification } from './profile-verification.js';
 export { default as mandatoryUserProfileValidation } from './mandatory-user-profile-validation.js';
+export { default as identifierVerification } from './identifier-verification.js';

--- a/packages/core/src/routes/interaction/verifications/mandatory-user-profile-validation.ts
+++ b/packages/core/src/routes/interaction/verifications/mandatory-user-profile-validation.ts
@@ -1,5 +1,5 @@
 import type { Profile, SignInExperience, User } from '@logto/schemas';
-import { MissingProfile, SignInIdentifier } from '@logto/schemas';
+import { Event, MissingProfile, SignInIdentifier } from '@logto/schemas';
 import type { Nullable } from '@silverhand/essentials';
 import type { Context } from 'koa';
 
@@ -8,20 +8,8 @@ import { findUserById } from '#src/queries/user.js';
 import assertThat from '#src/utils/assert-that.js';
 
 import type { WithSignInExperienceContext } from '../middleware/koa-session-sign-in-experience-guard.js';
-import type { Identifier, AccountIdIdentifier } from '../types/index.js';
+import type { IdentifierVerifiedInteractionResult } from '../types/index.js';
 import { isUserPasswordSet } from '../utils/index.js';
-
-const findUserByIdentifiers = async (identifiers: Identifier[]) => {
-  const accountIdentifier = identifiers.find(
-    (identifier): identifier is AccountIdIdentifier => identifier.key === 'accountId'
-  );
-
-  if (!accountIdentifier) {
-    return null;
-  }
-
-  return findUserById(accountIdentifier.value);
-};
 
 // eslint-disable-next-line complexity
 const getMissingProfileBySignUpIdentifiers = ({
@@ -83,13 +71,14 @@ const getMissingProfileBySignUpIdentifiers = ({
 
 export default async function mandatoryUserProfileValidation(
   ctx: WithSignInExperienceContext<Context>,
-  identifiers: Identifier[],
-  profile?: Profile
+  interaction: IdentifierVerifiedInteractionResult
 ) {
   const {
     signInExperience: { signUp },
   } = ctx;
-  const user = await findUserByIdentifiers(identifiers);
+  const { event, accountId, profile } = interaction;
+
+  const user = event === Event.Register ? null : await findUserById(accountId);
   const missingProfileSet = getMissingProfileBySignUpIdentifiers({ signUp, user, profile });
 
   assertThat(

--- a/packages/core/src/routes/interaction/verifications/profile-verification-profile-exist.test.ts
+++ b/packages/core/src/routes/interaction/verifications/profile-verification-profile-exist.test.ts
@@ -1,11 +1,23 @@
 import { Event } from '@logto/schemas';
+import { Provider } from 'oidc-provider';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import { findUserById } from '#src/queries/user.js';
 import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
 
-import type { Identifier, InteractionContext } from '../types/index.js';
+import type {
+  Identifier,
+  IdentifierVerifiedInteractionResult,
+  InteractionContext,
+} from '../types/index.js';
+import { storeInteractionResult } from '../utils/interaction.js';
 import profileVerification from './profile-verification.js';
+
+jest.mock('oidc-provider', () => ({
+  Provider: jest.fn(() => ({
+    interactionDetails: jest.fn(async () => ({ params: {}, jti: 'jti' })),
+  })),
+}));
 
 jest.mock('#src/queries/user.js', () => ({
   findUserById: jest.fn().mockResolvedValue({ id: 'foo' }),
@@ -14,18 +26,28 @@ jest.mock('#src/queries/user.js', () => ({
   hasUserWithIdentity: jest.fn().mockResolvedValue(false),
 }));
 
+jest.mock('../utils/interaction.js', () => ({
+  storeInteractionResult: jest.fn(),
+}));
+
 jest.mock('../utils/index.js', () => ({
   isUserPasswordSet: jest.fn().mockResolvedValueOnce(true),
 }));
 
 describe('Existed profile should throw', () => {
+  const provider = new Provider('');
   const baseCtx = createContextWithRouteParameters();
   const identifiers: Identifier[] = [
     { key: 'accountId', value: 'foo' },
     { key: 'emailVerified', value: 'email' },
     { key: 'phoneVerified', value: 'phone' },
-    { key: 'social', connectorId: 'connectorId', value: { id: 'foo' } },
+    { key: 'social', connectorId: 'connectorId', userInfo: { id: 'foo' } },
   ];
+  const interaction: IdentifierVerifiedInteractionResult = {
+    event: Event.SignIn,
+    accountId: 'foo',
+    identifiers,
+  };
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -44,11 +66,12 @@ describe('Existed profile should throw', () => {
       },
     };
 
-    await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+    await expect(profileVerification(ctx, provider, interaction)).rejects.toMatchError(
       new RequestError({
         code: 'user.username_exists',
       })
     );
+    expect(storeInteractionResult).not.toBeCalled();
   });
 
   it('email exist', async () => {
@@ -64,11 +87,12 @@ describe('Existed profile should throw', () => {
       },
     };
 
-    await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+    await expect(profileVerification(ctx, provider, interaction)).rejects.toMatchError(
       new RequestError({
         code: 'user.email_exists',
       })
     );
+    expect(storeInteractionResult).not.toBeCalled();
   });
 
   it('phone exist', async () => {
@@ -84,11 +108,12 @@ describe('Existed profile should throw', () => {
       },
     };
 
-    await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+    await expect(profileVerification(ctx, provider, interaction)).rejects.toMatchError(
       new RequestError({
         code: 'user.sms_exists',
       })
     );
+    expect(storeInteractionResult).not.toBeCalled();
   });
 
   it('password exist', async () => {
@@ -104,10 +129,11 @@ describe('Existed profile should throw', () => {
       },
     };
 
-    await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+    await expect(profileVerification(ctx, provider, interaction)).rejects.toMatchError(
       new RequestError({
         code: 'user.password_exists',
       })
     );
+    expect(storeInteractionResult).not.toBeCalled();
   });
 });

--- a/packages/core/src/routes/interaction/verifications/profile-verification-profile-registered.test.ts
+++ b/packages/core/src/routes/interaction/verifications/profile-verification-profile-registered.test.ts
@@ -1,4 +1,5 @@
 import { Event } from '@logto/schemas';
+import { Provider } from 'oidc-provider';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import {
@@ -9,8 +10,23 @@ import {
 } from '#src/queries/user.js';
 import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
 
-import type { Identifier, InteractionContext } from '../types/index.js';
+import type {
+  Identifier,
+  InteractionContext,
+  IdentifierVerifiedInteractionResult,
+} from '../types/index.js';
+import { storeInteractionResult } from '../utils/interaction.js';
 import profileVerification from './profile-verification.js';
+
+jest.mock('oidc-provider', () => ({
+  Provider: jest.fn(() => ({
+    interactionDetails: jest.fn(async () => ({ params: {}, jti: 'jti' })),
+  })),
+}));
+
+jest.mock('../utils/interaction.js', () => ({
+  storeInteractionResult: jest.fn(),
+}));
 
 jest.mock('#src/queries/user.js', () => ({
   hasUser: jest.fn().mockResolvedValue(false),
@@ -31,10 +47,20 @@ const identifiers: Identifier[] = [
   { key: 'accountId', value: 'foo' },
   { key: 'emailVerified', value: 'email@logto.io' },
   { key: 'phoneVerified', value: '123456' },
-  { key: 'social', connectorId: 'connectorId', value: { id: 'foo' } },
+  { key: 'social', connectorId: 'connectorId', userInfo: { id: 'foo' } },
 ];
+const provider = new Provider('');
+
+const interaction: IdentifierVerifiedInteractionResult = {
+  event: Event.Register,
+  identifiers,
+};
 
 describe('register payload guard', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('username only should throw', async () => {
     const ctx: InteractionContext = {
       ...baseCtx,
@@ -46,7 +72,8 @@ describe('register payload guard', () => {
       },
     };
 
-    await expect(profileVerification(ctx, identifiers)).rejects.toThrow();
+    await expect(profileVerification(ctx, provider, interaction)).rejects.toThrow();
+    expect(storeInteractionResult).not.toBeCalled();
   });
 
   it('password only should throw', async () => {
@@ -60,7 +87,8 @@ describe('register payload guard', () => {
       },
     };
 
-    await expect(profileVerification(ctx, identifiers)).rejects.toThrow();
+    await expect(profileVerification(ctx, provider, interaction)).rejects.toThrow();
+    expect(storeInteractionResult).not.toBeCalled();
   });
 
   it('username password is valid', async () => {
@@ -75,7 +103,8 @@ describe('register payload guard', () => {
       },
     };
 
-    await expect(profileVerification(ctx, identifiers)).resolves.not.toThrow();
+    const result = await profileVerification(ctx, provider, interaction);
+    expect(result).toEqual({ ...interaction, profile: ctx.interactionPayload.profile });
   });
 
   it('username with a given email is valid', async () => {
@@ -90,7 +119,7 @@ describe('register payload guard', () => {
       },
     };
 
-    await expect(profileVerification(ctx, identifiers)).resolves.not.toThrow();
+    await expect(profileVerification(ctx, provider, interaction)).resolves.not.toThrow();
   });
 
   it('password with a given email is valid', async () => {
@@ -105,7 +134,7 @@ describe('register payload guard', () => {
       },
     };
 
-    await expect(profileVerification(ctx, identifiers)).resolves.not.toThrow();
+    await expect(profileVerification(ctx, provider, interaction)).resolves.not.toThrow();
   });
 });
 
@@ -124,12 +153,13 @@ describe('profile registered validation', () => {
       },
     };
 
-    await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+    await expect(profileVerification(ctx, provider, interaction)).rejects.toMatchError(
       new RequestError({
         code: 'user.username_exists_register',
         status: 422,
       })
     );
+    expect(storeInteractionResult).not.toBeCalled();
   });
 
   it('email is registered', async () => {
@@ -145,12 +175,13 @@ describe('profile registered validation', () => {
       },
     };
 
-    await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+    await expect(profileVerification(ctx, provider, interaction)).rejects.toMatchError(
       new RequestError({
         code: 'user.email_exists_register',
         status: 422,
       })
     );
+    expect(storeInteractionResult).not.toBeCalled();
   });
 
   it('phone is registered', async () => {
@@ -166,12 +197,13 @@ describe('profile registered validation', () => {
       },
     };
 
-    await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+    await expect(profileVerification(ctx, provider, interaction)).rejects.toMatchError(
       new RequestError({
         code: 'user.phone_exists_register',
         status: 422,
       })
     );
+    expect(storeInteractionResult).not.toBeCalled();
   });
 
   it('connector identity exist', async () => {
@@ -187,11 +219,12 @@ describe('profile registered validation', () => {
       },
     };
 
-    await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+    await expect(profileVerification(ctx, provider, interaction)).rejects.toMatchError(
       new RequestError({
         code: 'user.identity_exists',
         status: 422,
       })
     );
+    expect(storeInteractionResult).not.toBeCalled();
   });
 });

--- a/packages/core/src/routes/interaction/verifications/profile-verification-protected-identifier.test.ts
+++ b/packages/core/src/routes/interaction/verifications/profile-verification-protected-identifier.test.ts
@@ -1,10 +1,22 @@
 import { Event } from '@logto/schemas';
+import { Provider } from 'oidc-provider';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
 
 import type { Identifier, InteractionContext } from '../types/index.js';
+import { storeInteractionResult } from '../utils/interaction.js';
 import profileVerification from './profile-verification.js';
+
+jest.mock('oidc-provider', () => ({
+  Provider: jest.fn(() => ({
+    interactionDetails: jest.fn(async () => ({ params: {}, jti: 'jti' })),
+  })),
+}));
+
+jest.mock('../utils/interaction.js', () => ({
+  storeInteractionResult: jest.fn(),
+}));
 
 jest.mock('#src/queries/user.js', () => ({
   findUserById: jest.fn().mockResolvedValue({ id: 'foo' }),
@@ -21,6 +33,8 @@ jest.mock('#src/connectors/index.js', () => ({
 
 describe('profile protected identifier verification', () => {
   const baseCtx = createContextWithRouteParameters();
+  const interaction = { event: Event.SignIn, accountId: 'foo' };
+  const provider = new Provider('');
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -38,11 +52,10 @@ describe('profile protected identifier verification', () => {
         },
       };
 
-      const identifiers: Identifier[] = [{ key: 'accountId', value: 'foo' }];
-
-      await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+      await expect(profileVerification(ctx, provider, interaction)).rejects.toMatchError(
         new RequestError({ code: 'session.verification_session_not_found', status: 404 })
       );
+      expect(storeInteractionResult).not.toBeCalled();
     });
 
     it('email with unmatched identifier should throw', async () => {
@@ -56,13 +69,13 @@ describe('profile protected identifier verification', () => {
         },
       };
 
-      const identifiers: Identifier[] = [
-        { key: 'accountId', value: 'foo' },
-        { key: 'emailVerified', value: 'phone' },
-      ];
-      await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+      const identifiers: Identifier[] = [{ key: 'emailVerified', value: 'phone' }];
+      await expect(
+        profileVerification(ctx, provider, { ...interaction, identifiers })
+      ).rejects.toMatchError(
         new RequestError({ code: 'session.verification_session_not_found', status: 404 })
       );
+      expect(storeInteractionResult).not.toBeCalled();
     });
 
     it('email with proper identifier should not throw', async () => {
@@ -76,11 +89,19 @@ describe('profile protected identifier verification', () => {
         },
       };
 
-      const identifiers: Identifier[] = [
-        { key: 'accountId', value: 'foo' },
-        { key: 'emailVerified', value: 'email' },
-      ];
-      await expect(profileVerification(ctx, identifiers)).resolves.not.toThrow();
+      const identifiers: Identifier[] = [{ key: 'emailVerified', value: 'email' }];
+      await expect(
+        profileVerification(ctx, provider, { ...interaction, identifiers })
+      ).resolves.not.toThrow();
+      expect(storeInteractionResult).toBeCalledWith(
+        {
+          ...interaction,
+          identifiers,
+          profile: ctx.interactionPayload.profile,
+        },
+        ctx,
+        provider
+      );
     });
 
     it('phone without a verified identifier should throw', async () => {
@@ -94,11 +115,10 @@ describe('profile protected identifier verification', () => {
         },
       };
 
-      const identifiers: Identifier[] = [{ key: 'accountId', value: 'foo' }];
-
-      await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+      await expect(profileVerification(ctx, provider, interaction)).rejects.toMatchError(
         new RequestError({ code: 'session.verification_session_not_found', status: 404 })
       );
+      expect(storeInteractionResult).not.toBeCalled();
     });
 
     it('phone with unmatched identifier should throw', async () => {
@@ -112,13 +132,13 @@ describe('profile protected identifier verification', () => {
         },
       };
 
-      const identifiers: Identifier[] = [
-        { key: 'accountId', value: 'foo' },
-        { key: 'phoneVerified', value: 'email' },
-      ];
-      await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+      const identifiers: Identifier[] = [{ key: 'phoneVerified', value: 'email' }];
+      await expect(
+        profileVerification(ctx, provider, { ...interaction, identifiers })
+      ).rejects.toMatchError(
         new RequestError({ code: 'session.verification_session_not_found', status: 404 })
       );
+      expect(storeInteractionResult).not.toBeCalled();
     });
 
     it('phone with proper identifier should not throw', async () => {
@@ -132,11 +152,19 @@ describe('profile protected identifier verification', () => {
         },
       };
 
-      const identifiers: Identifier[] = [
-        { key: 'accountId', value: 'foo' },
-        { key: 'phoneVerified', value: 'phone' },
-      ];
-      await expect(profileVerification(ctx, identifiers)).resolves.not.toThrow();
+      const identifiers: Identifier[] = [{ key: 'phoneVerified', value: 'phone' }];
+      await expect(
+        profileVerification(ctx, provider, { ...interaction, identifiers })
+      ).resolves.not.toThrow();
+      expect(storeInteractionResult).toBeCalledWith(
+        {
+          ...interaction,
+          identifiers,
+          profile: ctx.interactionPayload.profile,
+        },
+        ctx,
+        provider
+      );
     });
 
     it('connectorId without a verified identifier should throw', async () => {
@@ -150,11 +178,14 @@ describe('profile protected identifier verification', () => {
         },
       };
 
-      const identifiers: Identifier[] = [{ key: 'accountId', value: 'foo' }];
+      const identifiers: Identifier[] = [{ key: 'emailVerified', value: 'foo@logto.io' }];
 
-      await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+      await expect(
+        profileVerification(ctx, provider, { ...interaction, identifiers })
+      ).rejects.toMatchError(
         new RequestError({ code: 'session.connector_session_not_found', status: 404 })
       );
+      expect(storeInteractionResult).not.toBeCalled();
     });
 
     it('connectorId with unmatched identifier should throw', async () => {
@@ -169,12 +200,14 @@ describe('profile protected identifier verification', () => {
       };
 
       const identifiers: Identifier[] = [
-        { key: 'accountId', value: 'foo' },
-        { key: 'social', connectorId: 'connectorId', value: { id: 'foo' } },
+        { key: 'social', connectorId: 'connectorId', userInfo: { id: 'foo' } },
       ];
-      await expect(profileVerification(ctx, identifiers)).rejects.toMatchError(
+      await expect(
+        profileVerification(ctx, provider, { ...interaction, identifiers })
+      ).rejects.toMatchError(
         new RequestError({ code: 'session.connector_session_not_found', status: 404 })
       );
+      expect(storeInteractionResult).not.toBeCalled();
     });
 
     it('connectorId with proper identifier should not throw', async () => {
@@ -190,10 +223,21 @@ describe('profile protected identifier verification', () => {
 
       const identifiers: Identifier[] = [
         { key: 'accountId', value: 'foo' },
-        { key: 'social', connectorId: 'logto', value: { id: 'foo' } },
+        { key: 'social', connectorId: 'logto', userInfo: { id: 'foo' } },
       ];
 
-      await expect(profileVerification(ctx, identifiers)).resolves.not.toThrow();
+      await expect(
+        profileVerification(ctx, provider, { ...interaction, identifiers })
+      ).resolves.not.toThrow();
+      expect(storeInteractionResult).toBeCalledWith(
+        {
+          ...interaction,
+          identifiers,
+          profile: ctx.interactionPayload.profile,
+        },
+        ctx,
+        provider
+      );
     });
   });
 });

--- a/packages/core/src/routes/interaction/verifications/user-identity-verification.test.ts
+++ b/packages/core/src/routes/interaction/verifications/user-identity-verification.test.ts
@@ -1,0 +1,268 @@
+import { Event } from '@logto/schemas';
+import { Provider } from 'oidc-provider';
+
+import RequestError from '#src/errors/RequestError/index.js';
+import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
+
+import type { PayloadVerifiedInteractionResult } from '../types/index.js';
+import findUserByIdentifier from '../utils/find-user-by-identifier.js';
+import { storeInteractionResult } from '../utils/interaction.js';
+import userIdentityVerification from './user-identity-verification.js';
+
+jest.mock('oidc-provider', () => ({
+  Provider: jest.fn(() => ({
+    interactionDetails: jest.fn(async () => ({ params: {}, jti: 'jti' })),
+  })),
+}));
+
+jest.mock('../utils/find-user-by-identifier.js', () => jest.fn());
+jest.mock('#src/lib/social.js', () => ({
+  findSocialRelatedUser: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('../utils/interaction.js', () => ({
+  ...jest.requireActual('../utils/interaction.js'),
+  storeInteractionResult: jest.fn(),
+}));
+
+describe('userIdentityVerification', () => {
+  const findUserByIdentifierMock = findUserByIdentifier as jest.Mock;
+
+  const ctx = createContextWithRouteParameters();
+  const provider = new Provider('');
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('empty identifiers with accountId', async () => {
+    const interaction: PayloadVerifiedInteractionResult = {
+      event: Event.SignIn,
+      accountId: 'foo',
+    };
+
+    const result = await userIdentityVerification(interaction, ctx, provider);
+
+    expect(storeInteractionResult).not.toBeCalled();
+    expect(result).toEqual(result);
+  });
+
+  it('empty identifiers withOut accountId should throw', async () => {
+    const interaction: PayloadVerifiedInteractionResult = {
+      event: Event.SignIn,
+    };
+
+    await expect(userIdentityVerification(interaction, ctx, provider)).rejects.toMatchError(
+      new RequestError({ code: 'session.unauthorized', status: 401 })
+    );
+    expect(storeInteractionResult).not.toBeCalled();
+  });
+
+  it('verify accountId identifier', async () => {
+    const interaction: PayloadVerifiedInteractionResult = {
+      event: Event.SignIn,
+      identifiers: [{ key: 'accountId', value: 'foo' }],
+    };
+
+    const result = await userIdentityVerification(interaction, ctx, provider);
+
+    expect(storeInteractionResult).toBeCalledWith(result, ctx, provider);
+    expect(result).toEqual({ event: Event.SignIn, accountId: 'foo', identifiers: [] });
+  });
+
+  it('verify emailVerified identifier', async () => {
+    findUserByIdentifierMock.mockResolvedValueOnce({ id: 'foo' });
+
+    const interaction: PayloadVerifiedInteractionResult = {
+      event: Event.SignIn,
+      identifiers: [{ key: 'emailVerified', value: 'email' }],
+    };
+
+    const result = await userIdentityVerification(interaction, ctx, provider);
+    expect(findUserByIdentifierMock).toBeCalledWith({ email: 'email' });
+    expect(storeInteractionResult).toBeCalledWith(result, ctx, provider);
+
+    expect(result).toEqual({ event: Event.SignIn, accountId: 'foo', identifiers: [] });
+  });
+
+  it('verify phoneVerified identifier', async () => {
+    findUserByIdentifierMock.mockResolvedValueOnce({ id: 'foo' });
+
+    const interaction: PayloadVerifiedInteractionResult = {
+      event: Event.SignIn,
+      identifiers: [{ key: 'phoneVerified', value: '123456' }],
+    };
+
+    const result = await userIdentityVerification(interaction, ctx, provider);
+    expect(findUserByIdentifierMock).toBeCalledWith({ phone: '123456' });
+    expect(storeInteractionResult).toBeCalledWith(result, ctx, provider);
+
+    expect(result).toEqual({ event: Event.SignIn, accountId: 'foo', identifiers: [] });
+  });
+
+  it('verify social identifier', async () => {
+    findUserByIdentifierMock.mockResolvedValueOnce({ id: 'foo' });
+
+    const interaction: PayloadVerifiedInteractionResult = {
+      event: Event.SignIn,
+      identifiers: [{ key: 'social', connectorId: 'connectorId', userInfo: { id: 'foo' } }],
+    };
+
+    const result = await userIdentityVerification(interaction, ctx, provider);
+    expect(findUserByIdentifierMock).toBeCalledWith({
+      connectorId: 'connectorId',
+      userInfo: { id: 'foo' },
+    });
+    expect(storeInteractionResult).toBeCalledWith(result, ctx, provider);
+
+    expect(result).toEqual({ event: Event.SignIn, accountId: 'foo', identifiers: [] });
+  });
+
+  it('verify social identifier user identity not exist', async () => {
+    findUserByIdentifierMock.mockResolvedValueOnce(null);
+
+    const interaction: PayloadVerifiedInteractionResult = {
+      event: Event.SignIn,
+      identifiers: [{ key: 'social', connectorId: 'connectorId', userInfo: { id: 'foo' } }],
+    };
+
+    await expect(userIdentityVerification(interaction, ctx, provider)).rejects.toMatchError(
+      new RequestError(
+        {
+          code: 'user.identity_not_exists',
+          status: 422,
+        },
+        null
+      )
+    );
+
+    expect(findUserByIdentifierMock).toBeCalledWith({
+      connectorId: 'connectorId',
+      userInfo: { id: 'foo' },
+    });
+
+    expect(storeInteractionResult).not.toBeCalled();
+  });
+
+  it('verify accountId and emailVerified identifier with same user', async () => {
+    findUserByIdentifierMock.mockResolvedValueOnce({ id: 'foo' });
+
+    const interaction: PayloadVerifiedInteractionResult = {
+      event: Event.SignIn,
+      identifiers: [
+        { key: 'accountId', value: 'foo' },
+        { key: 'emailVerified', value: 'email' },
+      ],
+    };
+
+    const result = await userIdentityVerification(interaction, ctx, provider);
+    expect(findUserByIdentifierMock).toBeCalledWith({ email: 'email' });
+    expect(storeInteractionResult).toBeCalledWith(result, ctx, provider);
+    expect(result).toEqual({ event: Event.SignIn, accountId: 'foo', identifiers: [] });
+  });
+
+  it('verify accountId and emailVerified identifier with email user not exist', async () => {
+    findUserByIdentifierMock.mockResolvedValueOnce(null);
+
+    const interaction: PayloadVerifiedInteractionResult = {
+      event: Event.SignIn,
+      identifiers: [
+        { key: 'accountId', value: 'foo' },
+        { key: 'emailVerified', value: 'email' },
+      ],
+    };
+
+    await expect(userIdentityVerification(interaction, ctx, provider)).rejects.toMatchError(
+      new RequestError({ code: 'user.user_not_exist', status: 404 })
+    );
+
+    expect(findUserByIdentifierMock).toBeCalledWith({ email: 'email' });
+    expect(storeInteractionResult).not.toBeCalled();
+  });
+
+  it('verify phoneVerified and emailVerified identifier with email user suspend', async () => {
+    findUserByIdentifierMock
+      .mockResolvedValueOnce({ id: 'foo' })
+      .mockResolvedValueOnce({ id: 'foo2', isSuspended: true });
+
+    const interaction: PayloadVerifiedInteractionResult = {
+      event: Event.SignIn,
+      identifiers: [
+        { key: 'emailVerified', value: 'email' },
+        { key: 'phoneVerified', value: '123456' },
+      ],
+    };
+
+    await expect(userIdentityVerification(interaction, ctx, provider)).rejects.toMatchError(
+      new RequestError({ code: 'user.suspended', status: 401 })
+    );
+
+    expect(findUserByIdentifierMock).toHaveBeenNthCalledWith(1, { email: 'email' });
+    expect(findUserByIdentifierMock).toHaveBeenNthCalledWith(2, { phone: '123456' });
+    expect(storeInteractionResult).not.toBeCalled();
+  });
+
+  it('verify phoneVerified and emailVerified identifier returns inconsistent id', async () => {
+    findUserByIdentifierMock
+      .mockResolvedValueOnce({ id: 'foo' })
+      .mockResolvedValueOnce({ id: 'foo2' });
+
+    const interaction: PayloadVerifiedInteractionResult = {
+      event: Event.SignIn,
+      identifiers: [
+        { key: 'emailVerified', value: 'email' },
+        { key: 'phoneVerified', value: '123456' },
+      ],
+    };
+
+    await expect(userIdentityVerification(interaction, ctx, provider)).rejects.toMatchError(
+      new RequestError('session.verification_failed')
+    );
+    expect(findUserByIdentifierMock).toHaveBeenNthCalledWith(1, { email: 'email' });
+    expect(findUserByIdentifierMock).toHaveBeenNthCalledWith(2, { phone: '123456' });
+    expect(storeInteractionResult).not.toBeCalled();
+  });
+
+  it('verify emailVerified identifier returns inconsistent id with existing accountId', async () => {
+    findUserByIdentifierMock.mockResolvedValueOnce({ id: 'foo' });
+
+    const interaction: PayloadVerifiedInteractionResult = {
+      event: Event.SignIn,
+      accountId: 'foo2',
+      identifiers: [{ key: 'emailVerified', value: 'email' }],
+    };
+
+    await expect(userIdentityVerification(interaction, ctx, provider)).rejects.toMatchError(
+      new RequestError('session.verification_failed')
+    );
+    expect(findUserByIdentifierMock).toBeCalledWith({ email: 'email' });
+    expect(storeInteractionResult).not.toBeCalled();
+  });
+
+  it('profile use identifier should remain', async () => {
+    findUserByIdentifierMock.mockResolvedValueOnce({ id: 'foo' });
+
+    const interaction: PayloadVerifiedInteractionResult = {
+      event: Event.SignIn,
+      identifiers: [
+        { key: 'emailVerified', value: 'email' },
+        { key: 'phoneVerified', value: '123456' },
+      ],
+      profile: {
+        phone: '123456',
+      },
+    };
+
+    const result = await userIdentityVerification(interaction, ctx, provider);
+    expect(findUserByIdentifierMock).toBeCalledWith({ email: 'email' });
+    expect(storeInteractionResult).toBeCalledWith(result, ctx, provider);
+    expect(result).toEqual({
+      event: Event.SignIn,
+      accountId: 'foo',
+      identifiers: [{ key: 'phoneVerified', value: '123456' }],
+      profile: {
+        phone: '123456',
+      },
+    });
+  });
+});

--- a/packages/core/src/routes/interaction/verifications/user-identity-verification.ts
+++ b/packages/core/src/routes/interaction/verifications/user-identity-verification.ts
@@ -1,5 +1,4 @@
 import { deduplicate } from '@silverhand/essentials';
-import type { Context } from 'koa';
 import type { Provider } from 'oidc-provider';
 
 import RequestError from '#src/errors/RequestError/index.js';
@@ -14,6 +13,7 @@ import type {
   PreAccountVerifiedInteractionResult,
   AccountVerifiedInteractionResult,
   Identifier,
+  InteractionContext,
 } from '../types/index.js';
 import findUserByIdentifier from '../utils/find-user-by-identifier.js';
 import { isProfileIdentifier } from '../utils/index.js';
@@ -76,11 +76,14 @@ const identifyUser = async (identifier: Identifier) => {
 
 export default async function userIdentityVerification(
   interaction: PreAccountVerifiedInteractionResult,
-  ctx: Context,
+  ctx: InteractionContext,
   provider: Provider
 ): Promise<AccountVerifiedInteractionResult> {
-  const { identifiers = [], profile, accountId } = interaction;
+  const { identifiers = [], accountId } = interaction;
+  // Need to merge the profile in payload
+  const profile = { ...interaction.profile, ...ctx.interactionPayload.profile };
 
+  // Filter all non-profile identifiers
   const userIdentifiers = identifiers.filter(
     (identifier) => !isProfileIdentifier(identifier, profile)
   );

--- a/packages/core/src/routes/interaction/verifications/user-identity-verification.ts
+++ b/packages/core/src/routes/interaction/verifications/user-identity-verification.ts
@@ -1,0 +1,125 @@
+import { deduplicate } from '@silverhand/essentials';
+import type { Context } from 'koa';
+import type { Provider } from 'oidc-provider';
+
+import RequestError from '#src/errors/RequestError/index.js';
+import { findSocialRelatedUser } from '#src/lib/social.js';
+import assertThat from '#src/utils/assert-that.js';
+import { maskUserInfo } from '#src/utils/format.js';
+
+import type {
+  SocialIdentifier,
+  VerifiedEmailIdentifier,
+  VerifiedPhoneIdentifier,
+  PreAccountVerifiedInteractionResult,
+  AccountVerifiedInteractionResult,
+  Identifier,
+} from '../types/index.js';
+import findUserByIdentifier from '../utils/find-user-by-identifier.js';
+import { isProfileIdentifier } from '../utils/index.js';
+import {
+  storeInteractionResult,
+  isAccountVerifiedInteractionResult,
+} from '../utils/interaction.js';
+
+const identifyUserByVerifiedPasscodeIdentifier = async (
+  identifier: VerifiedEmailIdentifier | VerifiedPhoneIdentifier
+) => {
+  const user = await findUserByIdentifier(
+    identifier.key === 'emailVerified' ? { email: identifier.value } : { phone: identifier.value }
+  );
+
+  assertThat(user, new RequestError({ code: 'user.user_not_exist', status: 404 }));
+
+  const { id, isSuspended } = user;
+
+  assertThat(!isSuspended, new RequestError({ code: 'user.suspended', status: 401 }));
+
+  return id;
+};
+
+const identifyUserBySocialIdentifier = async (identifier: SocialIdentifier) => {
+  const { connectorId, userInfo } = identifier;
+
+  const user = await findUserByIdentifier({ connectorId, userInfo });
+
+  if (!user) {
+    const relatedInfo = await findSocialRelatedUser(userInfo);
+
+    throw new RequestError(
+      {
+        code: 'user.identity_not_exists',
+        status: 422,
+      },
+      relatedInfo && { relatedUser: maskUserInfo(relatedInfo[0]) }
+    );
+  }
+
+  const { id, isSuspended } = user;
+
+  assertThat(!isSuspended, new RequestError({ code: 'user.suspended', status: 401 }));
+
+  return id;
+};
+
+const identifyUser = async (identifier: Identifier) => {
+  if (identifier.key === 'social') {
+    return identifyUserBySocialIdentifier(identifier);
+  }
+
+  if (identifier.key === 'accountId') {
+    return identifier.value;
+  }
+
+  return identifyUserByVerifiedPasscodeIdentifier(identifier);
+};
+
+export default async function userIdentityVerification(
+  interaction: PreAccountVerifiedInteractionResult,
+  ctx: Context,
+  provider: Provider
+): Promise<AccountVerifiedInteractionResult> {
+  const { identifiers = [], profile, accountId } = interaction;
+
+  const userIdentifiers = identifiers.filter(
+    (identifier) => !isProfileIdentifier(identifier, profile)
+  );
+
+  if (isAccountVerifiedInteractionResult(interaction) && userIdentifiers.length === 0) {
+    return interaction;
+  }
+
+  assertThat(
+    userIdentifiers.length > 0,
+    new RequestError({
+      code: 'session.unauthorized',
+      status: 401,
+    })
+  );
+
+  // Verify All non-profile identifiers
+  const accountIds = await Promise.all(
+    userIdentifiers.map(async (identifier) => identifyUser(identifier))
+  );
+
+  const deduplicateAccountIds = deduplicate(accountIds);
+
+  // Inconsistent identities
+  assertThat(
+    deduplicateAccountIds.length === 1 &&
+      deduplicateAccountIds[0] &&
+      (!accountId || accountId === deduplicateAccountIds[0]),
+    new RequestError('session.verification_failed')
+  );
+
+  // Assign verification result and filter out account verified identifiers
+  const verifiedInteraction: AccountVerifiedInteractionResult = {
+    ...interaction,
+    identifiers: identifiers.filter((identifier) => isProfileIdentifier(identifier, profile)),
+    accountId: deduplicateAccountIds[0],
+  };
+
+  await storeInteractionResult(verifiedInteraction, ctx, provider);
+
+  return verifiedInteraction;
+}

--- a/packages/phrases/src/locales/de/errors.ts
+++ b/packages/phrases/src/locales/de/errors.ts
@@ -78,6 +78,8 @@ const errors = {
     unauthorized: 'Bitte melde dich erst an.',
     unsupported_prompt_name: 'Nicht unterstützter prompt Name.',
     forgot_password_not_enabled: 'Forgot password is not enabled.',
+    verification_failed:
+      'Die Verifizierung war nicht erfolgreich. Starte die Verifizierung neu und versuche es erneut.',
   },
   connector: {
     // UNTRANSLATED

--- a/packages/phrases/src/locales/en/errors.ts
+++ b/packages/phrases/src/locales/en/errors.ts
@@ -78,6 +78,8 @@ const errors = {
     unauthorized: 'Please sign in first.',
     unsupported_prompt_name: 'Unsupported prompt name.',
     forgot_password_not_enabled: 'Forgot password is not enabled.',
+    verification_failed:
+      'The verification was not successful. Restart the verification flow and try again.',
   },
   connector: {
     general: 'An unexpected error occurred in connector.{{errorDescription}}',

--- a/packages/phrases/src/locales/fr/errors.ts
+++ b/packages/phrases/src/locales/fr/errors.ts
@@ -83,6 +83,8 @@ const errors = {
     unauthorized: "Veuillez vous enregistrer d'abord.",
     unsupported_prompt_name: "Nom d'invite non supporté.",
     forgot_password_not_enabled: 'Forgot password is not enabled.', // UNTRANSLATED
+    verification_failed:
+      'The verification was not successful. Restart the verification flow and try again.', // UNTRANSLATED
   },
   connector: {
     general: "Une erreur inattendue s'est produite dans le connecteur. {{errorDescription}}",

--- a/packages/phrases/src/locales/ko/errors.ts
+++ b/packages/phrases/src/locales/ko/errors.ts
@@ -77,6 +77,8 @@ const errors = {
     unauthorized: '로그인을 먼저 해주세요.',
     unsupported_prompt_name: '지원하지 않는 Prompt 이름이예요.',
     forgot_password_not_enabled: 'Forgot password is not enabled.', // UNTRANSLATED
+    verification_failed:
+      'The verification was not successful. Restart the verification flow and try again.', // UNTRANSLATED
   },
   connector: {
     general: '연동 중에 알 수 없는 오류가 발생했어요. {{errorDescription}}',

--- a/packages/phrases/src/locales/pt-pt/errors.ts
+++ b/packages/phrases/src/locales/pt-pt/errors.ts
@@ -79,6 +79,8 @@ const errors = {
     unauthorized: 'Faça login primeiro.',
     unsupported_prompt_name: 'Nome de prompt não suportado.',
     forgot_password_not_enabled: 'Forgot password is not enabled.', // UNTRANSLATED
+    verification_failed:
+      'The verification was not successful. Restart the verification flow and try again.', // UNTRANSLATED
   },
   connector: {
     general: 'Ocorreu um erro inesperado no conector.{{errorDescription}}',

--- a/packages/phrases/src/locales/tr-tr/errors.ts
+++ b/packages/phrases/src/locales/tr-tr/errors.ts
@@ -79,6 +79,8 @@ const errors = {
     unauthorized: 'Lütfen önce oturum açın.',
     unsupported_prompt_name: 'Desteklenmeyen prompt adı.',
     forgot_password_not_enabled: 'Forgot password is not enabled.', // UNTRANSLATED
+    verification_failed:
+      'The verification was not successful. Restart the verification flow and try again.', // UNTRANSLATED
   },
   connector: {
     general: 'Bağlayıcıda beklenmeyen bir hata oldu.{{errorDescription}}',

--- a/packages/phrases/src/locales/zh-cn/errors.ts
+++ b/packages/phrases/src/locales/zh-cn/errors.ts
@@ -75,6 +75,7 @@ const errors = {
     unauthorized: '请先登录',
     unsupported_prompt_name: '不支持的 prompt name',
     forgot_password_not_enabled: '忘记密码功能没有开启。',
+    verification_failed: '验证失败，请重新验证。',
   },
   connector: {
     general: '连接器发生未知错误{{errorDescription}}',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Refactor the interaction verification flow. Define a universal Interaction type data to be verified and manipulated cross the verification steps. 

Apologize for the massive PR size due to some file logic splits and test updates. Since they are truly hard to decouple. 

## Previous Implemented Design:
```js
route.put((ctx, provider) => {
// verify identifiers payload and try to locate the user account all at once
const verifiedIdentifiers = await identifierVerification(ctx, provider);

// verify profile payload 
const profile = await profileVerification(ctx, verifiedIdentifiers);

// verify required profiles
if (event !== Event.ForgotPassword) {
        await mandatoryUserProfileValidation(ctx, verifiedIdentifiers, profile);
      }
})
```

Problem:
1. We need to store the intermediate interaction status, (e.g. verified identifiers and profiles) if an exception is thrown at any steps. 
2. We need to merge the new verified interaction result with the previous existing interaction result in a PATCH request. In that case, we need to either pass in a merge tag into each verification method or throw the error out to the root scope and let the route handle the interaction save logic. Neither one is appropriate. 
3. The old `identifierVerification` method only verifies the new identifiers in the request payload but not the previously stored interaction identifiers.   e.g. the following case is miss verified
```
- PUT email + passcode register
- email profile verification failed. throw a user exist would you like to sign-in error
- store the `emailVerified` identifier in to the interaction result
- PATCH sign-in
- should load and verify the user account using the `emailVerified` identifier in the  interaction result session from the previous request
```

## Refactored Design
To make each verification step more precise and straight forward, we introduce the following basic concepts:

- Each verification method takes in an `interaction` object and returns an `interaction` object, but with part of the info verified with the given request payload.  e.g. identifiers and profiles.
-  Assign the intermediate verified interaction result after each step. (If any following verification failed, all the previous verified data will be properly kept.)


Based on the above assumptions, this PR includes the following updates:

| file | function | description |
| --- | -------- | ----------- |
| `/types/index` |  Interaction Types |  Defines all the intermediate interaction storage data type |
| `/utils/interactions/` | storeInteractionResult  | store our interaction result, this is a shallow merge of `event`, `identifiers` and `profile` |
| `/utils/interactions/` |  mergeIdentifiers | Deep merge all the identifiers. As currently, we only allow a single identifier instance for each different type. |
| `/verification/identifier-payload-verification` | identifierPayloadVerification |  Split from the original identifier verification method. Which only verify the identifier payload.  <br/>`password-identifier`-> `accountId identifier`, <br/> `passcode-identifier` -> `emailVerified or phoneVerified`, <br/> `social, data` -> `social user identifier`   <br/>  All verified identifiers will be stored in the interaction, and a `PayloadVerifiedInteractionResult` should be returned | 
| `/verification/user-identity-verification` | userIdentityVerification | Second step split from the original identifier verification method. Take all the verified identifiers, and verify the user's identity. Identifiers for the profile validation will be ignored.  A unique accountId will be verified. A `AccountIdVerifiedVerificationResult` should be store and returned. |
| `/verification/identifier-verification/` | identifierVerification |  The upper scope method, that capsulate the  previous two steps. `identifierPayloadVerification` + `userIdentityVerification`.  Only `SignIn` and `ForgotPassword` event type will go through the userIdentityVerification. The returned `IdentifierVerifiedInteractionResult` be a  `AccountIdVerifiedVerificationResult` for `SignIn` and `ForgotPassword` event or a `PayloadVerifiedInteractionResult` for `register` event  |
| `/verification/profile-verification` |.profileVerification  | Takes in the `IdentifierVerifiedInteractionResult` and verifies the merged profile from the request payload and interaction result. The logic behind remains still.  The old `findUserByIdentifier` is removed, as we verified the accountId for `SignIn` and `Forgotpassword` from the previous steps already.  A `ProfileVerifiedInteractionResult` with be stored and returned. |
| `/verification/mandatory-profile-validation` |  mandatoryUserProfileValidation  | Remine still, except takes in a standard `ProfileVerifiedInteractionResult` type as its input |


After the refactor, the interaction request flow would be like
<img width="585" alt="image" src="https://user-images.githubusercontent.com/36393111/205450895-3ed629f0-ae28-44ba-9de0-472476568aa6.png">



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT case updated and tested 
