### PR TITLE
fix: close icon should work on connector readme drawer

### DIFF
--- a/packages/console/src/containers/AppContent/components/UserInfo/index.module.scss
+++ b/packages/console/src/containers/AppContent/components/UserInfo/index.module.scss
@@ -14,7 +14,6 @@
     border-radius: 8px;
     width: 32px;
     height: 32px;
-    z-index: 1;
     transition: background 0.2s ease-in-out;
   }
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Click close icon on connector readme drawer should close the drawer. The button was affected by the underlying avatar mask that has z-index.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
- [x] This PR is not applicable for the checklist
