### PR TITLE
test: remove tests with defaultManagementApi.role.id

### DIFF
--- a/packages/integration-tests/src/tests/api/admin-user.roles.test.ts
+++ b/packages/integration-tests/src/tests/api/admin-user.roles.test.ts
@@ -1,4 +1,3 @@
-import { defaultManagementApi } from '@logto/schemas';
 import { HTTPError } from 'got';
 
 import { assignRolesToUser, getUserRoles, deleteRoleFromUser } from '#src/api/index.js';
@@ -35,9 +34,10 @@ describe('admin console user management (roles)', () => {
 
   it('should delete role from user successfully', async () => {
     const user = await createUserByAdmin();
+    const role = await createRole();
 
-    await assignRolesToUser(user.id, [defaultManagementApi.role.id]);
-    await deleteRoleFromUser(user.id, defaultManagementApi.role.id);
+    await assignRolesToUser(user.id, [role.id]);
+    await deleteRoleFromUser(user.id, role.id);
 
     const roles = await getUserRoles(user.id);
     expect(roles.length).toBe(0);
@@ -45,10 +45,9 @@ describe('admin console user management (roles)', () => {
 
   it('should delete non-exist-role from user failed', async () => {
     const user = await createUserByAdmin();
+    const role = await createRole();
 
-    const response = await deleteRoleFromUser(user.id, defaultManagementApi.role.id).catch(
-      (error: unknown) => error
-    );
+    const response = await deleteRoleFromUser(user.id, role.id).catch((error: unknown) => error);
     expect(response instanceof HTTPError && response.response.statusCode === 404).toBe(true);
   });
 });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Remove some tests with `defaultManagementApi.role.id` since it is deprecated.

There are some cases still using it since we are not able to query the "id" of an internal role. @gao-sun 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
