### PR TITLE
fix(console): font size of readme title and card title should be 16px

### DIFF
--- a/packages/console/src/pages/Connectors/components/Guide/index.module.scss
+++ b/packages/console/src/pages/Connectors/components/Guide/index.module.scss
@@ -46,7 +46,7 @@
       overflow: hidden;
 
       .readmeTitle {
-        font: var(--font-title-1);
+        font: var(--font-title-2);
         padding: _.unit(5) _.unit(6) _.unit(4);
         border-bottom: 1px solid var(--color-focused-variant);
       }
@@ -68,7 +68,7 @@
         margin-bottom: _.unit(6);
 
         .blockTitle {
-          font: var(--font-title-1);
+          font: var(--font-title-2);
           padding: _.unit(5) 0 _.unit(6);
           display: flex;
           align-items: center;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
The font size of the readme title and card title (of connector create form) should be 16px (previous font size is 20px)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
