### PR TITLE
refactor: stringify error before report to AppInsights

### DIFF
--- a/packages/app-insights/src/node.ts
+++ b/packages/app-insights/src/node.ts
@@ -4,10 +4,18 @@ import type { TelemetryClient } from 'applicationinsights';
 export const normalizeError = (error: unknown) => {
   const normalized = error instanceof Error ? error : new Error(String(error));
 
-  // Add message if empty otherwise Application Insights will respond 400
-  // and the error will not be recorded.
+  /**
+   * - Ensure the message if not empty otherwise Application Insights will respond 400
+   *   and the error will not be recorded.
+   * - We stringify error object here since other error properties won't show on the
+   *   ApplicationInsights details page.
+   */
   // eslint-disable-next-line @silverhand/fp/no-mutation
-  normalized.message ||= 'Error occurred.';
+  normalized.message = JSON.stringify(
+    error,
+    // ApplicationInsights shows call stack, no need to stringify
+    Object.getOwnPropertyNames(error).filter((value) => value !== 'stack')
+  );
 
   return normalized;
 };


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
AppInsights only shows error message and stack which is not convenient for debugging. This PR stringify the error object to provide a better experience.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="602" alt="image" src="https://github.com/logto-io/logto/assets/14722250/c43e515a-b61e-4455-b313-7383ad0780d2">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
