### PR TITLE
fix(console): should not check duplicated keys when key is empty

### DIFF
--- a/packages/console/src/pages/WebhookDetails/WebhookSettings/components/CustomHeaderField/index.tsx
+++ b/packages/console/src/pages/WebhookDetails/WebhookSettings/components/CustomHeaderField/index.tsx
@@ -35,7 +35,7 @@ function CustomHeaderField() {
       return true;
     }
 
-    if (headers.filter(({ key: _key }) => _key === key).length > 1) {
+    if (headers.filter(({ key: _key }) => _key.length > 0 && _key === key).length > 1) {
       return t('webhook_details.settings.key_duplicated_error');
     }
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
should not check duplicated keys when key is empty

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="804" alt="image" src="https://github.com/logto-io/logto/assets/10806653/382ea972-8840-41cb-ad9d-1d0d50579be9">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
