### PR TITLE
refactor(core): refactor backend password regex rule

### DIFF
--- a/packages/core/src/routes/admin-user.test.ts
+++ b/packages/core/src/routes/admin-user.test.ts
@@ -140,7 +140,7 @@ describe('adminUserRoutes', () => {
 
   it('POST /users', async () => {
     const username = 'MJAtLogto';
-    const password = 'PASSWORD';
+    const password = 'PASSWORD1234';
     const name = 'Michael';
     const { primaryEmail, primaryPhone } = mockUser;
 
@@ -171,7 +171,7 @@ describe('adminUserRoutes', () => {
     mockHasUser.mockImplementationOnce(async () => true);
 
     const username = 'MJAtLogto';
-    const password = 'PASSWORD';
+    const password = 'PASSWORD1234';
     const name = 'Michael';
 
     await expect(

--- a/packages/toolkit/core-kit/src/regex.test.ts
+++ b/packages/toolkit/core-kit/src/regex.test.ts
@@ -1,0 +1,45 @@
+import { passwordRegEx } from './regex.js';
+
+describe('passwordRegEx', () => {
+  it('should match password with at least 8 chars', () => {
+    expect(passwordRegEx.test('1234ddf')).toBeFalsy();
+    expect(passwordRegEx.test('1234ddf!')).toBeTruthy();
+  });
+
+  it('password should not contains non ASCII visible chars', () => {
+    expect(passwordRegEx.test('a1?aaaaa测试')).toBeFalsy();
+
+    expect(passwordRegEx.test('a1?aaaaa测试')).toBeFalsy();
+
+    expect(passwordRegEx.test('a1?aaaaa🌹')).toBeFalsy();
+
+    expect(passwordRegEx.test('a1?aaaaa')).toBeTruthy();
+  });
+
+  describe('password should contains at least 2 of 3 types of chars', () => {
+    const singleTypeChars = ['aaaaaaaa', '11111111', '!@#$%^&*(())'];
+
+    it.each(singleTypeChars)('single typed password format %p should be invalid', (password) => {
+      expect(passwordRegEx.test(password)).toBeFalsy();
+    });
+
+    const doubleTypeChars = [
+      'asdfghj1',
+      'asdfghj$',
+      '1234567@',
+      '1234567a',
+      '!@#$%^&1',
+      '!@#$%^&a',
+    ];
+
+    it.each(doubleTypeChars)('double typed password format %p should be valid', (password) => {
+      expect(passwordRegEx.test(password)).toBeTruthy();
+    });
+
+    const tripleTypeChars = ['ASD!@#45', 'a!@#$%123', '1ASDfg654', '*123345GHJ'];
+
+    it.each(tripleTypeChars)('triple typed password format %p should be valid', (password) => {
+      expect(passwordRegEx.test(password)).toBeTruthy();
+    });
+  });
+});

--- a/packages/toolkit/core-kit/src/regex.ts
+++ b/packages/toolkit/core-kit/src/regex.ts
@@ -1,9 +1,17 @@
 export const emailRegEx = /^\S+@\S+\.\S+$/;
 export const phoneRegEx = /^\d+$/;
 export const usernameRegEx = /^[A-Z_a-z]\w*$/;
-export const passwordRegEx = /^[\w!"#$%&'()*+,./:;<=>?@[\]^`{|}~-]{8,}$/;
 export const webRedirectUriProtocolRegEx = /^https?:$/;
 export const mobileUriSchemeProtocolRegEx = /^[a-z][\d_a-z]*(\.[\d_a-z]+)+:$/;
 export const hexColorRegEx = /^#[\da-f]{3}([\da-f]{3})?$/i;
 export const dateRegex = /^\d{4}(-\d{2}){2}/;
 export const noSpaceRegEx = /^\S+$/;
+
+const atLeastOneDigitAndOneLetters = /(?=.*\d)(?=.*[A-Za-z])/;
+const atLeastOneDigitAndOneSpecialChar = /(?=.*\d)(?=.*[!"#$%&'()*+,./:;<=>?@[\]^_`{|}~-])/;
+const atLeastOneLetterAndOneSpecialChar = /(?=.*[A-Za-z])(?=.*[!"#$%&'()*+,./:;<=>?@[\]^_`{|}~-])/;
+const allowedChars = /[\w!"#$%&'()*+,./:;<=>?@[\]^`{|}~-]{8,}/;
+
+export const passwordRegEx = new RegExp(
+  `^(${atLeastOneDigitAndOneLetters.source}|${atLeastOneDigitAndOneSpecialChar.source}|${atLeastOneLetterAndOneSpecialChar.source})${allowedChars.source}$`
+);


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate) and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

### Refactor backend password regex rule

The previous backend password regex rule is simple:
 - no less than 8 characters
 - contains only digits, letters and special symbols

Need to align with the front-end validation rule. Add an additional rule to the regex:
 - at least two different types of characters must be present.  


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT added

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [x] unit tests
- [ ] integration tests
- [ ] docs

OR

- [ ] This PR is not applicable for the checklist
