### PR TITLE
fix(console): use `getSafe` on the sie page

### DIFF
--- a/packages/console/src/pages/SignInExperience/components/SignUpAndSignInChangePreview/SignUpAndSignInDiffSection/SignInDiffSection.tsx
+++ b/packages/console/src/pages/SignInExperience/components/SignUpAndSignInChangePreview/SignUpAndSignInDiffSection/SignInDiffSection.tsx
@@ -1,5 +1,5 @@
 import type { SignInIdentifier } from '@logto/schemas';
-import { get } from '@silverhand/essentials';
+import { getSafe } from '@silverhand/essentials';
 import { detailedDiff } from 'deep-object-diff';
 import { useTranslation } from 'react-i18next';
 
@@ -28,13 +28,13 @@ const SignInDiffSection = ({ before, after, isAfter = false }: Props) => {
   const displaySignInMethodsObject = isAfter ? afterSignInMethodsObject : beforeSignInMethodsObject;
 
   const hasIdentifierChanged = (identifierKey: SignInIdentifier) =>
-    get(signInDiff, `added.${identifierKey.toLocaleLowerCase()}`) !== undefined;
+    getSafe(signInDiff, `added.${identifierKey.toLocaleLowerCase()}`) !== undefined;
 
   const hasAuthenticationChanged = (
     identifierKey: SignInIdentifier,
     authenticationKey: keyof SignInMethodsObject[SignInIdentifier]
   ) =>
-    get(signInDiff, `updated.${identifierKey.toLocaleLowerCase()}.${authenticationKey}`) !==
+    getSafe(signInDiff, `updated.${identifierKey.toLocaleLowerCase()}.${authenticationKey}`) !==
     undefined;
 
   // eslint-disable-next-line no-restricted-syntax

--- a/packages/console/src/pages/SignInExperience/components/SignUpAndSignInChangePreview/SignUpAndSignInDiffSection/SignUpDiffSection.tsx
+++ b/packages/console/src/pages/SignInExperience/components/SignUpAndSignInChangePreview/SignUpAndSignInDiffSection/SignUpDiffSection.tsx
@@ -1,5 +1,5 @@
 import type { SignUp } from '@logto/schemas';
-import { get } from '@silverhand/essentials';
+import { getSafe } from '@silverhand/essentials';
 import { diff } from 'deep-object-diff';
 import { useTranslation } from 'react-i18next';
 import { snakeCase } from 'snake-case';
@@ -22,7 +22,7 @@ const SignUpDiffSection = ({ before, after, isAfter = false }: Props) => {
   const parsedAfter = signInExperienceParser.toLocalSignUp(after);
   const signUpDiff = isAfter ? diff(parsedBefore, parsedAfter) : diff(parsedAfter, parsedBefore);
   const signUp = isAfter ? parsedAfter : parsedBefore;
-  const hasChanged = (path: keyof SignUpForm) => get(signUpDiff, path) !== undefined;
+  const hasChanged = (path: keyof SignUpForm) => getSafe(signUpDiff, path) !== undefined;
 
   const { identifier, password, verify } = signUp;
   const hasAuthentication = password || verify;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
the `get` method will throw an error if we try to get a value from an undefined prop value. Use `getSafe` to avoid this error on the SIE page.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.
