### PR TITLE
fix(console): read default theme value from local storage

### DIFF
--- a/packages/console/src/App.tsx
+++ b/packages/console/src/App.tsx
@@ -21,6 +21,7 @@ import ErrorBoundary from './containers/ErrorBoundary';
 import TenantAppContainer from './containers/TenantAppContainer';
 import AppConfirmModalProvider from './contexts/AppConfirmModalProvider';
 import AppEndpointsProvider from './contexts/AppEndpointsProvider';
+import { AppThemeProvider } from './contexts/AppThemeProvider';
 import TenantsProvider, { TenantsContext } from './contexts/TenantsProvider';
 
 void initI18n();
@@ -60,17 +61,19 @@ const Content = () => {
         scopes,
       }}
     >
-      <ErrorBoundary>
-        {!isCloud || isSettle ? (
-          <AppEndpointsProvider>
-            <AppConfirmModalProvider>
-              <TenantAppContainer />
-            </AppConfirmModalProvider>
-          </AppEndpointsProvider>
-        ) : (
-          <CloudApp />
-        )}
-      </ErrorBoundary>
+      <AppThemeProvider>
+        <ErrorBoundary>
+          {!isCloud || isSettle ? (
+            <AppEndpointsProvider>
+              <AppConfirmModalProvider>
+                <TenantAppContainer />
+              </AppConfirmModalProvider>
+            </AppEndpointsProvider>
+          ) : (
+            <CloudApp />
+          )}
+        </ErrorBoundary>
+      </AppThemeProvider>
     </LogtoProvider>
   );
 };

--- a/packages/console/src/cloud/App.tsx
+++ b/packages/console/src/cloud/App.tsx
@@ -1,6 +1,5 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
-import { AppThemeProvider } from '@/contexts/AppThemeProvider';
 import Callback from '@cloud/pages/Callback';
 
 import * as styles from './App.module.scss';
@@ -11,16 +10,14 @@ import { CloudRoute } from './types';
 const App = () => {
   return (
     <BrowserRouter>
-      <AppThemeProvider>
-        <div className={styles.app}>
-          <Routes>
-            <Route path={`/${CloudRoute.Callback}`} element={<Callback />} />
-            <Route path={`/${CloudRoute.SocialDemoCallback}`} element={<SocialDemoCallback />} />
-            <Route path={`/:tenantId/${CloudRoute.Callback}`} element={<Callback />} />
-            <Route path="/*" element={<Main />} />
-          </Routes>
-        </div>
-      </AppThemeProvider>
+      <div className={styles.app}>
+        <Routes>
+          <Route path={`/${CloudRoute.Callback}`} element={<Callback />} />
+          <Route path={`/${CloudRoute.SocialDemoCallback}`} element={<SocialDemoCallback />} />
+          <Route path={`/:tenantId/${CloudRoute.Callback}`} element={<Callback />} />
+          <Route path="/*" element={<Main />} />
+        </Routes>
+      </div>
     </BrowserRouter>
   );
 };

--- a/packages/console/src/contexts/AppThemeProvider/index.tsx
+++ b/packages/console/src/contexts/AppThemeProvider/index.tsx
@@ -23,11 +23,11 @@ const darkThemeWatchMedia = window.matchMedia('(prefers-color-scheme: dark)');
 const getThemeBySystemConfiguration = (): Theme =>
   darkThemeWatchMedia.matches ? Theme.Dark : Theme.Light;
 
-export const getAppearanceModeFromLocalStorage = (): AppearanceMode =>
+export const buildDefaultAppearanceMode = (): AppearanceMode =>
   trySafe(() => appearanceModeGuard.parse(localStorage.getItem(appearanceModeStorageKey))) ??
   DynamicAppearanceMode.System;
 
-const defaultAppearanceMode = getAppearanceModeFromLocalStorage();
+const defaultAppearanceMode = buildDefaultAppearanceMode();
 
 const defaultTheme =
   defaultAppearanceMode === DynamicAppearanceMode.System

