### PR TITLE
style(console): set the `TabNavItem` text color to neutral-30

### DIFF
--- a/packages/console/src/components/TabNav/TabNavItem.module.scss
+++ b/packages/console/src/components/TabNav/TabNavItem.module.scss
@@ -16,7 +16,7 @@
 
     a {
       display: inline-block;
-      color: var(--color-text-secondary);
+      color: var(--color-neutral-30);
       text-decoration: none;
       cursor: pointer;
     }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
According to the design file, set the `TabNavItem` text color to neutral-30.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Before
<img width="289" alt="image" src="https://user-images.githubusercontent.com/10806653/205572401-f6efadf3-6357-4e4a-ac8e-5a42e5c84047.png">

### After
<img width="264" alt="image" src="https://user-images.githubusercontent.com/10806653/205572470-ebd4818e-3def-4371-98a5-156771c9bc7b.png">

