### PR TITLE
refactor(core): add extraInfo to connector GET APIs response

### DIFF
--- a/packages/core/src/routes/connector/index.ts
+++ b/packages/core/src/routes/connector/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { buildRawConnector } from '@logto/cli/lib/connector/index.js';
 import { demoConnectorIds, validateConfig } from '@logto/connector-kit';
 import {
@@ -44,9 +45,15 @@ export default function connectorRoutes<T extends AuthedRouter>(
   const {
     signInExperiences: { removeUnavailableSocialConnectorTargets },
   } = tenant.libraries;
+
+  // Will accept other source of `extraInfo` in the future.
   const { emailServiceProviderConfig } = SystemContext.shared;
-  const buildExtraInfo = (connectorFactoryId: string) =>
-    buildExtraInfoFromEmailServiceData(connectorFactoryId, emailServiceProviderConfig);
+  const buildExtraInfo = (connectorFactoryId: string) => {
+    const extraInfo = {
+      ...buildExtraInfoFromEmailServiceData(connectorFactoryId, emailServiceProviderConfig),
+    };
+    return cleanDeep(extraInfo, { emptyObjects: false });
+  };
 
   router.post(
     '/connectors',
@@ -353,3 +360,5 @@ export default function connectorRoutes<T extends AuthedRouter>(
   connectorConfigTestingRoutes(router, tenant);
   connectorAuthorizationUriRoutes(router, tenant);
 }
+/** TODO @Darcy: refactor this file later. */
+/* eslint-enable max-lines */

--- a/packages/core/src/utils/connectors/index.ts
+++ b/packages/core/src/utils/connectors/index.ts
@@ -15,7 +15,7 @@ import {
 } from '@logto/connector-kit';
 import type { ConnectorFactoryResponse, ConnectorResponse, EmailServiceData } from '@logto/schemas';
 import { findPackage } from '@logto/shared';
-import { conditional, deduplicate, pick, trySafe } from '@silverhand/essentials';
+import { conditional, deduplicate, pick, trySafe, type Optional } from '@silverhand/essentials';
 
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
@@ -68,7 +68,7 @@ export const transpileConnectorFactory = ({
 export const buildExtraInfoFromEmailServiceData = (
   connectorFactoryId: string,
   emailServiceProviderConfig?: EmailServiceData
-): ConnectorResponse['extraInfo'] => {
+): Optional<Record<string, unknown>> => {
   return conditional(
     connectorFactoryId === ServiceConnector.Email &&
       emailServiceProviderConfig?.fromEmail && { fromEmail: emailServiceProviderConfig.fromEmail }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
add `extraInfo` to connector APIs response.
at this stage, `extraInfo` return only `fromEmail` of the email service provider's sender email address for Logto Email connector. In the future, we may extend the use cases of `extraInfo`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
<img width="2903" alt="image" src="https://github.com/logto-io/logto/assets/15182327/f1f798d7-96a4-4a46-be61-8b2bfc914160">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
