### PR TITLE
feat(test): add fulfill user profile integration tests

### DIFF
--- a/packages/core/src/routes/interaction/index.test.ts
+++ b/packages/core/src/routes/interaction/index.test.ts
@@ -227,6 +227,17 @@ describe('session -> interactionRoutes', () => {
       provider: createMockProvider(jest.fn().mockResolvedValue(baseProviderMock)),
     });
 
+    it('PUT /interaction/profile', async () => {
+      const body = {
+        email: 'email@logto.io',
+      };
+      const response = await sessionRequest.put(path).send(body);
+      expect(verifyProfileSettings).toBeCalled();
+      expect(getInteractionStorage).toBeCalled();
+      expect(storeInteractionResult).toBeCalled();
+      expect(response.status).toEqual(204);
+    });
+
     it('PATCH /interaction/profile', async () => {
       const body = {
         email: 'email@logto.io',

--- a/packages/core/src/routes/interaction/index.ts
+++ b/packages/core/src/routes/interaction/index.ts
@@ -166,6 +166,37 @@ export default function interactionRoutes<T extends AnonymousRouter>(
     }
   );
 
+  // Replace Interaction Profile
+  router.put(
+    `${interactionPrefix}/profile`,
+    koaGuard({
+      body: profileGuard,
+    }),
+    koaInteractionSie(),
+    async (ctx, next) => {
+      const profilePayload = ctx.guard.body;
+
+      const { signInExperience, interactionDetails } = ctx;
+      verifyProfileSettings(profilePayload, signInExperience);
+
+      // Check interaction exists
+      getInteractionStorage(interactionDetails.result);
+
+      await storeInteractionResult(
+        {
+          profile: profilePayload,
+        },
+        ctx,
+        provider,
+        true
+      );
+
+      ctx.status = 204;
+
+      return next();
+    }
+  );
+
   // Update Interaction Profile
   router.patch(
     `${interactionPrefix}/profile`,

--- a/packages/integration-tests/src/api/interaction.ts
+++ b/packages/integration-tests/src/api/interaction.ts
@@ -44,6 +44,15 @@ export const patchInteractionProfile = async (cookie: string, payload: Profile) 
     })
     .json();
 
+export const putInteractionProfile = async (cookie: string, payload: Profile) =>
+  api
+    .put('interaction/profile', {
+      headers: { cookie },
+      json: payload,
+      followRedirect: false,
+    })
+    .json();
+
 export const deleteInteractionProfile = async (cookie: string) =>
   api
     .delete('interaction/profile', {

--- a/packages/integration-tests/src/tests/api/interaction/forgot-password.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/forgot-password.test.ts
@@ -5,6 +5,7 @@ import {
   sendVerificationPasscode,
   deleteUser,
   patchInteractionIdentifiers,
+  putInteractionProfile,
   patchInteractionProfile,
 } from '#src/api/index.js';
 import { expectRejects, readPasscode } from '#src/helpers.js';
@@ -61,7 +62,7 @@ describe('reset password', () => {
 
     await expectRejects(client.submitInteraction(), 'user.new_password_required_in_profile');
 
-    await client.successSend(patchInteractionProfile, { password: userProfile.password });
+    await client.successSend(putInteractionProfile, { password: userProfile.password });
 
     await expectRejects(client.submitInteraction(), 'user.same_password');
 
@@ -115,7 +116,7 @@ describe('reset password', () => {
 
     await expectRejects(client.submitInteraction(), 'user.new_password_required_in_profile');
 
-    await client.successSend(patchInteractionProfile, { password: userProfile.password });
+    await client.successSend(putInteractionProfile, { password: userProfile.password });
 
     await expectRejects(client.submitInteraction(), 'user.same_password');
 

--- a/packages/integration-tests/src/tests/api/interaction/register-with-identifier.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/register-with-identifier.test.ts
@@ -6,6 +6,7 @@ import {
   putInteraction,
   deleteUser,
   patchInteractionIdentifiers,
+  putInteractionProfile,
   patchInteractionProfile,
   deleteInteractionProfile,
   putInteractionEvent,
@@ -90,7 +91,7 @@ describe('Register with passwordless identifier', () => {
       passcode: code,
     });
 
-    await client.successSend(patchInteractionProfile, {
+    await client.successSend(putInteractionProfile, {
       email: primaryEmail,
     });
 
@@ -98,6 +99,68 @@ describe('Register with passwordless identifier', () => {
 
     const id = await processSession(client, redirectTo);
     await logoutClient(client);
+    await deleteUser(id);
+  });
+
+  it('register with email and fulfill password', async () => {
+    await enableAllPasscodeSignInMethods({
+      identifiers: [SignInIdentifier.Email],
+      password: true,
+      verify: true,
+    });
+
+    const { primaryEmail, password } = generateNewUserProfile({
+      primaryEmail: true,
+      password: true,
+    });
+    const client = await initClient();
+
+    await client.successSend(putInteraction, {
+      event: InteractionEvent.Register,
+    });
+
+    await client.successSend(sendVerificationPasscode, {
+      event: InteractionEvent.Register,
+      email: primaryEmail,
+    });
+
+    const passcodeRecord = await readPasscode();
+
+    const { code } = passcodeRecord;
+
+    await client.successSend(patchInteractionIdentifiers, {
+      email: primaryEmail,
+      passcode: code,
+    });
+
+    await client.successSend(putInteractionProfile, {
+      email: primaryEmail,
+    });
+
+    await expectRejects(client.submitInteraction(), 'user.missing_profile');
+
+    await client.successSend(patchInteractionProfile, {
+      password,
+    });
+
+    const { redirectTo } = await client.submitInteraction();
+    await processSession(client, redirectTo);
+    await logoutClient(client);
+
+    // SignIn with email and password
+    await client.initSession();
+    await client.successSend(putInteraction, {
+      event: InteractionEvent.SignIn,
+      identifier: {
+        email: primaryEmail,
+        password,
+      },
+    });
+
+    const { redirectTo: redirectTo2 } = await client.submitInteraction();
+    const id = await processSession(client, redirectTo2);
+    await logoutClient(client);
+
     await deleteUser(id);
   });
 
@@ -134,7 +197,7 @@ describe('Register with passwordless identifier', () => {
       passcode: code,
     });
 
-    await client.successSend(patchInteractionProfile, {
+    await client.successSend(putInteractionProfile, {
       phone: primaryPhone,
     });
 
@@ -142,6 +205,67 @@ describe('Register with passwordless identifier', () => {
 
     const id = await processSession(client, redirectTo);
     await logoutClient(client);
+    await deleteUser(id);
+  });
+
+  it('register with phone and fulfill password', async () => {
+    await enableAllPasscodeSignInMethods({
+      identifiers: [SignInIdentifier.Sms],
+      password: true,
+      verify: true,
+    });
+
+    const { primaryPhone, password } = generateNewUserProfile({
+      primaryPhone: true,
+      password: true,
+    });
+    const client = await initClient();
+
+    await client.successSend(putInteraction, {
+      event: InteractionEvent.Register,
+    });
+
+    await client.successSend(sendVerificationPasscode, {
+      event: InteractionEvent.Register,
+      phone: primaryPhone,
+    });
+
+    const { code } = await readPasscode();
+
+    await client.successSend(patchInteractionIdentifiers, {
+      phone: primaryPhone,
+      passcode: code,
+    });
+
+    await client.successSend(putInteractionProfile, {
+      phone: primaryPhone,
+    });
+
+    await expectRejects(client.submitInteraction(), 'user.missing_profile');
+
+    await client.successSend(patchInteractionProfile, {
+      password,
+    });
+
+    const { redirectTo } = await client.submitInteraction();
+
+    await processSession(client, redirectTo);
+    await logoutClient(client);
+
+    // SignIn with phone and password
+    await client.initSession();
+    await client.successSend(putInteraction, {
+      event: InteractionEvent.SignIn,
+      identifier: {
+        phone: primaryPhone,
+        password,
+      },
+    });
+
+    const { redirectTo: redirectTo2 } = await client.submitInteraction();
+    const id = await processSession(client, redirectTo2);
+    await logoutClient(client);
+
     await deleteUser(id);
   });
 
@@ -182,7 +306,7 @@ describe('Register with passwordless identifier', () => {
       passcode: code,
     });
 
-    await client.successSend(patchInteractionProfile, {
+    await client.successSend(putInteractionProfile, {
       email: primaryEmail,
     });
 
@@ -235,7 +359,7 @@ describe('Register with passwordless identifier', () => {
       passcode: code,
     });
 
-    await client.successSend(patchInteractionProfile, {
+    await client.successSend(putInteractionProfile, {
       phone: primaryPhone,
     });
 

--- a/packages/integration-tests/src/tests/api/interaction/sign-in-with-passcode-identifier.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/sign-in-with-passcode-identifier.test.ts
@@ -4,7 +4,7 @@ import {
   sendVerificationPasscode,
   putInteraction,
   putInteractionEvent,
-  patchInteractionProfile,
+  putInteractionProfile,
   patchInteractionIdentifiers,
   deleteUser,
   updateSignInExperience,
@@ -15,7 +15,7 @@ import { generateEmail, generatePhone } from '#src/utils.js';
 import { initClient, processSession, logoutClient } from './utils/client.js';
 import { clearConnectorsByTypes, setEmailConnector, setSmsConnector } from './utils/connector.js';
 import { enableAllPasscodeSignInMethods } from './utils/sign-in-experience.js';
-import { generateNewUser } from './utils/user.js';
+import { generateNewUser, generateNewUserProfile } from './utils/user.js';
 
 describe('Sign-In flow using passcode identifiers', () => {
   beforeAll(async () => {
@@ -127,7 +127,7 @@ describe('Sign-In flow using passcode identifiers', () => {
     await expectRejects(client.submitInteraction(), 'user.user_not_exist');
 
     await client.successSend(putInteractionEvent, { event: InteractionEvent.Register });
-    await client.successSend(patchInteractionProfile, { email: newEmail });
+    await client.successSend(putInteractionProfile, { email: newEmail });
 
     const { redirectTo } = await client.submitInteraction();
 
@@ -167,12 +167,178 @@ describe('Sign-In flow using passcode identifiers', () => {
     await expectRejects(client.submitInteraction(), 'user.user_not_exist');
 
     await client.successSend(putInteractionEvent, { event: InteractionEvent.Register });
-    await client.successSend(patchInteractionProfile, { phone: newPhone });
+    await client.successSend(putInteractionProfile, { phone: newPhone });
 
     const { redirectTo } = await client.submitInteraction();
 
     const id = await processSession(client, redirectTo);
     await logoutClient(client);
     await deleteUser(id);
+  });
+
+  // Fulfill the username and password
+  it('email passcode sign-in', async () => {
+    await updateSignInExperience({
+      signUp: {
+        identifiers: [SignInIdentifier.Username],
+        password: true,
+        verify: false,
+      },
+    });
+
+    const { userProfile, user } = await generateNewUser({ primaryEmail: true });
+    const { username, password } = generateNewUserProfile({ username: true, password: true });
+
+    // SignIn with email
+    const client = await initClient();
+
+    await client.successSend(putInteraction, {
+      event: InteractionEvent.SignIn,
+    });
+
+    await client.successSend(sendVerificationPasscode, {
+      event: InteractionEvent.SignIn,
+      email: userProfile.primaryEmail,
+    });
+    const { code } = await readPasscode();
+
+    await client.successSend(patchInteractionIdentifiers, {
+      email: userProfile.primaryEmail,
+      passcode: code,
+    });
+
+    await expectRejects(client.submitInteraction(), 'user.missing_profile');
+
+    // Fulfill user profile
+    await client.successSend(putInteractionProfile, {
+      username,
+      password,
+    });
+
+    const { redirectTo } = await client.submitInteraction();
+
+    await processSession(client, redirectTo);
+    await logoutClient(client);
+
+    await client.initSession();
+    // SignIn with username and password
+    await client.successSend(putInteraction, {
+      event: InteractionEvent.SignIn,
+      identifier: {
+        username,
+        password,
+      },
+    });
+
+    const { redirectTo: redirectTo2 } = await client.submitInteraction();
+    await processSession(client, redirectTo2);
+    await logoutClient(client);
+
+    await deleteUser(user.id);
+  });
+
+  it('email passcode sign-in with existing password', async () => {
+    await updateSignInExperience({
+      signUp: {
+        identifiers: [SignInIdentifier.Username],
+        password: true,
+        verify: false,
+      },
+    });
+
+    const { userProfile, user } = await generateNewUser({ primaryEmail: true, password: true });
+    const { username, password } = generateNewUserProfile({ username: true, password: true });
+
+    // SignIn with email
+    const client = await initClient();
+
+    await client.successSend(putInteraction, {
+      event: InteractionEvent.SignIn,
+    });
+
+    await client.successSend(sendVerificationPasscode, {
+      event: InteractionEvent.SignIn,
+      email: userProfile.primaryEmail,
+    });
+    const { code } = await readPasscode();
+
+    await client.successSend(patchInteractionIdentifiers, {
+      email: userProfile.primaryEmail,
+      passcode: code,
+    });
+
+    await expectRejects(client.submitInteraction(), 'user.missing_profile');
+
+    // Fulfill user profile with existing password
+    await client.successSend(putInteractionProfile, {
+      username,
+      password,
+    });
+
+    await expectRejects(client.submitInteraction(), 'user.password_exists_in_profile');
+
+    await client.successSend(putInteractionProfile, {
+      username,
+    });
+
+    const { redirectTo } = await client.submitInteraction();
+
+    await processSession(client, redirectTo);
+    await logoutClient(client);
+    await deleteUser(user.id);
+  });
+
+  it('email passcode sign-in with registered username', async () => {
+    await updateSignInExperience({
+      signUp: {
+        identifiers: [SignInIdentifier.Username],
+        password: true,
+        verify: false,
+      },
+    });
+
+    const { userProfile, user } = await generateNewUser({ primaryEmail: true });
+    const { userProfile: userProfile2, user: user2 } = await generateNewUser({ username: true });
+    const { username, password } = generateNewUserProfile({ username: true, password: true });
+
+    // SignIn with email
+    const client = await initClient();
+
+    await client.successSend(putInteraction, {
+      event: InteractionEvent.SignIn,
+    });
+
+    await client.successSend(sendVerificationPasscode, {
+      event: InteractionEvent.SignIn,
+      email: userProfile.primaryEmail,
+    });
+    const { code } = await readPasscode();
+
+    await client.successSend(patchInteractionIdentifiers, {
+      email: userProfile.primaryEmail,
+      passcode: code,
+    });
+
+    await expectRejects(client.submitInteraction(), 'user.missing_profile');
+
+    // Fulfill user profile with existing password
+    await client.successSend(putInteractionProfile, {
+      username: userProfile2.username,
+      password,
+    });
+
+    await expectRejects(client.submitInteraction(), 'user.username_already_in_use');
+
+    await client.successSend(putInteractionProfile, {
+      username,
+      password,
+    });
+
+    const { redirectTo } = await client.submitInteraction();
+
+    await processSession(client, redirectTo);
+    await logoutClient(client);
+    await deleteUser(user.id);
+    await deleteUser(user2.id);
   });
 });

--- a/packages/integration-tests/src/tests/api/interaction/sign-in-with-password-identifier.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/sign-in-with-password-identifier.test.ts
@@ -1,14 +1,32 @@
-import { InteractionEvent } from '@logto/schemas';
+import { InteractionEvent, ConnectorType, SignInIdentifier } from '@logto/schemas';
 
-import { putInteraction, deleteUser } from '#src/api/index.js';
+import {
+  putInteraction,
+  sendVerificationPasscode,
+  patchInteractionIdentifiers,
+  putInteractionProfile,
+  deleteUser,
+} from '#src/api/index.js';
+import { readPasscode, expectRejects } from '#src/helpers.js';
 
 import { initClient, processSession, logoutClient } from './utils/client.js';
-import { enableAllPasswordSignInMethods } from './utils/sign-in-experience.js';
-import { generateNewUser } from './utils/user.js';
+import { clearConnectorsByTypes, setSmsConnector, setEmailConnector } from './utils/connector.js';
+import {
+  enableAllPasswordSignInMethods,
+  enableAllPasscodeSignInMethods,
+} from './utils/sign-in-experience.js';
+import { generateNewUser, generateNewUserProfile } from './utils/user.js';
 
 describe('Sign-In flow using password identifiers', () => {
   beforeAll(async () => {
     await enableAllPasswordSignInMethods();
+    await clearConnectorsByTypes([ConnectorType.Sms, ConnectorType.Email]);
+    await setSmsConnector();
+    await setEmailConnector();
+  });
+
+  afterAll(async () => {
+    await clearConnectorsByTypes([ConnectorType.Sms, ConnectorType.Email]);
   });
 
   it('sign-in with username and password', async () => {
@@ -66,6 +84,126 @@ describe('Sign-In flow using password identifiers', () => {
     const { redirectTo } = await client.submitInteraction();
 
     await processSession(client, redirectTo);
+    await logoutClient(client);
+
+    await deleteUser(user.id);
+  });
+
+  // Fulfill the email address
+  it('sign-in with username and password and fulfill the email', async () => {
+    await enableAllPasscodeSignInMethods({
+      identifiers: [SignInIdentifier.Email],
+      password: true,
+      verify: true,
+    });
+
+    const { userProfile, user } = await generateNewUser({ username: true, password: true });
+    const { primaryEmail } = generateNewUserProfile({ primaryEmail: true });
+    const client = await initClient();
+
+    await client.successSend(putInteraction, {
+      event: InteractionEvent.SignIn,
+      identifier: {
+        username: userProfile.username,
+        password: userProfile.password,
+      },
+    });
+
+    await expectRejects(client.submitInteraction(), 'user.missing_profile');
+
+    await client.successSend(sendVerificationPasscode, {
+      event: InteractionEvent.SignIn,
+      email: primaryEmail,
+    });
+
+    const { code } = await readPasscode();
+
+    await client.successSend(patchInteractionIdentifiers, {
+      email: primaryEmail,
+      passcode: code,
+    });
+
+    await client.successSend(putInteractionProfile, {
+      email: primaryEmail,
+    });
+
+    const { redirectTo } = await client.submitInteraction();
+
+    await processSession(client, redirectTo);
+    await logoutClient(client);
+
+    // SignIn with email and password
+    await client.initSession();
+    await client.successSend(putInteraction, {
+      event: InteractionEvent.SignIn,
+      identifier: {
+        email: primaryEmail,
+        password: userProfile.password,
+      },
+    });
+
+    const { redirectTo: redirectTo2 } = await client.submitInteraction();
+    await processSession(client, redirectTo2);
+    await logoutClient(client);
+
+    await deleteUser(user.id);
+  });
+
+  // Fulfill the phone number
+  it('sign-in with username and password and fulfill the phone number', async () => {
+    await enableAllPasscodeSignInMethods({
+      identifiers: [SignInIdentifier.Sms, SignInIdentifier.Email],
+      password: true,
+      verify: true,
+    });
+
+    const { userProfile, user } = await generateNewUser({ username: true, password: true });
+    const { primaryPhone } = generateNewUserProfile({ primaryPhone: true });
+    const client = await initClient();
+
+    await client.successSend(putInteraction, {
+      event: InteractionEvent.SignIn,
+      identifier: {
+        username: userProfile.username,
+        password: userProfile.password,
+      },
+    });
+
+    await expectRejects(client.submitInteraction(), 'user.missing_profile');
+
+    await client.successSend(sendVerificationPasscode, {
+      event: InteractionEvent.SignIn,
+      phone: primaryPhone,
+    });
+
+    const { code } = await readPasscode();
+
+    await client.successSend(patchInteractionIdentifiers, {
+      phone: primaryPhone,
+      passcode: code,
+    });
+
+    await client.successSend(putInteractionProfile, {
+      phone: primaryPhone,
+    });
+
+    const { redirectTo } = await client.submitInteraction();
+
+    await processSession(client, redirectTo);
+    await logoutClient(client);
+
+    // SignIn with new phone and password
+    await client.initSession();
+    await client.successSend(putInteraction, {
+      event: InteractionEvent.SignIn,
+      identifier: {
+        phone: primaryPhone,
+        password: userProfile.password,
+      },
+    });
+
+    const { redirectTo: redirectTo2 } = await client.submitInteraction();
+    await processSession(client, redirectTo2);
     await logoutClient(client);
 
     await deleteUser(user.id);

--- a/packages/integration-tests/src/tests/api/interaction/social-interaction.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/social-interaction.test.ts
@@ -7,7 +7,7 @@ import {
   deleteUser,
   putInteractionEvent,
   patchInteractionIdentifiers,
-  patchInteractionProfile,
+  putInteractionProfile,
 } from '#src/api/index.js';
 import { expectRejects } from '#src/helpers.js';
 import { generateUserId } from '#src/utils.js';
@@ -61,7 +61,7 @@ describe('Social Identifier Interactions', () => {
       await expectRejects(client.submitInteraction(), 'user.identity_not_exist');
 
       await client.successSend(putInteractionEvent, { event: InteractionEvent.Register });
-      await client.successSend(patchInteractionProfile, { connectorId });
+      await client.successSend(putInteractionProfile, { connectorId });
 
       const { redirectTo } = await client.submitInteraction();
 
@@ -120,7 +120,7 @@ describe('Social Identifier Interactions', () => {
       await expectRejects(client.submitInteraction(), 'user.identity_not_exist');
 
       await client.successSend(patchInteractionIdentifiers, { username, password });
-      await client.successSend(patchInteractionProfile, { connectorId });
+      await client.successSend(putInteractionProfile, { connectorId });
 
       const { redirectTo } = await client.submitInteraction();
 
@@ -179,7 +179,7 @@ describe('Social Identifier Interactions', () => {
       await expectRejects(client.submitInteraction(), 'user.identity_not_exist');
 
       await client.successSend(patchInteractionIdentifiers, { connectorId, identityType: 'email' });
-      await client.successSend(patchInteractionProfile, { connectorId });
+      await client.successSend(putInteractionProfile, { connectorId });
 
       const { redirectTo } = await client.submitInteraction();
 

--- a/packages/integration-tests/src/tests/api/interaction/utils/sign-in-experience.ts
+++ b/packages/integration-tests/src/tests/api/interaction/utils/sign-in-experience.ts
@@ -35,7 +35,7 @@ const defaultPasscodeSignInMethods = [
     identifier: SignInIdentifier.Username,
     password: true,
     verificationCode: false,
-    isPasswordPrimary: false,
+    isPasswordPrimary: true,
   },
   {
     identifier: SignInIdentifier.Email,


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
add fulfill user profile integration tests

Introduce a new `PUT /interaction/profile` to be able to overwrite the whole profile data.

e.g. 
1. the user has a username in the file
2. user sign-in and fulfill the profile using username and password
3. a username already exists error should be thrown
4. user should be able to remove the username, and replace the profile using a single password.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test passed
