### PR TITLE
refactor: fix application insights role names

### DIFF
--- a/packages/cloud/src/index.ts
+++ b/packages/cloud/src/index.ts
@@ -7,7 +7,7 @@ import { findUp } from 'find-up';
 dotenv.config({ path: await findUp('.env', {}) });
 
 const { appInsights } = await import('@logto/shared/app-insights');
-appInsights.setup('logto-cloud-eu');
+appInsights.setup('logto-cloud');
 
 const { default: withAuth } = await import('./middleware/with-auth.js');
 const { default: withHttpProxy } = await import('./middleware/with-http-proxy.js');

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,7 +9,7 @@ import SystemContext from './tenants/SystemContext.js';
 dotenv.config({ path: await findUp('.env', {}) });
 
 const { appInsights } = await import('@logto/shared/app-insights');
-appInsights.setup('logto-cloud-eu');
+appInsights.setup('logto');
 
 // Import after env has been configured
 const { loadConnectorFactories } = await import('./utils/connectors/index.js');


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- the role name of Application Insight should be region-irrelevant, since they'll be distinguished by endpoints
- instead, role names should be different per-app

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
/

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
