### PR TITLE
style(ui): fix mobile modal max-width

### DIFF
--- a/packages/ui/src/components/ConfirmModal/MobileModal.module.scss
+++ b/packages/ui/src/components/ConfirmModal/MobileModal.module.scss
@@ -9,6 +9,8 @@
   left: 20px;
   right: 20px;
   top: 50%;
+  max-width: var(--max-width);
+  margin: 0 auto;
   transform: translate(0, -50%);
   outline: none;
   border-radius: var(--radius);


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add mobile modal max-width on a wide screen like iPad.

<img width="809" alt="image" src="https://user-images.githubusercontent.com/36393111/213634437-8e64cb4d-cb66-4b03-8554-017fab348620.png">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally.
