### PR TITLE
refactor(console): remove redundant domain status guard

### DIFF
--- a/packages/console/src/pages/TenantSettings/tabs/TenantDomainSettings/components/CustomDomain/components/ActivationProcess/index.tsx
+++ b/packages/console/src/pages/TenantSettings/tabs/TenantDomainSettings/components/CustomDomain/components/ActivationProcess/index.tsx
@@ -1,11 +1,4 @@
-import {
-  DomainStatus,
-  type Domain,
-  type DomainDnsRecords,
-  type DomainDnsRecord,
-} from '@logto/schemas';
-
-import { isDomainStatus } from '../../utils';
+import { type Domain, type DomainDnsRecords, type DomainDnsRecord } from '@logto/schemas';
 
 import DnsRecordsTable from './components/DnsRecordsTable';
 import Step from './components/Step';
@@ -19,10 +12,7 @@ const isSetupSslDnsRecord = ({ type, name }: DomainDnsRecord) =>
   type.toUpperCase() === 'TXT' && name.includes('_acme-challenge');
 
 function ActivationProcess({ customDomain }: Props) {
-  const { dnsRecords, status } = customDomain;
-
-  // TODO @xiaoyijun Remove this type assertion when the LOG-6276 issue is done by @wangsijie
-  const typedDomainStatus = isDomainStatus(status) ? status : DomainStatus.Error;
+  const { dnsRecords, status: domainStatus } = customDomain;
 
   const { verifyDomainDnsRecord, setupSslDnsRecord } = dnsRecords.reduce<{
     verifyDomainDnsRecord: DomainDnsRecords;
@@ -50,7 +40,7 @@ function ActivationProcess({ customDomain }: Props) {
         step={1}
         title="domain.custom.verify_domain"
         tip="domain.custom.checking_dns_tip"
-        domainStatus={typedDomainStatus}
+        domainStatus={domainStatus}
       >
         <DnsRecordsTable records={verifyDomainDnsRecord} />
       </Step>
@@ -58,7 +48,7 @@ function ActivationProcess({ customDomain }: Props) {
         step={2}
         title="domain.custom.enable_ssl"
         tip="domain.custom.checking_dns_tip"
-        domainStatus={typedDomainStatus}
+        domainStatus={domainStatus}
       >
         <DnsRecordsTable records={setupSslDnsRecord} />
       </Step>

--- a/packages/console/src/pages/TenantSettings/tabs/TenantDomainSettings/components/CustomDomain/components/CustomDomainHeader/index.tsx
+++ b/packages/console/src/pages/TenantSettings/tabs/TenantDomainSettings/components/CustomDomain/components/CustomDomainHeader/index.tsx
@@ -13,8 +13,6 @@ import type { Props as TagProps } from '@/components/Tag';
 import useApi from '@/hooks/use-api';
 import { useConfirmModal } from '@/hooks/use-confirm-modal';
 
-import { isDomainStatus } from '../../utils';
-
 import * as styles from './index.module.scss';
 
 type Props = {
@@ -34,8 +32,7 @@ const domainStatusToTag: Record<
 
 function CustomDomainHeader({ customDomain: { id, domain, status }, onDeleteCustomDomain }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
-  // TODO @xiaoyijun Remove this type assertion when the LOG-6276 issue is done by @wangsijie
-  const tag = domainStatusToTag[isDomainStatus(status) ? status : DomainStatus.Error];
+  const tag = domainStatusToTag[status];
   const { show } = useConfirmModal();
   const api = useApi();
 

--- a/packages/console/src/pages/TenantSettings/tabs/TenantDomainSettings/components/CustomDomain/utils.ts
+++ b/packages/console/src/pages/TenantSettings/tabs/TenantDomainSettings/components/CustomDomain/utils.ts
@@ -1,6 +1,0 @@
-import { DomainStatus } from '@logto/schemas';
-import { z } from 'zod';
-
-// TODO @xiaoyijun Remove this type assertion when the LOG-6276 issue is done by @wangsijie
-export const isDomainStatus = (value: string): value is DomainStatus =>
-  z.nativeEnum(DomainStatus).safeParse(value).success;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Remove redundant domain status guard since now we have the type guard for the `DomainStatus` in the core.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
