### PR TITLE
feat: hooks schema and APIs

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
     "dbaeumer.vscode-eslint",
     "stylelint.vscode-stylelint",
     "clinyong.vscode-css-modules",
-    "vunguyentuan.vscode-css-variables"
+    "vunguyentuan.vscode-css-variables",
+    "frigus02.vscode-sql-tagged-template-literals-syntax-only"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,6 +36,7 @@
     "slonik",
     "stylelint",
     "topbar",
-    "hasura"
+    "hasura",
+    "withtyped"
   ]
 }

--- a/packages/cli/src/commands/database/seed/index.ts
+++ b/packages/cli/src/commands/database/seed/index.ts
@@ -11,6 +11,7 @@ import {
   createDemoAppApplication,
   defaultRole,
 } from '@logto/schemas';
+import { Hooks } from '@logto/schemas/models';
 import chalk from 'chalk';
 import type { DatabasePool, DatabaseTransactionConnection } from 'slonik';
 import { sql } from 'slonik';
@@ -44,6 +45,11 @@ const createTables = async (connection: DatabaseTransactionConnection) => {
   for (const [, query] of queries) {
     // eslint-disable-next-line no-await-in-loop
     await connection.query(sql`${raw(query)}`);
+  }
+
+  for (const table of [Hooks]) {
+    // eslint-disable-next-line no-await-in-loop
+    await connection.query(sql`${raw(table.raw)}`);
   }
 };
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,8 @@
     "@logto/schemas": "workspace:*",
     "@logto/shared": "workspace:*",
     "@silverhand/essentials": "^1.3.0",
+    "@withtyped/postgres": "^0.3.1",
+    "@withtyped/server": "^0.3.0",
     "chalk": "^5.0.0",
     "clean-deep": "^3.4.0",
     "date-fns": "^2.29.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,7 @@
     "@logto/shared": "workspace:*",
     "@silverhand/essentials": "^1.3.0",
     "@withtyped/postgres": "^0.3.1",
-    "@withtyped/server": "^0.3.0",
+    "@withtyped/server": "^0.3.1",
     "chalk": "^5.0.0",
     "clean-deep": "^3.4.0",
     "date-fns": "^2.29.3",

--- a/packages/core/src/env-set/create-query-client-by-env.ts
+++ b/packages/core/src/env-set/create-query-client-by-env.ts
@@ -1,0 +1,43 @@
+import { assert, assertEnv } from '@silverhand/essentials';
+import { PostgresQueryClient } from '@withtyped/postgres';
+import chalk from 'chalk';
+import { parseDsn } from 'slonik';
+
+import { MockQueryClient } from '#src/test-utils/query-client.js';
+
+const createQueryClientByEnv = (isTest: boolean) => {
+  // Database connection is disabled in unit test environment
+  if (isTest) {
+    return new MockQueryClient();
+  }
+
+  const key = 'DB_URL';
+
+  try {
+    const databaseDsn = assertEnv(key);
+    assert(parseDsn(databaseDsn), new Error('Database name is required in `DB_URL`'));
+
+    return new PostgresQueryClient({ connectionString: databaseDsn });
+  } catch (error: unknown) {
+    if (error instanceof Error && error.message === `env variable ${key} not found`) {
+      console.error(
+        `${chalk.red('[error]')} No Postgres DSN (${chalk.green(
+          key
+        )}) found in env variables.\n\n` +
+          `  Either provide it in your env, or add it to the ${chalk.blue(
+            '.env'
+          )} file in the Logto project root.\n\n` +
+          `  If you want to set up a new Logto database, run ${chalk.green(
+            'npm run cli db seed'
+          )} before setting env ${chalk.green(key)}.\n\n` +
+          `  Visit ${chalk.blue(
+            'https://docs.logto.io/docs/references/core/configuration'
+          )} for more info about setting up env.\n`
+      );
+    }
+
+    throw error;
+  }
+};
+
+export default createQueryClientByEnv;

