### PR TITLE
fix(console): code editor error and line number header width

### DIFF
--- a/packages/console/src/components/CodeEditor/index.tsx
+++ b/packages/console/src/components/CodeEditor/index.tsx
@@ -77,9 +77,9 @@ function CodeEditor({
   };
 
   // TODO @sijie temp solution for required error (the errorMessage is an empty string)
-  const finalErrorMessage = typeof error === 'string' && !!error ? error : t('general.required');
+  const finalErrorMessage = typeof error === 'string' ? error : t('general.required');
 
-  const maxLineNumberDigits = ((value ?? '').split('\n').length + 1).toString().length;
+  const maxLineNumberDigits = (value ?? '').split('\n').length.toString().length;
   const isShowingPlaceholder = !value;
 
   return (
@@ -133,7 +133,7 @@ function CodeEditor({
           </SyntaxHighlighter>
         </div>
       </div>
-      {finalErrorMessage && <div className={styles.errorMessage}>{finalErrorMessage}</div>}
+      {error && <div className={styles.errorMessage}>{finalErrorMessage}</div>}
     </>
   );
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
1. code editor is showing an error message all the time, which is not right.
2. code editor line number header width. Previously, content with 9 lines had the same line number header as content with 10 lines, which is wrong.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
1. Error message:
<img width="1967" alt="image" src="https://user-images.githubusercontent.com/15182327/233604941-805f471e-f7f5-4e78-9aac-fbc4c75e0dc3.png">
2. line number header width:
<img width="585" alt="image" src="https://user-images.githubusercontent.com/15182327/233605480-ff01d553-ed12-4e78-b350-cc21bc540880.png">
<img width="582" alt="image" src="https://user-images.githubusercontent.com/15182327/233605579-d0d0ba93-fbee-4021-bb73-b657e5fd5210.png">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
