### PR TITLE
fix(ui): add focus-visible border to countrySelector

### DIFF
--- a/packages/ui/src/components/InputFields/SmartInputField/CountryCodeSelector/CountryCodeDropdown/index.module.scss
+++ b/packages/ui/src/components/InputFields/SmartInputField/CountryCodeSelector/CountryCodeDropdown/index.module.scss
@@ -59,7 +59,6 @@
     &:hover {
       border-radius: _.unit(2);
       background: var(--color-overlay-neutral-hover);
-      color: var(--color-type-link);
     }
   }
 }

--- a/packages/ui/src/components/InputFields/SmartInputField/CountryCodeSelector/index.module.scss
+++ b/packages/ui/src/components/InputFields/SmartInputField/CountryCodeSelector/index.module.scss
@@ -3,7 +3,9 @@
 .countryCodeSelector {
   font: var(--font-label-1);
   color: var(--color-type-primary);
-  border: none;
+  border: _.border('transparent');
+  border-top-left-radius: var(--radius);
+  border-bottom-left-radius: var(--radius);
   background: none;
   position: relative;
   height: 100%;
@@ -13,22 +15,8 @@
   overflow: hidden;
   white-space: nowrap;
 
-  > select {
-    flex-shrink: 0;
-    appearance: none;
-    border: none;
-    outline: none;
-    background: none;
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    font-size: 0;
-
-    option {
-      font: var(--font-label-1);
-    }
+  &:focus-visible {
+    border: _.border(var(--color-brand-default));
   }
 
   > svg {
@@ -43,10 +31,6 @@
 :global(body.desktop) {
   .countryCodeSelector {
     font: var(--font-body-2);
-
-    > select option {
-      font: var(--font-body-2);
-    }
 
     > svg {
       margin-left: _.unit(2);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add a focus-visible border to countrySelector. Also removed legacy CSS styles. 

<img width="473" alt="image" src="https://user-images.githubusercontent.com/36393111/225881552-4ad3dad1-556f-4293-abac-d50b42b5de46.png">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
