### PR TITLE
refactor(core): optimize tenant disposal

### DIFF
--- a/packages/core/src/env-set/index.ts
+++ b/packages/core/src/env-set/index.ts
@@ -52,10 +52,6 @@ export class EnvSet {
     return this.#pool;
   }
 
-  get poolSafe() {
-    return this.#pool;
-  }
-
   get oidc() {
     if (!this.#oidc) {
       return throwNotLoadedError();

--- a/packages/core/src/tenants/Tenant.ts
+++ b/packages/core/src/tenants/Tenant.ts
@@ -34,6 +34,9 @@ export default class Tenant implements TenantContext {
     return new Tenant(envSet, id);
   }
 
+  #requestCount = 0;
+  #onRequestEmpty?: () => Promise<void>;
+
   public readonly provider: Provider;
   public readonly queries: Queries;
   public readonly libraries: Libraries;
@@ -129,5 +132,48 @@ export default class Tenant implements TenantContext {
 
     this.app = app;
     this.provider = provider;
+  }
+
+  public requestStart() {
+    this.#requestCount += 1;
+  }
+
+  public requestEnd() {
+    if (this.#requestCount > 0) {
+      this.#requestCount -= 1;
+
+      if (this.#requestCount === 0) {
+        void this.#onRequestEmpty?.();
+      }
+    }
+  }
+
+  /**
+   * Try to dispose the tenant resources. If there are any pending requests, this function will wait for them to end with 5s timeout.
+   *
+   * Currently this function only ends the database pool.
+   *
+   * @returns Resolves `true` for a normal disposal and `'timeout'` for a timeout.
+   */
+  public async dispose() {
+    if (this.#requestCount <= 0) {
+      await this.envSet.end();
+
+      return true;
+    }
+
+    return new Promise<true | 'timeout'>((resolve) => {
+      const timeout = setTimeout(async () => {
+        this.#onRequestEmpty = undefined;
+        await this.envSet.end();
+        resolve('timeout');
+      }, 5000);
+
+      this.#onRequestEmpty = async () => {
+        clearTimeout(timeout);
+        await this.envSet.end();
+        resolve(true);
+      };
+    });
   }
 }

--- a/packages/core/src/tenants/index.ts
+++ b/packages/core/src/tenants/index.ts
@@ -5,8 +5,8 @@ import Tenant from './Tenant.js';
 export class TenantPool {
   protected cache = new LRUCache<string, Tenant>({
     max: 100,
-    dispose: async (tenant) => {
-      await tenant.envSet.end();
+    dispose: (tenant) => {
+      void tenant.dispose();
     },
   });
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

fix an issue that database pool ends early before all requests are finished when calling `.dispose()` in LRU cache

- add `dispose()` in Tenant for gracefully dispose tenant resources
- `dispose()` will end database pool when all requests are finished, or timeout
- store tenant middleware function for better performance

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
tested on cloud, a lot of requests, no 5xx failure

<img width="410" alt="image" src="https://user-images.githubusercontent.com/14722250/224681061-60b08b2b-eb6a-4da9-8f6e-54b7c8c20802.png">

<img width="421" alt="image" src="https://user-images.githubusercontent.com/14722250/224681129-6105336f-8286-47e9-86cf-c6ac197194a1.png">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
