### PR TITLE
fix(console): avoid reading response error body more than once

### DIFF
--- a/packages/console/src/utils/subscription.ts
+++ b/packages/console/src/utils/subscription.ts
@@ -1,7 +1,7 @@
 import { ResponseError } from '@withtyped/client';
 import dayjs from 'dayjs';
 
-import { responseErrorBodyGuard } from '@/cloud/hooks/use-cloud-api';
+import { tryReadResponseErrorBody } from '@/cloud/hooks/use-cloud-api';
 import { type SubscriptionPlanResponse } from '@/cloud/types/router';
 import {
   communitySupportEnabledMap,
@@ -64,11 +64,7 @@ export const isExceededQuotaLimitError = async (error: unknown) => {
     return false;
   }
 
-  try {
-    const responseBody = await error.response.json();
-    const { message } = responseErrorBodyGuard.parse(responseBody);
-    return message.includes('Exceeded quota limit');
-  } catch {
-    return false;
-  }
+  const { message } = (await tryReadResponseErrorBody(error)) ?? {};
+
+  return Boolean(message?.includes('Exceeded quota limit'));
 };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
In the original implementation, when we call `isExceededQuotaLimitError`, the response error body will be read, but if the error is not an `ExceedQuotaLimitedError`, the `toastResponseError` function will read the error body once again. At this time, we will get a "body stream already read" error.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
