### PR TITLE
fix(core): add invalid body request error on oidc endpoints

### DIFF
--- a/packages/core/src/errors/RequestError/index.ts
+++ b/packages/core/src/errors/RequestError/index.ts
@@ -45,6 +45,10 @@ export default class RequestError extends Error {
   }
 
   get details(): Optional<string> {
+    if (this.data instanceof SyntaxError) {
+      return conditional(this.data.message);
+    }
+
     return conditional(this.data instanceof ZodError && formatZodError(this.data).join('\n'));
   }
 }

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -311,6 +311,10 @@ export default function initOidc(
    * Other parsers are explicitly disabled to keep it neat.
    */
   oidc.use(async (ctx, next) => {
+    // `koa-body` will throw `SyntaxError` if the request body is not a valid JSON
+    // By default any untracked server error will throw a `500` internal error. Instead of throwing 500 error
+    // we should throw a `400` RequestError for all the invalid request body input.
+
     try {
       await koaBody({ urlencoded: false, text: false })(ctx, next);
     } catch (error: unknown) {


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
should throw an invalid body request error for all OIDC endpoints' input syntax error



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
<img width="1004" alt="image" src="https://github.com/logto-io/logto/assets/36393111/b55681af-e9a0-4bb5-ae98-dfb51b22fee7">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
