### PR TITLE
fix(console): reset form values when creating connector

### DIFF
--- a/packages/console/src/pages/Connectors/components/ConnectorForm/ConfigForm.tsx
+++ b/packages/console/src/pages/Connectors/components/ConnectorForm/ConfigForm.tsx
@@ -1,6 +1,5 @@
 import type { ConnectorConfigFormItem } from '@logto/connector-kit';
 import { ConnectorType } from '@logto/connector-kit';
-import type { ConnectorFactoryResponse } from '@logto/schemas';
 import { useContext } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -16,20 +15,13 @@ import ConfigFormItems from '../ConfigForm';
 import * as styles from './ConfigForm.module.scss';
 
 type Props = {
-  configTemplate?: ConnectorFactoryResponse['configTemplate'];
   formItems?: ConnectorConfigFormItem[];
   className?: string;
   connectorId: string;
   connectorType?: ConnectorType;
 };
 
-const ConfigForm = ({
-  configTemplate,
-  formItems,
-  className,
-  connectorId,
-  connectorType,
-}: Props) => {
+const ConfigForm = ({ formItems, className, connectorId, connectorType }: Props) => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const {
     control,
@@ -56,7 +48,6 @@ const ConfigForm = ({
           <Controller
             name="config"
             control={control}
-            defaultValue={configTemplate}
             rules={{
               validate: (value) => jsonValidator(value) || t('errors.invalid_json_format'),
             }}

--- a/packages/console/src/pages/Connectors/components/Guide/index.tsx
+++ b/packages/console/src/pages/Connectors/components/Guide/index.tsx
@@ -48,7 +48,7 @@ const Guide = ({ connector, onClose }: Props) => {
   const parseJsonConfig = useConfigParser();
   const [conflictConnectorName, setConflictConnectorName] = useState<Record<string, string>>();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
-  const { type: connectorType, formItems, target, isStandard } = connector ?? {};
+  const { type: connectorType, formItems, target, isStandard, configTemplate } = connector ?? {};
 
   const { language } = i18next;
 
@@ -56,30 +56,29 @@ const Guide = ({ connector, onClose }: Props) => {
     connectorType !== ConnectorType.Sms && connectorType !== ConnectorType.Email;
   const methods = useForm<ConnectorFormType>({
     reValidateMode: 'onBlur',
-    defaultValues: {
-      ...(formItems ? initFormData(formItems) : {}),
-      syncProfile: SyncProfileMode.OnlyAtRegister,
-    },
   });
   const {
     formState: { isSubmitting },
     handleSubmit,
     watch,
-    setValue,
     setError,
+    reset,
   } = methods;
 
   useEffect(() => {
-    if (isSocialConnector && !isStandard && target) {
-      setValue('target', target);
-    }
-  }, [isSocialConnector, target, isStandard, setValue]);
+    reset({
+      ...(formItems ? initFormData(formItems) : {}),
+      ...(configTemplate ? { config: configTemplate } : {}),
+      ...(isSocialConnector && !isStandard && target ? { target } : {}),
+      syncProfile: SyncProfileMode.OnlyAtRegister,
+    });
+  }, [formItems, reset, configTemplate, target, isSocialConnector, isStandard]);
 
   if (!connector) {
     return null;
   }
 
-  const { id: connectorId, name, readme, configTemplate } = connector;
+  const { id: connectorId, name, readme } = connector;
   const { title, content } = splitMarkdownByTitle(readme);
   const connectorName = conditional(isLanguageTag(language) && name[language]) ?? name.en;
 
@@ -203,7 +202,6 @@ const Guide = ({ connector, onClose }: Props) => {
                   </div>
                   <ConfigForm
                     connectorId={callbackConnectorId.current}
-                    configTemplate={configTemplate}
                     connectorType={connectorType}
                     formItems={formItems}
                   />


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
For connector creation form: Reset form values everytime connector factory update.

The previous "default value" is unrelyable when the form is being "reused".

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
