### PR TITLE
fix(core): return role names for admin user detail api

### DIFF
--- a/packages/core/src/routes/admin-user.test.ts
+++ b/packages/core/src/routes/admin-user.test.ts
@@ -114,7 +114,7 @@ describe('adminUserRoutes', () => {
   it('GET /users/:userId', async () => {
     const response = await userRequest.get('/users/foo');
     expect(response.status).toEqual(200);
-    expect(response.body).toEqual(mockUserResponse);
+    expect(response.body).toEqual({ ...mockUserResponse, roleNames: ['admin'] });
   });
 
   it('POST /users', async () => {

--- a/packages/core/src/routes/admin-user.ts
+++ b/packages/core/src/routes/admin-user.ts
@@ -78,7 +78,7 @@ export default function adminUserRoutes<T extends AuthedRouter>(router: T) {
 
       const user = await findUserById(userId);
 
-      ctx.body = pick(user, ...userInfoSelectFields);
+      ctx.body = pick(user, 'roleNames', ...userInfoSelectFields);
 
       return next();
     }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
return `roleNames` for admin user detail api: `/users/:id`.

please notice that `roleNames` will be removed before lunching RBAC, so this is a temp solution.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested with "Audit Logs" page.