### PR TITLE
refactor(core,cloud): disable cache for index files

### DIFF
--- a/packages/core/src/middleware/koa-serve-static.ts
+++ b/packages/core/src/middleware/koa-serve-static.ts
@@ -7,23 +7,32 @@ import send from 'koa-send';
 
 import assertThat from '#src/utils/assert-that.js';
 
+const index = 'index.html';
+
 export default function serve(root: string) {
   assertThat(root, new Error('Root directory is required to serve files.'));
 
   const options: send.SendOptions = {
     root: path.resolve(root),
-    index: 'index.html',
+    index,
   };
 
   const serve: MiddlewareType = async (ctx, next) => {
     if (ctx.method === 'HEAD' || ctx.method === 'GET') {
-      await send(ctx, ctx.path, {
+      const filePath = await send(ctx, ctx.path, {
         ...options,
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         ...(!['/', `/${options.index || ''}`].some((path) => ctx.path.endsWith(path)) && {
           maxage: 604_800_000 /* 7 days */,
         }),
       });
+
+      const filename = path.basename(filePath);
+
+      // No cache for the index file
+      if (filename === index || filename.startsWith(index + '.')) {
+        ctx.set('Cache-Control', 'no-cache, no-store, must-revalidate');
+      }
     }
 
     return next();


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
explicitly disable cache for the index file in order to keep fresh and avoid cache invalidation issues.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

both console and main flow set the proper header

<img width="742" alt="image" src="https://user-images.githubusercontent.com/14722250/224473092-74600531-881b-43de-a27b-b7da5d875b5f.png">

<img width="726" alt="image" src="https://user-images.githubusercontent.com/14722250/224473155-0bc62003-506e-43d7-8970-328aacd9433f.png">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
