### PR TITLE
fix(console): checkbox label should not wrap

### DIFF
--- a/packages/console/src/components/Checkbox/index.module.scss
+++ b/packages/console/src/components/Checkbox/index.module.scss
@@ -59,6 +59,7 @@
   .label {
     font: var(--font-body-medium);
     color: var(--color-text);
+    white-space: nowrap;
     cursor: inherit;
   }
 

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/SignInMethodEditBox/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/SignInMethodEditBox/index.module.scss
@@ -46,7 +46,7 @@
     }
 
     .swapButton {
-      margin-right: _.unit(4);
+      margin: 0 _.unit(4);
     }
 
     &.verifyCodePrimary {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
The checkbox label should not wrap in narrow containers.

Before:
![image](https://user-images.githubusercontent.com/12833674/209526480-809ce109-461e-4ec6-a5bf-ff61213c74c1.png)

After:
<img width="414" alt="image" src="https://user-images.githubusercontent.com/12833674/209526572-efab444a-0cb2-4b3f-8a20-09f01c9caac2.png">

<img width="499" alt="image" src="https://user-images.githubusercontent.com/12833674/209526922-7df6cfe7-5a8a-475c-ac1d-ec0c73e77c94.png">

Since the checkbox cannot be shrunk any further, the outer panel cannot be shrunk, either.

Btw, the swap button in SIE should also have a margin left.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally
