### PR TITLE
fix(core): should throw error when multiple connector factories have same id

### DIFF
--- a/packages/core/src/utils/connectors/factories.ts
+++ b/packages/core/src/utils/connectors/factories.ts
@@ -7,17 +7,36 @@ import { getConnectorPackagesFromDirectory } from '@logto/cli/lib/utils.js';
 import { findPackage } from '@logto/shared';
 import chalk from 'chalk';
 
+import RequestError from '#src/errors/RequestError/index.js';
 import type { ConnectorFactory } from '#src/utils/connectors/types.js';
 
 import { notImplemented } from './consts.js';
 import { parseMetadata, validateConnectorModule } from './index.js';
 import { loadConnector } from './loader.js';
 
+const checkDuplicateConnectorFactoriesId = (connectorFactories: ConnectorFactory[]) => {
+  const connectorFactoriesId = connectorFactories.map(({ metadata }) => metadata.id);
+  const connectorFactoriesIdSet = new Set(connectorFactoriesId);
+
+  if (connectorFactoriesId.length !== connectorFactoriesIdSet.size) {
+    const duplicatedConnectorFactoryIds = connectorFactoriesId.filter(
+      (id, index) => connectorFactoriesId.indexOf(id) !== index
+    );
+    throw new RequestError({
+      code: 'connector.more_than_one_connector_factory',
+      status: 422,
+      connectorIds: duplicatedConnectorFactoryIds.map((id) => `${id}`).join(', '),
+    });
+  }
+};
+
 // eslint-disable-next-line @silverhand/fp/no-let
 let cachedConnectorFactories: ConnectorFactory[] | undefined;
 
 export const loadConnectorFactories = async () => {
   if (cachedConnectorFactories) {
+    checkDuplicateConnectorFactoriesId(cachedConnectorFactories);
+
     return cachedConnectorFactories;
   }
 
@@ -64,6 +83,8 @@ export const loadConnectorFactories = async () => {
   cachedConnectorFactories = connectorFactories.filter(
     (connectorFactory): connectorFactory is ConnectorFactory => connectorFactory !== undefined
   );
+
+  checkDuplicateConnectorFactoriesId(cachedConnectorFactories);
 
   return cachedConnectorFactories;
 };

--- a/packages/core/src/utils/connectors/factories.ts
+++ b/packages/core/src/utils/connectors/factories.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { connectorDirectory } from '@logto/cli/lib/constants.js';
 import { getConnectorPackagesFromDirectory } from '@logto/cli/lib/utils.js';
 import { findPackage } from '@logto/shared';
+import { deduplicate } from '@silverhand/essentials';
 import chalk from 'chalk';
 
 import RequestError from '#src/errors/RequestError/index.js';
@@ -15,12 +16,12 @@ import { parseMetadata, validateConnectorModule } from './index.js';
 import { loadConnector } from './loader.js';
 
 const checkDuplicateConnectorFactoriesId = (connectorFactories: ConnectorFactory[]) => {
-  const connectorFactoriesId = connectorFactories.map(({ metadata }) => metadata.id);
-  const connectorFactoriesIdSet = new Set(connectorFactoriesId);
+  const connectorFactoryIds = connectorFactories.map(({ metadata }) => metadata.id);
+  const deduplicatedConnectorFactoryIds = deduplicate(connectorFactoryIds);
 
-  if (connectorFactoriesId.length !== connectorFactoriesIdSet.size) {
-    const duplicatedConnectorFactoryIds = connectorFactoriesId.filter(
-      (id, index) => connectorFactoriesId.indexOf(id) !== index
+  if (connectorFactoryIds.length !== deduplicatedConnectorFactoryIds.length) {
+    const duplicatedConnectorFactoryIds = deduplicatedConnectorFactoryIds.filter(
+      (deduplicateId) => connectorFactoryIds.filter((id) => id === deduplicateId).length > 1
     );
     throw new RequestError({
       code: 'connector.more_than_one_connector_factory',

--- a/packages/phrases/src/locales/de/errors.ts
+++ b/packages/phrases/src/locales/de/errors.ts
@@ -113,6 +113,8 @@ const errors = {
     social_auth_code_invalid: 'Unable to get access token, please check authorization code.',
     more_than_one_sms: 'The number of SMS connectors is larger then 1.',
     more_than_one_email: 'The number of Email connectors is larger then 1.',
+    more_than_one_connector_factory:
+      'Found multiple connector factories (with id {{connectorIds}}), you may uninstall unnecessary ones.', // UNTRANSLATED
     db_connector_type_mismatch: 'There is a connector in the DB that does not match the type.',
     not_found_with_connector_id: 'Can not find connector with given standard connector id.',
     multiple_instances_not_supported:

--- a/packages/phrases/src/locales/en/errors.ts
+++ b/packages/phrases/src/locales/en/errors.ts
@@ -112,6 +112,8 @@ const errors = {
     social_auth_code_invalid: 'Unable to get access token, please check authorization code.',
     more_than_one_sms: 'The number of SMS connectors is larger then 1.',
     more_than_one_email: 'The number of Email connectors is larger then 1.',
+    more_than_one_connector_factory:
+      'Found multiple connector factories (with id {{connectorIds}}), you may uninstall unnecessary ones.', // UNTRANSLATED
     db_connector_type_mismatch: 'There is a connector in the DB that does not match the type.',
     not_found_with_connector_id: 'Can not find connector with given standard connector id.',
     multiple_instances_not_supported:

--- a/packages/phrases/src/locales/fr/errors.ts
+++ b/packages/phrases/src/locales/fr/errors.ts
@@ -118,6 +118,8 @@ const errors = {
       "Impossible d'obtenir le jeton d'accès, veuillez vérifier le code d'autorisation.",
     more_than_one_sms: 'Le nombre de connecteurs SMS est supérieur à 1.',
     more_than_one_email: 'Le nombre de connecteurs Email est supérieur à 1.',
+    more_than_one_connector_factory:
+      'Found multiple connector factories (with id {{connectorIds}}), you may uninstall unnecessary ones.', // UNTRANSLATED
     db_connector_type_mismatch:
       'Il y a un connecteur dans la base de donnée qui ne correspond pas au type.',
     not_found_with_connector_id: 'Can not find connector with given standard connector id.', // UNTRANSLATED

--- a/packages/phrases/src/locales/ko/errors.ts
+++ b/packages/phrases/src/locales/ko/errors.ts
@@ -109,6 +109,8 @@ const errors = {
     social_auth_code_invalid: 'Access 토큰을 가져올 수 없어요. Authorization 코드를 확인해 주세요.',
     more_than_one_sms: 'SMS 서비스는 1개만 연동되어야 해요.',
     more_than_one_email: '이메일 서비스는 1개만 연동되어야 해요.',
+    more_than_one_connector_factory:
+      'Found multiple connector factories (with id {{connectorIds}}), you may uninstall unnecessary ones.', // UNTRANSLATED
     db_connector_type_mismatch: '종류가 일치하지 않은 연동 서비스가 DB에 존재해요.',
     not_found_with_connector_id: '주어진 연동 ID로 연동 설정을 찾을 수 없어요.',
     multiple_instances_not_supported: '선택된 연동 기준으로 여러 인스턴스를 생성할 수 없어요.',

--- a/packages/phrases/src/locales/pt-br/errors.ts
+++ b/packages/phrases/src/locales/pt-br/errors.ts
@@ -114,6 +114,8 @@ const errors = {
       'Não foi possível obter o token de acesso, verifique o código de autorização.',
     more_than_one_sms: 'O número de conectores SMS é maior que 1.',
     more_than_one_email: 'O número de conectores de e-mail é maior que 1.',
+    more_than_one_connector_factory:
+      'Found multiple connector factories (with id {{connectorIds}}), you may uninstall unnecessary ones.', // UNTRANSLATED
     db_connector_type_mismatch: 'Existe um conector no banco de dados que não corresponde ao tipo.',
     not_found_with_connector_id:
       'Não é possível encontrar o conector com o ID de conector padrão fornecido.',

--- a/packages/phrases/src/locales/pt-pt/errors.ts
+++ b/packages/phrases/src/locales/pt-pt/errors.ts
@@ -114,6 +114,8 @@ const errors = {
       'Não foi possível obter o token de acesso, verifique o código de autorização.',
     more_than_one_sms: 'O número de conectores SMS é maior que 1.',
     more_than_one_email: 'O número de conectores de e-mail é maior que 1.',
+    more_than_one_connector_factory:
+      'Found multiple connector factories (with id {{connectorIds}}), you may uninstall unnecessary ones.', // UNTRANSLATED
     db_connector_type_mismatch: 'Há um conector no banco de dados que não corresponde ao tipo.',
     not_found_with_connector_id: 'Can not find connector with given standard connector id.', // UNTRANSLATED
     multiple_instances_not_supported:

--- a/packages/phrases/src/locales/tr-tr/errors.ts
+++ b/packages/phrases/src/locales/tr-tr/errors.ts
@@ -113,6 +113,8 @@ const errors = {
     social_auth_code_invalid: 'Erişim tokenı alınamıyor, lütfen yetkilendirme kodunu kontrol edin.',
     more_than_one_sms: 'SMS bağlayıcılarının sayısı 1den fazla.',
     more_than_one_email: 'E-posta adresi bağlayıcılarının sayısı 1den fazla.',
+    more_than_one_connector_factory:
+      'Found multiple connector factories (with id {{connectorIds}}), you may uninstall unnecessary ones.', // UNTRANSLATED
     db_connector_type_mismatch: 'Dbde türle eşleşmeyen bir bağlayıcı var.',
     not_found_with_connector_id: 'Can not find connector with given standard connector id.', // UNTRANSLATED
     multiple_instances_not_supported:

--- a/packages/phrases/src/locales/zh-cn/errors.ts
+++ b/packages/phrases/src/locales/zh-cn/errors.ts
@@ -105,6 +105,7 @@ const errors = {
     social_auth_code_invalid: '无法获取 access_token，请检查授权 code 是否有效',
     more_than_one_sms: '同时存在超过 1 个短信连接器',
     more_than_one_email: '同时存在超过 1 个邮件连接器',
+    more_than_one_connector_factory: '找到多个连接器工厂（id 为 {{connectorIds}}），请删除多余项。',
     db_connector_type_mismatch: '数据库中存在一个类型不匹配的连接。',
     not_found_with_connector_id: '找不到所给 connector id 对应的连接器',
     multiple_instances_not_supported: '你选择的连接器不支持创建多实例。',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
1. should throw when multiple factories are found with given `id`.
2. refactor response of GET /connector-factories(/:id) APIs.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
