### PR TITLE
chore: should clear connector session after getSession()

### DIFF
--- a/packages/core/src/routes/session/utils.ts
+++ b/packages/core/src/routes/session/utils.ts
@@ -181,7 +181,12 @@ export const getConnectorSessionResult = async (
     })
     .safeParse(result);
 
-  assertThat(signInResult.success, 'session.connector_validation_session_not_found');
+  assertThat(result && signInResult.success, 'session.connector_validation_session_not_found');
+
+  const { connectorSession, ...rest } = result;
+  await provider.interactionResult(ctx.req, ctx.res, {
+    ...rest,
+  });
 
   return signInResult.data.connectorSession;
 };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
should clear connector session after getSession() as values stored in `connectorSession` is for one-time validation use.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A
