### PR TITLE
refactor(console): connector guide readme content scrollbar

### DIFF
--- a/packages/console/src/pages/Connectors/components/Guide/index.module.scss
+++ b/packages/console/src/pages/Connectors/components/Guide/index.module.scss
@@ -52,21 +52,17 @@
       border: 1.5px solid var(--color-focused-variant);
       border-radius: 16px;
       margin: 0 _.unit(6) _.unit(6) 0;
+      overflow-y: auto;
 
       .readmeTitle {
         font: var(--font-title-2);
         padding: _.unit(5) _.unit(6) _.unit(4);
         border-bottom: 1px solid var(--color-focused-variant);
-
-        &.invisible {
-          display: none;
-        }
       }
 
       .readmeContent {
         flex: 1;
         padding: 0 _.unit(6) _.unit(4);
-        overflow-y: auto;
       }
     }
 

--- a/packages/console/src/pages/Connectors/components/Guide/index.module.scss
+++ b/packages/console/src/pages/Connectors/components/Guide/index.module.scss
@@ -57,13 +57,16 @@
         font: var(--font-title-2);
         padding: _.unit(5) _.unit(6) _.unit(4);
         border-bottom: 1px solid var(--color-focused-variant);
+
+        &.invisible {
+          display: none;
+        }
       }
 
       .readmeContent {
         flex: 1;
-        padding: 0 _.unit(6);
+        padding: 0 _.unit(6) _.unit(4);
         overflow-y: auto;
-        padding-bottom: _.unit(4);
       }
     }
 

--- a/packages/console/src/pages/Connectors/components/Guide/index.tsx
+++ b/packages/console/src/pages/Connectors/components/Guide/index.tsx
@@ -3,8 +3,10 @@ import { isLanguageTag } from '@logto/language-kit';
 import type { ConnectorFactoryResponse, ConnectorResponse, RequestErrorBody } from '@logto/schemas';
 import { ConnectorType } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
+import classNames from 'classnames';
 import i18next from 'i18next';
 import { HTTPError } from 'ky';
+import { OverlayScrollbarsComponent } from 'overlayscrollbars-react';
 import { useEffect, useRef, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
@@ -48,8 +50,12 @@ const Guide = ({ connector, onClose }: Props) => {
   const [conflictConnectorName, setConflictConnectorName] = useState<Record<string, string>>();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { type: connectorType, formItems, target, isStandard, configTemplate } = connector ?? {};
-
   const { language } = i18next;
+
+  const readmeTitleRef = useRef<HTMLDivElement>(null);
+  const [contentScrollTop, setContentScrollTop] = useState(0);
+  const isReadmeTitleInVisible =
+    readmeTitleRef.current && contentScrollTop > Number(readmeTitleRef.current.clientHeight);
 
   const isSocialConnector =
     connectorType !== ConnectorType.Sms && connectorType !== ConnectorType.Email;
@@ -182,8 +188,26 @@ const Guide = ({ connector, onClose }: Props) => {
         </div>
         <div className={styles.content}>
           <div className={styles.readme}>
-            <div className={styles.readmeTitle}>README: {title}</div>
-            <Markdown className={styles.readmeContent}>{content}</Markdown>
+            <div
+              ref={readmeTitleRef}
+              className={classNames(styles.readmeTitle, isReadmeTitleInVisible && styles.invisible)}
+            >
+              README: {title}
+            </div>
+            <OverlayScrollbarsComponent
+              options={{ scrollbars: { autoHide: 'leave', autoHideDelay: 0 } }}
+              className={styles.readmeContent}
+              events={{
+                scroll: (instance) => {
+                  const {
+                    viewport: { scrollTop },
+                  } = instance.elements();
+                  setContentScrollTop(scrollTop);
+                },
+              }}
+            >
+              <Markdown>{content}</Markdown>
+            </OverlayScrollbarsComponent>
           </div>
           <div className={styles.setup}>
             <FormProvider {...methods}>

--- a/packages/console/src/pages/Connectors/components/Guide/index.tsx
+++ b/packages/console/src/pages/Connectors/components/Guide/index.tsx
@@ -3,10 +3,8 @@ import { isLanguageTag } from '@logto/language-kit';
 import type { ConnectorFactoryResponse, ConnectorResponse, RequestErrorBody } from '@logto/schemas';
 import { ConnectorType } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
-import classNames from 'classnames';
 import i18next from 'i18next';
 import { HTTPError } from 'ky';
-import { OverlayScrollbarsComponent } from 'overlayscrollbars-react';
 import { useEffect, useRef, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
@@ -20,6 +18,7 @@ import CardTitle from '@/components/CardTitle';
 import DangerousRaw from '@/components/DangerousRaw';
 import IconButton from '@/components/IconButton';
 import Markdown from '@/components/Markdown';
+import OverlayScrollbar from '@/components/OverlayScrollbar';
 import { ConnectorsTabs } from '@/consts/page-tabs';
 import useApi from '@/hooks/use-api';
 import useConfigs from '@/hooks/use-configs';
@@ -51,11 +50,6 @@ const Guide = ({ connector, onClose }: Props) => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { type: connectorType, formItems, target, isStandard, configTemplate } = connector ?? {};
   const { language } = i18next;
-
-  const readmeTitleRef = useRef<HTMLDivElement>(null);
-  const [contentScrollTop, setContentScrollTop] = useState(0);
-  const isReadmeTitleInVisible =
-    readmeTitleRef.current && contentScrollTop > Number(readmeTitleRef.current.clientHeight);
 
   const isSocialConnector =
     connectorType !== ConnectorType.Sms && connectorType !== ConnectorType.Email;
@@ -187,28 +181,10 @@ const Guide = ({ connector, onClose }: Props) => {
           />
         </div>
         <div className={styles.content}>
-          <div className={styles.readme}>
-            <div
-              ref={readmeTitleRef}
-              className={classNames(styles.readmeTitle, isReadmeTitleInVisible && styles.invisible)}
-            >
-              README: {title}
-            </div>
-            <OverlayScrollbarsComponent
-              options={{ scrollbars: { autoHide: 'leave', autoHideDelay: 0 } }}
-              className={styles.readmeContent}
-              events={{
-                scroll: (instance) => {
-                  const {
-                    viewport: { scrollTop },
-                  } = instance.elements();
-                  setContentScrollTop(scrollTop);
-                },
-              }}
-            >
-              <Markdown>{content}</Markdown>
-            </OverlayScrollbarsComponent>
-          </div>
+          <OverlayScrollbar className={styles.readme}>
+            <div className={styles.readmeTitle}>README: {title}</div>
+            <Markdown className={styles.readmeContent}>{content}</Markdown>
+          </OverlayScrollbar>
           <div className={styles.setup}>
             <FormProvider {...methods}>
               <form autoComplete="off" onSubmit={onSubmit}>

--- a/packages/console/src/scss/overlayscrollbars.scss
+++ b/packages/console/src/scss/overlayscrollbars.scss
@@ -4,6 +4,8 @@
   &.os-theme-light {
     &.os-scrollbar-vertical {
       width: 12px;
+      padding: 8px 2px;
+
 
       > .os-scrollbar-track {
         > .os-scrollbar-handle {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- The readme title should scroll with the readme content.
- Display the scroll bar only when the cursor is over the content.
- Adjust the overlay scrollbar paddings since the original paddings do not fit the scrollable content well.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

![Mar-22-2023 11-23-25](https://user-images.githubusercontent.com/10806653/226794202-2179f94e-5160-4edc-9170-35e9daa01e93.gif)



<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
