### PR TITLE
Revert "style(console): skeletons should not overlap the table header"

### DIFF
--- a/packages/console/src/scss/table.module.scss
+++ b/packages/console/src/scss/table.module.scss
@@ -27,7 +27,6 @@ tr.clickable {
       background: var(--color-layer-1);
       position: sticky;
       top: 0;
-      z-index: 1;
     }
 
     tbody {


### PR DESCRIPTION
Reverts logto-io/logto#2592
This fix caused another bug:
<img width="443" alt="image" src="https://user-images.githubusercontent.com/10806653/205862224-5d14ab63-f8fb-4cb3-849f-63c4a0014f13.png">

And the root solution is that we should scroll the table to the top when the page number changes.