### PR TITLE
feat(cloud): add demo connector configs on tenant create

### DIFF
--- a/packages/cloud/src/queries/connector.ts
+++ b/packages/cloud/src/queries/connector.ts
@@ -1,7 +1,9 @@
-import type { Connector } from '@logto/schemas';
+import type { Connector, CreateConnector } from '@logto/schemas';
 import type { PostgreSql } from '@withtyped/postgres';
 import { sql } from '@withtyped/postgres';
-import type { Queryable } from '@withtyped/server';
+import type { JsonObject, Queryable } from '@withtyped/server';
+
+import { insertInto } from '#src/utils/query.js';
 
 export type ConnectorsQuery = ReturnType<typeof createConnectorsQuery>;
 
@@ -18,5 +20,10 @@ export const createConnectorsQuery = (client: Queryable<PostgreSql>) => {
     return rows;
   };
 
-  return { findAllConnectors };
+  const insertConnector = async (
+    // TODO @sijie update with-typed "JsonObject" to support "unknown" value
+    connector: Pick<CreateConnector, 'id' | 'tenantId' | 'connectorId'> & { config: JsonObject }
+  ) => client.query(insertInto(connector, 'connectors'));
+
+  return { findAllConnectors, insertConnector };
 };

--- a/packages/cloud/src/queries/service-logs.ts
+++ b/packages/cloud/src/queries/service-logs.ts
@@ -15,7 +15,7 @@ export const createServiceLogsQueries = (client: Queryable<PostgreSql>) => {
     const { rows } = await client.query<{ count: number }>(sql`
       select count(id) as count
       from service_logs
-      where tenantId = ${tenantId}
+      where tenant_id = ${tenantId}
         and type = ${type}
     `);
 

--- a/packages/core/src/routes/connector.ts
+++ b/packages/core/src/routes/connector.ts
@@ -2,7 +2,7 @@ import { buildRawConnector } from '@logto/cli/lib/connector/index.js';
 import { VerificationCodeType, validateConfig } from '@logto/connector-kit';
 import { emailRegEx, phoneRegEx, buildIdGenerator } from '@logto/core-kit';
 import { arbitraryObjectGuard, Connectors, ConnectorType } from '@logto/schemas';
-import { demoConnectorIds } from '@logto/shared';
+import { demoConnectors } from '@logto/shared';
 import cleanDeep from 'clean-deep';
 import { string, object } from 'zod';
 
@@ -72,7 +72,8 @@ export default function connectorRoutes<T extends AuthedRouter>(
     const connectorFactories = await loadConnectorFactories();
     ctx.body = connectorFactories
       .map((connectorFactory) => transpileConnectorFactory(connectorFactory))
-      .filter(({ id }) => !demoConnectorIds.includes(id));
+      // eslint-disable-next-line unicorn/prefer-includes
+      .filter(({ id }) => !Object.values(demoConnectors).some((connectorId) => connectorId === id));
 
     return next();
   });

--- a/packages/shared/src/models/connector.ts
+++ b/packages/shared/src/models/connector.ts
@@ -1,1 +1,4 @@
-export const demoConnectorIds = ['logto-email', 'logto-sms'];
+export const demoConnectors = {
+  sms: 'logto-sms',
+  email: 'logto-email',
+} as const;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
add demo connector configs on tenant create.

notice: there is no alteration script for existing tenant for 2 reasons:

1. Demo connector is only for "new tenant"
2. It is hard to get "endpoints" on current alter process.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested: create a new tenant, and got a demo email connector, send email sucessfully.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
