### PR TITLE
refactor(core): fix CORS

### DIFF
--- a/packages/core/src/middleware/koa-cors.test.ts
+++ b/packages/core/src/middleware/koa-cors.test.ts
@@ -23,7 +23,7 @@ const { default: koaCors } = await import('./koa-cors.js');
 const noop = async () => {};
 
 const mockContext = (method: RequestMethod, url: string) => {
-  const ctx = createMockContext({ method, url });
+  const ctx = createMockContext({ method, headers: { origin: new URL(url).origin } });
 
   const setSpy = jest.spyOn(ctx, 'set');
 

--- a/packages/core/src/middleware/koa-cors.ts
+++ b/packages/core/src/middleware/koa-cors.ts
@@ -9,7 +9,7 @@ export default function koaCors<StateT, ContextT, ResponseBodyT>(
 ): MiddlewareType<StateT, ContextT, ResponseBodyT> {
   return cors({
     origin: (ctx) => {
-      const { origin } = ctx;
+      const { origin } = ctx.request.headers;
 
       if (
         origin &&


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
should use `ctx.request.headers.origin` instead of `ctx.origin`

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
local tested CORS OK

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
