### PR TITLE
refactor(core): loosen request body checks on admin user apis

### DIFF
--- a/packages/core/src/routes/admin-user.test.ts
+++ b/packages/core/src/routes/admin-user.test.ts
@@ -121,10 +121,16 @@ describe('adminUserRoutes', () => {
   it('POST /users should throw with invalid input params', async () => {
     const username = 'MJAtLogto';
     const name = 'Michael';
+    const invalidEmail = 'invalid-email';
+    const invalidPhone = 'invalid-phone';
 
     // Invalid input format
     await expect(
-      userRequest.post('/users').send({ username, password: 'abc', name })
+      userRequest.post('/users').send({ username, primaryEmail: invalidEmail, name })
+    ).resolves.toHaveProperty('status', 400);
+
+    await expect(
+      userRequest.post('/users').send({ username, primaryPhone: invalidPhone, name })
     ).resolves.toHaveProperty('status', 400);
   });
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Loosen request body checks on the `PATCH /users/:userId` and `POST /users` APIs, and enforce the regex checks on client sides of admin console only. This makes it easier for the end users who iteracts with Logto through the management API.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT and IT

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] docs
