### PR TITLE
refactor(console): `TabNavItem` props type

### DIFF
--- a/packages/console/src/components/TabNav/TabNavItem.tsx
+++ b/packages/console/src/components/TabNav/TabNavItem.tsx
@@ -6,13 +6,23 @@ import { onKeyDownHandler } from '@/utilities/a11y';
 
 import * as styles from './TabNavItem.module.scss';
 
-type Props = {
-  href?: string;
+type BaseProps = {
   isActive?: boolean;
   errorCount?: number;
-  onClick?: () => void;
   children: React.ReactNode;
 };
+
+type LinkStyleProps = {
+  href: string;
+};
+
+type TabStyleProps = {
+  onClick: () => void;
+};
+
+type Props =
+  | (BaseProps & LinkStyleProps & Partial<Record<keyof TabStyleProps, undefined>>)
+  | (BaseProps & TabStyleProps & Partial<Record<keyof LinkStyleProps, undefined>>);
 
 const TabNavItem = ({ children, href, isActive, errorCount = 0, onClick }: Props) => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
the `TabNavItem` component has to style:
1. link style, which will receive a `href` prop
2. tab style, which will receive an `onClick` prop

Refactor the `TabNavItem` props type to limit the props; we can only pass a `href` or an `onClick`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
```js
<TabNavItem href="test">Test</TabNavItem> // success

<TabNavItem onClick={() => { console.log('test'); }}>Test</TabNavItem> // success

<TabNavItem href="test" onClick={() => { console.log('test'); }}>Test</TabNavItem> // type error

<TabNavItem>Test</TabNavItem> // type error
```
![image](https://user-images.githubusercontent.com/10806653/206677812-f647e10e-2f08-44a5-8667-7502d570dc2f.png)
