### PR TITLE
refactor(console): fix connector guide form submit issue

### DIFF
--- a/packages/console/src/components/Switch/index.tsx
+++ b/packages/console/src/components/Switch/index.tsx
@@ -12,7 +12,7 @@ const Switch = ({ label, ...rest }: Props, ref?: Ref<HTMLInputElement>) => {
     <div className={styles.wrapper}>
       <div className={styles.label}>{label}</div>
       <label className={styles.switch}>
-        <input type="checkbox" defaultChecked={false} {...rest} ref={ref} />
+        <input type="checkbox" {...rest} ref={ref} />
         <span className={styles.slider} />
       </label>
     </div>

--- a/packages/console/src/pages/Connectors/components/ConfigForm/index.tsx
+++ b/packages/console/src/pages/Connectors/components/ConfigForm/index.tsx
@@ -49,22 +49,22 @@ const ConfigForm = ({ formItems }: Props) => {
     const hasError = Boolean(errors[item.key]);
     const errorMessage = errors[item.key]?.message;
 
-    const commonProperties = {
+    const buildCommonProperties = () => ({
       ...register(item.key, { required: item.required }),
       placeholder: item.placeholder,
       hasError,
-    };
+    });
 
     if (item.type === ConnectorConfigFormItemType.Text) {
-      return <TextInput {...commonProperties} />;
+      return <TextInput {...buildCommonProperties()} />;
     }
 
     if (item.type === ConnectorConfigFormItemType.MultilineText) {
-      return <Textarea rows={5} {...commonProperties} />;
+      return <Textarea rows={5} {...buildCommonProperties()} />;
     }
 
     if (item.type === ConnectorConfigFormItemType.Number) {
-      return <TextInput type="number" {...commonProperties} />;
+      return <TextInput type="number" {...buildCommonProperties()} />;
     }
 
     return (


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- remove `defaultChecked` from `<Switch />` since it's not reasonable to use the prop when it's a controlled input
- build form common properties when needed to avoid submitting issue

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- no "default checked and checked bot set" warning in console
- connector guide form is ok to submit with only strictly necessary info
- currently no switch needs `defaultValue`

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
