### PR TITLE
fix(console): admin user should be able to set email if current email is null

### DIFF
--- a/packages/console/src/pages/Profile/components/LinkAccountSection/index.tsx
+++ b/packages/console/src/pages/Profile/components/LinkAccountSection/index.tsx
@@ -160,7 +160,7 @@ const LinkAccountSection = ({ user, onUpdate }: Props) => {
                 <NotSet />
               ),
             action: {
-              name: 'profile.change',
+              name: user.primaryEmail ? 'profile.change' : 'profile.link',
               handler: () => {
                 navigate('link-email', {
                   state: { email: user.primaryEmail, action: 'changeEmail' },

--- a/packages/console/src/pages/Profile/containers/LinkEmailModal/index.tsx
+++ b/packages/console/src/pages/Profile/containers/LinkEmailModal/index.tsx
@@ -1,4 +1,5 @@
 import { emailRegEx } from '@logto/core-kit';
+import { conditional } from '@silverhand/essentials';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -43,6 +44,8 @@ const LinkEmailModal = () => {
     })();
   };
 
+  const currentEmail = conditional(checkLocationState(state) && state.email);
+
   return (
     <MainFlowLikeModal
       title="profile.link_account.link_email"
@@ -54,7 +57,8 @@ const LinkEmailModal = () => {
           required: t('profile.link_account.email_required'),
           pattern: { value: emailRegEx, message: t('profile.link_account.invalid_email') },
           validate: (value) =>
-            (checkLocationState(state) && state.email !== value) ||
+            !currentEmail ||
+            currentEmail !== value ||
             t('profile.link_account.identical_email_address'),
         })}
         errorMessage={errors.email?.message}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
In admin console user profile page, user should be able to set email regardless the current email is empty or not. Previously, the UI will block the email linking process if the current email is empty.

https://linear.app/silverhand/issue/LOG-5591/link-email-error

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Locally tested using an account without email, can link to an email successfully

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
