### PR TITLE
fix(console): fallback broken connector logo to default image

### DIFF
--- a/packages/console/src/components/ConnectorLogo/index.module.scss
+++ b/packages/console/src/components/ConnectorLogo/index.module.scss
@@ -1,0 +1,57 @@
+.container {
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  background-color: var(--color-hover);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+
+  > img {
+    width: 28px;
+    height: 28px;
+  }
+
+  &.large {
+    width: 60px;
+    height: 60px;
+    border-radius: 12px;
+
+    > img {
+      width: 42px;
+      height: 42px;
+    }
+  }
+
+  &.small {
+    width: 20px;
+    height: 20px;
+    background-color: transparent;
+    border-radius: unset;
+
+    > img {
+      width: 20px;
+      height: 20px;
+    }
+  }
+}
+
+.logo {
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  flex-shrink: 0;
+
+  &.large {
+    width: 60px;
+    height: 60px;
+    border-radius: 12px;
+  }
+
+  &.small {
+    width: 20px;
+    height: 20px;
+    border-radius: 6px;
+  }
+}

--- a/packages/console/src/components/ConnectorLogo/index.tsx
+++ b/packages/console/src/components/ConnectorLogo/index.tsx
@@ -1,19 +1,25 @@
 import type { ConnectorResponse } from '@logto/schemas';
 import { AppearanceMode } from '@logto/schemas';
+import classNames from 'classnames';
 
 import { useTheme } from '@/hooks/use-theme';
+
+import ImageWithErrorFallback from '../ImageWithErrorFallback';
+import * as styles from './index.module.scss';
 
 type Props = {
   className?: string;
   data: Pick<ConnectorResponse, 'logo' | 'logoDark'>;
+  size?: 'small' | 'medium' | 'large';
 };
 
