### PR TITLE
refactor: support EC key and ES signing algorithms

### DIFF
--- a/.changeset-staged/six-falcons-sin.md
+++ b/.changeset-staged/six-falcons-sin.md
@@ -1,0 +1,7 @@
+---
+"@logto/cli": minor
+"@logto/core": minor
+---
+
+- cli: use `ec` with `secp384r1` as the default key generation type
+- core: use `ES384` as the signing algorithm for EC keys

--- a/packages/cli/src/commands/database/utilities.ts
+++ b/packages/cli/src/commands/database/utilities.ts
@@ -3,20 +3,42 @@ import { promisify } from 'util';
 
 import { nanoid } from 'nanoid';
 
-export const generateOidcPrivateKey = async () => {
-  const { privateKey } = await promisify(generateKeyPair)('rsa', {
-    modulusLength: 4096,
-    publicKeyEncoding: {
-      type: 'spki',
-      format: 'pem',
-    },
-    privateKeyEncoding: {
-      type: 'pkcs8',
-      format: 'pem',
-    },
-  });
+export const generateOidcPrivateKey = async (type: 'rsa' | 'ec' = 'ec') => {
+  if (type === 'rsa') {
+    const { privateKey } = await promisify(generateKeyPair)('rsa', {
+      modulusLength: 4096,
+      publicKeyEncoding: {
+        type: 'spki',
+        format: 'pem',
+      },
+      privateKeyEncoding: {
+        type: 'pkcs8',
+        format: 'pem',
+      },
+    });
 
-  return privateKey;
+    return privateKey;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (type === 'ec') {
+    const { privateKey } = await promisify(generateKeyPair)('ec', {
+      // https://security.stackexchange.com/questions/78621/which-elliptic-curve-should-i-use
+      namedCurve: 'secp384r1',
+      publicKeyEncoding: {
+        type: 'spki',
+        format: 'pem',
+      },
+      privateKeyEncoding: {
+        type: 'pkcs8',
+        format: 'pem',
+      },
+    });
+
+    return privateKey;
+  }
+
+  throw new Error(`Unsupported private key ${String(type)}`);
 };
 
 export const generateOidcCookieKey = () => nanoid();

--- a/packages/core/src/event-listeners/index.ts
+++ b/packages/core/src/event-listeners/index.ts
@@ -13,4 +13,7 @@ export const addOidcEventListeners = (provider: Provider) => {
   provider.addListener('grant.revoked', grantRevocationListener);
   provider.addListener('interaction.started', interactionStartedListener);
   provider.addListener('interaction.ended', interactionEndedListener);
+  provider.addListener('server_error', (_, error) => {
+    console.error('OIDC Provider server_error:', error);
+  });
 };

--- a/packages/core/src/oidc/utils.ts
+++ b/packages/core/src/oidc/utils.ts
@@ -4,12 +4,11 @@ import { conditional } from '@silverhand/essentials';
 import type { AllClientMetadata, ClientAuthMethod } from 'oidc-provider';
 import { errors } from 'oidc-provider';
 
-export const getConstantClientMetadata = (
-  type: ApplicationType
-): Pick<
-  AllClientMetadata,
-  'application_type' | 'grant_types' | 'token_endpoint_auth_method' | 'response_types'
-> => {
+import envSet from '#src/env-set/index.js';
+
+export const getConstantClientMetadata = (type: ApplicationType): AllClientMetadata => {
+  const { jwkSigningAlg } = envSet.oidc;
+
   const getTokenEndpointAuthMethod = (): ClientAuthMethod => {
     switch (type) {
       case ApplicationType.Native:
@@ -28,6 +27,11 @@ export const getConstantClientMetadata = (
         : [GrantType.AuthorizationCode, GrantType.RefreshToken],
     token_endpoint_auth_method: getTokenEndpointAuthMethod(),
     response_types: conditional(type === ApplicationType.MachineToMachine && []),
+    // https://www.scottbrady91.com/jose/jwts-which-signing-algorithm-should-i-use
+    authorization_signed_response_alg: jwkSigningAlg,
+    userinfo_signed_response_alg: jwkSigningAlg,
+    id_token_signed_response_alg: jwkSigningAlg,
+    introspection_signed_response_alg: jwkSigningAlg,
   };
 };
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- cli: use `ec` with `secp384r1` as the default key generation type
- core: use `ES384` as the signing algorithm for EC keys

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

the tests are executed in order:

- [x] Sign in with an old key (RSA)
- [x] Rotate a new EC key and continue to use the existing RSA signed Access Token
- [x] Sign out (failed with ID Token hint validation, keep as it is for now, update in a new PR when settle)
- [x] Sign in again, do something, sign out

The new token has a significant length reduction but it's still secure. See the links in code.


