### PR TITLE
chore: allow setting appinsights string in core Dockerfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             additional_connector_args=--cloud
+            applicationinsights_connection_string=${{ (inputs.target || 'dev') == 'dev' && secrets.APPLICATIONINSIGHTS_CONNECTION_STRING || secrets.APPLICATIONINSIGHTS_CONNECTION_STRING_PROD }}
 
       - name: Setup Depot
         if: ${{ startsWith(github.ref, 'refs/tags/') }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ COPY . .
 ### Install dependencies and build ###
 RUN node .scripts/update-parcelrc.js
 RUN pnpm i
+
+ARG applicationinsights_connection_string
+ENV APPLICATIONINSIGHTS_CONNECTION_STRING=${applicationinsights_connection_string}
 RUN pnpm -r build
 
 ### Add official connectors ###


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
since we are tracking the main flow for Logto Cloud, it is required to pass an ApplicationInsights connection string to make it works.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
the change is copied from our cloud image. hard to test it now, will test after merge.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
