### PR TITLE
feat(connector): make official connectors scope configurable

### DIFF
--- a/packages/connectors/connector-alipay-web/README.md
+++ b/packages/connectors/connector-alipay-web/README.md
@@ -64,6 +64,7 @@ Alipay Web connector is designed for desktop Web applications. It takes advantag
     - Fill out the `privateKey` field with contents from the private key file mentioned in step 2. Please MAKE SURE to use '\n' to replace all newline characters and do not remove header and footer in private key file.
     - Fill out the `signType` field with 'RSA2' due to the `Public key` signing mode we chose in step 7 of "Create And Configure Alipay Apps".
     - Fill out the `charset` field with either 'gbk' or 'utf8'. You can leave this field blank as it is OPTIONAL. The default value is set to be 'utf8'.
+    - Fill out the `scope` field with either 'auth_base' or 'auth_user'. You can leave this field blank as it is OPTIONAL. The default value is set to be 'auth_user'. You can check out the [difference](https://opendocs.alipay.com/fw/api/105942) between different values.
 
 ### Config types
 
@@ -73,6 +74,7 @@ Alipay Web connector is designed for desktop Web applications. It takes advantag
 | privateKey | string                 | N/A                          |
 | signType   | enum string            | 'RSA' \| 'RSA2'              |
 | charset    | enum string (OPTIONAL) | 'gbk' \| 'utf8' \| undefined |
+| scope      | enum string (OPTIONAL) | 'auth_user' \| 'auth_base'   |
 
 ## Test Alipay web connector
 
@@ -128,6 +130,7 @@ Once Alipay web connector is enabled, you can build and run your web app to see 
     - 将你在第 2 步中获得的密钥对的私钥填入 `privateKey` 字段。请保留私钥文件内容中的文件头和文件尾，并 **确保** 使用 '\n' 替换了所有换行符。
     - 将你在第 2 步中所获得的密钥的签名模式 'RSA2' 填入 `signType` 字段。
     - 在 `charset` 字段中填入 'gbk' 或 'utf8' 字符串。这个字段也可以选择不填，此时我们会使用 'utf8' 的默认值。
+    - 在 `scope` 字段中填入 'auth_user' 或者 'auth_base'。这个字段也可以选择不填，此时我们会使用 'auth_user' 的默认值。你可以在[这里](https://opendocs.alipay.com/fw/api/105942)查看更多关于这两个值的信息。
 
 ### 配置类型
 
@@ -137,6 +140,7 @@ Once Alipay web connector is enabled, you can build and run your web app to see 
 | privateKey | string                 | N/A                          |
 | signType   | enum string            | 'RSA' \| 'RSA2'              |
 | charset    | enum string (OPTIONAL) | 'gbk' \| 'utf8' \| undefined |
+| scope      | enum string (OPTIONAL) | 'auth_user' \| 'auth_base'   |
 
 ## 测试支付宝网页连接器
 

--- a/packages/connectors/connector-alipay-web/src/constant.ts
+++ b/packages/connectors/connector-alipay-web/src/constant.ts
@@ -73,6 +73,15 @@ export const defaultMetadata: ConnectorMetadata = {
       ],
       defaultValue: 'utf8',
     },
+    {
+      key: 'scope',
+      label: 'Scope',
+      type: ConnectorConfigFormItemType.Text,
+      required: false,
+      placeholder: '<scope>',
+      description:
+        "The `scope` determines permissions granted by the user's authorization. If you are not sure what to enter, do not worry, just leave it blank.",
+    },
   ],
 };
 

