### PR TITLE
refactor(core,ui): refactor get phrases for preview

### DIFF
--- a/packages/core/src/routes/phrase.test.ts
+++ b/packages/core/src/routes/phrase.test.ts
@@ -163,4 +163,16 @@ describe('when the application is not admin-console', () => {
     expect(getPhrases).toBeCalledTimes(1);
     expect(getPhrases).toBeCalledWith(customizedLanguage, [customizedLanguage]);
   });
+
+  it('should call getPhrases with specific language is provided in params', async () => {
+    findDefaultSignInExperience.mockResolvedValueOnce({
+      ...mockSignInExperience,
+      languageInfo: {
+        autoDetect: true,
+        fallbackLanguage: customizedLanguage,
+      },
+    });
+    await expect(phraseRequest.get('/phrase?lng=fr')).resolves.toHaveProperty('status', 200);
+    expect(getPhrases).toBeCalledWith('fr', [customizedLanguage]);
+  });
 });

--- a/packages/core/src/routes/phrase.ts
+++ b/packages/core/src/routes/phrase.ts
@@ -55,8 +55,6 @@ export default function phraseRoutes<T extends AnonymousRouter>(
           (tag) => isBuiltInLanguageTag(tag) || customLanguages.includes(tag)
         ) ?? 'en';
 
-      console.log(language);
-
       ctx.set('Content-Language', language);
       ctx.body = await getPhrases(language, customLanguages);
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -40,7 +40,7 @@ const App = () => {
       const settings = await getSignInExperienceSettings();
 
       // Note: i18n must be initialized ahead of page render
-      await initI18n(settings.languageInfo);
+      await initI18n();
 
       // Init the page settings and render
       setExperienceSettings(settings);

--- a/packages/ui/src/apis/settings.ts
+++ b/packages/ui/src/apis/settings.ts
@@ -11,17 +11,23 @@ export const getSignInExperience = async <T extends SignInExperienceResponse>():
   return ky.get('/api/.well-known/sign-in-exp').json<T>();
 };
 
-export const getPhrases = async (lng?: string) =>
+export const getPhrases = async ({
+  localLanguage,
+  language,
+}: {
+  localLanguage?: string;
+  language?: string;
+}) =>
   ky
     .extend({
       hooks: {
         beforeRequest: [
           (request) => {
-            if (lng) {
-              request.headers.set('Accept-Language', lng);
+            if (localLanguage) {
+              request.headers.set('Accept-Language', localLanguage);
             }
           },
         ],
       },
     })
-    .get('/api/phrase');
+    .get(`/api/phrase${language ? `?lng=${language}` : ''}`);

--- a/packages/ui/src/i18n/init.ts
+++ b/packages/ui/src/i18n/init.ts
@@ -1,15 +1,11 @@
-import type { LanguageInfo } from '@logto/schemas';
 import type { InitOptions } from 'i18next';
 import i18next from 'i18next';
 import { initReactI18next } from 'react-i18next';
 
-import { getI18nResource, detectLanguage } from '@/i18n/utils';
+import { getI18nResource } from '@/i18n/utils';
 
-const initI18n = async (languageSettings?: LanguageInfo) => {
-  // Get language settings from the SIE
-  const locale = detectLanguage(languageSettings);
-
-  const { resources, lng } = await getI18nResource(locale);
+const initI18n = async () => {
+  const { resources, lng } = await getI18nResource();
 
   const options: InitOptions = {
     resources,

--- a/packages/ui/src/i18n/utils.ts
+++ b/packages/ui/src/i18n/utils.ts
@@ -8,10 +8,18 @@ import LanguageDetector from 'i18next-browser-languagedetector';
 import { getPhrases } from '@/apis/settings';
 
 export const getI18nResource = async (
-  locale?: string | string[]
+  language?: string
 ): Promise<{ resources: Resource; lng: string }> => {
+  const detectedLanguage = detectLanguage();
+
   try {
-    const response = await getPhrases(Array.isArray(locale) ? locale.join(' ') : locale);
+    const response = await getPhrases({
+      localLanguage: Array.isArray(detectedLanguage)
+        ? detectedLanguage.join(' ')
+        : detectedLanguage,
+      language,
+    });
+
     const phrases = await response.json<LocalePhrase>();
     const lng = response.headers.get('Content-Language');
 
@@ -53,8 +61,8 @@ export const detectLanguage = (languageSettings?: LanguageInfo) => {
 };
 
 // Must be called after i18n's initialization
-export const changeLanguage = async (targetLanguage: string) => {
-  const { resources, lng } = await getI18nResource(targetLanguage);
+export const changeLanguage = async (language: string) => {
+  const { resources, lng } = await getI18nResource(language);
 
   for (const [namespace, resource] of Object.entries(resources[lng] ?? {})) {
     i18next.addResourceBundle(lng, namespace, resource);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Refactor gets phrases for preview.

Previous design:

Core:
`GET /phrases` API reads the requested language from the header as the detected language and reads the DB SIE language settings; if is auto detect enabled, it returns the detected language phrases, else it returns the fallback language phrases. 

UI:
Detect the system language using i18n. Load the SIE language settings and preview configs. 
- If is preview, set the request header content as preview configs returned language. 
- If SIE has auto-detect disabled, set the request header content as the fallback language.  
- Else detect from the i18n system.

| DB auto detect | DB fallback lng | useragent language | preview config | request header | response language |
| --- | --- | --- | --- | --- | --- |
| true | zh | en | N/A | en | en |
| false | zh | en | N/A | zh | zh |
| true | zh | en | fr | fr | fr |
| false | zh | en | fr | fr | zh (expect to be fr) |

Issue:
When the user plays around in the preview, turn auto detect from `disabled` status into `enabled` status without clicking on the save button. The DB settings remain auto-detect false. Any requested language will fall back to the fallback language settings.  

Updates:
Core:
- Add query params to the `GET /phrases` API, which has the highest priority if present. 
- If no query params are provided, read the detected language from the request header and compare it with the SIE settings. 
UI:
Request header content settings always sync with the user's browser settings. Always represent the 'detected language' status.
For preview config, always pass the language configs as the request query params. Represents the force language settings regardless of the detected language in the header and SIE DB settings. 

| DB auto detect | DB fallback lng | useragent language | preview config | request header | request query | response language |
| --- | --- | --- | --- | --- | --- | --- |
| true | zh | en | N/A | en | N/A | en |
| false | zh | en | N/A | en | N/A | zh |
| true | zh | en | fr | en | fr | fr |
| false | zh | en | fr | en | fr | fr |


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

test locally
UT added 