### PR TITLE
fix(ui): added search + hash string interpolation

### DIFF
--- a/packages/ui/src/hooks/use-social-callback-handler.ts
+++ b/packages/ui/src/hooks/use-social-callback-handler.ts
@@ -8,8 +8,16 @@ const useSocialCallbackHandler = () => {
 
   const socialCallbackHandler = useCallback(
     (connectorId: string) => {
-      // Apple use fragment mode to store auth parameter. Need to support it.
-      const search = window.location.search || '?' + window.location.hash.slice(1);
+      // Get search string to evaluate
+      const searchString = window.location.search;
+
+      // Get hash string to evaluate
+      const hashString = window.location.hash;
+
+      // Define evaluated search string
+      const search = `${searchString || '?'}${
+        searchString && hashString ? '&' : ''
+      }${hashString.slice(1)}`;
 
       // Get native callback link from storage
       const callbackLink = getCallbackLinkFromStorage(connectorId);


### PR DESCRIPTION
Greetings from cheqd,

We're implementing a [Telegram connector](https://github.com/cheqd/community-credentials-auth/tree/develop).

- Basic flow is extracted from [Telegram Login Widget](https://core.telegram.org/widgets/login).
- Data integrity checks are being handled internally.
- Flow returns a hash string, which should be parsed as query param.
  - Combination of ?state=x&tgAuthFlow=y should be parsed out of:
    - window.location.search
    - window.location.hash
    - Implementation should be backwards compatible + interoperable with existing connectors.

PS:
- [x] This PR is not applicable for the checklist