### PR TITLE
feat: pass user agent to connector

### DIFF
--- a/packages/core/src/routes/interaction/utils/social-verification.ts
+++ b/packages/core/src/routes/interaction/utils/social-verification.ts
@@ -28,8 +28,12 @@ export const createSocialAuthorizationUrl = async (
 
   assertThat(connector.type === ConnectorType.Social, 'connector.unexpected_type');
 
+  const {
+    headers: { 'user-agent': userAgent },
+  } = ctx.request;
+
   return connector.getAuthorizationUri(
-    { state, redirectUri },
+    { state, redirectUri, headers: { userAgent } },
     async (connectorStorage: ConnectorSession) =>
       assignConnectorSessionResult(ctx, provider, connectorStorage)
   );

--- a/packages/core/src/routes/session/social.ts
+++ b/packages/core/src/routes/session/social.ts
@@ -52,13 +52,16 @@ export default function socialRoutes<T extends AnonymousRouterLegacy>(
       }),
     }),
     async (ctx, next) => {
+      const {
+        headers: { 'user-agent': userAgent },
+      } = ctx.request;
       await provider.interactionDetails(ctx.req, ctx.res);
       const { connectorId, state, redirectUri } = ctx.guard.body;
       assertThat(state && redirectUri, 'session.insufficient_info');
       const connector = await getLogtoConnectorById(connectorId);
       assertThat(connector.type === ConnectorType.Social, 'connector.unexpected_type');
       const redirectTo = await connector.getAuthorizationUri(
-        { state, redirectUri },
+        { state, redirectUri, headers: { userAgent } },
         async (connectorStorage: ConnectorSession) =>
           assignConnectorSessionResult(ctx, provider, connectorStorage)
       );

--- a/packages/toolkit/connector-kit/src/types.ts
+++ b/packages/toolkit/connector-kit/src/types.ts
@@ -166,6 +166,7 @@ export type GetAuthorizationUri = (
   payload: {
     state: string;
     redirectUri: string;
+    headers?: { userAgent?: string };
   },
   setSession?: SetSession
 ) => Promise<string>;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
pass user agent to connectors.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
CI.
Also tested locally and connector can get `userAgent` as expected.
<img width="1106" alt="image" src="https://user-images.githubusercontent.com/15182327/210032416-7aae0562-d470-45db-9f13-0cdb0ac368ab.png">
