### PR TITLE
style(console): fix dropdown title text ellipsis

### DIFF
--- a/packages/console/src/components/Select/index.module.scss
+++ b/packages/console/src/components/Select/index.module.scss
@@ -15,9 +15,10 @@
   font: var(--font-body-medium);
   cursor: pointer;
   position: relative;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+
+  .title {
+    @include _.text-ellipsis;
+  }
 
   &.open {
     border-color: var(--color-primary);

--- a/packages/console/src/components/Select/index.tsx
+++ b/packages/console/src/components/Select/index.tsx
@@ -80,7 +80,7 @@ const Select = <T extends string>({
           }
         }}
       >
-        {current?.title ?? placeholder}
+        <div className={styles.title}>{current?.title ?? placeholder}</div>
         {isClearable && (
           <IconButton
             className={classNames(styles.icon, styles.clear)}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
the select title text ellipsis rule should apply to the title not the whole component.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Before
<img width="330" alt="image" src="https://user-images.githubusercontent.com/10806653/206664020-20fdeee8-1cc7-4b1d-aa6d-4c37c00aa989.png">

### After
<img width="315" alt="image" src="https://user-images.githubusercontent.com/10806653/206664105-5a1c31f8-c715-485d-817f-4b104d210634.png">

