### PR TITLE
feat(console): add current plan form for subscription page

### DIFF
--- a/packages/console/src/cloud/types/router.ts
+++ b/packages/console/src/cloud/types/router.ts
@@ -8,3 +8,5 @@ export type SubscriptionPlanResponse = GuardedResponse<
 >[number];
 
 export type Subscription = GuardedResponse<GetRoutes['/api/tenants/:tenantId/subscription']>;
+
+export type SubscriptionUsage = GuardedResponse<GetRoutes['/api/tenants/:tenantId/usage']>;

--- a/packages/console/src/components/PlanDescription/index.module.scss
+++ b/packages/console/src/components/PlanDescription/index.module.scss
@@ -1,0 +1,7 @@
+@use '@/scss/underscore' as _;
+
+.description {
+  margin-top: _.unit(1);
+  font: var(--font-body-2);
+  color: var(--color-text-secondary);
+}

--- a/packages/console/src/components/PlanDescription/index.tsx
+++ b/packages/console/src/components/PlanDescription/index.tsx
@@ -1,0 +1,33 @@
+import { type TFuncKey } from 'i18next';
+
+import DynamicT from '@/ds-components/DynamicT';
+import { ReservedPlanName } from '@/types/subscriptions';
+
+import * as styles from './index.module.scss';
+
+const registeredPlanDescriptionPhrasesMap: Record<
+  string,
+  TFuncKey<'translation', 'admin_console.subscription'> | undefined
+> = {
+  [ReservedPlanName.Free]: 'free_plan_description',
+  [ReservedPlanName.Hobby]: 'hobby_plan_description',
+  [ReservedPlanName.Pro]: 'pro_plan_description',
+};
+
+type Props = { planName: string };
+
+function PlanDescription({ planName }: Props) {
+  const description = registeredPlanDescriptionPhrasesMap[planName];
+
+  if (!description) {
+    return null;
+  }
+
+  return (
+    <div className={styles.description}>
+      <DynamicT forKey={`subscription.${description}`} />
+    </div>
+  );
+}
+
+export default PlanDescription;

--- a/packages/console/src/consts/subscriptions.ts
+++ b/packages/console/src/consts/subscriptions.ts
@@ -6,7 +6,7 @@ import {
   SubscriptionPlanTableGroupKey,
 } from '@/types/subscriptions';
 
