### PR TITLE
refactor(core): fix api issues

### DIFF
--- a/packages/core/src/app/init.ts
+++ b/packages/core/src/app/init.ts
@@ -19,6 +19,12 @@ const logListening = (type: 'core' | 'admin' = 'core') => {
 
 export default async function initApp(app: Koa): Promise<void> {
   app.use(async (ctx, next) => {
+    if (EnvSet.values.isDomainBasedMultiTenancy && ctx.URL.pathname === '/status') {
+      ctx.status = 204;
+
+      return next();
+    }
+
     const tenantId = getTenantId(ctx.URL);
 
     if (!tenantId) {

--- a/packages/core/src/middleware/koa-body-etag.ts
+++ b/packages/core/src/middleware/koa-body-etag.ts
@@ -17,7 +17,7 @@ export default function koaBodyEtag<StateT, ContextT, ResponseBodyT>(
     await next();
 
     // eslint-disable-next-line no-restricted-syntax
-    if (methods.includes(ctx.method as Uppercase<Method>)) {
+    if (methods.includes(ctx.method as Uppercase<Method>) && ctx.body) {
       ctx.response.etag = etag(JSON.stringify(ctx.body));
 
       if (ctx.fresh) {

--- a/packages/core/src/routes/init.ts
+++ b/packages/core/src/routes/init.ts
@@ -3,6 +3,7 @@ import Koa from 'koa';
 import Router from 'koa-router';
 
 import { EnvSet } from '#src/env-set/index.js';
+import koaBodyEtag from '#src/middleware/koa-body-etag.js';
 import koaCors from '#src/middleware/koa-cors.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 
@@ -68,6 +69,7 @@ export default function initApis(tenant: TenantContext): Koa {
 
   const { adminUrlSet, cloudUrlSet } = EnvSet.values;
   apisApp.use(koaCors(adminUrlSet, cloudUrlSet));
+  apisApp.use(koaBodyEtag());
 
   for (const router of createRouters(tenant)) {
     apisApp.use(router.routes()).use(router.allowedMethods());

--- a/packages/core/src/routes/well-known.ts
+++ b/packages/core/src/routes/well-known.ts
@@ -4,7 +4,6 @@ import { adminTenantId } from '@logto/schemas';
 
 import { EnvSet, getTenantEndpoint } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
-import koaBodyEtag from '#src/middleware/koa-body-etag.js';
 
 import type { AnonymousRouter, RouterInitArgs } from './types.js';
 
@@ -17,57 +16,49 @@ export default function wellKnownRoutes<T extends AnonymousRouter>(
   } = libraries;
 
   if (id === adminTenantId) {
-    router.get(
-      '/.well-known/endpoints/:tenantId',
-      async (ctx, next) => {
-        if (!ctx.params.tenantId) {
-          throw new RequestError('request.invalid_input');
-        }
-
-        ctx.body = {
-          user: getTenantEndpoint(ctx.params.tenantId, EnvSet.values),
-        };
-
-        return next();
-      },
-      koaBodyEtag()
-    );
-  }
-
-  router.get(
-    '/.well-known/sign-in-exp',
-    async (ctx, next) => {
-      const [signInExperience, logtoConnectors] = await Promise.all([
-        getSignInExperience(),
-        getLogtoConnectors(),
-      ]);
-
-      const forgotPassword = {
-        phone: logtoConnectors.some(({ type }) => type === ConnectorType.Sms),
-        email: logtoConnectors.some(({ type }) => type === ConnectorType.Email),
-      };
-
-      const socialConnectors = signInExperience.socialSignInConnectorTargets.reduce<
-        Array<ConnectorMetadata & { id: string }>
-      >((previous, connectorTarget) => {
-        const connectors = logtoConnectors.filter(
-          ({ metadata: { target } }) => target === connectorTarget
-        );
-
-        return [
-          ...previous,
-          ...connectors.map(({ metadata, dbEntry: { id } }) => ({ ...metadata, id })),
-        ];
-      }, []);
+    router.get('/.well-known/endpoints/:tenantId', async (ctx, next) => {
+      if (!ctx.params.tenantId) {
+        throw new RequestError('request.invalid_input');
+      }
 
       ctx.body = {
-        ...signInExperience,
-        socialConnectors,
-        forgotPassword,
+        user: getTenantEndpoint(ctx.params.tenantId, EnvSet.values),
       };
 
       return next();
-    },
-    koaBodyEtag()
-  );
+    });
+  }
+
+  router.get('/.well-known/sign-in-exp', async (ctx, next) => {
+    const [signInExperience, logtoConnectors] = await Promise.all([
+      getSignInExperience(),
+      getLogtoConnectors(),
+    ]);
+
+    const forgotPassword = {
+      phone: logtoConnectors.some(({ type }) => type === ConnectorType.Sms),
+      email: logtoConnectors.some(({ type }) => type === ConnectorType.Email),
+    };
+
+    const socialConnectors = signInExperience.socialSignInConnectorTargets.reduce<
+      Array<ConnectorMetadata & { id: string }>
+    >((previous, connectorTarget) => {
+      const connectors = logtoConnectors.filter(
+        ({ metadata: { target } }) => target === connectorTarget
+      );
+
+      return [
+        ...previous,
+        ...connectors.map(({ metadata, dbEntry: { id } }) => ({ ...metadata, id })),
+      ];
+    }, []);
+
+    ctx.body = {
+      ...signInExperience,
+      socialConnectors,
+      forgotPassword,
+    };
+
+    return next();
+  });
 }

--- a/packages/core/src/utils/test-utils.ts
+++ b/packages/core/src/utils/test-utils.ts
@@ -94,6 +94,7 @@ export const createContextWithRouteParameters = (
 
   return {
     ...ctx,
+    URL: ctx.URL,
     params: {},
     router: new Router(),
     _matchedRoute: undefined,


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- provide a global `/status` API for health check
- redirect to the current tenant URL when session not found (previously it's fixed to tenant endpoint which may include `*`)
- send etag for all `GET` APIs

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
CI + local tested

etag:

<img width="715" alt="image" src="https://user-images.githubusercontent.com/14722250/224478393-a2afd3f5-70b8-42e8-98cd-3e31ff55fd30.png">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
