### PR TITLE
feat(schemas,console): add planId to TenantInfo

### DIFF
--- a/packages/console/src/cloud/pages/Main/TenantLandingPage/TenantLandingPageContent/index.tsx
+++ b/packages/console/src/cloud/pages/Main/TenantLandingPage/TenantLandingPageContent/index.tsx
@@ -1,5 +1,4 @@
 import { Theme } from '@logto/schemas';
-import type { TenantInfo } from '@logto/schemas/models';
 import classNames from 'classnames';
 import { useContext, useState } from 'react';
 
@@ -11,6 +10,7 @@ import { TenantsContext } from '@/contexts/TenantsProvider';
 import Button from '@/ds-components/Button';
 import DynamicT from '@/ds-components/DynamicT';
 import useTheme from '@/hooks/use-theme';
+import type { TenantInfo } from '@/types/tenant';
 
 import * as styles from './index.module.scss';
 

--- a/packages/console/src/components/CreateTenantModal/SelectTenantPlanModal/index.tsx
+++ b/packages/console/src/components/CreateTenantModal/SelectTenantPlanModal/index.tsx
@@ -1,4 +1,3 @@
-import { type TenantInfo } from '@logto/schemas/models';
 import { toast } from 'react-hot-toast';
 import { Trans, useTranslation } from 'react-i18next';
 import Modal from 'react-modal';
@@ -12,6 +11,7 @@ import useSubscribe from '@/hooks/use-subscribe';
 import useSubscriptionPlans from '@/hooks/use-subscription-plans';
 import * as modalStyles from '@/scss/modal.module.scss';
 import { type SubscriptionPlan } from '@/types/subscriptions';
+import type { TenantInfo } from '@/types/tenant';
 
 import { type CreateTenantData } from '../type';
 

--- a/packages/console/src/components/CreateTenantModal/index.tsx
+++ b/packages/console/src/components/CreateTenantModal/index.tsx
@@ -1,6 +1,6 @@
 import type { AdminConsoleKey } from '@logto/phrases';
 import { Theme } from '@logto/schemas';
