### PR TITLE
fix(core): should not guard input when verifying password

### DIFF
--- a/packages/core/src/routes-me/user.ts
+++ b/packages/core/src/routes-me/user.ts
@@ -103,7 +103,7 @@ export default function userRoutes<T extends AuthedMeRouter>(
   router.post(
     '/password/verify',
     koaGuard({
-      body: object({ password: string().regex(passwordRegEx) }),
+      body: object({ password: string() }),
     }),
     async (ctx, next) => {
       const { id: userId } = ctx.auth;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Should not guard password input when verifying password, as we might have some history passwords that cannot pass the new regex guard.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Locally tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [ ] This PR is not applicable for the checklist
