### PR TITLE
refactor: move assign/get connector session to interaction path

### DIFF
--- a/packages/core/src/routes/interaction/index.test.ts
+++ b/packages/core/src/routes/interaction/index.test.ts
@@ -2,7 +2,6 @@ import { ConnectorType } from '@logto/connector-kit';
 import { Event, demoAppApplicationId } from '@logto/schemas';
 import { mockEsmWithActual, mockEsmDefault, mockEsm } from '@logto/shared/esm';
 
-import { mockSignInExperience } from '#src/__mocks__/sign-in-experience.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import type koaAuditLog from '#src/middleware/koa-audit-log.js';
 import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';

--- a/packages/core/src/routes/interaction/index.test.ts
+++ b/packages/core/src/routes/interaction/index.test.ts
@@ -2,6 +2,7 @@ import { ConnectorType } from '@logto/connector-kit';
 import { Event, demoAppApplicationId } from '@logto/schemas';
 import { mockEsmWithActual, mockEsmDefault, mockEsm } from '@logto/shared/esm';
 
+import { mockSignInExperience } from '#src/__mocks__/sign-in-experience.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import type koaAuditLog from '#src/middleware/koa-audit-log.js';
 import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';

--- a/packages/core/src/routes/interaction/index.ts
+++ b/packages/core/src/routes/interaction/index.ts
@@ -9,13 +9,13 @@ import RequestError from '#src/errors/RequestError/index.js';
 import { assignInteractionResults } from '#src/libraries/session.js';
 import koaAuditLog from '#src/middleware/koa-audit-log.js';
 import koaGuard from '#src/middleware/koa-guard.js';
-import { assignConnectorSessionResult } from '#src/routes/session/utils.js';
 import assertThat from '#src/utils/assert-that.js';
 
 import type { AnonymousRouter } from '../types.js';
 import submitInteraction from './actions/submit-interaction.js';
 import { sendPasscodePayloadGuard, socialAuthorizationUrlPayloadGuard } from './types/guard.js';
 import {
+  assignConnectorSessionResult,
   getInteractionStorage,
   storeInteractionResult,
   mergeIdentifiers,

--- a/packages/core/src/routes/interaction/utils/interaction.ts
+++ b/packages/core/src/routes/interaction/utils/interaction.ts
@@ -1,6 +1,9 @@
+import type { ConnectorSession } from '@logto/connector-kit';
+import { connectorSessionGuard } from '@logto/connector-kit';
 import type { Event, Profile } from '@logto/schemas';
 import type { Context } from 'koa';
 import type { Provider } from 'oidc-provider';
+import { z } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import assertThat from '#src/utils/assert-that.js';
@@ -125,4 +128,38 @@ export const clearInteractionStorage = async (ctx: Context, provider: Provider) 
   if (result) {
     await provider.interactionResult(ctx.req, ctx.res, {});
   }
+};
+
+export const assignConnectorSessionResult = async (
+  ctx: Context,
+  provider: Provider,
+  connectorSession: ConnectorSession
+) => {
+  const details = await provider.interactionDetails(ctx.req, ctx.res);
+  await provider.interactionResult(ctx.req, ctx.res, {
+    ...details.result,
+    connectorSession,
+  });
+};
+
+export const getConnectorSessionResult = async (
+  ctx: Context,
+  provider: Provider
+): Promise<ConnectorSession> => {
+  const { result } = await provider.interactionDetails(ctx.req, ctx.res);
+
+  const signInResult = z
+    .object({
+      connectorSession: connectorSessionGuard,
+    })
+    .safeParse(result);
+
+  assertThat(result && signInResult.success, 'session.connector_validation_session_not_found');
+
+  const { connectorSession, ...rest } = result;
+  await provider.interactionResult(ctx.req, ctx.res, {
+    ...rest,
+  });
+
+  return signInResult.data.connectorSession;
 };

--- a/packages/core/src/routes/interaction/verifications/identifier-payload-verification.ts
+++ b/packages/core/src/routes/interaction/verifications/identifier-payload-verification.ts
@@ -10,7 +10,7 @@ import type { Provider } from 'oidc-provider';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import { verifyUserPassword } from '#src/libraries/user.js';
-import { getConnectorSessionResult } from '#src/routes/session/utils.js';
+import { getConnectorSessionResult } from '#src/routes/interaction/utils/interaction.js';
 import assertThat from '#src/utils/assert-that.js';
 
 import type {

--- a/packages/core/src/routes/session/social.ts
+++ b/packages/core/src/routes/session/social.ts
@@ -26,16 +26,15 @@ import {
   updateUserById,
   findUserByIdentity,
 } from '#src/queries/user.js';
+import {
+  assignConnectorSessionResult,
+  getConnectorSessionResult,
+} from '#src/routes/interaction/utils/interaction.js';
 import assertThat from '#src/utils/assert-that.js';
 import { maskUserInfo } from '#src/utils/format.js';
 
 import type { AnonymousRouterLegacy } from '../types.js';
-import {
-  checkRequiredProfile,
-  getRoutePrefix,
-  assignConnectorSessionResult,
-  getConnectorSessionResult,
-} from './utils.js';
+import { checkRequiredProfile, getRoutePrefix } from './utils.js';
 
 export const registerRoute = getRoutePrefix('register', 'social');
 export const signInRoute = getRoutePrefix('sign-in', 'social');

--- a/packages/core/src/routes/session/utils.ts
+++ b/packages/core/src/routes/session/utils.ts
@@ -1,5 +1,3 @@
-import type { ConnectorSession } from '@logto/connector-kit';
-import { connectorSessionGuard } from '@logto/connector-kit';
 import type { PasscodeType, SignInExperience, User } from '@logto/schemas';
 import { SignInIdentifier } from '@logto/schemas';
 import type { LogPayload, LogType } from '@logto/schemas/lib/types/log-legacy.js';
@@ -155,40 +153,6 @@ export const getContinueSignInResult = async (
   );
 
   return rest;
-};
-
-export const assignConnectorSessionResult = async (
-  ctx: Context,
-  provider: Provider,
-  connectorSession: ConnectorSession
-) => {
-  const details = await provider.interactionDetails(ctx.req, ctx.res);
-  await provider.interactionResult(ctx.req, ctx.res, {
-    ...details.result,
-    connectorSession,
-  });
-};
-
-export const getConnectorSessionResult = async (
-  ctx: Context,
-  provider: Provider
-): Promise<ConnectorSession> => {
-  const { result } = await provider.interactionDetails(ctx.req, ctx.res);
-
-  const signInResult = z
-    .object({
-      connectorSession: connectorSessionGuard,
-    })
-    .safeParse(result);
-
-  assertThat(result && signInResult.success, 'session.connector_validation_session_not_found');
-
-  const { connectorSession, ...rest } = result;
-  await provider.interactionResult(ctx.req, ctx.res, {
-    ...rest,
-  });
-
-  return signInResult.data.connectorSession;
 };
 
 export const isUserPasswordSet = ({


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Move assign/get connector session result under the /interaction folder. Since /session path will be removed in the near future.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT and IT.
