### PR TITLE
refactor(console): add dedicated routes to AC guides

### DIFF
--- a/packages/console/src/containers/ConsoleContent/index.tsx
+++ b/packages/console/src/containers/ConsoleContent/index.tsx
@@ -55,6 +55,7 @@ const ConsoleContent = () => {
           <Route path="applications">
             <Route index element={<Applications />} />
             <Route path="create" element={<Applications />} />
+            <Route path=":id/guide" element={<ApplicationDetails />} />
             <Route path=":id" element={<ApplicationDetails />} />
           </Route>
           <Route path="api-resources">
@@ -77,6 +78,7 @@ const ConsoleContent = () => {
             <Route index element={<Navigate replace to={ConnectorsTabs.Passwordless} />} />
             <Route path=":tab" element={<Connectors />} />
             <Route path=":tab/create/:createType" element={<Connectors />} />
+            <Route path=":tab/guide/:factoryId" element={<Connectors />} />
             <Route path=":tab/:connectorId" element={<ConnectorDetails />} />
           </Route>
           <Route path="users">

--- a/packages/console/src/pages/ApplicationDetails/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/index.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import { Trans, useTranslation } from 'react-i18next';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import useSWR from 'swr';
 
 import Back from '@/assets/images/back.svg';
@@ -42,6 +42,8 @@ const mapToUriOriginFormatArrays = (value?: string[]) =>
 
 const ApplicationDetails = () => {
   const { id } = useParams();
+  const { pathname } = useLocation();
+  const isGuideView = !!id && pathname === `/applications/${id}/guide`;
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { data, error, mutate } = useSWR<ApplicationResponse, RequestError>(
     id && `api/applications/${id}`
@@ -224,6 +226,14 @@ const ApplicationDetails = () => {
         </>
       )}
       <UnsavedChangesAlertModal hasUnsavedChanges={!isDeleted && isDirty} />
+      {isGuideView && (
+        <Guide
+          app={data}
+          onClose={(id) => {
+            navigate(`/applications/${id}`);
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/packages/console/src/pages/Applications/components/ApplicationsPlaceholder/index.tsx
+++ b/packages/console/src/pages/Applications/components/ApplicationsPlaceholder/index.tsx
@@ -3,27 +3,24 @@ import { ApplicationType } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import Modal from 'react-modal';
-import { useNavigate } from 'react-router-dom';
 
 import Button from '@/components/Button';
 import useApi from '@/hooks/use-api';
 import useConfigs from '@/hooks/use-configs';
-import * as modalStyles from '@/scss/modal.module.scss';
 import { applicationTypeI18nKey } from '@/types/applications';
 
-import Guide from '../Guide';
 import TypeDescription from '../TypeDescription';
 import * as styles from './index.module.scss';
 
 const defaultAppName = 'My App';
 
-const ApplicationsPlaceholder = () => {
+type Props = {
+  onCreate: (createdApp: Application) => void;
+};
+
+const ApplicationsPlaceholder = ({ onCreate }: Props) => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
-  const navigate = useNavigate();
   const [isCreating, setIsCreating] = useState(false);
-  const [createdApplication, setCreatedApplication] = useState<Application>();
-  const isGetStartedModalOpen = Boolean(createdApplication);
   const api = useApi();
   const { updateConfigs } = useConfigs();
 
@@ -41,26 +38,16 @@ const ApplicationsPlaceholder = () => {
     try {
       const createdApp = await api.post('api/applications', { json: payload }).json<Application>();
 
-      setCreatedApplication(createdApp);
-
       void updateConfigs({
         applicationCreated: true,
         ...conditional(
           createdApp.type === ApplicationType.MachineToMachine && { m2mApplicationCreated: true }
         ),
       });
+      onCreate(createdApp);
     } finally {
       setIsCreating(false);
     }
-  };
-
-  const closeGuideModal = () => {
-    if (!createdApplication) {
-      return;
-    }
-
-    navigate(`/applications/${createdApplication.id}`);
-    setCreatedApplication(undefined);
   };
 
   return (
@@ -81,23 +68,13 @@ const ApplicationsPlaceholder = () => {
               className={styles.createButton}
               disabled={isCreating}
               title="general.create"
-              onClick={async () => {
-                await handleCreate(type);
+              onClick={() => {
+                void handleCreate(type);
               }}
             />
           </div>
         ))}
       </div>
-      {createdApplication && (
-        <Modal
-          shouldCloseOnEsc
-          isOpen={isGetStartedModalOpen}
-          className={modalStyles.fullScreen}
-          onRequestClose={closeGuideModal}
-        >
-          <Guide app={createdApplication} onClose={closeGuideModal} />
-        </Modal>
-      )}
     </div>
   );
 };

--- a/packages/console/src/pages/Applications/components/Guide/index.tsx
+++ b/packages/console/src/pages/Applications/components/Guide/index.tsx
@@ -4,12 +4,14 @@ import type { Optional } from '@silverhand/essentials';
 import i18next from 'i18next';
 import type { MDXProps } from 'mdx/types';
 import type { LazyExoticComponent } from 'react';
-import { useContext, cloneElement, lazy, Suspense, useEffect, useState } from 'react';
+import { useEffect, useContext, cloneElement, lazy, Suspense, useState } from 'react';
+import Modal from 'react-modal';
 
 import CodeEditor from '@/components/CodeEditor';
 import TextLink from '@/components/TextLink';
 import { AppEndpointsContext } from '@/contexts/AppEndpointsProvider';
 import DetailsSummary from '@/mdx-components/DetailsSummary';
+import * as modalStyles from '@/scss/modal.module.scss';
 import type { SupportedSdk } from '@/types/applications';
 import { applicationTypeAndSdkTypeMappings } from '@/types/applications';
 
@@ -19,9 +21,9 @@ import StepsSkeleton from '../StepsSkeleton';
 import * as styles from './index.module.scss';
 
 type Props = {
-  app: Application;
+  app?: Application;
   isCompact?: boolean;
-  onClose: () => void;
+  onClose: (id: string) => void;
 };
 
 const Guides: Record<string, LazyExoticComponent<(props: MDXProps) => JSX.Element>> = {
@@ -50,83 +52,93 @@ const Guides: Record<string, LazyExoticComponent<(props: MDXProps) => JSX.Elemen
 };
 
 const Guide = ({ app, isCompact, onClose }: Props) => {
-  const { id: appId, secret: appSecret, name: appName, type: appType, oidcClientMetadata } = app;
-  const sdks = applicationTypeAndSdkTypeMappings[appType];
-  const [selectedSdk, setSelectedSdk] = useState<Optional<SupportedSdk>>(sdks[0]);
+  const sdks = app && applicationTypeAndSdkTypeMappings[app.type];
+  const [selectedSdk, setSelectedSdk] = useState<Optional<SupportedSdk>>();
   const [activeStepIndex, setActiveStepIndex] = useState(-1);
   const { userEndpoint } = useContext(AppEndpointsContext);
 
-  // Directly close guide if no SDK available
   useEffect(() => {
-    if (!selectedSdk) {
-      onClose();
+    if (sdks?.length) {
+      setSelectedSdk(sdks[0]);
     }
-  }, [onClose, selectedSdk]);
+  }, [sdks]);
 
-  if (!selectedSdk) {
+  if (!app || !sdks || !selectedSdk) {
     return null;
   }
 
+  const { id: appId, secret: appSecret, name: appName, oidcClientMetadata } = app;
   const locale = i18next.language;
   const guideI18nKey = `${selectedSdk}_${locale}`.toLowerCase();
   const GuideComponent = Guides[guideI18nKey] ?? Guides[selectedSdk.toLowerCase()];
 
-  return (
-    <div className={styles.container}>
-      <GuideHeader
-        appName={appName}
-        selectedSdk={selectedSdk}
-        isCompact={isCompact}
-        onClose={onClose}
-      />
-      <div className={styles.content}>
-        {cloneElement(<SdkSelector sdks={sdks} selectedSdk={selectedSdk} />, {
-          className: styles.banner,
-          isCompact,
-          onChange: setSelectedSdk,
-          onToggle: () => {
-            setActiveStepIndex(0);
-          },
-        })}
-        <MDXProvider
-          components={{
-            code: ({ className, children }) => {
-              const [, language] = /language-(\w+)/.exec(className ?? '') ?? [];
+  const closeModal = () => {
+    onClose(appId);
+  };
 
-              return language ? (
-                <CodeEditor isReadonly language={language} value={String(children)} />
-              ) : (
-                <code>{String(children)}</code>
-              );
+  return (
+    <Modal
+      shouldCloseOnEsc
+      isOpen={Boolean(app)}
+      className={modalStyles.fullScreen}
+      onRequestClose={closeModal}
+    >
+      <div className={styles.container}>
+        <GuideHeader
+          appName={appName}
+          selectedSdk={selectedSdk}
+          isCompact={isCompact}
+          onClose={closeModal}
+        />
+        <div className={styles.content}>
+          {cloneElement(<SdkSelector sdks={sdks} selectedSdk={selectedSdk} />, {
+            className: styles.banner,
+            isCompact,
+            onChange: setSelectedSdk,
+            onToggle: () => {
+              setActiveStepIndex(0);
             },
-            a: ({ children, ...props }) => (
-              <TextLink {...props} target="_blank" rel="noopener noreferrer">
-                {children}
-              </TextLink>
-            ),
-            details: DetailsSummary,
-          }}
-        >
-          <Suspense fallback={<StepsSkeleton />}>
-            {GuideComponent && (
-              <GuideComponent
-                appId={appId}
-                appSecret={appSecret}
-                endpoint={userEndpoint}
-                redirectUris={oidcClientMetadata.redirectUris}
-                postLogoutRedirectUris={oidcClientMetadata.postLogoutRedirectUris}
-                activeStepIndex={activeStepIndex}
-                isCompact={isCompact}
-                onNext={(nextIndex: number) => {
-                  setActiveStepIndex(nextIndex);
-                }}
-                onComplete={onClose}
-              />
-            )}
-          </Suspense>
-        </MDXProvider>
+          })}
+          <MDXProvider
+            components={{
+              code: ({ className, children }) => {
+                const [, language] = /language-(\w+)/.exec(className ?? '') ?? [];
+
+                return language ? (
+                  <CodeEditor isReadonly language={language} value={String(children)} />
+                ) : (
+                  <code>{String(children)}</code>
+                );
+              },
+              a: ({ children, ...props }) => (
+                <TextLink {...props} target="_blank" rel="noopener noreferrer">
+                  {children}
+                </TextLink>
+              ),
+              details: DetailsSummary,
+            }}
+          >
+            <Suspense fallback={<StepsSkeleton />}>
+              {GuideComponent && (
+                <GuideComponent
+                  appId={appId}
+                  appSecret={appSecret}
+                  endpoint={userEndpoint}
+                  redirectUris={oidcClientMetadata.redirectUris}
+                  postLogoutRedirectUris={oidcClientMetadata.postLogoutRedirectUris}
+                  activeStepIndex={activeStepIndex}
+                  isCompact={isCompact}
+                  onNext={(nextIndex: number) => {
+                    setActiveStepIndex(nextIndex);
+                  }}
+                  onComplete={closeModal}
+                />
+              )}
+            </Suspense>
+          </MDXProvider>
+        </div>
       </div>
-    </div>
+    </Modal>
   );
 };
 

--- a/packages/console/src/pages/Connectors/components/ConnectorForm/ConfigForm.tsx
+++ b/packages/console/src/pages/Connectors/components/ConnectorForm/ConfigForm.tsx
@@ -20,7 +20,7 @@ type Props = {
   formItems?: ConnectorConfigFormItem[];
   className?: string;
   connectorId: string;
-  connectorType: ConnectorType;
+  connectorType?: ConnectorType;
 };
 
 const ConfigForm = ({

--- a/packages/console/src/pages/Connectors/components/CreateForm/index.tsx
+++ b/packages/console/src/pages/Connectors/components/CreateForm/index.tsx
@@ -14,7 +14,6 @@ import type { RequestError } from '@/hooks/use-api';
 import * as modalStyles from '@/scss/modal.module.scss';
 
 import { getConnectorGroups } from '../../utils';
-import Guide from '../Guide';
 import PlatformSelector from './PlatformSelector';
 import * as styles from './index.module.scss';
 import { getConnectorOrder } from './utils';
@@ -37,7 +36,6 @@ const CreateForm = ({ onClose, isOpen: isFormOpen, type }: Props) => {
   const isLoading = !factories && !existingConnectors && !connectorsError && !factoriesError;
   const [activeGroupId, setActiveGroupId] = useState<string>();
   const [activeFactoryId, setActiveFactoryId] = useState<string>();
-  const [isGetStartedModalOpen, setIsGetStartedModalOpen] = useState(false);
 
   const groups = useMemo(() => {
     if (!factories || !existingConnectors) {
@@ -73,11 +71,6 @@ const CreateForm = ({ onClose, isOpen: isFormOpen, type }: Props) => {
     [activeGroupId, groups]
   );
 
-  const activeFactory = useMemo(
-    () => factories?.find(({ id }) => id === activeFactoryId),
-    [activeFactoryId, factories]
-  );
-
   const cardTitle = useMemo(() => {
     if (type === ConnectorType.Email) {
       return 'connectors.setup_title.email';
@@ -89,6 +82,22 @@ const CreateForm = ({ onClose, isOpen: isFormOpen, type }: Props) => {
 
     return 'connectors.setup_title.social';
   }, [type]);
+
+  const modalSize = useMemo(() => {
+    if (groups.length <= 2) {
+      return 'medium';
+    }
+
+    if (groups.length === 3) {
+      return 'large';
+    }
+
+    return 'xlarge';
+  }, [groups.length]);
+
+  if (!isFormOpen) {
+    return null;
+  }
 
   const handleGroupChange = (groupId: string) => {
     setActiveGroupId(groupId);
@@ -103,25 +112,6 @@ const CreateForm = ({ onClose, isOpen: isFormOpen, type }: Props) => {
 
     setActiveFactoryId(firstAvailableConnector?.id);
   };
-
-  const closeModal = () => {
-    setIsGetStartedModalOpen(false);
-    onClose?.(activeFactoryId);
-    setActiveGroupId(undefined);
-    setActiveFactoryId(undefined);
-  };
-
-  const modalSize = useMemo(() => {
-    if (groups.length <= 2) {
-      return 'medium';
-    }
-
-    if (groups.length === 3) {
-      return 'large';
-    }
-
-    return 'xlarge';
-  }, [groups]);
 
   return (
     <Modal
@@ -141,7 +131,7 @@ const CreateForm = ({ onClose, isOpen: isFormOpen, type }: Props) => {
             type="primary"
             disabled={!activeFactoryId}
             onClick={() => {
-              setIsGetStartedModalOpen(true);
+              onClose?.(activeFactoryId);
             }}
           />
         }
@@ -180,16 +170,6 @@ const CreateForm = ({ onClose, isOpen: isFormOpen, type }: Props) => {
             connectorId={activeFactoryId}
             onConnectorIdChange={setActiveFactoryId}
           />
-        )}
-        {activeFactory && (
-          <Modal
-            shouldCloseOnEsc
-            isOpen={isGetStartedModalOpen}
-            className={modalStyles.fullScreen}
-            onRequestClose={closeModal}
-          >
-            <Guide connector={activeFactory} onClose={closeModal} />
-          </Modal>
         )}
       </ModalLayout>
     </Modal>

--- a/packages/console/src/pages/Connectors/components/Guide/index.tsx
+++ b/packages/console/src/pages/Connectors/components/Guide/index.tsx
@@ -5,10 +5,11 @@ import { ConnectorType } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
 import i18next from 'i18next';
 import { HTTPError } from 'ky';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
+import Modal from 'react-modal';
 import { useNavigate } from 'react-router-dom';
 
 import Close from '@/assets/images/close.svg';
@@ -21,6 +22,7 @@ import { ConnectorsTabs } from '@/consts/page-tabs';
 import useApi from '@/hooks/use-api';
 import useConfigs from '@/hooks/use-configs';
 import SenderTester from '@/pages/ConnectorDetails/components/SenderTester';
+import * as modalStyles from '@/scss/modal.module.scss';
 
 import type { ConnectorFormType } from '../../types';
 import { SyncProfileMode } from '../../types';
@@ -34,30 +36,22 @@ import * as styles from './index.module.scss';
 const targetErrorCode = 'connector.multiple_target_with_same_platform';
 
 type Props = {
-  connector: ConnectorFactoryResponse;
-  onClose: () => void;
+  connector?: ConnectorFactoryResponse;
+  onClose: (id?: string) => void;
 };
 
 const Guide = ({ connector, onClose }: Props) => {
   const api = useApi({ hideErrorToast: true });
   const navigate = useNavigate();
-  const [callbackConnectorId, setCallbackConnectorId] = useState<string>(generateStandardId());
+  const callbackConnectorId = useRef(generateStandardId());
   const { updateConfigs } = useConfigs();
   const parseJsonConfig = useConfigParser();
   const [conflictConnectorName, setConflictConnectorName] = useState<Record<string, string>>();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
-  const {
-    id: connectorId,
-    type: connectorType,
-    name,
-    readme,
-    formItems,
-    target,
-    isStandard,
-  } = connector;
-  const { title, content } = splitMarkdownByTitle(readme);
+  const { type: connectorType, formItems, target, isStandard } = connector ?? {};
+
   const { language } = i18next;
-  const connectorName = conditional(isLanguageTag(language) && name[language]) ?? name.en;
+
   const isSocialConnector =
     connectorType !== ConnectorType.Sms && connectorType !== ConnectorType.Email;
   const methods = useForm<ConnectorFormType>({
@@ -76,10 +70,18 @@ const Guide = ({ connector, onClose }: Props) => {
   } = methods;
 
   useEffect(() => {
-    if (isSocialConnector && !isStandard) {
+    if (isSocialConnector && !isStandard && target) {
       setValue('target', target);
     }
   }, [isSocialConnector, target, isStandard, setValue]);
+
+  if (!connector) {
+    return null;
+  }
+
+  const { id: connectorId, name, readme, configTemplate } = connector;
+  const { title, content } = splitMarkdownByTitle(readme);
+  const connectorName = conditional(isLanguageTag(language) && name[language]) ?? name.en;
 
   const onSubmit = handleSubmit(async (data) => {
     if (isSubmitting) {
@@ -89,14 +91,13 @@ const Guide = ({ connector, onClose }: Props) => {
     // Recover error state
     setConflictConnectorName(undefined);
 
-    const { formItems, isStandard, id: connectorId, type } = connector;
     const config = formItems ? parseFormConfig(data, formItems) : parseJsonConfig(data.config);
     const { syncProfile, name, logo, logoDark, target } = data;
 
     const basePayload = {
       config,
       connectorId,
-      id: conditional(type === ConnectorType.Social && callbackConnectorId),
+      id: conditional(connectorType === ConnectorType.Social && callbackConnectorId.current),
       metadata: conditional(
         isStandard && {
           logo,
@@ -149,77 +150,91 @@ const Guide = ({ connector, onClose }: Props) => {
   });
 
   return (
-    <div className={styles.container}>
-      <div className={styles.header}>
-        <IconButton size="large" onClick={onClose}>
-          <Close className={styles.closeIcon} />
-        </IconButton>
-        <div className={styles.separator} />
-        <CardTitle
-          size="small"
-          title={<DangerousRaw>{connectorName}</DangerousRaw>}
-          subtitle="connectors.guide.subtitle"
-        />
-      </div>
-      <div className={styles.content}>
-        <div className={styles.readme}>
-          <div className={styles.readmeTitle}>README: {title}</div>
-          <Markdown className={styles.readmeContent}>{content}</Markdown>
+    <Modal
+      shouldCloseOnEsc
+      isOpen={Boolean(connector)}
+      className={modalStyles.fullScreen}
+      onRequestClose={() => {
+        onClose();
+      }}
+    >
+      <div className={styles.container}>
+        <div className={styles.header}>
+          <IconButton
+            size="large"
+            onClick={() => {
+              onClose(callbackConnectorId.current);
+            }}
+          >
+            <Close className={styles.closeIcon} />
+          </IconButton>
+          <div className={styles.separator} />
+          <CardTitle
+            size="small"
+            title={<DangerousRaw>{connectorName}</DangerousRaw>}
+            subtitle="connectors.guide.subtitle"
+          />
         </div>
-        <div className={styles.setup}>
-          <FormProvider {...methods}>
-            <form onSubmit={onSubmit}>
-              {isSocialConnector && (
+        <div className={styles.content}>
+          <div className={styles.readme}>
+            <div className={styles.readmeTitle}>README: {title}</div>
+            <Markdown className={styles.readmeContent}>{content}</Markdown>
+          </div>
+          <div className={styles.setup}>
+            <FormProvider {...methods}>
+              <form onSubmit={onSubmit}>
+                {isSocialConnector && (
+                  <div className={styles.block}>
+                    <div className={styles.blockTitle}>
+                      <div className={styles.number}>1</div>
+                      <div>{t('connectors.guide.general_setting')}</div>
+                    </div>
+                    <BasicForm
+                      isAllowEditTarget={isStandard}
+                      isStandard={isStandard}
+                      conflictConnectorName={conflictConnectorName}
+                    />
+                  </div>
+                )}
                 <div className={styles.block}>
                   <div className={styles.blockTitle}>
-                    <div className={styles.number}>1</div>
-                    <div>{t('connectors.guide.general_setting')}</div>
+                    <div className={styles.number}>{isSocialConnector ? 2 : 1}</div>
+                    <div>{t('connectors.guide.parameter_configuration')}</div>
                   </div>
-                  <BasicForm
-                    isAllowEditTarget={connector.isStandard}
-                    isStandard={connector.isStandard}
-                    conflictConnectorName={conflictConnectorName}
-                  />
-                </div>
-              )}
-              <div className={styles.block}>
-                <div className={styles.blockTitle}>
-                  <div className={styles.number}>{isSocialConnector ? 2 : 1}</div>
-                  <div>{t('connectors.guide.parameter_configuration')}</div>
-                </div>
-                <ConfigForm
-                  connectorId={callbackConnectorId}
-                  configTemplate={connector.configTemplate}
-                  connectorType={connectorType}
-                  formItems={connector.formItems}
-                />
-              </div>
-              {!isSocialConnector && (
-                <div className={styles.block}>
-                  <div className={styles.blockTitle}>
-                    <div className={styles.number}>2</div>
-                    <div>{t('connectors.guide.test_connection')}</div>
-                  </div>
-                  <SenderTester
-                    connectorId={connectorId}
+                  <ConfigForm
+                    connectorId={callbackConnectorId.current}
+                    configTemplate={configTemplate}
                     connectorType={connectorType}
-                    config={watch('config')}
+                    formItems={formItems}
                   />
                 </div>
-              )}
-              <div className={styles.footer}>
-                <Button
-                  title="connectors.save_and_done"
-                  type="primary"
-                  htmlType="submit"
-                  isLoading={isSubmitting}
-                />
-              </div>
-            </form>
-          </FormProvider>
+                {!isSocialConnector && (
+                  <div className={styles.block}>
+                    <div className={styles.blockTitle}>
+                      <div className={styles.number}>2</div>
+                      <div>{t('connectors.guide.test_connection')}</div>
+                    </div>
+                    <SenderTester
+                      connectorId={connectorId}
+                      connectorType={connectorType}
+                      config={watch('config')}
+                    />
+                  </div>
+                )}
+                <div className={styles.footer}>
+                  <Button
+                    title="connectors.save_and_done"
+                    type="primary"
+                    htmlType="submit"
+                    isLoading={isSubmitting}
+                  />
+                </div>
+              </form>
+            </FormProvider>
+          </div>
         </div>
       </div>
-    </div>
+    </Modal>
   );
 };
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- Add dedicated router paths for both application guides and connector guides in admin console
- De-couple creation form modals and guide modals, so that opening guide modals will automatically close creation forms. Currently the form and the guide modal are stacked on each other.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Locally tested OK

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
- [x] This PR is not applicable for the checklist
