### PR TITLE
fix: remove unsafe-inline and unsafe-eval

### DIFF
--- a/packages/cloud/src/middleware/with-security-headers.ts
+++ b/packages/cloud/src/middleware/with-security-headers.ts
@@ -96,7 +96,7 @@ export default function withSecurityHeaders<InputContext extends RequestContext>
           directives: {
             'upgrade-insecure-requests': null,
             imgSrc: ["'self'", 'data:', 'https:'],
-            scriptSrc: ["'self'", "'unsafe-eval'", "'unsafe-inline'", ...gtagOrigins],
+            scriptSrc: ["'self'", ...gtagOrigins],
             connectSrc: [
               "'self'",
               ...adminOrigins,

--- a/packages/core/src/middleware/koa-security-headers.ts
+++ b/packages/core/src/middleware/koa-security-headers.ts
@@ -77,7 +77,7 @@ export default function koaSecurityHeaders<StateT, ContextT, ResponseBodyT>(
       directives: {
         'upgrade-insecure-requests': null,
         imgSrc: ["'self'", 'data:', 'https:'],
-        scriptSrc: ["'self'", "'unsafe-eval'", "'unsafe-inline'"],
+        scriptSrc: ["'self'"],
         connectSrc: ["'self'", tenantEndpointOrigin, ...developmentOrigins, ...appInsightsOrigins],
         // WARNING: high risk Need to allow self hosted terms of use page loaded in an iframe
         frameSrc: ["'self'", 'https:'],
@@ -96,7 +96,7 @@ export default function koaSecurityHeaders<StateT, ContextT, ResponseBodyT>(
       directives: {
         'upgrade-insecure-requests': null,
         imgSrc: ["'self'", 'data:', 'https:'],
-        scriptSrc: ["'self'", "'unsafe-eval'", "'unsafe-inline'"],
+        scriptSrc: ["'self'"],
         connectSrc: ["'self'", ...adminOrigins, ...coreOrigins, ...developmentOrigins],
         // Allow Main Flow origin loaded in preview iframe
         frameSrc: ["'self'", ...adminOrigins, ...coreOrigins],


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Remove the unsafe-inline and unsafe-eval allowance tags. It looks like ApplicationInsights is no longer adding inline script. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
