### PR TITLE
fix(console): refresh hook on data updated

### DIFF
--- a/packages/console/src/pages/WebhookDetails/index.tsx
+++ b/packages/console/src/pages/WebhookDetails/index.tsx
@@ -42,7 +42,7 @@ function WebhookDetails() {
   const { data, error, mutate } = useSWR<HookResponse, RequestError>(
     id && buildUrl(`api/hooks/${id}`, { includeExecutionStats: String(true) })
   );
-  const { executionStats } = data ?? {};
+  const { enabled: isEnabled, executionStats } = data ?? {};
   const isLoading = !data && !error;
   const api = useApi();
 
@@ -53,7 +53,6 @@ function WebhookDetails() {
   const [isDeleting, setIsDeleting] = useState(false);
   const [isDisableFormOpen, setIsDisableFormOpen] = useState(false);
   const [isUpdatingEnableState, setIsUpdatingEnableState] = useState(false);
-  const [isEnabled, setIsEnabled] = useState(data?.enabled ?? true);
 
   useEffect(() => {
     setIsDeleteFormOpen(false);
@@ -84,11 +83,12 @@ function WebhookDetails() {
     setIsUpdatingEnableState(true);
 
     try {
-      const { enabled } = await api
+      const updatedHook = await api
         .patch(`api/hooks/${data.id}`, { json: { enabled: !isEnabled } })
         .json<Hook>();
-      setIsEnabled(enabled);
+      void mutate({ ...updatedHook, executionStats: data.executionStats });
       setIsDisableFormOpen(false);
+      const { enabled } = updatedHook;
       toast.success(
         t(enabled ? 'webhook_details.webhook_reactivated' : 'webhook_details.webhook_disabled')
       );


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
### Existing problem
When we change the enable state of a webhook, the state won't change when we return the details page from the list item since the `/hooks/:id` swr request caches the old data.

### Solution
We need to refresh the hook data when its content has been changed.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
