### PR TITLE
refactor(console): table hover behaviors

### DIFF
--- a/packages/console/src/components/Table/index.module.scss
+++ b/packages/console/src/components/Table/index.module.scss
@@ -67,28 +67,28 @@
 
           &.clickable {
             cursor: pointer;
+          }
+        }
 
-            &:hover {
-              background: var(--color-hover);
+        tr.hoverEffect:hover {
+          background: var(--color-hover);
 
-              td {
-                border-top: 1px solid transparent;
-              }
+          td {
+            border-top: 1px solid transparent;
+          }
 
-              + tr {
-                td {
-                  border-top: 1px solid transparent;
-                }
-              }
-
-              td:first-child {
-                border-radius: 8px 0 0 8px;
-              }
-
-              td:last-child {
-                border-radius: 0 8px 8px 0;
-              }
+          + tr {
+            td {
+              border-top: 1px solid transparent;
             }
+          }
+
+          td:first-child {
+            border-radius: 8px 0 0 8px;
+          }
+
+          td:last-child {
+            border-radius: 0 8px 8px 0;
           }
         }
       }

--- a/packages/console/src/components/Table/index.tsx
+++ b/packages/console/src/components/Table/index.tsx
@@ -28,6 +28,7 @@ type Props<
   columns: Array<Column<TFieldValues>>;
   rowIndexKey: TName;
   filter?: ReactNode;
+  isRowHoverEffectDisabled?: boolean;
   isRowClickable?: (row: TFieldValues) => boolean;
   rowClickHandler?: (row: TFieldValues) => void;
   className?: string;
@@ -48,6 +49,7 @@ const Table = <
   columns,
   rowIndexKey,
   filter,
+  isRowHoverEffectDisabled = false,
   rowClickHandler,
   isRowClickable = () => Boolean(rowClickHandler),
   className,
@@ -130,7 +132,10 @@ const Table = <
                     return (
                       <tr
                         key={row[rowIndexKey]}
-                        className={classNames(rowClickable && styles.clickable)}
+                        className={classNames(
+                          rowClickable && styles.clickable,
+                          !isRowHoverEffectDisabled && styles.hoverEffect
+                        )}
                         onClick={onClick}
                       >
                         {columns.map(({ dataIndex, colSpan, className, render }) => (

--- a/packages/console/src/pages/SignInExperience/tabs/Others/components/ManageLanguage/LanguageEditor/LanguageDetails.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/Others/components/ManageLanguage/LanguageEditor/LanguageDetails.tsx
@@ -177,6 +177,7 @@ const LanguageDetails = () => {
       </div>
       <div className={styles.container}>
         <Table
+          isRowHoverEffectDisabled
           className={styles.content}
           headerClassName={styles.tableWrapper}
           bodyClassName={styles.tableWrapper}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Per offline discussion, the `Table` component should have the following behaviors on hover:
- The hover effect should exist by default
- When the row is clickable, the pointer should be a cursor
- When the row is unclickable, the pointer should be default

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
![table-hover-state](https://user-images.githubusercontent.com/10806653/212237929-854c0b2d-7fc6-4af3-8d34-a1bb2a23de33.gif)

