### PR TITLE
feat(cli): export add connectors utils

### DIFF
--- a/packages/cli/src/commands/connector/utils.ts
+++ b/packages/cli/src/commands/connector/utils.ts
@@ -132,9 +132,7 @@ export const getLocalConnectorPackages = async (instancePath: string) => {
   return packages.map(({ name }) => [name, path.join(directory, name)] as const);
 };
 
-export const addConnectors = async (instancePath: string, packageNames: string[]) => {
-  const cwd = getConnectorDirectory(instancePath);
-
+export const addConnectorsToPath = async (cwd: string, packageNames: string[]) => {
   if (!existsSync(cwd)) {
     await fs.mkdir(cwd, { recursive: true });
   }
@@ -195,11 +193,17 @@ export const addConnectors = async (instancePath: string, packageNames: string[]
   }
 };
 
+export const addConnectors = async (instancePath: string, packageNames: string[]) => {
+  const cwd = getConnectorDirectory(instancePath);
+
+  await addConnectorsToPath(cwd, packageNames);
+};
+
 const officialConnectorPrefix = '@logto/connector-';
 
 type PackageMeta = { name: string; scope: string; version: string };
 
-const fetchOfficialConnectorList = async (includingCloudConnectors = false) => {
+export const fetchOfficialConnectorList = async (includingCloudConnectors = false) => {
   // See https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md#get-v1search
   type FetchResult = {
     objects: Array<{


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

### Context
We need to install connectors to the cloud package after the cloud migration. Intend to leverage the existing connector install logic in our @logto/cli


### update

- Export the `fetchOfficialConnectorList` 
- Extract an `addConnectorsToPath` function from the original `addConnectors` unit method. Instead of accepting a logto instance path, allow install connectors to any given director.  Thus we can install connectors to a cloud-based directory. 


### Expected usage

```js
// cloud/packages/cloud/,script/installConnectors.js

import {fetchOfficialConnectorList, addConnectorsToPath} from '@logto/cli/lib/command/connectors/utils.js' 

const officialConnectors = await fetchOfficialConnectorList();
await addConnectorsToPath('./connectors', officialConnectors);

```


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test the cli command locally. 

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
