### PR TITLE
fix(console): use correct vanillajs isAuthenticated method in guide

### DIFF
--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/vanilla.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/vanilla.mdx
@@ -105,7 +105,7 @@ Insert the code below in your `/callback` route:
 ```ts
 try {
   await logtoClient.handleSignInCallback(window.location.href);
-  console.log(logtoClient.isAuthenticated); // true
+  console.log(await logtoClient.isAuthenticated()); // true
 } catch {
   // Handle error
 }

--- a/packages/console/src/assets/docs/tutorial/integrate-sdk/vanilla_zh-cn.mdx
+++ b/packages/console/src/assets/docs/tutorial/integrate-sdk/vanilla_zh-cn.mdx
@@ -98,7 +98,7 @@ const logtoClient = new LogtoClient({
 ```ts
 try {
   await logtoClient.handleSignInCallback(window.location.href);
-  console.log(logtoClient.isAuthenticated); // true
+  console.log(await logtoClient.isAuthenticated()); // true
 } catch {
   // 处理错误
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The vanillajs examples still use the outdated  `logtoClient.isAuthenticated` that doesn't work with the latest SDKs, this PR replaces them with `await logtoClient.isAuthenticated()`
I will create a separate PR for the docs repo as well.

**Note:** I am unsure if the other JS libraries like next/vue/react/etc. also need this change, as I am not familiar with how to set up/use them.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Docs only

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] docs

OR

- [ ] This PR is not applicable for the checklist
