### PR TITLE
fix(schemas): guard string length for default value field

### DIFF
--- a/packages/schemas/src/gen/schema.ts
+++ b/packages/schemas/src/gen/schema.ts
@@ -47,9 +47,7 @@ export const generateSchema = ({ name, fields }: TableWithType) => {
 
         return `  ${camelcase(name)}: z.${isEnum ? `nativeEnum(${type})` : `${type}()`}${
           // Non-nullable strings should have a min length of 1
-          conditionalString(
-            isString && !(nullable || hasDefaultValue || name === tenantId) && `.min(1)`
-          )
+          conditionalString(isString && !(nullable || name === tenantId) && `.min(1)`)
         }${
           // String types value in DB should have a max length
           conditionalString(isString && maxLength && `.max(${maxLength})`)


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Should guard the string length for non-nullable fields event with a default value defined in DB.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
