### PR TITLE
style(console): remove full-width limit of add social dropdown

### DIFF
--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/SocialConnectorEditBox/AddButton.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/SocialConnectorEditBox/AddButton.tsx
@@ -44,7 +44,6 @@ const AddButton = ({ options, onSelected, hasSelectedConnectors }: Props) => {
       dropdownClassName={classNames(
         hasSelectedConnectors ? styles.addAnotherDropdown : styles.dropdown
       )}
-      isDropdownFullWidth={!hasSelectedConnectors}
     >
       {options.map(({ target, logo, logoDark, name, connectors }) => (
         <DropdownItem


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Remove the full-width limit of add social dropdown because now the connector name is customized and maybe longer than the add button.
<img width="387" alt="image" src="https://user-images.githubusercontent.com/10806653/210034366-b14014b1-cfd0-4bad-8906-a361d9d99e54.png">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="212" alt="image" src="https://user-images.githubusercontent.com/10806653/210034378-7b3691ed-7432-48dc-bd00-a9724f30b5bb.png">

