### PR TITLE
feat(console): add interactionMode qs to AC

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -24,7 +24,7 @@
     "@logto/language-kit": "workspace:*",
     "@logto/phrases": "workspace:*",
     "@logto/phrases-ui": "workspace:*",
-    "@logto/react": "1.0.0",
+    "@logto/react": "1.1.0",
     "@logto/schemas": "workspace:*",
     "@mdx-js/react": "^1.6.22",
     "@parcel/compressor-brotli": "2.8.3",

--- a/packages/console/src/consts/index.ts
+++ b/packages/console/src/consts/index.ts
@@ -11,6 +11,6 @@ export const profileSocialLinkingKeyPrefix = 'logto:admin_console:linking_social
 export const requestTimeout = 20_000;
 export const defaultPageSize = 20;
 
-export enum queryParameterKeys {
+export enum searchKeys {
   signUp = 'sign_up',
 }

--- a/packages/console/src/consts/index.ts
+++ b/packages/console/src/consts/index.ts
@@ -12,5 +12,5 @@ export const requestTimeout = 20_000;
 export const defaultPageSize = 20;
 
 export enum queryParameterKeys {
-  signUp = 'signup',
+  signUp = 'sign_up',
 }

--- a/packages/console/src/consts/index.ts
+++ b/packages/console/src/consts/index.ts
@@ -10,3 +10,7 @@ export const appearanceModeStorageKey = 'logto:admin_console:appearance_mode';
 export const profileSocialLinkingKeyPrefix = 'logto:admin_console:linking_social_connector';
 export const requestTimeout = 20_000;
 export const defaultPageSize = 20;
+
+export enum queryParameterKeys {
+  signUp = 'signup',
+}

--- a/packages/console/src/containers/AppContent/index.tsx
+++ b/packages/console/src/containers/AppContent/index.tsx
@@ -7,7 +7,7 @@ import { Outlet, useHref, useLocation, useNavigate, useSearchParams } from 'reac
 import AppError from '@/components/AppError';
 import AppLoading from '@/components/AppLoading';
 import SessionExpired from '@/components/SessionExpired';
-import { queryParameterKeys } from '@/consts';
+import { searchKeys } from '@/consts';
 import { isCloud } from '@/consts/cloud';
 import useConfigs from '@/hooks/use-configs';
 import useScroll from '@/hooks/use-scroll';
@@ -38,7 +38,7 @@ const AppContent = () => {
 
   useEffect(() => {
     if (!isAuthenticated && !isLogtoLoading) {
-      const signUpFirst = searchParameters.get(queryParameterKeys.signUp);
+      const signUpFirst = searchParameters.get(searchKeys.signUp);
 
       void signIn(
         new URL(href, window.location.origin).toString(),

--- a/packages/console/src/containers/AppContent/index.tsx
+++ b/packages/console/src/containers/AppContent/index.tsx
@@ -2,11 +2,12 @@ import { LogtoClientError, LogtoError, useLogto } from '@logto/react';
 import { conditional } from '@silverhand/essentials';
 import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Outlet, useHref, useLocation, useNavigate } from 'react-router-dom';
+import { Outlet, useHref, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 
 import AppError from '@/components/AppError';
 import AppLoading from '@/components/AppLoading';
 import SessionExpired from '@/components/SessionExpired';
+import { queryParameterKeys } from '@/consts';
 import { isCloud } from '@/consts/cloud';
 import useConfigs from '@/hooks/use-configs';
 import useScroll from '@/hooks/use-scroll';
@@ -29,6 +30,7 @@ const AppContent = () => {
 
   const location = useLocation();
   const navigate = useNavigate();
+  const [searchParameters] = useSearchParams();
   const { firstItem } = useSidebarMenuItems();
   const scrollableContent = useRef<HTMLDivElement>(null);
   const { scrollTop } = useScroll(scrollableContent.current);
@@ -36,9 +38,14 @@ const AppContent = () => {
 
   useEffect(() => {
     if (!isAuthenticated && !isLogtoLoading) {
-      void signIn(new URL(href, window.location.origin).toString());
+      const signUpFirst = searchParameters.get(queryParameterKeys.signUp);
+
+      void signIn(
+        new URL(href, window.location.origin).toString(),
+        conditional(signUpFirst === 'true' && 'signUp')
+      );
     }
-  }, [href, isAuthenticated, isLogtoLoading, signIn]);
+  }, [href, isAuthenticated, isLogtoLoading, searchParameters, signIn]);
 
   useEffect(() => {
     // Navigate to the first menu item after configs are loaded.

--- a/packages/console/src/containers/AppContent/index.tsx
+++ b/packages/console/src/containers/AppContent/index.tsx
@@ -1,5 +1,5 @@
 import { LogtoClientError, LogtoError, useLogto } from '@logto/react';
-import { conditional } from '@silverhand/essentials';
+import { conditional, yes } from '@silverhand/essentials';
 import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Outlet, useHref, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
@@ -42,7 +42,7 @@ const AppContent = () => {
 
       void signIn(
         new URL(href, window.location.origin).toString(),
-        conditional(signUpFirst === 'true' && 'signUp')
+        conditional(yes(signUpFirst) && 'signUp')
       );
     }
   }, [href, isAuthenticated, isLogtoLoading, searchParameters, signIn]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,7 +187,7 @@ importers:
       '@logto/language-kit': workspace:*
       '@logto/phrases': workspace:*
       '@logto/phrases-ui': workspace:*
-      '@logto/react': 1.0.0
+      '@logto/react': 1.1.0
       '@logto/schemas': workspace:*
       '@mdx-js/react': ^1.6.22
       '@parcel/compressor-brotli': 2.8.3
@@ -264,7 +264,7 @@ importers:
       '@logto/language-kit': link:../toolkit/language-kit
       '@logto/phrases': link:../phrases
       '@logto/phrases-ui': link:../phrases-ui
-      '@logto/react': 1.0.0_react@18.2.0
+      '@logto/react': 1.1.0_react@18.2.0
       '@logto/schemas': link:../schemas
       '@mdx-js/react': 1.6.22_react@18.2.0
       '@parcel/compressor-brotli': 2.8.3_@parcel+core@2.8.3
@@ -2479,6 +2479,14 @@ packages:
       js-base64: 3.7.4
     dev: true
 
+  /@logto/browser/1.1.0:
+    resolution: {integrity: sha512-0NpRVM+D1d4bCwpQb0OcgE6cKKwLevqdMCBjVLlosi527ydMa25X3cEuvRw+bojxSF3QfS/Ig9GktS7xvUAnCg==}
+    dependencies:
+      '@logto/client': 1.1.0
+      '@silverhand/essentials': 1.3.0
+      js-base64: 3.7.4
+    dev: true
+
   /@logto/client/1.0.0:
     resolution: {integrity: sha512-80tqgNdZRT9hmxznpkpb1UjOdtBO5FMyFU2GYvym5j6zCTQxi3dGXlgNRzOUDX2sHM1PqkUvsVM2IzgMGGNjvg==}
     dependencies:
@@ -2490,8 +2498,28 @@ packages:
       lodash.once: 4.1.1
     dev: true
 
+  /@logto/client/1.1.0:
+    resolution: {integrity: sha512-HdUuH6vwbKzhLoa7JgWu85CMTU8a7lux9Uadv5yitMaJMEsYERUU0SntQC8jZ7K5/Ktc8r/3kbfo0MKyFNffMA==}
+    dependencies:
+      '@logto/js': 1.1.0
+      '@silverhand/essentials': 1.3.0
+      camelcase-keys: 7.0.2
+      jose: 4.11.1
+      lodash.get: 4.4.2
+      lodash.once: 4.1.1
+    dev: true
+
   /@logto/js/1.0.0:
     resolution: {integrity: sha512-brhyDIIDzIpsvcvQZHWjiYknKO//py3YnxfdWx9P1OkcyF1iIAiYv0o25/XXzfsb3XS0TkP1FdvLhLp/LDLz5g==}
+    dependencies:
+      '@silverhand/essentials': 1.3.0
+      camelcase-keys: 7.0.2
+      jose: 4.11.1
+      lodash.get: 4.4.2
+    dev: true
+
+  /@logto/js/1.1.0:
+    resolution: {integrity: sha512-YW8ou7DifY0T9Pfli3sZG9sdm5UbINcHEi9pkj6pGxVUX5lBWRxT+ZWGgOsRl4KtrPXzg9ivAAJHzyPRwZAf7g==}
     dependencies:
       '@silverhand/essentials': 1.3.0
       camelcase-keys: 7.0.2
@@ -2516,6 +2544,16 @@ packages:
       react: '>=16.8.0 || ^18.0.0'
     dependencies:
       '@logto/browser': 1.0.0
+      '@silverhand/essentials': 1.3.0
+      react: 18.2.0
+    dev: true
+
+  /@logto/react/1.1.0_react@18.2.0:
+    resolution: {integrity: sha512-uz7kevuDVd9CMXVhQ3Mt7eVcV0a5Ghcmn6YabS6Sjv9kJCmpRHXGJrVHP4mah+vSEUGirGtoKLVNE8kyPdDVIA==}
+    peerDependencies:
+      react: '>=16.8.0 || ^18.0.0'
+    dependencies:
+      '@logto/browser': 1.1.0
       '@silverhand/essentials': 1.3.0
       react: 18.2.0
     dev: true


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Allow AC to use the signup first user experience by a given interaction mode query params. 

e.g.  http://localhost:3002/console?signup=true

- bump the @logto/react SDK version
- read queryString `signup` from the search params. If the signup mode is specified, should use signup first user experience. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