--- a/packages/core/src/routes/hook.ts
+++ b/packages/core/src/routes/hook.ts
@@ -1,0 +1,32 @@
+import { Hooks } from '@logto/schemas/models';
+import { createModelRouter } from '@withtyped/postgres';
+import { koaAdapter, RequestError } from '@withtyped/server';
+import type { MiddlewareType } from 'koa';
+import koaBody from 'koa-body';
+
+import envSet from '#src/env-set/index.js';
+import LogtoRequestError from '#src/errors/RequestError/index.js';
+
+import type { AuthedRouter } from './types.js';
+
+// Organize this function if we decide to adopt withtyped eventually
+const errorHandler: MiddlewareType = async (_, next) => {
+  try {
+    await next();
+  } catch (error: unknown) {
+    if (error instanceof RequestError) {
+      throw new LogtoRequestError(
+        { code: 'request.general', status: error.status },
+        error.original
+      );
+    }
+
+    throw error;
+  }
+};
+
+export default function hookRoutes<T extends AuthedRouter>(router: T) {
+  const modelRouter = createModelRouter(Hooks, envSet.queryClient).withCrud();
+
+  router.all('/hooks/(.*)?', koaBody(), errorHandler, koaAdapter(modelRouter.routes()));
+}

--- a/packages/core/src/routes/init.ts
+++ b/packages/core/src/routes/init.ts
@@ -14,6 +14,7 @@ import authnRoutes from './authn.js';
 import connectorRoutes from './connector.js';
 import customPhraseRoutes from './custom-phrase.js';
 import dashboardRoutes from './dashboard.js';
+import hookRoutes from './hook.js';
 import interactionRoutes from './interaction/index.js';
 import logRoutes from './log.js';
 import phraseRoutes from './phrase.js';
@@ -48,6 +49,7 @@ const createRouters = (provider: Provider) => {
   roleRoutes(managementRouter);
   dashboardRoutes(managementRouter);
   customPhraseRoutes(managementRouter);
+  hookRoutes(managementRouter);
 
   const profileRouter: AnonymousRouter = new Router();
   profileRoutes(profileRouter, provider);

--- a/packages/core/src/test-utils/query-client.ts
+++ b/packages/core/src/test-utils/query-client.ts
@@ -1,0 +1,19 @@
+import type { PostgreSql } from '@withtyped/postgres';
+import { QueryClient } from '@withtyped/server';
+
+// Consider move to withtyped if everything goes well
+export class MockQueryClient extends QueryClient<PostgreSql> {
+  async connect() {
+    console.debug('MockQueryClient connect');
+  }
+
+  async end() {
+    console.debug('MockQueryClient end');
+  }
+
+  async query() {
+    console.debug('MockQueryClient query');
+
+    return { rows: [], rowCount: 0 };
+  }
+}

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -52,6 +52,6 @@
   },
   "prettier": "@silverhand/eslint-config/.prettierrc",
   "dependencies": {
-    "@withtyped/server": "^0.3.0"
+    "@withtyped/server": "^0.3.1"
   }
 }

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -50,5 +50,8 @@
   "eslintConfig": {
     "extends": "@silverhand"
   },
-  "prettier": "@silverhand/eslint-config/.prettierrc"
+  "prettier": "@silverhand/eslint-config/.prettierrc",
+  "dependencies": {
+    "@withtyped/server": "^0.3.0"
+  }
 }

--- a/packages/integration-tests/src/tests/api/hooks.test.ts
+++ b/packages/integration-tests/src/tests/api/hooks.test.ts
@@ -1,0 +1,31 @@
+import type { Hooks } from '@logto/schemas/models';
+import type { InferModelType } from '@withtyped/server';
+
+import { authedAdminApi } from '#src/api/index.js';
+
+describe('hooks', () => {
+  it('should be able to create, query, and delete a hook', async () => {
+    type Hook = InferModelType<typeof Hooks>;
+
+    const payload = {
+      event: 'PostRegister',
+      config: {
+        url: 'https://foo.bar',
+        headers: { foo: 'bar' },
+        retries: 3,
+      },
+    };
+    const created = await authedAdminApi.post('hooks', { json: payload }).json<Hook>();
+
+    expect(payload.event).toEqual(created.event);
+    expect(payload.config).toEqual(created.config);
+
+    expect(await authedAdminApi.get('hooks').json<Hook[]>()).toContainEqual(created);
+    expect(await authedAdminApi.get(`hooks/${created.id}`).json<Hook>()).toEqual(created);
+    expect(await authedAdminApi.delete(`hooks/${created.id}`)).toHaveProperty('statusCode', 204);
+    await expect(authedAdminApi.get(`hooks/${created.id}`)).rejects.toHaveProperty(
+      'response.statusCode',
+      404
+    );
+  });
+});

