### PR TITLE
feat: support png and jpeg files for connector logo

### DIFF
--- a/packages/core/src/connectors/utilities/index.ts
+++ b/packages/core/src/connectors/utilities/index.ts
@@ -34,16 +34,48 @@ export function validateConnectorModule(
   }
 }
 
-export const readUrl = async (
-  url: string,
-  baseUrl: string,
-  type: 'text' | 'svg'
-): Promise<string> => {
+type UrlType = 'text' | 'svg' | 'png' | 'jpeg' | undefined;
+
+const getUrlType = (url: string): UrlType => {
+  const splitUrl = url.split('/').filter(Boolean);
+
+  assertThat(
+    splitUrl.length > 1,
+    new ConnectorError(ConnectorErrorCodes.InvalidMetadata, { message: `Invalid url: ${url}.` })
+  );
+
+  const splitBaseUrl = splitUrl.slice(-1)[0]?.split('.').filter(Boolean);
+  const extension = splitBaseUrl && splitBaseUrl.length > 1 ? splitBaseUrl.slice(-1)[0] : undefined;
+
+  if (!extension) {
+    return undefined; // Short circuit for parsed URL.
+  }
+
+  if (extension === 'png' || extension === 'svg') {
+    return extension;
+  }
+
+  if (extension === 'jpg' || extension === 'jpeg') {
+    return 'jpeg';
+  }
+
+  if (extension === 'md' || extension === 'json' || extension === 'txt') {
+    return 'text';
+  }
+
+  throw new ConnectorError(ConnectorErrorCodes.InvalidMetadata, {
+    message: `Invalid url: ${url} with unsupported file type.`,
+  });
+};
+
+export const readUrl = async (url: string, baseUrl: string, type?: UrlType): Promise<string> => {
   if (!url) {
     return url;
   }
 
-  if (type !== 'text' && url.startsWith('http')) {
+  const urlType = type ?? getUrlType(url);
+
+  if (!urlType || (urlType !== 'text' && url.startsWith('http'))) {
     return url;
   }
 
@@ -51,10 +83,12 @@ export const readUrl = async (
     return url;
   }
 
-  if (type === 'svg') {
+  if (urlType === 'svg' || urlType === 'jpeg' || urlType === 'png') {
     const data = await readFile(path.join(baseUrl, url));
 
-    return `data:image/svg+xml;base64,${data.toString('base64')}`;
+    const imageTypes = urlType === 'svg' ? 'svg+xml' : urlType;
+
+    return `data:image/${imageTypes};base64,${data.toString('base64')}`;
   }
 
   return readFile(path.join(baseUrl, url), 'utf8');
@@ -63,8 +97,8 @@ export const readUrl = async (
 export const parseMetadata = async (metadata: AllConnector['metadata'], packagePath: string) => {
   return {
     ...metadata,
-    logo: await readUrl(metadata.logo, packagePath, 'svg'),
-    logoDark: metadata.logoDark && (await readUrl(metadata.logoDark, packagePath, 'svg')),
+    logo: await readUrl(metadata.logo, packagePath),
+    logoDark: metadata.logoDark && (await readUrl(metadata.logoDark, packagePath)),
     readme: await readUrl(metadata.readme, packagePath, 'text'),
     configTemplate: await readUrl(metadata.configTemplate, packagePath, 'text'),
   };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Support png and jpeg file for connector logo.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally with png and jpeg connector logo files. Logos, config templates and README files can display properly.
<img width="3008" alt="image" src="https://user-images.githubusercontent.com/15182327/209914412-8ea1d9ae-9710-41f1-99fe-1c52fb0cdb17.png">
<img width="3008" alt="image" src="https://user-images.githubusercontent.com/15182327/209914544-65ad8d96-a30d-484d-a3e4-6dd37a884520.png">
<img width="391" alt="image" src="https://user-images.githubusercontent.com/15182327/209914446-8f9bd7b9-8a1f-45d6-b5cd-1c1b579a88bc.png">

