### PR TITLE
fix(core): use unprefixed fields for query

### DIFF
--- a/.changeset/clever-taxis-complain.md
+++ b/.changeset/clever-taxis-complain.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": patch
+---
+
+fix applications_roles query

--- a/packages/core/src/queries/applications-roles.ts
+++ b/packages/core/src/queries/applications-roles.ts
@@ -7,6 +7,7 @@ import { sql } from 'slonik';
 import { DeletionError } from '#src/errors/SlonikError/index.js';
 
 const { table, fields } = convertToIdentifiers(ApplicationsRoles, true);
+const { fields: insertFields } = convertToIdentifiers(ApplicationsRoles);
 
 export const createApplicationsRolesQueries = (pool: CommonQueryMethods) => {
   const findApplicationsRolesByApplicationId = async (applicationId: string) =>
@@ -21,7 +22,9 @@ export const createApplicationsRolesQueries = (pool: CommonQueryMethods) => {
 
   const insertApplicationsRoles = async (applicationsRoles: CreateApplicationsRole[]) =>
     pool.query(sql`
-      insert into ${table} (${fields.id}, ${fields.applicationId}, ${fields.roleId}) values
+      insert into ${table} (${insertFields.id}, ${insertFields.applicationId}, ${
+      insertFields.roleId
+    }) values
       ${sql.join(
         applicationsRoles.map(
           ({ id, applicationId, roleId }) => sql`(${id}, ${applicationId}, ${roleId})`


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
prefixed fields cannot be used in `insert`

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
locally, m2m can enable admin access

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
