### PR TITLE
fix(console): doc button and get help link

### DIFF
--- a/packages/console/src/containers/AppContent/components/Topbar/Contact/ContactModal/index.module.scss
+++ b/packages/console/src/containers/AppContent/components/Topbar/Contact/ContactModal/index.module.scss
@@ -33,5 +33,9 @@
     .button {
       width: 90px;
     }
+
+    .link {
+      text-decoration: none;
+    }
   }
 }

--- a/packages/console/src/containers/AppContent/components/Topbar/Contact/ContactModal/index.tsx
+++ b/packages/console/src/containers/AppContent/components/Topbar/Contact/ContactModal/index.tsx
@@ -43,15 +43,9 @@ function ContactModal({ isOpen, onCancel }: Props) {
                     <DynamicT forKey={description} />
                   </div>
                 </div>
-                <div>
-                  <Button
-                    type="outline"
-                    title={label}
-                    to={link}
-                    className={styles.button}
-                    onClick={() => window.open(link)}
-                  />
-                </div>
+                <a href={link} target="_blank" className={styles.link} rel="noopener">
+                  <Button type="outline" title={label} className={styles.button} />
+                </a>
               </div>
             ))}
         </div>

--- a/packages/console/src/containers/AppContent/components/Topbar/DocumentNavButton/index.tsx
+++ b/packages/console/src/containers/AppContent/components/Topbar/DocumentNavButton/index.tsx
@@ -9,8 +9,12 @@ function DocumentNavButton() {
   const { documentationSiteUrl } = useDocumentationUrl();
   return (
     <div className={styles.documentNavButton}>
-      <DocumentIcon className={styles.icon} />
-      <TextLink href={documentationSiteUrl} target="_blank" className={styles.textLink}>
+      <TextLink
+        href={documentationSiteUrl}
+        target="_blank"
+        className={styles.textLink}
+        icon={<DocumentIcon className={styles.icon} />}
+      >
         <DangerousRaw>Docs</DangerousRaw>
       </TextLink>
     </div>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
1. fix console "docs button" bug, now icon is also clickable
2. use `<a>` component for console "get help" buttons.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
1. "docs button" icon clickable
<img width="2321" alt="image" src="https://github.com/logto-io/logto/assets/15182327/db0b6d6f-0399-4ef1-a531-6ff291d1e4d0">
<img width="473" alt="image" src="https://github.com/logto-io/logto/assets/15182327/560e50d6-f928-4e8c-acde-d0c8ce4ec83c">
2. can preview link on left-bottom corner when hover on "get help" buttons
<img width="1674" alt="image" src="https://github.com/logto-io/logto/assets/15182327/5b1c594a-815a-4669-8485-5cac6e4a9397">
<img width="1789" alt="image" src="https://github.com/logto-io/logto/assets/15182327/665b645c-4157-44eb-8aac-22a078cf5a15">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
