### PR TITLE
fix(console): fix toggle tip z-index on modal layer

### DIFF
--- a/packages/console/src/components/Tip/ToggleTip/index.module.scss
+++ b/packages/console/src/components/Tip/ToggleTip/index.module.scss
@@ -2,8 +2,8 @@
 
 .overlay {
   background: transparent;
-  position: fixed;
-  inset: 0;
+  padding: unset;
+  overflow-y: unset;
 
   .content {
     position: relative;

--- a/packages/console/src/components/Tip/ToggleTip/index.tsx
+++ b/packages/console/src/components/Tip/ToggleTip/index.tsx
@@ -1,8 +1,10 @@
+import classNames from 'classnames';
 import type { ReactNode } from 'react';
 import { useCallback, useState, useRef } from 'react';
 import ReactModal from 'react-modal';
 
 import usePosition from '@/hooks/use-position';
+import * as modalStyles from '@/scss/modal.module.scss';
 import type { HorizontalAlignment } from '@/types/positioning';
 import { onKeyDownHandler } from '@/utils/a11y';
 
@@ -79,7 +81,7 @@ function ToggleTip({
         shouldCloseOnEsc
         isOpen={isOpen}
         className={styles.content}
-        overlayClassName={styles.overlay}
+        overlayClassName={classNames(modalStyles.overlay, styles.overlay)}
         onRequestClose={onClose}
         onAfterOpen={mutate}
       >


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The toggle tip react modal should share the same z-index with other modals, or when a toggle tip is used inside a modal, it'll be covered.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="683" alt="image" src="https://github.com/logto-io/logto/assets/10806653/5e5561b8-a19d-447d-84c2-4f39877b1289">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
