### PR TITLE
refactor(core): migrate user library to factory mode

### DIFF
--- a/packages/core/src/libraries/session.ts
+++ b/packages/core/src/libraries/session.ts
@@ -6,6 +6,7 @@ import { errors } from 'oidc-provider';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import { findUserById, updateUserById } from '#src/queries/user.js';
+import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 
 export const assignInteractionResults = async (
@@ -37,7 +38,7 @@ export const assignInteractionResults = async (
 
 export const checkSessionHealth = async (
   ctx: Context,
-  provider: Provider,
+  { provider, queries: { users } }: TenantContext,
   tolerance = 10 * 60 // 10 mins
 ) => {
   const { accountId, loginTs } = await provider.Session.get(ctx);
@@ -48,7 +49,7 @@ export const checkSessionHealth = async (
   );
 
   if (!loginTs || loginTs < getUnixTime(new Date()) - tolerance) {
-    const { passwordEncrypted, primaryPhone, primaryEmail } = await findUserById(accountId);
+    const { passwordEncrypted, primaryPhone, primaryEmail } = await users.findUserById(accountId);
 
     // No authenticated method configured for this user. Pass!
     if (!passwordEncrypted && !primaryPhone && !primaryEmail) {

--- a/packages/core/src/libraries/user.ts
+++ b/packages/core/src/libraries/user.ts
@@ -7,31 +7,18 @@ import { deduplicate } from '@silverhand/essentials';
 import { argon2Verify } from 'hash-wasm';
 import pRetry from 'p-retry';
 
-import { buildInsertInto } from '#src/database/insert-into.js';
+import { buildInsertIntoWithPool } from '#src/database/insert-into.js';
 import envSet from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
-import { findRolesByRoleNames, insertRoles, findRoleByRoleName } from '#src/queries/roles.js';
-import { hasUser, hasUserWithEmail, hasUserWithId, hasUserWithPhone } from '#src/queries/user.js';
-import { insertUsersRoles } from '#src/queries/users-roles.js';
+import Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 import { encryptPassword } from '#src/utils/password.js';
 
 const userId = buildIdGenerator(12);
 const roleId = buildIdGenerator(21);
 
-export const generateUserId = async (retries = 500) =>
-  pRetry(
-    async () => {
-      const id = userId();
-
-      if (!(await hasUserWithId(id))) {
-        return id;
-      }
-
-      throw new Error('Cannot generate user ID in reasonable retries');
-    },
-    { retries, factor: 0 } // No need for exponential backoff
-  );
+/** @deprecated Don't use. This is for transition only and will be removed soon. */
+export const defaultQueries = new Queries(envSet.pool);
 
 export const encryptUserPassword = async (
   password: string
@@ -49,87 +36,121 @@ export const encryptUserPassword = async (
   return { passwordEncrypted, passwordEncryptionMethod };
 };
 
-export const verifyUserPassword = async (user: Nullable<User>, password: string): Promise<User> => {
-  assertThat(user, 'session.invalid_credentials');
-  const { passwordEncrypted, passwordEncryptionMethod } = user;
+export const createUserLibrary = (queries: Queries) => {
+  const {
+    pool,
+    roles: { findRolesByRoleNames, insertRoles, findRoleByRoleName },
+    users: { hasUser, hasUserWithEmail, hasUserWithId, hasUserWithPhone },
+    usersRoles: { insertUsersRoles },
+  } = queries;
 
-  assertThat(passwordEncrypted && passwordEncryptionMethod, 'session.invalid_credentials');
+  const generateUserId = async (retries = 500) =>
+    pRetry(
+      async () => {
+        const id = userId();
 
-  const result = await argon2Verify({ password, hash: passwordEncrypted });
+        if (!(await hasUserWithId(id))) {
+          return id;
+        }
 
-  assertThat(result, 'session.invalid_credentials');
-
-  return user;
-};
-
-const insertUserQuery = buildInsertInto<CreateUser, User>(Users, {
-  returning: true,
-});
-
-// Temp solution since Hasura requires a role to proceed authn.
-// The source of default roles should be guarded and moved to database once we implement RBAC.
-export const insertUser = async ({
-  roleNames,
-  ...rest
-}: OmitAutoSetFields<CreateUser> & { roleNames?: string[] }) => {
-  const computedRoleNames = deduplicate(
-    (roleNames ?? []).concat(envSet.values.userDefaultRoleNames)
-  );
-
-  if (computedRoleNames.length > 0) {
-    const existingRoles = await findRolesByRoleNames(computedRoleNames);
-    const missingRoleNames = computedRoleNames.filter(
-      (roleName) => !existingRoles.some(({ name }) => roleName === name)
+        throw new Error('Cannot generate user ID in reasonable retries');
+      },
+      { retries, factor: 0 } // No need for exponential backoff
     );
 
-    if (missingRoleNames.length > 0) {
-      await insertRoles(
-        missingRoleNames.map((name) => ({
-          id: roleId(),
-          name,
-          description: 'User default role.',
-        }))
+  const verifyUserPassword = async (user: Nullable<User>, password: string): Promise<User> => {
+    assertThat(user, 'session.invalid_credentials');
+    const { passwordEncrypted, passwordEncryptionMethod } = user;
+
+    assertThat(passwordEncrypted && passwordEncryptionMethod, 'session.invalid_credentials');
+
+    const result = await argon2Verify({ password, hash: passwordEncrypted });
+
+    assertThat(result, 'session.invalid_credentials');
+
+    return user;
+  };
+
+  const insertUserQuery = buildInsertIntoWithPool(pool)<CreateUser, User>(Users, {
+    returning: true,
+  });
+
+  // Temp solution since Hasura requires a role to proceed authn.
+  // The source of default roles should be guarded and moved to database once we implement RBAC.
+  const insertUser = async ({
+    roleNames,
+    ...rest
+  }: OmitAutoSetFields<CreateUser> & { roleNames?: string[] }) => {
+    const computedRoleNames = deduplicate(
+      (roleNames ?? []).concat(envSet.values.userDefaultRoleNames)
+    );
+
+    if (computedRoleNames.length > 0) {
+      const existingRoles = await findRolesByRoleNames(computedRoleNames);
+      const missingRoleNames = computedRoleNames.filter(
+        (roleName) => !existingRoles.some(({ name }) => roleName === name)
       );
-    }
-  }
 
-  const user = await insertUserQuery(rest);
-
-  await Promise.all([
-    computedRoleNames.map(async (roleName) => {
-      const role = await findRoleByRoleName(roleName);
-
-      if (!role) {
-        // Not expected to happen, just inserted above, so is 500
-        throw new Error(`Can not find role: ${roleName}`);
+      if (missingRoleNames.length > 0) {
+        await insertRoles(
+          missingRoleNames.map((name) => ({
+            id: roleId(),
+            name,
+            description: 'User default role.',
+          }))
+        );
       }
+    }
 
-      await insertUsersRoles([{ userId: user.id, roleId: role.id }]);
-    }),
-  ]);
+    const user = await insertUserQuery(rest);
 
-  return user;
+    await Promise.all([
+      computedRoleNames.map(async (roleName) => {
+        const role = await findRoleByRoleName(roleName);
+
+        if (!role) {
+          // Not expected to happen, just inserted above, so is 500
+          throw new Error(`Can not find role: ${roleName}`);
+        }
+
+        await insertUsersRoles([{ userId: user.id, roleId: role.id }]);
+      }),
+    ]);
+
+    return user;
+  };
+
+  const checkIdentifierCollision = async (
+    identifiers: {
+      username?: Nullable<string>;
+      primaryEmail?: Nullable<string>;
+      primaryPhone?: Nullable<string>;
+    },
+    excludeUserId?: string
+  ) => {
+    const { username, primaryEmail, primaryPhone } = identifiers;
+
+    if (username && (await hasUser(username, excludeUserId))) {
+      throw new RequestError({ code: 'user.username_already_in_use', status: 422 });
+    }
+
+    if (primaryEmail && (await hasUserWithEmail(primaryEmail, excludeUserId))) {
+      throw new RequestError({ code: 'user.email_already_in_use', status: 422 });
+    }
+
+    if (primaryPhone && (await hasUserWithPhone(primaryPhone, excludeUserId))) {
+      throw new RequestError({ code: 'user.phone_already_in_use', status: 422 });
+    }
+  };
+
+  return {
+    generateUserId,
+    verifyUserPassword,
+    insertUser,
+    checkIdentifierCollision,
+  };
 };
 
-export const checkIdentifierCollision = async (
-  identifiers: {
-    username?: Nullable<string>;
-    primaryEmail?: Nullable<string>;
-    primaryPhone?: Nullable<string>;
-  },
-  excludeUserId?: string
-) => {
-  const { username, primaryEmail, primaryPhone } = identifiers;
-
-  if (username && (await hasUser(username, excludeUserId))) {
-    throw new RequestError({ code: 'user.username_already_in_use', status: 422 });
-  }
-
-  if (primaryEmail && (await hasUserWithEmail(primaryEmail, excludeUserId))) {
-    throw new RequestError({ code: 'user.email_already_in_use', status: 422 });
-  }
-
-  if (primaryPhone && (await hasUserWithPhone(primaryPhone, excludeUserId))) {
-    throw new RequestError({ code: 'user.phone_already_in_use', status: 422 });
-  }
-};
+/** @deprecated Don't use. This is for transition only and will be removed soon. */
+export const { generateUserId, verifyUserPassword, insertUser, checkIdentifierCollision } =
+  createUserLibrary(defaultQueries);

--- a/packages/core/src/queries/application.test.ts
+++ b/packages/core/src/queries/application.test.ts
@@ -4,7 +4,6 @@ import { createMockPool, createMockQueryResult, sql } from 'slonik';
 import { snakeCase } from 'snake-case';
 
 import { mockApplication } from '#src/__mocks__/index.js';
-import envSet from '#src/env-set/index.js';
 import { DeletionError } from '#src/errors/SlonikError/index.js';
 import type { QueryType } from '#src/utils/test-utils.js';
 import { expectSqlAssert } from '#src/utils/test-utils.js';
@@ -13,14 +12,13 @@ const { jest } = import.meta;
 
 const mockQuery: jest.MockedFunction<QueryType> = jest.fn();
 
-jest.spyOn(envSet, 'pool', 'get').mockReturnValue(
-  createMockPool({
-    query: async (sql, values) => {
-      return mockQuery(sql, values);
-    },
-  })
-);
+const pool = createMockPool({
+  query: async (sql, values) => {
+    return mockQuery(sql, values);
+  },
+});
 
+const { createApplicationQueries } = await import('./application.js');
 const {
   findTotalNumberOfApplications,
   findAllApplications,
@@ -28,7 +26,7 @@ const {
   insertApplication,
   updateApplicationById,
   deleteApplicationById,
-} = await import('./application.js');
+} = createApplicationQueries(pool);
 
 describe('application query', () => {
   const { table, fields } = convertToIdentifiers(Applications);

--- a/packages/core/src/queries/application.ts
+++ b/packages/core/src/queries/application.ts
@@ -45,7 +45,7 @@ export const createApplicationQueries = (pool: CommonQueryMethods) => {
   ) => updateApplication({ set, where: { id }, jsonbMode: 'merge' });
 
   const deleteApplicationById = async (id: string) => {
-    const { rowCount } = await envSet.pool.query(sql`
+    const { rowCount } = await pool.query(sql`
       delete from ${table}
       where ${fields.id}=${id}
     `);

--- a/packages/core/src/queries/connector.test.ts
+++ b/packages/core/src/queries/connector.test.ts
@@ -3,7 +3,6 @@ import { convertToIdentifiers } from '@logto/shared';
 import { createMockPool, createMockQueryResult, sql } from 'slonik';
 
 import { mockConnector } from '#src/__mocks__/index.js';
-import envSet from '#src/env-set/index.js';
 import { DeletionError } from '#src/errors/SlonikError/index.js';
 import type { QueryType } from '#src/utils/test-utils.js';
 import { expectSqlAssert } from '#src/utils/test-utils.js';
@@ -12,14 +11,13 @@ const { jest } = import.meta;
 
 const mockQuery: jest.MockedFunction<QueryType> = jest.fn();
 
-jest.spyOn(envSet, 'pool', 'get').mockReturnValue(
-  createMockPool({
-    query: async (sql, values) => {
-      return mockQuery(sql, values);
-    },
-  })
-);
+const pool = createMockPool({
+  query: async (sql, values) => {
+    return mockQuery(sql, values);
+  },
+});
 
+const { createConnectorQueries } = await import('./connector.js');
 const {
   findAllConnectors,
   findConnectorById,
@@ -28,7 +26,7 @@ const {
   deleteConnectorByIds,
   insertConnector,
   updateConnector,
-} = await import('./connector.js');
+} = createConnectorQueries(pool);
 
 describe('connector queries', () => {
   const { table, fields } = convertToIdentifiers(Connectors);

--- a/packages/core/src/queries/oidc-model-instance.ts
+++ b/packages/core/src/queries/oidc-model-instance.ts
@@ -64,7 +64,7 @@ export const createOidcModelInstanceQueries = (pool: CommonQueryMethods) => {
   );
 
   const findPayloadById = async (modelName: string, id: string) => {
-    const result = await envSet.pool.maybeOne<QueryResult>(sql`
+    const result = await pool.maybeOne<QueryResult>(sql`
       ${findByModel(modelName)}
       and ${fields.id}=${id}
     `);
@@ -80,7 +80,7 @@ export const createOidcModelInstanceQueries = (pool: CommonQueryMethods) => {
     field: Field,
     value: T
   ) => {
-    const result = await envSet.pool.maybeOne<QueryResult>(sql`
+    const result = await pool.maybeOne<QueryResult>(sql`
       ${findByModel(modelName)}
       and ${fields.payload}->>${field}=${value}
     `);
@@ -89,7 +89,7 @@ export const createOidcModelInstanceQueries = (pool: CommonQueryMethods) => {
   };
 
   const consumeInstanceById = async (modelName: string, id: string) => {
-    await envSet.pool.query(sql`
+    await pool.query(sql`
       update ${table}
       set ${fields.consumedAt}=${convertToTimestamp()}
       where ${fields.modelName}=${modelName}
@@ -98,7 +98,7 @@ export const createOidcModelInstanceQueries = (pool: CommonQueryMethods) => {
   };
 
   const destroyInstanceById = async (modelName: string, id: string) => {
-    await envSet.pool.query(sql`
+    await pool.query(sql`
       delete from ${table}
       where ${fields.modelName}=${modelName}
       and ${fields.id}=${id}
@@ -106,7 +106,7 @@ export const createOidcModelInstanceQueries = (pool: CommonQueryMethods) => {
   };
 
   const revokeInstanceByGrantId = async (modelName: string, grantId: string) => {
-    await envSet.pool.query(sql`
+    await pool.query(sql`
       delete from ${table}
       where ${fields.modelName}=${modelName}
       and ${fields.payload}->>'grantId'=${grantId}
@@ -114,7 +114,7 @@ export const createOidcModelInstanceQueries = (pool: CommonQueryMethods) => {
   };
 
   const revokeInstanceByUserId = async (modelName: string, userId: string) => {
-    await envSet.pool.query(sql`
+    await pool.query(sql`
       delete from ${table}
       where ${fields.modelName}=${modelName}
       and ${fields.payload}->>'accountId'=${userId}

--- a/packages/core/src/queries/passcode.test.ts
+++ b/packages/core/src/queries/passcode.test.ts
@@ -5,7 +5,6 @@ import { createMockPool, createMockQueryResult, sql } from 'slonik';
 import { snakeCase } from 'snake-case';
 
 import { mockPasscode } from '#src/__mocks__/index.js';
-import envSet from '#src/env-set/index.js';
 import { DeletionError } from '#src/errors/SlonikError/index.js';
 import type { QueryType } from '#src/utils/test-utils.js';
 import { expectSqlAssert } from '#src/utils/test-utils.js';
@@ -14,21 +13,20 @@ const { jest } = import.meta;
 
 const mockQuery: jest.MockedFunction<QueryType> = jest.fn();
 
-jest.spyOn(envSet, 'pool', 'get').mockReturnValue(
-  createMockPool({
-    query: async (sql, values) => {
-      return mockQuery(sql, values);
-    },
-  })
-);
+const pool = createMockPool({
+  query: async (sql, values) => {
+    return mockQuery(sql, values);
+  },
+});
 
+const { createPasscodeQueries } = await import('./passcode.js');
 const {
   findUnconsumedPasscodeByJtiAndType,
   findUnconsumedPasscodesByJtiAndType,
   insertPasscode,
   deletePasscodeById,
   deletePasscodesByIds,
-} = await import('./passcode.js');
+} = createPasscodeQueries(pool);
 
 describe('passcode query', () => {
   const { table, fields } = convertToIdentifiers(Passcodes);

--- a/packages/core/src/queries/resource.test.ts
+++ b/packages/core/src/queries/resource.test.ts
@@ -3,7 +3,6 @@ import { convertToIdentifiers, convertToPrimitiveOrSql } from '@logto/shared';
 import { createMockPool, createMockQueryResult, sql } from 'slonik';
 
 import { mockResource } from '#src/__mocks__/index.js';
-import envSet from '#src/env-set/index.js';
 import { DeletionError } from '#src/errors/SlonikError/index.js';
 import type { QueryType } from '#src/utils/test-utils.js';
 import { expectSqlAssert } from '#src/utils/test-utils.js';
@@ -12,14 +11,13 @@ const { jest } = import.meta;
 
 const mockQuery: jest.MockedFunction<QueryType> = jest.fn();
 
-jest.spyOn(envSet, 'pool', 'get').mockReturnValue(
-  createMockPool({
-    query: async (sql, values) => {
-      return mockQuery(sql, values);
-    },
-  })
-);
+const pool = createMockPool({
+  query: async (sql, values) => {
+    return mockQuery(sql, values);
+  },
+});
 
+const { createResourceQueries } = await import('./resource.js');
 const {
   findTotalNumberOfResources,
   findAllResources,
@@ -28,7 +26,7 @@ const {
   insertResource,
   updateResourceById,
   deleteResourceById,
-} = await import('./resource.js');
+} = createResourceQueries(pool);
 
 describe('resource query', () => {
   const { table, fields } = convertToIdentifiers(Resources);

--- a/packages/core/src/queries/roles.test.ts
+++ b/packages/core/src/queries/roles.test.ts
@@ -3,7 +3,6 @@ import { convertToIdentifiers, convertToPrimitiveOrSql, excludeAutoSetFields } f
 import { createMockPool, createMockQueryResult, sql } from 'slonik';
 
 import { mockRole } from '#src/__mocks__/index.js';
-import envSet from '#src/env-set/index.js';
 import { DeletionError } from '#src/errors/SlonikError/index.js';
 import type { QueryType } from '#src/utils/test-utils.js';
 import { expectSqlAssert } from '#src/utils/test-utils.js';
@@ -12,14 +11,13 @@ const { jest } = import.meta;
 
 const mockQuery: jest.MockedFunction<QueryType> = jest.fn();
 
-jest.spyOn(envSet, 'pool', 'get').mockReturnValue(
-  createMockPool({
-    query: async (sql, values) => {
-      return mockQuery(sql, values);
-    },
-  })
-);
+const pool = createMockPool({
+  query: async (sql, values) => {
+    return mockQuery(sql, values);
+  },
+});
 
+const { createRolesQueries } = await import('./roles.js');
 const {
   deleteRoleById,
   findRoleById,
@@ -29,7 +27,7 @@ const {
   insertRole,
   insertRoles,
   updateRoleById,
-} = await import('./roles.js');
+} = createRolesQueries(pool);
 
 describe('roles query', () => {
   const { table, fields } = convertToIdentifiers(Roles);

--- a/packages/core/src/queries/sign-in-experience.test.ts
+++ b/packages/core/src/queries/sign-in-experience.test.ts
@@ -1,7 +1,6 @@
 import { createMockPool, createMockQueryResult } from 'slonik';
 
 import { mockSignInExperience } from '#src/__mocks__/index.js';
-import envSet from '#src/env-set/index.js';
 import type { QueryType } from '#src/utils/test-utils.js';
 import { expectSqlAssert } from '#src/utils/test-utils.js';
 
@@ -9,17 +8,15 @@ const { jest } = import.meta;
 
 const mockQuery: jest.MockedFunction<QueryType> = jest.fn();
 
-jest.spyOn(envSet, 'pool', 'get').mockReturnValue(
-  createMockPool({
-    query: async (sql, values) => {
-      return mockQuery(sql, values);
-    },
-  })
-);
+const pool = createMockPool({
+  query: async (sql, values) => {
+    return mockQuery(sql, values);
+  },
+});
 
-const { findDefaultSignInExperience, updateDefaultSignInExperience } = await import(
-  './sign-in-experience.js'
-);
+const { createSignInExperienceQueries } = await import('./sign-in-experience.js');
+const { findDefaultSignInExperience, updateDefaultSignInExperience } =
+  createSignInExperienceQueries(pool);
 
 describe('sign-in-experience query', () => {
   const id = 'default';

--- a/packages/core/src/routes/application.test.ts
+++ b/packages/core/src/routes/application.test.ts
@@ -5,9 +5,9 @@ import { pickDefault, createMockUtils } from '@logto/shared/esm';
 import { mockApplication } from '#src/__mocks__/index.js';
 
 const { jest } = import.meta;
-const { mockEsm } = createMockUtils(jest);
+const { mockEsm, mockEsmWithActual } = createMockUtils(jest);
 
-const { findApplicationById } = mockEsm('#src/queries/application.js', () => ({
+const { findApplicationById } = await mockEsmWithActual('#src/queries/application.js', () => ({
   findTotalNumberOfApplications: jest.fn(async () => ({ count: 10 })),
   findAllApplications: jest.fn(async () => [mockApplication]),
   findApplicationById: jest.fn(async () => mockApplication),

--- a/packages/core/src/routes/interaction/actions/submit-interaction.ts
+++ b/packages/core/src/routes/interaction/actions/submit-interaction.ts
@@ -1,12 +1,11 @@
 import type { User, Profile } from '@logto/schemas';
 import { InteractionEvent, UserRole, adminConsoleApplicationId } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
-import type Provider from 'oidc-provider';
 
 import { getLogtoConnectorById } from '#src/connectors/index.js';
 import { assignInteractionResults } from '#src/libraries/session.js';
-import { encryptUserPassword, generateUserId, insertUser } from '#src/libraries/user.js';
-import { hasActiveUsers, findUserById, updateUserById } from '#src/queries/user.js';
+import { encryptUserPassword } from '#src/libraries/user.js';
+import type TenantContext from '#src/tenants/TenantContext.js';
 
 import type { WithInteractionDetailsContext } from '../middleware/koa-interaction-details.js';
 import type {
@@ -130,8 +129,12 @@ const parseUserProfile = async (
 export default async function submitInteraction(
   interaction: VerifiedInteractionResult,
   ctx: WithInteractionDetailsContext,
-  provider: Provider
+  { provider, libraries, queries }: TenantContext
 ) {
+  const { hasActiveUsers, findUserById, updateUserById } = queries.users;
+  const {
+    users: { generateUserId, insertUser },
+  } = libraries;
   const { event, profile } = interaction;
 
   if (event === InteractionEvent.Register) {

--- a/packages/core/src/routes/interaction/index.ts
+++ b/packages/core/src/routes/interaction/index.ts
@@ -44,8 +44,9 @@ export const verificationPath = 'verification';
 type RouterContext<T> = T extends Router<unknown, infer Context> ? Context : never;
 
 export default function interactionRoutes<T extends AnonymousRouter>(
-  ...[anonymousRouter, { provider }]: RouterInitArgs<T>
+  ...[anonymousRouter, tenant]: RouterInitArgs<T>
 ) {
+  const { provider } = tenant;
   const router =
     // @ts-expect-error for good koa types
     // eslint-disable-next-line no-restricted-syntax
@@ -83,7 +84,7 @@ export default function interactionRoutes<T extends AnonymousRouter>(
       }
 
       const verifiedIdentifier = identifier && [
-        await verifyIdentifierPayload(ctx, provider, identifier, {
+        await verifyIdentifierPayload(ctx, tenant, identifier, {
           event,
         }),
       ];
@@ -166,7 +167,7 @@ export default function interactionRoutes<T extends AnonymousRouter>(
 
       const verifiedIdentifier = await verifyIdentifierPayload(
         ctx,
-        provider,
+        tenant,
         identifierPayload,
         interactionStorage
       );
@@ -301,7 +302,7 @@ export default function interactionRoutes<T extends AnonymousRouter>(
         await validateMandatoryUserProfile(ctx, verifiedInteraction);
       }
 
-      await submitInteraction(verifiedInteraction, ctx, provider);
+      await submitInteraction(verifiedInteraction, ctx, tenant);
 
       return next();
     }

--- a/packages/core/src/tenants/Libraries.ts
+++ b/packages/core/src/tenants/Libraries.ts
@@ -1,0 +1,9 @@
+import { createUserLibrary } from '#src/libraries/user.js';
+
+import type Queries from './Queries.js';
+
+export default class Libraries {
+  users = createUserLibrary(this.queries);
+
+  constructor(public readonly queries: Queries) {}
+}

--- a/packages/core/src/tenants/Tenant.ts
+++ b/packages/core/src/tenants/Tenant.ts
@@ -19,12 +19,14 @@ import koaWelcomeProxy from '#src/middleware/koa-welcome-proxy.js';
 import initOidc from '#src/oidc/init.js';
 import initRouter from '#src/routes/init.js';
 
+import Libraries from './Libraries.js';
 import Queries from './Queries.js';
 import type TenantContext from './TenantContext.js';
 
 export default class Tenant implements TenantContext {
   public readonly provider: Provider;
   public readonly queries: Queries;
+  public readonly libraries: Libraries;
 
   public readonly app: Koa;
 
@@ -34,8 +36,10 @@ export default class Tenant implements TenantContext {
 
   constructor(public id: string) {
     const queries = new Queries(envSet.pool);
+    const libraries = new Libraries(queries);
 
     this.queries = queries;
+    this.libraries = libraries;
 
     // Init app
     const app = new Koa();
@@ -50,7 +54,7 @@ export default class Tenant implements TenantContext {
     app.use(koaConnectorErrorHandler());
     app.use(koaI18next());
 
-    const apisApp = initRouter({ provider, queries });
+    const apisApp = initRouter({ provider, queries, libraries });
     app.use(mount('/api', apisApp));
 
     app.use(mount('/', koaRootProxy()));

--- a/packages/core/src/tenants/TenantContext.ts
+++ b/packages/core/src/tenants/TenantContext.ts
@@ -1,8 +1,10 @@
 import type Provider from 'oidc-provider';
 
+import type Libraries from './Libraries.js';
 import type Queries from './Queries.js';
 
 export default abstract class TenantContext {
   public abstract readonly provider: Provider;
   public abstract readonly queries: Queries;
+  public abstract readonly libraries: Libraries;
 }

--- a/packages/core/src/test-utils/tenant.ts
+++ b/packages/core/src/test-utils/tenant.ts
@@ -1,29 +1,61 @@
-import type Queries from '#src/tenants/Queries.js';
+import { createMockPool, createMockQueryResult } from 'slonik';
+
+import Libraries from '#src/tenants/Libraries.js';
+import Queries from '#src/tenants/Queries.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 
 import { createMockProvider } from './oidc-provider.js';
 
 const { jest } = import.meta;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
-const proxy: Queries = new Proxy<any>(
-  {},
-  {
-    get() {
-      return new Proxy(
-        {},
-        {
-          get() {
-            return jest.fn();
-          },
-        }
-      );
-    },
-  }
-);
+const pool = createMockPool({
+  query: async (sql, values) => {
+    return createMockQueryResult([]);
+  },
+});
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type DeepPartial<T> = T extends object
+  ? {
+      [P in keyof T]?: DeepPartial<T[P]>;
+    }
+  : T;
+
+export type Partial2<T> = { [key in keyof T]?: Partial<T[key]> };
 
 export class MockTenant implements TenantContext {
-  constructor(public provider = createMockProvider(), public queries = proxy) {}
+  public queries: Queries;
+  public libraries: Libraries;
+
+  constructor(
+    public provider = createMockProvider(),
+    queriesOverride?: Partial2<Queries>,
+    librariesOverride?: Partial2<Libraries>
+  ) {
+    this.queries = new Queries(pool);
+    this.setPartial('queries', queriesOverride);
+    this.libraries = new Libraries(this.queries);
+    this.setPartial('libraries', librariesOverride);
+  }
+
+  setPartialKey<Type extends 'queries' | 'libraries', Key extends keyof this[Type]>(
+    type: Type,
+    key: Key,
+    value: Partial<this[Type][Key]>
+  ) {
+    this[type][key] = { ...this[type][key], ...value };
+  }
+
+  setPartial<Type extends 'queries' | 'libraries'>(type: Type, value?: Partial2<this[Type]>) {
+    if (!value) {
+      return;
+    }
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const key of Object.keys(value) as Array<keyof this[Type]>) {
+      this.setPartialKey(type, key, { ...this[type][key], ...value[key] });
+    }
+  }
 }
 
 export const createMockTenantWithInteraction = (interactionDetails?: jest.Mock) =>


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

- add `Libraries` class to aggregate all libraries with a tenant context
- migrate `libraries/user.ts` to the factory mode and update related routes using the new factories
- make `MockTenant` more extendable by allowing **PARTIAL OVERRIDE** queries and libraries
- update unit tests accordingly

### ⚠️ Unit test pattern change

@logto-io/eng after this migration of all queries and libraries, mocking becomes more reasonable, see examples:
- `packages/core/src/queries/passcode.test.ts` mocking single query set only
- `packages/core/src/routes/admin-user.test.ts` mocking multiple query sets and library

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

CI