### PR TITLE
refactor(console): disable invalid pagination labels

### DIFF
--- a/packages/console/src/components/Pagination/index.module.scss
+++ b/packages/console/src/components/Pagination/index.module.scss
@@ -46,13 +46,10 @@
   }
 
   li.disabled {
-    .button {
-      cursor: not-allowed;
-      background: var(--color-neutral-95);
+    cursor: not-allowed;
 
-      &:hover {
-        background: var(--color-neutral-95);
-      }
+    .button {
+      background: var(--color-neutral-95);
     }
   }
 

--- a/packages/console/src/components/Pagination/index.tsx
+++ b/packages/console/src/components/Pagination/index.tsx
@@ -57,8 +57,22 @@ function Pagination({ page, totalCount, pageSize, className, mode = 'normal', on
             title={<DangerousRaw>{pageNumber}</DangerousRaw>}
           />
         )}
-        previousLabel={<Button className={styles.button} size="small" icon={<Previous />} />}
-        nextLabel={<Button className={styles.button} size="small" icon={<Next />} />}
+        previousLabel={
+          <Button
+            className={styles.button}
+            size="small"
+            icon={<Previous />}
+            disabled={page === 1}
+          />
+        }
+        nextLabel={
+          <Button
+            className={styles.button}
+            size="small"
+            icon={<Next />}
+            disabled={page === pageCount}
+          />
+        }
         breakLabel={
           <Button className={styles.button} size="small" title={<DangerousRaw>...</DangerousRaw>} />
         }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The pagination label button should be set to disable when it's invalid. Otherwise, it will have click and hover effects.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

![image](https://user-images.githubusercontent.com/10806653/229717168-33b74025-3d3f-4356-bdcb-d0bdd5c18c2e.png)

![image](https://user-images.githubusercontent.com/10806653/229717198-072ec750-ef51-4afc-a8d8-bceec123a1ff.png)


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
