### PR TITLE
feat(core): support fetching all applications without pagination

### DIFF
--- a/packages/core/src/routes/application.test.ts
+++ b/packages/core/src/routes/application.test.ts
@@ -58,7 +58,7 @@ describe('application route', () => {
     const response = await applicationRequest.get('/applications');
     expect(response.status).toEqual(200);
     expect(response.body).toEqual([mockApplication]);
-    expect(response.header).toHaveProperty('total-number', '10');
+    expect(response.header).not.toHaveProperty('total-number');
   });
 
   it('POST /applications', async () => {

--- a/packages/core/src/routes/application.ts
+++ b/packages/core/src/routes/application.ts
@@ -38,10 +38,16 @@ export default function applicationRoutes<T extends AuthedRouter>(
 
   router.get(
     '/applications',
-    koaPagination(),
+    koaPagination({ isOptional: true }),
     koaGuard({ response: z.array(Applications.guard), status: 200 }),
     async (ctx, next) => {
-      const { limit, offset } = ctx.pagination;
+      const { limit, offset, disabled: paginationDisabled } = ctx.pagination;
+
+      if (paginationDisabled) {
+        ctx.body = await findAllApplications();
+
+        return next();
+      }
 
       const [{ count }, applications] = await Promise.all([
         findTotalNumberOfApplications(),


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Support retrieving all applications without pagination because we need to separately count the number of m2m applications and other applications in some scenarios.

This approach is considered because we currently have limitations on applications (a maximum of 3 for free plans and 20 for hobby plans).

Additionally, in practical situations, each tenant's application count is not expected to be very high, so fetching all applications won't impact performance.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT & IT passed & test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
