### PR TITLE
fix(ui): should handle requiredProfile error on bindSocialRelatedUser

### DIFF
--- a/packages/ui/src/hooks/use-social-link-related-user.ts
+++ b/packages/ui/src/hooks/use-social-link-related-user.ts
@@ -3,8 +3,14 @@ import { useEffect } from 'react';
 import { bindSocialRelatedUser } from '@/apis/interaction';
 import useApi from '@/hooks/use-api';
 
+import useRequiredProfileErrorHandler from './use-required-profile-error-handler';
+
 const useBindSocialRelatedUser = () => {
-  const { result: bindUserResult, run: asyncBindSocialRelatedUser } = useApi(bindSocialRelatedUser);
+  const requiredProfileErrorHandlers = useRequiredProfileErrorHandler();
+  const { result: bindUserResult, run: asyncBindSocialRelatedUser } = useApi(
+    bindSocialRelatedUser,
+    requiredProfileErrorHandlers
+  );
 
   useEffect(() => {
     if (bindUserResult?.redirectTo) {


### PR DESCRIPTION


<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
should handle required profile errors on bindSocialRelatedUser flow

bug noticed on the social bindRelatedUserInfo flow. fulfill additional profile is not handled.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
