### PR TITLE
feat(core,toolkit): restrict scope of connector storage operation

### DIFF
--- a/.changeset-staged/eight-impalas-return.md
+++ b/.changeset-staged/eight-impalas-return.md
@@ -3,4 +3,4 @@
 "@logto/connector-kit": minor
 ---
 
-The `getUserInfo` method of connectors has been passed the `storage.get` and `storage.set` methods so that the connector instance can store and retrieve access token related information in the database.
+The `getUserInfo` method of connectors has been passed to the `storage.get` and `storage.set` methods so that the connector instance can store and retrieve access token related information in the database.

--- a/.changeset-staged/eight-impalas-return.md
+++ b/.changeset-staged/eight-impalas-return.md
@@ -1,0 +1,6 @@
+---
+"@logto/core": minor
+"@logto/connector-kit": minor
+---
+
+The `getUserInfo` method of connectors has been passed the `storage.get` and `storage.set` methods so that the connector instance can store and retrieve access token related information in the database.

--- a/packages/core/src/queries/connector.ts
+++ b/packages/core/src/queries/connector.ts
@@ -1,4 +1,4 @@
-import type { Connector } from '@logto/schemas';
+import type { Connector, Storage } from '@logto/schemas';
 import { Connectors } from '@logto/schemas';
 import { manyRows, convertToIdentifiers } from '@logto/shared';
 import type { CommonQueryMethods } from 'slonik';
@@ -32,17 +32,17 @@ export const createConnectorQueries = (pool: CommonQueryMethods) => {
       where ${fields.connectorId}=${connectorId}
     `);
 
-  const setValueByIdAndKey = async (id: string, key: string, value: unknown): Promise<void> => {
+  const setValueById = async (id: string, value: Storage): Promise<void> => {
     await updateConnector({
-      set: { storage: { [key]: value } },
+      set: { storage: value },
       where: { id },
       jsonbMode: 'merge',
     });
   };
 
-  const getValueByIdAndKey = async <T = unknown>(id: string, key: string): Promise<T> => {
-    const { value } = await pool.one<{ value: T }>(sql`
-      select ${fields.storage}->${key} as value
+  const getValueById = async (id: string): Promise<Storage> => {
+    const { value } = await pool.one<{ value: Storage }>(sql`
+      select ${fields.storage} as value
       from ${table}
       where ${fields.id} = ${id};
     `);
@@ -80,8 +80,8 @@ export const createConnectorQueries = (pool: CommonQueryMethods) => {
     findAllConnectors,
     findConnectorById,
     countConnectorByConnectorId,
-    setValueByIdAndKey,
-    getValueByIdAndKey,
+    setValueById,
+    getValueById,
     deleteConnectorById,
     deleteConnectorByIds,
     insertConnector,

--- a/packages/core/src/routes/interaction/utils/social-verification.ts
+++ b/packages/core/src/routes/interaction/utils/social-verification.ts
@@ -1,6 +1,6 @@
 import type { ConnectorSession, SocialUserInfo } from '@logto/connector-kit';
 import { connectorSessionGuard } from '@logto/connector-kit';
-import type { SocialConnectorPayload } from '@logto/schemas';
+import type { Storage, SocialConnectorPayload } from '@logto/schemas';
 import { ConnectorType } from '@logto/schemas';
 import type { Context } from 'koa';
 import type Provider from 'oidc-provider';
@@ -62,7 +62,7 @@ export const verifySocialIdentity = async (
     socials: { getUserInfoByAuthCode },
   } = libraries;
   const {
-    connectors: { setValueByIdAndKey, getValueByIdAndKey },
+    connectors: { setValueById, getValueById },
   } = queries;
 
   const log = ctx.createLog('Interaction.SignIn.Identifier.Social.Submit');
@@ -73,8 +73,8 @@ export const verifySocialIdentity = async (
     connectorData,
     async () => getConnectorSessionResult(ctx, provider),
     {
-      set: async (key: string, value: unknown) => setValueByIdAndKey(connectorId, key, value),
-      get: async (key: string) => getValueByIdAndKey(connectorId, key),
+      set: async (value: Storage) => setValueById(connectorId, value),
+      get: async () => getValueById(connectorId),
     }
   );
 

--- a/packages/toolkit/connector-kit/src/types.ts
+++ b/packages/toolkit/connector-kit/src/types.ts
@@ -1,7 +1,7 @@
 import type { LanguageTag } from '@logto/language-kit';
 import { isLanguageTag } from '@logto/language-kit';
 import type { ZodType } from 'zod';
-import { z, unknown } from 'zod';
+import { z } from 'zod';
 
 // MARK: Foundation
 export enum ConnectorType {
@@ -183,13 +183,20 @@ export type GetSession = () => Promise<ConnectorSession>;
 
 export type SetSession = (storage: ConnectorSession) => Promise<void>;
 
-export const storageGuard = z.record(unknown());
+export const storageGuard = z
+  .object({
+    accessToken: z.string(),
+    refreshToken: z.string(),
+    expiresIn: z.number(),
+    tokenType: z.string(),
+  })
+  .partial();
 
 export type Storage = z.infer<typeof storageGuard>;
 
-export type GetStorageValue = (key: string) => Promise<unknown>;
+export type GetStorageValue = () => Promise<Storage>;
 
-export type SetStorageValue = (key: string, value: unknown) => Promise<void>;
+export type SetStorageValue = (value: Storage) => Promise<void>;
 
 export type BaseConnector<Type extends ConnectorType> = {
   type: Type;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
restrict the scope of connector storage: only store access token related information in `storage` column.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [ ] This PR is not applicable for the checklist
