### PR TITLE
fix(core): add duplicate resource indicator error guard

### DIFF
--- a/packages/core/src/queries/resource.ts
+++ b/packages/core/src/queries/resource.ts
@@ -26,11 +26,12 @@ export const createResourceQueries = (pool: CommonQueryMethods) => {
       `)
     );
 
-  const findResourceByIndicator = async (indicator: string) =>
+  const findResourceByIndicator = async (indicator: string, excludeRoleId?: string) =>
     pool.maybeOne<Resource>(sql`
       select ${sql.join(Object.values(fields), sql`, `)}
       from ${table}
       where ${fields.indicator}=${indicator}
+      ${conditionalSql(excludeRoleId, (id) => sql`and ${fields.id}<>${id}`)}
     `);
 
   const findResourceById = buildFindEntityByIdWithPool(pool)(Resources);

--- a/packages/core/src/routes/resource.test.ts
+++ b/packages/core/src/routes/resource.test.ts
@@ -1,5 +1,6 @@
 import type { Resource, CreateResource } from '@logto/schemas';
 import { pickDefault, createMockUtils } from '@logto/shared/esm';
+import { type Nullable } from '@silverhand/essentials';
 
 import { mockResource, mockScope } from '#src/__mocks__/index.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
@@ -12,6 +13,12 @@ const { mockEsm } = createMockUtils(jest);
 const resources = {
   findTotalNumberOfResources: async () => ({ count: 10 }),
   findAllResources: async (): Promise<Resource[]> => [mockResource],
+  findResourceByIndicator: async (indicator: string): Promise<Nullable<Resource>> => {
+    if (indicator === mockResource.indicator) {
+      return mockResource;
+    }
+    return null;
+  },
   findResourceById: jest.fn(async (): Promise<Resource> => mockResource),
   insertResource: async (body: CreateResource): Promise<Resource> => ({
     ...mockResource,
@@ -114,6 +121,16 @@ describe('resource routes', () => {
     );
   });
 
+  it('POST /resource should throw with duplicated indicator', async () => {
+    const name = 'user api';
+    const { indicator } = mockResource;
+    const accessTokenTtl = 60;
+
+    await expect(
+      resourceRequest.post('/resources').send({ name, indicator, accessTokenTtl })
+    ).resolves.toHaveProperty('status', 422);
+  });
+
   it('GET /resources/:id', async () => {
     const response = await resourceRequest.get('/resources/foo');
 
@@ -144,6 +161,20 @@ describe('resource routes', () => {
   it('PATCH /resources/:id should throw with invalid propreties', async () => {
     const response = await resourceRequest.patch('/resources/foo').send({ indicator: 12 });
     expect(response.status).toEqual(400);
+  });
+
+  it('PATCH /resources/:id should throw with duplicated indicator', async () => {
+    const name = 'user api';
+    const { indicator } = mockResource;
+
+    await expect(resourceRequest.patch('/resources/foo').send({ name })).resolves.toHaveProperty(
+      'status',
+      200
+    );
+
+    await expect(
+      resourceRequest.patch('/resources/foo').send({ name, indicator })
+    ).resolves.toHaveProperty('status', 422);
   });
 
   it('DELETE /resources/:id', async () => {

--- a/packages/integration-tests/src/api/resource.ts
+++ b/packages/integration-tests/src/api/resource.ts
@@ -20,7 +20,7 @@ export const getResource = async (resourceId: string, options?: OptionsOfTextRes
 
 export const updateResource = async (
   resourceId: string,
-  payload: Partial<Omit<CreateResource, 'id' | 'indicator'>>
+  payload: Partial<Omit<CreateResource, 'id'>>
 ) =>
   authedAdminApi
     .patch(`resources/${resourceId}`, {

--- a/packages/integration-tests/src/tests/api/resource.test.ts
+++ b/packages/integration-tests/src/tests/api/resource.test.ts
@@ -2,6 +2,7 @@ import { defaultManagementApi } from '@logto/schemas';
 import { HTTPError } from 'got';
 
 import { createResource, getResource, updateResource, deleteResource } from '#src/api/index.js';
+import { createResponseWithCode } from '#src/helpers/admin-tenant.js';
 import { generateResourceIndicator, generateResourceName } from '#src/utils.js';
 
 describe('admin console api resources', () => {
@@ -25,6 +26,20 @@ describe('admin console api resources', () => {
     expect(fetchedCreatedResource).toBeTruthy();
   });
 
+  it('should throw error when create api resource with duplicated resource indicator', async () => {
+    const resourceName = generateResourceName();
+    const resourceIndicator = generateResourceIndicator();
+
+    // Create first resource
+    await createResource(resourceName, resourceIndicator);
+
+    // Create second resource with same indicator should throw
+    const resourceName2 = generateResourceName();
+    await expect(createResource(resourceName2, resourceIndicator)).rejects.toMatchObject(
+      createResponseWithCode(422)
+    );
+  });
+
   it('should update api resource details successfully', async () => {
     const resource = await createResource();
 
@@ -41,6 +56,20 @@ describe('admin console api resources', () => {
     expect(updatedResource.id).toBe(resource.id);
     expect(updatedResource.name).toBe(newResourceName);
     expect(updatedResource.accessTokenTtl).toBe(newAccessTokenTtl);
+  });
+
+  it('should throw error when update api resource with duplicated resource indicator', async () => {
+    const resourceName = generateResourceName();
+    const resourceIndicator = generateResourceIndicator();
+
+    // Create first resource
+    await createResource(resourceName, resourceIndicator);
+    const resource2 = await createResource();
+
+    // Update resource2 with resourceIndicator should throw
+    await expect(
+      updateResource(resource2.id, { indicator: resourceIndicator })
+    ).rejects.toMatchObject(createResponseWithCode(422));
   });
 
   it('should delete api resource successfully', async () => {

--- a/packages/phrases/src/locales/de/errors/index.ts
+++ b/packages/phrases/src/locales/de/errors/index.ts
@@ -7,6 +7,7 @@ import log from './log.js';
 import oidc from './oidc.js';
 import password from './password.js';
 import request from './request.js';
+import resource from './resource.js';
 import role from './role.js';
 import scope from './scope.js';
 import session from './session.js';
@@ -34,6 +35,7 @@ const errors = {
   role,
   scope,
   storage,
+  resource,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/de/errors/resource.ts
+++ b/packages/phrases/src/locales/de/errors/resource.ts
@@ -1,0 +1,5 @@
+const resource = {
+  resource_identifier_in_use: 'Die API-Kennung {{indicator}} wird bereits verwendet',
+};
+
+export default resource;

--- a/packages/phrases/src/locales/en/errors/index.ts
+++ b/packages/phrases/src/locales/en/errors/index.ts
@@ -7,6 +7,7 @@ import log from './log.js';
 import oidc from './oidc.js';
 import password from './password.js';
 import request from './request.js';
+import resource from './resource.js';
 import role from './role.js';
 import scope from './scope.js';
 import session from './session.js';
@@ -34,6 +35,7 @@ const errors = {
   role,
   scope,
   storage,
+  resource,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/en/errors/resource.ts
+++ b/packages/phrases/src/locales/en/errors/resource.ts
@@ -1,0 +1,5 @@
+const resource = {
+  resource_identifier_in_use: 'The API identifier {{indicator}} is already in use',
+};
+
+export default resource;

--- a/packages/phrases/src/locales/es/errors/index.ts
+++ b/packages/phrases/src/locales/es/errors/index.ts
@@ -7,6 +7,7 @@ import log from './log.js';
 import oidc from './oidc.js';
 import password from './password.js';
 import request from './request.js';
+import resource from './resource.js';
 import role from './role.js';
 import scope from './scope.js';
 import session from './session.js';
@@ -34,6 +35,7 @@ const errors = {
   role,
   scope,
   storage,
+  resource,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/es/errors/resource.ts
+++ b/packages/phrases/src/locales/es/errors/resource.ts
@@ -1,0 +1,5 @@
+const resource = {
+  resource_identifier_in_use: '"El identificador de API {{indicator}} ya está en uso',
+};
+
+export default resource;

--- a/packages/phrases/src/locales/fr/errors/index.ts
+++ b/packages/phrases/src/locales/fr/errors/index.ts
@@ -7,6 +7,7 @@ import log from './log.js';
 import oidc from './oidc.js';
 import password from './password.js';
 import request from './request.js';
+import resource from './resource.js';
 import role from './role.js';
 import scope from './scope.js';
 import session from './session.js';
@@ -34,6 +35,7 @@ const errors = {
   role,
   scope,
   storage,
+  resource,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/fr/errors/resource.ts
+++ b/packages/phrases/src/locales/fr/errors/resource.ts
@@ -1,0 +1,5 @@
+const resource = {
+  resource_identifier_in_use: "L'identifiant d'API {{indicator}} est déjà utilisé",
+};
+
+export default resource;

--- a/packages/phrases/src/locales/it/errors/index.ts
+++ b/packages/phrases/src/locales/it/errors/index.ts
@@ -7,6 +7,7 @@ import log from './log.js';
 import oidc from './oidc.js';
 import password from './password.js';
 import request from './request.js';
+import resource from './resource.js';
 import role from './role.js';
 import scope from './scope.js';
 import session from './session.js';
@@ -34,6 +35,7 @@ const errors = {
   role,
   scope,
   storage,
+  resource,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/it/errors/resource.ts
+++ b/packages/phrases/src/locales/it/errors/resource.ts
@@ -1,0 +1,5 @@
+const resource = {
+  resource_identifier_in_use: "L'identificatore API {{indicator}} è già in uso",
+};
+
+export default resource;

--- a/packages/phrases/src/locales/ja/errors/index.ts
+++ b/packages/phrases/src/locales/ja/errors/index.ts
@@ -7,6 +7,7 @@ import log from './log.js';
 import oidc from './oidc.js';
 import password from './password.js';
 import request from './request.js';
+import resource from './resource.js';
 import role from './role.js';
 import scope from './scope.js';
 import session from './session.js';
@@ -34,6 +35,7 @@ const errors = {
   role,
   scope,
   storage,
+  resource,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/ja/errors/resource.ts
+++ b/packages/phrases/src/locales/ja/errors/resource.ts
@@ -1,0 +1,5 @@
+const resource = {
+  resource_identifier_in_use: 'API識別子 {{indicator}} はすでに使用されています',
+};
+
+export default resource;

--- a/packages/phrases/src/locales/ko/errors/index.ts
+++ b/packages/phrases/src/locales/ko/errors/index.ts
@@ -7,6 +7,7 @@ import log from './log.js';
 import oidc from './oidc.js';
 import password from './password.js';
 import request from './request.js';
+import resource from './resource.js';
 import role from './role.js';
 import scope from './scope.js';
 import session from './session.js';
@@ -34,6 +35,7 @@ const errors = {
   role,
   scope,
   storage,
+  resource,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/ko/errors/resource.ts
+++ b/packages/phrases/src/locales/ko/errors/resource.ts
@@ -1,0 +1,5 @@
+const resource = {
+  resource_identifier_in_use: 'API 식별자 {{indicator}}가 이미 사용 중입니다',
+};
+
+export default resource;

--- a/packages/phrases/src/locales/pl-pl/errors/index.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/index.ts
@@ -7,6 +7,7 @@ import log from './log.js';
 import oidc from './oidc.js';
 import password from './password.js';
 import request from './request.js';
+import resource from './resource.js';
 import role from './role.js';
 import scope from './scope.js';
 import session from './session.js';
@@ -34,6 +35,7 @@ const errors = {
   role,
   scope,
   storage,
+  resource,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/pl-pl/errors/resource.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/resource.ts
@@ -1,0 +1,5 @@
+const resource = {
+  resource_identifier_in_use: 'Identyfikator API {{indicator}} jest już używany',
+};
+
+export default resource;

--- a/packages/phrases/src/locales/pt-br/errors/index.ts
+++ b/packages/phrases/src/locales/pt-br/errors/index.ts
@@ -7,6 +7,7 @@ import log from './log.js';
 import oidc from './oidc.js';
 import password from './password.js';
 import request from './request.js';
+import resource from './resource.js';
 import role from './role.js';
 import scope from './scope.js';
 import session from './session.js';
@@ -34,6 +35,7 @@ const errors = {
   role,
   scope,
   storage,
+  resource,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/pt-br/errors/resource.ts
+++ b/packages/phrases/src/locales/pt-br/errors/resource.ts
@@ -1,0 +1,5 @@
+const resource = {
+  resource_identifier_in_use: 'O identificador de API {{indicator}} já está em uso',
+};
+
+export default resource;

--- a/packages/phrases/src/locales/pt-pt/errors/index.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/index.ts
@@ -7,6 +7,7 @@ import log from './log.js';
 import oidc from './oidc.js';
 import password from './password.js';
 import request from './request.js';
+import resource from './resource.js';
 import role from './role.js';
 import scope from './scope.js';
 import session from './session.js';
@@ -34,6 +35,7 @@ const errors = {
   role,
   scope,
   storage,
+  resource,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/pt-pt/errors/resource.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/resource.ts
@@ -1,0 +1,5 @@
+const resource = {
+  resource_identifier_in_use: 'O identificador da API {{indicator}} já está em uso',
+};
+
+export default resource;

--- a/packages/phrases/src/locales/ru/errors/index.ts
+++ b/packages/phrases/src/locales/ru/errors/index.ts
@@ -7,6 +7,7 @@ import log from './log.js';
 import oidc from './oidc.js';
 import password from './password.js';
 import request from './request.js';
+import resource from './resource.js';
 import role from './role.js';
 import scope from './scope.js';
 import session from './session.js';
@@ -34,6 +35,7 @@ const errors = {
   role,
   scope,
   storage,
+  resource,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/ru/errors/resource.ts
+++ b/packages/phrases/src/locales/ru/errors/resource.ts
@@ -1,0 +1,5 @@
+const resource = {
+  resource_identifier_in_use: 'Идентификатор API {{indicator}} уже используется',
+};
+
+export default resource;

--- a/packages/phrases/src/locales/tr-tr/errors/index.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/index.ts
@@ -7,6 +7,7 @@ import log from './log.js';
 import oidc from './oidc.js';
 import password from './password.js';
 import request from './request.js';
+import resource from './resource.js';
 import role from './role.js';
 import scope from './scope.js';
 import session from './session.js';
@@ -34,6 +35,7 @@ const errors = {
   role,
   scope,
   storage,
+  resource,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/tr-tr/errors/resource.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/resource.ts
@@ -1,0 +1,5 @@
+const resource = {
+  resource_identifier_in_use: 'API tanımlayıcısı {{indicator}} zaten kullanımda',
+};
+
+export default resource;

--- a/packages/phrases/src/locales/zh-cn/errors/index.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/index.ts
@@ -7,6 +7,7 @@ import log from './log.js';
 import oidc from './oidc.js';
 import password from './password.js';
 import request from './request.js';
+import resource from './resource.js';
 import role from './role.js';
 import scope from './scope.js';
 import session from './session.js';
@@ -34,6 +35,7 @@ const errors = {
   role,
   scope,
   storage,
+  resource,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/zh-cn/errors/resource.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/resource.ts
@@ -1,0 +1,5 @@
+const resource = {
+  resource_identifier_in_use: 'API 标识符 {{indicator}} 已被使用',
+};
+
+export default resource;

--- a/packages/phrases/src/locales/zh-hk/errors/index.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/index.ts
@@ -7,6 +7,7 @@ import log from './log.js';
 import oidc from './oidc.js';
 import password from './password.js';
 import request from './request.js';
+import resource from './resource.js';
 import role from './role.js';
 import scope from './scope.js';
 import session from './session.js';
@@ -34,6 +35,7 @@ const errors = {
   role,
   scope,
   storage,
+  resource,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/zh-hk/errors/resource.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/resource.ts
@@ -1,0 +1,5 @@
+const resource = {
+  resource_identifier_in_use: 'API 識別碼 {{indicator}} 已經被使用',
+};
+
+export default resource;

--- a/packages/phrases/src/locales/zh-tw/errors/index.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/index.ts
@@ -7,6 +7,7 @@ import log from './log.js';
 import oidc from './oidc.js';
 import password from './password.js';
 import request from './request.js';
+import resource from './resource.js';
 import role from './role.js';
 import scope from './scope.js';
 import session from './session.js';
@@ -34,6 +35,7 @@ const errors = {
   role,
   scope,
   storage,
+  resource,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/zh-tw/errors/resource.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/resource.ts
@@ -1,0 +1,5 @@
+const resource = {
+  resource_identifier_in_use: 'API 識別碼 {{indicator}} 已經被使用',
+};
+
+export default resource;


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->


Follow `POST roles` deduplicate role name pattern. Add duplicate resource indicator error guard. to `POST resource` and `PATCH /resource/:id` API.




<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

<img width="1017" alt="image" src="https://user-images.githubusercontent.com/36393111/235307143-26b79bd6-6c72-4e61-9633-6170c7bda190.png">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] docs

OR

- [ ] This PR is not applicable for the checklist
