### PR TITLE
fix(console): add url check for logo

### DIFF
--- a/packages/console/src/pages/Connectors/components/ConnectorForm/index.tsx
+++ b/packages/console/src/pages/Connectors/components/ConnectorForm/index.tsx
@@ -12,6 +12,7 @@ import FormField from '@/components/FormField';
 import Select from '@/components/Select';
 import TextInput from '@/components/TextInput';
 import TextLink from '@/components/TextLink';
+import { uriValidator } from '@/utilities/validator';
 
 import type { ConnectorFormType } from '../../types';
 import { SyncProfileMode } from '../../types';
@@ -60,14 +61,27 @@ const ConnectorForm = ({ connector, isAllowEditTarget }: Props) => {
             <div className={styles.tip}>{t('connectors.guide.name_tip')}</div>
           </FormField>
           <FormField title="connectors.guide.logo">
-            <TextInput placeholder={t('connectors.guide.logo_placeholder')} {...register('logo')} />
+            <TextInput
+              placeholder={t('connectors.guide.logo_placeholder')}
+              hasError={Boolean(errors.logo)}
+              errorMessage={errors.logo?.message}
+              {...register('logo', {
+                validate: (value) =>
+                  !value || uriValidator(value) || t('errors.invalid_uri_format'),
+              })}
+            />
             <div className={styles.tip}>{t('connectors.guide.logo_tip')}</div>
           </FormField>
           {darkVisible && (
             <FormField title="connectors.guide.logo_dark">
               <TextInput
                 placeholder={t('connectors.guide.logo_dark_placeholder')}
-                {...register('logoDark')}
+                hasError={Boolean(errors.logoDark)}
+                errorMessage={errors.logoDark?.message}
+                {...register('logoDark', {
+                  validate: (value) =>
+                    !value || uriValidator(value) || t('errors.invalid_uri_format'),
+                })}
               />
               <div className={styles.tip}>{t('connectors.guide.logo_dark_tip')}</div>
             </FormField>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add url checks for connector logo `TextInput`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

<img width="398" alt="截屏2022-12-30 上午11 27 02" src="https://user-images.githubusercontent.com/5717882/210031499-3f628cfe-f8d0-4902-b2dd-f6bb2217abe8.png">
