### PR TITLE
refactor: fix initial sie config for cloud

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             admin_endpoint=https://auth.logto.${{ inputs.target == 'prod' && 'io' || 'dev' }}/
-            applicationinsights_connection_string=${{ secrets.APPLICATIONINSIGHTS_CONNECTION_STRING }}
+            applicationinsights_connection_string=${{ (inputs.target || 'dev') == 'dev' && secrets.APPLICATIONINSIGHTS_CONNECTION_STRING || secrets.APPLICATIONINSIGHTS_CONNECTION_STRING_PROD }}
 
   deploy-core:
     runs-on: ubuntu-latest

--- a/packages/schemas/src/seeds/sign-in-experience.ts
+++ b/packages/schemas/src/seeds/sign-in-experience.ts
@@ -1,6 +1,6 @@
 import { generateDarkColor } from '@logto/core-kit';
 
-import type { SignInExperience } from '../db-entries/index.js';
+import type { CreateSignInExperience } from '../db-entries/index.js';
 import { SignInMode } from '../db-entries/index.js';
 import { SignInIdentifier } from '../foundations/index.js';
 import { adminTenantId, defaultTenantId } from './tenant.js';
@@ -10,7 +10,7 @@ const defaultPrimaryColor = '#6139F6';
 export const createDefaultSignInExperience = (
   forTenantId: string,
   isCloud: boolean
-): Readonly<SignInExperience> =>
+): Readonly<CreateSignInExperience> =>
   Object.freeze({
     tenantId: forTenantId,
     id: 'default',
@@ -20,8 +20,8 @@ export const createDefaultSignInExperience = (
       darkPrimaryColor: generateDarkColor(defaultPrimaryColor),
     },
     branding: {
-      logoUrl: isCloud ? '' : 'https://logto.io/logo.svg',
-      darkLogoUrl: isCloud ? '' : 'https://logto.io/logo-dark.svg',
+      logoUrl: isCloud ? undefined : 'https://logto.io/logo.svg',
+      darkLogoUrl: isCloud ? undefined : 'https://logto.io/logo-dark.svg',
     },
     languageInfo: {
       autoDetect: true,
@@ -53,7 +53,7 @@ export const createDefaultSignInExperience = (
 /** @deprecated Use `createDefaultSignInExperience()` instead. */
 export const defaultSignInExperience = createDefaultSignInExperience(defaultTenantId, false);
 
-export const createAdminTenantSignInExperience = (): Readonly<SignInExperience> =>
+export const createAdminTenantSignInExperience = (): Readonly<CreateSignInExperience> =>
   Object.freeze({
     ...defaultSignInExperience,
     tenantId: adminTenantId,


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
correct sie initial config type and use `undefined` for logo urls on cloud

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

data looks good for initial tenants

<img width="722" alt="image" src="https://user-images.githubusercontent.com/14722250/226297210-4f47a85f-5372-4062-a42e-65285e9f6417.png">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
