### PR TITLE
refactor(schemas,toolkit): clean up zod dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
   },
   "dependencies": {
     "@logto/cli": "workspace:^1.1.0"
+  },
+  "optionalDependencies": {
+    "zod": "^3.20.2"
   }
 }

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -57,7 +57,8 @@
     "roarr": "^7.11.0",
     "slonik": "^30.0.0",
     "slonik-sql-tag-raw": "^1.1.4",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "zod": "^3.20.2"
   },
   "eslintConfig": {
     "extends": "@silverhand",
@@ -86,7 +87,9 @@
     "@logto/phrases": "workspace:^1.3.0",
     "@logto/phrases-ui": "workspace:^1.2.0",
     "@logto/shared": "workspace:^2.0.0",
-    "@withtyped/server": "^0.9.0",
+    "@withtyped/server": "^0.9.0"
+  },
+  "peerDependencies": {
     "zod": "^3.20.2"
   }
 }

--- a/packages/toolkit/connector-kit/package.json
+++ b/packages/toolkit/connector-kit/package.json
@@ -39,9 +39,6 @@
     "@logto/language-kit": "workspace:^1.0.0",
     "@silverhand/essentials": "^2.5.0"
   },
-  "optionalDependencies": {
-    "zod": "^3.20.2"
-  },
   "devDependencies": {
     "@jest/types": "^29.0.3",
     "@silverhand/eslint-config": "3.0.1",
@@ -53,7 +50,8 @@
     "lint-staged": "^13.0.0",
     "prettier": "^2.8.2",
     "tslib": "^2.4.1",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "zod": "^3.20.2"
   },
   "engines": {
     "node": "^18.12.0"
@@ -64,5 +62,8 @@
   "prettier": "@silverhand/eslint-config/.prettierrc",
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependencies": {
+    "zod": "^3.20.2"
   }
 }

--- a/packages/toolkit/core-kit/package.json
+++ b/packages/toolkit/core-kit/package.json
@@ -43,9 +43,6 @@
     "@logto/shared": "workspace:^2.0.0",
     "color": "^4.2.3"
   },
-  "optionalDependencies": {
-    "zod": "^3.20.2"
-  },
   "devDependencies": {
     "@jest/types": "^29.0.3",
     "@silverhand/eslint-config": "3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ importers:
       '@logto/cli':
         specifier: workspace:^1.1.0
         version: link:packages/cli
+    optionalDependencies:
+      zod:
+        specifier: ^3.20.2
+        version: 3.20.2
     devDependencies:
       '@changesets/cli':
         specifier: ^2.25.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3554,9 +3554,6 @@ importers:
       '@withtyped/server':
         specifier: ^0.9.0
         version: 0.9.0
-      zod:
-        specifier: ^3.20.2
-        version: 3.20.2
     devDependencies:
       '@silverhand/eslint-config':
         specifier: 3.0.1
@@ -3612,6 +3609,9 @@ importers:
       typescript:
         specifier: ^5.0.0
         version: 5.0.2
+      zod:
+        specifier: ^3.20.2
+        version: 3.20.2
 
   packages/shared:
     dependencies:
@@ -3670,10 +3670,6 @@ importers:
       '@silverhand/essentials':
         specifier: ^2.5.0
         version: 2.5.0
-    optionalDependencies:
-      zod:
-        specifier: ^3.20.2
-        version: 3.20.2
     devDependencies:
       '@jest/types':
         specifier: ^29.0.3
@@ -3708,6 +3704,9 @@ importers:
       typescript:
         specifier: ^5.0.0
         version: 5.0.2
+      zod:
+        specifier: ^3.20.2
+        version: 3.20.2
 
   packages/toolkit/core-kit:
     dependencies:
@@ -3720,10 +3719,6 @@ importers:
       color:
         specifier: ^4.2.3
         version: 4.2.3
-    optionalDependencies:
-      zod:
-        specifier: ^3.20.2
-        version: 3.20.2
     devDependencies:
       '@jest/types':
         specifier: ^29.0.3


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
clean up zod dependencies

For cloud migration purposes, we will use the Logto repo as a sub-module of the cloud repo. All the cloud service's internal logto dependency will be directed to the logto sub-module packages. e.g. @logto/schemas, @logto/connector-kit. 
A different version of Zod brings painful trouble. Thus mark all the Zod as a peer dependency in these commonly shared packages. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally build passed 

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
