### PR TITLE
fix(schemas): add non-empty string type guard

### DIFF
--- a/.changeset/smooth-icons-fetch.md
+++ b/.changeset/smooth-icons-fetch.md
@@ -1,0 +1,7 @@
+---
+"@logto/schemas": patch
+---
+
+## Add min length 1 type guard for all string typed db schema fields
+
+Update the `@logto/schemas` zod guard generation method to include a min length of 1 for all the required string typed db fields.

--- a/packages/integration-tests/src/tests/api/resource.scope.test.ts
+++ b/packages/integration-tests/src/tests/api/resource.scope.test.ts
@@ -72,7 +72,6 @@ describe('scopes', () => {
     const createdScope2 = await createScope(resource.id);
     const response = await updateScope(resource.id, createdScope2.id, {
       name: createdScope.name,
-      description: '',
     }).catch((error: unknown) => error);
     expect(response instanceof HTTPError && response.response.statusCode === 422).toBe(true);
   });

--- a/packages/integration-tests/src/tests/api/resource.scope.test.ts
+++ b/packages/integration-tests/src/tests/api/resource.scope.test.ts
@@ -40,7 +40,14 @@ describe('scopes', () => {
     expect(response instanceof HTTPError && response.response.statusCode === 404).toBe(true);
   });
 
-  it('should return 400 if scope name is empty or has empty space', async () => {
+  it('should return 400 if scope name is empty', async () => {
+    const resource = await createResource();
+
+    const response = await createScope(resource.id, '').catch((error: unknown) => error);
+    expect(response instanceof HTTPError && response.response.statusCode === 400).toBe(true);
+  });
+
+  it('should return 400 if scope name has empty space', async () => {
     const resource = await createResource();
 
     const response = await createScope(resource.id, 'scope id').catch((error: unknown) => error);

--- a/packages/schemas/src/gen/schema.ts
+++ b/packages/schemas/src/gen/schema.ts
@@ -45,11 +45,15 @@ export const generateSchema = ({ name, fields }: TableWithType) => {
           )}${conditionalString((nullable || hasDefaultValue) && '.optional()')},`;
         }
 
-        return `  ${camelcase(name)}: z.${
-          isEnum ? `nativeEnum(${type})` : `${type}()`
-        }${conditionalString(isString && maxLength && `.max(${maxLength})`)}${conditionalString(
-          isArray && '.array()'
-        )}${conditionalString(nullable && '.nullable()')}${conditionalString(
+        return `  ${camelcase(name)}: z.${isEnum ? `nativeEnum(${type})` : `${type}()`}${
+          // Non-nullable strings should have a min length of 1
+          conditionalString(isString && !(nullable || hasDefaultValue) && `.min(1)`)
+        }${
+          // String types value in DB should have a max length
+          conditionalString(isString && maxLength && `.max(${maxLength})`)
+        }${conditionalString(isArray && '.array()')}${conditionalString(
+          nullable && '.nullable()'
+        )}${conditionalString(
           (nullable || hasDefaultValue || name === tenantId) && '.optional()'
         )},`;
       }
@@ -65,11 +69,13 @@ export const generateSchema = ({ name, fields }: TableWithType) => {
         )},`;
       }
 
-      return `  ${camelcase(name)}: z.${
-        isEnum ? `nativeEnum(${type})` : `${type}()`
-      }${conditionalString(isString && maxLength && `.max(${maxLength})`)}${conditionalString(
-        isArray && '.array()'
-      )}${conditionalString(nullable && '.nullable()')},`;
+      return `  ${camelcase(name)}: z.${isEnum ? `nativeEnum(${type})` : `${type}()`}${
+        // Non-nullable strings should have a min length of 1
+        conditionalString(isString && !nullable && `.min(1)`)
+      }${
+        // String types value in DB should have a max length
+        conditionalString(isString && maxLength && `.max(${maxLength})`)
+      }${conditionalString(isArray && '.array()')}${conditionalString(nullable && '.nullable()')},`;
     }),
     '  });',
     '',

--- a/packages/schemas/src/gen/schema.ts
+++ b/packages/schemas/src/gen/schema.ts
@@ -69,10 +69,15 @@ export const generateSchema = ({ name, fields }: TableWithType) => {
         )},`;
       }
 
-      return `  ${camelcase(name)}: z.${isEnum ? `nativeEnum(${type})` : `${type}()`}${
+      /**
+       * @TODO @xiaoyijun need to add this guard to the response type as well after the hook migration
+       * ${
         // Non-nullable strings should have a min length of 1
         conditionalString(isString && !nullable && `.min(1)`)
-      }${
+      }
+       */
+
+      return `  ${camelcase(name)}: z.${isEnum ? `nativeEnum(${type})` : `${type}()`}${
         // String types value in DB should have a max length
         conditionalString(isString && maxLength && `.max(${maxLength})`)
       }${conditionalString(isArray && '.array()')}${conditionalString(nullable && '.nullable()')},`;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add a non-empty string type guard to all the required, string typed DB fields.


Context:
We have a [empty string converter](https://github.com/logto-io/logto/blob/6c3a5a6899f6c608c5e9b7ae8b9c4cbd745417dc/packages/shared/src/database/sql.ts#L57) implemented what will convert all empty string value inputs into null before inserting into DB. 
For those not null fields, this will end up with a DB update error.  Without handling it exclusively, all our DB insertion-related APIs will throw 500. 

Per our convention, an empty string is not allowed for all the non-null fields. So a non-empty string guard should be applied to those required string fields. 

Solution:

Update the schema guard gen method to include the string().min(1) guard if the current field type is a string and not null without any default values.


Use Application schema as an example; the guards will look like this after the updates:
<img width="906" alt="image" src="https://github.com/logto-io/logto/assets/36393111/8bfa9802-1b86-48c4-86a7-f4b0e90b42c0">


Use Hooks schema as an example field with the default value provided does not need the guard. 
<img width="823" alt="image" src="https://github.com/logto-io/logto/assets/36393111/2a514b15-5a3f-454b-bd63-c3d4842d5bc5">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally. Add an exclusive empty string integration test case on the POST /resource/:id/scopes API. An empty string name will violate the payload guard and return an invalid payload error. 

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [x] integration tests
- [] docs

OR

- [ ] This PR is not applicable for the checklist
