### PR TITLE
refactor: remove deprecated singleton instances

### DIFF
--- a/packages/cli/src/commands/database/seed/oidc-config.ts
+++ b/packages/cli/src/commands/database/seed/oidc-config.ts
@@ -2,7 +2,7 @@ import { readFile } from 'fs/promises';
 
 import type { LogtoOidcConfigType } from '@logto/schemas';
 import { LogtoOidcConfigKey } from '@logto/schemas';
-import { getEnv, getEnvAsStringArray } from '@silverhand/essentials';
+import { getEnvAsStringArray } from '@silverhand/essentials';
 
 import { generateOidcCookieKey, generateOidcPrivateKey } from '../utilities.js';
 
@@ -66,12 +66,5 @@ export const oidcConfigReaders: {
     const keys = getEnvAsStringArray(envKey);
 
     return { value: keys.length > 0 ? keys : [generateOidcCookieKey()], fromEnv: keys.length > 0 };
-  },
-  [LogtoOidcConfigKey.RefreshTokenReuseInterval]: async () => {
-    const envKey = 'OIDC_REFRESH_TOKEN_REUSE_INTERVAL';
-    const raw = Number(getEnv(envKey));
-    const value = Math.max(3, raw || 0);
-
-    return { value, fromEnv: raw === value };
   },
 };

--- a/packages/core/jest.setup.js
+++ b/packages/core/jest.setup.js
@@ -6,9 +6,26 @@ import { createMockUtils } from '@logto/shared/esm';
 import { createMockQueryResult, createMockPool } from 'slonik';
 
 const { jest } = import.meta;
-const { mockEsm } = createMockUtils(jest);
+const { mockEsm, mockEsmWithActual, mockEsmDefault } = createMockUtils(jest);
 
