### PR TITLE
feat(console): should mask confidential connector config values by default

### DIFF
--- a/packages/console/src/components/TextInput/index.module.scss
+++ b/packages/console/src/components/TextInput/index.module.scss
@@ -6,6 +6,12 @@
   display: none;
 }
 
+.hideTextContainerContent {
+  input {
+    -webkit-text-security: disc;
+  }
+}
+
 .container {
   display: flex;
   align-items: center;

--- a/packages/console/src/components/TextInput/index.tsx
+++ b/packages/console/src/components/TextInput/index.tsx
@@ -9,7 +9,12 @@ import {
   forwardRef,
   type Ref,
   useEffect,
+  useState,
 } from 'react';
+
+import EyeClosed from '@/assets/images/eye-closed.svg';
+import Eye from '@/assets/images/eye.svg';
+import IconButton from '@/components/IconButton';
 
 import * as styles from './index.module.scss';
 
@@ -17,13 +22,39 @@ type Props = Omit<HTMLProps<HTMLInputElement>, 'size'> & {
   error?: string | boolean;
   icon?: ReactElement;
   suffix?: ReactElement;
+  isConfidential?: boolean;
 };
 
 function TextInput(
-  { error, icon, suffix, disabled, className, readOnly, type = 'text', ...rest }: Props,
+  {
+    error,
+    icon,
+    suffix,
+    disabled,
+    className,
+    readOnly,
+    type = 'text',
+    isConfidential = false,
+    ...rest
+  }: Props,
   reference: Ref<Nullable<HTMLInputElement>>
 ) {
   const innerRef = useRef<HTMLInputElement>(null);
+  const [isContentHidden, setIsContentHidden] = useState(true);
+
+  const toggleHiddenContent = () => {
+    setIsContentHidden((previous) => !previous);
+  };
+
+  const suffixIcon =
+    isConfidential && type === 'text' ? (
+      <IconButton onClick={toggleHiddenContent}>
+        {isContentHidden ? <EyeClosed /> : <Eye />}
+      </IconButton>
+    ) : (
+      suffix
+    );
+
   useImperativeHandle(reference, () => innerRef.current);
 
   useEffect(() => {
@@ -54,6 +85,7 @@ function TextInput(
         className={classNames(
           styles.container,
           error && styles.error,
+          isConfidential && isContentHidden && type === 'text' && styles.hideTextContainerContent,
           icon && styles.withIcon,
           disabled && styles.disabled,
           readOnly && styles.readOnly
@@ -61,9 +93,9 @@ function TextInput(
       >
         {icon && <span className={styles.icon}>{icon}</span>}
         <input type={type} {...rest} ref={innerRef} disabled={disabled} readOnly={readOnly} />
-        {suffix &&
-          cloneElement(suffix, {
-            className: classNames([suffix.props.className, styles.suffix]),
+        {suffixIcon &&
+          cloneElement(suffixIcon, {
+            className: classNames([suffixIcon.props.className, styles.suffix]),
           })}
       </div>
       {Boolean(error) && typeof error === 'string' && (

--- a/packages/console/src/pages/Connectors/components/ConfigForm/index.tsx
+++ b/packages/console/src/pages/Connectors/components/ConfigForm/index.tsx
@@ -60,7 +60,13 @@ function ConfigForm({ formItems }: Props) {
     });
 
     if (item.type === ConnectorConfigFormItemType.Text) {
-      return <TextInput {...buildCommonProperties()} />;
+      return (
+        <TextInput
+          {...buildCommonProperties()}
+          // TODO: update connectors form config and remove RegExp check
+          isConfidential={item.isConfidential ?? /(Key|Secret)$/.test(item.key)}
+        />
+      );
     }
 
     if (item.type === ConnectorConfigFormItemType.MultilineText) {

--- a/packages/toolkit/connector-kit/src/types.ts
+++ b/packages/toolkit/connector-kit/src/types.ts
@@ -114,6 +114,7 @@ const baseConfigFormItem = {
     .optional(),
   description: z.string().optional(),
   tooltip: z.string().optional(),
+  isConfidential: z.boolean().optional(), // For `Text` type only.
 };
 
 const connectorConfigFormItemGuard = z.discriminatedUnion('type', [


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
should mask confidential values in the connector config by default (on both create and detail pages).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally. 
<img width="3351" alt="image" src="https://user-images.githubusercontent.com/15182327/228903598-68716621-8732-4ea7-9e9d-a091f2c9323b.png">
<img width="3355" alt="image" src="https://user-images.githubusercontent.com/15182327/228903898-1f97e3a2-2d9e-4c31-bda8-4d9787049518.png">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset-staged`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
