### PR TITLE
feat(cloud,schemas,cli): update cloud service tenant APIs

### DIFF
--- a/packages/cloud/src/routes/tenants.ts
+++ b/packages/cloud/src/routes/tenants.ts
@@ -1,29 +1,37 @@
-import { CloudScope } from '@logto/schemas';
+import { CloudScope, tenantInfoGuard, createTenantGuard } from '@logto/schemas';
 import { createRouter, RequestError } from '@withtyped/server';
 
 import type { TenantsLibrary } from '#src/libraries/tenants.js';
-import { tenantInfoGuard } from '#src/libraries/tenants.js';
 import type { WithAuthContext } from '#src/middleware/with-auth.js';
 
 export const tenantsRoutes = (library: TenantsLibrary) =>
   createRouter<WithAuthContext, '/tenants'>('/tenants')
     .get('/', { response: tenantInfoGuard.array() }, async (context, next) => {
-      return next({ ...context, json: await library.getAvailableTenants(context.auth.id) });
+      return next({
+        ...context,
+        json: await library.getAvailableTenants(context.auth.id),
+        status: 200,
+      });
     })
-    .post('/', { response: tenantInfoGuard }, async (context, next) => {
-      if (
-        ![CloudScope.CreateTenant, CloudScope.ManageTenant].some((scope) =>
-          context.auth.scopes.includes(scope)
-        )
-      ) {
-        throw new RequestError('Forbidden due to lack of permission.', 403);
+    .post(
+      '/',
+      {
+        body: createTenantGuard.pick({ name: true, tag: true }).required(),
+        response: tenantInfoGuard,
+      },
+      async (context, next) => {
+        if (
+          ![CloudScope.CreateTenant, CloudScope.ManageTenant].some((scope) =>
+            context.auth.scopes.includes(scope)
+          )
+        ) {
+          throw new RequestError('Forbidden due to lack of permission.', 403);
+        }
+
+        return next({
+          ...context,
+          json: await library.createNewTenant(context.auth.id, context.guarded.body),
+          status: 201,
+        });
       }
-
-      const tenants = await library.getAvailableTenants(context.auth.id);
-
-      if (!context.auth.scopes.includes(CloudScope.ManageTenant) && tenants.length > 0) {
-        throw new RequestError('The user already has a tenant.', 409);
-      }
-
-      return next({ ...context, json: await library.createNewTenant(context.auth.id) });
-    });
+    );

--- a/packages/cloud/src/test-utils/libraries.ts
+++ b/packages/cloud/src/test-utils/libraries.ts
@@ -12,7 +12,7 @@ export class MockTenantsLibrary implements TenantsLibrary {
   }
 
   public getAvailableTenants = jest.fn<Promise<TenantInfo[]>, [string]>();
-  public createNewTenant = jest.fn<Promise<TenantInfo>, [string]>();
+  public createNewTenant = jest.fn<Promise<TenantInfo>, [string, Record<string, unknown>]>();
 }
 
 export class MockServicesLibrary implements ServicesLibrary {

--- a/packages/console/src/cloud/pages/Main/Tenants.tsx
+++ b/packages/console/src/cloud/pages/Main/Tenants.tsx
@@ -1,4 +1,4 @@
-import type { TenantInfo } from '@logto/schemas';
+import { type TenantInfo, TenantTag } from '@logto/schemas';
 import { useCallback, useContext, useEffect } from 'react';
 
 import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
@@ -19,7 +19,15 @@ function Tenants({ data, onAdd }: Props) {
   const { navigate } = useContext(TenantsContext);
 
   const createTenant = useCallback(async () => {
-    onAdd(await api.post('api/tenants').json<TenantInfo>());
+    onAdd(
+      /**
+       * `name` and `tag` are required for POST /tenants API, add fixed value to avoid throwing error.
+       * This page page will be removed in upcoming changes on multi-tenancy cloud console.
+       */
+      await api
+        .post('api/tenants', { json: { name: 'My Project', tag: TenantTag.Development } })
+        .json<TenantInfo>()
+    );
   }, [api, onAdd]);
 
   useEffect(() => {

--- a/packages/console/src/contexts/TenantsProvider.tsx
+++ b/packages/console/src/contexts/TenantsProvider.tsx
@@ -1,5 +1,4 @@
-import type { TenantInfo } from '@logto/schemas';
-import { defaultManagementApi } from '@logto/schemas';
+import { type TenantInfo, TenantTag, defaultManagementApi } from '@logto/schemas';
 import { conditional, noop } from '@silverhand/essentials';
 import type { ReactNode } from 'react';
 import { useCallback, useMemo, createContext, useState } from 'react';
@@ -22,7 +21,11 @@ export type Tenants = {
 };
 
 const { tenantId, indicator } = defaultManagementApi.resource;
-const initialTenants = conditional(!isCloud && [{ id: tenantId, indicator }]);
+const initialTenants = conditional(
+  !isCloud && [
+    { id: tenantId, name: `tenant_${tenantId}`, tag: `${TenantTag.Development}`, indicator }, // Make `tag` value to be string type.
+  ]
+);
 
 export const TenantsContext = createContext<Tenants>({
   tenants: initialTenants,

--- a/packages/integration-tests/src/api/tenant.ts
+++ b/packages/integration-tests/src/api/tenant.ts
@@ -1,13 +1,16 @@
-import type { TenantInfo } from '@logto/schemas';
+import type { CreateTenant, TenantInfo } from '@logto/schemas';
 
 import { cloudApi } from './api.js';
 
-export const createTenant = async (accessToken: string) => {
+export const createTenant = async (
+  accessToken: string,
+  payload: Required<Pick<CreateTenant, 'name' | 'tag'>>
+) => {
   return cloudApi
     .extend({
       headers: { authorization: `Bearer ${accessToken}` },
     })
-    .post('tenants')
+    .post('tenants', { json: payload })
     .json<TenantInfo>();
 };
 

--- a/packages/integration-tests/src/tests/api-cloud/tenant.test.ts
+++ b/packages/integration-tests/src/tests/api-cloud/tenant.test.ts
@@ -5,6 +5,9 @@ import {
   type Resource,
   type Scope,
   type Role,
+  TenantTag,
+  type TenantInfo,
+  type CreateTenant,
 } from '@logto/schemas';
 
 import { authedAdminTenantApi } from '#src/api/api.js';
@@ -15,25 +18,55 @@ describe('Tenant APIs', () => {
   it('should be able to create multiple tenants for `admin` role', async () => {
     const { client } = await createUserAndSignInToCloudClient(AdminTenantRole.Admin);
     const accessToken = await client.getAccessToken(cloudApiIndicator);
-    const tenant1 = await createTenant(accessToken);
-    const tenant2 = await createTenant(accessToken);
-    expect(tenant1).toHaveProperty('id');
-    expect(tenant2).toHaveProperty('id');
+    const payload1 = {
+      name: 'tenant1',
+      tag: TenantTag.Staging,
+    };
+    const tenant1 = await createTenant(accessToken, payload1);
+    const payload2 = {
+      name: 'tenant2',
+      tag: TenantTag.Production,
+    };
+    const tenant2 = await createTenant(accessToken, payload2);
+    for (const [payload, tenant] of [
+      [payload1, tenant1],
+      [payload2, tenant2],
+    ] as Array<[Required<Pick<CreateTenant, 'name' | 'tag'>>, TenantInfo]>) {
+      expect(tenant).toHaveProperty('id');
+      expect(tenant).toHaveProperty('tag', payload.tag);
+      expect(tenant).toHaveProperty('name', payload.name);
+    }
     const tenants = await getTenants(accessToken);
     expect(tenants.length).toBeGreaterThan(2);
-    expect(tenants.find((tenant) => tenant.id === tenant1.id)).toBeDefined();
-    expect(tenants.find((tenant) => tenant.id === tenant2.id)).toBeDefined();
+    expect(tenants.find((tenant) => tenant.id === tenant1.id)).toStrictEqual(tenant1);
+    expect(tenants.find((tenant) => tenant.id === tenant2.id)).toStrictEqual(tenant2);
   });
 
-  it('should create only one tenant for `user` role', async () => {
+  it('should be able to create multiple tenants for `user` role', async () => {
     const { client } = await createUserAndSignInToCloudClient(AdminTenantRole.User);
     const accessToken = await client.getAccessToken(cloudApiIndicator);
-    const tenant1 = await createTenant(accessToken);
-    await expect(createTenant(accessToken)).rejects.toThrow();
-    expect(tenant1).toHaveProperty('id');
+    const payload1 = {
+      name: 'tenant1',
+      tag: TenantTag.Staging,
+    };
+    const tenant1 = await createTenant(accessToken, payload1);
+    const payload2 = {
+      name: 'tenant2',
+      tag: TenantTag.Development,
+    };
+    const tenant2 = await createTenant(accessToken, payload2);
+    for (const [payload, tenant] of [
+      [payload1, tenant1],
+      [payload2, tenant2],
+    ] as Array<[Required<Pick<CreateTenant, 'name' | 'tag'>>, TenantInfo]>) {
+      expect(tenant).toHaveProperty('id');
+      expect(tenant).toHaveProperty('tag', payload.tag);
+      expect(tenant).toHaveProperty('name', payload.name);
+    }
     const tenants = await getTenants(accessToken);
-    expect(tenants.length).toEqual(1);
-    expect(tenants.find((tenant) => tenant.id === tenant1.id)).toBeDefined();
+    expect(tenants.length).toEqual(2);
+    expect(tenants.find((tenant) => tenant.id === tenant1.id)).toStrictEqual(tenant1);
+    expect(tenants.find((tenant) => tenant.id === tenant2.id)).toStrictEqual(tenant2);
   });
 
   it('`user` role should have `CloudScope.ManageTenantSelf` scope', async () => {
@@ -43,14 +76,16 @@ describe('Tenant APIs', () => {
     const scopes = await authedAdminTenantApi
       .get(`resources/${cloudApiResource!.id}/scopes`)
       .json<Scope[]>();
-    const manageOwnTenantScope = scopes.find((scope) => scope.name === CloudScope.ManageTenantSelf);
-    expect(manageOwnTenantScope).toBeDefined();
+    const manageTenantSelfScope = scopes.find(
+      (scope) => scope.name === CloudScope.ManageTenantSelf
+    );
+    expect(manageTenantSelfScope).toBeDefined();
     const roles = await authedAdminTenantApi.get('roles').json<Role[]>();
     const userRole = roles.find(({ name }) => name === 'user');
     expect(userRole).toBeDefined();
     const roleScopes = await authedAdminTenantApi
       .get(`roles/${userRole!.id}/scopes`)
       .json<Scope[]>();
-    expect(roleScopes.find(({ id }) => id === manageOwnTenantScope!.id)).toBeDefined();
+    expect(roleScopes.find(({ id }) => id === manageTenantSelfScope!.id)).toBeDefined();
   });
 });

--- a/packages/schemas/src/seeds/tenant.ts
+++ b/packages/schemas/src/seeds/tenant.ts
@@ -10,5 +10,3 @@ export const adminTenantId = 'admin';
  * type, manually define it here for now.
  */
 export type TenantModel = InferModelType<typeof Tenants>;
-export type CreateTenant = Pick<TenantModel, 'id' | 'dbUser' | 'dbUserPassword'> &
-  Partial<Pick<TenantModel, 'name'>>;

--- a/packages/schemas/src/types/tenant.ts
+++ b/packages/schemas/src/types/tenant.ts
@@ -1,10 +1,29 @@
+import { z } from 'zod';
+
+import { type TenantModel } from '../seeds/tenant.js';
+
 export enum TenantTag {
   Development = 'development',
   Staging = 'staging',
   Production = 'production',
 }
 
-export type TenantInfo = {
-  id: string;
-  indicator: string;
-};
+export type PatchTenant = Partial<Pick<TenantModel, 'name' | 'tag'>>;
+export type CreateTenant = Pick<TenantModel, 'id' | 'dbUser' | 'dbUserPassword'> &
+  PatchTenant & { createdAt?: number };
+
+export const createTenantGuard = z.object({
+  id: z.string(),
+  dbUser: z.string(),
+  dbUserPassword: z.string(),
+  name: z.string().optional(),
+  tag: z.nativeEnum(TenantTag).optional(),
+  createdAt: z.number().optional(),
+});
+
+export type TenantInfo = Pick<TenantModel, 'id' | 'name' | 'tag'> & { indicator: string };
+
+export const tenantInfoGuard: z.ZodType<TenantInfo> = createTenantGuard
+  .pick({ id: true, name: true, tag: true })
+  .extend({ indicator: z.string() })
+  .required();


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Update cloud service tenant GET and POST APIs:
1. POST /tenants
      - can specify tenant's `name` and `tag` when creating new tenants
      - both CloudScope.ManageTenant and CloudScope.CreateTenant can create more than one tenants
      - update response guard since we've added `name` and `tag` for tenants
2. GET /tenants
      - update response guard since we've added `name` and `tag` for tenants

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UTs and call APIs locally.
Also update integration tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] docs

OR

- [ ] This PR is not applicable for the checklist
