### PR TITLE
refactor: update connector interfaces

### DIFF
--- a/.changeset-staged/nine-apes-attend.md
+++ b/.changeset-staged/nine-apes-attend.md
@@ -1,0 +1,5 @@
+---
+"@logto/connector-kit": minor
+---
+
+`getSession` and `setSession` are actually used as REQUIRED parameters, update interface definition.

--- a/packages/core/src/libraries/social.ts
+++ b/packages/core/src/libraries/social.ts
@@ -65,7 +65,7 @@ export const createSocialLibrary = (queries: Queries, connectorLibrary: Connecto
   const getUserInfoByAuthCode = async (
     connectorId: string,
     data: unknown,
-    getConnectorSession?: GetSession
+    getConnectorSession: GetSession
   ): Promise<SocialUserInfo> => {
     const connector = await getConnector(connectorId);
 

--- a/packages/toolkit/connector-kit/src/types.ts
+++ b/packages/toolkit/connector-kit/src/types.ts
@@ -191,7 +191,7 @@ export type GetAuthorizationUri = (
     jti: string;
     headers: { userAgent?: string };
   },
-  setSession?: SetSession
+  setSession: SetSession
 ) => Promise<string>;
 
 export const socialUserInfoGuard = z.object({
@@ -206,5 +206,5 @@ export type SocialUserInfo = z.infer<typeof socialUserInfoGuard>;
 
 export type GetUserInfo = (
   data: unknown,
-  getSession?: GetSession
+  getSession: GetSession
 ) => Promise<SocialUserInfo & Record<string, string | boolean | number | undefined>>;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Update connector interfaces since `getSession` and `setSession` passed to both `getAuthorizationUri` and `getUserInfo` are actually used as REQUIRED parameters.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally, UTs and ITs.
