### PR TITLE
refactor(core): remove deprecated query functions

### DIFF
--- a/packages/core/src/libraries/user.ts
+++ b/packages/core/src/libraries/user.ts
@@ -50,8 +50,8 @@ export const createUserLibrary = (queries: Queries) => {
   const {
     pool,
     roles: { findRolesByRoleNames, insertRoles, findRoleByRoleName },
-    users: { hasUser, hasUserWithEmail, hasUserWithId, hasUserWithPhone },
-    usersRoles: { insertUsersRoles },
+    users: { hasUser, hasUserWithEmail, hasUserWithId, hasUserWithPhone, findUsersByIds },
+    usersRoles: { insertUsersRoles, findUsersRolesByRoleId },
   } = queries;
 
   const generateUserId = async (retries = 500) =>
@@ -140,9 +140,26 @@ export const createUserLibrary = (queries: Queries) => {
     }
   };
 
+  const findUsersByRoleName = async (roleName: string) => {
+    const role = await findRoleByRoleName(roleName);
+
+    if (!role) {
+      return [];
+    }
+
+    const usersRoles = await findUsersRolesByRoleId(role.id);
+
+    if (usersRoles.length === 0) {
+      return [];
+    }
+
+    return findUsersByIds(usersRoles.map(({ userId }) => userId));
+  };
+
   return {
     generateUserId,
     insertUser,
     checkIdentifierCollision,
+    findUsersByRoleName,
   };
 };

--- a/packages/core/src/middleware/koa-check-demo-app.ts
+++ b/packages/core/src/middleware/koa-check-demo-app.ts
@@ -1,13 +1,13 @@
 import { demoAppApplicationId } from '@logto/schemas';
 import type { MiddlewareType } from 'koa';
 
-import { findApplicationById } from '#src/queries/application.js';
+import type Queries from '#src/tenants/Queries.js';
 
