### PR TITLE
feat: support default API Resource

### DIFF
--- a/.changeset/small-hats-confess.md
+++ b/.changeset/small-hats-confess.md
@@ -1,0 +1,13 @@
+---
+"@logto/console": minor
+"@logto/core": minor
+"@logto/integration-tests": minor
+"@logto/phrases": minor
+"@logto/schemas": minor
+---
+
+Support setting default API Resource from Console and API
+
+- New API Resources will not be treated as default.
+- Added `PATCH /resources/:id/is-default` to setting `isDefault` for an API Resource.
+  - Only one default API Resource is allowed per tenant. Setting one API default will reset all others.

--- a/packages/console/src/pages/ApiResourceDetails/index.module.scss
+++ b/packages/console/src/pages/ApiResourceDetails/index.module.scss
@@ -33,7 +33,7 @@
       object-fit: cover;
     }
 
-    .meta {
+    .metadata {
       margin-left: _.unit(6);
       display: flex;
       flex-direction: column;
@@ -42,6 +42,23 @@
       .name {
         font: var(--font-title-1);
         color: var(--color-text);
+      }
+
+      .row {
+        display: flex;
+        align-items: center;
+        gap: _.unit(1);
+      }
+
+      .text {
+        font: var(--font-label-2);
+        color: var(--color-text-secondary);
+      }
+
+      .verticalBar {
+        @include _.vertical-bar;
+        height: 12px;
+        margin: 0 _.unit(2);
       }
     }
   }

--- a/packages/console/src/pages/ApiResourceDetails/index.tsx
+++ b/packages/console/src/pages/ApiResourceDetails/index.tsx
@@ -19,6 +19,7 @@ import DeleteConfirmModal from '@/components/DeleteConfirmModal';
 import DetailsPage from '@/components/DetailsPage';
 import PageMeta from '@/components/PageMeta';
 import TabNav, { TabNavItem } from '@/components/TabNav';
+import Tag from '@/components/Tag';
 import { ApiResourceDetailsTabs } from '@/consts/page-tabs';
 import type { RequestError } from '@/hooks/use-api';
 import useApi from '@/hooks/use-api';
