### PR TITLE
fix(core): reject the revoked resouce scopes fron OIDC Grant

### DIFF
--- a/.changeset/rude-panthers-tickle.md
+++ b/.changeset/rude-panthers-tickle.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": patch
+---
+
+reject the pre-granted resource scopes from OIDC Grant enity, if the scope has been revoked from the user or client.

--- a/packages/core/src/oidc/utils.ts
+++ b/packages/core/src/oidc/utils.ts
@@ -1,7 +1,7 @@
-import type { CustomClientMetadata, OidcClientMetadata } from '@logto/schemas';
+import type { CustomClientMetadata, OidcClientMetadata, Scope } from '@logto/schemas';
 import { ApplicationType, customClientMetadataGuard, GrantType } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
-import type { AllClientMetadata, ClientAuthMethod } from 'oidc-provider';
+import type { AllClientMetadata, ClientAuthMethod, KoaContextWithOIDC } from 'oidc-provider';
 import { errors } from 'oidc-provider';
 
 import type { EnvSet } from '#src/env-set/index.js';
@@ -63,4 +63,33 @@ export const isOriginAllowed = (
   const redirectUriOrigins = redirectUris.map((uri) => new URL(uri).origin);
 
   return [...corsAllowedOrigins, ...redirectUriOrigins].includes(origin);
+};
+
+/**
+ * OIDC Provider by default won't revoke the pre-granted resource scopes
+ * even if the scope has been remove from the target user
+ */
+export const rejectRevokedResourceScopesFromGrant = (
+  ctx: KoaContextWithOIDC,
+  resourceIndicator: string,
+  resourceScopes: readonly Scope[]
+) => {
+  const { Grant } = ctx.oidc.entities;
+
+  if (!Grant) {
+    return;
+  }
+
+  const grantedResourceScope = Grant.getResourceScope(resourceIndicator);
+  const grantedResourceScopes = conditional(
+    Boolean(grantedResourceScope) && grantedResourceScope.split(' ')
+  );
+
+  const revokedScopes = grantedResourceScopes?.filter((scope) =>
+    resourceScopes.every(({ name }) => name !== scope)
+  );
+
+  if (revokedScopes?.length) {
+    Grant.rejectResourceScope(resourceIndicator, revokedScopes.join(' '));
+  }
 };


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Reject the revoked resource scopes from OIDC Grant.

Issue:
By default, OIDC providers keep using the pre-granted resource scopes to issue new access tokens.

<img width="1020" alt="image" src="https://github.com/logto-io/logto/assets/36393111/e538e695-428b-489d-8aea-c40dd17d7f0e">


Instead, it should always pick the scopes from the latest `getResourceServerInfo` method. 

All pre-granted scopes should be revoked immediately if any specific role or scope has been removed from the user. 


Workaround:  Call a `Grant.rejectResourceScopes` method to manually remove all these revoked scopes. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

Before revoke:
![WX20230524-105712@2x](https://github.com/logto-io/logto/assets/36393111/893ee039-db6c-46c6-8ef0-3294ad6a6c47)

After revoking the role from the user:
![WX20230524-105928@2x](https://github.com/logto-io/logto/assets/36393111/9baebd5d-0188-404d-91a4-6eff9e01ae3e)


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [ ] This PR is not applicable for the checklist
