### PR TITLE
fix(ui): fix bind social account link lead to register bug

### DIFF
--- a/packages/ui/src/apis/interaction.ts
+++ b/packages/ui/src/apis/interaction.ts
@@ -186,6 +186,12 @@ export const registerWithVerifiedSocial = async (connectorId: string) => {
 };
 
 export const bindSocialRelatedUser = async (payload: SocialEmailPayload | SocialPhonePayload) => {
+  await api.put(`${interactionPrefix}/event`, {
+    json: {
+      event: InteractionEvent.SignIn,
+    },
+  });
+
   await api.patch(`${interactionPrefix}/identifiers`, {
     json: payload,
   });


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Hotfix for binding social account link leads to register flow bug. 

Issue:
1. create an account with an email e.g. `logto@google.com`
2. sign-in with google social connector using the `logto@google.com`'s related google account.
3. should lead to the bind with the existing account page:
 <img width="563" alt="image" src="https://user-images.githubusercontent.com/36393111/226797252-0c06230e-c6bb-45f1-a118-a2bf1f1244c7.png">
4.  Click on the Link to another email button at the bottom
5. should lead to the bind new email page
<img width="567" alt="image" src="https://user-images.githubusercontent.com/36393111/226797691-6580cf39-c29f-4b81-b2ea-03032606be47.png">

6. Click on the back button to navigate back to the previous bind with the existing account page

7. Click on the bind related user button on top

Expected behavior, bind the google social identity to the existing `logto@google.com` account and signin successfully.
Actual behavior, continue jumping to the bind new email page.



Root cause:
The current main-flow interaction API is not stateless. 

When first clicking on the bind with another email button, a post API will update the current interaction event to register back on the server side.

Then click on the bind with existing user button. The interaction event needs to be successfully set back to sign-in. 

Hotfix, force set interaction event to sign in whenever you click on the bind social-related account button.

TODO: The issue should be addressed systematically.  We need to refactor the current interaction API design to be stateless.  Issue added. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable to the checklist
