### PR TITLE
refactor: move admin console app to database

### DIFF
--- a/packages/cli/src/commands/database/seed/tables.ts
+++ b/packages/cli/src/commands/database/seed/tables.ts
@@ -10,6 +10,7 @@ import {
   createMeApiInAdminTenant,
   createDefaultSignInExperience,
   createAdminTenantSignInExperience,
+  createDefaultAdminConsoleApplication,
 } from '@logto/schemas';
 import { Hooks, Tenants } from '@logto/schemas/models';
 import type { DatabaseTransactionConnection } from 'slonik';
@@ -128,6 +129,7 @@ export const seedTables = async (
       insertInto(createDefaultSignInExperience(defaultTenantId), 'sign_in_experiences')
     ),
     connection.query(insertInto(createAdminTenantSignInExperience(), 'sign_in_experiences')),
+    connection.query(insertInto(createDefaultAdminConsoleApplication(), 'applications')),
     updateDatabaseTimestamp(connection, latestTimestamp),
   ]);
 };

--- a/packages/console/src/App.tsx
+++ b/packages/console/src/App.tsx
@@ -13,7 +13,7 @@ import './scss/overlayscrollbars.scss';
 import '@fontsource/roboto-mono';
 import AppLoading from '@/components/AppLoading';
 import Toast from '@/components/Toast';
-import { managementApi, meApi } from '@/consts/management-api';
+import { getManagementApi, meApi } from '@/consts/management-api';
 import AppBoundary from '@/containers/AppBoundary';
 import AppLayout from '@/containers/AppLayout';
 import ErrorBoundary from '@/containers/ErrorBoundary';
@@ -48,6 +48,7 @@ import {
   UserDetailsTabs,
   adminTenantEndpoint,
   getUserTenantId,
+  getBasename,
 } from './consts';
 import { isCloud } from './consts/cloud';
 import AppContent from './containers/AppContent';
@@ -161,26 +162,29 @@ const Main = () => {
   );
 };
 
-const App = () => (
-  <BrowserRouter basename={`/${getUserTenantId() ?? ''}`}>
-    <AppEndpointsProvider>
-      <LogtoProvider
-        config={{
-          endpoint: adminTenantEndpoint,
-          appId: adminConsoleApplicationId,
-          resources: [managementApi.indicator, meApi.indicator],
-          scopes: [
-            UserScope.Email,
-            UserScope.Identities,
-            UserScope.CustomData,
-            managementApi.scopeAll,
-          ],
-        }}
-      >
-        <Main />
-      </LogtoProvider>
-    </AppEndpointsProvider>
-  </BrowserRouter>
-);
+const App = () => {
+  const managementApi = getManagementApi(getUserTenantId());
 
+  return (
+    <BrowserRouter basename={getBasename()}>
+      <AppEndpointsProvider>
+        <LogtoProvider
+          config={{
+            endpoint: adminTenantEndpoint,
+            appId: adminConsoleApplicationId,
+            resources: [managementApi.indicator, meApi.indicator],
+            scopes: [
+              UserScope.Email,
+              UserScope.Identities,
+              UserScope.CustomData,
+              managementApi.scopeAll,
+            ],
+          }}
+        >
+          <Main />
+        </LogtoProvider>
+      </AppEndpointsProvider>
+    </BrowserRouter>
+  );
+};
 export default App;

--- a/packages/console/src/consts/management-api.ts
+++ b/packages/console/src/consts/management-api.ts
@@ -1,14 +1,10 @@
-import {
-  adminTenantId,
-  defaultTenantId,
-  getManagementApiResourceIndicator,
-  PredefinedScope,
-} from '@logto/schemas';
+import { adminTenantId, getManagementApiResourceIndicator, PredefinedScope } from '@logto/schemas';
 
