### PR TITLE
fix: should return demo app data when query api

### DIFF
--- a/packages/console/src/pages/AuditLogDetails/index.tsx
+++ b/packages/console/src/pages/AuditLogDetails/index.tsx
@@ -1,4 +1,5 @@
 import type { User, Log } from '@logto/schemas';
+import { demoAppApplicationId } from '@logto/schemas';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useParams } from 'react-router-dom';
@@ -74,7 +75,10 @@ const AuditLogDetails = () => {
                   <div className={styles.label}>{t('log_details.application')}</div>
                   <div>
                     {data.payload.applicationId ? (
-                      <ApplicationName isLink applicationId={data.payload.applicationId} />
+                      <ApplicationName
+                        isLink={data.payload.applicationId !== demoAppApplicationId}
+                        applicationId={data.payload.applicationId}
+                      />
                     ) : (
                       '-'
                     )}

--- a/packages/core/src/oidc/adapter.ts
+++ b/packages/core/src/oidc/adapter.ts
@@ -46,7 +46,7 @@ const buildDemoAppClientMetadata = (envSet: EnvSet): AllClientMetadata => {
   return {
     ...getConstantClientMetadata(envSet, ApplicationType.SPA),
     client_id: demoAppApplicationId,
-    client_name: 'Demo App',
+    client_name: 'Live Preview',
     redirect_uris: urlStrings,
     post_logout_redirect_uris: urlStrings,
   };

--- a/packages/demo-app/src/index.html
+++ b/packages/demo-app/src/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon.png">
     <link rel="icon" href="./favicon.ico" />
-    <title>Logto Demo App</title>
+    <title>Logto Live Preview</title>
 </head>
 
 <body>

--- a/packages/schemas/src/seeds/application.ts
+++ b/packages/schemas/src/seeds/application.ts
@@ -1,6 +1,6 @@
 import { generateStandardId } from '@logto/core-kit';
 
-import type { CreateApplication } from '../db-entries/index.js';
+import type { Application, CreateApplication } from '../db-entries/index.js';
 import { ApplicationType } from '../db-entries/index.js';
 import { adminTenantId } from './tenant.js';
 
@@ -12,6 +12,18 @@ import { adminTenantId } from './tenant.js';
 export const adminConsoleApplicationId = 'admin-console';
 
 export const demoAppApplicationId = 'demo-app';
+
+export const buildDemoAppDataForTenant = (tenantId: string): Application => ({
+  tenantId,
+  id: demoAppApplicationId,
+  name: 'Live Preview',
+  secret: '',
+  description: 'Preview for Sign-in Experience.',
+  type: ApplicationType.SPA,
+  oidcClientMetadata: { redirectUris: [], postLogoutRedirectUris: [] },
+  customClientMetadata: {},
+  createdAt: 0,
+});
 
 export const createDefaultAdminConsoleApplication = (): Readonly<CreateApplication> =>
   Object.freeze({


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
![image](https://user-images.githubusercontent.com/14722250/223463776-cde5e8da-608d-4669-ac1b-2dc961c33454.png)

demo app has been removed from database, but our audit logs will query the application data for info display

- update display name "Demo App" -> "Live Preview"
- return fixed data when query application by ID in core
- make demo app not clickable on audit log details

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="583" alt="image" src="https://user-images.githubusercontent.com/14722250/223463231-a3d4967c-7e4a-4fb9-9721-80f0acd30396.png">

also no error is showing now

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
