### PR TITLE
chore(cloud): add payload to service log

### DIFF
--- a/packages/cloud/src/libraries/services.ts
+++ b/packages/cloud/src/libraries/services.ts
@@ -11,7 +11,7 @@ import type { ServiceLogType } from '@logto/schemas';
 import { adminTenantId } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 import { trySafe } from '@silverhand/essentials';
-import { RequestError } from '@withtyped/server';
+import { type JsonObject, RequestError } from '@withtyped/server';
 
 import type { Queries } from '#src/queries/index.js';
 import type { LogtoConnector } from '#src/utils/connector/index.js';
@@ -107,11 +107,12 @@ export class ServicesLibrary {
     return sendMessage(data);
   }
 
-  async addLog(tenantId: string, type: ServiceLogType) {
+  async addLog(tenantId: string, type: ServiceLogType, payload?: JsonObject) {
     return this.queries.serviceLogs.insertLog({
       id: generateStandardId(),
       type,
       tenantId,
+      payload,
     });
   }
 

--- a/packages/cloud/src/libraries/services.ts
+++ b/packages/cloud/src/libraries/services.ts
@@ -11,11 +11,12 @@ import type { ServiceLogType } from '@logto/schemas';
 import { adminTenantId } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 import { trySafe } from '@silverhand/essentials';
-import { type JsonObject, RequestError } from '@withtyped/server';
+import { RequestError } from '@withtyped/server';
 
 import type { Queries } from '#src/queries/index.js';
 import type { LogtoConnector } from '#src/utils/connector/index.js';
 import { loadConnectorFactories } from '#src/utils/connector/index.js';
+import { jsonObjectGuard } from '#src/utils/guard.js';
 
 export const serviceCountLimitForTenant = 100;
 
@@ -107,12 +108,12 @@ export class ServicesLibrary {
     return sendMessage(data);
   }
 
-  async addLog(tenantId: string, type: ServiceLogType, payload?: JsonObject) {
+  async addLog(tenantId: string, type: ServiceLogType, payload?: unknown) {
     return this.queries.serviceLogs.insertLog({
       id: generateStandardId(),
       type,
       tenantId,
-      payload,
+      payload: trySafe(() => jsonObjectGuard.parse(payload)),
     });
   }
 

--- a/packages/cloud/src/queries/service-logs.ts
+++ b/packages/cloud/src/queries/service-logs.ts
@@ -8,7 +8,6 @@ import { insertInto } from '#src/utils/query.js';
 export type ServiceLogsQueries = ReturnType<typeof createServiceLogsQueries>;
 
 export const createServiceLogsQueries = (client: Queryable<PostgreSql>) => {
-  // TODO: @sijie make with-typed JsonObject compatible with unknown or unify JsonObject and ArbitraryObject
   const insertLog = async (data: Omit<CreateServiceLog, 'payload'> & { payload?: JsonObject }) =>
     client.query(insertInto(data, 'service_logs'));
 

--- a/packages/cloud/src/queries/service-logs.ts
+++ b/packages/cloud/src/queries/service-logs.ts
@@ -1,14 +1,15 @@
 import type { CreateServiceLog, ServiceLogType } from '@logto/schemas';
 import type { PostgreSql } from '@withtyped/postgres';
 import { sql } from '@withtyped/postgres';
-import type { Queryable } from '@withtyped/server';
+import type { JsonObject, Queryable } from '@withtyped/server';
 
 import { insertInto } from '#src/utils/query.js';
 
 export type ServiceLogsQueries = ReturnType<typeof createServiceLogsQueries>;
 
 export const createServiceLogsQueries = (client: Queryable<PostgreSql>) => {
-  const insertLog = async (data: Omit<CreateServiceLog, 'payload'>) =>
+  // TODO: @sijie make with-typed JsonObject compatible with unknown or unify JsonObject and ArbitraryObject
+  const insertLog = async (data: Omit<CreateServiceLog, 'payload'> & { payload?: JsonObject }) =>
     client.query(insertInto(data, 'service_logs'));
 
   const countTenantLogs = async (tenantId: string, type: ServiceLogType) => {

--- a/packages/cloud/src/routes/service.test.ts
+++ b/packages/cloud/src/routes/service.test.ts
@@ -65,7 +65,9 @@ describe('POST /api/services/send-email', () => {
       async ({ status }) => {
         expect(status).toBe(201);
         expect(library.sendMessage).toBeCalledWith(ConnectorType.Email, mockSendMessagePayload);
-        expect(library.addLog).toBeCalledWith('tenantId', ServiceLogType.SendEmail);
+        expect(library.addLog).toBeCalledWith('tenantId', ServiceLogType.SendEmail, {
+          data: mockSendMessagePayload,
+        });
       },
       createHttpContext()
     );
@@ -125,7 +127,9 @@ describe('POST /api/services/send-sms', () => {
       async ({ status }) => {
         expect(status).toBe(201);
         expect(library.sendMessage).toBeCalledWith(ConnectorType.Sms, mockSendMessagePayload);
-        expect(library.addLog).toBeCalledWith('tenantId', ServiceLogType.SendSms);
+        expect(library.addLog).toBeCalledWith('tenantId', ServiceLogType.SendSms, {
+          data: mockSendMessagePayload,
+        });
       },
       createHttpContext()
     );

--- a/packages/cloud/src/routes/services.ts
+++ b/packages/cloud/src/routes/services.ts
@@ -29,7 +29,7 @@ export const servicesRoutes = (library: ServicesLibrary) =>
         }
 
         await library.sendMessage(ConnectorType.Email, context.guarded.body.data);
-        await library.addLog(tenantId, ServiceLogType.SendEmail);
+        await library.addLog(tenantId, ServiceLogType.SendEmail, context.guarded.body);
 
         return next({ ...context, status: 201 });
       }
@@ -55,7 +55,7 @@ export const servicesRoutes = (library: ServicesLibrary) =>
         }
 
         await library.sendMessage(ConnectorType.Sms, context.guarded.body.data);
-        await library.addLog(tenantId, ServiceLogType.SendSms);
+        await library.addLog(tenantId, ServiceLogType.SendSms, context.guarded.body);
 
         return next({ ...context, status: 201 });
       }

--- a/packages/cloud/src/utils/guard.ts
+++ b/packages/cloud/src/utils/guard.ts
@@ -1,0 +1,13 @@
+import type { Json } from '@withtyped/server';
+import { z } from 'zod';
+
+/**
+ * `jsonGuard` copied from https://github.com/colinhacks/zod#json-type.
+ * Can be moved to @logto/shared if needed.
+ */
+
+const jsonGuard: z.ZodType<Json> = z.lazy(() =>
+  z.union([z.number(), z.boolean(), z.string(), z.null(), z.array(jsonGuard), z.record(jsonGuard)])
+);
+
+export const jsonObjectGuard = z.record(jsonGuard);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
1. Add `payload` to `service logs`.
2. Replace `ArbitraryObject` with `JsonObject`.
    Since @logto/cloud is using `JsonObject` and other packages are all using `ArbitraryObject`. `JsonObject` is actually used in PostgreSQL DB schemas, so it is reasonable to replace `ArbitraryObject` with `JsonObject`. Otherwise, any database-related types involved in the cloud would require manually replacing the value of type `ArbitraryObject` with `JsonObject`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
Call the corresponding API and found correct payloads has beed added.
<img width="310" alt="image" src="https://user-images.githubusercontent.com/15182327/232750242-8d4fe3d4-91d6-4b70-a8cf-c43ff41d41fd.png">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
