### PR TITLE
refactor(cli): remove official connectors inquiry

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,13 +4,12 @@
   "commit": false,
   "//": "CAUTION: When updating the fields below, you should also update README accordingly.",
   "fixed": [[
-    "@logto/cli",
-    "@logto/create"
-  ], [
     "@logto/core",
     "@logto/console",
     "@logto/integration-tests",
-    "@logto/ui"
+    "@logto/ui",
+    "@logto/cli",
+    "@logto/create"
   ]],
   "linked": [[
     "@logto/schemas",

--- a/packages/cli/src/commands/install/index.ts
+++ b/packages/cli/src/commands/install/index.ts
@@ -3,7 +3,6 @@ import type { CommandModule } from 'yargs';
 
 import { getDatabaseUrlFromConfig } from '../../database.js';
 import { log } from '../../utilities.js';
-import { addOfficialConnectors } from '../connector/utils.js';
 import {
   validateNodeVersion,
   inquireInstancePath,
@@ -13,7 +12,6 @@ import {
   createEnv,
   logFinale,
   decompress,
-  inquireOfficialConnectors,
   isUrl,
 } from './utils.js';
 
@@ -51,16 +49,6 @@ const installLogto = async ({ path, skipSeed, officialConnectors, downloadUrl }:
 
   // Save to dot env
   await createEnv(instancePath, await getDatabaseUrlFromConfig());
-
-  // Add official connectors
-  if (await inquireOfficialConnectors(officialConnectors)) {
-    await addOfficialConnectors(instancePath);
-  } else {
-    log.info(
-      'Skipped adding official connectors.\n\n' +
-        `  You can use the ${chalk.green('connector add')} command to add connectors at any time.\n`
-    );
-  }
 
   // Finale
   logFinale(instancePath);

--- a/packages/cli/src/commands/install/utils.ts
+++ b/packages/cli/src/commands/install/utils.ts
@@ -11,6 +11,7 @@ import * as semver from 'semver';
 import tar from 'tar';
 
 import { createPoolAndDatabaseIfNeeded } from '../../database.js';
+import { packageJson } from '../../package-json.js';
 import {
   cliConfig,
   ConfigKey,
@@ -101,12 +102,13 @@ export const validateDatabase = async () => {
 
 export const downloadRelease = async (url?: string) => {
   const tarFilePath = path.resolve(os.tmpdir(), './logto.tar.gz');
+  const from =
+    url ??
+    `https://github.com/logto-io/logto/releases/download/v${packageJson.version}/logto.tar.gz`;
 
-  log.info(`Download Logto to ${tarFilePath}`);
-  await downloadFile(
-    url ?? 'https://github.com/logto-io/logto/releases/latest/download/logto.tar.gz',
-    tarFilePath
-  );
+  log.info(`Download Logto from ${from}`);
+  log.info(`Target ${tarFilePath}`);
+  await downloadFile(from, tarFilePath);
 
   return tarFilePath;
 };

--- a/packages/cli/src/commands/install/utils.ts
+++ b/packages/cli/src/commands/install/utils.ts
@@ -166,20 +166,6 @@ export const logFinale = (instancePath: string) => {
   );
 };
 
-export const inquireOfficialConnectors = async (initialAnswer?: boolean) => {
-  const { value } = await inquirer.prompt<{ value: boolean }>(
-    {
-      name: 'value',
-      message: 'Do you want to add official connectors?',
-      type: 'confirm',
-      default: true,
-    },
-    { value: initialAnswer }
-  );
-
-  return value;
-};
-
 export const isUrl = (string: string) => {
   try {
     // On purpose to test


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- remove official connectors inquiry since we added them as built-in in all distributions
- lock default download to make sure the schemas in cli matches the distribution - we use an in-CLI schema module to provide a convenient way for DB alteration without source code. So CLI have to keep the schema dependency - maybe we can ask user to choose the schema source in the future.
- lock cli version with the core group since now cli will download the fixed version distribution when init

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

- no official connector prompt during init
- default download version now points to a specific release

<img width="764" alt="image" src="https://user-images.githubusercontent.com/14722250/210038551-9a56032a-ccdf-40eb-a4b1-739609fad8a5.png">

