### PR TITLE
fix(schemas): fix aleration script typo

### DIFF
--- a/packages/schemas/alterations/next-1673349501-sms-sign-in-identifier-to-phone.ts
+++ b/packages/schemas/alterations/next-1673349501-sms-sign-in-identifier-to-phone.ts
@@ -4,7 +4,7 @@ import type { AlterationScript } from '../lib/types/alteration.js';
 
 enum OldSignInIdentifier {
   Email = 'email',
-  Sms = 'Sms',
+  Sms = 'sms',
   Username = 'username',
 }
 
@@ -32,7 +32,7 @@ type OldSignInExperience = {
 
 enum SignInIdentifier {
   Email = 'email',
-  Phone = 'Phone',
+  Phone = 'phone',
   Username = 'username',
 }
 


### PR DESCRIPTION
fix alteration script typo

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
fix a bug in the alteration script.  The enum value has a typo and failed to migrate the data properly. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

