### PR TITLE
fix(console): text input in AC should support both 36px and 44px heights

### DIFF
--- a/packages/console/src/components/TextInput/index.module.scss
+++ b/packages/console/src/components/TextInput/index.module.scss
@@ -16,9 +16,13 @@
   transition-timing-function: ease-in-out;
   transition-duration: 0.2s;
   padding: 0 _.unit(3);
-  height: 44px;
+  height: 36px;
   background: var(--color-layer-1);
   font: var(--font-body-2);
+
+  &.large {
+    height: 44px;
+  }
 
   &.withIcon {
     display: flex;

--- a/packages/console/src/components/TextInput/index.tsx
+++ b/packages/console/src/components/TextInput/index.tsx
@@ -4,11 +4,12 @@ import { cloneElement, forwardRef } from 'react';
 
 import * as styles from './index.module.scss';
 
-type Props = HTMLProps<HTMLInputElement> & {
+type Props = Omit<HTMLProps<HTMLInputElement>, 'size'> & {
   hasError?: boolean;
   errorMessage?: string;
   icon?: ReactElement;
   suffix?: ReactElement;
+  size?: 'medium' | 'large';
 };
 
 const TextInput = (
@@ -21,6 +22,7 @@ const TextInput = (
     className,
     readOnly,
     value,
+    size = 'medium',
     ...rest
   }: Props,
   reference: ForwardedRef<HTMLInputElement>
@@ -33,7 +35,8 @@ const TextInput = (
           hasError && styles.error,
           icon && styles.withIcon,
           disabled && styles.disabled,
-          readOnly && styles.readOnly
+          readOnly && styles.readOnly,
+          styles[size]
         )}
       >
         {icon && <span className={styles.icon}>{icon}</span>}

--- a/packages/console/src/pages/Profile/containers/BasicUserInfoUpdateModal/index.tsx
+++ b/packages/console/src/pages/Profile/containers/BasicUserInfoUpdateModal/index.tsx
@@ -109,6 +109,7 @@ const BasicUserInfoUpdateModal = ({ field, value: initialValue, isOpen, onClose 
             })}
             placeholder={getInputPlaceholder()}
             errorMessage={errors[field]?.message}
+            size="large"
             onKeyDown={(event) => {
               if (event.key === 'Enter') {
                 void onSubmit();

--- a/packages/console/src/pages/Profile/containers/ChangePasswordModal/index.tsx
+++ b/packages/console/src/pages/Profile/containers/ChangePasswordModal/index.tsx
@@ -116,6 +116,7 @@ const ChangePasswordModal = () => {
             <ClearInput />
           </IconButton>
         }
+        size="large"
         onKeyDown={onKeyDown}
       />
       <TextInput
@@ -135,6 +136,7 @@ const ChangePasswordModal = () => {
             <ClearInput />
           </IconButton>
         }
+        size="large"
         onKeyDown={onKeyDown}
       />
       <Checkbox

--- a/packages/console/src/pages/Profile/containers/LinkEmailModal/index.tsx
+++ b/packages/console/src/pages/Profile/containers/LinkEmailModal/index.tsx
@@ -62,6 +62,7 @@ const LinkEmailModal = () => {
             t('profile.link_account.identical_email_address'),
         })}
         errorMessage={errors.email?.message}
+        size="large"
         onKeyDown={(event) => {
           if (event.key === 'Enter') {
             onSubmit();

--- a/packages/console/src/pages/Profile/containers/VerifyPasswordModal/index.tsx
+++ b/packages/console/src/pages/Profile/containers/VerifyPasswordModal/index.tsx
@@ -88,6 +88,7 @@ const VerifyPasswordModal = () => {
             {showPassword ? <PasswordShowIcon /> : <PasswordHideIcon />}
           </IconButton>
         }
+        size="large"
         onKeyDown={(event) => {
           if (event.key === 'Enter') {
             onSubmit();


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Support both 36px and 44px heights in TextInput component in admin console, and use 36px by default. Since in mainflow UI all text inputs are by default 44px in height, AC profile subpages should also align with it.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally and it works as expected

By default inputs are 36px in height:
<img width="807" alt="image" src="https://user-images.githubusercontent.com/12833674/223899665-f01e9ad3-78fd-4c2d-8dfc-2c54b0a40b99.png">

In profile modals inputs are 44px:
<img width="717" alt="image" src="https://user-images.githubusercontent.com/12833674/223899756-2222d642-44ee-4c70-a71a-98a675b5fac4.png">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
