### PR TITLE
fix(console): set RHF default value

### DIFF
--- a/packages/console/src/pages/TenantSettings/TenantBasicSettings/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantBasicSettings/index.tsx
@@ -16,6 +16,12 @@ import ProfileForm from './ProfileForm';
 import * as styles from './index.module.scss';
 import { type TenantSettingsForm } from './types.js';
 
+const tenantProfileToForm = (tenant?: TenantInfo): TenantSettingsForm => {
+  return {
+    profile: { name: tenant?.name ?? 'My project', tag: tenant?.tag ?? TenantTag.Development },
+  };
+};
+
 function TenantBasicSettings() {
   const {
     api: cloudApi,
@@ -36,7 +42,9 @@ function TenantBasicSettings() {
     }
   }, [requestError]);
 
-  const methods = useForm<TenantSettingsForm>();
+  const methods = useForm<TenantSettingsForm>({
+    defaultValues: tenantProfileToForm(currentTenant),
+  });
   const {
     watch,
     reset,
@@ -45,8 +53,7 @@ function TenantBasicSettings() {
   } = methods;
 
   useEffect(() => {
-    const { name, tag } = currentTenant ?? { name: 'My project', tag: TenantTag.Development };
-    reset({ profile: { name, tag } });
+    reset(tenantProfileToForm(currentTenant));
   }, [currentTenant, reset]);
 
   const saveData = async (data: { name?: string; tag?: TenantTag }) => {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
set RHF default value instead of manually triggering RHF reset().
Previously, the component could return before setting the RHF init value (where empty form can not provider current tenant info). Also, manually triggering RHF `reset()` could lead to too many rerenders.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
Before this fix, can easily trigger by switching between sidebar buttons.
<img width="1900" alt="image" src="https://github.com/logto-io/logto/assets/15182327/03f20b5f-aac3-446a-9a7b-2229181c3e07">
After the change, the tenant settings page does not crash again.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
