### PR TITLE
fix(console): passwordless connectors should not show callbackUri

### DIFF
--- a/packages/console/src/pages/ConnectorDetails/components/ConnectorContent.tsx
+++ b/packages/console/src/pages/ConnectorDetails/components/ConnectorContent.tsx
@@ -115,7 +115,11 @@ const ConnectorContent = ({ isDeleted, connectorData, onConnectorUpdated }: Prop
             !isSocialConnector && getDocumentationUrl('/docs/references/connectors')
           )}
         >
-          <ConfigForm formItems={connectorData.formItems} connectorId={connectorData.id} />
+          <ConfigForm
+            formItems={connectorData.formItems}
+            connectorId={connectorData.id}
+            connectorType={connectorData.type}
+          />
         </FormCard>
         {/* Tell typescript that the connectorType is Email or Sms */}
         {connectorData.type !== ConnectorType.Social && (

--- a/packages/console/src/pages/Connectors/components/ConnectorForm/ConfigForm.tsx
+++ b/packages/console/src/pages/Connectors/components/ConnectorForm/ConfigForm.tsx
@@ -1,4 +1,5 @@
 import type { ConnectorConfigFormItem } from '@logto/connector-kit';
+import { ConnectorType } from '@logto/connector-kit';
 import type { ConnectorFactoryResponse } from '@logto/schemas';
 import { useContext } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
@@ -19,9 +20,16 @@ type Props = {
   formItems?: ConnectorConfigFormItem[];
   className?: string;
   connectorId: string;
+  connectorType: ConnectorType;
 };
 
-const ConfigForm = ({ configTemplate, formItems, className, connectorId }: Props) => {
+const ConfigForm = ({
+  configTemplate,
+  formItems,
+  className,
+  connectorId,
+  connectorType,
+}: Props) => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const {
     control,
@@ -31,14 +39,16 @@ const ConfigForm = ({ configTemplate, formItems, className, connectorId }: Props
 
   return (
     <div className={className}>
-      <FormField title="connectors.guide.callback_uri">
-        <CopyToClipboard
-          className={styles.copyToClipboard}
-          variant="border"
-          value={new URL(`/callback/${connectorId}`, userEndpoint).toString()}
-        />
-        <div className={styles.description}>{t('connectors.guide.callback_uri_description')}</div>
-      </FormField>
+      {connectorType === ConnectorType.Social && (
+        <FormField title="connectors.guide.callback_uri">
+          <CopyToClipboard
+            className={styles.copyToClipboard}
+            variant="border"
+            value={new URL(`/callback/${connectorId}`, userEndpoint).toString()}
+          />
+          <div className={styles.description}>{t('connectors.guide.callback_uri_description')}</div>
+        </FormField>
+      )}
       {formItems ? (
         <ConfigFormItems formItems={formItems} />
       ) : (

--- a/packages/console/src/pages/Connectors/components/Guide/index.tsx
+++ b/packages/console/src/pages/Connectors/components/Guide/index.tsx
@@ -190,6 +190,7 @@ const Guide = ({ connector, onClose }: Props) => {
                 <ConfigForm
                   connectorId={callbackConnectorId}
                   configTemplate={connector.configTemplate}
+                  connectorType={connectorType}
                   formItems={connector.formItems}
                 />
               </div>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
passwordless connectors should not show callbackUri on both create and details pages.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
Details page:
<img width="1248" alt="image" src="https://user-images.githubusercontent.com/15182327/223309726-676bba60-573e-40ab-81cd-db320b165d61.png">
Create page:
<img width="2107" alt="image" src="https://user-images.githubusercontent.com/15182327/223309775-9861a429-ab38-45ef-a8f0-5d4bf49d3586.png">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
