### PR TITLE
chore: response of connector POST API should be ConnectorResponse

### DIFF
--- a/packages/core/src/routes/connector.test.ts
+++ b/packages/core/src/routes/connector.test.ts
@@ -40,6 +40,7 @@ const {
   countConnectorByConnectorId,
   deleteConnectorById,
   deleteConnectorByIds,
+  insertConnector,
 } = await mockEsmWithActual('#src/queries/connector.js', () => ({
   findConnectorById: jest.fn(),
   countConnectorByConnectorId: jest.fn(),
@@ -165,20 +166,16 @@ describe('connector route', () => {
           ...mockLogtoConnector,
         },
       ]);
-      const response = await connectorRequest.post('/connectors').send({
+      await connectorRequest.post('/connectors').send({
         connectorId: 'connectorId',
         config: { cliend_id: 'client_id', client_secret: 'client_secret' },
       });
-      expect(response.body).toMatchObject(
+      expect(insertConnector).toHaveBeenCalledWith(
         expect.objectContaining({
           connectorId: 'connectorId',
-          config: {
-            cliend_id: 'client_id',
-            client_secret: 'client_secret',
-          },
+          config: { cliend_id: 'client_id', client_secret: 'client_secret' },
         })
       );
-      expect(response).toHaveProperty('statusCode', 200);
     });
 
     it('throws when connector factory not found', async () => {
@@ -216,12 +213,12 @@ describe('connector route', () => {
           ...mockLogtoConnector,
         },
       ]);
-      const response = await connectorRequest.post('/connectors').send({
+      await connectorRequest.post('/connectors').send({
         connectorId: 'id0',
         config: { cliend_id: 'client_id', client_secret: 'client_secret' },
         metadata: { target: 'new_target' },
       });
-      expect(response.body).toMatchObject(
+      expect(insertConnector).toHaveBeenCalledWith(
         expect.objectContaining({
           connectorId: 'id0',
           config: {
@@ -231,7 +228,6 @@ describe('connector route', () => {
           metadata: { target: 'new_target' },
         })
       );
-      expect(response).toHaveProperty('statusCode', 200);
     });
 
     it('throws when add more than 1 instance with non-connector factory', async () => {
@@ -266,12 +262,11 @@ describe('connector route', () => {
         },
       ]);
       countConnectorByConnectorId.mockResolvedValueOnce({ count: 0 });
-      const response = await connectorRequest.post('/connectors').send({
+      await connectorRequest.post('/connectors').send({
         connectorId: 'id1',
         config: { cliend_id: 'client_id', client_secret: 'client_secret' },
       });
-      expect(response).toHaveProperty('statusCode', 200);
-      expect(response.body).toMatchObject(
+      expect(insertConnector).toHaveBeenCalledWith(
         expect.objectContaining({
           connectorId: 'id1',
           config: {

--- a/packages/core/src/routes/connector.ts
+++ b/packages/core/src/routes/connector.ts
@@ -159,7 +159,7 @@ export default function connectorRoutes<T extends AuthedRouter>(router: T) {
       }
 
       const insertConnectorId = generateConnectorId();
-      ctx.body = await insertConnector({
+      await insertConnector({
         id: insertConnectorId,
         connectorId,
         ...cleanDeep({ syncProfile, config, metadata }),
@@ -185,6 +185,9 @@ export default function connectorRoutes<T extends AuthedRouter>(router: T) {
           await deleteConnectorByIds(conflictingConnectorIds);
         }
       }
+
+      const connector = await getLogtoConnectorById(insertConnectorId);
+      ctx.body = transpileLogtoConnector(connector);
 
       return next();
     }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
response of the connector's POST API should be ConnectorResponse, this aligns with other connector APIs.
The current response of POST API is `Connector`, which is the type of connector table.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Passed UTs and ITs.
