### PR TITLE
refactor: check alteration timestamp when seed database

### DIFF
--- a/packages/cli/src/commands/database/alteration/utils.ts
+++ b/packages/cli/src/commands/database/alteration/utils.ts
@@ -22,8 +22,10 @@ export const getTimestampFromFilename = (filename: string) => {
   return Number(match[1]);
 };
 
+export const getAlterationDirectory = () => getPathInModule('@logto/schemas', 'alterations-js');
+
 export const getAlterationFiles = async (): Promise<AlterationFile[]> => {
-  const alterationDirectory = getPathInModule('@logto/schemas', 'alterations-js');
+  const alterationDirectory = getAlterationDirectory();
 
   /**
    * We copy all alteration scripts to the CLI package root directory,


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
check alteration timestamp before table seeding to make sure alteration folder structure is expected

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

removed compiled scripts, then:

<img width="510" alt="image" src="https://user-images.githubusercontent.com/14722250/209429003-75a47d78-f51f-4375-a216-be311261883f.png">
