### PR TITLE
ci: build arm64 per release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,11 +51,26 @@ jobs:
           registry: ghcr.io
           username: silverhand-bot
           password: ${{ secrets.BOT_PAT }}
+      
+      - name: Setup Docker Buildx
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
       - name: Setup Depot
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: depot/setup-action@v1
 
-      - name: Build
+      - name: Build and push
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: depot/build-push-action@v1
         with:
           platforms: linux/amd64, linux/arm64


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
use depot to build on release only

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
the master workflow run showed depot can [build and push](https://github.com/logto-io/logto/actions/runs/4182578476/jobs/7245842130) arm64 images

<img width="758" alt="image" src="https://user-images.githubusercontent.com/14722250/219001736-c7f5f37c-9e4b-459f-977f-0780dca6404c.png">
