### PR TITLE
fix(console): userinfo submenu should have shadow effect

### DIFF
--- a/packages/console/src/containers/AppLayout/components/SubMenu/index.module.scss
+++ b/packages/console/src/containers/AppLayout/components/SubMenu/index.module.scss
@@ -33,6 +33,7 @@
   background: var(--color-float);
   border: 1px solid var(--color-divider);
   border-radius: _.unit(2);
+  box-shadow: var(--shadow-2);
 
   &.visible {
     display: block;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
UserInfo sub-menu should have shadow effect properly applied.

<img width="600" alt="image" src="https://user-images.githubusercontent.com/12833674/222179517-361c4095-d698-4286-bfb3-547aae9f78da.png">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
