### PR TITLE
refactor: rename `appearanceMode` to `themeAdaptionStrategy`

### DIFF
--- a/packages/console/src/consts/index.ts
+++ b/packages/console/src/consts/index.ts
@@ -6,7 +6,7 @@ export * from './tenants';
 export * from './page-tabs';
 export * from './external-links';
 
-export const themeStorageKey = 'logto:admin_console:theme';
+export const themeAdaptionStrategyStorageKey = 'logto:admin_console:theme_adaption_strategy';
 export const profileSocialLinkingKeyPrefix = 'logto:admin_console:linking_social_connector';
 export const requestTimeout = 20_000;
 export const defaultPageSize = 20;

--- a/packages/console/src/containers/AppContent/components/UserInfo/index.tsx
+++ b/packages/console/src/containers/AppContent/components/UserInfo/index.tsx
@@ -1,6 +1,6 @@
 import { builtInLanguageOptions as consoleBuiltInLanguageOptions } from '@logto/phrases';
 import { useLogto } from '@logto/react';
-import { AppearanceMode } from '@logto/schemas';
+import { ThemeAdaptionStrategy } from '@logto/schemas';
 import classNames from 'classnames';
 import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -35,7 +35,7 @@ const UserInfo = () => {
 
   const [isLoading, setIsLoading] = useState(false);
   const {
-    data: { language, appearanceMode },
+    data: { language, themeAdaptionStrategy },
     update,
   } = useUserPreferences();
 
@@ -98,21 +98,21 @@ const UserInfo = () => {
           title="menu.appearance.label"
           options={[
             {
-              value: AppearanceMode.SyncWithSystem,
+              value: ThemeAdaptionStrategy.FollowSystem,
               title: t('menu.appearance.system'),
             },
             {
-              value: AppearanceMode.LightMode,
+              value: ThemeAdaptionStrategy.LightOnly,
               title: t('menu.appearance.light'),
             },
             {
-              value: AppearanceMode.DarkMode,
+              value: ThemeAdaptionStrategy.DarkOnly,
               title: t('menu.appearance.dark'),
             },
           ]}
-          selectedOption={appearanceMode}
-          onItemClick={(appearanceMode) => {
-            void update({ appearanceMode });
+          selectedOption={themeAdaptionStrategy}
+          onItemClick={(themeAdaptionStrategy) => {
+            void update({ themeAdaptionStrategy });
             setShowDropdown(false);
           }}
         />

--- a/packages/console/src/contexts/AppThemeProvider/index.tsx
+++ b/packages/console/src/contexts/AppThemeProvider/index.tsx
@@ -1,4 +1,4 @@
-import { AppearanceMode } from '@logto/schemas';
+import { ThemeAdaptionStrategy } from '@logto/schemas';
 import { conditionalString } from '@silverhand/essentials';
 import type { ReactNode } from 'react';
 import { useEffect, useMemo, useState, createContext } from 'react';
@@ -29,7 +29,7 @@ export const AppThemeProvider = ({ fixedTheme, children }: Props) => {
   const [theme, setTheme] = useState<Theme>(Theme.LightMode);
 
   const {
-    data: { appearanceMode },
+    data: { themeAdaptionStrategy },
   } = useUserPreferences();
 
   useEffect(() => {
@@ -39,8 +39,10 @@ export const AppThemeProvider = ({ fixedTheme, children }: Props) => {
       return;
     }
 
-    if (appearanceMode !== AppearanceMode.SyncWithSystem) {
-      setTheme(appearanceMode === AppearanceMode.LightMode ? Theme.LightMode : Theme.DarkMode);
+    if (themeAdaptionStrategy !== ThemeAdaptionStrategy.FollowSystem) {
+      setTheme(
+        themeAdaptionStrategy === ThemeAdaptionStrategy.LightOnly ? Theme.LightMode : Theme.DarkMode
+      );
 
       return;
     }
@@ -56,7 +58,7 @@ export const AppThemeProvider = ({ fixedTheme, children }: Props) => {
     return () => {
       darkThemeWatchMedia.removeEventListener('change', changeTheme);
     };
-  }, [appearanceMode, fixedTheme]);
+  }, [themeAdaptionStrategy, fixedTheme]);
 
   // Set Theme Mode
   useEffect(() => {

--- a/packages/console/src/hooks/use-user-preferences.ts
+++ b/packages/console/src/hooks/use-user-preferences.ts
@@ -1,10 +1,10 @@
 import { builtInLanguages as builtInConsoleLanguages } from '@logto/phrases';
-import { AppearanceMode } from '@logto/schemas';
+import { ThemeAdaptionStrategy } from '@logto/schemas';
 import type { Nullable, Optional } from '@silverhand/essentials';
 import { useEffect, useMemo } from 'react';
 import { z } from 'zod';
 
-import { themeStorageKey } from '@/consts';
+import { themeAdaptionStrategyStorageKey } from '@/consts';
 
 import useMeCustomData from './use-me-custom-data';
 
@@ -12,7 +12,7 @@ const adminConsolePreferencesKey = 'adminConsolePreferences';
 
 const userPreferencesGuard = z.object({
   language: z.enum(builtInConsoleLanguages).optional(),
-  appearanceMode: z.nativeEnum(AppearanceMode),
+  themeAdaptionStrategy: z.nativeEnum(ThemeAdaptionStrategy),
   experienceNoticeConfirmed: z.boolean().optional(),
   getStartedHidden: z.boolean().optional(),
   connectorSieNoticeConfirmed: z.boolean().optional(),
@@ -34,11 +34,11 @@ const useUserPreferences = () => {
     return parsed.success
       ? parsed.data[adminConsolePreferencesKey]
       : {
-          appearanceMode:
+          themeAdaptionStrategy:
             getEnumFromArray(
-              Object.values(AppearanceMode),
-              localStorage.getItem(themeStorageKey)
-            ) ?? AppearanceMode.SyncWithSystem,
+              Object.values(ThemeAdaptionStrategy),
+              localStorage.getItem(themeAdaptionStrategyStorageKey)
+            ) ?? ThemeAdaptionStrategy.FollowSystem,
         };
   }, [data]);
 
@@ -52,8 +52,8 @@ const useUserPreferences = () => {
   };
 
   useEffect(() => {
-    localStorage.setItem(themeStorageKey, userPreferences.appearanceMode);
-  }, [userPreferences.appearanceMode]);
+    localStorage.setItem(themeAdaptionStrategyStorageKey, userPreferences.themeAdaptionStrategy);
+  }, [userPreferences.themeAdaptionStrategy]);
 
   return {
     isLoading,

--- a/packages/console/src/utils/theme.ts
+++ b/packages/console/src/utils/theme.ts
@@ -1,13 +1,15 @@
-import { AppearanceMode } from '@logto/schemas';
+import { ThemeAdaptionStrategy } from '@logto/schemas';
 import { trySafe } from '@silverhand/essentials';
 import { z } from 'zod';
 
-import { themeStorageKey } from '@/consts';
+import { themeAdaptionStrategyStorageKey } from '@/consts';
 import { Theme } from '@/types/theme';
 
-export const getTheme = (appearanceMode: AppearanceMode): Theme => {
-  if (appearanceMode !== AppearanceMode.SyncWithSystem) {
-    return appearanceMode === AppearanceMode.LightMode ? Theme.LightMode : Theme.DarkMode;
+export const getTheme = (themeAdaptionStrategy: ThemeAdaptionStrategy): Theme => {
+  if (themeAdaptionStrategy !== ThemeAdaptionStrategy.FollowSystem) {
+    return themeAdaptionStrategy === ThemeAdaptionStrategy.LightOnly
+      ? Theme.LightMode
+      : Theme.DarkMode;
   }
 
   const darkThemeWatchMedia = window.matchMedia('(prefers-color-scheme: dark)');
@@ -18,6 +20,9 @@ export const getTheme = (appearanceMode: AppearanceMode): Theme => {
 
 export const getThemeFromLocalStorage = () =>
   getTheme(
-    trySafe(() => z.nativeEnum(AppearanceMode).parse(localStorage.getItem(themeStorageKey))) ??
-      AppearanceMode.SyncWithSystem
+    trySafe(() =>
+      z
+        .nativeEnum(ThemeAdaptionStrategy)
+        .parse(localStorage.getItem(themeAdaptionStrategyStorageKey))
+    ) ?? ThemeAdaptionStrategy.FollowSystem
   );

--- a/packages/schemas/alterations/next-1678803775-remove-deprecated-logto-config-item.ts
+++ b/packages/schemas/alterations/next-1678803775-remove-deprecated-logto-config-item.ts
@@ -1,0 +1,84 @@
+import type { DatabaseTransactionConnection } from 'slonik';
+import { sql } from 'slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const adminConsoleConfigKey = 'adminConsole';
+const defaultAppearanceMode = 'system';
+const defaultLanguage = 'en';
+
+type OldAdminConsoleData = {
+  language: string;
+  appearanceMode: string;
+} & Record<string, unknown>;
+
+type OldLogtoAdminConsoleConfig = {
+  tenantId: string;
+  value: OldAdminConsoleData;
+};
+
+type NewAdminConsoleData = Omit<OldAdminConsoleData, 'language' | 'appearanceMode'>;
+
+type NewLogtoAdminConsoleConfig = {
+  tenantId: string;
+  value: NewAdminConsoleData;
+};
+
+const alterAdminConsoleData = async (
+  logtoConfig: OldLogtoAdminConsoleConfig,
+  pool: DatabaseTransactionConnection
+) => {
+  const { tenantId, value: oldAdminConsoleData } = logtoConfig;
+
+  const {
+    language, // Extract to remove from config
+    appearanceMode, // Extract to remove from config
+    ...others
+  } = oldAdminConsoleData;
+
+  const newAdminConsoleData: NewAdminConsoleData = {
+    ...others,
+  };
+
+  await pool.query(
+    sql`update logto_configs set value = ${JSON.stringify(
+      newAdminConsoleData
+    )} where tenant_id = ${tenantId} and key = ${adminConsoleConfigKey}`
+  );
+};
+
+const rollbackAdminConsoleData = async (
+  logtoConfig: NewLogtoAdminConsoleConfig,
+  pool: DatabaseTransactionConnection
+) => {
+  const { tenantId, value: newAdminConsoleData } = logtoConfig;
+
+  const oldAdminConsoleData: OldAdminConsoleData = {
+    ...newAdminConsoleData,
+    language: defaultLanguage,
+    appearanceMode: defaultAppearanceMode,
+  };
+
+  await pool.query(
+    sql`update logto_configs set value = ${JSON.stringify(
+      oldAdminConsoleData
+    )} where tenant_id = ${tenantId} and key = ${adminConsoleConfigKey}`
+  );
+};
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    const rows = await pool.many<OldLogtoAdminConsoleConfig>(
+      sql`select * from logto_configs where key = ${adminConsoleConfigKey}`
+    );
+    await Promise.all(rows.map(async (row) => alterAdminConsoleData(row, pool)));
+  },
+  down: async (pool) => {
+    const rows = await pool.many<NewLogtoAdminConsoleConfig>(
+      sql`select * from logto_configs where key = ${adminConsoleConfigKey}`
+    );
+    await Promise.all(rows.map(async (row) => rollbackAdminConsoleData(row, pool)));
+  },
+};
+
+export default alteration;

--- a/packages/schemas/alterations/next-1678829762-rename-appearance-mode.ts
+++ b/packages/schemas/alterations/next-1678829762-rename-appearance-mode.ts
@@ -103,7 +103,7 @@ const rollbackAdminConsoleData = async (
   await pool.query(
     sql`update users set custom_data = ${JSON.stringify(
       oldCustomData
-    )} where where tenant_id = ${tenantId} and id = ${id}`
+    )} where tenant_id = ${tenantId} and id = ${id}`
   );
 };
 

--- a/packages/schemas/alterations/next-1678829762-rename-appearance-mode.ts
+++ b/packages/schemas/alterations/next-1678829762-rename-appearance-mode.ts
@@ -1,0 +1,121 @@
+import type { DatabaseTransactionConnection } from 'slonik';
+import { sql } from 'slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+enum AppearanceMode {
+  SyncWithSystem = 'system',
+  LightMode = 'light',
+  DarkMode = 'dark',
+}
+
+enum ThemeAdaptionStrategy {
+  FollowSystem = 'followSystem',
+  LightOnly = 'lightOnly',
+  DarkOnly = 'darkOnly',
+}
+
+const appearanceModeToThemeAdaptionStrategyMappings: Record<AppearanceMode, ThemeAdaptionStrategy> =
+  {
+    [AppearanceMode.SyncWithSystem]: ThemeAdaptionStrategy.FollowSystem,
+    [AppearanceMode.LightMode]: ThemeAdaptionStrategy.LightOnly,
+    [AppearanceMode.DarkMode]: ThemeAdaptionStrategy.DarkOnly,
+  } as const;
+
+const themeAdaptionStrategyToAppearanceModeMappings: Record<ThemeAdaptionStrategy, AppearanceMode> =
+  {
+    [ThemeAdaptionStrategy.FollowSystem]: AppearanceMode.SyncWithSystem,
+    [ThemeAdaptionStrategy.LightOnly]: AppearanceMode.LightMode,
+    [ThemeAdaptionStrategy.DarkOnly]: AppearanceMode.DarkMode,
+  } as const;
+
+type OldConsolePreferences = {
+  appearanceMode: AppearanceMode;
+} & Record<string, unknown>;
+
+type OldUserCustomData = {
+  adminConsolePreferences: OldConsolePreferences;
+} & Record<string, unknown>;
+
+type NewConsolePreferences = {
+  themeAdaptionStrategy: ThemeAdaptionStrategy;
+} & Record<string, unknown>;
+
+type NewUserCustomData = {
+  adminConsolePreferences: NewConsolePreferences;
+} & Record<string, unknown>;
+
+type OldUserData = {
+  tenantId: string;
+  id: string;
+  customData: OldUserCustomData;
+};
+
+type NewUserData = {
+  tenantId: string;
+  id: string;
+  customData: NewUserCustomData;
+};
+
+const alterAdminConsoleData = async (
+  userData: OldUserData,
+  pool: DatabaseTransactionConnection
+) => {
+  const { tenantId, id, customData: oldCustomData } = userData;
+
+  const { adminConsolePreferences: oldAdminConsolePreferences, ...others } = oldCustomData;
+
+  const { appearanceMode, ...othersPreferences } = oldAdminConsolePreferences;
+
+  const newUserCustomData: NewUserCustomData = {
+    ...others,
+    adminConsolePreferences: {
+      ...othersPreferences,
+      themeAdaptionStrategy: appearanceModeToThemeAdaptionStrategyMappings[appearanceMode],
+    },
+  };
+
+  await pool.query(
+    sql`update users set custom_data = ${JSON.stringify(
+      newUserCustomData
+    )} where tenant_id = ${tenantId} and id = ${id}`
+  );
+};
+
+const rollbackAdminConsoleData = async (
+  userData: NewUserData,
+  pool: DatabaseTransactionConnection
+) => {
+  const { tenantId, id, customData: newCustomData } = userData;
+
+  const { adminConsolePreferences: newAdminConsolePreferences, ...others } = newCustomData;
+
+  const { themeAdaptionStrategy, ...othersPreferences } = newAdminConsolePreferences;
+
+  const oldCustomData: OldUserCustomData = {
+    ...others,
+    adminConsolePreferences: {
+      ...othersPreferences,
+      appearanceMode: themeAdaptionStrategyToAppearanceModeMappings[themeAdaptionStrategy],
+    },
+  };
+
+  await pool.query(
+    sql`update users set custom_data = ${JSON.stringify(
+      oldCustomData
+    )} where where tenant_id = ${tenantId} and id = ${id}`
+  );
+};
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    const rows = await pool.many<OldUserData>(sql`select tenant_id, id, custom_data from users`);
+    await Promise.all(rows.map(async (row) => alterAdminConsoleData(row, pool)));
+  },
+  down: async (pool) => {
+    const rows = await pool.many<NewUserData>(sql`select tenant_id, id, custom_data from users`);
+    await Promise.all(rows.map(async (row) => rollbackAdminConsoleData(row, pool)));
+  },
+};
+
+export default alteration;

--- a/packages/schemas/alterations/next-1678829762-rename-appearance-mode.ts
+++ b/packages/schemas/alterations/next-1678829762-rename-appearance-mode.ts
@@ -109,10 +109,26 @@ const rollbackAdminConsoleData = async (
 
 const alteration: AlterationScript = {
   up: async (pool) => {
+    const { count: userCount } = await pool.one<{ count: number }>(sql`select count(*) from users`);
+
+    if (userCount <= 0) {
+      console.log('No users found, skipping alteration');
+
+      return;
+    }
+
     const rows = await pool.many<OldUserData>(sql`select tenant_id, id, custom_data from users`);
     await Promise.all(rows.map(async (row) => alterAdminConsoleData(row, pool)));
   },
   down: async (pool) => {
+    const { count: userCount } = await pool.one<{ count: number }>(sql`select count(*) from users`);
+
+    if (userCount <= 0) {
+      console.log('No users found, skipping alteration');
+
+      return;
+    }
+
     const rows = await pool.many<NewUserData>(sql`select tenant_id, id, custom_data from users`);
     await Promise.all(rows.map(async (row) => rollbackAdminConsoleData(row, pool)));
   },

--- a/packages/schemas/src/foundations/jsonb-types.ts
+++ b/packages/schemas/src/foundations/jsonb-types.ts
@@ -153,10 +153,10 @@ export type CustomContent = z.infer<typeof customContentGuard>;
  * Settings
  */
 
-export enum AppearanceMode {
-  SyncWithSystem = 'system',
-  LightMode = 'light',
-  DarkMode = 'dark',
+export enum ThemeAdaptionStrategy {
+  FollowSystem = 'followSystem',
+  LightOnly = 'lightOnly',
+  DarkOnly = 'darkOnly',
 }
 
 /* === Phrases === */

--- a/packages/schemas/src/seeds/logto-config.ts
+++ b/packages/schemas/src/seeds/logto-config.ts
@@ -1,7 +1,5 @@
 import { CreateLogtoConfig } from '../db-entries/index.js';
-import { AppearanceMode } from '../foundations/index.js';
-import type { AdminConsoleData } from '../types/index.js';
-import { LogtoTenantConfigKey } from '../types/index.js';
+import { AdminConsoleData, LogtoTenantConfigKey } from '../types/index.js';
 
 export const createDefaultAdminConsoleConfig = (
   forTenantId: string
@@ -14,8 +12,6 @@ export const createDefaultAdminConsoleConfig = (
     tenantId: forTenantId,
     key: LogtoTenantConfigKey.AdminConsole,
     value: {
-      language: 'en',
-      appearanceMode: AppearanceMode.SyncWithSystem,
       livePreviewChecked: false,
       applicationCreated: false,
       signInExperienceCustomized: false,
@@ -23,5 +19,5 @@ export const createDefaultAdminConsoleConfig = (
       selfHostingChecked: false,
       communityChecked: false,
       m2mApplicationCreated: false,
-    },
+    } satisfies AdminConsoleData,
   } satisfies CreateLogtoConfig);

--- a/packages/ui/src/types/index.ts
+++ b/packages/ui/src/types/index.ts
@@ -1,9 +1,4 @@
-import type {
-  SignInExperience,
-  ConnectorMetadata,
-  AppearanceMode,
-  SignInIdentifier,
-} from '@logto/schemas';
+import type { SignInExperience, ConnectorMetadata, SignInIdentifier } from '@logto/schemas';
 
 export enum UserFlow {
   signIn = 'sign-in',
@@ -42,7 +37,7 @@ export enum ConfirmModalMessage {
 export type PreviewConfig = {
   signInExperience: SignInExperienceResponse;
   language: string;
-  mode: AppearanceMode.LightMode | AppearanceMode.DarkMode;
+  mode: Theme;
   platform: Platform;
   isNative: boolean;
 };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- Rename `appearanceMode` to `ThemeAdaptionStrategy` for better differentiation between the theme adaptation strategy and the theme itself, thus avoiding confusion between the two.
- Remove `language` and `appearanceMode` from AdminConsoleData in the Logto Config because they have been deprecated in previous iterations.

### Todo
- Enable `AppThemeProvider` to retrieve the user's previous `ThemeAdaptionStrategy` settings from local storage and support theme adaption for the cloud app (https://github.com/logto-io/logto/pull/3417)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Test alteration up & down processing locally since there is no users in the CI db test env
- [x] Change theme in the admin console
- [x] Change theme in the OS settings
- [x] Theme theme adaption strategy is successfully stored in the local storage.
- [x] Change theme in the sie preview 

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
