### PR TITLE
fix(core): verify an empty string password should return 400 instead of 500

### DIFF
--- a/packages/core/src/routes/admin-user.test.ts
+++ b/packages/core/src/routes/admin-user.test.ts
@@ -319,6 +319,14 @@ describe('adminUserRoutes', () => {
     expect(response.status).toEqual(204);
   });
 
+  it('POST /users/:userId/password/verify should throw 400 if password is empty', async () => {
+    const password = '';
+    await expect(
+      userRequest.post(`/users/foo/password/verify`).send({ password })
+    ).resolves.toHaveProperty('status', 400);
+    expect(verifyUserPassword).not.toHaveBeenCalled();
+  });
+
   it('POST /users/:userId/password/verify should throw if password is invalid', async () => {
     const password = 'invalidPassword';
     verifyUserPassword.mockImplementationOnce(async () => {

--- a/packages/core/src/routes/admin-user.ts
+++ b/packages/core/src/routes/admin-user.ts
@@ -212,8 +212,8 @@ export default function adminUserRoutes<T extends AuthedRouter>(
     '/users/:userId/password/verify',
     koaGuard({
       params: object({ userId: string() }),
-      body: object({ password: string() }),
-      status: [204],
+      body: object({ password: string().min(1) }),
+      status: [204, 404, 422],
     }),
     async (ctx, next) => {
       const {

--- a/packages/integration-tests/src/api/admin-user.ts
+++ b/packages/integration-tests/src/api/admin-user.ts
@@ -65,3 +65,6 @@ export const postUserIdentity = async (
       },
     })
     .json<Identities>();
+
+export const verifyUserPassword = async (userId: string, password: string) =>
+  authedAdminApi.post(`users/${userId}/password/verify`, { json: { password } });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
When verifing password, the input `password` in the request payload should not be an empty string. If the input password is an empty string, the API should return 400 instead of 500 error.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested. UT and IT will be updated tomorrow

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
- [x] unit tests
- [x] integration tests
