### PR TITLE
chore: add Uffizzi demo button in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,17 @@ Boringly, we call it "[customer identity access management](https://en.wikipedia
 - Visit our 🎨 [website](https://logto.io) for a brief introduction if you are new to Logto.
 - A step-by-step guide is available on 📖 [docs.logto.io](https://docs.logto.io).
 
+### Interactive demo
+
+[![Uffizzi](https://cdn.uffizzi.com/demo-button.svg)](https://app.uffizzi.com/demo/github.com/logto-io/logto)
+
+Recommended. Click and wait for a few seconds to start exploring Logto in your own browser!
+
+[![GitPod](https://raw.githubusercontent.com/gitpod-io/gitpod/30da76375c996109f243491b23e47feefab7217f/components/dashboard/public/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/logto-io/demo)
+
+If you launch Logto via GitPod, please wait until you see the message like `App is running at https://3001-...gitpod.io` in the terminal, press Cmd (or Ctrl on Windows) and click the URL to continue your Logto journey.
+
 ### Launch Logto
-
-#### Online demo (GitPod)
-
-[Click here](https://gitpod.io/#https://github.com/logto-io/demo) to launch Logto via GitPod. Once you see the message like `App is running at https://3001-...gitpod.io` in the terminal, press Cmd (or Ctrl) and click the URL to continue your Logto journey.
 
 #### Docker Compose
 

--- a/docker-compose.demo.uffizzi.yml
+++ b/docker-compose.demo.uffizzi.yml
@@ -1,0 +1,37 @@
+# This compose file is for demonstration only, do not use in prod.
+version: "3.9"
+
+x-uffizzi:
+  ingress:
+    service: app
+    port: 3001
+
+services:
+  app:
+    depends_on:
+      - "postgres"
+    image: registry.uffizzi.com/logto-io/logto:prerelease
+    ports:
+      - 3001:3001
+    environment:
+      TRUST_PROXY_HEADER: 1
+      DB_URL: postgres://postgres:p0stgr3s@localhost:5432/logto
+    deploy:
+      resources:
+        limits:
+          memory: 2000M
+    entrypoint: /bin/sh
+    command:
+      - "-c"
+      - "npm run cli db seed -- --swe && ENDPOINT=$$UFFIZZI_URL npm start"
+
+  postgres:
+    image: postgres:14-alpine
+    user: postgres
+    environment:
+      POSTGRES_USER: "postgres"
+      POSTGRES_PASSWORD: "p0stgr3s"
+    deploy:
+      resources:
+        limits:
+          memory: 500M


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
This PR adds a button to the project `README` which allows visitors to the logto project to get a live, interactive demo of logto with one click. Each demo instance is a sandboxed [Uffizzi](https://www.uffizzi.com) environment that is isolated from other demos, like all Uffizzi previews. This button requires **no configuration** by visitors, and it **does not** require them to have a Uffizzi account.  

[![Demo](https://cdn.uffizzi.com/demo-button.svg)](https://app.uffizzi.com/demo/github.com/logto-io/logto)

### How it works
This button makes a request to a public route `https://app.uffizzi.com/demo/github.com/logto-io/logto` which will trigger a demo deployment of logto on Uffizzi Cloud based on [this configuration](https://github.com/gadkins/logto/blob/uffizzi-live-demo-button/docker-compose.demo.uffizzi.yml). Note that if you want to demo a different tag than `logto-io/logto:prerelease`, let me know as I will need to make a change on the backend. You'll be able to make changes yourself in `docker-compose.demo.uffizzi.yml` in the next iteration.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
To test this PR you can click on the button above, or try it from my fork [here](https://github.com/gadkins/logto/tree/uffizzi-live-demo-button#interactive-demo). 