### PR TITLE
fix(console): fix sign-in methods deletion error

### DIFF
--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/SignUpForm.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/SignUpForm.tsx
@@ -103,6 +103,7 @@ const SignUpForm = () => {
 
     // Note: we need to revalidate the sign-in methods after we have submitted
     if (submitCount) {
+      // Note: wait for the form to be updated before validating the new data.
       setTimeout(() => {
         void trigger('signIn.methods');
       }, 0);

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/SignUpForm.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/SignUpForm.tsx
@@ -103,7 +103,9 @@ const SignUpForm = () => {
 
     // Note: we need to revalidate the sign-in methods after we have submitted
     if (submitCount) {
-      void trigger('signIn.methods');
+      setTimeout(() => {
+        void trigger('signIn.methods');
+      }, 0);
     }
   };
 

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/SignInMethodEditBox/index.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/SignInMethodEditBox/index.tsx
@@ -35,7 +35,9 @@ const SignInMethodEditBox = () => {
 
   const revalidate = () => {
     if (submitCount) {
-      void trigger(`signIn.methods`);
+      setTimeout(() => {
+        void trigger('signIn.methods');
+      }, 0);
     }
   };
 

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/SignInMethodEditBox/index.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/SignInMethodEditBox/index.tsx
@@ -35,6 +35,7 @@ const SignInMethodEditBox = () => {
 
   const revalidate = () => {
     if (submitCount) {
+      // Note: wait for the form to be updated before validating the new data.
       setTimeout(() => {
         void trigger('signIn.methods');
       }, 0);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
When we call the `trigger` method to validate the form data after `remove()`, the react hook form will validate the new data with the old data index rather than the data index after `delete()`, so add a time out to wait for the form to update.

Example:
we have an array data `[0, 1]`; after we remove the index `0` element, the array becomes `[1]`, but the react hook form will validate the old data index, so the index `1` item will be checked, and we will get `undefined` from the `[1]` at index `1`, and the app will crash:
<img width="689" alt="image" src="https://user-images.githubusercontent.com/10806653/226178955-7100fb39-6c04-448a-b079-2574b39a49e2.png">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
