### PR TITLE
refactor(console): share constant string values between pages

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -45,6 +45,7 @@
     "@types/react-dom": "^18.0.0",
     "@types/react-modal": "^3.13.1",
     "@types/react-syntax-highlighter": "^15.5.1",
+    "camelcase": "^7.0.0",
     "classnames": "^2.3.1",
     "clean-deep": "^3.4.0",
     "cross-env": "^7.0.3",

--- a/packages/console/src/App.tsx
+++ b/packages/console/src/App.tsx
@@ -32,6 +32,7 @@ import Users from '@/pages/Users';
 import Welcome from '@/pages/Welcome';
 
 import { ConnectorsTabs, SignInExperienceTabs, UserTabs } from './consts/page-tabs';
+import { Page } from './consts/pathnames';
 import { getBasename } from './utilities/router';
 
 void initI18n();
@@ -45,44 +46,44 @@ const Main = () => {
         <AppBoundary>
           <Toast />
           <Routes>
-            <Route path="callback" element={<Callback />} />
-            <Route path="welcome" element={<Welcome />} />
+            <Route path={Page.Callback} element={<Callback />} />
+            <Route path={Page.Welcome} element={<Welcome />} />
             <Route element={<AppContent />}>
               <Route path="*" element={<NotFound />} />
-              <Route path="get-started" element={<GetStarted />} />
-              <Route path="applications">
+              <Route path={Page.GetStarted} element={<GetStarted />} />
+              <Route path={Page.Applications}>
                 <Route index element={<Applications />} />
                 <Route path="create" element={<Applications />} />
                 <Route path=":id" element={<ApplicationDetails />} />
               </Route>
-              <Route path="api-resources">
+              <Route path={Page.ApiResources}>
                 <Route index element={<ApiResources />} />
                 <Route path="create" element={<ApiResources />} />
                 <Route path=":id" element={<ApiResourceDetails />} />
               </Route>
-              <Route path="connectors">
+              <Route path={Page.Connectors}>
                 <Route index element={<Navigate replace to={ConnectorsTabs.Passwordless} />} />
                 <Route path=":tab" element={<Connectors />} />
                 <Route path=":tab/create/:createType" element={<Connectors />} />
                 <Route path=":tab/:connectorId" element={<ConnectorDetails />} />
               </Route>
-              <Route path="users">
+              <Route path={Page.Users}>
                 <Route index element={<Users />} />
                 <Route path=":userId" element={<Navigate replace to={UserTabs.Details} />} />
                 <Route path={`:userId/${UserTabs.Details}`} element={<UserDetails />} />
                 <Route path={`:userId/${UserTabs.Logs}`} element={<UserDetails />} />
                 <Route path={`:userId/${UserTabs.Logs}/:logId`} element={<AuditLogDetails />} />
               </Route>
-              <Route path="sign-in-experience">
+              <Route path={Page.SignInExperience}>
                 <Route index element={<Navigate replace to={SignInExperienceTabs.Branding} />} />
                 <Route path=":tab" element={<SignInExperience />} />
               </Route>
-              <Route path="settings" element={<Settings />} />
-              <Route path="audit-logs">
+              <Route path={Page.Settings} element={<Settings />} />
+              <Route path={Page.AuditLogs}>
                 <Route index element={<AuditLogs />} />
                 <Route path=":logId" element={<AuditLogDetails />} />
               </Route>
-              <Route path="dashboard" element={<Dashboard />} />
+              <Route path={Page.Dashboard} element={<Dashboard />} />
             </Route>
           </Routes>
         </AppBoundary>

--- a/packages/console/src/App.tsx
+++ b/packages/console/src/App.tsx
@@ -32,7 +32,7 @@ import Users from '@/pages/Users';
 import Welcome from '@/pages/Welcome';
 
 import { ConnectorsTabs, SignInExperienceTabs, UserTabs } from './consts/page-tabs';
-import { Page } from './consts/pathnames';
+import { ActionPath, PagePath, Parameters } from './consts/pathnames';
 import { getBasename } from './utilities/router';
 
 void initI18n();
@@ -46,44 +46,59 @@ const Main = () => {
         <AppBoundary>
           <Toast />
           <Routes>
-            <Route path={Page.Callback} element={<Callback />} />
-            <Route path={Page.Welcome} element={<Welcome />} />
+            <Route path={PagePath.Callback} element={<Callback />} />
+            <Route path={PagePath.Welcome} element={<Welcome />} />
             <Route element={<AppContent />}>
               <Route path="*" element={<NotFound />} />
-              <Route path={Page.GetStarted} element={<GetStarted />} />
-              <Route path={Page.Applications}>
+              <Route path={PagePath.GetStarted} element={<GetStarted />} />
+              <Route path={PagePath.Applications}>
                 <Route index element={<Applications />} />
-                <Route path="create" element={<Applications />} />
-                <Route path=":id" element={<ApplicationDetails />} />
+                <Route path={`${ActionPath.Create}`} element={<Applications />} />
+                <Route path={`:${Parameters.Id}`} element={<ApplicationDetails />} />
               </Route>
-              <Route path={Page.ApiResources}>
+              <Route path={PagePath.ApiResources}>
                 <Route index element={<ApiResources />} />
-                <Route path="create" element={<ApiResources />} />
-                <Route path=":id" element={<ApiResourceDetails />} />
+                <Route path={`${ActionPath.Create}`} element={<ApiResources />} />
+                <Route path={`:${Parameters.Id}`} element={<ApiResourceDetails />} />
               </Route>
-              <Route path={Page.Connectors}>
+              <Route path={PagePath.Connectors}>
                 <Route index element={<Navigate replace to={ConnectorsTabs.Passwordless} />} />
-                <Route path=":tab" element={<Connectors />} />
-                <Route path=":tab/create/:createType" element={<Connectors />} />
-                <Route path=":tab/:connectorId" element={<ConnectorDetails />} />
+                <Route path={`:${Parameters.Tab}`} element={<Connectors />} />
+                <Route
+                  path={`:${Parameters.Tab}/${ActionPath.Create}/:${Parameters.CreateType}`}
+                  element={<Connectors />}
+                />
+                <Route
+                  path={`:${Parameters.Tab}/:${Parameters.ConnectorId}`}
+                  element={<ConnectorDetails />}
+                />
               </Route>
-              <Route path={Page.Users}>
+              <Route path={PagePath.Users}>
                 <Route index element={<Users />} />
-                <Route path=":userId" element={<Navigate replace to={UserTabs.Details} />} />
-                <Route path={`:userId/${UserTabs.Details}`} element={<UserDetails />} />
-                <Route path={`:userId/${UserTabs.Logs}`} element={<UserDetails />} />
-                <Route path={`:userId/${UserTabs.Logs}/:logId`} element={<AuditLogDetails />} />
+                <Route
+                  path={`:${Parameters.UserId}`}
+                  element={<Navigate replace to={UserTabs.Details} />}
+                />
+                <Route
+                  path={`:${Parameters.UserId}/${UserTabs.Details}`}
+                  element={<UserDetails />}
+                />
+                <Route path={`:${Parameters.UserId}/${UserTabs.Logs}`} element={<UserDetails />} />
+                <Route
+                  path={`:${Parameters.UserId}/${UserTabs.Logs}/:${Parameters.LogId}`}
+                  element={<AuditLogDetails />}
+                />
               </Route>
-              <Route path={Page.SignInExperience}>
+              <Route path={PagePath.SignInExperience}>
                 <Route index element={<Navigate replace to={SignInExperienceTabs.Branding} />} />
-                <Route path=":tab" element={<SignInExperience />} />
+                <Route path={`:${Parameters.Tab}`} element={<SignInExperience />} />
               </Route>
-              <Route path={Page.Settings} element={<Settings />} />
-              <Route path={Page.AuditLogs}>
+              <Route path={PagePath.Settings} element={<Settings />} />
+              <Route path={PagePath.AuditLogs}>
                 <Route index element={<AuditLogs />} />
-                <Route path=":logId" element={<AuditLogDetails />} />
+                <Route path={`:${Parameters.LogId}`} element={<AuditLogDetails />} />
               </Route>
-              <Route path={Page.Dashboard} element={<Dashboard />} />
+              <Route path={PagePath.Dashboard} element={<Dashboard />} />
             </Route>
           </Routes>
         </AppBoundary>

--- a/packages/console/src/App.tsx
+++ b/packages/console/src/App.tsx
@@ -31,7 +31,7 @@ import UserDetails from '@/pages/UserDetails';
 import Users from '@/pages/Users';
 import Welcome from '@/pages/Welcome';
 
-import { SignInExperiencePage } from './consts/page-tabs';
+import { ConnectorsPage, SignInExperiencePage } from './consts/page-tabs';
 import { getBasename } from './utilities/router';
 
 void initI18n();
@@ -63,9 +63,10 @@ const Main = () => {
                 <Route path=":id" element={<ApiResourceDetails />} />
               </Route>
               <Route path="connectors">
-                <Route index element={<Connectors />} />
-                <Route path="social" element={<Connectors />} />
-                <Route path=":connectorId" element={<ConnectorDetails />} />
+                <Route index element={<Navigate replace to={ConnectorsPage.Passwordless} />} />
+                <Route path=":tab" element={<Connectors />} />
+                <Route path=":tab/create/:createType" element={<Connectors />} />
+                <Route path=":tab/:connectorId" element={<ConnectorDetails />} />
               </Route>
               <Route path="users">
                 <Route index element={<Users />} />

--- a/packages/console/src/App.tsx
+++ b/packages/console/src/App.tsx
@@ -53,13 +53,11 @@ const Main = () => {
               <Route path="applications">
                 <Route index element={<Applications />} />
                 <Route path="create" element={<Applications />} />
-                <Route path=":id">
-                  <Route index element={<Navigate replace to="settings" />} />
-                  <Route path="settings" element={<ApplicationDetails />} />
-                </Route>
+                <Route path=":id" element={<ApplicationDetails />} />
               </Route>
               <Route path="api-resources">
                 <Route index element={<ApiResources />} />
+                <Route path="create" element={<ApiResources />} />
                 <Route path=":id" element={<ApiResourceDetails />} />
               </Route>
               <Route path="connectors">

--- a/packages/console/src/App.tsx
+++ b/packages/console/src/App.tsx
@@ -31,7 +31,7 @@ import UserDetails from '@/pages/UserDetails';
 import Users from '@/pages/Users';
 import Welcome from '@/pages/Welcome';
 
-import { ConnectorsPage, SignInExperiencePage } from './consts/page-tabs';
+import { ConnectorsTabs, SignInExperienceTabs, UserTabs } from './consts/page-tabs';
 import { getBasename } from './utilities/router';
 
 void initI18n();
@@ -63,19 +63,20 @@ const Main = () => {
                 <Route path=":id" element={<ApiResourceDetails />} />
               </Route>
               <Route path="connectors">
-                <Route index element={<Navigate replace to={ConnectorsPage.Passwordless} />} />
+                <Route index element={<Navigate replace to={ConnectorsTabs.Passwordless} />} />
                 <Route path=":tab" element={<Connectors />} />
                 <Route path=":tab/create/:createType" element={<Connectors />} />
                 <Route path=":tab/:connectorId" element={<ConnectorDetails />} />
               </Route>
               <Route path="users">
                 <Route index element={<Users />} />
-                <Route path=":userId" element={<UserDetails />} />
-                <Route path=":userId/logs" element={<UserDetails />} />
-                <Route path=":userId/logs/:logId" element={<AuditLogDetails />} />
+                <Route path=":userId" element={<Navigate replace to={UserTabs.Details} />} />
+                <Route path={`:userId/${UserTabs.Details}`} element={<UserDetails />} />
+                <Route path={`:userId/${UserTabs.Logs}`} element={<UserDetails />} />
+                <Route path={`:userId/${UserTabs.Logs}/:logId`} element={<AuditLogDetails />} />
               </Route>
               <Route path="sign-in-experience">
-                <Route index element={<Navigate replace to={SignInExperiencePage.BrandingTab} />} />
+                <Route index element={<Navigate replace to={SignInExperienceTabs.Branding} />} />
                 <Route path=":tab" element={<SignInExperience />} />
               </Route>
               <Route path="settings" element={<Settings />} />

--- a/packages/console/src/components/AppContent/components/Sidebar/components/Item/index.tsx
+++ b/packages/console/src/components/AppContent/components/Sidebar/components/Item/index.tsx
@@ -1,3 +1,4 @@
+import { assert } from '@silverhand/essentials';
 import classNames from 'classnames';
 import type { ReactChild, ReactNode } from 'react';
 import { useMemo, useState } from 'react';
@@ -5,7 +6,8 @@ import type { TFuncKey } from 'react-i18next';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 
-import { getPath } from '../../utils';
+import type { Page } from '@/consts/pathnames';
+
 import * as styles from './index.module.scss';
 
 type Props = {
@@ -14,9 +16,10 @@ type Props = {
   isActive?: boolean;
   modal?: (isOpen: boolean, onCancel: () => void) => ReactNode;
   externalLink?: string;
+  pagePath?: Page;
 };
 
-const Item = ({ icon, titleKey, modal, externalLink, isActive = false }: Props) => {
+const Item = ({ icon, titleKey, modal, externalLink, pagePath, isActive = false }: Props) => {
   const { t } = useTranslation(undefined, {
     keyPrefix: 'admin_console.tabs',
   });
@@ -58,8 +61,18 @@ const Item = ({ icon, titleKey, modal, externalLink, isActive = false }: Props) 
     );
   }
 
+  if (!pagePath) {
+    return null;
+  }
+  assert(
+    pagePath,
+    new Error(
+      'A `pagePath` is required when neither `modal` nor `externalLink` is specified to a side bar item.'
+    )
+  );
+
   return (
-    <Link to={getPath(titleKey)} className={classNames(styles.row, isActive && styles.active)}>
+    <Link to={`/${pagePath}`} className={classNames(styles.row, isActive && styles.active)}>
       {content}
     </Link>
   );

--- a/packages/console/src/components/AppContent/components/Sidebar/components/Item/index.tsx
+++ b/packages/console/src/components/AppContent/components/Sidebar/components/Item/index.tsx
@@ -6,7 +6,7 @@ import type { TFuncKey } from 'react-i18next';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 
-import type { Page } from '@/consts/pathnames';
+import type { PagePath } from '@/consts/pathnames';
 
 import * as styles from './index.module.scss';
 
@@ -16,7 +16,7 @@ type Props = {
   isActive?: boolean;
   modal?: (isOpen: boolean, onCancel: () => void) => ReactNode;
   externalLink?: string;
-  pagePath?: Page;
+  pagePath?: PagePath;
 };
 
 const Item = ({ icon, titleKey, modal, externalLink, pagePath, isActive = false }: Props) => {

--- a/packages/console/src/components/AppContent/components/Sidebar/hook.tsx
+++ b/packages/console/src/components/AppContent/components/Sidebar/hook.tsx
@@ -2,6 +2,7 @@ import type { Optional } from '@silverhand/essentials';
 import type { FC, ReactNode } from 'react';
 import type { TFuncKey } from 'react-i18next';
 
+import { Page } from '@/consts/pathnames';
 import useDocumentationUrl from '@/hooks/use-documentation-url';
 import useUserPreferences from '@/hooks/use-user-preferences';
 
@@ -23,6 +24,7 @@ type SidebarItem = {
   isHidden?: boolean;
   modal?: (isOpen: boolean, onCancel: () => void) => ReactNode;
   externalLink?: string;
+  pagePath?: Page;
 };
 
 type SidebarSection = {
@@ -57,10 +59,12 @@ export const useSidebarMenuItems = (): {
           Icon: Bolt,
           title: 'get_started',
           isHidden: getStartedHidden,
+          pagePath: Page.GetStarted,
         },
         {
           Icon: BarGraph,
           title: 'dashboard',
+          pagePath: Page.Dashboard,
         },
       ],
     },
@@ -70,18 +74,22 @@ export const useSidebarMenuItems = (): {
         {
           Icon: Box,
           title: 'applications',
+          pagePath: Page.Applications,
         },
         {
           Icon: Cloud,
           title: 'api_resources',
+          pagePath: Page.ApiResources,
         },
         {
           Icon: Web,
           title: 'sign_in_experience',
+          pagePath: Page.SignInExperience,
         },
         {
           Icon: Connection,
           title: 'connectors',
+          pagePath: Page.Connectors,
         },
       ],
     },
@@ -91,10 +99,12 @@ export const useSidebarMenuItems = (): {
         {
           Icon: UserProfile,
           title: 'users',
+          pagePath: Page.Users,
         },
         {
           Icon: List,
           title: 'audit_logs',
+          pagePath: Page.AuditLogs,
         },
       ],
     },

--- a/packages/console/src/components/AppContent/components/Sidebar/hook.tsx
+++ b/packages/console/src/components/AppContent/components/Sidebar/hook.tsx
@@ -2,7 +2,7 @@ import type { Optional } from '@silverhand/essentials';
 import type { FC, ReactNode } from 'react';
 import type { TFuncKey } from 'react-i18next';
 
-import { Page } from '@/consts/pathnames';
+import { PagePath } from '@/consts/pathnames';
 import useDocumentationUrl from '@/hooks/use-documentation-url';
 import useUserPreferences from '@/hooks/use-user-preferences';
 
@@ -24,7 +24,7 @@ type SidebarItem = {
   isHidden?: boolean;
   modal?: (isOpen: boolean, onCancel: () => void) => ReactNode;
   externalLink?: string;
-  pagePath?: Page;
+  pagePath?: PagePath;
 };
 
 type SidebarSection = {
@@ -59,12 +59,12 @@ export const useSidebarMenuItems = (): {
           Icon: Bolt,
           title: 'get_started',
           isHidden: getStartedHidden,
-          pagePath: Page.GetStarted,
+          pagePath: PagePath.GetStarted,
         },
         {
           Icon: BarGraph,
           title: 'dashboard',
-          pagePath: Page.Dashboard,
+          pagePath: PagePath.Dashboard,
         },
       ],
     },
@@ -74,22 +74,22 @@ export const useSidebarMenuItems = (): {
         {
           Icon: Box,
           title: 'applications',
-          pagePath: Page.Applications,
+          pagePath: PagePath.Applications,
         },
         {
           Icon: Cloud,
           title: 'api_resources',
-          pagePath: Page.ApiResources,
+          pagePath: PagePath.ApiResources,
         },
         {
           Icon: Web,
           title: 'sign_in_experience',
-          pagePath: Page.SignInExperience,
+          pagePath: PagePath.SignInExperience,
         },
         {
           Icon: Connection,
           title: 'connectors',
-          pagePath: Page.Connectors,
+          pagePath: PagePath.Connectors,
         },
       ],
     },
@@ -99,12 +99,12 @@ export const useSidebarMenuItems = (): {
         {
           Icon: UserProfile,
           title: 'users',
-          pagePath: Page.Users,
+          pagePath: PagePath.Users,
         },
         {
           Icon: List,
           title: 'audit_logs',
-          pagePath: Page.AuditLogs,
+          pagePath: PagePath.AuditLogs,
         },
       ],
     },

--- a/packages/console/src/components/AppContent/components/Sidebar/index.tsx
+++ b/packages/console/src/components/AppContent/components/Sidebar/index.tsx
@@ -1,12 +1,13 @@
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 
+import { Page } from '@/consts/pathnames';
+
 import Item from './components/Item';
 import Section from './components/Section';
 import { useSidebarMenuItems } from './hook';
 import Gear from './icons/Gear';
 import * as styles from './index.module.scss';
-import { getPath } from './utils';
 
 const Sidebar = () => {
   const { t } = useTranslation(undefined, {
@@ -20,15 +21,16 @@ const Sidebar = () => {
       {sections.map(({ title, items }) => (
         <Section key={title} title={t(title)}>
           {items.map(
-            ({ title, Icon, isHidden, modal, externalLink }) =>
+            ({ title, Icon, isHidden, modal, externalLink, pagePath }) =>
               !isHidden && (
                 <Item
                   key={title}
                   titleKey={title}
                   icon={<Icon />}
-                  isActive={location.pathname.startsWith(getPath(title))}
+                  isActive={pagePath && location.pathname.startsWith(`/${pagePath}`)}
                   modal={modal}
                   externalLink={externalLink}
+                  pagePath={pagePath}
                 />
               )
           )}
@@ -38,12 +40,11 @@ const Sidebar = () => {
       <Item
         titleKey="settings"
         icon={<Gear />}
-        isActive={location.pathname.startsWith(getPath('settings'))}
+        isActive={location.pathname.startsWith(`/${Page.Settings}`)}
+        pagePath={Page.Settings}
       />
     </div>
   );
 };
 
 export default Sidebar;
-
-export * from './utils';

--- a/packages/console/src/components/AppContent/components/Sidebar/index.tsx
+++ b/packages/console/src/components/AppContent/components/Sidebar/index.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 
-import { Page } from '@/consts/pathnames';
+import { PagePath } from '@/consts/pathnames';
 
 import Item from './components/Item';
 import Section from './components/Section';
@@ -40,8 +40,8 @@ const Sidebar = () => {
       <Item
         titleKey="settings"
         icon={<Gear />}
-        isActive={location.pathname.startsWith(`/${Page.Settings}`)}
-        pagePath={Page.Settings}
+        isActive={location.pathname.startsWith(`/${PagePath.Settings}`)}
+        pagePath={PagePath.Settings}
       />
     </div>
   );

--- a/packages/console/src/components/AppContent/components/Sidebar/utils.ts
+++ b/packages/console/src/components/AppContent/components/Sidebar/utils.ts
@@ -1,3 +1,0 @@
-import kebabCase from 'lodash.kebabcase';
-
-export const getPath = (title: string): string => `/${kebabCase(title)}`;

--- a/packages/console/src/components/AppContent/index.tsx
+++ b/packages/console/src/components/AppContent/index.tsx
@@ -11,7 +11,7 @@ import useScroll from '@/hooks/use-scroll';
 import useSettings from '@/hooks/use-settings';
 import useUserPreferences from '@/hooks/use-user-preferences';
 
-import Sidebar, { getPath } from './components/Sidebar';
+import Sidebar from './components/Sidebar';
 import { useSidebarMenuItems } from './components/Sidebar/hook';
 import Topbar from './components/Topbar';
 import * as styles from './index.module.scss';
@@ -39,9 +39,9 @@ const AppContent = () => {
   useEffect(() => {
     // Navigate to the first menu item after configs are loaded.
     if (!isLoading && location.pathname === '/') {
-      navigate(getPath(firstItem?.title ?? ''));
+      navigate(`/${firstItem?.pagePath ?? ''}`);
     }
-  }, [firstItem?.title, isLoading, location.pathname, navigate]);
+  }, [firstItem?.pagePath, isLoading, location.pathname, navigate]);
 
   if (error) {
     if (error instanceof LogtoClientError) {

--- a/packages/console/src/components/ApplicationName/index.tsx
+++ b/packages/console/src/components/ApplicationName/index.tsx
@@ -4,6 +4,8 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import useSWR from 'swr';
 
+import { getApplicationDetailsPathname } from '@/utilities/router';
+
 import * as styles from './index.module.scss';
 
 type Props = {
@@ -21,7 +23,11 @@ const ApplicationName = ({ applicationId, isLink = false }: Props) => {
 
   if (isLink && !isAdminConsole) {
     return (
-      <Link className={styles.link} to={`/applications/${applicationId}`} target="_blank">
+      <Link
+        className={styles.link}
+        to={getApplicationDetailsPathname(applicationId)}
+        target="_blank"
+      >
         {name}
       </Link>
     );

--- a/packages/console/src/components/TabNav/TabNavItem.tsx
+++ b/packages/console/src/components/TabNav/TabNavItem.tsx
@@ -27,7 +27,7 @@ type Props =
 const TabNavItem = ({ children, href, isActive, errorCount = 0, onClick }: Props) => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const location = useLocation();
-  const selected = href ? location.pathname === href : isActive;
+  const selected = href ? location.pathname.startsWith(href) : isActive;
 
   return (
     <div className={styles.item}>

--- a/packages/console/src/components/UserName/index.tsx
+++ b/packages/console/src/components/UserName/index.tsx
@@ -4,7 +4,9 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import useSWR from 'swr';
 
+import { UserTabs } from '@/consts/page-tabs';
 import type { RequestError } from '@/hooks/use-api';
+import { getUserPathname } from '@/utilities/router';
 
 import * as styles from './index.module.scss';
 
@@ -29,7 +31,11 @@ const UserName = ({ userId, isLink = false }: Props) => {
   return (
     <div className={styles.userName}>
       {isLink && !isAdmin ? (
-        <Link to={`/users/${userId}`} target="_blank" className={styles.link}>
+        <Link
+          to={getUserPathname(userId, UserTabs.Details)}
+          target="_blank"
+          className={styles.link}
+        >
           {name}
         </Link>
       ) : (

--- a/packages/console/src/components/UserName/index.tsx
+++ b/packages/console/src/components/UserName/index.tsx
@@ -4,9 +4,8 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import useSWR from 'swr';
 
-import { UserTabs } from '@/consts/page-tabs';
 import type { RequestError } from '@/hooks/use-api';
-import { getUserPathname } from '@/utilities/router';
+import { getUserDetailsPathname } from '@/utilities/router';
 
 import * as styles from './index.module.scss';
 
@@ -31,11 +30,7 @@ const UserName = ({ userId, isLink = false }: Props) => {
   return (
     <div className={styles.userName}>
       {isLink && !isAdmin ? (
-        <Link
-          to={getUserPathname(userId, UserTabs.Details)}
-          target="_blank"
-          className={styles.link}
-        >
+        <Link to={getUserDetailsPathname(userId)} target="_blank" className={styles.link}>
           {name}
         </Link>
       ) : (

--- a/packages/console/src/consts/page-tabs.ts
+++ b/packages/console/src/consts/page-tabs.ts
@@ -1,3 +1,8 @@
+export enum ConnectorsPage {
+  Passwordless = 'passwordless',
+  SocialTab = 'social',
+}
+
 export enum SignInExperiencePage {
   BrandingTab = 'branding',
   SignUpAndSignInTab = 'sign-up-and-sign-in',

--- a/packages/console/src/consts/page-tabs.ts
+++ b/packages/console/src/consts/page-tabs.ts
@@ -1,10 +1,15 @@
-export enum ConnectorsPage {
+export enum ConnectorsTabs {
   Passwordless = 'passwordless',
-  SocialTab = 'social',
+  Social = 'social',
 }
 
-export enum SignInExperiencePage {
-  BrandingTab = 'branding',
-  SignUpAndSignInTab = 'sign-up-and-sign-in',
-  OthersTab = 'others',
+export enum UserTabs {
+  Details = 'details',
+  Logs = 'logs',
+}
+
+export enum SignInExperienceTabs {
+  Branding = 'branding',
+  SignUpAndSignIn = 'sign-up-and-sign-in',
+  Others = 'others',
 }

--- a/packages/console/src/consts/pathnames.ts
+++ b/packages/console/src/consts/pathnames.ts
@@ -1,4 +1,4 @@
-export enum Page {
+export enum PagePath {
   Callback = 'callback',
   Welcome = 'welcome',
   GetStarted = 'get-started',
@@ -10,4 +10,17 @@ export enum Page {
   Users = 'users',
   AuditLogs = 'audit-logs',
   Settings = 'settings',
+}
+
+export enum ActionPath {
+  Create = 'create',
+}
+
+export enum Parameters {
+  Id = 'id',
+  UserId = 'userId',
+  LogId = 'logId',
+  ConnectorId = 'connectorId',
+  CreateType = 'createType',
+  Tab = 'tab',
 }

--- a/packages/console/src/consts/pathnames.ts
+++ b/packages/console/src/consts/pathnames.ts
@@ -1,0 +1,13 @@
+export enum Page {
+  Callback = 'callback',
+  Welcome = 'welcome',
+  GetStarted = 'get-started',
+  Dashboard = 'dashboard',
+  Applications = 'applications',
+  ApiResources = 'api-resources',
+  SignInExperience = 'sign-in-experience',
+  Connectors = 'connectors',
+  Users = 'users',
+  AuditLogs = 'audit-logs',
+  Settings = 'settings',
+}

--- a/packages/console/src/pages/ApiResourceDetails/index.tsx
+++ b/packages/console/src/pages/ApiResourceDetails/index.tsx
@@ -25,6 +25,7 @@ import TabNav, { TabNavItem } from '@/components/TabNav';
 import TextInput from '@/components/TextInput';
 import TextLink from '@/components/TextLink';
 import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
+import { Parameters } from '@/consts/pathnames';
 import type { RequestError } from '@/hooks/use-api';
 import useApi from '@/hooks/use-api';
 import { useTheme } from '@/hooks/use-theme';
@@ -40,7 +41,7 @@ type FormData = {
 
 const ApiResourceDetails = () => {
   const location = useLocation();
-  const { id } = useParams();
+  const { [Parameters.Id]: id } = useParams();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const navigate = useNavigate();
   const { data, error, mutate } = useSWR<Resource, RequestError>(id && `/api/resources/${id}`);

--- a/packages/console/src/pages/ApiResourceDetails/index.tsx
+++ b/packages/console/src/pages/ApiResourceDetails/index.tsx
@@ -25,7 +25,7 @@ import TabNav, { TabNavItem } from '@/components/TabNav';
 import TextInput from '@/components/TextInput';
 import TextLink from '@/components/TextLink';
 import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
-import { Parameters } from '@/consts/pathnames';
+import type { Parameters } from '@/consts/pathnames';
 import type { RequestError } from '@/hooks/use-api';
 import useApi from '@/hooks/use-api';
 import { useTheme } from '@/hooks/use-theme';
@@ -41,7 +41,7 @@ type FormData = {
 
 const ApiResourceDetails = () => {
   const location = useLocation();
-  const { [Parameters.Id]: id } = useParams();
+  const { id } = useParams<{ [Parameters.Id]: string }>();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const navigate = useNavigate();
   const { data, error, mutate } = useSWR<Resource, RequestError>(id && `/api/resources/${id}`);

--- a/packages/console/src/pages/ApiResourceDetails/index.tsx
+++ b/packages/console/src/pages/ApiResourceDetails/index.tsx
@@ -29,6 +29,7 @@ import type { RequestError } from '@/hooks/use-api';
 import useApi from '@/hooks/use-api';
 import { useTheme } from '@/hooks/use-theme';
 import * as detailsStyles from '@/scss/details.module.scss';
+import { getApiResourcesPathname } from '@/utilities/router';
 
 import * as styles from './index.module.scss';
 
@@ -97,7 +98,7 @@ const ApiResourceDetails = () => {
       setIsDeleting(false);
       setIsDeleteFormOpen(false);
       toast.success(t('api_resource_details.api_resource_deleted', { name: data.name }));
-      navigate(`/api-resources`);
+      navigate(getApiResourcesPathname());
     } catch {
       setIsDeleting(false);
     }
@@ -105,7 +106,7 @@ const ApiResourceDetails = () => {
 
   return (
     <div className={detailsStyles.container}>
-      <TextLink to="/api-resources" icon={<Back />} className={styles.backLink}>
+      <TextLink to={getApiResourcesPathname()} icon={<Back />} className={styles.backLink}>
         {t('api_resource_details.back_to_api_resources')}
       </TextLink>
       {isLoading && <DetailsSkeleton />}

--- a/packages/console/src/pages/ApiResources/index.tsx
+++ b/packages/console/src/pages/ApiResources/index.tsx
@@ -1,11 +1,10 @@
 import type { Resource } from '@logto/schemas';
 import { AppearanceMode } from '@logto/schemas';
 import classNames from 'classnames';
-import { useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import Modal from 'react-modal';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import useSWR from 'swr';
 
 import ApiResourceDark from '@/assets/images/api-resource-dark.svg';
@@ -24,16 +23,20 @@ import { useTheme } from '@/hooks/use-theme';
 import * as modalStyles from '@/scss/modal.module.scss';
 import * as resourcesStyles from '@/scss/resources.module.scss';
 import * as tableStyles from '@/scss/table.module.scss';
+import {
+  getApiResourceDetailsPathname,
+  getApiResourcesPathname,
+  getCreateApiResourcePathname,
+} from '@/utilities/router';
 
 import CreateForm from './components/CreateForm';
 import * as styles from './index.module.scss';
 
-const buildDetailsLink = (id: string) => `/api-resources/${id}`;
-
 const pageSize = 20;
 
 const ApiResources = () => {
-  const [isCreateFormOpen, setIsCreateFormOpen] = useState(false);
+  const { pathname } = useLocation();
+  const isCreateNew = pathname.endsWith('/create');
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const [query, setQuery] = useSearchParams();
   const pageIndex = Number(query.get('page') ?? '1');
@@ -55,28 +58,29 @@ const ApiResources = () => {
           size="large"
           icon={<Plus />}
           onClick={() => {
-            setIsCreateFormOpen(true);
+            navigate(getCreateApiResourcePathname());
           }}
         />
         <Modal
           shouldCloseOnEsc
-          isOpen={isCreateFormOpen}
+          isOpen={isCreateNew}
           className={modalStyles.content}
           overlayClassName={modalStyles.overlay}
           onRequestClose={() => {
-            setIsCreateFormOpen(false);
+            navigate(getApiResourcesPathname());
           }}
         >
           <CreateForm
             onClose={(createdApiResource) => {
-              setIsCreateFormOpen(false);
-
               if (createdApiResource) {
                 toast.success(
                   t('api_resources.api_resource_created', { name: createdApiResource.name })
                 );
-                navigate(buildDetailsLink(createdApiResource.id));
+                navigate(getApiResourceDetailsPathname(createdApiResource.id), { replace: true });
+
+                return;
               }
+              navigate(getApiResourcesPathname());
             }}
           />
         </Modal>
@@ -109,7 +113,7 @@ const ApiResources = () => {
                     title="api_resources.create"
                     type="outline"
                     onClick={() => {
-                      setIsCreateFormOpen(true);
+                      navigate(getCreateApiResourcePathname());
                     }}
                   />
                 </TableEmpty>
@@ -123,14 +127,14 @@ const ApiResources = () => {
                     key={id}
                     className={tableStyles.clickable}
                     onClick={() => {
-                      navigate(buildDetailsLink(id));
+                      navigate(getApiResourceDetailsPathname(id));
                     }}
                   >
                     <td>
                       <ItemPreview
                         title={name}
                         icon={<ResourceIcon className={styles.icon} />}
-                        to={buildDetailsLink(id)}
+                        to={getApiResourceDetailsPathname(id)}
                       />
                     </td>
                     <td>

--- a/packages/console/src/pages/ApiResources/index.tsx
+++ b/packages/console/src/pages/ApiResources/index.tsx
@@ -18,6 +18,7 @@ import Pagination from '@/components/Pagination';
 import TableEmpty from '@/components/Table/TableEmpty';
 import TableError from '@/components/Table/TableError';
 import TableLoading from '@/components/Table/TableLoading';
+import { ActionPath } from '@/consts/pathnames';
 import type { RequestError } from '@/hooks/use-api';
 import { useTheme } from '@/hooks/use-theme';
 import * as modalStyles from '@/scss/modal.module.scss';
@@ -36,7 +37,7 @@ const pageSize = 20;
 
 const ApiResources = () => {
   const { pathname } = useLocation();
-  const isCreateNew = pathname.endsWith('/create');
+  const isCreateNew = pathname.endsWith(`/${ActionPath.Create}`);
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const [query, setQuery] = useSearchParams();
   const pageIndex = Number(query.get('page') ?? '1');

--- a/packages/console/src/pages/ApplicationDetails/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/index.tsx
@@ -27,6 +27,7 @@ import useApi from '@/hooks/use-api';
 import useDocumentationUrl from '@/hooks/use-documentation-url';
 import * as detailsStyles from '@/scss/details.module.scss';
 import { applicationTypeI18nKey } from '@/types/applications';
+import { getApplicationDetailsPathname, getApplicationsPathname } from '@/utilities/router';
 
 import Guide from '../Applications/components/Guide';
 import AdvancedSettings from './components/AdvancedSettings';
@@ -114,7 +115,7 @@ const ApplicationDetails = () => {
       setIsDeleting(false);
       setIsDeleteFormOpen(false);
       toast.success(t('application_details.application_deleted', { name: data.name }));
-      navigate(`/applications`);
+      navigate(getApplicationsPathname());
     } catch {
       setIsDeleting(false);
     }
@@ -126,7 +127,7 @@ const ApplicationDetails = () => {
 
   return (
     <div className={detailsStyles.container}>
-      <TextLink to="/applications" icon={<Back />} className={styles.backLink}>
+      <TextLink to={getApplicationsPathname()} icon={<Back />} className={styles.backLink}>
         {t('application_details.back_to_applications')}
       </TextLink>
       {isLoading && <DetailsSkeleton />}
@@ -197,7 +198,7 @@ const ApplicationDetails = () => {
             </div>
           </Card>
           <TabNav>
-            <TabNavItem href={`/applications/${data.id}/settings`}>
+            <TabNavItem href={getApplicationDetailsPathname(data.id)}>
               {t('general.settings_nav')}
             </TabNavItem>
           </TabNav>

--- a/packages/console/src/pages/ApplicationDetails/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/index.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import { Trans, useTranslation } from 'react-i18next';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import useSWR from 'swr';
 
 import Back from '@/assets/images/back.svg';
@@ -22,6 +22,7 @@ import Drawer from '@/components/Drawer';
 import TabNav, { TabNavItem } from '@/components/TabNav';
 import TextLink from '@/components/TextLink';
 import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
+import { Parameters } from '@/consts/pathnames';
 import type { RequestError } from '@/hooks/use-api';
 import useApi from '@/hooks/use-api';
 import useDocumentationUrl from '@/hooks/use-documentation-url';
@@ -41,8 +42,7 @@ const mapToUriOriginFormatArrays = (value?: string[]) =>
   value?.filter(Boolean).map((uri) => decodeURIComponent(new URL(uri).origin));
 
 const ApplicationDetails = () => {
-  const { id } = useParams();
-  const { pathname } = useLocation();
+  const { [Parameters.Id]: id } = useParams();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { data, error, mutate } = useSWR<Application, RequestError>(
     id && `/api/applications/${id}`

--- a/packages/console/src/pages/ApplicationDetails/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/index.tsx
@@ -22,7 +22,7 @@ import Drawer from '@/components/Drawer';
 import TabNav, { TabNavItem } from '@/components/TabNav';
 import TextLink from '@/components/TextLink';
 import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
-import { Parameters } from '@/consts/pathnames';
+import type { Parameters } from '@/consts/pathnames';
 import type { RequestError } from '@/hooks/use-api';
 import useApi from '@/hooks/use-api';
 import useDocumentationUrl from '@/hooks/use-documentation-url';
@@ -42,7 +42,7 @@ const mapToUriOriginFormatArrays = (value?: string[]) =>
   value?.filter(Boolean).map((uri) => decodeURIComponent(new URL(uri).origin));
 
 const ApplicationDetails = () => {
-  const { [Parameters.Id]: id } = useParams();
+  const { id } = useParams<{ [Parameters.Id]: string }>();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { data, error, mutate } = useSWR<Application, RequestError>(
     id && `/api/applications/${id}`

--- a/packages/console/src/pages/Applications/index.tsx
+++ b/packages/console/src/pages/Applications/index.tsx
@@ -21,6 +21,11 @@ import * as modalStyles from '@/scss/modal.module.scss';
 import * as resourcesStyles from '@/scss/resources.module.scss';
 import * as tableStyles from '@/scss/table.module.scss';
 import { applicationTypeI18nKey } from '@/types/applications';
+import {
+  getApplicationDetailsPathname,
+  getApplicationsPathname,
+  getCreateApplicationPathname,
+} from '@/utilities/router';
 
 import CreateForm from './components/CreateForm';
 import * as styles from './index.module.scss';
@@ -29,8 +34,8 @@ const pageSize = 20;
 
 const Applications = () => {
   const navigate = useNavigate();
-  const location = useLocation();
-  const isCreateNew = location.pathname.endsWith('/create');
+  const { pathname } = useLocation();
+  const isCreateNew = pathname.endsWith('/create');
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const [query, setQuery] = useSearchParams();
   const pageIndex = Number(query.get('page') ?? '1');
@@ -50,7 +55,7 @@ const Applications = () => {
           type="primary"
           size="large"
           onClick={() => {
-            navigate('/applications/create');
+            navigate(getCreateApplicationPathname());
           }}
         />
         <Modal
@@ -59,22 +64,22 @@ const Applications = () => {
           className={modalStyles.content}
           overlayClassName={modalStyles.overlay}
           onRequestClose={() => {
-            navigate('/applications');
+            navigate(getApplicationsPathname());
           }}
         >
           <CreateForm
             onClose={(createdApp) => {
               if (createdApp) {
                 toast.success(t('applications.application_created', { name: createdApp.name }));
-                navigate(`/applications/${createdApp.id}`);
+                navigate(getApplicationDetailsPathname(createdApp.id), { replace: true });
 
                 return;
               }
-              navigate('/applications');
+              navigate(getApplicationsPathname());
             }}
           />
         </Modal>
-      </div>{' '}
+      </div>
       <div className={resourcesStyles.table}>
         <div className={tableStyles.scrollable}>
           <table className={classNames(!data && tableStyles.empty)}>
@@ -105,7 +110,7 @@ const Applications = () => {
                     title="applications.create"
                     type="outline"
                     onClick={() => {
-                      navigate('/applications/create');
+                      navigate(getCreateApplicationPathname());
                     }}
                   />
                 </TableEmpty>
@@ -115,7 +120,7 @@ const Applications = () => {
                   key={id}
                   className={tableStyles.clickable}
                   onClick={() => {
-                    navigate(`/applications/${id}`);
+                    navigate(getApplicationDetailsPathname(id));
                   }}
                 >
                   <td>
@@ -123,7 +128,7 @@ const Applications = () => {
                       title={name}
                       subtitle={t(`${applicationTypeI18nKey[type]}.title`)}
                       icon={<ApplicationIcon className={styles.icon} type={type} />}
-                      to={`/applications/${id}`}
+                      to={getApplicationDetailsPathname(id)}
                     />
                   </td>
                   <td>

--- a/packages/console/src/pages/Applications/index.tsx
+++ b/packages/console/src/pages/Applications/index.tsx
@@ -16,6 +16,7 @@ import Pagination from '@/components/Pagination';
 import TableEmpty from '@/components/Table/TableEmpty';
 import TableError from '@/components/Table/TableError';
 import TableLoading from '@/components/Table/TableLoading';
+import { ActionPath } from '@/consts/pathnames';
 import type { RequestError } from '@/hooks/use-api';
 import * as modalStyles from '@/scss/modal.module.scss';
 import * as resourcesStyles from '@/scss/resources.module.scss';
@@ -35,7 +36,7 @@ const pageSize = 20;
 const Applications = () => {
   const navigate = useNavigate();
   const { pathname } = useLocation();
-  const isCreateNew = pathname.endsWith('/create');
+  const isCreateNew = pathname.endsWith(`/${ActionPath.Create}`);
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const [query, setQuery] = useSearchParams();
   const pageIndex = Number(query.get('page') ?? '1');

--- a/packages/console/src/pages/AuditLogDetails/index.tsx
+++ b/packages/console/src/pages/AuditLogDetails/index.tsx
@@ -14,7 +14,7 @@ import TabNav, { TabNavItem } from '@/components/TabNav';
 import TextLink from '@/components/TextLink';
 import UserName from '@/components/UserName';
 import { logEventTitle } from '@/consts/logs';
-import { Parameters } from '@/consts/pathnames';
+import type { Parameters } from '@/consts/pathnames';
 import type { RequestError } from '@/hooks/use-api';
 import * as detailsStyles from '@/scss/details.module.scss';
 import { getAuditLogDetailsPathname, getUserLogDetailsPathname } from '@/utilities/router';
@@ -29,7 +29,10 @@ const getDetailsTabNavLink = (logId: string, userId?: string) =>
   userId ? getUserLogDetailsPathname(userId, logId) : getAuditLogDetailsPathname(logId);
 
 const AuditLogDetails = () => {
-  const { [Parameters.UserId]: userId, [Parameters.LogId]: logId } = useParams();
+  const { userId, logId } = useParams<{
+    [Parameters.UserId]: string;
+    [Parameters.LogId]: string;
+  }>();
   const { pathname } = useLocation();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { data, error } = useSWR<LogDto, RequestError>(logId && `/api/logs/${logId}`);

--- a/packages/console/src/pages/AuditLogDetails/index.tsx
+++ b/packages/console/src/pages/AuditLogDetails/index.tsx
@@ -16,7 +16,7 @@ import UserName from '@/components/UserName';
 import { logEventTitle } from '@/consts/logs';
 import type { RequestError } from '@/hooks/use-api';
 import * as detailsStyles from '@/scss/details.module.scss';
-import { getUserLogPathname } from '@/utilities/router';
+import { getUserLogDetailsPathname } from '@/utilities/router';
 
 import EventIcon from './components/EventIcon';
 import * as styles from './index.module.scss';
@@ -25,7 +25,7 @@ const getAuditLogDetailsRelatedResourceLink = (pathname: string) =>
   `/${pathname.slice(0, pathname.lastIndexOf('/'))}`;
 
 const getDetailsTabNavLink = (logId: string, userId?: string) =>
-  userId ? getUserLogPathname(userId, logId) : `/audit-logs/${logId}`;
+  userId ? getUserLogDetailsPathname(userId, logId) : `/audit-logs/${logId}`;
 
 const AuditLogDetails = () => {
   const { userId, logId } = useParams();

--- a/packages/console/src/pages/AuditLogDetails/index.tsx
+++ b/packages/console/src/pages/AuditLogDetails/index.tsx
@@ -16,6 +16,7 @@ import UserName from '@/components/UserName';
 import { logEventTitle } from '@/consts/logs';
 import type { RequestError } from '@/hooks/use-api';
 import * as detailsStyles from '@/scss/details.module.scss';
+import { getUserLogPathname } from '@/utilities/router';
 
 import EventIcon from './components/EventIcon';
 import * as styles from './index.module.scss';
@@ -24,7 +25,7 @@ const getAuditLogDetailsRelatedResourceLink = (pathname: string) =>
   `/${pathname.slice(0, pathname.lastIndexOf('/'))}`;
 
 const getDetailsTabNavLink = (logId: string, userId?: string) =>
-  userId ? `/users/${userId}/logs/${logId}` : `/audit-logs/${logId}`;
+  userId ? getUserLogPathname(userId, logId) : `/audit-logs/${logId}`;
 
 const AuditLogDetails = () => {
   const { userId, logId } = useParams();

--- a/packages/console/src/pages/AuditLogDetails/index.tsx
+++ b/packages/console/src/pages/AuditLogDetails/index.tsx
@@ -14,9 +14,10 @@ import TabNav, { TabNavItem } from '@/components/TabNav';
 import TextLink from '@/components/TextLink';
 import UserName from '@/components/UserName';
 import { logEventTitle } from '@/consts/logs';
+import { Parameters } from '@/consts/pathnames';
 import type { RequestError } from '@/hooks/use-api';
 import * as detailsStyles from '@/scss/details.module.scss';
-import { getUserLogDetailsPathname } from '@/utilities/router';
+import { getAuditLogDetailsPathname, getUserLogDetailsPathname } from '@/utilities/router';
 
 import EventIcon from './components/EventIcon';
 import * as styles from './index.module.scss';
@@ -25,10 +26,10 @@ const getAuditLogDetailsRelatedResourceLink = (pathname: string) =>
   `/${pathname.slice(0, pathname.lastIndexOf('/'))}`;
 
 const getDetailsTabNavLink = (logId: string, userId?: string) =>
-  userId ? getUserLogDetailsPathname(userId, logId) : `/audit-logs/${logId}`;
+  userId ? getUserLogDetailsPathname(userId, logId) : getAuditLogDetailsPathname(logId);
 
 const AuditLogDetails = () => {
-  const { userId, logId } = useParams();
+  const { [Parameters.UserId]: userId, [Parameters.LogId]: logId } = useParams();
   const { pathname } = useLocation();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { data, error } = useSWR<LogDto, RequestError>(logId && `/api/logs/${logId}`);

--- a/packages/console/src/pages/ConnectorDetails/components/ConnectorTabs/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/components/ConnectorTabs/index.tsx
@@ -6,7 +6,7 @@ import { Link } from 'react-router-dom';
 import useSWR from 'swr';
 
 import { connectorPlatformLabel } from '@/consts';
-import { ConnectorsPage } from '@/consts/page-tabs';
+import { ConnectorsTabs } from '@/consts/page-tabs';
 import ConnectorPlatformIcon from '@/icons/ConnectorPlatformIcon';
 import { getConnectorPathname } from '@/utilities/router';
 
@@ -40,8 +40,8 @@ const ConnectorTabs = ({ target, connectorId }: Props) => {
           key={connector.id}
           to={getConnectorPathname(
             connector.type === ConnectorType.Social
-              ? ConnectorsPage.SocialTab
-              : ConnectorsPage.Passwordless,
+              ? ConnectorsTabs.Social
+              : ConnectorsTabs.Passwordless,
             connector.id
           )}
           className={classNames(styles.tab, connector.id === connectorId && styles.active)}

--- a/packages/console/src/pages/ConnectorDetails/components/ConnectorTabs/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/components/ConnectorTabs/index.tsx
@@ -1,12 +1,14 @@
 import type { ConnectorResponse } from '@logto/schemas';
-import { ConnectorPlatform } from '@logto/schemas';
+import { ConnectorType, ConnectorPlatform } from '@logto/schemas';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import useSWR from 'swr';
 
 import { connectorPlatformLabel } from '@/consts';
+import { ConnectorsPage } from '@/consts/page-tabs';
 import ConnectorPlatformIcon from '@/icons/ConnectorPlatformIcon';
+import { getConnectorPathname } from '@/utilities/router';
 
 import * as styles from './index.module.scss';
 
@@ -36,7 +38,12 @@ const ConnectorTabs = ({ target, connectorId }: Props) => {
       {connectors.map((connector) => (
         <Link
           key={connector.id}
-          to={`/connectors/${connector.id}`}
+          to={getConnectorPathname(
+            connector.type === ConnectorType.Social
+              ? ConnectorsPage.SocialTab
+              : ConnectorsPage.Passwordless,
+            connector.id
+          )}
           className={classNames(styles.tab, connector.id === connectorId && styles.active)}
         >
           {connector.platform && (

--- a/packages/console/src/pages/ConnectorDetails/components/ConnectorTabs/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/components/ConnectorTabs/index.tsx
@@ -1,14 +1,13 @@
 import type { ConnectorResponse } from '@logto/schemas';
-import { ConnectorType, ConnectorPlatform } from '@logto/schemas';
+import { ConnectorPlatform } from '@logto/schemas';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import useSWR from 'swr';
 
 import { connectorPlatformLabel } from '@/consts';
-import { ConnectorsTabs } from '@/consts/page-tabs';
 import ConnectorPlatformIcon from '@/icons/ConnectorPlatformIcon';
-import { getConnectorPathname } from '@/utilities/router';
+import { getConnectorDetailsPathname } from '@/utilities/router';
 
 import * as styles from './index.module.scss';
 
@@ -38,12 +37,7 @@ const ConnectorTabs = ({ target, connectorId }: Props) => {
       {connectors.map((connector) => (
         <Link
           key={connector.id}
-          to={getConnectorPathname(
-            connector.type === ConnectorType.Social
-              ? ConnectorsTabs.Social
-              : ConnectorsTabs.Passwordless,
-            connector.id
-          )}
+          to={getConnectorDetailsPathname(connector.type, connector.id)}
           className={classNames(styles.tab, connector.id === connectorId && styles.active)}
         >
           {connector.platform && (

--- a/packages/console/src/pages/ConnectorDetails/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/index.tsx
@@ -23,7 +23,7 @@ import TabNav, { TabNavItem } from '@/components/TabNav';
 import TextLink from '@/components/TextLink';
 import UnnamedTrans from '@/components/UnnamedTrans';
 import { ConnectorsTabs } from '@/consts/page-tabs';
-import { Parameters } from '@/consts/pathnames';
+import type { Parameters } from '@/consts/pathnames';
 import type { RequestError } from '@/hooks/use-api';
 import useApi from '@/hooks/use-api';
 import useConnectorInUse from '@/hooks/use-connector-in-use';
@@ -38,7 +38,7 @@ import ConnectorTypeName from './components/ConnectorTypeName';
 import * as styles from './index.module.scss';
 
 const ConnectorDetails = () => {
-  const { [Parameters.ConnectorId]: connectorId } = useParams();
+  const { connectorId } = useParams<{ [Parameters.ConnectorId]: string }>();
   const { mutate: mutateGlobal } = useSWRConfig();
   const [isDeleted, setIsDeleted] = useState(false);
   const [isReadMeOpen, setIsReadMeOpen] = useState(false);

--- a/packages/console/src/pages/ConnectorDetails/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/index.tsx
@@ -23,6 +23,7 @@ import TabNav, { TabNavItem } from '@/components/TabNav';
 import TextLink from '@/components/TextLink';
 import UnnamedTrans from '@/components/UnnamedTrans';
 import { ConnectorsTabs } from '@/consts/page-tabs';
+import { Parameters } from '@/consts/pathnames';
 import type { RequestError } from '@/hooks/use-api';
 import useApi from '@/hooks/use-api';
 import useConnectorInUse from '@/hooks/use-connector-in-use';
@@ -37,7 +38,7 @@ import ConnectorTypeName from './components/ConnectorTypeName';
 import * as styles from './index.module.scss';
 
 const ConnectorDetails = () => {
-  const { connectorId } = useParams();
+  const { [Parameters.ConnectorId]: connectorId } = useParams();
   const { mutate: mutateGlobal } = useSWRConfig();
   const [isDeleted, setIsDeleted] = useState(false);
   const [isReadMeOpen, setIsReadMeOpen] = useState(false);

--- a/packages/console/src/pages/ConnectorDetails/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/index.tsx
@@ -22,11 +22,13 @@ import Status from '@/components/Status';
 import TabNav, { TabNavItem } from '@/components/TabNav';
 import TextLink from '@/components/TextLink';
 import UnnamedTrans from '@/components/UnnamedTrans';
+import { ConnectorsPage } from '@/consts/page-tabs';
 import type { RequestError } from '@/hooks/use-api';
 import useApi from '@/hooks/use-api';
 import useConnectorInUse from '@/hooks/use-connector-in-use';
 import { useTheme } from '@/hooks/use-theme';
 import * as detailsStyles from '@/scss/details.module.scss';
+import { getConnectorPathname } from '@/utilities/router';
 
 import CreateForm from '../Connectors/components/CreateForm';
 import ConnectorContent from './components/ConnectorContent';
@@ -74,17 +76,15 @@ const ConnectorDetails = () => {
     toast.success(t('connector_details.connector_deleted'));
     await mutateGlobal('/api/connectors');
 
-    if (isSocial) {
-      navigate(`/connectors/social`, { replace: true });
-    } else {
-      navigate(`/connectors`, { replace: true });
-    }
+    navigate(
+      getConnectorPathname(isSocial ? ConnectorsPage.SocialTab : ConnectorsPage.Passwordless)
+    );
   };
 
   return (
     <div className={detailsStyles.container}>
       <TextLink
-        to={isSocial ? '/connectors/social' : '/connectors'}
+        to={getConnectorPathname(isSocial ? ConnectorsPage.SocialTab : ConnectorsPage.Passwordless)}
         icon={<Back />}
         className={styles.backLink}
       >
@@ -120,7 +120,7 @@ const ConnectorDetails = () => {
               )}
               <div className={styles.verticalBar} />
               <div className={styles.text}>ID</div>
-              <CopyToClipboard value={data.id} />
+              <CopyToClipboard size="small" value={data.id} />
             </div>
           </div>
           <div className={styles.operations}>
@@ -169,14 +169,24 @@ const ConnectorDetails = () => {
               type={data.type}
               onClose={(connectorId?: string) => {
                 setIsSetupOpen(false);
-                navigate(`/connectors/${connectorId ?? ''}`);
+                navigate(
+                  getConnectorPathname(
+                    isSocial ? ConnectorsPage.SocialTab : ConnectorsPage.Passwordless,
+                    connectorId
+                  )
+                );
               }}
             />
           </div>
         </Card>
       )}
       <TabNav>
-        <TabNavItem href={`/connectors/${connectorId ?? ''}`}>
+        <TabNavItem
+          href={getConnectorPathname(
+            isSocial ? ConnectorsPage.SocialTab : ConnectorsPage.Passwordless,
+            connectorId
+          )}
+        >
           {t('general.settings_nav')}
         </TabNavItem>
       </TabNav>

--- a/packages/console/src/pages/ConnectorDetails/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/index.tsx
@@ -22,7 +22,7 @@ import Status from '@/components/Status';
 import TabNav, { TabNavItem } from '@/components/TabNav';
 import TextLink from '@/components/TextLink';
 import UnnamedTrans from '@/components/UnnamedTrans';
-import { ConnectorsPage } from '@/consts/page-tabs';
+import { ConnectorsTabs } from '@/consts/page-tabs';
 import type { RequestError } from '@/hooks/use-api';
 import useApi from '@/hooks/use-api';
 import useConnectorInUse from '@/hooks/use-connector-in-use';
@@ -76,15 +76,13 @@ const ConnectorDetails = () => {
     toast.success(t('connector_details.connector_deleted'));
     await mutateGlobal('/api/connectors');
 
-    navigate(
-      getConnectorPathname(isSocial ? ConnectorsPage.SocialTab : ConnectorsPage.Passwordless)
-    );
+    navigate(getConnectorPathname(isSocial ? ConnectorsTabs.Social : ConnectorsTabs.Passwordless));
   };
 
   return (
     <div className={detailsStyles.container}>
       <TextLink
-        to={getConnectorPathname(isSocial ? ConnectorsPage.SocialTab : ConnectorsPage.Passwordless)}
+        to={getConnectorPathname(isSocial ? ConnectorsTabs.Social : ConnectorsTabs.Passwordless)}
         icon={<Back />}
         className={styles.backLink}
       >
@@ -171,7 +169,7 @@ const ConnectorDetails = () => {
                 setIsSetupOpen(false);
                 navigate(
                   getConnectorPathname(
-                    isSocial ? ConnectorsPage.SocialTab : ConnectorsPage.Passwordless,
+                    isSocial ? ConnectorsTabs.Social : ConnectorsTabs.Passwordless,
                     connectorId
                   )
                 );
@@ -183,7 +181,7 @@ const ConnectorDetails = () => {
       <TabNav>
         <TabNavItem
           href={getConnectorPathname(
-            isSocial ? ConnectorsPage.SocialTab : ConnectorsPage.Passwordless,
+            isSocial ? ConnectorsTabs.Social : ConnectorsTabs.Passwordless,
             connectorId
           )}
         >

--- a/packages/console/src/pages/Connectors/components/ConnectorName/index.tsx
+++ b/packages/console/src/pages/Connectors/components/ConnectorName/index.tsx
@@ -11,10 +11,9 @@ import {
   connectorPlatformLabel,
   connectorTitlePlaceHolder,
 } from '@/consts/connectors';
-import { ConnectorsTabs } from '@/consts/page-tabs';
 import { useTheme } from '@/hooks/use-theme';
 import ConnectorPlatformIcon from '@/icons/ConnectorPlatformIcon';
-import { getConnectorPathname } from '@/utilities/router';
+import { getConnectorDetailsPathname } from '@/utilities/router';
 
 import * as styles from './index.module.scss';
 
@@ -52,15 +51,7 @@ const ConnectorName = ({ type, connectors, onClickSetup }: Props) => {
   }
 
   return (
-    <Link
-      to={getConnectorPathname(
-        connector.type === ConnectorType.Social
-          ? ConnectorsTabs.Social
-          : ConnectorsTabs.Passwordless,
-        connector.id
-      )}
-      className={styles.link}
-    >
+    <Link to={getConnectorDetailsPathname(connector.type, connector.id)} className={styles.link}>
       <ItemPreview
         title={<UnnamedTrans resource={connector.name} />}
         subtitle={

--- a/packages/console/src/pages/Connectors/components/ConnectorName/index.tsx
+++ b/packages/console/src/pages/Connectors/components/ConnectorName/index.tsx
@@ -11,7 +11,7 @@ import {
   connectorPlatformLabel,
   connectorTitlePlaceHolder,
 } from '@/consts/connectors';
-import { ConnectorsPage } from '@/consts/page-tabs';
+import { ConnectorsTabs } from '@/consts/page-tabs';
 import { useTheme } from '@/hooks/use-theme';
 import ConnectorPlatformIcon from '@/icons/ConnectorPlatformIcon';
 import { getConnectorPathname } from '@/utilities/router';
@@ -55,8 +55,8 @@ const ConnectorName = ({ type, connectors, onClickSetup }: Props) => {
     <Link
       to={getConnectorPathname(
         connector.type === ConnectorType.Social
-          ? ConnectorsPage.SocialTab
-          : ConnectorsPage.Passwordless,
+          ? ConnectorsTabs.Social
+          : ConnectorsTabs.Passwordless,
         connector.id
       )}
       className={styles.link}

--- a/packages/console/src/pages/Connectors/components/ConnectorName/index.tsx
+++ b/packages/console/src/pages/Connectors/components/ConnectorName/index.tsx
@@ -11,8 +11,10 @@ import {
   connectorPlatformLabel,
   connectorTitlePlaceHolder,
 } from '@/consts/connectors';
+import { ConnectorsPage } from '@/consts/page-tabs';
 import { useTheme } from '@/hooks/use-theme';
 import ConnectorPlatformIcon from '@/icons/ConnectorPlatformIcon';
+import { getConnectorPathname } from '@/utilities/router';
 
 import * as styles from './index.module.scss';
 
@@ -50,7 +52,15 @@ const ConnectorName = ({ type, connectors, onClickSetup }: Props) => {
   }
 
   return (
-    <Link to={`/connectors/${connector.id}`} className={styles.link}>
+    <Link
+      to={getConnectorPathname(
+        connector.type === ConnectorType.Social
+          ? ConnectorsPage.SocialTab
+          : ConnectorsPage.Passwordless,
+        connector.id
+      )}
+      className={styles.link}
+    >
       <ItemPreview
         title={<UnnamedTrans resource={connector.name} />}
         subtitle={

--- a/packages/console/src/pages/Connectors/components/ConnectorRow/index.tsx
+++ b/packages/console/src/pages/Connectors/components/ConnectorRow/index.tsx
@@ -6,8 +6,10 @@ import { useNavigate } from 'react-router-dom';
 
 import Status from '@/components/Status';
 import { connectorTitlePlaceHolder } from '@/consts/connectors';
+import { ConnectorsPage } from '@/consts/page-tabs';
 import useConnectorInUse from '@/hooks/use-connector-in-use';
 import * as tableStyles from '@/scss/table.module.scss';
+import { getConnectorPathname } from '@/utilities/router';
 
 import ConnectorName from '../ConnectorName';
 
@@ -29,7 +31,12 @@ const ConnectorRow = ({ type, connectors, onClickSetup }: Props) => {
       return;
     }
 
-    navigate(`/connectors/${firstConnector.id}`);
+    navigate(
+      getConnectorPathname(
+        type === ConnectorType.Social ? ConnectorsPage.SocialTab : ConnectorsPage.Passwordless,
+        firstConnector.id
+      )
+    );
   };
 
   return (

--- a/packages/console/src/pages/Connectors/components/ConnectorRow/index.tsx
+++ b/packages/console/src/pages/Connectors/components/ConnectorRow/index.tsx
@@ -6,10 +6,9 @@ import { useNavigate } from 'react-router-dom';
 
 import Status from '@/components/Status';
 import { connectorTitlePlaceHolder } from '@/consts/connectors';
-import { ConnectorsTabs } from '@/consts/page-tabs';
 import useConnectorInUse from '@/hooks/use-connector-in-use';
 import * as tableStyles from '@/scss/table.module.scss';
-import { getConnectorPathname } from '@/utilities/router';
+import { getConnectorDetailsPathname } from '@/utilities/router';
 
 import ConnectorName from '../ConnectorName';
 
@@ -31,12 +30,7 @@ const ConnectorRow = ({ type, connectors, onClickSetup }: Props) => {
       return;
     }
 
-    navigate(
-      getConnectorPathname(
-        type === ConnectorType.Social ? ConnectorsTabs.Social : ConnectorsTabs.Passwordless,
-        firstConnector.id
-      )
-    );
+    navigate(getConnectorDetailsPathname(type, firstConnector.id));
   };
 
   return (

--- a/packages/console/src/pages/Connectors/components/ConnectorRow/index.tsx
+++ b/packages/console/src/pages/Connectors/components/ConnectorRow/index.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from 'react-router-dom';
 
 import Status from '@/components/Status';
 import { connectorTitlePlaceHolder } from '@/consts/connectors';
-import { ConnectorsPage } from '@/consts/page-tabs';
+import { ConnectorsTabs } from '@/consts/page-tabs';
 import useConnectorInUse from '@/hooks/use-connector-in-use';
 import * as tableStyles from '@/scss/table.module.scss';
 import { getConnectorPathname } from '@/utilities/router';
@@ -33,7 +33,7 @@ const ConnectorRow = ({ type, connectors, onClickSetup }: Props) => {
 
     navigate(
       getConnectorPathname(
-        type === ConnectorType.Social ? ConnectorsPage.SocialTab : ConnectorsPage.Passwordless,
+        type === ConnectorType.Social ? ConnectorsTabs.Social : ConnectorsTabs.Passwordless,
         firstConnector.id
       )
     );

--- a/packages/console/src/pages/Connectors/components/Guide/index.tsx
+++ b/packages/console/src/pages/Connectors/components/Guide/index.tsx
@@ -14,10 +14,12 @@ import CardTitle from '@/components/CardTitle';
 import DangerousRaw from '@/components/DangerousRaw';
 import IconButton from '@/components/IconButton';
 import Markdown from '@/components/Markdown';
+import { ConnectorsPage } from '@/consts/page-tabs';
 import useApi from '@/hooks/use-api';
 import useSettings from '@/hooks/use-settings';
 import SenderTester from '@/pages/ConnectorDetails/components/SenderTester';
 import { safeParseJson } from '@/utilities/json';
+import { getConnectorPathname } from '@/utilities/router';
 
 import type { ConnectorFormType } from '../../types';
 import { SyncProfileMode } from '../../types';
@@ -95,7 +97,12 @@ const Guide = ({ connector, onClose }: Props) => {
 
     onClose();
     toast.success(t('general.saved'));
-    navigate(`/connectors/${createdConnector.id}`);
+    navigate(
+      getConnectorPathname(
+        isSocialConnector ? ConnectorsPage.SocialTab : ConnectorsPage.Passwordless,
+        createdConnector.id
+      )
+    );
   });
 
   return (

--- a/packages/console/src/pages/Connectors/components/Guide/index.tsx
+++ b/packages/console/src/pages/Connectors/components/Guide/index.tsx
@@ -14,12 +14,11 @@ import CardTitle from '@/components/CardTitle';
 import DangerousRaw from '@/components/DangerousRaw';
 import IconButton from '@/components/IconButton';
 import Markdown from '@/components/Markdown';
-import { ConnectorsTabs } from '@/consts/page-tabs';
 import useApi from '@/hooks/use-api';
 import useSettings from '@/hooks/use-settings';
 import SenderTester from '@/pages/ConnectorDetails/components/SenderTester';
 import { safeParseJson } from '@/utilities/json';
-import { getConnectorPathname } from '@/utilities/router';
+import { getConnectorDetailsPathname } from '@/utilities/router';
 
 import type { ConnectorFormType } from '../../types';
 import { SyncProfileMode } from '../../types';
@@ -97,12 +96,7 @@ const Guide = ({ connector, onClose }: Props) => {
 
     onClose();
     toast.success(t('general.saved'));
-    navigate(
-      getConnectorPathname(
-        isSocialConnector ? ConnectorsTabs.Social : ConnectorsTabs.Passwordless,
-        createdConnector.id
-      )
-    );
+    navigate(getConnectorDetailsPathname(connectorType, createdConnector.id), { replace: true });
   });
 
   return (

--- a/packages/console/src/pages/Connectors/components/Guide/index.tsx
+++ b/packages/console/src/pages/Connectors/components/Guide/index.tsx
@@ -14,7 +14,7 @@ import CardTitle from '@/components/CardTitle';
 import DangerousRaw from '@/components/DangerousRaw';
 import IconButton from '@/components/IconButton';
 import Markdown from '@/components/Markdown';
-import { ConnectorsPage } from '@/consts/page-tabs';
+import { ConnectorsTabs } from '@/consts/page-tabs';
 import useApi from '@/hooks/use-api';
 import useSettings from '@/hooks/use-settings';
 import SenderTester from '@/pages/ConnectorDetails/components/SenderTester';
@@ -99,7 +99,7 @@ const Guide = ({ connector, onClose }: Props) => {
     toast.success(t('general.saved'));
     navigate(
       getConnectorPathname(
-        isSocialConnector ? ConnectorsPage.SocialTab : ConnectorsPage.Passwordless,
+        isSocialConnector ? ConnectorsTabs.Social : ConnectorsTabs.Passwordless,
         createdConnector.id
       )
     );

--- a/packages/console/src/pages/Connectors/index.tsx
+++ b/packages/console/src/pages/Connectors/index.tsx
@@ -16,6 +16,7 @@ import TableEmpty from '@/components/Table/TableEmpty';
 import TableError from '@/components/Table/TableError';
 import TableLoading from '@/components/Table/TableLoading';
 import { ConnectorsTabs } from '@/consts/page-tabs';
+import { Parameters } from '@/consts/pathnames';
 import useConnectorGroups from '@/hooks/use-connector-groups';
 import { useTheme } from '@/hooks/use-theme';
 import * as resourcesStyles from '@/scss/resources.module.scss';
@@ -32,7 +33,10 @@ const isConnectorType = (value: string): value is ConnectorType =>
   Object.values<string>(ConnectorType).includes(value);
 
 const Connectors = () => {
-  const { tab = ConnectorsTabs.Passwordless, createType } = useParams();
+  const {
+    [Parameters.Tab]: tab = ConnectorsTabs.Passwordless,
+    [Parameters.CreateType]: createType,
+  } = useParams();
   const isSocial = tab === ConnectorsTabs.Social;
   const navigate = useNavigate();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });

--- a/packages/console/src/pages/Connectors/index.tsx
+++ b/packages/console/src/pages/Connectors/index.tsx
@@ -16,7 +16,7 @@ import TableEmpty from '@/components/Table/TableEmpty';
 import TableError from '@/components/Table/TableError';
 import TableLoading from '@/components/Table/TableLoading';
 import { ConnectorsTabs } from '@/consts/page-tabs';
-import { Parameters } from '@/consts/pathnames';
+import type { Parameters } from '@/consts/pathnames';
 import useConnectorGroups from '@/hooks/use-connector-groups';
 import { useTheme } from '@/hooks/use-theme';
 import * as resourcesStyles from '@/scss/resources.module.scss';
@@ -33,10 +33,10 @@ const isConnectorType = (value: string): value is ConnectorType =>
   Object.values<string>(ConnectorType).includes(value);
 
 const Connectors = () => {
-  const {
-    [Parameters.Tab]: tab = ConnectorsTabs.Passwordless,
-    [Parameters.CreateType]: createType,
-  } = useParams();
+  const { tab = ConnectorsTabs.Passwordless, createType } = useParams<{
+    [Parameters.Tab]: string;
+    [Parameters.CreateType]: string;
+  }>();
   const isSocial = tab === ConnectorsTabs.Social;
   const navigate = useNavigate();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });

--- a/packages/console/src/pages/Connectors/index.tsx
+++ b/packages/console/src/pages/Connectors/index.tsx
@@ -5,7 +5,6 @@ import classNames from 'classnames';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
-import { snakeCase } from 'snake-case';
 
 import Plus from '@/assets/images/plus.svg';
 import SocialConnectorEmptyDark from '@/assets/images/social-connector-empty-dark.svg';
@@ -21,16 +20,13 @@ import useConnectorGroups from '@/hooks/use-connector-groups';
 import { useTheme } from '@/hooks/use-theme';
 import * as resourcesStyles from '@/scss/resources.module.scss';
 import * as tableStyles from '@/scss/table.module.scss';
-import { getConnectorPathname } from '@/utilities/router';
+import { getConnectorsPathname, getCreateConnectorPathname } from '@/utilities/router';
 
 import ConnectorRow from './components/ConnectorRow';
 import ConnectorStatusField from './components/ConnectorStatusField';
 import CreateForm from './components/CreateForm';
 import SignInExperienceSetupNotice from './components/SignInExperienceSetupNotice';
 import * as styles from './index.module.scss';
-
-const getCreatePagePathName = (connectorType: ConnectorType) =>
-  `create/${snakeCase(connectorType)}`;
 
 const isConnectorType = (value: string): value is ConnectorType =>
   Object.values<string>(ConnectorType).includes(value);
@@ -81,17 +77,17 @@ const Connectors = () => {
               size="large"
               icon={<Plus />}
               onClick={() => {
-                navigate(getCreatePagePathName(ConnectorType.Social));
+                navigate(getCreateConnectorPathname(ConnectorType.Social));
               }}
             />
           )}
         </div>
         <SignInExperienceSetupNotice />
         <TabNav className={styles.tabs}>
-          <TabNavItem href={getConnectorPathname(ConnectorsTabs.Passwordless)}>
+          <TabNavItem href={getConnectorsPathname(ConnectorsTabs.Passwordless)}>
             {t('connectors.tab_email_sms')}
           </TabNavItem>
-          <TabNavItem href={getConnectorPathname(ConnectorsTabs.Social)}>
+          <TabNavItem href={getConnectorsPathname(ConnectorsTabs.Social)}>
             {t('connectors.tab_social')}
           </TabNavItem>
         </TabNav>
@@ -132,7 +128,7 @@ const Connectors = () => {
                       title="connectors.create"
                       type="outline"
                       onClick={() => {
-                        navigate(getCreatePagePathName(ConnectorType.Social));
+                        navigate(getCreateConnectorPathname(ConnectorType.Social));
                       }}
                     />
                   </TableEmpty>
@@ -142,7 +138,7 @@ const Connectors = () => {
                     connectors={smsConnector ? [smsConnector] : []}
                     type={ConnectorType.Sms}
                     onClickSetup={() => {
-                      navigate(getCreatePagePathName(ConnectorType.Sms));
+                      navigate(getCreateConnectorPathname(ConnectorType.Sms));
                     }}
                   />
                 )}
@@ -151,7 +147,7 @@ const Connectors = () => {
                     connectors={emailConnector ? [emailConnector] : []}
                     type={ConnectorType.Email}
                     onClickSetup={() => {
-                      navigate(getCreatePagePathName(ConnectorType.Email));
+                      navigate(getCreateConnectorPathname(ConnectorType.Email));
                     }}
                   />
                 )}
@@ -170,7 +166,7 @@ const Connectors = () => {
         )}
         onClose={() => {
           navigate(
-            getConnectorPathname(isSocial ? ConnectorsTabs.Social : ConnectorsTabs.Passwordless)
+            getConnectorsPathname(isSocial ? ConnectorsTabs.Social : ConnectorsTabs.Passwordless)
           );
           void mutate();
         }}

--- a/packages/console/src/pages/Connectors/index.tsx
+++ b/packages/console/src/pages/Connectors/index.tsx
@@ -16,7 +16,7 @@ import TabNav, { TabNavItem } from '@/components/TabNav';
 import TableEmpty from '@/components/Table/TableEmpty';
 import TableError from '@/components/Table/TableError';
 import TableLoading from '@/components/Table/TableLoading';
-import { ConnectorsPage } from '@/consts/page-tabs';
+import { ConnectorsTabs } from '@/consts/page-tabs';
 import useConnectorGroups from '@/hooks/use-connector-groups';
 import { useTheme } from '@/hooks/use-theme';
 import * as resourcesStyles from '@/scss/resources.module.scss';
@@ -36,8 +36,8 @@ const isConnectorType = (value: string): value is ConnectorType =>
   Object.values<string>(ConnectorType).includes(value);
 
 const Connectors = () => {
-  const { tab = ConnectorsPage.Passwordless, createType } = useParams();
-  const isSocial = tab === ConnectorsPage.SocialTab;
+  const { tab = ConnectorsTabs.Passwordless, createType } = useParams();
+  const isSocial = tab === ConnectorsTabs.Social;
   const navigate = useNavigate();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { data, error, mutate } = useConnectorGroups();
@@ -88,10 +88,10 @@ const Connectors = () => {
         </div>
         <SignInExperienceSetupNotice />
         <TabNav className={styles.tabs}>
-          <TabNavItem href={getConnectorPathname(ConnectorsPage.Passwordless)}>
+          <TabNavItem href={getConnectorPathname(ConnectorsTabs.Passwordless)}>
             {t('connectors.tab_email_sms')}
           </TabNavItem>
-          <TabNavItem href={getConnectorPathname(ConnectorsPage.SocialTab)}>
+          <TabNavItem href={getConnectorPathname(ConnectorsTabs.Social)}>
             {t('connectors.tab_social')}
           </TabNavItem>
         </TabNav>
@@ -170,7 +170,7 @@ const Connectors = () => {
         )}
         onClose={() => {
           navigate(
-            getConnectorPathname(isSocial ? ConnectorsPage.SocialTab : ConnectorsPage.Passwordless)
+            getConnectorPathname(isSocial ? ConnectorsTabs.Social : ConnectorsTabs.Passwordless)
           );
           void mutate();
         }}

--- a/packages/console/src/pages/GetStarted/hook.ts
+++ b/packages/console/src/pages/GetStarted/hook.ts
@@ -18,10 +18,12 @@ import PasswordlessDark from '@/assets/images/passwordless-dark.svg';
 import Passwordless from '@/assets/images/passwordless.svg';
 import SocialDark from '@/assets/images/social-dark.svg';
 import Social from '@/assets/images/social.svg';
+import { ConnectorsPage } from '@/consts/page-tabs';
 import { RequestError } from '@/hooks/use-api';
 import useDocumentationUrl from '@/hooks/use-documentation-url';
 import useSettings from '@/hooks/use-settings';
 import { useTheme } from '@/hooks/use-theme';
+import { getConnectorPathname } from '@/utilities/router';
 
 type GetStartedMetadata = {
   id: string;
@@ -100,7 +102,7 @@ const useGetStartedMetadata = () => {
         buttonText: 'general.set_up',
         isComplete: settings?.passwordlessConfigured,
         onClick: () => {
-          navigate('/connectors');
+          navigate(getConnectorPathname(ConnectorsPage.Passwordless));
         },
       },
       {
@@ -111,7 +113,7 @@ const useGetStartedMetadata = () => {
         buttonText: 'general.add',
         isComplete: settings?.socialSignInConfigured,
         onClick: () => {
-          navigate('/connectors/social');
+          navigate(getConnectorPathname(ConnectorsPage.SocialTab));
         },
       },
       {

--- a/packages/console/src/pages/GetStarted/hook.ts
+++ b/packages/console/src/pages/GetStarted/hook.ts
@@ -23,7 +23,7 @@ import { RequestError } from '@/hooks/use-api';
 import useDocumentationUrl from '@/hooks/use-documentation-url';
 import useSettings from '@/hooks/use-settings';
 import { useTheme } from '@/hooks/use-theme';
-import { getConnectorPathname } from '@/utilities/router';
+import { getConnectorsPathname, getCreateApplicationPathname } from '@/utilities/router';
 
 type GetStartedMetadata = {
   id: string;
@@ -80,7 +80,7 @@ const useGetStartedMetadata = () => {
         buttonText: 'general.create',
         isComplete: settings?.applicationCreated,
         onClick: () => {
-          navigate('/applications/create');
+          navigate(getCreateApplicationPathname());
         },
       },
       {
@@ -102,7 +102,7 @@ const useGetStartedMetadata = () => {
         buttonText: 'general.set_up',
         isComplete: settings?.passwordlessConfigured,
         onClick: () => {
-          navigate(getConnectorPathname(ConnectorsTabs.Passwordless));
+          navigate(getConnectorsPathname(ConnectorsTabs.Passwordless));
         },
       },
       {
@@ -113,7 +113,7 @@ const useGetStartedMetadata = () => {
         buttonText: 'general.add',
         isComplete: settings?.socialSignInConfigured,
         onClick: () => {
-          navigate(getConnectorPathname(ConnectorsTabs.Social));
+          navigate(getConnectorsPathname(ConnectorsTabs.Social));
         },
       },
       {

--- a/packages/console/src/pages/GetStarted/hook.ts
+++ b/packages/console/src/pages/GetStarted/hook.ts
@@ -18,7 +18,7 @@ import PasswordlessDark from '@/assets/images/passwordless-dark.svg';
 import Passwordless from '@/assets/images/passwordless.svg';
 import SocialDark from '@/assets/images/social-dark.svg';
 import Social from '@/assets/images/social.svg';
-import { ConnectorsPage } from '@/consts/page-tabs';
+import { ConnectorsTabs } from '@/consts/page-tabs';
 import { RequestError } from '@/hooks/use-api';
 import useDocumentationUrl from '@/hooks/use-documentation-url';
 import useSettings from '@/hooks/use-settings';
@@ -102,7 +102,7 @@ const useGetStartedMetadata = () => {
         buttonText: 'general.set_up',
         isComplete: settings?.passwordlessConfigured,
         onClick: () => {
-          navigate(getConnectorPathname(ConnectorsPage.Passwordless));
+          navigate(getConnectorPathname(ConnectorsTabs.Passwordless));
         },
       },
       {
@@ -113,7 +113,7 @@ const useGetStartedMetadata = () => {
         buttonText: 'general.add',
         isComplete: settings?.socialSignInConfigured,
         onClick: () => {
-          navigate(getConnectorPathname(ConnectorsPage.SocialTab));
+          navigate(getConnectorPathname(ConnectorsTabs.Social));
         },
       },
       {

--- a/packages/console/src/pages/SignInExperience/index.tsx
+++ b/packages/console/src/pages/SignInExperience/index.tsx
@@ -13,6 +13,7 @@ import SubmitFormChangesActionBar from '@/components/SubmitFormChangesActionBar'
 import TabNav, { TabNavItem } from '@/components/TabNav';
 import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
 import { SignInExperienceTabs } from '@/consts/page-tabs';
+import { Parameters } from '@/consts/pathnames';
 import type { RequestError } from '@/hooks/use-api';
 import useApi from '@/hooks/use-api';
 import useSettings from '@/hooks/use-settings';
@@ -38,7 +39,7 @@ import {
 
 const SignInExperience = () => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
-  const { tab } = useParams();
+  const { [Parameters.Tab]: tab } = useParams();
   const { data, error, mutate } = useSWR<SignInExperienceType, RequestError>('/api/sign-in-exp');
   const { settings, error: settingsError, updateSettings, mutate: mutateSettings } = useSettings();
   const { error: languageError, isLoading: isLoadingLanguages } = useUiLanguages();

--- a/packages/console/src/pages/SignInExperience/index.tsx
+++ b/packages/console/src/pages/SignInExperience/index.tsx
@@ -12,7 +12,7 @@ import ConfirmModal from '@/components/ConfirmModal';
 import SubmitFormChangesActionBar from '@/components/SubmitFormChangesActionBar';
 import TabNav, { TabNavItem } from '@/components/TabNav';
 import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
-import { SignInExperiencePage } from '@/consts/page-tabs';
+import { SignInExperienceTabs } from '@/consts/page-tabs';
 import type { RequestError } from '@/hooks/use-api';
 import useApi from '@/hooks/use-api';
 import useSettings from '@/hooks/use-settings';
@@ -132,19 +132,19 @@ const SignInExperience = () => {
       />
       <TabNav className={styles.tabs}>
         <TabNavItem
-          href={`/sign-in-experience/${SignInExperiencePage.BrandingTab}`}
+          href={`/sign-in-experience/${SignInExperienceTabs.Branding}`}
           errorCount={getBrandingErrorCount(errors)}
         >
           {t('sign_in_exp.tabs.branding')}
         </TabNavItem>
         <TabNavItem
-          href={`/sign-in-experience/${SignInExperiencePage.SignUpAndSignInTab}`}
+          href={`/sign-in-experience/${SignInExperienceTabs.SignUpAndSignIn}`}
           errorCount={getSignUpAndSignInErrorCount(errors, formData)}
         >
           {t('sign_in_exp.tabs.sign_up_and_sign_in')}
         </TabNavItem>
         <TabNavItem
-          href={`/sign-in-experience/${SignInExperiencePage.OthersTab}`}
+          href={`/sign-in-experience/${SignInExperienceTabs.Others}`}
           errorCount={getOthersErrorCount(errors)}
         >
           {t('sign_in_exp.tabs.others')}
@@ -156,9 +156,9 @@ const SignInExperience = () => {
           <div className={classNames(styles.contentTop, isDirty && styles.withSubmitActionBar)}>
             <FormProvider {...methods}>
               <form className={styles.form}>
-                <Branding isActive={tab === SignInExperiencePage.BrandingTab} />
-                <SignUpAndSignIn isActive={tab === SignInExperiencePage.SignUpAndSignInTab} />
-                <Others isActive={tab === SignInExperiencePage.OthersTab} />
+                <Branding isActive={tab === SignInExperienceTabs.Branding} />
+                <SignUpAndSignIn isActive={tab === SignInExperienceTabs.SignUpAndSignIn} />
+                <Others isActive={tab === SignInExperienceTabs.Others} />
               </form>
             </FormProvider>
             {formData.id && (

--- a/packages/console/src/pages/SignInExperience/index.tsx
+++ b/packages/console/src/pages/SignInExperience/index.tsx
@@ -13,7 +13,7 @@ import SubmitFormChangesActionBar from '@/components/SubmitFormChangesActionBar'
 import TabNav, { TabNavItem } from '@/components/TabNav';
 import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
 import { SignInExperienceTabs } from '@/consts/page-tabs';
-import { Parameters } from '@/consts/pathnames';
+import type { Parameters } from '@/consts/pathnames';
 import type { RequestError } from '@/hooks/use-api';
 import useApi from '@/hooks/use-api';
 import useSettings from '@/hooks/use-settings';
@@ -39,7 +39,7 @@ import {
 
 const SignInExperience = () => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
-  const { [Parameters.Tab]: tab } = useParams();
+  const { tab } = useParams<{ [Parameters.Tab]: string }>();
   const { data, error, mutate } = useSWR<SignInExperienceType, RequestError>('/api/sign-in-exp');
   const { settings, error: settingsError, updateSettings, mutate: mutateSettings } = useSettings();
   const { error: languageError, isLoading: isLoadingLanguages } = useUiLanguages();

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/ConnectorSetupWarning.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/ConnectorSetupWarning.tsx
@@ -3,7 +3,9 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import Alert from '@/components/Alert';
 import TextLink from '@/components/TextLink';
+import { ConnectorsPage } from '@/consts/page-tabs';
 import useEnabledConnectorTypes from '@/hooks/use-enabled-connector-types';
+import { getConnectorPathname } from '@/utilities/router';
 
 type Props = {
   requiredConnectors: ConnectorType[];
@@ -29,7 +31,11 @@ const ConnectorSetupWarning = ({ requiredConnectors }: Props) => {
             components={{
               a: (
                 <TextLink
-                  to={connectorType === ConnectorType.Social ? '/connectors/social' : '/connectors'}
+                  to={getConnectorPathname(
+                    connectorType === ConnectorType.Social
+                      ? ConnectorsPage.SocialTab
+                      : ConnectorsPage.Passwordless
+                  )}
                   target="_blank"
                 />
               ),

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/ConnectorSetupWarning.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/ConnectorSetupWarning.tsx
@@ -5,7 +5,7 @@ import Alert from '@/components/Alert';
 import TextLink from '@/components/TextLink';
 import { ConnectorsTabs } from '@/consts/page-tabs';
 import useEnabledConnectorTypes from '@/hooks/use-enabled-connector-types';
-import { getConnectorPathname } from '@/utilities/router';
+import { getConnectorsPathname } from '@/utilities/router';
 
 type Props = {
   requiredConnectors: ConnectorType[];
@@ -31,7 +31,7 @@ const ConnectorSetupWarning = ({ requiredConnectors }: Props) => {
             components={{
               a: (
                 <TextLink
-                  to={getConnectorPathname(
+                  to={getConnectorsPathname(
                     connectorType === ConnectorType.Social
                       ? ConnectorsTabs.Social
                       : ConnectorsTabs.Passwordless

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/ConnectorSetupWarning.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/ConnectorSetupWarning.tsx
@@ -3,7 +3,7 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import Alert from '@/components/Alert';
 import TextLink from '@/components/TextLink';
-import { ConnectorsPage } from '@/consts/page-tabs';
+import { ConnectorsTabs } from '@/consts/page-tabs';
 import useEnabledConnectorTypes from '@/hooks/use-enabled-connector-types';
 import { getConnectorPathname } from '@/utilities/router';
 
@@ -33,8 +33,8 @@ const ConnectorSetupWarning = ({ requiredConnectors }: Props) => {
                 <TextLink
                   to={getConnectorPathname(
                     connectorType === ConnectorType.Social
-                      ? ConnectorsPage.SocialTab
-                      : ConnectorsPage.Passwordless
+                      ? ConnectorsTabs.Social
+                      : ConnectorsTabs.Passwordless
                   )}
                   target="_blank"
                 />

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/SocialConnectorEditBox/index.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/SocialConnectorEditBox/index.tsx
@@ -7,7 +7,7 @@ import DraggableItem from '@/components/Transfer/DraggableItem';
 import { ConnectorsTabs } from '@/consts/page-tabs';
 import useConnectorGroups from '@/hooks/use-connector-groups';
 import type { ConnectorGroup } from '@/types/connector';
-import { getConnectorPathname } from '@/utilities/router';
+import { getConnectorsPathname } from '@/utilities/router';
 
 import ConnectorSetupWarning from '../ConnectorSetupWarning';
 import AddButton from './AddButton';
@@ -90,7 +90,7 @@ const SocialConnectorEditBox = ({ value, onChange }: Props) => {
       <div className={styles.setUpHint}>
         {t('sign_in_exp.sign_up_and_sign_in.social_sign_in.set_up_hint.not_in_list')}
         <TextLink
-          to={getConnectorPathname(ConnectorsTabs.Social)}
+          to={getConnectorsPathname(ConnectorsTabs.Social)}
           target="_blank"
           className={styles.setup}
         >

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/SocialConnectorEditBox/index.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/SocialConnectorEditBox/index.tsx
@@ -4,8 +4,10 @@ import { useTranslation } from 'react-i18next';
 import TextLink from '@/components/TextLink';
 import DragDropProvider from '@/components/Transfer/DragDropProvider';
 import DraggableItem from '@/components/Transfer/DraggableItem';
+import { ConnectorsPage } from '@/consts/page-tabs';
 import useConnectorGroups from '@/hooks/use-connector-groups';
 import type { ConnectorGroup } from '@/types/connector';
+import { getConnectorPathname } from '@/utilities/router';
 
 import ConnectorSetupWarning from '../ConnectorSetupWarning';
 import AddButton from './AddButton';
@@ -87,7 +89,11 @@ const SocialConnectorEditBox = ({ value, onChange }: Props) => {
       <ConnectorSetupWarning requiredConnectors={[ConnectorType.Social]} />
       <div className={styles.setUpHint}>
         {t('sign_in_exp.sign_up_and_sign_in.social_sign_in.set_up_hint.not_in_list')}
-        <TextLink to="/connectors/social" target="_blank" className={styles.setup}>
+        <TextLink
+          to={getConnectorPathname(ConnectorsPage.SocialTab)}
+          target="_blank"
+          className={styles.setup}
+        >
           {t('sign_in_exp.sign_up_and_sign_in.social_sign_in.set_up_hint.set_up_more')}
         </TextLink>
         {t('sign_in_exp.sign_up_and_sign_in.social_sign_in.set_up_hint.go_to')}

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/SocialConnectorEditBox/index.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/SocialConnectorEditBox/index.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import TextLink from '@/components/TextLink';
 import DragDropProvider from '@/components/Transfer/DragDropProvider';
 import DraggableItem from '@/components/Transfer/DraggableItem';
-import { ConnectorsPage } from '@/consts/page-tabs';
+import { ConnectorsTabs } from '@/consts/page-tabs';
 import useConnectorGroups from '@/hooks/use-connector-groups';
 import type { ConnectorGroup } from '@/types/connector';
 import { getConnectorPathname } from '@/utilities/router';
@@ -90,7 +90,7 @@ const SocialConnectorEditBox = ({ value, onChange }: Props) => {
       <div className={styles.setUpHint}>
         {t('sign_in_exp.sign_up_and_sign_in.social_sign_in.set_up_hint.not_in_list')}
         <TextLink
-          to={getConnectorPathname(ConnectorsPage.SocialTab)}
+          to={getConnectorPathname(ConnectorsTabs.Social)}
           target="_blank"
           className={styles.setup}
         >

--- a/packages/console/src/pages/UserDetails/index.tsx
+++ b/packages/console/src/pages/UserDetails/index.tsx
@@ -25,7 +25,7 @@ import type { RequestError } from '@/hooks/use-api';
 import useApi from '@/hooks/use-api';
 import * as detailsStyles from '@/scss/details.module.scss';
 import * as modalStyles from '@/scss/modal.module.scss';
-import { getUserPathname } from '@/utilities/router';
+import { getUserPathname, getUsersPathname } from '@/utilities/router';
 
 import CreateSuccess from './components/CreateSuccess';
 import ResetPasswordForm from './components/ResetPasswordForm';
@@ -72,7 +72,7 @@ const UserDetails = () => {
       setIsDeleting(false);
       setIsDeleteFormOpen(false);
       toast.success(t('user_details.deleted', { name: data.name }));
-      navigate('/users');
+      navigate(getUsersPathname());
     } catch {
       setIsDeleting(false);
     }
@@ -80,7 +80,7 @@ const UserDetails = () => {
 
   return (
     <div className={classNames(detailsStyles.container, isLogs && styles.resourceLayout)}>
-      <TextLink to="/users" icon={<Back />} className={styles.backLink}>
+      <TextLink to={getUsersPathname()} icon={<Back />} className={styles.backLink}>
         {t('user_details.back_to_users')}
       </TextLink>
       {isLoading && <DetailsSkeleton />}

--- a/packages/console/src/pages/UserDetails/index.tsx
+++ b/packages/console/src/pages/UserDetails/index.tsx
@@ -20,10 +20,12 @@ import TabNav, { TabNavItem } from '@/components/TabNav';
 import TextLink from '@/components/TextLink';
 import { generatedPasswordStorageKey } from '@/consts';
 import { generateAvatarPlaceHolderById } from '@/consts/avatars';
+import { UserTabs } from '@/consts/page-tabs';
 import type { RequestError } from '@/hooks/use-api';
 import useApi from '@/hooks/use-api';
 import * as detailsStyles from '@/scss/details.module.scss';
 import * as modalStyles from '@/scss/modal.module.scss';
+import { getUserPathname } from '@/utilities/router';
 
 import CreateSuccess from './components/CreateSuccess';
 import ResetPasswordForm from './components/ResetPasswordForm';
@@ -34,7 +36,7 @@ import { userDetailsParser } from './utils';
 
 const UserDetails = () => {
   const location = useLocation();
-  const isLogs = location.pathname.endsWith('/logs');
+  const isLogs = location.pathname.endsWith(`/${UserTabs.Logs}`);
   const { userId } = useParams();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const [isDeleteFormOpen, setIsDeleteFormOpen] = useState(false);
@@ -170,8 +172,12 @@ const UserDetails = () => {
             </div>
           </Card>
           <TabNav>
-            <TabNavItem href={`/users/${userId}`}>{t('general.settings_nav')}</TabNavItem>
-            <TabNavItem href={`/users/${userId}/logs`}>{t('user_details.tab_logs')}</TabNavItem>
+            <TabNavItem href={getUserPathname(userId, UserTabs.Details)}>
+              {t('general.settings_nav')}
+            </TabNavItem>
+            <TabNavItem href={getUserPathname(userId, UserTabs.Logs)}>
+              {t('user_details.tab_logs')}
+            </TabNavItem>
           </TabNav>
           {isLogs && <UserLogs userId={data.id} />}
           {!isLogs && userFormData && (

--- a/packages/console/src/pages/UserDetails/index.tsx
+++ b/packages/console/src/pages/UserDetails/index.tsx
@@ -21,6 +21,7 @@ import TextLink from '@/components/TextLink';
 import { generatedPasswordStorageKey } from '@/consts';
 import { generateAvatarPlaceHolderById } from '@/consts/avatars';
 import { UserTabs } from '@/consts/page-tabs';
+import { Parameters } from '@/consts/pathnames';
 import type { RequestError } from '@/hooks/use-api';
 import useApi from '@/hooks/use-api';
 import * as detailsStyles from '@/scss/details.module.scss';
@@ -37,7 +38,7 @@ import { userDetailsParser } from './utils';
 const UserDetails = () => {
   const location = useLocation();
   const isLogs = location.pathname.endsWith(`/${UserTabs.Logs}`);
-  const { userId } = useParams();
+  const { [Parameters.UserId]: userId } = useParams();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const [isDeleteFormOpen, setIsDeleteFormOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);

--- a/packages/console/src/pages/UserDetails/index.tsx
+++ b/packages/console/src/pages/UserDetails/index.tsx
@@ -21,7 +21,7 @@ import TextLink from '@/components/TextLink';
 import { generatedPasswordStorageKey } from '@/consts';
 import { generateAvatarPlaceHolderById } from '@/consts/avatars';
 import { UserTabs } from '@/consts/page-tabs';
-import { Parameters } from '@/consts/pathnames';
+import type { Parameters } from '@/consts/pathnames';
 import type { RequestError } from '@/hooks/use-api';
 import useApi from '@/hooks/use-api';
 import * as detailsStyles from '@/scss/details.module.scss';
@@ -38,7 +38,7 @@ import { userDetailsParser } from './utils';
 const UserDetails = () => {
   const location = useLocation();
   const isLogs = location.pathname.endsWith(`/${UserTabs.Logs}`);
-  const { [Parameters.UserId]: userId } = useParams();
+  const { userId } = useParams<{ [Parameters.UserId]: string }>();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const [isDeleteFormOpen, setIsDeleteFormOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);

--- a/packages/console/src/pages/UserDetails/index.tsx
+++ b/packages/console/src/pages/UserDetails/index.tsx
@@ -25,7 +25,7 @@ import type { RequestError } from '@/hooks/use-api';
 import useApi from '@/hooks/use-api';
 import * as detailsStyles from '@/scss/details.module.scss';
 import * as modalStyles from '@/scss/modal.module.scss';
-import { getUserPathname, getUsersPathname } from '@/utilities/router';
+import { getUserDetailsPathname, getUserLogsPathname, getUsersPathname } from '@/utilities/router';
 
 import CreateSuccess from './components/CreateSuccess';
 import ResetPasswordForm from './components/ResetPasswordForm';
@@ -172,12 +172,10 @@ const UserDetails = () => {
             </div>
           </Card>
           <TabNav>
-            <TabNavItem href={getUserPathname(userId, UserTabs.Details)}>
+            <TabNavItem href={getUserDetailsPathname(userId)}>
               {t('general.settings_nav')}
             </TabNavItem>
-            <TabNavItem href={getUserPathname(userId, UserTabs.Logs)}>
-              {t('user_details.tab_logs')}
-            </TabNavItem>
+            <TabNavItem href={getUserLogsPathname(userId)}>{t('user_details.tab_logs')}</TabNavItem>
           </TabNav>
           {isLogs && <UserLogs userId={data.id} />}
           {!isLogs && userFormData && (

--- a/packages/console/src/pages/Users/index.tsx
+++ b/packages/console/src/pages/Users/index.tsx
@@ -20,10 +20,12 @@ import TableError from '@/components/Table/TableError';
 import TableLoading from '@/components/Table/TableLoading';
 import { generatedPasswordStorageKey } from '@/consts';
 import { generateAvatarPlaceHolderById } from '@/consts/avatars';
+import { UserTabs } from '@/consts/page-tabs';
 import type { RequestError } from '@/hooks/use-api';
 import * as modalStyles from '@/scss/modal.module.scss';
 import * as resourcesStyles from '@/scss/resources.module.scss';
 import * as tableStyles from '@/scss/table.module.scss';
+import { getUserPathname } from '@/utilities/router';
 
 import CreateForm from './components/CreateForm';
 import * as styles from './index.module.scss';
@@ -75,7 +77,7 @@ const Users = () => {
 
               if (createdUser && password) {
                 sessionStorage.setItem(generatedPasswordStorageKey, password);
-                navigate(`/users/${createdUser.id}`);
+                navigate(getUserPathname(createdUser.id, UserTabs.Details));
               }
             }}
           />
@@ -134,7 +136,7 @@ const Users = () => {
                   key={id}
                   className={tableStyles.clickable}
                   onClick={() => {
-                    navigate(`/users/${id}`);
+                    navigate(getUserPathname(id, UserTabs.Details));
                   }}
                 >
                   <td>
@@ -148,7 +150,7 @@ const Users = () => {
                           src={avatar ?? generateAvatarPlaceHolderById(id)}
                         />
                       }
-                      to={`/users/${id}`}
+                      to={getUserPathname(id, UserTabs.Details)}
                       size="compact"
                     />
                   </td>

--- a/packages/console/src/pages/Users/index.tsx
+++ b/packages/console/src/pages/Users/index.tsx
@@ -20,12 +20,11 @@ import TableError from '@/components/Table/TableError';
 import TableLoading from '@/components/Table/TableLoading';
 import { generatedPasswordStorageKey } from '@/consts';
 import { generateAvatarPlaceHolderById } from '@/consts/avatars';
-import { UserTabs } from '@/consts/page-tabs';
 import type { RequestError } from '@/hooks/use-api';
 import * as modalStyles from '@/scss/modal.module.scss';
 import * as resourcesStyles from '@/scss/resources.module.scss';
 import * as tableStyles from '@/scss/table.module.scss';
-import { getUserPathname } from '@/utilities/router';
+import { getUserDetailsPathname } from '@/utilities/router';
 
 import CreateForm from './components/CreateForm';
 import * as styles from './index.module.scss';
@@ -77,7 +76,7 @@ const Users = () => {
 
               if (createdUser && password) {
                 sessionStorage.setItem(generatedPasswordStorageKey, password);
-                navigate(getUserPathname(createdUser.id, UserTabs.Details));
+                navigate(getUserDetailsPathname(createdUser.id));
               }
             }}
           />
@@ -136,7 +135,7 @@ const Users = () => {
                   key={id}
                   className={tableStyles.clickable}
                   onClick={() => {
-                    navigate(getUserPathname(id, UserTabs.Details));
+                    navigate(getUserDetailsPathname(id));
                   }}
                 >
                   <td>
@@ -150,7 +149,7 @@ const Users = () => {
                           src={avatar ?? generateAvatarPlaceHolderById(id)}
                         />
                       }
-                      to={getUserPathname(id, UserTabs.Details)}
+                      to={getUserDetailsPathname(id)}
                       size="compact"
                     />
                   </td>

--- a/packages/console/src/utilities/router.ts
+++ b/packages/console/src/utilities/router.ts
@@ -1,6 +1,11 @@
+import type { ConnectorsPage } from '@/consts/page-tabs';
+
 export const getBasename = (prefix: string, developmentPort: string): string => {
   const isBasenameNeeded =
     process.env.NODE_ENV !== 'development' || process.env.PORT === developmentPort;
 
   return isBasenameNeeded ? '/' + prefix : '';
 };
+
+export const getConnectorPathname = (tab: ConnectorsPage, connectorId?: string) =>
+  `/connectors/${tab}${connectorId ? `/${connectorId}` : ''}`;

--- a/packages/console/src/utilities/router.ts
+++ b/packages/console/src/utilities/router.ts
@@ -1,4 +1,5 @@
-import type { ConnectorsPage } from '@/consts/page-tabs';
+import type { ConnectorsTabs } from '@/consts/page-tabs';
+import { UserTabs } from '@/consts/page-tabs';
 
 export const getBasename = (prefix: string, developmentPort: string): string => {
   const isBasenameNeeded =
@@ -7,5 +8,10 @@ export const getBasename = (prefix: string, developmentPort: string): string => 
   return isBasenameNeeded ? '/' + prefix : '';
 };
 
-export const getConnectorPathname = (tab: ConnectorsPage, connectorId?: string) =>
+export const getConnectorPathname = (tab: ConnectorsTabs, connectorId?: string) =>
   `/connectors/${tab}${connectorId ? `/${connectorId}` : ''}`;
+
+export const getUserPathname = (userId: string, tab: UserTabs) => `/users/${userId}/${tab}`;
+
+export const getUserLogPathname = (userId: string, logId: string) =>
+  `/users/${userId}/${UserTabs.Logs}/${logId}`;

--- a/packages/console/src/utilities/router.ts
+++ b/packages/console/src/utilities/router.ts
@@ -1,5 +1,7 @@
-import type { ConnectorsTabs } from '@/consts/page-tabs';
-import { UserTabs } from '@/consts/page-tabs';
+import { ConnectorType } from '@logto/schemas';
+import { snakeCase } from 'snake-case';
+
+import { ConnectorsTabs, UserTabs } from '@/consts/page-tabs';
 
 export const getBasename = (prefix: string, developmentPort: string): string => {
   const isBasenameNeeded =
@@ -8,8 +10,33 @@ export const getBasename = (prefix: string, developmentPort: string): string => 
   return isBasenameNeeded ? '/' + prefix : '';
 };
 
-export const getConnectorPathname = (tab: ConnectorsTabs, connectorId?: string) =>
-  `/connectors/${tab}${connectorId ? `/${connectorId}` : ''}`;
+export const getApplicationsPathname = () => `/applications`;
+
+export const getApplicationDetailsPathname = (appId: string) => `/applications/${appId}`;
+
+export const getCreateApplicationPathname = () => `/applications/create`;
+
+export const getApiResourcesPathname = () => `/api-resources`;
+
+export const getApiResourceDetailsPathname = (resourceId: string) => `/api-resources/${resourceId}`;
+
+export const getCreateApiResourcePathname = () => `/api-resources/create`;
+
+export const getConnectorsPathname = (tab: ConnectorsTabs) => `/connectors/${tab}`;
+
+export const getConnectorDetailsPathname = (connectorType: ConnectorType, connectorId: string) => {
+  const tab =
+    connectorType === ConnectorType.Social ? ConnectorsTabs.Social : ConnectorsTabs.Passwordless;
+
+  return `/connectors/${tab}/${connectorId}`;
+};
+
+export const getCreateConnectorPathname = (connectorType: ConnectorType) => {
+  const tab =
+    connectorType === ConnectorType.Social ? ConnectorsTabs.Social : ConnectorsTabs.Passwordless;
+
+  return `/connectors/${tab}/create/${snakeCase(connectorType, { delimiter: '-' })}`;
+};
 
 export const getUserPathname = (userId: string, tab: UserTabs) => `/users/${userId}/${tab}`;
 

--- a/packages/console/src/utilities/router.ts
+++ b/packages/console/src/utilities/router.ts
@@ -2,7 +2,7 @@ import { ConnectorType } from '@logto/schemas';
 import kebabCase from 'lodash.kebabcase';
 
 import { ConnectorsTabs, UserTabs } from '@/consts/page-tabs';
-import { Page } from '@/consts/pathnames';
+import { PagePath } from '@/consts/pathnames';
 
 export const getBasename = (prefix: string, developmentPort: string): string => {
   const isBasenameNeeded =
@@ -11,41 +11,47 @@ export const getBasename = (prefix: string, developmentPort: string): string => 
   return isBasenameNeeded ? `/${prefix}` : '';
 };
 
-export const getApplicationsPathname = () => `/${Page.Applications}`;
+export const getApplicationsPathname = () => `/${PagePath.Applications}`;
 
-export const getApplicationDetailsPathname = (appId: string) => `/${Page.Applications}/${appId}`;
+export const getApplicationDetailsPathname = (appId: string) =>
+  `/${PagePath.Applications}/${appId}`;
 
-export const getCreateApplicationPathname = () => `/${Page.Applications}/create`;
+export const getCreateApplicationPathname = () => `/${PagePath.Applications}/create`;
 
-export const getApiResourcesPathname = () => `/${Page.ApiResources}`;
+export const getApiResourcesPathname = () => `/${PagePath.ApiResources}`;
 
 export const getApiResourceDetailsPathname = (resourceId: string) =>
-  `/${Page.ApiResources}/${resourceId}`;
+  `/${PagePath.ApiResources}/${resourceId}`;
 
-export const getCreateApiResourcePathname = () => `/${Page.ApiResources}/create`;
+export const getCreateApiResourcePathname = () => `/${PagePath.ApiResources}/create`;
 
-export const getConnectorsPathname = (tab: ConnectorsTabs) => `/${Page.Connectors}/${tab}`;
+export const getConnectorsPathname = (tab: ConnectorsTabs) => `/${PagePath.Connectors}/${tab}`;
 
 export const getConnectorDetailsPathname = (connectorType: ConnectorType, connectorId: string) => {
   const tab =
     connectorType === ConnectorType.Social ? ConnectorsTabs.Social : ConnectorsTabs.Passwordless;
 
-  return `/${Page.ApiResources}/${tab}/${connectorId}`;
+  return `/${PagePath.ApiResources}/${tab}/${connectorId}`;
 };
 
 export const getCreateConnectorPathname = (connectorType: ConnectorType) => {
   const tab =
     connectorType === ConnectorType.Social ? ConnectorsTabs.Social : ConnectorsTabs.Passwordless;
 
-  return `/${Page.ApiResources}/${tab}/create/${kebabCase(connectorType)}`;
+  return `/${PagePath.ApiResources}/${tab}/create/${kebabCase(connectorType)}`;
 };
 
-export const getUsersPathname = () => `/${Page.Users}`;
+export const getUsersPathname = () => `/${PagePath.Users}`;
 
 export const getUserDetailsPathname = (userId: string) =>
-  `/${Page.Users}/${userId}/${UserTabs.Details}`;
+  `/${PagePath.Users}/${userId}/${UserTabs.Details}`;
 
-export const getUserLogsPathname = (userId: string) => `/${Page.Users}/${userId}/${UserTabs.Logs}`;
+export const getUserLogsPathname = (userId: string) =>
+  `/${PagePath.Users}/${userId}/${UserTabs.Logs}`;
 
 export const getUserLogDetailsPathname = (userId: string, logId: string) =>
-  `/${Page.Users}/${userId}/${UserTabs.Logs}/${logId}`;
+  `/${PagePath.Users}/${userId}/${UserTabs.Logs}/${logId}`;
+
+export const getAuditLogsPathname = () => `/${PagePath.AuditLogs}`;
+
+export const getAuditLogDetailsPathname = (logId: string) => `/${PagePath.AuditLogs}/${logId}`;

--- a/packages/console/src/utilities/router.ts
+++ b/packages/console/src/utilities/router.ts
@@ -11,6 +11,10 @@ export const getBasename = (prefix: string, developmentPort: string): string => 
   return isBasenameNeeded ? `/${prefix}` : '';
 };
 
+/**
+ * Application routes
+ */
+
 export const getApplicationsPathname = () => `/${PagePath.Applications}`;
 
 export const getApplicationDetailsPathname = (appId: string) =>
@@ -18,12 +22,20 @@ export const getApplicationDetailsPathname = (appId: string) =>
 
 export const getCreateApplicationPathname = () => `/${PagePath.Applications}/create`;
 
+/**
+ * API Resource routes
+ */
+
 export const getApiResourcesPathname = () => `/${PagePath.ApiResources}`;
 
 export const getApiResourceDetailsPathname = (resourceId: string) =>
   `/${PagePath.ApiResources}/${resourceId}`;
 
 export const getCreateApiResourcePathname = () => `/${PagePath.ApiResources}/create`;
+
+/**
+ * Connector routes
+ */
 
 export const getConnectorsPathname = (tab: ConnectorsTabs) => `/${PagePath.Connectors}/${tab}`;
 
@@ -41,6 +53,10 @@ export const getCreateConnectorPathname = (connectorType: ConnectorType) => {
   return `/${PagePath.ApiResources}/${tab}/create/${kebabCase(connectorType)}`;
 };
 
+/**
+ * User routes
+ */
+
 export const getUsersPathname = () => `/${PagePath.Users}`;
 
 export const getUserDetailsPathname = (userId: string) =>
@@ -51,6 +67,10 @@ export const getUserLogsPathname = (userId: string) =>
 
 export const getUserLogDetailsPathname = (userId: string, logId: string) =>
   `/${PagePath.Users}/${userId}/${UserTabs.Logs}/${logId}`;
+
+/**
+ * Audit Log routes
+ */
 
 export const getAuditLogsPathname = () => `/${PagePath.AuditLogs}`;
 

--- a/packages/console/src/utilities/router.ts
+++ b/packages/console/src/utilities/router.ts
@@ -2,45 +2,50 @@ import { ConnectorType } from '@logto/schemas';
 import kebabCase from 'lodash.kebabcase';
 
 import { ConnectorsTabs, UserTabs } from '@/consts/page-tabs';
+import { Page } from '@/consts/pathnames';
 
 export const getBasename = (prefix: string, developmentPort: string): string => {
   const isBasenameNeeded =
     process.env.NODE_ENV !== 'development' || process.env.PORT === developmentPort;
 
-  return isBasenameNeeded ? '/' + prefix : '';
+  return isBasenameNeeded ? `/${prefix}` : '';
 };
 
-export const getApplicationsPathname = () => '/applications';
+export const getApplicationsPathname = () => `/${Page.Applications}`;
 
-export const getApplicationDetailsPathname = (appId: string) => `/applications/${appId}`;
+export const getApplicationDetailsPathname = (appId: string) => `/${Page.Applications}/${appId}`;
 
-export const getCreateApplicationPathname = () => '/applications/create';
+export const getCreateApplicationPathname = () => `/${Page.Applications}/create`;
 
-export const getApiResourcesPathname = () => '/api-resources';
+export const getApiResourcesPathname = () => `/${Page.ApiResources}`;
 
-export const getApiResourceDetailsPathname = (resourceId: string) => `/api-resources/${resourceId}`;
+export const getApiResourceDetailsPathname = (resourceId: string) =>
+  `/${Page.ApiResources}/${resourceId}`;
 
-export const getCreateApiResourcePathname = () => '/api-resources/create';
+export const getCreateApiResourcePathname = () => `/${Page.ApiResources}/create`;
 
-export const getConnectorsPathname = (tab: ConnectorsTabs) => `/connectors/${tab}`;
+export const getConnectorsPathname = (tab: ConnectorsTabs) => `/${Page.Connectors}/${tab}`;
 
 export const getConnectorDetailsPathname = (connectorType: ConnectorType, connectorId: string) => {
   const tab =
     connectorType === ConnectorType.Social ? ConnectorsTabs.Social : ConnectorsTabs.Passwordless;
 
-  return `/connectors/${tab}/${connectorId}`;
+  return `/${Page.ApiResources}/${tab}/${connectorId}`;
 };
 
 export const getCreateConnectorPathname = (connectorType: ConnectorType) => {
   const tab =
     connectorType === ConnectorType.Social ? ConnectorsTabs.Social : ConnectorsTabs.Passwordless;
 
-  return `/connectors/${tab}/create/${kebabCase(connectorType)}`;
+  return `/${Page.ApiResources}/${tab}/create/${kebabCase(connectorType)}`;
 };
 
-export const getUsersPathname = () => '/users';
+export const getUsersPathname = () => `/${Page.Users}`;
 
-export const getUserPathname = (userId: string, tab: UserTabs) => `/users/${userId}/${tab}`;
+export const getUserDetailsPathname = (userId: string) =>
+  `/${Page.Users}/${userId}/${UserTabs.Details}`;
 
-export const getUserLogPathname = (userId: string, logId: string) =>
-  `/users/${userId}/${UserTabs.Logs}/${logId}`;
+export const getUserLogsPathname = (userId: string) => `/${Page.Users}/${userId}/${UserTabs.Logs}`;
+
+export const getUserLogDetailsPathname = (userId: string, logId: string) =>
+  `/${Page.Users}/${userId}/${UserTabs.Logs}/${logId}`;

--- a/packages/console/src/utilities/router.ts
+++ b/packages/console/src/utilities/router.ts
@@ -1,5 +1,5 @@
 import { ConnectorType } from '@logto/schemas';
-import { snakeCase } from 'snake-case';
+import kebabCase from 'lodash.kebabcase';
 
 import { ConnectorsTabs, UserTabs } from '@/consts/page-tabs';
 
@@ -10,17 +10,17 @@ export const getBasename = (prefix: string, developmentPort: string): string => 
   return isBasenameNeeded ? '/' + prefix : '';
 };
 
-export const getApplicationsPathname = () => `/applications`;
+export const getApplicationsPathname = () => '/applications';
 
 export const getApplicationDetailsPathname = (appId: string) => `/applications/${appId}`;
 
-export const getCreateApplicationPathname = () => `/applications/create`;
+export const getCreateApplicationPathname = () => '/applications/create';
 
-export const getApiResourcesPathname = () => `/api-resources`;
+export const getApiResourcesPathname = () => '/api-resources';
 
 export const getApiResourceDetailsPathname = (resourceId: string) => `/api-resources/${resourceId}`;
 
-export const getCreateApiResourcePathname = () => `/api-resources/create`;
+export const getCreateApiResourcePathname = () => '/api-resources/create';
 
 export const getConnectorsPathname = (tab: ConnectorsTabs) => `/connectors/${tab}`;
 
@@ -35,8 +35,10 @@ export const getCreateConnectorPathname = (connectorType: ConnectorType) => {
   const tab =
     connectorType === ConnectorType.Social ? ConnectorsTabs.Social : ConnectorsTabs.Passwordless;
 
-  return `/connectors/${tab}/create/${snakeCase(connectorType, { delimiter: '-' })}`;
+  return `/connectors/${tab}/create/${kebabCase(connectorType)}`;
 };
+
+export const getUsersPathname = () => '/users';
 
 export const getUserPathname = (userId: string, tab: UserTabs) => `/users/${userId}/${tab}`;
 

--- a/packages/console/src/utilities/router.ts
+++ b/packages/console/src/utilities/router.ts
@@ -43,14 +43,14 @@ export const getConnectorDetailsPathname = (connectorType: ConnectorType, connec
   const tab =
     connectorType === ConnectorType.Social ? ConnectorsTabs.Social : ConnectorsTabs.Passwordless;
 
-  return `/${PagePath.ApiResources}/${tab}/${connectorId}`;
+  return `/${PagePath.Connectors}/${tab}/${connectorId}`;
 };
 
 export const getCreateConnectorPathname = (connectorType: ConnectorType) => {
   const tab =
     connectorType === ConnectorType.Social ? ConnectorsTabs.Social : ConnectorsTabs.Passwordless;
 
-  return `/${PagePath.ApiResources}/${tab}/create/${kebabCase(connectorType)}`;
+  return `/${PagePath.Connectors}/${tab}/create/${kebabCase(connectorType)}`;
 };
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,7 @@ importers:
       '@types/react-dom': ^18.0.0
       '@types/react-modal': ^3.13.1
       '@types/react-syntax-highlighter': ^15.5.1
+      camelcase: ^7.0.0
       classnames: ^2.3.1
       clean-deep: ^3.4.0
       cross-env: ^7.0.3
@@ -203,6 +204,7 @@ importers:
       '@types/react-dom': 18.0.6
       '@types/react-modal': 3.13.1
       '@types/react-syntax-highlighter': 15.5.1
+      camelcase: 7.0.0
       classnames: 2.3.1
       clean-deep: 3.4.0
       cross-env: 7.0.3


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Share constant string values between Admin Console pages since we will use specific path segments for some commonly used logic between pages. E.g., `/create` is used for create-modal pages.

- Add a `pathnames.ts` file to define some constants to share them between all pages.
- Add some `getSomePathname` utils to align pathnames on different pages.
- Decouple the `i18n` keys with router names in the `SidebarItem` component. Add a `pagePath` prop to define the related page link.
- Refactor the connector's `react-router` definitions in the `App.tsx` file, and add a `/create` route to handle the creating logic of connectors. Now, the create connector's modal relies on the browser location, not the internal state of the page component.

### Recommended Review Flow
`src/constants/page-tabs`, `src/constants/pathnames`, and `src/utilities/routers` are added & modified, then I refactor all related codes in the whole code base.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.
