### PR TITLE
feat(core): get hook execution stats

### DIFF
--- a/packages/core/src/libraries/hook.ts
+++ b/packages/core/src/libraries/hook.ts
@@ -4,6 +4,8 @@ import {
   InteractionEvent,
   LogResult,
   userInfoSelectFields,
+  type Hook,
+  type HookResponse,
 } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 import { conditional, pick, trySafe } from '@silverhand/essentials';
@@ -33,7 +35,7 @@ export type Interaction = Awaited<ReturnType<Provider['interactionDetails']>>;
 export const createHookLibrary = (queries: Queries) => {
   const {
     applications: { findApplicationById },
-    logs: { insertLog },
+    logs: { insertLog, getHookExecutionStatsByHookId },
     // TODO: @gao should we use the library function thus we can pass full userinfo to the payload?
     users: { findUserById },
     hooks: { findAllHooks },
@@ -127,5 +129,13 @@ export const createHookLibrary = (queries: Queries) => {
     );
   };
 
-  return { triggerInteractionHooksIfNeeded };
+  const attachExecutionStatsToHook = async (hook: Hook): Promise<HookResponse> => ({
+    ...hook,
+    executionStats: await getHookExecutionStatsByHookId(hook.id),
+  });
+
+  return {
+    triggerInteractionHooksIfNeeded,
+    attachExecutionStatsToHook,
+  };
 };

--- a/packages/schemas/src/types/hook.ts
+++ b/packages/schemas/src/types/hook.ts
@@ -1,4 +1,6 @@
-import { type Application, type User } from '../db-entries/index.js';
+import { z } from 'zod';
+
+import { Hooks, type Application, type User } from '../db-entries/index.js';
 import { type HookEvent } from '../foundations/index.js';
 
 import type { userInfoSelectFields } from './user.js';
@@ -13,3 +15,16 @@ export type HookEventPayload = {
   user?: Pick<User, (typeof userInfoSelectFields)[number]>;
   application?: Pick<Application, 'id' | 'type' | 'name' | 'description'>;
 } & Record<string, unknown>;
+
+const hookExecutionStatsGuard = z.object({
+  successCount: z.number(),
+  requestCount: z.number(),
+});
+
+export type HookExecutionStats = z.infer<typeof hookExecutionStatsGuard>;
+
+export const hookResponseGuard = Hooks.guard.extend({
+  executionStats: hookExecutionStatsGuard,
+});
+
+export type HookResponse = z.infer<typeof hookResponseGuard>;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Support `includeRecentState` query for `GET /hooks` and `GET /hooks/:id` to fetch hook recent state.

RecentState:
```ts
export const hookResponseGuard = Hooks.guard.extend({
  recentState: z
    .object({
      successCount: z.number(),
      requestCount: z.number(),
    })
});

export type HookResponse = z.infer<typeof hookResponseGuard>;
```

The recent state is use in the coming feature:
<img width="820" alt="image" src="https://github.com/logto-io/logto/assets/10806653/fe3945b8-6920-4d34-a638-470bb9aa1d86">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT & IT & Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
