### PR TITLE
refactor(console): hide error toast in language modal

### DIFF
--- a/packages/console/src/hooks/use-api.ts
+++ b/packages/console/src/hooks/use-api.ts
@@ -13,13 +13,8 @@ import { TenantsContext } from '@/contexts/TenantsProvider';
 import { useConfirmModal } from './use-confirm-modal';
 
 export class RequestError extends Error {
-  status: number;
-  body?: RequestErrorBody;
-
-  constructor(status: number, body: RequestErrorBody) {
+  constructor(public readonly status: number, public readonly body?: RequestErrorBody) {
     super('Request error occurred.');
-    this.status = status;
-    this.body = body;
   }
 }
 

--- a/packages/console/src/hooks/use-swr-fetcher.ts
+++ b/packages/console/src/hooks/use-swr-fetcher.ts
@@ -1,4 +1,3 @@
-import type { RequestErrorBody } from '@logto/schemas';
 import { HTTPError } from 'ky';
 import type { KyInstance } from 'ky/distribution/types/ky';
 import { useCallback } from 'react';
@@ -41,8 +40,9 @@ const useSwrFetcher: useSwrFetcherHook = <T>(api: KyInstance) => {
       } catch (error: unknown) {
         if (error instanceof HTTPError) {
           const { response } = error;
-          const metadata = await response.json<RequestErrorBody>();
-          throw new RequestError(response.status, metadata);
+          // See https://stackoverflow.com/questions/53511974/javascript-fetch-failed-to-execute-json-on-response-body-stream-is-locked
+          // for why `.clone()` is needed
+          throw new RequestError(response.status, await response.clone().json());
         }
         throw error;
       }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
don't show toast for errors when fetching custom phrases since it doesn't matter for updating

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
local tested, no toast when response with 404

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
