### PR TITLE
feat(console): display webhook execution stats

### DIFF
--- a/packages/console/src/pages/WebhookDetails/index.module.scss
+++ b/packages/console/src/pages/WebhookDetails/index.module.scss
@@ -26,10 +26,6 @@
     > div {
       display: flex;
       align-items: center;
-
-      > *:not(:last-child) {
-        margin-right: _.unit(2);
-      }
     }
 
     .title {
@@ -40,11 +36,23 @@
     .text {
       font: var(--font-label-2);
       color: var(--color-text-secondary);
+      margin-right: _.unit(2);
     }
 
     .verticalBar {
       @include _.vertical-bar;
       height: 12px;
+      margin: 0 _.unit(2);
+    }
+
+    .state {
+      display: flex;
+      align-items: center;
+      font: var(--font-body-2);
+
+      .successRate {
+        margin-right: _.unit(1);
+      }
     }
   }
 }

--- a/packages/console/src/pages/WebhookDetails/types.ts
+++ b/packages/console/src/pages/WebhookDetails/types.ts
@@ -1,9 +1,9 @@
-import { type Hook } from '@logto/schemas';
+import { type HookResponse, type Hook } from '@logto/schemas';
 
 import { type BasicWebhookFormType } from '../Webhooks/types';
 
 export type WebhookDetailsOutletContext = {
-  hook: Hook;
+  hook: HookResponse;
   isDeleting: boolean;
   onHookUpdated: (hook?: Hook) => void;
 };

--- a/packages/console/src/pages/Webhooks/components/SuccessRate/index.tsx
+++ b/packages/console/src/pages/Webhooks/components/SuccessRate/index.tsx
@@ -1,0 +1,24 @@
+import Tag from '@/components/Tag';
+
+type Props = {
+  successCount: number;
+  totalCount: number;
+  className?: string;
+};
+
+function SuccessRate({ successCount, totalCount, className }: Props) {
+  if (totalCount === 0) {
+    return <div>-</div>;
+  }
+
+  const percent = (successCount / totalCount) * 100;
+  const statusStyle = percent < 90 ? 'error' : percent < 99 ? 'alert' : 'success';
+
+  return (
+    <Tag variant="plain" type="state" status={statusStyle} className={className}>
+      {percent.toFixed(2)}%
+    </Tag>
+  );
+}
+
+export default SuccessRate;

--- a/packages/console/src/pages/Webhooks/index.module.scss
+++ b/packages/console/src/pages/Webhooks/index.module.scss
@@ -1,5 +1,13 @@
+@use '@/scss/underscore' as _;
+
 .icon {
   width: 40px;
   height: 40px;
   flex-shrink: 0;
+}
+
+.requests {
+  font: var(--font-body-2);
+  text-align: right;
+  margin-right: _.unit(4);
 }

--- a/packages/core/src/libraries/hook.ts
+++ b/packages/core/src/libraries/hook.ts
@@ -4,6 +4,8 @@ import {
   InteractionEvent,
   LogResult,
   userInfoSelectFields,
+  type Hook,
+  type HookResponse,
 } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 import { conditional, pick, trySafe } from '@silverhand/essentials';
@@ -33,7 +35,7 @@ export type Interaction = Awaited<ReturnType<Provider['interactionDetails']>>;
 export const createHookLibrary = (queries: Queries) => {
   const {
     applications: { findApplicationById },
-    logs: { insertLog },
+    logs: { insertLog, getHookExecutionStatsByHookId },
     // TODO: @gao should we use the library function thus we can pass full userinfo to the payload?
     users: { findUserById },
     hooks: { findAllHooks },
@@ -127,5 +129,13 @@ export const createHookLibrary = (queries: Queries) => {
     );
   };
 
-  return { triggerInteractionHooksIfNeeded };
+  const attachExecutionStatsToHook = async (hook: Hook): Promise<HookResponse> => ({
+    ...hook,
+    executionStats: await getHookExecutionStatsByHookId(hook.id),
+  });
+
+  return {
+    triggerInteractionHooksIfNeeded,
+    attachExecutionStatsToHook,
+  };
 };

