### PR TITLE
fix(console): should not block admin tenant owner from creating more tenants

### DIFF
--- a/packages/console/src/consts/tenants.ts
+++ b/packages/console/src/consts/tenants.ts
@@ -37,3 +37,5 @@ export const getUserTenantId = () => {
 export const getBasename = () => (isCloud ? '/' + getUserTenantId() : ossConsolePath);
 
 export const getSignOutRedirectPathname = () => (isCloud ? '/' : ossConsolePath);
+
+export const maxFreeTenantNumbers = 3;

--- a/packages/console/src/containers/AppContent/components/Topbar/TenantSelector/index.tsx
+++ b/packages/console/src/containers/AppContent/components/Topbar/TenantSelector/index.tsx
@@ -40,7 +40,7 @@ function TenantSelector() {
     () =>
       /** Should not block admin tenant owners from creating more than three tenants */
       tenants &&
-      !tenants.map(({ id }) => id).includes(adminTenantId) &&
+      !tenants.some(({ id }) => id === adminTenantId) &&
       tenants.length >= maxFreeTenantNumbers,
     [tenants]
   );

--- a/packages/console/src/containers/AppContent/components/Topbar/TenantSelector/index.tsx
+++ b/packages/console/src/containers/AppContent/components/Topbar/TenantSelector/index.tsx
@@ -1,3 +1,4 @@
+import { adminTenantId } from '@logto/schemas';
 import { type TenantInfo } from '@logto/schemas/models';
 import classNames from 'classnames';
 import { useContext, useRef, useState, useEffect, useMemo } from 'react';
@@ -10,6 +11,7 @@ import Tick from '@/assets/icons/tick.svg';
 import { useCloudSwr } from '@/cloud/hooks/use-cloud-swr';
 import CreateTenantModal from '@/cloud/pages/Main/TenantLandingPage/TenantLandingPageContent/CreateTenantModal';
 import AppError from '@/components/AppError';
+import { maxFreeTenantNumbers } from '@/consts/tenants';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import Divider from '@/ds-components/Divider';
 import Dropdown, { DropdownItem } from '@/ds-components/Dropdown';
@@ -34,6 +36,15 @@ function TenantSelector() {
     return tenants?.find((tenant) => tenant.id === currentTenantId);
   }, [currentTenantId, tenants]);
 
+  const isCreateButtonDisabled = useMemo(
+    () =>
+      /** Should not block admin tenant owners from creating more than three tenants */
+      tenants &&
+      !tenants.map(({ id }) => id).includes(adminTenantId) &&
+      tenants.length >= maxFreeTenantNumbers,
+    [tenants]
+  );
+
   const anchorRef = useRef<HTMLDivElement>(null);
   const [showDropdown, setShowDropdown] = useState(false);
   const [showCreateTenantModal, setShowCreateTenantModal] = useState(false);
@@ -45,8 +56,6 @@ function TenantSelector() {
   if (!tenants?.length || !currentTenantInfo) {
     return null;
   }
-
-  const isCreateButtonDisabled = tenants.length >= 3;
 
   return (
     <>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
should not block admin tenant owner from creating more tenants.
Logto team members' lives matter.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
Can create new tenant since this is admin tenant owner.
<img width="1664" alt="image" src="https://github.com/logto-io/logto/assets/15182327/95833116-a789-452f-bbb9-c8909fde4ac1">
Can not create more than three tenants since this is a normal user.
<img width="1660" alt="image" src="https://github.com/logto-io/logto/assets/15182327/9827a1b1-6cd4-4de9-b5ac-7d0b8b30e44f">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
