### PR TITLE
fix(console): fix github avatar broken issue

### DIFF
--- a/packages/console/src/components/ImageWithErrorFallback/index.tsx
+++ b/packages/console/src/components/ImageWithErrorFallback/index.tsx
@@ -39,14 +39,7 @@ function ImageWithErrorFallback({
 
   return (
     <div className={containerClassName}>
-      <img
-        className={className}
-        src={src}
-        alt={alt}
-        onError={errorHandler}
-        {...props}
-        crossOrigin="anonymous"
-      />
+      <img className={className} src={src} alt={alt} onError={errorHandler} {...props} />
     </div>
   );
 }

--- a/packages/core/src/middleware/koa-security-headers.ts
+++ b/packages/core/src/middleware/koa-security-headers.ts
@@ -56,6 +56,7 @@ export default function koaSecurityHeaders<StateT, ContextT, ResponseBodyT>(
 
   const basicSecurityHeaderSettings: HelmetOptions = {
     contentSecurityPolicy: false, // Exclusively set per app
+    crossOriginEmbedderPolicy: { policy: 'credentialless' },
     expectCt: false, // Not recommended, will be deprecated by modern browsers
     dnsPrefetchControl: false,
     referrerPolicy: {


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
remove the crossOrigin settings on the avatar image element. As the original GitHub user avatar URL does not specify the 
Access-Control-Allow-Origin policy.

Before:
<img width="1381" alt="image" src="https://github.com/logto-io/logto/assets/36393111/68e17c87-7327-441d-930a-7449527434f4">


After:
<img width="439" alt="image" src="https://github.com/logto-io/logto/assets/36393111/25e242fa-3510-47ea-9b24-ddd5c3569b82">
<img width="888" alt="image" src="https://github.com/logto-io/logto/assets/36393111/d7549140-bdf0-4c52-8bdb-a27c207c8a53">



<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
