### PR TITLE
chore: force bump schemas version

### DIFF
--- a/.changeset/small-ears-sip.md
+++ b/.changeset/small-ears-sip.md
@@ -1,0 +1,5 @@
+---
+"@logto/schemas": patch
+---
+
+force version bump


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
NPM says in the [workflow run](https://github.com/logto-io/logto/actions/runs/4477672059/jobs/7869495586):

>  400 Bad Request - PUT https://registry.npmjs.org/@logto%2fschemas - Cannot publish over previously published version "1.0.0".

but we cannot find the version in NPM, i didn't force unpublish this version as well. try bumping the version. related #3568

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
wait for release

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
