### PR TITLE
fix(core): compatibility for `retries` field in HookConfig

### DIFF
--- a/packages/console/src/pages/WebhookDetails/utils.ts
+++ b/packages/console/src/pages/WebhookDetails/utils.ts
@@ -40,7 +40,7 @@ export const webhookDetailsParser = {
         url,
         headers: headersObject,
         /**
-         * This is for backward compatibility, and will be removed in the minor version update.
+         * This is for backward compatibility.
          */
         retries: 3,
       },

--- a/packages/console/src/pages/WebhookDetails/utils.ts
+++ b/packages/console/src/pages/WebhookDetails/utils.ts
@@ -39,6 +39,10 @@ export const webhookDetailsParser = {
       config: {
         url,
         headers: headersObject,
+        /**
+         * This is for backward compatibility, and will be removed in the minor version update.
+         */
+        retries: 3,
       },
     };
   },

--- a/packages/core/src/libraries/hook.test.ts
+++ b/packages/core/src/libraries/hook.test.ts
@@ -26,7 +26,7 @@ const hook: Hook = {
   events: [HookEvent.PostSignIn],
   signingKey: 'signing_key',
   enabled: true,
-  config: { headers: { bar: 'baz' }, url },
+  config: { headers: { bar: 'baz' }, url, retries: 3 },
   createdAt: Date.now() / 1000,
 };
 

--- a/packages/core/src/libraries/hook.ts
+++ b/packages/core/src/libraries/hook.ts
@@ -78,7 +78,7 @@ export const createHookLibrary = (queries: Queries) => {
     } satisfies Omit<HookEventPayload, 'hookId'>;
 
     await Promise.all(
-      rows.map(async ({ config: { url, headers }, id }) => {
+      rows.map(async ({ config: { url, headers, retries }, id }) => {
         consoleLog.info(`\tTriggering hook ${id} due to ${hookEvent} event`);
         const json: HookEventPayload = { hookId: id, ...payload };
         const logEntry = new LogEntry(`TriggerHook.${hookEvent}`);
@@ -90,7 +90,7 @@ export const createHookLibrary = (queries: Queries) => {
           .post(url, {
             headers: { 'user-agent': 'Logto (https://logto.io)', ...headers },
             json,
-            retry: { limit: 3 },
+            retry: { limit: retries },
             timeout: { request: 10_000 },
           })
           .then(async (response) => {

--- a/packages/integration-tests/src/tests/api/hooks.test.ts
+++ b/packages/integration-tests/src/tests/api/hooks.test.ts
@@ -13,6 +13,7 @@ const createPayload = (event: HookEvent, url = 'not_work_url'): Partial<Hook> =>
   config: {
     url,
     headers: { foo: 'bar' },
+    retries: 3,
   },
 });
 

--- a/packages/schemas/src/foundations/jsonb-types.ts
+++ b/packages/schemas/src/foundations/jsonb-types.ts
@@ -211,6 +211,13 @@ export const hookConfigGuard = z.object({
   url: z.string(),
   /** Additional headers that attach to the request */
   headers: z.record(z.string()).optional(),
+  /**
+   * @deprecated
+   * Retry times when hook response status >= 500.
+   * Now the retry times is fixed to 3.
+   * Keep for backward compatibility.
+   */
+  retries: z.number().gte(0).lte(3),
 });
 
 export type HookConfig = z.infer<typeof hookConfigGuard>;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
After the hook schema update, the old hook API should be able to fetch hook data with the `retries` field in the HookConfig.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT & Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
