### PR TITLE
feat(core): add send and verify APIs for generic type verification code

### DIFF
--- a/.changeset-staged/unlucky-months-clap.md
+++ b/.changeset-staged/unlucky-months-clap.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": minor
+---
+
+Add support to send and verify verification code in management APIs

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,16 +27,17 @@
     "Alipay",
     "CIAM",
     "codecov",
+    "hasura",
     "Logto",
     "oidc",
     "passcode",
+    "passcodes",
     "Passwordless",
     "pnpm",
     "silverhand",
     "slonik",
     "stylelint",
     "topbar",
-    "hasura",
     "withtyped"
   ]
 }

--- a/packages/core/src/routes/init.ts
+++ b/packages/core/src/routes/init.ts
@@ -23,6 +23,7 @@ import signInExperiencesRoutes from './sign-in-experience/index.js';
 import statusRoutes from './status.js';
 import swaggerRoutes from './swagger.js';
 import type { AnonymousRouter, AuthedRouter } from './types.js';
+import verificationCodeRoutes from './verification-code.js';
 import wellKnownRoutes from './well-known.js';
 
 const createRouters = (tenant: TenantContext) => {
@@ -43,6 +44,7 @@ const createRouters = (tenant: TenantContext) => {
   dashboardRoutes(managementRouter, tenant);
   customPhraseRoutes(managementRouter, tenant);
   hookRoutes(managementRouter, tenant);
+  verificationCodeRoutes(managementRouter, tenant);
 
   const anonymousRouter: AnonymousRouter = new Router();
   phraseRoutes(anonymousRouter, tenant);

--- a/packages/core/src/routes/interaction/index.ts
+++ b/packages/core/src/routes/interaction/index.ts
@@ -1,5 +1,11 @@
 import type { LogtoErrorCode } from '@logto/phrases';
-import { InteractionEvent, eventGuard, identifierPayloadGuard, profileGuard } from '@logto/schemas';
+import {
+  InteractionEvent,
+  eventGuard,
+  identifierPayloadGuard,
+  profileGuard,
+  requestVerificationCodePayloadGuard,
+} from '@logto/schemas';
 import type Router from 'koa-router';
 import { z } from 'zod';
 
@@ -17,10 +23,7 @@ import koaInteractionDetails from './middleware/koa-interaction-details.js';
 import type { WithInteractionDetailsContext } from './middleware/koa-interaction-details.js';
 import koaInteractionHooks from './middleware/koa-interaction-hooks.js';
 import koaInteractionSie from './middleware/koa-interaction-sie.js';
-import {
-  sendVerificationCodePayloadGuard,
-  socialAuthorizationUrlPayloadGuard,
-} from './types/guard.js';
+import { socialAuthorizationUrlPayloadGuard } from './types/guard.js';
 import {
   getInteractionStorage,
   storeInteractionResult,
@@ -328,7 +331,7 @@ export default function interactionRoutes<T extends AnonymousRouter>(
   router.post(
     `${interactionPrefix}/${verificationPath}/verification-code`,
     koaGuard({
-      body: sendVerificationCodePayloadGuard,
+      body: requestVerificationCodePayloadGuard,
     }),
     async (ctx, next) => {
       const { interactionDetails, guard, createLog } = ctx;

--- a/packages/core/src/routes/interaction/types/guard.ts
+++ b/packages/core/src/routes/interaction/types/guard.ts
@@ -1,17 +1,7 @@
 import { socialUserInfoGuard } from '@logto/connector-kit';
-import { emailRegEx, phoneRegEx, validateRedirectUrl } from '@logto/core-kit';
+import { validateRedirectUrl } from '@logto/core-kit';
 import { eventGuard, profileGuard, InteractionEvent } from '@logto/schemas';
 import { z } from 'zod';
-
-// Verification Send Route Payload Guard
-export const sendVerificationCodePayloadGuard = z.union([
-  z.object({
-    email: z.string().regex(emailRegEx),
-  }),
-  z.object({
-    phone: z.string().regex(phoneRegEx),
-  }),
-]);
 
 // Social Authorization Uri Route Payload Guard
 export const socialAuthorizationUrlPayloadGuard = z.object({

--- a/packages/core/src/routes/interaction/types/index.ts
+++ b/packages/core/src/routes/interaction/types/index.ts
@@ -2,15 +2,12 @@ import type { SocialUserInfo } from '@logto/connector-kit';
 import type {
   UsernamePasswordPayload,
   EmailPasswordPayload,
-  EmailVerificationCodePayload,
   PhonePasswordPayload,
-  PhoneVerificationCodePayload,
   InteractionEvent,
 } from '@logto/schemas';
 import type { z } from 'zod';
 
 import type {
-  sendVerificationCodePayloadGuard,
   socialAuthorizationUrlPayloadGuard,
   accountIdIdentifierGuard,
   verifiedEmailIdentifierGuard,
@@ -29,12 +26,6 @@ export type PasswordIdentifierPayload =
   | UsernamePasswordPayload
   | EmailPasswordPayload
   | PhonePasswordPayload;
-
-export type VerificationCodeIdentifierPayload =
-  | EmailVerificationCodePayload
-  | PhoneVerificationCodePayload;
-
-export type SendVerificationCodePayload = z.infer<typeof sendVerificationCodePayloadGuard>;
 
 export type SocialAuthorizationUrlPayload = z.infer<typeof socialAuthorizationUrlPayloadGuard>;
 

--- a/packages/core/src/routes/interaction/utils/index.ts
+++ b/packages/core/src/routes/interaction/utils/index.ts
@@ -1,9 +1,11 @@
-import type { SocialConnectorPayload, User, IdentifierPayload } from '@logto/schemas';
-
 import type {
-  VerificationCodeIdentifierPayload,
-  PasswordIdentifierPayload,
-} from '../types/index.js';
+  SocialConnectorPayload,
+  User,
+  IdentifierPayload,
+  VerifyVerificationCodePayload,
+} from '@logto/schemas';
+
+import type { PasswordIdentifierPayload } from '../types/index.js';
 
 export const isPasswordIdentifier = (
   identifier: IdentifierPayload
@@ -11,7 +13,7 @@ export const isPasswordIdentifier = (
 
 export const isVerificationCodeIdentifier = (
   identifier: IdentifierPayload
-): identifier is VerificationCodeIdentifierPayload => 'verificationCode' in identifier;
+): identifier is VerifyVerificationCodePayload => 'verificationCode' in identifier;
 
 export const isSocialIdentifier = (
   identifier: IdentifierPayload

--- a/packages/core/src/routes/interaction/utils/verification-code-validation.ts
+++ b/packages/core/src/routes/interaction/utils/verification-code-validation.ts
@@ -1,13 +1,12 @@
 import { VerificationCodeType } from '@logto/connector-kit';
-import type { InteractionEvent } from '@logto/schemas';
+import type {
+  InteractionEvent,
+  RequestVerificationCodePayload,
+  VerifyVerificationCodePayload,
+} from '@logto/schemas';
 
 import type { PasscodeLibrary } from '#src/libraries/passcode.js';
 import type { LogContext } from '#src/middleware/koa-audit-log.js';
-
-import type {
-  SendVerificationCodePayload,
-  VerificationCodeIdentifierPayload,
-} from '../types/index.js';
 
 /**
  * Refactor Needed:
@@ -23,7 +22,7 @@ const getVerificationCodeTypeByEvent = (event: InteractionEvent): VerificationCo
   eventToVerificationCodeTypeMap[event];
 
 export const sendVerificationCodeToIdentifier = async (
-  payload: SendVerificationCodePayload & { event: InteractionEvent },
+  payload: RequestVerificationCodePayload & { event: InteractionEvent },
   jti: string,
   createLog: LogContext['createLog'],
   { createPasscode, sendPasscode }: PasscodeLibrary
@@ -41,7 +40,7 @@ export const sendVerificationCodeToIdentifier = async (
 };
 
 export const verifyIdentifierByVerificationCode = async (
-  payload: VerificationCodeIdentifierPayload & { event: InteractionEvent },
+  payload: VerifyVerificationCodePayload & { event: InteractionEvent },
   jti: string,
   createLog: LogContext['createLog'],
   passcodeLibrary: PasscodeLibrary

--- a/packages/core/src/routes/interaction/verifications/identifier-payload-verification.ts
+++ b/packages/core/src/routes/interaction/verifications/identifier-payload-verification.ts
@@ -3,6 +3,7 @@ import type {
   IdentifierPayload,
   SocialConnectorPayload,
   SocialIdentityPayload,
+  VerifyVerificationCodePayload,
 } from '@logto/schemas';
 
 import RequestError from '#src/errors/RequestError/index.js';
@@ -13,7 +14,6 @@ import assertThat from '#src/utils/assert-that.js';
 
 import type {
   PasswordIdentifierPayload,
-  VerificationCodeIdentifierPayload,
   SocialIdentifier,
   VerifiedEmailIdentifier,
   VerifiedPhoneIdentifier,
@@ -53,7 +53,7 @@ const verifyPasswordIdentifier = async (
 
 const verifyVerificationCodeIdentifier = async (
   event: InteractionEvent,
-  identifier: VerificationCodeIdentifierPayload,
+  identifier: VerifyVerificationCodePayload,
   ctx: WithLogContext,
   { provider, libraries }: TenantContext
 ): Promise<VerifiedEmailIdentifier | VerifiedPhoneIdentifier> => {

--- a/packages/core/src/routes/verification-code.test.ts
+++ b/packages/core/src/routes/verification-code.test.ts
@@ -1,0 +1,94 @@
+import { VerificationCodeType } from '@logto/connector-kit';
+import { createMockUtils, pickDefault } from '@logto/shared/esm';
+
+import { MockTenant } from '#src/test-utils/tenant.js';
+import { createRequester } from '#src/utils/test-utils.js';
+
+const { jest } = import.meta;
+const { mockEsmWithActual } = createMockUtils(jest);
+
+const passcodeLibraries = await mockEsmWithActual('#src/libraries/passcode.js', () => ({
+  createPasscode: jest.fn(),
+  sendPasscode: jest.fn(),
+  verifyPasscode: jest.fn(),
+}));
+
+const { createPasscode, sendPasscode, verifyPasscode } = passcodeLibraries;
+
+const passcodeQueries = await mockEsmWithActual('#src/queries/passcode.js', () => ({
+  findUnconsumedPasscodeByIdentifierAndType: jest.fn(async () => null),
+  findUnconsumedPasscodesByIdentifierAndType: jest.fn(),
+}));
+
+const verificationCodeRoutes = await pickDefault(import('./verification-code.js'));
+
+describe('Generic verification code flow triggered by management API', () => {
+  const tenantContext = new MockTenant(
+    undefined,
+    { passcodes: passcodeQueries },
+    {
+      passcodes: passcodeLibraries,
+    }
+  );
+  const verificationCodeRequest = createRequester({
+    authedRoutes: verificationCodeRoutes,
+    tenantContext,
+  });
+  const type = VerificationCodeType.Generic;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('POST /verification-codes with email should not throw', async () => {
+    const email = 'test@abc.com';
+    const response = await verificationCodeRequest.post('/verification-codes').send({ email });
+    expect(response.status).toEqual(204);
+    expect(createPasscode).toBeCalledWith(undefined, type, { email });
+    expect(sendPasscode).toBeCalled();
+  });
+
+  test('POST /verification-codes with phone number should not throw', async () => {
+    const phone = '1234567890';
+    const response = await verificationCodeRequest.post('/verification-codes').send({ phone });
+    expect(response.status).toEqual(204);
+    expect(createPasscode).toBeCalledWith(undefined, type, { phone });
+    expect(sendPasscode).toBeCalled();
+  });
+
+  test('POST /verification-codes with invalid payload should throw', async () => {
+    await expect(
+      verificationCodeRequest.post('/verification-codes').send({
+        foo: 'bar',
+      })
+    ).resolves.toHaveProperty('status', 400);
+  });
+
+  test('POST /verification-codes/verify with email and code should not throw', async () => {
+    const email = 'test@abc.com';
+    const verificationCode = '000000';
+    const response = await verificationCodeRequest
+      .post('/verification-codes/verify')
+      .send({ email, verificationCode });
+    expect(response.status).toEqual(204);
+    expect(verifyPasscode).toBeCalledWith(undefined, type, verificationCode, { email });
+  });
+
+  test('POST /verification-codes/verify with phone number and code should not throw', async () => {
+    const phone = '1234567890';
+    const verificationCode = '123456';
+    const response = await verificationCodeRequest
+      .post('/verification-codes/verify')
+      .send({ phone, verificationCode });
+    expect(response.status).toEqual(204);
+    expect(verifyPasscode).toBeCalledWith(undefined, type, verificationCode, { phone });
+  });
+
+  test('POST /verification-codes/verify with invalid payload should throw', async () => {
+    await expect(
+      verificationCodeRequest.post('/verification-codes/verify').send({
+        foo: 'bar',
+      })
+    ).resolves.toHaveProperty('status', 400);
+  });
+});

--- a/packages/core/src/routes/verification-code.ts
+++ b/packages/core/src/routes/verification-code.ts
@@ -1,0 +1,49 @@
+import { VerificationCodeType } from '@logto/connector-kit';
+import {
+  requestVerificationCodePayloadGuard,
+  verifyVerificationCodePayloadGuard,
+} from '@logto/schemas';
+
+import koaGuard from '#src/middleware/koa-guard.js';
+
+import type { AuthedRouter, RouterInitArgs } from './types.js';
+
+const codeType = VerificationCodeType.Generic;
+
+export default function verificationCodeRoutes<T extends AuthedRouter>(
+  ...[router, { libraries }]: RouterInitArgs<T>
+) {
+  const {
+    passcodes: { createPasscode, sendPasscode, verifyPasscode },
+  } = libraries;
+
+  router.post(
+    '/verification-codes',
+    koaGuard({
+      body: requestVerificationCodePayloadGuard,
+    }),
+    async (ctx, next) => {
+      const code = await createPasscode(undefined, codeType, ctx.guard.body);
+      await sendPasscode(code);
+
+      ctx.status = 204;
+
+      return next();
+    }
+  );
+
+  router.post(
+    '/verification-codes/verify',
+    koaGuard({
+      body: verifyVerificationCodePayloadGuard,
+    }),
+    async (ctx, next) => {
+      const { verificationCode, ...identifier } = ctx.guard.body;
+      await verifyPasscode(undefined, codeType, verificationCode, identifier);
+
+      ctx.status = 204;
+
+      return next();
+    }
+  );
+}

--- a/packages/schemas/src/types/index.ts
+++ b/packages/schemas/src/types/index.ts
@@ -8,3 +8,4 @@ export * from './search.js';
 export * from './resource.js';
 export * from './scope.js';
 export * from './role.js';
+export * from './verification-code.js';

--- a/packages/schemas/src/types/interactions.ts
+++ b/packages/schemas/src/types/interactions.ts
@@ -2,6 +2,14 @@ import { emailRegEx, phoneRegEx, usernameRegEx, passwordRegEx } from '@logto/cor
 import { z } from 'zod';
 
 import { arbitraryObjectGuard } from '../foundations/index.js';
+import type {
+  EmailVerificationCodePayload,
+  PhoneVerificationCodePayload,
+} from './verification-code.js';
+import {
+  emailVerificationCodePayloadGuard,
+  phoneVerificationCodePayloadGuard,
+} from './verification-code.js';
 
 /**
  * Detailed Identifier Methods guard
@@ -24,18 +32,6 @@ export const phonePasswordPayloadGuard = z.object({
   password: z.string().min(1),
 });
 export type PhonePasswordPayload = z.infer<typeof phonePasswordPayloadGuard>;
-
-export const emailVerificationCodePayloadGuard = z.object({
-  email: z.string().regex(emailRegEx),
-  verificationCode: z.string().min(1),
-});
-export type EmailVerificationCodePayload = z.infer<typeof emailVerificationCodePayloadGuard>;
-
-export const phoneVerificationCodePayloadGuard = z.object({
-  phone: z.string().regex(phoneRegEx),
-  verificationCode: z.string().min(1),
-});
-export type PhoneVerificationCodePayload = z.infer<typeof phoneVerificationCodePayloadGuard>;
 
 export const socialConnectorPayloadGuard = z.object({
   connectorId: z.string(),

--- a/packages/schemas/src/types/verification-code.ts
+++ b/packages/schemas/src/types/verification-code.ts
@@ -1,0 +1,36 @@
+import { emailRegEx, phoneRegEx } from '@logto/core-kit';
+import { z } from 'zod';
+
+const emailIdentifierGuard = z.string().regex(emailRegEx);
+const phoneIdentifierGuard = z.string().regex(phoneRegEx);
+const codeGuard = z.string().min(1);
+
+// Used when requesting Logto to send a verification code to email or phone
+export const requestVerificationCodePayloadGuard = z.union([
+  z.object({ email: emailIdentifierGuard }),
+  z.object({ phone: phoneIdentifierGuard }),
+]);
+
+export type RequestVerificationCodePayload = z.infer<typeof requestVerificationCodePayloadGuard>;
+
+export const emailVerificationCodePayloadGuard = z.object({
+  email: emailIdentifierGuard,
+  verificationCode: codeGuard,
+});
+export type EmailVerificationCodePayload = z.infer<typeof emailVerificationCodePayloadGuard>;
+
+export const phoneVerificationCodePayloadGuard = z.object({
+  phone: phoneIdentifierGuard,
+  verificationCode: codeGuard,
+});
+export type PhoneVerificationCodePayload = z.infer<typeof phoneVerificationCodePayloadGuard>;
+
+// Used when requesting Logto to verify the validity of a verification code
+export const verifyVerificationCodePayloadGuard = z.union([
+  emailVerificationCodePayloadGuard,
+  phoneVerificationCodePayloadGuard,
+]);
+
+export type VerifyVerificationCodePayload =
+  | EmailVerificationCodePayload
+  | PhoneVerificationCodePayload;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
* Add `/verification-code` API route to support `Generic` type passcode
* Add `request code` and `verify code` APIs and util logics
* Refactor: extract verification code related zod guards and types to `schemas`, and re-use them everywhere

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally with postman
