### PR TITLE
refactor(schemas): sync cloud m2m credential to logto config

### DIFF
--- a/packages/schemas/src/seeds/logto-config.ts
+++ b/packages/schemas/src/seeds/logto-config.ts
@@ -1,6 +1,8 @@
 import { type CreateLogtoConfig } from '../db-entries/index.js';
-import type { AdminConsoleData } from '../types/index.js';
+import type { AdminConsoleData, CloudConnectionData } from '../types/index.js';
 import { LogtoTenantConfigKey } from '../types/index.js';
+
+import { cloudApiIndicator } from './cloud-api.js';
 
 export const createDefaultAdminConsoleConfig = (
   forTenantId: string
@@ -21,5 +23,24 @@ export const createDefaultAdminConsoleConfig = (
       roleCreated: false,
       communityChecked: false,
       m2mApplicationCreated: false,
+    },
+  } satisfies CreateLogtoConfig);
+
+export const createDefaultCloudConnectionConfig = (
+  forTenantId: string,
+  appId: string,
+  appSecret: string
+): Readonly<{
+  tenantId: string;
+  key: LogtoTenantConfigKey;
+  value: CloudConnectionData;
+}> =>
+  Object.freeze({
+    tenantId: forTenantId,
+    key: LogtoTenantConfigKey.CloudConnection,
+    value: {
+      appId,
+      appSecret,
+      resource: cloudApiIndicator,
     },
   } satisfies CreateLogtoConfig);

--- a/packages/schemas/src/types/logto-config.ts
+++ b/packages/schemas/src/types/logto-config.ts
@@ -34,13 +34,24 @@ export const adminConsoleDataGuard = z.object({
 
 export type AdminConsoleData = z.infer<typeof adminConsoleDataGuard>;
 
+/* --- Logto tenant cloud connection config --- */
+export const cloudConnectionDataGuard = z.object({
+  appId: z.string(),
+  appSecret: z.string(),
+  resource: z.string(),
+});
+
+export type CloudConnectionData = z.infer<typeof cloudConnectionDataGuard>;
+
 export enum LogtoTenantConfigKey {
   AdminConsole = 'adminConsole',
+  CloudConnection = 'cloudConnection',
   /** The URL to redirect when session not found in Sign-in Experience. */
   SessionNotFoundRedirectUrl = 'sessionNotFoundRedirectUrl',
 }
 export type LogtoTenantConfigType = {
   [LogtoTenantConfigKey.AdminConsole]: AdminConsoleData;
+  [LogtoTenantConfigKey.CloudConnection]: CloudConnectionData;
   [LogtoTenantConfigKey.SessionNotFoundRedirectUrl]: { url: string };
 };
 
@@ -48,6 +59,7 @@ export const logtoTenantConfigGuard: Readonly<{
   [key in LogtoTenantConfigKey]: ZodType<LogtoTenantConfigType[key]>;
 }> = Object.freeze({
   [LogtoTenantConfigKey.AdminConsole]: adminConsoleDataGuard,
+  [LogtoTenantConfigKey.CloudConnection]: cloudConnectionDataGuard,
   [LogtoTenantConfigKey.SessionNotFoundRedirectUrl]: z.object({ url: z.string() }),
 });
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
sync cloud m2m credential to logto config:
1. utils functions and corresponding types' definition

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally, can successfully sync `default` tenant's m2m app credentials.
<img width="1063" alt="image" src="https://github.com/logto-io/logto/assets/15182327/0412e9b7-7689-496f-a2a4-a4e4821be034">
<img width="1235" alt="image" src="https://github.com/logto-io/logto/assets/15182327/8cbe46ab-3469-4002-b0cd-f71431ef8b05">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
