### PR TITLE
refactor(console): modal open logic

### DIFF
--- a/packages/console/src/App.tsx
+++ b/packages/console/src/App.tsx
@@ -53,10 +53,7 @@ const Main = () => {
               <Route path="applications">
                 <Route index element={<Applications />} />
                 <Route path="create" element={<Applications />} />
-                <Route path=":id">
-                  <Route index element={<Navigate replace to="settings" />} />
-                  <Route path="settings" element={<ApplicationDetails />} />
-                </Route>
+                <Route path=":id" element={<ApplicationDetails />} />
               </Route>
               <Route path="api-resources">
                 <Route index element={<ApiResources />} />

--- a/packages/console/src/components/AppContent/components/Sidebar/components/Item/ModalItem.tsx
+++ b/packages/console/src/components/AppContent/components/Sidebar/components/Item/ModalItem.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import useModalControl from '@/hooks/use-modal-control';
+
+import * as styles from './index.module.scss';
+
+export type Props = {
+  name: string;
+  modal: (isOpen: boolean, onCancel: () => void) => ReactNode;
+  content: ReactNode;
+};
+
+const ModalItem = ({ name, modal, content }: Props) => {
+  const { open, isOpen } = useModalControl(name);
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <button
+        className={styles.row}
+        onClick={() => {
+          open();
+        }}
+      >
+        {content}
+      </button>
+      {modal(isOpen, () => {
+        navigate(-1);
+      })}
+    </>
+  );
+};
+
+export default ModalItem;

--- a/packages/console/src/components/AppContent/components/Sidebar/components/Item/index.tsx
+++ b/packages/console/src/components/AppContent/components/Sidebar/components/Item/index.tsx
@@ -1,18 +1,20 @@
 import classNames from 'classnames';
-import type { ReactChild, ReactNode } from 'react';
-import { useMemo, useState } from 'react';
+import type { ReactChild } from 'react';
+import { useMemo } from 'react';
 import type { TFuncKey } from 'react-i18next';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 
 import { getPath } from '../../utils';
+import ModalItem from './ModalItem';
+import type { Props as ModalItemProps } from './ModalItem';
 import * as styles from './index.module.scss';
 
 type Props = {
   icon?: ReactChild;
   titleKey: TFuncKey<'translation', 'admin_console.tabs'>;
   isActive?: boolean;
-  modal?: (isOpen: boolean, onCancel: () => void) => ReactNode;
+  modal?: Omit<ModalItemProps, 'content'>;
   externalLink?: string;
 };
 
@@ -20,7 +22,6 @@ const Item = ({ icon, titleKey, modal, externalLink, isActive = false }: Props) 
   const { t } = useTranslation(undefined, {
     keyPrefix: 'admin_console.tabs',
   });
