### PR TITLE
fix(schemas): modify management api default scope name

### DIFF
--- a/packages/schemas/alterations/next-1673465463-ac-scope-name.ts
+++ b/packages/schemas/alterations/next-1673465463-ac-scope-name.ts
@@ -1,0 +1,22 @@
+import { sql } from 'slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const newScopeName = 'management-api:default';
+const oldScopeName = 'default';
+const recordId = 'management-api-scope';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      update scopes set name = ${newScopeName} where id = ${recordId}
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      update scopes set name = ${oldScopeName} where id = ${recordId}
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/seeds/scope.ts
+++ b/packages/schemas/src/seeds/scope.ts
@@ -5,7 +5,7 @@ export const managementResourceScopeId = 'management-api-scope';
 
 export const managementResourceScope: Readonly<CreateScope> = Object.freeze({
   id: managementResourceScopeId,
-  name: 'default',
+  name: 'management-api:default',
   description: 'Default scope for management API',
   resourceId: managementResourceId,
 });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
modify management api default scope name to `mangement-api-default`, the original name `default` may be ambigous in some situations.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested with the DB seeded from master branch.
