### PR TITLE
chore: send testing sms/email using Generic template type

### DIFF
--- a/packages/core/src/routes/connector.test.ts
+++ b/packages/core/src/routes/connector.test.ts
@@ -449,7 +449,7 @@ describe('connector route', () => {
       expect(sendMessage).toHaveBeenCalledWith(
         {
           to: '12345678901',
-          type: VerificationCodeType.Test,
+          type: VerificationCodeType.Generic,
           payload: {
             code: '000000',
           },
@@ -477,7 +477,7 @@ describe('connector route', () => {
       expect(sendMessage).toHaveBeenCalledWith(
         {
           to: 'test@email.com',
-          type: VerificationCodeType.Test,
+          type: VerificationCodeType.Generic,
           payload: {
             code: '000000',
           },

--- a/packages/core/src/routes/connector.ts
+++ b/packages/core/src/routes/connector.ts
@@ -309,7 +309,7 @@ export default function connectorRoutes<T extends AuthedRouter>(
       await sendMessage(
         {
           to: subject,
-          type: VerificationCodeType.Test,
+          type: VerificationCodeType.Generic,
           payload: {
             code: '000000',
           },

--- a/packages/toolkit/connector-kit/src/types.ts
+++ b/packages/toolkit/connector-kit/src/types.ts
@@ -75,6 +75,7 @@ export enum VerificationCodeType {
   /** @deprecated */
   Continue = 'Continue',
   Generic = 'Generic',
+  /** @deprecated Use `Generic` type template for sending test sms/email use case */
   Test = 'Test',
 }
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Send testing sms/email using Generic template type.
After this change, four types of templates (Register, SignIn, ForgotPassword and Generic) are mandated.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
ITs and UTs.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
