### PR TITLE
fix(console): trim trailing spaces in app guide code sample

### DIFF
--- a/packages/console/src/pages/Applications/components/Guide/index.tsx
+++ b/packages/console/src/pages/Applications/components/Guide/index.tsx
@@ -94,9 +94,9 @@ function Guide({ app, isCompact, onClose }: Props) {
               const [, language] = /language-(\w+)/.exec(String(className ?? '')) ?? [];
 
               return language ? (
-                <CodeEditor isReadonly language={language} value={String(children)} />
+                <CodeEditor isReadonly language={language} value={String(children).trimEnd()} />
               ) : (
-                <code>{String(children)}</code>
+                <code>{String(children).trimEnd()}</code>
               );
             },
             a: ({ children, ...props }) => (


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Trim trailing spaces of code samples in application guides to avoid empty code lines.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Before:
<img width="1965" alt="image" src="https://user-images.githubusercontent.com/15182327/236370400-3a298b7f-2936-4ac3-ad9a-c940adc7c7ad.png">
After fix:
<img width="1967" alt="image" src="https://user-images.githubusercontent.com/15182327/236370216-ce67eeb4-6f07-40f4-ba23-e58e508f7c48.png">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
