### PR TITLE
style(ui): fix phone input field padding issue

### DIFF
--- a/packages/ui/src/components/Input/index.module.scss
+++ b/packages/ui/src/components/Input/index.module.scss
@@ -21,6 +21,7 @@
     color: var(--color-type-secondary);
     width: 24px;
     height: 24px;
+    cursor: pointer;
   }
 
   input {
@@ -31,6 +32,10 @@
     font: var(--font-body-1);
     color: var(--color-type-primary);
     align-self: stretch;
+
+    &:not(:first-child) {
+      padding-left: _.unit(1);
+    }
 
     &::placeholder {
       color: var(--color-type-secondary);

--- a/packages/ui/src/components/Input/phoneInput.module.scss
+++ b/packages/ui/src/components/Input/phoneInput.module.scss
@@ -20,10 +20,6 @@
     height: 100%;
     font-size: 0;
   }
-
-  + input {
-    padding-left: _.unit(1);
-  }
 }
 
 :global(body.mobile) {


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fix phone input field padding issue. CSS rule fixing.

Before:
<img width="532" alt="image" src="https://user-images.githubusercontent.com/36393111/213349382-550fc7b7-e4fa-4b2b-bba1-918157d04dc4.png">


After:
<img width="521" alt="image" src="https://user-images.githubusercontent.com/36393111/213349276-9c58f2f9-158d-46eb-8fd1-31073954e3c1.png">




<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
