### PR TITLE
refactor(core,connector): store and get fromEmail from logto email connector

### DIFF
--- a/packages/connectors/connector-logto-email/src/constant.ts
+++ b/packages/connectors/connector-logto-email/src/constant.ts
@@ -95,6 +95,11 @@ export const defaultMetadata: ConnectorMetadata = {
       type: ConnectorConfigFormItemType.Text,
     },
   ],
+  /**
+   * This is the email address that will be used as the sender of the email, should align with
+   * the `fromEmail` of emailServiceProvider stored in cloud.systems table.
+   */
+  fromEmail: 'no-reply@logto.email',
 };
 
 export const scope = ['send:email'];

--- a/packages/connectors/connector-logto-email/src/index.ts
+++ b/packages/connectors/connector-logto-email/src/index.ts
@@ -20,8 +20,6 @@ import { grantAccessToken } from './grant-access-token.js';
 import type { LogtoEmailConfig } from './types.js';
 import { logtoEmailConfigGuard } from './types.js';
 
-export type { EmailServiceBasicConfig } from './types.js';
-
 const sendMessage =
   (getConfig: GetConnectorConfig): SendMessageFunction =>
   async (data, inputConfig) => {

--- a/packages/core/src/routes/connector/index.ts
+++ b/packages/core/src/routes/connector/index.ts
@@ -1,11 +1,5 @@
-/* eslint-disable max-lines */
 import { buildRawConnector } from '@logto/cli/lib/connector/index.js';
-import {
-  demoConnectorIds,
-  validateConfig,
-  ServiceConnector,
-  type ConnectorMetadata,
-} from '@logto/connector-kit';
+import { demoConnectorIds, validateConfig } from '@logto/connector-kit';
 import {
   connectorFactoryResponseGuard,
   Connectors,
@@ -13,13 +7,13 @@ import {
   connectorResponseGuard,
 } from '@logto/schemas';
 import { buildIdGenerator } from '@logto/shared';
-import { conditional } from '@silverhand/essentials';
 import cleanDeep from 'clean-deep';
 import { string, object } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import assertThat from '#src/utils/assert-that.js';
+import { buildExtraInfo } from '#src/utils/connectors/extra-information.js';
 import {
   loadConnectorFactories,
   transpileConnectorFactory,
@@ -33,20 +27,6 @@ import connectorAuthorizationUriRoutes from './authorization-uri.js';
 import connectorConfigTestingRoutes from './config-testing.js';
 
 const generateConnectorId = buildIdGenerator(12);
-
-const getFromEmailFromMetadata = (metadata: ConnectorMetadata) => {
-  const result = object({ fromEmail: string() }).safeParse(metadata);
-  return conditional(result.success && result.data.fromEmail);
-};
-
-// Will accept other source of `extraInfo` in the future.
-const buildExtraInfo = (metadata: ConnectorMetadata) => {
-  const fromEmail = getFromEmailFromMetadata(metadata);
-  const extraInfo = {
-    ...conditional(fromEmail && metadata.id === ServiceConnector.Email && { fromEmail }),
-  };
-  return cleanDeep(extraInfo, { emptyObjects: false });
-};
 
 export default function connectorRoutes<T extends AuthedRouter>(
   ...[router, tenant]: RouterInitArgs<T>
@@ -369,5 +349,3 @@ export default function connectorRoutes<T extends AuthedRouter>(
   connectorConfigTestingRoutes(router, tenant);
   connectorAuthorizationUriRoutes(router, tenant);
 }
-/** TODO @Darcy: refactor this file later. */
-/* eslint-enable max-lines */

--- a/packages/core/src/tenants/SystemContext.ts
+++ b/packages/core/src/tenants/SystemContext.ts
@@ -1,12 +1,9 @@
 import {
   CloudflareKey,
-  EmailServiceProviderKey,
   type HostnameProviderData,
   type StorageProviderData,
-  type EmailServiceData,
   hostnameProviderDataGuard,
   storageProviderDataGuard,
-  emailServiceDataGuard,
   StorageProviderKey,
   type SystemKey,
 } from '@logto/schemas';
@@ -20,7 +17,6 @@ export default class SystemContext {
   static shared = new SystemContext();
   public storageProviderConfig?: StorageProviderData;
   public hostnameProviderConfig?: HostnameProviderData;
-  public emailServiceProviderConfig?: EmailServiceData;
 
   async loadProviderConfigs(pool: CommonQueryMethods) {
     await Promise.all([
@@ -36,13 +32,6 @@ export default class SystemContext {
           pool,
           CloudflareKey.HostnameProvider,
           hostnameProviderDataGuard
-        );
-      })(),
-      (async () => {
-        this.emailServiceProviderConfig = await this.loadConfig(
-          pool,
-          EmailServiceProviderKey.EmailServiceProvider,
-          emailServiceDataGuard
         );
       })(),
     ]);

--- a/packages/core/src/utils/connectors/extra-information.ts
+++ b/packages/core/src/utils/connectors/extra-information.ts
@@ -1,0 +1,18 @@
+import { type ConnectorMetadata, ServiceConnector } from '@logto/connector-kit';
+import { conditional } from '@silverhand/essentials';
+import cleanDeep from 'clean-deep';
+import { string, object } from 'zod';
+
+const getFromEmailFromMetadata = (metadata: ConnectorMetadata) => {
+  const result = object({ fromEmail: string() }).safeParse(metadata);
+  return conditional(result.success && result.data.fromEmail);
+};
+
+// Will accept other source of `extraInfo` in the future.
+export const buildExtraInfo = (metadata: ConnectorMetadata) => {
+  const fromEmail = getFromEmailFromMetadata(metadata);
+  const extraInfo = {
+    ...conditional(fromEmail && metadata.id === ServiceConnector.Email && { fromEmail }),
+  };
+  return cleanDeep(extraInfo, { emptyObjects: false });
+};

--- a/packages/core/src/utils/connectors/index.ts
+++ b/packages/core/src/utils/connectors/index.ts
@@ -12,11 +12,10 @@ import {
   ConnectorType,
   type EmailConnector,
   type SmsConnector,
-  ServiceConnector,
 } from '@logto/connector-kit';
-import type { ConnectorFactoryResponse, ConnectorResponse, EmailServiceData } from '@logto/schemas';
+import type { ConnectorFactoryResponse, ConnectorResponse } from '@logto/schemas';
 import { findPackage } from '@logto/shared';
-import { conditional, deduplicate, pick, trySafe, type Optional } from '@silverhand/essentials';
+import { conditional, deduplicate, pick, trySafe } from '@silverhand/essentials';
 
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
@@ -74,20 +73,6 @@ export const transpileConnectorFactory = ({
     /** Temporarily block entering Logto email connector as well until this feature is ready for prod. */
     isDemo: isDemoConnector(metadata.id),
   };
-};
-
-/**
- * `extraInfo` is only used to expose email service vendors `fromEmail` setup to Logto email connector.
- * Can extend this method in the future for other use cases.
- */
-export const buildExtraInfoFromEmailServiceData = (
-  connectorFactoryId: string,
-  emailServiceProviderConfig?: EmailServiceData
-): Optional<Record<string, unknown>> => {
-  return conditional(
-    connectorFactoryId === ServiceConnector.Email &&
-      emailServiceProviderConfig?.fromEmail && { fromEmail: emailServiceProviderConfig.fromEmail }
-  );
 };
 
 const checkDuplicateConnectorFactoriesId = (connectorFactories: ConnectorFactory[]) => {

--- a/packages/toolkit/connector-kit/src/types.ts
+++ b/packages/toolkit/connector-kit/src/types.ts
@@ -138,19 +138,21 @@ const connectorConfigFormItemGuard = z.discriminatedUnion('type', [
 
 export type ConnectorConfigFormItem = z.infer<typeof connectorConfigFormItemGuard>;
 
-export const connectorMetadataGuard = z.object({
-  id: z.string(),
-  target: z.string(),
-  platform: z.nativeEnum(ConnectorPlatform).nullable(),
-  name: i18nPhrasesGuard,
-  logo: z.string(),
-  logoDark: z.string().nullable(),
-  description: i18nPhrasesGuard,
-  isStandard: z.boolean().optional(),
-  readme: z.string(),
-  configTemplate: z.string().optional(),
-  formItems: connectorConfigFormItemGuard.array().optional(),
-});
+export const connectorMetadataGuard = z
+  .object({
+    id: z.string(),
+    target: z.string(),
+    platform: z.nativeEnum(ConnectorPlatform).nullable(),
+    name: i18nPhrasesGuard,
+    logo: z.string(),
+    logoDark: z.string().nullable(),
+    description: i18nPhrasesGuard,
+    isStandard: z.boolean().optional(),
+    readme: z.string(),
+    configTemplate: z.string().optional(),
+    formItems: connectorConfigFormItemGuard.array().optional(),
+  })
+  .catchall(z.unknown());
 
 export const configurableConnectorMetadataGuard = connectorMetadataGuard
   .pick({


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
store to and get `fromEmail` (for console display use) from logto email connector's metadata.

- background:
`fromEmail` is in the configuration of the email service vendor, used to represent the sender address of the email vendor. It cannot be modified by Logto users from the logto email service connector but needs to be displayed there.

- current status:
We stored the email service config in the systems table of the DB. Later the systems table will be separated into logto/core's and logto/cloud's. The email service config will be moved to the logto/cloud's systems table (since this will only be used by Logto cloud). As a result, the methods in logto/core will no longer be able to access the value of `fromEmail` in the config.

- expected status after the change:
The best practice is to add a new API in the cloud service to get the public information (including the value of `fromEmail`) in the email service config. This may lead to frequent requests to this API. Considering that the value of `fromEmail` rarely changes, it can be saved as a constant in the logto email connector's metadata.

We made following changes:
1. `ConnectorMetadata` type can now accept arbitrary fields and add `fromEmail` to the logto email connector's metadata.
2. reorg logto/core and move `buildExtraInfo` to utils.
3. remove load email service provider's config logics from `SystemContext` when boot Logto instance, since this config will be migrated to @logto/cloud `systems` table.

See offline slack discussion [thread1](https://silverhand-io.slack.com/archives/C02A8G4HVAM/p1689152030845549) and  [thread2](https://silverhand-io.slack.com/archives/C02CMB8JVJB/p1689165294739349) for more information.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally, can successfully get the value.
<img width="2130" alt="image" src="https://github.com/logto-io/logto/assets/15182327/7f887452-4e68-43fa-80ac-817eb9c6ccf6">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
