### PR TITLE
fix(demo-app): demo app notificaiton should always follow system language

### DIFF
--- a/packages/core/src/libraries/sign-in-experience/index.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.ts
@@ -82,15 +82,9 @@ export const getSignInExperienceForApplication = async (
 
   // Insert Demo App Notification
   if (applicationId === demoAppApplicationId) {
-    const {
-      socialSignInConnectorTargets,
-      languageInfo: { autoDetect, fallbackLanguage },
-    } = signInExperience;
+    const { socialSignInConnectorTargets } = signInExperience;
 
-    const notification = i18next.t(
-      'demo_app.notification',
-      autoDetect ? undefined : { lng: fallbackLanguage }
-    );
+    const notification = i18next.t('demo_app.notification');
 
     return {
       ...signInExperience,


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
demo app notification should always follow the system language discard of SIE language settings.

<img width="710" alt="image" src="https://user-images.githubusercontent.com/36393111/210332325-515d334f-cf75-4384-bb50-edf983d646db.png">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
 test locally

