### PR TITLE
refactor(core): refactor interaction identifier verification flow

### DIFF
--- a/packages/core/src/routes/interaction/actions/submit-interaction.test.ts
+++ b/packages/core/src/routes/interaction/actions/submit-interaction.test.ts
@@ -186,6 +186,7 @@ describe('submit action', () => {
     const interaction: VerifiedForgotPasswordInteractionResult = {
       event: InteractionEvent.ForgotPassword,
       accountId: 'foo',
+      identifiers: [{ key: 'accountId', value: 'foo' }],
       profile: { password: 'password' },
     };
     await submitInteraction(interaction, ctx, provider);

--- a/packages/core/src/routes/interaction/actions/submit-interaction.test.ts
+++ b/packages/core/src/routes/interaction/actions/submit-interaction.test.ts
@@ -153,7 +153,7 @@ describe('submit action', () => {
     });
   });
 
-  it('sign-in', async () => {
+  it('sign-in with new profile', async () => {
     getLogtoConnectorById.mockResolvedValueOnce({
       metadata: { target: 'logto' },
       dbEntry: { syncProfile: false },
@@ -177,6 +177,30 @@ describe('submit action', () => {
         logto: { userId: userInfo.id, details: userInfo },
         google: { userId: 'googleId', details: {} },
       },
+      lastSignInAt: now,
+    });
+    expect(assignInteractionResults).toBeCalledWith(ctx, provider, { login: { accountId: 'foo' } });
+  });
+
+  it('sign-in and sync new Social', async () => {
+    getLogtoConnectorById.mockResolvedValueOnce({
+      metadata: { target: 'logto' },
+      dbEntry: { syncProfile: true },
+    });
+
+    const interaction: VerifiedSignInInteractionResult = {
+      event: InteractionEvent.SignIn,
+      accountId: 'foo',
+      profile: { email: 'email' },
+      identifiers,
+    };
+
+    await submitInteraction(interaction, ctx, provider);
+    expect(getLogtoConnectorById).toBeCalledWith('logto');
+    expect(updateUserById).toBeCalledWith('foo', {
+      primaryEmail: 'email',
+      name: userInfo.name,
+      avatar: userInfo.avatar,
       lastSignInAt: now,
     });
     expect(assignInteractionResults).toBeCalledWith(ctx, provider, { login: { accountId: 'foo' } });

--- a/packages/core/src/routes/interaction/types/guard.ts
+++ b/packages/core/src/routes/interaction/types/guard.ts
@@ -67,7 +67,7 @@ export const verifiedSignInteractionResultGuard = z.object({
   event: z.literal(InteractionEvent.SignIn),
   accountId: z.string(),
   profile: profileGuard.optional(),
-  identifiers: z.array(identifierGuard).optional(),
+  identifiers: z.array(identifierGuard),
 });
 
 export const forgotPasswordProfileGuard = z.object({
@@ -77,5 +77,6 @@ export const forgotPasswordProfileGuard = z.object({
 export const verifiedForgotPasswordInteractionResultGuard = z.object({
   event: z.literal(InteractionEvent.ForgotPassword),
   accountId: z.string(),
+  identifiers: z.array(identifierGuard),
   profile: forgotPasswordProfileGuard,
 });

--- a/packages/core/src/routes/interaction/types/index.ts
+++ b/packages/core/src/routes/interaction/types/index.ts
@@ -68,11 +68,13 @@ export type ForgotPasswordInteractionResult = Omit<AnonymousInteractionResult, '
 };
 
 export type AccountVerifiedInteractionResult =
-  | (Omit<SignInInteractionResult, 'accountId'> & {
+  | (Omit<SignInInteractionResult, 'accountId' | 'identifiers'> & {
       accountId: string;
+      identifiers: Identifier[];
     })
-  | (Omit<ForgotPasswordInteractionResult, 'accountId'> & {
+  | (Omit<ForgotPasswordInteractionResult, 'accountId' | 'identifiers'> & {
       accountId: string;
+      identifiers: Identifier[];
     });
 
 export type IdentifierVerifiedInteractionResult =

--- a/packages/core/src/routes/interaction/utils/interaction.test.ts
+++ b/packages/core/src/routes/interaction/utils/interaction.test.ts
@@ -44,7 +44,7 @@ describe('interaction utils', () => {
           { email: 'foo@logto.io', connectorId: 'foo_connector' }
         )
       ).toEqual({
-        userAccountIdentifiers: [usernameIdentifier, phoneIdentifier],
+        authIdentifiers: [usernameIdentifier, phoneIdentifier],
         profileIdentifiers: [emailIdentifier, socialIdentifier],
       });
     });

--- a/packages/core/src/routes/interaction/utils/interaction.ts
+++ b/packages/core/src/routes/interaction/utils/interaction.ts
@@ -48,7 +48,7 @@ export const mergeIdentifiers = (newIdentifier: Identifier, oldIdentifiers?: Ide
 /**
  * Categorize the identifiers based on their different use cases
  * @typedef {Object} result
- * @property {Identifier[]} userAccountIdentifiers - identifiers to verify a specific user account e.g. for sign-in and reset-password
+ * @property {Identifier[]} authIdentifiers - identifiers to verify a specific user account e.g. for sign-in and reset-password
  * @property {Identifier[]} profileIdentifiers - identifiers to verify a new anonymous profile e.g. new email, new phone or new social identity
  *
  * @param {Identifier[]} identifiers
@@ -59,10 +59,10 @@ export const categorizeIdentifiers = (
   identifiers: Identifier[],
   profile?: Profile
 ): {
-  userAccountIdentifiers: Identifier[];
+  authIdentifiers: Identifier[];
   profileIdentifiers: Identifier[];
 } => {
-  const userAccountIdentifiers = new Set<Identifier>();
+  const authIdentifiers = new Set<Identifier>();
   const profileIdentifiers = new Set<Identifier>();
 
   for (const identifier of identifiers) {
@@ -70,11 +70,11 @@ export const categorizeIdentifiers = (
       profileIdentifiers.add(identifier);
       continue;
     }
-    userAccountIdentifiers.add(identifier);
+    authIdentifiers.add(identifier);
   }
 
   return {
-    userAccountIdentifiers: [...userAccountIdentifiers],
+    authIdentifiers: [...authIdentifiers],
     profileIdentifiers: [...profileIdentifiers],
   };
 };

--- a/packages/core/src/routes/interaction/verifications/mandatory-user-profile-validation.test.ts
+++ b/packages/core/src/routes/interaction/verifications/mandatory-user-profile-validation.test.ts
@@ -32,6 +32,7 @@ describe('validateMandatoryUserProfile', () => {
   };
   const interaction: IdentifierVerifiedInteractionResult = {
     event: InteractionEvent.SignIn,
+    identifiers: [{ key: 'accountId', value: 'foo' }],
     accountId: 'foo',
   };
 

--- a/packages/core/src/routes/interaction/verifications/profile-verification-forgot-password.test.ts
+++ b/packages/core/src/routes/interaction/verifications/profile-verification-forgot-password.test.ts
@@ -3,6 +3,8 @@ import { createMockUtils, pickDefault } from '@logto/shared/esm';
 
 import RequestError from '#src/errors/RequestError/index.js';
 
+import type { Identifier } from '../types/index.js';
+
 const { jest } = import.meta;
 const { mockEsm, mockEsmWithActual } = createMockUtils(jest);
 
@@ -19,6 +21,7 @@ const verifyProfile = await pickDefault(import('./profile-verification.js'));
 describe('forgot password interaction profile verification', () => {
   const baseInteraction = {
     event: InteractionEvent.ForgotPassword,
+    identifiers: [{ key: 'accountId', value: 'foo' }] as Identifier[],
     accountId: 'foo',
   };
 

--- a/packages/core/src/routes/interaction/verifications/profile-verification-protected-identifier.test.ts
+++ b/packages/core/src/routes/interaction/verifications/profile-verification-protected-identifier.test.ts
@@ -24,7 +24,11 @@ mockEsm('#src/connectors/index.js', () => ({
 const verifyProfile = await pickDefault(import('./profile-verification.js'));
 
 describe('profile protected identifier verification', () => {
-  const baseInteraction = { event: InteractionEvent.SignIn, accountId: 'foo' };
+  const baseInteraction = {
+    event: InteractionEvent.SignIn,
+    identifiers: [{ key: 'accountId', value: 'foo' }] as Identifier[],
+    accountId: 'foo',
+  };
 
   afterEach(() => {
     jest.clearAllMocks();

--- a/packages/core/src/routes/interaction/verifications/user-identity-verification.test.ts
+++ b/packages/core/src/routes/interaction/verifications/user-identity-verification.test.ts
@@ -23,18 +23,7 @@ describe('verifyUserAccount', () => {
     jest.clearAllMocks();
   });
 
-  it('empty identifiers with accountId', async () => {
-    const interaction: SignInInteractionResult = {
-      event: InteractionEvent.SignIn,
-      accountId: 'foo',
-    };
-
-    const result = await verifyUserAccount(interaction);
-
-    expect(result).toEqual(result);
-  });
-
-  it('empty identifiers withOut accountId should throw', async () => {
+  it('empty identifiers should throw', async () => {
     const interaction: SignInInteractionResult = {
       event: InteractionEvent.SignIn,
     };
@@ -52,7 +41,7 @@ describe('verifyUserAccount', () => {
 
     const result = await verifyUserAccount(interaction);
 
-    expect(result).toEqual({ event: InteractionEvent.SignIn, accountId: 'foo', identifiers: [] });
+    expect(result).toEqual({ ...interaction, accountId: 'foo' });
   });
 
   it('verify emailVerified identifier', async () => {
@@ -66,7 +55,7 @@ describe('verifyUserAccount', () => {
     const result = await verifyUserAccount(interaction);
     expect(findUserByIdentifierMock).toBeCalledWith({ email: 'email' });
 
-    expect(result).toEqual({ event: InteractionEvent.SignIn, accountId: 'foo', identifiers: [] });
+    expect(result).toEqual({ ...interaction, accountId: 'foo' });
   });
 
   it('verify phoneVerified identifier', async () => {
@@ -80,7 +69,7 @@ describe('verifyUserAccount', () => {
     const result = await verifyUserAccount(interaction);
     expect(findUserByIdentifierMock).toBeCalledWith({ phone: '123456' });
 
-    expect(result).toEqual({ event: InteractionEvent.SignIn, accountId: 'foo', identifiers: [] });
+    expect(result).toEqual({ ...interaction, accountId: 'foo' });
   });
 
   it('verify social identifier', async () => {
@@ -97,7 +86,7 @@ describe('verifyUserAccount', () => {
       userInfo: { id: 'foo' },
     });
 
-    expect(result).toEqual({ event: InteractionEvent.SignIn, accountId: 'foo', identifiers: [] });
+    expect(result).toEqual({ ...interaction, accountId: 'foo' });
   });
 
   it('verify social identifier user identity not exist', async () => {
@@ -138,7 +127,7 @@ describe('verifyUserAccount', () => {
     const result = await verifyUserAccount(interaction);
     expect(findUserByIdentifierMock).toBeCalledWith({ email: 'email' });
 
-    expect(result).toEqual({ event: InteractionEvent.SignIn, accountId: 'foo', identifiers: [] });
+    expect(result).toEqual({ ...interaction, accountId: 'foo' });
   });
 
   it('verify accountId and emailVerified identifier with email user not exist', async () => {
@@ -234,17 +223,6 @@ describe('verifyUserAccount', () => {
     const result = await verifyUserAccount(interaction);
     expect(findUserByIdentifierMock).toBeCalledWith({ email: 'email' });
 
-    expect(result).toEqual({
-      event: InteractionEvent.SignIn,
-      accountId: 'foo',
-      identifiers: [
-        { key: 'social', connectorId: 'connectorId', userInfo: { id: 'foo' } },
-        { key: 'phoneVerified', value: '123456' },
-      ],
-      profile: {
-        phone: '123456',
-        connectorId: 'connectorId',
-      },
-    });
+    expect(result).toEqual({ ...interaction, accountId: 'foo' });
   });
 });


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This update is pre-condition  for LOG-4985

### Previously
We removed all the identifiers from the interaction storage after the user authentication for performance improvement.

### Issue
On the user sign-in flow, we need to sync the social identity's user name and avatar if sync-on-sign-in is enabled. So we must keep the social identifiers even after the user authentication is verified. 

### Updates
Rename the `userAccountIdentifiers` to `authIdentifiers` @charIeszhao 
Keep all the identifiers in the record after user account verification flow.
Update the related type of SIgnIn and ForgotPassword interaction results. Identifiers must exist. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT updates
Integration passed
