### PR TITLE
fix(console): language and theme should have default value

### DIFF
--- a/packages/console/src/containers/AppContent/components/SubMenu/index.tsx
+++ b/packages/console/src/containers/AppContent/components/SubMenu/index.tsx
@@ -19,7 +19,7 @@ type Props<T> = {
   icon?: ReactNode;
   title: AdminConsoleKey;
   options: Array<Option<T>>;
-  selectedOption?: T;
+  selectedOption: T;
   onItemClick: (value: T) => void;
 };
 

--- a/packages/console/src/containers/AppContent/components/UserInfo/index.tsx
+++ b/packages/console/src/containers/AppContent/components/UserInfo/index.tsx
@@ -44,8 +44,6 @@ const UserInfo = () => {
     return <UserInfoSkeleton />;
   }
 
-  const { avatar, name } = user ?? {};
-
   return (
     <>
       <div

--- a/packages/console/src/hooks/use-user-preferences.ts
+++ b/packages/console/src/hooks/use-user-preferences.ts
@@ -1,8 +1,10 @@
 import { builtInLanguages as builtInConsoleLanguages } from '@logto/phrases';
+import type { Theme } from '@logto/schemas';
 import { useContext, useEffect, useMemo } from 'react';
 import { z } from 'zod';
 
 import { AppThemeContext, buildDefaultAppearanceMode } from '@/contexts/AppThemeProvider';
+import type { DynamicAppearanceMode } from '@/types/appearance-mode';
 import { appearanceModeGuard } from '@/types/appearance-mode';
 
 import useMeCustomData from './use-me-custom-data';
@@ -11,13 +13,23 @@ const adminConsolePreferencesKey = 'adminConsolePreferences';
 
 const userPreferencesGuard = z.object({
   language: z.enum(builtInConsoleLanguages).optional(),
-  appearanceMode: appearanceModeGuard,
+  appearanceMode: appearanceModeGuard.optional(),
   experienceNoticeConfirmed: z.boolean().optional(),
   getStartedHidden: z.boolean().optional(),
   connectorSieNoticeConfirmed: z.boolean().optional(),
 });
 
 export type UserPreferences = z.infer<typeof userPreferencesGuard>;
+
+type DefaultUserPreference = {
+  language: (typeof builtInConsoleLanguages)[number];
+  appearanceMode: Theme | DynamicAppearanceMode.System;
+} & Omit<UserPreferences, 'language' | 'appearanceMode'>;
+
+const defaultUserPreferences: DefaultUserPreference = {
+  appearanceMode: buildDefaultAppearanceMode(),
+  language: 'en',
+};
 
 const useUserPreferences = () => {
   const { data, error, isLoading, isLoaded, update: updateMeCustomData } = useMeCustomData();
@@ -27,10 +39,11 @@ const useUserPreferences = () => {
     const parsed = z.object({ [adminConsolePreferencesKey]: userPreferencesGuard }).safeParse(data);
 
     return parsed.success
-      ? parsed.data[adminConsolePreferencesKey]
-      : {
-          appearanceMode: buildDefaultAppearanceMode(),
-        };
+      ? {
+          ...defaultUserPreferences,
+          ...parsed.data[adminConsolePreferencesKey],
+        }
+      : defaultUserPreferences;
   }, [data]);
 
   const update = async (data: Partial<UserPreferences>) => {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Language and theme selection should have default value.

<img width="551" alt="image" src="https://user-images.githubusercontent.com/12833674/226245373-3fa202cb-d25d-456a-8a85-9e9df6d96908.png">

<img width="542" alt="image" src="https://user-images.githubusercontent.com/12833674/226245397-d3b53fff-74da-4819-8b0b-642cda91e028.png">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Clear user preference in database and click user avatar. In the popup menu, language and theme have selected value, which is `en` and `sync with system` by default.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
- [x] This PR is not applicable for the checklist
