### PR TITLE
refactor(schemas): remove eslint in generate script

### DIFF
--- a/packages/schemas/generate.sh
+++ b/packages/schemas/generate.sh
@@ -4,4 +4,3 @@ rm -rf lib/
 pnpm exec tsc -p tsconfig.build.gen.json
 rm -rf src/db-entries
 node lib/index.js
-pnpm exec eslint src/db-entries/** --fix

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -55,6 +55,7 @@
     "rules": {
       "@typescript-eslint/ban-types": "off"
     },
+    "ignorePatterns": ["src/db-entries/"],
     "overrides": [
       {
         "files": [

--- a/packages/schemas/src/gen/schema.ts
+++ b/packages/schemas/src/gen/schema.ts
@@ -51,7 +51,7 @@ export const generateSchema = ({ name, fields }: TableWithType) => {
         )},`;
       }
     ),
-    '  });',
+    '});',
     '',
     `const guard: Guard<${modelName}> = z.object({`,
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

as we don't commit the generated files, we also don't care that much about the format. it's already readable.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

10x faster for generate script alone. good for `prepack` script (tons of execution) as well.

<img width="713" alt="image" src="https://user-images.githubusercontent.com/14722250/207670590-6c2855b4-33cf-4bd4-bce3-8410e2099d00.png">
