### PR TITLE
refactor(ui): refactor smart input field

### DIFF
--- a/packages/ui/src/components/InputFields/SmartInputField/index.tsx
+++ b/packages/ui/src/components/InputFields/SmartInputField/index.tsx
@@ -43,7 +43,7 @@ const SmartInputField = (
     onInputValueClear,
     identifierType,
   } = useSmartInputField({
-    defaultType,
+    _defaultType: defaultType,
     defaultValue,
     enabledTypes,
   });

--- a/packages/ui/src/components/InputFields/SmartInputField/use-smart-input-field.ts
+++ b/packages/ui/src/components/InputFields/SmartInputField/use-smart-input-field.ts
@@ -20,35 +20,35 @@ const digitsRegex = /^\d*$/;
 
 type Props = {
   defaultValue?: string;
-  defaultType?: IdentifierInputType;
+  _defaultType?: IdentifierInputType;
   enabledTypes: IdentifierInputType[];
 };
 
-const useSmartInputField = ({ defaultType, defaultValue, enabledTypes }: Props) => {
+const useSmartInputField = ({ _defaultType, defaultValue, enabledTypes }: Props) => {
   const enabledTypeSet = useMemo(() => new Set(enabledTypes), [enabledTypes]);
 
-  if (defaultType) {
-    assert(
-      enabledTypeSet.has(defaultType),
-      new Error(
-        `Invalid input type. Current inputType ${defaultType} is detected but missing in enabledTypes`
-      )
-    );
-  }
+  assert(
+    !_defaultType || enabledTypeSet.has(_defaultType),
+    new Error(
+      `Invalid input type. Current inputType ${
+        _defaultType ?? ''
+      } is detected but missing in enabledTypes`
+    )
+  );
 
   // Parse default type from enabled types if default type is not provided and only one type is enabled
-  const _defaultType = useMemo(
-    () => defaultType ?? (enabledTypes.length === 1 ? enabledTypes[0] : undefined),
-    [defaultType, enabledTypes]
+  const defaultType = useMemo(
+    () => _defaultType ?? (enabledTypes.length === 1 ? enabledTypes[0] : undefined),
+    [_defaultType, enabledTypes]
   );
 
   // Parse default value if provided
   const { countryCode: defaultCountryCode, inputValue: defaultInputValue } = useMemo(
-    () => parseIdentifierValue(_defaultType, defaultValue),
-    [_defaultType, defaultValue]
+    () => parseIdentifierValue(defaultType, defaultValue),
+    [defaultType, defaultValue]
   );
 
-  const [currentType, setCurrentType] = useState(_defaultType);
+  const [currentType, setCurrentType] = useState(defaultType);
 
   const [countryCode, setCountryCode] = useState<string>(
     defaultCountryCode ?? getDefaultCountryCallingCode()
@@ -64,7 +64,7 @@ const useSmartInputField = ({ defaultType, defaultValue, enabledTypes }: Props) 
       }
 
       if (enabledTypeSet.size === 1) {
-        return _defaultType;
+        return defaultType;
       }
 
       const hasAtSymbol = value.includes('@');
@@ -92,7 +92,7 @@ const useSmartInputField = ({ defaultType, defaultValue, enabledTypes }: Props) 
 
       return currentType;
     },
-    [_defaultType, currentType, enabledTypeSet]
+    [defaultType, currentType, enabledTypeSet]
   );
 
   const onCountryCodeChange = useCallback<ChangeEventHandler<HTMLSelectElement>>(
@@ -118,8 +118,8 @@ const useSmartInputField = ({ defaultType, defaultValue, enabledTypes }: Props) 
 
   const onInputValueClear = useCallback(() => {
     setInputValue('');
-    setCurrentType(enabledTypeSet.size === 1 ? _defaultType : undefined);
-  }, [_defaultType, enabledTypeSet.size]);
+    setCurrentType(enabledTypeSet.size === 1 ? defaultType : undefined);
+  }, [defaultType, enabledTypeSet.size]);
 
   return {
     countryCode,

--- a/packages/ui/src/components/InputFields/SmartInputField/use-smart-input-field.ts
+++ b/packages/ui/src/components/InputFields/SmartInputField/use-smart-input-field.ts
@@ -36,7 +36,7 @@ const useSmartInputField = ({ defaultType, defaultValue, enabledTypes }: Props) 
     );
   }
 
