### PR TITLE
feat(schemas): add custom domain progress to console config

### DIFF
--- a/packages/core/src/__mocks__/index.ts
+++ b/packages/core/src/__mocks__/index.ts
@@ -1,14 +1,15 @@
 import { VerificationCodeType } from '@logto/connector-kit';
-import type {
-  AdminConsoleData,
-  Application,
-  Passcode,
-  Resource,
-  Role,
-  Scope,
-  UsersRole,
+import {
+  type AdminConsoleData,
+  type Application,
+  CustomDomainProgress,
+  type Passcode,
+  type Resource,
+  type Role,
+  type Scope,
+  type UsersRole,
+  ApplicationType,
 } from '@logto/schemas';
-import { ApplicationType } from '@logto/schemas';
 
 export * from './connector.js';
 export * from './sign-in-experience.js';
@@ -98,6 +99,7 @@ export const mockAdminConsoleData: AdminConsoleData = {
   roleCreated: false,
   communityChecked: false,
   m2mApplicationCreated: false,
+  customDomainProgress: CustomDomainProgress.NotStarted,
 };
 
 export const mockPasscode: Passcode = {

--- a/packages/integration-tests/src/tests/api/logto-config.test.ts
+++ b/packages/integration-tests/src/tests/api/logto-config.test.ts
@@ -1,4 +1,4 @@
-import { type AdminConsoleData } from '@logto/schemas';
+import { CustomDomainProgress, type AdminConsoleData } from '@logto/schemas';
 
 import { getAdminConsoleConfig, updateAdminConsoleConfig } from '#src/api/index.js';
 
@@ -11,6 +11,7 @@ const defaultAdminConsoleConfig: AdminConsoleData = {
   roleCreated: false,
   communityChecked: false,
   m2mApplicationCreated: false,
+  customDomainProgress: CustomDomainProgress.NotStarted,
 };
 
 describe('admin console sign-in experience', () => {

--- a/packages/schemas/alterations/next-1686035346-add-custom-domain-progress-to-console-config.ts
+++ b/packages/schemas/alterations/next-1686035346-add-custom-domain-progress-to-console-config.ts
@@ -1,0 +1,81 @@
+import type { DatabaseTransactionConnection } from 'slonik';
+import { sql } from 'slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const adminConsoleConfigKey = 'adminConsole';
+
+enum CustomDomainProgress {
+  NotStarted = 'NotStarted',
+  InProgress = 'InProgress',
+  Completed = 'Completed',
+}
+
+type OldAdminConsoleData = Record<string, unknown>;
+
+type OldLogtoAdminConsoleConfig = {
+  tenantId: string;
+  value: OldAdminConsoleData;
+};
+
+type NewAdminConsoleData = {
+  customDomainProgress: CustomDomainProgress;
+} & OldAdminConsoleData;
+
+type NewLogtoAdminConsoleConfig = {
+  tenantId: string;
+  value: NewAdminConsoleData;
+};
+
+const alterAdminConsoleData = async (
+  logtoConfig: OldLogtoAdminConsoleConfig,
+  pool: DatabaseTransactionConnection
+) => {
+  const { tenantId, value: oldAdminConsoleConfig } = logtoConfig;
+
+  const newAdminConsoleData: NewAdminConsoleData = {
+    ...oldAdminConsoleConfig,
+    customDomainProgress: CustomDomainProgress.NotStarted,
+  };
+
+  await pool.query(
+    sql`update logto_configs set value = ${JSON.stringify(
+      newAdminConsoleData
+    )} where tenant_id = ${tenantId} and key = ${adminConsoleConfigKey}`
+  );
+};
+
+const rollbackAdminConsoleData = async (
+  logtoConfig: NewLogtoAdminConsoleConfig,
+  pool: DatabaseTransactionConnection
+) => {
+  const { tenantId, value: newAdminConsoleConfig } = logtoConfig;
+
+  const {
+    customDomainProgress, // Extract to remove from config
+    ...oldAdminConsoleData
+  } = newAdminConsoleConfig;
+
+  await pool.query(
+    sql`update logto_configs set value = ${JSON.stringify(
+      oldAdminConsoleData
+    )} where tenant_id = ${tenantId} and key = ${adminConsoleConfigKey}`
+  );
+};
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    const rows = await pool.many<OldLogtoAdminConsoleConfig>(
+      sql`select * from logto_configs where key = ${adminConsoleConfigKey}`
+    );
+    await Promise.all(rows.map(async (row) => alterAdminConsoleData(row, pool)));
+  },
+  down: async (pool) => {
+    const rows = await pool.many<NewLogtoAdminConsoleConfig>(
+      sql`select * from logto_configs where key = ${adminConsoleConfigKey}`
+    );
+    await Promise.all(rows.map(async (row) => rollbackAdminConsoleData(row, pool)));
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/seeds/logto-config.ts
+++ b/packages/schemas/src/seeds/logto-config.ts
@@ -1,6 +1,9 @@
 import { type CreateLogtoConfig } from '../db-entries/index.js';
-import type { AdminConsoleData } from '../types/index.js';
-import { LogtoTenantConfigKey } from '../types/index.js';
+import {
+  type AdminConsoleData,
+  LogtoTenantConfigKey,
+  CustomDomainProgress,
+} from '../types/index.js';
 
 export const createDefaultAdminConsoleConfig = (
   forTenantId: string
@@ -21,5 +24,6 @@ export const createDefaultAdminConsoleConfig = (
       roleCreated: false,
       communityChecked: false,
       m2mApplicationCreated: false,
+      customDomainProgress: CustomDomainProgress.NotStarted,
     },
   } satisfies CreateLogtoConfig);

--- a/packages/schemas/src/types/logto-config.ts
+++ b/packages/schemas/src/types/logto-config.ts
@@ -20,6 +20,12 @@ export const logtoOidcConfigGuard: Readonly<{
 });
 
 /* --- Logto tenant configs --- */
+export enum CustomDomainProgress {
+  NotStarted = 'NotStarted',
+  InProgress = 'InProgress',
+  Completed = 'Completed',
+}
+
 export const adminConsoleDataGuard = z.object({
   // Get started challenges
   livePreviewChecked: z.boolean(),
@@ -30,6 +36,8 @@ export const adminConsoleDataGuard = z.object({
   furtherReadingsChecked: z.boolean(),
   roleCreated: z.boolean(),
   m2mApplicationCreated: z.boolean(),
+  // Custom domain console states
+  customDomainProgress: z.nativeEnum(CustomDomainProgress),
 });
 
 export type AdminConsoleData = z.infer<typeof adminConsoleDataGuard>;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
We need to track the custom domain progress in the admin console since we want to implement the feature below:
- When our custom domain is active, we want to display the success toast and the update domain alert.
<img width="892" alt="image" src="https://github.com/logto-io/logto/assets/10806653/a70c5167-c567-4b29-9cf4-c041db5e1edf">

### Why do we need a `customDomainProgress` in our admin console config?

The process of activating a custom domain is asynchronous.
In the front end, we periodically retrieve the status of the custom domain from the backend.
However, based on the backend status, we cannot determine how the front end should react.
For example, when the backend returns the status "Active", we cannot determine if it is the first time the custom domain has been activated.

So the `customDomainProgress` comes to our help.
When the `customDomainProgress` is `InProgress` and the custom domain status is `Active`, we know it is the first time the custom domain has been activated and then we update the `customDomainProgress` to `Completed`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
All tests passed & Test Locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