-  const [isOpen, setIsOpen] = useState(false);
 
   const content = useMemo(
     () => (
@@ -33,21 +34,7 @@ const Item = ({ icon, titleKey, modal, externalLink, isActive = false }: Props) 
   );
 
   if (modal) {
-    return (
-      <>
-        <button
-          className={styles.row}
-          onClick={() => {
-            setIsOpen(true);
-          }}
-        >
-          {content}
-        </button>
-        {modal(isOpen, () => {
-          setIsOpen(false);
-        })}
-      </>
-    );
+    return <ModalItem {...modal} content={content} />;
   }
 
   if (externalLink) {

--- a/packages/console/src/components/AppContent/components/Sidebar/hook.tsx
+++ b/packages/console/src/components/AppContent/components/Sidebar/hook.tsx
@@ -1,11 +1,12 @@
 import type { Optional } from '@silverhand/essentials';
-import type { FC, ReactNode } from 'react';
+import type { FC } from 'react';
 import type { TFuncKey } from 'react-i18next';
 
 import useDocumentationUrl from '@/hooks/use-documentation-url';
 import useUserPreferences from '@/hooks/use-user-preferences';
 
 import Contact from './components/Contact';
+import type { Props as ModalItemProps } from './components/Item/ModalItem';
 import BarGraph from './icons/BarGraph';
 import Bolt from './icons/Bolt';
 import Box from './icons/Box';
@@ -21,7 +22,7 @@ type SidebarItem = {
   Icon: FC;
   title: TFuncKey<'translation', 'admin_console.tabs'>;
   isHidden?: boolean;
-  modal?: (isOpen: boolean, onCancel: () => void) => ReactNode;
+  modal?: Omit<ModalItemProps, 'content'>;
   externalLink?: string;
 };
 
@@ -104,7 +105,10 @@ export const useSidebarMenuItems = (): {
         {
           Icon: ContactIcon,
           title: 'contact_us',
-          modal: (isOpen, onCancel) => <Contact isOpen={isOpen} onCancel={onCancel} />,
+          modal: {
+            name: 'contact_us',
+            modal: (isOpen, onCancel) => <Contact isOpen={isOpen} onCancel={onCancel} />,
+          },
         },
         {
           Icon: Document,

--- a/packages/console/src/components/UnsavedChangesAlertModal/index.tsx
+++ b/packages/console/src/components/UnsavedChangesAlertModal/index.tsx
@@ -50,14 +50,20 @@ const UnsavedChangesAlertModal = ({ hasUnsavedChanges, parentPath }: Props) => {
         location: { pathname: targetPathname },
       } = transition;
 
+      const executeTransition = () => {
+        unblock();
+        transition.retry();
+      };
+
       // Note: We don't want to show the alert if the user is navigating to the same page.
       if (targetPathname === pathname) {
+        executeTransition();
+
         return;
       }
 
       if (parentPath && targetPathname.startsWith(parentPath)) {
-        unblock();
-        transition.retry();
+        executeTransition();
 
         return;
       }
@@ -67,8 +73,7 @@ const UnsavedChangesAlertModal = ({ hasUnsavedChanges, parentPath }: Props) => {
       setTransition({
         ...transition,
         retry() {
-          unblock();
-          transition.retry();
+          executeTransition();
         },
       });
     });

--- a/packages/console/src/hooks/use-modal-control.ts
+++ b/packages/console/src/hooks/use-modal-control.ts
@@ -1,0 +1,28 @@
+import { useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+const useModalControl = (modalName: string) => {
+  const modalSearchParametersKey = `m_${modalName}`;
+  const [searchParameters, setSearchParameters] = useSearchParams();
+
+  const open = useCallback(
+    (data?: string) => {
+      searchParameters.append(modalSearchParametersKey, data ?? 'true');
+      setSearchParameters(searchParameters);
+    },
+    [modalSearchParametersKey, searchParameters, setSearchParameters]
+  );
+
+  const getOpenData = useCallback(
+    () => searchParameters.get(modalSearchParametersKey) ?? undefined,
+    [modalSearchParametersKey, searchParameters]
+  );
+
+  return {
+    open,
+    getOpenData,
+    isOpen: Boolean(getOpenData()),
+  };
+};
+
+export default useModalControl;

--- a/packages/console/src/pages/ApiResourceDetails/index.tsx
+++ b/packages/console/src/pages/ApiResourceDetails/index.tsx
@@ -27,6 +27,7 @@ import TextLink from '@/components/TextLink';
 import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
 import type { RequestError } from '@/hooks/use-api';
 import useApi from '@/hooks/use-api';
+import useModalControl from '@/hooks/use-modal-control';
 import { useTheme } from '@/hooks/use-theme';
 import * as detailsStyles from '@/scss/details.module.scss';
 
@@ -49,8 +50,8 @@ const ApiResourceDetails = () => {
 
   const isLogtoManagementApiResource = data?.id === managementResource.id;
 
+  const { open, isOpen } = useModalControl('delete_api_resource');
   const [isDeleting, setIsDeleting] = useState(false);
-  const [isDeleted, setIsDeleted] = useState(false);
 
   const {
     handleSubmit,
@@ -62,8 +63,6 @@ const ApiResourceDetails = () => {
   });
 
   const api = useApi();
-
-  const [isDeleteFormOpen, setIsDeleteFormOpen] = useState(false);
 
   useEffect(() => {
     if (!data) {
@@ -93,11 +92,9 @@ const ApiResourceDetails = () => {
 
     try {
       await api.delete(`/api/resources/${data.id}`);
-      setIsDeleted(true);
       setIsDeleting(false);
-      setIsDeleteFormOpen(false);
       toast.success(t('api_resource_details.api_resource_deleted', { name: data.name }));
-      navigate(`/api-resources`);
+      navigate(`/api-resources`, { replace: true });
     } catch {
       setIsDeleting(false);
     }
@@ -130,20 +127,20 @@ const ApiResourceDetails = () => {
                     icon={<Delete />}
                     type="danger"
                     onClick={() => {
-                      setIsDeleteFormOpen(true);
+                      open();
                     }}
                   >
                     {t('general.delete')}
                   </ActionMenuItem>
                 </ActionMenu>
                 <DeleteConfirmModal
-                  isOpen={isDeleteFormOpen}
+                  isOpen={isOpen}
                   isLoading={isDeleting}
                   expectedInput={data.name}
                   className={styles.deleteConfirm}
                   inputPlaceholder={t('api_resource_details.enter_your_api_resource_name')}
                   onCancel={() => {
-                    setIsDeleteFormOpen(false);
+                    navigate(-1);
                   }}
                   onConfirm={onDelete}
                 >
@@ -191,7 +188,7 @@ const ApiResourceDetails = () => {
           </DetailsForm>
         </>
       )}
-      <UnsavedChangesAlertModal hasUnsavedChanges={!isDeleted && isDirty} />
+      <UnsavedChangesAlertModal hasUnsavedChanges={!isOpen && isDirty} />
     </div>
   );
 };

--- a/packages/console/src/pages/ApiResources/index.tsx
+++ b/packages/console/src/pages/ApiResources/index.tsx
@@ -1,7 +1,6 @@
 import type { Resource } from '@logto/schemas';
 import { AppearanceMode } from '@logto/schemas';
 import classNames from 'classnames';
-import { useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import Modal from 'react-modal';
@@ -20,6 +19,7 @@ import TableEmpty from '@/components/Table/TableEmpty';
 import TableError from '@/components/Table/TableError';
 import TableLoading from '@/components/Table/TableLoading';
 import type { RequestError } from '@/hooks/use-api';
+import useModalControl from '@/hooks/use-modal-control';
 import { useTheme } from '@/hooks/use-theme';
 import * as modalStyles from '@/scss/modal.module.scss';
 import * as resourcesStyles from '@/scss/resources.module.scss';
@@ -33,7 +33,7 @@ const buildDetailsLink = (id: string) => `/api-resources/${id}`;
 const pageSize = 20;
 
 const ApiResources = () => {
-  const [isCreateFormOpen, setIsCreateFormOpen] = useState(false);
+  const { open, isOpen } = useModalControl('create_application');
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const [query, setQuery] = useSearchParams();
   const pageIndex = Number(query.get('page') ?? '1');
@@ -55,28 +55,29 @@ const ApiResources = () => {
           size="large"
           icon={<Plus />}
           onClick={() => {
-            setIsCreateFormOpen(true);
+            open();
           }}
         />
         <Modal
           shouldCloseOnEsc
-          isOpen={isCreateFormOpen}
+          isOpen={isOpen}
           className={modalStyles.content}
           overlayClassName={modalStyles.overlay}
           onRequestClose={() => {
-            setIsCreateFormOpen(false);
+            navigate(-1);
           }}
         >
           <CreateForm
             onClose={(createdApiResource) => {
-              setIsCreateFormOpen(false);
-
               if (createdApiResource) {
                 toast.success(
                   t('api_resources.api_resource_created', { name: createdApiResource.name })
                 );
-                navigate(buildDetailsLink(createdApiResource.id));
+                navigate(buildDetailsLink(createdApiResource.id), { replace: true });
+
+                return;
               }
+              navigate(-1);
             }}
           />
         </Modal>
@@ -109,7 +110,7 @@ const ApiResources = () => {
                     title="api_resources.create"
                     type="outline"
                     onClick={() => {
-                      setIsCreateFormOpen(true);
+                      open();
                     }}
                   />
                 </TableEmpty>

--- a/packages/console/src/pages/Applications/index.tsx
+++ b/packages/console/src/pages/Applications/index.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import Modal from 'react-modal';
-import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import useSWR from 'swr';
 
 import Plus from '@/assets/images/plus.svg';
@@ -17,6 +17,7 @@ import TableEmpty from '@/components/Table/TableEmpty';
 import TableError from '@/components/Table/TableError';
 import TableLoading from '@/components/Table/TableLoading';
 import type { RequestError } from '@/hooks/use-api';
+import useModalControl from '@/hooks/use-modal-control';
 import * as modalStyles from '@/scss/modal.module.scss';
 import * as resourcesStyles from '@/scss/resources.module.scss';
 import * as tableStyles from '@/scss/table.module.scss';
@@ -29,8 +30,7 @@ const pageSize = 20;
 
 const Applications = () => {
   const navigate = useNavigate();
-  const location = useLocation();
-  const isCreateNew = location.pathname.endsWith('/create');
+  const { open, isOpen } = useModalControl('create_application');
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const [query, setQuery] = useSearchParams();
   const pageIndex = Number(query.get('page') ?? '1');
@@ -50,27 +50,27 @@ const Applications = () => {
           type="primary"
           size="large"
           onClick={() => {
-            navigate('/applications/create');
+            open();
           }}
         />
         <Modal
           shouldCloseOnEsc
-          isOpen={isCreateNew}
+          isOpen={isOpen}
           className={modalStyles.content}
           overlayClassName={modalStyles.overlay}
           onRequestClose={() => {
-            navigate('/applications');
+            navigate(-1);
           }}
         >
           <CreateForm
             onClose={(createdApp) => {
               if (createdApp) {
                 toast.success(t('applications.application_created', { name: createdApp.name }));
-                navigate(`/applications/${createdApp.id}`);
+                navigate(`/applications/${createdApp.id}`, { replace: true });
 
                 return;
               }
-              navigate('/applications');
+              navigate(-1);
             }}
           />
         </Modal>
@@ -105,7 +105,7 @@ const Applications = () => {
                     title="applications.create"
                     type="outline"
                     onClick={() => {
-                      navigate('/applications/create');
+                      open();
                     }}
                   />
                 </TableEmpty>

--- a/packages/console/src/pages/ConnectorDetails/components/ConnectorContent.tsx
+++ b/packages/console/src/pages/ConnectorDetails/components/ConnectorContent.tsx
@@ -18,12 +18,12 @@ import * as styles from '../index.module.scss';
 import SenderTester from './SenderTester';
 
 type Props = {
-  isDeleted: boolean;
+  hasOpenedModal: boolean;
   connectorData: ConnectorResponse;
   onConnectorUpdated: (connector: ConnectorResponse) => void;
 };
 
-const ConnectorContent = ({ isDeleted, connectorData, onConnectorUpdated }: Props) => {
+const ConnectorContent = ({ hasOpenedModal, connectorData, onConnectorUpdated }: Props) => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const api = useApi();
   const methods = useForm<ConnectorFormType>({
@@ -114,7 +114,7 @@ const ConnectorContent = ({ isDeleted, connectorData, onConnectorUpdated }: Prop
           )}
         </FormCard>
       </DetailsForm>
-      <UnsavedChangesAlertModal hasUnsavedChanges={!isDeleted && isDirty} />
+      <UnsavedChangesAlertModal hasUnsavedChanges={!hasOpenedModal && isDirty} />
     </FormProvider>
   );
 };

--- a/packages/console/src/pages/Connectors/components/ConnectorName/index.module.scss
+++ b/packages/console/src/pages/Connectors/components/ConnectorName/index.module.scss
@@ -1,10 +1,5 @@
 @use '@/scss/underscore' as _;
 
-a.link {
-  color: inherit;
-  text-decoration: none;
-}
-
 .logoContainer {
   width: 40px;
   height: 40px;

--- a/packages/console/src/pages/Connectors/components/ConnectorName/index.tsx
+++ b/packages/console/src/pages/Connectors/components/ConnectorName/index.tsx
@@ -1,7 +1,6 @@
 import type { ConnectorResponse } from '@logto/schemas';
 import { AppearanceMode, ConnectorType } from '@logto/schemas';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
 
 import Button from '@/components/Button';
 import ItemPreview from '@/components/ItemPreview';
@@ -50,42 +49,41 @@ const ConnectorName = ({ type, connectors, onClickSetup }: Props) => {
   }
 
   return (
-    <Link to={`/connectors/${connector.id}`} className={styles.link}>
-      <ItemPreview
-        title={<UnnamedTrans resource={connector.name} />}
-        subtitle={
-          <>
-            {type !== ConnectorType.Social && connector.id}
-            {type === ConnectorType.Social && connectors.length > 1 && (
-              <div className={styles.platforms}>
-                {connectors.map(
-                  ({ id, platform }) =>
-                    platform && (
-                      <div key={id} className={styles.platform}>
-                        <ConnectorPlatformIcon platform={platform} />
-                        {t(`${connectorPlatformLabel[platform]}`)}
-                      </div>
-                    )
-                )}
-              </div>
-            )}
-          </>
-        }
-        icon={
-          <div className={styles.logoContainer}>
-            <img
-              className={styles.logo}
-              alt="logo"
-              src={
-                theme === AppearanceMode.DarkMode && connector.logoDark
-                  ? connector.logoDark
-                  : connector.logo
-              }
-            />
-          </div>
-        }
-      />
-    </Link>
+    <ItemPreview
+      title={<UnnamedTrans resource={connector.name} />}
+      subtitle={
+        <>
+          {type !== ConnectorType.Social && connector.id}
+          {type === ConnectorType.Social && connectors.length > 1 && (
+            <div className={styles.platforms}>
+              {connectors.map(
+                ({ id, platform }) =>
+                  platform && (
+                    <div key={id} className={styles.platform}>
+                      <ConnectorPlatformIcon platform={platform} />
+                      {t(`${connectorPlatformLabel[platform]}`)}
+                    </div>
+                  )
+              )}
+            </div>
+          )}
+        </>
+      }
+      icon={
+        <div className={styles.logoContainer}>
+          <img
+            className={styles.logo}
+            alt="logo"
+            src={
+              theme === AppearanceMode.DarkMode && connector.logoDark
+                ? connector.logoDark
+                : connector.logo
+            }
+          />
+        </div>
+      }
+      to={`/connectors/${connector.id}`}
+    />
   );
 };
 

--- a/packages/console/src/pages/Connectors/components/Guide/index.tsx
+++ b/packages/console/src/pages/Connectors/components/Guide/index.tsx
@@ -95,7 +95,7 @@ const Guide = ({ connector, onClose }: Props) => {
 
     onClose();
     toast.success(t('general.saved'));
-    navigate(`/connectors/${createdConnector.id}`);
+    navigate(`/connectors/${createdConnector.id}`, { replace: true });
   });
 
   return (

--- a/packages/console/src/pages/GetStarted/hook.ts
+++ b/packages/console/src/pages/GetStarted/hook.ts
@@ -78,7 +78,7 @@ const useGetStartedMetadata = () => {
         buttonText: 'general.create',
         isComplete: settings?.applicationCreated,
         onClick: () => {
-          navigate('/applications/create');
+          navigate('/applications?m_create_application=true');
         },
       },
       {

--- a/packages/console/src/pages/SignInExperience/index.tsx
+++ b/packages/console/src/pages/SignInExperience/index.tsx
@@ -91,7 +91,7 @@ const SignInExperience = () => {
     const formatted = signInExperienceParser.toRemoteModel(formData);
 
     // Sign-in methods changed, need to show confirm modal first.
-    if (!hasSignUpAndSignInConfigChanged(data, formatted)) {
+    if (hasSignUpAndSignInConfigChanged(data, formatted)) {
       setDataToCompare(formatted);
 
       return;

--- a/packages/console/src/pages/SignInExperience/tabs/Others/components/ManageLanguage/ManageLanguageButton.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/Others/components/ManageLanguage/ManageLanguageButton.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import Button from '@/components/Button';
+import useModalControl from '@/hooks/use-modal-control';
 
 import LanguageEditor from './LanguageEditor';
 
@@ -9,7 +10,8 @@ type Props = {
 };
 
 const ManageLanguageButton = ({ className }: Props) => {
-  const [isLanguageEditorOpen, setIsLanguageEditorOpen] = useState(false);
+  const { open, isOpen } = useModalControl('manage_language');
+  const navigate = useNavigate();
 
   return (
     <>
@@ -19,13 +21,13 @@ const ManageLanguageButton = ({ className }: Props) => {
         title="sign_in_exp.others.languages.manage_language"
         className={className}
         onClick={() => {
-          setIsLanguageEditorOpen(true);
+          open();
         }}
       />
       <LanguageEditor
-        isOpen={isLanguageEditorOpen}
+        isOpen={isOpen}
         onClose={() => {
-          setIsLanguageEditorOpen(false);
+          navigate(-1);
         }}
       />
     </>

--- a/packages/console/src/pages/SignInExperience/utils/form.ts
+++ b/packages/console/src/pages/SignInExperience/utils/form.ts
@@ -67,12 +67,9 @@ export const hasSignUpAndSignInConfigChanged = (
   after: SignInExperience
 ): boolean => {
   return (
-    !hasSignUpSettingsChanged(before.signUp, after.signUp) &&
-    !hasSignInMethodsChanged(before.signIn.methods, after.signIn.methods) &&
-    !hasSocialTargetsChanged(
-      before.socialSignInConnectorTargets,
-      after.socialSignInConnectorTargets
-    )
+    hasSignUpSettingsChanged(before.signUp, after.signUp) ||
+    hasSignInMethodsChanged(before.signIn.methods, after.signIn.methods) ||
+    hasSocialTargetsChanged(before.socialSignInConnectorTargets, after.socialSignInConnectorTargets)
   );
 };
 

--- a/packages/console/src/pages/UserDetails/components/UserSettings.tsx
+++ b/packages/console/src/pages/UserDetails/components/UserSettings.tsx
@@ -22,10 +22,10 @@ type Props = {
   userData: User;
   userFormData: UserDetailsForm;
   onUserUpdated: (user?: User) => void;
-  isDeleted: boolean;
+  hasDeleteModalOpened: boolean;
 };
 
-const UserSettings = ({ userData, userFormData, isDeleted, onUserUpdated }: Props) => {
+const UserSettings = ({ userData, userFormData, hasDeleteModalOpened, onUserUpdated }: Props) => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
   const {
@@ -144,7 +144,7 @@ const UserSettings = ({ userData, userFormData, isDeleted, onUserUpdated }: Prop
           </FormField>
         </FormCard>
       </DetailsForm>
-      <UnsavedChangesAlertModal hasUnsavedChanges={!isDeleted && isDirty} />
+      <UnsavedChangesAlertModal hasUnsavedChanges={!hasDeleteModalOpened && isDirty} />
     </>
   );
 };

--- a/packages/console/src/pages/Users/index.tsx
+++ b/packages/console/src/pages/Users/index.tsx
@@ -1,7 +1,6 @@
 import type { User } from '@logto/schemas';
 import { conditional, conditionalString } from '@silverhand/essentials';
 import classNames from 'classnames';
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import Modal from 'react-modal';
 import { useNavigate, useSearchParams } from 'react-router-dom';
@@ -21,6 +20,7 @@ import TableLoading from '@/components/Table/TableLoading';
 import { generatedPasswordStorageKey } from '@/consts';
 import { generateAvatarPlaceHolderById } from '@/consts/avatars';
 import type { RequestError } from '@/hooks/use-api';
+import useModalControl from '@/hooks/use-modal-control';
 import * as modalStyles from '@/scss/modal.module.scss';
 import * as resourcesStyles from '@/scss/resources.module.scss';
 import * as tableStyles from '@/scss/table.module.scss';
@@ -33,7 +33,7 @@ const pageSize = 20;
 const userTableColumn = 3;
 
 const Users = () => {
-  const [isCreateFormOpen, setIsCreateFormOpen] = useState(false);
+  const { open, isOpen } = useModalControl('create_user');
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const [query, setQuery] = useSearchParams();
   const pageIndex = Number(query.get('page') ?? '1');
@@ -57,26 +57,27 @@ const Users = () => {
           type="primary"
           icon={<Plus />}
           onClick={() => {
-            setIsCreateFormOpen(true);
+            open();
           }}
         />
         <Modal
           shouldCloseOnEsc
-          isOpen={isCreateFormOpen}
+          isOpen={isOpen}
           className={modalStyles.content}
           overlayClassName={modalStyles.overlay}
           onRequestClose={() => {
-            setIsCreateFormOpen(false);
+            navigate(-1);
           }}
         >
           <CreateForm
             onClose={(createdUser, password) => {
-              setIsCreateFormOpen(false);
-
               if (createdUser && password) {
                 sessionStorage.setItem(generatedPasswordStorageKey, password);
-                navigate(`/users/${createdUser.id}`);
+                navigate(`/users/${createdUser.id}`, { replace: true });
+
+                return;
               }
+              navigate(-1);
             }}
           />
         </Modal>
@@ -124,7 +125,7 @@ const Users = () => {
                     title="users.create"
                     type="outline"
                     onClick={() => {
-                      setIsCreateFormOpen(true);
+                      open();
                     }}
                   />
                 </TableEmpty>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate) and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
### Existing Problems
LOG-4891: Url should not change when the modal is open

The modal's open state is stored in components, and this causes modals still be visible when the location changes:

![modal-bugs](https://user-images.githubusercontent.com/10806653/208584033-76374d43-36e8-4764-ad1f-fb309423a71a.gif)

### Solution
Relate the modal's open state with the search parameters of the location; when the location changes, the modal will be closed.

- Add an `useModalControl` hook to access the modal state from the location easily.
- Replace related modal logic with the newly implemented `useModalControl` logic.

### Related Changes
- Reorg the `/applications/:id` router configs for the `settings` string is no longer needed in the pathname.
- Refactor the `SideBarItem` to support this 'search-params-controlled' modal.
- Fix the `UnsavedChangesModal` component to allow skipping the unsaved changes alert when search parameters change.
- Fix: remove the `Link` wrapper of the `ConnectorName`, and move the link to the `<ItemPreview />` directly, since the `Link` wrapper will trigger a navigation behavior, and this trigger event will bubble to the outer `<ConnectorRow />` component, the `<ConnectorRow />` will trigger the navigation again. But the `<itemPreview />` will stop propagation for us.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
![modal-fix](https://user-images.githubusercontent.com/10806653/208585921-f74d6e3d-d3aa-4ecb-9bde-9b037f183516.gif)
