### PR TITLE
refactor(core): remove the reportOnly flag

### DIFF
--- a/.changeset/cool-oranges-cheer.md
+++ b/.changeset/cool-oranges-cheer.md
@@ -1,0 +1,8 @@
+---
+"@logto/cloud": patch
+"@logto/core": patch
+---
+
+### Enable strict CSP policy check header
+
+This change removes the report only flag from CSP security header settings, which will enables the strict CSP policy check for all requests.

--- a/packages/cloud/src/middleware/with-security-headers.ts
+++ b/packages/cloud/src/middleware/with-security-headers.ts
@@ -86,8 +86,6 @@ export default function withSecurityHeaders<InputContext extends RequestContext>
         frameguard: false,
         contentSecurityPolicy: {
           useDefaults: true,
-          // Temporary set to report only to avoid breaking the app
-          reportOnly: true,
           directives: {
             'upgrade-insecure-requests': null,
             imgSrc: ["'self'", 'data:', 'https:'],

--- a/packages/core/src/middleware/koa-security-headers.ts
+++ b/packages/core/src/middleware/koa-security-headers.ts
@@ -76,8 +76,6 @@ export default function koaSecurityHeaders<StateT, ContextT, ResponseBodyT>(
     },
     contentSecurityPolicy: {
       useDefaults: true,
-      // Temporary set to report only to avoid breaking the app
-      reportOnly: true,
       directives: {
         'upgrade-insecure-requests': null,
         imgSrc: ["'self'", 'data:', 'https:'],
@@ -103,8 +101,6 @@ export default function koaSecurityHeaders<StateT, ContextT, ResponseBodyT>(
     frameguard: false,
     contentSecurityPolicy: {
       useDefaults: true,
-      // Temporary set to report only to avoid breaking the app
-      reportOnly: true,
       directives: {
         'upgrade-insecure-requests': null,
         imgSrc: ["'self'", 'data:', 'https:'],


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Remove all the reportOnly flags of the CSP security headers. Bring up strict policy check.

Before: 
<img width="176" alt="image" src="https://github.com/logto-io/logto/assets/36393111/76be0be8-f614-4284-b0b7-96cf51058c9d">
After:
<img width="177" alt="image" src="https://github.com/logto-io/logto/assets/36393111/b1d67e2b-e7c6-4bd3-b78c-684a3ed71b7a">



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [] This PR is not applicable to the checklist
