### PR TITLE
feat(console): add scrollbar for tenant selector

### DIFF
--- a/packages/console/src/containers/AppContent/components/Topbar/TenantSelector/index.module.scss
+++ b/packages/console/src/containers/AppContent/components/Topbar/TenantSelector/index.module.scss
@@ -58,6 +58,15 @@
 .dropdown {
   max-width: 500px;
   min-width: 320px;
+
+  > div:first-child {
+    max-height: calc(100vh - (64px - _.unit(4) + _.unit(1)) - _.unit(6) - (40px + _.unit(1) * 2)); // Secure 24px bottom safe margin.
+    overflow-y: hidden;
+
+    &:hover {
+      overflow-y: auto;
+    }
+  }
 }
 
 .dropdownItem {

--- a/packages/console/src/containers/AppContent/components/Topbar/TenantSelector/index.tsx
+++ b/packages/console/src/containers/AppContent/components/Topbar/TenantSelector/index.tsx
@@ -70,21 +70,23 @@ function TenantSelector() {
           setShowDropdown(false);
         }}
       >
-        {tenants.map(({ id, name, tag }) => (
-          <DropdownItem
-            key={id}
-            className={styles.dropdownItem}
-            onClick={() => {
-              window.open(new URL(`/${id}`, window.location.origin).toString(), '_self');
-            }}
-          >
-            <div className={styles.dropdownName}>{name}</div>
-            <TenantEnvTag className={styles.dropdownTag} tag={tag} />
-            <Tick
-              className={classNames(styles.checkIcon, id === currentTenantId && styles.visible)}
-            />
-          </DropdownItem>
-        ))}
+        <div>
+          {tenants.map(({ id, name, tag }) => (
+            <DropdownItem
+              key={id}
+              className={styles.dropdownItem}
+              onClick={() => {
+                window.open(new URL(`/${id}`, window.location.origin).toString(), '_self');
+              }}
+            >
+              <div className={styles.dropdownName}>{name}</div>
+              <TenantEnvTag className={styles.dropdownTag} tag={tag} />
+              <Tick
+                className={classNames(styles.checkIcon, id === currentTenantId && styles.visible)}
+              />
+            </DropdownItem>
+          ))}
+        </div>
         <Divider />
         <div
           role="button"


### PR DESCRIPTION


<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
add scrollbar for tenant selector when there are too many tenants.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
<img width="1128" alt="image" src="https://github.com/logto-io/logto/assets/15182327/a2d2050a-299b-484e-a512-59eb1794c337">
<img width="1127" alt="image" src="https://github.com/logto-io/logto/assets/15182327/a00884d1-b6b3-4e0b-8119-893fb58e9cd1">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
