### PR TITLE
ci: use short sha fro event_dispatch payload

### DIFF
--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -15,10 +15,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # `github.sha` is the full SHA, but the short SHA looks nicer
+      - name: Set short SHA output
+        id: sha
+        run: echo "short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
       - name: Dispatch Event
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.BOT_PAT }}
           repository: ${{ matrix.target }}
           event-type: ${{ github.event_name }}
-          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "sha_short": "${{ steps.sha.outputs.short }}"}'


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
short SHA looks nicer in the commit message header as currently the full sha will result a new line:

<img width="659" alt="image" src="https://github.com/logto-io/logto/assets/14722250/e25d19ed-5982-4d87-9ba3-338de371c888">

will keep the full sha in the commit message body

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
should be alright. need to submit a new PR in the cloud repo after merge

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
