### PR TITLE
fix(console): hide success rate on the hook details page when no request happened

### DIFF
--- a/packages/console/src/pages/WebhookDetails/index.tsx
+++ b/packages/console/src/pages/WebhookDetails/index.tsx
@@ -42,6 +42,7 @@ function WebhookDetails() {
   const { data, error, mutate } = useSWR<HookResponse, RequestError>(
     id && buildUrl(`api/hooks/${id}`, { includeExecutionStats: String(true) })
   );
+  const { executionStats } = data ?? {};
   const isLoading = !data && !error;
   const api = useApi();
 
@@ -113,18 +114,22 @@ function WebhookDetails() {
             <div className={styles.metadata}>
               <div className={styles.title}>{data.name}</div>
               <div>
-                {isEnabled ? (
+                {isEnabled && executionStats ? (
                   <div className={styles.state}>
-                    <SuccessRate
-                      className={styles.successRate}
-                      successCount={data.executionStats.successCount}
-                      totalCount={data.executionStats.requestCount}
-                    />
-                    <DynamicT forKey="webhook_details.success_rate" />
-                    <div className={styles.verticalBar} />
+                    {executionStats.requestCount > 0 && (
+                      <>
+                        <SuccessRate
+                          className={styles.successRate}
+                          successCount={executionStats.successCount}
+                          totalCount={executionStats.requestCount}
+                        />
+                        <DynamicT forKey="webhook_details.success_rate" />
+                        <div className={styles.verticalBar} />
+                      </>
+                    )}
                     <DynamicT
                       forKey="webhook_details.requests"
-                      interpolation={{ value: data.executionStats.requestCount }}
+                      interpolation={{ value: executionStats.requestCount }}
                     />
                   </div>
                 ) : (


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
hide success rate on the hook details page when no request happened

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Before
<img width="660" alt="image" src="https://github.com/logto-io/logto/assets/10806653/087a2ee9-f994-4230-aa8e-c989baee679f">

### After
<img width="513" alt="image" src="https://github.com/logto-io/logto/assets/10806653/22509f2f-90e8-4b96-9257-4feac9397ba9">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
