### PR TITLE
feat: setting cloud role name for AppInsights in React

### DIFF
--- a/.changeset/real-falcons-greet.md
+++ b/.changeset/real-falcons-greet.md
@@ -1,0 +1,7 @@
+---
+"@logto/app-insights": minor
+"@logto/console": patch
+"@logto/ui": patch
+---
+
+support setting cloud role name for AppInsights in React

--- a/packages/console/src/App.tsx
+++ b/packages/console/src/App.tsx
@@ -28,7 +28,7 @@ import TenantsProvider, { TenantsContext } from './contexts/TenantsProvider';
 
 // Use `.then()` for better compatibility, update to top-level await some day
 // eslint-disable-next-line unicorn/prefer-top-level-await
-void appInsightsReact.setup().then((success) => {
+void appInsightsReact.setup('console').then((success) => {
   if (success) {
     console.debug('Initialized ApplicationInsights');
   }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -29,7 +29,7 @@ import './scss/normalized.scss';
 if (shouldTrack) {
   // Use `.then()` for better compatibility, update to top-level await some day
   // eslint-disable-next-line unicorn/prefer-top-level-await, promise/prefer-await-to-then
-  void appInsightsReact.setup().then((success) => {
+  void appInsightsReact.setup('ui').then((success) => {
     if (success) {
       console.debug('Initialized ApplicationInsights');
     }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- support seting cloud role name for React apps
- allow explicit passing connection string for React SDK since it may lose context of `process` when building

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
works in localhost, pending cloud test
<img width="221" alt="image" src="https://user-images.githubusercontent.com/14722250/233064148-0e29f222-9c5a-450a-beac-1002769b8736.png">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`

// skipped since this is internal
- [ ] unit tests
- [ ] integration tests
- [ ] docs
