### PR TITLE
chore: update Dockerfile to support custom command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,5 @@ FROM node:18-alpine as app
 WORKDIR /etc/logto
 COPY --from=builder /etc/logto .
 EXPOSE 3001
-ENTRYPOINT ["npm", "start"]
+ENTRYPOINT ["npm", "run"]
+CMD ["start"]


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary

Modify Dockerfile so we can use cli from the docker image directly.

e.g. This PR adds support for something like `docker run ghcr.io/logto-io/logto:1.3.1 cli db seed`


<!-- MANDATORY -->
## Testing

N/A


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [ x] This PR is not applicable for the checklist
