### PR TITLE
style(console): fix demo tag background color

### DIFF
--- a/packages/console/src/pages/Connectors/components/ConnectorName/DemoTag.module.scss
+++ b/packages/console/src/pages/Connectors/components/ConnectorName/DemoTag.module.scss
@@ -2,7 +2,7 @@
 
 .tag {
   font: var(--font-label-3);
-  background-color: var(--color-alert-99);
+  background-color: var(--color-alert-container);
   padding: _.unit(0.5) _.unit(1.5);
   border-radius: 10px;
   user-select: none;

--- a/packages/toolkit/core-kit/scss/_console-themes.scss
+++ b/packages/toolkit/core-kit/scss/_console-themes.scss
@@ -108,6 +108,7 @@
   --color-on-error: var(--color-all-100);
   --color-error-container: var(--color-error-90);
   --color-on-error-container: var(--color-error-10);
+  --color-alert-container: var(--color-alert-99);
   --color-background: var(--color-neutral-99);
   --color-on-background: var(--color-neutral-10);
   --color-surface: var(--color-neutral-99);
@@ -280,6 +281,7 @@
   --color-on-error: var(--color-all-0);
   --color-error-container: var(--color-error-90);
   --color-on-error-container: var(--color-error-30);
+  --color-alert-container: var(--color-alert-90);
   --color-background: var(--color-neutral-99);
   --color-on-background: var(--color-neutral-10);
   --color-surface: var(--color-neutral-99);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- add a color token `--color-alert-container`
- set the demo tag background color to `--color-alert-container`

light Mode:
<img width="180" alt="image" src="https://user-images.githubusercontent.com/10806653/226158770-51428232-a332-4168-9bf4-75f153f0c5d4.png">


darkMode:
<img width="181" alt="image" src="https://user-images.githubusercontent.com/10806653/226158758-78b2a4ef-03ce-4d8a-953e-11f41937857f.png">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="411" alt="image" src="https://user-images.githubusercontent.com/10806653/226158778-90a0fb40-f6e3-4fdc-b8f3-5cc9badf2217.png">

<img width="310" alt="image" src="https://user-images.githubusercontent.com/10806653/226158783-51791519-6311-428a-b799-2c5837fdbc84.png">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
