### PR TITLE
feat(console): save and update user default tenant id

### DIFF
--- a/packages/console/src/cloud/pages/Main/Redirect.tsx
+++ b/packages/console/src/cloud/pages/Main/Redirect.tsx
@@ -3,15 +3,12 @@ import { useContext, useEffect } from 'react';
 import AppLoading from '@/components/AppLoading';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 
-function Redirect() {
-  const { navigateTenant, tenants, currentTenant } = useContext(TenantsContext);
+function Redirect({ toTenantId }: { toTenantId: string }) {
+  const { navigateTenant } = useContext(TenantsContext);
 
   useEffect(() => {
-    if (!currentTenant) {
-      /** Fallback to another available tenant instead of showing `Forbidden`. */
-      navigateTenant(tenants[0]?.id ?? '');
-    }
-  }, [navigateTenant, currentTenant, tenants]);
+    navigateTenant(toTenantId);
+  }, [navigateTenant, toTenantId]);
 
   return <AppLoading />;
 }

--- a/packages/console/src/cloud/pages/Main/index.tsx
+++ b/packages/console/src/cloud/pages/Main/index.tsx
@@ -1,7 +1,6 @@
-import { useContext } from 'react';
-
 import AppLoading from '@/components/AppLoading';
-import { TenantsContext } from '@/contexts/TenantsProvider';
+import useMeCustomData from '@/hooks/use-me-custom-data';
+import useUserDefaultTenantId from '@/hooks/use-user-default-tenant-id';
 import useUserOnboardingData from '@/onboarding/hooks/use-user-onboarding-data';
 
 import AutoCreateTenant from './AutoCreateTenant';
@@ -9,19 +8,17 @@ import Redirect from './Redirect';
 import TenantLandingPage from './TenantLandingPage';
 
 export default function Main() {
-  const { tenants } = useContext(TenantsContext);
-  const { isOnboarding, isLoaded } = useUserOnboardingData();
+  const { isLoaded } = useMeCustomData();
+  const { isOnboarding } = useUserOnboardingData();
+  const { defaultTenantId } = useUserDefaultTenantId();
 
   if (!isLoaded) {
     return <AppLoading />;
   }
 
-  /**
-   * If current tenant ID is not set, but there is at least one tenant available,
-   * trigger a redirect to the first tenant.
-   */
-  if (tenants[0]) {
-    return <Redirect />;
+  // If current tenant ID is not set, but the defaultTenantId is available.
+  if (defaultTenantId) {
+    return <Redirect toTenantId={defaultTenantId} />;
   }
 
   // A new user has just signed up and has no tenant, needs to create a new tenant.

--- a/packages/console/src/contexts/TenantsProvider.tsx
+++ b/packages/console/src/contexts/TenantsProvider.tsx
@@ -41,6 +41,7 @@ type Tenants = {
    */
   currentTenantStatus: CurrentTenantStatus;
   setCurrentTenantStatus: (status: CurrentTenantStatus) => void;
+  /** Navigate to the given tenant ID. */
   navigateTenant: (tenantId: string, options?: NavigateOptions) => void;
 };
 

--- a/packages/console/src/hooks/use-user-default-tenant-id.ts
+++ b/packages/console/src/hooks/use-user-default-tenant-id.ts
@@ -13,7 +13,6 @@ const key = 'defaultTenantId';
  *
  * - By default, the default tenant ID is empty, which means the first tenant is the default tenant.
  * - If the default tenant ID is not available to the user anymore, it semantically equals to the first tenant ID.
- * - If the user manually navigates to a tenant, the default tenant ID will be set to the target tenant ID.
  */
 const useUserDefaultTenantId = () => {
   const { data, update: updateMeCustomData } = useMeCustomData();
@@ -41,12 +40,7 @@ const useUserDefaultTenantId = () => {
 
   return {
     defaultTenantId,
-    /**
-     * Update the default tenant ID to the current tenant ID if:
-     *
-     * 1. The current tenant ID is not empty.
-     * 2. The default tenant ID does not equal to the current tenant ID.
-     */
+    /** Update the default tenant ID to the current tenant ID. */
     updateIfNeeded,
   };
 };

--- a/packages/console/src/hooks/use-user-default-tenant-id.ts
+++ b/packages/console/src/hooks/use-user-default-tenant-id.ts
@@ -1,0 +1,54 @@
+import { trySafe } from '@silverhand/essentials';
+import { useCallback, useContext, useMemo } from 'react';
+import { z } from 'zod';
+
+import { TenantsContext } from '@/contexts/TenantsProvider';
+
+import useMeCustomData from './use-me-custom-data';
+
+const key = 'defaultTenantId';
+
+/**
+ * A hook that gets the default tenant ID for the current user from user's `customData`.
+ *
+ * - By default, the default tenant ID is empty, which means the first tenant is the default tenant.
+ * - If the default tenant ID is not available to the user anymore, it semantically equals to the first tenant ID.
+ * - If the user manually navigates to a tenant, the default tenant ID will be set to the target tenant ID.
+ */
+const useUserDefaultTenantId = () => {
+  const { data, update: updateMeCustomData } = useMeCustomData();
+  const { tenants, currentTenantId } = useContext(TenantsContext);
+
+  const defaultTenantId = useMemo(() => {
+    const storedId = trySafe(() => z.object({ [key]: z.string() }).parse(data)[key]);
+
+    // Ensure the stored ID is still available to the user.
+    if (storedId && tenants.some(({ id }) => id === storedId)) {
+      return storedId;
+    }
+
+    // Fall back to the first tenant ID.
+    return tenants[0]?.id;
+  }, [data, tenants]);
+
+  const updateIfNeeded = useCallback(async () => {
+    if (currentTenantId !== defaultTenantId) {
+      await updateMeCustomData({
+        [key]: currentTenantId,
+      });
+    }
+  }, [currentTenantId, defaultTenantId, updateMeCustomData]);
+
+  return {
+    defaultTenantId,
+    /**
+     * Update the default tenant ID to the current tenant ID if:
+     *
+     * 1. The current tenant ID is not empty.
+     * 2. The default tenant ID does not equal to the current tenant ID.
+     */
+    updateIfNeeded,
+  };
+};
+
+export default useUserDefaultTenantId;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

introduce and save "user's default tenant id" to custom data, which means the last tenant id that user opened or the first available tenant id. fall back to empty if there's no tenant available.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] switch tenant, `defaultTenantId` will be updated in custom data
- [ ] (pending test in dev) if no tenant available, `defaultTenantId` will be updated to an empty string

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

sorry i'm currently out of bandwidth for writing integration tests for this nice-to-have feature. will try to add some when we refactor the tenant navigation LOG-6474.

also due to this implementation, you may not see the `PATCH` request for local dev since the new page loads too quick. this will also be fixed in LOG-6474.

- [x] This PR is not applicable for the checklist
