### PR TITLE
refactor(cloud): wrap create tenant in transaction

### DIFF
--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@logto/cloud",
   "version": "0.1.0",
-  "description": "☁️ Logto Cloud service.",
+  "description": "Logto Cloud service.",
   "main": "build/index.js",
   "author": "Silverhand Inc. <contact@silverhand.io>",
   "license": "Elastic-2.0",

--- a/packages/cloud/src/consts/rbac.ts
+++ b/packages/cloud/src/consts/rbac.ts
@@ -1,0 +1,3 @@
+export enum CloudScope {
+  CreateTenant = 'create:tenant',
+}

--- a/packages/cloud/src/index.ts
+++ b/packages/cloud/src/index.ts
@@ -4,12 +4,12 @@ import createServer, { compose, withRequest } from '@withtyped/server';
 import dotenv from 'dotenv';
 import { findUp } from 'find-up';
 
-import withAuth from './middleware/with-auth.js';
-import withHttpProxy from './middleware/with-http-proxy.js';
-import withPathname from './middleware/with-pathname.js';
-import withSpa from './middleware/with-spa.js';
-
 dotenv.config({ path: await findUp('.env', {}) });
+
+const { default: withAuth } = await import('./middleware/with-auth.js');
+const { default: withHttpProxy } = await import('./middleware/with-http-proxy.js');
+const { default: withPathname } = await import('./middleware/with-pathname.js');
+const { default: withSpa } = await import('./middleware/with-spa.js');
 
 const { EnvSet } = await import('./env-set/index.js');
 const { default: router } = await import('./routes/index.js');

--- a/packages/cloud/src/queries/tenants.ts
+++ b/packages/cloud/src/queries/tenants.ts
@@ -8,14 +8,15 @@ import {
   PredefinedScope,
   CreateRolesScope,
 } from '@logto/schemas';
-import type { PostgresQueryClient } from '@withtyped/postgres';
+import type { PostgreSql } from '@withtyped/postgres';
 import { dangerousRaw, id, sql } from '@withtyped/postgres';
+import type { Queryable } from '@withtyped/server';
 
 import { insertInto } from '#src/utils/query.js';
 
 export type TenantsQueries = ReturnType<typeof createTenantsQueries>;
 
-export const createTenantsQueries = (client: PostgresQueryClient) => {
+export const createTenantsQueries = (client: Queryable<PostgreSql>) => {
   const getManagementApiLikeIndicatorsForUser = async (userId: string) =>
     client.query<{ indicator: string }>(sql`
       select resources.indicator from roles

--- a/packages/cloud/src/queries/users.ts
+++ b/packages/cloud/src/queries/users.ts
@@ -1,11 +1,12 @@
 import type { UsersRole } from '@logto/schemas';
-import type { PostgresQueryClient } from '@withtyped/postgres';
+import type { PostgreSql } from '@withtyped/postgres';
+import type { Queryable } from '@withtyped/server';
 
 import { insertInto } from '#src/utils/query.js';
 
 export type UsersQueries = ReturnType<typeof createUsersQueries>;
 
-export const createUsersQueries = (client: PostgresQueryClient) => {
+export const createUsersQueries = (client: Queryable<PostgreSql>) => {
   const assignRoleToUser = async (data: UsersRole) => client.query(insertInto(data, 'users_roles'));
 
   return { assignRoleToUser };

--- a/packages/cloud/src/queries/utils.ts
+++ b/packages/cloud/src/queries/utils.ts
@@ -1,8 +1,9 @@
-import type { PostgresQueryClient } from '@withtyped/postgres';
+import type { PostgreSql } from '@withtyped/postgres';
 import { sql } from '@withtyped/postgres';
+import type { Queryable } from '@withtyped/server';
 import { RequestError } from '@withtyped/server';
 
-export const getDatabaseName = async (client: PostgresQueryClient) => {
+export const getDatabaseName = async (client: Queryable<PostgreSql>) => {
   const {
     rows: [first],
   } = await client.query<{ currentDatabase: string }>(sql`

--- a/packages/cloud/src/routes/tenants.ts
+++ b/packages/cloud/src/routes/tenants.ts
@@ -1,21 +1,26 @@
 import { createRouter, RequestError } from '@withtyped/server';
 
-import { createTenantsLibrary, tenantInfoGuard } from '#src/libraries/tenants.js';
+import { CloudScope } from '#src/consts/rbac.js';
+import { tenantInfoGuard, TenantsLibrary } from '#src/libraries/tenants.js';
 import type { WithAuthContext } from '#src/middleware/with-auth.js';
 import { Queries } from '#src/queries/index.js';
 
-const { getAvailableTenants, createNewTenant } = createTenantsLibrary(Queries.default);
+const library = new TenantsLibrary(Queries.default);
 
 export const tenants = createRouter<WithAuthContext, '/tenants'>('/tenants')
   .get('/', { response: tenantInfoGuard.array() }, async (context, next) => {
-    return next({ ...context, json: await getAvailableTenants(context.auth.id) });
+    return next({ ...context, json: await library.getAvailableTenants(context.auth.id) });
   })
   .post('/', { response: tenantInfoGuard }, async (context, next) => {
-    const tenants = await getAvailableTenants(context.auth.id);
+    if (!context.auth.scopes.includes(CloudScope.CreateTenant)) {
+      throw new RequestError('Forbidden due to lack of permission.', 403);
+    }
+
+    const tenants = await library.getAvailableTenants(context.auth.id);
 
     if (tenants.length > 0) {
       throw new RequestError('The user already has a tenant.', 409);
     }
 
-    return next({ ...context, json: await createNewTenant(context.auth.id) });
+    return next({ ...context, json: await library.createNewTenant(context.auth.id) });
   });

--- a/packages/schemas/src/seeds/management-api.ts
+++ b/packages/schemas/src/seeds/management-api.ts
@@ -14,7 +14,7 @@ export type AdminData = {
 const defaultResourceId = 'management-api';
 const defaultScopeAllId = 'management-api-all';
 
-// Consider combine this with `createAdminData()`
+// Consider combining this with `createAdminData()`
 /** The fixed Management API Resource for `default` tenant. */
 export const defaultManagementApi = Object.freeze({
   resource: {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- support development user id header
- wrap create tenant in transaction to ensure it's an one-or-nothing action
- use class for libraries for a better closure management
- check scope for tenant creating

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- tested success creating
<img width="369" alt="image" src="https://user-images.githubusercontent.com/14722250/220006589-6e584516-3438-4431-81b4-7c3690298ff8.png">

- failed to create due to "already has a tenant"
- failed to create due to a query error (in this case, manually update development user id to a non-existing one), check database nothing changed