### PR TITLE
fix(ui): update password sign-in link state value

### DIFF
--- a/packages/ui/src/containers/VerificationCode/PasswordSignInLink.tsx
+++ b/packages/ui/src/containers/VerificationCode/PasswordSignInLink.tsx
@@ -18,7 +18,7 @@ const PasswordSignInLink = ({ className, method, target }: Props) => {
       icon={<SwitchIcon />}
       text="action.sign_in_via_password"
       to={`/${UserFlow.signIn}/password`}
-      state={{ [method]: target }}
+      state={{ identifier: method, value: target }}
     />
   );
 };


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the verification-code page switch to the password sign-in page throwing the session not found bug

<img width="413" alt="image" src="https://user-images.githubusercontent.com/36393111/219257308-6c76d5c9-f84b-454a-94ce-9d2cefd569c7.png">

The verification-code page as well as password page location.state data schema has been updated to {`identifier: SignInIdentifier, value: string}.`

All the state passed by the manual navigation method  has been updated, the state value of 'PasswordSignInLink' here is missed. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally.
