### PR TITLE
chore(connector): update the parse of email usage api response

### DIFF
--- a/packages/connectors/connector-logto-email/src/index.ts
+++ b/packages/connectors/connector-logto-email/src/index.ts
@@ -1,5 +1,6 @@
 import { assert } from '@silverhand/essentials';
 import { HTTPError, got } from 'got';
+import { z } from 'zod';
 
 import type {
   CreateConnector,
@@ -13,6 +14,7 @@ import {
   validateConfig,
   ConnectorError,
   ConnectorErrorCodes,
+  parseJson,
 } from '@logto/connector-kit';
 
 import { defaultMetadata, defaultTimeout, emailEndpoint, usageEndpoint } from './constant.js';
@@ -101,7 +103,7 @@ const getUsage =
       },
     });
 
-    return Number(httpResponse.body);
+    return z.object({ count: z.number() }).parse(parseJson(httpResponse.body)).count;
   };
 
 const createLogtoEmailConnector: CreateConnector<EmailConnector> = async ({ getConfig }) => {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
update the parse of API call response since the update on the response  of the cloud GET /emails/usage API.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally along with the change on cloud API (see [this change](https://github.com/logto-io/cloud/pull/99)), can successfully get the usage.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
