### PR TITLE
refactor: fix cloud dev

### DIFF
--- a/packages/cli/src/commands/database/seed/cloud.ts
+++ b/packages/cli/src/commands/database/seed/cloud.ts
@@ -16,7 +16,9 @@ import { log } from '../../../utils.js';
 export const appendAdminConsoleRedirectUris = async (pool: CommonQueryMethods) => {
   const redirectUris = new GlobalValues().cloudUrlSet
     .deduplicated()
-    .map((endpoint) => appendPath(endpoint, defaultTenantId, 'callback'));
+    .flatMap((endpoint) =>
+      [defaultTenantId, adminTenantId].map((tenantId) => appendPath(endpoint, tenantId, 'callback'))
+    );
 
   const metadataKey = sql.identifier(['oidc_client_metadata']);
 

--- a/packages/console/src/contexts/AppEndpointsProvider.tsx
+++ b/packages/console/src/contexts/AppEndpointsProvider.tsx
@@ -11,8 +11,12 @@ type Props = {
 };
 
 export type AppEndpoints = {
+  /**
+   * The Logto endpoint for the current tenant.
+   *
+   * Always use this value as the base URL when referring to the Logto URL of the current user's tenant.
+   */
   userEndpoint?: URL;
-  adminEndpoint?: URL;
 };
 
 export const AppEndpointsContext = createContext<AppEndpoints>({});

--- a/packages/core/src/routes/interaction/actions/submit-interaction.test.ts
+++ b/packages/core/src/routes/interaction/actions/submit-interaction.test.ts
@@ -119,7 +119,7 @@ describe('submit action', () => {
         id: 'uid',
         ...upsertProfile,
       },
-      []
+      ['user']
     );
     expect(assignInteractionResults).toBeCalledWith(ctx, tenant.provider, {
       login: { accountId: 'uid' },

--- a/packages/core/src/routes/interaction/actions/submit-interaction.ts
+++ b/packages/core/src/routes/interaction/actions/submit-interaction.ts
@@ -16,6 +16,7 @@ import { assignInteractionResults } from '#src/libraries/session.js';
 import { encryptUserPassword } from '#src/libraries/user.js';
 import type { LogEntry } from '#src/middleware/koa-audit-log.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
+import { conditionalArray } from '#src/utils/array.js';
 import { getTenantId } from '#src/utils/tenant.js';
 
 import type { WithInteractionDetailsContext } from '../middleware/koa-interaction-details.js';
@@ -167,8 +168,10 @@ export default async function submitInteraction(
 
     const { client_id } = ctx.interactionDetails.params;
 
+    const { isCloud } = EnvSet.values;
+    const isInAdminTenant = getTenantId(ctx.URL) === adminTenantId;
     const isCreatingFirstAdminUser =
-      getTenantId(ctx.URL) === adminTenantId &&
+      isInAdminTenant &&
       String(client_id) === adminConsoleApplicationId &&
       !(await hasActiveUsers());
 
@@ -177,20 +180,18 @@ export default async function submitInteraction(
         id,
         ...upsertProfile,
       },
-      isCreatingFirstAdminUser
-        ? [
-            UserRole.User,
-            getManagementApiAdminName(defaultTenantId),
-            ...(EnvSet.values.isCloud ? [getManagementApiAdminName(adminTenantId)] : []),
-          ]
-        : []
+      conditionalArray<string>(
+        isInAdminTenant && UserRole.User,
+        isCreatingFirstAdminUser && getManagementApiAdminName(defaultTenantId),
+        isCreatingFirstAdminUser && isCloud && getManagementApiAdminName(adminTenantId)
+      )
     );
 
     // In OSS, we need to limit sign-in experience to "sign-in only" once
     // the first admin has been create since we don't want other unexpected registrations
     if (isCreatingFirstAdminUser) {
       await updateDefaultSignInExperience({
-        signInMode: EnvSet.values.isCloud ? SignInMode.SignInAndRegister : SignInMode.SignIn,
+        signInMode: isCloud ? SignInMode.SignInAndRegister : SignInMode.SignIn,
       });
     }
 

--- a/packages/core/src/utils/array.ts
+++ b/packages/core/src/utils/array.ts
@@ -1,0 +1,5 @@
+import type { Falsy } from '@silverhand/essentials';
+import { notFalsy } from '@silverhand/essentials';
+
+export const conditionalArray = <T>(...exp: Array<T | Falsy>): T[] =>
+  exp.filter((value): value is Exclude<T, Falsy> => notFalsy(value));

--- a/packages/shared/src/env/GlobalValues.ts
+++ b/packages/shared/src/env/GlobalValues.ts
@@ -109,10 +109,13 @@ export default class GlobalValues {
   constructor() {
     if (this.isPathBasedMultiTenancy) {
       console.warn(
-        '\n****** WARNING ******\n\n' +
+        '\n****** LOGTO WARNING ******\n\n' +
           'Path-based multi-tenancy is an internal dev-only feature. It is unstable and not intended for production use.\n\n' +
-          'Known issue: Sign-in experience is unavailable in user tenants.\n\n' +
-          '****** WARNING ******\n'
+          'Known issues:\n\n' +
+          '- Sign-in experience is unavailable in user tenants.\n' +
+          '- The Admin Console may display incorrect user endpoints on multiple pages, such as guide, config, etc.' +
+          ' This issue is caused by the native URL constructor new URL(), which overrides the base pathname.\n\n' +
+          '****** END LOGTO WARNING ******\n'
       );
     }
   }

--- a/packages/shared/src/env/GlobalValues.ts
+++ b/packages/shared/src/env/GlobalValues.ts
@@ -57,6 +57,8 @@ export default class GlobalValues {
   public readonly isDomainBasedMultiTenancy = this.urlSet.endpoint.hostname.includes('*');
 
   /**
+   * **NOTE: This is an internal dev-only feature.**
+   *
    * This value indicates path-based multi-tenancy (PBMT) is enabled by setting env variable `PATH_BASED_MULTI_TENANCY` to a truthy value.
    *
    * Note the value will always be `false` if domain-based multi-tenancy is enabled.
@@ -85,6 +87,9 @@ export default class GlobalValues {
     return this.isDomainBasedMultiTenancy || this.isPathBasedMultiTenancy;
   }
 
+  /** If the env explicitly indicates it's in the cloud environment. */
+  public readonly isCloud = yes(getEnv('IS_CLOUD'));
+
   // eslint-disable-next-line unicorn/consistent-function-scoping
   public readonly databaseUrl = tryThat(() => assertEnv('DB_URL'), throwErrorWithDsnMessage);
   public readonly developmentTenantId = getEnv('DEVELOPMENT_TENANT_ID');
@@ -99,5 +104,16 @@ export default class GlobalValues {
 
   public get endpoint(): URL {
     return this.urlSet.endpoint;
+  }
+
+  constructor() {
+    if (this.isPathBasedMultiTenancy) {
+      console.warn(
+        '\n****** WARNING ******\n\n' +
+          'Path-based multi-tenancy is an internal dev-only feature. It is unstable and not intended for production use.\n\n' +
+          'Known issue: Sign-in experience is unavailable in user tenants.\n\n' +
+          '****** WARNING ******\n'
+      );
+    }
   }
 }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- add admin console callback URI for cloud seed
- assign `admin:admin` role for the first admin user if cloud
- add warning for path-based multi-tenancy
- change admin SIE to `SignInAndRegister` after first registration if cloud

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

with env:

```env
PATH_BASED_MULTI_TENANCY=1
IS_CLOUD=1
```

with command:

```bash
pnpm cli db seed --cloud
pnpm dev:cloud
```

- [x] service is up
- [x] access `http://localhost:3003`, shows welcome
- [x] register a new user, see "Choose a tenant"
- [x] enter both tenant OK
- [x] change admin tenant SIE, sign-out, it reflects the update
- [x] the following user will automatically create a new tenant, without admin tenant access

<img width="293" alt="image" src="https://user-images.githubusercontent.com/14722250/222684613-d982a630-ad7f-4f8a-91fb-5a7bdf883086.png">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
