### PR TITLE
fix(ui): update country code detection logic

### DIFF
--- a/packages/ui/src/utils/country-code.test.ts
+++ b/packages/ui/src/utils/country-code.test.ts
@@ -35,6 +35,9 @@ describe('country-code', () => {
 
     await i18next.changeLanguage('en-CA');
     expect(getDefaultCountryCode()).toEqual('CA');
+
+    await i18next.changeLanguage('ru');
+    expect(getDefaultCountryCode()).toEqual('RU');
   });
 
   it('getDefaultCountryCallingCode', async () => {
@@ -55,6 +58,9 @@ describe('country-code', () => {
 
     await i18next.changeLanguage('en-CA');
     expect(getDefaultCountryCallingCode()).toEqual('1');
+
+    await i18next.changeLanguage('ru');
+    expect(getDefaultCountryCallingCode()).toEqual('7');
   });
 
   it('getCountryList should sort properly', async () => {

--- a/packages/ui/src/utils/country-code.ts
+++ b/packages/ui/src/utils/country-code.ts
@@ -29,10 +29,16 @@ export const getDefaultCountryCode = (): CountryCode => {
   const { language } = i18next;
 
   // Extract the country code from language tag suffix
-  const [, countryCode] = language.split('-');
+  const [languageCode, countryCode] = language.split('-');
 
   if (countryCode && isValidCountryCode(countryCode)) {
     return countryCode;
+  }
+
+  const upperCaseLanguageCode = languageCode?.toUpperCase();
+
+  if (upperCaseLanguageCode && isValidCountryCode(upperCaseLanguageCode)) {
+    return upperCaseLanguageCode;
   }
 
   return countryCallingCodeMap[language] ?? fallbackCountryCode;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
update country code detection logic. Languages like Russan has the language code as `ru`. 
Add the fallback logic, trying to detect the country code directly from the language code prefix.




<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT added. 
