### PR TITLE
refactor(schemas): specify tenants table schema

### DIFF
--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -86,7 +86,7 @@
     "@logto/phrases": "workspace:^1.4.1",
     "@logto/phrases-ui": "workspace:^1.2.0",
     "@logto/shared": "workspace:^2.0.0",
-    "@withtyped/server": "^0.12.5"
+    "@withtyped/server": "^0.12.7"
   },
   "peerDependencies": {
     "zod": "^3.20.2"

--- a/packages/schemas/src/models/tenants.ts
+++ b/packages/schemas/src/models/tenants.ts
@@ -8,7 +8,8 @@ export enum TenantTag {
   Production = 'production',
 }
 
-export const Tenants = createModel(/* sql */ `
+export const Tenants = createModel(
+  /* Sql */ `
   /* init_order = 0 */
   create table tenants (
     id varchar(21) not null,
@@ -22,7 +23,9 @@ export const Tenants = createModel(/* sql */ `
       unique (db_user)
   );
   /* no_after_each */
-`)
+`,
+  'public'
+)
   .extend('tag', z.nativeEnum(TenantTag))
   .extend('createdAt', { readonly: true });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3547,8 +3547,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../shared
       '@withtyped/server':
-        specifier: ^0.12.5
-        version: 0.12.5(zod@3.20.2)
+        specifier: ^0.12.7
+        version: 0.12.7(zod@3.20.2)
       zod:
         specifier: ^3.20.2
         version: 3.20.2
@@ -7163,7 +7163,7 @@ packages:
     resolution: {integrity: sha512-4XsXlCC0uZHcfazV09/4YKo4koqvSzQlkPUAToTp/WHpb6h2XDOJh5/hi55LXL4zp0PCcgpErKRxFCtgXCc6WQ==}
     dependencies:
       '@logto/client': 2.2.0
-      '@silverhand/essentials': 2.6.2
+      '@silverhand/essentials': 2.7.0
       js-base64: 3.7.5
     dev: true
 
@@ -9825,6 +9825,16 @@ packages:
       '@silverhand/essentials': 2.7.0
       '@withtyped/shared': 0.2.2
       zod: 3.20.2
+
+  /@withtyped/server@0.12.7(zod@3.20.2):
+    resolution: {integrity: sha512-NNT78ZZmSZiEosxI3iW/kVx1KEG5vetvpEXNl0Gy58OlOnI8l/7h8Q//JZJ268xWOKyaNI4KrngTRtL5uvZu9Q==}
+    peerDependencies:
+      zod: ^3.19.1
+    dependencies:
+      '@silverhand/essentials': 2.7.0
+      '@withtyped/shared': 0.2.2
+      zod: 3.20.2
+    dev: false
 
   /@withtyped/shared@0.2.2:
     resolution: {integrity: sha512-Vpcj12NqaoZ8M5Z/1kffheI9FBZEm9goed0THmgTcMKXLHjXSRbMZMp0olVxovEgaTIAydshqJOQUXKZMctIZw==}


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- upgrade withtyped packages
- specify tenant model schema to `public` since we're changing the search_path to cloud only in cloud queries

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
locally tested with cloud, can enter console (with tenant-related APIs called)

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
