### PR TITLE
fix(schemas): remove incorrect tenantInfoGuard type

### DIFF
--- a/packages/schemas/src/models/tenants.ts
+++ b/packages/schemas/src/models/tenants.ts
@@ -30,6 +30,6 @@ export type TenantModel = InferModelType<typeof Tenants>;
 
 export type TenantInfo = Pick<TenantModel, 'id' | 'name' | 'tag'> & { indicator: string };
 
-export const tenantInfoGuard: z.ZodType<TenantInfo> = Tenants.guard('model')
+export const tenantInfoGuard = Tenants.guard('model')
   .pick({ id: true, name: true, tag: true })
   .extend({ indicator: z.string() });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The type definition for `tenantInfoGuard` is incorret, resulting the lost of method "extend", remove it, use auto type infer.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Existing CI tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
