### PR TITLE
fix(console): fix the back link of the log details page

### DIFF
--- a/packages/console/src/pages/AuditLogDetails/index.tsx
+++ b/packages/console/src/pages/AuditLogDetails/index.tsx
@@ -21,7 +21,7 @@ import EventIcon from './components/EventIcon';
 import * as styles from './index.module.scss';
 
 const getAuditLogDetailsRelatedResourceLink = (pathname: string) =>
-  `/${pathname.slice(0, pathname.lastIndexOf('/'))}`;
+  `${pathname.slice(0, pathname.lastIndexOf('/'))}`;
 
 const getDetailsTabNavLink = (logId: string, userId?: string) =>
   userId ? `/users/${userId}/logs/${logId}` : `/audit-logs/${logId}`;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Now the `pathname` from `useLocation` will start with `/`, so remove the redundant leading `/` in the `getAuditLogDetailsRelatedResourceLink` method.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
