### PR TITLE
fix(console): text color of docs and help button

### DIFF
--- a/packages/console/src/containers/AppContent/components/Topbar/Contact/index.module.scss
+++ b/packages/console/src/containers/AppContent/components/Topbar/Contact/index.module.scss
@@ -33,6 +33,6 @@
 
   span {
     font: var(--font-label-2);
-    color: var(--color-neutral-variant-50);
+    color: var(--color-neutral-variant-30);
   }
 }

--- a/packages/console/src/containers/AppContent/components/Topbar/DocumentNavButton/index.module.scss
+++ b/packages/console/src/containers/AppContent/components/Topbar/DocumentNavButton/index.module.scss
@@ -32,7 +32,7 @@
 
   span {
     font: var(--font-label-2);
-    color: var(--color-neutral-variant-50);
+    color: var(--color-neutral-variant-30);
   }
 }
 


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
text color of docs and help button should be neutral variant 30 (currently is neutral variant 50, which is not right).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
<img width="1654" alt="image" src="https://github.com/logto-io/logto/assets/15182327/e176f3b2-9b83-4ae5-9fc1-4c69fdbd998f">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
