### PR TITLE
fix(core): get cf id before insert

### DIFF
--- a/packages/core/src/libraries/domain.test.ts
+++ b/packages/core/src/libraries/domain.test.ts
@@ -30,8 +30,9 @@ const { MockQueries } = await import('#src/test-utils/tenant.js');
 const { createDomainLibrary } = await import('./domain.js');
 
 const updateDomainById = jest.fn(async (_, data) => data);
-const { syncDomainStatus, addDomainToCloudflare } = createDomainLibrary(
-  new MockQueries({ domains: { updateDomainById } })
+const insertDomain = jest.fn(async (data) => data);
+const { syncDomainStatus, addDomain } = createDomainLibrary(
+  new MockQueries({ domains: { updateDomainById, insertDomain } })
 );
 
 const fallbackOrigin = 'fake_origin';
@@ -51,9 +52,9 @@ afterAll(() => {
 
 describe('addDomainToCloudflare()', () => {
   it('should call createCustomHostname and return cloudflare data', async () => {
-    const response = await addDomainToCloudflare(mockDomain);
+    const response = await addDomain(mockDomain.domain);
     expect(createCustomHostname).toBeCalledTimes(1);
-    expect(updateDomainById).toBeCalledTimes(1);
+    expect(insertDomain).toBeCalledTimes(1);
     expect(response.cloudflareData).toMatchObject(mockCloudflareData);
   });
 });

--- a/packages/core/src/routes/domain.test.ts
+++ b/packages/core/src/routes/domain.test.ts
@@ -24,12 +24,17 @@ const domains = {
 };
 
 const syncDomainStatus = jest.fn(async (domain: Domain): Promise<Domain> => domain);
-const addDomainToCloudflare = jest.fn(async (domain: Domain): Promise<Domain> => domain);
+const addDomain = jest.fn(
+  async (domain: string): Promise<Domain> => ({
+    ...mockDomain,
+    domain,
+  })
+);
 
 const mockLibraries = {
   domains: {
     syncDomainStatus,
-    addDomainToCloudflare,
+    addDomain,
   },
 };
 

--- a/packages/core/src/routes/domain.ts
+++ b/packages/core/src/routes/domain.ts
@@ -1,5 +1,4 @@
 import { Domains, domainResponseGuard, domainSelectFields } from '@logto/schemas';
-import { generateStandardId } from '@logto/shared';
 import { pick } from '@silverhand/essentials';
 import { z } from 'zod';
 
@@ -13,10 +12,10 @@ export default function domainRoutes<T extends AuthedRouter>(
   ...[router, { queries, libraries }]: RouterInitArgs<T>
 ) {
   const {
-    domains: { findAllDomains, findDomainById, insertDomain, deleteDomainById },
+    domains: { findAllDomains, findDomainById, deleteDomainById },
   } = queries;
   const {
-    domains: { syncDomainStatus, addDomainToCloudflare },
+    domains: { syncDomainStatus, addDomain },
   } = libraries;
 
   router.get(
@@ -70,12 +69,7 @@ export default function domainRoutes<T extends AuthedRouter>(
         })
       );
 
-      const syncedDomain = await addDomainToCloudflare(
-        await insertDomain({
-          ...ctx.guard.body,
-          id: generateStandardId(),
-        })
-      );
+      const syncedDomain = await addDomain(ctx.guard.body.domain);
 
       ctx.status = 201;
       ctx.body = pick(syncedDomain, ...domainSelectFields);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Call Cloudflare API to create and get remote ID before inserting to our database, this can prevent the hanging domain (without remote ID) from creation.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UTs

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] docs

OR

- [ ] This PR is not applicable for the checklist
