### PR TITLE
fix(console): profile social linking in cloud env should use correct URL without double slashes

### DIFF
--- a/packages/console/src/pages/Profile/components/LinkAccountSection/index.tsx
+++ b/packages/console/src/pages/Profile/components/LinkAccountSection/index.tsx
@@ -49,8 +49,9 @@ const LinkAccountSection = ({ user, onUpdate }: Props) => {
 
   const getSocialAuthorizationUri = useCallback(
     async (connectorId: string) => {
+      const adminTenantEndpointUrl = new URL(adminTenantEndpoint);
       const state = buildIdGenerator(8)();
-      const redirectUri = `${adminTenantEndpoint}/callback/${connectorId}`;
+      const redirectUri = new URL(`/callback/${connectorId}`, adminTenantEndpointUrl).toString();
       const { redirectTo } = await api
         .post('me/social/authorization-uri', { json: { connectorId, state, redirectUri } })
         .json<{ redirectTo: string }>();
@@ -66,6 +67,8 @@ const LinkAccountSection = ({ user, onUpdate }: Props) => {
     if (!connectors) {
       return [];
     }
+
+    const adminTenantEndpointUrl = new URL(adminTenantEndpoint);
 
     return connectors.map(({ id, name, logo, logoDark, target }) => {
       const logoSrc = theme === AppearanceMode.DarkMode && logoDark ? logoDark : logo;
@@ -108,7 +111,7 @@ const LinkAccountSection = ({ user, onUpdate }: Props) => {
               const authUri = await getSocialAuthorizationUri(id);
               const callback = new URL(
                 `${getBasename()}/handle-social`,
-                `${adminTenantEndpoint}`
+                adminTenantEndpointUrl
               ).toString();
 
               const queries = new URLSearchParams({
@@ -118,7 +121,7 @@ const LinkAccountSection = ({ user, onUpdate }: Props) => {
               });
 
               const newWindow = popupWindow(
-                `${adminTenantEndpoint}/springboard?${queries.toString()}`,
+                new URL(`/springboard?${queries.toString()}`, adminTenantEndpointUrl).toString(),
                 'Link social account with Logto',
                 600,
                 640


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix a bug in cloud environment that linking social account in profile ended up with double slashes (`//`) in the URL, which is illigal.

The fix leverages JavaScript `URL` utilities to handle possible double slashes in the URL

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally with appending `/` intentially in the admin tenant URL, works fine

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
