### PR TITLE
fix(console): use SWR for user endpoint

### DIFF
--- a/packages/console/src/containers/TenantAccess/index.tsx
+++ b/packages/console/src/containers/TenantAccess/index.tsx
@@ -56,10 +56,17 @@ export default function TenantAccess() {
     /**
      * The official cache clean method, see {@link https://github.com/vercel/swr/issues/1887#issuecomment-1171269211 | this comment}.
      *
-     * We need to exclude the `me` key because it's not tenant-aware. If don't, we
-     * need to manually revalidate the `me` key to make console work again.
+     * Exceptions:
+     * - Exclude the `me` key because it's not tenant-aware. If don't, we need to manually
+     * revalidate the `me` key to make console work again.
+     * - Exclude keys that include `/.well-known/` because they are usually static and
+     * should not be revalidated.
      */
-    void mutate((key) => key !== 'me', undefined, { rollbackOnError: false, throwOnError: false });
+    void mutate(
+      (key) => typeof key !== 'string' || (key !== 'me' && !key.includes('/.well-known/')),
+      undefined,
+      { rollbackOnError: false, throwOnError: false }
+    );
   }, [mutate, currentTenantId]);
 
   useEffect(() => {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
user endpoints should have different cached values per tenant, while it's used to be only one cached value. it causes 401 when switching tenant because the endpoint is stable. use `useSWRImmutable` for user endpoint to fix it.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] switch tenant, no 401

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
