### PR TITLE
feat(core): added a new endpoint to replace user roles

### DIFF
--- a/packages/core/src/__mocks__/index.ts
+++ b/packages/core/src/__mocks__/index.ts
@@ -6,6 +6,7 @@ import type {
   Resource,
   Role,
   Scope,
+  UsersRole,
 } from '@logto/schemas';
 import { ApplicationType } from '@logto/schemas';
 
@@ -72,6 +73,13 @@ export const mockRole: Role = {
   description: 'admin',
 };
 
+export const mockRole2: Role = {
+  tenantId: 'fake_tenant',
+  id: 'role_id2',
+  name: 'admin2',
+  description: 'admin2',
+};
+
 export const mockAdminConsoleData: AdminConsoleData = {
   demoChecked: false,
   applicationCreated: false,
@@ -92,4 +100,11 @@ export const mockPasscode: Passcode = {
   consumed: false,
   tryCount: 2,
   createdAt: 10,
+};
+
+export const mockUserRole: UsersRole = {
+  tenantId: 'fake_tenant',
+  id: 'user_role_id',
+  userId: 'foo',
+  roleId: 'role_id',
 };

--- a/packages/core/src/routes/admin-user-role.test.ts
+++ b/packages/core/src/routes/admin-user-role.test.ts
@@ -50,9 +50,9 @@ describe('user role routes', () => {
     ]);
   });
 
-  it('PATCH /users/:id/roles', async () => {
+  it('PUT /users/:id/roles', async () => {
     findUsersRolesByUserId.mockResolvedValueOnce([mockUserRole]);
-    const response = await roleRequester.patch(`/users/${mockUser.id}/roles`).send({
+    const response = await roleRequester.put(`/users/${mockUser.id}/roles`).send({
       roleIds: [mockRole2.id],
     });
     expect(response.status).toEqual(200);

--- a/packages/core/src/routes/admin-user-role.test.ts
+++ b/packages/core/src/routes/admin-user-role.test.ts
@@ -1,6 +1,6 @@
 import { pickDefault } from '@logto/shared/esm';
 
-import { mockRole, mockUser } from '#src/__mocks__/index.js';
+import { mockRole, mockUser, mockRole2, mockUserRole } from '#src/__mocks__/index.js';
 import { mockId, mockStandardId } from '#src/test-utils/nanoid.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
 import { createRequester } from '#src/utils/test-utils.js';
@@ -47,6 +47,18 @@ describe('user role routes', () => {
     expect(response.status).toEqual(201);
     expect(insertUsersRoles).toHaveBeenCalledWith([
       { id: mockId, userId: mockUser.id, roleId: mockRole.id },
+    ]);
+  });
+
+  it('PATCH /users/:id/roles', async () => {
+    findUsersRolesByUserId.mockResolvedValueOnce([mockUserRole]);
+    const response = await roleRequester.patch(`/users/${mockUser.id}/roles`).send({
+      roleIds: [mockRole2.id],
+    });
+    expect(response.status).toEqual(200);
+    expect(deleteUsersRolesByUserIdAndRoleId).toHaveBeenCalledWith(mockUser.id, mockRole.id);
+    expect(insertUsersRoles).toHaveBeenCalledWith([
+      { id: mockId, userId: mockUser.id, roleId: mockRole2.id },
     ]);
   });
 

--- a/packages/core/src/routes/admin-user-role.ts
+++ b/packages/core/src/routes/admin-user-role.ts
@@ -99,7 +99,7 @@ export default function adminUserRoleRoutes<T extends AuthedRouter>(
     }
   );
 
-  router.patch(
+  router.put(
     '/users/:userId/roles',
     koaGuard({
       params: object({ userId: string() }),


### PR DESCRIPTION
## Summary
The api endpoint `POST /api/users/:userId/roles` accepts `roleIds[]` to assign roles to the user. As relevant to my use case, I implemented a `PUT /api/users/:userId/roles` to replace user's roles. Hoping to see this commit merged as I guess it might find its place in other projects as well.

Refer to here, Discord thread for origin of this:
https://discord.com/channels/965845662535147551/1077713036485349587

## Testing
I've created relevant tests that you can see in committed files and they are part of usual test process.