### PR TITLE
fix(console): align the preview background color with the ui page

### DIFF
--- a/packages/console/src/pages/SignInExperience/components/Preview/index.tsx
+++ b/packages/console/src/pages/SignInExperience/components/Preview/index.tsx
@@ -194,7 +194,7 @@ const Preview = ({ signInExperience, className }: Props) => {
         style={conditional(
           platform === 'desktopWeb' && {
             // Set background color to match iframe's background color on both dark and light mode.
-            backgroundColor: mode === AppearanceMode.DarkMode ? '#2A2C31' : '#e5e1ec',
+            backgroundColor: mode === AppearanceMode.DarkMode ? '#000' : '#e5e1ec',
           }
         )}
       >


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Align the preview background color with the UI page, for the UI page's background has been updated.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Before
<img width="624" alt="image" src="https://user-images.githubusercontent.com/10806653/207007831-a22d4952-4677-4f5c-b0c7-11c86abb3890.png">

### After
<img width="622" alt="image" src="https://user-images.githubusercontent.com/10806653/207007575-05a130dd-906a-4eb9-a06b-2c2cb3f6b82a.png">

