### PR TITLE
style(console): add padding-bottom to get-started and dashboard page

### DIFF
--- a/packages/console/src/pages/Dashboard/index.module.scss
+++ b/packages/console/src/pages/Dashboard/index.module.scss
@@ -4,6 +4,7 @@
   display: flex;
   flex-direction: column;
   overflow-y: auto;
+  padding-bottom: _.unit(6);
 }
 
 .header {

--- a/packages/console/src/pages/GetStarted/index.module.scss
+++ b/packages/console/src/pages/GetStarted/index.module.scss
@@ -4,6 +4,7 @@
   display: flex;
   flex-direction: column;
   overflow-y: auto;
+  padding-bottom: _.unit(6);
 }
 
 .header {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
style(console): add padding-bottom to get-started and dashboard page.

Bug:
<img width="1231" alt="image" src="https://user-images.githubusercontent.com/10806653/212806908-f20a230d-6906-44e3-ba09-74b06bcfdd6b.png">
<img width="1229" alt="image" src="https://user-images.githubusercontent.com/10806653/212806945-247ba219-bb73-4b0b-bade-86755b439e0a.png">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="1260" alt="image" src="https://user-images.githubusercontent.com/10806653/212806690-8dc2b435-0539-4f8c-b472-0deb65f3b6eb.png">
<img width="1258" alt="image" src="https://user-images.githubusercontent.com/10806653/212806725-b32f4540-6259-4612-b5f4-7af135c3226b.png">