--- a/packages/connectors/connector-alipay-web/src/index.ts
+++ b/packages/connectors/connector-alipay-web/src/index.ts
@@ -30,7 +30,7 @@ import {
   authorizationEndpoint,
   methodForAccessToken,
   methodForUserInfo,
-  scope,
+  scope as defaultScope,
   defaultMetadata,
   defaultTimeout,
   timestampFormat,
@@ -49,14 +49,14 @@ const getAuthorizationUri =
     const config = await getConfig(defaultMetadata.id);
     validateConfig<AlipayConfig>(config, alipayConfigGuard);
 
-    const { appId: app_id } = config;
+    const { appId: app_id, scope } = config;
 
     const redirect_uri = encodeURI(redirectUri);
 
     const queryParameters = new URLSearchParams({
       app_id,
       redirect_uri, // The variable `redirectUri` should match {appId, appSecret}
-      scope,
+      scope: scope ?? defaultScope,
       state,
     });
 

--- a/packages/connectors/connector-alipay-web/src/types.ts
+++ b/packages/connectors/connector-alipay-web/src/types.ts
@@ -9,6 +9,7 @@ export const alipayConfigGuard = z.object({
   privateKey: z.string(),
   signType: z.enum(alipaySigningAlgorithms),
   charset: charsetGuard.default(fallbackCharset),
+  scope: z.string().optional(),
 });
 
 export type AlipayConfig = z.infer<typeof alipayConfigGuard>;

--- a/packages/connectors/connector-discord/README.md
+++ b/packages/connectors/connector-discord/README.md
@@ -9,6 +9,7 @@ The Discord connector provides a way for your application to use Discord as an a
     - [Config types](#config-types)
       - [clientId](#clientid)
       - [clientSecret](#clientsecret)
+      - [scope](#scope)
 
 ## Register a developer application
 - Visit [Discord Developer Portal](https://discord.com/developers/applications) and sign in with your Discord account.
@@ -26,6 +27,7 @@ The Discord connector provides a way for your application to use Discord as an a
 |--------------|---------|
 | clientId     | string  |
 | clientSecret | string  |
+| scope        | string  |
 
 #### clientId
 `clientId` is the `CLIENT ID` field we saved earlier.
@@ -34,3 +36,7 @@ The Discord connector provides a way for your application to use Discord as an a
 #### clientSecret
 `clientSecret` is the `CLIENT SECRET` we saved earlier.
 (If you've lost it you need to click **Reset Secret**)
+
+#### scope
+`scope` is the permissions granted by the user's authorization. The default value is `identify email`.
+You can see the full list of scopes [here](https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes).

--- a/packages/connectors/connector-discord/src/constant.ts
+++ b/packages/connectors/connector-discord/src/constant.ts
@@ -52,6 +52,15 @@ export const defaultMetadata: ConnectorMetadata = {
       label: 'Client Secret',
       placeholder: '<client-secret>',
     },
+    {
+      key: 'scope',
+      type: ConnectorConfigFormItemType.Text,
+      required: false,
+      label: 'Scope',
+      placeholder: '<scope>',
+      description:
+        "The `scope` determines permissions granted by the user's authorization. If you are not sure what to enter, do not worry, just leave it blank.",
+    },
   ],
 };
 

--- a/packages/connectors/connector-discord/src/index.ts
+++ b/packages/connectors/connector-discord/src/index.ts
@@ -24,7 +24,7 @@ import {
 
 import {
   defaultMetadata,
-  scope,
+  scope as defaultScope,
   authorizationEndpoint,
   accessTokenEndpoint,
   defaultTimeout,
@@ -48,7 +48,7 @@ const getAuthorizationUri =
       client_id: config.clientId,
       redirect_uri: redirectUri,
       response_type: 'code',
-      scope,
+      scope: config.scope ?? defaultScope,
       state,
     });
 

--- a/packages/connectors/connector-discord/src/types.ts
+++ b/packages/connectors/connector-discord/src/types.ts
@@ -12,6 +12,7 @@ const nullishToUndefined = <T = unknown>(input: Nullable<T>): Optional<T> => {
 export const discordConfigGuard = z.object({
   clientId: z.string(),
   clientSecret: z.string(),
+  scope: z.string().optional(),
 });
 
 export type DiscordConfig = z.infer<typeof discordConfigGuard>;

--- a/packages/connectors/connector-facebook/README.md
+++ b/packages/connectors/connector-facebook/README.md
@@ -41,6 +41,7 @@ The Facebook connector provides a concise way for your application to use Facebo
 4. Fill out the Logto connector settings:
     - Fill out the `clientId` field with the string from _App ID_.
     - Fill out the `clientSecret` field with the string from _App secret_.
+    - Fill out the `scope` field with a comma or space separated list of [permissions](https://developers.facebook.com/docs/permissions/reference) in string. If you do not specify a scope, the default scope is `email,public_profile`.
 
 ## Test sign-in with Facebook's test users
 
@@ -70,6 +71,7 @@ E.g., the pure _business type_ app doesn't have the "live" switch button, but it
 |--------------|--------|
 | clientId     | string |
 | clientSecret | string |
+| scope        | string |
 
 ## References
 

--- a/packages/connectors/connector-facebook/src/constant.ts
+++ b/packages/connectors/connector-facebook/src/constant.ts
@@ -49,6 +49,15 @@ export const defaultMetadata: ConnectorMetadata = {
       label: 'Client Secret',
       placeholder: '<client-secret>',
     },
+    {
+      key: 'scope',
+      type: ConnectorConfigFormItemType.Text,
+      required: false,
+      label: 'Scope',
+      placeholder: '<scope>',
+      description:
+        "The `scope` determines permissions granted by the user's authorization. If you are not sure what to enter, do not worry, just leave it blank.",
+    },
   ],
 };
 

--- a/packages/connectors/connector-facebook/src/index.ts
+++ b/packages/connectors/connector-facebook/src/index.ts
@@ -24,7 +24,7 @@ import {
 import {
   accessTokenEndpoint,
   authorizationEndpoint,
-  scope,
+  scope as defaultScope,
   userInfoEndpoint,
   defaultMetadata,
   defaultTimeout,
@@ -49,7 +49,7 @@ const getAuthorizationUri =
       redirect_uri: redirectUri,
       response_type: 'code',
       state,
-      scope, // Only support fixed scope for v1.
+      scope: config.scope ?? defaultScope,
     });
 
     return `${authorizationEndpoint}?${queryParameters.toString()}`;

--- a/packages/connectors/connector-facebook/src/types.ts
+++ b/packages/connectors/connector-facebook/src/types.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 export const facebookConfigGuard = z.object({
   clientId: z.string(),
   clientSecret: z.string(),
+  scope: z.string().optional(),
 });
 
 export type FacebookConfig = z.infer<typeof facebookConfigGuard>;

--- a/packages/connectors/connector-github/README.md
+++ b/packages/connectors/connector-github/README.md
@@ -42,12 +42,15 @@ You can also find `Client ID` and generate `Client secrets` in OAuth app detail 
 
 Fill out the `clientId` and `clientSecret` field with _Client ID_ and _Client Secret_ you've got from OAuth app detail pages mentioned in the previous section.
 
+`scope` is a space-delimited list of [scopes](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps). If not provided, scope defaults to be `read:user`.
+
 ### Config types
 
 | Name         | Type   |
 |--------------|--------|
 | clientId     | string |
 | clientSecret | string |
+| scope        | string |
 
 
 ## Test GitHub connector

--- a/packages/connectors/connector-github/src/constant.ts
+++ b/packages/connectors/connector-github/src/constant.ts
@@ -40,6 +40,15 @@ export const defaultMetadata: ConnectorMetadata = {
       required: true,
       placeholder: '<client-secret>',
     },
+    {
+      key: 'scope',
+      type: ConnectorConfigFormItemType.Text,
+      label: 'Scope',
+      required: false,
+      placeholder: '<scope>',
+      description:
+        "The `scope` determines permissions granted by the user's authorization. If you are not sure what to enter, do not worry, just leave it blank.",
+    },
   ],
 };
 

--- a/packages/connectors/connector-github/src/index.ts
+++ b/packages/connectors/connector-github/src/index.ts
@@ -20,7 +20,7 @@ import qs from 'query-string';
 import {
   authorizationEndpoint,
   accessTokenEndpoint,
-  scope,
+  scope as defaultScope,
   userInfoEndpoint,
   defaultMetadata,
   defaultTimeout,
@@ -43,7 +43,7 @@ const getAuthorizationUri =
       client_id: config.clientId,
       redirect_uri: redirectUri,
       state,
-      scope, // Only support fixed scope for v1.
+      scope: config.scope ?? defaultScope,
     });
 
     return `${authorizationEndpoint}?${queryParameters.toString()}`;

--- a/packages/connectors/connector-github/src/types.ts
+++ b/packages/connectors/connector-github/src/types.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 export const githubConfigGuard = z.object({
   clientId: z.string(),
   clientSecret: z.string(),
+  scope: z.string().optional(),
 });
 
 export type GithubConfig = z.infer<typeof githubConfigGuard>;

--- a/packages/connectors/connector-google/README.md
+++ b/packages/connectors/connector-google/README.md
@@ -12,6 +12,7 @@ The Google connector provides a succinct way for your application to use Googleâ
       - [Config scopes](#config-scopes)
       - [Add test users (External user type only)](#add-test-users-external-user-type-only)
   - [Obtain OAuth 2.0 credentials](#obtain-oauth-20-credentials)
+  - [Configure your connector](#configure-your-connector)
     - [Config types](#config-types)
   - [References](#references)
 
@@ -39,7 +40,7 @@ Now you will be on the **Edit app registration** page.
 
 #### Config scopes
 
-- Click **ADD OR REMOVE SCOPES** and select `../auth/userinfo.email`, `../auth/userinfo.profile` and `openid` in the popup drawer, and click **UPDATE** to finish.
+- Click **ADD OR REMOVE SCOPES** and select `../auth/userinfo.email`, `../auth/userinfo.profile` and `openid` in the popup drawer, and click **UPDATE** to finish. It is recommended that you consider adding all the scopes you may use, otherwise some scopes you added in the configuration may not work.
 - Fill out the form as you need.
 - Click **SAVE AND CONTINUE** to continue.
 
@@ -60,12 +61,19 @@ Now you should have the Google OAuth 2.0 consent screen configured.
 - Click **+ Add URI** in the ****Authorized redirect URIs**** section to set up the ****Authorized redirect URIs****, which redirect the user to the application after logging in. In our case, this will be `${your_logto_endpoint}/callback/${connector_id}`. e.g. `https://logto.dev/callback/${connector_id}`. The `connector_id` can be found on the top bar of the Logto Admin Console connector details page.
 - Click **Create** to finish and then you will get the **Client ID** and **Client Secret**.
 
+## Configure your connector
+
+Fill out the `clientId` and `clientSecret` field with _Client ID_ and _Client Secret_ you've got from OAuth app detail pages mentioned in the previous section.
+
+`scope` is a space-delimited list of [scopes](https://developers.google.com/identity/protocols/oauth2/scopes). If not provided, scope defaults to be `openid profile email`.
+
 ### Config types
 
 | Name         | Type   |
 |--------------|--------|
 | clientId     | string |
 | clientSecret | string |
+| scope        | string |
 
 ## References
 * [Google Identity: Setting up OAuth 2.0](https://developers.google.com/identity/protocols/oauth2/openid-connect#appsetup)

--- a/packages/connectors/connector-google/src/constant.ts
+++ b/packages/connectors/connector-google/src/constant.ts
@@ -40,6 +40,15 @@ export const defaultMetadata: ConnectorMetadata = {
       required: true,
       placeholder: '<client-secret>',
     },
+    {
+      key: 'scope',
+      type: ConnectorConfigFormItemType.Text,
+      label: 'Scope',
+      required: false,
+      placeholder: '<scope>',
+      description:
+        "The `scope` determines permissions granted by the user's authorization. If you are not sure what to enter, do not worry, just leave it blank.",
+    },
   ],
 };
 

--- a/packages/connectors/connector-google/src/index.ts
+++ b/packages/connectors/connector-google/src/index.ts
@@ -23,7 +23,7 @@ import {
 import {
   accessTokenEndpoint,
   authorizationEndpoint,
-  scope,
+  scope as defaultScope,
   userInfoEndpoint,
   defaultMetadata,
   defaultTimeout,
@@ -47,7 +47,7 @@ const getAuthorizationUri =
       redirect_uri: redirectUri,
       response_type: 'code',
       state,
-      scope,
+      scope: config.scope ?? defaultScope,
     });
 
     return `${authorizationEndpoint}?${queryParameters.toString()}`;

--- a/packages/connectors/connector-google/src/types.ts
+++ b/packages/connectors/connector-google/src/types.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 export const googleConfigGuard = z.object({
   clientId: z.string(),
   clientSecret: z.string(),
+  scope: z.string().optional(),
 });
 
 export type GoogleConfig = z.infer<typeof googleConfigGuard>;

--- a/packages/connectors/connector-wechat-web/README.md
+++ b/packages/connectors/connector-wechat-web/README.md
@@ -14,6 +14,7 @@ The official Logto connector for WeChat social sign-in in web apps.
       - [Basic info](#basic-info)
       - [Website info](#website-info)
       - [Waiting for the review result](#waiting-for-the-review-result)
+    - [Configure your WeChat connector](#configure-your-wechat-connector)
     - [Test WeChat web connector](#test-wechat-web-connector)
 - [微信网页连接器](#微信网页连接器)
   - [开始上手](#开始上手)
@@ -23,6 +24,7 @@ The official Logto connector for WeChat social sign-in in web apps.
       - [基础信息](#基础信息)
       - [网站信息](#网站信息)
       - [等待审核结果](#等待审核结果)
+    - [配置微信网页连接器](#配置微信网页连接器)
     - [测试微信网页连接器](#测试微信网页连接器)
 
 ## Get started
@@ -66,6 +68,12 @@ Fill "Authorization callback domain" (授权回调域) with your Logto domain. E
 After completing the website info, click "Submit Review" to continue. Usually, the review goes fast, which will end within 1-2 days.
 
 We suspect the reviewer is allocated randomly on each submission since the standard is floating. You may get rejected the first time, but don't give up! State your status quo and ask the reviewer how to modify it.
+
+### Configure your WeChat connector
+
+Fill out the `clientId` and `clientSecret` field with _Client ID_ and _Client Secret_ you've got from OAuth app detail pages.
+
+Fill out the `scope` field with either 'snsapi_userinfo' or 'snsapi_base'. You can leave this field blank as it is OPTIONAL. The default value is set to be 'snsapi_userinfo'. You can check out the [difference](https://developers.weixin.qq.com/doc/offiaccount/OA_Web_Apps/Wechat_webpage_authorization.html) between different values.
 
 ### Test WeChat web connector
 
@@ -116,6 +124,12 @@ Once WeChat web connector is enabled, you can sign in to your app again to see i
 完成输入网站信息之后，点按「提交审核」以继续。审核速度通常很快，1-2 天即可完成。
 
 我们怀疑每次提交审核者都是随机分配的，因为审核标准飘忽不定。第一次提交也许会被拒绝，但别灰心！陈述你的现状并询问审核者如何修改。
+
+### 配置微信网页连接器
+
+分别用 OAuth 应用详情页面中的 _Client ID_ 和 _Client Secret_ 填写 `clientId` 和 `clientSecret` 字段。
+
+在 `scope` 字段中填入 'snsapi_userinfo' 或者 'snsapi_base'。这个字段也可以选择不填，此时我们会使用 'snsapi_userinfo' 的默认值。你可以在[这里](https://developers.weixin.qq.com/doc/offiaccount/OA_Web_Apps/Wechat_webpage_authorization.html)查看更多关于这两个值的信息。
 
 ### 测试微信网页连接器
 

--- a/packages/connectors/connector-wechat-web/src/constant.ts
+++ b/packages/connectors/connector-wechat-web/src/constant.ts
@@ -45,6 +45,15 @@ export const defaultMetadata: ConnectorMetadata = {
       type: ConnectorConfigFormItemType.Text,
       placeholder: '<app-secret>',
     },
+    {
+      key: 'scope',
+      type: ConnectorConfigFormItemType.Text,
+      label: 'Scope',
+      required: false,
+      placeholder: '<scope>',
+      description:
+        "The `scope` determines permissions granted by the user's authorization. If you are not sure what to enter, do not worry, just leave it blank.",
+    },
   ],
 };
 

--- a/packages/connectors/connector-wechat-web/src/index.ts
+++ b/packages/connectors/connector-wechat-web/src/index.ts
@@ -25,7 +25,7 @@ import {
   authorizationEndpoint,
   accessTokenEndpoint,
   userInfoEndpoint,
-  scope,
+  scope as defaultScope,
   defaultMetadata,
   defaultTimeout,
   invalidAccessTokenErrcode,
@@ -49,13 +49,13 @@ const getAuthorizationUri =
     const config = await getConfig(defaultMetadata.id);
     validateConfig<WechatConfig>(config, wechatConfigGuard);
 
-    const { appId } = config;
+    const { appId, scope } = config;
 
     const queryParameters = new URLSearchParams({
       appid: appId,
       redirect_uri: encodeURI(redirectUri), // The variable `redirectUri` should match {appId, appSecret}
       response_type: 'code',
-      scope,
+      scope: scope ?? defaultScope,
       state,
     });
 

--- a/packages/connectors/connector-wechat-web/src/types.ts
+++ b/packages/connectors/connector-wechat-web/src/types.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 
-export const wechatConfigGuard = z.object({ appId: z.string(), appSecret: z.string() });
+export const wechatConfigGuard = z.object({
+  appId: z.string(),
+  appSecret: z.string(),
+  scope: z.string().optional(),
+});
 
 export type WechatConfig = z.infer<typeof wechatConfigGuard>;
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Make official connectors' (non-standard social connectors) scope configurable.
Previously, we only supported fixed scopes, which are not flexible.
TODO: Non-empty scope for the Apple connector should have a different response handler than the current design, will do this later.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
