### PR TITLE
fix(console): hide the demo_app phrases in ac

### DIFF
--- a/packages/console/src/pages/SignInExperience/tabs/Others/components/ManageLanguage/LanguageEditor/LanguageDetails.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/Others/components/ManageLanguage/LanguageEditor/LanguageDetails.tsx
@@ -45,7 +45,11 @@ const LanguageDetails = () => {
   const fetcher = useSwrFetcher<CustomPhraseResponse>(fetchApi);
 
   const translationEntries = useMemo(
-    () => Object.entries((isBuiltIn ? resource[selectedLanguage] : en).translation),
+    () =>
+      Object.entries((isBuiltIn ? resource[selectedLanguage] : en).translation).filter(
+        // Filter out the demo app phrases in AC
+        ([groupKey]) => groupKey !== 'demo_app'
+      ),
     [isBuiltIn, selectedLanguage]
   );
 


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
hide the demo_app phrases in ac, demo_app phrase are not customizable.

<img width="1024" alt="image" src="https://user-images.githubusercontent.com/36393111/225227761-c146c1c9-b159-4f75-ba61-a7444dda1e57.png">



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
