### PR TITLE
fix(console): adding social connector should mark related get-started action item as completed

### DIFF
--- a/.changeset/little-carpets-change.md
+++ b/.changeset/little-carpets-change.md
@@ -1,0 +1,6 @@
+---
+"@logto/console": patch
+"@logto/schemas": patch
+---
+
+Adding social connectors will now mark the related get-started action item as completed.

--- a/packages/console/src/pages/Connectors/components/Guide/index.tsx
+++ b/packages/console/src/pages/Connectors/components/Guide/index.tsx
@@ -125,9 +125,7 @@ function Guide({ connector, onClose }: Props) {
         })
         .json<ConnectorResponse>();
 
-      await updateConfigs({
-        ...conditional(!isSocialConnector && { passwordlessConfigured: true }),
-      });
+      await updateConfigs({ passwordlessConfigured: true });
 
       onClose();
       toast.success(t('general.saved'));

--- a/packages/schemas/alterations/next-1681267285-fix-get-started-passwordless-status.ts
+++ b/packages/schemas/alterations/next-1681267285-fix-get-started-passwordless-status.ts
@@ -1,0 +1,32 @@
+import { sql } from 'slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const adminConsoleConfigKey = 'adminConsole';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    const tenantIds = await pool.many<{ id: string }>(sql`select id from tenants`);
+
+    await Promise.all(
+      tenantIds.map(async ({ id }) => {
+        const { count } = await pool.one<{ count: number }>(sql`
+          select count(*) from connectors
+            where tenant_id = ${id} and connector_id <> 'logto-sms' and connector_id <> 'logto-email' and connector_id <> 'logto-social-demo';
+        `);
+
+        if (count > 0) {
+          await pool.query(sql`
+            update logto_configs set value = jsonb_set(value, '{passwordlessConfigured}', 'true')
+              where tenant_id = ${id} and key = ${adminConsoleConfigKey};
+          `);
+        }
+      })
+    );
+  },
+  down: async () => {
+    // Do nothing as there is no alteration made to the DB schemas, only fixing data.
+  },
+};
+
+export default alteration;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Adding a social connector should mark the related "Scale passwordless sign in by adding your own connectors" action item as completed in get-started page.

Previously only adding email or SMS connectors can mark this as completed, which is a bit too strict, as social sign-in should also be considered as a passwordless sign-in option.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Restored item status in DB, and adding a new social connector DID mark the action item as completed
- [x] Restored item status in DB, and adding a new SMS connector DID mark the action item as completed
- [x] Run the DB alteration script, and if no connectors are found in DB then the status won't be updated.
- [x] Run the DB alteration script with existing social connectors, the action item status was updated to completed.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changset`
