### PR TITLE
chore(cli): lock logto schemas version

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,7 @@
     "@logto/language-kit": "workspace:^1.0.0",
     "@logto/phrases": "workspace:^1.2.0",
     "@logto/phrases-ui": "workspace:^1.2.0",
-    "@logto/schemas": "workspace:^1.2.3",
+    "@logto/schemas": "workspace:1.2.3",
     "@logto/shared": "workspace:^2.0.0",
     "@silverhand/essentials": "^2.5.0",
     "chalk": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,7 +109,7 @@ importers:
         specifier: workspace:^1.2.0
         version: link:../phrases-ui
       '@logto/schemas':
-        specifier: workspace:^1.2.3
+        specifier: workspace:1.2.3
         version: link:../schemas
       '@logto/shared':
         specifier: workspace:^2.0.0


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Lock the dependency version of `@logto/schemas` in order to prevent unexpected issues when seeding or alterating database in an older version of cli.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
- [x] This PR is not applicable for the checklist
