### PR TITLE
fix(console): app insights wrapper direct children style

### DIFF
--- a/packages/console/src/containers/ConsoleContent/index.module.scss
+++ b/packages/console/src/containers/ConsoleContent/index.module.scss
@@ -16,7 +16,7 @@
   }
 
   // App Insights wrapper on cloud env prevents the CSS assignment to direct children
-  .appInsightsWrapper > * {
+  [class='appInsightsWrapper'] > * {
     @include _.main-content-width;
   }
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix app insights wrapper direct children style in AC main pages.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
Previous:
<img width="2922" alt="image" src="https://user-images.githubusercontent.com/15182327/228417753-6671acc3-deb5-4c1f-97c6-f79b47071d9d.png">
After fix:
<img width="2911" alt="image" src="https://user-images.githubusercontent.com/15182327/228417516-93b3b5a0-0ac5-46d5-ad65-ba0fc61acc27.png">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
- [x] This PR is not applicable for the checklist
