### PR TITLE
fix(console): code editor line wrap

### DIFF
--- a/packages/console/src/components/CodeEditor/index.module.scss
+++ b/packages/console/src/components/CodeEditor/index.module.scss
@@ -48,7 +48,7 @@
       font-size: 14px;
       line-height: 1.5;
       font-family: 'Roboto Mono', monospace;
-      white-space: nowrap;
+      white-space: pre;
       word-break: normal;
       position: absolute;
       inset: 0;

--- a/packages/console/src/components/CodeEditor/index.tsx
+++ b/packages/console/src/components/CodeEditor/index.tsx
@@ -104,6 +104,7 @@ function CodeEditor({
             autoComplete="off"
             autoCorrect="off"
             data-gramm="false"
+            wrap="false"
             readOnly={isReadonly}
             spellCheck="false"
             value={value}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
code editor line wrap failed (while being selected in textarea) when showing code snippets read from mdx file.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
<img width="1040" alt="image" src="https://user-images.githubusercontent.com/15182327/228423806-2fa82c63-df10-4656-bf7d-31043d28e543.png">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
- [x] This PR is not applicable for the checklist
