### PR TITLE
refactor(console): turn off auto-complete in connector forms

### DIFF
--- a/packages/console/src/components/DetailsForm/index.tsx
+++ b/packages/console/src/components/DetailsForm/index.tsx
@@ -5,16 +5,27 @@ import SubmitFormChangesActionBar from '../SubmitFormChangesActionBar';
 import * as styles from './index.module.scss';
 
 type Props = {
+  autoComplete?: string;
   isDirty: boolean;
   isSubmitting: boolean;
-  children: ReactNode;
   onSubmit: () => Promise<void>;
   onDiscard: () => void;
+  children: ReactNode;
 };
 
-const DetailsForm = ({ isDirty, isSubmitting, onSubmit, onDiscard, children }: Props) => {
+const DetailsForm = ({
+  autoComplete,
+  isDirty,
+  isSubmitting,
+  onSubmit,
+  onDiscard,
+  children,
+}: Props) => {
   return (
-    <form className={classNames(styles.container, isDirty && styles.withSubmitActionBar)}>
+    <form
+      className={classNames(styles.container, isDirty && styles.withSubmitActionBar)}
+      autoComplete={autoComplete}
+    >
       <div className={styles.fields}>{children}</div>
       <SubmitFormChangesActionBar
         isOpen={isDirty}

--- a/packages/console/src/pages/ConnectorDetails/components/ConnectorContent.tsx
+++ b/packages/console/src/pages/ConnectorDetails/components/ConnectorContent.tsx
@@ -101,6 +101,7 @@ const ConnectorContent = ({ isDeleted, connectorData, onConnectorUpdated }: Prop
   return (
     <FormProvider {...methods}>
       <DetailsForm
+        autoComplete="off"
         isDirty={isDirty}
         isSubmitting={isSubmitting}
         onDiscard={reset}

--- a/packages/console/src/pages/Connectors/components/Guide/index.tsx
+++ b/packages/console/src/pages/Connectors/components/Guide/index.tsx
@@ -181,7 +181,7 @@ const Guide = ({ connector, onClose }: Props) => {
           </div>
           <div className={styles.setup}>
             <FormProvider {...methods}>
-              <form onSubmit={onSubmit}>
+              <form autoComplete="off" onSubmit={onSubmit}>
                 {isSocialConnector && (
                   <div className={styles.block}>
                     <div className={styles.blockTitle}>


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
connector usually hold credentials that are not suitable for auto-complete

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
local tested, no auto complete

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