@@ -81,9 +82,18 @@ function ApiResourceDetails() {
           <Card className={styles.header}>
             <div className={styles.info}>
               <Icon className={styles.icon} />
-              <div className={styles.meta}>
+              <div className={styles.metadata}>
                 <div className={styles.name}>{data.name}</div>
-                <CopyToClipboard size="small" value={data.indicator} />
+                <div className={styles.row}>
+                  {data.isDefault && (
+                    <>
+                      <Tag>{t('api_resources.default_api')}</Tag>
+                      <div className={styles.verticalBar} />
+                    </>
+                  )}
+                  <div className={styles.text}>API Identifier</div>
+                  <CopyToClipboard size="small" value={data.indicator} />
+                </div>
               </div>
             </div>
             {!isLogtoManagementApiResource && (

--- a/packages/console/src/pages/ApiResources/index.tsx
+++ b/packages/console/src/pages/ApiResources/index.tsx
@@ -13,6 +13,7 @@ import CopyToClipboard from '@/components/CopyToClipboard';
 import EmptyDataPlaceholder from '@/components/EmptyDataPlaceholder';
 import ItemPreview from '@/components/ItemPreview';
 import ListPage from '@/components/ListPage';
+import Tag from '@/components/Tag';
 import { defaultPageSize } from '@/consts';
 import { ApiResourceDetailsTabs } from '@/consts/page-tabs';
 import type { RequestError } from '@/hooks/use-api';
@@ -79,11 +80,12 @@ function ApiResources() {
             title: t('api_resources.api_name'),
             dataIndex: 'name',
             colSpan: 6,
-            render: ({ id, name }) => (
+            render: ({ id, name, isDefault }) => (
               <ItemPreview
                 title={name}
                 icon={<ResourceIcon className={styles.icon} />}
                 to={buildDetailsPathname(id)}
+                suffix={isDefault && <Tag>{t('api_resources.default_api')}</Tag>}
               />
             ),
           },

--- a/packages/console/src/pages/ApplicationDetails/index.module.scss
+++ b/packages/console/src/pages/ApplicationDetails/index.module.scss
@@ -56,7 +56,7 @@
       color: var(--color-text);
     }
 
-    .details {
+    .row {
       white-space: nowrap;
 
       > * {

--- a/packages/console/src/pages/ApplicationDetails/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/index.tsx
@@ -147,7 +147,7 @@ function ApplicationDetails() {
             <ApplicationIcon type={data.type} className={styles.icon} />
             <div className={styles.metadata}>
               <div className={styles.name}>{data.name}</div>
-              <div className={styles.details}>
+              <div className={styles.row}>
                 <Tag>{t(`${applicationTypeI18nKey[data.type]}.title`)}</Tag>
                 <div className={styles.verticalBar} />
                 <div className={styles.text}>App ID</div>

--- a/packages/core/src/__mocks__/index.ts
+++ b/packages/core/src/__mocks__/index.ts
@@ -40,6 +40,7 @@ export const mockResource: Resource = {
   name: 'management api',
   indicator: 'logto.dev/api',
   accessTokenTtl: 3600,
+  isDefault: false,
 };
 
 export const mockResource2: Resource = {
@@ -48,6 +49,7 @@ export const mockResource2: Resource = {
   name: 'management api',
   indicator: 'logto.dev/api',
   accessTokenTtl: 3600,
+  isDefault: false,
 };
 
 export const mockResource3: Resource = {
@@ -56,6 +58,7 @@ export const mockResource3: Resource = {
   name: 'management api',
   indicator: 'logto.dev/api',
   accessTokenTtl: 3600,
+  isDefault: false,
 };
 
 export const mockScope: Scope = {

--- a/packages/core/src/errors/SlonikError/index.ts
+++ b/packages/core/src/errors/SlonikError/index.ts
@@ -3,14 +3,8 @@ import type { OmitAutoSetFields, UpdateWhereData } from '@logto/shared';
 import { SlonikError } from 'slonik';
 
 export class DeletionError extends SlonikError {
-  table?: string;
-  id?: string;
-
-  public constructor(table?: string, id?: string) {
+  public constructor(public readonly table?: string, public readonly id?: string) {
     super('Resource not found.');
-
-    this.table = table;
-    this.id = id;
   }
 }
 
@@ -18,17 +12,11 @@ export class UpdateError<
   CreateSchema extends SchemaLike,
   Schema extends CreateSchema
 > extends SlonikError {
-  schema: GeneratedSchema<CreateSchema, Schema>;
-  detail: UpdateWhereData<Schema>;
-
   public constructor(
-    schema: GeneratedSchema<CreateSchema, Schema>,
-    detail: UpdateWhereData<Schema>
+    public readonly schema: GeneratedSchema<CreateSchema, Schema>,
+    public readonly detail: Partial<UpdateWhereData<Schema>>
   ) {
     super('Resource not found.');
-
-    this.schema = schema;
-    this.detail = detail;
   }
 }
 
@@ -36,16 +24,10 @@ export class InsertionError<
   CreateSchema extends SchemaLike,
   Schema extends CreateSchema
 > extends SlonikError {
-  schema: GeneratedSchema<CreateSchema, Schema>;
-  detail?: OmitAutoSetFields<CreateSchema>;
-
   public constructor(
-    schema: GeneratedSchema<CreateSchema, Schema>,
-    detail?: OmitAutoSetFields<CreateSchema>
+    public readonly schema: GeneratedSchema<CreateSchema, Schema>,
+    public readonly detail?: OmitAutoSetFields<CreateSchema>
   ) {
     super('Create Error.');
-
-    this.schema = schema;
-    this.detail = detail;
   }
 }

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -48,7 +48,7 @@ export default function initOidc(
     defaultRefreshTokenTtl,
   } = envSet.oidc;
   const {
-    resources: { findResourceByIndicator },
+    resources: { findResourceByIndicator, findDefaultResource },
     users: { findUserById },
   } = queries;
   const { findUserScopesForResourceIndicator } = libraries.users;
@@ -105,7 +105,10 @@ export default function initOidc(
       // https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#featuresresourceindicators
       resourceIndicators: {
         enabled: true,
-        defaultResource: () => '',
+        defaultResource: async () => {
+          const resource = await findDefaultResource();
+          return resource?.indicator ?? '';
+        },
         // Disable the auto use of authorization_code granted resource feature
         useGrantedResource: () => false,
         getResourceServerInfo: async (ctx, indicator) => {

--- a/packages/core/src/queries/resource.ts
+++ b/packages/core/src/queries/resource.ts
@@ -38,7 +38,7 @@ export const createResourceQueries = (pool: CommonQueryMethods) => {
       await connection.query(sql`
         update ${table}
           set ${fields.isDefault}=false
-          where ${fields.id}!=${id};
+          where ${fields.isDefault}=true;
       `);
       const returning = await connection.maybeOne<Resource>(sql`
         update ${table}

--- a/packages/core/src/routes/resource.test.ts
+++ b/packages/core/src/routes/resource.test.ts
@@ -101,6 +101,7 @@ describe('resource routes', () => {
       id: 'randomId',
       name,
       indicator,
+      isDefault: false,
       accessTokenTtl,
       scopes: [],
     });
@@ -157,7 +158,7 @@ describe('resource routes', () => {
     });
   });
 
-  it('PATCH /resources/:id should throw with invalid propreties', async () => {
+  it('PATCH /resources/:id should throw with invalid properties', async () => {
     const response = await resourceRequest.patch('/resources/foo').send({ name: 12 });
     expect(response.status).toEqual(400);
   });

--- a/packages/integration-tests/src/api/resource.ts
+++ b/packages/integration-tests/src/api/resource.ts
@@ -34,3 +34,8 @@ export const updateResource = async (
 
 export const deleteResource = async (resourceId: string) =>
   authedAdminApi.delete(`resources/${resourceId}`);
+
+export const setDefaultResource = async (resourceId: string, isDefault = true) =>
+  authedAdminApi
+    .patch(`resources/${resourceId}/is-default`, { json: { isDefault } })
+    .json<Resource>();

--- a/packages/integration-tests/src/tests/api/resource.test.ts
+++ b/packages/integration-tests/src/tests/api/resource.test.ts
@@ -7,6 +7,7 @@ import {
   getResources,
   updateResource,
   deleteResource,
+  setDefaultResource,
 } from '#src/api/index.js';
 import { createResponseWithCode } from '#src/helpers/admin-tenant.js';
 import { generateResourceIndicator, generateResourceName } from '#src/utils.js';
@@ -123,5 +124,23 @@ describe('admin console api resources', () => {
   it('should throw 404 when delete api resource not found', async () => {
     const response = await deleteResource('dummy_id').catch((error: unknown) => error);
     expect(response instanceof HTTPError && response.response.statusCode === 404).toBe(true);
+  });
+
+  it('be able to set only one default api resource', async () => {
+    const [resource1, resource2] = await Promise.all([
+      createResource(generateResourceName(), generateResourceIndicator()),
+      createResource(generateResourceName(), generateResourceIndicator()),
+    ]);
+
+    await setDefaultResource(resource1.id);
+    await setDefaultResource(resource2.id);
+
+    const resources = await getResources();
+    const defaultData = resources.filter(({ isDefault }) => isDefault);
+
+    expect(defaultData).toHaveLength(1);
+    expect(defaultData[0]?.id).toBe(resource2.id);
+
+    await Promise.all([deleteResource(resource1.id), deleteResource(resource2.id)]);
   });
 });

--- a/packages/phrases/src/locales/de/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/api-resources.ts
@@ -2,16 +2,16 @@ const api_resources = {
   page_title: 'API Ressourcen',
   title: 'API Ressourcen',
   subtitle: 'Lege APIs an, die du in deinen autorisierten Anwendungen verwenden kannst',
-  create: 'Erstelle API Ressource',
-  api_name: 'API Name',
-  api_name_placeholder: 'Gib einen API Namen ein',
-  api_identifier: 'API Identifikator',
+  create: 'API Ressource erstellen',
+  api_name: 'API-Name',
+  api_name_placeholder: 'Gib einen API-Namen ein',
+  api_identifier: 'API-Identifikator',
   api_identifier_tip:
-    'Der eindeutige Identifikator der API Ressource muss eine absolute URI ohne Fragmentbezeichner (#) sein. Entspricht dem <a>Ressourcen Parameter</a> in OAuth 2.0.',
-  default_api: 'Default API', // UNTRANSLATED
+    'Der eindeutige Identifikator der API-Ressource muss eine absolute URI ohne Fragmentbezeichner (#) sein. Entspricht dem <a>Ressourcenparameter</a> in OAuth 2.0.',
+  default_api: 'Standard-API',
   default_api_label:
-    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
-  api_resource_created: 'Die API Ressource {{name}} wurde erfolgreich angelegt',
+    'Pro Mandant kann nur eine Standard-API festgelegt werden. Wenn eine Standard-API festgelegt ist, kann der Ressourcenparameter in der Authentifizierungsanfrage weggelassen werden. Folgende Token-Austauschvorgänge verwenden standardmäßig die API als Publikum, was zur Ausgabe von JWTs führt.',
+  api_resource_created: 'Die API-Ressource {{name}} wurde erfolgreich erstellt',
   api_identifier_placeholder: 'https://dein-api-identifikator/',
 };
 

--- a/packages/phrases/src/locales/de/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/api-resources.ts
@@ -8,6 +8,9 @@ const api_resources = {
   api_identifier: 'API Identifikator',
   api_identifier_tip:
     'Der eindeutige Identifikator der API Ressource muss eine absolute URI ohne Fragmentbezeichner (#) sein. Entspricht dem <a>Ressourcen Parameter</a> in OAuth 2.0.',
+  default_api: 'Default API', // UNTRANSLATED
+  default_api_label:
+    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
   api_resource_created: 'Die API Ressource {{name}} wurde erfolgreich angelegt',
   api_identifier_placeholder: 'https://dein-api-identifikator/',
 };

--- a/packages/phrases/src/locales/de/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/api-resources.ts
@@ -5,14 +5,14 @@ const api_resources = {
   create: 'API Ressource erstellen',
   api_name: 'API-Name',
   api_name_placeholder: 'Gib einen API-Namen ein',
-  api_identifier: 'API-Identifikator',
+  api_identifier: 'API Identifier',
+  api_identifier_placeholder: 'https://your-api-identifier/',
   api_identifier_tip:
     'Der eindeutige Identifikator der API-Ressource muss eine absolute URI ohne Fragmentbezeichner (#) sein. Entspricht dem <a>Ressourcenparameter</a> in OAuth 2.0.',
   default_api: 'Standard-API',
   default_api_label:
     'Pro Mandant kann nur eine Standard-API festgelegt werden. Wenn eine Standard-API festgelegt ist, kann der Ressourcenparameter in der Authentifizierungsanfrage weggelassen werden. Folgende Token-Austauschvorgänge verwenden standardmäßig die API als Publikum, was zur Ausgabe von JWTs führt.',
   api_resource_created: 'Die API-Ressource {{name}} wurde erfolgreich erstellt',
-  api_identifier_placeholder: 'https://dein-api-identifikator/',
 };
 
 export default api_resources;

--- a/packages/phrases/src/locales/en/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/api-resources.ts
@@ -5,14 +5,14 @@ const api_resources = {
   create: 'Create API Resource',
   api_name: 'API name',
   api_name_placeholder: 'Enter your API name',
-  api_identifier: 'API identifier',
+  api_identifier: 'API Identifier',
+  api_identifier_placeholder: 'https://your-api-identifier/',
   api_identifier_tip:
     'The unique identifier to the API resource. It must be an absolute URI and has no fragment (#) component. Equals to the <a>resource parameter</a> in OAuth 2.0.',
   default_api: 'Default API',
   default_api_label:
     'Only zero or one default API can be set per tenant.\nWhen a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.',
   api_resource_created: 'The API resource {{name}} has been successfully created',
-  api_identifier_placeholder: 'https://your-api-identifier/',
 };
 
 export default api_resources;

--- a/packages/phrases/src/locales/en/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/api-resources.ts
@@ -10,7 +10,7 @@ const api_resources = {
     'The unique identifier to the API resource. It must be an absolute URI and has no fragment (#) component. Equals to the <a>resource parameter</a> in OAuth 2.0.',
   default_api: 'Default API',
   default_api_label:
-    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API.\nWhen a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.',
+    'Only zero or one default API can be set per tenant.\nWhen a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.',
   api_resource_created: 'The API resource {{name}} has been successfully created',
   api_identifier_placeholder: 'https://your-api-identifier/',
 };

--- a/packages/phrases/src/locales/en/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/api-resources.ts
@@ -8,6 +8,9 @@ const api_resources = {
   api_identifier: 'API identifier',
   api_identifier_tip:
     'The unique identifier to the API resource. It must be an absolute URI and has no fragment (#) component. Equals to the <a>resource parameter</a> in OAuth 2.0.',
+  default_api: 'Default API',
+  default_api_label:
+    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API.\nWhen a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.',
   api_resource_created: 'The API resource {{name}} has been successfully created',
   api_identifier_placeholder: 'https://your-api-identifier/',
 };

--- a/packages/phrases/src/locales/es/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/api-resources.ts
@@ -5,14 +5,14 @@ const api_resources = {
   create: 'Crear recurso de API',
   api_name: 'Nombre de la API',
   api_name_placeholder: 'Ingrese el nombre de su API',
-  api_identifier: 'Identificador de API',
+  api_identifier: 'API Identifier',
+  api_identifier_placeholder: 'https://your-api-identifier/',
   api_identifier_tip:
     'El identificador único para el recurso de API. Debe ser una URI absoluta y no tiene componente de fragmento (#). Es igual al <a>parámetro de recurso</a> en OAuth 2.0.',
   default_api: 'API por defecto',
   default_api_label:
     'Sólo se puede establecer cero o una API por defecto por inquilino. Cuando se designa una API por defecto, el parámetro de recurso se puede omitir en la solicitud de autenticación. Las posteriores intercambios de tokens utilizarán esa API como audiencia por defecto, lo que dará lugar a la emisión de JWTs.',
   api_resource_created: 'El recurso de API {{name}} se ha creado correctamente',
-  api_identifier_placeholder: 'https://su-identificador-de-api/',
 };
 
 export default api_resources;

--- a/packages/phrases/src/locales/es/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/api-resources.ts
@@ -8,6 +8,9 @@ const api_resources = {
   api_identifier: 'Identificador de API',
   api_identifier_tip:
     'El identificador único para el recurso de API. Debe ser una URI absoluta y no tiene componente de fragmento (#). Es igual al <a>parámetro de recurso</a> en OAuth 2.0.',
+  default_api: 'Default API', // UNTRANSLATED
+  default_api_label:
+    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
   api_resource_created: 'El recurso de API {{name}} se ha creado correctamente',
   api_identifier_placeholder: 'https://su-identificador-de-api/',
 };

--- a/packages/phrases/src/locales/es/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/api-resources.ts
@@ -8,9 +8,9 @@ const api_resources = {
   api_identifier: 'Identificador de API',
   api_identifier_tip:
     'El identificador único para el recurso de API. Debe ser una URI absoluta y no tiene componente de fragmento (#). Es igual al <a>parámetro de recurso</a> en OAuth 2.0.',
-  default_api: 'Default API', // UNTRANSLATED
+  default_api: 'API por defecto',
   default_api_label:
-    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
+    'Sólo se puede establecer cero o una API por defecto por inquilino. Cuando se designa una API por defecto, el parámetro de recurso se puede omitir en la solicitud de autenticación. Las posteriores intercambios de tokens utilizarán esa API como audiencia por defecto, lo que dará lugar a la emisión de JWTs.',
   api_resource_created: 'El recurso de API {{name}} se ha creado correctamente',
   api_identifier_placeholder: 'https://su-identificador-de-api/',
 };

--- a/packages/phrases/src/locales/fr/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/api-resources.ts
@@ -5,14 +5,14 @@ const api_resources = {
   create: 'Créer une ressource API',
   api_name: "Nom de l'API",
   api_name_placeholder: "Entrez votre nom d'API",
-  api_identifier: 'Identifiant API',
+  api_identifier: 'API Identifier',
+  api_identifier_placeholder: 'https://your-api-identifier/',
   api_identifier_tip:
     "L'identifiant unique de la ressource API. Il doit s'agir d'un URI absolu et ne doit pas comporter de fragment (#). Équivaut au <a>paramètre de ressource</> dans OAuth 2.0.",
   default_api: 'API par défaut',
   default_api_label:
     'Seulement zéro ou une API par défaut peut être définie par tenant. Lorsqu\'une API par défaut est désignée, le paramètre "resource" peut être omis dans la demande d\'authentification. Les échanges de jetons ultérieurs utiliseront cette API comme public cible par défaut, ce qui entraînera la délivrance de JWT.',
   api_resource_created: 'La ressource API {{name}} a été créée avec succès.',
-  api_identifier_placeholder: 'https://votre-identifiant-api/',
 };
 
 export default api_resources;

--- a/packages/phrases/src/locales/fr/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/api-resources.ts
@@ -8,9 +8,9 @@ const api_resources = {
   api_identifier: 'Identifiant API',
   api_identifier_tip:
     "L'identifiant unique de la ressource API. Il doit s'agir d'un URI absolu et ne doit pas comporter de fragment (#). Équivaut au <a>paramètre de ressource</> dans OAuth 2.0.",
-  default_api: 'Default API', // UNTRANSLATED
+  default_api: 'API par défaut',
   default_api_label:
-    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
+    'Seulement zéro ou une API par défaut peut être définie par tenant. Lorsqu\'une API par défaut est désignée, le paramètre "resource" peut être omis dans la demande d\'authentification. Les échanges de jetons ultérieurs utiliseront cette API comme public cible par défaut, ce qui entraînera la délivrance de JWT.',
   api_resource_created: 'La ressource API {{name}} a été créée avec succès.',
   api_identifier_placeholder: 'https://votre-identifiant-api/',
 };

--- a/packages/phrases/src/locales/fr/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/api-resources.ts
@@ -8,6 +8,9 @@ const api_resources = {
   api_identifier: 'Identifiant API',
   api_identifier_tip:
     "L'identifiant unique de la ressource API. Il doit s'agir d'un URI absolu et ne doit pas comporter de fragment (#). Équivaut au <a>paramètre de ressource</> dans OAuth 2.0.",
+  default_api: 'Default API', // UNTRANSLATED
+  default_api_label:
+    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
   api_resource_created: 'La ressource API {{name}} a été créée avec succès.',
   api_identifier_placeholder: 'https://votre-identifiant-api/',
 };

--- a/packages/phrases/src/locales/it/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/api-resources.ts
@@ -8,9 +8,9 @@ const api_resources = {
   api_identifier: 'Identificatore API',
   api_identifier_tip:
     "L'identificatore univoco della risorsa API. Deve essere un URI assoluto e non ha componenti di frammento (#). Corrisponde al parametro <a>risorsa</a> in OAuth 2.0.",
-  default_api: 'Default API', // UNTRANSLATED
+  default_api: 'API predefinita',
   default_api_label:
-    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
+    'Solo zero o una API predefinita possono essere impostate per tenant. Quando viene designata una API predefinita, il parametro di risorsa può essere omesso nella richiesta di autorizzazione. Gli scambi di token successivi utilizzeranno quell API come destinatario per impostazione predefinita, con conseguente rilascio di JWT.',
   api_resource_created: 'La risorsa API {{name}} è stata creata con successo',
   api_identifier_placeholder: 'https://tuo-identificatore-api/',
 };

--- a/packages/phrases/src/locales/it/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/api-resources.ts
@@ -5,14 +5,14 @@ const api_resources = {
   create: 'Crea risorsa API',
   api_name: 'Nome API',
   api_name_placeholder: "Inserisci il nome dell'API",
-  api_identifier: 'Identificatore API',
+  api_identifier: 'API Identifier',
+  api_identifier_placeholder: 'https://your-api-identifier/',
   api_identifier_tip:
     "L'identificatore univoco della risorsa API. Deve essere un URI assoluto e non ha componenti di frammento (#). Corrisponde al parametro <a>risorsa</a> in OAuth 2.0.",
   default_api: 'API predefinita',
   default_api_label:
     'Solo zero o una API predefinita possono essere impostate per tenant. Quando viene designata una API predefinita, il parametro di risorsa può essere omesso nella richiesta di autorizzazione. Gli scambi di token successivi utilizzeranno quell API come destinatario per impostazione predefinita, con conseguente rilascio di JWT.',
   api_resource_created: 'La risorsa API {{name}} è stata creata con successo',
-  api_identifier_placeholder: 'https://tuo-identificatore-api/',
 };
 
 export default api_resources;

--- a/packages/phrases/src/locales/it/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/api-resources.ts
@@ -8,6 +8,9 @@ const api_resources = {
   api_identifier: 'Identificatore API',
   api_identifier_tip:
     "L'identificatore univoco della risorsa API. Deve essere un URI assoluto e non ha componenti di frammento (#). Corrisponde al parametro <a>risorsa</a> in OAuth 2.0.",
+  default_api: 'Default API', // UNTRANSLATED
+  default_api_label:
+    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
   api_resource_created: 'La risorsa API {{name}} è stata creata con successo',
   api_identifier_placeholder: 'https://tuo-identificatore-api/',
 };

--- a/packages/phrases/src/locales/ja/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/api-resources.ts
@@ -8,6 +8,9 @@ const api_resources = {
   api_identifier: 'API 識別子',
   api_identifier_tip:
     'API リソースの一意の識別子です。絶対URIで、フラグメント(#)コンポーネントはありません。OAuth 2.0での<a>resource parameter</a>に等しいです。',
+  default_api: 'Default API', // UNTRANSLATED
+  default_api_label:
+    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
   api_resource_created: 'APIリソース{{name}}が正常に作成されました',
   api_identifier_placeholder: 'https://your-api-identifier/',
 };

--- a/packages/phrases/src/locales/ja/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/api-resources.ts
@@ -5,14 +5,14 @@ const api_resources = {
   create: 'API リソースを作成',
   api_name: 'API 名',
   api_name_placeholder: 'API 名を入力してください',
-  api_identifier: 'API 識別子',
+  api_identifier: 'API Identifier',
+  api_identifier_placeholder: 'https://your-api-identifier/',
   api_identifier_tip:
     'API リソースの一意の識別子です。絶対URIで、フラグメント(#)コンポーネントはありません。OAuth 2.0での<a>resource parameter</a>に等しいです。',
   default_api: 'デフォルトのAPI',
   default_api_label:
     'テナントごとにデフォルトのAPIを0または1つだけ設定できます。デフォルトのAPIが指定されている場合、認証リクエストでリソースパラメータを省略できます。その後のトークン交換は、デフォルトのAPIを対象として行われます。それにより、JWTが発行されます。',
   api_resource_created: 'APIリソース{{name}}が正常に作成されました',
-  api_identifier_placeholder: 'https://your-api-identifier/',
 };
 
 export default api_resources;

--- a/packages/phrases/src/locales/ja/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/api-resources.ts
@@ -8,9 +8,9 @@ const api_resources = {
   api_identifier: 'API 識別子',
   api_identifier_tip:
     'API リソースの一意の識別子です。絶対URIで、フラグメント(#)コンポーネントはありません。OAuth 2.0での<a>resource parameter</a>に等しいです。',
-  default_api: 'Default API', // UNTRANSLATED
+  default_api: 'デフォルトのAPI',
   default_api_label:
-    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
+    'テナントごとにデフォルトのAPIを0または1つだけ設定できます。デフォルトのAPIが指定されている場合、認証リクエストでリソースパラメータを省略できます。その後のトークン交換は、デフォルトのAPIを対象として行われます。それにより、JWTが発行されます。',
   api_resource_created: 'APIリソース{{name}}が正常に作成されました',
   api_identifier_placeholder: 'https://your-api-identifier/',
 };

--- a/packages/phrases/src/locales/ko/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/api-resources.ts
@@ -8,9 +8,9 @@ const api_resources = {
   api_identifier: 'API 식별자',
   api_identifier_tip:
     'API 리소스에 대한 고유한 식별자예요. 절대 URI여야 하며 조각 (#) 컴포넌트가 없어야 해요. OAuth 2.0의 <a>resource parameter</a>와 같아요.',
-  default_api: 'Default API', // UNTRANSLATED
+  default_api: 'Default API',
   default_api_label:
-    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
+    '테넌트 당 기본 API는 0개 또는 1개만 지정 할 수 있어요. 기본 API가 지정되면 인증 요청에서 리소스 매개 변수를 생략할 수 있어요. 이후 토큰 교환이 기본적으로 대상에 해당하는 API를 사용하여 수행되어 JWT가 발급되어요.',
   api_resource_created: '{{name}} API 리소스가 성공적으로 생성되었어요.',
   api_identifier_placeholder: 'https://your-api-identifier/',
 };

--- a/packages/phrases/src/locales/ko/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/api-resources.ts
@@ -5,14 +5,14 @@ const api_resources = {
   create: 'API 리소스 생성',
   api_name: 'API 이름',
   api_name_placeholder: 'API 이름 입력',
-  api_identifier: 'API 식별자',
+  api_identifier: 'API Identifier',
+  api_identifier_placeholder: 'https://your-api-identifier/',
   api_identifier_tip:
     'API 리소스에 대한 고유한 식별자예요. 절대 URI여야 하며 조각 (#) 컴포넌트가 없어야 해요. OAuth 2.0의 <a>resource parameter</a>와 같아요.',
   default_api: 'Default API',
   default_api_label:
     '테넌트 당 기본 API는 0개 또는 1개만 지정 할 수 있어요. 기본 API가 지정되면 인증 요청에서 리소스 매개 변수를 생략할 수 있어요. 이후 토큰 교환이 기본적으로 대상에 해당하는 API를 사용하여 수행되어 JWT가 발급되어요.',
   api_resource_created: '{{name}} API 리소스가 성공적으로 생성되었어요.',
-  api_identifier_placeholder: 'https://your-api-identifier/',
 };
 
 export default api_resources;

--- a/packages/phrases/src/locales/ko/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/api-resources.ts
@@ -8,6 +8,9 @@ const api_resources = {
   api_identifier: 'API 식별자',
   api_identifier_tip:
     'API 리소스에 대한 고유한 식별자예요. 절대 URI여야 하며 조각 (#) 컴포넌트가 없어야 해요. OAuth 2.0의 <a>resource parameter</a>와 같아요.',
+  default_api: 'Default API', // UNTRANSLATED
+  default_api_label:
+    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
   api_resource_created: '{{name}} API 리소스가 성공적으로 생성되었어요.',
   api_identifier_placeholder: 'https://your-api-identifier/',
 };

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/api-resources.ts
@@ -8,6 +8,9 @@ const api_resources = {
   api_identifier: 'Identyfikator API',
   api_identifier_tip:
     'Unikalny identyfikator zasobu API. Musi to być bezwzględny adres URI bez składnika fragmentu (#). Jest równy <a>parametrowi zasobu</a> w standardzie OAuth 2.0.',
+  default_api: 'Default API', // UNTRANSLATED
+  default_api_label:
+    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
   api_resource_created: 'Zasób API {{name}} został pomyślnie utworzony',
   api_identifier_placeholder: 'https://identyfikator-twojego-api/',
 };

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/api-resources.ts
@@ -8,9 +8,9 @@ const api_resources = {
   api_identifier: 'Identyfikator API',
   api_identifier_tip:
     'Unikalny identyfikator zasobu API. Musi to być bezwzględny adres URI bez składnika fragmentu (#). Jest równy <a>parametrowi zasobu</a> w standardzie OAuth 2.0.',
-  default_api: 'Default API', // UNTRANSLATED
+  default_api: 'Domyślne API',
   default_api_label:
-    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
+    'Tylko jedno API domyślne może być ustawione na jeden najem. Kiedy określone zostanie API domyślne, parametr zasobu może zostać pominięty w żądaniu autoryzacji. Następujące procesy wymiany tokenu będą domyślnie korzystać z tego API, co umożliwi wydanie JWT.',
   api_resource_created: 'Zasób API {{name}} został pomyślnie utworzony',
   api_identifier_placeholder: 'https://identyfikator-twojego-api/',
 };

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/api-resources.ts
@@ -5,14 +5,14 @@ const api_resources = {
   create: 'Utwórz zasób API',
   api_name: 'Nazwa API',
   api_name_placeholder: 'Wprowadź nazwę swojego API',
-  api_identifier: 'Identyfikator API',
+  api_identifier: 'API Identifier',
+  api_identifier_placeholder: 'https://your-api-identifier/',
   api_identifier_tip:
     'Unikalny identyfikator zasobu API. Musi to być bezwzględny adres URI bez składnika fragmentu (#). Jest równy <a>parametrowi zasobu</a> w standardzie OAuth 2.0.',
   default_api: 'Domyślne API',
   default_api_label:
     'Tylko jedno API domyślne może być ustawione na jeden najem. Kiedy określone zostanie API domyślne, parametr zasobu może zostać pominięty w żądaniu autoryzacji. Następujące procesy wymiany tokenu będą domyślnie korzystać z tego API, co umożliwi wydanie JWT.',
   api_resource_created: 'Zasób API {{name}} został pomyślnie utworzony',
-  api_identifier_placeholder: 'https://identyfikator-twojego-api/',
 };
 
 export default api_resources;

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/api-resources.ts
@@ -5,14 +5,14 @@ const api_resources = {
   create: 'Criar recurso de API',
   api_name: 'Nome da API',
   api_name_placeholder: 'Digite o nome da sua API',
-  api_identifier: 'Identificador de API',
+  api_identifier: 'API Identifier',
+  api_identifier_placeholder: 'https://your-api-identifier/',
   api_identifier_tip:
     'O identificador exclusivo para o recurso da API. Deve ser um URI absoluto e não tem nenhum componente de fragmento (#). Igual ao <a>parâmetro de recurso</a> em OAuth 2.0.',
   default_api: 'API padrão',
   default_api_label:
     'Apenas uma API padrão pode ser definida por locatário. Quando uma API padrão é definida, o parâmetro de recurso pode ser omitido na solicitação de autenticação. As trocas de token subsequentes usarão essa API como audiência por padrão, resultando na emissão de JWTs.',
   api_resource_created: 'O recurso API {{name}} foi criado com sucesso',
-  api_identifier_placeholder: 'https://seu-identificador-de-api/',
 };
 
 export default api_resources;

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/api-resources.ts
@@ -8,11 +8,11 @@ const api_resources = {
   api_identifier: 'Identificador de API',
   api_identifier_tip:
     'O identificador exclusivo para o recurso da API. Deve ser um URI absoluto e não tem nenhum componente de fragmento (#). Igual ao <a>parâmetro de recurso</a> em OAuth 2.0.',
-  default_api: 'Default API', // UNTRANSLATED
+  default_api: 'API padrão',
   default_api_label:
-    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
+    'Apenas uma API padrão pode ser definida por locatário. Quando uma API padrão é definida, o parâmetro de recurso pode ser omitido na solicitação de autenticação. As trocas de token subsequentes usarão essa API como audiência por padrão, resultando na emissão de JWTs.',
   api_resource_created: 'O recurso API {{name}} foi criado com sucesso',
-  api_identifier_placeholder: 'https://your-api-identifier/',
+  api_identifier_placeholder: 'https://seu-identificador-de-api/',
 };
 
 export default api_resources;

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/api-resources.ts
@@ -8,6 +8,9 @@ const api_resources = {
   api_identifier: 'Identificador de API',
   api_identifier_tip:
     'O identificador exclusivo para o recurso da API. Deve ser um URI absoluto e não tem nenhum componente de fragmento (#). Igual ao <a>parâmetro de recurso</a> em OAuth 2.0.',
+  default_api: 'Default API', // UNTRANSLATED
+  default_api_label:
+    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
   api_resource_created: 'O recurso API {{name}} foi criado com sucesso',
   api_identifier_placeholder: 'https://your-api-identifier/',
 };

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/api-resources.ts
@@ -5,14 +5,14 @@ const api_resources = {
   create: 'Criar recurso de API',
   api_name: 'Nome da API',
   api_name_placeholder: 'Insira o nome da sua API',
-  api_identifier: 'Identificador da API',
+  api_identifier: 'API Identifier',
+  api_identifier_placeholder: 'https://your-api-identifier/',
   api_identifier_tip:
     'O identificador exclusivo para o recurso de API. Deve ser um URI absoluto e não ter um componente de fragmento (#). Igual ao <a>parâmetro resource</a> no OAuth 2.0.',
   default_api: 'API padrão',
   default_api_label:
     'Somente uma API padrão pode ser definida por inquilino. Quando uma API padrão é definida, o parâmetro de recurso pode ser omitido na solicitação de autorização. Subsequentes trocas de token usarão essa API como audiência por padrão, resultando na emissão de JWTs.',
   api_resource_created: 'O recurso de API {{name}} foi criado com sucesso',
-  api_identifier_placeholder: 'https://seu-identificador-de-api/',
 };
 
 export default api_resources;

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/api-resources.ts
@@ -1,18 +1,18 @@
 const api_resources = {
-  page_title: 'Recursos API',
-  title: 'Recursos API',
-  subtitle: 'Defina APIs que pode consumir nos aplicações autorizadas',
-  create: 'Criar recurso API',
+  page_title: 'Recursos de API',
+  title: 'Recursos de API',
+  subtitle: 'Defina as APIs que podem ser consumidas ​​pelas aplicações autorizadas',
+  create: 'Criar recurso de API',
   api_name: 'Nome da API',
-  api_name_placeholder: 'Introduza o nome da sua API',
-  api_identifier: 'identificador da API',
+  api_name_placeholder: 'Insira o nome da sua API',
+  api_identifier: 'Identificador da API',
   api_identifier_tip:
-    'O identificador exclusivo para o recurso API. Deve ser um URI absoluto e não tem componente de fragmento (#). Igual ao <a>resource parameter</a> no OAuth 2.0.',
-  default_api: 'Default API', // UNTRANSLATED
+    'O identificador exclusivo para o recurso de API. Deve ser um URI absoluto e não ter um componente de fragmento (#). Igual ao <a>parâmetro resource</a> no OAuth 2.0.',
+  default_api: 'API padrão',
   default_api_label:
-    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
-  api_resource_created: 'O recurso API {{name}} foi criado com sucesso',
-  api_identifier_placeholder: 'https://your-api-identifier/',
+    'Somente uma API padrão pode ser definida por inquilino. Quando uma API padrão é definida, o parâmetro de recurso pode ser omitido na solicitação de autorização. Subsequentes trocas de token usarão essa API como audiência por padrão, resultando na emissão de JWTs.',
+  api_resource_created: 'O recurso de API {{name}} foi criado com sucesso',
+  api_identifier_placeholder: 'https://seu-identificador-de-api/',
 };
 
 export default api_resources;

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/api-resources.ts
@@ -8,6 +8,9 @@ const api_resources = {
   api_identifier: 'identificador da API',
   api_identifier_tip:
     'O identificador exclusivo para o recurso API. Deve ser um URI absoluto e não tem componente de fragmento (#). Igual ao <a>resource parameter</a> no OAuth 2.0.',
+  default_api: 'Default API', // UNTRANSLATED
+  default_api_label:
+    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
   api_resource_created: 'O recurso API {{name}} foi criado com sucesso',
   api_identifier_placeholder: 'https://your-api-identifier/',
 };

--- a/packages/phrases/src/locales/ru/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/api-resources.ts
@@ -5,14 +5,14 @@ const api_resources = {
   create: 'Создать ресурс API',
   api_name: 'Название API',
   api_name_placeholder: 'Введите название вашего API',
-  api_identifier: 'Идентификатор API',
+  api_identifier: 'API Identifier',
+  api_identifier_placeholder: 'https://your-api-identifier/',
   api_identifier_tip:
     'Уникальный идентификатор для ресурса API. Он должен быть абсолютным URI и не иметь фрагмента (#). Равен параметру <a>resource</a> в OAuth 2.0.',
   default_api: 'API по умолчанию',
   default_api_label:
     'В каждом арендаторе может быть только один API по умолчанию. Когда устанавливается API по умолчанию, можно опустить параметр <a>resource</a> в запросе на аутентификацию. Последующие запросы на обмен токенами будут использовать указанное API в качестве аудитории по умолчанию, что приведет к выдаче JWT.',
   api_resource_created: 'Ресурс API {{name}} был успешно создан',
-  api_identifier_placeholder: 'https://your-api-identifier/',
 };
 
 export default api_resources;

--- a/packages/phrases/src/locales/ru/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/api-resources.ts
@@ -8,9 +8,9 @@ const api_resources = {
   api_identifier: 'Идентификатор API',
   api_identifier_tip:
     'Уникальный идентификатор для ресурса API. Он должен быть абсолютным URI и не иметь фрагмента (#). Равен параметру <a>resource</a> в OAuth 2.0.',
-  default_api: 'Default API', // UNTRANSLATED
+  default_api: 'API по умолчанию',
   default_api_label:
-    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
+    'В каждом арендаторе может быть только один API по умолчанию. Когда устанавливается API по умолчанию, можно опустить параметр <a>resource</a> в запросе на аутентификацию. Последующие запросы на обмен токенами будут использовать указанное API в качестве аудитории по умолчанию, что приведет к выдаче JWT.',
   api_resource_created: 'Ресурс API {{name}} был успешно создан',
   api_identifier_placeholder: 'https://your-api-identifier/',
 };

--- a/packages/phrases/src/locales/ru/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/api-resources.ts
@@ -8,6 +8,9 @@ const api_resources = {
   api_identifier: 'Идентификатор API',
   api_identifier_tip:
     'Уникальный идентификатор для ресурса API. Он должен быть абсолютным URI и не иметь фрагмента (#). Равен параметру <a>resource</a> в OAuth 2.0.',
+  default_api: 'Default API', // UNTRANSLATED
+  default_api_label:
+    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
   api_resource_created: 'Ресурс API {{name}} был успешно создан',
   api_identifier_placeholder: 'https://your-api-identifier/',
 };

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/api-resources.ts
@@ -8,6 +8,9 @@ const api_resources = {
   api_identifier: 'API belirteci',
   api_identifier_tip:
     'Api kaynağına özgün belirteç. Mutlak URI olmalı ve parça bileşeni (#) içermemeli. OAuth 2.0deki <a>kaynak parametresine</a> eşittir.',
+  default_api: 'Default API', // UNTRANSLATED
+  default_api_label:
+    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
   api_resource_created: '{{name}} API kaynağı başarıyla oluşturuldu',
   api_identifier_placeholder: 'https://your-api-identifier/',
 };

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/api-resources.ts
@@ -1,16 +1,16 @@
 const api_resources = {
   page_title: 'API Kaynakları',
   title: 'API Kaynakları',
-  subtitle: 'Yetkili uygulamalarınızdan kullanabileceğiniz APIleri tanımlayınız',
+  subtitle: "Yetkili uygulamalarınızdan kullanabileceğiniz API'leri tanımlayınız",
   create: 'API Kaynağı oluştur',
   api_name: 'API Adı',
   api_name_placeholder: 'API adını giriniz',
   api_identifier: 'API belirteci',
   api_identifier_tip:
     'Api kaynağına özgün belirteç. Mutlak URI olmalı ve parça bileşeni (#) içermemeli. OAuth 2.0deki <a>kaynak parametresine</a> eşittir.',
-  default_api: 'Default API', // UNTRANSLATED
+  default_api: 'Varsayılan API',
   default_api_label:
-    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
+    'Mandant başına sadece sıfır veya bir varsayılan API ayarlanabilir. Varsayılan bir API belirlendiğinde, auth isteğindeki kaynak parametresi çıkarılabilir. Sonraki token değişimlerinde varsayılan olarak bu API hedef alınarak JWTler oluşturulur.',
   api_resource_created: '{{name}} API kaynağı başarıyla oluşturuldu',
   api_identifier_placeholder: 'https://your-api-identifier/',
 };

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/api-resources.ts
@@ -5,14 +5,14 @@ const api_resources = {
   create: 'API Kaynağı oluştur',
   api_name: 'API Adı',
   api_name_placeholder: 'API adını giriniz',
-  api_identifier: 'API belirteci',
+  api_identifier: 'API Identifier',
+  api_identifier_placeholder: 'https://your-api-identifier/',
   api_identifier_tip:
     'Api kaynağına özgün belirteç. Mutlak URI olmalı ve parça bileşeni (#) içermemeli. OAuth 2.0deki <a>kaynak parametresine</a> eşittir.',
   default_api: 'Varsayılan API',
   default_api_label:
     'Mandant başına sadece sıfır veya bir varsayılan API ayarlanabilir. Varsayılan bir API belirlendiğinde, auth isteğindeki kaynak parametresi çıkarılabilir. Sonraki token değişimlerinde varsayılan olarak bu API hedef alınarak JWTler oluşturulur.',
   api_resource_created: '{{name}} API kaynağı başarıyla oluşturuldu',
-  api_identifier_placeholder: 'https://your-api-identifier/',
 };
 
 export default api_resources;

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/api-resources.ts
@@ -10,6 +10,9 @@ const api_resources = {
   api_identifier_tip:
     '对于 API 资源的唯一标识符。它必须是一个绝对 URI 并没有 fragment (#) 组件。等价于 OAuth 2.0 中的 <a>resource parameter</a>。',
   api_resource_created: ' API 资源 {{name}} 已成功创建。',
+  default_api: 'Default API', // UNTRANSLATED
+  default_api_label:
+    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
 };
 
 export default api_resources;

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/api-resources.ts
@@ -5,14 +5,14 @@ const api_resources = {
   create: '创建 API 资源',
   api_name: 'API 名称',
   api_name_placeholder: '输入API名称',
-  api_identifier: 'API Identifier',
+  api_identifier: 'API 标识符',
   api_identifier_placeholder: 'https://your-api-identifier/',
   api_identifier_tip:
     '对于 API 资源的唯一标识符。它必须是一个绝对 URI 并没有 fragment (#) 组件。等价于 OAuth 2.0 中的 <a>resource parameter</a>。',
   api_resource_created: ' API 资源 {{name}} 已成功创建。',
-  default_api: 'Default API', // UNTRANSLATED
+  default_api: '默认API',
   default_api_label:
-    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
+    '每个租户只能设置零个或一个默认API。当指定默认API时，可以在认证请求中省略资源参数。后续令牌交换将默认使用该API作为受众，导致JWT的签发。',
 };
 
 export default api_resources;

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/api-resources.ts
@@ -5,14 +5,14 @@ const api_resources = {
   create: '创建 API 资源',
   api_name: 'API 名称',
   api_name_placeholder: '输入API名称',
-  api_identifier: 'API 标识符',
+  api_identifier: 'API Identifier',
   api_identifier_placeholder: 'https://your-api-identifier/',
   api_identifier_tip:
     '对于 API 资源的唯一标识符。它必须是一个绝对 URI 并没有 fragment (#) 组件。等价于 OAuth 2.0 中的 <a>resource parameter</a>。',
   api_resource_created: ' API 资源 {{name}} 已成功创建。',
   default_api: '默认API',
   default_api_label:
-    '每个租户只能设置零个或一个默认API。当指定默认API时，可以在认证请求中省略资源参数。后续令牌交换将默认使用该API作为受众，导致JWT的签发。',
+    '每个租户只能设置零个或一个默认 API。当指定默认 API 时，可以在认证请求中省略资源参数。后续令牌交换将默认使用该 API 作为 Audience，导致 JWT 的签发。',
 };
 
 export default api_resources;

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/api-resources.ts
@@ -5,14 +5,14 @@ const api_resources = {
   create: '創建 API 資源',
   api_name: 'API 名稱',
   api_name_placeholder: '輸入 API 名稱',
-  api_identifier: 'API Identifier',
+  api_identifier: 'API 描述符',
   api_identifier_placeholder: 'https://your-api-identifier/',
   api_identifier_tip:
     '對於 API 資源的唯一標識符。它必須是一個絕對 URI 並沒有 fragment (#) 組件。等價於 OAuth 2.0 中的 <a>resource parameter</a>。',
   api_resource_created: ' API 資源 {{name}} 已成功創建。',
-  default_api: 'Default API', // UNTRANSLATED
+  default_api: '預設的 API',
   default_api_label:
-    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
+    '一个租户只能设置零或一个默认 API。当指定默认 API 时，可以在身份验证请求中省略资源参数，还可以使用该 API 作为默认受众方进行令牌交换，从而发放 JWT。',
 };
 
 export default api_resources;

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/api-resources.ts
@@ -10,6 +10,9 @@ const api_resources = {
   api_identifier_tip:
     '對於 API 資源的唯一標識符。它必須是一個絕對 URI 並沒有 fragment (#) 組件。等價於 OAuth 2.0 中的 <a>resource parameter</a>。',
   api_resource_created: ' API 資源 {{name}} 已成功創建。',
+  default_api: 'Default API', // UNTRANSLATED
+  default_api_label:
+    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
 };
 
 export default api_resources;

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/api-resources.ts
@@ -5,14 +5,14 @@ const api_resources = {
   create: '創建 API 資源',
   api_name: 'API 名稱',
   api_name_placeholder: '輸入API名稱',
-  api_identifier: 'API 辨識碼',
-  api_identifier_placeholder: 'https://你的-api-辨識碼/',
+  api_identifier: 'API Identifier',
+  api_identifier_placeholder: 'https://your-api-identifier/',
   api_identifier_tip:
     '對於 API 資源的唯一標識符。它必須是一個絕對 URI，並沒有 fragment (#) 組件。等價於 OAuth 2.0 中的 <a>resource parameter</a>。',
   api_resource_created: ' API 資源 {{name}} 已成功創建。',
   default_api: '預設 API',
   default_api_label:
-    '一個租戶只能設定零個或一個預設 API。當指定了預設 API 後，可以在授權請求中省略資源參數。隨後的令牌交換將使用該 API 作為默認的受眾端，從而產生 JWT。',
+    '一個租戶只能設定零個或一個預設 API。當指定了預設 API 後，可以在授權請求中省略 `resource` 參數。隨後的令牌交換將使用該 API 作為默認的 Audience，從而產生 JWT。',
 };
 
 export default api_resources;

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/api-resources.ts
@@ -10,6 +10,9 @@ const api_resources = {
   api_identifier_tip:
     '對於 API 資源的唯一標識符。它必須是一個絕對 URI，並沒有 fragment (#) 組件。等價於 OAuth 2.0 中的 <a>resource parameter</a>。',
   api_resource_created: ' API 資源 {{name}} 已成功創建。',
+  default_api: 'Default API', // UNTRANSLATED
+  default_api_label:
+    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
 };
 
 export default api_resources;

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/api-resources.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/api-resources.ts
@@ -5,14 +5,14 @@ const api_resources = {
   create: '創建 API 資源',
   api_name: 'API 名稱',
   api_name_placeholder: '輸入API名稱',
-  api_identifier: 'API Identifier',
-  api_identifier_placeholder: 'https://your-api-identifier/',
+  api_identifier: 'API 辨識碼',
+  api_identifier_placeholder: 'https://你的-api-辨識碼/',
   api_identifier_tip:
     '對於 API 資源的唯一標識符。它必須是一個絕對 URI，並沒有 fragment (#) 組件。等價於 OAuth 2.0 中的 <a>resource parameter</a>。',
   api_resource_created: ' API 資源 {{name}} 已成功創建。',
-  default_api: 'Default API', // UNTRANSLATED
+  default_api: '預設 API',
   default_api_label:
-    'If the current API Resource is set as the default API for the tenant, while each tenant can have either 0 or 1 default API. When a default API is designated, the resource parameter can be omitted in the auth request. Subsequent token exchanges will use that API as the audience by default, resulting in the issuance of JWTs.', // UNTRANSLATED
+    '一個租戶只能設定零個或一個預設 API。當指定了預設 API 後，可以在授權請求中省略資源參數。隨後的令牌交換將使用該 API 作為默認的受眾端，從而產生 JWT。',
 };
 
 export default api_resources;

--- a/packages/schemas/alterations/next-1685285719-support-default-resource.ts
+++ b/packages/schemas/alterations/next-1685285719-support-default-resource.ts
@@ -1,0 +1,23 @@
+import { sql } from 'slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      alter table resources
+        add column is_default boolean not null default (false);
+      create unique index resources__is_default_true
+        on resources (tenant_id)
+        where is_default = true;
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      alter table resources
+        drop is_default; 
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/resources.sql
+++ b/packages/schemas/tables/resources.sql
@@ -6,6 +6,7 @@ create table resources (
   id varchar(21) not null,
   name text not null,
   indicator text not null, /* resource indicator also used as audience */
+  is_default boolean not null default (false),
   access_token_ttl bigint not null default(3600), /* expiration value in seconds, default is 1h */
   primary key (id),
   constraint resources__indicator
@@ -14,3 +15,7 @@ create table resources (
 
 create index resources__id
   on resources (tenant_id, id);
+
+create unique index resources__is_default_true
+  on resources (tenant_id)
+  where is_default = true;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
implement "default resource" toggle to integrate authorization (RBAC) with third-party apps without requiring Resource Indicators to be implemented.

default resource is tenant-level unique. setting a resource to default will unset all other resources.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

<img width="638" alt="image" src="https://github.com/logto-io/logto/assets/14722250/8f3cf663-857c-48cc-b27a-f577700132e0">

<img width="542" alt="image" src="https://github.com/logto-io/logto/assets/14722250/3dc93373-eb0c-4b9e-aecd-4a54c7257013">

- tested locally, when the default resource is designated, the grant behavior will be what described in the oidc-provider documentation
- tested with our community member kAd. worked as expected: ChatGPT plugin OAuth will use the default resource and Logto will issue proper scopes.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] Unit tests
- [x] Integration tests
- [x] Docs (https://github.com/logto-io/docs/pull/449)