### PR TITLE
fix(console): set min-width to left control panel in SIE

### DIFF
--- a/packages/console/src/pages/SignInExperience/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/index.module.scss
@@ -30,6 +30,7 @@
       .form {
         flex: 1;
         margin-right: _.unit(3);
+        min-width: 535px;
       }
 
       .preview {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Set a minimum 535px to the left control panel in Sign-In Experience page, in order to avoid being shrunk in a narrower browser window.

535px is a magic number determined by the minimum requirement of the elements in English translation. I think we can use it before our designers make the final decision.

Before:
<img width="622" alt="image" src="https://user-images.githubusercontent.com/12833674/209531252-4badac1b-fd89-4ca5-a9af-816fa0d69e59.png">

After:
<img width="606" alt="image" src="https://user-images.githubusercontent.com/12833674/209531352-5bda8415-324a-4fa2-afb3-d10698a6e3d2.png">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Locally tested
