### PR TITLE
WIP uffizzi: route 3001 to '/' and 3002 to '/console'

### DIFF
--- a/docker-compose.uffizzi.yml
+++ b/docker-compose.uffizzi.yml
@@ -37,7 +37,7 @@ services:
     entrypoint: /bin/sh
     command:
       - "-c"
-      - "npm run cli db seed -- --swe && ENDPOINT=$$UFFIZZI_URL npm start"
+      - "npm run cli db seed -- --swe && ADMIN_ENDPOINT=$$UFFIZZI_URL/console ENDPOINT=$$UFFIZZI_URL npm start"
 
   postgres:
     image: postgres:14-alpine

--- a/docker-compose.uffizzi.yml
+++ b/docker-compose.uffizzi.yml
@@ -3,14 +3,22 @@ version: "3.9"
 
 x-uffizzi:
   ingress:
-    service: app
-    port: 3001
+    service: nginx
+    port: 8081
   continuous_previews:
     deploy_preview_when_pull_request_is_opened: true
     delete_preview_when_pull_request_is_closed: true
     share_to_github: true
 
 services:
+  nginx:
+    image: nginx:alpine
+    restart: unless-stopped
+    ports:
+      - "8081:8081"
+    volumes:
+      - ./uffizzi/nginx:/etc/nginx
+
   app:
     depends_on:
       - "postgres"

--- a/uffizzi/nginx/nginx.conf
+++ b/uffizzi/nginx/nginx.conf
@@ -11,7 +11,7 @@ http {
             proxy_pass http://localhost:3001;
         }
 
-        location /meilisearch/ {
+        location /console/ {
             proxy_pass http://localhost:3002;
         }
     }

--- a/uffizzi/nginx/nginx.conf
+++ b/uffizzi/nginx/nginx.conf
@@ -1,0 +1,19 @@
+
+events {
+  worker_connections  4096;  ## Default: 1024
+}
+
+http {
+    server {
+        listen 8081;
+
+        location / {
+            proxy_pass http://localhost:3001;
+        }
+
+        location /meilisearch/ {
+            proxy_pass http://localhost:3002;
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
This change updates the uffizzi preview to route all requests coming to / to 3001 port and other requests coming to /console to 3002 port of the logto application container.

