### PR TITLE
chore(core): update custom phrase PUT API response status

### DIFF
--- a/packages/core/src/routes/custom-phrase.test.ts
+++ b/packages/core/src/routes/custom-phrase.test.ts
@@ -154,7 +154,7 @@ describe('customPhraseRoutes', () => {
       const response = await customPhraseRequest
         .put(`/custom-phrases/${mockLanguageTag}`)
         .send(translation);
-      expect(response.status).toEqual(200);
+      expect(response.status).toEqual(201);
       expect(response.body).toEqual(mockCustomPhrases[mockLanguageTag]);
     });
 

--- a/packages/core/src/routes/custom-phrase.ts
+++ b/packages/core/src/routes/custom-phrase.ts
@@ -67,7 +67,7 @@ export default function customPhraseRoutes<T extends AuthedRouter>(
       params: object({ languageTag: languageTagGuard }),
       body: translationGuard,
       response: CustomPhrases.guard,
-      status: [200, 422],
+      status: [201, 422],
     }),
     async (ctx, next) => {
       const {
@@ -83,6 +83,7 @@ export default function customPhraseRoutes<T extends AuthedRouter>(
       );
 
       ctx.body = await upsertCustomPhrase(languageTag, translation);
+      ctx.status = 201;
 
       return next();
     }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
update custom phrase PUT API response status, per discussion in slack, POST and PUT operations should respond status 201 on success.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UTs and ITs.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
