### PR TITLE
fix(console): dark visible base on initial form data

### DIFF
--- a/packages/console/src/pages/ConnectorDetails/components/ConnectorContent.tsx
+++ b/packages/console/src/pages/ConnectorDetails/components/ConnectorContent.tsx
@@ -103,7 +103,11 @@ const ConnectorContent = ({ isDeleted, connectorData, onConnectorUpdated }: Prop
           description="connector_details.settings_description"
           learnMoreLink="https://docs.logto.io/docs/references/connectors"
         >
-          <ConnectorForm connector={connectorData} />
+          <ConnectorForm
+            connectorType={connectorData.type}
+            isStandard={connectorData.isStandard}
+            isDarkDefaultVisible={Boolean(connectorData.metadata.logoDark)}
+          />
           {connectorData.type !== ConnectorType.Social && (
             <SenderTester
               className={styles.senderTest}

--- a/packages/console/src/pages/Connectors/components/ConnectorForm/index.tsx
+++ b/packages/console/src/pages/Connectors/components/ConnectorForm/index.tsx
@@ -19,19 +19,27 @@ import { SyncProfileMode } from '../../types';
 import * as styles from './index.module.scss';
 
 type Props = {
-  connector: ConnectorFactoryResponse;
+  connectorType: ConnectorType;
+  isStandard: ConnectorFactoryResponse['isStandard'];
+  configTemplate?: ConnectorFactoryResponse['configTemplate'];
   isAllowEditTarget?: boolean;
+  isDarkDefaultVisible?: boolean;
 };
 
-const ConnectorForm = ({ connector, isAllowEditTarget }: Props) => {
+const ConnectorForm = ({
+  configTemplate,
+  isStandard,
+  isAllowEditTarget,
+  isDarkDefaultVisible,
+  connectorType,
+}: Props) => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
-  const { configTemplate, isStandard, logoDark } = connector;
   const {
     control,
     register,
     formState: { errors },
   } = useFormContext<ConnectorFormType>();
-  const [darkVisible, setDarkVisible] = useState(Boolean(logoDark));
+  const [darkVisible, setDarkVisible] = useState(Boolean(isDarkDefaultVisible));
 
   const toggleDarkVisible = () => {
     setDarkVisible((previous) => !previous);
@@ -141,7 +149,7 @@ const ConnectorForm = ({ connector, isAllowEditTarget }: Props) => {
           )}
         />
       </FormField>
-      {connector.type === ConnectorType.Social && (
+      {connectorType === ConnectorType.Social && (
         <FormField title="connectors.guide.sync_profile">
           <Controller
             name="syncProfile"

--- a/packages/console/src/pages/Connectors/components/Guide/index.tsx
+++ b/packages/console/src/pages/Connectors/components/Guide/index.tsx
@@ -122,7 +122,12 @@ const Guide = ({ connector, onClose }: Props) => {
           <div className={styles.title}>{t('connectors.guide.connector_setting')}</div>
           <FormProvider {...methods}>
             <form onSubmit={onSubmit}>
-              <ConnectorForm isAllowEditTarget connector={connector} />
+              <ConnectorForm
+                isAllowEditTarget
+                connectorType={connector.type}
+                configTemplate={connector.configTemplate}
+                isStandard={connector.isStandard}
+              />
               {!isSocialConnector && (
                 <SenderTester
                   className={styles.tester}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Set default dark visibility based on the initial formdata: if `darkLogo` has value.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested