### PR TITLE
refactor: allow admin to create tenants

### DIFF
--- a/.changeset-staged/gold-mugs-allow.md
+++ b/.changeset-staged/gold-mugs-allow.md
@@ -1,0 +1,16 @@
+---
+"@logto/cli": minor
+"@logto/cloud": minor
+"@logto/console": minor
+"@logto/core": minor
+"@logto/integration-tests": minor
+"@logto/phrases": minor
+"@logto/phrases-ui": minor
+"@logto/schemas": minor
+"@logto/shared": minor
+"@logto/connector-kit": minor
+"@logto/core-kit": minor
+"@logto/ui": minor
+---
+
+Allow admin tenant admin to create tenants without limitation

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,7 +46,7 @@
     "@logto/core-kit": "workspace:*",
     "@logto/schemas": "workspace:*",
     "@logto/shared": "workspace:*",
-    "@silverhand/essentials": "2.2.0",
+    "@silverhand/essentials": "2.3.0",
     "chalk": "^5.0.0",
     "decamelize": "^6.0.0",
     "dotenv": "^16.0.0",

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -23,7 +23,7 @@
     "@logto/core-kit": "workspace:*",
     "@logto/schemas": "workspace:*",
     "@logto/shared": "workspace:*",
-    "@silverhand/essentials": "2.2.0",
+    "@silverhand/essentials": "2.3.0",
     "@withtyped/postgres": "^0.8.1",
     "@withtyped/server": "^0.8.0",
     "chalk": "^5.0.0",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -33,7 +33,7 @@
     "@parcel/transformer-svg-react": "2.8.3",
     "@silverhand/eslint-config": "2.0.1",
     "@silverhand/eslint-config-react": "2.0.1",
-    "@silverhand/essentials": "2.2.0",
+    "@silverhand/essentials": "2.3.0",
     "@silverhand/ts-config": "2.0.3",
     "@silverhand/ts-config-react": "2.0.3",
     "@tsconfig/docusaurus": "^1.0.5",

--- a/packages/console/src/components/SessionExpired/index.tsx
+++ b/packages/console/src/components/SessionExpired/index.tsx
@@ -1,21 +1,24 @@
 import { useLogto } from '@logto/react';
 import { useTranslation } from 'react-i18next';
-import { useHref } from 'react-router-dom';
 
 import AppError from '../AppError';
 import Button from '../Button';
 import * as styles from './index.module.scss';
 
-const SessionExpired = () => {
-  const { error, signIn } = useLogto();
-  const href = useHref('/callback');
+type Props = {
+  error: Error;
+  callbackHref?: string;
+};
+
+const SessionExpired = ({ callbackHref = '/callback', error }: Props) => {
+  const { signIn, signOut } = useLogto();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
   return (
     <AppError
       title={t('session_expired.title')}
       errorMessage={t('session_expired.subtitle')}
-      callStack={error?.stack}
+      callStack={error.stack}
     >
       <Button
         className={styles.retryButton}
@@ -23,7 +26,7 @@ const SessionExpired = () => {
         type="outline"
         title="session_expired.button"
         onClick={() => {
-          void signIn(new URL(href, window.location.origin).toString());
+          void signIn(new URL(callbackHref, window.location.origin).toString());
         }}
       />
     </AppError>

--- a/packages/console/src/containers/AppLayout/index.tsx
+++ b/packages/console/src/containers/AppLayout/index.tsx
@@ -46,7 +46,7 @@ const AppLayout = () => {
 
   if (error) {
     if (error instanceof LogtoClientError) {
-      return <SessionExpired />;
+      return <SessionExpired error={error} callbackHref={href} />;
     }
 
     if (error instanceof LogtoError && error.code === 'crypto_subtle_unavailable') {

--- a/packages/console/src/hooks/use-api.ts
+++ b/packages/console/src/hooks/use-api.ts
@@ -1,5 +1,6 @@
 import { useLogto } from '@logto/react';
 import type { RequestErrorBody } from '@logto/schemas';
+import { conditionalArray } from '@silverhand/essentials';
 import ky from 'ky';
 import { useCallback, useContext, useMemo } from 'react';
 import { toast } from 'react-hot-toast';
@@ -76,15 +77,14 @@ export const useStaticApi = ({
         prefixUrl,
         timeout: requestTimeout,
         hooks: {
-          beforeError: hideErrorToast
-            ? []
-            : [
-                async (error) => {
-                  await toastError(error.response);
+          beforeError: conditionalArray(
+            !hideErrorToast &&
+              (async (error) => {
+                await toastError(error.response);
 
-                  return error;
-                },
-              ],
+                return error;
+              })
+          ),
           beforeRequest: [
             async (request) => {
               if (isAuthenticated) {

--- a/packages/console/src/pages/Welcome/index.tsx
+++ b/packages/console/src/pages/Welcome/index.tsx
@@ -28,7 +28,7 @@ const Welcome = () => {
 
   if (error) {
     if (error instanceof LogtoClientError) {
-      return <SessionExpired />;
+      return <SessionExpired error={error} callbackHref={href} />;
     }
 
     return <AppError errorMessage={error.message} callStack={error.stack} />;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,7 @@
     "@logto/phrases-ui": "workspace:*",
     "@logto/schemas": "workspace:*",
     "@logto/shared": "workspace:*",
-    "@silverhand/essentials": "2.2.0",
+    "@silverhand/essentials": "2.3.0",
     "@withtyped/postgres": "^0.8.1",
     "@withtyped/server": "^0.8.0",
     "chalk": "^5.0.0",

--- a/packages/core/src/routes/interaction/actions/submit-interaction.ts
+++ b/packages/core/src/routes/interaction/actions/submit-interaction.ts
@@ -8,7 +8,7 @@ import {
   InteractionEvent,
   adminConsoleApplicationId,
 } from '@logto/schemas';
-import { conditional } from '@silverhand/essentials';
+import { conditional, conditionalArray } from '@silverhand/essentials';
 
 import { EnvSet } from '#src/env-set/index.js';
 import type { ConnectorLibrary } from '#src/libraries/connector.js';
@@ -16,7 +16,6 @@ import { assignInteractionResults } from '#src/libraries/session.js';
 import { encryptUserPassword } from '#src/libraries/user.js';
 import type { LogEntry } from '#src/middleware/koa-audit-log.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
-import { conditionalArray } from '#src/utils/array.js';
 import { getTenantId } from '#src/utils/tenant.js';
 
 import type { WithInteractionDetailsContext } from '../middleware/koa-interaction-details.js';

--- a/packages/core/src/utils/array.ts
+++ b/packages/core/src/utils/array.ts
@@ -1,5 +1,0 @@
-import type { Falsy } from '@silverhand/essentials';
-import { notFalsy } from '@silverhand/essentials';
-
-export const conditionalArray = <T>(...exp: Array<T | Falsy>): T[] =>
-  exp.filter((value): value is Exclude<T, Falsy> => notFalsy(value));

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -27,7 +27,7 @@
     "@logto/schemas": "workspace:*",
     "@peculiar/webcrypto": "^1.3.3",
     "@silverhand/eslint-config": "2.0.1",
-    "@silverhand/essentials": "2.2.0",
+    "@silverhand/essentials": "2.3.0",
     "@silverhand/ts-config": "2.0.3",
     "@types/jest": "^29.1.2",
     "@types/jest-environment-puppeteer": "^5.0.2",

--- a/packages/phrases-ui/package.json
+++ b/packages/phrases-ui/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@logto/core-kit": "workspace:*",
     "@logto/language-kit": "workspace:*",
-    "@silverhand/essentials": "2.2.0",
+    "@silverhand/essentials": "2.3.0",
     "zod": "^3.20.2"
   },
   "devDependencies": {

--- a/packages/phrases/package.json
+++ b/packages/phrases/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@logto/core-kit": "workspace:*",
     "@logto/language-kit": "workspace:*",
-    "@silverhand/essentials": "2.2.0",
+    "@silverhand/essentials": "2.3.0",
     "zod": "^3.20.2"
   },
   "devDependencies": {

--- a/packages/schemas/alterations/next-1677907982-allow-admin-create-multiple-tenants.ts
+++ b/packages/schemas/alterations/next-1677907982-allow-admin-create-multiple-tenants.ts
@@ -1,0 +1,56 @@
+import { generateStandardId } from '@logto/core-kit';
+import { sql } from 'slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const adminTenantId = 'admin';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    const scopeId = generateStandardId();
+    const { id: resourceId } = await pool.one<{ id: string }>(sql`
+      select id from resources
+      where tenant_id = ${adminTenantId}
+      and indicator = 'https://cloud.logto.io/api'
+    `);
+
+    await pool.query(sql`
+      insert into scopes (tenant_id, id, name, description, resource_id)
+        values (
+          ${adminTenantId},
+          ${scopeId},
+          'manage:tenant',
+          'Allow managing existing tenants, including create without limitation, update, and delete.',
+          ${resourceId}
+        );
+    `);
+
+    const { id: roleId } = await pool.one<{ id: string }>(sql`
+      select id from roles
+      where tenant_id = ${adminTenantId}
+      and name = 'admin:admin'
+    `);
+
+    await pool.query(sql`
+      insert into roles_scopes (tenant_id, id, role_id, scope_id)
+        values (
+          ${adminTenantId},
+          ${generateStandardId()},
+          ${roleId},
+          ${scopeId}
+        );
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      delete from scopes
+        using resources
+        where resources.id = scopes.resource_id
+        and scopes.tenant_id = ${adminTenantId}
+        and resources.indicator = 'https://cloud.logto.io/api'
+        and scopes.name='manage:tenant';
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@silverhand/eslint-config": "2.0.1",
-    "@silverhand/essentials": "2.2.0",
+    "@silverhand/essentials": "2.3.0",
     "@silverhand/ts-config": "2.0.3",
     "@types/inquirer": "^9.0.0",
     "@types/jest": "^29.1.2",

--- a/packages/schemas/src/seeds/cloud-api.ts
+++ b/packages/schemas/src/seeds/cloud-api.ts
@@ -1,5 +1,6 @@
 import { generateStandardId } from '@logto/core-kit';
 
+import type { CreateScope } from '../index.js';
 import { UserRole } from '../types/index.js';
 import type { UpdateAdminData } from './management-api.js';
 import { adminTenantId } from './tenant.js';
@@ -9,28 +10,36 @@ export const cloudApiIndicator = 'https://cloud.logto.io/api';
 
 export enum CloudScope {
   CreateTenant = 'create:tenant',
+  ManageTenant = 'manage:tenant',
 }
 
-export const createCloudApi = (): Readonly<UpdateAdminData> => {
+export const createCloudApi = (): Readonly<[UpdateAdminData, ...CreateScope[]]> => {
   const resourceId = generateStandardId();
-
-  return Object.freeze({
-    resource: {
-      tenantId: adminTenantId,
-      id: resourceId,
-      indicator: cloudApiIndicator,
-      name: `Logto Cloud API`,
-    },
-    scope: {
-      tenantId: adminTenantId,
-      id: generateStandardId(),
-      name: CloudScope.CreateTenant,
-      description: 'Allow creating new tenants.',
-      resourceId,
-    },
-    role: {
-      tenantId: adminTenantId,
-      name: UserRole.User,
-    },
+  const buildScope = (name: CloudScope, description: string) => ({
+    tenantId: adminTenantId,
+    id: generateStandardId(),
+    name,
+    description,
+    resourceId,
   });
+
+  return Object.freeze([
+    {
+      resource: {
+        tenantId: adminTenantId,
+        id: resourceId,
+        indicator: cloudApiIndicator,
+        name: `Logto Cloud API`,
+      },
+      scope: buildScope(CloudScope.CreateTenant, 'Allow creating new tenants.'),
+      role: {
+        tenantId: adminTenantId,
+        name: UserRole.User,
+      },
+    },
+    buildScope(
+      CloudScope.ManageTenant,
+      'Allow managing existing tenants, including create without limitation, update, and delete.'
+    ),
+  ]);
 };

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@logto/core-kit": "workspace:*",
     "@logto/schemas": "workspace:*",
-    "@silverhand/essentials": "2.2.0",
+    "@silverhand/essentials": "2.3.0",
     "chalk": "^5.0.0",
     "find-up": "^6.3.0",
     "nanoid": "^4.0.0",

--- a/packages/toolkit/connector-kit/package.json
+++ b/packages/toolkit/connector-kit/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@logto/core-kit": "workspace:*",
     "@logto/language-kit": "workspace:*",
-    "@silverhand/essentials": "2.2.0"
+    "@silverhand/essentials": "2.3.0"
   },
   "optionalDependencies": {
     "zod": "^3.20.2"

--- a/packages/toolkit/core-kit/package.json
+++ b/packages/toolkit/core-kit/package.json
@@ -50,7 +50,7 @@
     "@jest/types": "^29.0.3",
     "@silverhand/eslint-config": "2.0.1",
     "@silverhand/eslint-config-react": "2.0.1",
-    "@silverhand/essentials": "2.2.0",
+    "@silverhand/essentials": "2.3.0",
     "@silverhand/ts-config": "2.0.3",
     "@types/color": "^3.0.3",
     "@types/jest": "^29.0.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -31,7 +31,7 @@
     "@react-spring/web": "^9.6.1",
     "@silverhand/eslint-config": "2.0.1",
     "@silverhand/eslint-config-react": "2.0.1",
-    "@silverhand/essentials": "2.2.0",
+    "@silverhand/essentials": "2.3.0",
     "@silverhand/jest-config": "1.2.2",
     "@silverhand/ts-config": "2.0.3",
     "@silverhand/ts-config-react": "2.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
       '@logto/schemas': workspace:*
       '@logto/shared': workspace:*
       '@silverhand/eslint-config': 2.0.1
-      '@silverhand/essentials': 2.2.0
+      '@silverhand/essentials': 2.3.0
       '@silverhand/ts-config': 2.0.3
       '@types/inquirer': ^9.0.0
       '@types/jest': ^29.1.2
@@ -68,7 +68,7 @@ importers:
       '@logto/core-kit': link:../toolkit/core-kit
       '@logto/schemas': link:../schemas
       '@logto/shared': link:../shared
-      '@silverhand/essentials': 2.2.0
+      '@silverhand/essentials': 2.3.0
       chalk: 5.1.2
       decamelize: 6.0.0
       dotenv: 16.0.0
@@ -111,7 +111,7 @@ importers:
       '@logto/schemas': workspace:*
       '@logto/shared': workspace:*
       '@silverhand/eslint-config': 2.0.1
-      '@silverhand/essentials': 2.2.0
+      '@silverhand/essentials': 2.3.0
       '@silverhand/ts-config': 2.0.3
       '@types/http-proxy': ^1.17.9
       '@types/mime-types': ^2.1.1
@@ -137,7 +137,7 @@ importers:
       '@logto/core-kit': link:../toolkit/core-kit
       '@logto/schemas': link:../schemas
       '@logto/shared': link:../shared
-      '@silverhand/essentials': 2.2.0
+      '@silverhand/essentials': 2.3.0
       '@withtyped/postgres': 0.8.1_@withtyped+server@0.8.0
       '@withtyped/server': 0.8.0
       chalk: 5.1.2
@@ -178,7 +178,7 @@ importers:
       '@parcel/transformer-svg-react': 2.8.3
       '@silverhand/eslint-config': 2.0.1
       '@silverhand/eslint-config-react': 2.0.1
-      '@silverhand/essentials': 2.2.0
+      '@silverhand/essentials': 2.3.0
       '@silverhand/ts-config': 2.0.3
       '@silverhand/ts-config-react': 2.0.3
       '@tsconfig/docusaurus': ^1.0.5
@@ -251,7 +251,7 @@ importers:
       '@parcel/transformer-svg-react': 2.8.3_@parcel+core@2.8.3
       '@silverhand/eslint-config': 2.0.1_kjzxg5porcw5dx54sezsklj5cy
       '@silverhand/eslint-config-react': 2.0.1_kz2ighe3mj4zdkvq5whtl3dq4u
-      '@silverhand/essentials': 2.2.0
+      '@silverhand/essentials': 2.3.0
       '@silverhand/ts-config': 2.0.3_typescript@4.9.4
       '@silverhand/ts-config-react': 2.0.3_typescript@4.9.4
       '@tsconfig/docusaurus': 1.0.5
@@ -321,7 +321,7 @@ importers:
       '@logto/schemas': workspace:*
       '@logto/shared': workspace:*
       '@silverhand/eslint-config': 2.0.1
-      '@silverhand/essentials': 2.2.0
+      '@silverhand/essentials': 2.3.0
       '@silverhand/ts-config': 2.0.3
       '@types/debug': ^4.1.7
       '@types/etag': ^1.8.1
@@ -398,7 +398,7 @@ importers:
       '@logto/phrases-ui': link:../phrases-ui
       '@logto/schemas': link:../schemas
       '@logto/shared': link:../shared
-      '@silverhand/essentials': 2.2.0
+      '@silverhand/essentials': 2.3.0
       '@withtyped/postgres': 0.8.1_@withtyped+server@0.8.0
       '@withtyped/server': 0.8.0
       chalk: 5.1.2
@@ -543,7 +543,7 @@ importers:
       '@logto/schemas': workspace:*
       '@peculiar/webcrypto': ^1.3.3
       '@silverhand/eslint-config': 2.0.1
-      '@silverhand/essentials': 2.2.0
+      '@silverhand/essentials': 2.3.0
       '@silverhand/ts-config': 2.0.3
       '@types/jest': ^29.1.2
       '@types/jest-environment-puppeteer': ^5.0.2
@@ -571,7 +571,7 @@ importers:
       '@logto/schemas': link:../schemas
       '@peculiar/webcrypto': 1.3.3
       '@silverhand/eslint-config': 2.0.1_kjzxg5porcw5dx54sezsklj5cy
-      '@silverhand/essentials': 2.2.0
+      '@silverhand/essentials': 2.3.0
       '@silverhand/ts-config': 2.0.3_typescript@4.9.4
       '@types/jest': 29.1.2
       '@types/jest-environment-puppeteer': 5.0.2
@@ -594,7 +594,7 @@ importers:
       '@logto/core-kit': workspace:*
       '@logto/language-kit': workspace:*
       '@silverhand/eslint-config': 2.0.1
-      '@silverhand/essentials': 2.2.0
+      '@silverhand/essentials': 2.3.0
       '@silverhand/ts-config': 2.0.3
       eslint: ^8.34.0
       lint-staged: ^13.0.0
@@ -604,7 +604,7 @@ importers:
     dependencies:
       '@logto/core-kit': link:../toolkit/core-kit
       '@logto/language-kit': link:../toolkit/language-kit
-      '@silverhand/essentials': 2.2.0
+      '@silverhand/essentials': 2.3.0
       zod: 3.20.2
     devDependencies:
       '@silverhand/eslint-config': 2.0.1_kjzxg5porcw5dx54sezsklj5cy
@@ -619,7 +619,7 @@ importers:
       '@logto/core-kit': workspace:*
       '@logto/language-kit': workspace:*
       '@silverhand/eslint-config': 2.0.1
-      '@silverhand/essentials': 2.2.0
+      '@silverhand/essentials': 2.3.0
       '@silverhand/ts-config': 2.0.3
       buffer: ^5.7.1
       eslint: ^8.34.0
@@ -630,7 +630,7 @@ importers:
     dependencies:
       '@logto/core-kit': link:../toolkit/core-kit
       '@logto/language-kit': link:../toolkit/language-kit
-      '@silverhand/essentials': 2.2.0
+      '@silverhand/essentials': 2.3.0
       zod: 3.20.2
     devDependencies:
       '@silverhand/eslint-config': 2.0.1_kjzxg5porcw5dx54sezsklj5cy
@@ -649,7 +649,7 @@ importers:
       '@logto/phrases': workspace:*
       '@logto/phrases-ui': workspace:*
       '@silverhand/eslint-config': 2.0.1
-      '@silverhand/essentials': 2.2.0
+      '@silverhand/essentials': 2.3.0
       '@silverhand/ts-config': 2.0.3
       '@types/inquirer': ^9.0.0
       '@types/jest': ^29.1.2
@@ -678,7 +678,7 @@ importers:
       zod: 3.20.2
     devDependencies:
       '@silverhand/eslint-config': 2.0.1_kjzxg5porcw5dx54sezsklj5cy
-      '@silverhand/essentials': 2.2.0
+      '@silverhand/essentials': 2.3.0
       '@silverhand/ts-config': 2.0.3_typescript@4.9.4
       '@types/inquirer': 9.0.3
       '@types/jest': 29.1.2
@@ -702,7 +702,7 @@ importers:
       '@logto/core-kit': workspace:*
       '@logto/schemas': workspace:*
       '@silverhand/eslint-config': 2.0.1
-      '@silverhand/essentials': 2.2.0
+      '@silverhand/essentials': 2.3.0
       '@silverhand/ts-config': 2.0.3
       '@types/jest': ^29.1.2
       '@types/node': ^18.11.18
@@ -718,7 +718,7 @@ importers:
     dependencies:
       '@logto/core-kit': link:../toolkit/core-kit
       '@logto/schemas': link:../schemas
-      '@silverhand/essentials': 2.2.0
+      '@silverhand/essentials': 2.3.0
       chalk: 5.1.2
       find-up: 6.3.0
       nanoid: 4.0.0
@@ -740,7 +740,7 @@ importers:
       '@logto/core-kit': workspace:*
       '@logto/language-kit': workspace:*
       '@silverhand/eslint-config': 2.0.1
-      '@silverhand/essentials': 2.2.0
+      '@silverhand/essentials': 2.3.0
       '@silverhand/ts-config': 2.0.3
       '@types/node': ^18.11.18
       eslint: ^8.34.0
@@ -752,7 +752,7 @@ importers:
     dependencies:
       '@logto/core-kit': link:../core-kit
       '@logto/language-kit': link:../language-kit
-      '@silverhand/essentials': 2.2.0
+      '@silverhand/essentials': 2.3.0
     optionalDependencies:
       zod: 3.20.2
     devDependencies:
@@ -771,7 +771,7 @@ importers:
       '@logto/language-kit': workspace:*
       '@silverhand/eslint-config': 2.0.1
       '@silverhand/eslint-config-react': 2.0.1
-      '@silverhand/essentials': 2.2.0
+      '@silverhand/essentials': 2.3.0
       '@silverhand/ts-config': 2.0.3
       '@types/color': ^3.0.3
       '@types/jest': ^29.0.3
@@ -798,7 +798,7 @@ importers:
       '@jest/types': 29.3.1
       '@silverhand/eslint-config': 2.0.1_kjzxg5porcw5dx54sezsklj5cy
       '@silverhand/eslint-config-react': 2.0.1_wfldc7mlde5bb3fdzap5arn6me
-      '@silverhand/essentials': 2.2.0
+      '@silverhand/essentials': 2.3.0
       '@silverhand/ts-config': 2.0.3_typescript@4.9.4
       '@types/color': 3.0.3
       '@types/jest': 29.1.2
@@ -858,7 +858,7 @@ importers:
       '@react-spring/web': ^9.6.1
       '@silverhand/eslint-config': 2.0.1
       '@silverhand/eslint-config-react': 2.0.1
-      '@silverhand/essentials': 2.2.0
+      '@silverhand/essentials': 2.3.0
       '@silverhand/jest-config': 1.2.2
       '@silverhand/ts-config': 2.0.3
       '@silverhand/ts-config-react': 2.0.3
@@ -916,7 +916,7 @@ importers:
       '@react-spring/web': 9.6.1_biqbaboplfbrettd7655fr4n2y
       '@silverhand/eslint-config': 2.0.1_kjzxg5porcw5dx54sezsklj5cy
       '@silverhand/eslint-config-react': 2.0.1_kz2ighe3mj4zdkvq5whtl3dq4u
-      '@silverhand/essentials': 2.2.0
+      '@silverhand/essentials': 2.3.0
       '@silverhand/jest-config': 1.2.2_ky6c64xxalg2hsll4xx3evq2dy
       '@silverhand/ts-config': 2.0.3_typescript@4.9.4
       '@silverhand/ts-config-react': 2.0.3_typescript@4.9.4
@@ -3621,8 +3621,8 @@ packages:
       lodash.pick: 4.4.0
     dev: true
 
-  /@silverhand/essentials/2.2.0:
-    resolution: {integrity: sha512-xoj/wAnPUt9ZAzt7QCHhSKZPweZnNJU7tBYrDTf54db6L+++SiXYIyckKDY+vKkGACn9kTAWPF74qSfYt1OQtA==}
+  /@silverhand/essentials/2.3.0:
+    resolution: {integrity: sha512-vZ8eT0ew2bTIo86vwcPSduL1o2oXxH9DPnQe8sV3K3g1/sSgCyAj9ULHObZLjg/YNGlp16Wiby1hSs8P9VtU7g==}
     engines: {node: ^16.13.0 || ^18.12.0 || ^19.2.0, pnpm: ^7}
 
   /@silverhand/jest-config/1.2.2_ky6c64xxalg2hsll4xx3evq2dy:


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- add `manage:tenant` scope in Cloud API, which indicates the ability to create tenants without limitation, update, and delete tenants
- show session expired page for cloud api 401 error
- refactor `<ErrorBoundary>` a little bit

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

a fresh setup, create the first user, and click "Create Tenant" has no limitation

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changset-staged`
- [ ] unit tests (n/a)
- [ ] integration tests (next pr)
- [ ] docs (n/a)
