### PR TITLE
refactor(core): update connector APIs for parsing config

### DIFF
--- a/packages/core/src/utils/endpoint.ts
+++ b/packages/core/src/utils/endpoint.ts
@@ -2,9 +2,7 @@ import { appendPath } from '@silverhand/essentials';
 
 import { EnvSet } from '#src/env-set/index.js';
 
-/** Will use this method in upcoming changes. */
-// eslint-disable-next-line import/no-unused-modules
-export const getCloudConnectionEndpoints = async () => {
+export const getCloudConnectionEndpoints = () => {
   const { cloudUrlSet, adminUrlSet } = EnvSet.values;
   return {
     tokenEndpoint: appendPath(adminUrlSet.endpoint, 'oidc/token').toString(),


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
update connector APIs for parsing config.
For connectors relies on cloud service APIs, we use an M2M app connection internally. In order to keep the M2M credentials invisible to end-users, we need to:
1. hide the credential in GET APIs (not only in the front end, but the response of GET APIs can also be checked in the browser's console)
2. should attach the credential before calling PATCH and test APIs.

TODO:
should refactor this:
`configPatcher` and `configPruner` are using cross routes, should be placed in libraries or something similar for reuse. The issue is that, this method relies on both functions from `logtoConfigs` and `connectors` libraries. Maybe should have a level in which the methods can rely on different libraries.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
