### PR TITLE
feat(console): add default domain content for domains page

### DIFF
--- a/packages/console/src/pages/TenantSettings/tabs/TenantDomainSettings/components/DefaultDomain/index.module.scss
+++ b/packages/console/src/pages/TenantSettings/tabs/TenantDomainSettings/components/DefaultDomain/index.module.scss
@@ -1,0 +1,15 @@
+@use '@/scss/underscore' as _;
+
+.container {
+  padding: _.unit(5) _.unit(6);
+  border: 1px solid var(--color-divider);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: _.unit(1);
+
+  .domain {
+    font: var(--font-title-2);
+    max-width: max-content;
+  }
+}

--- a/packages/console/src/pages/TenantSettings/tabs/TenantDomainSettings/components/DefaultDomain/index.tsx
+++ b/packages/console/src/pages/TenantSettings/tabs/TenantDomainSettings/components/DefaultDomain/index.tsx
@@ -1,0 +1,27 @@
+import { useContext } from 'react';
+
+import CopyToClipboard from '@/components/CopyToClipboard';
+import DynamicT from '@/components/DynamicT';
+import Tag from '@/components/Tag';
+import { AppEndpointsContext } from '@/contexts/AppEndpointsProvider';
+
+import * as styles from './index.module.scss';
+
+function DefaultDomain() {
+  const { userEndpoint } = useContext(AppEndpointsContext);
+
+  if (!userEndpoint) {
+    return null;
+  }
+
+  return (
+    <div className={styles.container}>
+      <CopyToClipboard className={styles.domain} value={userEndpoint.host} variant="text" />
+      <Tag status="success" type="state" variant="plain">
+        <DynamicT forKey="domain.status.in_used" />
+      </Tag>
+    </div>
+  );
+}
+
+export default DefaultDomain;

--- a/packages/console/src/pages/TenantSettings/tabs/TenantDomainSettings/index.tsx
+++ b/packages/console/src/pages/TenantSettings/tabs/TenantDomainSettings/index.tsx
@@ -1,6 +1,22 @@
+import FormCard from '@/components/FormCard';
+import FormField from '@/components/FormField';
+
+import DefaultDomain from './components/DefaultDomain';
+
 function TenantDomainSettings() {
-  // TODO @xiaoyijun implement this page
-  return <div>TenantDomainSettings (WIP)</div>;
+  return (
+    <div>
+      {/* TODO: @xiaoyijun add the custom domain form card */}
+      <FormCard
+        title="domain.default.default_domain"
+        description="domain.default.default_domain_description"
+      >
+        <FormField title="domain.default.default_domain_field">
+          <DefaultDomain />
+        </FormField>
+      </FormCard>
+    </div>
+  );
 }
 
 export default TenantDomainSettings;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

## Note
- This PR is for code review only since it's blocked by #3938.
- This PR won't be merged unless related PRs it depends on have been completed. 
- These codes are placed under the `console/src/pages/TenantSettings` folder temporarily, and after the #3938 has been complete, we may move them to a cloud-only related code folder if needed.

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add the default domain content for the domains page:
<img width="1025" alt="image" src="https://github.com/logto-io/logto/assets/10806653/2e7763e5-a49b-492c-9b79-f47b58b66e89">

Note:
The `Domains` component is a temporary tab page, and we will have another PR to implement the whole tab page and integrate it onto the `TenantSettings` page after #3938.



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

![image](https://github.com/logto-io/logto/assets/10806653/b76ca25e-93d1-4cb1-861e-b71c1a28ae8f)


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
