### PR TITLE
fix(ui): fix continue flow verification-code 404 bug

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -95,13 +95,13 @@ const App = () => {
                   <Route path="reset" element={<ResetPassword />} />
                 </Route>
 
+                {/* Passwordless verification code */}
+                <Route path=":flow/verification-code" element={<VerificationCode />} />
+
                 {/* Continue set up missing profile */}
                 <Route path="continue">
                   <Route path=":method" element={<Continue />} />
                 </Route>
-
-                {/* Passwordless verification code */}
-                <Route path=":flow/verification-code" element={<VerificationCode />} />
 
                 {/* Social sign-in pages */}
                 <Route path="social">

--- a/packages/ui/src/hooks/use-send-verification-code.ts
+++ b/packages/ui/src/hooks/use-send-verification-code.ts
@@ -46,7 +46,7 @@ const useSendVerificationCode = (flow: UserFlow, replaceCurrentPage?: boolean) =
       if (result) {
         navigate(
           {
-            pathname: `verification-code`,
+            pathname: `/${flow}/verification-code`,
             search: location.search,
           },
           {

--- a/packages/ui/src/pages/ForgotPassword/ForgotPasswordForm/index.test.tsx
+++ b/packages/ui/src/pages/ForgotPassword/ForgotPasswordForm/index.test.tsx
@@ -5,7 +5,7 @@ import { MemoryRouter } from 'react-router-dom';
 
 import renderWithPageContext from '@/__mocks__/RenderWithPageContext';
 import { putInteraction, sendVerificationCode } from '@/apis/interaction';
-import { VerificationCodeIdentifier } from '@/types';
+import { UserFlow, VerificationCodeIdentifier } from '@/types';
 
 import ForgotPasswordForm from '.';
 
@@ -81,7 +81,7 @@ describe('ForgotPasswordForm', () => {
           expect(sendVerificationCode).toBeCalledWith({ email });
           expect(mockedNavigate).toBeCalledWith(
             {
-              pathname: 'verification-code',
+              pathname: `/${UserFlow.forgotPassword}/verification-code`,
               search: '',
             },
             { state: { identifier, value }, replace: undefined }

--- a/packages/ui/src/pages/SignInPassword/PasswordForm/index.test.tsx
+++ b/packages/ui/src/pages/SignInPassword/PasswordForm/index.test.tsx
@@ -7,6 +7,7 @@ import {
   putInteraction,
   sendVerificationCode,
 } from '@/apis/interaction';
+import { UserFlow } from '@/types';
 
 import PasswordForm from '.';
 
@@ -89,7 +90,7 @@ describe('PasswordSignInForm', () => {
 
         expect(mockedNavigate).toBeCalledWith(
           {
-            pathname: 'verification-code',
+            pathname: `/${UserFlow.signIn}/verification-code`,
             search: '',
           },
           {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate) and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fx the continue flow verification-code 404 bug.

Context:
1. Among the previous SmartInputField refactor PRs, all secondary pages like` sign-in/email,` or `register/email` have been removed, except for the continue page. We still use subpaths `/continue/email`, `/continue/phone`.  
2. The verification code page route was updated as `/${flow}/verification-code`.  
3.  the `sendVerificationCode` callback handler uses related path navigation
  - 'sign-in' -> 'sign-in/verification-code'
  - 'register' -> 'register/verification-code'
  - 'forgot-password' -> 'forgot-password/verification-code'
  - 'continue/email' -> 'continue/email/verification-code'
 

Bug:
 'continue/email/verification-code' route path will lead to a 404 page.

Fix: use the absolute path for verification-code page. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

