### PR TITLE
feat(core): add management API to verify user password

### DIFF
--- a/.changeset/new-windows-rescue.md
+++ b/.changeset/new-windows-rescue.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": patch
+---
+
+Add new management API `/users/:userId/password/verify` to help verify user password, which would be helpful when building custom profile or sign-in pages


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add management API to help verify user password. This is helpful when building a custom sign-in or profile page.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT and local testing

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changset`
- [x] unit tests
- [ ] integration tests
- [ ] docs

