### PR TITLE
feat(schemas,core): add `sessionNotFoundRedirectUrl` tenant config

### DIFF
--- a/.changeset-staged/lemon-spies-switch.md
+++ b/.changeset-staged/lemon-spies-switch.md
@@ -1,0 +1,9 @@
+---
+"@logto/core": minor
+"@logto/schemas": minor
+---
+
+**Add `sessionNotFoundRedirectUrl` tenant config**
+
+- User can use this optional config to designate the URL to redirect if session not found in Sign-in Experience.
+- Session guard now works for root path as well.

--- a/packages/core/src/queries/logto-config.ts
+++ b/packages/core/src/queries/logto-config.ts
@@ -1,5 +1,5 @@
 import type { AdminConsoleData, LogtoConfig, LogtoConfigKey } from '@logto/schemas';
-import { AdminConsoleConfigKey, LogtoConfigs } from '@logto/schemas';
+import { LogtoTenantConfigKey, LogtoConfigs } from '@logto/schemas';
 import { convertToIdentifiers } from '@logto/shared';
 import type { CommonQueryMethods } from 'slonik';
 import { sql } from 'slonik';
@@ -10,14 +10,14 @@ export const createLogtoConfigQueries = (pool: CommonQueryMethods) => {
   const getAdminConsoleConfig = async () =>
     pool.one<Record<string, unknown>>(sql`
       select ${fields.value} from ${table}
-      where ${fields.key} = ${AdminConsoleConfigKey.AdminConsole}
+      where ${fields.key} = ${LogtoTenantConfigKey.AdminConsole}
     `);
 
   const updateAdminConsoleConfig = async (value: Partial<AdminConsoleData>) =>
     pool.one<Record<string, unknown>>(sql`
       update ${table}
       set ${fields.value} = coalesce(${fields.value},'{}'::jsonb) || ${sql.jsonb(value)}
-      where ${fields.key} = ${AdminConsoleConfigKey.AdminConsole}
+      where ${fields.key} = ${LogtoTenantConfigKey.AdminConsole}
       returning ${fields.value}
     `);
 

--- a/packages/core/src/tenants/Tenant.ts
+++ b/packages/core/src/tenants/Tenant.ts
@@ -131,7 +131,7 @@ export default class Tenant implements TenantContext {
     }
 
     // Mount UI
-    app.use(compose([koaSpaSessionGuard(provider), koaSpaProxy(mountedApps)]));
+    app.use(compose([koaSpaSessionGuard(provider, queries), koaSpaProxy(mountedApps)]));
 
     this.app = app;
     this.provider = provider;

--- a/packages/schemas/src/seeds/logto-config.ts
+++ b/packages/schemas/src/seeds/logto-config.ts
@@ -1,18 +1,18 @@
 import { CreateLogtoConfig } from '../db-entries/index.js';
 import { AppearanceMode } from '../foundations/index.js';
 import type { AdminConsoleData } from '../types/index.js';
-import { AdminConsoleConfigKey } from '../types/index.js';
+import { LogtoTenantConfigKey } from '../types/index.js';
 
 export const createDefaultAdminConsoleConfig = (
   forTenantId: string
 ): Readonly<{
   tenantId: string;
-  key: AdminConsoleConfigKey;
+  key: LogtoTenantConfigKey;
   value: AdminConsoleData;
 }> =>
   Object.freeze({
     tenantId: forTenantId,
-    key: AdminConsoleConfigKey.AdminConsole,
+    key: LogtoTenantConfigKey.AdminConsole,
     value: {
       language: 'en',
       appearanceMode: AppearanceMode.SyncWithSystem,

--- a/packages/schemas/src/types/logto-config.ts
+++ b/packages/schemas/src/types/logto-config.ts
@@ -1,7 +1,7 @@
 import type { ZodType } from 'zod';
 import { z } from 'zod';
 
-// Logto OIDC config
+/* --- Logto OIDC configs --- */
 export enum LogtoOidcConfigKey {
   PrivateKeys = 'oidc.privateKeys',
   CookieKeys = 'oidc.cookieKeys',
@@ -19,7 +19,7 @@ export const logtoOidcConfigGuard: Readonly<{
   [LogtoOidcConfigKey.CookieKeys]: z.string().array(),
 });
 
-// Admin console config
+/* --- Logto tenant configs --- */
 export const adminConsoleDataGuard = z.object({
   // Get started challenges
   livePreviewChecked: z.boolean(),
@@ -33,30 +33,34 @@ export const adminConsoleDataGuard = z.object({
 
 export type AdminConsoleData = z.infer<typeof adminConsoleDataGuard>;
 
-export enum AdminConsoleConfigKey {
+export enum LogtoTenantConfigKey {
   AdminConsole = 'adminConsole',
+  /** The URL to redirect when session not found in Sign-in Experience. */
+  SessionNotFoundRedirectUrl = 'sessionNotFoundRedirectUrl',
 }
-export type AdminConsoleConfigType = {
-  [AdminConsoleConfigKey.AdminConsole]: AdminConsoleData;
+export type LogtoTenantConfigType = {
+  [LogtoTenantConfigKey.AdminConsole]: AdminConsoleData;
+  [LogtoTenantConfigKey.SessionNotFoundRedirectUrl]: { url: string };
 };
 
-export const adminConsoleConfigGuard: Readonly<{
-  [key in AdminConsoleConfigKey]: ZodType<AdminConsoleConfigType[key]>;
+export const logtoTenantConfigGuard: Readonly<{
+  [key in LogtoTenantConfigKey]: ZodType<LogtoTenantConfigType[key]>;
 }> = Object.freeze({
-  [AdminConsoleConfigKey.AdminConsole]: adminConsoleDataGuard,
+  [LogtoTenantConfigKey.AdminConsole]: adminConsoleDataGuard,
+  [LogtoTenantConfigKey.SessionNotFoundRedirectUrl]: z.object({ url: z.string() }),
 });
 
-// Summary
-export type LogtoConfigKey = LogtoOidcConfigKey | AdminConsoleConfigKey;
-export type LogtoConfigType = LogtoOidcConfigType | AdminConsoleConfigType;
-export type LogtoConfigGuard = typeof logtoOidcConfigGuard & typeof adminConsoleConfigGuard;
+/* --- Summary --- */
+export type LogtoConfigKey = LogtoOidcConfigKey | LogtoTenantConfigKey;
+export type LogtoConfigType = LogtoOidcConfigType | LogtoTenantConfigType;
+export type LogtoConfigGuard = typeof logtoOidcConfigGuard & typeof logtoTenantConfigGuard;
 
 export const logtoConfigKeys: readonly LogtoConfigKey[] = Object.freeze([
   ...Object.values(LogtoOidcConfigKey),
-  ...Object.values(AdminConsoleConfigKey),
+  ...Object.values(LogtoTenantConfigKey),
 ]);
 
 export const logtoConfigGuards: LogtoConfigGuard = Object.freeze({
   ...logtoOidcConfigGuard,
-  ...adminConsoleConfigGuard,
+  ...logtoTenantConfigGuard,
 });


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- user can use this optional config to designate the URL to redirect if session not found in Sign-in Experience
- guard root path as well since admin tenant is separated from user tenant

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
local tested, Logto redirects as expected.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changset-staged`
- [x] unit tests
- [ ] integration tests (unit tests work pretty good in this scenario)
- [ ] docs (assume this is an internal feature for now)
