### PR TITLE
fix(core): error invalid credentials should return 401 instead of 400

### DIFF
--- a/packages/core/src/libraries/user.ts
+++ b/packages/core/src/libraries/user.ts
@@ -33,14 +33,17 @@ export const encryptUserPassword = async (
 };
 
 export const verifyUserPassword = async (user: Nullable<User>, password: string): Promise<User> => {
-  assertThat(user, 'session.invalid_credentials');
+  assertThat(user, new RequestError({ code: 'session.invalid_credentials', status: 401 }));
   const { passwordEncrypted, passwordEncryptionMethod } = user;
 
-  assertThat(passwordEncrypted && passwordEncryptionMethod, 'session.invalid_credentials');
+  assertThat(
+    passwordEncrypted && passwordEncryptionMethod,
+    new RequestError({ code: 'session.invalid_credentials', status: 401 })
+  );
 
   const result = await argon2Verify({ password, hash: passwordEncrypted });
 
-  assertThat(result, 'session.invalid_credentials');
+  assertThat(result, new RequestError({ code: 'session.invalid_credentials', status: 401 }));
 
   return user;
 };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
When `invalid credential` error occurs, the core service should return http status code 401 instead of 400.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [x] unit tests
- [x] integration tests
- [ ] docs

OR

- [ ] This PR is not applicable for the checklist
