### PR TITLE
ci: filter out ignore group when exec lifecycle scripts

### DIFF
--- a/.scripts/version.js
+++ b/.scripts/version.js
@@ -29,7 +29,8 @@ const getIgnoreGroup = () => {
   });
 }
 
-const ignoreCmd = getIgnoreGroup()
+const ignoreGroup = getIgnoreGroup();
+const ignoreCmd = ignoreGroup
   .map(({ name }) => ` \\\n  --ignore ${name}`)
   .join('');
 const cmd = ('pnpm changeset version' + ignoreCmd);
@@ -44,8 +45,11 @@ console.log(cmd);
 
 await execAsync(cmd).catch(catchCmdError);
 
+const filterCmd = ignoreGroup
+  .map(({ name }) => ` \\\n  --filter \\!${name}`)
+  .join('');
 // Manually run lifecycle script since changesets didn't
-await execAsync('pnpm -r version').catch(catchCmdError);
+await execAsync(`pnpm -r ${filterCmd} version`).catch(catchCmdError);
 
 // Sanity check for prepublish scripts
-await execAsync('pnpm -r prepublishOnly').catch(catchCmdError);
+await execAsync(`pnpm -r ${filterCmd} prepublishOnly`).catch(catchCmdError);


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
partially execute lifecycle scripts based on the release group

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

[CI](https://github.com/logto-io/logto/actions/runs/4035528020), see the core group runs db alteration renaming script but the toolkit group does not