### PR TITLE
fix(core,connector): use isProduction as email service feature switch

### DIFF
--- a/packages/connectors/connector-logto-email/src/constant.ts
+++ b/packages/connectors/connector-logto-email/src/constant.ts
@@ -104,9 +104,9 @@ export const scope = ['send:email'];
 
 export const defaultTimeout = 5000;
 
-export const oldEmailEndpoint = '/services/send-email';
-export const newEmailEndpoint = '/services/mails';
+/** @deprecated Will be replaced by `/services/mails` soon. */
+export const demoEmailEndpoint = '/services/send-email';
 export const emailEndpoint =
-  getEnv('NODE_ENV') === 'production' ? oldEmailEndpoint : newEmailEndpoint;
+  getEnv('NODE_ENV') === 'production' ? demoEmailEndpoint : '/services/mails';
 
 export const usageEndpoint = '/services/mails/usage';

--- a/packages/connectors/connector-logto-email/src/constant.ts
+++ b/packages/connectors/connector-logto-email/src/constant.ts
@@ -1,3 +1,5 @@
+import { getEnv } from '@silverhand/essentials';
+
 import type { ConnectorMetadata } from '@logto/connector-kit';
 import { ConnectorConfigFormItemType } from '@logto/connector-kit';
 
@@ -102,6 +104,9 @@ export const scope = ['send:email'];
 
 export const defaultTimeout = 5000;
 
-export const emailEndpoint = '/services/mails';
+export const oldEmailEndpoint = '/services/send-email';
+export const newEmailEndpoint = '/services/mails';
+export const emailEndpoint =
+  getEnv('NODE_ENV') === 'production' ? oldEmailEndpoint : newEmailEndpoint;
 
 export const usageEndpoint = '/services/mails/usage';

--- a/packages/core/src/utils/connectors/index.ts
+++ b/packages/core/src/utils/connectors/index.ts
@@ -28,6 +28,14 @@ export const isPasswordlessLogtoConnector = (
 ): connector is LogtoConnector<EmailConnector | SmsConnector> =>
   connector.type !== ConnectorType.Social;
 
+/**
+ * Treat Logto service connectors as demo connectors in production since they are not available
+ * for public use yet.
+ */
+const isDemoConnector = (connectorId: string) =>
+  demoConnectorIds.includes(connectorId) ||
+  (EnvSet.values.isProduction && serviceConnectorIds.includes(connectorId));
+
 export const transpileLogtoConnector = async (
   connector: LogtoConnector,
   extraInfo?: ConnectorResponse['extraInfo']
@@ -41,10 +49,8 @@ export const transpileLogtoConnector = async (
   );
   const { dbEntry, metadata, type } = connector;
   const { config, connectorId: id } = dbEntry;
-  /** Temporarily block entering Logto email connector as well until this feature is ready for prod. */
-  const isDemo =
-    demoConnectorIds.includes(id) ||
-    (EnvSet.values.isProduction && serviceConnectorIds.includes(id));
+
+  const isDemo = isDemoConnector(id);
 
   return {
     type,
@@ -66,9 +72,7 @@ export const transpileConnectorFactory = ({
     type,
     ...metadata,
     /** Temporarily block entering Logto email connector as well until this feature is ready for prod. */
-    isDemo:
-      demoConnectorIds.includes(metadata.id) ||
-      (EnvSet.values.isProduction && serviceConnectorIds.includes(metadata.id)),
+    isDemo: isDemoConnector(metadata.id),
   };
 };
 

--- a/packages/core/src/utils/connectors/index.ts
+++ b/packages/core/src/utils/connectors/index.ts
@@ -8,6 +8,7 @@ import { connectorDirectory } from '@logto/cli/lib/constants.js';
 import { getConnectorPackagesFromDirectory } from '@logto/cli/lib/utils.js';
 import {
   demoConnectorIds,
+  serviceConnectorIds,
   ConnectorType,
   type EmailConnector,
   type SmsConnector,
@@ -40,7 +41,10 @@ export const transpileLogtoConnector = async (
   );
   const { dbEntry, metadata, type } = connector;
   const { config, connectorId: id } = dbEntry;
-  const isDemo = demoConnectorIds.includes(id);
+  /** Temporarily block entering Logto email connector as well until this feature is ready for prod. */
+  const isDemo =
+    demoConnectorIds.includes(id) ||
+    (EnvSet.values.isProduction && serviceConnectorIds.includes(id));
 
   return {
     type,
@@ -61,7 +65,10 @@ export const transpileConnectorFactory = ({
   return {
     type,
     ...metadata,
-    isDemo: demoConnectorIds.includes(metadata.id),
+    /** Temporarily block entering Logto email connector as well until this feature is ready for prod. */
+    isDemo:
+      demoConnectorIds.includes(metadata.id) ||
+      (EnvSet.values.isProduction && serviceConnectorIds.includes(metadata.id)),
   };
 };
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
use `isProduction` as logto email service feature switch, users from production env can not access to WIP logto email service.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Can switch cloud service API `endpoint` and `isDemo` properly according to NODE_ENV.
NODE_ENV=production, isDemo = true
<img width="1134" alt="image" src="https://github.com/logto-io/logto/assets/15182327/76af9a89-fe15-4919-82e1-480232ee9a13">
otherwise, isDemo = false
<img width="1136" alt="image" src="https://github.com/logto-io/logto/assets/15182327/450bde0d-5baf-4c8a-a25b-b581332da2a4">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
