### PR TITLE
feat(core): allow set primaryPhone in post user admin api

### DIFF
--- a/packages/core/src/routes/admin-user.test.ts
+++ b/packages/core/src/routes/admin-user.test.ts
@@ -129,11 +129,11 @@ describe('adminUserRoutes', () => {
     const username = 'MJAtLogto';
     const password = 'PASSWORD';
     const name = 'Michael';
-    const primaryEmail = 'foo@logto.io';
+    const { primaryEmail, primaryPhone } = mockUser;
 
     const response = await userRequest
       .post('/users')
-      .send({ primaryEmail, username, password, name });
+      .send({ primaryEmail, primaryPhone, username, password, name });
     expect(response.status).toEqual(200);
     expect(response.body).toEqual({
       ...mockUserResponse,


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Context:
Trying to implement user creation util method for integration test use. Notice our admin-user management API post new user only accepts username and email as user identifiers. Should allow to set phone as well. Align with the PATCH method. 

Allow set primaryPhone in post user admin API


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

UT case updated