### PR TITLE
refactor(console): remove extra scrollbar spaces

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -81,6 +81,7 @@
     "react-syntax-highlighter": "^15.5.0",
     "recharts": "^2.1.13",
     "remark-gfm": "^3.0.1",
+    "simplebar-react": "^2.4.3",
     "snake-case": "^3.0.4",
     "stylelint": "^14.9.1",
     "swr": "^1.3.0",

--- a/packages/console/src/App.tsx
+++ b/packages/console/src/App.tsx
@@ -4,7 +4,10 @@ import { adminConsoleApplicationId, managementResource } from '@logto/schemas';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { SWRConfig } from 'swr';
 
+import 'simplebar-react/dist/simplebar.min.css';
 import './scss/normalized.scss';
+import './scss/simplebar.scss';
+
 // eslint-disable-next-line import/no-unassigned-import
 import '@fontsource/roboto-mono';
 import AppBoundary from '@/components/AppBoundary';

--- a/packages/console/src/components/AppContent/components/Sidebar/index.tsx
+++ b/packages/console/src/components/AppContent/components/Sidebar/index.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
+import SimpleBar from 'simplebar-react';
 
 import Item from './components/Item';
 import Section from './components/Section';
@@ -16,7 +17,7 @@ const Sidebar = () => {
   const { sections } = useSidebarMenuItems();
 
   return (
-    <div className={styles.sidebar}>
+    <SimpleBar className={styles.sidebar}>
       {sections.map(({ title, items }) => (
         <Section key={title} title={t(title)}>
           {items.map(
@@ -40,7 +41,7 @@ const Sidebar = () => {
         icon={<Gear />}
         isActive={location.pathname.startsWith(getPath('settings'))}
       />
-    </div>
+    </SimpleBar>
   );
 };
 

--- a/packages/console/src/components/Dropdown/index.module.scss
+++ b/packages/console/src/components/Dropdown/index.module.scss
@@ -33,4 +33,9 @@
 .list {
   margin: 0;
   overflow-y: auto;
+
+  ul {
+    margin: 0;
+    padding-inline-start: unset;
+  }
 }

--- a/packages/console/src/components/Dropdown/index.tsx
+++ b/packages/console/src/components/Dropdown/index.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import type { ReactNode, RefObject } from 'react';
 import { useRef } from 'react';
 import ReactModal from 'react-modal';
+import SimpleBar from 'simplebar-react';
 
 import usePosition from '@/hooks/use-position';
 import type { HorizontalAlignment } from '@/types/positioning';
@@ -65,15 +66,16 @@ const Dropdown = ({
     >
       <div ref={overlayRef} className={styles.dropdownContainer}>
         {title && <div className={classNames(styles.title, titleClassName)}>{title}</div>}
-        <ul
-          className={classNames(styles.list, className)}
-          role="menu"
-          tabIndex={0}
-          onClick={onClose}
-          onKeyDown={onKeyDownHandler({ Enter: onClose, Esc: onClose })}
-        >
-          {children}
-        </ul>
+        <SimpleBar className={classNames(styles.list, className)}>
+          <ul
+            role="menu"
+            tabIndex={0}
+            onClick={onClose}
+            onKeyDown={onKeyDownHandler({ Enter: onClose, Esc: onClose })}
+          >
+            {children}
+          </ul>
+        </SimpleBar>
       </div>
     </ReactModal>
   );

--- a/packages/console/src/components/Table/StickyHeaderTable.module.scss
+++ b/packages/console/src/components/Table/StickyHeaderTable.module.scss
@@ -13,7 +13,8 @@
 
   .bodyTable {
     flex: 1;
-    overflow-y: scroll;
+    overflow: auto;
+    max-height: 100%;
     padding-bottom: _.unit(2);
 
     tr {

--- a/packages/console/src/components/Table/StickyHeaderTable.tsx
+++ b/packages/console/src/components/Table/StickyHeaderTable.tsx
@@ -1,6 +1,7 @@
 import { assert } from '@silverhand/essentials';
 import classNames from 'classnames';
 import type { ReactElement } from 'react';
+import SimpleBar from 'simplebar-react';
 
 import * as styles from './StickyHeaderTable.module.scss';
 
@@ -27,12 +28,12 @@ const StickyHeaderTable = ({ header, colGroup, className, children: body }: Prop
         {colGroup}
         {header}
       </table>
-      <div className={styles.bodyTable}>
+      <SimpleBar className={styles.bodyTable}>
         <table>
           {colGroup}
           {body}
         </table>
-      </div>
+      </SimpleBar>
     </div>
   );
 };

--- a/packages/console/src/pages/SignInExperience/tabs/Others/components/ManageLanguage/LanguageEditor/LanguageNav.module.scss
+++ b/packages/console/src/pages/SignInExperience/tabs/Others/components/ManageLanguage/LanguageEditor/LanguageNav.module.scss
@@ -11,6 +11,7 @@
 
   .languageItemList {
     flex: 1;
+    max-height: 100%;
     margin-top: _.unit(3);
     overflow-y: auto;
   }

--- a/packages/console/src/pages/SignInExperience/tabs/Others/components/ManageLanguage/LanguageEditor/LanguageNav.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/Others/components/ManageLanguage/LanguageEditor/LanguageNav.tsx
@@ -1,6 +1,7 @@
 import type { LanguageTag } from '@logto/language-kit';
 import { isLanguageTag, languages as uiLanguageNameMapping } from '@logto/language-kit';
 import { useContext } from 'react';
+import SimpleBar from 'simplebar-react';
 
 import useUiLanguages from '@/hooks/use-ui-languages';
 
@@ -52,7 +53,7 @@ const LanguageNav = () => {
   return (
     <div className={style.languageNav}>
       <AddLanguageSelector options={languageOptions} onSelect={onAddLanguage} />
-      <div className={style.languageItemList}>
+      <SimpleBar className={style.languageItemList}>
         {languages.map((languageTag) => (
           <LanguageItem
             key={languageTag}
@@ -63,7 +64,7 @@ const LanguageNav = () => {
             }}
           />
         ))}
-      </div>
+      </SimpleBar>
     </div>
   );
 };

--- a/packages/console/src/scss/simplebar.scss
+++ b/packages/console/src/scss/simplebar.scss
@@ -1,0 +1,25 @@
+/* stylelint-disable selector-class-pattern */
+.simplebar-scrollbar {
+  min-height: 40px;
+}
+
+.simplebar-scrollbar::before {
+  background: var(--color-neutral-variant-80);
+  left: 0;
+  right: 0;
+  border-radius: 8px;
+}
+
+.simplebar-track.simplebar-vertical {
+  width: 8px;
+}
+
+.simplebar-scrollbar.simplebar-visible::before {
+  opacity: 100%;
+}
+
+.simplebar-track.simplebar-vertical .simplebar-scrollbar::before {
+  top: 0;
+  bottom: 0;
+}
+/* stylelint-enable selector-class-pattern */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,7 @@ importers:
       react-syntax-highlighter: ^15.5.0
       recharts: ^2.1.13
       remark-gfm: ^3.0.1
+      simplebar-react: ^2.4.3
       snake-case: ^3.0.4
       stylelint: ^14.9.1
       swr: ^1.3.0
@@ -236,6 +237,7 @@ importers:
       react-syntax-highlighter: 15.5.0_react@18.2.0
       recharts: 2.1.13_v2m5e27vhdewzwhryxwfaorcca
       remark-gfm: 3.0.1
+      simplebar-react: 2.4.3_biqbaboplfbrettd7655fr4n2y
       snake-case: 3.0.4
       stylelint: 14.9.1
       swr: 1.3.0_react@18.2.0
@@ -2241,6 +2243,10 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
+
+  /@juggle/resize-observer/3.4.0:
+    resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
     dev: true
 
   /@koa/cors/3.4.3:
@@ -5178,6 +5184,10 @@ packages:
     engines: {node: '>=14.16'}
     dev: true
 
+  /can-use-dom/0.1.0:
+    resolution: {integrity: sha512-ceOhN1DL7Y4O6M0j9ICgmTYziV89WMd96SvSl0REd8PMgrY0B/WBOPoed5S1KUmJqXgUXh8gzSe6E3ae27upsQ==}
+    dev: true
+
   /caniuse-lite/1.0.30001419:
     resolution: {integrity: sha512-aFO1r+g6R7TW+PNQxKzjITwLOyDhVRLjW0LcwS/HCZGUUKTGNp9+IwLC4xyDSZBygVL/mxaFR3HIV6wEKQuSzw==}
     dev: true
@@ -5597,8 +5607,8 @@ packages:
 
   /core-js/3.21.1:
     resolution: {integrity: sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==}
+    deprecated: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.
     requiresBuild: true
-    dev: false
 
   /core-util-is/1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -10245,6 +10255,10 @@ packages:
     resolution: {integrity: sha1-soqmKIorn8ZRA1x3EfZathkDMaY=}
     dev: true
 
+  /lodash.debounce/4.0.8:
+    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
+    dev: true
+
   /lodash.get/4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
     dev: true
@@ -10280,6 +10294,10 @@ packages:
 
   /lodash.startcase/4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
+    dev: true
+
+  /lodash.throttle/4.1.1:
+    resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
     dev: true
 
   /lodash.transform/4.6.0:
@@ -13308,6 +13326,29 @@ packages:
     engines: {node: '>=8.10.0'}
     dependencies:
       semver: 7.0.0
+    dev: true
+
+  /simplebar-react/2.4.3_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-Ep8gqAUZAS5IC2lT5RE4t1ZFUIVACqbrSRQvFV9a6NbVUzXzOMnc4P82Hl8Ak77AnPQvmgUwZS7aUKLyBoMAcg==}
+    peerDependencies:
+      react: ^0.14.9 || ^15.3.0 || ^16.0.0-rc || ^16.0 || ^17.0 || ^18.0.0
+      react-dom: ^0.14.9 || ^15.3.0 || ^16.0.0-rc || ^16.0 || ^17.0 || ^18.0.0
+    dependencies:
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      simplebar: 5.3.9
+    dev: true
+
+  /simplebar/5.3.9:
+    resolution: {integrity: sha512-1vIIpjDvY9sVH14e0LGeiCiTFU3ILqAghzO6OI9axeG+mvU/vMSrvXeAXkBolqFFz3XYaY8n5ahH9MeP3sp2Ag==}
+    dependencies:
+      '@juggle/resize-observer': 3.4.0
+      can-use-dom: 0.1.0
+      core-js: 3.21.1
+      lodash.debounce: 4.0.8
+      lodash.memoize: 4.1.2
+      lodash.throttle: 4.1.1
     dev: true
 
   /sinon/15.0.0:


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Use `SimpleBar` to remove extra scrollbar spaces from pages.

- Replace related scrollbars with the `SimpleBar` component.
- Add `max-height: 100%` to `flex:1` items for the `SimpleBar` component relay on the `maxHeight` prop in CSS.

### Todo
- Replace scrollbars in the table component when the table is completely refactored in https://github.com/logto-io/logto/pull/2738

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="1300" alt="image" src="https://user-images.githubusercontent.com/10806653/209649336-38c00e12-ceaf-429c-9fd1-b6f4d632bfe5.png">
<img width="194" alt="image" src="https://user-images.githubusercontent.com/10806653/209649380-dce3c30a-5176-42ec-a97c-f4b80bd0b1ec.png">
<img width="160" alt="image" src="https://user-images.githubusercontent.com/10806653/209649417-a221b3f4-c22d-4958-9528-6214619c6beb.png">

