### PR TITLE
fix(console): auto expand dark logo field

### DIFF
--- a/packages/console/src/pages/Connectors/components/ConnectorForm/index.tsx
+++ b/packages/console/src/pages/Connectors/components/ConnectorForm/index.tsx
@@ -24,13 +24,13 @@ type Props = {
 
 const ConnectorForm = ({ connector, isAllowEditTarget }: Props) => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
-  const { configTemplate, isStandard } = connector;
+  const { configTemplate, isStandard, logoDark } = connector;
   const {
     control,
     register,
     formState: { errors },
   } = useFormContext<ConnectorFormType>();
-  const [darkVisible, setDarkVisible] = useState(false);
+  const [darkVisible, setDarkVisible] = useState(Boolean(logoDark));
 
   const toggleDarkVisible = () => {
     setDarkVisible((previous) => !previous);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
auto expand dark logo field is value is set.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
local tested
