### PR TITLE
fix(console): fix theme initial value

### DIFF
--- a/packages/console/src/components/AppError/index.tsx
+++ b/packages/console/src/components/AppError/index.tsx
@@ -6,7 +6,7 @@ import ErrorDark from '@/assets/images/error-dark.svg';
 import Error from '@/assets/images/error.svg';
 import KeyboardArrowDown from '@/assets/images/keyboard-arrow-down.svg';
 import KeyboardArrowUp from '@/assets/images/keyboard-arrow-up.svg';
-import useTheme from '@/hooks/use-theme';
+import { getThemeFromLocalStorage } from '@/contexts/AppThemeProvider';
 import { onKeyDownHandler } from '@/utils/a11y';
 
 import * as styles from './index.module.scss';
@@ -22,7 +22,7 @@ type Props = {
 const AppError = ({ title, errorCode, errorMessage, callStack, children }: Props) => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const [isDetailsOpen, setIsDetailsOpen] = useState(false);
-  const theme = useTheme();
+  const theme = getThemeFromLocalStorage();
 
   return (
     <div className={styles.container}>

--- a/packages/console/src/components/AppLoading/index.tsx
+++ b/packages/console/src/components/AppLoading/index.tsx
@@ -3,12 +3,12 @@ import { Theme } from '@logto/schemas';
 import IllustrationDark from '@/assets/images/loading-illustration-dark.svg';
 import Illustration from '@/assets/images/loading-illustration.svg';
 import { Daisy as Spinner } from '@/components/Spinner';
-import useTheme from '@/hooks/use-theme';
+import { getThemeFromLocalStorage } from '@/contexts/AppThemeProvider';
 
 import * as styles from './index.module.scss';
 
 const AppLoading = () => {
-  const theme = useTheme();
+  const theme = getThemeFromLocalStorage();
 
   return (
     <div className={styles.container}>

--- a/packages/console/src/contexts/AppThemeProvider/index.tsx
+++ b/packages/console/src/contexts/AppThemeProvider/index.tsx
@@ -19,8 +19,6 @@ type AppTheme = {
   theme: Theme;
 };
 
-const defaultTheme: Theme = Theme.Light;
-
 const darkThemeWatchMedia = window.matchMedia('(prefers-color-scheme: dark)');
 const getThemeBySystemConfiguration = (): Theme =>
   darkThemeWatchMedia.matches ? Theme.Dark : Theme.Light;
@@ -29,12 +27,24 @@ export const getAppearanceModeFromLocalStorage = (): AppearanceMode =>
   trySafe(() => appearanceModeGuard.parse(localStorage.getItem(appearanceModeStorageKey))) ??
   DynamicAppearanceMode.System;
 
+export const getThemeFromLocalStorage = () => {
+  const appearanceMode = getAppearanceModeFromLocalStorage();
+
+  if (appearanceMode === DynamicAppearanceMode.System) {
+    return getThemeBySystemConfiguration();
+  }
+
+  return appearanceMode;
+};
+
+const cachedTheme = getThemeFromLocalStorage();
+
 export const AppThemeContext = createContext<AppTheme>({
-  theme: defaultTheme,
+  theme: cachedTheme,
 });
 
 export const AppThemeProvider = ({ fixedTheme, appearanceMode, children }: Props) => {
-  const [theme, setTheme] = useState<Theme>(defaultTheme);
+  const [theme, setTheme] = useState<Theme>(cachedTheme);
 
   useEffect(() => {
     if (fixedTheme) {

--- a/packages/console/src/onboarding/App.tsx
+++ b/packages/console/src/onboarding/App.tsx
@@ -2,7 +2,6 @@ import { Theme } from '@logto/schemas';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { SWRConfig } from 'swr';
 
-import AppLoading from '@/components/AppLoading';
 import Toast from '@/components/Toast';
 import { getBasename } from '@/consts';
 import AppBoundary from '@/containers/AppBoundary';
@@ -27,12 +26,7 @@ const App = () => {
 
   const {
     data: { questionnaire },
-    isLoaded,
   } = useUserOnboardingData();
-
-  if (!isLoaded) {
-    return <AppLoading />;
-  }
 
   return (
     <BrowserRouter basename={getBasename()}>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- The default theme in the `AppThemeContext` should load from local storage.
- The `AppLoading` and `AppError` should read theme from local storage since they're used globally.
- Remove the `AppLoading` from the onboarding app since the `TenantAppContainer` has already loaded the onboarding data.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
