### PR TITLE
refactor(console): handling cloud errors

### DIFF
--- a/packages/console/src/App.tsx
+++ b/packages/console/src/App.tsx
@@ -17,6 +17,7 @@ import initI18n from '@/i18n/init';
 
 import { adminTenantEndpoint } from './consts';
 import { isCloud } from './consts/cloud';
+import ErrorBoundary from './containers/ErrorBoundary';
 import AppConfirmModalProvider from './contexts/AppConfirmModalProvider';
 import AppEndpointsProvider from './contexts/AppEndpointsProvider';
 import TenantsProvider, { TenantsContext } from './contexts/TenantsProvider';
@@ -68,9 +69,11 @@ const Content = () => {
 
 const App = () => {
   return (
-    <TenantsProvider>
-      <Content />
-    </TenantsProvider>
+    <ErrorBoundary>
+      <TenantsProvider>
+        <Content />
+      </TenantsProvider>
+    </ErrorBoundary>
   );
 };
 export default App;

--- a/packages/console/src/components/AppError/index.tsx
+++ b/packages/console/src/components/AppError/index.tsx
@@ -6,8 +6,8 @@ import ErrorDark from '@/assets/images/error-dark.svg';
 import Error from '@/assets/images/error.svg';
 import KeyboardArrowDown from '@/assets/images/keyboard-arrow-down.svg';
 import KeyboardArrowUp from '@/assets/images/keyboard-arrow-up.svg';
-import { useTheme } from '@/hooks/use-theme';
 import { onKeyDownHandler } from '@/utils/a11y';
+import { getThemeFromLocalStorage } from '@/utils/theme';
 
 import * as styles from './index.module.scss';
 
@@ -22,7 +22,7 @@ type Props = {
 const AppError = ({ title, errorCode, errorMessage, callStack, children }: Props) => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const [isDetailsOpen, setIsDetailsOpen] = useState(false);
-  const theme = useTheme();
+  const theme = getThemeFromLocalStorage(); // Should be able to use the component in an offline environment
 
   return (
     <div className={styles.container}>

--- a/packages/console/src/components/AppLoading/Offline.tsx
+++ b/packages/console/src/components/AppLoading/Offline.tsx
@@ -1,12 +1,7 @@
-import { AppearanceMode } from '@logto/schemas';
-import { trySafe } from '@silverhand/essentials';
-import { z } from 'zod';
-
 import IllustrationDark from '@/assets/images/loading-illustration-dark.svg';
 import Illustration from '@/assets/images/loading-illustration.svg';
 import { Daisy as Spinner } from '@/components/Spinner';
-import { themeStorageKey } from '@/consts';
-import { getTheme } from '@/utils/theme';
+import { getThemeFromLocalStorage } from '@/utils/theme';
 
 import * as styles from './index.module.scss';
 
@@ -14,10 +9,7 @@ import * as styles from './index.module.scss';
  * An fullscreen loading component fetches local stored theme without sending request.
  */
 export const AppLoadingOffline = () => {
-  const theme = getTheme(
-    trySafe(() => z.nativeEnum(AppearanceMode).parse(localStorage.getItem(themeStorageKey))) ??
-      AppearanceMode.SyncWithSystem
-  );
+  const theme = getThemeFromLocalStorage();
 
   return (
     <div className={styles.container}>

--- a/packages/console/src/containers/ErrorBoundary/index.tsx
+++ b/packages/console/src/containers/ErrorBoundary/index.tsx
@@ -16,10 +16,8 @@ type State = {
 };
 
 class ErrorBoundary extends Component<Props, State> {
-  static getDerivedStateFromError(error: Error) {
-    const errorMessage = conditional(
-      typeof error === 'object' && typeof error.message === 'string' && error.message
-    );
+  static getDerivedStateFromError(error: Error): State {
+    const errorMessage = String(error);
 
     const callStack = conditional(
       typeof error === 'object' &&
@@ -35,6 +33,24 @@ class ErrorBoundary extends Component<Props, State> {
     errorMessage: undefined,
     hasError: false,
   };
+
+  promiseRejectionHandler(error: unknown) {
+    this.setState(
+      ErrorBoundary.getDerivedStateFromError(
+        error instanceof Error ? error : new Error(String(error))
+      )
+    );
+  }
+
+  componentDidMount(): void {
+    window.addEventListener('unhandledrejection', (event) => {
+      this.promiseRejectionHandler(event.reason);
+    });
+  }
+
+  componentWillUnmount(): void {
+    window.removeEventListener('unhandledrejection', this.promiseRejectionHandler);
+  }
 
   render() {
     const { children } = this.props;

--- a/packages/console/src/hooks/use-swr-options.ts
+++ b/packages/console/src/hooks/use-swr-options.ts
@@ -4,7 +4,7 @@ import useApi, { RequestError } from './use-api';
 import useSwrFetcher from './use-swr-fetcher';
 
 const useSwrOptions = (): SWRConfiguration => {
-  const api = useApi({ hideErrorToast: true });
+  const api = useApi();
   const fetcher = useSwrFetcher(api);
 
   return {

--- a/packages/console/src/utils/theme.ts
+++ b/packages/console/src/utils/theme.ts
@@ -1,4 +1,8 @@
 import { AppearanceMode } from '@logto/schemas';
+import { trySafe } from '@silverhand/essentials';
+import { z } from 'zod';
+
+import { themeStorageKey } from '@/consts';
 
 export const getTheme = (appearanceMode: AppearanceMode) => {
   if (appearanceMode !== AppearanceMode.SyncWithSystem) {
@@ -10,3 +14,9 @@ export const getTheme = (appearanceMode: AppearanceMode) => {
 
   return theme;
 };
+
+export const getThemeFromLocalStorage = () =>
+  getTheme(
+    trySafe(() => z.nativeEnum(AppearanceMode).parse(localStorage.getItem(themeStorageKey))) ??
+      AppearanceMode.SyncWithSystem
+  );


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- bring back `<ErrorBoundary>` and catch async errors
- make `<AppError>` an offline component

remembering the old days when typing `componentXyz` lifecycle functions

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

caught

<img width="830" alt="image" src="https://user-images.githubusercontent.com/14722250/222329277-59539e67-0afe-4932-a185-13e1573989f0.png">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
