### PR TITLE
feat: create tenant for new users

### DIFF
--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -19,11 +19,12 @@
     "start": "NODE_ENV=production node ."
   },
   "dependencies": {
+    "@logto/cli": "workspace:*",
     "@logto/core-kit": "workspace:*",
     "@logto/schemas": "workspace:*",
     "@logto/shared": "workspace:*",
     "@silverhand/essentials": "2.2.0",
-    "@withtyped/postgres": "^0.8.0",
+    "@withtyped/postgres": "^0.8.1",
     "@withtyped/server": "^0.8.0",
     "chalk": "^5.0.0",
     "decamelize": "^6.0.0",

--- a/packages/console/src/cloud/pages/Main/Tenants.tsx
+++ b/packages/console/src/cloud/pages/Main/Tenants.tsx
@@ -21,12 +21,14 @@ const Tenants = ({ data, onAdd }: Props) => {
   }, [api, onAdd]);
 
   useEffect(() => {
-    if (data.length <= 1) {
-      if (data[0]) {
-        window.location.assign('/' + data[0].id);
-      } else {
-        void createTenant();
-      }
+    if (data.length > 1) {
+      return;
+    }
+
+    if (data[0]) {
+      window.location.assign('/' + data[0].id);
+    } else {
+      void createTenant();
     }
   }, [createTenant, data]);
 

--- a/packages/console/src/cloud/pages/Main/Tenants.tsx
+++ b/packages/console/src/cloud/pages/Main/Tenants.tsx
@@ -1,6 +1,7 @@
 import type { TenantInfo } from '@logto/schemas';
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 
+import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
 import { AppLoadingOffline } from '@/components/AppLoading/Offline';
 import Button from '@/components/Button';
 import DangerousRaw from '@/components/DangerousRaw';
@@ -9,18 +10,25 @@ import * as styles from './index.module.scss';
 
 type Props = {
   data: TenantInfo[];
+  onAdd: (tenant: TenantInfo) => void;
 };
 
-const Tenants = ({ data }: Props) => {
+const Tenants = ({ data, onAdd }: Props) => {
+  const api = useCloudApi();
+
+  const createTenant = useCallback(async () => {
+    onAdd(await api.post('api/tenants').json<TenantInfo>());
+  }, [api, onAdd]);
+
   useEffect(() => {
     if (data.length <= 1) {
       if (data[0]) {
         window.location.assign('/' + data[0].id);
       } else {
-        // Todo: create tenant
+        void createTenant();
       }
     }
-  }, [data]);
+  }, [createTenant, data]);
 
   if (data.length > 1) {
     return (
@@ -31,6 +39,8 @@ const Tenants = ({ data }: Props) => {
             <Button title={<DangerousRaw>{id}</DangerousRaw>} />
           </a>
         ))}
+        <h3>Create a tenant</h3>
+        <Button title={<DangerousRaw>Create New</DangerousRaw>} onClick={createTenant} />
       </div>
     );
   }

--- a/packages/console/src/cloud/pages/Main/index.tsx
+++ b/packages/console/src/cloud/pages/Main/index.tsx
@@ -33,7 +33,14 @@ const Protected = () => {
       return <Redirect tenants={tenants} toTenantId={currentTenantId} />;
     }
 
-    return <Tenants data={tenants} />;
+    return (
+      <Tenants
+        data={tenants}
+        onAdd={(tenant) => {
+          setTenants([...tenants, tenant]);
+        }}
+      />
+    );
   }
 
   return <AppLoadingOffline />;

--- a/packages/core/nodemon.json
+++ b/packages/core/nodemon.json
@@ -8,7 +8,8 @@
     "../*/lib/",
     "../core/src/",
     "../core/node_modules/",
-    ".env"
+    ".env",
+    "../../.env"
   ],
   "ext": "json,js,jsx,ts,tsx",
   "delay": 500

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,7 @@
     "@logto/schemas": "workspace:*",
     "@logto/shared": "workspace:*",
     "@silverhand/essentials": "2.2.0",
-    "@withtyped/postgres": "^0.8.0",
+    "@withtyped/postgres": "^0.8.1",
     "@withtyped/server": "^0.8.0",
     "chalk": "^5.0.0",
     "clean-deep": "^3.4.0",

