### PR TITLE
fix(connector): signature method for both Aliyun DM and SMS

### DIFF
--- a/.changeset/odd-pumpkins-poke.md
+++ b/.changeset/odd-pumpkins-poke.md
@@ -1,0 +1,6 @@
+---
+"@logto/connector-aliyun-dm": patch
+"@logto/connector-aliyun-sms": patch
+---
+
+Fix Aliyun Direct Mail and Aliyun Short Message Service connectors' signature functions.

--- a/packages/connectors/connector-aliyun-sms/src/utils.ts
+++ b/packages/connectors/connector-aliyun-sms/src/utils.ts
@@ -1,32 +1,35 @@
+import { type Optional } from '@silverhand/essentials';
 import { got } from 'got';
-import { createHmac } from 'node:crypto';
+import { createHmac, randomUUID } from 'node:crypto';
 
 import type { PublicParameters } from './types.js';
-
 // Aliyun has special escape rules.
 // https://help.aliyun.com/document_detail/29442.html
 const escaper = (string_: string) =>
   encodeURIComponent(string_)
-    .replace(/\*/g, '%2A')
-    .replace(/'/g, '%27')
     .replace(/!/g, '%21')
     .replace(/"/g, '%22')
+    .replace(/'/g, '%27')
     .replace(/\(/g, '%28')
     .replace(/\)/g, '%29')
+    .replace(/\*/g, '%2A')
     .replace(/\+/g, '%2B');
+
+// Format date string to 'YYYY-MM-DDThh:mm:ssZ' format.
+const formatDateString = (date: Date) => {
+  const rawString = date.toISOString();
+  return rawString.replace(/\.\d{3}Z$/, 'Z'); // Trim milliseconds.
+};
 
 export const getSignature = (
   parameters: Record<string, string>,
   secret: string,
   method: string
 ) => {
-  const canonicalizedQuery = Object.keys(parameters)
-    .map((key) => {
-      const value = parameters[key];
-
-      return value === undefined ? '' : `${escaper(key)}=${escaper(value)}`;
+  const canonicalizedQuery = Object.entries(parameters)
+    .map(([key, value]) => {
+      return `${escaper(key)}=${escaper(value)}`;
     })
-    .filter(Boolean)
     .slice()
     .sort()
     .join('&');
@@ -41,11 +44,14 @@ export const request = async (
   parameters: PublicParameters & Record<string, string>,
   accessKeySecret: string
 ) => {
-  const finalParameters: Record<string, string> = {
+  const finalParameters = Object.entries<Optional<string>>({
     ...parameters,
-    SignatureNonce: String(Math.random()),
-    Timestamp: new Date().toISOString(),
-  };
+    SignatureNonce: randomUUID(),
+    Timestamp: formatDateString(new Date()),
+  }).reduce<Record<string, string>>(
+    (result, [key, value]) => (value === undefined ? result : { ...result, [key]: value }),
+    {}
+  );
   const signature = getSignature(finalParameters, accessKeySecret, 'POST');
 
   return got.post({


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
1. Fix Aliyun DM and SMS connectors' signature process, should remove undefined keys before generating signature.
2. Use `generateStandardId` to generate a random signature nonce.
3. Align timestamp to the format of 'YYYY-MM-DDThh:mm:ssZ'.
Attached is the [up-to-date document](https://help.aliyun.com/document_detail/29440.html?spm=a2c4g.29442.0.0.361d3581nNwZqv).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally, can send and receive email/sms successfully.
Before this change, the client-generated signature does not match the Aliyun server-generated signature if `From Alias` is not given.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [ ] This PR is not applicable for the checklist
