### PR TITLE
style(console): update min-width of the sie page

### DIFF
--- a/packages/console/src/pages/SignInExperience/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/index.module.scss
@@ -33,11 +33,11 @@
 
       > * {
         flex: 1;
-        min-width: 540px;
+        min-width: 510px;
       }
 
       .form {
-        margin-right: _.unit(6);
+        margin-right: _.unit(3);
       }
 
       .preview {

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/SignInMethodEditBox/SignInMethodItem.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/SignInMethodEditBox/SignInMethodItem.tsx
@@ -62,7 +62,6 @@ function SignInMethodItem({
             )}
           >
             <Checkbox
-              className={styles.checkBox}
               label={t('sign_in_exp.sign_up_and_sign_in.sign_in.password_auth')}
               checked={password}
               disabled={!isPasswordCheckable}
@@ -84,7 +83,6 @@ function SignInMethodItem({
                   </IconButton>
                 </Tooltip>
                 <Checkbox
-                  className={styles.checkBox}
                   label={t('sign_in_exp.sign_up_and_sign_in.sign_in.verification_code_auth')}
                   checked={verificationCode}
                   disabled={!isVerificationCodeCheckable}

--- a/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/SignInMethodEditBox/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/tabs/SignUpAndSignIn/components/SignInMethodEditBox/index.module.scss
@@ -40,13 +40,10 @@
     padding: 0 _.unit(2);
     flex-grow: 1;
 
-    .checkBox {
-      flex-grow: 1;
-      width: 100%;
-    }
-
     .swapButton {
-      margin: 0 _.unit(4);
+      flex-grow: 1;
+      display: flex;
+      justify-content: center;
     }
 
     &.verifyCodePrimary {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Currently, the min-width is set at 540, making the laptop view too big and exceeding the screen size.
So the designer changes the min-width to 510 and updates the gap between sie form and preview from 24px to 12px.

I also removed the redundant `checkbox` class for the signInMethod item since the original implementation is not perfect and will cause the style to break when the min-width is set to 510.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="1063" alt="image" src="https://github.com/logto-io/logto/assets/10806653/dd5984e7-ff90-4a7f-8f5f-2486d2fafdd7">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
