### PR TITLE
feat(core): add the bind social identifier type

### DIFF
--- a/packages/core/src/routes/interaction/types/guard.ts
+++ b/packages/core/src/routes/interaction/types/guard.ts
@@ -56,6 +56,7 @@ export const getSocialAuthorizationUrlPayloadGuard = z.object({
   state: z.string(),
   redirectUri: z.string().refine((url) => validateRedirectUrl(url, 'web')),
 });
+
 // Register Profile Guard
 const emailProfileGuard = emailPasscodePayloadGuard.pick({ email: true });
 const phoneProfileGuard = phonePasscodePayloadGuard.pick({ phone: true });

--- a/packages/core/src/routes/interaction/utils/index.ts
+++ b/packages/core/src/routes/interaction/utils/index.ts
@@ -16,7 +16,8 @@ export const isPasscodeIdentifier = (
 
 export const isSocialIdentifier = (
   identifier: IdentifierPayload
-): identifier is SocialConnectorPayload => 'connectorId' in identifier;
+): identifier is SocialConnectorPayload =>
+  'connectorId' in identifier && 'connectorData' in identifier;
 
 export const isProfileIdentifier = (identifier: Identifier, profile?: Profile) => {
   if (identifier.key === 'accountId') {

--- a/packages/schemas/src/types/interactions.ts
+++ b/packages/schemas/src/types/interactions.ts
@@ -41,6 +41,12 @@ export const socialConnectorPayloadGuard = z.object({
 });
 export type SocialConnectorPayload = z.infer<typeof socialConnectorPayloadGuard>;
 
+export const socialIdentityPayloadGuard = z.object({
+  connectorId: z.string(),
+  identityType: z.union([z.literal('phone'), z.literal('email')]),
+});
+export type SocialIdentityPayload = z.infer<typeof socialIdentityPayloadGuard>;
+
 /**
  * Interaction Payload Guard
  */
@@ -59,6 +65,7 @@ export const identifierPayloadGuard = z.union([
   emailPasscodePayloadGuard,
   phonePasscodePayloadGuard,
   socialConnectorPayloadGuard,
+  socialIdentityPayloadGuard,
 ]);
 
 export type IdentifierPayload =
@@ -67,7 +74,8 @@ export type IdentifierPayload =
   | PhonePasswordPayload
   | EmailPasscodePayload
   | PhonePasscodePayload
-  | SocialConnectorPayload;
+  | SocialConnectorPayload
+  | SocialIdentityPayload;
 
 export const profileGuard = z.object({
   username: z.string().regex(usernameRegEx).optional(),


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
add the missing part bind social identifier type.

This is needed to cover the bind-related account with the social flow. 

1. user sign-in with social connector
2. social identity verified and returns a social identity with id and email 
3. logto user can't not be located using the verified social identity id.
4. Find a related user account with email same as the verified social identity email
5. An account not exist error is thrown with related account info
6. User is able to sign in with the social verified email identity and bind the social account directly. 

payload: {connectorId, identityType: email | phone}

if no social identifier with the required `identityType` in its userInfo is found, a connector session not fount error should throw. 




<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

UT case provided
