### PR TITLE
fix(console): fix connector form validation for switch

### DIFF
--- a/.changeset-staged/pretty-hounds-sneeze.md
+++ b/.changeset-staged/pretty-hounds-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@logto/console": patch
+---
+
+Fix connector config form's validation for "switch" field.

--- a/packages/console/src/pages/Connectors/components/ConfigForm/index.tsx
+++ b/packages/console/src/pages/Connectors/components/ConfigForm/index.tsx
@@ -73,7 +73,8 @@ function ConfigForm({ formItems }: Props) {
         name={item.key}
         control={control}
         rules={{
-          required: item.required,
+          // For switch, "false" will be treated as an empty value, so we need to set required to false.
+          required: item.type === ConnectorConfigFormItemType.Switch ? false : item.required,
           validate:
             item.type === ConnectorConfigFormItemType.Json
               ? (value) =>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix connector form validation for switch: the "false" value is treated as empty, so set the switch field's "required" to always false, because it won't have empty value actually.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [ ] This PR is not applicable for the checklist
