### PR TITLE
fix: should block add of social connector when original target and platform exists

### DIFF
--- a/packages/core/src/routes/connector.ts
+++ b/packages/core/src/routes/connector.ts
@@ -138,13 +138,16 @@ export default function connectorRoutes<T extends AuthedRouter>(router: T) {
         })
       );
 
-      if (body.metadata?.target && connectorFactory.type === ConnectorType.Social) {
+      if (connectorFactory.type === ConnectorType.Social) {
         const connectors = await getLogtoConnectors();
+        const connectorTarget = body.metadata?.target ?? connectorFactory.metadata.target;
         assertThat(
-          !connectors.some(
-            ({ metadata: { target, platform } }) =>
-              target === body.metadata?.target && platform === connectorFactory.metadata.platform
-          ),
+          !connectors
+            .filter(({ type }) => type === ConnectorType.Social)
+            .some(
+              ({ metadata: { target, platform } }) =>
+                target === connectorTarget && platform === connectorFactory.metadata.platform
+            ),
           new RequestError({ code: 'connector.multiple_target_with_same_platform', status: 422 })
         );
       }


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
should block add of social connector when original target and platform exists.
The add of non-standar social connector does not check the target+platform conflicting, which is not right.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Passed ITs and UTs.
Also tested locally.
<img width="1456" alt="image" src="https://user-images.githubusercontent.com/15182327/206202634-584233f5-0e21-4e40-afbc-a301918fc24b.png">
<img width="1800" alt="image" src="https://user-images.githubusercontent.com/15182327/206202409-0202d5a4-ef09-4961-8dad-8fc68537e25e.png">
