### PR TITLE
style(ui): fix social button text cut-off

### DIFF
--- a/packages/ui/src/components/Button/SocialLinkButton.module.scss
+++ b/packages/ui/src/components/Button/SocialLinkButton.module.scss
@@ -21,6 +21,7 @@
 
   span {
     @include _.multi-line-ellipsis(2);
+    line-height: _.unit(5);
   }
 
   .placeHolder {
@@ -29,5 +30,11 @@
     &:first-child {
       min-width: _.unit(10);
     }
+  }
+}
+
+:global(body.desktop) {
+  .name span {
+    line-height: _.unit(4);
   }
 }

--- a/packages/ui/src/components/Button/index.module.scss
+++ b/packages/ui/src/components/Button/index.module.scss
@@ -8,7 +8,6 @@
   border-radius: var(--radius);
   cursor: pointer;
   font: var(--font-label-1);
-  line-height: 16px;
   -webkit-appearance: none;
   -webkit-tap-highlight-color: transparent;
   transition: background 0.2s ease-in-out;
@@ -60,7 +59,6 @@
 :global(body.desktop) {
   .button {
     font: var(--font-label-2);
-    line-height: 14px;
   }
 
   .primary {


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix social button text cut-off issue

Line height was set less than the font-size. 

Before:
<img width="472" alt="image" src="https://user-images.githubusercontent.com/36393111/221745392-7700604c-d8e8-4155-94e5-5a73192217ea.png">

After:
<img width="442" alt="image" src="https://user-images.githubusercontent.com/36393111/221745162-9bf054b8-7c44-4d3e-984b-3adf140c30eb.png">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
