### PR TITLE
fix(console,core,toolkit): passwordless connector sender tester

### DIFF
--- a/packages/cli/src/connector/types.ts
+++ b/packages/cli/src/connector/types.ts
@@ -7,7 +7,7 @@ export type ConnectorFactory<T extends AllConnector = AllConnector> = Pick<
   T,
   'type' | 'metadata'
 > & {
-  createConnector: CreateConnector<AllConnector>;
+  createConnector: CreateConnector<T>;
   path: string;
 };
 

--- a/packages/cli/src/connector/utils.ts
+++ b/packages/cli/src/connector/utils.ts
@@ -2,7 +2,12 @@ import { existsSync } from 'fs';
 import { readFile } from 'fs/promises';
 import path from 'path';
 
-import type { AllConnector, BaseConnector, GetConnectorConfig } from '@logto/connector-kit';
+import type {
+  AllConnector,
+  BaseConnector,
+  ConnectorMetadata,
+  GetConnectorConfig,
+} from '@logto/connector-kit';
 import { ConnectorError, ConnectorErrorCodes, ConnectorType } from '@logto/connector-kit';
 
 import { notImplemented } from './consts.js';
@@ -64,10 +69,10 @@ export const parseMetadata = async (
   };
 };
 
-export const buildRawConnector = async (
-  connectorFactory: ConnectorFactory,
+export const buildRawConnector = async <T extends AllConnector = AllConnector>(
+  connectorFactory: ConnectorFactory<T>,
   getConnectorConfig?: GetConnectorConfig
-) => {
+): Promise<{ rawConnector: T; rawMetadata: ConnectorMetadata }> => {
   const { createConnector, path: packagePath } = connectorFactory;
   const rawConnector = await createConnector({
     getConfig: getConnectorConfig ?? notImplemented,

--- a/packages/console/src/pages/ConnectorDetails/components/ConnectorContent.tsx
+++ b/packages/console/src/pages/ConnectorDetails/components/ConnectorContent.tsx
@@ -135,9 +135,14 @@ const ConnectorContent = ({ isDeleted, connectorData, onConnectorUpdated }: Prop
         {connectorData.type !== ConnectorType.Social && (
           <FormCard title="connector_details.test_connection">
             <SenderTester
-              connectorId={connectorData.id}
+              connectorFactoryId={connectorData.connectorId}
               connectorType={connectorData.type}
-              config={watch('config')}
+              formConfig={
+                connectorData.formItems
+                  ? parseFormConfig(watch(), connectorData.formItems)
+                  : undefined
+              }
+              stringConfig={watch('config')}
             />
           </FormCard>
         )}

--- a/packages/console/src/pages/ConnectorDetails/components/ConnectorContent.tsx
+++ b/packages/console/src/pages/ConnectorDetails/components/ConnectorContent.tsx
@@ -2,7 +2,7 @@ import type { ConnectorResponse } from '@logto/schemas';
 import { ConnectorType } from '@logto/schemas';
 import type { Optional } from '@silverhand/essentials';
 import { conditional } from '@silverhand/essentials';
-import { useCallback, useEffect } from 'react';
+import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
@@ -14,8 +14,8 @@ import useApi from '@/hooks/use-api';
 import useDocumentationUrl from '@/hooks/use-documentation-url';
 import BasicForm from '@/pages/Connectors/components/ConnectorForm/BasicForm';
 import ConfigForm from '@/pages/Connectors/components/ConnectorForm/ConfigForm';
-import { useConfigParser } from '@/pages/Connectors/components/ConnectorForm/hooks';
-import { initFormData, parseFormConfig } from '@/pages/Connectors/components/ConnectorForm/utils';
+import { useConnectorFormConfigParser } from '@/pages/Connectors/components/ConnectorForm/hooks';
+import { initFormData } from '@/pages/Connectors/components/ConnectorForm/utils';
 import type { ConnectorFormType } from '@/pages/Connectors/types';
 import { SyncProfileMode } from '@/pages/Connectors/types';
 
@@ -38,7 +38,6 @@ const getConnectorTarget = (connectorData: ConnectorResponse): Optional<string> 
 const ConnectorContent = ({ isDeleted, connectorData, onConnectorUpdated }: Props) => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { getDocumentationUrl } = useDocumentationUrl();
-  const parseJsonConfig = useConfigParser();
   const api = useApi();
   const methods = useForm<ConnectorFormType>({
     reValidateMode: 'onBlur',
@@ -70,16 +69,11 @@ const ConnectorContent = ({ isDeleted, connectorData, onConnectorUpdated }: Prop
     });
   }, [connectorData, reset]);
 
-  const parseConfig = useCallback(
-    (data: ConnectorFormType, formItems: ConnectorResponse['formItems']) => {
-      return formItems ? parseFormConfig(data, formItems) : parseJsonConfig(data.config);
-    },
-    [parseJsonConfig]
-  );
+  const configParser = useConnectorFormConfigParser();
 
   const onSubmit = handleSubmit(async (data) => {
     const { formItems, isStandard, id } = connectorData;
-    const config = parseConfig(data, formItems);
+    const config = configParser(data, formItems);
     const { syncProfile, name, logo, logoDark, target } = data;
 
     const payload = isSocialConnector
@@ -144,7 +138,7 @@ const ConnectorContent = ({ isDeleted, connectorData, onConnectorUpdated }: Prop
             <SenderTester
               connectorFactoryId={connectorData.connectorId}
               connectorType={connectorData.type}
-              parse={() => parseConfig(watch(), connectorData.formItems)}
+              parse={() => configParser(watch(), connectorData.formItems)}
             />
           </FormCard>
         )}

--- a/packages/console/src/pages/ConnectorDetails/components/ConnectorContent.tsx
+++ b/packages/console/src/pages/ConnectorDetails/components/ConnectorContent.tsx
@@ -2,7 +2,7 @@ import type { ConnectorResponse } from '@logto/schemas';
 import { ConnectorType } from '@logto/schemas';
 import type { Optional } from '@silverhand/essentials';
 import { conditional } from '@silverhand/essentials';
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
@@ -70,9 +70,16 @@ const ConnectorContent = ({ isDeleted, connectorData, onConnectorUpdated }: Prop
     });
   }, [connectorData, reset]);
 
+  const parseConfig = useCallback(
+    (data: ConnectorFormType, formItems: ConnectorResponse['formItems']) => {
+      return formItems ? parseFormConfig(data, formItems) : parseJsonConfig(data.config);
+    },
+    [parseJsonConfig]
+  );
+
   const onSubmit = handleSubmit(async (data) => {
     const { formItems, isStandard, id } = connectorData;
-    const config = formItems ? parseFormConfig(data, formItems) : parseJsonConfig(data.config);
+    const config = parseConfig(data, formItems);
     const { syncProfile, name, logo, logoDark, target } = data;
 
     const payload = isSocialConnector
@@ -137,10 +144,7 @@ const ConnectorContent = ({ isDeleted, connectorData, onConnectorUpdated }: Prop
             <SenderTester
               connectorFactoryId={connectorData.connectorId}
               connectorType={connectorData.type}
-              formConfig={conditional(
-                connectorData.formItems && parseFormConfig(watch(), connectorData.formItems)
-              )}
-              stringConfig={watch('config')}
+              parse={() => parseConfig(watch(), connectorData.formItems)}
             />
           </FormCard>
         )}

--- a/packages/console/src/pages/ConnectorDetails/components/ConnectorContent.tsx
+++ b/packages/console/src/pages/ConnectorDetails/components/ConnectorContent.tsx
@@ -137,11 +137,9 @@ const ConnectorContent = ({ isDeleted, connectorData, onConnectorUpdated }: Prop
             <SenderTester
               connectorFactoryId={connectorData.connectorId}
               connectorType={connectorData.type}
-              formConfig={
-                connectorData.formItems
-                  ? parseFormConfig(watch(), connectorData.formItems)
-                  : undefined
-              }
+              formConfig={conditional(
+                connectorData.formItems && parseFormConfig(watch(), connectorData.formItems)
+              )}
               stringConfig={watch('config')}
             />
           </FormCard>

--- a/packages/console/src/pages/ConnectorDetails/components/SenderTester/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/components/SenderTester/index.tsx
@@ -1,9 +1,8 @@
 import { emailRegEx, phoneInputRegEx } from '@logto/core-kit';
 import { ConnectorType } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 
 import Button from '@/components/Button';
@@ -11,8 +10,8 @@ import FormField from '@/components/FormField';
 import TextInput from '@/components/TextInput';
 import { Tooltip } from '@/components/Tip';
 import useApi from '@/hooks/use-api';
+import { useConfigParser } from '@/pages/Connectors/components/ConnectorForm/hooks';
 import { onKeyDownHandler } from '@/utils/a11y';
-import { safeParseJson } from '@/utils/json';
 
 import * as styles from './index.module.scss';
 
@@ -62,32 +61,13 @@ const SenderTester = ({
     };
   }, [showTooltip]);
 
-  const stringConfigParser = useCallback(
-    (config?: string) => {
-      if (!config) {
-        toast.error(t('connector_details.save_error_empty_config'));
-
-        return;
-      }
-
-      const result = safeParseJson(config);
-
-      if (!result.success) {
-        toast.error(result.error);
-
-        return;
-      }
-
-      return result.data;
-    },
-    [t]
-  );
+  const configParser = useConfigParser();
 
   const onSubmit = handleSubmit(async (formData) => {
     const { sendTo } = formData;
 
     const data = {
-      config: formConfig ?? stringConfigParser(stringConfig),
+      config: formConfig ?? configParser(stringConfig ?? ''),
       ...(isSms
         ? { phone: sendTo.replace(/[ ()-]/g, '').replace(/\+/g, '00') }
         : { email: sendTo }),

--- a/packages/console/src/pages/ConnectorDetails/components/SenderTester/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/components/SenderTester/index.tsx
@@ -10,7 +10,6 @@ import FormField from '@/components/FormField';
 import TextInput from '@/components/TextInput';
 import { Tooltip } from '@/components/Tip';
 import useApi from '@/hooks/use-api';
-import { useConfigParser } from '@/pages/Connectors/components/ConnectorForm/hooks';
 import { onKeyDownHandler } from '@/utils/a11y';
 
 import * as styles from './index.module.scss';
@@ -19,21 +18,14 @@ type Props = {
   connectorFactoryId: string;
   connectorType: Exclude<ConnectorType, ConnectorType.Social>;
   className?: string;
-  formConfig?: Record<string, unknown>;
-  stringConfig?: string;
+  parse: () => unknown;
 };
 
 type FormData = {
   sendTo: string;
 };
 
-const SenderTester = ({
-  connectorFactoryId,
-  connectorType,
-  className,
-  formConfig,
-  stringConfig,
-}: Props) => {
+const SenderTester = ({ connectorFactoryId, connectorType, className, parse }: Props) => {
   const [showTooltip, setShowTooltip] = useState(false);
   const {
     handleSubmit,
@@ -61,13 +53,11 @@ const SenderTester = ({
     };
   }, [showTooltip]);
 
-  const configParser = useConfigParser();
-
   const onSubmit = handleSubmit(async (formData) => {
     const { sendTo } = formData;
 
     const data = {
-      config: formConfig ?? configParser(stringConfig ?? ''),
+      config: parse(),
       ...(isSms
         ? { phone: sendTo.replace(/[ ()-]/g, '').replace(/\+/g, '00') }
         : { email: sendTo }),

--- a/packages/console/src/pages/Connectors/components/ConnectorForm/hooks.tsx
+++ b/packages/console/src/pages/Connectors/components/ConnectorForm/hooks.tsx
@@ -1,9 +1,12 @@
+import type { ConnectorResponse } from '@logto/schemas';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 
+import { parseFormConfig } from '@/pages/Connectors/components/ConnectorForm/utils';
+import type { ConnectorFormType } from '@/pages/Connectors/types';
 import { safeParseJson } from '@/utils/json';
 
-export const useConfigParser = () => {
+export const useJsonStringConfigParser = () => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
   return (config: string) => {
@@ -22,5 +25,13 @@ export const useConfigParser = () => {
     }
 
     return result.data;
+  };
+};
+
+export const useConnectorFormConfigParser = () => {
+  const parseJsonConfig = useJsonStringConfigParser();
+
+  return (data: ConnectorFormType, formItems: ConnectorResponse['formItems']) => {
+    return formItems ? parseFormConfig(data, formItems) : parseJsonConfig(data.config);
   };
 };

--- a/packages/console/src/pages/Connectors/components/Guide/index.tsx
+++ b/packages/console/src/pages/Connectors/components/Guide/index.tsx
@@ -213,9 +213,10 @@ const Guide = ({ connector, onClose }: Props) => {
                       <div>{t('connectors.guide.test_connection')}</div>
                     </div>
                     <SenderTester
-                      connectorId={connectorId}
+                      connectorFactoryId={connectorId}
                       connectorType={connectorType}
-                      config={watch('config')}
+                      formConfig={formItems ? parseFormConfig(watch(), formItems) : undefined}
+                      stringConfig={watch('config')}
                     />
                   </div>
                 )}

--- a/packages/console/src/pages/Connectors/components/Guide/index.tsx
+++ b/packages/console/src/pages/Connectors/components/Guide/index.tsx
@@ -215,7 +215,7 @@ const Guide = ({ connector, onClose }: Props) => {
                     <SenderTester
                       connectorFactoryId={connectorId}
                       connectorType={connectorType}
-                      formConfig={formItems ? parseFormConfig(watch(), formItems) : undefined}
+                      formConfig={conditional(formItems && parseFormConfig(watch(), formItems))}
                       stringConfig={watch('config')}
                     />
                   </div>

--- a/packages/console/src/pages/Connectors/components/Guide/index.tsx
+++ b/packages/console/src/pages/Connectors/components/Guide/index.tsx
@@ -5,7 +5,7 @@ import { ConnectorType } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
 import i18next from 'i18next';
 import { HTTPError } from 'ky';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
@@ -74,6 +74,13 @@ const Guide = ({ connector, onClose }: Props) => {
     });
   }, [formItems, reset, configTemplate, target, isSocialConnector, isStandard]);
 
+  const parseConfig = useCallback(
+    (data: ConnectorFormType, formItems: ConnectorResponse['formItems']) => {
+      return formItems ? parseFormConfig(data, formItems) : parseJsonConfig(data.config);
+    },
+    [parseJsonConfig]
+  );
+
   if (!connector) {
     return null;
   }
@@ -90,7 +97,7 @@ const Guide = ({ connector, onClose }: Props) => {
     // Recover error state
     setConflictConnectorName(undefined);
 
-    const config = formItems ? parseFormConfig(data, formItems) : parseJsonConfig(data.config);
+    const config = parseConfig(data, formItems);
     const { syncProfile, name, logo, logoDark, target } = data;
 
     const basePayload = {
@@ -215,8 +222,7 @@ const Guide = ({ connector, onClose }: Props) => {
                     <SenderTester
                       connectorFactoryId={connectorId}
                       connectorType={connectorType}
-                      formConfig={conditional(formItems && parseFormConfig(watch(), formItems))}
-                      stringConfig={watch('config')}
+                      parse={() => parseConfig(watch(), formItems)}
                     />
                   </div>
                 )}

--- a/packages/integration-tests/src/tests/api/connector.test.ts
+++ b/packages/integration-tests/src/tests/api/connector.test.ts
@@ -142,10 +142,10 @@ test('send SMS/email test message', async () => {
   const email = 'test@example.com';
 
   await expect(
-    sendSmsTestMessage(connectorIdMap.get(mockSmsConnectorId), phone, mockSmsConnectorConfig)
+    sendSmsTestMessage(mockSmsConnectorId, phone, mockSmsConnectorConfig)
   ).resolves.not.toThrow();
   await expect(
-    sendEmailTestMessage(connectorIdMap.get(mockEmailConnectorId), email, mockEmailConnectorConfig)
+    sendEmailTestMessage(mockEmailConnectorId, email, mockEmailConnectorConfig)
   ).resolves.not.toThrow();
   await expect(sendSmsTestMessage(mockSmsConnectorId, phone, {})).rejects.toThrow(HTTPError);
   await expect(sendEmailTestMessage(mockEmailConnectorId, email, {})).rejects.toThrow(HTTPError);

--- a/packages/toolkit/connector-kit/src/types.ts
+++ b/packages/toolkit/connector-kit/src/types.ts
@@ -198,7 +198,7 @@ export type BaseConnector<Type extends ConnectorType> = {
   configGuard: ZodType;
 };
 
-export type CreateConnector<T extends BaseConnector<ConnectorType>> = (options: {
+export type CreateConnector<T extends AllConnector> = (options: {
   getConfig: GetConnectorConfig;
 }) => Promise<T>;
 


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
passwordless connector sender test throws an invalid config error.
When creating connectors, the instance is not created (and hence can find no connector instance to test with), as a result, we should send message via connector built with corresponding connector factory.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
<img width="1390" alt="image" src="https://user-images.githubusercontent.com/15182327/226107997-52e18688-3617-4ae0-8d3f-69599d77c72a.png">
<img width="1937" alt="image" src="https://user-images.githubusercontent.com/15182327/226108067-25e4e595-1abd-48dc-8eca-625c64e1bfa3.png">
<img width="1932" alt="image" src="https://user-images.githubusercontent.com/15182327/226108138-7c3479ef-25e9-438e-ac35-750f98ecc241.png">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
