### PR TITLE
style(ui): move scroll bar outside

### DIFF
--- a/packages/ui/src/components/InputFields/SmartInputField/CountryCodeSelector/CountryCodeDropdown/index.module.scss
+++ b/packages/ui/src/components/InputFields/SmartInputField/CountryCodeSelector/CountryCodeDropdown/index.module.scss
@@ -37,10 +37,10 @@
 }
 
 .countryList {
-  margin: 0;
-  padding: 0;
+  margin: 0 _.unit(-3);
+  padding: 0 _.unit(3);
   list-style: none;
-  overflow: auto;
+  overflow: scroll;
 
   li {
     padding: _.unit(1) _.unit(2) _.unit(1) _.unit(7);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Move the scroll bar to the outer box, 

<img width="403" alt="image" src="https://user-images.githubusercontent.com/36393111/225823412-6974c298-2267-44d3-a66a-e25148f24feb.png">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
