### PR TITLE
fix(test): fix cloud UI test create new account idling URL mismatch error

### DIFF
--- a/packages/console/src/cloud/pages/Main/index.tsx
+++ b/packages/console/src/cloud/pages/Main/index.tsx
@@ -1,7 +1,8 @@
 import { useLogto } from '@logto/react';
+import { type TenantInfo } from '@logto/schemas/models';
 import { conditional, yes } from '@silverhand/essentials';
 import { HTTPError } from 'ky';
-import { useContext, useEffect, useState } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 import { useHref, useSearchParams } from 'react-router-dom';
 
 import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
@@ -36,6 +37,13 @@ function Protected() {
     }
   }, [api, setTenants, tenants]);
 
+  const onAdd = useCallback(
+    (tenant: TenantInfo) => {
+      setTenants([...(tenants ?? []), tenant]);
+    },
+    [setTenants, tenants]
+  );
+
   if (error) {
     if (error instanceof HTTPError && error.response.status === 401) {
       return <SessionExpired error={error} />;
@@ -49,14 +57,7 @@ function Protected() {
       return <Redirect tenants={tenants} toTenantId={currentTenantId} />;
     }
 
-    return (
-      <Tenants
-        data={tenants}
-        onAdd={(tenant) => {
-          setTenants([...tenants, tenant]);
-        }}
-      />
-    );
+    return <Tenants data={tenants} onAdd={onAdd} />;
   }
 
   return <AppLoading />;

--- a/packages/integration-tests/src/tests/ui-cloud/smoke.test.ts
+++ b/packages/integration-tests/src/tests/ui-cloud/smoke.test.ts
@@ -169,9 +169,7 @@ describe('smoke testing for cloud', () => {
     });
 
     await expect(page).toClick('button[name=submit]');
-    await page.waitForNavigation({ waitUntil: 'networkidle0' });
-
-    console.log('???', page.url());
+    await page.waitForNavigation({ waitUntil: 'networkidle0', timeout: 5000 });
 
     expect(page.url().startsWith(logtoCloudUrl.href)).toBeTruthy();
     expect(new URL(page.url()).pathname.endsWith('/onboarding/welcome')).toBeTruthy();


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix cloud UI test URL mismatch.
The `onAdd` method passed to `<Tenants />` component triggers frequent re-rendering of the `useEffect` which automatically create tenant for new registered users. The re-render of this `useEffect` will create tons of tenants for the current use. This caused the redirect to onboarding process timeout.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
