### PR TITLE
fix(console): avoid connector custom config fields conflict with reserved fields

### DIFF
--- a/packages/console/src/components/ConnectorForm/ConfigForm/ConfigFormFields/index.tsx
+++ b/packages/console/src/components/ConnectorForm/ConfigForm/ConfigFormFields/index.tsx
@@ -1,5 +1,6 @@
 import type { ConnectorConfigFormItem } from '@logto/connector-kit';
 import { ConnectorConfigFormItemType } from '@logto/connector-kit';
+import { conditional } from '@silverhand/essentials';
 import { useMemo } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -25,11 +26,13 @@ function ConfigFormFields({ formItems }: Props) {
     watch,
     register,
     control,
-    formState: { errors },
+    formState: {
+      errors: { formConfig: formConfigErrors },
+    },
   } = useFormContext<ConnectorFormType>();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
-  const values = watch();
+  const values = watch('formConfig');
 
   const filteredFormItems = useMemo(() => {
     return formItems.filter((item) => {
@@ -46,10 +49,13 @@ function ConfigFormFields({ formItems }: Props) {
   }, [formItems, values]);
 
   const renderFormItem = (item: ConnectorConfigFormItem) => {
-    const error = errors[item.key]?.message ?? Boolean(errors[item.key]);
+    const error = conditional(
+      formConfigErrors &&
+        (formConfigErrors[item.key]?.message ?? Boolean(formConfigErrors[item.key]))
+    );
 
     const buildCommonProperties = () => ({
-      ...register(item.key, {
+      ...register(`formConfig.${item.key}`, {
         required: item.required,
         valueAsNumber: item.type === ConnectorConfigFormItemType.Number,
       }),
@@ -77,7 +83,7 @@ function ConfigFormFields({ formItems }: Props) {
 
     return (
       <Controller
-        name={item.key}
+        name={`formConfig.${item.key}`}
         control={control}
         rules={{
           // For switch, "false" will be treated as an empty value, so we need to set required to false.

--- a/packages/console/src/components/ConnectorForm/ConfigForm/index.tsx
+++ b/packages/console/src/components/ConnectorForm/ConfigForm/index.tsx
@@ -69,14 +69,14 @@ function ConfigForm({ formItems, className, connectorId, connectorType }: Props)
       ) : (
         <FormField title="connectors.guide.config">
           <Controller
-            name="config"
+            name="jsonConfig"
             control={control}
             rules={{
               validate: (value) => jsonValidator(value) || t('errors.invalid_json_format'),
             }}
             render={({ field: { onChange, value } }) => (
               <CodeEditor
-                error={errors.config?.message ?? Boolean(errors.config)}
+                error={errors.jsonConfig?.message ?? Boolean(errors.jsonConfig)}
                 language="json"
                 value={value}
                 onChange={onChange}

--- a/packages/console/src/hooks/use-connector-form-config-parser.tsx
+++ b/packages/console/src/hooks/use-connector-form-config-parser.tsx
@@ -32,6 +32,8 @@ export const useConnectorFormConfigParser = () => {
   const parseJsonConfig = useJsonStringConfigParser();
 
   return (data: ConnectorFormType, formItems: ConnectorResponse['formItems']) => {
-    return formItems ? parseFormConfig(data, formItems) : parseJsonConfig(data.config);
+    return formItems
+      ? parseFormConfig(data.formConfig, formItems)
+      : parseJsonConfig(data.jsonConfig);
   };
 };

--- a/packages/console/src/pages/Connectors/Guide/index.tsx
+++ b/packages/console/src/pages/Connectors/Guide/index.tsx
@@ -64,16 +64,23 @@ function Guide({ connector, onClose }: Props) {
     watch,
     setError,
     reset,
+    setValue,
   } = methods;
 
   useEffect(() => {
+    const formConfig = conditional(formItems && initFormData(formItems));
     reset({
-      ...(formItems ? initFormData(formItems) : {}),
-      ...(configTemplate ? { config: configTemplate } : {}),
+      ...(configTemplate ? { jsonConfig: configTemplate } : {}),
       ...(isSocialConnector && !isStandard && target ? { target } : {}),
       syncProfile: SyncProfileMode.OnlyAtRegister,
     });
-  }, [formItems, reset, configTemplate, target, isSocialConnector, isStandard]);
+    /**
+     * Note:
+     * Set `formConfig` independently.
+     * Since react-hook-form's reset function infers `Record<string, unknown>` to `{ [x: string]: {} | undefined }` incorrectly.
+     */
+    setValue('formConfig', formConfig ?? {}, { shouldDirty: false });
+  }, [formItems, reset, configTemplate, target, isSocialConnector, isStandard, setValue]);
 
   const configParser = useConnectorFormConfigParser();
 

--- a/packages/console/src/types/connector.ts
+++ b/packages/console/src/types/connector.ts
@@ -14,10 +14,11 @@ export enum SyncProfileMode {
 }
 
 export type ConnectorFormType = {
-  config: string;
+  jsonConfig: string; // Support editing configs by the code editor
+  formConfig: Record<string, unknown>; // Support custom connector config form
   name: string;
   logo: string;
   logoDark: string;
   target: string;
   syncProfile: SyncProfileMode;
-} & Record<string, unknown>; // Extend custom connector config form
+};

--- a/packages/console/src/utils/connector-form.ts
+++ b/packages/console/src/utils/connector-form.ts
@@ -1,7 +1,6 @@
 import type { ConnectorConfigFormItem } from '@logto/connector-kit';
 import { ConnectorConfigFormItemType } from '@logto/connector-kit';
 
-import type { ConnectorFormType } from '@/types/connector';
 import { safeParseJson } from '@/utils/json';
 
 export const initFormData = (
@@ -21,9 +20,12 @@ export const initFormData = (
   return Object.fromEntries(data);
 };
 
-export const parseFormConfig = (data: ConnectorFormType, formItems: ConnectorConfigFormItem[]) => {
+export const parseFormConfig = (
+  config: Record<string, unknown>,
+  formItems: ConnectorConfigFormItem[]
+) => {
   return Object.fromEntries(
-    Object.entries(data)
+    Object.entries(config)
       .map(([key, value]) => {
         // Filter out empty input
         if (value === '') {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The previous ConnectorFormType type directly added the extended custom connector config data to the top-level of the data, whereas the correct approach would be to add it to the config field.
We need to fix it since if the fields in the custom config conflict with the reserved form fields, it can lead to unexpected bugs.

Bug: custom config fields now seat in the top-level of the data
<img width="745" alt="image" src="https://github.com/logto-io/logto/assets/10806653/b9da9729-cef4-4f40-99f8-b54b644b47c7">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Fixed:
<img width="1333" alt="image" src="https://github.com/logto-io/logto/assets/10806653/94572eeb-fbd0-407c-9411-c38d64aa9eab">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
