### PR TITLE
fix(console): set height limit to language dropdown

### DIFF
--- a/packages/console/src/containers/AppContent/components/SubMenu/index.module.scss
+++ b/packages/console/src/containers/AppContent/components/SubMenu/index.module.scss
@@ -29,14 +29,14 @@
   position: absolute;
   top: -4px;
   right: calc(100% + 5px);
-  display: none;
+  visibility: hidden;
   background: var(--color-float);
   border: 1px solid var(--color-divider);
   border-radius: _.unit(2);
   box-shadow: var(--shadow-2);
 
   &.visible {
-    display: block;
+    visibility: visible;
   }
 }
 

--- a/packages/console/src/containers/AppContent/components/SubMenu/index.tsx
+++ b/packages/console/src/containers/AppContent/components/SubMenu/index.tsx
@@ -1,12 +1,12 @@
 import type { AdminConsoleKey } from '@logto/phrases';
 import classNames from 'classnames';
-import type { ReactNode } from 'react';
-import { useState, useRef } from 'react';
+import { type ReactNode, useCallback, useEffect, useState, useRef } from 'react';
 
 import ArrowRight from '@/assets/images/arrow-right.svg';
 import Tick from '@/assets/images/tick.svg';
 import { DropdownItem } from '@/components/Dropdown';
 import DynamicT from '@/components/DynamicT';
+import OverlayScrollbar from '@/components/OverlayScrollbar';
 import type { Option } from '@/components/Select';
 import Spacer from '@/components/Spacer';
 import { onKeyDownHandler } from '@/utils/a11y';
@@ -23,6 +23,11 @@ type Props<T> = {
   onItemClick: (value: T) => void;
 };
 
+const menuItemHeight = 40;
+const menuItemMargin = 4;
+const menuBorderSize = 1;
+const menuBottomPadding = 16;
+
 function SubMenu<T extends string>({
   className,
   menuItemClassName,
@@ -36,6 +41,32 @@ function SubMenu<T extends string>({
   const [showMenu, setShowMenu] = useState(false);
   const mouseEnterTimeoutRef = useRef(0);
   const mouseLeaveTimeoutRef = useRef(0);
+  const [menuHeight, setMenuHeight] = useState<number>();
+
+  const calculateDropdownHeight = useCallback(() => {
+    if (anchorRef.current) {
+      const anchorRect = anchorRef.current.getBoundingClientRect();
+      const originalMenuHeight =
+        options.length * menuItemHeight +
+        (options.length + 1) * menuItemMargin +
+        2 * menuBorderSize;
+      const availableHeight = window.innerHeight - anchorRect.top - menuBottomPadding;
+
+      setMenuHeight(Math.min(originalMenuHeight, availableHeight));
+    }
+  }, [options.length]);
+
+  useEffect(() => {
+    calculateDropdownHeight();
+
+    window.addEventListener('resize', calculateDropdownHeight);
+    window.addEventListener('scroll', calculateDropdownHeight);
+
+    return () => {
+      window.removeEventListener('resize', calculateDropdownHeight);
+      window.removeEventListener('scroll', calculateDropdownHeight);
+    };
+  }, [calculateDropdownHeight]);
 
   return (
     <div
@@ -71,7 +102,10 @@ function SubMenu<T extends string>({
       </span>
       <Spacer />
       <ArrowRight className={styles.icon} />
-      <div className={classNames(styles.menu, showMenu && styles.visible)}>
+      <OverlayScrollbar
+        className={classNames(styles.menu, showMenu && styles.visible)}
+        style={{ maxHeight: menuHeight }}
+      >
         {options.map(({ value, title }) => {
           const selected = value === selectedOption;
 
@@ -92,7 +126,7 @@ function SubMenu<T extends string>({
             </DropdownItem>
           );
         })}
-      </div>
+      </OverlayScrollbar>
     </div>
   );
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Set a max height limit to the language selection menu, according to the browser window size.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.

- When the browser height is big enough, no scrollbar is seen.
<img width="562" alt="image" src="https://user-images.githubusercontent.com/12833674/233950129-1b302e45-4a1b-4c9a-8686-05e2e1263ab6.png">

- When browser available height is less than the menu size, the height limit will be set and we can see scrollbar on the menu when hovering the menu.
<img width="556" alt="image" src="https://user-images.githubusercontent.com/12833674/233949769-531b002c-3846-4c89-ba6a-bab5dd384eb0.png">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
- [x] This PR is not applicable for the checklist
