### PR TITLE
style(console): update permission table style

### DIFF
--- a/packages/console/src/components/PermissionsTable/index.module.scss
+++ b/packages/console/src/components/PermissionsTable/index.module.scss
@@ -13,6 +13,10 @@
     .searchInput {
       width: 306px;
     }
+
+    .createButton {
+      margin-left: _.unit(2);
+    }
   }
 
   .name {
@@ -32,5 +36,9 @@
   .link {
     display: block;
     @include _.text-ellipsis;
+  }
+
+  .deleteColumn {
+    text-align: right;
   }
 }

--- a/packages/console/src/components/PermissionsTable/index.tsx
+++ b/packages/console/src/components/PermissionsTable/index.tsx
@@ -94,7 +94,8 @@ function PermissionsTable({
   const deleteColumn: Column<ScopeResponse> = {
     title: null,
     dataIndex: 'delete',
-    colSpan: 1,
+    colSpan: 2,
+    className: styles.deleteColumn,
     render: (scope) =>
       /**
        * When the table is read-only, hide the delete button rather than the whole column to keep the table column spaces.
@@ -143,6 +144,7 @@ function PermissionsTable({
           {!isReadOnly && (
             <Button
               title={createButtonTitle}
+              className={styles.createButton}
               type="primary"
               size="large"
               icon={<Plus />}

--- a/packages/console/src/components/Table/index.module.scss
+++ b/packages/console/src/components/Table/index.module.scss
@@ -4,6 +4,7 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  min-width: min-content;
 }
 
 .tableContainer {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The origin permission table has three style problems:
1. the table will clip the content when the table is small, so add a `min-with` to ensure the table will fully display the content.
2. the create button should have a margin between the search input component.
3. the delete column with `colspan=1` is too short to display the delete button correctly.

<img width="741" alt="image" src="https://user-images.githubusercontent.com/10806653/232669453-62582bcd-e246-4212-a8ef-af6e7c3d63b9.png">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="640" alt="image" src="https://user-images.githubusercontent.com/10806653/232669498-07cc12e0-050a-450a-b47a-80ff339c39d1.png">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
