### PR TITLE
fix(core): should not block social email/phone identifiers by SIE

### DIFF
--- a/packages/core/src/routes/interaction/utils/sign-in-experience-valiation.test.ts
+++ b/packages/core/src/routes/interaction/utils/sign-in-experience-valiation.test.ts
@@ -266,6 +266,36 @@ describe('identifier validation', () => {
       });
     }).not.toThrow();
   });
+
+  it('connector phone should not throw', () => {
+    const identifier = { phone: '123456', connectorId: 'logto' };
+
+    expect(() => {
+      verifyIdentifierSettings(identifier, {
+        ...mockSignInExperience,
+        signIn: {
+          methods: mockSignInExperience.signIn.methods.filter(
+            ({ identifier }) => identifier !== SignInIdentifier.Phone
+          ),
+        },
+      });
+    }).not.toThrow();
+  });
+
+  it('connector email should not throw', () => {
+    const identifier = { email: 'foo@logto.io', connectorId: 'logto' };
+
+    expect(() => {
+      verifyIdentifierSettings(identifier, {
+        ...mockSignInExperience,
+        signIn: {
+          methods: mockSignInExperience.signIn.methods.filter(
+            ({ identifier }) => identifier !== SignInIdentifier.Email
+          ),
+        },
+      });
+    }).not.toThrow();
+  });
 });
 
 describe('profile validation', () => {

--- a/packages/core/src/routes/interaction/utils/sign-in-experience-validation.ts
+++ b/packages/core/src/routes/interaction/utils/sign-in-experience-validation.ts
@@ -42,6 +42,12 @@ export const verifyIdentifierSettings = (
     return;
   }
 
+  // Social Identifier  TODO: @darcy, @sijie
+  // should not verify connector related identifier here
+  if ('connectorId' in identifier) {
+    return;
+  }
+
   // Email Identifier
   if ('email' in identifier) {
     assertThat(
@@ -86,7 +92,7 @@ export const verifyIdentifierSettings = (
           return false;
         }
 
-        // Phone verificationCode Verification: SignIn verificationCode enabled or SignUp Email verify enabled
+        // Phone verificationCode Verification: SignIn verificationCode enabled or SignUp Phone verify enabled
         if (
           'verificationCode' in identifier &&
           !verificationCode &&
@@ -101,8 +107,6 @@ export const verifyIdentifierSettings = (
       forbiddenIdentifierError
     );
   }
-
-  // Social Identifier  TODO: @darcy, @sijie
 };
 
 export const verifyProfileSettings = (profile: Profile, { signUp }: SignInExperience) => {


### PR DESCRIPTION


<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Should not block social email/phone identifiers by SIE sign-in settings.

Issue:

Social bind related user flow. Should not block the API event if email is disabled in the sign-in-experience settings.

Solution, does not check the SIE settings for all social identity typed identifiers. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
UT updated
