### PR TITLE
refactor: update webhook API

### DIFF
--- a/packages/core/src/__mocks__/hook.ts
+++ b/packages/core/src/__mocks__/hook.ts
@@ -1,0 +1,65 @@
+import { type Hook, HookEvent } from '@logto/schemas';
+
+export const mockNanoIdForHook = 'random_string';
+
+export const mockCreatedAtForHook = 1_650_969_000_000;
+
+export const mockTenantIdForHook = 'fake_tenant';
+
+export const mockHook: Hook = {
+  tenantId: mockTenantIdForHook,
+  id: mockNanoIdForHook,
+  name: 'foo',
+  event: null,
+  events: [HookEvent.PostRegister],
+  config: {
+    url: 'https://example.com',
+  },
+  signingKey: mockNanoIdForHook,
+  enabled: true,
+  createdAt: mockCreatedAtForHook,
+};
+
+const mockHookData1: Hook = {
+  tenantId: mockTenantIdForHook,
+  id: 'hook_id_1',
+  name: 'foo',
+  event: null,
+  events: [HookEvent.PostRegister],
+  config: {
+    url: 'https://example1.com',
+  },
+  signingKey: mockNanoIdForHook,
+  enabled: true,
+  createdAt: mockCreatedAtForHook,
+};
+
+const mockHookData2: Hook = {
+  tenantId: mockTenantIdForHook,
+  id: 'hook_id_2',
+  name: 'bar',
+  event: null,
+  events: [HookEvent.PostResetPassword],
+  config: {
+    url: 'https://example2.com',
+  },
+  signingKey: mockNanoIdForHook,
+  enabled: true,
+  createdAt: mockCreatedAtForHook,
+};
+
+const mockHookData3: Hook = {
+  tenantId: mockTenantIdForHook,
+  id: 'hook_id_3',
+  name: 'baz',
+  event: null,
+  events: [HookEvent.PostSignIn],
+  config: {
+    url: 'https://example3.com',
+  },
+  signingKey: mockNanoIdForHook,
+  enabled: true,
+  createdAt: mockCreatedAtForHook,
+};
+
+export const mockHookList: Hook[] = [mockHookData1, mockHookData2, mockHookData3];

