### PR TITLE
refactor(console): extract toggle tip logic into a `ToggleTipButton` component

### DIFF
--- a/packages/console/src/components/ToggleTipButton/index.module.scss
+++ b/packages/console/src/components/ToggleTipButton/index.module.scss
@@ -1,0 +1,19 @@
+@use '@/scss/underscore' as _;
+
+.toggleTipButton {
+  border-radius: 4px;
+  padding: _.unit(1);
+
+  .icon {
+    > svg {
+      display: block;
+      cursor: pointer;
+      width: 16px;
+      height: 16px;
+    }
+  }
+
+  &:hover {
+    background: var(--color-hover);
+  }
+}

--- a/packages/console/src/components/ToggleTipButton/index.tsx
+++ b/packages/console/src/components/ToggleTipButton/index.tsx
@@ -1,0 +1,59 @@
+import classNames from 'classnames';
+import type { ReactElement } from 'react';
+import { useRef, useState } from 'react';
+
+import Tip from '@/assets/images/tip.svg';
+import type { HorizontalAlignment } from '@/hooks/use-position';
+import { onKeyDownHandler } from '@/utilities/a11y';
+
+import type { TipBubblePosition } from '../TipBubble';
+import ToggleTip from '../ToggleTip';
+import * as styles from './index.module.scss';
+
+type Props = {
+  render: (closeTipHandler: () => void) => ReactElement;
+  className?: string;
+  tipPosition?: TipBubblePosition;
+  tipHorizontalAlignment?: HorizontalAlignment;
+};
+
+const ToggleTipButton = ({ render, className, tipPosition, tipHorizontalAlignment }: Props) => {
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const [isTipOpen, setIsTipOpen] = useState(false);
+
+  const closeTipHandler = () => {
+    setIsTipOpen(false);
+  };
+
+  return (
+    <div className={classNames(styles.toggleTipButton, className)}>
+      <div
+        ref={anchorRef}
+        role="tab"
+        tabIndex={0}
+        className={styles.icon}
+        onClick={() => {
+          setIsTipOpen(true);
+        }}
+        onKeyDown={onKeyDownHandler(() => {
+          setIsTipOpen(true);
+        })}
+      >
+        <Tip />
+      </div>
+      <ToggleTip
+        isOpen={isTipOpen}
+        anchorRef={anchorRef}
+        position={tipPosition}
+        horizontalAlign={tipHorizontalAlignment}
+        onClose={() => {
+          setIsTipOpen(false);
+        }}
+      >
+        {render(closeTipHandler)}
+      </ToggleTip>
+    </div>
+  );
+};
+
+export default ToggleTipButton;

--- a/packages/console/src/pages/Connectors/components/ConnectorStatusField/index.module.scss
+++ b/packages/console/src/pages/Connectors/components/ConnectorStatusField/index.module.scss
@@ -3,14 +3,9 @@
 .field {
   display: flex;
   align-items: center;
-}
 
-.tipIcon {
-  margin-left: _.unit(1);
-
-  > svg {
-    display: block;
-    cursor: pointer;
+  .tipButton {
+    margin-left: _.unit(1);
   }
 }
 

--- a/packages/console/src/pages/Connectors/components/ConnectorStatusField/index.tsx
+++ b/packages/console/src/pages/Connectors/components/ConnectorStatusField/index.tsx
@@ -1,62 +1,42 @@
-import { useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 
-import Tip from '@/assets/images/tip.svg';
-import ToggleTip from '@/components/ToggleTip';
-import { onKeyDownHandler } from '@/utilities/a11y';
+import ToggleTipButton from '@/components/ToggleTipButton';
 
 import * as styles from './index.module.scss';
 
 const ConnectorStatusField = () => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
-  const [isTipOpen, setIsTipOpen] = useState(false);
-  const anchorRef = useRef<HTMLDivElement>(null);
 
   return (
     <div className={styles.field}>
       {t('connectors.connector_status')}
-      <div ref={anchorRef} className={styles.tipIcon}>
-        <Tip
-          tabIndex={0}
-          onClick={() => {
-            setIsTipOpen(true);
-          }}
-          onKeyDown={onKeyDownHandler(() => {
-            setIsTipOpen(true);
-          })}
-        />
-      </div>
-      <ToggleTip
-        isOpen={isTipOpen}
-        anchorRef={anchorRef}
-        position="top"
-        horizontalAlign="center"
-        onClose={() => {
-          setIsTipOpen(false);
-        }}
-      >
-        <div className={styles.title}>{t('connectors.connector_status')}</div>
-        <div className={styles.content}>
-          <Trans
-            components={{
-              a: (
-                <Link
-                  to="/sign-in-experience/sign-up-and-sign-in"
-                  target="_blank"
-                  onClick={() => {
-                    setIsTipOpen(false);
-                  }}
-                />
-              ),
-            }}
-          >
-            {t('connectors.not_in_use_tip.content', {
-              link: t('connectors.not_in_use_tip.go_to_sie'),
-            })}
-          </Trans>
-        </div>
-      </ToggleTip>
+      <ToggleTipButton
+        tipHorizontalAlignment="center"
+        className={styles.tipButton}
+        render={(closeTipHandler) => (
+          <>
+            <div className={styles.title}>{t('connectors.connector_status')}</div>
+            <div className={styles.content}>
+              <Trans
+                components={{
+                  a: (
+                    <Link
+                      to="/sign-in-experience/sign-up-and-sign-in"
+                      target="_blank"
+                      onClick={closeTipHandler}
+                    />
+                  ),
+                }}
+              >
+                {t('connectors.not_in_use_tip.content', {
+                  link: t('connectors.not_in_use_tip.go_to_sie'),
+                })}
+              </Trans>
+            </div>
+          </>
+        )}
+      />
     </div>
   );
 };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
According to the new design standard, we need to replace all info tooltips with toggle tips and add a hover state to the toggle tip button.

So we added a `ToggleTipButton` component to extract related logic, and we will share this component in the future PR which will replace old tooltips.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Hover state:
<img width="344" alt="image" src="https://user-images.githubusercontent.com/10806653/205602238-e62a968c-2a8c-4c37-ab67-6cd1a2978d21.png">

### Work as expected
<img width="386" alt="image" src="https://user-images.githubusercontent.com/10806653/205602560-c0d17209-f864-4034-932f-964cad163057.png">


