### PR TITLE
fix(console): remove react warning from Switch component

### DIFF
--- a/packages/console/src/components/Switch/index.tsx
+++ b/packages/console/src/components/Switch/index.tsx
@@ -3,16 +3,16 @@ import { forwardRef } from 'react';
 
 import * as styles from './index.module.scss';
 
-type Props = HTMLProps<HTMLInputElement> & {
+type Props = Omit<HTMLProps<HTMLInputElement>, 'value'> & {
   label?: ReactNode;
 };
 
-function Switch({ label, ...rest }: Props, ref?: Ref<HTMLInputElement>) {
+function Switch({ label, checked = false, ...rest }: Props, ref?: Ref<HTMLInputElement>) {
   return (
     <div className={styles.wrapper}>
       <div className={styles.label}>{label}</div>
       <label className={styles.switch}>
-        <input type="checkbox" {...rest} ref={ref} />
+        <input type="checkbox" checked={checked} {...rest} ref={ref} />
         <span className={styles.slider} />
       </label>
     </div>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Remove the React warning about "Changing an uncontrolled input to be controlled" from `Switch` component in Admin Console.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Locally tested. No warning in debugger console when opening forms that have switch components.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
- [x] This PR is not applicable for the checklist
