### PR TITLE
fix(core): should block POST of non-standard social connectors with conflicting `target`

### DIFF
--- a/packages/core/src/routes/connector.test.ts
+++ b/packages/core/src/routes/connector.test.ts
@@ -193,7 +193,7 @@ describe('connector route', () => {
       expect(response).toHaveProperty('statusCode', 422);
     });
 
-    it('should post a new record when add more than 1 instance with connector factory', async () => {
+    it('should post a new record when add more than 1 instance with standard connector factory', async () => {
       loadConnectorFactories.mockResolvedValueOnce([
         {
           ...mockConnectorFactory,
@@ -231,7 +231,26 @@ describe('connector route', () => {
       );
     });
 
-    it('throws when add more than 1 instance with non-connector factory', async () => {
+    it('throws when add more than 1 instance with target is an empty string with standard connector factory', async () => {
+      loadConnectorFactories.mockResolvedValueOnce([
+        {
+          ...mockConnectorFactory,
+          metadata: {
+            ...mockMetadata,
+            id: 'id0',
+            isStandard: true,
+            platform: ConnectorPlatform.Universal,
+          },
+        },
+      ]);
+      const response = await connectorRequest.post('/connectors').send({
+        connectorId: 'id0',
+        metadata: { target: '' },
+      });
+      expect(response).toHaveProperty('statusCode', 400);
+    });
+
+    it('throws when add more than 1 instance with non-standard connector factory', async () => {
       loadConnectorFactories.mockResolvedValueOnce([
         {
           ...mockConnectorFactory,
@@ -321,7 +340,6 @@ describe('connector route', () => {
             id: 'id0',
             platform: ConnectorPlatform.Universal,
             target: 'target',
-            isStandard: true,
           },
         },
       ]);
@@ -341,7 +359,6 @@ describe('connector route', () => {
       ]);
       const response = await connectorRequest.post('/connectors').send({
         connectorId: 'id0',
-        metadata: { target: 'target' },
       });
       expect(response).toHaveProperty('statusCode', 422);
     });

--- a/packages/core/src/routes/connector.ts
+++ b/packages/core/src/routes/connector.ts
@@ -127,7 +127,7 @@ export default function connectorRoutes<T extends AuthedRouter>(router: T) {
       }
 
       assertThat(
-        connectorFactory.metadata.isStandard !== true || metadata?.target,
+        connectorFactory.metadata.isStandard !== true || Boolean(metadata?.target),
         'connector.should_specify_target'
       );
       assertThat(
@@ -151,7 +151,8 @@ export default function connectorRoutes<T extends AuthedRouter>(router: T) {
             .filter(({ type }) => type === ConnectorType.Social)
             .some(
               ({ metadata: { target, platform } }) =>
-                target === cleanDeep(metadata)?.target &&
+                target ===
+                  (metadata ? cleanDeep(metadata).target : connectorFactory.metadata.target) &&
                 platform === connectorFactory.metadata.platform
             ),
           new RequestError({ code: 'connector.multiple_target_with_same_platform', status: 422 })


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
1. When POST non-standard social connectors, `metadata` should not be updated. As a result, when `metadata` is not presented in `ctx.body.guard`, `target` of `connectorFactory` should be checked.
2. Potential undesired empty string of `ctx.body.guard.metadata.target` could be given, this case should be considered.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally with AC.
Also updated related UTs.