--- a/packages/schemas/alterations/1.0.0_beta.10-1-logto-config.ts
+++ b/packages/schemas/alterations/1.0.0_beta.10-1-logto-config.ts
@@ -1,6 +1,6 @@
 import { sql } from 'slonik';
 
-import type { AlterationScript } from '../src/types/alteration.js';
+import type { AlterationScript } from '../lib/types/alteration.js';
 
 const alteration: AlterationScript = {
   up: async (pool) => {

--- a/packages/schemas/alterations/1.0.0_beta.10-1663923211-machine-to-machine-app.ts
+++ b/packages/schemas/alterations/1.0.0_beta.10-1663923211-machine-to-machine-app.ts
@@ -1,6 +1,6 @@
 import { sql } from 'slonik';
 
-import type { AlterationScript } from '../src/types/alteration.js';
+import type { AlterationScript } from '../lib/types/alteration.js';
 
 const alteration: AlterationScript = {
   up: async (pool) => {

--- a/packages/schemas/alterations/1.0.0_beta.10-1664265197-custom-phrases.ts
+++ b/packages/schemas/alterations/1.0.0_beta.10-1664265197-custom-phrases.ts
@@ -1,6 +1,6 @@
 import { sql } from 'slonik';
 
-import type { AlterationScript } from '../src/types/alteration.js';
+import type { AlterationScript } from '../lib/types/alteration.js';
 
 const alteration: AlterationScript = {
   up: async (pool) => {

--- a/packages/schemas/alterations/1.0.0_beta.11-1664347703-rename-language-key-to-tag.ts
+++ b/packages/schemas/alterations/1.0.0_beta.11-1664347703-rename-language-key-to-tag.ts
@@ -1,6 +1,6 @@
 import { sql } from 'slonik';
 
-import type { AlterationScript } from '../src/types/alteration.js';
+import type { AlterationScript } from '../lib/types/alteration.js';
 
 const alteration: AlterationScript = {
   up: async (pool) => {

--- a/packages/schemas/alterations/1.0.0_beta.11-1664356000-add-created-at-column-to-users.ts
+++ b/packages/schemas/alterations/1.0.0_beta.11-1664356000-add-created-at-column-to-users.ts
@@ -1,6 +1,6 @@
 import { sql } from 'slonik';
 
-import type { AlterationScript } from '../src/types/alteration.js';
+import type { AlterationScript } from '../lib/types/alteration.js';
 
 const alteration: AlterationScript = {
   up: async (pool) => {

--- a/packages/schemas/alterations/1.0.0_beta.11-1664462389-correct-user-created-at-column-by-user-logs.ts
+++ b/packages/schemas/alterations/1.0.0_beta.11-1664462389-correct-user-created-at-column-by-user-logs.ts
@@ -1,6 +1,6 @@
 import { sql } from 'slonik';
 
-import type { AlterationScript } from '../src/types/alteration.js';
+import type { AlterationScript } from '../lib/types/alteration.js';
 
 const alteration: AlterationScript = {
   up: async (pool) => {

--- a/packages/schemas/alterations/1.0.0_beta.14-1665300135-sign-in-sign-up.ts
+++ b/packages/schemas/alterations/1.0.0_beta.14-1665300135-sign-in-sign-up.ts
@@ -1,6 +1,6 @@
 import { sql } from 'slonik';
 
-import type { AlterationScript } from '../src/types/alteration.js';
+import type { AlterationScript } from '../lib/types/alteration.js';
 
 enum SignInMethodState {
   Primary = 'primary',

--- a/packages/schemas/alterations/1.0.0_beta.14-1667283640-remove-forgot-password.ts
+++ b/packages/schemas/alterations/1.0.0_beta.14-1667283640-remove-forgot-password.ts
@@ -1,6 +1,6 @@
 import { sql } from 'slonik';
 
-import type { AlterationScript } from '../src/types/alteration.js';
+import type { AlterationScript } from '../lib/types/alteration.js';
 
 const alteration: AlterationScript = {
   up: async (pool) => {

--- a/packages/schemas/alterations/1.0.0_beta.14-1667292082-remove-sign-in-method.ts
+++ b/packages/schemas/alterations/1.0.0_beta.14-1667292082-remove-sign-in-method.ts
@@ -1,6 +1,6 @@
 import { sql } from 'slonik';
 
-import type { AlterationScript } from '../src/types/alteration.js';
+import type { AlterationScript } from '../lib/types/alteration.js';
 
 const alteration: AlterationScript = {
   up: async (pool) => {

--- a/packages/schemas/alterations/1.0.0_beta.14-1667374974-user-suspend.ts
+++ b/packages/schemas/alterations/1.0.0_beta.14-1667374974-user-suspend.ts
@@ -1,6 +1,6 @@
 import { sql } from 'slonik';
 
-import type { AlterationScript } from '../src/types/alteration.js';
+import type { AlterationScript } from '../lib/types/alteration.js';
 
 const alteration: AlterationScript = {
   up: async (pool) => {

--- a/packages/schemas/alterations/1.0.0_beta.14-1667900481-add-passcode-type-continue.ts
+++ b/packages/schemas/alterations/1.0.0_beta.14-1667900481-add-passcode-type-continue.ts
@@ -1,6 +1,6 @@
 import { sql } from 'slonik';
 
-import type { AlterationScript } from '../src/types/alteration.js';
+import type { AlterationScript } from '../lib/types/alteration.js';
 
 const alteration: AlterationScript = {
   up: async (pool) => {

--- a/packages/schemas/alterations/next-1668666590-support-multiple-connector-instances.ts
+++ b/packages/schemas/alterations/next-1668666590-support-multiple-connector-instances.ts
@@ -1,6 +1,6 @@
 import { sql } from 'slonik';
 
-import type { AlterationScript } from '../src/types/alteration.js';
+import type { AlterationScript } from '../lib/types/alteration.js';
 
 const alteration: AlterationScript = {
   up: async (pool) => {

--- a/packages/schemas/alterations/next-1668666600-remove-connector-enabled.ts
+++ b/packages/schemas/alterations/next-1668666600-remove-connector-enabled.ts
@@ -1,6 +1,6 @@
 import { sql } from 'slonik';
 
-import type { AlterationScript } from '../src/types/alteration.js';
+import type { AlterationScript } from '../lib/types/alteration.js';
 
 const alteration: AlterationScript = {
   up: async (pool) => {

--- a/packages/schemas/alterations/next-1669091623-roles-and-scopes.ts
+++ b/packages/schemas/alterations/next-1669091623-roles-and-scopes.ts
@@ -1,6 +1,6 @@
 import { sql } from 'slonik';
 
-import type { AlterationScript } from '../src/types/alteration.js';
+import type { AlterationScript } from '../lib/types/alteration.js';
 
 const alteration: AlterationScript = {
   up: async (pool) => {

--- a/packages/schemas/alterations/next-1669702299-sign-up.ts
+++ b/packages/schemas/alterations/next-1669702299-sign-up.ts
@@ -2,7 +2,7 @@ import { isSameArray } from '@silverhand/essentials';
 import type { DatabaseTransactionConnection } from 'slonik';
 import { sql } from 'slonik';
 
-import type { AlterationScript } from '../src/types/alteration.js';
+import type { AlterationScript } from '../lib/types/alteration.js';
 
 enum DeprecatedSignUpIdentifier {
   Email = 'email',

--- a/packages/schemas/alterations/next-1671039448-add-user-name-index.ts
+++ b/packages/schemas/alterations/next-1671039448-add-user-name-index.ts
@@ -1,6 +1,6 @@
 import { sql } from 'slonik';
 
-import type { AlterationScript } from '../src/types/alteration.js';
+import type { AlterationScript } from '../lib/types/alteration.js';
 
 const alteration: AlterationScript = {
   up: async (pool) => {

--- a/packages/schemas/alterations/next-1671080370-terms-of-use.ts
+++ b/packages/schemas/alterations/next-1671080370-terms-of-use.ts
@@ -1,7 +1,7 @@
 import type { DatabaseTransactionConnection } from 'slonik';
 import { sql } from 'slonik';
 
-import type { AlterationScript } from '../src/types/alteration.js';
+import type { AlterationScript } from '../lib/types/alteration.js';
 
 type DeprecatedTermsOfUse = {
   enabled: boolean;

--- a/packages/schemas/alterations/next-1671509870-hooks.ts
+++ b/packages/schemas/alterations/next-1671509870-hooks.ts
@@ -1,0 +1,26 @@
+import { sql } from 'slonik';
+
+import type { AlterationScript } from '../src/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      create table hooks (
+        id varchar(32) not null,
+        event varchar(128) not null,
+        config jsonb /* @use HookConfig */ not null,
+        created_at timestamptz not null default(now()),
+        primary key (id)
+      );
+
+      create index hooks__event on hooks (event);
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      drop table hooks;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/alterations/next-1671509870-hooks.ts
+++ b/packages/schemas/alterations/next-1671509870-hooks.ts
@@ -1,6 +1,6 @@
 import { sql } from 'slonik';
 
-import type { AlterationScript } from '../src/types/alteration.js';
+import type { AlterationScript } from '../lib/types/alteration.js';
 
 const alteration: AlterationScript = {
   up: async (pool) => {

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -82,6 +82,7 @@
     "@logto/language-kit": "workspace:*",
     "@logto/phrases": "workspace:*",
     "@logto/phrases-ui": "workspace:*",
+    "@withtyped/server": "^0.3.0",
     "zod": "^3.20.2"
   }
 }

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -82,7 +82,7 @@
     "@logto/language-kit": "workspace:*",
     "@logto/phrases": "workspace:*",
     "@logto/phrases-ui": "workspace:*",
-    "@withtyped/server": "^0.3.0",
+    "@withtyped/server": "^0.3.1",
     "zod": "^3.20.2"
   }
 }

--- a/packages/schemas/src/models/hooks.ts
+++ b/packages/schemas/src/models/hooks.ts
@@ -1,0 +1,45 @@
+import { generateStandardId } from '@logto/core-kit';
+import { createModel } from '@withtyped/server';
+import { z } from 'zod';
+
+export enum HookEvent {
+  PostRegister = 'PostRegister',
+  PostSignIn = 'PostSignIn',
+  PostForgotPassword = 'PostForgotPassword',
+}
+
+export type HookConfig = {
+  /** We don't need `type` since v1 only has web hook */
+  // type: 'web';
+  /** Method fixed to `POST` */
+  url: string;
+  /** Additional headers that attach to the request */
+  headers?: Record<string, string>;
+  /**
+   * Retry times when hook response status >= 500.
+   *
+   * Must be less than or equal to `3`. Use `0` to disable retry.
+   **/
+  retries: number;
+};
+
+export const hookConfigGuard: z.ZodType<HookConfig> = z.object({
+  url: z.string(),
+  headers: z.record(z.string()).optional(),
+  retries: z.number().gte(0).lte(3),
+});
+
+export const Hooks = createModel(/* sql */ `
+  create table hooks (
+    id varchar(32) not null,
+    event varchar(128) not null,
+    config jsonb /* @use HookConfig */ not null,
+    created_at timestamptz not null default(now()),
+    primary key (id)
+  );
+
+  create index hooks__event on hooks (event);
+`)
+  .extend('id', { default: () => generateStandardId(), readonly: true })
+  .extend('event', z.nativeEnum(HookEvent)) // Tried to use `.refine()` to show the correct error path, but not working.
+  .extend('config', hookConfigGuard);

--- a/packages/schemas/src/models/index.ts
+++ b/packages/schemas/src/models/index.ts
@@ -1,0 +1,1 @@
+export * from './hooks.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,6 +279,8 @@ importers:
       '@types/oidc-provider': ^7.12.0
       '@types/sinon': ^10.0.13
       '@types/supertest': ^2.0.11
+      '@withtyped/postgres': ^0.3.1
+      '@withtyped/server': ^0.3.0
       chalk: ^5.0.0
       clean-deep: ^3.4.0
       copyfiles: ^2.4.1
@@ -335,6 +337,8 @@ importers:
       '@logto/schemas': link:../schemas
       '@logto/shared': link:../shared
       '@silverhand/essentials': 1.3.0
+      '@withtyped/postgres': 0.3.1_@withtyped+server@0.3.0
+      '@withtyped/server': 0.3.0
       chalk: 5.1.2
       clean-deep: 3.4.0
       date-fns: 2.29.3
@@ -579,6 +583,7 @@ importers:
       '@types/lodash.uniq': ^4.5.6
       '@types/node': ^16.0.0
       '@types/pluralize': ^0.0.29
+      '@withtyped/server': ^0.3.0
       camelcase: ^7.0.0
       eslint: ^8.21.0
       jest: ^29.1.2
@@ -595,6 +600,7 @@ importers:
       '@logto/language-kit': link:../toolkit/language-kit
       '@logto/phrases': link:../phrases
       '@logto/phrases-ui': link:../phrases-ui
+      '@withtyped/server': 0.3.0
       zod: 3.20.2
     devDependencies:
       '@silverhand/eslint-config': 1.3.0_eu7dlo3qq5moigliolva3udaxa
@@ -4336,6 +4342,14 @@ packages:
     resolution: {integrity: sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==}
     dev: true
 
+  /@types/pg/8.6.5:
+    resolution: {integrity: sha512-tOkGtAqRVkHa/PVZicq67zuujI4Oorfglsr2IbKofDwBSysnaqSx7W1mDqFqdkGE6Fbgh+PZAl0r/BWON/mozw==}
+    dependencies:
+      '@types/node': 17.0.23
+      pg-protocol: 1.5.0
+      pg-types: 2.2.0
+    dev: false
+
   /@types/pluralize/0.0.29:
     resolution: {integrity: sha512-BYOID+l2Aco2nBik+iYS4SZX0Lf20KPILP5RGmM1IgzdwNdTs0eebiFriOPcej1sX9mLnSoiNte5zcFxssgpGA==}
     dev: true
@@ -4642,6 +4656,29 @@ packages:
       '@typescript-eslint/types': 5.40.0
       eslint-visitor-keys: 3.3.0
     dev: true
+
+  /@withtyped/postgres/0.3.1_@withtyped+server@0.3.0:
+    resolution: {integrity: sha512-+XP+kbmTKKpv/5Nf4KDVKfWp6kYGIyty3aUUnSrBY0KLdOUfesuPjFK6S7sNgbh+7pvk/iU48/3UDsjuy4m+SQ==}
+    peerDependencies:
+      '@withtyped/server': ^0.3.0
+    dependencies:
+      '@types/pg': 8.6.5
+      '@withtyped/server': 0.3.0
+      '@withtyped/shared': 0.2.0
+      pg: 8.8.0
+    transitivePeerDependencies:
+      - pg-native
+    dev: false
+
+  /@withtyped/server/0.3.0:
+    resolution: {integrity: sha512-fvKf3JryFKIOgGp2z2YBbjiJrSKznuUUlH7Kv9v1gcQxkJXYjSbb0tDY4ObJjKGIrhqIJLWV4Gx40ANJMBDqww==}
+    dependencies:
+      '@withtyped/shared': 0.2.0
+    dev: false
+
+  /@withtyped/shared/0.2.0:
+    resolution: {integrity: sha512-SADIVEospfIWAVK0LxX7F1T04hsWMZ0NkfR3lNfvJqOktJ52GglI3FOTVYOM1NJYReDT6pR0XFlCfaF8TVPt8w==}
+    dev: false
 
   /JSONStream/1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -11952,6 +11989,14 @@ packages:
     dependencies:
       pg: 8.7.3
 
+  /pg-pool/3.5.2_pg@8.8.0:
+    resolution: {integrity: sha512-His3Fh17Z4eg7oANLob6ZvH8xIVen3phEZh2QuyrIl4dQSDVEabNducv6ysROKpDNPSD+12tONZVWfSgMvDD9w==}
+    peerDependencies:
+      pg: '>=8.0'
+    dependencies:
+      pg: 8.8.0
+    dev: false
+
   /pg-protocol/1.5.0:
     resolution: {integrity: sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ==}
 
@@ -12005,6 +12050,24 @@ packages:
       pg-protocol: 1.5.0
       pg-types: 2.2.0
       pgpass: 1.0.4
+
+  /pg/8.8.0:
+    resolution: {integrity: sha512-UXYN0ziKj+AeNNP7VDMwrehpACThH7LUl/p8TDFpEUuSejCUIwGSfxpHsPvtM6/WXFy6SU4E5RG4IJV/TZAGjw==}
+    engines: {node: '>= 8.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+    dependencies:
+      buffer-writer: 2.0.0
+      packet-reader: 1.0.0
+      pg-connection-string: 2.5.0
+      pg-pool: 3.5.2_pg@8.8.0
+      pg-protocol: 1.5.0
+      pg-types: 2.2.0
+      pgpass: 1.0.4
+    dev: false
 
   /pgpass/1.0.4:
     resolution: {integrity: sha512-YmuA56alyBq7M59vxVBfPJrGSozru8QAdoNlWuW3cz8l+UX3cWge0vTvjKhsSHSJpo3Bom8/Mm6hf0TR5GY0+w==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -482,7 +482,7 @@ importers:
       '@types/jest': ^29.1.2
       '@types/jest-environment-puppeteer': ^5.0.2
       '@types/node': ^16.0.0
-      '@withtyped/server': ^0.3.0
+      '@withtyped/server': ^0.3.1
       dotenv: ^16.0.0
       eslint: ^8.21.0
       got: ^12.5.3
@@ -496,7 +496,7 @@ importers:
       text-encoder: ^0.0.4
       typescript: ^4.9.4
     dependencies:
-      '@withtyped/server': 0.3.0
+      '@withtyped/server': 0.3.1
     devDependencies:
       '@jest/types': 29.1.2
       '@logto/js': 1.0.0-beta.14
@@ -4671,12 +4671,6 @@ packages:
       pg: 8.8.0
     transitivePeerDependencies:
       - pg-native
-    dev: false
-
-  /@withtyped/server/0.3.0:
-    resolution: {integrity: sha512-fvKf3JryFKIOgGp2z2YBbjiJrSKznuUUlH7Kv9v1gcQxkJXYjSbb0tDY4ObJjKGIrhqIJLWV4Gx40ANJMBDqww==}
-    dependencies:
-      '@withtyped/shared': 0.2.0
     dev: false
 
   /@withtyped/server/0.3.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,7 +280,7 @@ importers:
       '@types/sinon': ^10.0.13
       '@types/supertest': ^2.0.11
       '@withtyped/postgres': ^0.3.1
-      '@withtyped/server': ^0.3.0
+      '@withtyped/server': ^0.3.1
       chalk: ^5.0.0
       clean-deep: ^3.4.0
       copyfiles: ^2.4.1
@@ -337,8 +337,8 @@ importers:
       '@logto/schemas': link:../schemas
       '@logto/shared': link:../shared
       '@silverhand/essentials': 1.3.0
-      '@withtyped/postgres': 0.3.1_@withtyped+server@0.3.0
-      '@withtyped/server': 0.3.0
+      '@withtyped/postgres': 0.3.1_@withtyped+server@0.3.1
+      '@withtyped/server': 0.3.1
       chalk: 5.1.2
       clean-deep: 3.4.0
       date-fns: 2.29.3
@@ -482,6 +482,7 @@ importers:
       '@types/jest': ^29.1.2
       '@types/jest-environment-puppeteer': ^5.0.2
       '@types/node': ^16.0.0
+      '@withtyped/server': ^0.3.0
       dotenv: ^16.0.0
       eslint: ^8.21.0
       got: ^12.5.3
@@ -494,6 +495,8 @@ importers:
       puppeteer: ^19.0.0
       text-encoder: ^0.0.4
       typescript: ^4.9.4
+    dependencies:
+      '@withtyped/server': 0.3.0
     devDependencies:
       '@jest/types': 29.1.2
       '@logto/js': 1.0.0-beta.14
@@ -583,7 +586,7 @@ importers:
       '@types/lodash.uniq': ^4.5.6
       '@types/node': ^16.0.0
       '@types/pluralize': ^0.0.29
-      '@withtyped/server': ^0.3.0
+      '@withtyped/server': ^0.3.1
       camelcase: ^7.0.0
       eslint: ^8.21.0
       jest: ^29.1.2
@@ -600,7 +603,7 @@ importers:
       '@logto/language-kit': link:../toolkit/language-kit
       '@logto/phrases': link:../phrases
       '@logto/phrases-ui': link:../phrases-ui
-      '@withtyped/server': 0.3.0
+      '@withtyped/server': 0.3.1
       zod: 3.20.2
     devDependencies:
       '@silverhand/eslint-config': 1.3.0_eu7dlo3qq5moigliolva3udaxa
@@ -4657,13 +4660,13 @@ packages:
       eslint-visitor-keys: 3.3.0
     dev: true
 
-  /@withtyped/postgres/0.3.1_@withtyped+server@0.3.0:
+  /@withtyped/postgres/0.3.1_@withtyped+server@0.3.1:
     resolution: {integrity: sha512-+XP+kbmTKKpv/5Nf4KDVKfWp6kYGIyty3aUUnSrBY0KLdOUfesuPjFK6S7sNgbh+7pvk/iU48/3UDsjuy4m+SQ==}
     peerDependencies:
       '@withtyped/server': ^0.3.0
     dependencies:
       '@types/pg': 8.6.5
-      '@withtyped/server': 0.3.0
+      '@withtyped/server': 0.3.1
       '@withtyped/shared': 0.2.0
       pg: 8.8.0
     transitivePeerDependencies:
@@ -4672,6 +4675,12 @@ packages:
 
   /@withtyped/server/0.3.0:
     resolution: {integrity: sha512-fvKf3JryFKIOgGp2z2YBbjiJrSKznuUUlH7Kv9v1gcQxkJXYjSbb0tDY4ObJjKGIrhqIJLWV4Gx40ANJMBDqww==}
+    dependencies:
+      '@withtyped/shared': 0.2.0
+    dev: false
+
+  /@withtyped/server/0.3.1:
+    resolution: {integrity: sha512-AI4QDHVTgv5GWPomWCgP5vqgVWaiby1vm56LBbSqe6r1DTPOZrySoxNoaE5XTQzYX1Jd3pzq1CsOd5AxkgCfpg==}
     dependencies:
       '@withtyped/shared': 0.2.0
     dev: false


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

- init withtyped query client
- add hooks schema and APIs using withtyped, also resolves LOG-4633, LOG-4634, LOG-4635, LOG-4636, LOG-4637

enabled APIs:

- `POST /hooks`
- `GET /hooks`
- `GET /hooks/:id`
- `PATCH /hooks/:id`
- `PUT /hooks/:id`
- `DELETE /hooks/:id`

### Follow-ups

- combine withtyped OpenAPI JSON with the current result
- trigger hooks when needed

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

- CI
- local postman
- basic integration tests (withtyped already cover all API integration tests, we still need to do some API tests while they are plugged into koa)
