### PR TITLE
fix(console): avoid updating dirty form data

### DIFF
--- a/packages/console/src/pages/ApplicationDetails/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/index.tsx
@@ -85,8 +85,12 @@ function ApplicationDetails() {
       return;
     }
 
+    if (isDirty) {
+      return;
+    }
+
     reset(data);
-  }, [data, reset]);
+  }, [data, isDirty, reset]);
 
   const onSubmit = handleSubmit(
     trySubmitSafe(async (formData) => {
@@ -114,6 +118,7 @@ function ApplicationDetails() {
           },
         })
         .json<Application>();
+      reset(formData);
       void mutate();
       toast.success(t('general.saved'));
     })

--- a/packages/console/src/pages/ConnectorDetails/ConnectorContent/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/ConnectorContent/index.tsx
@@ -68,8 +68,14 @@ function ConnectorContent({ isDeleted, connectorData, onConnectorUpdated }: Prop
   const isEmailServiceConnector = connectorId === ServiceConnector.Email;
 
   useEffect(() => {
+    /**
+     * Note: should not refresh form data when the form is dirty.
+     */
+    if (isDirty) {
+      return;
+    }
     reset(formData);
-  }, [formData, reset]);
+  }, [formData, isDirty, reset]);
 
   const configParser = useConnectorFormConfigParser();
 
@@ -97,6 +103,10 @@ function ConnectorContent({ isDeleted, connectorData, onConnectorUpdated }: Prop
           json: body,
         })
         .json<ConnectorResponse>();
+      /**
+       * Note: reset form dirty state before updating the form data.
+       */
+      reset();
       onConnectorUpdated(updatedConnector);
       toast.success(t('general.saved'));
     })

--- a/packages/console/src/pages/SignInExperience/index.tsx
+++ b/packages/console/src/pages/SignInExperience/index.tsx
@@ -111,10 +111,13 @@ function SignInExperience() {
   }, [data]);
 
   useEffect(() => {
+    if (isDirty) {
+      return;
+    }
     if (defaultFormData) {
       reset(defaultFormData);
     }
-  }, [reset, defaultFormData]);
+  }, [reset, defaultFormData, isDirty]);
 
   const saveData = async () => {
     setIsSaving(true);
@@ -125,6 +128,7 @@ function SignInExperience() {
           json: signInExperienceParser.toRemoteModel(getValues()),
         })
         .json<SignInExperienceType>();
+      reset(signInExperienceParser.toLocalForm(updatedData));
       void mutate(updatedData);
       setDataToCompare(undefined);
       await updateConfigs({ signInExperienceCustomized: true });

--- a/packages/console/src/pages/SignInExperience/tabs/Others/components/ManageLanguage/LanguageEditor/index.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/Others/components/ManageLanguage/LanguageEditor/index.tsx
@@ -34,6 +34,7 @@ function LanguageEditorModal({ isOpen, onClose }: Props) {
     setPreSelectedLanguage,
     setPreAddedLanguage,
     setConfirmationState,
+    setIsDirty,
   } = useContext(LanguageEditorContext);
 
   useEffect(() => {
@@ -68,6 +69,7 @@ function LanguageEditorModal({ isOpen, onClose }: Props) {
     }
 
     setConfirmationState('none');
+    setIsDirty(false);
   };
 
   return (


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
When the connector usage data changes, we will get a brand new `connectorData`, this new data will cause the connector form to be reset.

Other pages may have the same issue, updated together.

We should not update dirty form data, user input should be kept.

### Todo
This is a legacy issue since the beginning of the project.
We rely on the `useEffect` hook to set the default values of the form, which sometimes causes the form to be reset by `useEffect`.
The correct approach would be to render the form after retrieving the backend data.

- LOG-6514: Refactor: Render Form After the Data is Fetched

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Check all pages
- [x] Fix pages may have this issue

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
