### PR TITLE
feat: support array field for db

### DIFF
--- a/packages/core/src/database/insert-into.test.ts
+++ b/packages/core/src/database/insert-into.test.ts
@@ -96,4 +96,6 @@ describe('buildInsertInto()', () => {
       new InsertionError(Users, dataToInsert)
     );
   });
+
+  // TODO(LOG-6039) @xiaoyijun Add tests for inserting data with array fields when hooks is updated
 });

--- a/packages/schemas/src/gen/schema.ts
+++ b/packages/schemas/src/gen/schema.ts
@@ -41,8 +41,10 @@ export const generateSchema = ({ name, fields }: TableWithType) => {
       ({ name, type, isArray, isEnum, nullable, hasDefaultValue, tsType, isString, maxLength }) => {
         if (tsType) {
           return `  ${camelcase(name)}: ${camelcase(tsType)}Guard${conditionalString(
-            nullable && '.nullable()'
-          )}${conditionalString((nullable || hasDefaultValue) && '.optional()')},`;
+            isArray && '.array()'
+          )}${conditionalString(nullable && '.nullable()')}${conditionalString(
+            (nullable || hasDefaultValue) && '.optional()'
+          )},`;
         }
 
         return `  ${camelcase(name)}: z.${
@@ -61,8 +63,8 @@ export const generateSchema = ({ name, fields }: TableWithType) => {
     ...fields.map(({ name, type, isArray, isEnum, nullable, tsType, isString, maxLength }) => {
       if (tsType) {
         return `  ${camelcase(name)}: ${camelcase(tsType)}Guard${conditionalString(
-          nullable && '.nullable()'
-        )},`;
+          isArray && '.array()'
+        )}${conditionalString(nullable && '.nullable()')},`;
       }
 
       return `  ${camelcase(name)}: z.${

--- a/packages/shared/src/database/sql.test.ts
+++ b/packages/shared/src/database/sql.test.ts
@@ -51,7 +51,11 @@ describe('convertToPrimitiveOrSql()', () => {
     expect(convertToPrimitiveOrSql(normalKey, 123)).toEqual(123);
     expect(convertToPrimitiveOrSql(normalKey, true)).toEqual(true);
     expect(convertToPrimitiveOrSql(normalKey, { foo: 'bar' })).toEqual('{"foo":"bar"}');
-    expect(convertToPrimitiveOrSql(normalKey, ['bar'])).toEqual('["bar"]');
+    expect(convertToPrimitiveOrSql(normalKey, ['bar'])).toEqual({
+      sql: 'ARRAY[$1]',
+      type: SqlToken,
+      values: ['bar'],
+    });
   });
 
   it('converts empty string to null value', () => {
@@ -131,6 +135,18 @@ describe('convertToTimestamp()', () => {
       sql: 'to_timestamp($1)',
       type: SqlToken,
       values: [time.valueOf() / 1000],
+    });
+  });
+});
+
+describe('convertToTimestamp()', () => {
+  const key = 'foo';
+  const value = ['bar', 'baz'];
+  it('converts value to sql when the value is an array', () => {
+    expect(convertToPrimitiveOrSql(key, value)).toEqual({
+      sql: 'ARRAY[$1, $2]',
+      type: SqlToken,
+      values: value,
     });
   });
 });

--- a/packages/shared/src/database/sql.ts
+++ b/packages/shared/src/database/sql.ts
@@ -43,6 +43,9 @@ export const convertToPrimitiveOrSql = (
   }
 
   if (typeof value === 'object') {
+    if (Array.isArray(value)) {
+      return sql`ARRAY[${sql.join(value, sql`, `)}]`;
+    }
     return JSON.stringify(value);
   }
 

--- a/packages/shared/src/database/types.ts
+++ b/packages/shared/src/database/types.ts
@@ -1,7 +1,12 @@
 import type { IdentifierSqlToken } from 'slonik';
 
-export type SchemaValuePrimitive = string | number | boolean | undefined;
-export type SchemaValue = SchemaValuePrimitive | Record<string, unknown> | unknown[] | null;
+export type SchemaValuePrimitive = string | number | boolean;
+export type SchemaValue =
+  | SchemaValuePrimitive
+  | SchemaValuePrimitive[]
+  | Record<string, unknown>
+  | null
+  | undefined;
 export type SchemaLike<Key extends string = string> = {
   [key in Key]: SchemaValue;
 };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
support array field for db
- fix: should add `.array()` to custom ts types when the corresponded db field type is an array
- refactor the `SchemaValuePrimitive` to fit the slonik `ValueExpression` type when constructing sql.
- support array value in `convertToPrimitiveOrSql `

## Todo
- LOG-6039: Add tests for inserting data with array fields when hooks is updated


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT & Tested the coming new feature( new PR is WIP)

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