--- a/packages/core/src/libraries/hook.ts
+++ b/packages/core/src/libraries/hook.ts
@@ -81,7 +81,7 @@ export const createHookLibrary = (queries: Queries) => {
     } satisfies Omit<HookEventPayload, 'hookId'>;
 
     await Promise.all(
-      rows.map(async ({ config: { url, headers, retries }, id }) => {
+      rows.map(async ({ config: { url, headers }, id }) => {
         consoleLog.info(`\tTriggering hook ${id} due to ${hookEvent} event`);
         const json: HookEventPayload = { hookId: id, ...payload };
         const logEntry = new LogEntry(`TriggerHook.${hookEvent}`);
@@ -93,7 +93,7 @@ export const createHookLibrary = (queries: Queries) => {
           .post(url, {
             headers: { 'user-agent': 'Logto (https://logto.io)', ...headers },
             json,
-            retry: { limit: retries },
+            retry: { limit: 3 },
             timeout: { request: 10_000 },
           })
           .then(async (response) => {

--- a/packages/core/src/libraries/hook.ts
+++ b/packages/core/src/libraries/hook.ts
@@ -53,7 +53,10 @@ export const createHookLibrary = (queries: Queries) => {
 
     const hookEvent = eventToHook[event];
     const found = await findAllHooks();
-    const rows = found.filter(({ event }) => event === hookEvent);
+    const rows = found.filter(
+      ({ event, events, enabled }) =>
+        enabled && (events.length > 0 ? events.includes(hookEvent) : event === hookEvent) // For backward compatibility
+    );
 
     if (rows.length === 0) {
       return;

--- a/packages/core/src/libraries/hook.ts
+++ b/packages/core/src/libraries/hook.ts
@@ -81,7 +81,7 @@ export const createHookLibrary = (queries: Queries) => {
     } satisfies Omit<HookEventPayload, 'hookId'>;
 
     await Promise.all(
-      rows.map(async ({ config: { url, headers }, id }) => {
+      rows.map(async ({ config: { url, headers, retries }, id }) => {
         consoleLog.info(`\tTriggering hook ${id} due to ${hookEvent} event`);
         const json: HookEventPayload = { hookId: id, ...payload };
         const logEntry = new LogEntry(`TriggerHook.${hookEvent}`);
@@ -93,7 +93,7 @@ export const createHookLibrary = (queries: Queries) => {
           .post(url, {
             headers: { 'user-agent': 'Logto (https://logto.io)', ...headers },
             json,
-            retry: { limit: 3 },
+            retry: { limit: retries ?? 3 },
             timeout: { request: 10_000 },
           })
           .then(async (response) => {

--- a/packages/core/src/routes/hook.test.ts
+++ b/packages/core/src/routes/hook.test.ts
@@ -71,7 +71,7 @@ describe('hook routes', () => {
     };
 
     const response = await hookRequest.post('/hooks').send({ name, events, config });
-    expect(response.status).toEqual(200);
+    expect(response.status).toEqual(201);
     expect(response.body.id).toBeTruthy();
     expect(response.body.signingKey).toBeTruthy();
 
@@ -93,7 +93,7 @@ describe('hook routes', () => {
     };
 
     const response = await hookRequest.post('/hooks').send({ name, events, config });
-    expect(response.status).toEqual(200);
+    expect(response.status).toEqual(201);
     expect(response.body.id).toBeTruthy();
     expect(response.body.signingKey).toBeTruthy();
 
@@ -126,7 +126,7 @@ describe('hook routes', () => {
       },
     };
     const response = await hookRequest.post('/hooks').send(payload);
-    expect(response.status).toEqual(200);
+    expect(response.status).toEqual(201);
     const generatedId = response.body.id as string;
 
     expect(response.body).toMatchObject({

--- a/packages/core/src/routes/hook.test.ts
+++ b/packages/core/src/routes/hook.test.ts
@@ -140,20 +140,6 @@ describe('hook routes', () => {
     });
   });
 
-  it('POST /hooks/:id/signing-key', async () => {
-    const targetMockHook = mockHookList[0] ?? mockHook;
-    const originalSigningKey = targetMockHook.signingKey;
-    const response = await hookRequest.post(`/hooks/${targetMockHook.id}/signing-key`).send();
-    expect(response.status).toEqual(200);
-
-    const newSigningKey = response.body.signingKey as string;
-    expect(originalSigningKey).not.toEqual(newSigningKey);
-    expect(response.body).toEqual({
-      ...targetMockHook,
-      signingKey: newSigningKey,
-    });
-  });
-
   it('PATCH /hooks/:id', async () => {
     const targetMockHook = mockHookList[0] ?? mockHook;
     const name = 'newName';
@@ -223,6 +209,20 @@ describe('hook routes', () => {
     expect(response.status).toEqual(200);
     expect(response.body).toEqual(targetMockHook);
     expect(response.body.config.signingKey).not.toEqual(newSigningKey);
+  });
+
+  it('PATCH /hooks/:id/signing-key should update the singing key of a hook', async () => {
+    const targetMockHook = mockHookList[0] ?? mockHook;
+    const originalSigningKey = targetMockHook.signingKey;
+    const response = await hookRequest.patch(`/hooks/${targetMockHook.id}/signing-key`).send();
+    expect(response.status).toEqual(200);
+
+    const newSigningKey = response.body.signingKey as string;
+    expect(originalSigningKey).not.toEqual(newSigningKey);
+    expect(response.body).toEqual({
+      ...targetMockHook,
+      signingKey: newSigningKey,
+    });
   });
 
   it('DELETE /hooks/:id', async () => {

--- a/packages/core/src/routes/hook.test.ts
+++ b/packages/core/src/routes/hook.test.ts
@@ -1,0 +1,234 @@
+import {
+  HookEvent,
+  type Hook,
+  type HookEvents,
+  type HookConfig,
+  type CreateHook,
+} from '@logto/schemas';
+import { pickDefault } from '@logto/shared/esm';
+
+import {
+  mockCreatedAtForHook,
+  mockHook,
+  mockHookList,
+  mockNanoIdForHook,
+  mockTenantIdForHook,
+} from '#src/__mocks__/hook.js';
+import { MockTenant } from '#src/test-utils/tenant.js';
+import { createRequester } from '#src/utils/test-utils.js';
+
+const { jest } = import.meta;
+
+const hooks = {
+  findAllHooks: async (): Promise<Hook[]> => mockHookList,
+  insertHook: async (data: CreateHook): Promise<Hook> => ({
+    ...mockHook,
+    ...data,
+  }),
+  findHookById: async (id: string): Promise<Hook> => {
+    const hook = mockHookList.find((hook) => hook.id === id);
+    if (!hook) {
+      throw new Error('Not found');
+    }
+    return hook;
+  },
+  updateHookById: async (id: string, data: Partial<CreateHook>): Promise<Hook> => {
+    const targetHook = mockHookList.find((hook) => hook.id === id) ?? mockHook;
+    return {
+      ...targetHook,
+      ...data,
+    };
+  },
+  deleteHookById: jest.fn(),
+};
+
+const tenantContext = new MockTenant(undefined, { hooks });
+
+const hookRoutes = await pickDefault(import('./hook.js'));
+
+describe('hook routes', () => {
+  const hookRequest = createRequester({ authedRoutes: hookRoutes, tenantContext });
+
+  it('GET /hooks', async () => {
+    const response = await hookRequest.get('/hooks');
+    expect(response.status).toEqual(200);
+    expect(response.body).toEqual(mockHookList);
+    expect(response.header).not.toHaveProperty('total-number');
+  });
+
+  it('GET /hooks/:id', async () => {
+    const hookIdInMockList = mockHookList[0]?.id ?? '';
+    const response = await hookRequest.get(`/hooks/${hookIdInMockList}`);
+    expect(response.status).toEqual(200);
+    expect(response.body.id).toBe(hookIdInMockList);
+  });
+
+  it('POST /hooks', async () => {
+    const name = 'fooName';
+    const events: HookEvents = [HookEvent.PostRegister];
+    const config: HookConfig = {
+      url: 'https://example.com',
+    };
+
+    const response = await hookRequest.post('/hooks').send({ name, events, config });
+    expect(response.status).toEqual(200);
+    expect(response.body.id).toBeTruthy();
+    expect(response.body.signingKey).toBeTruthy();
+
+    expect(response.body).toMatchObject({
+      tenantId: mockTenantIdForHook,
+      name,
+      events,
+      config,
+      enabled: true,
+      createdAt: mockCreatedAtForHook,
+    });
+  });
+
+  it('POST /hooks should be able to create a hook with multi events', async () => {
+    const name = 'anyName';
+    const events: HookEvents = [HookEvent.PostSignIn, HookEvent.PostRegister];
+    const config: HookConfig = {
+      url: 'https://example.com',
+    };
+
+    const response = await hookRequest.post('/hooks').send({ name, events, config });
+    expect(response.status).toEqual(200);
+    expect(response.body.id).toBeTruthy();
+    expect(response.body.signingKey).toBeTruthy();
+
+    expect(response.body).toMatchObject({
+      tenantId: mockTenantIdForHook,
+      name,
+      events,
+      config,
+      enabled: true,
+      createdAt: mockCreatedAtForHook,
+    });
+  });
+
+  it('POST /hooks should fail when no events are provided', async () => {
+    const payload: Partial<Hook> = {
+      name: 'hook_name',
+      config: {
+        url: 'https://example.com',
+      },
+    };
+    await expect(hookRequest.post('/hooks').send(payload)).resolves.toHaveProperty('status', 422);
+  });
+
+  it('POST /hooks should success when create a hook with the old payload format', async () => {
+    const payload: Partial<Hook> = {
+      event: HookEvent.PostRegister,
+      config: {
+        url: 'https://example.com',
+        retries: 2,
+      },
+    };
+    const response = await hookRequest.post('/hooks').send(payload);
+    expect(response.status).toEqual(200);
+    const generatedId = response.body.id as string;
+
+    expect(response.body).toMatchObject({
+      tenantId: mockTenantIdForHook,
+      id: generatedId,
+      event: HookEvent.PostRegister,
+      config: {
+        url: 'https://example.com',
+        retries: 2,
+      },
+    });
+  });
+
+  it('POST /hooks/:id/signing-key', async () => {
+    const targetMockHook = mockHookList[0] ?? mockHook;
+    const originalSigningKey = targetMockHook.signingKey;
+    const response = await hookRequest.post(`/hooks/${targetMockHook.id}/signing-key`).send();
+    expect(response.status).toEqual(200);
+
+    const newSigningKey = response.body.signingKey as string;
+    expect(originalSigningKey).not.toEqual(newSigningKey);
+    expect(response.body).toEqual({
+      ...targetMockHook,
+      signingKey: newSigningKey,
+    });
+  });
+
+  it('PATCH /hooks/:id', async () => {
+    const targetMockHook = mockHookList[0] ?? mockHook;
+    const name = 'newName';
+    const events: HookEvents = [HookEvent.PostSignIn];
+    const config: HookConfig = {
+      url: 'https://new.com',
+    };
+
+    const response = await hookRequest
+      .patch(`/hooks/${targetMockHook.id}`)
+      .send({ name, events, config, enabled: false });
+
+    expect(response.status).toEqual(200);
+    expect(response.body).toMatchObject({
+      name,
+      events,
+      config,
+      enabled: false,
+    });
+  });
+
+  it('PATCH /hooks/:id should success when update a hook with multi events', async () => {
+    const targetMockHook = mockHookList[0] ?? mockHook;
+    const events = [HookEvent.PostSignIn, HookEvent.PostResetPassword];
+    const response = await hookRequest.patch(`/hooks/${targetMockHook.id}`).send({ events });
+
+    expect(response.status).toEqual(200);
+    expect(response.body).toMatchObject({
+      events,
+    });
+  });
+
+  it('PATCH /hooks/:id should success when update a hook with the old payload format', async () => {
+    const targetMockHook = mockHookList[0] ?? mockHook;
+    const event = HookEvent.PostSignIn;
+    const response = await hookRequest.patch(`/hooks/${targetMockHook.id}`).send({
+      event,
+      config: {
+        retries: 1,
+      },
+    });
+
+    expect(response.status).toEqual(200);
+    expect(response.body).toMatchObject({
+      event,
+      config: {
+        retries: 1,
+      },
+    });
+  });
+
+  it('PATCH /hooks/:id with empty events list should fail', async () => {
+    const invalidEvents: HookEvent[] = [];
+    const response = await hookRequest
+      .patch(`/hooks/${mockNanoIdForHook}`)
+      .send({ events: invalidEvents });
+    expect(response.status).toEqual(400);
+  });
+
+  it('PATCH /hooks/:id should not update signing key', async () => {
+    const targetMockHook = mockHookList[0] ?? mockHook;
+    const newSigningKey = `New-${targetMockHook.signingKey}`;
+    const response = await hookRequest
+      .patch(`/hooks/${targetMockHook.id}`)
+      .send({ signingKey: newSigningKey });
+
+    expect(response.status).toEqual(200);
+    expect(response.body).toEqual(targetMockHook);
+    expect(response.body.config.signingKey).not.toEqual(newSigningKey);
+  });
+
+  it('DELETE /hooks/:id', async () => {
+    await expect(hookRequest.delete(`/hooks/${mockNanoIdForHook}`)).resolves.toHaveProperty(
+      'status',
+      204
+    );
+  });
+});

--- a/packages/core/src/routes/hook.test.ts
+++ b/packages/core/src/routes/hook.test.ts
@@ -114,7 +114,7 @@ describe('hook routes', () => {
         url: 'https://example.com',
       },
     };
-    await expect(hookRequest.post('/hooks').send(payload)).resolves.toHaveProperty('status', 422);
+    await expect(hookRequest.post('/hooks').send(payload)).resolves.toHaveProperty('status', 400);
   });
 
   it('POST /hooks should success when create a hook with the old payload format', async () => {

--- a/packages/core/src/routes/hook.test.ts
+++ b/packages/core/src/routes/hook.test.ts
@@ -178,6 +178,7 @@ describe('hook routes', () => {
     const response = await hookRequest.patch(`/hooks/${targetMockHook.id}`).send({
       event,
       config: {
+        url: 'https://example2.com',
         retries: 1,
       },
     });
@@ -186,6 +187,7 @@ describe('hook routes', () => {
     expect(response.body).toMatchObject({
       event,
       config: {
+        url: 'https://example2.com',
         retries: 1,
       },
     });

--- a/packages/core/src/routes/hook.ts
+++ b/packages/core/src/routes/hook.ts
@@ -47,11 +47,11 @@ export default function hookRoutes<T extends AuthedRouter>(
     koaGuard({
       body: createHookGuard,
       response: Hooks.guard,
-      status: [201, 422],
+      status: [201, 400],
     }),
     async (ctx, next) => {
       const { event, events, ...rest } = ctx.guard.body;
-      assertThat(events ?? event, new RequestError({ code: 'hook.missing_events', status: 422 }));
+      assertThat(events ?? event, new RequestError({ code: 'hook.missing_events', status: 400 }));
 
       ctx.body = await insertHook({
         ...rest,

--- a/packages/core/src/routes/hook.ts
+++ b/packages/core/src/routes/hook.ts
@@ -1,6 +1,6 @@
 import { Hooks, createHookGuard, updateHookGuard } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
-import { conditional, deduplicate } from '@silverhand/essentials';
+import { conditional } from '@silverhand/essentials';
 import { object, string } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
@@ -57,9 +57,10 @@ export default function hookRoutes<T extends AuthedRouter>(
         ...rest,
         id: generateStandardId(),
         signingKey: generateStandardId(),
+        events: events ?? [],
         ...conditional(event && { event }),
-        ...conditional(events && { events: deduplicate(events) }),
       });
+
       ctx.status = 201;
 
       return next();
@@ -80,7 +81,7 @@ export default function hookRoutes<T extends AuthedRouter>(
         body,
       } = ctx.guard;
 
-      const { events, config: configToUpdate, ...rest } = body;
+      const { config: configToUpdate, ...rest } = body;
 
       const hook = await findHookById(id);
       const { config } = hook;
@@ -88,7 +89,6 @@ export default function hookRoutes<T extends AuthedRouter>(
       ctx.body = await updateHookById(id, {
         ...rest,
         config: { ...config, ...configToUpdate },
-        ...conditional(events && { events: deduplicate(events) }),
       });
 
       return next();

--- a/packages/core/src/routes/hook.ts
+++ b/packages/core/src/routes/hook.ts
@@ -1,7 +1,7 @@
 import { Hooks, createHookGuard, updateHookGuard } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 import { conditional } from '@silverhand/essentials';
-import { object, string } from 'zod';
+import { z } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
@@ -27,7 +27,7 @@ export default function hookRoutes<T extends AuthedRouter>(
   router.get(
     '/hooks/:id',
     koaGuard({
-      params: object({ id: string() }),
+      params: z.object({ id: z.string() }),
       response: Hooks.guard,
       status: [200, 404],
     }),
@@ -71,7 +71,7 @@ export default function hookRoutes<T extends AuthedRouter>(
   router.patch(
     '/hooks/:id',
     koaGuard({
-      params: object({ id: string() }),
+      params: z.object({ id: z.string() }),
       body: updateHookGuard,
       response: Hooks.guard,
       status: [200, 404],
@@ -99,7 +99,7 @@ export default function hookRoutes<T extends AuthedRouter>(
   router.patch(
     '/hooks/:id/signing-key',
     koaGuard({
-      params: object({ id: string() }),
+      params: z.object({ id: z.string() }),
       response: Hooks.guard,
       status: [200, 404],
     }),
@@ -118,7 +118,7 @@ export default function hookRoutes<T extends AuthedRouter>(
 
   router.delete(
     '/hooks/:id',
-    koaGuard({ params: object({ id: string() }), status: [204, 404] }),
+    koaGuard({ params: z.object({ id: z.string() }), status: [204, 404] }),
     async (ctx, next) => {
       const { id } = ctx.guard.params;
       await deleteHookById(id);

--- a/packages/core/src/routes/hook.ts
+++ b/packages/core/src/routes/hook.ts
@@ -50,7 +50,7 @@ export default function hookRoutes<T extends AuthedRouter>(
       status: [201, 400],
     }),
     async (ctx, next) => {
-      const { event, events, ...rest } = ctx.guard.body;
+      const { event, events, enabled, ...rest } = ctx.guard.body;
       assertThat(events ?? event, new RequestError({ code: 'hook.missing_events', status: 400 }));
 
       ctx.body = await insertHook({
@@ -58,6 +58,7 @@ export default function hookRoutes<T extends AuthedRouter>(
         id: generateStandardId(),
         signingKey: generateStandardId(),
         events: events ?? [],
+        enabled: enabled ?? true,
         ...conditional(event && { event }),
       });
 

--- a/packages/core/src/routes/hook.ts
+++ b/packages/core/src/routes/hook.ts
@@ -50,7 +50,6 @@ export default function hookRoutes<T extends AuthedRouter>(
     '/hooks',
     koaGuard({
       body: Hooks.createGuard.omit({ id: true, signingKey: true }).extend({
-        name: z.string().min(1).max(256).optional(),
         events: nonemptyUniqueHookEventsGuard.optional(),
       }),
       response: Hooks.guard,
@@ -79,10 +78,9 @@ export default function hookRoutes<T extends AuthedRouter>(
     '/hooks/:id',
     koaGuard({
       params: z.object({ id: z.string() }),
-      body: Hooks.guard
-        .pick({ event: true, config: true, enabled: true })
+      body: Hooks.createGuard
+        .omit({ id: true, signingKey: true })
         .extend({
-          name: z.string().min(1).max(256),
           events: nonemptyUniqueHookEventsGuard,
         })
         .partial(),

--- a/packages/core/src/routes/hook.ts
+++ b/packages/core/src/routes/hook.ts
@@ -66,26 +66,6 @@ export default function hookRoutes<T extends AuthedRouter>(
     }
   );
 
-  router.post(
-    '/hooks/:id/signing-key',
-    koaGuard({
-      params: object({ id: string() }),
-      response: Hooks.guard,
-      status: [200, 404],
-    }),
-    async (ctx, next) => {
-      const {
-        params: { id },
-      } = ctx.guard;
-
-      ctx.body = await updateHookById(id, {
-        signingKey: generateStandardId(),
-      });
-
-      return next();
-    }
-  );
-
   router.patch(
     '/hooks/:id',
     koaGuard({
@@ -109,6 +89,26 @@ export default function hookRoutes<T extends AuthedRouter>(
         ...rest,
         config: { ...config, ...configToUpdate },
         ...conditional(events && { events: deduplicate(events) }),
+      });
+
+      return next();
+    }
+  );
+
+  router.patch(
+    '/hooks/:id/signing-key',
+    koaGuard({
+      params: object({ id: string() }),
+      response: Hooks.guard,
+      status: [200, 404],
+    }),
+    async (ctx, next) => {
+      const {
+        params: { id },
+      } = ctx.guard;
+
+      ctx.body = await updateHookById(id, {
+        signingKey: generateStandardId(),
       });
 
       return next();

--- a/packages/core/src/utils/zod.ts
+++ b/packages/core/src/utils/zod.ts
@@ -252,12 +252,18 @@ export const zodTypeToSwagger = (
     };
   }
 
-  // TO-DO: Improve swagger output for zod schema with refinement (validate through JS functions)
-  if (config instanceof ZodEffects && config._def.effect.type === 'refinement') {
-    return {
-      type: 'object',
-      description: 'Validator function',
-    };
+  if (config instanceof ZodEffects) {
+    if (config._def.effect.type === 'transform') {
+      return zodTypeToSwagger(config._def.schema);
+    }
+
+    // TO-DO: Improve swagger output for zod schema with refinement (validate through JS functions)
+    if (config._def.effect.type === 'refinement') {
+      return {
+        type: 'object',
+        description: 'Validator function',
+      };
+    }
   }
 
   throw new RequestError('swagger.invalid_zod_type', config);

--- a/packages/integration-tests/src/tests/api/hooks.test.ts
+++ b/packages/integration-tests/src/tests/api/hooks.test.ts
@@ -1,19 +1,24 @@
-import type { Hook, LogKey } from '@logto/schemas';
+import type { Hook, HookConfig, LogKey } from '@logto/schemas';
 import { HookEvent, SignInIdentifier, LogResult, InteractionEvent } from '@logto/schemas';
 
 import { authedAdminApi, deleteUser, getLogs, putInteraction } from '#src/api/index.js';
+import { createResponseWithCode } from '#src/helpers/admin-tenant.js';
 import { initClient, processSession } from '#src/helpers/client.js';
 import { createMockServer } from '#src/helpers/index.js';
 import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser, generateNewUserProfile } from '#src/helpers/user.js';
 import { waitFor } from '#src/utils.js';
 
-const createPayload = (event: HookEvent, url = 'not_work_url'): Partial<Hook> => ({
-  event,
+type CreateHookPayload = Pick<Hook, 'name' | 'events'> & {
+  config: HookConfig;
+};
+
+const createPayload = (event: HookEvent, url = 'not_work_url'): CreateHookPayload => ({
+  name: 'hook_name',
+  events: [event],
   config: {
     url,
     headers: { foo: 'bar' },
-    retries: 3,
   },
 });
 
@@ -37,8 +42,33 @@ describe('hooks', () => {
     const payload = createPayload(HookEvent.PostRegister);
     const created = await authedAdminApi.post('hooks', { json: payload }).json<Hook>();
 
-    expect(payload.event).toEqual(created.event);
-    expect(payload.config).toEqual(created.config);
+    expect(created).toMatchObject(payload);
+
+    expect(await authedAdminApi.get('hooks').json<Hook[]>()).toContainEqual(created);
+    expect(await authedAdminApi.get(`hooks/${created.id}`).json<Hook>()).toEqual(created);
+    expect(
+      await authedAdminApi
+        .patch(`hooks/${created.id}`, { json: { events: [HookEvent.PostSignIn] } })
+        .json<Hook>()
+    ).toMatchObject({ ...created, events: [HookEvent.PostSignIn] });
+    expect(await authedAdminApi.delete(`hooks/${created.id}`)).toHaveProperty('statusCode', 204);
+    await expect(authedAdminApi.get(`hooks/${created.id}`)).rejects.toHaveProperty(
+      'response.statusCode',
+      404
+    );
+  });
+
+  it('should be able to create, query, update, and delete a hook by the original API', async () => {
+    const payload = {
+      event: HookEvent.PostRegister,
+      config: {
+        url: 'not_work_url',
+        retries: 2,
+      },
+    };
+    const created = await authedAdminApi.post('hooks', { json: payload }).json<Hook>();
+
+    expect(created).toMatchObject(payload);
 
     expect(await authedAdminApi.get('hooks').json<Hook[]>()).toContainEqual(created);
     expect(await authedAdminApi.get(`hooks/${created.id}`).json<Hook>()).toEqual(created);
@@ -46,11 +76,55 @@ describe('hooks', () => {
       await authedAdminApi
         .patch(`hooks/${created.id}`, { json: { event: HookEvent.PostSignIn } })
         .json<Hook>()
-    ).toEqual({ ...created, event: HookEvent.PostSignIn });
+    ).toMatchObject({
+      ...created,
+      event: HookEvent.PostSignIn,
+    });
     expect(await authedAdminApi.delete(`hooks/${created.id}`)).toHaveProperty('statusCode', 204);
     await expect(authedAdminApi.get(`hooks/${created.id}`)).rejects.toHaveProperty(
       'response.statusCode',
       404
+    );
+  });
+
+  it('should throw error when creating a hook with an empty hook name', async () => {
+    const payload = {
+      name: '',
+      events: [HookEvent.PostRegister],
+      config: {
+        url: 'not_work_url',
+      },
+    };
+    await expect(authedAdminApi.post('hooks', { json: payload })).rejects.toMatchObject(
+      createResponseWithCode(400)
+    );
+  });
+
+  it('should throw error when no event is provided when creating a hook', async () => {
+    const payload = {
+      name: 'hook_name',
+      config: {
+        url: 'not_work_url',
+      },
+    };
+    await expect(authedAdminApi.post('hooks', { json: payload })).rejects.toMatchObject(
+      createResponseWithCode(422)
+    );
+  });
+
+  it('should throw error if update a hook with a invalid hook id', async () => {
+    const payload = {
+      name: 'new_hook_name',
+    };
+
+    await expect(authedAdminApi.patch('hooks/invalid_id', { json: payload })).rejects.toMatchObject(
+      createResponseWithCode(404)
+    );
+  });
+
+  it('should throw error if regenerate a hook signing key with a invalid hook id', async () => {
+    await expect(authedAdminApi.post('hooks/invalid_id/signing-key')).rejects.toMatchObject(
+      createResponseWithCode(404)
     );
   });
 
@@ -93,10 +167,19 @@ describe('hooks', () => {
   });
 
   it('should trigger multiple register hooks and record properly when interaction finished', async () => {
-    const [hook1, hook2] = await Promise.all([
+    const [hook1, hook2, hook3] = await Promise.all([
       authedAdminApi.post('hooks', { json: createPayload(HookEvent.PostRegister) }).json<Hook>(),
       authedAdminApi
         .post('hooks', { json: createPayload(HookEvent.PostRegister, 'http://localhost:9999') })
+        .json<Hook>(),
+      // Using the old API to create a hook
+      authedAdminApi
+        .post('hooks', {
+          json: {
+            event: HookEvent.PostRegister,
+            config: { url: 'http://localhost:9999', retries: 2 },
+          },
+        })
         .json<Hook>(),
     ]);
     const logKey: LogKey = 'TriggerHook.PostRegister';
@@ -128,11 +211,17 @@ describe('hooks', () => {
         ({ payload: { hookId, result } }) => hookId === hook2.id && result === LogResult.Success
       )
     ).toBeTruthy();
+    expect(
+      logs.some(
+        ({ payload: { hookId, result } }) => hookId === hook3.id && result === LogResult.Success
+      )
+    ).toBeTruthy();
 
     // Clean up
     await Promise.all([
       authedAdminApi.delete(`hooks/${hook1.id}`),
       authedAdminApi.delete(`hooks/${hook2.id}`),
+      authedAdminApi.delete(`hooks/${hook3.id}`),
     ]);
     await deleteUser(id);
   });

--- a/packages/integration-tests/src/tests/api/hooks.test.ts
+++ b/packages/integration-tests/src/tests/api/hooks.test.ts
@@ -108,7 +108,7 @@ describe('hooks', () => {
       },
     };
     await expect(authedAdminApi.post('hooks', { json: payload })).rejects.toMatchObject(
-      createResponseWithCode(422)
+      createResponseWithCode(400)
     );
   });
 

--- a/packages/integration-tests/src/tests/api/hooks.test.ts
+++ b/packages/integration-tests/src/tests/api/hooks.test.ts
@@ -123,7 +123,7 @@ describe('hooks', () => {
   });
 
   it('should throw error if regenerate a hook signing key with a invalid hook id', async () => {
-    await expect(authedAdminApi.post('hooks/invalid_id/signing-key')).rejects.toMatchObject(
+    await expect(authedAdminApi.patch('hooks/invalid_id/signing-key')).rejects.toMatchObject(
       createResponseWithCode(404)
     );
   });

--- a/packages/phrases/src/locales/de/errors/hook.ts
+++ b/packages/phrases/src/locales/de/errors/hook.ts
@@ -1,0 +1,5 @@
+const hook = {
+  missing_events: 'Sie müssen mindestens ein Ereignis angeben.',
+};
+
+export default hook;

--- a/packages/phrases/src/locales/de/errors/index.ts
+++ b/packages/phrases/src/locales/de/errors/index.ts
@@ -2,6 +2,7 @@ import auth from './auth.js';
 import connector from './connector.js';
 import entity from './entity.js';
 import guard from './guard.js';
+import hook from './hook.js';
 import localization from './localization.js';
 import log from './log.js';
 import oidc from './oidc.js';
@@ -36,6 +37,7 @@ const errors = {
   scope,
   storage,
   resource,
+  hook,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/en/errors/hook.ts
+++ b/packages/phrases/src/locales/en/errors/hook.ts
@@ -1,0 +1,5 @@
+const hook = {
+  missing_events: 'You need to provide at least one event.',
+};
+
+export default hook;

--- a/packages/phrases/src/locales/en/errors/index.ts
+++ b/packages/phrases/src/locales/en/errors/index.ts
@@ -2,6 +2,7 @@ import auth from './auth.js';
 import connector from './connector.js';
 import entity from './entity.js';
 import guard from './guard.js';
+import hook from './hook.js';
 import localization from './localization.js';
 import log from './log.js';
 import oidc from './oidc.js';
@@ -36,6 +37,7 @@ const errors = {
   scope,
   storage,
   resource,
+  hook,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/es/errors/hook.ts
+++ b/packages/phrases/src/locales/es/errors/hook.ts
@@ -1,0 +1,5 @@
+const hook = {
+  missing_events: 'Necesita proporcionar al menos un evento.',
+};
+
+export default hook;

--- a/packages/phrases/src/locales/es/errors/index.ts
+++ b/packages/phrases/src/locales/es/errors/index.ts
@@ -2,6 +2,7 @@ import auth from './auth.js';
 import connector from './connector.js';
 import entity from './entity.js';
 import guard from './guard.js';
+import hook from './hook.js';
 import localization from './localization.js';
 import log from './log.js';
 import oidc from './oidc.js';
@@ -36,6 +37,7 @@ const errors = {
   scope,
   storage,
   resource,
+  hook,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/fr/errors/hook.ts
+++ b/packages/phrases/src/locales/fr/errors/hook.ts
@@ -1,0 +1,5 @@
+const hook = {
+  missing_events: 'Vous devez fournir au moins un événement.',
+};
+
+export default hook;

--- a/packages/phrases/src/locales/fr/errors/index.ts
+++ b/packages/phrases/src/locales/fr/errors/index.ts
@@ -2,6 +2,7 @@ import auth from './auth.js';
 import connector from './connector.js';
 import entity from './entity.js';
 import guard from './guard.js';
+import hook from './hook.js';
 import localization from './localization.js';
 import log from './log.js';
 import oidc from './oidc.js';
@@ -36,6 +37,7 @@ const errors = {
   scope,
   storage,
   resource,
+  hook,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/it/errors/hook.ts
+++ b/packages/phrases/src/locales/it/errors/hook.ts
@@ -1,0 +1,5 @@
+const hook = {
+  missing_events: 'È necessario fornire almeno un evento.',
+};
+
+export default hook;

--- a/packages/phrases/src/locales/it/errors/index.ts
+++ b/packages/phrases/src/locales/it/errors/index.ts
@@ -2,6 +2,7 @@ import auth from './auth.js';
 import connector from './connector.js';
 import entity from './entity.js';
 import guard from './guard.js';
+import hook from './hook.js';
 import localization from './localization.js';
 import log from './log.js';
 import oidc from './oidc.js';
@@ -36,6 +37,7 @@ const errors = {
   scope,
   storage,
   resource,
+  hook,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/ja/errors/hook.ts
+++ b/packages/phrases/src/locales/ja/errors/hook.ts
@@ -1,0 +1,5 @@
+const hook = {
+  missing_events: '少なくとも1つのイベントを提供する必要があります。',
+};
+
+export default hook;

--- a/packages/phrases/src/locales/ja/errors/index.ts
+++ b/packages/phrases/src/locales/ja/errors/index.ts
@@ -2,6 +2,7 @@ import auth from './auth.js';
 import connector from './connector.js';
 import entity from './entity.js';
 import guard from './guard.js';
+import hook from './hook.js';
 import localization from './localization.js';
 import log from './log.js';
 import oidc from './oidc.js';
@@ -36,6 +37,7 @@ const errors = {
   scope,
   storage,
   resource,
+  hook,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/ko/errors/hook.ts
+++ b/packages/phrases/src/locales/ko/errors/hook.ts
@@ -1,0 +1,5 @@
+const hook = {
+  missing_events: '최소한 하나의 이벤트를 제공해야 합니다.',
+};
+
+export default hook;

--- a/packages/phrases/src/locales/ko/errors/index.ts
+++ b/packages/phrases/src/locales/ko/errors/index.ts
@@ -2,6 +2,7 @@ import auth from './auth.js';
 import connector from './connector.js';
 import entity from './entity.js';
 import guard from './guard.js';
+import hook from './hook.js';
 import localization from './localization.js';
 import log from './log.js';
 import oidc from './oidc.js';
@@ -36,6 +37,7 @@ const errors = {
   scope,
   storage,
   resource,
+  hook,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/pl-pl/errors/hook.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/hook.ts
@@ -1,0 +1,5 @@
+const hook = {
+  missing_events: 'Musisz podać przynajmniej jedno zdarzenie.',
+};
+
+export default hook;

--- a/packages/phrases/src/locales/pl-pl/errors/index.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/index.ts
@@ -2,6 +2,7 @@ import auth from './auth.js';
 import connector from './connector.js';
 import entity from './entity.js';
 import guard from './guard.js';
+import hook from './hook.js';
 import localization from './localization.js';
 import log from './log.js';
 import oidc from './oidc.js';
@@ -36,6 +37,7 @@ const errors = {
   scope,
   storage,
   resource,
+  hook,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/pt-br/errors/hook.ts
+++ b/packages/phrases/src/locales/pt-br/errors/hook.ts
@@ -1,0 +1,5 @@
+const hook = {
+  missing_events: 'Você precisa fornecer pelo menos um evento.',
+};
+
+export default hook;

--- a/packages/phrases/src/locales/pt-br/errors/index.ts
+++ b/packages/phrases/src/locales/pt-br/errors/index.ts
@@ -2,6 +2,7 @@ import auth from './auth.js';
 import connector from './connector.js';
 import entity from './entity.js';
 import guard from './guard.js';
+import hook from './hook.js';
 import localization from './localization.js';
 import log from './log.js';
 import oidc from './oidc.js';
@@ -36,6 +37,7 @@ const errors = {
   scope,
   storage,
   resource,
+  hook,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/pt-pt/errors/hook.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/hook.ts
@@ -1,0 +1,5 @@
+const hook = {
+  missing_events: 'Você precisa fornecer pelo menos um evento.',
+};
+
+export default hook;

--- a/packages/phrases/src/locales/pt-pt/errors/index.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/index.ts
@@ -2,6 +2,7 @@ import auth from './auth.js';
 import connector from './connector.js';
 import entity from './entity.js';
 import guard from './guard.js';
+import hook from './hook.js';
 import localization from './localization.js';
 import log from './log.js';
 import oidc from './oidc.js';
@@ -36,6 +37,7 @@ const errors = {
   scope,
   storage,
   resource,
+  hook,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/ru/errors/hook.ts
+++ b/packages/phrases/src/locales/ru/errors/hook.ts
@@ -1,0 +1,5 @@
+const hook = {
+  missing_events: 'Вы должны предоставить как минимум одно событие.',
+};
+
+export default hook;

--- a/packages/phrases/src/locales/ru/errors/index.ts
+++ b/packages/phrases/src/locales/ru/errors/index.ts
@@ -2,6 +2,7 @@ import auth from './auth.js';
 import connector from './connector.js';
 import entity from './entity.js';
 import guard from './guard.js';
+import hook from './hook.js';
 import localization from './localization.js';
 import log from './log.js';
 import oidc from './oidc.js';
@@ -36,6 +37,7 @@ const errors = {
   scope,
   storage,
   resource,
+  hook,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/tr-tr/errors/hook.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/hook.ts
@@ -1,0 +1,5 @@
+const hook = {
+  missing_events: 'En az bir etkinlik sağlamanız gerekiyor.',
+};
+
+export default hook;

--- a/packages/phrases/src/locales/tr-tr/errors/index.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/index.ts
@@ -2,6 +2,7 @@ import auth from './auth.js';
 import connector from './connector.js';
 import entity from './entity.js';
 import guard from './guard.js';
+import hook from './hook.js';
 import localization from './localization.js';
 import log from './log.js';
 import oidc from './oidc.js';
@@ -36,6 +37,7 @@ const errors = {
   scope,
   storage,
   resource,
+  hook,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/zh-cn/errors/hook.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/hook.ts
@@ -1,0 +1,5 @@
+const hook = {
+  missing_events: '你需要提供至少一个事件。',
+};
+
+export default hook;

--- a/packages/phrases/src/locales/zh-cn/errors/index.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/index.ts
@@ -2,6 +2,7 @@ import auth from './auth.js';
 import connector from './connector.js';
 import entity from './entity.js';
 import guard from './guard.js';
+import hook from './hook.js';
 import localization from './localization.js';
 import log from './log.js';
 import oidc from './oidc.js';
@@ -36,6 +37,7 @@ const errors = {
   scope,
   storage,
   resource,
+  hook,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/zh-hk/errors/hook.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/hook.ts
@@ -1,0 +1,5 @@
+const hook = {
+  missing_events: '你需要至少提供一個事件。',
+};
+
+export default hook;

--- a/packages/phrases/src/locales/zh-hk/errors/index.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/index.ts
@@ -2,6 +2,7 @@ import auth from './auth.js';
 import connector from './connector.js';
 import entity from './entity.js';
 import guard from './guard.js';
+import hook from './hook.js';
 import localization from './localization.js';
 import log from './log.js';
 import oidc from './oidc.js';
@@ -36,6 +37,7 @@ const errors = {
   scope,
   storage,
   resource,
+  hook,
 };
 
 export default errors;

--- a/packages/phrases/src/locales/zh-tw/errors/hook.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/hook.ts
@@ -1,0 +1,5 @@
+const hook = {
+  missing_events: '你需要至少提供一個事件。',
+};
+
+export default hook;

--- a/packages/phrases/src/locales/zh-tw/errors/index.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/index.ts
@@ -2,6 +2,7 @@ import auth from './auth.js';
 import connector from './connector.js';
 import entity from './entity.js';
 import guard from './guard.js';
+import hook from './hook.js';
 import localization from './localization.js';
 import log from './log.js';
 import oidc from './oidc.js';
@@ -36,6 +37,7 @@ const errors = {
   scope,
   storage,
   resource,
+  hook,
 };
 
 export default errors;

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -41,7 +41,6 @@
   },
   "devDependencies": {
     "@silverhand/eslint-config": "3.0.1",
-    "@silverhand/essentials": "^2.5.0",
     "@silverhand/ts-config": "3.0.0",
     "@types/inquirer": "^9.0.0",
     "@types/jest": "^29.4.0",
@@ -86,6 +85,7 @@
     "@logto/phrases": "workspace:^1.2.0",
     "@logto/phrases-ui": "workspace:^1.2.0",
     "@logto/shared": "workspace:^2.0.0",
+    "@silverhand/essentials": "^2.5.0",
     "@withtyped/server": "^0.9.0",
     "zod": "^3.20.2"
   }

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@silverhand/eslint-config": "3.0.1",
+    "@silverhand/essentials": "^2.5.0",
     "@silverhand/ts-config": "3.0.0",
     "@types/inquirer": "^9.0.0",
     "@types/jest": "^29.4.0",
@@ -85,7 +86,6 @@
     "@logto/phrases": "workspace:^1.2.0",
     "@logto/phrases-ui": "workspace:^1.2.0",
     "@logto/shared": "workspace:^2.0.0",
-    "@silverhand/essentials": "^2.5.0",
     "@withtyped/server": "^0.9.0",
     "zod": "^3.20.2"
   }

--- a/packages/schemas/src/foundations/jsonb-types.ts
+++ b/packages/schemas/src/foundations/jsonb-types.ts
@@ -217,7 +217,7 @@ export const hookConfigGuard = z.object({
    * Now the retry times is fixed to 3.
    * Keep for backward compatibility.
    */
-  retries: z.number().gte(0).lte(3),
+  retries: z.number().gte(0).lte(3).optional(),
 });
 
 export type HookConfig = z.infer<typeof hookConfigGuard>;

--- a/packages/schemas/src/types/hook.ts
+++ b/packages/schemas/src/types/hook.ts
@@ -1,5 +1,12 @@
+import { boolean, object, string } from 'zod';
+
 import { type Application, type User } from '../db-entries/index.js';
-import { type HookEvent } from '../foundations/index.js';
+import {
+  hookEventsGuard,
+  type HookEvent,
+  hookConfigGuard,
+  hookEventGuard,
+} from '../foundations/index.js';
 
 import type { userInfoSelectFields } from './user.js';
 
@@ -13,3 +20,17 @@ export type HookEventPayload = {
   user?: Pick<User, (typeof userInfoSelectFields)[number]>;
   application?: Pick<Application, 'id' | 'type' | 'name' | 'description'>;
 } & Record<string, unknown>;
+
+export const createHookGuard = object({
+  // Note: ensure the user will not create a hook with an empty name.
+  name: string().min(1).optional(),
+  event: hookEventGuard.optional(),
+  events: hookEventsGuard.nonempty().optional(),
+  config: hookConfigGuard,
+  enabled: boolean().optional().default(true),
+});
+
+export const updateHookGuard = createHookGuard
+  .omit({ events: true, enabled: true })
+  .deepPartial()
+  .extend({ events: hookEventsGuard.nonempty().optional(), enabled: boolean().optional() });

--- a/packages/schemas/src/types/hook.ts
+++ b/packages/schemas/src/types/hook.ts
@@ -1,5 +1,5 @@
-import type { Application, User } from '../db-entries/index.js';
-import type { HookEvent } from '../foundations/index.js';
+import { type Application, type User } from '../db-entries/index.js';
+import { type HookEvent } from '../foundations/index.js';
 
 import type { userInfoSelectFields } from './user.js';
 

--- a/packages/schemas/src/types/hook.ts
+++ b/packages/schemas/src/types/hook.ts
@@ -32,10 +32,10 @@ export const createHookGuard = object({
   event: hookEventGuard.optional(),
   events: nonemptyUniqueHookEventsGuard.optional(),
   config: hookConfigGuard,
-  enabled: boolean().optional().default(true),
+  enabled: boolean().optional(),
 });
 
 export const updateHookGuard = createHookGuard
-  .omit({ events: true, enabled: true })
+  .omit({ events: true })
   .deepPartial()
-  .extend({ events: nonemptyUniqueHookEventsGuard.optional(), enabled: boolean().optional() });
+  .extend({ events: nonemptyUniqueHookEventsGuard.optional() });

--- a/packages/schemas/src/types/hook.ts
+++ b/packages/schemas/src/types/hook.ts
@@ -1,13 +1,5 @@
-import { deduplicate } from '@silverhand/essentials';
-import { boolean, object, string } from 'zod';
-
 import { type Application, type User } from '../db-entries/index.js';
-import {
-  hookEventsGuard,
-  type HookEvent,
-  hookConfigGuard,
-  hookEventGuard,
-} from '../foundations/index.js';
+import { type HookEvent } from '../foundations/index.js';
 
 import type { userInfoSelectFields } from './user.js';
 
@@ -21,21 +13,3 @@ export type HookEventPayload = {
   user?: Pick<User, (typeof userInfoSelectFields)[number]>;
   application?: Pick<Application, 'id' | 'type' | 'name' | 'description'>;
 } & Record<string, unknown>;
-
-const nonemptyUniqueHookEventsGuard = hookEventsGuard
-  .nonempty()
-  .transform((events) => deduplicate(events));
-
-export const createHookGuard = object({
-  // Note: ensure the user will not create a hook with an empty name.
-  name: string().min(1).optional(),
-  event: hookEventGuard.optional(),
-  events: nonemptyUniqueHookEventsGuard.optional(),
-  config: hookConfigGuard,
-  enabled: boolean().optional(),
-});
-
-export const updateHookGuard = createHookGuard
-  .omit({ events: true })
-  .deepPartial()
-  .extend({ events: nonemptyUniqueHookEventsGuard.optional() });

--- a/packages/schemas/src/types/hook.ts
+++ b/packages/schemas/src/types/hook.ts
@@ -24,7 +24,7 @@ export type HookEventPayload = {
 
 const nonemptyUniqueHookEventsGuard = hookEventsGuard
   .nonempty()
-  .refine((events) => deduplicate(events));
+  .transform((events) => deduplicate(events));
 
 export const createHookGuard = object({
   // Note: ensure the user will not create a hook with an empty name.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3548,9 +3548,6 @@ importers:
       '@logto/shared':
         specifier: workspace:^2.0.0
         version: link:../shared
-      '@silverhand/essentials':
-        specifier: ^2.5.0
-        version: 2.6.2
       '@withtyped/server':
         specifier: ^0.9.0
         version: 0.9.0
@@ -3561,6 +3558,9 @@ importers:
       '@silverhand/eslint-config':
         specifier: 3.0.1
         version: 3.0.1(eslint@8.34.0)(prettier@2.8.4)(typescript@5.0.2)
+      '@silverhand/essentials':
+        specifier: ^2.5.0
+        version: 2.6.2
       '@silverhand/ts-config':
         specifier: 3.0.0
         version: 3.0.0(typescript@5.0.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3560,7 +3560,7 @@ importers:
         version: 3.0.1(eslint@8.34.0)(prettier@2.8.4)(typescript@5.0.2)
       '@silverhand/essentials':
         specifier: ^2.5.0
-        version: 2.6.2
+        version: 2.5.0
       '@silverhand/ts-config':
         specifier: 3.0.0
         version: 3.0.0(typescript@5.0.2)
@@ -8612,6 +8612,7 @@ packages:
   /@silverhand/essentials@2.6.2:
     resolution: {integrity: sha512-1b5u2BGEa14V3o8XzaE7eL+nuwmQe8c1wqSMcGvq+KAusPPZo9tV4glbfF16Xi/ohv37vUpBGJ2DNf4CfuxBLw==}
     engines: {node: ^16.13.0 || ^18.12.0 || ^19.2.0, pnpm: ^8.0.0}
+    dev: true
 
   /@silverhand/jest-config@3.0.0(jest@29.5.0):
     resolution: {integrity: sha512-5ezkX1/EVQiL2Y3lMY3jLT00GvyRgNKWAB/LIToVN0BQPnasdzKV6sSn2wrQD6XY3lNvR9TBdZajGmG/jtcRjA==}
@@ -9731,7 +9732,7 @@ packages:
   /@withtyped/server@0.9.0:
     resolution: {integrity: sha512-uQlX9Bj8607eR0sxL4i0I3J1cz5KmzBoMlcjvr6KJ0+iT1FWbNK3zQZMaKcRj5Em7MmWwsFIFkgrdQweqaHhSg==}
     dependencies:
-      '@silverhand/essentials': 2.6.2
+      '@silverhand/essentials': 2.5.0
       '@withtyped/shared': 0.2.0
     dev: false
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3548,6 +3548,9 @@ importers:
       '@logto/shared':
         specifier: workspace:^2.0.0
         version: link:../shared
+      '@silverhand/essentials':
+        specifier: ^2.5.0
+        version: 2.6.2
       '@withtyped/server':
         specifier: ^0.9.0
         version: 0.9.0
@@ -3558,9 +3561,6 @@ importers:
       '@silverhand/eslint-config':
         specifier: 3.0.1
         version: 3.0.1(eslint@8.34.0)(prettier@2.8.4)(typescript@5.0.2)
-      '@silverhand/essentials':
-        specifier: ^2.5.0
-        version: 2.5.0
       '@silverhand/ts-config':
         specifier: 3.0.0
         version: 3.0.0(typescript@5.0.2)
@@ -8612,7 +8612,6 @@ packages:
   /@silverhand/essentials@2.6.2:
     resolution: {integrity: sha512-1b5u2BGEa14V3o8XzaE7eL+nuwmQe8c1wqSMcGvq+KAusPPZo9tV4glbfF16Xi/ohv37vUpBGJ2DNf4CfuxBLw==}
     engines: {node: ^16.13.0 || ^18.12.0 || ^19.2.0, pnpm: ^8.0.0}
-    dev: true
 
   /@silverhand/jest-config@3.0.0(jest@29.5.0):
     resolution: {integrity: sha512-5ezkX1/EVQiL2Y3lMY3jLT00GvyRgNKWAB/LIToVN0BQPnasdzKV6sSn2wrQD6XY3lNvR9TBdZajGmG/jtcRjA==}
@@ -9732,7 +9731,7 @@ packages:
   /@withtyped/server@0.9.0:
     resolution: {integrity: sha512-uQlX9Bj8607eR0sxL4i0I3J1cz5KmzBoMlcjvr6KJ0+iT1FWbNK3zQZMaKcRj5Em7MmWwsFIFkgrdQweqaHhSg==}
     dependencies:
-      '@silverhand/essentials': 2.5.0
+      '@silverhand/essentials': 2.6.2
       '@withtyped/shared': 0.2.0
     dev: false
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Update webhook APIs to fit the newly implemented webhook schema.

- update `POST /hooks`, `PATCH /hooks/:id` 
- add `POST /hooks/:id/signing-key`
- deprecated the `retries` field in the `HookConfig` and fixed the retries to 3
- support transform effect zod type for swagger

The API Design Doc: https://www.notion.so/silverhand/Hook-v2-Tech-Design-Phase-1-cb62e7435c1d46d4bba47a1031943fb0?pvs=4#3a8794898c7247cc8e7a4666186ce241

The Doc Update PR（WIP）: https://github.com/logto-io/docs/pull/426


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT & IT & Test locally.

### Swagger
<img width="543" alt="image" src="https://github.com/logto-io/logto/assets/10806653/a8a19ac7-dba8-43fb-af09-a36f7272523f">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] docs

OR

- [x] This PR is not applicable for the checklist
