### PR TITLE
fix: the destination of switch to another passwordless connector

### DIFF
--- a/packages/console/src/pages/ConnectorDetails/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/index.tsx
@@ -36,6 +36,7 @@ import ConnectorTabs from './components/ConnectorTabs';
 import ConnectorTypeName from './components/ConnectorTypeName';
 import * as styles from './index.module.scss';
 
+// TODO: refactor path-related operation utils in both Connectors and ConnectorDetails page
 const getConnectorsPathname = (isSocial: boolean) =>
   `/connectors/${isSocial ? ConnectorsTabs.Social : ConnectorsTabs.Passwordless}`;
 
@@ -202,7 +203,7 @@ const ConnectorDetails = () => {
                   setIsSetupOpen(false);
 
                   if (connectorId) {
-                    navigate(`${getConnectorsPathname(isSocial)}/${connectorId}`);
+                    navigate(`${getConnectorsPathname(isSocial)}/guide/${connectorId}`);
                   }
                 }}
               />


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Switch to another passwordless connector should go to the guide page instead of the detailed page (since the connector has not been created, it will throw 404).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