--- a/packages/phrases/src/locales/de/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/webhook-details.ts
@@ -2,7 +2,7 @@ const webhook_details = {
   page_title: 'Webhook-Details',
   back_to_webhooks: 'Zurück zu Webhooks',
   not_in_use: 'Nicht in Nutzung',
-  success_rate: '{{value, number}} Erfolgsrate',
+  success_rate: 'Erfolgsrate',
   requests: '{{value, number}} Requests in 24 Stunden',
   disable_webhook: 'Webhook deaktivieren',
   disable_reminder:

--- a/packages/phrases/src/locales/en/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/webhook-details.ts
@@ -2,7 +2,7 @@ const webhook_details = {
   page_title: 'Webhook details',
   back_to_webhooks: 'Back to Webhooks',
   not_in_use: 'Not in use',
-  success_rate: '{{value, number}} success rate',
+  success_rate: 'success rate',
   requests: '{{value, number}} requests in 24h',
   disable_webhook: 'Disable webhook',
   disable_reminder:

--- a/packages/phrases/src/locales/es/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/webhook-details.ts
@@ -2,7 +2,7 @@ const webhook_details = {
   page_title: 'Detalles de Webhook',
   back_to_webhooks: 'Volver a Webhooks',
   not_in_use: 'No se está usando',
-  success_rate: 'Tasa de éxito: {{value, number}}',
+  success_rate: 'Tasa de éxito',
   requests: 'Solicitudes en 24h: {{value, number}}',
   disable_webhook: 'Desactivar webhook',
   disable_reminder:

--- a/packages/phrases/src/locales/fr/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/webhook-details.ts
@@ -2,7 +2,7 @@ const webhook_details = {
   page_title: 'Détails du webhook',
   back_to_webhooks: 'Retour aux webhooks',
   not_in_use: "Pas en cours d'utilisation",
-  success_rate: 'Taux de réussite de {{value, number}}',
+  success_rate: 'Taux de réussite',
   requests: '{{value, number}} requêtes en 24h',
   disable_webhook: 'Désactiver le webhook',
   disable_reminder:

--- a/packages/phrases/src/locales/it/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/webhook-details.ts
@@ -2,7 +2,7 @@ const webhook_details = {
   page_title: 'Dettagli webhook',
   back_to_webhooks: 'Torna ai Webhook',
   not_in_use: 'Non in uso',
-  success_rate: 'Tasso di successo {{value,number}}',
+  success_rate: 'Tasso di successo',
   requests: '{{value, number}} richieste in 24h',
   disable_webhook: 'Disabilita webhook',
   disable_reminder:

--- a/packages/phrases/src/locales/ja/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/webhook-details.ts
@@ -2,7 +2,7 @@ const webhook_details = {
   page_title: 'Webhookの詳細',
   back_to_webhooks: 'Webhooksに戻る',
   not_in_use: '使用されていない',
-  success_rate: '{{value, number}}成功率',
+  success_rate: '成功率',
   requests: '24時間に{{value, number}}件のリクエスト',
   disable_webhook: 'Webhookを無効にする',
   disable_reminder:

--- a/packages/phrases/src/locales/ko/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/webhook-details.ts
@@ -2,7 +2,7 @@ const webhook_details = {
   page_title: 'Webhook 담당자',
   back_to_webhooks: 'Webhooks로 돌아가기',
   not_in_use: '사용 중이 아님',
-  success_rate: '{{value, number}} 성공율',
+  success_rate: '성공율',
   requests: '24시간 동안 {{value, number}}개의 요청',
   disable_webhook: 'Webhook 비활성화',
   disable_reminder:

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/webhook-details.ts
@@ -2,7 +2,7 @@ const webhook_details = {
   page_title: 'Szczegóły webhooka',
   back_to_webhooks: 'Wróć do Webhooks',
   not_in_use: 'Nieaktywne',
-  success_rate: 'Stosunek sukcesów: {{value, number}}',
+  success_rate: 'Stosunek sukcesów',
   requests: '{{value, number}} żądań w ciągu 24h',
   disable_webhook: 'Wyłącz webhook',
   disable_reminder:

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/webhook-details.ts
@@ -2,7 +2,7 @@ const webhook_details = {
   page_title: 'Detalhes do webhook',
   back_to_webhooks: 'Voltar para Webhooks',
   not_in_use: 'Não em uso',
-  success_rate: 'Taxa de sucesso de {{value, number}}',
+  success_rate: 'Taxa de sucesso',
   requests: '{{value, number}} requisições em 24h',
   disable_webhook: 'Desativar webhook',
   disable_reminder:

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/webhook-details.ts
@@ -2,7 +2,7 @@ const webhook_details = {
   page_title: 'Detalhes do webhook',
   back_to_webhooks: 'Voltar para Webhooks',
   not_in_use: 'Não está em uso',
-  success_rate: 'Taxa de sucesso de {{value, number}}',
+  success_rate: 'Taxa de sucesso',
   requests: '{{value, number}} solicitações em 24h',
   disable_webhook: 'Desativar o webhook',
   disable_reminder:

--- a/packages/phrases/src/locales/ru/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/webhook-details.ts
@@ -2,7 +2,7 @@ const webhook_details = {
   page_title: 'Данные вебхука',
   back_to_webhooks: 'Вернуться к вебхукам',
   not_in_use: 'Не используется',
-  success_rate: 'Коэффициент успешности {{value, number}}',
+  success_rate: 'Коэффициент успешности',
   requests: '{{value, number}} запросов за 24 часа',
   disable_webhook: 'Отключить вебхук',
   disable_reminder:

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/webhook-details.ts
@@ -2,7 +2,7 @@ const webhook_details = {
   page_title: 'Webhook ayrıntıları',
   back_to_webhooks: 'Webhooklara geri dön',
   not_in_use: 'Kullanılmıyor',
-  success_rate: '{{value, number}} başarı oranı',
+  success_rate: 'başarı oranı',
   requests: '24 saatte {{value, number}} istek',
   disable_webhook: 'Webhooku devre dışı bırak',
   disable_reminder:

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/webhook-details.ts
@@ -2,7 +2,7 @@ const webhook_details = {
   page_title: 'Webhook 详情',
   back_to_webhooks: '返回 Webhooks',
   not_in_use: '未使用',
-  success_rate: '{{value, number}} 成功率',
+  success_rate: '成功率',
   requests: '24 小时内请求次数：{{value, number}}',
   disable_webhook: '禁用 Webhook',
   disable_reminder: '是否确定重新激活此 Webhook？重新激活后将不会向端点 URL 发送 HTTP 请求。',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/webhook-details.ts
@@ -2,7 +2,7 @@ const webhook_details = {
   page_title: 'Webhook 詳細資料',
   back_to_webhooks: '返回 Webhooks',
   not_in_use: '未啟用',
-  success_rate: '{{value, number}} 成功率',
+  success_rate: '成功率',
   requests: '24 小時內收到 {{value, number}} 個請求',
   disable_webhook: '停用 webhook',
   disable_reminder: '確定要重新啟用此 webhook？重新啟用後，不會對端點 URL 發送 HTTP 請求。',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/webhook-details.ts
@@ -2,7 +2,7 @@ const webhook_details = {
   page_title: 'Webhook 詳情',
   back_to_webhooks: '返回 Webhooks',
   not_in_use: '未使用',
-  success_rate: '{{value, number}} 成功率',
+  success_rate: '成功率',
   requests: '24 小時內 {{value, number}} 個請求',
   disable_webhook: '停用 Webhook',
   disable_reminder: '確定要重新啟用此 Webhook 嗎？繼續操作後，將不會向端點 URL 發送 HTTP 請求。',

--- a/packages/schemas/src/types/hook.ts
+++ b/packages/schemas/src/types/hook.ts
@@ -1,4 +1,6 @@
-import { type Application, type User } from '../db-entries/index.js';
+import { z } from 'zod';
+
+import { Hooks, type Application, type User } from '../db-entries/index.js';
 import { type HookEvent } from '../foundations/index.js';
 
 import type { userInfoSelectFields } from './user.js';
@@ -13,3 +15,16 @@ export type HookEventPayload = {
   user?: Pick<User, (typeof userInfoSelectFields)[number]>;
   application?: Pick<Application, 'id' | 'type' | 'name' | 'description'>;
 } & Record<string, unknown>;
+
+const hookExecutionStatsGuard = z.object({
+  successCount: z.number(),
+  requestCount: z.number(),
+});
+
+export type HookExecutionStats = z.infer<typeof hookExecutionStatsGuard>;
+
+export const hookResponseGuard = Hooks.guard.extend({
+  executionStats: hookExecutionStatsGuard,
+});
+
+export type HookResponse = z.infer<typeof hookResponseGuard>;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Display the webhook execution stats in the admin console.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
![image](https://github.com/logto-io/logto/assets/10806653/b1cf131c-c323-4e69-bd98-b237ff76aa44)
![image](https://github.com/logto-io/logto/assets/10806653/b1fa182f-e6b9-4911-b21b-bbe1e2297d3f)


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