-export const managementApi = Object.freeze({
-  indicator: getManagementApiResourceIndicator(defaultTenantId),
-  scopeAll: PredefinedScope.All,
-});
+export const getManagementApi = (tenantId: string) =>
+  Object.freeze({
+    indicator: getManagementApiResourceIndicator(tenantId),
+    scopeAll: PredefinedScope.All,
+  });
 
 export const meApi = Object.freeze({
   indicator: getManagementApiResourceIndicator(adminTenantId, 'me'),

--- a/packages/console/src/consts/tenants.ts
+++ b/packages/console/src/consts/tenants.ts
@@ -1,6 +1,19 @@
+import { defaultTenantId, ossConsolePath } from '@logto/schemas';
+
+import { isCloud } from './cloud';
+
 const isProduction = process.env.NODE_ENV === 'production';
 
 export const adminTenantEndpoint =
   process.env.ADMIN_TENANT_ENDPOINT ??
   (isProduction ? window.location.origin : 'http://localhost:3002');
-export const getUserTenantId = () => window.location.pathname.split('/')[1];
+
+export const getUserTenantId = () => {
+  if (isCloud) {
+    return window.location.pathname.split('/')[1] ?? '';
+  }
+
+  return defaultTenantId;
+};
+
+export const getBasename = () => (isCloud ? '/' + getUserTenantId() : ossConsolePath);

--- a/packages/console/src/hooks/use-api.ts
+++ b/packages/console/src/hooks/use-api.ts
@@ -5,7 +5,7 @@ import { useCallback, useContext, useMemo } from 'react';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 
-import { managementApi, requestTimeout } from '@/consts';
+import { getManagementApi, getUserTenantId, requestTimeout } from '@/consts';
 import { AppEndpointsContext } from '@/containers/AppEndpointsProvider';
 
 export class RequestError extends Error {
@@ -28,7 +28,7 @@ type StaticApiProps = {
 export const useStaticApi = ({
   prefixUrl,
   hideErrorToast,
-  resourceIndicator = managementApi.indicator,
+  resourceIndicator = getManagementApi(getUserTenantId()).indicator,
 }: StaticApiProps) => {
   const { isAuthenticated, getAccessToken } = useLogto();
   const { t, i18n } = useTranslation(undefined, { keyPrefix: 'admin_console' });

--- a/packages/core/src/middleware/koa-console-redirect-proxy.ts
+++ b/packages/core/src/middleware/koa-console-redirect-proxy.ts
@@ -1,3 +1,6 @@
+import path from 'path';
+
+import { ossConsolePath } from '@logto/schemas';
 import type { MiddlewareType } from 'koa';
 import type { IRouterParamContext } from 'koa-router';
 
@@ -13,14 +16,14 @@ export default function koaConsoleRedirectProxy<
   return async (ctx, next) => {
     const hasUser = await hasActiveUsers();
 
-    if ((ctx.path === '/' || ctx.path === '/console') && !hasUser) {
-      ctx.redirect('/console/welcome');
+    if ((ctx.path === '/' || ctx.path === ossConsolePath) && !hasUser) {
+      ctx.redirect(path.join(ossConsolePath, '/welcome'));
 
       return;
     }
 
-    if ((ctx.path === '/' || ctx.path === '/console/welcome') && hasUser) {
-      ctx.redirect('/console');
+    if ((ctx.path === '/' || ctx.path === path.join(ossConsolePath, '/welcome')) && hasUser) {
+      ctx.redirect(ossConsolePath);
 
       return;
     }

--- a/packages/core/src/tenants/Tenant.ts
+++ b/packages/core/src/tenants/Tenant.ts
@@ -83,14 +83,17 @@ export default class Tenant implements TenantContext {
       // Mount `/me` APIs for admin tenant
       app.use(mount('/me', initMeApis(tenantContext)));
 
-      // Mount Admin Console
-      app.use(koaConsoleRedirectProxy(queries));
-      app.use(
-        mount(
-          '/' + AdminApps.Console,
-          koaSpaProxy(mountedApps, AdminApps.Console, 5002, AdminApps.Console)
-        )
-      );
+      // Mount Admin Console when needed
+      // Skip in domain-based multi-tenancy since Logto Cloud serves Admin Console in this case
+      if (!EnvSet.values.isDomainBasedMultiTenancy) {
+        app.use(koaConsoleRedirectProxy(queries));
+        app.use(
+          mount(
+            '/' + AdminApps.Console,
+            koaSpaProxy(mountedApps, AdminApps.Console, 5002, AdminApps.Console)
+          )
+        );
+      }
     } else {
       // Mount demo app
       app.use(

--- a/packages/schemas/alterations/next-1676956206-move-console-sie-to-database.ts
+++ b/packages/schemas/alterations/next-1676956206-move-console-sie-to-database.ts
@@ -40,12 +40,17 @@ const data = {
     ],
   },
   socialSignInConnectorTargets: [],
-  signInMode: 'Register',
   customCss: null,
-};
+} as const;
 
 const alteration: AlterationScript = {
   up: async (pool) => {
+    const hasActiveUsers = await pool.exists(sql`
+      select id
+      from users
+      where tenant_id = 'default'
+      limit 1
+    `);
     await pool.query(sql`
       insert into sign_in_experiences (
         tenant_id,
@@ -69,7 +74,7 @@ const alteration: AlterationScript = {
         ${sql.jsonb(data.signUp)},
         ${sql.jsonb(data.signIn)},
         ${sql.jsonb(data.socialSignInConnectorTargets)},
-        ${data.signInMode},
+        ${hasActiveUsers ? 'SignIn' : 'Register'},
         ${data.customCss}
       );
     `);

--- a/packages/schemas/alterations/next-1677059985-move-console-application-to-database.ts
+++ b/packages/schemas/alterations/next-1677059985-move-console-application-to-database.ts
@@ -1,0 +1,37 @@
+import { generateStandardId } from '@logto/core-kit';
+import { sql } from 'slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      insert into applications (
+        tenant_id,
+        id,
+        name,
+        secret,
+        description,
+        type,
+        oidc_client_metadata
+      ) values (
+        'admin',
+        'admin-console',
+        'Admin Console',
+        ${generateStandardId()},
+        'Logto Admin Console.',
+        'SPA',
+        '{ "redirectUris": [], "postLogoutRedirectUris": [] }'::jsonb
+      );
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      delete from applications
+        where tenant_id = 'admin'
+        and id = 'admin-console';
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/consts/index.ts
+++ b/packages/schemas/src/consts/index.ts
@@ -1,1 +1,2 @@
-export * from './cloud.js';
+export * from './system.js';
+export * from './oidc.js';

--- a/packages/schemas/src/consts/oidc.ts
+++ b/packages/schemas/src/consts/oidc.ts
@@ -1,0 +1,1 @@
+export const tenantIdKey = 'tenant_id';

--- a/packages/schemas/src/consts/system.ts
+++ b/packages/schemas/src/consts/system.ts
@@ -1,2 +1,14 @@
+/** The API Resource Indicator for Logto Cloud. It's only useful when domain-based multi-tenancy is enabled. */
 export const cloudApiIndicator = 'https://cloud.logto.io/api';
+
+/**
+ * In OSS:
+ *
+ * - Only one single user tenant (`default`) is available.
+ * - Admin tenant and Admin Console share one endpoint (`ADMIN_ENDPOINT`).
+ *
+ * There's no need to parse tenant ID from the first path segment in OSS, and the segment should be a fixed value.
+ *
+ * If we use `/default`, the URL will look ugly; thus we keep the old fashion `/console`.
+ */
 export const ossConsolePath = '/console';

--- a/packages/schemas/src/consts/system.ts
+++ b/packages/schemas/src/consts/system.ts
@@ -1,1 +1,2 @@
 export const cloudApiIndicator = 'https://cloud.logto.io/api';
+export const ossConsolePath = '/console';

--- a/packages/schemas/src/seeds/application.ts
+++ b/packages/schemas/src/seeds/application.ts
@@ -1,3 +1,9 @@
+import { generateStandardId } from '@logto/core-kit';
+
+import type { CreateApplication } from '../db-entries/index.js';
+import { ApplicationType } from '../db-entries/index.js';
+import { adminTenantId } from './tenant.js';
+
 /**
  * The fixed application ID for Admin Console.
  *
@@ -6,3 +12,14 @@
 export const adminConsoleApplicationId = 'admin-console';
 
 export const demoAppApplicationId = 'demo-app';
+
+export const createDefaultAdminConsoleApplication = (): Readonly<CreateApplication> =>
+  Object.freeze({
+    tenantId: adminTenantId,
+    id: adminConsoleApplicationId,
+    name: 'Admin Console',
+    secret: generateStandardId(),
+    description: 'Logto Admin Console.',
+    type: ApplicationType.SPA,
+    oidcClientMetadata: { redirectUris: [], postLogoutRedirectUris: [] },
+  });


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
move admin console app to database since Logto Cloud needs dynamically add / remove Redirect URIs

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
local tested for OSS experience, works as expected for console sign in/out. will test on the cloud later
