### PR TITLE
style(ui): fix logto signature hit area

### DIFF
--- a/packages/ui/src/components/LogtoSignature/index.tsx
+++ b/packages/ui/src/components/LogtoSignature/index.tsx
@@ -1,5 +1,4 @@
 import { Theme } from '@logto/schemas';
-import classNames from 'classnames';
 import { useContext } from 'react';
 
 import LogtoLogtoDark from '@/assets/icons/logto-logo-dark.svg';
@@ -24,17 +23,19 @@ const LogtoSignature = ({ className }: Props) => {
   const LogtoLogo = theme === Theme.Light ? LogtoLogoLight : LogtoLogtoDark;
 
   return (
-    <a
-      className={classNames(styles.signature, className)}
-      aria-label="Powered By Logto"
-      href={logtoUrl.toString()}
-      target="_blank"
-      rel="noopener"
-    >
-      <span className={styles.text}>Powered by</span>
-      <LogtoLogoShadow className={styles.staticIcon} />
-      <LogtoLogo className={styles.highlightIcon} />
-    </a>
+    <div className={className}>
+      <a
+        className={styles.signature}
+        aria-label="Powered By Logto"
+        href={logtoUrl.toString()}
+        target="_blank"
+        rel="noopener"
+      >
+        <span className={styles.text}>Powered by</span>
+        <LogtoLogoShadow className={styles.staticIcon} />
+        <LogtoLogo className={styles.highlightIcon} />
+      </a>
+    </div>
   );
 };
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The logto signature padding space on the desktop should not affect the default hyperlink's hitting area.

Apply spacing styles to an extra wrapper layer. So the hyperlink element's hitting area won't be affected. 

NOTICE: On the desktop, we styled the Logto Signature with position absolute + vertical transition. Outer box margin space will overflow. Have to use padding-bottom to guarantee the bottom spacing 

<img width="195" alt="image" src="https://user-images.githubusercontent.com/36393111/225919849-6eaf0ecf-7c50-41ef-bccd-2bc3a1ba6243.png">

<img width="189" alt="image" src="https://user-images.githubusercontent.com/36393111/225919800-32b5662c-6548-48cd-ad99-20aaa00db807.png">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