--- a/packages/core/src/env-set/GlobalValues.ts
+++ b/packages/core/src/env-set/GlobalValues.ts
@@ -1,14 +1,14 @@
 import { tryThat } from '@logto/shared';
-import { assertEnv, getEnv, getEnvAsStringArray } from '@silverhand/essentials';
+import { assertEnv, getEnv, getEnvAsStringArray, yes } from '@silverhand/essentials';
 
 import UrlSet from './UrlSet.js';
-import { isTrue } from './parameters.js';
 import { throwErrorWithDsnMessage } from './throw-errors.js';
 
 export default class GlobalValues {
   public readonly isProduction = getEnv('NODE_ENV') === 'production';
   public readonly isTest = getEnv('NODE_ENV') === 'test';
-  public readonly isIntegrationTest = isTrue(getEnv('INTEGRATION_TEST'));
+  public readonly isIntegrationTest = yes(getEnv('INTEGRATION_TEST'));
+  public readonly isCloud = yes(process.env.IS_CLOUD);
 
   public readonly httpsCert = process.env.HTTPS_CERT_PATH;
   public readonly httpsKey = process.env.HTTPS_KEY_PATH;
@@ -25,8 +25,8 @@ export default class GlobalValues {
   public readonly developmentTenantId = getEnv('DEVELOPMENT_TENANT_ID');
   public readonly userDefaultRoleNames = getEnvAsStringArray('USER_DEFAULT_ROLE_NAMES');
   public readonly developmentUserId = getEnv('DEVELOPMENT_USER_ID');
-  public readonly trustProxyHeader = isTrue(getEnv('TRUST_PROXY_HEADER'));
-  public readonly ignoreConnectorVersionCheck = isTrue(getEnv('IGNORE_CONNECTOR_VERSION_CHECK'));
+  public readonly trustProxyHeader = yes(getEnv('TRUST_PROXY_HEADER'));
+  public readonly ignoreConnectorVersionCheck = yes(getEnv('IGNORE_CONNECTOR_VERSION_CHECK'));
 
   public get dbUrl(): string {
     return this.databaseUrl;

--- a/packages/core/src/env-set/UrlSet.ts
+++ b/packages/core/src/env-set/UrlSet.ts
@@ -1,12 +1,10 @@
-import { deduplicate, getEnv, trySafe } from '@silverhand/essentials';
-
-import { isTrue } from './parameters.js';
+import { deduplicate, getEnv, trySafe, yes } from '@silverhand/essentials';
 
 export default class UrlSet {
   readonly #port = Number(getEnv(this.envPrefix + 'PORT') || this.defaultPort);
   readonly #endpoint = getEnv(this.envPrefix + 'ENDPOINT');
 
-  public readonly isLocalhostDisabled = isTrue(getEnv(this.envPrefix + 'DISABLE_LOCALHOST'));
+  public readonly isLocalhostDisabled = yes(getEnv(this.envPrefix + 'DISABLE_LOCALHOST'));
 
   constructor(
     public readonly isHttpsEnabled: boolean,

--- a/packages/core/src/env-set/parameters.ts
+++ b/packages/core/src/env-set/parameters.ts
@@ -1,6 +1,0 @@
-import type { Nullable } from '@silverhand/essentials';
-
-export const isTrue = (value?: Nullable<string>) =>
-  // We need to leverage the native type guard
-  // eslint-disable-next-line no-implicit-coercion
-  !!value && ['1', 'true', 'y', 'yes', 'yep', 'yeah'].includes(value.toLowerCase());

--- a/packages/core/src/oidc/adapter.ts
+++ b/packages/core/src/oidc/adapter.ts
@@ -18,8 +18,11 @@ import { getConstantClientMetadata } from './utils.js';
  * as Admin Console is attached to the admin tenant in OSS and its endpoints are dynamic (from env variable).
  */
 const transpileMetadata = (clientId: string, data: AllClientMetadata): AllClientMetadata => {
-  const { adminUrlSet } = EnvSet.values;
-  const urls = adminUrlSet.deduplicated().map((url) => appendPath(url, '/console').toString());
+  const { adminUrlSet, cloudUrlSet } = EnvSet.values;
+  const urls = [
+    ...adminUrlSet.deduplicated().map((url) => appendPath(url, '/console').toString()),
+    ...cloudUrlSet.deduplicated().map(String),
+  ];
 
   if (clientId === adminConsoleApplicationId) {
     return {

--- a/packages/core/src/routes/interaction/consent.ts
+++ b/packages/core/src/routes/interaction/consent.ts
@@ -2,11 +2,6 @@ import { conditional } from '@silverhand/essentials';
 import type Router from 'koa-router';
 import { z } from 'zod';
 
-<<<<<<< HEAD
-=======
-import { EnvSet } from '#src/env-set/index.js';
-import RequestError from '#src/errors/RequestError/index.js';
->>>>>>> a73612239 (feat: create tenant for new users)
 import { assignInteractionResults, saveUserFirstConsentedAppId } from '#src/libraries/session.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';

--- a/packages/core/src/routes/interaction/consent.ts
+++ b/packages/core/src/routes/interaction/consent.ts
@@ -2,6 +2,11 @@ import { conditional } from '@silverhand/essentials';
 import type Router from 'koa-router';
 import { z } from 'zod';
 
+<<<<<<< HEAD
+=======
+import { EnvSet } from '#src/env-set/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
+>>>>>>> a73612239 (feat: create tenant for new users)
 import { assignInteractionResults, saveUserFirstConsentedAppId } from '#src/libraries/session.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';

--- a/packages/core/src/routes/resource.ts
+++ b/packages/core/src/routes/resource.ts
@@ -1,9 +1,9 @@
 import { buildIdGenerator } from '@logto/core-kit';
 import { Resources, Scopes } from '@logto/schemas';
 import { tryThat } from '@logto/shared';
+import { yes } from '@silverhand/essentials';
 import { object, string } from 'zod';
 
-import { isTrue } from '#src/env-set/parameters.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
@@ -54,7 +54,7 @@ export default function resourceRoutes<T extends AuthedRouter>(
 
       if (disabled) {
         const resources = await findAllResources();
-        ctx.body = isTrue(includeScopes) ? await attachScopesToResources(resources) : resources;
+        ctx.body = yes(includeScopes) ? await attachScopesToResources(resources) : resources;
 
         return next();
       }
@@ -65,7 +65,7 @@ export default function resourceRoutes<T extends AuthedRouter>(
       ]);
 
       ctx.pagination.totalCount = count;
-      ctx.body = isTrue(includeScopes) ? await attachScopesToResources(resources) : resources;
+      ctx.body = yes(includeScopes) ? await attachScopesToResources(resources) : resources;
 
       return next();
     }

--- a/packages/core/src/utils/search.ts
+++ b/packages/core/src/utils/search.ts
@@ -1,10 +1,8 @@
 import { SearchJointMode, SearchMatchMode } from '@logto/schemas';
 import type { Nullable, Optional } from '@silverhand/essentials';
-import { conditionalString } from '@silverhand/essentials';
+import { yes, conditionalString } from '@silverhand/essentials';
 import { sql } from 'slonik';
 import { snakeCase } from 'snake-case';
-
-import { isTrue } from '#src/env-set/parameters.js';
 
 import assertThat from './assert-that.js';
 import { isEnum } from './type.js';
@@ -83,7 +81,7 @@ const getSearchMetadata = (searchParameters: URLSearchParams, allowedFields?: st
   const matchMode = new Map<Optional<string>, SearchMatchMode>();
   const matchValues = new Map<Optional<string>, string[]>();
   const joint = getJointMode(searchParameters.get('joint') ?? searchParameters.get('jointMode'));
-  const isCaseSensitive = isTrue(searchParameters.get('isCaseSensitive') ?? 'false');
+  const isCaseSensitive = yes(searchParameters.get('isCaseSensitive') ?? 'false');
 
   // Parse the following values and return:
   // 1. Search modes per field, if available

--- a/packages/core/src/utils/tenant.ts
+++ b/packages/core/src/utils/tenant.ts
@@ -24,12 +24,14 @@ export const getTenantId = (url: URL) => {
     adminUrlSet,
   } = EnvSet.values;
 
-  if ((!isProduction || isIntegrationTest) && developmentTenantId) {
-    return developmentTenantId;
-  }
-
   if (adminUrlSet.deduplicated().some((endpoint) => isEndpointOf(url, endpoint))) {
     return adminTenantId;
+  }
+
+  if ((!isProduction || isIntegrationTest) && developmentTenantId) {
+    console.log(`Found dev tenant ID ${developmentTenantId}.`);
+
+    return developmentTenantId;
   }
 
   if (

--- a/packages/schemas/src/seeds/logto-config.ts
+++ b/packages/schemas/src/seeds/logto-config.ts
@@ -6,6 +6,7 @@ import { AdminConsoleConfigKey } from '../types/index.js';
 export const createDefaultAdminConsoleConfig = (
   forTenantId: string
 ): Readonly<{
+  tenantId: string;
   key: AdminConsoleConfigKey;
   value: AdminConsoleData;
 }> =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,7 @@ importers:
 
   packages/cloud:
     specifiers:
+      '@logto/cli': workspace:*
       '@logto/core-kit': workspace:*
       '@logto/schemas': workspace:*
       '@logto/shared': workspace:*
@@ -115,7 +116,7 @@ importers:
       '@types/http-proxy': ^1.17.9
       '@types/mime-types': ^2.1.1
       '@types/node': ^18.11.18
-      '@withtyped/postgres': ^0.8.0
+      '@withtyped/postgres': ^0.8.1
       '@withtyped/server': ^0.8.0
       chalk: ^5.0.0
       decamelize: ^6.0.0
@@ -131,11 +132,12 @@ importers:
       typescript: ^4.9.4
       zod: ^3.20.2
     dependencies:
+      '@logto/cli': link:../cli
       '@logto/core-kit': link:../toolkit/core-kit
       '@logto/schemas': link:../schemas
       '@logto/shared': link:../shared
       '@silverhand/essentials': 2.2.0
-      '@withtyped/postgres': 0.8.0_@withtyped+server@0.8.0
+      '@withtyped/postgres': 0.8.1_@withtyped+server@0.8.0
       '@withtyped/server': 0.8.0
       chalk: 5.1.2
       decamelize: 6.0.0
@@ -333,7 +335,7 @@ importers:
       '@types/semver': ^7.3.12
       '@types/sinon': ^10.0.13
       '@types/supertest': ^2.0.11
-      '@withtyped/postgres': ^0.8.0
+      '@withtyped/postgres': ^0.8.1
       '@withtyped/server': ^0.8.0
       chalk: ^5.0.0
       clean-deep: ^3.4.0
@@ -393,7 +395,7 @@ importers:
       '@logto/schemas': link:../schemas
       '@logto/shared': link:../shared
       '@silverhand/essentials': 2.2.0
-      '@withtyped/postgres': 0.8.0_@withtyped+server@0.8.0
+      '@withtyped/postgres': 0.8.1_@withtyped+server@0.8.0
       '@withtyped/server': 0.8.0
       chalk: 5.1.2
       clean-deep: 3.4.0
@@ -4563,8 +4565,8 @@ packages:
       eslint-visitor-keys: 3.3.0
     dev: true
 
-  /@withtyped/postgres/0.8.0_@withtyped+server@0.8.0:
-    resolution: {integrity: sha512-cyhHR1lEV1cs0yDfmHvqR4R52kxgI/JCDd2fizOCzgIE6Z9g3GjYjeVtTl/fTaoDz/QDaXKwfkuxd0N7HSY7uw==}
+  /@withtyped/postgres/0.8.1_@withtyped+server@0.8.0:
+    resolution: {integrity: sha512-BkX1SPDV8bZFn1LEI6jzTes+y/4BGuPEBOi8p6jH9ZBySTuaW0/JqgEb1aKk5GtJ0aFGXhgq4Fk+JkLOc6zehA==}
     peerDependencies:
       '@withtyped/server': ^0.8.0
     dependencies:


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
this pr is a followup of #3247. resolves LOG-5487.

automatically create a new tenant if user has no tenant available in cloud service. console will call `POST /api/tenants` and redirect to the newly created tenant.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

- [x] new user with no tenant -> create and redirect to console
- [x] user with an existing tenant -> redirect to console
- [x] user with multiple tenants -> show "choose tenant" page

## Upcoming

- optimize redirect and api calls
- add seed command for cloud database
- allow admin tenant admin to create multiple tenants
- tests will be added later
- frontend error handling
- (maybe) setup cloud dev env without custom domain, (e.g. `localhost`)

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
