### PR TITLE
refactor(ui): update set password form

### DIFF
--- a/packages/integration-tests/src/tests/ui/smoke.test.ts
+++ b/packages/integration-tests/src/tests/ui/smoke.test.ts
@@ -36,8 +36,8 @@ describe('smoke testing', () => {
     expect(page.url()).toBe(new URL('register/username/password', logtoUrl).href);
 
     const passwordField = await page.waitForSelector('input[name=new-password]');
-    const confirmPasswordField = await page.waitForSelector('input[name=confirm-new-password]');
-    const saveButton = await page.waitForSelector('button');
+    const confirmPasswordField = await page.waitForSelector('input[name=confirm-password]');
+    const saveButton = await page.waitForSelector('button[name=submit]');
     await passwordField.type(consolePassword);
     await confirmPasswordField.type(consolePassword);
 

--- a/packages/integration-tests/src/tests/ui/smoke.test.ts
+++ b/packages/integration-tests/src/tests/ui/smoke.test.ts
@@ -35,8 +35,8 @@ describe('smoke testing', () => {
 
     expect(page.url()).toBe(new URL('register/username/password', logtoUrl).href);
 
-    const passwordField = await page.waitForSelector('input[name=new-password]');
-    const confirmPasswordField = await page.waitForSelector('input[name=confirm-password]');
+    const passwordField = await page.waitForSelector('input[name=newPassword]');
+    const confirmPasswordField = await page.waitForSelector('input[name=confirmPassword]');
     const saveButton = await page.waitForSelector('button[name=submit]');
     await passwordField.type(consolePassword);
     await confirmPasswordField.type(consolePassword);

--- a/packages/phrases-ui/src/locales/de.ts
+++ b/packages/phrases-ui/src/locales/de.ts
@@ -38,6 +38,7 @@ const translation = {
     link_another_email: 'Link another email', // UNTRANSLATED
     link_another_phone: 'Link another phone', // UNTRANSLATED
     link_another_email_or_phone: 'Link another email or phone', // UNTRANSLATED
+    show_password: 'Show password', // UNTRANSLATED
   },
   description: {
     email: 'Email',

--- a/packages/phrases-ui/src/locales/en.ts
+++ b/packages/phrases-ui/src/locales/en.ts
@@ -36,6 +36,7 @@ const translation = {
     link_another_email: 'Link another email',
     link_another_phone: 'Link another phone',
     link_another_email_or_phone: 'Link another email or phone',
+    show_password: 'Show password',
   },
   description: {
     email: 'email',

--- a/packages/phrases-ui/src/locales/fr.ts
+++ b/packages/phrases-ui/src/locales/fr.ts
@@ -38,6 +38,7 @@ const translation = {
     link_another_email: 'Link another email', // UNTRANSLATED
     link_another_phone: 'Link another phone', // UNTRANSLATED
     link_another_email_or_phone: 'Link another email or phone', // UNTRANSLATED
+    show_password: 'Show password', // UNTRANSLATED
   },
   description: {
     email: 'email',

--- a/packages/phrases-ui/src/locales/ko.ts
+++ b/packages/phrases-ui/src/locales/ko.ts
@@ -38,6 +38,7 @@ const translation = {
     link_another_email: 'Link another email', // UNTRANSLATED
     link_another_phone: 'Link another phone', // UNTRANSLATED
     link_another_email_or_phone: 'Link another email or phone', // UNTRANSLATED
+    show_password: 'Show password', // UNTRANSLATED
   },
   description: {
     email: '이메일',

--- a/packages/phrases-ui/src/locales/pt-br.ts
+++ b/packages/phrases-ui/src/locales/pt-br.ts
@@ -38,6 +38,7 @@ const translation = {
     link_another_email: 'Link another email', // UNTRANSLATED
     link_another_phone: 'Link another phone', // UNTRANSLATED
     link_another_email_or_phone: 'Link another email or phone', // UNTRANSLATED
+    show_password: 'Show password', // UNTRANSLATED
   },
   description: {
     email: 'e-mail',

--- a/packages/phrases-ui/src/locales/pt-pt.ts
+++ b/packages/phrases-ui/src/locales/pt-pt.ts
@@ -38,6 +38,7 @@ const translation = {
     link_another_email: 'Link another email', // UNTRANSLATED
     link_another_phone: 'Link another phone', // UNTRANSLATED
     link_another_email_or_phone: 'Link another email or phone', // UNTRANSLATED
+    show_password: 'Show password', // UNTRANSLATED
   },
   description: {
     email: 'email',

--- a/packages/phrases-ui/src/locales/tr-tr.ts
+++ b/packages/phrases-ui/src/locales/tr-tr.ts
@@ -38,6 +38,7 @@ const translation = {
     link_another_email: 'Link another email', // UNTRANSLATED
     link_another_phone: 'Link another phone', // UNTRANSLATED
     link_another_email_or_phone: 'Link another email or phone', // UNTRANSLATED
+    show_password: 'Show password', // UNTRANSLATED
   },
   description: {
     email: 'e-posta adresi',

--- a/packages/phrases-ui/src/locales/zh-cn.ts
+++ b/packages/phrases-ui/src/locales/zh-cn.ts
@@ -38,6 +38,7 @@ const translation = {
     link_another_email: 'Link another email', // UNTRANSLATED
     link_another_phone: 'Link another phone', // UNTRANSLATED
     link_another_email_or_phone: 'Link another email or phone', // UNTRANSLATED
+    show_password: 'Show password', // UNTRANSLATED
   },
   description: {
     email: '邮箱',

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -61,6 +61,7 @@
     "react": "^18.0.0",
     "react-device-detect": "^2.2.2",
     "react-dom": "^18.0.0",
+    "react-hook-form": "^7.34.0",
     "react-i18next": "^11.18.3",
     "react-modal": "^3.15.1",
     "react-router-dom": "^6.2.2",

--- a/packages/ui/src/components/InputField/index.module.scss
+++ b/packages/ui/src/components/InputField/index.module.scss
@@ -31,7 +31,7 @@
     }
   }
 
-  .actionButton {
+  .suffix {
     position: absolute;
     right: _.unit(4);
     top: 50%;

--- a/packages/ui/src/components/InputField/index.module.scss
+++ b/packages/ui/src/components/InputField/index.module.scss
@@ -27,7 +27,7 @@
     }
 
     &:not(:last-child) {
-      padding-right: 40px;
+      padding-right: _.unit(10);
     }
   }
 
@@ -41,7 +41,7 @@
     display: none;
 
     &.visible {
-      display: 'flex';
+      display: flex;
     }
   }
 

--- a/packages/ui/src/components/InputField/index.module.scss
+++ b/packages/ui/src/components/InputField/index.module.scss
@@ -1,0 +1,90 @@
+@use '@/scss/underscore' as _;
+
+.inputField {
+  position: relative;
+  @include _.flex-row;
+  border: _.border(var(--color-line-border));
+  border-radius: var(--radius);
+  overflow: hidden;
+  transition-property: outline, border;
+  transition-timing-function: ease-in-out;
+  transition-duration: 0.2s;
+
+  // fix in safari input field line-height issue
+  height: 44px;
+
+  input {
+    padding: 0 _.unit(4);
+    flex: 1;
+    background: none;
+    caret-color: var(--color-brand-default);
+    font: var(--font-body-1);
+    color: var(--color-type-primary);
+    align-self: stretch;
+
+    &::placeholder {
+      color: var(--color-type-secondary);
+    }
+
+    &:not(:last-child) {
+      padding-right: 40px;
+    }
+  }
+
+  .actionButton {
+    position: absolute;
+    right: _.unit(4);
+    top: 50%;
+    transform: translateY(-50%);
+    width: _.unit(8);
+    height: _.unit(8);
+    display: none;
+
+    &.visible {
+      display: 'flex';
+    }
+  }
+
+  &:focus-within {
+    border: _.border(var(--color-brand-default));
+
+    input {
+      outline: none;
+    }
+
+    .focusVisible {
+      display: flex;
+    }
+  }
+
+  &.danger {
+    border: _.border(var(--color-danger-default));
+
+    input {
+      caret-color: var(--color-danger-default);
+    }
+  }
+}
+
+.errorMessage {
+  margin-top: _.unit(1);
+  margin-left: _.unit(0.5);
+}
+
+:global(body.desktop) {
+  .inputField {
+    outline: 3px solid transparent;
+
+    input {
+      font: var(--font-body-2);
+    }
+
+    &:focus-within {
+      outline-color: var(--color-overlay-brand-focused);
+    }
+
+    &.danger:focus-within {
+      outline-color: var(--color-overlay-danger-focused);
+    }
+  }
+}

--- a/packages/ui/src/components/InputField/index.tsx
+++ b/packages/ui/src/components/InputField/index.tsx
@@ -1,0 +1,39 @@
+import classNames from 'classnames';
+import type { ForwardedRef, HTMLProps, ReactElement } from 'react';
+import { forwardRef, cloneElement } from 'react';
+
+import type { ErrorType } from '@/components/ErrorMessage';
+import ErrorMessage from '@/components/ErrorMessage';
+
+import * as styles from './index.module.scss';
+
+type Props = HTMLProps<HTMLInputElement> & {
+  className?: string;
+  error?: ErrorType;
+  isDanger?: boolean;
+  suffix?: ReactElement;
+  isSuffixFocusVisible?: boolean;
+  isSuffixVisible?: boolean;
+};
+
+const InputField = (
+  { className, error, isDanger, suffix, isSuffixFocusVisible, ...props }: Props,
+  reference: ForwardedRef<HTMLInputElement>
+) => (
+  <div className={className}>
+    <div className={classNames(styles.inputField, isDanger && styles.danger)}>
+      <input {...props} ref={reference} />
+      {suffix &&
+        cloneElement(suffix, {
+          className: classNames([
+            suffix.props.className,
+            styles.actionButton,
+            isSuffixFocusVisible && styles.focusVisible,
+          ]),
+        })}
+    </div>
+    {error && <ErrorMessage error={error} className={styles.errorMessage} />}
+  </div>
+);
+
+export default forwardRef(InputField);

--- a/packages/ui/src/components/InputField/index.tsx
+++ b/packages/ui/src/components/InputField/index.tsx
@@ -17,7 +17,7 @@ type Props = HTMLProps<HTMLInputElement> & {
 };
 
 const InputField = (
-  { className, error, isDanger, suffix, isSuffixFocusVisible, ...props }: Props,
+  { className, error, isDanger, suffix, isSuffixFocusVisible, isSuffixVisible, ...props }: Props,
   reference: ForwardedRef<HTMLInputElement>
 ) => (
   <div className={className}>
@@ -27,8 +27,9 @@ const InputField = (
         cloneElement(suffix, {
           className: classNames([
             suffix.props.className,
-            styles.actionButton,
+            styles.suffix,
             isSuffixFocusVisible && styles.focusVisible,
+            isSuffixVisible && styles.visible,
           ]),
         })}
     </div>

--- a/packages/ui/src/components/TermsOfUse/index.module.scss
+++ b/packages/ui/src/components/TermsOfUse/index.module.scss
@@ -7,7 +7,7 @@
   cursor: pointer;
 }
 
-.checkBox {
+.checkbox {
   margin-right: _.unit(2);
   fill: var(--color-type-secondary);
   cursor: pointer;

--- a/packages/ui/src/components/TermsOfUse/index.tsx
+++ b/packages/ui/src/components/TermsOfUse/index.tsx
@@ -40,7 +40,7 @@ const TermsOfUse = ({ name, className, termsUrl, isChecked, onChange, onTermsCli
         ' ': toggle,
       })}
     >
-      <Checkbox name={name} checked={isChecked} className={styles.checkBox} />
+      <Checkbox name={name} checked={isChecked} className={styles.checkbox} />
       <div className={styles.content}>
         {prefix}
         <TextLink

--- a/packages/ui/src/containers/SetPassword/TogglePassword.tsx
+++ b/packages/ui/src/containers/SetPassword/TogglePassword.tsx
@@ -1,0 +1,41 @@
+import { useTranslation } from 'react-i18next';
+
+import Checkbox from '@/components/Checkbox';
+import { onKeyDownHandler } from '@/utils/a11y';
+
+import * as styles from './index.module.scss';
+
+type Props = {
+  isChecked?: boolean;
+  onChange: (checked: boolean) => void;
+};
+
+const TogglePassword = ({ isChecked, onChange }: Props) => {
+  const { t } = useTranslation();
+
+  const toggle = () => {
+    onChange(!isChecked);
+  };
+
+  return (
+    <div
+      role="radio"
+      aria-checked={isChecked}
+      tabIndex={0}
+      className={styles.passwordSwitch}
+      onClick={toggle}
+      onKeyDown={onKeyDownHandler({
+        Escape: () => {
+          onChange(false);
+        },
+        Enter: toggle,
+        ' ': toggle,
+      })}
+    >
+      <Checkbox name="toggle-password" checked={isChecked} className={styles.checkBox} />
+      <div className={styles.content}>{t('action.show_password')}</div>
+    </div>
+  );
+};
+
+export default TogglePassword;

--- a/packages/ui/src/containers/SetPassword/TogglePassword.tsx
+++ b/packages/ui/src/containers/SetPassword/TogglePassword.tsx
@@ -33,7 +33,7 @@ const TogglePassword = ({ isChecked, onChange }: Props) => {
       })}
     >
       <Checkbox name="toggle-password" checked={isChecked} className={styles.checkBox} />
-      <div className={styles.content}>{t('action.show_password')}</div>
+      <div>{t('action.show_password')}</div>
     </div>
   );
 };

--- a/packages/ui/src/containers/SetPassword/TogglePassword.tsx
+++ b/packages/ui/src/containers/SetPassword/TogglePassword.tsx
@@ -32,7 +32,7 @@ const TogglePassword = ({ isChecked, onChange }: Props) => {
         ' ': toggle,
       })}
     >
-      <Checkbox name="toggle-password" checked={isChecked} className={styles.checkBox} />
+      <Checkbox name="toggle-password" checked={isChecked} className={styles.checkbox} />
       <div>{t('action.show_password')}</div>
     </div>
   );

--- a/packages/ui/src/containers/SetPassword/index.module.scss
+++ b/packages/ui/src/containers/SetPassword/index.module.scss
@@ -8,12 +8,26 @@
   }
 
   .inputField,
-  .formErrors {
+  .formErrors,
+  .passwordSwitch {
     margin-bottom: _.unit(4);
   }
 
   .formErrors {
     margin-left: _.unit(0.5);
     margin-top: _.unit(-3);
+  }
+}
+
+.passwordSwitch {
+  @include _.flex-row;
+  width: 100%;
+  user-select: none;
+  cursor: pointer;
+
+  .checkBox {
+    margin-right: _.unit(2);
+    fill: var(--color-type-secondary);
+    cursor: pointer;
   }
 }

--- a/packages/ui/src/containers/SetPassword/index.module.scss
+++ b/packages/ui/src/containers/SetPassword/index.module.scss
@@ -25,7 +25,7 @@
   user-select: none;
   cursor: pointer;
 
-  .checkBox {
+  .checkbox {
     margin-right: _.unit(2);
     fill: var(--color-type-secondary);
     cursor: pointer;

--- a/packages/ui/src/containers/SetPassword/index.test.tsx
+++ b/packages/ui/src/containers/SetPassword/index.test.tsx
@@ -15,24 +15,32 @@ describe('<SetPassword />', () => {
       <SetPassword errorMessage="error" onSubmit={submit} />
     );
     expect(container.querySelector('input[name="new-password"]')).not.toBeNull();
-    expect(container.querySelector('input[name="confirm-new-password"]')).not.toBeNull();
+    expect(container.querySelector('input[name="confirm-password"]')).not.toBeNull();
     expect(queryByText('error')).not.toBeNull();
     expect(queryByText('action.save_password')).not.toBeNull();
   });
 
-  test('password are required', () => {
+  test('password are required', async () => {
     const { queryByText, getByText } = render(
       <SetPassword clearErrorMessage={clearError} onSubmit={submit} />
     );
+
     const submitButton = getByText('action.save_password');
-    fireEvent.click(submitButton);
+
+    act(() => {
+      fireEvent.click(submitButton);
+    });
 
     expect(clearError).toBeCalled();
-    expect(queryByText('password_required')).not.toBeNull();
+
+    await waitFor(() => {
+      expect(queryByText('password_required')).not.toBeNull();
+    });
+
     expect(submit).not.toBeCalled();
   });
 
-  test('password less than 6 chars should throw', () => {
+  test('password less than 6 chars should throw', async () => {
     const { queryByText, getByText, container } = render(<SetPassword onSubmit={submit} />);
     const submitButton = getByText('action.save_password');
     const passwordInput = container.querySelector('input[name="new-password"]');
@@ -45,7 +53,9 @@ describe('<SetPassword />', () => {
       fireEvent.click(submitButton);
     });
 
-    expect(queryByText('password_min_length')).not.toBeNull();
+    await waitFor(() => {
+      expect(queryByText('password_min_length')).not.toBeNull();
+    });
 
     expect(submit).not.toBeCalled();
 
@@ -56,14 +66,16 @@ describe('<SetPassword />', () => {
       }
     });
 
-    expect(queryByText('password_min_length')).toBeNull();
+    await waitFor(() => {
+      expect(queryByText('password_min_length')).toBeNull();
+    });
   });
 
-  test('password mismatch with confirmPassword should throw', () => {
+  test('password mismatch with confirmPassword should throw', async () => {
     const { queryByText, getByText, container } = render(<SetPassword onSubmit={submit} />);
     const submitButton = getByText('action.save_password');
     const passwordInput = container.querySelector('input[name="new-password"]');
-    const confirmPasswordInput = container.querySelector('input[name="confirm-new-password"]');
+    const confirmPasswordInput = container.querySelector('input[name="confirm-password"]');
 
     act(() => {
       if (passwordInput) {
@@ -77,7 +89,9 @@ describe('<SetPassword />', () => {
       fireEvent.click(submitButton);
     });
 
-    expect(queryByText('passwords_do_not_match')).not.toBeNull();
+    await waitFor(() => {
+      expect(queryByText('passwords_do_not_match')).not.toBeNull();
+    });
 
     expect(submit).not.toBeCalled();
 
@@ -88,14 +102,16 @@ describe('<SetPassword />', () => {
       }
     });
 
-    expect(queryByText('passwords_do_not_match')).toBeNull();
+    await waitFor(() => {
+      expect(queryByText('passwords_do_not_match')).toBeNull();
+    });
   });
 
   test('should submit properly', async () => {
     const { queryByText, getByText, container } = render(<SetPassword onSubmit={submit} />);
     const submitButton = getByText('action.save_password');
     const passwordInput = container.querySelector('input[name="new-password"]');
-    const confirmPasswordInput = container.querySelector('input[name="confirm-new-password"]');
+    const confirmPasswordInput = container.querySelector('input[name="confirm-password"]');
 
     act(() => {
       if (passwordInput) {

--- a/packages/ui/src/containers/SetPassword/index.test.tsx
+++ b/packages/ui/src/containers/SetPassword/index.test.tsx
@@ -20,7 +20,7 @@ describe('<SetPassword />', () => {
     expect(queryByText('action.save_password')).not.toBeNull();
   });
 
-  test('password are required', async () => {
+  test('password is required', async () => {
     const { queryByText, getByText } = render(
       <SetPassword clearErrorMessage={clearError} onSubmit={submit} />
     );

--- a/packages/ui/src/containers/SetPassword/index.test.tsx
+++ b/packages/ui/src/containers/SetPassword/index.test.tsx
@@ -14,8 +14,8 @@ describe('<SetPassword />', () => {
     const { queryByText, container } = render(
       <SetPassword errorMessage="error" onSubmit={submit} />
     );
-    expect(container.querySelector('input[name="new-password"]')).not.toBeNull();
-    expect(container.querySelector('input[name="confirm-password"]')).not.toBeNull();
+    expect(container.querySelector('input[name="newPassword"]')).not.toBeNull();
+    expect(container.querySelector('input[name="confirmPassword"]')).not.toBeNull();
     expect(queryByText('error')).not.toBeNull();
     expect(queryByText('action.save_password')).not.toBeNull();
   });
@@ -43,7 +43,7 @@ describe('<SetPassword />', () => {
   test('password less than 6 chars should throw', async () => {
     const { queryByText, getByText, container } = render(<SetPassword onSubmit={submit} />);
     const submitButton = getByText('action.save_password');
-    const passwordInput = container.querySelector('input[name="new-password"]');
+    const passwordInput = container.querySelector('input[name="newPassword"]');
 
     if (passwordInput) {
       fireEvent.change(passwordInput, { target: { value: '12345' } });
@@ -74,8 +74,8 @@ describe('<SetPassword />', () => {
   test('password mismatch with confirmPassword should throw', async () => {
     const { queryByText, getByText, container } = render(<SetPassword onSubmit={submit} />);
     const submitButton = getByText('action.save_password');
-    const passwordInput = container.querySelector('input[name="new-password"]');
-    const confirmPasswordInput = container.querySelector('input[name="confirm-password"]');
+    const passwordInput = container.querySelector('input[name="newPassword"]');
+    const confirmPasswordInput = container.querySelector('input[name="confirmPassword"]');
 
     act(() => {
       if (passwordInput) {
@@ -110,8 +110,8 @@ describe('<SetPassword />', () => {
   test('should submit properly', async () => {
     const { queryByText, getByText, container } = render(<SetPassword onSubmit={submit} />);
     const submitButton = getByText('action.save_password');
-    const passwordInput = container.querySelector('input[name="new-password"]');
-    const confirmPasswordInput = container.querySelector('input[name="confirm-password"]');
+    const passwordInput = container.querySelector('input[name="newPassword"]');
+    const confirmPasswordInput = container.querySelector('input[name="confirmPassword"]');
 
     act(() => {
       if (passwordInput) {

--- a/packages/ui/src/containers/SetPassword/index.tsx
+++ b/packages/ui/src/containers/SetPassword/index.tsx
@@ -23,8 +23,8 @@ type Props = {
 };
 
 type FieldState = {
-  ['new-password']: string;
-  ['confirm-password']: string;
+  newPassword: string;
+  confirmPassword: string;
 };
 
 const SetPassword = ({
@@ -46,7 +46,7 @@ const SetPassword = ({
     formState: { errors },
   } = useForm<FieldState>({
     reValidateMode: 'onChange',
-    defaultValues: { 'new-password': '', 'confirm-password': '' },
+    defaultValues: { newPassword: '', confirmPassword: '' },
   });
 
   const onSubmitHandler = useCallback(
@@ -54,14 +54,14 @@ const SetPassword = ({
       clearErrorMessage?.();
 
       void handleSubmit((data, event) => {
-        onSubmit(data['new-password']);
+        onSubmit(data.newPassword);
         event?.preventDefault();
       })(event);
     },
     [clearErrorMessage, handleSubmit, onSubmit]
   );
 
-  const newPasswordError = passwordErrorWatcher(errors['new-password']);
+  const newPasswordError = passwordErrorWatcher(errors.newPassword);
 
   return (
     <form className={classNames(styles.form, className)} onSubmit={onSubmitHandler}>
@@ -75,12 +75,12 @@ const SetPassword = ({
         isDanger={!!newPasswordError}
         error={newPasswordError}
         aria-invalid={!!newPasswordError}
-        {...register('new-password', { required: true, minLength: 6 })}
-        isSuffixFocusVisible={!!watch('new-password')}
+        {...register('newPassword', { required: true, minLength: 6 })}
+        isSuffixFocusVisible={!!watch('newPassword')}
         suffix={
           <IconButton
             onClick={() => {
-              resetField('new-password');
+              resetField('newPassword');
             }}
           >
             <ClearIcon />
@@ -94,16 +94,16 @@ const SetPassword = ({
         type={showPassword ? 'text' : 'password'}
         autoComplete="new-password"
         placeholder={t('input.confirm_password')}
-        error={errors['confirm-password'] && 'passwords_do_not_match'}
-        aria-invalid={!!errors['confirm-password']}
-        {...register('confirm-password', {
-          validate: (value) => value === watch('new-password'),
+        error={errors.confirmPassword && 'passwords_do_not_match'}
+        aria-invalid={!!errors.confirmPassword}
+        {...register('confirmPassword', {
+          validate: (value) => value === watch('newPassword'),
         })}
-        isSuffixFocusVisible={!!watch('confirm-password')}
+        isSuffixFocusVisible={!!watch('confirmPassword')}
         suffix={
           <IconButton
             onClick={() => {
-              resetField('confirm-password');
+              resetField('confirmPassword');
             }}
           >
             <ClearIcon />

--- a/packages/ui/src/containers/SetPassword/index.tsx
+++ b/packages/ui/src/containers/SetPassword/index.tsx
@@ -116,6 +116,7 @@ const SetPassword = ({
       <TogglePassword isChecked={showPassword} onChange={setShowPassword} />
 
       <Button
+        name="submit"
         title="action.save_password"
         onClick={async () => {
           onSubmitHandler();

--- a/packages/ui/src/pages/Continue/SetPassword/index.test.tsx
+++ b/packages/ui/src/pages/Continue/SetPassword/index.test.tsx
@@ -24,8 +24,8 @@ describe('SetPassword', () => {
         <SetPassword />
       </SettingsProvider>
     );
-    expect(container.querySelector('input[name="new-password"]')).not.toBeNull();
-    expect(container.querySelector('input[name="confirm-password"]')).not.toBeNull();
+    expect(container.querySelector('input[name="newPassword"]')).not.toBeNull();
+    expect(container.querySelector('input[name="confirmPassword"]')).not.toBeNull();
     expect(queryByText('action.save_password')).not.toBeNull();
   });
 
@@ -36,8 +36,8 @@ describe('SetPassword', () => {
       </SettingsProvider>
     );
     const submitButton = getByText('action.save_password');
-    const passwordInput = container.querySelector('input[name="new-password"]');
-    const confirmPasswordInput = container.querySelector('input[name="confirm-password"]');
+    const passwordInput = container.querySelector('input[name="newPassword"]');
+    const confirmPasswordInput = container.querySelector('input[name="confirmPassword"]');
 
     act(() => {
       if (passwordInput) {

--- a/packages/ui/src/pages/Continue/SetPassword/index.test.tsx
+++ b/packages/ui/src/pages/Continue/SetPassword/index.test.tsx
@@ -25,7 +25,7 @@ describe('SetPassword', () => {
       </SettingsProvider>
     );
     expect(container.querySelector('input[name="new-password"]')).not.toBeNull();
-    expect(container.querySelector('input[name="confirm-new-password"]')).not.toBeNull();
+    expect(container.querySelector('input[name="confirm-password"]')).not.toBeNull();
     expect(queryByText('action.save_password')).not.toBeNull();
   });
 
@@ -37,7 +37,7 @@ describe('SetPassword', () => {
     );
     const submitButton = getByText('action.save_password');
     const passwordInput = container.querySelector('input[name="new-password"]');
-    const confirmPasswordInput = container.querySelector('input[name="confirm-new-password"]');
+    const confirmPasswordInput = container.querySelector('input[name="confirm-password"]');
 
     act(() => {
       if (passwordInput) {

--- a/packages/ui/src/pages/PasswordRegisterWithUsername/index.test.tsx
+++ b/packages/ui/src/pages/PasswordRegisterWithUsername/index.test.tsx
@@ -37,7 +37,7 @@ describe('<PasswordRegisterWithUsername />', () => {
     );
 
     expect(container.querySelector('input[name="new-password"]')).not.toBeNull();
-    expect(container.querySelector('input[name="confirm-new-password"]')).not.toBeNull();
+    expect(container.querySelector('input[name="confirm-password"]')).not.toBeNull();
     expect(queryByText('action.save_password')).not.toBeNull();
   });
 
@@ -69,7 +69,7 @@ describe('<PasswordRegisterWithUsername />', () => {
 
     const submitButton = getByText('action.save_password');
     const passwordInput = container.querySelector('input[name="new-password"]');
-    const confirmPasswordInput = container.querySelector('input[name="confirm-new-password"]');
+    const confirmPasswordInput = container.querySelector('input[name="confirm-password"]');
 
     act(() => {
       if (passwordInput) {

--- a/packages/ui/src/pages/PasswordRegisterWithUsername/index.test.tsx
+++ b/packages/ui/src/pages/PasswordRegisterWithUsername/index.test.tsx
@@ -36,8 +36,8 @@ describe('<PasswordRegisterWithUsername />', () => {
       </SettingsProvider>
     );
 
-    expect(container.querySelector('input[name="new-password"]')).not.toBeNull();
-    expect(container.querySelector('input[name="confirm-password"]')).not.toBeNull();
+    expect(container.querySelector('input[name="newPassword"]')).not.toBeNull();
+    expect(container.querySelector('input[name="confirmPassword"]')).not.toBeNull();
     expect(queryByText('action.save_password')).not.toBeNull();
   });
 
@@ -56,7 +56,7 @@ describe('<PasswordRegisterWithUsername />', () => {
       </SettingsProvider>
     );
 
-    expect(container.querySelector('input[name="new-password"]')).toBeNull();
+    expect(container.querySelector('input[name="newPassword"]')).toBeNull();
     expect(queryByText('description.not_found')).not.toBeNull();
   });
 
@@ -68,8 +68,8 @@ describe('<PasswordRegisterWithUsername />', () => {
     );
 
     const submitButton = getByText('action.save_password');
-    const passwordInput = container.querySelector('input[name="new-password"]');
-    const confirmPasswordInput = container.querySelector('input[name="confirm-password"]');
+    const passwordInput = container.querySelector('input[name="newPassword"]');
+    const confirmPasswordInput = container.querySelector('input[name="confirmPassword"]');
 
     act(() => {
       if (passwordInput) {

--- a/packages/ui/src/pages/ResetPassword/index.test.tsx
+++ b/packages/ui/src/pages/ResetPassword/index.test.tsx
@@ -27,16 +27,16 @@ describe('ForgotPassword', () => {
       </MemoryRouter>
     );
 
-    expect(container.querySelector('input[name="new-password"]')).not.toBeNull();
-    expect(container.querySelector('input[name="confirm-password"]')).not.toBeNull();
+    expect(container.querySelector('input[name="newPassword"]')).not.toBeNull();
+    expect(container.querySelector('input[name="confirmPassword"]')).not.toBeNull();
     expect(queryByText('action.save_password')).not.toBeNull();
   });
 
   test('should submit properly', async () => {
     const { getByText, container } = renderWithPageContext(<ResetPassword />);
     const submitButton = getByText('action.save_password');
-    const passwordInput = container.querySelector('input[name="new-password"]');
-    const confirmPasswordInput = container.querySelector('input[name="confirm-password"]');
+    const passwordInput = container.querySelector('input[name="newPassword"]');
+    const confirmPasswordInput = container.querySelector('input[name="confirmPassword"]');
 
     act(() => {
       if (passwordInput) {

--- a/packages/ui/src/pages/ResetPassword/index.test.tsx
+++ b/packages/ui/src/pages/ResetPassword/index.test.tsx
@@ -28,7 +28,7 @@ describe('ForgotPassword', () => {
     );
 
     expect(container.querySelector('input[name="new-password"]')).not.toBeNull();
-    expect(container.querySelector('input[name="confirm-new-password"]')).not.toBeNull();
+    expect(container.querySelector('input[name="confirm-password"]')).not.toBeNull();
     expect(queryByText('action.save_password')).not.toBeNull();
   });
 
@@ -36,7 +36,7 @@ describe('ForgotPassword', () => {
     const { getByText, container } = renderWithPageContext(<ResetPassword />);
     const submitButton = getByText('action.save_password');
     const passwordInput = container.querySelector('input[name="new-password"]');
-    const confirmPasswordInput = container.querySelector('input[name="confirm-new-password"]');
+    const confirmPasswordInput = container.querySelector('input[name="confirm-password"]');
 
     act(() => {
       if (passwordInput) {

--- a/packages/ui/src/utils/form.ts
+++ b/packages/ui/src/utils/form.ts
@@ -1,0 +1,13 @@
+import type { FieldError } from 'react-hook-form';
+
+import type { ErrorType } from '@/components/ErrorMessage';
+
+export const passwordErrorWatcher = (error?: FieldError): ErrorType | undefined => {
+  switch (error?.type) {
+    case 'required':
+      return 'password_required';
+    case 'minLength':
+      return { code: 'password_min_length', data: { min: 6 } };
+    default:
+  }
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -813,6 +813,7 @@ importers:
       react: ^18.0.0
       react-device-detect: ^2.2.2
       react-dom: ^18.0.0
+      react-hook-form: ^7.34.0
       react-i18next: ^11.18.3
       react-modal: ^3.15.1
       react-router-dom: ^6.2.2
@@ -868,6 +869,7 @@ importers:
       react: 18.2.0
       react-device-detect: 2.2.2_biqbaboplfbrettd7655fr4n2y
       react-dom: 18.2.0_react@18.2.0
+      react-hook-form: 7.34.0_react@18.2.0
       react-i18next: 11.18.3_shxxmfhtk2bc4pbx5cyq3uoph4
       react-modal: 3.15.1_biqbaboplfbrettd7655fr4n2y
       react-router-dom: 6.2.2_biqbaboplfbrettd7655fr4n2y


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

This PR is the start of a series of MainFlow form refactors.  

1. Define the new `InputField` Component.  the old `Input` component will be deprecated gradually. 
2. Add react-hook-form as a new dependent. Deprecate the local useForm hook gradually. 
3. Add a password toggle checkbox to control password visibility. 
4. Did some minor optimize of the password form following the suggestion from this [blog](https://web.dev/sign-in-form-best-practices/#accessible-password-inputs)

<img width="647" alt="image" src="https://user-images.githubusercontent.com/36393111/215311986-97285c38-e11a-44c8-89e8-8970e6a2c27a.png">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
UT updated
