### PR TITLE
fix(ui): fix ui preview critical bug

### DIFF
--- a/packages/ui/src/Layout/AppLayout/index.module.scss
+++ b/packages/ui/src/Layout/AppLayout/index.module.scss
@@ -1,20 +1,5 @@
 @use '@/scss/underscore' as _;
 
-/* Preview Settings */
-.preview {
-  pointer-events: none;
-  user-select: none;
-
-  .viewBox::-webkit-scrollbar {
-    display: none;
-  }
-
-  main {
-    pointer-events: none;
-    user-select: none;
-  }
-}
-
 /* Main Layout */
 .viewBox {
   position: absolute;

--- a/packages/ui/src/Providers/AppBoundary/AppMeta.tsx
+++ b/packages/ui/src/Providers/AppBoundary/AppMeta.tsx
@@ -1,6 +1,7 @@
 import { conditionalString } from '@silverhand/essentials';
+import classNames from 'classnames';
 import i18next from 'i18next';
-import { useContext, useEffect } from 'react';
+import { useContext } from 'react';
 import { Helmet } from 'react-helmet';
 
 import PageContext from '@/Providers/PageContextProvider/PageContext';
@@ -17,24 +18,14 @@ import * as styles from './index.module.scss';
  * - data-theme: set html data-theme attribute
  * - favicon: set favicon
  * - apple-touch-icon: set apple touch icon
+ * - body class: set preview body class
  * - body class: set platform body class
  * - body class: set theme body class
  * - custom css: set custom css style tag
  */
 
 const AppMeta = () => {
-  const { experienceSettings, theme, platform } = useContext(PageContext);
-
-  useEffect(() => {
-    document.body.classList.remove(
-      conditionalString(styles.light),
-      conditionalString(styles.dark),
-      'mobile',
-      'desktop'
-    );
-    document.body.classList.add(conditionalString(styles[theme]));
-    document.body.classList.add(platform === 'mobile' ? 'mobile' : 'desktop');
-  }, [platform, theme]);
+  const { experienceSettings, theme, platform, isPreview } = useContext(PageContext);
 
   return (
     <Helmet>
@@ -46,6 +37,13 @@ const AppMeta = () => {
         sizes="180x180"
       />
       {experienceSettings?.customCss && <style>{experienceSettings.customCss}</style>}
+      <body
+        className={classNames(
+          conditionalString(isPreview && styles.preview),
+          platform === 'mobile' ? 'mobile' : 'desktop',
+          conditionalString(styles[theme])
+        )}
+      />
     </Helmet>
   );
 };

--- a/packages/ui/src/Providers/AppBoundary/AppMeta.tsx
+++ b/packages/ui/src/Providers/AppBoundary/AppMeta.tsx
@@ -1,7 +1,6 @@
 import { conditionalString } from '@silverhand/essentials';
-import classNames from 'classnames';
 import i18next from 'i18next';
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 
 import PageContext from '@/Providers/PageContextProvider/PageContext';
@@ -26,6 +25,17 @@ import * as styles from './index.module.scss';
 const AppMeta = () => {
   const { experienceSettings, theme, platform } = useContext(PageContext);
 
+  useEffect(() => {
+    document.body.classList.remove(
+      conditionalString(styles.light),
+      conditionalString(styles.dark),
+      'mobile',
+      'desktop'
+    );
+    document.body.classList.add(conditionalString(styles[theme]));
+    document.body.classList.add(platform === 'mobile' ? 'mobile' : 'desktop');
+  }, [platform, theme]);
+
   return (
     <Helmet>
       <html lang={i18next.language} data-theme={theme} />
@@ -36,14 +46,6 @@ const AppMeta = () => {
         sizes="180x180"
       />
       {experienceSettings?.customCss && <style>{experienceSettings.customCss}</style>}
-      <body
-        className={classNames(
-          // Should preserve any existing classNames
-          conditionalString(document.body.className),
-          platform === 'mobile' ? 'mobile' : 'desktop',
-          conditionalString(styles[theme])
-        )}
-      />
     </Helmet>
   );
 };

--- a/packages/ui/src/Providers/AppBoundary/index.module.scss
+++ b/packages/ui/src/Providers/AppBoundary/index.module.scss
@@ -11,6 +11,21 @@ body {
   }
 }
 
+/* Preview Settings */
+.preview {
+  pointer-events: none;
+  user-select: none;
+
+  .viewBox::-webkit-scrollbar {
+    display: none;
+  }
+
+  main {
+    pointer-events: none;
+    user-select: none;
+  }
+}
+
 :global(body.mobile) {
   --max-width: 360px;
   background: var(--color-bg-body);

--- a/packages/ui/src/Providers/SettingsProvider/use-preview.ts
+++ b/packages/ui/src/Providers/SettingsProvider/use-preview.ts
@@ -1,8 +1,6 @@
 import { ConnectorPlatform } from '@logto/schemas';
-import { conditionalString } from '@silverhand/essentials';
 import { useContext, useEffect, useState } from 'react';
 
-import * as styles from '@/Layout/AppLayout/index.module.scss';
 import PageContext from '@/Providers/PageContextProvider/PageContext';
 import initI18n from '@/i18n/init';
 import { changeLanguage } from '@/i18n/utils';
@@ -17,9 +15,6 @@ const usePreview = () => {
   useEffect(() => {
     // Init i18n
     const i18nInit = initI18n();
-
-    // Block pointer event
-    document.body.classList.add(conditionalString(styles.preview));
 
     // Listen to the message from the ancestor window
     const previewMessageHandler = async (event: MessageEvent) => {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

fix ui switch platform and theme style messed up bug

<img width="475" alt="image" src="https://github.com/logto-io/logto/assets/36393111/5a0c7c49-a1b8-4eab-b82c-99c73ae052de">


Bug: when using the react Helmet concat existing classnames on body, failed to clean up the original platform and theme-related classnames. 

Instead of direct contact, the old classname should render new classnames directly. 

Move the preview classname logic under the AppMeta component as well. Let all the body classnames controlled at a same place. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally
<img width="627" alt="image" src="https://github.com/logto-io/logto/assets/36393111/12c99c74-c03d-491b-9152-7f7b93c5d0f6">



<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
test locally

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
