### PR TITLE
fix(console): skip validation for empty value in json editor

### DIFF
--- a/packages/console/src/components/CodeEditor/index.tsx
+++ b/packages/console/src/components/CodeEditor/index.tsx
@@ -1,7 +1,8 @@
 import { conditional } from '@silverhand/essentials';
 import classNames from 'classnames';
 import type { ChangeEvent, KeyboardEvent } from 'react';
-import { useRef } from 'react';
+import { useMemo, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { PrismAsyncLight as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { a11yDark as theme } from 'react-syntax-highlighter/dist/esm/styles/prism';
 
@@ -32,6 +33,7 @@ const CodeEditor = ({
   placeholder,
 }: Props) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
   const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
     const { value } = event.currentTarget;
@@ -54,6 +56,15 @@ const CodeEditor = ({
       onChange?.(newText);
     }
   };
+
+  // TODO @sijie temp solution for required error (the errorMessage is an empty string)
+  const finalErrorMessage = useMemo(() => {
+    if (errorMessage) {
+      return errorMessage;
+    }
+
+    return t('general.required');
+  }, [errorMessage, t]);
 
   return (
     <>
@@ -101,7 +112,7 @@ const CodeEditor = ({
           </SyntaxHighlighter>
         </div>
       </div>
-      {hasError && errorMessage && <div className={styles.errorMessage}>{errorMessage}</div>}
+      {hasError && <div className={styles.errorMessage}>{finalErrorMessage}</div>}
     </>
   );
 };

--- a/packages/console/src/pages/Connectors/components/ConfigForm/index.tsx
+++ b/packages/console/src/pages/Connectors/components/ConfigForm/index.tsx
@@ -71,15 +71,15 @@ const ConfigForm = ({ formItems }: Props) => {
       <Controller
         name={item.key}
         control={control}
-        rules={
-          item.type === ConnectorConfigFormItemType.Json
-            ? {
-                validate: (value) =>
+        rules={{
+          required: item.required,
+          validate:
+            item.type === ConnectorConfigFormItemType.Json
+              ? (value) =>
                   (typeof value === 'string' && jsonValidator(value)) ||
-                  t('errors.invalid_json_format'),
-              }
-            : undefined
-        }
+                  t('errors.invalid_json_format')
+              : undefined,
+        }}
         render={({ field: { onChange, value } }) => {
           if (item.type === ConnectorConfigFormItemType.Switch) {
             return (


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
In connector form's JSON field, if the value is empty, the form should not try to validate if it is a valid JSON.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
