### PR TITLE
fix(console): clear connector create form state on closed

### DIFF
--- a/packages/console/src/pages/Connectors/index.tsx
+++ b/packages/console/src/pages/Connectors/index.tsx
@@ -163,14 +163,16 @@ const Connectors = () => {
           </div>
         </div>
       </div>
-      <CreateForm
-        isOpen={Boolean(createConnectorType)}
-        type={createConnectorType}
-        onClose={() => {
-          navigate(`${basePathname}/${tab}`);
-          void mutate();
-        }}
-      />
+      {Boolean(createConnectorType) && (
+        <CreateForm
+          isOpen
+          type={createConnectorType}
+          onClose={() => {
+            navigate(`${basePathname}/${tab}`);
+            void mutate();
+          }}
+        />
+      )}
     </>
   );
 };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Clear connector create form state on closed.

BUG:
The create form modal state will reserve when we close the form by clicking the back button of the browser.
So we decide to re-render the create form modal each time we open it.

https://user-images.githubusercontent.com/10806653/210036775-58a92b71-9ab2-4a4c-bcfa-eca647f4749e.mp4



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.
