### PR TITLE
refactor(ui): refactor useApi

### DIFF
--- a/packages/ui/src/containers/SetPassword/index.test.tsx
+++ b/packages/ui/src/containers/SetPassword/index.test.tsx
@@ -28,7 +28,7 @@ describe('<SetPassword />', () => {
     const submitButton = getByText('action.save_password');
 
     act(() => {
-      fireEvent.click(submitButton);
+      fireEvent.submit(submitButton);
     });
 
     expect(clearError).toBeCalled();
@@ -50,7 +50,7 @@ describe('<SetPassword />', () => {
     }
 
     act(() => {
-      fireEvent.click(submitButton);
+      fireEvent.submit(submitButton);
     });
 
     await waitFor(() => {
@@ -86,7 +86,7 @@ describe('<SetPassword />', () => {
         fireEvent.change(confirmPasswordInput, { target: { value: '012345' } });
       }
 
-      fireEvent.click(submitButton);
+      fireEvent.submit(submitButton);
     });
 
     await waitFor(() => {
@@ -122,7 +122,7 @@ describe('<SetPassword />', () => {
         fireEvent.change(confirmPasswordInput, { target: { value: '123456' } });
       }
 
-      fireEvent.click(submitButton);
+      fireEvent.submit(submitButton);
     });
 
     expect(queryByText('passwords_do_not_match')).toBeNull();

--- a/packages/ui/src/containers/SetPassword/index.tsx
+++ b/packages/ui/src/containers/SetPassword/index.tsx
@@ -115,13 +115,7 @@ const SetPassword = ({
 
       <TogglePassword isChecked={showPassword} onChange={setShowPassword} />
 
-      <Button
-        name="submit"
-        title="action.save_password"
-        onClick={() => {
-          onSubmitHandler();
-        }}
-      />
+      <Button name="submit" title="action.save_password" htmlType="submit" />
 
       <input hidden type="submit" />
     </form>

--- a/packages/ui/src/containers/UsernameForm/UsernameRegister/use-username-register.ts
+++ b/packages/ui/src/containers/UsernameForm/UsernameRegister/use-username-register.ts
@@ -3,8 +3,9 @@ import { useState, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { registerWithUsernamePassword } from '@/apis/interaction';
-import type { ErrorHandlers } from '@/hooks/use-api';
 import useApi from '@/hooks/use-api';
+import type { ErrorHandlers } from '@/hooks/use-error-handler';
+import useErrorHandler from '@/hooks/use-error-handler';
 import { UserFlow } from '@/types';
 
 const useUsernameRegister = () => {
@@ -27,13 +28,18 @@ const useUsernameRegister = () => {
     [navigate]
   );
 
-  const { run: asyncRegister } = useApi(registerWithUsernamePassword, errorHandlers);
+  const handleError = useErrorHandler();
+  const asyncRegister = useApi(registerWithUsernamePassword);
 
   const onSubmit = useCallback(
     async (username: string) => {
-      await asyncRegister(username);
+      const [error] = await asyncRegister(username);
+
+      if (error) {
+        await handleError(error, errorHandlers);
+      }
     },
-    [asyncRegister]
+    [asyncRegister, errorHandlers, handleError]
   );
 
   return { errorMessage, clearErrorMessage, onSubmit };

--- a/packages/ui/src/containers/VerificationCode/use-general-verification-code-error-handler.ts
+++ b/packages/ui/src/containers/VerificationCode/use-general-verification-code-error-handler.ts
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react';
 
-import type { ErrorHandlers } from '@/hooks/use-api';
+import type { ErrorHandlers } from '@/hooks/use-error-handler';
 
 const useGeneralVerificationCodeErrorHandler = () => {
   const [errorMessage, setErrorMessage] = useState<string>();

--- a/packages/ui/src/containers/VerificationCode/use-resend-verification-code.ts
+++ b/packages/ui/src/containers/VerificationCode/use-resend-verification-code.ts
@@ -5,6 +5,7 @@ import { useTimer } from 'react-timer-hook';
 
 import { getSendVerificationCodeApi } from '@/apis/utils';
 import useApi from '@/hooks/use-api';
+import useErrorHandler from '@/hooks/use-error-handler';
 import { PageContext } from '@/hooks/use-page-context';
 import type { UserFlow } from '@/types';
 
@@ -29,17 +30,24 @@ const useResendVerificationCode = (
     expiryTimestamp: getTimeout(),
   });
 
-  const { run: sendVerificationCode } = useApi(getSendVerificationCodeApi(type));
+  const handleError = useErrorHandler();
+  const sendVerificationCode = useApi(getSendVerificationCodeApi(type));
 
   const onResendVerificationCode = useCallback(async () => {
     const payload = method === SignInIdentifier.Email ? { email: target } : { phone: target };
-    const result = await sendVerificationCode(payload);
+    const [error, result] = await sendVerificationCode(payload);
+
+    if (error) {
+      await handleError(error);
+
+      return;
+    }
 
     if (result) {
       setToast(t('description.passcode_sent'));
       restart(getTimeout(), true);
     }
-  }, [method, restart, sendVerificationCode, setToast, target]);
+  }, [handleError, method, restart, sendVerificationCode, setToast, target]);
 
   return {
     seconds,

--- a/packages/ui/src/hooks/use-error-handler.ts
+++ b/packages/ui/src/hooks/use-error-handler.ts
@@ -1,0 +1,53 @@
+import type { LogtoErrorCode } from '@logto/phrases';
+import type { RequestErrorBody } from '@logto/schemas';
+import { HTTPError } from 'ky';
+import { useCallback, useContext } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { PageContext } from '@/hooks/use-page-context';
+
+export type ErrorHandlers = {
+  [key in LogtoErrorCode]?: (error: RequestErrorBody) => void | Promise<void>;
+} & {
+  // Overwrite default global error handle logic
+  global?: (error: RequestErrorBody) => void | Promise<void>;
+};
+
+const useErrorHandler = () => {
+  const { t } = useTranslation();
+  const { setToast } = useContext(PageContext);
+
+  const handleError = useCallback(
+    async (error: unknown, errorHandlers?: ErrorHandlers) => {
+      if (error instanceof HTTPError) {
+        try {
+          const logtoError = await error.response.json<RequestErrorBody>();
+
+          const { code, message } = logtoError;
+          const handler = errorHandlers?.[code] ?? errorHandlers?.global;
+
+          if (handler) {
+            await handler(logtoError);
+          } else {
+            setToast(message);
+          }
+
+          return;
+        } catch {
+          setToast(t('error.unknown'));
+          console.error(error);
+
+          return;
+        }
+      }
+
+      setToast(t('error.unknown'));
+      console.error(error);
+    },
+    [setToast, t]
+  );
+
+  return handleError;
+};
+
+export default useErrorHandler;

--- a/packages/ui/src/hooks/use-password-sign-in.ts
+++ b/packages/ui/src/hooks/use-password-sign-in.ts
@@ -1,9 +1,10 @@
-import { useState, useMemo, useCallback, useEffect } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 
 import type { PasswordSignInPayload } from '@/apis/interaction';
 import { signInWithPasswordIdentifier } from '@/apis/interaction';
-import type { ErrorHandlers } from '@/hooks/use-api';
 import useApi from '@/hooks/use-api';
+import type { ErrorHandlers } from '@/hooks/use-error-handler';
+import useErrorHandler from '@/hooks/use-error-handler';
 import { UserFlow } from '@/types';
 
 import useRequiredProfileErrorHandler from './use-required-profile-error-handler';
@@ -15,8 +16,10 @@ const usePasswordSignIn = () => {
     setErrorMessage('');
   }, []);
 
-  const requiredProfileErrorHandler = useRequiredProfileErrorHandler({ flow: UserFlow.signIn });
+  const handleError = useErrorHandler();
+  const asyncSignIn = useApi(signInWithPasswordIdentifier);
 
+  const requiredProfileErrorHandler = useRequiredProfileErrorHandler({ flow: UserFlow.signIn });
   const errorHandlers: ErrorHandlers = useMemo(
     () => ({
       'session.invalid_credentials': (error) => {
@@ -27,19 +30,21 @@ const usePasswordSignIn = () => {
     [requiredProfileErrorHandler]
   );
 
-  const { result, run: asyncSignIn } = useApi(signInWithPasswordIdentifier, errorHandlers);
-
-  useEffect(() => {
-    if (result?.redirectTo) {
-      window.location.replace(result.redirectTo);
-    }
-  }, [result]);
-
   const onSubmit = useCallback(
     async (payload: PasswordSignInPayload) => {
-      await asyncSignIn(payload);
+      const [error, result] = await asyncSignIn(payload);
+
+      if (error) {
+        await handleError(error, errorHandlers);
+
+        return;
+      }
+
+      if (result?.redirectTo) {
+        window.location.replace(result.redirectTo);
+      }
     },
-    [asyncSignIn]
+    [asyncSignIn, errorHandlers, handleError]
   );
 
   return {

--- a/packages/ui/src/hooks/use-required-profile-error-handler.ts
+++ b/packages/ui/src/hooks/use-required-profile-error-handler.ts
@@ -7,7 +7,7 @@ import { UserFlow, SearchParameters } from '@/types';
 import { missingProfileErrorDataGuard } from '@/types/guard';
 import { queryStringify } from '@/utils';
 
-import type { ErrorHandlers } from './use-api';
+import type { ErrorHandlers } from './use-error-handler';
 import { PageContext } from './use-page-context';
 
 type Options = {

--- a/packages/ui/src/hooks/use-social-link-account.ts
+++ b/packages/ui/src/hooks/use-social-link-account.ts
@@ -1,18 +1,30 @@
-import { useEffect } from 'react';
+import { useCallback } from 'react';
 
 import { linkWithSocial } from '@/apis/interaction';
 import useApi from '@/hooks/use-api';
 
+import useErrorHandler from './use-error-handler';
+
 const useLinkSocial = () => {
-  const { result: linkResult, run: asyncLinkWithSocial } = useApi(linkWithSocial);
+  const handleError = useErrorHandler();
+  const asyncLinkWithSocial = useApi(linkWithSocial);
 
-  useEffect(() => {
-    if (linkResult?.redirectTo) {
-      window.location.replace(linkResult.redirectTo);
-    }
-  }, [linkResult]);
+  return useCallback(
+    async (connectorId: string) => {
+      const [error, result] = await asyncLinkWithSocial(connectorId);
 
-  return asyncLinkWithSocial;
+      if (error) {
+        await handleError(error);
+
+        return;
+      }
+
+      if (result?.redirectTo) {
+        window.location.replace(result.redirectTo);
+      }
+    },
+    [asyncLinkWithSocial, handleError]
+  );
 };
 
 export default useLinkSocial;

--- a/packages/ui/src/hooks/use-social-link-related-user.ts
+++ b/packages/ui/src/hooks/use-social-link-related-user.ts
@@ -1,24 +1,33 @@
-import { useEffect } from 'react';
+import { useCallback } from 'react';
 
 import { bindSocialRelatedUser } from '@/apis/interaction';
-import useApi from '@/hooks/use-api';
 
+import useApi from './use-api';
+import useErrorHandler from './use-error-handler';
 import useRequiredProfileErrorHandler from './use-required-profile-error-handler';
 
 const useBindSocialRelatedUser = () => {
+  const handleError = useErrorHandler();
   const requiredProfileErrorHandlers = useRequiredProfileErrorHandler();
-  const { result: bindUserResult, run: asyncBindSocialRelatedUser } = useApi(
-    bindSocialRelatedUser,
-    requiredProfileErrorHandlers
+
+  const asyncBindSocialRelatedUser = useApi(bindSocialRelatedUser);
+
+  return useCallback(
+    async (...payload: Parameters<typeof bindSocialRelatedUser>) => {
+      const [error, result] = await asyncBindSocialRelatedUser(...payload);
+
+      if (error) {
+        await handleError(error, requiredProfileErrorHandlers);
+
+        return;
+      }
+
+      if (result?.redirectTo) {
+        window.location.replace(result.redirectTo);
+      }
+    },
+    [asyncBindSocialRelatedUser, handleError, requiredProfileErrorHandlers]
   );
-
-  useEffect(() => {
-    if (bindUserResult?.redirectTo) {
-      window.location.replace(bindUserResult.redirectTo);
-    }
-  }, [bindUserResult]);
-
-  return asyncBindSocialRelatedUser;
 };
 
 export default useBindSocialRelatedUser;

--- a/packages/ui/src/hooks/use-social-sign-in-listener.ts
+++ b/packages/ui/src/hooks/use-social-sign-in-listener.ts
@@ -11,8 +11,9 @@ import { socialAccountNotExistErrorDataGuard } from '@/types/guard';
 import { parseQueryParameters } from '@/utils';
 import { stateValidation } from '@/utils/social-connectors';
 
-import type { ErrorHandlers } from './use-api';
 import useApi from './use-api';
+import useErrorHandler from './use-error-handler';
+import type { ErrorHandlers } from './use-error-handler';
 import { PageContext } from './use-page-context';
 import useRequiredProfileErrorHandler from './use-required-profile-error-handler';
 import { useSieMethods } from './use-sie';
@@ -25,7 +26,9 @@ const useSocialSignInListener = (connectorId?: string) => {
 
   const navigate = useNavigate();
 
+  const handleError = useErrorHandler();
   const registerWithSocial = useSocialRegister(connectorId, true);
+  const asyncSignInWithSocial = useApi(signInWithSocial);
 
   const accountNotExistErrorHandler = useCallback(
     async (error: RequestErrorBody) => {
@@ -50,12 +53,10 @@ const useSocialSignInListener = (connectorId?: string) => {
     },
     [connectorId, navigate, registerWithSocial]
   );
-
   const requiredProfileErrorHandlers = useRequiredProfileErrorHandler({
     replace: true,
     flow: UserFlow.signIn,
   });
-
   const signInWithSocialErrorHandlers: ErrorHandlers = useMemo(
     () => ({
       'user.identity_not_exist': async (error) => {
@@ -73,14 +74,11 @@ const useSocialSignInListener = (connectorId?: string) => {
     [requiredProfileErrorHandlers, signInMode, accountNotExistErrorHandler, setToast]
   );
 
-  const { result, run: asyncSignInWithSocial } = useApi(
-    signInWithSocial,
-    signInWithSocialErrorHandlers
-  );
-
   const signInWithSocialHandler = useCallback(
     async (connectorId: string, data: Record<string, unknown>) => {
-      void asyncSignInWithSocial({
+      console.log('triggered');
+
+      const [error, result] = await asyncSignInWithSocial({
         connectorId,
         connectorData: {
           // For validation use only
@@ -88,15 +86,19 @@ const useSocialSignInListener = (connectorId?: string) => {
           ...data,
         },
       });
-    },
-    [asyncSignInWithSocial]
-  );
 
-  useEffect(() => {
-    if (result?.redirectTo) {
-      window.location.replace(result.redirectTo);
-    }
-  }, [result]);
+      if (error) {
+        await handleError(error, signInWithSocialErrorHandlers);
+
+        return;
+      }
+
+      if (result?.redirectTo) {
+        window.location.replace(result.redirectTo);
+      }
+    },
+    [asyncSignInWithSocial, handleError, signInWithSocialErrorHandlers]
+  );
 
   // Social Sign-In Callback Handler
   useEffect(() => {

--- a/packages/ui/src/pages/Consent/index.tsx
+++ b/packages/ui/src/pages/Consent/index.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useContext } from 'react';
+import { useEffect, useContext, useState } from 'react';
 
 import { consent } from '@/apis/consent';
 import { LoadingIcon } from '@/components/LoadingLayer';
 import useApi from '@/hooks/use-api';
+import useErrorHandler from '@/hooks/use-error-handler';
 import { PageContext } from '@/hooks/use-page-context';
 import { getLogoUrl } from '@/utils/logo';
 
@@ -10,18 +11,27 @@ import * as styles from './index.module.scss';
 
 const Consent = () => {
   const { experienceSettings, theme } = useContext(PageContext);
-  const { error, result, run: asyncConsent } = useApi(consent);
+  const handleError = useErrorHandler();
+  const asyncConsent = useApi(consent);
   const branding = experienceSettings?.branding;
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    void asyncConsent();
-  }, [asyncConsent]);
+    (async () => {
+      const [error, result] = await asyncConsent();
+      setLoading(false);
 
-  useEffect(() => {
-    if (result?.redirectTo) {
-      window.location.replace(result.redirectTo);
-    }
-  }, [result]);
+      if (error) {
+        await handleError(error);
+
+        return;
+      }
+
+      if (result?.redirectTo) {
+        window.location.replace(result.redirectTo);
+      }
+    })();
+  }, [asyncConsent, handleError]);
 
   return (
     <div className={styles.wrapper}>
@@ -31,7 +41,7 @@ const Consent = () => {
           src={getLogoUrl({ theme, logoUrl: branding.logoUrl, darkLogoUrl: branding.darkLogoUrl })}
         />
       )}
-      {!error && <LoadingIcon />}
+      {loading && <LoadingIcon />}
     </div>
   );
 };

--- a/packages/ui/src/pages/PasswordRegisterWithUsername/index.tsx
+++ b/packages/ui/src/pages/PasswordRegisterWithUsername/index.tsx
@@ -9,7 +9,7 @@ import useUsernamePasswordRegister from './use-username-password-register';
 
 const PasswordRegisterWithUsername = () => {
   const { signUpMethods } = useSieMethods();
-  const { setPassword } = useUsernamePasswordRegister();
+  const setPassword = useUsernamePasswordRegister();
 
   if (!signUpMethods.includes(SignInIdentifier.Username)) {
     return <ErrorPage />;

--- a/packages/ui/src/pages/SignIn/PasswordSignInForm/index.test.tsx
+++ b/packages/ui/src/pages/SignIn/PasswordSignInForm/index.test.tsx
@@ -73,7 +73,7 @@ describe('UsernamePasswordSignInForm', () => {
     const submitButton = getByText('action.sign_in');
 
     act(() => {
-      fireEvent.click(submitButton);
+      fireEvent.submit(submitButton);
     });
 
     await waitFor(() => {
@@ -118,7 +118,7 @@ describe('UsernamePasswordSignInForm', () => {
     });
 
     act(() => {
-      fireEvent.click(submitButton);
+      fireEvent.submit(submitButton);
     });
 
     await waitFor(() => {
@@ -153,7 +153,7 @@ describe('UsernamePasswordSignInForm', () => {
     });
 
     act(() => {
-      fireEvent.click(submitButton);
+      fireEvent.submit(submitButton);
     });
 
     await waitFor(() => {
@@ -186,7 +186,7 @@ describe('UsernamePasswordSignInForm', () => {
     });
 
     act(() => {
-      fireEvent.click(submitButton);
+      fireEvent.submit(submitButton);
     });
 
     act(() => {

--- a/packages/ui/src/pages/SignIn/PasswordSignInForm/index.tsx
+++ b/packages/ui/src/pages/SignIn/PasswordSignInForm/index.tsx
@@ -130,13 +130,7 @@ const PasswordSignInForm = ({ className, autoFocus, signInMethods }: Props) => {
 
       <TermsOfUse className={styles.terms} />
 
-      <Button
-        name="submit"
-        title="action.sign_in"
-        onClick={() => {
-          void onSubmitHandler();
-        }}
-      />
+      <Button name="submit" title="action.sign_in" htmlType="submit" />
 
       <input hidden type="submit" />
     </form>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
refactor `useApi` logic. Call API synchronize.

When trying to merge our input fields using smart input-field, the previous implementation of `useApi` hook becomes painful.  

previously:
```js
import someApi from '@/api/someApi';

const errorHandlers = { /* ...  */};

const {result, run} = useApi(someApi, errorHandlers);

useEffect(() => { /* callback */}, [result]);

void run(args);
```
As you may see, the error handlers and API calls are coupled together and handled centrally.  It is hard to customize error-handling logic based on API runtime input. 

Update:

decouple the errorHandler hook and API hook. Make everything sync as we used to write API requests. Not smart but straight forward. 

```js

import someApi from '@/api/someApi';

const errorHandlers = { /* ...  */};
const request= useApi(someApi);
const handlerError = useErrorHandler();

(payload) => {
  const [error, result] = await request(payload);
  
  if (error) {
     handlerError(error, errorHandlers);
     return;
  }

  if (result) {

   }
}

```


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT passed test locally for some major API request
