### PR TITLE
refactor(console): add a11y to the `SenderTester`

### DIFF
--- a/packages/console/src/pages/ConnectorDetails/components/SenderTester/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/components/SenderTester/index.tsx
@@ -12,6 +12,7 @@ import FormField from '@/components/FormField';
 import TextInput from '@/components/TextInput';
 import { Tooltip } from '@/components/Tip';
 import useApi from '@/hooks/use-api';
+import { onKeyDownHandler } from '@/utilities/a11y';
 import { safeParseJson } from '@/utilities/json';
 
 import * as styles from './index.module.scss';
@@ -91,6 +92,7 @@ const SenderTester = ({ connectorId, connectorType, config, className }: Props) 
                 ? t('connector_details.test_sms_placeholder')
                 : t('connector_details.test_email_placeholder')
             }
+            onKeyDown={onKeyDownHandler({ Enter: onSubmit })}
             {...register('sendTo', {
               required: true,
               pattern: {

--- a/packages/console/src/utilities/a11y.ts
+++ b/packages/console/src/utilities/a11y.ts
@@ -15,7 +15,11 @@ export const onKeyDownHandler =
     }
 
     if (typeof callback === 'object') {
-      callback[key]?.(event);
-      event.preventDefault();
+      const handler = callback[key];
+
+      if (handler) {
+        handler(event);
+        event.preventDefault();
+      }
     }
   };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Now, we can hit `Enter` to send test messages to the target account.

- Fix(console): the `onKeyDownHandler` should not block unregistered event key input.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Hit `Enter` and the POST request is made.
<img width="857" alt="image" src="https://user-images.githubusercontent.com/10806653/206996597-6449e77e-7bc8-4127-8d09-413d460cd9b3.png">

