### PR TITLE
refactor(core): return 422 if failed to send a webhook test payload

### DIFF
--- a/packages/core/src/libraries/hook/index.test.ts
+++ b/packages/core/src/libraries/hook/index.test.ts
@@ -147,7 +147,7 @@ describe('testHook', () => {
       new RequestError({
         code: 'hook.send_test_payload_failed',
         message: 'test error',
-        status: 500,
+        status: 422,
       })
     );
   });

--- a/packages/core/src/libraries/hook/index.ts
+++ b/packages/core/src/libraries/hook/index.ts
@@ -154,7 +154,7 @@ export const createHookLibrary = (queries: Queries) => {
       throw new RequestError({
         code: 'hook.send_test_payload_failed',
         message: conditional(error instanceof Error && String(error)) ?? 'Unknown error',
-        status: 500,
+        status: 422,
       });
     }
   };

--- a/packages/core/src/routes/hook.ts
+++ b/packages/core/src/routes/hook.ts
@@ -159,7 +159,7 @@ export default function hookRoutes<T extends AuthedRouter>(
     koaGuard({
       params: z.object({ id: z.string() }),
       body: z.object({ events: nonemptyUniqueHookEventsGuard, config: hookConfigGuard }),
-      status: [204, 404, 500],
+      status: [204, 404, 422],
     }),
     async (ctx, next) => {
       const {

--- a/packages/integration-tests/src/tests/api/hook/hook.testing.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.testing.test.ts
@@ -53,14 +53,14 @@ describe('hook testing', () => {
     ).rejects.toMatchObject(createResponseWithCode(404));
   });
 
-  it('should return 500 if the hook endpoint is not working', async () => {
+  it('should return 422 if the hook endpoint is not working', async () => {
     const payload = getHookCreationPayload(HookEvent.PostRegister);
     const created = await authedAdminApi.post('hooks', { json: payload }).json<Hook>();
     await expect(
       authedAdminApi.post(`hooks/${created.id}/test`, {
         json: { events: [HookEvent.PostSignIn], config: { url: 'not_work_url' } },
       })
-    ).rejects.toMatchObject(createResponseWithCode(500));
+    ).rejects.toMatchObject(createResponseWithCode(422));
 
     // Clean Up
     await authedAdminApi.delete(`hooks/${created.id}`);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
We should return 422 if failed to send a webhook test payload to the endpoint since we will record 500 errors in our error-tracking service.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT & IT & Test locally.
![image](https://github.com/logto-io/logto/assets/10806653/2727388e-092c-47a7-bd49-5ebe495ea1f9)

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