-export enum ReservedPlanId {
+enum ReservedPlanId {
   free = 'free',
   hobby = 'hobby',
   pro = 'pro',

--- a/packages/console/src/hooks/use-current-subscription-usage.ts
+++ b/packages/console/src/hooks/use-current-subscription-usage.ts
@@ -2,20 +2,21 @@ import { useContext } from 'react';
 import useSWR from 'swr';
 
 import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
-import { type Subscription } from '@/cloud/types/router';
+import { type SubscriptionUsage } from '@/cloud/types/router';
 import { isCloud } from '@/consts/env';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 
-const useCurrentSubscription = () => {
+const useCurrentSubscriptionUsage = () => {
   const { currentTenantId } = useContext(TenantsContext);
   const cloudApi = useCloudApi();
-  return useSWR<Subscription, Error>(
-    isCloud && `/api/tenants/${currentTenantId}/subscription`,
+
+  return useSWR<SubscriptionUsage, Error>(
+    isCloud && `/api/tenants/${currentTenantId}/usage`,
     async () =>
-      cloudApi.get('/api/tenants/:tenantId/subscription', {
+      cloudApi.get('/api/tenants/:tenantId/usage', {
         params: { tenantId: currentTenantId },
       })
   );
 };
 
-export default useCurrentSubscription;
+export default useCurrentSubscriptionUsage;

--- a/packages/console/src/hooks/use-subscription-plans.ts
+++ b/packages/console/src/hooks/use-subscription-plans.ts
@@ -11,10 +11,12 @@ import { addSupportQuotaToPlan } from '@/utils/subscription';
 
 const useSubscriptionPlans = () => {
   const cloudApi = useCloudApi();
-  const { data: subscriptionPlansResponse, error } = useSWRImmutable<
-    SubscriptionPlanResponse[],
-    Error
-  >(isCloud && '/api/subscription-plans', async () => cloudApi.get('/api/subscription-plans'));
+  const useSwrResponse = useSWRImmutable<SubscriptionPlanResponse[], Error>(
+    isCloud && '/api/subscription-plans',
+    async () => cloudApi.get('/api/subscription-plans')
+  );
+
+  const { data: subscriptionPlansResponse } = useSwrResponse;
 
   const subscriptionPlans: Optional<SubscriptionPlan[]> = useMemo(() => {
     if (!subscriptionPlansResponse) {
@@ -49,9 +51,8 @@ const useSubscriptionPlans = () => {
   }, [subscriptionPlansResponse]);
 
   return {
+    ...useSwrResponse,
     data: subscriptionPlans,
-    error,
-    isLoading: !subscriptionPlans && !error,
   };
 };
 

--- a/packages/console/src/pages/TenantSettings/Subscription/CurrentPlan/MauLimitExceededNotification/index.tsx
+++ b/packages/console/src/pages/TenantSettings/Subscription/CurrentPlan/MauLimitExceededNotification/index.tsx
@@ -1,0 +1,36 @@
+import DynamicT from '@/ds-components/DynamicT';
+import InlineNotification from '@/ds-components/InlineNotification';
+import { type SubscriptionPlan } from '@/types/subscriptions';
+
+type Props = {
+  activeUsers: number;
+  currentPlan: SubscriptionPlan;
+  className?: string;
+};
+
+function MauLimitExceededNotification({ activeUsers, currentPlan, className }: Props) {
+  const {
+    quota: { mauLimit },
+  } = currentPlan;
+  if (
+    !mauLimit || // Unlimited
+    activeUsers < mauLimit
+  ) {
+    return null;
+  }
+
+  return (
+    <InlineNotification
+      severity="error"
+      action="subscription.upgrade_pro"
+      className={className}
+      onClick={() => {
+        // Todo @xiaoyijun Implement buy plan
+      }}
+    >
+      <DynamicT forKey="subscription.overfill_quota_warning" />
+    </InlineNotification>
+  );
+}
+
+export default MauLimitExceededNotification;

--- a/packages/console/src/pages/TenantSettings/Subscription/CurrentPlan/NextBillInfo/index.module.scss
+++ b/packages/console/src/pages/TenantSettings/Subscription/CurrentPlan/NextBillInfo/index.module.scss
@@ -1,0 +1,38 @@
+@use '@/scss/underscore' as _;
+
+.container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-radius: 12px;
+  border: 1px solid var(--color-divider);
+  background: var(--color-layer-1);
+  padding: _.unit(5) _.unit(6);
+}
+
+.billInfo {
+  display: flex;
+  flex-direction: column;
+}
+
+.price {
+  font: var(--font-title-2);
+  display: flex;
+  align-items: center;
+}
+
+.description {
+  margin-top: _.unit(2);
+  font: var(--font-body-2);
+  color: var(--color-text-secondary);
+}
+
+.articleLink {
+  color: var(--color-text-secondary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+
+  &:active {
+    color: var(--color-text-secondary);
+  }
+}

--- a/packages/console/src/pages/TenantSettings/Subscription/CurrentPlan/NextBillInfo/index.tsx
+++ b/packages/console/src/pages/TenantSettings/Subscription/CurrentPlan/NextBillInfo/index.tsx
@@ -1,0 +1,61 @@
+import { Trans, useTranslation } from 'react-i18next';
+
+import Tip from '@/assets/icons/tip.svg';
+import Button from '@/ds-components/Button';
+import DynamicT from '@/ds-components/DynamicT';
+import IconButton from '@/ds-components/IconButton';
+import TextLink from '@/ds-components/TextLink';
+import { ToggleTip } from '@/ds-components/Tip';
+
+import * as styles from './index.module.scss';
+
+type Props = {
+  cost: number;
+};
+
+function NextBillInfo({ cost }: Props) {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.billInfo}>
+        <div className={styles.price}>
+          <span>{`$${cost.toLocaleString()}`}</span>
+          {}
+          {cost > 0 && (
+            <ToggleTip content={<DynamicT forKey="subscription.next_bill_tip" />}>
+              <IconButton size="small">
+                <Tip />
+              </IconButton>
+            </ToggleTip>
+          )}
+        </div>
+        <div className={styles.description}>
+          <Trans
+            components={{
+              a: (
+                <TextLink
+                  href="https://blog.logto.io/logto-pricing-model"
+                  target="_blank"
+                  className={styles.articleLink}
+                />
+              ),
+            }}
+          >
+            {t('subscription.next_bill_hint')}
+          </Trans>
+        </div>
+      </div>
+      {cost > 0 && (
+        <Button
+          title="subscription.manage_payment"
+          onClick={() => {
+            // Todo @xiaoyijun Management payment
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+export default NextBillInfo;

--- a/packages/console/src/pages/TenantSettings/Subscription/CurrentPlan/PlanUsage/index.module.scss
+++ b/packages/console/src/pages/TenantSettings/Subscription/CurrentPlan/PlanUsage/index.module.scss
@@ -1,0 +1,39 @@
+@use '@/scss/underscore' as _;
+
+.container {
+  border-radius: 12px;
+  border: 1px solid var(--color-divider);
+  background: var(--color-layer-1);
+  padding: _.unit(5) _.unit(6);
+
+  > div:not(:first-child) {
+    margin-top: _.unit(2);
+  }
+}
+
+.usage {
+  font: var(--font-title-2);
+  vertical-align: middle;
+  display: inline-flex;
+  align-items: center;
+}
+
+.planCycle {
+  font: var(--font-body-2);
+}
+
+.usageBar {
+  border-radius: 4px;
+  background-color: var(--color-layer-2);
+  height: 18px;
+
+  .usageBarInner {
+    border-radius: 4px;
+    background-color: var(--color-primary-80);
+    height: 18px;
+
+    &.overuse {
+      background-color: var(--color-error-40);
+    }
+  }
+}

--- a/packages/console/src/pages/TenantSettings/Subscription/CurrentPlan/index.module.scss
+++ b/packages/console/src/pages/TenantSettings/Subscription/CurrentPlan/index.module.scss
@@ -1,0 +1,13 @@
+@use '@/scss/underscore' as _;
+
+.planInfo {
+  margin-bottom: _.unit(6);
+
+  .name {
+    font: var(--font-title-1);
+  }
+}
+
+.notification {
+  margin-top: _.unit(6);
+}

--- a/packages/console/src/pages/TenantSettings/Subscription/CurrentPlan/index.tsx
+++ b/packages/console/src/pages/TenantSettings/Subscription/CurrentPlan/index.tsx
@@ -1,0 +1,50 @@
+import { type SubscriptionUsage, type Subscription } from '@/cloud/types/router';
+import FormCard from '@/components/FormCard';
+import PlanDescription from '@/components/PlanDescription';
+import PlanName from '@/components/PlanName';
+import FormField from '@/ds-components/FormField';
+import { type SubscriptionPlan } from '@/types/subscriptions';
+
+import MauLimitExceedNotification from './MauLimitExceededNotification';
+import NextBillInfo from './NextBillInfo';
+import PlanUsage from './PlanUsage';
+import * as styles from './index.module.scss';
+
+type Props = {
+  subscription: Subscription;
+  subscriptionPlan: SubscriptionPlan;
+  subscriptionUsage: SubscriptionUsage;
+};
+
+function CurrentPlan({ subscription, subscriptionPlan, subscriptionUsage }: Props) {
+  const { name } = subscriptionPlan;
+
+  return (
+    <FormCard title="subscription.current_plan" description="subscription.current_plan_description">
+      <div className={styles.planInfo}>
+        <div className={styles.name}>
+          <PlanName name={name} />
+        </div>
+        <PlanDescription planName={name} />
+      </div>
+      <FormField title="subscription.plan_usage">
+        <PlanUsage
+          currentSubscription={subscription}
+          currentPlan={subscriptionPlan}
+          subscriptionUsage={subscriptionUsage}
+        />
+      </FormField>
+      <FormField title="subscription.next_bill">
+        {/* Todo @xiaoyijun retrieve cost from subscription usage on the feature is ready in the backend */}
+        <NextBillInfo cost={1000} />
+      </FormField>
+      <MauLimitExceedNotification
+        activeUsers={subscriptionUsage.activeUsers}
+        currentPlan={subscriptionPlan}
+        className={styles.notification}
+      />
+    </FormCard>
+  );
+}
+
+export default CurrentPlan;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add the current plan form for the subscription page according to the design: https://www.figma.com/file/KYdX2tPPOw3DEag0D3hAxr/%F0%9F%86%9A-Console-Payment?type=design&node-id=1-24947&mode=dev

### Note
The `PlanDescription` component is added to the `@/components` folder since it will be used in other pages in up coming PRs

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

![image](https://github.com/logto-io/logto/assets/10806653/e9bf197a-f3f2-4da3-8fa6-06afbc6c6bc4)

![image](https://github.com/logto-io/logto/assets/10806653/6d288ff2-44fc-4c71-a645-a0b68bd9aa5b)


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
