### PR TITLE
feat(cloud): add status apis

### DIFF
--- a/packages/cloud/src/index.ts
+++ b/packages/cloud/src/index.ts
@@ -13,12 +13,14 @@ const { default: withSpa } = await import('./middleware/with-spa.js');
 
 const { EnvSet } = await import('./env-set/index.js');
 const { default: router } = await import('./routes/index.js');
+const { default: anonymousRouter } = await import('./routes-anonymous/index.js');
 
 const ignorePathnames = ['/api'];
 
 const { listen } = createServer({
   port: 3003,
   composer: compose(withRequest())
+    .and(anonymousRouter.routes())
     .and(
       withPathname(
         '/api',

--- a/packages/cloud/src/middleware/with-pathname.ts
+++ b/packages/cloud/src/middleware/with-pathname.ts
@@ -8,7 +8,10 @@ import type {
 import { matchPathname } from '#src/utils/url.js';
 
 /**
- * Build a middleware function that conditionally runs the given middleware function based on pathname prefix.
+ * Build a middleware function that conditionally runs the given middleware function when:
+ *
+ * - The current pathname matches the given pathname prefix; and
+ * - `context.status` is unset (i.e. `undefined`).
  *
  * @param pathname The pathname prefix to match.
  * @param run The middleware function to run with the prefix matches.
@@ -22,7 +25,7 @@ export default function withPathname<
     next: NextFunction<InputContext | OutputContext>,
     httpContext: HttpContext
   ) => {
-    if (!matchPathname(pathname, context.request.url.pathname)) {
+    if (context.status ?? !matchPathname(pathname, context.request.url.pathname)) {
       return next(context);
     }
 

--- a/packages/cloud/src/routes-anonymous/index.ts
+++ b/packages/cloud/src/routes-anonymous/index.ts
@@ -1,0 +1,9 @@
+import { createRouter } from '@withtyped/server';
+
+const router = createRouter('/api')
+  .get('/status', {}, async (context, next) => next({ ...context, status: 204 }))
+  .get('/teapot', {}, async (context, next) =>
+    next({ ...context, status: 418, json: { message: 'The server refuses to brew coffee.' } })
+  );
+
+export default router;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
add two APIs for status check. not sure [I'm a teapot](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/418) is proper, but it looks harmless

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

locally. status APIs don't need auth