### PR TITLE
fix(schemas): remove the notnull string min-length guard from response type

### DIFF
--- a/packages/integration-tests/src/tests/api/application.test.ts
+++ b/packages/integration-tests/src/tests/api/application.test.ts
@@ -64,6 +64,11 @@ describe('admin console application', () => {
     expect(updatedAgainApplication.isAdmin).toBeFalsy();
   });
 
+  it('should get demo app application successfully', async () => {
+    const application = await getApplication('demo-app');
+    expect(application.id).toBe('demo-app');
+  });
+
   it('should fetch all applications created above', async () => {
     const applications = await getApplications();
     const applicationNames = applications.map(({ name }) => name);

--- a/packages/schemas/src/gen/schema.ts
+++ b/packages/schemas/src/gen/schema.ts
@@ -65,7 +65,6 @@ export const generateSchema = ({ name, fields }: TableWithType) => {
     `const guard: Guard<${modelName}> = z.object({`,
 
     ...fields.map(
-      // eslint-disable-next-line complexity
       ({ name, type, isArray, isEnum, nullable, tsType, isString, maxLength, hasDefaultValue }) => {
         if (tsType) {
           return `  ${camelcase(name)}: ${camelcase(tsType)}Guard${conditionalString(
@@ -74,11 +73,6 @@ export const generateSchema = ({ name, fields }: TableWithType) => {
         }
 
         return `  ${camelcase(name)}: z.${isEnum ? `nativeEnum(${type})` : `${type}()`}${
-          // Non-nullable strings should have a min length of 1
-          conditionalString(
-            isString && !(nullable || hasDefaultValue || name === tenantId) && `.min(1)`
-          )
-        }${
           // String types value in DB should have a max length
           conditionalString(isString && maxLength && `.max(${maxLength})`)
         }${conditionalString(isArray && '.array()')}${conditionalString(


### PR DESCRIPTION


<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Remove the not null string min-length guard from the response type

Issue:
Previously to avoid the not-null string field db field throwing a 500 error when inserting an empty string into the DB, we added a min length of 1 guard to all the non-null string fields.
However, we have our secret application field defined as a non-null field with a static seed secret value empty. 

<img width="859" alt="image" src="https://github.com/logto-io/logto/assets/36393111/e18afbb5-38b2-4d6b-b6a0-f96265b37abb">


Remove the strict string length guard from the return type guard. Allow empty string to exist as a default value or some internal settings. Simply guard the external API through CreateGuard.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Add integration test to cover the case

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] docs

OR

- [ ] This PR is not applicable for the checklist
