### PR TITLE
fix(console): tenant with access token should be redirected

### DIFF
--- a/packages/console/src/cloud/pages/Main/Redirect.tsx
+++ b/packages/console/src/cloud/pages/Main/Redirect.tsx
@@ -25,6 +25,7 @@ function Redirect({ tenants, toTenantId }: Props) {
       // fetch the full-scoped (with all available tenants) token.
       if (await trySafe(getAccessToken(indicator))) {
         setIsSettle(true);
+        navigate(toTenantId);
       } else {
         void signIn(new URL(href, window.location.origin).toString());
       }
@@ -33,7 +34,7 @@ function Redirect({ tenants, toTenantId }: Props) {
     if (tenant) {
       void validate(tenant.indicator);
     }
-  }, [getAccessToken, href, setIsSettle, signIn, tenant]);
+  }, [getAccessToken, href, navigate, setIsSettle, signIn, tenant, toTenantId]);
 
   if (!tenant) {
     /** Fallback to another available tenant instead of showing `Forbidden`. */


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
tenant with access token should be redirected.
Previously, tenants with it's access token granted can not be automatically redirected to its own console page.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