-const ConnectorLogo = ({ className, data }: Props) => {
+const ConnectorLogo = ({ className, data, size = 'medium' }: Props) => {
   const theme = useTheme();
 
   return (
-    <img
-      className={className}
+    <ImageWithErrorFallback
+      containerClassName={classNames(styles.container, styles[size])}
+      className={classNames(styles.logo, styles[size], className)}
       alt="logo"
       src={theme === AppearanceMode.DarkMode && data.logoDark ? data.logoDark : data.logo}
     />

--- a/packages/console/src/components/ImageWithErrorFallback/index.tsx
+++ b/packages/console/src/components/ImageWithErrorFallback/index.tsx
@@ -6,12 +6,9 @@ import FallbackImageDark from '@/assets/images/broken-image-dark.svg';
 import FallbackImageLight from '@/assets/images/broken-image-light.svg';
 import { useTheme } from '@/hooks/use-theme';
 
-const ImageWithErrorFallback = ({
-  src,
-  alt,
-  className,
-  ...props
-}: ImgHTMLAttributes<HTMLImageElement>) => {
+type Props = { containerClassName?: string } & ImgHTMLAttributes<HTMLImageElement>;
+
+const ImageWithErrorFallback = ({ src, alt, className, containerClassName, ...props }: Props) => {
   const [hasError, setHasError] = useState(false);
   const theme = useTheme();
   const Fallback = theme === AppearanceMode.LightMode ? FallbackImageLight : FallbackImageDark;
@@ -24,7 +21,11 @@ const ImageWithErrorFallback = ({
     return <Fallback className={className} />;
   }
 
-  return <img className={className} src={src} alt={alt} onError={errorHandler} {...props} />;
+  return (
+    <div className={containerClassName}>
+      <img className={className} src={src} alt={alt} onError={errorHandler} {...props} />
+    </div>
+  );
 };
 
 export default ImageWithErrorFallback;

--- a/packages/console/src/pages/ConnectorDetails/index.module.scss
+++ b/packages/console/src/pages/ConnectorDetails/index.module.scss
@@ -6,29 +6,13 @@
 }
 
 .header {
-  padding: _.unit(6);
+  padding: _.unit(6) _.unit(8);
   display: flex;
   align-items: center;
   justify-content: space-between;
 
   > *:not(:first-child) {
     margin-left: _.unit(6);
-  }
-
-  .logoContainer {
-    margin-left: _.unit(2);
-    width: 60px;
-    height: 60px;
-    border-radius: 12px;
-    background-color: var(--color-hover);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .logo {
-    width: 42px;
-    height: 42px;
   }
 
   .operations {

--- a/packages/console/src/pages/ConnectorDetails/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/index.tsx
@@ -124,9 +124,7 @@ const ConnectorDetails = () => {
       {!requestError && data && (
         <>
           <Card className={styles.header}>
-            <div className={styles.logoContainer}>
-              <ConnectorLogo data={data} className={styles.logo} />
-            </div>
+            <ConnectorLogo data={data} size="large" />
             <div className={styles.metadata}>
               <div>
                 <div className={styles.name}>

--- a/packages/console/src/pages/Connectors/components/ConnectorName/index.tsx
+++ b/packages/console/src/pages/Connectors/components/ConnectorName/index.tsx
@@ -78,11 +78,7 @@ const ConnectorName = ({ connectorGroup }: Props) => {
           )}
         </>
       }
-      icon={
-        <div className={styles.logoContainer}>
-          <ConnectorLogo className={styles.logo} data={connector} />
-        </div>
-      }
+      icon={<ConnectorLogo data={connector} />}
       to={`/connectors/${
         connector.type === ConnectorType.Social
           ? ConnectorsTabs.Social

--- a/packages/console/src/pages/Connectors/components/CreateForm/index.module.scss
+++ b/packages/console/src/pages/Connectors/components/CreateForm/index.module.scss
@@ -43,21 +43,9 @@
       font: var(--font-body-2);
       display: flex;
 
-      .logo {
-        width: 40px;
-        height: 40px;
-        display: flex;
-        align-items: center;
-        margin-right: _.unit(3);
-
-        img {
-          width: 40px;
-          height: 40px;
-        }
-      }
-
       .content {
         flex: 1;
+        margin-left: _.unit(3);
 
         .name {
           font: var(--font-label-2);

--- a/packages/console/src/pages/Connectors/components/CreateForm/index.tsx
+++ b/packages/console/src/pages/Connectors/components/CreateForm/index.tsx
@@ -161,9 +161,7 @@ const CreateForm = ({ onClose, isOpen: isFormOpen, type }: Props) => {
           {groups.map(({ id, name, logo, logoDark, description }) => (
             <Radio key={id} value={id}>
               <div className={styles.connector}>
-                <div className={styles.logo}>
-                  <ConnectorLogo data={{ logo, logoDark }} />
-                </div>
+                <ConnectorLogo data={{ logo, logoDark }} />
                 <div className={styles.content}>
                   <div className={classNames(styles.name)}>
                     <UnnamedTrans resource={name} />

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/SocialConnectorEditBox/AddButton.module.scss
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/SocialConnectorEditBox/AddButton.module.scss
@@ -16,14 +16,9 @@
   display: flex;
   align-items: center;
 
-  .logo {
-    margin-right: _.unit(3);
-    width: 20px;
-    height: 20px;
-  }
-
   .name {
     font: var(--font-body-2);
+    margin-left: _.unit(3);
   }
 
   .icon {

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/SocialConnectorEditBox/AddButton.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/SocialConnectorEditBox/AddButton.tsx
@@ -53,7 +53,7 @@ const AddButton = ({ options, onSelected, hasSelectedConnectors }: Props) => {
           }}
         >
           <div className={styles.title}>
-            <ConnectorLogo data={{ logo, logoDark }} className={styles.logo} />
+            <ConnectorLogo data={{ logo, logoDark }} size="small" />
             <UnnamedTrans resource={name} className={styles.name} />
             {connectors.length > 1 &&
               connectors.map(({ platform }) => (

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/SocialConnectorEditBox/SelectedConnectorItem.module.scss
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/SocialConnectorEditBox/SelectedConnectorItem.module.scss
@@ -20,16 +20,12 @@
 
     .draggableIcon {
       color: var(--color-text-secondary);
-    }
-
-    .logo {
-      margin: auto _.unit(3);
-      width: 20px;
-      height: 20px;
+      margin-right: _.unit(3);
     }
 
     .name {
       font: var(--font-label-2);
+      margin-left: _.unit(3);
     }
 
     .icon {

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/SocialConnectorEditBox/SelectedConnectorItem.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/SocialConnectorEditBox/SelectedConnectorItem.tsx
@@ -21,7 +21,7 @@ const SelectedConnectorItem = ({
     <div className={styles.item}>
       <div className={styles.info}>
         <Draggable className={styles.draggableIcon} />
-        <ConnectorLogo data={{ logo, logoDark }} className={styles.logo} />
+        <ConnectorLogo data={{ logo, logoDark }} size="small" />
         <UnnamedTrans resource={name} className={styles.name} />
         {connectors.length > 1 &&
           connectors.map(({ platform }) => (


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fallback broken connector logo to a system default image.

Before:
<img width="642" alt="image" src="https://user-images.githubusercontent.com/12833674/223753462-7d64695e-5079-4181-b49b-4941d3c04a63.png">

After:
<img width="603" alt="image" src="https://user-images.githubusercontent.com/12833674/223754097-7b6d1226-cfe6-42cc-bf32-70b35c3c9bcb.png">

<img width="505" alt="image" src="https://user-images.githubusercontent.com/12833674/223754995-9fc1908e-5b84-426c-9a02-600798d2fab2.png">

<img width="577" alt="image" src="https://user-images.githubusercontent.com/12833674/223753630-bdf6bf56-3898-4891-8a8e-127752a5c691.png">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Go to connector list page, connector details page and sign-in-experience page to check the broken connector logo

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
