### PR TITLE
fix(ui): set tabIndex -1 for hidden countryCode

### DIFF
--- a/packages/ui/src/components/InputFields/SmartInputField/AnimatedPrefix/index.tsx
+++ b/packages/ui/src/components/InputFields/SmartInputField/AnimatedPrefix/index.tsx
@@ -48,7 +48,7 @@ const AnimatedPrefix = ({ children, isVisible }: Props) => {
 
   return (
     <animated.div className={styles.prefix} style={animation} data-testid="prefix">
-      {cloneElement(children, { ref: elementRef })}
+      {cloneElement(children, { ref: elementRef, isVisible })}
     </animated.div>
   );
 };

--- a/packages/ui/src/components/InputFields/SmartInputField/CountryCodeSelector/index.tsx
+++ b/packages/ui/src/components/InputFields/SmartInputField/CountryCodeSelector/index.tsx
@@ -14,11 +14,12 @@ type Props = {
   className?: string;
   value?: string;
   inputRef?: Nullable<HTMLInputElement>;
+  isVisible?: boolean;
   onChange?: (value: string) => void;
 };
 
 const CountryCodeSelector = (
-  { className, value, inputRef, onChange }: Props,
+  { className, value, inputRef, isVisible = true, onChange }: Props,
   ref: ForwardedRef<HTMLDivElement>
 ) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -41,7 +42,7 @@ const CountryCodeSelector = (
       ref={ref}
       className={classNames(styles.countryCodeSelector, className)}
       role="button"
-      tabIndex={0}
+      tabIndex={isVisible ? 0 : -1}
       onClick={showDropDown}
       onKeyDown={onKeyDownHandler({
         Enter: showDropDown,


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

setTabIndex -1 for hidden countryCode


Issue: 

Community report, when navigating through the sign-in form using the tab key, instead of directly focusing on the input element, it focused on the wrapper first.

Cause:
We have a hidden country code selector field that remains accessible through the key board. 


Fix: 
Set the prefix element tabIndex to -1 if it is not visible.



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
