### PR TITLE
ci: use node 18 as default

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -55,7 +55,6 @@ jobs:
       - name: Setup Node and pnpm
         uses: silverhand-io/actions-node-pnpm-run-steps@v2
         with:
-          node-version: 18
           run-install: false
 
       # Setup integration test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Setup Node and pnpm
         uses: silverhand-io/actions-node-pnpm-run-steps@v2
-        with:
-          node-version: 18
 
       - name: Build
         run: pnpm ci:build
@@ -34,8 +32,6 @@ jobs:
 
       - name: Setup Node and pnpm
         uses: silverhand-io/actions-node-pnpm-run-steps@v2
-        with:
-          node-version: 18
 
       - name: Prepack
         run: pnpm prepack
@@ -54,8 +50,6 @@ jobs:
 
       - name: Setup Node and pnpm
         uses: silverhand-io/actions-node-pnpm-run-steps@v2
-        with:
-          node-version: 18
 
       - name: Build for test
         run: pnpm -r build:test
@@ -101,8 +95,6 @@ jobs:
 
       - name: Setup Node and pnpm
         uses: silverhand-io/actions-node-pnpm-run-steps@v2
-        with:
-          node-version: 18
 
       - name: Build
         run: pnpm prepack

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:16-alpine as builder
+FROM node:18-alpine as builder
 WORKDIR /etc/logto
 ENV CI=true
 
@@ -28,7 +28,7 @@ RUN NODE_ENV=production pnpm i
 RUN rm -rf .parcel-cache pnpm-*.yaml
 
 # Seal stage
-FROM node:16-alpine as app
+FROM node:18-alpine as app
 WORKDIR /etc/logto
 COPY --from=builder /etc/logto .
 EXPOSE 3001


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- remove explicit node 18 since our [run steps](https://github.com/silverhand-io/actions-node-pnpm-run-steps/blob/master/action.yml#L6) now uses 18 as default
- use node 18 to build docker image

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

CI