### PR TITLE
refactor(console): keep pagination when the table is loading

### DIFF
--- a/packages/console/src/components/AuditLogTable/index.tsx
+++ b/packages/console/src/components/AuditLogTable/index.tsx
@@ -145,7 +145,7 @@ const AuditLogTable = ({ userId }: Props) => {
       </div>
       <Pagination
         pageIndex={pageIndex}
-        totalCount={totalCount ?? 0}
+        totalCount={totalCount}
         pageSize={pageSize}
         className={styles.pagination}
         onChange={(page) => {

--- a/packages/console/src/components/Pagination/index.tsx
+++ b/packages/console/src/components/Pagination/index.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import { useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import ReactPaginate from 'react-paginate';
 
@@ -10,7 +11,7 @@ import * as styles from './index.module.scss';
 
 type Props = {
   pageIndex: number;
-  totalCount: number;
+  totalCount?: number;
   pageSize: number;
   className?: string;
   onChange?: (pageIndex: number) => void;
@@ -18,19 +19,41 @@ type Props = {
 
 const Pagination = ({ pageIndex, totalCount, pageSize, className, onChange }: Props) => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
-  const pageCount = Math.ceil(totalCount / pageSize);
+
+  /**
+   * Note:
+   * The `totalCount` will become `undefined` temporarily when fetching data on page changes, and this causes the pagination to disappear.
+   * Cache `totalCount` to solve this problem.
+   */
+  const totalCountRef = useRef(totalCount);
+  const cachedTotalCount = useMemo(() => {
+    if (totalCount === undefined) {
+      if (totalCountRef.current === undefined) {
+        return 0;
+      }
+
+      return totalCountRef.current;
+    }
+
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    totalCountRef.current = totalCount;
+
+    return totalCount;
+  }, [totalCount]);
+
+  const pageCount = Math.ceil(cachedTotalCount / pageSize);
 
   if (pageCount <= 1) {
     return null;
   }
 
   const min = (pageIndex - 1) * pageSize + 1;
-  const max = Math.min(pageIndex * pageSize, totalCount);
+  const max = Math.min(pageIndex * pageSize, cachedTotalCount);
 
   return (
     <div className={classNames(styles.container, className)}>
       <div className={styles.positionInfo}>
-        {t('general.page_info', { min, max, total: totalCount })}
+        {t('general.page_info', { min, max, total: cachedTotalCount })}
       </div>
       <ReactPaginate
         className={styles.pagination}

--- a/packages/console/src/components/Pagination/index.tsx
+++ b/packages/console/src/components/Pagination/index.tsx
@@ -1,7 +1,8 @@
 import classNames from 'classnames';
-import { useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import ReactPaginate from 'react-paginate';
+
+import useCacheValue from '@/hooks/use-cache-value';
 
 import Button from '../Button';
 import DangerousRaw from '../DangerousRaw';
@@ -25,21 +26,7 @@ const Pagination = ({ pageIndex, totalCount, pageSize, className, onChange }: Pr
    * The `totalCount` will become `undefined` temporarily when fetching data on page changes, and this causes the pagination to disappear.
    * Cache `totalCount` to solve this problem.
    */
-  const totalCountRef = useRef(totalCount);
-  const cachedTotalCount = useMemo(() => {
-    if (totalCount === undefined) {
-      if (totalCountRef.current === undefined) {
-        return 0;
-      }
-
-      return totalCountRef.current;
-    }
-
-    // eslint-disable-next-line @silverhand/fp/no-mutation
-    totalCountRef.current = totalCount;
-
-    return totalCount;
-  }, [totalCount]);
+  const cachedTotalCount = useCacheValue(totalCount) ?? 0;
 
   const pageCount = Math.ceil(cachedTotalCount / pageSize);
 

--- a/packages/console/src/hooks/use-cache-value.ts
+++ b/packages/console/src/hooks/use-cache-value.ts
@@ -1,16 +1,15 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useState } from 'react';
 
 const useCacheValue = <T>(value: T) => {
-  const cachedValue = useRef<T>();
+  const [cachedValue, setCachedValue] = useState<T>();
 
   useEffect(() => {
     if (value !== undefined) {
-      // eslint-disable-next-line @silverhand/fp/no-mutation
-      cachedValue.current = value;
+      setCachedValue(value);
     }
-  }, [value, cachedValue]);
+  }, [value, setCachedValue]);
 
-  return cachedValue.current;
+  return cachedValue;
 };
 
 export default useCacheValue;

--- a/packages/console/src/hooks/use-cache-value.ts
+++ b/packages/console/src/hooks/use-cache-value.ts
@@ -7,7 +7,7 @@ const useCacheValue = <T>(value: T) => {
     if (value !== undefined) {
       setCachedValue(value);
     }
-  }, [value, setCachedValue]);
+  }, [value]);
 
   return cachedValue;
 };

--- a/packages/console/src/hooks/use-cache-value.ts
+++ b/packages/console/src/hooks/use-cache-value.ts
@@ -1,0 +1,16 @@
+import { useEffect, useRef } from 'react';
+
+const useCacheValue = <T>(value: T) => {
+  const cachedValue = useRef<T>();
+
+  useEffect(() => {
+    if (value !== undefined) {
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      cachedValue.current = value;
+    }
+  }, [value, cachedValue]);
+
+  return cachedValue.current;
+};
+
+export default useCacheValue;

--- a/packages/console/src/pages/ApiResources/index.tsx
+++ b/packages/console/src/pages/ApiResources/index.tsx
@@ -145,7 +145,7 @@ const ApiResources = () => {
       </div>
       <Pagination
         pageIndex={pageIndex}
-        totalCount={totalCount ?? 0}
+        totalCount={totalCount}
         pageSize={pageSize}
         className={styles.pagination}
         onChange={(page) => {

--- a/packages/console/src/pages/Applications/index.tsx
+++ b/packages/console/src/pages/Applications/index.tsx
@@ -137,7 +137,7 @@ const Applications = () => {
       </div>
       <Pagination
         pageIndex={pageIndex}
-        totalCount={totalCount ?? 0}
+        totalCount={totalCount}
         pageSize={pageSize}
         className={styles.pagination}
         onChange={(page) => {

--- a/packages/console/src/pages/Users/index.tsx
+++ b/packages/console/src/pages/Users/index.tsx
@@ -164,7 +164,7 @@ const Users = () => {
       </div>
       <Pagination
         pageIndex={pageIndex}
-        totalCount={totalCount ?? 0}
+        totalCount={totalCount}
         pageSize={pageSize}
         className={styles.pagination}
         onChange={(page) => {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Bug: the pagination is disappeared when the table is loading.

Root cause:
The `totalCount` will become `undefined` when fetching data on page changes, and this causes the pagination to disappear.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Before
<img width="1213" alt="image" src="https://user-images.githubusercontent.com/10806653/207281091-08e034a1-a22c-4b3a-95c4-a0ad0aca378d.png">

### After
![image](https://user-images.githubusercontent.com/10806653/207280744-b6f51202-fdff-4dee-8de9-572dad2d122c.png)

