### PR TITLE
style(console): fix inspire me button padding-right

### DIFF
--- a/packages/console/src/onboarding/pages/SignInExperience/components/InspireMe/index.module.scss
+++ b/packages/console/src/onboarding/pages/SignInExperience/components/InspireMe/index.module.scss
@@ -25,6 +25,7 @@
 
   .button {
     border-color: var(--color-neutral-variant-80);
+    // Note: this is a special case for the inspire me button since the bulb icon does not follow the standard icon size
     padding-right: _.unit(7);
 
     &:not(:disabled) {

--- a/packages/console/src/onboarding/pages/SignInExperience/components/InspireMe/index.module.scss
+++ b/packages/console/src/onboarding/pages/SignInExperience/components/InspireMe/index.module.scss
@@ -25,6 +25,7 @@
 
   .button {
     border-color: var(--color-neutral-variant-80);
+    padding-right: _.unit(7);
 
     &:not(:disabled) {
       &:not(:active),


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The icon for the light bulb is relatively large and specialized, a 24x24 box was used to frame it, leaving some padding on the left side, which made it look off-center. Therefore, the designer decided to add an additional 4px of padding after "inspire me".

Since the default margin-right is `_.unit(6)` so change it to `_.unit(7)`.


<img width="703" alt="image" src="https://user-images.githubusercontent.com/10806653/225873430-49ab547f-6b94-45b8-9e6b-353a475ae9fb.png">

<img width="454" alt="image" src="https://user-images.githubusercontent.com/10806653/225873473-86f52dc1-7734-41a1-9e9b-f50fd4863705.png">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="479" alt="image" src="https://user-images.githubusercontent.com/10806653/225873372-8457d227-e829-4fd1-9b93-a50c780a220a.png">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [ ] This PR is not applicable for the checklist
