### PR TITLE
fix(core): mask password in audit log

### DIFF
--- a/.changeset-staged/afraid-eagles-retire.md
+++ b/.changeset-staged/afraid-eagles-retire.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": minor
+---
+
+- mask sensitive password value in audit logs


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Mask the password in the audit logs.

TODO:
should encrypt the password ahead before insert into the interaction storage. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
UT added
![WX20230216-155417@2x](https://user-images.githubusercontent.com/36393111/219302871-5d37ff64-6e48-4284-ae13-b6c9fd896159.png)
![WX20230216-155237@2x](https://user-images.githubusercontent.com/36393111/219302886-b56c873b-2e9e-4e50-8f8e-d260ee449155.png)



