### PR TITLE
fix(console): fix linked social account not shown bug

### DIFF
--- a/packages/console/src/components/UserInfoCard/index.tsx
+++ b/packages/console/src/components/UserInfoCard/index.tsx
@@ -1,6 +1,7 @@
 import type { IdTokenClaims } from '@logto/react';
 import type { User } from '@logto/schemas';
 import classNames from 'classnames';
+import { useTranslation } from 'react-i18next';
 
 import UserAvatar from '../UserAvatar';
 import * as styles from './index.module.scss';
@@ -15,6 +16,8 @@ type Props = {
 };
 
 const UserInfoCard = ({ className, user, avatarSize = 'medium' }: Props) => {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+
   const { name, username, avatar, picture, primaryEmail, email } = user ?? {};
   const avatarToDisplay = avatar ?? picture;
   const nameToDisplay = name ?? username;
@@ -29,6 +32,9 @@ const UserInfoCard = ({ className, user, avatarSize = 'medium' }: Props) => {
       <div className={styles.nameWrapper}>
         <div className={styles.name}>{nameToDisplay}</div>
         {emailToDisplay && <div className={styles.email}>{emailToDisplay}</div>}
+        {!nameToDisplay && !emailToDisplay && (
+          <div className={styles.email}>({t('profile.link_account.anonymous')})</div>
+        )}
       </div>
     </div>
   );

--- a/packages/console/src/types/profile.ts
+++ b/packages/console/src/types/profile.ts
@@ -6,12 +6,3 @@ export const locationStateGuard = s.object({
 });
 
 export type LocationState = s.Infer<typeof locationStateGuard>;
-
-export const socialUserInfoGuard = s.object({
-  id: s.string(),
-  name: s.string(),
-  email: s.string(),
-  avatar: s.string(),
-});
-
-export type SocialUserInfo = s.Infer<typeof socialUserInfoGuard>;

--- a/packages/phrases/src/locales/de/translation/admin-console/profile.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/profile.ts
@@ -19,6 +19,7 @@ const profile = {
     email_required: 'Email is required', // UNTRANSLATED
     invalid_email: 'Invalid email address', // UNTRANSLATED
     identical_email_address: 'The input email address is identical to the current one', // UNTRANSLATED
+    anonymous: 'Anonymous', // UNTRANSLATED
   },
   password: {
     title: 'PASSWORD & SECURITY', // UNTRANSLATED

--- a/packages/phrases/src/locales/en/translation/admin-console/profile.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/profile.ts
@@ -19,6 +19,7 @@ const profile = {
     email_required: 'Email is required',
     invalid_email: 'Invalid email address',
     identical_email_address: 'The input email address is identical to the current one',
+    anonymous: 'Anonymous',
   },
   password: {
     title: 'PASSWORD & SECURITY',

--- a/packages/phrases/src/locales/fr/translation/admin-console/profile.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/profile.ts
@@ -19,6 +19,7 @@ const profile = {
     email_required: 'Email is required', // UNTRANSLATED
     invalid_email: 'Invalid email address', // UNTRANSLATED
     identical_email_address: 'The input email address is identical to the current one', // UNTRANSLATED
+    anonymous: 'Anonymous', // UNTRANSLATED
   },
   password: {
     title: 'PASSWORD & SECURITY', // UNTRANSLATED

--- a/packages/phrases/src/locales/ko/translation/admin-console/profile.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/profile.ts
@@ -19,6 +19,7 @@ const profile = {
     email_required: 'Email is required', // UNTRANSLATED
     invalid_email: 'Invalid email address', // UNTRANSLATED
     identical_email_address: 'The input email address is identical to the current one', // UNTRANSLATED
+    anonymous: 'Anonymous', // UNTRANSLATED
   },
   password: {
     title: 'PASSWORD & SECURITY', // UNTRANSLATED

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/profile.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/profile.ts
@@ -19,6 +19,7 @@ const profile = {
     email_required: 'Email is required', // UNTRANSLATED
     invalid_email: 'Invalid email address', // UNTRANSLATED
     identical_email_address: 'The input email address is identical to the current one', // UNTRANSLATED
+    anonymous: 'Anonymous', // UNTRANSLATED
   },
   password: {
     title: 'PASSWORD & SECURITY', // UNTRANSLATED

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/profile.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/profile.ts
@@ -19,6 +19,7 @@ const profile = {
     email_required: 'Email is required', // UNTRANSLATED
     invalid_email: 'Invalid email address', // UNTRANSLATED
     identical_email_address: 'The input email address is identical to the current one', // UNTRANSLATED
+    anonymous: 'Anonymous', // UNTRANSLATED
   },
   password: {
     title: 'PASSWORD & SECURITY', // UNTRANSLATED

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/profile.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/profile.ts
@@ -19,6 +19,7 @@ const profile = {
     email_required: 'Email is required', // UNTRANSLATED
     invalid_email: 'Invalid email address', // UNTRANSLATED
     identical_email_address: 'The input email address is identical to the current one', // UNTRANSLATED
+    anonymous: 'Anonymous', // UNTRANSLATED
   },
   password: {
     title: 'PASSWORD & SECURITY', // UNTRANSLATED

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/profile.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/profile.ts
@@ -18,6 +18,7 @@ const profile = {
     email_required: '邮箱不能为空',
     invalid_email: '无效的邮箱地址',
     identical_email_address: '输入的邮箱地址与当前邮箱地址相同',
+    anonymous: '匿名',
   },
   password: {
     title: '密码与安全',


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix linked social account not shown bug


Issue: 
When a GitHub user does not have a public email and name specified in their account, the resulting social user info data will have undefined values for the email and name fields. 
The original socialUserInfo guard has these two fields marked as required. Thus the returned identities did not pass the data guard. 


Fix: 
Use the same guard in @logto/connector-kit, keep SSOT. Allow name, email, phone optional.  Display anonymous if neither name nor email is found. 


<img width="808" alt="image" src="https://user-images.githubusercontent.com/36393111/226316768-cece3a73-378b-4568-92ba-43b26c8ebe03.png">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
