### PR TITLE
style(console): fix connector dark collapse button margin

### DIFF
--- a/packages/console/src/pages/Connectors/components/ConnectorForm/BasicForm.module.scss
+++ b/packages/console/src/pages/Connectors/components/ConnectorForm/BasicForm.module.scss
@@ -5,3 +5,7 @@
   font: var(--font-body-2);
   margin-top: _.unit(0.5);
 }
+
+.fieldButton {
+  margin-top: _.unit(2);
+}

--- a/packages/console/src/pages/Connectors/components/ConnectorForm/BasicForm.tsx
+++ b/packages/console/src/pages/Connectors/components/ConnectorForm/BasicForm.tsx
@@ -89,17 +89,19 @@ const BasicForm = ({
               />
             </FormField>
           )}
-          <Button
-            size="small"
-            type="text"
-            title={
-              darkVisible
-                ? 'connectors.guide.logo_dark_collapse'
-                : 'connectors.guide.logo_dark_show'
-            }
-            trailingIcon={darkVisible ? <CaretUp /> : <CaretDown />}
-            onClick={toggleDarkVisible}
-          />
+          <div className={styles.fieldButton}>
+            <Button
+              size="small"
+              type="text"
+              title={
+                darkVisible
+                  ? 'connectors.guide.logo_dark_collapse'
+                  : 'connectors.guide.logo_dark_show'
+              }
+              trailingIcon={darkVisible ? <CaretUp /> : <CaretDown />}
+              onClick={toggleDarkVisible}
+            />
+          </div>
           <FormField
             isRequired
             title="connectors.guide.target"


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix margin style for "show logo settings for dark mode".

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="382" alt="image" src="https://user-images.githubusercontent.com/5717882/221455627-48c770a6-8f2c-43cb-8d96-e99092f79b55.png">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
