### PR TITLE
feat(core): add 401,403 status guard to all management api routes

### DIFF
--- a/packages/core/src/middleware/koa-auth/index.ts
+++ b/packages/core/src/middleware/koa-auth/index.ts
@@ -5,7 +5,7 @@ import type { Optional } from '@silverhand/essentials';
 import type { JWK } from 'jose';
 import { createLocalJWKSet, jwtVerify } from 'jose';
 import type { MiddlewareType, Request } from 'koa';
-import type { IRouterParamContext } from 'koa-router';
+import type { IMiddleware, IRouterParamContext } from 'koa-router';
 import { z } from 'zod';
 
 import { EnvSet } from '#src/env-set/index.js';
@@ -103,11 +103,17 @@ export const verifyBearerTokenFromRequest = async (
   }
 };
 
+export const isKoaAuthMiddleware = <Type extends IMiddleware>(function_: Type) =>
+  function_.name === 'authMiddleware';
+
 export default function koaAuth<StateT, ContextT extends IRouterParamContext, ResponseBodyT>(
   envSet: EnvSet,
   audience: string
 ): MiddlewareType<StateT, WithAuthContext<ContextT>, ResponseBodyT> {
-  return async (ctx, next) => {
+  const authMiddleware: MiddlewareType<StateT, WithAuthContext<ContextT>, ResponseBodyT> = async (
+    ctx,
+    next
+  ) => {
     const { sub, clientId, scopes } = await verifyBearerTokenFromRequest(
       envSet,
       ctx.request,
@@ -126,4 +132,6 @@ export default function koaAuth<StateT, ContextT extends IRouterParamContext, Re
 
     return next();
   };
+
+  return authMiddleware;
 }

--- a/packages/core/src/routes/role.scope.ts
+++ b/packages/core/src/routes/role.scope.ts
@@ -42,7 +42,7 @@ export default function roleScopeRoutes<T extends AuthedRouter>(
     koaGuard({
       params: object({ id: string().min(1) }),
       response: scopeResponseGuard.array(),
-      status: [200, 404],
+      status: [200, 400, 404],
     }),
     async (ctx, next) => {
       const {


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Automatically add 401,403 error codes status guard to all management API routes.

e.g. for GET & POST /applications API

<img width="1034" alt="image" src="https://github.com/logto-io/logto/assets/36393111/1241faeb-e488-4d46-abcd-de3fb6661284">


<img width="1332" alt="image" src="https://github.com/logto-io/logto/assets/36393111/c1b1024e-ba92-4bbf-91bd-7f0b9f954241">



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
