### PR TITLE
fix(core,connector): fix patch connector api cannot reset config/metadata bug

### DIFF
--- a/packages/connectors/connector-mock-email-alternative/src/index.ts
+++ b/packages/connectors/connector-mock-email-alternative/src/index.ts
@@ -26,7 +26,7 @@ const sendMessage =
     const config = inputConfig ?? (await getConfig(defaultMetadata.id));
     validateConfig<MockMailConfig>(config, mockMailConfigGuard);
     const { templates } = config;
-    const template = templates.find((template) => template.usageType === type);
+    const template = templates?.find((template) => template.usageType === type);
 
     assert(
       template,

--- a/packages/connectors/connector-mock-email-alternative/src/types.ts
+++ b/packages/connectors/connector-mock-email-alternative/src/types.ts
@@ -12,11 +12,13 @@ const templateGuard = z.object({
   content: z.string(), // With variable {{code}}, support HTML
 });
 
-export const mockMailConfigGuard = z.object({
-  apiKey: z.string(),
-  fromEmail: z.string(),
-  fromName: z.string().optional(),
-  templates: z.array(templateGuard),
-});
+export const mockMailConfigGuard = z
+  .object({
+    apiKey: z.string(),
+    fromEmail: z.string(),
+    fromName: z.string().optional(),
+    templates: z.array(templateGuard),
+  })
+  .partial();
 
 export type MockMailConfig = z.infer<typeof mockMailConfigGuard>;

--- a/packages/core/src/database/update-where.ts
+++ b/packages/core/src/database/update-where.ts
@@ -32,7 +32,7 @@ export const buildUpdateWhereWithPool =
     const connectKeyValueWithEqualSign = (data: Partial<Schema>, jsonbMode: 'replace' | 'merge') =>
       Object.entries<SchemaValue>(data)
         .map(([key, value]) => {
-          if (!isKeyOfSchema(key)) {
+          if (!isKeyOfSchema(key) || value === undefined) {
             return;
           }
 

--- a/packages/core/src/routes/connector/index.patch.test.ts
+++ b/packages/core/src/routes/connector/index.patch.test.ts
@@ -179,6 +179,34 @@ describe('connector data routes', () => {
       );
     });
 
+    it('successfully reset connector config', async () => {
+      getLogtoConnectors.mockResolvedValue([
+        {
+          dbEntry: mockConnector,
+          metadata: { ...mockMetadata, isStandard: true },
+          type: ConnectorType.Social,
+          ...mockLogtoConnector,
+        },
+      ]);
+      updateConnector.mockResolvedValueOnce({
+        ...mockConnector,
+        config: {},
+      });
+      const response = await connectorRequest.patch('/connectors/id').send({
+        config: {},
+      });
+      expect(response).toHaveProperty('statusCode', 200);
+      expect(updateConnector).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'id' },
+          set: {
+            config: {},
+          },
+          jsonbMode: 'replace',
+        })
+      );
+    });
+
     it('successfully updates connector config and metadata', async () => {
       getLogtoConnectors.mockResolvedValue([
         {
@@ -235,9 +263,6 @@ describe('connector data routes', () => {
         ...mockConnector,
         metadata: {
           target: 'connector',
-          name: { en: '' },
-          logo: '',
-          logoDark: '',
         },
       });
       const response = await connectorRequest.patch('/connectors/id').send({

--- a/packages/core/src/routes/connector/index.ts
+++ b/packages/core/src/routes/connector/index.ts
@@ -6,8 +6,10 @@ import {
   Connectors,
   ConnectorType,
   connectorResponseGuard,
+  type JsonObject,
 } from '@logto/schemas';
 import { buildIdGenerator } from '@logto/shared';
+import { conditional } from '@silverhand/essentials';
 import cleanDeep from 'clean-deep';
 import { string, object } from 'zod';
 
@@ -319,7 +321,17 @@ export default function connectorRoutes<T extends AuthedRouter>(
       }
 
       await updateConnector({
-        set: cleanDeep({ config, metadata, syncProfile }),
+        set: {
+          /**
+           * `JsonObject` has all non-undefined values, and `cleanDeep` method with default settings
+           * drops all keys with undefined values, the return type of `Partial<JsonObject>` is still `JsonObject`.
+           * The type inference failed to infer this, manually assign type `JsonObject`.
+           */
+          // eslint-disable-next-line no-restricted-syntax
+          config: conditional(config && (cleanDeep(config) as JsonObject)),
+          metadata: conditional(metadata && cleanDeep(metadata)),
+          syncProfile,
+        },
         where: { id },
         jsonbMode: 'replace',
       });

--- a/packages/integration-tests/src/tests/api/connector.test.ts
+++ b/packages/integration-tests/src/tests/api/connector.test.ts
@@ -115,6 +115,10 @@ test('connector set-up flow', async () => {
     currentConnectors.find((connector) => connector.connectorId === mockAlternativeEmailConnectorId)
       ?.config
   ).toEqual(mockAlternativeEmailConnectorConfig);
+  // Can reset the connector config to empty object `{}` (when it is valid).
+  await expect(updateConnectorConfig(id, { config: {} })).resolves.not.toThrow();
+  const alternativeEmailConnector = await getConnector(id);
+  expect(alternativeEmailConnector.config).toEqual({});
 
   /*
    * Delete (i.e. disable) a connector


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix patch connector API cannot reset `config` / `metadata` bug.
Previously, `cleanDeep` will remove empty objects and hence reset `config` or `metadata` field to {} is not accepted by API. It's because `cleanDeep` will remove empty object values' keys before this change.

Update logto mock email alternative connector config guard to accept empty object config, so that we can test the case via integration test.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Add UT and IT to cover this case and tested locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
