### PR TITLE
refactor(phrases): update rbac-related removing phrases

### DIFF
--- a/packages/console/src/components/PermissionsTable/index.tsx
+++ b/packages/console/src/components/PermissionsTable/index.tsx
@@ -28,6 +28,7 @@ type Props = {
   isLoading: boolean;
   errorMessage?: string;
   createButtonTitle: AdminConsoleKey;
+  deleteButtonTitle?: AdminConsoleKey;
   isReadOnly?: boolean;
   isApiColumnVisible?: boolean;
   pagination?: PaginationProps;
@@ -42,6 +43,7 @@ const PermissionsTable = ({
   isLoading,
   errorMessage,
   createButtonTitle,
+  deleteButtonTitle = 'general.delete',
   isReadOnly = false,
   isApiColumnVisible = false,
   pagination,
@@ -89,7 +91,7 @@ const PermissionsTable = ({
        * When the table is read-only, hide the delete button rather than the whole column to keep the table column spaces.
        */
       isReadOnly ? null : (
-        <Tooltip content={t('general.delete')}>
+        <Tooltip content={<div>{t(deleteButtonTitle)}</div>}>
           <IconButton
             onClick={() => {
               deleteHandler(scope);

--- a/packages/console/src/pages/RoleDetails/RolePermissions/index.tsx
+++ b/packages/console/src/pages/RoleDetails/RolePermissions/index.tsx
@@ -72,6 +72,7 @@ const RolePermissions = () => {
         scopes={scopes}
         isLoading={isLoading}
         createButtonTitle="role_details.permission.assign_button"
+        deleteButtonTitle="general.remove"
         createHandler={() => {
           setIsAssignPermissionsModalOpen(true);
         }}
@@ -100,7 +101,7 @@ const RolePermissions = () => {
         <ConfirmModal
           isOpen
           isLoading={isDeleting}
-          confirmButtonText="general.delete"
+          confirmButtonText="general.remove"
           onCancel={() => {
             setScopeToBeDeleted(undefined);
           }}

--- a/packages/console/src/pages/RoleDetails/RoleUsers/index.tsx
+++ b/packages/console/src/pages/RoleDetails/RoleUsers/index.tsx
@@ -114,7 +114,7 @@ const RoleUsers = () => {
             dataIndex: 'delete',
             colSpan: 1,
             render: (user) => (
-              <Tooltip content={t('general.delete')}>
+              <Tooltip content={t('general.remove')}>
                 <IconButton
                   onClick={() => {
                     setUserToBeDeleted(user);
@@ -174,7 +174,7 @@ const RoleUsers = () => {
         <ConfirmModal
           isOpen
           isLoading={isDeleting}
-          confirmButtonText="general.delete"
+          confirmButtonText="general.remove"
           onCancel={() => {
             setUserToBeDeleted(undefined);
           }}

--- a/packages/console/src/pages/UserDetails/UserRoles/index.tsx
+++ b/packages/console/src/pages/UserDetails/UserRoles/index.tsx
@@ -98,7 +98,7 @@ const UserRoles = () => {
             dataIndex: 'delete',
             colSpan: 1,
             render: (role) => (
-              <Tooltip content={t('general.delete')}>
+              <Tooltip content={t('general.remove')}>
                 <IconButton
                   onClick={() => {
                     setRoleToBeDeleted(role);
@@ -161,7 +161,7 @@ const UserRoles = () => {
         <ConfirmModal
           isOpen
           isLoading={isDeleting}
-          confirmButtonText="general.delete"
+          confirmButtonText="general.remove"
           onCancel={() => {
             setRoleToBeDeleted(undefined);
           }}

--- a/packages/phrases/src/locales/de/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/general.ts
@@ -43,6 +43,7 @@ const general = {
   learn_more: 'Learn more', // UNTRANSLATED
   tab_errors: '{{count, number}} errors', // UNTRANSLATED
   skip_for_now: 'Skip for now', // UNTRANSLATED
+  remove: 'Remove', // UNTRANSLATED
 };
 
 export default general;

--- a/packages/phrases/src/locales/de/translation/admin-console/role-details.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/role-details.ts
@@ -23,7 +23,7 @@ const role_details = {
     confirm_assign: 'Assign Permission', // UNTRANSLATED
     permission_assigned: 'The selected permissions were successfully assigned to this role!', // UNTRANSLATED
     deletion_description:
-      'If this permission is deleted, the affected user with this role will lose the access granted by this permission.', // UNTRANSLATED
+      'If this permission is removed, the affected user with this role will lose the access granted by this permission.', // UNTRANSLATED
     permission_deleted: 'The permission "{{name}}" was successfully removed from this role!', // UNTRANSLATED
     empty: 'No permission available', // UNTRANSLATED
   },

--- a/packages/phrases/src/locales/en/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/general.ts
@@ -42,6 +42,7 @@ const general = {
   learn_more: 'Learn more',
   tab_errors: '{{count, number}} errors',
   skip_for_now: 'Skip for now',
+  remove: 'Remove',
 };
 
 export default general;

--- a/packages/phrases/src/locales/en/translation/admin-console/role-details.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/role-details.ts
@@ -23,7 +23,7 @@ const role_details = {
     confirm_assign: 'Assign Permission',
     permission_assigned: 'The selected permissions were successfully assigned to this role!',
     deletion_description:
-      'If this permission is deleted, the affected user with this role will lose the access granted by this permission.',
+      'If this permission is removed, the affected user with this role will lose the access granted by this permission.',
     permission_deleted: 'The permission "{{name}}" was successfully removed from this role!',
     empty: 'No permission available',
   },

--- a/packages/phrases/src/locales/fr/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/general.ts
@@ -43,6 +43,7 @@ const general = {
   learn_more: 'Learn more', // UNTRANSLATED
   tab_errors: '{{count, number}} errors', // UNTRANSLATED
   skip_for_now: 'Skip for now', // UNTRANSLATED
+  remove: 'Remove', // UNTRANSLATED
 };
 
 export default general;

--- a/packages/phrases/src/locales/fr/translation/admin-console/role-details.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/role-details.ts
@@ -23,7 +23,7 @@ const role_details = {
     confirm_assign: 'Assign Permission', // UNTRANSLATED
     permission_assigned: 'The selected permissions were successfully assigned to this role!', // UNTRANSLATED
     deletion_description:
-      'If this permission is deleted, the affected user with this role will lose the access granted by this permission.', // UNTRANSLATED
+      'If this permission is removed, the affected user with this role will lose the access granted by this permission.', // UNTRANSLATED
     permission_deleted: 'The permission "{{name}}" was successfully removed from this role!', // UNTRANSLATED
     empty: 'No permission available', // UNTRANSLATED
   },

--- a/packages/phrases/src/locales/ko/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/general.ts
@@ -42,6 +42,7 @@ const general = {
   learn_more: '더 알아보기',
   tab_errors: '{{count, number}} 오류',
   skip_for_now: 'Skip for now', // UNTRANSLATED
+  remove: 'Remove', // UNTRANSLATED
 };
 
 export default general;

--- a/packages/phrases/src/locales/ko/translation/admin-console/role-details.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/role-details.ts
@@ -23,7 +23,7 @@ const role_details = {
     confirm_assign: 'Assign Permission', // UNTRANSLATED
     permission_assigned: 'The selected permissions were successfully assigned to this role!', // UNTRANSLATED
     deletion_description:
-      'If this permission is deleted, the affected user with this role will lose the access granted by this permission.', // UNTRANSLATED
+      'If this permission is removed, the affected user with this role will lose the access granted by this permission.', // UNTRANSLATED
     permission_deleted: 'The permission "{{name}}" was successfully removed from this role!', // UNTRANSLATED
     empty: 'No permission available', // UNTRANSLATED
   },

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/general.ts
@@ -43,6 +43,7 @@ const general = {
   learn_more: 'Saber mais',
   tab_errors: '{{count, number}} erros',
   skip_for_now: 'Skip for now', // UNTRANSLATED
+  remove: 'Remove', // UNTRANSLATED
 };
 
 export default general;

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/role-details.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/role-details.ts
@@ -23,7 +23,7 @@ const role_details = {
     confirm_assign: 'Assign Permission', // UNTRANSLATED
     permission_assigned: 'The selected permissions were successfully assigned to this role!', // UNTRANSLATED
     deletion_description:
-      'If this permission is deleted, the affected user with this role will lose the access granted by this permission.', // UNTRANSLATED
+      'If this permission is removed, the affected user with this role will lose the access granted by this permission.', // UNTRANSLATED
     permission_deleted: 'The permission "{{name}}" was successfully removed from this role!', // UNTRANSLATED
     empty: 'No permission available', // UNTRANSLATED
   },

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/general.ts
@@ -42,6 +42,7 @@ const general = {
   learn_more: 'Learn more', // UNTRANSLATED
   tab_errors: '{{count, number}} errors', // UNTRANSLATED
   skip_for_now: 'Skip for now', // UNTRANSLATED
+  remove: 'Remove', // UNTRANSLATED
 };
 
 export default general;

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/role-details.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/role-details.ts
@@ -23,7 +23,7 @@ const role_details = {
     confirm_assign: 'Assign Permission', // UNTRANSLATED
     permission_assigned: 'The selected permissions were successfully assigned to this role!', // UNTRANSLATED
     deletion_description:
-      'If this permission is deleted, the affected user with this role will lose the access granted by this permission.', // UNTRANSLATED
+      'If this permission is removed, the affected user with this role will lose the access granted by this permission.', // UNTRANSLATED
     permission_deleted: 'The permission "{{name}}" was successfully removed from this role!', // UNTRANSLATED
     empty: 'No permission available', // UNTRANSLATED
   },

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/general.ts
@@ -43,6 +43,7 @@ const general = {
   learn_more: 'Learn more', // UNTRANSLATED
   tab_errors: '{{count, number}} errors', // UNTRANSLATED
   skip_for_now: 'Skip for now', // UNTRANSLATED
+  remove: 'Remove', // UNTRANSLATED
 };
 
 export default general;

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/role-details.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/role-details.ts
@@ -23,7 +23,7 @@ const role_details = {
     confirm_assign: 'Assign Permission', // UNTRANSLATED
     permission_assigned: 'The selected permissions were successfully assigned to this role!', // UNTRANSLATED
     deletion_description:
-      'If this permission is deleted, the affected user with this role will lose the access granted by this permission.', // UNTRANSLATED
+      'If this permission is removed, the affected user with this role will lose the access granted by this permission.', // UNTRANSLATED
     permission_deleted: 'The permission "{{name}}" was successfully removed from this role!', // UNTRANSLATED
     empty: 'No permission available', // UNTRANSLATED
   },

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/general.ts
@@ -42,6 +42,7 @@ const general = {
   learn_more: 'Learn more', // UNTRANSLATED
   tab_errors: '{{count, number}} errors', // UNTRANSLATED
   skip_for_now: 'Skip for now', // UNTRANSLATED
+  remove: '移除',
 };
 
 export default general;

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/role-details.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/role-details.ts
@@ -23,7 +23,7 @@ const role_details = {
     confirm_assign: 'Assign Permission', // UNTRANSLATED
     permission_assigned: 'The selected permissions were successfully assigned to this role!', // UNTRANSLATED
     deletion_description:
-      'If this permission is deleted, the affected user with this role will lose the access granted by this permission.', // UNTRANSLATED
+      'If this permission is removed, the affected user with this role will lose the access granted by this permission.', // UNTRANSLATED
     permission_deleted: 'The permission "{{name}}" was successfully removed from this role!', // UNTRANSLATED
     empty: 'No permission available', // UNTRANSLATED
   },


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
In the following 3 situations, we should use 'remove' instead of 'delete':
- Remove permissions from a role
- Remove users from a role
- Remove roles from a user

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.
