### PR TITLE
fix(console): fix sign-up identifier key

### DIFF
--- a/packages/console/src/pages/SignInExperience/constants.ts
+++ b/packages/console/src/pages/SignInExperience/constants.ts
@@ -9,7 +9,7 @@ export const signInIdentifiers = Object.values(SignInIdentifier);
 export const signUpIdentifiersMapping: { [key in SignUpIdentifier]: SignInIdentifier[] } = {
   [SignUpIdentifier.Username]: [SignInIdentifier.Username],
   [SignUpIdentifier.Email]: [SignInIdentifier.Email],
-  [SignUpIdentifier.Sms]: [SignInIdentifier.Phone],
+  [SignUpIdentifier.Phone]: [SignInIdentifier.Phone],
   [SignUpIdentifier.EmailOrSms]: [SignInIdentifier.Email, SignInIdentifier.Phone],
   [SignUpIdentifier.None]: [],
 };

--- a/packages/console/src/pages/SignInExperience/types.ts
+++ b/packages/console/src/pages/SignInExperience/types.ts
@@ -2,7 +2,7 @@ import type { SignInExperience, SignInIdentifier, SignUp } from '@logto/schemas'
 
 export enum SignUpIdentifier {
   Email = 'email',
-  Sms = 'sms',
+  Phone = 'phone',
   Username = 'username',
   EmailOrSms = 'emailOrSms',
   None = 'none',


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix sign-up identifier key

AC uses the `SignUpIdentifier.Sms` as phrase index.  Replace with phone

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

test locally
