### PR TITLE
fix(console): language dropdown height should be calculated properly on first load

### DIFF
--- a/packages/console/src/containers/AppContent/components/SubMenu/index.tsx
+++ b/packages/console/src/containers/AppContent/components/SubMenu/index.tsx
@@ -1,6 +1,6 @@
 import type { AdminConsoleKey } from '@logto/phrases';
 import classNames from 'classnames';
-import { type ReactNode, useCallback, useEffect, useState, useRef } from 'react';
+import { type ReactNode, useCallback, useState, useRef } from 'react';
 
 import ArrowRight from '@/assets/images/arrow-right.svg';
 import Tick from '@/assets/images/tick.svg';
@@ -26,7 +26,7 @@ type Props<T> = {
 const menuItemHeight = 40;
 const menuItemMargin = 4;
 const menuBorderSize = 1;
-const menuBottomPadding = 16;
+const menuBottomMargin = 16;
 
 function SubMenu<T extends string>({
   className,
@@ -50,23 +50,11 @@ function SubMenu<T extends string>({
         options.length * menuItemHeight +
         (options.length + 1) * menuItemMargin +
         2 * menuBorderSize;
-      const availableHeight = window.innerHeight - anchorRect.top - menuBottomPadding;
+      const availableHeight = window.innerHeight - anchorRect.top - menuBottomMargin;
 
       setMenuHeight(Math.min(originalMenuHeight, availableHeight));
     }
   }, [options.length]);
-
-  useEffect(() => {
-    calculateDropdownHeight();
-
-    window.addEventListener('resize', calculateDropdownHeight);
-    window.addEventListener('scroll', calculateDropdownHeight);
-
-    return () => {
-      window.removeEventListener('resize', calculateDropdownHeight);
-      window.removeEventListener('scroll', calculateDropdownHeight);
-    };
-  }, [calculateDropdownHeight]);
 
   return (
     <div
@@ -79,6 +67,7 @@ function SubMenu<T extends string>({
       })}
       onMouseEnter={() => {
         window.clearTimeout(mouseLeaveTimeoutRef.current);
+        calculateDropdownHeight();
         // eslint-disable-next-line @silverhand/fp/no-mutation
         mouseEnterTimeoutRef.current = window.setTimeout(() => {
           setShowMenu(true);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the language selection dropdown height on first load.
Previously since the parent container position is recalculated after loaded, we got wrong calculation result for the submenu dropdown height on first load, because the height calculation is done before the parent container position is updated.

Now it's changed to recalculate the height every time before it shows up (on mouse enter).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Refresh the page and click to open userinfo menu, and then hover on "Language" item, the submenu dropdown height should be calculated properly based on current browser size and its parent position.

<img width="562" alt="image" src="https://user-images.githubusercontent.com/12833674/234241518-24b808c5-34fd-4abd-ae8c-477f6fbdc065.png">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
- [x] This PR is not applicable for the checklist