-import { TenantTag, type TenantInfo } from '@logto/schemas/models';
+import { TenantTag } from '@logto/schemas/models';
 import { useState } from 'react';
 import { Controller, FormProvider, useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
@@ -18,6 +18,7 @@ import RadioGroup, { Radio } from '@/ds-components/RadioGroup';
 import TextInput from '@/ds-components/TextInput';
 import useTheme from '@/hooks/use-theme';
 import * as modalStyles from '@/scss/modal.module.scss';
+import type { TenantInfo } from '@/types/tenant';
 
 import SelectTenantPlanModal from './SelectTenantPlanModal';
 import * as styles from './index.module.scss';

--- a/packages/console/src/components/CreateTenantModal/type.ts
+++ b/packages/console/src/components/CreateTenantModal/type.ts
@@ -1,3 +1,3 @@
-import { type TenantInfo } from '@logto/schemas/models';
+import type { TenantInfo } from '@/types/tenant';
 
 export type CreateTenantData = Pick<TenantInfo, 'name' | 'tag'>;

--- a/packages/console/src/containers/AppContent/components/Topbar/TenantSelector/index.tsx
+++ b/packages/console/src/containers/AppContent/components/Topbar/TenantSelector/index.tsx
@@ -1,5 +1,4 @@
 import { adminTenantId, maxFreeTenantLimit } from '@logto/schemas';
-import { type TenantInfo } from '@logto/schemas/models';
 import classNames from 'classnames';
 import { useContext, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -12,6 +11,7 @@ import { TenantsContext } from '@/contexts/TenantsProvider';
 import Divider from '@/ds-components/Divider';
 import Dropdown, { DropdownItem } from '@/ds-components/Dropdown';
 import OverlayScrollbar from '@/ds-components/OverlayScrollbar';
+import type { TenantInfo } from '@/types/tenant';
 import { onKeyDownHandler } from '@/utils/a11y';
 
 import TenantEnvTag from './TenantEnvTag';

--- a/packages/console/src/containers/TenantAccess/index.tsx
+++ b/packages/console/src/containers/TenantAccess/index.tsx
@@ -1,5 +1,4 @@
 import { useLogto } from '@logto/react';
-import { type TenantInfo } from '@logto/schemas/lib/models/tenants.js';
 import { trySafe } from '@silverhand/essentials';
 import { useContext, useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
@@ -10,6 +9,7 @@ import AppLoading from '@/components/AppLoading';
 import type ProtectedRoutes from '@/containers/ProtectedRoutes';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import useUserDefaultTenantId from '@/hooks/use-user-default-tenant-id';
+import type { TenantInfo } from '@/types/tenant';
 
 /**
  * The container that ensures the user has access to the current tenant. When the user is

--- a/packages/console/src/contexts/TenantsProvider.tsx
+++ b/packages/console/src/contexts/TenantsProvider.tsx
@@ -1,12 +1,12 @@
 import { defaultManagementApi } from '@logto/schemas';
-import { type TenantInfo, TenantTag } from '@logto/schemas/models';
+import { TenantTag } from '@logto/schemas/models';
 import { conditionalArray, noop } from '@silverhand/essentials';
 import type { ReactNode } from 'react';
 import { useCallback, useMemo, createContext, useState } from 'react';
 
 import { isCloud } from '@/consts/env';
-import { ReservedPlanId } from '@/consts/subscriptions';
 import { getUserTenantId } from '@/consts/tenants';
+import type { TenantInfo } from '@/types/tenant';
 
 /**
  * The current tenant status of access validation. When it's `validated`, it indicates that a
@@ -58,7 +58,6 @@ const initialTenants = Object.freeze(
       name: `tenant_${tenantId}`,
       tag: TenantTag.Development,
       indicator,
-      planId: ReservedPlanId.free,
     }
   )
 );

--- a/packages/console/src/contexts/TenantsProvider.tsx
+++ b/packages/console/src/contexts/TenantsProvider.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from 'react';
 import { useCallback, useMemo, createContext, useState } from 'react';
 
 import { isCloud } from '@/consts/env';
+import { ReservedPlanId } from '@/consts/subscriptions';
 import { getUserTenantId } from '@/consts/tenants';
 
 /**
@@ -52,7 +53,13 @@ const { tenantId, indicator } = defaultManagementApi.resource;
  */
 const initialTenants = Object.freeze(
   conditionalArray(
-    !isCloud && { id: tenantId, name: `tenant_${tenantId}`, tag: TenantTag.Development, indicator }
+    !isCloud && {
+      id: tenantId,
+      name: `tenant_${tenantId}`,
+      tag: TenantTag.Development,
+      indicator,
+      planId: ReservedPlanId.free,
+    }
   )
 );
 

--- a/packages/console/src/pages/TenantSettings/TenantBasicSettings/DeleteModal/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantBasicSettings/DeleteModal/index.tsx
@@ -1,4 +1,3 @@
-import { type TenantInfo } from '@logto/schemas/models';
 import classNames from 'classnames';
 import { useTranslation, Trans } from 'react-i18next';
 
@@ -6,6 +5,7 @@ import { contactEmailLink } from '@/consts';
 import { tenantTagMap } from '@/containers/AppContent/components/Topbar/TenantSelector/TenantEnvTag';
 import DeleteConfirmModal from '@/ds-components/DeleteConfirmModal';
 import TextLink from '@/ds-components/TextLink';
+import type { TenantInfo } from '@/types/tenant';
 
 import * as styles from './index.module.scss';
 

--- a/packages/console/src/pages/TenantSettings/TenantBasicSettings/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantBasicSettings/index.tsx
@@ -1,4 +1,4 @@
-import { type TenantInfo, TenantTag } from '@logto/schemas/models';
+import { TenantTag } from '@logto/schemas/models';
 import classNames from 'classnames';
 import { useContext, useEffect, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
@@ -11,6 +11,7 @@ import PageMeta from '@/components/PageMeta';
 import SubmitFormChangesActionBar from '@/components/SubmitFormChangesActionBar';
 import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
 import { TenantsContext } from '@/contexts/TenantsProvider';
+import type { TenantInfo } from '@/types/tenant';
 
 import DeleteCard from './DeleteCard';
 import DeleteModal from './DeleteModal';

--- a/packages/console/src/types/tenant.ts
+++ b/packages/console/src/types/tenant.ts
@@ -1,0 +1,7 @@
+import { type TenantInfo as FullTenantInfo } from '@logto/schemas/models';
+
+/**
+ * We added an required `planId` field to the `TenantInfo` type, need to update the cloud
+ * API to get this field, temporarily use this type to avoid type error.
+ */
+export type TenantInfo = Omit<FullTenantInfo, 'planId'> & { planId?: string };

--- a/packages/schemas/src/models/tenants.ts
+++ b/packages/schemas/src/models/tenants.ts
@@ -31,8 +31,11 @@ export const Tenants = createModel(
 
 export type TenantModel = InferModelType<typeof Tenants>;
 
-export type TenantInfo = Pick<TenantModel, 'id' | 'name' | 'tag'> & { indicator: string };
+export type TenantInfo = Pick<TenantModel, 'id' | 'name' | 'tag'> & {
+  indicator: string;
+  planId: string;
+};
 
 export const tenantInfoGuard = Tenants.guard('model')
   .pick({ id: true, name: true, tag: true })
-  .extend({ indicator: z.string() });
+  .extend({ indicator: z.string(), planId: z.string() });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Current status:
Users without the admin role can create no more than 10 tenants.

Expectation:
In the future, all tenants will have a subscription plan, we do not allow users without the admin role to have more than 10 "Free plan" tenants. As a result, we need to add a tag to indicate whether the tenant is with free subscription plan or not, although we have cloud API available to get the subscription details for all tenants, this change can save a lot of cloud API calls.

Changes:
Add `planId` to TenantInfo, which is the response type of GET /tenants API.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
