### PR TITLE
fix(console): align console input field height

### DIFF
--- a/packages/console/src/components/Markdown/index.tsx
+++ b/packages/console/src/components/Markdown/index.tsx
@@ -44,7 +44,7 @@ const Markdown = ({ className, children }: Props) => {
       remarkPlugins={[remarkGfm]}
       className={classNames(styles.markdown, className)}
       components={{
-        code: ({ node, inline, className, children, ...props }) => {
+        code: ({ inline, className, children, ...props }) => {
           const [, codeBlockType] = /language-(\w+)/.exec(className ?? '') ?? [];
 
           return inline ? (

--- a/packages/console/src/components/TextInput/index.module.scss
+++ b/packages/console/src/components/TextInput/index.module.scss
@@ -20,10 +20,6 @@
   background: var(--color-layer-1);
   font: var(--font-body-2);
 
-  &.large {
-    height: 44px;
-  }
-
   &.withIcon {
     display: flex;
     align-items: center;

--- a/packages/console/src/components/TextInput/index.tsx
+++ b/packages/console/src/components/TextInput/index.tsx
@@ -9,7 +9,6 @@ type Props = Omit<HTMLProps<HTMLInputElement>, 'size'> & {
   errorMessage?: string;
   icon?: ReactElement;
   suffix?: ReactElement;
-  size?: 'medium' | 'large';
 };
 
 const TextInput = (
@@ -21,7 +20,6 @@ const TextInput = (
     disabled,
     className,
     readOnly,
-    size = 'medium',
     ...rest
   }: Props,
   reference: ForwardedRef<HTMLInputElement>
@@ -34,8 +32,7 @@ const TextInput = (
           hasError && styles.error,
           icon && styles.withIcon,
           disabled && styles.disabled,
-          readOnly && styles.readOnly,
-          styles[size]
+          readOnly && styles.readOnly
         )}
       >
         {icon && <span className={styles.icon}>{icon}</span>}

--- a/packages/console/src/onboarding/pages/SignInExperience/index.tsx
+++ b/packages/console/src/onboarding/pages/SignInExperience/index.tsx
@@ -14,8 +14,8 @@ import FormField from '@/components/FormField';
 import OverlayScrollbar from '@/components/OverlayScrollbar';
 import TextInput from '@/components/TextInput';
 import { ImageUploaderField } from '@/components/Uploader';
-import type { RequestError } from '@/hooks/use-api';
 import useApi from '@/hooks/use-api';
+import type { RequestError } from '@/hooks/use-api';
 import useUserAssetsService from '@/hooks/use-user-assets-service';
 import ActionBar from '@/onboarding/components/ActionBar';
 import { CardSelector, MultiCardSelector } from '@/onboarding/components/CardSelector';
@@ -118,7 +118,6 @@ const SignInExperience = () => {
                 />
               ) : (
                 <TextInput
-                  size="large"
                   {...register('logo', {
                     validate: (value) =>
                       !value || uriValidator(value) || t('errors.invalid_uri_format'),

--- a/packages/console/src/pages/Profile/containers/BasicUserInfoUpdateModal/index.tsx
+++ b/packages/console/src/pages/Profile/containers/BasicUserInfoUpdateModal/index.tsx
@@ -133,7 +133,6 @@ const BasicUserInfoUpdateModal = ({ field, value: initialValue, isOpen, onClose 
             autoFocus
             placeholder={getInputPlaceholder()}
             errorMessage={errors[field]?.message}
-            size="large"
             onKeyDown={(event) => {
               if (event.key === 'Enter') {
                 void onSubmit();

--- a/packages/console/src/pages/Profile/containers/ChangePasswordModal/index.tsx
+++ b/packages/console/src/pages/Profile/containers/ChangePasswordModal/index.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import ClearInput from '@/assets/images/clear-input.svg';
 import Button from '@/components/Button';
@@ -34,7 +34,6 @@ const ChangePasswordModal = () => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const navigate = useNavigate();
   const { show: showModal } = useConfirmModal();
-  const { state } = useLocation();
   const {
     watch,
     reset,
@@ -118,7 +117,6 @@ const ChangePasswordModal = () => {
             <ClearInput />
           </IconButton>
         }
-        size="large"
         onKeyDown={onKeyDown}
       />
       <TextInput
@@ -138,7 +136,6 @@ const ChangePasswordModal = () => {
             <ClearInput />
           </IconButton>
         }
-        size="large"
         onKeyDown={onKeyDown}
       />
       <Checkbox

--- a/packages/console/src/pages/Profile/containers/LinkEmailModal/index.tsx
+++ b/packages/console/src/pages/Profile/containers/LinkEmailModal/index.tsx
@@ -64,7 +64,6 @@ const LinkEmailModal = () => {
         // eslint-disable-next-line jsx-a11y/no-autofocus
         autoFocus
         errorMessage={errors.email?.message}
-        size="large"
         onKeyDown={(event) => {
           if (event.key === 'Enter') {
             onSubmit();

--- a/packages/console/src/pages/Profile/containers/VerifyPasswordModal/index.tsx
+++ b/packages/console/src/pages/Profile/containers/VerifyPasswordModal/index.tsx
@@ -90,7 +90,6 @@ const VerifyPasswordModal = () => {
             {showPassword ? <PasswordShowIcon /> : <PasswordHideIcon />}
           </IconButton>
         }
-        size="large"
         onKeyDown={(event) => {
           if (event.key === 'Enter') {
             onSubmit();

--- a/packages/ui/src/Layout/AppLayout/index.module.scss
+++ b/packages/ui/src/Layout/AppLayout/index.module.scss
@@ -68,6 +68,7 @@
     position: absolute;
     bottom: 0;
     transform: translateY(calc(100% + _.unit(7)));
+    // Have to use padding instead of margin. Overflow margin spacing will be ignored by the browser.
     padding-bottom: _.unit(7);
   }
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
align console input field height. Remove all the large 44px height input styling. 

P.S. Also, commit a missing comment for PR #3472 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
<img width="478" alt="image" src="https://user-images.githubusercontent.com/36393111/225916340-d0e86fc2-9939-4076-a624-45c4d38fcea6.png">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
