### PR TITLE
fix(core): add opaque access token event listener

### DIFF
--- a/packages/core/src/event-listeners/access-token.ts
+++ b/packages/core/src/event-listeners/access-token.ts
@@ -4,7 +4,7 @@ import { getUtcStartOfToday } from '#src/oidc/utils.js';
 import type Queries from '#src/tenants/Queries.js';
 
 export const accessTokenIssuedListener = async (
-  accessToken: { accountId: string },
+  accessToken: { accountId?: string },
   queries: Queries
 ) => {
   const { accountId } = accessToken;

--- a/packages/core/src/event-listeners/index.ts
+++ b/packages/core/src/event-listeners/index.ts
@@ -18,6 +18,9 @@ export const addOidcEventListeners = (provider: Provider, queries: Queries) => {
   provider.addListener('access_token.issued', async (token) => {
     return accessTokenIssuedListener(token, queries);
   });
+  provider.addListener('access_token.saved', async (token) => {
+    return accessTokenIssuedListener(token, queries);
+  });
   provider.addListener('interaction.started', interactionStartedListener);
   provider.addListener('interaction.ended', interactionEndedListener);
   provider.addListener('server_error', (_, error) => {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add opaque access token event listener to add active users.

According to the [doc](https://github.com/panva/node-oidc-provider/blob/v7.x/docs/events.md), when an opaque access token is issued, event `access_token.issued` won't be triggered, need to use `access_token.saved`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
