### PR TITLE
fix(console): search users by phone

### DIFF
--- a/packages/console/src/pages/Users/index.tsx
+++ b/packages/console/src/pages/Users/index.tsx
@@ -42,7 +42,7 @@ const Users = () => {
   const keyword = query.get('search') ?? '';
   const { data, error, mutate } = useSWR<[User[], number], RequestError>(
     `/api/users?page=${pageIndex}&page_size=${pageSize}&hideAdminUser=true${conditionalString(
-      keyword && `&search=%${keyword}%`
+      keyword && `&search=${encodeURIComponent(`%${keyword}%`)}`
     )}`
   );
   const isLoading = !data && !error;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The % character is used in URL encoding to represent special characters or reserved characters in a URL.

Before the string is sent to the back-end, the browser will decode it, converting %12345% back into the original character. If %12345% cannot be decoded, it will appear as \x12345% on the back end.

This causes the bug when searching users by phone; we send `%{phone}%`, and the back end will get `\x{phone}%`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="986" alt="image" src="https://user-images.githubusercontent.com/10806653/209959570-918a5921-59ad-4913-b949-08aa49c78bda.png">

