### PR TITLE
style(console): hidden role item info on overflow

### DIFF
--- a/packages/console/src/components/UserRolesTransfer/components/TargetRoleItem/index.module.scss
+++ b/packages/console/src/components/UserRolesTransfer/components/TargetRoleItem/index.module.scss
@@ -15,6 +15,8 @@
     flex: 1 1 0;
     display: flex;
     align-items: center;
+    margin-right: _.unit(2);
+    overflow: hidden;
 
     .name {
       @include _.text-ellipsis;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- hidden role item info on overflow
- add margin-right to the info content.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Before
![image](https://user-images.githubusercontent.com/10806653/212929308-335742fe-e146-46b1-b05f-60ffc99b03e9.png)

### After
<img width="406" alt="image" src="https://user-images.githubusercontent.com/10806653/212929374-6b13bce9-2259-45a4-9e37-2b076234b8c0.png">
