### PR TITLE
ci: update release workflow

### DIFF
--- a/.github/workflows/clean-up-images.yml
+++ b/.github/workflows/clean-up-images.yml
@@ -17,5 +17,5 @@ jobs:
           account-type: org
           org-name: logto-io
           keep-at-least: 1
-          untagged-only: true
+          filter-tags: "sha-*"
           token: ${{ secrets.BOT_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=sha
+            type=raw,value=${{ inputs.target || 'dev' }},enable=${{ !startsWith(github.ref, 'refs/tags/') }}
             type=edge
 
       - name: Login to DockerHub
@@ -111,7 +111,7 @@ jobs:
             ghcr.io/logto-io/cloud
           # https://github.com/docker/metadata-action
           tags: |
-            type=sha
+            type=raw,value=${{ inputs.target || 'dev' }},enable=${{ !startsWith(github.ref, 'refs/tags/') }}
             type=edge
 
       - name: Login to GitHub Container Registry
@@ -153,10 +153,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set short sha
-        id: sha
-        run: echo "short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-
       - name: Setup Node and pnpm
         if: ${{ (inputs.target || 'dev') == 'dev' && matrix.target == 'core' }}
         uses: silverhand-io/actions-node-pnpm-run-steps@v3
@@ -186,7 +182,7 @@ jobs:
         with:
           app-name: ${{ vars.APP_NAME }}
           slot-name: staging
-          images: ghcr.io/logto-io/${{ matrix.image }}:sha-${{ steps.sha.outputs.short }}
+          images: ghcr.io/logto-io/${{ matrix.image }}:${{ (inputs.target || 'dev') }}
 
   swap-staging-prod:
     strategy:


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- use the target deployment environment `dev` and `prod` to tag current deployed images instead of `sha-*` since it is unstable and unclear
  - the original idea is to use tag to know which exact commit is deployed. since GitHub has [Deployments](https://github.com/logto-io/logto/deployments). to keep it simple, we can use a fixed tag for this.
- remove `sha-*` tagged and untagged images regularly.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
will test after merge

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
