### PR TITLE
fix(core): s3 region fallback

### DIFF
--- a/packages/core/src/utils/storage/s3-storage.ts
+++ b/packages/core/src/utils/storage/s3-storage.ts
@@ -9,11 +9,7 @@ export const buildS3Storage = (
   secretAccessKey: string
 ) => {
   // Endpoint example: s3.us-west-2.amazonaws.com
-  const region = /s3\.([^.]*)\.amazonaws/.exec(endpoint)?.[1];
-
-  if (!region) {
-    throw new Error('Invalid S3 endpoint, can not find region');
-  }
+  const region = /s3\.([^.]*)\.amazonaws/.exec(endpoint)?.[1] ?? 'us-east-1';
 
   const client = new S3Client({
     region,


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
Fixed a bug that broke integration with custom s3.

Added a fallback to "us-east-1" as recommended in [this comment](https://github.com/aws/aws-sdk-js-v3/issues/1845#issuecomment-754832210).

During the test, I found that an incorrectly specified region can still break the integration with Minio if the region specified in Minio itself is different from "us-east-1".

The region setting should still be moved to the S3 provider configuration. My solution is just a quick fix.

<!-- Provide detailed PR description below -->


<!-- MANDATORY -->
## Testing
Locally
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
