### PR TITLE
style(console): skeletons should not overlap the table header

### DIFF
--- a/packages/console/src/scss/table.module.scss
+++ b/packages/console/src/scss/table.module.scss
@@ -27,6 +27,7 @@ tr.clickable {
       background: var(--color-layer-1);
       position: sticky;
       top: 0;
+      z-index: 1;
     }
 
     tbody {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
style(console): skeletons should not overlap the table header

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Before
<img width="780" alt="image" src="https://user-images.githubusercontent.com/10806653/205808083-86df8ea2-6610-4364-a71d-3ac1f23ee6cd.png">

### After
<img width="1589" alt="image" src="https://user-images.githubusercontent.com/10806653/205808113-5a84ddd4-f254-4b6d-b02f-d1c845c5ce44.png">

