### PR TITLE
fix(console): main content should take 100% available height

### DIFF
--- a/packages/console/src/containers/ConsoleContent/index.module.scss
+++ b/packages/console/src/containers/ConsoleContent/index.module.scss
@@ -12,6 +12,7 @@
 
 .main {
   width: 100%;
+  height: 100%;
   padding: 0 _.unit(6) 0 _.unit(2);
   min-width: 636px;
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix a main content height issue caused by introducing overlay scrollbar globally. The main content should take 100% of the available height.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested OK

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
- [x] This PR is not applicable for the checklist
