### PR TITLE
fix(ui): fix preview classname overwrite bug

### DIFF
--- a/.changeset/six-starfishes-hide.md
+++ b/.changeset/six-starfishes-hide.md
@@ -1,0 +1,7 @@
+---
+"@logto/ui": patch
+---
+
+Bug fix main flow preview mode should not allow user interaction.
+
+- Recover the missing preview classname from the preview mode body element

--- a/packages/ui/src/Providers/AppBoundary/AppMeta.tsx
+++ b/packages/ui/src/Providers/AppBoundary/AppMeta.tsx
@@ -38,6 +38,8 @@ const AppMeta = () => {
       {experienceSettings?.customCss && <style>{experienceSettings.customCss}</style>}
       <body
         className={classNames(
+          // Should preserve any existing classNames
+          conditionalString(document.body.className),
           platform === 'mobile' ? 'mobile' : 'desktop',
           conditionalString(styles[theme])
         )}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the preview class name has been overwritten bug.

Bug:
The preview UI is editable on AC.

Expected behavior:
Preview UI should not allow user interaction.


Cause:
Adding class names using react-helmet overwrites the body class name instead of merging.  Miss use of the react helmet. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [ ] This PR is not applicable for the checklist