-  // Parse default value from enabled types if default type is not provided and only one type is enabled
+  // Parse default type from enabled types if default type is not provided and only one type is enabled
   const _defaultType = useMemo(
     () => defaultType ?? (enabledTypes.length === 1 ? enabledTypes[0] : undefined),
     [defaultType, enabledTypes]

--- a/packages/ui/src/components/InputFields/SmartInputField/use-smart-input-field.ts
+++ b/packages/ui/src/components/InputFields/SmartInputField/use-smart-input-field.ts
@@ -11,85 +11,88 @@ export type IdentifierInputType =
   | SignInIdentifier.Phone
   | SignInIdentifier.Username;
 
-export type EnabledIdentifierTypes = IdentifierInputType[];
+export type IdentifierInputValue = {
+  type: IdentifierInputType | undefined;
+  value: string;
+};
 
 const digitsRegex = /^\d*$/;
 
 type Props = {
   defaultValue?: string;
-  onChange?: (value: string) => void;
-  enabledTypes: EnabledIdentifierTypes;
-  currentType: IdentifierInputType;
-  onTypeChange?: (type: IdentifierInputType) => void;
+  defaultType?: IdentifierInputType;
+  enabledTypes: IdentifierInputType[];
 };
 
-const useSmartInputField = ({
-  onChange,
-  currentType,
-  enabledTypes,
-  onTypeChange,
-  defaultValue,
-}: Props) => {
-  const { countryCode: defaultCountryCode, inputValue: defaultInputValue } = parseIdentifierValue(
-    currentType,
-    defaultValue
+const useSmartInputField = ({ defaultType, defaultValue, enabledTypes }: Props) => {
+  const enabledTypeSet = useMemo(() => new Set(enabledTypes), [enabledTypes]);
+
+  if (defaultType) {
+    assert(
+      enabledTypeSet.has(defaultType),
+      new Error(
+        `Invalid input type. Current inputType ${defaultType} is detected but missing in enabledTypes`
+      )
+    );
+  }
+
+  // Parse default value from enabled types if default type is not provided and only one type is enabled
+  const _defaultType = useMemo(
+    () => defaultType ?? (enabledTypes.length === 1 ? enabledTypes[0] : undefined),
+    [defaultType, enabledTypes]
   );
+
+  // Parse default value if provided
+  const { countryCode: defaultCountryCode, inputValue: defaultInputValue } = useMemo(
+    () => parseIdentifierValue(_defaultType, defaultValue),
+    [_defaultType, defaultValue]
+  );
+
+  const [currentType, setCurrentType] = useState(_defaultType);
 
   const [countryCode, setCountryCode] = useState<string>(
     defaultCountryCode ?? getDefaultCountryCallingCode()
   );
 
   const [inputValue, setInputValue] = useState<string>(defaultInputValue ?? '');
-  const enabledTypeSet = useMemo(() => new Set(enabledTypes), [enabledTypes]);
-
-  assert(
-    enabledTypeSet.has(currentType),
-    new Error(
-      `Invalid input type. Current inputType ${currentType} is detected but missing in enabledTypes`
-    )
-  );
 
   const detectInputType = useCallback(
     (value: string) => {
-      if (!value || enabledTypeSet.size === 1) {
-        return currentType;
+      // Reset InputType
+      if (!value && enabledTypeSet.size > 1) {
+        return;
+      }
+
+      if (enabledTypeSet.size === 1) {
+        return _defaultType;
       }
 
       const hasAtSymbol = value.includes('@');
       const isAllDigits = digitsRegex.test(value);
 
-      const isEmailDetected = enabledTypeSet.has(SignInIdentifier.Email) && hasAtSymbol;
-
-      const isPhoneDetected =
-        enabledTypeSet.has(SignInIdentifier.Phone) && value.length > 3 && isAllDigits;
-
-      if (isPhoneDetected) {
+      if (enabledTypeSet.has(SignInIdentifier.Phone) && value.length >= 3 && isAllDigits) {
         return SignInIdentifier.Phone;
       }
 
-      if (isEmailDetected) {
+      if (enabledTypeSet.has(SignInIdentifier.Email) && hasAtSymbol) {
         return SignInIdentifier.Email;
       }
 
-      if (
-        currentType === SignInIdentifier.Email &&
-        enabledTypeSet.has(SignInIdentifier.Username) &&
-        !hasAtSymbol
-      ) {
+      if (currentType === SignInIdentifier.Phone && isAllDigits) {
+        return SignInIdentifier.Phone;
+      }
+
+      if (enabledTypeSet.has(SignInIdentifier.Username)) {
         return SignInIdentifier.Username;
       }
 
-      if (
-        currentType === SignInIdentifier.Phone &&
-        enabledTypeSet.has(SignInIdentifier.Username) &&
-        !isAllDigits
-      ) {
-        return SignInIdentifier.Username;
+      if (enabledTypeSet.has(SignInIdentifier.Email)) {
+        return SignInIdentifier.Email;
       }
 
       return currentType;
     },
-    [currentType, enabledTypeSet]
+    [_defaultType, currentType, enabledTypeSet]
   );
 
   const onCountryCodeChange = useCallback<ChangeEventHandler<HTMLSelectElement>>(
@@ -97,10 +100,9 @@ const useSmartInputField = ({
       if (currentType === SignInIdentifier.Phone) {
         const code = value.replace(/\D/g, '');
         setCountryCode(code);
-        onChange?.(`${code}${inputValue}`);
       }
     },
-    [currentType, inputValue, onChange]
+    [currentType]
   );
 
   const onInputValueChange = useCallback<ChangeEventHandler<HTMLInputElement>>(
@@ -109,20 +111,15 @@ const useSmartInputField = ({
       setInputValue(trimValue);
 
       const type = detectInputType(trimValue);
-
-      if (type !== currentType) {
-        onTypeChange?.(type);
-      }
-
-      onChange?.(type === SignInIdentifier.Phone ? `${countryCode}${trimValue}` : trimValue);
+      setCurrentType(type);
     },
-    [countryCode, currentType, detectInputType, onChange, onTypeChange]
+    [detectInputType]
   );
 
   const onInputValueClear = useCallback(() => {
     setInputValue('');
-    onChange?.('');
-  }, [onChange]);
+    setCurrentType(enabledTypeSet.size === 1 ? _defaultType : undefined);
+  }, [_defaultType, enabledTypeSet.size]);
 
   return {
     countryCode,
@@ -130,6 +127,7 @@ const useSmartInputField = ({
     inputValue,
     onInputValueChange,
     onInputValueClear,
+    identifierType: currentType,
   };
 };
 

--- a/packages/ui/src/components/InputFields/SmartInputField/utils.test.ts
+++ b/packages/ui/src/components/InputFields/SmartInputField/utils.test.ts
@@ -11,7 +11,7 @@ describe('Smart Input Field Util Methods', () => {
 
   describe('getInputHtmlProps', () => {
     it('Should return correct html props for phone', () => {
-      const props = getInputHtmlProps(SignInIdentifier.Phone, [SignInIdentifier.Phone]);
+      const props = getInputHtmlProps([SignInIdentifier.Phone], SignInIdentifier.Phone);
       expect(props.type).toBe('tel');
       expect(props.pattern).toBe('[0-9]*');
       expect(props.inputMode).toBe('numeric');
@@ -19,29 +19,29 @@ describe('Smart Input Field Util Methods', () => {
     });
 
     it('Should return correct html props for email', () => {
-      const props = getInputHtmlProps(SignInIdentifier.Email, [SignInIdentifier.Email]);
+      const props = getInputHtmlProps([SignInIdentifier.Email], SignInIdentifier.Email);
       expect(props.type).toBe('email');
       expect(props.inputMode).toBe('email');
       expect(props.placeholder).toBe('input.email');
     });
 
     it('Should return correct html props for username', () => {
-      const props = getInputHtmlProps(SignInIdentifier.Username, [SignInIdentifier.Username]);
+      const props = getInputHtmlProps([SignInIdentifier.Username], SignInIdentifier.Username);
       expect(props.type).toBe('text');
       expect(props.placeholder).toBe('input.username');
     });
 
     it('Should return correct html props for username email or phone', () => {
-      const props = getInputHtmlProps(SignInIdentifier.Username, enabledTypes);
+      const props = getInputHtmlProps(enabledTypes, SignInIdentifier.Username);
       expect(props.type).toBe('text');
       expect(props.placeholder).toBe('input.username / input.email / input.phone_number');
     });
 
     it('Should return correct html props for email or phone', () => {
-      const props = getInputHtmlProps(SignInIdentifier.Email, [
-        SignInIdentifier.Email,
-        SignInIdentifier.Phone,
-      ]);
+      const props = getInputHtmlProps(
+        [SignInIdentifier.Email, SignInIdentifier.Phone],
+        SignInIdentifier.Email
+      );
       expect(props.type).toBe('text');
       expect(props.placeholder).toBe('input.email / input.phone_number');
     });

--- a/packages/ui/src/components/InputFields/SmartInputField/utils.ts
+++ b/packages/ui/src/components/InputFields/SmartInputField/utils.ts
@@ -5,11 +5,11 @@ import type { TFuncKey } from 'react-i18next';
 
 import { identifierInputPlaceholderMap } from '@/utils/form';
 
-import type { IdentifierInputType, EnabledIdentifierTypes } from './use-smart-input-field';
+import type { IdentifierInputType } from './use-smart-input-field';
 
 export const getInputHtmlProps = (
-  currentType: IdentifierInputType,
-  enabledTypes: EnabledIdentifierTypes
+  enabledTypes: IdentifierInputType[],
+  currentType?: IdentifierInputType
 ): Pick<HTMLProps<HTMLInputElement>, 'type' | 'pattern' | 'inputMode' | 'placeholder'> => {
   if (currentType === SignInIdentifier.Phone && enabledTypes.length === 1) {
     return {

--- a/packages/ui/src/components/InputFields/index.tsx
+++ b/packages/ui/src/components/InputFields/index.tsx
@@ -1,7 +1,3 @@
 export { default as InputField } from './InputField';
 export { default as PasswordInputField } from './PasswordInputField';
-export {
-  default as SmartInputField,
-  type IdentifierInputType,
-  type EnabledIdentifierTypes,
-} from './SmartInputField';
+export { default as SmartInputField } from './SmartInputField';

--- a/packages/ui/src/containers/ForgotPasswordLink/index.tsx
+++ b/packages/ui/src/containers/ForgotPasswordLink/index.tsx
@@ -4,8 +4,8 @@ import TextLink from '@/components/TextLink';
 import { UserFlow } from '@/types';
 
 type Props = {
-  identifier: SignInIdentifier;
-  value: string;
+  identifier?: SignInIdentifier;
+  value?: string;
   className?: string;
 };
 

--- a/packages/ui/src/containers/SetPassword/index.test.tsx
+++ b/packages/ui/src/containers/SetPassword/index.test.tsx
@@ -63,6 +63,7 @@ describe('<SetPassword />', () => {
       // Clear error
       if (passwordInput) {
         fireEvent.change(passwordInput, { target: { value: '123456' } });
+        fireEvent.blur(passwordInput);
       }
     });
 
@@ -99,6 +100,7 @@ describe('<SetPassword />', () => {
       // Clear Error
       if (confirmPasswordInput) {
         fireEvent.change(confirmPasswordInput, { target: { value: '123456' } });
+        fireEvent.blur(confirmPasswordInput);
       }
     });
 

--- a/packages/ui/src/containers/SetPassword/index.tsx
+++ b/packages/ui/src/containers/SetPassword/index.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -42,11 +42,17 @@ const SetPassword = ({
     watch,
     resetField,
     handleSubmit,
-    formState: { errors },
+    formState: { errors, isValid },
   } = useForm<FieldState>({
-    reValidateMode: 'onChange',
+    reValidateMode: 'onBlur',
     defaultValues: { newPassword: '', confirmPassword: '' },
   });
+
+  useEffect(() => {
+    if (!isValid) {
+      clearErrorMessage?.();
+    }
+  }, [clearErrorMessage, isValid]);
 
   const onSubmitHandler = useCallback(
     (event?: React.FormEvent<HTMLFormElement>) => {

--- a/packages/ui/src/pages/Continue/IdentifierProfileForm/index.tsx
+++ b/packages/ui/src/pages/Continue/IdentifierProfileForm/index.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -43,9 +43,9 @@ const IdentifierProfileForm = ({
   const {
     handleSubmit,
     control,
-    formState: { errors },
+    formState: { errors, isValid },
   } = useForm<FormState>({
-    reValidateMode: 'onChange',
+    reValidateMode: 'onBlur',
     defaultValues: {
       identifier: {
         type: defaultType,
@@ -53,6 +53,12 @@ const IdentifierProfileForm = ({
       },
     },
   });
+
+  useEffect(() => {
+    if (!isValid) {
+      clearErrorMessage?.();
+    }
+  }, [clearErrorMessage, isValid]);
 
   const onSubmitHandler = useCallback(
     async (event?: React.FormEvent<HTMLFormElement>) => {

--- a/packages/ui/src/pages/ForgotPassword/ForgotPasswordForm/index.tsx
+++ b/packages/ui/src/pages/ForgotPassword/ForgotPasswordForm/index.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -44,9 +44,9 @@ const ForgotPasswordForm = ({
   const {
     handleSubmit,
     control,
-    formState: { errors },
+    formState: { errors, isValid },
   } = useForm<FormState>({
-    reValidateMode: 'onChange',
+    reValidateMode: 'onBlur',
     defaultValues: {
       identifier: {
         type: defaultType,
@@ -54,6 +54,12 @@ const ForgotPasswordForm = ({
       },
     },
   });
+
+  useEffect(() => {
+    if (!isValid) {
+      clearErrorMessage();
+    }
+  }, [clearErrorMessage, isValid]);
 
   const onSubmitHandler = useCallback(
     async (event?: React.FormEvent<HTMLFormElement>) => {

--- a/packages/ui/src/pages/ForgotPassword/index.tsx
+++ b/packages/ui/src/pages/ForgotPassword/index.tsx
@@ -20,7 +20,11 @@ const ForgotPassword = () => {
 
   const getDefaultIdentifierType = useCallback(
     (identifier?: SignInIdentifier) => {
-      if (identifier === SignInIdentifier.Username || identifier === SignInIdentifier.Email) {
+      if (
+        identifier === SignInIdentifier.Username ||
+        identifier === SignInIdentifier.Email ||
+        !identifier
+      ) {
         return enabledMethodSet.has(SignInIdentifier.Email)
           ? SignInIdentifier.Email
           : SignInIdentifier.Phone;

--- a/packages/ui/src/pages/Register/IdentifierRegisterForm/index.test.tsx
+++ b/packages/ui/src/pages/Register/IdentifierRegisterForm/index.test.tsx
@@ -94,6 +94,7 @@ describe('<IdentifierRegisterForm />', () => {
 
       act(() => {
         fireEvent.change(usernameInput, { target: { value: 'username' } });
+        fireEvent.blur(usernameInput);
       });
 
       await waitFor(() => {
@@ -120,6 +121,7 @@ describe('<IdentifierRegisterForm />', () => {
 
       act(() => {
         fireEvent.change(usernameInput, { target: { value: 'username' } });
+        fireEvent.blur(usernameInput);
       });
 
       await waitFor(() => {
@@ -179,6 +181,7 @@ describe('<IdentifierRegisterForm />', () => {
 
         act(() => {
           fireEvent.change(emailInput, { target: { value: 'foo@logto.io' } });
+          fireEvent.blur(emailInput);
         });
 
         await waitFor(() => {
@@ -235,6 +238,7 @@ describe('<IdentifierRegisterForm />', () => {
 
         act(() => {
           fireEvent.change(phoneInput, { target: { value: '8573333333' } });
+          fireEvent.blur(phoneInput);
         });
 
         await waitFor(() => {

--- a/packages/ui/src/pages/Register/IdentifierRegisterForm/index.test.tsx
+++ b/packages/ui/src/pages/Register/IdentifierRegisterForm/index.test.tsx
@@ -50,7 +50,7 @@ describe('<IdentifierRegisterForm />', () => {
     [SignInIdentifier.Email],
     [SignInIdentifier.Phone],
     [SignInIdentifier.Email, SignInIdentifier.Phone],
-  ])('username %o register form', (...signUpMethods) => {
+  ])('%p %p register form', (...signUpMethods) => {
     test('default render', () => {
       const { queryByText, container } = renderForm(signUpMethods);
       expect(container.querySelector('input[name="identifier"]')).not.toBeNull();

--- a/packages/ui/src/pages/Register/IdentifierRegisterForm/index.tsx
+++ b/packages/ui/src/pages/Register/IdentifierRegisterForm/index.tsx
@@ -1,13 +1,13 @@
-import { SignInIdentifier } from '@logto/schemas';
+import type { SignInIdentifier } from '@logto/schemas';
 import classNames from 'classnames';
-import { useState, useCallback } from 'react';
+import { useCallback } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
 import Button from '@/components/Button';
 import ErrorMessage from '@/components/ErrorMessage';
-import type { IdentifierInputType } from '@/components/InputFields';
 import { SmartInputField } from '@/components/InputFields';
+import type { IdentifierInputValue } from '@/components/InputFields/SmartInputField';
 import TermsOfUse from '@/containers/TermsOfUse';
 import useTerms from '@/hooks/use-terms';
 import { getGeneralIdentifierErrorMessage, validateIdentifierField } from '@/utils/form';
@@ -23,15 +23,12 @@ type Props = {
 };
 
 type FormState = {
-  identifier: string;
+  identifier: IdentifierInputValue;
 };
 
 const IdentifierRegisterForm = ({ className, autoFocus, signUpMethods }: Props) => {
   const { t } = useTranslation();
   const { termsValidation } = useTerms();
-  const [inputType, setInputType] = useState<IdentifierInputType>(
-    signUpMethods[0] ?? SignInIdentifier.Username
-  );
 
   const { errorMessage, clearErrorMessage, onSubmit } = useOnSubmit();
 
@@ -47,15 +44,19 @@ const IdentifierRegisterForm = ({ className, autoFocus, signUpMethods }: Props) 
     async (event?: React.FormEvent<HTMLFormElement>) => {
       clearErrorMessage();
 
-      void handleSubmit(async ({ identifier }, event) => {
+      void handleSubmit(async ({ identifier: { type, value } }) => {
+        if (!type) {
+          return;
+        }
+
         if (!(await termsValidation())) {
           return;
         }
 
-        await onSubmit(inputType, identifier);
+        await onSubmit(type, value);
       })(event);
     },
-    [clearErrorMessage, handleSubmit, inputType, onSubmit, termsValidation]
+    [clearErrorMessage, handleSubmit, onSubmit, termsValidation]
   );
 
   return (
@@ -64,9 +65,12 @@ const IdentifierRegisterForm = ({ className, autoFocus, signUpMethods }: Props) 
         control={control}
         name="identifier"
         rules={{
-          required: getGeneralIdentifierErrorMessage(signUpMethods, 'required'),
-          validate: (value) => {
-            const errorMessage = validateIdentifierField(inputType, value);
+          validate: ({ type, value }) => {
+            if (!type || !value) {
+              return getGeneralIdentifierErrorMessage(signUpMethods, 'required');
+            }
+
+            const errorMessage = validateIdentifierField(type, value);
 
             if (errorMessage) {
               return typeof errorMessage === 'string'
@@ -83,11 +87,9 @@ const IdentifierRegisterForm = ({ className, autoFocus, signUpMethods }: Props) 
             autoFocus={autoFocus}
             className={styles.inputField}
             {...field}
-            currentType={inputType}
             isDanger={!!errors.identifier || !!errorMessage}
             errorMessage={errors.identifier?.message}
             enabledTypes={signUpMethods}
-            onTypeChange={setInputType}
           />
         )}
       />

--- a/packages/ui/src/pages/Register/IdentifierRegisterForm/index.tsx
+++ b/packages/ui/src/pages/Register/IdentifierRegisterForm/index.tsx
@@ -1,6 +1,6 @@
 import type { SignInIdentifier } from '@logto/schemas';
 import classNames from 'classnames';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -34,11 +34,17 @@ const IdentifierRegisterForm = ({ className, autoFocus, signUpMethods }: Props) 
 
   const {
     handleSubmit,
-    formState: { errors },
+    formState: { errors, isValid },
     control,
   } = useForm<FormState>({
-    reValidateMode: 'onChange',
+    reValidateMode: 'onBlur',
   });
+
+  useEffect(() => {
+    if (!isValid) {
+      clearErrorMessage();
+    }
+  }, [clearErrorMessage, isValid]);
 
   const onSubmitHandler = useCallback(
     async (event?: React.FormEvent<HTMLFormElement>) => {

--- a/packages/ui/src/pages/SignIn/IdentifierSignInForm/index.tsx
+++ b/packages/ui/src/pages/SignIn/IdentifierSignInForm/index.tsx
@@ -1,6 +1,6 @@
 import type { SignIn } from '@logto/schemas';
 import classNames from 'classnames';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 
 import Button from '@/components/Button';
@@ -37,10 +37,16 @@ const IdentifierSignInForm = ({ className, autoFocus, signInMethods }: Props) =>
   const {
     handleSubmit,
     control,
-    formState: { errors },
+    formState: { errors, isValid },
   } = useForm<FormState>({
-    reValidateMode: 'onChange',
+    reValidateMode: 'onBlur',
   });
+
+  useEffect(() => {
+    if (!isValid) {
+      clearErrorMessage();
+    }
+  }, [clearErrorMessage, isValid]);
 
   const onSubmitHandler = useCallback(
     async (event?: React.FormEvent<HTMLFormElement>) => {

--- a/packages/ui/src/pages/SignIn/PasswordSignInForm/index.test.tsx
+++ b/packages/ui/src/pages/SignIn/PasswordSignInForm/index.test.tsx
@@ -90,10 +90,12 @@ describe('UsernamePasswordSignInForm', () => {
 
     act(() => {
       fireEvent.change(identifierInput, { target: { value: 'username' } });
+      fireEvent.blur(identifierInput);
     });
 
     act(() => {
       fireEvent.change(passwordInput, { target: { value: 'password' } });
+      fireEvent.blur(passwordInput);
     });
 
     await waitFor(() => {
@@ -128,6 +130,7 @@ describe('UsernamePasswordSignInForm', () => {
 
     act(() => {
       fireEvent.change(identifierInput, { target: { value: validInput } });
+      fireEvent.blur(identifierInput);
     });
 
     await waitFor(() => {

--- a/packages/ui/src/pages/SignIn/PasswordSignInForm/index.tsx
+++ b/packages/ui/src/pages/SignIn/PasswordSignInForm/index.tsx
@@ -1,6 +1,6 @@
 import type { SignInIdentifier } from '@logto/schemas';
 import classNames from 'classnames';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -41,9 +41,9 @@ const PasswordSignInForm = ({ className, autoFocus, signInMethods }: Props) => {
     register,
     handleSubmit,
     control,
-    formState: { errors },
+    formState: { errors, isValid },
   } = useForm<FormState>({
-    reValidateMode: 'onChange',
+    reValidateMode: 'onBlur',
     defaultValues: {
       identifier: {},
       password: '',
@@ -71,6 +71,12 @@ const PasswordSignInForm = ({ className, autoFocus, signInMethods }: Props) => {
     },
     [clearErrorMessage, handleSubmit, onSubmit, termsValidation]
   );
+
+  useEffect(() => {
+    if (!isValid) {
+      clearErrorMessage();
+    }
+  }, [clearErrorMessage, isValid]);
 
   return (
     <form className={classNames(styles.form, className)} onSubmit={onSubmitHandler}>

--- a/packages/ui/src/pages/SignInPassword/PasswordForm/index.tsx
+++ b/packages/ui/src/pages/SignInPassword/PasswordForm/index.tsx
@@ -1,6 +1,6 @@
 import { SignInIdentifier } from '@logto/schemas';
 import classNames from 'classnames';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -41,11 +41,17 @@ const PasswordForm = ({
   const {
     register,
     handleSubmit,
-    formState: { errors },
+    formState: { errors, isValid },
   } = useForm<FormState>({
-    reValidateMode: 'onChange',
+    reValidateMode: 'onBlur',
     defaultValues: { password: '' },
   });
+
+  useEffect(() => {
+    if (!isValid) {
+      clearErrorMessage();
+    }
+  }, [clearErrorMessage, isValid]);
 
   const onSubmitHandler = useCallback(
     async (event?: React.FormEvent<HTMLFormElement>) => {

--- a/packages/ui/src/utils/form.ts
+++ b/packages/ui/src/utils/form.ts
@@ -2,7 +2,7 @@ import { SignInIdentifier } from '@logto/schemas';
 import i18next from 'i18next';
 import type { TFuncKey } from 'react-i18next';
 
-import type { IdentifierInputType } from '@/components/InputFields';
+import type { IdentifierInputType } from '@/components/InputFields/SmartInputField';
 
 import { parsePhoneNumber } from './country-code';
 import { validateUsername, validateEmail, validatePhone } from './field-validations';
@@ -48,7 +48,7 @@ export const validateIdentifierField = (type: IdentifierInputType, value: string
   }
 };
 
-export const parseIdentifierValue = (type: IdentifierInputType, value?: string) => {
+export const parseIdentifierValue = (type?: IdentifierInputType, value?: string) => {
   if (type === SignInIdentifier.Phone && value) {
     const validPhoneNumber = parsePhoneNumber(value);
 


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Refactor smart input field after product feature review.


This PR address the following feature updates:
1. Should hide the country code selector (show default input type) if the value is empty
2. Should hide the country code selector when clicking on the clear input button.
3. Should switch to phone number input mode if more than 2 digits are detected


Also, include the following tech improvements:
1. Set the default input type to be undefined unless specified. 
   -  previously at least one non-empty input type must be specified for the SmartInputField
   - should keep the input type undefined if the input value is empty and more than one possible input type is enabled
   - this will resolve the first two feature requests listed above
2. Since we use the react-hook-form's controller on all smart input fields. Move the `inputType`  state within the `SmartInputField` component itself instead of being maintained from the out scope.  Update the form field 'identifier' type as an object `{type, value}`.  This will make the whole type and value mutation logic more straightforward. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

test locally
UT updated