### PR TITLE
fix(ui): native app postMessage listener should be registered properly

### DIFF
--- a/packages/ui/src/containers/SocialSignIn/SocialSignInList/index.tsx
+++ b/packages/ui/src/containers/SocialSignIn/SocialSignInList/index.tsx
@@ -2,6 +2,7 @@ import type { ConnectorMetadata } from '@logto/schemas';
 import classNames from 'classnames';
 
 import SocialLinkButton from '@/components/Button/SocialLinkButton';
+import useNativeMessageListener from '@/hooks/use-native-message-listener';
 import useSocial from '@/hooks/use-social';
 import { getLogoUrl } from '@/utils/logo';
 
@@ -14,6 +15,7 @@ type Props = {
 
 const SocialSignInList = ({ className, socialConnectors = [] }: Props) => {
   const { invokeSocialSignIn, theme } = useSocial();
+  useNativeMessageListener();
 
   return (
     <div className={classNames(styles.socialLinkList, className)}>

--- a/packages/ui/src/containers/SocialSignIn/index.tsx
+++ b/packages/ui/src/containers/SocialSignIn/index.tsx
@@ -1,5 +1,4 @@
 import TermsOfUse from '@/containers/TermsOfUse';
-import useNativeMessageListener from '@/hooks/use-native-message-listener';
 import useSocial from '@/hooks/use-social';
 
 import SocialSignInList from './SocialSignInList';
@@ -11,7 +10,6 @@ type Props = {
 
 const SocialSignIn = ({ className }: Props) => {
   const { socialConnectors } = useSocial();
-  useNativeMessageListener();
 
   return (
     <>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Move native app postMessage listener from `<SocialSignIn />` container to its sub-component `<SocialSignInList />`, as the former container is used conditionally when no other sign-in method is configured other than social.

<img width="539" alt="image" src="https://user-images.githubusercontent.com/12833674/218959935-9f84a761-14f9-49df-81a2-9bd86f1529cc.png">

This seems only affects the sign-in flow using native platform connectors (alipay-native, wechat-native).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [ ] Pending real device testing with alipay-native connector
