### PR TITLE
feat: enable OIDC introspection endpoint

### DIFF
--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -87,6 +87,7 @@ export default function initOidc(
     features: {
       userinfo: { enabled: true },
       revocation: { enabled: true },
+      introspection: { enabled: true },
       devInteractions: { enabled: false },
       clientCredentials: { enabled: true },
       rpInitiatedLogout: {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
Re-enables the OIDC introspection endpoint, which was disabled in https://github.com/logto-io/logto/pull/886. Some applications require this, such as Mediawiki with the OpenIDConnect extension.

<!-- MANDATORY -->
## Testing
I built an image with the change, and used it with an application which requires the endpoint, Mediawiki. 

<!-- MANDATORY -->
## Checklist
- [x] This PR is not applicable for the checklist, this was something that was implemented (fully?) working before, but the endpoint was later disabled.