-export default function koaCheckDemoApp<StateT, ContextT, ResponseBodyT>(): MiddlewareType<
-  StateT,
-  ContextT,
-  ResponseBodyT
-> {
+export default function koaCheckDemoApp<StateT, ContextT, ResponseBodyT>(
+  queries: Queries
+): MiddlewareType<StateT, ContextT, ResponseBodyT> {
+  const { findApplicationById } = queries.applications;
+
   return async (ctx, next) => {
     try {
       await findApplicationById(demoAppApplicationId);

--- a/packages/core/src/oidc/adapter.ts
+++ b/packages/core/src/oidc/adapter.ts
@@ -8,15 +8,7 @@ import { errors } from 'oidc-provider';
 import snakecaseKeys from 'snakecase-keys';
 
 import envSet, { MountedApps } from '#src/env-set/index.js';
-import { findApplicationById } from '#src/queries/application.js';
-import {
-  consumeInstanceById,
-  destroyInstanceById,
-  findPayloadById,
-  findPayloadByPayloadField,
-  revokeInstanceByGrantId,
-  upsertInstance,
-} from '#src/queries/oidc-model-instance.js';
+import type Queries from '#src/tenants/Queries.js';
 import { appendPath } from '#src/utils/url.js';
 
 import { getConstantClientMetadata } from './utils.js';
@@ -54,7 +46,22 @@ const buildDemoAppUris = (
   return data;
 };
 
-export default function postgresAdapter(modelName: string): ReturnType<AdapterFactory> {
+export default function postgresAdapter(
+  queries: Queries,
+  modelName: string
+): ReturnType<AdapterFactory> {
+  const {
+    applications: { findApplicationById },
+    oidcModelInstances: {
+      consumeInstanceById,
+      destroyInstanceById,
+      findPayloadById,
+      findPayloadByPayloadField,
+      revokeInstanceByGrantId,
+      upsertInstance,
+    },
+  } = queries;
+
   if (modelName === 'Client') {
     const reject = async () => {
       throw new Error('Not implemented');

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -45,7 +45,7 @@ export default function initOidc(queries: Queries): Provider {
   } as const);
 
   const oidc = new Provider(issuer, {
-    adapter: postgresAdapter,
+    adapter: postgresAdapter.bind(null, queries),
     renderError: (_ctx, _out, error) => {
       console.error(error);
 

--- a/packages/core/src/queries/application.ts
+++ b/packages/core/src/queries/application.ts
@@ -9,7 +9,6 @@ import { buildFindEntityByIdWithPool } from '#src/database/find-entity-by-id.js'
 import { buildInsertIntoWithPool } from '#src/database/insert-into.js';
 import { getTotalRowCountWithPool } from '#src/database/row-count.js';
 import { buildUpdateWhereWithPool } from '#src/database/update-where.js';
-import envSet from '#src/env-set/index.js';
 import { DeletionError } from '#src/errors/SlonikError/index.js';
 
 const { table, fields } = convertToIdentifiers(Applications);
@@ -65,14 +64,3 @@ export const createApplicationQueries = (pool: CommonQueryMethods) => {
     deleteApplicationById,
   };
 };
-
-/** @deprecated Will be removed soon. Use createApplicationQueries() factory instead. */
-export const {
-  findTotalNumberOfApplications,
-  findAllApplications,
-  findApplicationById,
-  insertApplication,
-  updateApplication,
-  updateApplicationById,
-  deleteApplicationById,
-} = createApplicationQueries(envSet.pool);

--- a/packages/core/src/queries/connector.ts
+++ b/packages/core/src/queries/connector.ts
@@ -6,7 +6,6 @@ import { sql } from 'slonik';
 
 import { buildInsertIntoWithPool } from '#src/database/insert-into.js';
 import { buildUpdateWhereWithPool } from '#src/database/update-where.js';
-import envSet from '#src/env-set/index.js';
 import { DeletionError } from '#src/errors/SlonikError/index.js';
 
 const { table, fields } = convertToIdentifiers(Connectors);
@@ -72,14 +71,3 @@ export const createConnectorQueries = (pool: CommonQueryMethods) => {
     updateConnector,
   };
 };
-
-/** @deprecated Will be removed soon. Use createConnectorQueries() factory instead. */
-export const {
-  findAllConnectors,
-  findConnectorById,
-  countConnectorByConnectorId,
-  deleteConnectorById,
-  deleteConnectorByIds,
-  insertConnector,
-  updateConnector,
-} = createConnectorQueries(envSet.pool);

--- a/packages/core/src/queries/custom-phrase.ts
+++ b/packages/core/src/queries/custom-phrase.ts
@@ -5,7 +5,6 @@ import type { CommonQueryMethods } from 'slonik';
 import { sql } from 'slonik';
 
 import { buildInsertIntoWithPool } from '#src/database/insert-into.js';
-import envSet from '#src/env-set/index.js';
 import { DeletionError } from '#src/errors/SlonikError/index.js';
 
 const { table, fields } = convertToIdentifiers(CustomPhrases);
@@ -69,12 +68,3 @@ export const createCustomPhraseQueries = (pool: CommonQueryMethods) => {
     deleteCustomPhraseByLanguageTag,
   };
 };
-
-/** @deprecated Will be removed soon. Use createCustomPhraseQueries() factory instead. */
-export const {
-  findAllCustomLanguageTags,
-  findAllCustomPhrases,
-  findCustomPhraseByLanguageTag,
-  upsertCustomPhrase,
-  deleteCustomPhraseByLanguageTag,
-} = createCustomPhraseQueries(envSet.pool);

--- a/packages/core/src/queries/log.ts
+++ b/packages/core/src/queries/log.ts
@@ -6,7 +6,6 @@ import { sql } from 'slonik';
 
 import { buildFindEntityByIdWithPool } from '#src/database/find-entity-by-id.js';
 import { buildInsertIntoWithPool } from '#src/database/insert-into.js';
-import envSet from '#src/env-set/index.js';
 
 const { table, fields } = convertToIdentifiers(Logs);
 
@@ -88,13 +87,3 @@ export const createLogQueries = (pool: CommonQueryMethods) => {
     countActiveUsersByTimeInterval,
   };
 };
-
-/** @deprecated Will be removed soon. Use createLogQueries() factory instead. */
-export const {
-  insertLog,
-  countLogs,
-  findLogs,
-  findLogById,
-  getDailyActiveUserCountsByTimeInterval,
-  countActiveUsersByTimeInterval,
-} = createLogQueries(envSet.pool);

--- a/packages/core/src/queries/oidc-model-instance.ts
+++ b/packages/core/src/queries/oidc-model-instance.ts
@@ -131,14 +131,3 @@ export const createOidcModelInstanceQueries = (pool: CommonQueryMethods) => {
     revokeInstanceByUserId,
   };
 };
-
-/** @deprecated Will be removed soon. Use createOidcModelInstanceQueries() factory instead. */
-export const {
-  upsertInstance,
-  findPayloadById,
-  findPayloadByPayloadField,
-  consumeInstanceById,
-  destroyInstanceById,
-  revokeInstanceByGrantId,
-  revokeInstanceByUserId,
-} = createOidcModelInstanceQueries(envSet.pool);

--- a/packages/core/src/queries/passcode.ts
+++ b/packages/core/src/queries/passcode.ts
@@ -6,7 +6,6 @@ import type { CommonQueryMethods } from 'slonik';
 import { sql } from 'slonik';
 
 import { buildInsertIntoWithPool } from '#src/database/insert-into.js';
-import envSet from '#src/env-set/index.js';
 import { DeletionError } from '#src/errors/SlonikError/index.js';
 
 const { table, fields } = convertToIdentifiers(Passcodes);
@@ -82,14 +81,3 @@ export const createPasscodeQueries = (pool: CommonQueryMethods) => {
     deletePasscodesByIds,
   };
 };
-
-/** @deprecated Will be removed soon. Use createPasscodeQueries() factory instead. */
-export const {
-  findUnconsumedPasscodeByJtiAndType,
-  findUnconsumedPasscodesByJtiAndType,
-  insertPasscode,
-  consumePasscode,
-  increasePasscodeTryCount,
-  deletePasscodeById,
-  deletePasscodesByIds,
-} = createPasscodeQueries(envSet.pool);

--- a/packages/core/src/queries/resource.ts
+++ b/packages/core/src/queries/resource.ts
@@ -9,7 +9,6 @@ import { buildFindEntityByIdWithPool } from '#src/database/find-entity-by-id.js'
 import { buildInsertIntoWithPool } from '#src/database/insert-into.js';
 import { getTotalRowCountWithPool } from '#src/database/row-count.js';
 import { buildUpdateWhereWithPool } from '#src/database/update-where.js';
-import envSet from '#src/env-set/index.js';
 import { DeletionError } from '#src/errors/SlonikError/index.js';
 
 const { table, fields } = convertToIdentifiers(Resources);
@@ -80,16 +79,3 @@ export const createResourceQueries = (pool: CommonQueryMethods) => {
     deleteResourceById,
   };
 };
-
-/** @deprecated Will be removed soon. Use createResourceQueries() factory instead. */
-export const {
-  findTotalNumberOfResources,
-  findAllResources,
-  findResourceByIndicator,
-  findResourceById,
-  findResourcesByIds,
-  insertResource,
-  updateResource,
-  updateResourceById,
-  deleteResourceById,
-} = createResourceQueries(envSet.pool);

--- a/packages/core/src/queries/roles-scopes.ts
+++ b/packages/core/src/queries/roles-scopes.ts
@@ -4,7 +4,6 @@ import { convertToIdentifiers } from '@logto/shared';
 import type { CommonQueryMethods } from 'slonik';
 import { sql } from 'slonik';
 
-import envSet from '#src/env-set/index.js';
 import { DeletionError } from '#src/errors/SlonikError/index.js';
 
 const { table, fields } = convertToIdentifiers(RolesScopes);
@@ -39,7 +38,3 @@ export const createRolesScopesQueries = (pool: CommonQueryMethods) => {
 
   return { insertRolesScopes, findRolesScopesByRoleId, deleteRolesScope };
 };
-
-/** @deprecated Will be removed soon. Use createRolesScopesQueries() factory instead. */
-export const { insertRolesScopes, findRolesScopesByRoleId, deleteRolesScope } =
-  createRolesScopesQueries(envSet.pool);

--- a/packages/core/src/queries/scope.ts
+++ b/packages/core/src/queries/scope.ts
@@ -8,7 +8,6 @@ import { sql } from 'slonik';
 import { buildFindEntityByIdWithPool } from '#src/database/find-entity-by-id.js';
 import { buildInsertIntoWithPool } from '#src/database/insert-into.js';
 import { buildUpdateWhereWithPool } from '#src/database/update-where.js';
-import envSet from '#src/env-set/index.js';
 import { DeletionError } from '#src/errors/SlonikError/index.js';
 import type { Search } from '#src/utils/search.js';
 import { buildConditionsFromSearch } from '#src/utils/search.js';
@@ -117,18 +116,3 @@ export const createScopeQueries = (pool: CommonQueryMethods) => {
     deleteScopeById,
   };
 };
-
-/** @deprecated Will be removed soon. Use createScopeQueries() factory instead. */
-export const {
-  findScopes,
-  countScopes,
-  findScopeByNameAndResourceId,
-  findScopesByResourceId,
-  findScopesByResourceIds,
-  findScopesByIds,
-  insertScope,
-  findScopeById,
-  updateScope,
-  updateScopeById,
-  deleteScopeById,
-} = createScopeQueries(envSet.pool);

--- a/packages/core/src/queries/setting.ts
+++ b/packages/core/src/queries/setting.ts
@@ -5,7 +5,6 @@ import type { CommonQueryMethods } from 'slonik';
 
 import { buildFindEntityByIdWithPool } from '#src/database/find-entity-by-id.js';
 import { buildUpdateWhereWithPool } from '#src/database/update-where.js';
-import envSet from '#src/env-set/index.js';
 
 export const defaultSettingId = 'default';
 
@@ -23,6 +22,3 @@ export const createSettingQueries = (pool: CommonQueryMethods) => {
 
   return { getSetting, updateSetting };
 };
-
-/** @deprecated Will be removed soon. Use createSettingQueries() factory instead. */
-export const { getSetting, updateSetting } = createSettingQueries(envSet.pool);

--- a/packages/core/src/queries/sign-in-experience.ts
+++ b/packages/core/src/queries/sign-in-experience.ts
@@ -4,7 +4,6 @@ import type { CommonQueryMethods } from 'slonik';
 
 import { buildFindEntityByIdWithPool } from '#src/database/find-entity-by-id.js';
 import { buildUpdateWhereWithPool } from '#src/database/update-where.js';
-import envSet from '#src/env-set/index.js';
 
 const id = 'default';
 
@@ -24,7 +23,3 @@ export const createSignInExperienceQueries = (pool: CommonQueryMethods) => {
 
   return { updateDefaultSignInExperience, findDefaultSignInExperience };
 };
-
-/** @deprecated Will be removed soon. Use createSignInExperienceQueries() factory instead. */
-export const { updateDefaultSignInExperience, findDefaultSignInExperience } =
-  createSignInExperienceQueries(envSet.pool);

--- a/packages/core/src/queries/user.ts
+++ b/packages/core/src/queries/user.ts
@@ -11,6 +11,7 @@ import { DeletionError } from '#src/errors/SlonikError/index.js';
 import type { Search } from '#src/utils/search.js';
 import { buildConditionsFromSearch } from '#src/utils/search.js';
 
+// TODO: @sijie remove this
 import { findRoleByRoleName, findRolesByRoleIds } from './roles.js';
 import { findUsersRolesByRoleId, findUsersRolesByUserId } from './users-roles.js';
 

--- a/packages/core/src/queries/user.ts
+++ b/packages/core/src/queries/user.ts
@@ -12,8 +12,8 @@ import type { Search } from '#src/utils/search.js';
 import { buildConditionsFromSearch } from '#src/utils/search.js';
 
 // TODO: @sijie remove this
-import { findRoleByRoleName, findRolesByRoleIds } from './roles.js';
-import { findUsersRolesByRoleId, findUsersRolesByUserId } from './users-roles.js';
+import { findRolesByRoleIds } from './roles.js';
+import { findUsersRolesByUserId } from './users-roles.js';
 
 const { table, fields } = convertToIdentifiers(Users);
 
@@ -216,22 +216,6 @@ export const createUserQueries = (pool: CommonQueryMethods) => {
       group by date(${fields.createdAt})
     `);
 
-  const findUsersByRoleName = async (roleName: string) => {
-    const role = await findRoleByRoleName(roleName);
-
-    if (!role) {
-      return [];
-    }
-
-    const usersRoles = await findUsersRolesByRoleId(role.id);
-
-    if (usersRoles.length === 0) {
-      return [];
-    }
-
-    return findUsersByIds(usersRoles.map(({ userId }) => userId));
-  };
-
   return {
     findUserByUsername,
     findUserByEmail,
@@ -251,7 +235,6 @@ export const createUserQueries = (pool: CommonQueryMethods) => {
     deleteUserIdentity,
     hasActiveUsers,
     getDailyNewUserCountsByTimeInterval,
-    findUsersByRoleName,
   };
 };
 
@@ -275,5 +258,4 @@ export const {
   deleteUserIdentity,
   hasActiveUsers,
   getDailyNewUserCountsByTimeInterval,
-  findUsersByRoleName,
 } = createUserQueries(envSet.pool);

--- a/packages/core/src/routes/admin-user-role.test.ts
+++ b/packages/core/src/routes/admin-user-role.test.ts
@@ -1,29 +1,32 @@
-import { pickDefault, createMockUtils } from '@logto/shared/esm';
+import { pickDefault } from '@logto/shared/esm';
 
 import { mockRole, mockUser } from '#src/__mocks__/index.js';
+import { MockTenant } from '#src/test-utils/tenant.js';
 import { createRequester } from '#src/utils/test-utils.js';
 
 const { jest } = import.meta;
 
-const { mockEsmWithActual } = createMockUtils(jest);
+const users = { findUserById: jest.fn() };
 
-await mockEsmWithActual('#src/queries/user.js', () => ({
-  findUserById: jest.fn(),
-}));
-const { findRolesByRoleIds } = await mockEsmWithActual('#src/queries/roles.js', () => ({
+const roles = {
   findRolesByRoleIds: jest.fn(),
   findRoleById: jest.fn(),
-}));
-const { findUsersRolesByUserId, insertUsersRoles, deleteUsersRolesByUserIdAndRoleId } =
-  await mockEsmWithActual('#src/queries/users-roles.js', () => ({
-    findUsersRolesByUserId: jest.fn(),
-    insertUsersRoles: jest.fn(),
-    deleteUsersRolesByUserIdAndRoleId: jest.fn(),
-  }));
+};
+const { findRolesByRoleIds } = roles;
+
+const usersRoles = {
+  findUsersRolesByUserId: jest.fn(),
+  insertUsersRoles: jest.fn(),
+  deleteUsersRolesByUserIdAndRoleId: jest.fn(),
+};
+const { findUsersRolesByUserId, insertUsersRoles, deleteUsersRolesByUserIdAndRoleId } = usersRoles;
+
+const tenantContext = new MockTenant(undefined, { usersRoles, users, roles });
+
 const roleRoutes = await pickDefault(import('./admin-user-role.js'));
 
 describe('user role routes', () => {
-  const roleRequester = createRequester({ authedRoutes: roleRoutes });
+  const roleRequester = createRequester({ authedRoutes: roleRoutes, tenantContext });
 
   it('GET /users/:id/roles', async () => {
     findUsersRolesByUserId.mockResolvedValueOnce([]);

--- a/packages/core/src/routes/admin-user-role.ts
+++ b/packages/core/src/routes/admin-user-role.ts
@@ -2,20 +2,19 @@ import { object, string } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
-import { findRolesByRoleIds, findRoleById } from '#src/queries/roles.js';
-import { findUserById } from '#src/queries/user.js';
-import {
-  deleteUsersRolesByUserIdAndRoleId,
-  findUsersRolesByUserId,
-  insertUsersRoles,
-} from '#src/queries/users-roles.js';
 import assertThat from '#src/utils/assert-that.js';
 
 import type { AuthedRouter, RouterInitArgs } from './types.js';
 
 export default function adminUserRoleRoutes<T extends AuthedRouter>(
-  ...[router]: RouterInitArgs<T>
+  ...[router, { queries }]: RouterInitArgs<T>
 ) {
+  const {
+    roles: { findRolesByRoleIds, findRoleById },
+    users: { findUserById },
+    usersRoles: { deleteUsersRolesByUserIdAndRoleId, findUsersRolesByUserId, insertUsersRoles },
+  } = queries;
+
   router.get(
     '/users/:userId/roles',
     koaGuard({

--- a/packages/core/src/routes/admin-user.ts
+++ b/packages/core/src/routes/admin-user.ts
@@ -30,12 +30,11 @@ export default function adminUserRoutes<T extends AuthedRouter>(
       updateUserById,
       hasUserWithEmail,
       hasUserWithPhone,
-      findUsersByRoleName,
     },
     usersRoles: { deleteUsersRolesByUserIdAndRoleId, findUsersRolesByRoleId, insertUsersRoles },
   } = queries;
   const {
-    users: { checkIdentifierCollision, generateUserId, insertUser },
+    users: { checkIdentifierCollision, generateUserId, insertUser, findUsersByRoleName },
   } = libraries;
 
   router.get('/users', koaPagination(), async (ctx, next) => {

--- a/packages/core/src/routes/application.ts
+++ b/packages/core/src/routes/application.ts
@@ -5,20 +5,23 @@ import { object, string } from 'zod';
 import koaGuard from '#src/middleware/koa-guard.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
 import { buildOidcClientMetadata } from '#src/oidc/utils.js';
-import {
-  deleteApplicationById,
-  findApplicationById,
-  findAllApplications,
-  insertApplication,
-  updateApplicationById,
-  findTotalNumberOfApplications,
-} from '#src/queries/application.js';
 
 import type { AuthedRouter, RouterInitArgs } from './types.js';
 
 const applicationId = buildIdGenerator(21);
 
-export default function applicationRoutes<T extends AuthedRouter>(...[router]: RouterInitArgs<T>) {
+export default function applicationRoutes<T extends AuthedRouter>(
+  ...[router, { queries }]: RouterInitArgs<T>
+) {
+  const {
+    deleteApplicationById,
+    findApplicationById,
+    findAllApplications,
+    insertApplication,
+    updateApplicationById,
+    findTotalNumberOfApplications,
+  } = queries.applications;
+
   router.get('/applications', koaPagination(), async (ctx, next) => {
     const { limit, offset } = ctx.pagination;
 

--- a/packages/core/src/routes/custom-phrase.ts
+++ b/packages/core/src/routes/custom-phrase.ts
@@ -7,13 +7,6 @@ import { object } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
-import {
-  deleteCustomPhraseByLanguageTag,
-  findAllCustomPhrases,
-  findCustomPhraseByLanguageTag,
-  upsertCustomPhrase,
-} from '#src/queries/custom-phrase.js';
-import { findDefaultSignInExperience } from '#src/queries/sign-in-experience.js';
 import assertThat from '#src/utils/assert-that.js';
 import { isStrictlyPartial } from '#src/utils/translation.js';
 
@@ -24,7 +17,19 @@ const cleanDeepTranslation = (translation: Translation) =>
   // eslint-disable-next-line no-restricted-syntax
   cleanDeep(translation) as Translation;
 
-export default function customPhraseRoutes<T extends AuthedRouter>(...[router]: RouterInitArgs<T>) {
+export default function customPhraseRoutes<T extends AuthedRouter>(
+  ...[router, { queries }]: RouterInitArgs<T>
+) {
+  const {
+    customPhrases: {
+      deleteCustomPhraseByLanguageTag,
+      findAllCustomPhrases,
+      findCustomPhraseByLanguageTag,
+      upsertCustomPhrase,
+    },
+    signInExperiences: { findDefaultSignInExperience },
+  } = queries;
+
   router.get(
     '/custom-phrases',
     koaGuard({

--- a/packages/core/src/routes/dashboard.ts
+++ b/packages/core/src/routes/dashboard.ts
@@ -3,11 +3,6 @@ import { endOfDay, format, subDays } from 'date-fns';
 import { object, string } from 'zod';
 
 import koaGuard from '#src/middleware/koa-guard.js';
-import {
-  countActiveUsersByTimeInterval,
-  getDailyActiveUserCountsByTimeInterval,
-} from '#src/queries/log.js';
-import { countUsers, getDailyNewUserCountsByTimeInterval } from '#src/queries/user.js';
 
 import type { AuthedRouter, RouterInitArgs } from './types.js';
 
@@ -17,7 +12,14 @@ const indices = (length: number) => [...Array.from({ length }).keys()];
 
 const getEndOfDayTimestamp = (date: Date | number) => endOfDay(date).valueOf();
 
-export default function dashboardRoutes<T extends AuthedRouter>(...[router]: RouterInitArgs<T>) {
+export default function dashboardRoutes<T extends AuthedRouter>(
+  ...[router, { queries }]: RouterInitArgs<T>
+) {
+  const {
+    logs: { countActiveUsersByTimeInterval, getDailyActiveUserCountsByTimeInterval },
+    users: { countUsers, getDailyNewUserCountsByTimeInterval },
+  } = queries;
+
   router.get('/dashboard/users/total', async (ctx, next) => {
     const { count: totalUserCount } = await countUsers();
     ctx.body = { totalUserCount };

--- a/packages/core/src/routes/log.ts
+++ b/packages/core/src/routes/log.ts
@@ -3,11 +3,14 @@ import { object, string } from 'zod';
 
 import koaGuard from '#src/middleware/koa-guard.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
-import { countLogs, findLogById, findLogs } from '#src/queries/log.js';
 
 import type { AuthedRouter, RouterInitArgs } from './types.js';
 
-export default function logRoutes<T extends AuthedRouter>(...[router]: RouterInitArgs<T>) {
+export default function logRoutes<T extends AuthedRouter>(
+  ...[router, { queries }]: RouterInitArgs<T>
+) {
+  const { countLogs, findLogById, findLogs } = queries.logs;
+
   router.get(
     '/logs',
     koaPagination(),

--- a/packages/core/src/routes/role.ts
+++ b/packages/core/src/routes/role.ts
@@ -7,31 +7,6 @@ import { object, string, z } from 'zod';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
-import { findResourcesByIds } from '#src/queries/resource.js';
-import {
-  deleteRolesScope,
-  findRolesScopesByRoleId,
-  insertRolesScopes,
-} from '#src/queries/roles-scopes.js';
-import {
-  countRoles,
-  deleteRoleById,
-  findRoleById,
-  findRoleByRoleName,
-  findRoles,
-  insertRole,
-  updateRoleById,
-} from '#src/queries/roles.js';
-import { findScopeById, findScopesByIds } from '#src/queries/scope.js';
-import { findUserById, findUsersByIds } from '#src/queries/user.js';
-import {
-  countUsersRolesByRoleId,
-  deleteUsersRolesByUserIdAndRoleId,
-  findFirstUsersRolesByRoleIdAndUserIds,
-  findUsersRolesByRoleId,
-  findUsersRolesByUserId,
-  insertUsersRoles,
-} from '#src/queries/users-roles.js';
 import assertThat from '#src/utils/assert-that.js';
 import { parseSearchParamsForSearch } from '#src/utils/search.js';
 
@@ -39,7 +14,33 @@ import type { AuthedRouter, RouterInitArgs } from './types.js';
 
 const roleId = buildIdGenerator(21);
 
-export default function roleRoutes<T extends AuthedRouter>(...[router]: RouterInitArgs<T>) {
+export default function roleRoutes<T extends AuthedRouter>(
+  ...[router, { queries }]: RouterInitArgs<T>
+) {
+  const {
+    resources: { findResourcesByIds },
+    rolesScopes: { deleteRolesScope, findRolesScopesByRoleId, insertRolesScopes },
+    roles: {
+      countRoles,
+      deleteRoleById,
+      findRoleById,
+      findRoleByRoleName,
+      findRoles,
+      insertRole,
+      updateRoleById,
+    },
+    scopes: { findScopeById, findScopesByIds },
+    users: { findUserById, findUsersByIds },
+    usersRoles: {
+      countUsersRolesByRoleId,
+      deleteUsersRolesByUserIdAndRoleId,
+      findFirstUsersRolesByRoleIdAndUserIds,
+      findUsersRolesByRoleId,
+      findUsersRolesByUserId,
+      insertUsersRoles,
+    },
+  } = queries;
+
   router.get('/roles', koaPagination({ isOptional: true }), async (ctx, next) => {
     const { limit, offset, disabled } = ctx.pagination;
     const { searchParams } = ctx.request.URL;

--- a/packages/core/src/routes/setting.test.ts
+++ b/packages/core/src/routes/setting.test.ts
@@ -1,23 +1,25 @@
 import type { Setting, CreateSetting } from '@logto/schemas';
-import { pickDefault, createMockUtils } from '@logto/shared/esm';
+import { pickDefault } from '@logto/shared/esm';
 
 import { mockSetting } from '#src/__mocks__/index.js';
+import { MockTenant } from '#src/test-utils/tenant.js';
 import { createRequester } from '#src/utils/test-utils.js';
 
-const { mockEsm } = createMockUtils(import.meta.jest);
-
-mockEsm('#src/queries/setting.js', () => ({
+const settings = {
   getSetting: async (): Promise<Setting> => mockSetting,
   updateSetting: async (data: Partial<CreateSetting>): Promise<Setting> => ({
     ...mockSetting,
     ...data,
   }),
-}));
+};
 
 const settingRoutes = await pickDefault(import('./setting.js'));
 
 describe('settings routes', () => {
-  const roleRequester = createRequester({ authedRoutes: settingRoutes });
+  const roleRequester = createRequester({
+    authedRoutes: settingRoutes,
+    tenantContext: new MockTenant(undefined, { settings }),
+  });
 
   it('GET /settings', async () => {
     const response = await roleRequester.get('/settings');

--- a/packages/core/src/routes/setting.ts
+++ b/packages/core/src/routes/setting.ts
@@ -1,11 +1,14 @@
 import { Settings } from '@logto/schemas';
 
 import koaGuard from '#src/middleware/koa-guard.js';
-import { getSetting, updateSetting } from '#src/queries/setting.js';
 
 import type { AuthedRouter, RouterInitArgs } from './types.js';
 
-export default function settingRoutes<T extends AuthedRouter>(...[router]: RouterInitArgs<T>) {
+export default function settingRoutes<T extends AuthedRouter>(
+  ...[router, { queries }]: RouterInitArgs<T>
+) {
+  const { getSetting, updateSetting } = queries.settings;
+
   router.get('/settings', async (ctx, next) => {
     const { id, ...rest } = await getSetting();
     ctx.body = rest;

--- a/packages/core/src/tenants/Tenant.ts
+++ b/packages/core/src/tenants/Tenant.ts
@@ -73,7 +73,10 @@ export default class Tenant implements TenantContext {
     app.use(
       mount(
         '/' + MountedApps.DemoApp,
-        compose([koaCheckDemoApp(), koaSpaProxy(MountedApps.DemoApp, 5003, MountedApps.DemoApp)])
+        compose([
+          koaCheckDemoApp(this.queries),
+          koaSpaProxy(MountedApps.DemoApp, 5003, MountedApps.DemoApp),
+        ])
       )
     );
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
now all query functions will run in a tenant context

@wangsijie there are two queries in `queries/user.ts` look deprecated, would you like to remove them when convenient?

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

CI