### PR TITLE
chore(core,ui): set jest config coverage report to all files

### DIFF
--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('jest').Config} */
 const config = {
   transform: {},
+  collectCoverageFrom: ['**/*.{js,ts}'],
   coveragePathIgnorePatterns: ['/node_modules/', '/src/__mocks__/'],
   coverageReporters: ['text-summary', 'lcov'],
   coverageProvider: 'v8',

--- a/packages/ui/jest.config.ts
+++ b/packages/ui/jest.config.ts
@@ -4,6 +4,9 @@ const config: Config.InitialOptions = {
   roots: ['<rootDir>/src'],
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/src/jest.setup.ts'],
+  collectCoverageFrom: ['**/*.{js,jsx,ts,tsx}'],
+  coveragePathIgnorePatterns: ['/node_modules/', '/src/__mocks__/', '/src/include.d/'],
+  coverageReporters: ['text-summary', 'lcov'],
   transform: {
     '^.+\\.(t|j)sx?$': [
       '@swc/jest',


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Set jest config coverage report to all files.

The default settings only collect the coverage info for all the test-covered files. 
Should cover test missed files as well. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test localy

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
