### PR TITLE
refactor: update pubilsh flow

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -15,21 +15,14 @@ So, we are using our own "grouping" release strategy in this monorepo:
 
 ### Core
 
-The release group that includes the Logto core products, which consists of the following packages:
+The release group that includes the Logto core service and its schemas and cli, which consists of the following packages:
 
-- @logto/console
 - @logto/core (main)
-- @logto/integration-tests
-- @logto/ui
-
-Their version will be in sync, and forms our main release.
-
-### CLI
-
-The release group that includes Logto CLI and its aliases:
-
-- @logto/cli (main)
+- @logto/schemas
+- @logto/cli
 - @logto/create
+
+Their versions will be always in sync, and forms our main release.
 
 ### Others
 

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,14 +5,11 @@
   "//": "CAUTION: When updating the fields below, you should also update README accordingly.",
   "fixed": [[
     "@logto/core",
-    "@logto/console",
-    "@logto/integration-tests",
-    "@logto/ui",
+    "@logto/schemas",
     "@logto/cli",
     "@logto/create"
   ]],
   "linked": [[
-    "@logto/schemas",
     "@logto/phrases",
     "@logto/phrases-ui"
   ]],

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -1,17 +1,9 @@
 name: Changesets
 
 on:
-  workflow_dispatch:
-    inputs:
-      releaseGroup:
-        description: 'The release group to bump version and create pull request'
-        required: true
-        type: choice
-        # This should be synced with `/.scripts/version.js`
-        options:
-          - core
-          - toolkit
-
+  push:
+    branches:
+      - master
   pull_request:
 
 concurrency:
@@ -19,16 +11,6 @@ concurrency:
 
 jobs:
   changesets:
-    strategy:
-      matrix:
-        # Multiline expression https://stackoverflow.com/a/67532120/12514940
-        group: |-
-          ${{
-            github.event_name == 'pull_request' &&
-            fromJSON('["core", "toolkit"]') ||
-            fromJSON(format('["{0}"]', inputs.releaseGroup))
-          }}
-
     runs-on: ubuntu-latest
 
     steps:
@@ -55,19 +37,18 @@ jobs:
 
       - name: Version packages
         run: |
-          node .scripts/version.js ${{ matrix.group }}
+          node .scripts/version.js
           pnpm i --no-frozen-lockfile
           git status
 
       - name: Create pull request
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'push'
         uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.BOT_PAT }}
-          commit-message: 'release: version ${{ matrix.group }} packages'
+          commit-message: 'release: version packages'
           committer: silverhand-bot <bot@silverhand.io>
           author: silverhand-bot <bot@silverhand.io>
           base: master
-          branch: release/version-${{ matrix.group }}-packages
-          title: 'release: version ${{ matrix.group }} packages'
-          body: 'This is an automatic pull request from the result of `node .scripts/version.js ${{ matrix.group }}` command. Merge it will trigger the publish flow for versioned packages.'
+          branch: release/version-packages
+          title: 'release: version packages'

--- a/.scripts/version.js
+++ b/.scripts/version.js
@@ -2,38 +2,8 @@ import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
 
 const execAsync = promisify(exec);
-const versionGroup = process.argv[2];
 
-if (process.argv.length > 3) {
-  throw new Error('Extraneous arguments found. Only one optional argument for version group name is allowed.');
-}
-
-// This is configured based on our practice. Change with care.
-// Should be synced with `/.github/workflows/changesets.yml`
-const allowedGroups = { core: 'core', toolkit: 'toolkit' };
-if (!Object.values(allowedGroups).includes(versionGroup)) {
-  throw new Error('Version group is invalid. Should be one of ' + Object.values(allowedGroups).join(', ') + '.');
-}
-
-const { allPackages } = await import('./packages-meta.js');
-
-const getIgnoreGroup = () => {
-  console.log(`=== Versioning ${versionGroup} group packages ===`);
-
-  return allPackages.filter(({ path }) => {
-    if (versionGroup === allowedGroups.toolkit) {
-      return !path.includes(allowedGroups.toolkit + '/');
-    }
-
-    return false;
-  });
-}
-
-const ignoreGroup = getIgnoreGroup();
-const ignoreCmd = ignoreGroup
-  .map(({ name }) => ` \\\n  --ignore ${name}`)
-  .join('');
-const cmd = ('pnpm changeset version' + ignoreCmd);
+const cmd = ('pnpm changeset version');
 
 const catchCmdError = ({ stderr, stdout, code }) => {
   console.log(stdout);
@@ -45,11 +15,9 @@ console.log(cmd);
 
 await execAsync(cmd).catch(catchCmdError);
 
-const filterCmd = ignoreGroup
-  .map(({ name }) => ` \\\n  --filter \\!${name}`)
-  .join('');
 // Manually run lifecycle script since changesets didn't
-await execAsync(`pnpm -r ${filterCmd} version`).catch(catchCmdError);
+await execAsync(`pnpm -r version`).catch(catchCmdError);
 
 // Sanity check for prepublish scripts
-await execAsync(`pnpm -r ${filterCmd} prepublishOnly`).catch(catchCmdError);
+await execAsync(`pnpm -r prepack`).catch(catchCmdError);
+await execAsync(`pnpm -r prepublishOnly`).catch(catchCmdError);


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- reorg the "core release group" for better versioning
- remove the concept of "release group" for publishing to make life eaiser

> **Note**
> The choose of fixed group is for better context alignment, e.g. when we talk about "schemas@v1.2.3", we can make sure it's aligned with the core version. other packages can have their own versions.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
CI, also pending a test publishing

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
