### PR TITLE
fix(ui): use String.prototype.replace to make it compatible with legacy version browsers

### DIFF
--- a/packages/ui/src/components/Input/PhoneInput.tsx
+++ b/packages/ui/src/components/Input/PhoneInput.tsx
@@ -91,7 +91,7 @@ const PhoneInput = ({
             setOnFocus(false);
           }}
           onChange={({ target: { value } }) => {
-            onChange({ nationalNumber: value.replaceAll(/\D/g, '') });
+            onChange({ nationalNumber: value.replace(/\D/g, '') });
           }}
         />
         {nationalNumber && onFocus && (


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
https://caniuse.com/?search=replaceAll
This is not a complete solution, but a workaround, but I found that there is no reason to use the replaceAll api in this scenario (it does exactly same thing as replace, but require modern browser (chrome > 85).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested use android emulator with chrome 80
