### PR TITLE
fix(console): navigate to log details page on user log clicked

### DIFF
--- a/packages/console/src/App.tsx
+++ b/packages/console/src/App.tsx
@@ -108,10 +108,9 @@ const Main = () => {
                   <Route index element={<Navigate replace to={UserDetailsTabs.Settings} />} />
                   <Route path={UserDetailsTabs.Settings} element={<UserSettings />} />
                   <Route path={UserDetailsTabs.Roles} element={<UserRoles />} />
-                  <Route path={UserDetailsTabs.Logs} element={<UserLogs />}>
-                    <Route path=":logId" element={<AuditLogDetails />} />
-                  </Route>
+                  <Route path={UserDetailsTabs.Logs} element={<UserLogs />} />
                 </Route>
+                <Route path={`:id/${UserDetailsTabs.Logs}/:logId`} element={<AuditLogDetails />} />
               </Route>
               <Route path="audit-logs">
                 <Route index element={<AuditLogs />} />


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
The route of the `AuditLogDetails` component should be independent since we use `Outlet` to handle the user details page's tabs.
<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="1224" alt="image" src="https://user-images.githubusercontent.com/10806653/215396262-5c899ca4-4cef-4b8b-8d5a-95520914364c.png">

