### PR TITLE
fix(ui): call error callback  after async error handler

### DIFF
--- a/packages/ui/src/containers/VerificationCode/use-continue-flow-code-verification.ts
+++ b/packages/ui/src/containers/VerificationCode/use-continue-flow-code-verification.ts
@@ -46,12 +46,10 @@ const useContinueFlowCodeVerification = (
 
   const verifyVerificationCodeErrorHandlers: ErrorHandlers = useMemo(
     () => ({
-      'user.phone_already_in_use': () => {
-        void identifierExistErrorHandler(SignInIdentifier.Phone, target);
-      },
-      'user.email_already_in_use': () => {
-        void identifierExistErrorHandler(SignInIdentifier.Email, target);
-      },
+      'user.phone_already_in_use': async () =>
+        identifierExistErrorHandler(SignInIdentifier.Phone, target),
+      'user.email_already_in_use': async () =>
+        identifierExistErrorHandler(SignInIdentifier.Email, target),
       ...requiredProfileErrorHandler,
       ...generalVerificationCodeErrorHandlers,
       callback: errorCallback,

--- a/packages/ui/src/containers/VerificationCode/use-forgot-password-flow-code-verification.ts
+++ b/packages/ui/src/containers/VerificationCode/use-forgot-password-flow-code-verification.ts
@@ -24,9 +24,8 @@ const useForgotPasswordFlowCodeVerification = (
 
   const errorHandlers: ErrorHandlers = useMemo(
     () => ({
-      'user.user_not_exist': () => {
-        void identifierErrorHandler(IdentifierErrorType.IdentifierNotExist, method, target);
-      },
+      'user.user_not_exist': async () =>
+        identifierErrorHandler(IdentifierErrorType.IdentifierNotExist, method, target),
       'user.new_password_required_in_profile': () => {
         navigate(`/${UserFlow.forgotPassword}/reset`, { replace: true });
       },


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
should call the error callback after the async error handler is resolved.

E.g. 

The verification code should clear after the error confirm modal is closed. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

