### PR TITLE
fix(core): block logto email connector (create and enter detail page)

### DIFF
--- a/packages/core/src/utils/connectors/index.ts
+++ b/packages/core/src/utils/connectors/index.ts
@@ -8,6 +8,7 @@ import { connectorDirectory } from '@logto/cli/lib/constants.js';
 import { getConnectorPackagesFromDirectory } from '@logto/cli/lib/utils.js';
 import {
   demoConnectorIds,
+  serviceConnectorIds,
   ConnectorType,
   type EmailConnector,
   type SmsConnector,
@@ -39,7 +40,8 @@ export const transpileLogtoConnector = async (
   );
   const { dbEntry, metadata, type } = connector;
   const { config, connectorId: id } = dbEntry;
-  const isDemo = demoConnectorIds.includes(id);
+  /** Temporarily block entering Logto email connector as well until this feature is ready for prod. */
+  const isDemo = demoConnectorIds.includes(id) || serviceConnectorIds.includes(id);
 
   return {
     type,
@@ -57,7 +59,12 @@ export const transpileConnectorFactory = ({
   metadata,
   type,
 }: ConnectorFactory): ConnectorFactoryResponse => {
-  return { type, ...metadata, isDemo: demoConnectorIds.includes(metadata.id) };
+  return {
+    type,
+    ...metadata,
+    /** Temporarily block entering Logto email connector as well until this feature is ready for prod. */
+    isDemo: demoConnectorIds.includes(metadata.id) || serviceConnectorIds.includes(metadata.id),
+  };
 };
 
 const checkDuplicateConnectorFactoriesId = (connectorFactories: ConnectorFactory[]) => {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
block logto email connector:
1. enter detail page and change the connector config
2. create logto email connector

Will remove this block when the whole feature is ready for Prod.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
tested locally.
1. can not enter detail page:
<img width="2273" alt="image" src="https://github.com/logto-io/logto/assets/15182327/b16b1aea-faff-48bd-8abe-7f449170673c">
2. can not create logto email connector:
<img width="2255" alt="image" src="https://github.com/logto-io/logto/assets/15182327/606bb2ed-d321-4c2e-84b3-1d8ad919c724">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
