### PR TITLE
refactor(cli): use current directory as instance path if no input

### DIFF
--- a/.changeset/wise-dingos-compete.md
+++ b/.changeset/wise-dingos-compete.md
@@ -1,0 +1,5 @@
+---
+"@logto/cli": patch
+---
+
+use current directory as instance path if no path input for cli

--- a/packages/cli/src/commands/connector/utils.ts
+++ b/packages/cli/src/commands/connector/utils.ts
@@ -53,6 +53,10 @@ const validatePath = async (value: string) => {
 
 export const inquireInstancePath = async (initialPath?: string) => {
   const inquire = async () => {
+    if (!initialPath && (await validatePath('.')) === true) {
+      return path.resolve('.');
+    }
+
     if (!isTty()) {
       assert(initialPath, new Error('Path is missing'));
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
except installation, use current directory as instance path if user doesn't input one

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

listed connector without inquiring instance path

<img width="264" alt="image" src="https://user-images.githubusercontent.com/14722250/230714083-fb6d1e3f-aaa7-4878-815c-86dcfa8c885b.png">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changset`
- [ ] unit tests
- [ ] integration tests
- [x] docs https://github.com/logto-io/docs/pull/405
