### PR TITLE
feat: update get/set connector session for multiple times read/write

### DIFF
--- a/.changeset-staged/good-feet-own.md
+++ b/.changeset-staged/good-feet-own.md
@@ -4,3 +4,4 @@
 
 1. Add `connectorId`, `connectorFactoryId` and `jti` to `GetAuthorizationUri`.
 2. Make `ConnectorSession` compatible for arbitrary keys.
+3. Add `mode` (controls the connector session updating scheme) and `preserveResult` (controls whether to clear connector session after getting operation) to `SetSession` and `GetSession` respectively.

--- a/packages/core/src/routes/interaction/utils/interaction.ts
+++ b/packages/core/src/routes/interaction/utils/interaction.ts
@@ -1,4 +1,4 @@
-import type { ConnectorSession } from '@logto/connector-kit';
+import type { ConnectorSession, SetSessionMode } from '@logto/connector-kit';
 import { connectorSessionGuard } from '@logto/connector-kit';
 import type { Profile } from '@logto/schemas';
 import { InteractionEvent } from '@logto/schemas';
@@ -137,7 +137,7 @@ export const assignConnectorSessionResult = async (
   ctx: Context,
   provider: Provider,
   connectorSession: ConnectorSession,
-  mode: 'replace' | 'merge' = 'replace'
+  mode: SetSessionMode = 'replace'
 ) => {
   const { result } = await provider.interactionDetails(ctx.req, ctx.res);
 
@@ -167,7 +167,7 @@ export const assignConnectorSessionResult = async (
 export const getConnectorSessionResult = async (
   ctx: Context,
   provider: Provider,
-  clearAfterGet = true
+  preserveResult = false
 ): Promise<ConnectorSession> => {
   const { result } = await provider.interactionDetails(ctx.req, ctx.res);
 
@@ -182,7 +182,7 @@ export const getConnectorSessionResult = async (
     'session.connector_validation_session_not_found'
   );
 
-  if (clearAfterGet) {
+  if (!preserveResult) {
     const { connectorSession, ...rest } = result;
     await provider.interactionResult(ctx.req, ctx.res, {
       ...rest,

--- a/packages/core/src/routes/interaction/utils/social-verification.ts
+++ b/packages/core/src/routes/interaction/utils/social-verification.ts
@@ -1,6 +1,7 @@
-import type { ConnectorSession, SocialUserInfo } from '@logto/connector-kit';
+import type { ConnectorSession, SetSessionMode, SocialUserInfo } from '@logto/connector-kit';
 import type { SocialConnectorPayload } from '@logto/schemas';
 import { ConnectorType } from '@logto/schemas';
+import type { Optional } from '@silverhand/essentials';
 
 import type { WithLogContext } from '#src/middleware/koa-audit-log.js';
 import {
@@ -50,8 +51,8 @@ export const createSocialAuthorizationUrl = async (
       jti,
       headers: { userAgent },
     },
-    async (connectorStorage: ConnectorSession) =>
-      assignConnectorSessionResult(ctx, provider, connectorStorage)
+    async (connectorStorage: ConnectorSession, mode: SetSessionMode) =>
+      assignConnectorSessionResult(ctx, provider, connectorStorage, mode)
   );
 };
 
@@ -67,8 +68,11 @@ export const verifySocialIdentity = async (
   const log = ctx.createLog('Interaction.SignIn.Identifier.Social.Submit');
   log.append({ connectorId, connectorData });
 
-  const userInfo = await getUserInfoByAuthCode(connectorId, connectorData, async () =>
-    getConnectorSessionResult(ctx, provider)
+  const userInfo = await getUserInfoByAuthCode(
+    connectorId,
+    connectorData,
+    async (preserveResult: Optional<boolean>) =>
+      getConnectorSessionResult(ctx, provider, preserveResult)
   );
 
   log.append(userInfo);

--- a/packages/toolkit/connector-kit/src/types.ts
+++ b/packages/toolkit/connector-kit/src/types.ts
@@ -1,5 +1,6 @@
 import type { LanguageTag } from '@logto/language-kit';
 import { isLanguageTag } from '@logto/language-kit';
+import type { Optional } from '@silverhand/essentials';
 import type { ZodType } from 'zod';
 import { z } from 'zod';
 
@@ -136,9 +137,11 @@ export const connectorSessionGuard = z
 
 export type ConnectorSession = z.infer<typeof connectorSessionGuard>;
 
-export type GetSession = () => Promise<ConnectorSession>;
+export type GetSession = (preserveResult?: boolean) => Promise<ConnectorSession>;
 
-export type SetSession = (storage: ConnectorSession) => Promise<void>;
+export type SetSessionMode = Optional<'replace' | 'merge'>;
+
+export type SetSession = (storage: ConnectorSession, mode: SetSessionMode) => Promise<void>;
 
 export type BaseConnector<Type extends ConnectorType> = {
   type: Type;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Update get/set connector session to support multiple times read and write.
In the previous design, every time we get the connector session, connector info stored in the session will hence be cleared. Set connector session ONLY support `replace` update scheme, now we can merge new updates with existing storage.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A
