### PR TITLE
refactor(core): improve cache behavior

### DIFF
--- a/packages/core/src/caches/index.test.ts
+++ b/packages/core/src/caches/index.test.ts
@@ -13,6 +13,7 @@ mockEsm('redis', () => ({
     set: mockFunction,
     get: mockFunction,
     del: mockFunction,
+    ping: async () => 'PONG',
     connect: mockFunction,
     disconnect: mockFunction,
     on: mockFunction,

--- a/packages/core/src/caches/index.ts
+++ b/packages/core/src/caches/index.ts
@@ -40,10 +40,14 @@ export class RedisCache implements CacheStore {
   async connect() {
     if (this.client) {
       await this.client.connect();
-      consoleLog.info('[CACHE] Connected to Redis');
-    } else {
-      consoleLog.warn('[CACHE] No Redis client initialized, skipping');
+      const pong = await this.client.ping();
+
+      if (pong === 'PONG') {
+        consoleLog.info('[CACHE] Connected to Redis');
+        return;
+      }
     }
+    consoleLog.warn('[CACHE] No Redis client initialized, skipping');
   }
 
   async disconnect() {

--- a/packages/core/src/caches/well-known.ts
+++ b/packages/core/src/caches/well-known.ts
@@ -3,6 +3,7 @@ import { type Optional, trySafe } from '@silverhand/essentials';
 import { type ZodType, z } from 'zod';
 
 import { type ConnectorWellKnown, connectorWellKnownGuard } from '#src/utils/connectors/types.js';
+import { consoleLog } from '#src/utils/console.js';
 
 import { type CacheStore } from './types.js';
 
@@ -172,6 +173,7 @@ export class WellKnownCache {
           const cachedValue = await trySafe(kvCache.get(type, promiseKey));
 
           if (cachedValue) {
+            consoleLog.info('[CACHE] Well-known cache hit for', type, promiseKey);
             return cachedValue;
           }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,5 +44,5 @@ try {
   consoleLog.error('Error while initializing app:');
   consoleLog.error(error);
 
-  await Promise.all([trySafe(tenantPool.endAll()), trySafe(redisCache.disconnect())]);
+  void Promise.all([trySafe(tenantPool.endAll()), trySafe(redisCache.disconnect())]);
 }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- use `.pong()` to measure success of cache connection since Redis may connect without any permission which will result a false positive 
- log well-known cache hit for better debugging
- `void` promises when app init with error

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
local tested with several Redis connection strings and well-known cache hits

<img width="572" alt="image" src="https://user-images.githubusercontent.com/14722250/232434989-18ab2d03-233f-42d0-b6fa-38bf674da89f.png">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