--- a/packages/console/src/contexts/AppThemeProvider/index.tsx
+++ b/packages/console/src/contexts/AppThemeProvider/index.tsx
@@ -16,7 +16,7 @@ type Props = {
 type Context = {
   theme: Theme;
   setAppearanceMode: (mode: AppearanceMode) => void;
-  setFixedTheme: React.Dispatch<React.SetStateAction<Theme | undefined>>;
+  setThemeOverride: React.Dispatch<React.SetStateAction<Theme | undefined>>;
 };
 
 const darkThemeWatchMedia = window.matchMedia('(prefers-color-scheme: dark)');
@@ -37,12 +37,12 @@ const defaultTheme =
 export const AppThemeContext = createContext<Context>({
   theme: defaultTheme,
   setAppearanceMode: noop,
-  setFixedTheme: noop,
+  setThemeOverride: noop,
 });
 
 export const AppThemeProvider = ({ children }: Props) => {
   const [theme, setTheme] = useState<Theme>(defaultTheme);
-  const [fixedTheme, setFixedTheme] = useState<Theme>();
+  const [themeOverride, setThemeOverride] = useState<Theme>();
   const [mode, setMode] = useState<AppearanceMode>(defaultAppearanceMode);
 
   const setAppearanceMode = (mode: AppearanceMode) => {
@@ -51,8 +51,8 @@ export const AppThemeProvider = ({ children }: Props) => {
   };
 
   useEffect(() => {
-    if (fixedTheme) {
-      setTheme(fixedTheme);
+    if (themeOverride) {
+      setTheme(themeOverride);
 
       return;
     }
@@ -74,7 +74,7 @@ export const AppThemeProvider = ({ children }: Props) => {
     return () => {
       darkThemeWatchMedia.removeEventListener('change', changeTheme);
     };
-  }, [mode, fixedTheme]);
+  }, [mode, themeOverride]);
 
   // Set Theme Mode
   useEffect(() => {
@@ -86,7 +86,7 @@ export const AppThemeProvider = ({ children }: Props) => {
     () => ({
       theme,
       setAppearanceMode,
-      setFixedTheme,
+      setThemeOverride,
     }),
     [theme]
   );

--- a/packages/console/src/hooks/use-user-preferences.ts
+++ b/packages/console/src/hooks/use-user-preferences.ts
@@ -2,7 +2,7 @@ import { builtInLanguages as builtInConsoleLanguages } from '@logto/phrases';
 import { useContext, useEffect, useMemo } from 'react';
 import { z } from 'zod';
 
-import { AppThemeContext, getAppearanceModeFromLocalStorage } from '@/contexts/AppThemeProvider';
+import { AppThemeContext, buildDefaultAppearanceMode } from '@/contexts/AppThemeProvider';
 import { appearanceModeGuard } from '@/types/appearance-mode';
 
 import useMeCustomData from './use-me-custom-data';
@@ -29,7 +29,7 @@ const useUserPreferences = () => {
     return parsed.success
       ? parsed.data[adminConsolePreferencesKey]
       : {
-          appearanceMode: getAppearanceModeFromLocalStorage(),
+          appearanceMode: buildDefaultAppearanceMode(),
         };
   }, [data]);
 

--- a/packages/console/src/hooks/use-user-preferences.ts
+++ b/packages/console/src/hooks/use-user-preferences.ts
@@ -1,9 +1,8 @@
 import { builtInLanguages as builtInConsoleLanguages } from '@logto/phrases';
-import { useEffect, useMemo } from 'react';
+import { useContext, useEffect, useMemo } from 'react';
 import { z } from 'zod';
 
-import { appearanceModeStorageKey } from '@/consts';
-import { getAppearanceModeFromLocalStorage } from '@/contexts/AppThemeProvider';
+import { AppThemeContext, getAppearanceModeFromLocalStorage } from '@/contexts/AppThemeProvider';
 import { appearanceModeGuard } from '@/types/appearance-mode';
 
 import useMeCustomData from './use-me-custom-data';
@@ -22,6 +21,7 @@ export type UserPreferences = z.infer<typeof userPreferencesGuard>;
 
 const useUserPreferences = () => {
   const { data, error, isLoading, isLoaded, update: updateMeCustomData } = useMeCustomData();
+  const { setAppearanceMode } = useContext(AppThemeContext);
 
   const userPreferences = useMemo(() => {
     const parsed = z.object({ [adminConsolePreferencesKey]: userPreferencesGuard }).safeParse(data);
@@ -43,8 +43,8 @@ const useUserPreferences = () => {
   };
 
   useEffect(() => {
-    localStorage.setItem(appearanceModeStorageKey, userPreferences.appearanceMode);
-  }, [userPreferences.appearanceMode]);
+    setAppearanceMode(userPreferences.appearanceMode);
+  }, [setAppearanceMode, userPreferences.appearanceMode]);
 
   return {
     isLoading,

--- a/packages/console/src/onboarding/App.tsx
+++ b/packages/console/src/onboarding/App.tsx
@@ -1,4 +1,5 @@
 import { Theme } from '@logto/schemas';
+import { useContext, useEffect } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { SWRConfig } from 'swr';
 
@@ -6,7 +7,7 @@ import AppLoading from '@/components/AppLoading';
 import Toast from '@/components/Toast';
 import { getBasename } from '@/consts';
 import AppBoundary from '@/containers/AppBoundary';
-import { AppThemeProvider } from '@/contexts/AppThemeProvider';
+import { AppThemeContext } from '@/contexts/AppThemeProvider';
 import useSwrOptions from '@/hooks/use-swr-options';
 import NotFound from '@/pages/NotFound';
 
@@ -24,6 +25,15 @@ const welcomePathname = getOnboardingPage(OnboardingPage.Welcome);
 
 const App = () => {
   const swrOptions = useSwrOptions();
+  const { setFixedTheme } = useContext(AppThemeContext);
+
+  useEffect(() => {
+    setFixedTheme(Theme.Light);
+
+    return () => {
+      setFixedTheme(undefined);
+    };
+  }, [setFixedTheme]);
 
   const {
     data: { questionnaire },
@@ -38,39 +48,31 @@ const App = () => {
     <BrowserRouter basename={getBasename()}>
       <div className={styles.app}>
         <SWRConfig value={swrOptions}>
-          <AppThemeProvider fixedTheme={Theme.Light}>
-            <AppBoundary>
-              <Toast />
-              <Routes>
+          <AppBoundary>
+            <Toast />
+            <Routes>
+              <Route index element={<Navigate replace to={welcomePathname} />} />
+              <Route path={`/${OnboardingRoute.Onboarding}`} element={<AppContent />}>
                 <Route index element={<Navigate replace to={welcomePathname} />} />
-                <Route path={`/${OnboardingRoute.Onboarding}`} element={<AppContent />}>
-                  <Route index element={<Navigate replace to={welcomePathname} />} />
-                  <Route path={OnboardingPage.Welcome} element={<Welcome />} />
-                  <Route
-                    path={OnboardingPage.AboutUser}
-                    element={questionnaire ? <About /> : <Navigate replace to={welcomePathname} />}
-                  />
-                  <Route
-                    path={OnboardingPage.SignInExperience}
-                    element={
-                      questionnaire ? (
-                        <SignInExperience />
-                      ) : (
-                        <Navigate replace to={welcomePathname} />
-                      )
-                    }
-                  />
-                  <Route
-                    path={OnboardingPage.Congrats}
-                    element={
-                      questionnaire ? <Congrats /> : <Navigate replace to={welcomePathname} />
-                    }
-                  />
-                </Route>
-                <Route path="*" element={<NotFound />} />
-              </Routes>
-            </AppBoundary>
-          </AppThemeProvider>
+                <Route path={OnboardingPage.Welcome} element={<Welcome />} />
+                <Route
+                  path={OnboardingPage.AboutUser}
+                  element={questionnaire ? <About /> : <Navigate replace to={welcomePathname} />}
+                />
+                <Route
+                  path={OnboardingPage.SignInExperience}
+                  element={
+                    questionnaire ? <SignInExperience /> : <Navigate replace to={welcomePathname} />
+                  }
+                />
+                <Route
+                  path={OnboardingPage.Congrats}
+                  element={questionnaire ? <Congrats /> : <Navigate replace to={welcomePathname} />}
+                />
+              </Route>
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </AppBoundary>
         </SWRConfig>
       </div>
     </BrowserRouter>

--- a/packages/console/src/onboarding/App.tsx
+++ b/packages/console/src/onboarding/App.tsx
@@ -25,15 +25,15 @@ const welcomePathname = getOnboardingPage(OnboardingPage.Welcome);
 
 const App = () => {
   const swrOptions = useSwrOptions();
-  const { setFixedTheme } = useContext(AppThemeContext);
+  const { setThemeOverride } = useContext(AppThemeContext);
 
   useEffect(() => {
-    setFixedTheme(Theme.Light);
+    setThemeOverride(Theme.Light);
 
     return () => {
-      setFixedTheme(undefined);
+      setThemeOverride(undefined);
     };
-  }, [setFixedTheme]);
+  }, [setThemeOverride]);
 
   const {
     data: { questionnaire },

--- a/packages/console/src/pages/Main/index.tsx
+++ b/packages/console/src/pages/Main/index.tsx
@@ -6,9 +6,7 @@ import { getBasename } from '@/consts';
 import AppBoundary from '@/containers/AppBoundary';
 import AppContent from '@/containers/AppContent';
 import ConsoleContent from '@/containers/ConsoleContent';
-import { AppThemeProvider } from '@/contexts/AppThemeProvider';
 import useSwrOptions from '@/hooks/use-swr-options';
-import useUserPreferences from '@/hooks/use-user-preferences';
 import Callback from '@/pages/Callback';
 import Welcome from '@/pages/Welcome';
 
@@ -16,26 +14,21 @@ import HandleSocialCallback from '../Profile/containers/HandleSocialCallback';
 
 const Main = () => {
   const swrOptions = useSwrOptions();
-  const {
-    data: { appearanceMode },
-  } = useUserPreferences();
 
   return (
     <BrowserRouter basename={getBasename()}>
       <SWRConfig value={swrOptions}>
-        <AppThemeProvider appearanceMode={appearanceMode}>
-          <AppBoundary>
-            <Toast />
-            <Routes>
-              <Route path="callback" element={<Callback />} />
-              <Route path="welcome" element={<Welcome />} />
-              <Route path="handle-social" element={<HandleSocialCallback />} />
-              <Route element={<AppContent />}>
-                <Route path="/*" element={<ConsoleContent />} />
-              </Route>
-            </Routes>
-          </AppBoundary>
-        </AppThemeProvider>
+        <AppBoundary>
+          <Toast />
+          <Routes>
+            <Route path="callback" element={<Callback />} />
+            <Route path="welcome" element={<Welcome />} />
+            <Route path="handle-social" element={<HandleSocialCallback />} />
+            <Route element={<AppContent />}>
+              <Route path="/*" element={<ConsoleContent />} />
+            </Route>
+          </Routes>
+        </AppBoundary>
       </SWRConfig>
     </BrowserRouter>
   );


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- The default theme in the `AppThemeContext` should load from local storage.
- Wrap the whole app with `AppThemeProvider` since it provides the theme context for all apps.
- Export a `setFixedTheme` API to support modifying the fixed theme in specific apps.
- Export a `setAppearanceMode` API to support updating the appearance when the user preference is updated.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
![Mar-19-2023 23-45-25](https://user-images.githubusercontent.com/10806653/226187549-fbf9dc7a-6308-4e18-b5a6-dcc2a1e03701.gif)


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
