### PR TITLE
fix(core): trigger reset password hook

### DIFF
--- a/.changeset/silly-impalas-pump.md
+++ b/.changeset/silly-impalas-pump.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": patch
+---
+
+Bug fix: reset password webhook should be triggered when the user resets password

--- a/packages/core/src/libraries/hook/index.test.ts
+++ b/packages/core/src/libraries/hook/index.test.ts
@@ -5,7 +5,6 @@ import { createMockUtils } from '@logto/shared/esm';
 import { mockHook } from '#src/__mocks__/hook.js';
 import RequestError from '#src/errors/RequestError/index.js';
 
-import type { Interaction } from './index.js';
 import { generateHookTestPayload, parseResponse } from './utils.js';
 
 const { jest } = import.meta;
@@ -50,7 +49,7 @@ const findAllHooks = jest.fn().mockResolvedValue([hook]);
 const findHookById = jest.fn().mockResolvedValue(hook);
 
 const { createHookLibrary } = await import('./index.js');
-const { triggerInteractionHooksIfNeeded, attachExecutionStatsToHook, testHook } = createHookLibrary(
+const { triggerInteractionHooks, attachExecutionStatsToHook, testHook } = createHookLibrary(
   new MockQueries({
     users: {
       findUserById: jest.fn().mockReturnValue({
@@ -67,28 +66,17 @@ const { triggerInteractionHooksIfNeeded, attachExecutionStatsToHook, testHook } 
   })
 );
 
-describe('triggerInteractionHooksIfNeeded()', () => {
+describe('triggerInteractionHooks()', () => {
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  it('should return if no user ID found', async () => {
-    await triggerInteractionHooksIfNeeded(InteractionEvent.SignIn);
-
-    expect(findAllHooks).not.toBeCalled();
   });
 
   it('should set correct payload when hook triggered', async () => {
     jest.useFakeTimers().setSystemTime(100_000);
 
-    await triggerInteractionHooksIfNeeded(
-      InteractionEvent.SignIn,
-      // @ts-expect-error
-      {
-        jti: 'some_jti',
-        result: { login: { accountId: '123' } },
-        params: { client_id: 'some_client' },
-      } as Interaction
+    await triggerInteractionHooks(
+      { event: InteractionEvent.SignIn, sessionId: 'some_jti', applicationId: 'some_client' },
+      { userId: '123' }
     );
 
     expect(findAllHooks).toHaveBeenCalled();

--- a/packages/core/src/routes/interaction/actions/submit-interaction.test.ts
+++ b/packages/core/src/routes/interaction/actions/submit-interaction.test.ts
@@ -64,6 +64,7 @@ describe('submit action', () => {
     ...createMockLogContext(),
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     interactionDetails: { params: {} } as Awaited<ReturnType<Provider['interactionDetails']>>,
+    assignInteractionHookResult: jest.fn(),
   };
   const profile = {
     username: 'username',

--- a/packages/core/src/routes/interaction/consent.ts
+++ b/packages/core/src/routes/interaction/consent.ts
@@ -1,5 +1,6 @@
 import { conditional } from '@silverhand/essentials';
 import type Router from 'koa-router';
+import { type IRouterParamContext } from 'koa-router';
 import { z } from 'zod';
 
 import { assignInteractionResults, saveUserFirstConsentedAppId } from '#src/libraries/session.js';
@@ -9,7 +10,7 @@ import assertThat from '#src/utils/assert-that.js';
 import { interactionPrefix } from './const.js';
 import type { WithInteractionDetailsContext } from './middleware/koa-interaction-details.js';
 
-export default function consentRoutes<T>(
+export default function consentRoutes<T extends IRouterParamContext>(
   router: Router<unknown, WithInteractionDetailsContext<T>>,
   { provider, libraries, queries }: TenantContext
 ) {

--- a/packages/core/src/routes/interaction/index.ts
+++ b/packages/core/src/routes/interaction/index.ts
@@ -285,7 +285,7 @@ export default function interactionRoutes<T extends AnonymousRouter>(
   router.post(
     `${interactionPrefix}/submit`,
     koaInteractionSie(queries),
-    koaInteractionHooks(tenant),
+    koaInteractionHooks(libraries),
     async (ctx, next) => {
       const { interactionDetails, createLog } = ctx;
       const interactionStorage = getInteractionStorage(interactionDetails.result);

--- a/packages/core/src/routes/interaction/middleware/koa-interaction-details.ts
+++ b/packages/core/src/routes/interaction/middleware/koa-interaction-details.ts
@@ -1,15 +1,18 @@
 import type { MiddlewareType } from 'koa';
+import { type IRouterParamContext } from 'koa-router';
 import type Provider from 'oidc-provider';
 
-import type { WithLogContext } from '#src/middleware/koa-audit-log.js';
-
-export type WithInteractionDetailsContext<ContextT = WithLogContext> = ContextT & {
+export type WithInteractionDetailsContext<
+  ContextT extends IRouterParamContext = IRouterParamContext
+> = ContextT & {
   interactionDetails: Awaited<ReturnType<Provider['interactionDetails']>>;
 };
 
-export default function koaInteractionDetails<StateT, ContextT>(
-  provider: Provider
-): MiddlewareType<StateT, WithInteractionDetailsContext<ContextT>> {
+export default function koaInteractionDetails<
+  StateT,
+  ContextT extends IRouterParamContext,
+  ResponseT
+>(provider: Provider): MiddlewareType<StateT, WithInteractionDetailsContext<ContextT>, ResponseT> {
   return async (ctx, next) => {
     ctx.interactionDetails = await provider.interactionDetails(ctx.req, ctx.res);
 

--- a/packages/core/src/routes/interaction/middleware/koa-interaction-hooks.ts
+++ b/packages/core/src/routes/interaction/middleware/koa-interaction-hooks.ts
@@ -1,31 +1,69 @@
-import { trySafe } from '@silverhand/essentials';
+import { type Optional, trySafe, conditionalString } from '@silverhand/essentials';
 import type { MiddlewareType } from 'koa';
 import type { IRouterParamContext } from 'koa-router';
 
-import type TenantContext from '#src/tenants/TenantContext.js';
+import {
+  type InteractionHookContext,
+  type InteractionHookResult,
+} from '#src/libraries/hook/index.js';
+import type Libraries from '#src/tenants/Libraries.js';
 
 import { getInteractionStorage } from '../utils/interaction.js';
 
 import type { WithInteractionDetailsContext } from './koa-interaction-details.js';
 
+type AssignInteractionHookResult = (result: InteractionHookResult) => void;
+
+export type WithInteractionHooksContext<
+  ContextT extends IRouterParamContext = IRouterParamContext
+> = ContextT & { assignInteractionHookResult: AssignInteractionHookResult };
+
+/**
+ * The factory to create a new interaction hook middleware function.
+ * Interaction related event hooks will be triggered once we got the interaction hook result.
+ * Use `assignInteractionHookResult` to assign the interaction hook result.
+ */
 export default function koaInteractionHooks<
   StateT,
-  ContextT extends WithInteractionDetailsContext<IRouterParamContext>,
+  ContextT extends WithInteractionDetailsContext,
   ResponseT
 >({
-  provider,
-  libraries: {
-    hooks: { triggerInteractionHooksIfNeeded },
-  },
-}: TenantContext): MiddlewareType<StateT, ContextT, ResponseT> {
+  hooks: { triggerInteractionHooks },
+}: Libraries): MiddlewareType<StateT, WithInteractionHooksContext<ContextT>, ResponseT> {
   return async (ctx, next) => {
     const { event } = getInteractionStorage(ctx.interactionDetails.result);
+    const {
+      interactionDetails,
+      header: { 'user-agent': userAgent },
+    } = ctx;
+
+    // Predefined interaction hook context
+    const interactionHookContext: InteractionHookContext = {
+      event,
+      sessionId: interactionDetails.jti,
+      applicationId: conditionalString(interactionDetails.params.client_id),
+    };
+
+    // eslint-disable-next-line @silverhand/fp/no-let
+    let interactionHookResult: Optional<InteractionHookResult>;
+
+    /**
+     * Assign an interaction hook result to trigger webhook.
+     * Calling it multiple times will overwrite the original result, but only one webhook will be triggered.
+     * @param result The result to assign.
+     */
+    ctx.assignInteractionHookResult = (result) => {
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      interactionHookResult = result;
+    };
 
     await next();
 
-    // Get up-to-date interaction details
-    const details = await trySafe(provider.interactionDetails(ctx.req, ctx.res));
-    // Hooks should not crash the app
-    void trySafe(triggerInteractionHooksIfNeeded(event, details, ctx.header['user-agent']));
+    if (interactionHookResult) {
+      // Hooks should not crash the app
+      void trySafe(
+        triggerInteractionHooks(interactionHookContext, interactionHookResult, userAgent)
+      );
+    }
   };
 }

--- a/packages/core/src/routes/interaction/middleware/koa-interaction-sie.ts
+++ b/packages/core/src/routes/interaction/middleware/koa-interaction-sie.ts
@@ -1,15 +1,13 @@
 import type { SignInExperience } from '@logto/schemas';
 import type { MiddlewareType } from 'koa';
+import { type IRouterParamContext } from 'koa-router';
 
 import type Queries from '#src/tenants/Queries.js';
 
-import type { WithInteractionDetailsContext } from './koa-interaction-details.js';
+export type WithInteractionSieContext<ContextT extends IRouterParamContext = IRouterParamContext> =
+  ContextT & { signInExperience: SignInExperience };
 
-export type WithInteractionSieContext<ContextT> = WithInteractionDetailsContext<ContextT> & {
-  signInExperience: SignInExperience;
-};
-
-export default function koaInteractionSie<StateT, ContextT, ResponseT>({
+export default function koaInteractionSie<StateT, ContextT extends IRouterParamContext, ResponseT>({
   signInExperiences: { findDefaultSignInExperience },
 }: Queries): MiddlewareType<StateT, WithInteractionSieContext<ContextT>, ResponseT> {
   return async (ctx, next) => {

--- a/packages/core/src/routes/interaction/verifications/mandatory-user-profile-validation.ts
+++ b/packages/core/src/routes/interaction/verifications/mandatory-user-profile-validation.ts
@@ -2,12 +2,12 @@ import type { Profile, SignInExperience, User } from '@logto/schemas';
 import { InteractionEvent, MissingProfile, SignInIdentifier } from '@logto/schemas';
 import type { Nullable } from '@silverhand/essentials';
 import { conditional } from '@silverhand/essentials';
-import type { Context } from 'koa';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
+import { type WithInteractionDetailsContext } from '../middleware/koa-interaction-details.js';
 import type { WithInteractionSieContext } from '../middleware/koa-interaction-sie.js';
 import type {
   SocialIdentifier,
@@ -213,7 +213,7 @@ const fillMissingProfileWithSocialIdentity = async (
 
 export default async function validateMandatoryUserProfile(
   userQueries: Queries['users'],
-  ctx: WithInteractionSieContext<Context>,
+  ctx: WithInteractionSieContext & WithInteractionDetailsContext,
   interaction: MandatoryProfileValidationInteraction
 ) {
   const { signUp } = ctx.signInExperience;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

In this PR, we need to improve & fix the following problems:

- The current hook trigger logic relies on specific interaction details that may not have consistent data schema. 
- During the reset password process, the interaction details are cleared upon completion, which makes the reset password hook fails to trigger when needed.

### Solution
- Store a hook-related interaction context in the middleware before processing an interaction; this context will be used when triggering hooks and will not lose during the interaction process.
- Add a hook-related interaction result variable in the middleware; we will trigger related hooks after we have processed the interaction when the result is assigned during the interaction process.

### Updates
- Refactor and rename `triggerInteractionHooksIfNeeded` to `triggerInteractionHooks`
- Adjust related middleware TS types to support the new interaction hook middleware

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT & IT & Test with local go application & Test with [Sivx Play](https://play.svix.com/) service

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] docs

OR

- [ ] This PR is not applicable for the checklist
