### PR TITLE
fix(schemas): fix sendgrid email service config

### DIFF
--- a/packages/schemas/src/types/system.ts
+++ b/packages/schemas/src/types/system.ts
@@ -81,20 +81,28 @@ export enum OtherEmailTemplate {
 
 export const otherEmailTemplateGuard = z.nativeEnum(OtherEmailTemplate);
 
+const emailServiceBasicConfig = {
+  fromName: z.string(),
+  fromEmail: z.string(),
+  templates: z.record(
+    verificationCodeTypeGuard.or(otherEmailTemplateGuard),
+    z.object({
+      subject: z.string(),
+      content: z.string(),
+    })
+  ),
+};
+
+export const sendgridEmailServiceDataGuard = z.object({
+  provider: z.literal(EmailServiceProvider.SendGrid),
+  apiKey: z.string(),
+  ...emailServiceBasicConfig,
+});
+
+export type SendgridEmailServiceData = z.infer<typeof sendgridEmailServiceDataGuard>;
+
 export const emailServiceDataGuard = z.discriminatedUnion('provider', [
-  z.object({
-    provider: z.literal(EmailServiceProvider.SendGrid),
-    appId: z.string(),
-    appSecret: z.string(),
-    fromEmail: z.string(),
-    templates: z.record(
-      verificationCodeTypeGuard.or(otherEmailTemplateGuard),
-      z.object({
-        subject: z.string(),
-        content: z.string(),
-      })
-    ),
-  }),
+  sendgridEmailServiceDataGuard,
 ]);
 
 export type EmailServiceData = z.infer<typeof emailServiceDataGuard>;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix Sendgrid email service config:
1. for sendgrid, only `apiKey` is required, previously the email service guard does not distinguish different providers.
2. also add required `fromName`.
<img width="805" alt="image" src="https://github.com/logto-io/logto/assets/15182327/949dcd5b-f5de-4300-9981-18a27778e4c4">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
