### PR TITLE
fix: use only necessary domains in CSP

### DIFF
--- a/packages/cloud/src/middleware/with-security-headers.ts
+++ b/packages/cloud/src/middleware/with-security-headers.ts
@@ -34,7 +34,7 @@ export default function withSecurityHeaders<InputContext extends RequestContext>
 
   const adminOrigins = adminUrlSet.origins;
   const cloudOrigins = cloudUrlSet.origins;
-  const urlSetOrigins = urlSet.origins;
+  const coreOrigins = urlSet.origins;
   const developmentOrigins = conditionalArray(!isProduction && 'ws:');
   const appInsightsOrigins = ['https://*.applicationinsights.azure.com'];
 
@@ -94,11 +94,11 @@ export default function withSecurityHeaders<InputContext extends RequestContext>
               "'self'",
               ...adminOrigins,
               ...cloudOrigins,
-              ...urlSetOrigins,
+              ...coreOrigins,
               ...developmentOrigins,
               ...appInsightsOrigins,
             ],
-            frameSrc: ["'self'", ...urlSetOrigins, ...adminOrigins],
+            frameSrc: ["'self'", ...coreOrigins, ...adminOrigins],
           },
         },
       },


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix CSP middleware to use correct origins

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Console CSP

**Connect Src**
- [x] Admin tenant origins
- [x] User tenant origins

**Frame Src**
- [x] Admin tenant origin
- [x] User tenant origins

### Cloud CSP

**Connect Src**
- [x] Current tenant origins

**Frame Ancestors**
- [x] Admin tenant origins

### In browser

- [x] sign in/out console ok
- [x] console shows sie preview

<img width="1109" alt="image" src="https://github.com/logto-io/logto/assets/14722250/4f8ee386-d11c-4ff0-8a2f-4f5e53cad719">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
