### PR TITLE
fix(console): hide some log headers for webhook event

### DIFF
--- a/packages/console/src/pages/AuditLogDetails/index.tsx
+++ b/packages/console/src/pages/AuditLogDetails/index.tsx
@@ -29,7 +29,7 @@ const getAuditLogDetailsRelatedResourceLink = (pathname: string) =>
 const getDetailsTabNavLink = (logId: string, userId?: string) =>
   userId ? `/users/${userId}/logs/${logId}` : `/audit-logs/${logId}`;
 
-const isWebHookEventLog = (key?: string) =>
+const isWebhookEventLog = (key?: string) =>
   key && Object.values<string>(hookEventLogKey).includes(key);
 
 function AuditLogDetails() {
@@ -63,7 +63,7 @@ function AuditLogDetails() {
     return null;
   }
 
-  const isWebHookEvent = isWebHookEventLog(data?.key);
+  const isWebHookEvent = isWebhookEventLog(data?.key);
 
   return (
     <DetailsPage

--- a/packages/console/src/pages/AuditLogDetails/index.tsx
+++ b/packages/console/src/pages/AuditLogDetails/index.tsx
@@ -16,6 +16,7 @@ import PageMeta from '@/components/PageMeta';
 import TabNav, { TabNavItem } from '@/components/TabNav';
 import UserName from '@/components/UserName';
 import { logEventTitle } from '@/consts/logs';
+import { hookEventLogKey } from '@/consts/webhooks';
 import type { RequestError } from '@/hooks/use-api';
 import { getUserTitle } from '@/utils/user';
 
@@ -27,6 +28,9 @@ const getAuditLogDetailsRelatedResourceLink = (pathname: string) =>
 
 const getDetailsTabNavLink = (logId: string, userId?: string) =>
   userId ? `/users/${userId}/logs/${logId}` : `/audit-logs/${logId}`;
+
+const isWebHookEventLog = (key?: string) =>
+  key && Object.values<string>(hookEventLogKey).includes(key);
 
 function AuditLogDetails() {
   const { userId, hookId, logId } = useParams();
@@ -59,6 +63,8 @@ function AuditLogDetails() {
     return null;
   }
 
+  const isWebHookEvent = isWebHookEventLog(data?.key);
+
   return (
     <DetailsPage
       backLink={backLink}
@@ -79,29 +85,37 @@ function AuditLogDetails() {
                   <div className={styles.label}>{t('log_details.event_key')}</div>
                   <div>{data.key}</div>
                 </div>
-                <div className={styles.infoItem}>
-                  <div className={styles.label}>{t('log_details.application')}</div>
-                  <div>
-                    {data.payload.applicationId ? (
-                      <ApplicationName
-                        isLink={data.payload.applicationId !== demoAppApplicationId}
-                        applicationId={data.payload.applicationId}
-                      />
-                    ) : (
-                      '-'
-                    )}
-                  </div>
-                </div>
-                <div className={styles.infoItem}>
-                  <div className={styles.label}>{t('log_details.ip_address')}</div>
-                  <div>{data.payload.ip ?? '-'}</div>
-                </div>
-                <div className={styles.infoItem}>
-                  <div className={styles.label}>{t('log_details.user')}</div>
-                  <div>
-                    {data.payload.userId ? <UserName isLink userId={data.payload.userId} /> : '-'}
-                  </div>
-                </div>
+                {!isWebHookEvent && (
+                  <>
+                    <div className={styles.infoItem}>
+                      <div className={styles.label}>{t('log_details.application')}</div>
+                      <div>
+                        {data.payload.applicationId ? (
+                          <ApplicationName
+                            isLink={data.payload.applicationId !== demoAppApplicationId}
+                            applicationId={data.payload.applicationId}
+                          />
+                        ) : (
+                          '-'
+                        )}
+                      </div>
+                    </div>
+                    <div className={styles.infoItem}>
+                      <div className={styles.label}>{t('log_details.ip_address')}</div>
+                      <div>{data.payload.ip ?? '-'}</div>
+                    </div>
+                    <div className={styles.infoItem}>
+                      <div className={styles.label}>{t('log_details.user')}</div>
+                      <div>
+                        {data.payload.userId ? (
+                          <UserName isLink userId={data.payload.userId} />
+                        ) : (
+                          '-'
+                        )}
+                      </div>
+                    </div>
+                  </>
+                )}
                 <div className={styles.infoItem}>
                   <div className={styles.label}>{t('log_details.log_id')}</div>
                   <div>{data.id}</div>
@@ -111,12 +125,14 @@ function AuditLogDetails() {
                   <div>{new Date(data.createdAt).toLocaleString()}</div>
                 </div>
               </div>
-              <div>
-                <div className={styles.infoItem}>
-                  <div className={styles.label}>{t('log_details.user_agent')}</div>
-                  <div>{data.payload.userAgent}</div>
+              {!isWebHookEvent && (
+                <div>
+                  <div className={styles.infoItem}>
+                    <div className={styles.label}>{t('log_details.user_agent')}</div>
+                    <div>{data.payload.userAgent}</div>
+                  </div>
                 </div>
-              </div>
+              )}
             </div>
           </Card>
           <TabNav>

--- a/packages/schemas/src/types/log/hook.ts
+++ b/packages/schemas/src/types/log/hook.ts
@@ -2,7 +2,7 @@ import type { HookEvent } from '../../foundations/index.js';
 
 /** The type of a hook event. */
 export enum Type {
-  ExchangeTokenBy = 'TriggerHook',
+  TriggerHook = 'TriggerHook',
 }
 
 export type LogKey = `${Type}.${HookEvent}`;


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Hide some log info from headers if the log type is webhook. As all the following properties are always empty. 
- ua
- userId
- ip-address
- appid

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<img width="1243" alt="image" src="https://github.com/logto-io/logto/assets/36393111/f1cec411-ebda-493f-95e4-0c7ad6d657bc">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
