### PR TITLE
fix(console): add origin for `getUrl`

### DIFF
--- a/packages/console/src/hooks/use-tenant-pathname.ts
+++ b/packages/console/src/hooks/use-tenant-pathname.ts
@@ -93,9 +93,7 @@ function useTenantPathname(): TenantPathname {
   );
 
   const getUrl = useCallback(
-    (pathname = '/') => {
-      return appendPath(new URL(href), tenantSegment, pathname);
-    },
+    (pathname = '/') => appendPath(new URL(window.location.origin), href, tenantSegment, pathname),
     [href, tenantSegment]
   );
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
In the old `getUrl` implementation, we want to use `useHref('/')` to get a URL that can be used to link to the given `to` location, but the react-router does not work as what the [doc](https://reactrouter.com/en/main/hooks/use-href) says. The `useHref('/')` always returns `/`, and the origin is missing.

So we prepend the origin to the URL to get a correct result.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
