### PR TITLE
fix(ui): reset InputField on enabledTypes change

### DIFF
--- a/packages/ui/src/components/InputFields/SmartInputField/use-smart-input-field.ts
+++ b/packages/ui/src/components/InputFields/SmartInputField/use-smart-input-field.ts
@@ -3,6 +3,7 @@ import { assert } from '@silverhand/essentials';
 import { useState, useCallback, useMemo } from 'react';
 import type { ChangeEventHandler } from 'react';
 
+import useUpdateEffect from '@/hooks/use-update-effect';
 import { getDefaultCountryCallingCode } from '@/utils/country-code';
 import { parseIdentifierValue } from '@/utils/form';
 
@@ -120,6 +121,12 @@ const useSmartInputField = ({ _defaultType, defaultValue, enabledTypes }: Props)
     setInputValue('');
     setCurrentType(enabledTypeSet.size === 1 ? defaultType : undefined);
   }, [defaultType, enabledTypeSet.size]);
+
+  // CAUTION: For preview use only, enabledTypes and defaultType should not be changed after component mounted
+  useUpdateEffect(() => {
+    setInputValue('');
+    setCurrentType(defaultType);
+  }, [defaultType]);
 
   return {
     countryCode,

--- a/packages/ui/src/hooks/use-update-effect.ts
+++ b/packages/ui/src/hooks/use-update-effect.ts
@@ -1,0 +1,19 @@
+import type { DependencyList, EffectCallback } from 'react';
+import { useEffect, useRef } from 'react';
+
+const useUpdateEffect = (effect: EffectCallback, dependencies: DependencyList | undefined = []) => {
+  const isMounted = useRef(false);
+
+  useEffect(() => {
+    if (!isMounted.current) {
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      isMounted.current = true;
+
+      return;
+    }
+
+    return effect();
+  }, [...dependencies]);
+};
+
+export default useUpdateEffect;


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->



This PR is aimed at fixing a bug in preview mode. The identifier InputField type is not updated when SIE settings are changed. Should reset the InputField if the enabled types are changed.

This fix is for preview mode use only. The input field's enabled types props in production should not be changed. 



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
UT passed

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