-mockEsm('#src/env-set/index.js', () => ({
+process.env.DB_URL = 'postgres://mock.db.url';
+process.env.ENDPOINT = 'https://logto.test';
+process.env.NODE_ENV = 'test';
+
+mockEsm('#src/libraries/logto-config.js', () => ({
+  createLogtoConfigLibrary: () => ({ getOidcConfigs: () => ({}) }),
+}));
+
+mockEsm('#src/env-set/check-alteration-state.js', () => ({
+  checkAlterationState: () => true,
+}));
+
+// eslint-disable-next-line unicorn/consistent-function-scoping
+mockEsmDefault('#src/env-set/oidc.js', () => () => ({
+  issuer: 'https://logto.test/oidc',
+}));
+
+await mockEsmWithActual('#src/env-set/index.js', () => ({
   MountedApps: {
     Api: 'api',
     Oidc: 'oidc',
@@ -16,13 +33,8 @@ mockEsm('#src/env-set/index.js', () => ({
     DemoApp: 'demo-app',
     Welcome: 'welcome',
   },
+  // TODO: Remove after clean up of default env sets
   default: {
-    get values() {
-      return {
-        endpoint: 'https://logto.test',
-        adminConsoleUrl: 'https://logto.test/console',
-      };
-    },
     get oidc() {
       return {
         issuer: 'https://logto.test/oidc',

--- a/packages/core/src/app/init.ts
+++ b/packages/core/src/app/init.ts
@@ -5,11 +5,11 @@ import { deduplicate } from '@silverhand/essentials';
 import chalk from 'chalk';
 import type Koa from 'koa';
 
-import envSet from '#src/env-set/index.js';
+import { EnvSet } from '#src/env-set/index.js';
 import { tenantPool, defaultTenant } from '#src/tenants/index.js';
 
 const logListening = () => {
-  const { localhostUrl, endpoint } = envSet.values;
+  const { localhostUrl, endpoint } = EnvSet.values;
 
   for (const url of deduplicate([localhostUrl, endpoint])) {
     console.log(chalk.bold(chalk.green(`App is running at ${url}`)));
@@ -19,12 +19,12 @@ const logListening = () => {
 export default async function initApp(app: Koa): Promise<void> {
   app.use(async (ctx, next) => {
     // TODO: add multi-tenancy logic
-    const tenant = tenantPool.get(defaultTenant);
+    const tenant = await tenantPool.get(defaultTenant);
 
     return tenant.run(ctx, next);
   });
 
-  const { isHttpsEnabled, httpsCert, httpsKey, port } = envSet.values;
+  const { isHttpsEnabled, httpsCert, httpsKey, port } = EnvSet.values;
 
   if (isHttpsEnabled && httpsCert && httpsKey) {
     http2

--- a/packages/core/src/database/find-entity-by-id.ts
+++ b/packages/core/src/database/find-entity-by-id.ts
@@ -3,7 +3,6 @@ import { convertToIdentifiers } from '@logto/shared';
 import type { CommonQueryMethods } from 'slonik';
 import { sql, NotFoundError } from 'slonik';
 
-import envSet from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import assertThat from '#src/utils/assert-that.js';
 import { isKeyOf } from '#src/utils/schema.js';
@@ -39,6 +38,3 @@ export const buildFindEntityByIdWithPool =
       }
     };
   };
-
-/** @deprecated Will be removed soon. Use buildFindEntityByIdWithPool() factory instead. */
-export const buildFindEntityById = buildFindEntityByIdWithPool(envSet.pool);

--- a/packages/core/src/database/insert-into.ts
+++ b/packages/core/src/database/insert-into.ts
@@ -10,7 +10,6 @@ import { has } from '@silverhand/essentials';
 import type { CommonQueryMethods, IdentifierSqlToken } from 'slonik';
 import { sql } from 'slonik';
 
-import envSet from '#src/env-set/index.js';
 import { InsertionError } from '#src/errors/SlonikError/index.js';
 import assertThat from '#src/utils/assert-that.js';
 
@@ -86,6 +85,3 @@ export const buildInsertIntoWithPool =
       return entry;
     };
   };
-
-/** @deprecated Will be removed soon. Use buildInsertIntoWithPool() factory instead. */
-export const buildInsertInto = buildInsertIntoWithPool(envSet.pool);

--- a/packages/core/src/database/row-count.ts
+++ b/packages/core/src/database/row-count.ts
@@ -1,14 +1,9 @@
 import type { CommonQueryMethods, IdentifierSqlToken } from 'slonik';
 import { sql } from 'slonik';
 
-import envSet from '#src/env-set/index.js';
-
 export const getTotalRowCountWithPool =
   (pool: CommonQueryMethods) => async (table: IdentifierSqlToken) =>
     pool.one<{ count: number }>(sql`
       select count(*)
       from ${table}
     `);
-
-/** @deprecated Will be removed soon. Use getTotalRowCountWithPool() factory instead. */
-export const getTotalRowCount = getTotalRowCountWithPool(envSet.pool);

--- a/packages/core/src/database/update-where.ts
+++ b/packages/core/src/database/update-where.ts
@@ -6,7 +6,6 @@ import { notFalsy } from '@silverhand/essentials';
 import type { CommonQueryMethods } from 'slonik';
 import { sql } from 'slonik';
 
-import envSet from '#src/env-set/index.js';
 import { UpdateError } from '#src/errors/SlonikError/index.js';
 import assertThat from '#src/utils/assert-that.js';
 import { isKeyOf } from '#src/utils/schema.js';
@@ -72,6 +71,3 @@ export const buildUpdateWhereWithPool =
       return data;
     };
   };
-
-/** @deprecated Will be removed soon. Use buildUpdateWhereWithPool() factory instead. */
-export const buildUpdateWhere = buildUpdateWhereWithPool(envSet.pool);

--- a/packages/core/src/env-set/oidc.ts
+++ b/packages/core/src/env-set/oidc.ts
@@ -16,7 +16,6 @@ const loadOidcValues = async (issuer: string, configs: LogtoOidcConfigType) => {
   const privateJwks = await Promise.all(privateKeys.map(async (key) => exportJWK(key)));
   const publicJwks = await Promise.all(publicKeys.map(async (key) => exportJWK(key)));
   const localJWKSet = createLocalJWKSet({ keys: publicJwks });
-  const refreshTokenReuseInterval = configs[LogtoOidcConfigKey.RefreshTokenReuseInterval];
 
   // Use ES384 if it's an Elliptic Curve key, otherwise fall back to default
   // It's for backwards compatibility since we were using RSA keys before v1.0.0-beta.20
@@ -28,7 +27,6 @@ const loadOidcValues = async (issuer: string, configs: LogtoOidcConfigType) => {
     jwkSigningAlg,
     localJWKSet,
     issuer,
-    refreshTokenReuseInterval,
     defaultIdTokenTtl: 60 * 60,
     defaultRefreshTokenTtl: 14 * 24 * 60 * 60,
   });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,19 +3,19 @@ import dotenv from 'dotenv';
 import { findUp } from 'find-up';
 import Koa from 'koa';
 
+import { EnvSet } from './env-set/index.js';
 import initI18n from './i18n/init.js';
+import { tenantPool } from './tenants/index.js';
 
 dotenv.config({ path: await findUp('.env', {}) });
 
 // Import after env has configured
-const { default: envSet } = await import('./env-set/index.js');
-await envSet.load();
 
 const { loadConnectorFactories } = await import('./utils/connectors/factories.js');
 
 try {
   const app = new Koa({
-    proxy: envSet.values.trustProxyHeader,
+    proxy: EnvSet.values.trustProxyHeader,
   });
   await initI18n();
   await loadConnectorFactories();
@@ -27,5 +27,5 @@ try {
   console.error('Error while initializing app:');
   console.error(error);
 
-  await Promise.all([envSet.poolSafe?.end(), envSet.queryClientSafe?.end()]).catch(noop);
+  await tenantPool.endAll().catch(noop);
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,15 +3,15 @@ import dotenv from 'dotenv';
 import { findUp } from 'find-up';
 import Koa from 'koa';
 
-import { EnvSet } from './env-set/index.js';
 import initI18n from './i18n/init.js';
-import { tenantPool } from './tenants/index.js';
 
 dotenv.config({ path: await findUp('.env', {}) });
 
 // Import after env has configured
 
 const { loadConnectorFactories } = await import('./utils/connectors/factories.js');
+const { EnvSet } = await import('./env-set/index.js');
+const { tenantPool } = await import('./tenants/index.js');
 
 try {
   const app = new Koa({

--- a/packages/core/src/libraries/__mocks__/logto-config.ts
+++ b/packages/core/src/libraries/__mocks__/logto-config.ts
@@ -18,7 +18,6 @@ const { privateKey } = generateKeyPairSync('rsa', {
 const getOidcConfigs = async (): Promise<LogtoOidcConfigType> => ({
   [LogtoOidcConfigKey.PrivateKeys]: [privateKey],
   [LogtoOidcConfigKey.CookieKeys]: ['LOGTOSEKRIT1'],
-  [LogtoOidcConfigKey.RefreshTokenReuseInterval]: 3,
 });
 
 export const createLogtoConfigLibrary = () => ({ getOidcConfigs });

--- a/packages/core/src/libraries/hook.ts
+++ b/packages/core/src/libraries/hook.ts
@@ -29,6 +29,7 @@ export const createHookLibrary = (queries: Queries, { hook }: ModelRouters) => {
   const {
     applications: { findApplicationById },
     logs: { insertLog },
+    // TODO: @gao should we use the library function thus we can pass full userinfo to the payload?
     users: { findUserById },
   } = queries;
 

--- a/packages/core/src/libraries/session.ts
+++ b/packages/core/src/libraries/session.ts
@@ -3,7 +3,7 @@ import type { InteractionResults } from 'oidc-provider';
 import type Provider from 'oidc-provider';
 import { errors } from 'oidc-provider';
 
-import { findUserById, updateUserById } from '#src/queries/user.js';
+import type Queries from '#src/tenants/Queries.js';
 
 export const assignInteractionResults = async (
   ctx: Context,
@@ -32,7 +32,12 @@ export const assignInteractionResults = async (
   ctx.body = { redirectTo };
 };
 
-export const saveUserFirstConsentedAppId = async (userId: string, applicationId: string) => {
+export const saveUserFirstConsentedAppId = async (
+  queries: Queries,
+  userId: string,
+  applicationId: string
+) => {
+  const { findUserById, updateUserById } = queries.users;
   const { applicationId: firstConsentedAppId } = await findUserById(userId);
 
   if (!firstConsentedAppId) {

--- a/packages/core/src/middleware/koa-auth.ts
+++ b/packages/core/src/middleware/koa-auth.ts
@@ -7,7 +7,7 @@ import { jwtVerify } from 'jose';
 import type { MiddlewareType, Request } from 'koa';
 import type { IRouterParamContext } from 'koa-router';
 
-import envSet from '#src/env-set/index.js';
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import assertThat from '#src/utils/assert-that.js';
 
@@ -46,10 +46,11 @@ type TokenInfo = {
 };
 
 export const verifyBearerTokenFromRequest = async (
+  envSet: EnvSet,
   request: Request,
   resourceIndicator: Optional<string>
 ): Promise<TokenInfo> => {
-  const { isProduction, isIntegrationTest, developmentUserId } = envSet.values;
+  const { isProduction, isIntegrationTest, developmentUserId } = EnvSet.values;
   const userId = request.headers['development-user-id']?.toString() ?? developmentUserId;
 
   if ((!isProduction || isIntegrationTest) && userId) {
@@ -78,10 +79,12 @@ export const verifyBearerTokenFromRequest = async (
 };
 
 export default function koaAuth<StateT, ContextT extends IRouterParamContext, ResponseBodyT>(
+  envSet: EnvSet,
   forRole?: UserRole
 ): MiddlewareType<StateT, WithAuthContext<ContextT>, ResponseBodyT> {
   return async (ctx, next) => {
     const { sub, clientId, roleNames } = await verifyBearerTokenFromRequest(
+      envSet,
       ctx.request,
       managementResource.indicator
     );

--- a/packages/core/src/middleware/koa-error-handler.ts
+++ b/packages/core/src/middleware/koa-error-handler.ts
@@ -2,7 +2,7 @@ import type { RequestErrorBody } from '@logto/schemas';
 import type { Middleware } from 'koa';
 import { HttpError } from 'koa';
 
-import envSet from '#src/env-set/index.js';
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 
 export default function koaErrorHandler<StateT, ContextT, BodyT>(): Middleware<
@@ -14,7 +14,7 @@ export default function koaErrorHandler<StateT, ContextT, BodyT>(): Middleware<
     try {
       await next();
     } catch (error: unknown) {
-      if (!envSet.values.isProduction) {
+      if (!EnvSet.values.isProduction) {
         console.error(error);
       }
 
@@ -31,7 +31,7 @@ export default function koaErrorHandler<StateT, ContextT, BodyT>(): Middleware<
       }
 
       // Should log 500 errors in prod anyway
-      if (envSet.values.isProduction) {
+      if (EnvSet.values.isProduction) {
         console.error(error);
       }
 

--- a/packages/core/src/middleware/koa-guard.ts
+++ b/packages/core/src/middleware/koa-guard.ts
@@ -5,7 +5,7 @@ import koaBody from 'koa-body';
 import type { IMiddleware, IRouterParamContext } from 'koa-router';
 import type { ZodType, ZodTypeDef } from 'zod';
 
-import envSet from '#src/env-set/index.js';
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import ServerError from '#src/errors/ServerError/index.js';
 import assertThat from '#src/utils/assert-that.js';
@@ -119,7 +119,7 @@ export default function koaGuard<
       const result = response.safeParse(ctx.body);
 
       if (!result.success) {
-        if (!envSet.values.isProduction) {
+        if (!EnvSet.values.isProduction) {
           console.error('Invalid response:', result.error);
         }
         throw new ServerError();

--- a/packages/core/src/middleware/koa-root-proxy.ts
+++ b/packages/core/src/middleware/koa-root-proxy.ts
@@ -1,7 +1,7 @@
 import type { MiddlewareType } from 'koa';
 import type { IRouterParamContext } from 'koa-router';
 
-import envSet from '#src/env-set/index.js';
+import { EnvSet } from '#src/env-set/index.js';
 import { appendPath } from '#src/utils/url.js';
 
 export default function koaRootProxy<
@@ -9,7 +9,7 @@ export default function koaRootProxy<
   ContextT extends IRouterParamContext,
   ResponseBodyT
 >(): MiddlewareType<StateT, ContextT, ResponseBodyT> {
-  const { endpoint } = envSet.values;
+  const { endpoint } = EnvSet.values;
 
   return async (ctx, next) => {
     const requestPath = ctx.request.path;

--- a/packages/core/src/middleware/koa-spa-proxy.test.ts
+++ b/packages/core/src/middleware/koa-spa-proxy.test.ts
@@ -1,6 +1,7 @@
 import { pickDefault, createMockUtils } from '@logto/shared/esm';
+import Sinon from 'sinon';
 
-import envSet, { MountedApps } from '#src/env-set/index.js';
+import { EnvSet, MountedApps } from '#src/env-set/index.js';
 import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
 
 const { jest } = import.meta;
@@ -53,8 +54,8 @@ describe('koaSpaProxy middleware', () => {
   });
 
   it('production env should overwrite the request path to root if no target ui file are detected', async () => {
-    const spy = jest.spyOn(envSet, 'values', 'get').mockReturnValue({
-      ...envSet.values,
+    const stub = Sinon.stub(EnvSet, 'values').value({
+      ...EnvSet.values,
       isProduction: true,
     });
 
@@ -66,12 +67,12 @@ describe('koaSpaProxy middleware', () => {
 
     expect(mockStaticMiddleware).toBeCalled();
     expect(ctx.request.path).toEqual('/');
-    spy.mockRestore();
+    stub.restore();
   });
 
   it('production env should call the static middleware if path hit the ui file directory', async () => {
-    const spy = jest.spyOn(envSet, 'values', 'get').mockReturnValue({
-      ...envSet.values,
+    const stub = Sinon.stub(EnvSet, 'values').value({
+      ...EnvSet.values,
       isProduction: true,
     });
 
@@ -81,6 +82,6 @@ describe('koaSpaProxy middleware', () => {
 
     await koaSpaProxy()(ctx, next);
     expect(mockStaticMiddleware).toBeCalled();
-    spy.mockRestore();
+    stub.restore();
   });
 });

--- a/packages/core/src/middleware/koa-spa-proxy.ts
+++ b/packages/core/src/middleware/koa-spa-proxy.ts
@@ -5,7 +5,7 @@ import type { MiddlewareType } from 'koa';
 import proxy from 'koa-proxies';
 import type { IRouterParamContext } from 'koa-router';
 
-import envSet, { MountedApps } from '#src/env-set/index.js';
+import { EnvSet, MountedApps } from '#src/env-set/index.js';
 import serveStatic from '#src/middleware/koa-serve-static.js';
 
 export default function koaSpaProxy<StateT, ContextT extends IRouterParamContext, ResponseBodyT>(
@@ -17,7 +17,7 @@ export default function koaSpaProxy<StateT, ContextT extends IRouterParamContext
 
   const distributionPath = path.join('..', packagePath, 'dist');
 
-  const spaProxy: Middleware = envSet.values.isProduction
+  const spaProxy: Middleware = EnvSet.values.isProduction
     ? serveStatic(distributionPath)
     : proxy('*', {
         target: `http://localhost:${port}`,
@@ -45,7 +45,7 @@ export default function koaSpaProxy<StateT, ContextT extends IRouterParamContext
       return next();
     }
 
-    if (!envSet.values.isProduction) {
+    if (!EnvSet.values.isProduction) {
       return spaProxy(ctx, next);
     }
 

--- a/packages/core/src/middleware/koa-spa-session-guard.ts
+++ b/packages/core/src/middleware/koa-spa-session-guard.ts
@@ -2,7 +2,7 @@ import type { MiddlewareType } from 'koa';
 import type { IRouterParamContext } from 'koa-router';
 import type Provider from 'oidc-provider';
 
-import envSet from '#src/env-set/index.js';
+import { EnvSet } from '#src/env-set/index.js';
 import { appendPath } from '#src/utils/url.js';
 
 // Need To Align With UI
@@ -20,7 +20,7 @@ export default function koaSpaSessionGuard<
   ContextT extends IRouterParamContext,
   ResponseBodyT
 >(provider: Provider): MiddlewareType<StateT, ContextT, ResponseBodyT> {
-  const { endpoint } = envSet.values;
+  const { endpoint } = EnvSet.values;
 
   return async (ctx, next) => {
     const requestPath = ctx.request.path;

--- a/packages/core/src/middleware/koa-welcome-proxy.ts
+++ b/packages/core/src/middleware/koa-welcome-proxy.ts
@@ -1,16 +1,17 @@
 import type { MiddlewareType } from 'koa';
 import type { IRouterParamContext } from 'koa-router';
 
-import envSet from '#src/env-set/index.js';
-import { hasActiveUsers } from '#src/queries/user.js';
+import { EnvSet } from '#src/env-set/index.js';
+import type Queries from '#src/tenants/Queries.js';
 import { appendPath } from '#src/utils/url.js';
 
 export default function koaWelcomeProxy<
   StateT,
   ContextT extends IRouterParamContext,
   ResponseBodyT
->(): MiddlewareType<StateT, ContextT, ResponseBodyT> {
-  const { adminConsoleUrl } = envSet.values;
+>(queries: Queries): MiddlewareType<StateT, ContextT, ResponseBodyT> {
+  const { hasActiveUsers } = queries.users;
+  const { adminConsoleUrl } = EnvSet.values;
 
   return async (ctx) => {
     if (await hasActiveUsers()) {

--- a/packages/core/src/oidc/adapter.test.ts
+++ b/packages/core/src/oidc/adapter.test.ts
@@ -3,6 +3,7 @@ import { createMockUtils } from '@logto/shared/esm';
 import snakecaseKeys from 'snakecase-keys';
 
 import { mockApplication } from '#src/__mocks__/index.js';
+import { envSetForTest } from '#src/test-utils/env-set.js';
 import { MockQueries } from '#src/test-utils/tenant.js';
 
 import { getConstantClientMetadata } from './utils.js';
@@ -47,7 +48,7 @@ const now = Date.now();
 describe('postgres Adapter', () => {
   it('Client Modal', async () => {
     const rejectError = new Error('Not implemented');
-    const adapter = postgresAdapter(queries, 'Client');
+    const adapter = postgresAdapter(envSetForTest, queries, 'Client');
 
     await expect(adapter.upsert('client', {}, 0)).rejects.toMatchError(rejectError);
     await expect(adapter.findByUserCode('foo')).rejects.toMatchError(rejectError);
@@ -71,7 +72,7 @@ describe('postgres Adapter', () => {
       client_id,
       client_name,
       client_secret,
-      ...getConstantClientMetadata(type),
+      ...getConstantClientMetadata(envSetForTest, type),
       ...snakecaseKeys(oidcClientMetadata),
       ...customClientMetadata,
     });
@@ -84,7 +85,7 @@ describe('postgres Adapter', () => {
     const id = 'fooId';
     const grantId = 'grantId';
     const expireAt = 60;
-    const adapter = postgresAdapter(queries, modelName);
+    const adapter = postgresAdapter(envSetForTest, queries, modelName);
 
     await adapter.upsert(id, { uid, userCode }, expireAt);
     expect(upsertInstance).toBeCalledWith({

--- a/packages/core/src/oidc/init.test.ts
+++ b/packages/core/src/oidc/init.test.ts
@@ -1,9 +1,12 @@
-import { MockQueries } from '#src/test-utils/tenant.js';
+import { envSetForTest } from '#src/test-utils/env-set.js';
+import { MockTenant } from '#src/test-utils/tenant.js';
 
 import initOidc from './init.js';
 
 describe('oidc provider init', () => {
   it('init should not throw', async () => {
-    expect(() => initOidc(new MockQueries())).not.toThrow();
+    const { queries, libraries } = new MockTenant();
+
+    expect(() => initOidc(envSetForTest, queries, libraries)).not.toThrow();
   });
 });

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -8,13 +8,13 @@ import { tryThat } from '@logto/shared';
 import Provider, { errors } from 'oidc-provider';
 import snakecaseKeys from 'snakecase-keys';
 
-import envSet from '#src/env-set/index.js';
+import type { EnvSet } from '#src/env-set/index.js';
 import { addOidcEventListeners } from '#src/event-listeners/index.js';
-import { createUserLibrary } from '#src/libraries/user.js';
 import koaAuditLog from '#src/middleware/koa-audit-log.js';
 import postgresAdapter from '#src/oidc/adapter.js';
 import { isOriginAllowed, validateCustomClientMetadata } from '#src/oidc/utils.js';
 import { routes } from '#src/routes/consts.js';
+import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
@@ -23,12 +23,7 @@ import { claimToUserKey, getUserClaims } from './scope.js';
 // Temporarily removed 'EdDSA' since it's not supported by browser yet
 const supportedSigningAlgs = Object.freeze(['RS256', 'PS256', 'ES256', 'ES384', 'ES512'] as const);
 
-export default function initOidc(queries: Queries): Provider {
-  const {
-    applications: { findApplicationById },
-    resources: { findResourceByIndicator },
-    users: { findUserById },
-  } = queries;
+export default function initOidc(envSet: EnvSet, queries: Queries, libraries: Libraries): Provider {
   const {
     issuer,
     cookieKeys,
@@ -37,7 +32,11 @@ export default function initOidc(queries: Queries): Provider {
     defaultIdTokenTtl,
     defaultRefreshTokenTtl,
   } = envSet.oidc;
-  const { findUserScopesForResourceId } = createUserLibrary(queries);
+  const {
+    applications: { findApplicationById },
+    resources: { findResourceByIndicator },
+  } = queries;
+  const { findUserByIdWithRoles, findUserScopesForResourceId } = libraries.users;
   const logoutSource = readFileSync('static/html/logout.html', 'utf8');
 
   const cookieConfig = Object.freeze({
@@ -47,7 +46,7 @@ export default function initOidc(queries: Queries): Provider {
   } as const);
 
   const oidc = new Provider(issuer, {
-    adapter: postgresAdapter.bind(null, queries),
+    adapter: postgresAdapter.bind(null, envSet, queries),
     renderError: (_ctx, _out, error) => {
       console.error(error);
 
@@ -136,7 +135,7 @@ export default function initOidc(queries: Queries): Provider {
     claims: userClaims,
     // https://github.com/panva/node-oidc-provider/tree/main/docs#findaccount
     findAccount: async (_ctx, sub) => {
-      const user = await findUserById(sub);
+      const user = await findUserByIdWithRoles(sub);
 
       return {
         accountId: sub,
@@ -192,7 +191,7 @@ export default function initOidc(queries: Queries): Provider {
       if (token.kind === 'AccessToken') {
         const { accountId } = token;
         const { roleNames } = await tryThat(
-          findUserById(accountId),
+          findUserByIdWithRoles(accountId),
           new errors.InvalidClient(`invalid user ${accountId}`)
         );
 

--- a/packages/core/src/oidc/utils.test.ts
+++ b/packages/core/src/oidc/utils.test.ts
@@ -1,5 +1,7 @@
 import { ApplicationType, CustomClientMetadataKey, GrantType } from '@logto/schemas';
 
+import { envSetForTest } from '#src/test-utils/env-set.js';
+
 import {
   isOriginAllowed,
   buildOidcClientMetadata,
@@ -8,22 +10,22 @@ import {
 } from './utils.js';
 
 describe('getConstantClientMetadata()', () => {
-  expect(getConstantClientMetadata(ApplicationType.SPA)).toEqual({
+  expect(getConstantClientMetadata(envSetForTest, ApplicationType.SPA)).toEqual({
     application_type: 'web',
     grant_types: [GrantType.AuthorizationCode, GrantType.RefreshToken],
     token_endpoint_auth_method: 'none',
   });
-  expect(getConstantClientMetadata(ApplicationType.Native)).toEqual({
+  expect(getConstantClientMetadata(envSetForTest, ApplicationType.Native)).toEqual({
     application_type: 'native',
     grant_types: [GrantType.AuthorizationCode, GrantType.RefreshToken],
     token_endpoint_auth_method: 'none',
   });
-  expect(getConstantClientMetadata(ApplicationType.Traditional)).toEqual({
+  expect(getConstantClientMetadata(envSetForTest, ApplicationType.Traditional)).toEqual({
     application_type: 'web',
     grant_types: [GrantType.AuthorizationCode, GrantType.RefreshToken],
     token_endpoint_auth_method: 'client_secret_basic',
   });
-  expect(getConstantClientMetadata(ApplicationType.MachineToMachine)).toEqual({
+  expect(getConstantClientMetadata(envSetForTest, ApplicationType.MachineToMachine)).toEqual({
     application_type: 'web',
     grant_types: [GrantType.ClientCredentials],
     token_endpoint_auth_method: 'client_secret_basic',

--- a/packages/core/src/oidc/utils.ts
+++ b/packages/core/src/oidc/utils.ts
@@ -4,9 +4,12 @@ import { conditional } from '@silverhand/essentials';
 import type { AllClientMetadata, ClientAuthMethod } from 'oidc-provider';
 import { errors } from 'oidc-provider';
 
-import envSet from '#src/env-set/index.js';
+import type { EnvSet } from '#src/env-set/index.js';
 
-export const getConstantClientMetadata = (type: ApplicationType): AllClientMetadata => {
+export const getConstantClientMetadata = (
+  envSet: EnvSet,
+  type: ApplicationType
+): AllClientMetadata => {
   const { jwkSigningAlg } = envSet.oidc;
 
   const getTokenEndpointAuthMethod = (): ClientAuthMethod => {

--- a/packages/core/src/queries/roles.ts
+++ b/packages/core/src/queries/roles.ts
@@ -8,7 +8,6 @@ import { sql } from 'slonik';
 import { buildFindEntityByIdWithPool } from '#src/database/find-entity-by-id.js';
 import { buildInsertIntoWithPool } from '#src/database/insert-into.js';
 import { buildUpdateWhereWithPool } from '#src/database/update-where.js';
-import envSet from '#src/env-set/index.js';
 import { DeletionError } from '#src/errors/SlonikError/index.js';
 import type { Search } from '#src/utils/search.js';
 import { buildConditionsFromSearch } from '#src/utils/search.js';
@@ -132,18 +131,3 @@ export const createRolesQueries = (pool: CommonQueryMethods) => {
     deleteRoleById,
   };
 };
-
-/** @deprecated Will be removed soon. Use createRolesQueries() factory instead. */
-export const {
-  countRoles,
-  findRoles,
-  findRolesByRoleIds,
-  findRolesByRoleNames,
-  findRoleByRoleName,
-  insertRoles,
-  insertRole,
-  findRoleById,
-  updateRole,
-  updateRoleById,
-  deleteRoleById,
-} = createRolesQueries(envSet.pool);

--- a/packages/core/src/queries/user.ts
+++ b/packages/core/src/queries/user.ts
@@ -1,4 +1,4 @@
-import type { User, CreateUser, UserWithRoleNames } from '@logto/schemas';
+import type { User, CreateUser } from '@logto/schemas';
 import { SearchJointMode, Users } from '@logto/schemas';
 import type { OmitAutoSetFields } from '@logto/shared';
 import { conditionalSql, convertToIdentifiers } from '@logto/shared';
@@ -6,14 +6,9 @@ import type { CommonQueryMethods } from 'slonik';
 import { sql } from 'slonik';
 
 import { buildUpdateWhereWithPool } from '#src/database/update-where.js';
-import envSet from '#src/env-set/index.js';
 import { DeletionError } from '#src/errors/SlonikError/index.js';
 import type { Search } from '#src/utils/search.js';
 import { buildConditionsFromSearch } from '#src/utils/search.js';
-
-// TODO: @sijie remove this
-import { findRolesByRoleIds } from './roles.js';
-import { findUsersRolesByUserId } from './users-roles.js';
 
 const { table, fields } = convertToIdentifiers(Users);
 
@@ -39,22 +34,12 @@ export const createUserQueries = (pool: CommonQueryMethods) => {
       where ${fields.primaryPhone}=${phone}
     `);
 
-  const findUserById = async (id: string): Promise<UserWithRoleNames> => {
-    const user = await pool.one<User>(sql`
+  const findUserById = async (id: string): Promise<User> =>
+    pool.one<User>(sql`
       select ${sql.join(Object.values(fields), sql`,`)}
       from ${table}
       where ${fields.id}=${id}
     `);
-    const userRoles = await findUsersRolesByUserId(user.id);
-
-    const roles =
-      userRoles.length > 0 ? await findRolesByRoleIds(userRoles.map(({ roleId }) => roleId)) : [];
-
-    return {
-      ...user,
-      roleNames: roles.map(({ name }) => name),
-    };
-  };
 
   const findUserByIdentity = async (target: string, userId: string) =>
     pool.maybeOne<User>(
@@ -237,25 +222,3 @@ export const createUserQueries = (pool: CommonQueryMethods) => {
     getDailyNewUserCountsByTimeInterval,
   };
 };
-
-/** @deprecated Will be removed soon. Use createUserQueries() factory instead. */
-export const {
-  findUserByUsername,
-  findUserByEmail,
-  findUserByPhone,
-  findUserById,
-  findUserByIdentity,
-  hasUser,
-  hasUserWithId,
-  hasUserWithEmail,
-  hasUserWithPhone,
-  hasUserWithIdentity,
-  countUsers,
-  findUsers,
-  findUsersByIds,
-  updateUserById,
-  deleteUserById,
-  deleteUserIdentity,
-  hasActiveUsers,
-  getDailyNewUserCountsByTimeInterval,
-} = createUserQueries(envSet.pool);

--- a/packages/core/src/queries/users-roles.ts
+++ b/packages/core/src/queries/users-roles.ts
@@ -4,7 +4,6 @@ import { conditionalSql, convertToIdentifiers } from '@logto/shared';
 import type { CommonQueryMethods } from 'slonik';
 import { sql } from 'slonik';
 
-import envSet from '#src/env-set/index.js';
 import { DeletionError } from '#src/errors/SlonikError/index.js';
 
 const { table, fields } = convertToIdentifiers(UsersRoles);
@@ -72,13 +71,3 @@ export const createUsersRolesQueries = (pool: CommonQueryMethods) => {
     deleteUsersRolesByUserIdAndRoleId,
   };
 };
-
-/** @deprecated Will be removed soon. Use createUsersRolesQueries() factory instead. */
-export const {
-  countUsersRolesByRoleId,
-  findFirstUsersRolesByRoleIdAndUserIds,
-  findUsersRolesByUserId,
-  findUsersRolesByRoleId,
-  insertUsersRoles,
-  deleteUsersRolesByUserIdAndRoleId,
-} = createUsersRolesQueries(envSet.pool);

--- a/packages/core/src/routes/admin-user.test.ts
+++ b/packages/core/src/routes/admin-user.test.ts
@@ -92,6 +92,7 @@ const { encryptUserPassword } = await mockEsmWithActual('#src/libraries/user.js'
 }));
 
 const usersLibraries = {
+  findUserByIdWithRoles: jest.fn(async (id: string) => mockUser),
   generateUserId: jest.fn(async () => 'fooId'),
   insertUser: jest.fn(
     async (user: CreateUser): Promise<User> => ({
@@ -100,6 +101,7 @@ const usersLibraries = {
     })
   ),
 } satisfies Partial<Libraries['users']>;
+const { findUserByIdWithRoles } = usersLibraries;
 
 const adminUserRoutes = await pickDefault(import('./admin-user.js'));
 
@@ -279,7 +281,7 @@ describe('adminUserRoutes', () => {
     const name = 'Michael';
     const avatar = 'http://www.michael.png';
 
-    findUserById.mockImplementationOnce(() => {
+    findUserByIdWithRoles.mockImplementationOnce(() => {
       throw new Error(' ');
     });
 
@@ -324,7 +326,7 @@ describe('adminUserRoutes', () => {
     await expect(
       userRequest.patch('/users/foo').send({ roleNames: ['superadmin'] })
     ).resolves.toHaveProperty('status', 400);
-    expect(findUserById).toHaveBeenCalledTimes(1);
+    expect(findUserByIdWithRoles).toHaveBeenCalledTimes(1);
     expect(updateUserById).not.toHaveBeenCalled();
   });
 
@@ -341,7 +343,7 @@ describe('adminUserRoutes', () => {
     const password = '123456';
     const response = await userRequest.patch(`/users/${mockedUserId}/password`).send({ password });
     expect(encryptUserPassword).toHaveBeenCalledWith(password);
-    expect(updateUserById).toHaveBeenCalledTimes(1);
+    expect(findUserById).toHaveBeenCalledTimes(1);
     expect(response.status).toEqual(200);
     expect(response.body).toEqual({
       ...mockUserResponse,

--- a/packages/core/src/routes/admin-user.ts
+++ b/packages/core/src/routes/admin-user.ts
@@ -34,7 +34,13 @@ export default function adminUserRoutes<T extends AuthedRouter>(
     usersRoles: { deleteUsersRolesByUserIdAndRoleId, findUsersRolesByRoleId, insertUsersRoles },
   } = queries;
   const {
-    users: { checkIdentifierCollision, generateUserId, insertUser, findUsersByRoleName },
+    users: {
+      checkIdentifierCollision,
+      generateUserId,
+      insertUser,
+      findUsersByRoleName,
+      findUserByIdWithRoles,
+    },
   } = libraries;
 
   router.get('/users', koaPagination(), async (ctx, next) => {
@@ -81,7 +87,7 @@ export default function adminUserRoutes<T extends AuthedRouter>(
         params: { userId },
       } = ctx.guard;
 
-      const user = await findUserById(userId);
+      const user = await findUserByIdWithRoles(userId);
 
       ctx.body = pick(user, 'roleNames', ...userInfoSelectFields);
 
@@ -204,7 +210,7 @@ export default function adminUserRoutes<T extends AuthedRouter>(
         body,
       } = ctx.guard;
 
-      const user = await findUserById(userId);
+      const user = await findUserByIdWithRoles(userId);
       await checkIdentifierCollision(body, userId);
 
       const { roleNames, ...userUpdates } = body;
@@ -357,6 +363,8 @@ export default function adminUserRoutes<T extends AuthedRouter>(
       ctx.body = pick(updatedUser, ...userInfoSelectFields);
 
       return next();
+      // TODO: @sijie break into smaller files
+      // eslint-disable-next-line max-lines
     }
   );
 }

--- a/packages/core/src/routes/authn.test.ts
+++ b/packages/core/src/routes/authn.test.ts
@@ -1,7 +1,6 @@
 import { pickDefault, createMockUtils } from '@logto/shared/esm';
 
 import RequestError from '#src/errors/RequestError/index.js';
-import { createRequester } from '#src/utils/test-utils.js';
 
 const { jest } = import.meta;
 const { mockEsmWithActual } = createMockUtils(jest);
@@ -13,6 +12,7 @@ const { verifyBearerTokenFromRequest } = await mockEsmWithActual(
   })
 );
 
+const { createRequester } = await import('#src/utils/test-utils.js');
 const request = createRequester({
   anonymousRoutes: await pickDefault(import('#src/routes/authn.js')),
 });
@@ -71,7 +71,7 @@ describe('authn route for Hasura', () => {
 
   describe('with failed verification', () => {
     beforeEach(() => {
-      verifyBearerTokenFromRequest.mockImplementation(async (_, resource) => {
+      verifyBearerTokenFromRequest.mockImplementation(async (_, __, resource) => {
         if (resource) {
           throw new RequestError({ code: 'auth.jwt_sub_missing', status: 401 });
         }

--- a/packages/core/src/routes/authn.ts
+++ b/packages/core/src/routes/authn.ts
@@ -12,7 +12,9 @@ import type { AnonymousRouter, RouterInitArgs } from './types.js';
  * This router will have a route `/authn` to authenticate tokens with a general manner.
  * For now, we only implement the API for Hasura authentication.
  */
-export default function authnRoutes<T extends AnonymousRouter>(...[router]: RouterInitArgs<T>) {
+export default function authnRoutes<T extends AnonymousRouter>(
+  ...[router, { envSet }]: RouterInitArgs<T>
+) {
   router.get(
     '/authn/hasura',
     koaGuard({
@@ -25,7 +27,7 @@ export default function authnRoutes<T extends AnonymousRouter>(...[router]: Rout
 
       const verifyToken = async (expectedResource?: string) => {
         try {
-          return await verifyBearerTokenFromRequest(ctx.request, expectedResource);
+          return await verifyBearerTokenFromRequest(envSet, ctx.request, expectedResource);
         } catch {
           return {
             sub: undefined,

--- a/packages/core/src/routes/init.ts
+++ b/packages/core/src/routes/init.ts
@@ -31,7 +31,7 @@ const createRouters = (tenant: TenantContext) => {
   interactionRoutes(interactionRouter, tenant);
 
   const managementRouter: AuthedRouter = new Router();
-  managementRouter.use(koaAuth(UserRole.Admin));
+  managementRouter.use(koaAuth(tenant.envSet, UserRole.Admin));
   applicationRoutes(managementRouter, tenant);
   settingRoutes(managementRouter, tenant);
   connectorRoutes(managementRouter, tenant);

--- a/packages/core/src/routes/interaction/consent.test.ts
+++ b/packages/core/src/routes/interaction/consent.test.ts
@@ -2,8 +2,10 @@ import type { User } from '@logto/schemas';
 import { createMockUtils } from '@logto/shared/esm';
 
 import { mockUser } from '#src/__mocks__/index.js';
-import { GrantMock } from '#src/test-utils/oidc-provider.js';
-import { createMockTenantWithInteraction } from '#src/test-utils/tenant.js';
+import type Queries from '#src/tenants/Queries.js';
+import { createMockProvider, GrantMock } from '#src/test-utils/oidc-provider.js';
+import type { Partial2 } from '#src/test-utils/tenant.js';
+import { MockTenant } from '#src/test-utils/tenant.js';
 import { createRequester } from '#src/utils/test-utils.js';
 
 import { interactionPrefix } from './const.js';
@@ -28,10 +30,14 @@ class Grant extends GrantMock {
   }
 }
 
-const { findUserById, updateUserById } = await mockEsmWithActual('#src/queries/user.js', () => ({
+const userQueries = {
   findUserById: jest.fn(async (): Promise<User> => mockUser),
   updateUserById: jest.fn(async (..._args: unknown[]) => ({ id: 'id' })),
-}));
+};
+const { findUserById, updateUserById } = userQueries;
+
+// @ts-expect-error
+const queries: Partial2<Queries> = { users: userQueries };
 
 const { assignInteractionResults } = await mockEsmWithActual('#src/libraries/session.js', () => ({
   assignInteractionResults: jest.fn(),
@@ -53,9 +59,9 @@ describe('interaction -> consent', () => {
   it('with empty details and reusing old grant', async () => {
     const sessionRequest = createRequester({
       anonymousRoutes: interactionRoutes,
-      tenantContext: createMockTenantWithInteraction(
-        jest.fn().mockResolvedValue(baseInteractionDetails),
-        Grant
+      tenantContext: new MockTenant(
+        createMockProvider(jest.fn().mockResolvedValue(baseInteractionDetails), Grant),
+        queries
       ),
     });
 
@@ -74,12 +80,15 @@ describe('interaction -> consent', () => {
   it('with empty details and creating new grant', async () => {
     const sessionRequest = createRequester({
       anonymousRoutes: interactionRoutes,
-      tenantContext: createMockTenantWithInteraction(
-        jest.fn().mockResolvedValue({
-          ...baseInteractionDetails,
-          grantId: 'exists',
-        }),
-        Grant
+      tenantContext: new MockTenant(
+        createMockProvider(
+          jest.fn().mockResolvedValue({
+            ...baseInteractionDetails,
+            grantId: 'exists',
+          }),
+          Grant
+        ),
+        queries
       ),
     });
 
@@ -99,16 +108,19 @@ describe('interaction -> consent', () => {
   it('should save application id when the user first consented', async () => {
     const sessionRequest = createRequester({
       anonymousRoutes: interactionRoutes,
-      tenantContext: createMockTenantWithInteraction(
-        jest.fn().mockResolvedValue({
-          ...baseInteractionDetails,
-          prompt: {
-            name: 'consent',
-            details: {},
-            reasons: ['consent_prompt', 'native_client_prompt'],
-          },
-        }),
-        Grant
+      tenantContext: new MockTenant(
+        createMockProvider(
+          jest.fn().mockResolvedValue({
+            ...baseInteractionDetails,
+            prompt: {
+              name: 'consent',
+              details: {},
+              reasons: ['consent_prompt', 'native_client_prompt'],
+            },
+          }),
+          Grant
+        ),
+        queries
       ),
     });
 
@@ -121,20 +133,23 @@ describe('interaction -> consent', () => {
   it('missingOIDCScope and missingResourceScopes', async () => {
     const sessionRequest = createRequester({
       anonymousRoutes: interactionRoutes,
-      tenantContext: createMockTenantWithInteraction(
-        jest.fn().mockResolvedValue({
-          ...baseInteractionDetails,
-          prompt: {
-            details: {
-              missingOIDCScope: ['scope1', 'scope2'],
-              missingResourceScopes: {
-                resource1: ['scope1', 'scope2'],
-                resource2: ['scope3'],
+      tenantContext: new MockTenant(
+        createMockProvider(
+          jest.fn().mockResolvedValue({
+            ...baseInteractionDetails,
+            prompt: {
+              details: {
+                missingOIDCScope: ['scope1', 'scope2'],
+                missingResourceScopes: {
+                  resource1: ['scope1', 'scope2'],
+                  resource2: ['scope3'],
+                },
               },
             },
-          },
-        }),
-        Grant
+          }),
+          Grant
+        ),
+        queries
       ),
     });
 

--- a/packages/core/src/routes/interaction/index.ts
+++ b/packages/core/src/routes/interaction/index.ts
@@ -297,7 +297,7 @@ export default function interactionRoutes<T extends AnonymousRouter>(
       const verifiedInteraction = await verifyProfile(tenant, accountVerifiedInteraction);
 
       if (event !== InteractionEvent.ForgotPassword) {
-        await validateMandatoryUserProfile(ctx, verifiedInteraction);
+        await validateMandatoryUserProfile(queries.users, ctx, verifiedInteraction);
       }
 
       await submitInteraction(verifiedInteraction, ctx, tenant, log);
@@ -351,5 +351,5 @@ export default function interactionRoutes<T extends AnonymousRouter>(
     }
   );
 
-  consentRoutes(router, provider);
+  consentRoutes(router, tenant);
 }

--- a/packages/core/src/routes/interaction/verifications/mandatory-user-profile-validation.ts
+++ b/packages/core/src/routes/interaction/verifications/mandatory-user-profile-validation.ts
@@ -4,7 +4,7 @@ import type { Nullable } from '@silverhand/essentials';
 import type { Context } from 'koa';
 
 import RequestError from '#src/errors/RequestError/index.js';
-import { findUserById } from '#src/queries/user.js';
+import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
 import type { WithInteractionSieContext } from '../middleware/koa-interaction-sie.js';
@@ -84,13 +84,15 @@ const validateRegisterMandatoryUserProfile = (profile?: Profile) => {
 };
 
 export default async function validateMandatoryUserProfile(
+  userQueries: Queries['users'],
   ctx: WithInteractionSieContext<Context>,
   interaction: IdentifierVerifiedInteractionResult
 ) {
   const { signUp } = ctx.signInExperience;
   const { event, accountId, profile } = interaction;
 
-  const user = event === InteractionEvent.Register ? null : await findUserById(accountId);
+  const user =
+    event === InteractionEvent.Register ? null : await userQueries.findUserById(accountId);
   const missingProfileSet = getMissingProfileBySignUpIdentifiers({ signUp, user, profile });
 
   assertThat(

--- a/packages/core/src/tenants/Tenant.test.ts
+++ b/packages/core/src/tenants/Tenant.test.ts
@@ -29,8 +29,8 @@ mockEsmDefault('#src/oidc/init.js', () => () => createMockProvider());
 const Tenant = await pickDefault(import('./Tenant.js'));
 
 describe('Tenant', () => {
-  it('should call middleware factories', () => {
-    const _ = new Tenant('foo');
+  it('should call middleware factories', async () => {
+    await Tenant.create('foo');
 
     for (const middleware of middlewareList) {
       expect(middleware).toBeCalled();

--- a/packages/core/src/tenants/Tenant.ts
+++ b/packages/core/src/tenants/Tenant.ts
@@ -5,7 +5,7 @@ import koaLogger from 'koa-logger';
 import mount from 'koa-mount';
 import type Provider from 'oidc-provider';
 
-import envSet, { MountedApps } from '#src/env-set/index.js';
+import { EnvSet, MountedApps } from '#src/env-set/index.js';
 import koaCheckDemoApp from '#src/middleware/koa-check-demo-app.js';
 import koaConnectorErrorHandler from '#src/middleware/koa-connector-error-handler.js';
 import koaErrorHandler from '#src/middleware/koa-error-handler.js';
@@ -26,6 +26,13 @@ import Queries from './Queries.js';
 import type TenantContext from './TenantContext.js';
 
 export default class Tenant implements TenantContext {
+  static async create(id: string) {
+    const envSet = new EnvSet();
+    await envSet.load();
+
+    return new Tenant(envSet, id);
+  }
+
   public readonly provider: Provider;
   public readonly queries: Queries;
   public readonly libraries: Libraries;
@@ -37,11 +44,12 @@ export default class Tenant implements TenantContext {
     return mount(this.app);
   }
 
-  constructor(public id: string) {
+  constructor(public readonly envSet: EnvSet, public readonly id: string) {
     const modelRouters = createModelRouters(envSet.queryClient);
     const queries = new Queries(envSet.pool);
     const libraries = new Libraries(queries, modelRouters);
 
+    this.envSet = envSet;
     this.modelRouters = modelRouters;
     this.queries = queries;
     this.libraries = libraries;
@@ -49,7 +57,7 @@ export default class Tenant implements TenantContext {
     // Init app
     const app = new Koa();
 
-    const provider = initOidc(queries);
+    const provider = initOidc(envSet, queries, libraries);
     app.use(mount('/oidc', provider.app));
 
     app.use(koaLogger());
@@ -59,12 +67,12 @@ export default class Tenant implements TenantContext {
     app.use(koaConnectorErrorHandler());
     app.use(koaI18next());
 
-    const apisApp = initRouter({ provider, queries, libraries, modelRouters });
+    const apisApp = initRouter({ provider, queries, libraries, modelRouters, envSet });
     app.use(mount('/api', apisApp));
 
     app.use(mount('/', koaRootProxy()));
 
-    app.use(mount('/' + MountedApps.Welcome, koaWelcomeProxy()));
+    app.use(mount('/' + MountedApps.Welcome, koaWelcomeProxy(queries)));
 
     app.use(
       mount('/' + MountedApps.Console, koaSpaProxy(MountedApps.Console, 5002, MountedApps.Console))

--- a/packages/core/src/tenants/TenantContext.ts
+++ b/packages/core/src/tenants/TenantContext.ts
@@ -1,11 +1,13 @@
 import type Provider from 'oidc-provider';
 
+import type { EnvSet } from '#src/env-set/index.js';
 import type { ModelRouters } from '#src/model-routers/index.js';
 
 import type Libraries from './Libraries.js';
 import type Queries from './Queries.js';
 
 export default abstract class TenantContext {
+  public abstract readonly envSet: EnvSet;
   public abstract readonly provider: Provider;
   public abstract readonly queries: Queries;
   public abstract readonly libraries: Libraries;

--- a/packages/core/src/tenants/index.ts
+++ b/packages/core/src/tenants/index.ts
@@ -5,17 +5,27 @@ import Tenant from './Tenant.js';
 class TenantPool {
   protected cache = new LRUCache<string, Tenant>({ max: 500 });
 
-  get(tenantId: string): Tenant {
+  async get(tenantId: string): Promise<Tenant> {
     const tenant = this.cache.get(tenantId);
 
     if (tenant) {
       return tenant;
     }
 
-    const newTenant = new Tenant(tenantId);
+    const newTenant = await Tenant.create(tenantId);
     this.cache.set(tenantId, newTenant);
 
     return newTenant;
+  }
+
+  async endAll(): Promise<void> {
+    await Promise.all(
+      this.cache.dump().flatMap(([, tenant]) => {
+        const { poolSafe, queryClientSafe } = tenant.value.envSet;
+
+        return [poolSafe?.end(), queryClientSafe?.end()];
+      })
+    );
   }
 }
 

--- a/packages/core/src/test-utils/env-set.ts
+++ b/packages/core/src/test-utils/env-set.ts
@@ -1,0 +1,6 @@
+import { EnvSet } from '#src/env-set/index.js';
+
+/** FOR TEST PURPOSE ONLY, DON'T USE IN PROD. */
+export const envSetForTest = new EnvSet();
+
+await envSetForTest.load();

--- a/packages/core/src/test-utils/tenant.ts
+++ b/packages/core/src/test-utils/tenant.ts
@@ -5,6 +5,7 @@ import Libraries from '#src/tenants/Libraries.js';
 import Queries from '#src/tenants/Queries.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 
+import { envSetForTest } from './env-set.js';
 import type { GrantMock } from './oidc-provider.js';
 import { createMockProvider } from './oidc-provider.js';
 import { MockQueryClient } from './query-client.js';
@@ -44,6 +45,7 @@ export type DeepPartial<T> = T extends object
 export type Partial2<T> = { [key in keyof T]?: Partial<T[key]> };
 
 export class MockTenant implements TenantContext {
+  public envSet = envSetForTest;
   public queries: Queries;
   public libraries: Libraries;
   public modelRouters = createModelRouters(new MockQueryClient());

--- a/packages/schemas/src/types/logto-config.ts
+++ b/packages/schemas/src/types/logto-config.ts
@@ -25,13 +25,11 @@ export const alterationStateGuard: Readonly<{
 export enum LogtoOidcConfigKey {
   PrivateKeys = 'oidc.privateKeys',
   CookieKeys = 'oidc.cookieKeys',
-  RefreshTokenReuseInterval = 'oidc.refreshTokenReuseInterval',
 }
 
 export type LogtoOidcConfigType = {
   [LogtoOidcConfigKey.PrivateKeys]: string[];
   [LogtoOidcConfigKey.CookieKeys]: string[];
-  [LogtoOidcConfigKey.RefreshTokenReuseInterval]: number;
 };
 
 export const logtoOidcConfigGuard: Readonly<{
@@ -39,12 +37,6 @@ export const logtoOidcConfigGuard: Readonly<{
 }> = Object.freeze({
   [LogtoOidcConfigKey.PrivateKeys]: z.string().array(),
   [LogtoOidcConfigKey.CookieKeys]: z.string().array(),
-  /**
-   * This interval helps to avoid concurrency issues when exchanging the rotating refresh token multiple times within a given timeframe.
-   * During the leeway window (in seconds), the consumed refresh token will be considered as valid.
-   * This is useful for distributed apps and serverless apps like Next.js, in which there is no shared memory.
-   */
-  [LogtoOidcConfigKey.RefreshTokenReuseInterval]: z.number().gte(3),
 });
 
 // Summary


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- remove deprecated database query builders
- remove default env set, now every env set always has a tenant context
- remove `refreshTokenReuseInterval` configuration and hard code to 3s

also resolves LOG-5115

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
CI
