### PR TITLE
fix(ui): remove social callback page from history

### DIFF
--- a/packages/ui/src/hooks/use-social-register.ts
+++ b/packages/ui/src/hooks/use-social-register.ts
@@ -5,8 +5,11 @@ import { registerWithVerifiedSocial } from '@/apis/interaction';
 import useApi from './use-api';
 import useRequiredProfileErrorHandler from './use-required-profile-error-handler';
 
-const useSocialRegister = (connectorId?: string) => {
-  const requiredProfileErrorHandlers = useRequiredProfileErrorHandler({ linkSocial: connectorId });
+const useSocialRegister = (connectorId?: string, replace?: boolean) => {
+  const requiredProfileErrorHandlers = useRequiredProfileErrorHandler({
+    linkSocial: connectorId,
+    replace,
+  });
 
   const { result: registerResult, run: asyncRegisterWithSocial } = useApi(
     registerWithVerifiedSocial,

--- a/packages/ui/src/hooks/use-social-sign-in-listener.ts
+++ b/packages/ui/src/hooks/use-social-sign-in-listener.ts
@@ -25,7 +25,7 @@ const useSocialSignInListener = (connectorId?: string) => {
 
   const navigate = useNavigate();
 
-  const registerWithSocial = useSocialRegister(connectorId);
+  const registerWithSocial = useSocialRegister(connectorId, true);
 
   const accountNotExistErrorHandler = useCallback(
     async (error: RequestErrorBody) => {
@@ -51,7 +51,10 @@ const useSocialSignInListener = (connectorId?: string) => {
     [connectorId, navigate, registerWithSocial]
   );
 
-  const requiredProfileErrorHandlers = useRequiredProfileErrorHandler({ flow: UserFlow.signIn });
+  const requiredProfileErrorHandlers = useRequiredProfileErrorHandler({
+    replace: true,
+    flow: UserFlow.signIn,
+  });
 
   const signInWithSocialErrorHandlers: ErrorHandlers = useMemo(
     () => ({


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Remove the social callback page from history.

### Previous issue
We have a social sign-in callback page implemented.  It will parse the social auth data from callback URL search parameters and trigger a social sign-in request to the Logto server. 
Depending on different social account statuses, the user may be redirected to the link social account or bind email/phone page. 
When the user clicks on the back button at the next link page, it will return to the social callback page and triggers the sign-in request again, ending with an authorization failed error. 


### Solution
Checked with designers. Using the `replace` type nav for all the navigation actions on the social callback page. This will remove the page from the history stack.  Click on the back button should lead the user back to the third-party sign-in page. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

