### PR TITLE
refactor(console): use plan id to index plan descriptions

### DIFF
--- a/packages/console/src/components/CreateTenantModal/SelectTenantPlanModal/PlanCardItem/index.tsx
+++ b/packages/console/src/components/CreateTenantModal/SelectTenantPlanModal/PlanCardItem/index.tsx
@@ -78,7 +78,7 @@ function PlanCardItem({ plan, onSelect }: Props) {
           </div>
         </div>
         <div className={styles.description}>
-          <PlanDescription planName={planName} />
+          <PlanDescription planId={planId} />
         </div>
       </div>
       <div className={styles.content}>

--- a/packages/console/src/components/PlanDescription/index.tsx
+++ b/packages/console/src/components/PlanDescription/index.tsx
@@ -1,21 +1,21 @@
 import { type TFuncKey } from 'i18next';
 
+import { ReservedPlanId } from '@/consts/subscriptions';
 import DynamicT from '@/ds-components/DynamicT';
-import { ReservedPlanName } from '@/types/subscriptions';
 
 const registeredPlanDescriptionPhrasesMap: Record<
   string,
   TFuncKey<'translation', 'admin_console.subscription'> | undefined
 > = {
-  [ReservedPlanName.Free]: 'free_plan_description',
-  [ReservedPlanName.Hobby]: 'hobby_plan_description',
-  [ReservedPlanName.Pro]: 'pro_plan_description',
+  [ReservedPlanId.free]: 'free_plan_description',
+  [ReservedPlanId.hobby]: 'hobby_plan_description',
+  [ReservedPlanId.pro]: 'pro_plan_description',
 };
 
-type Props = { planName: string };
+type Props = { planId: string };
 
-function PlanDescription({ planName }: Props) {
-  const description = registeredPlanDescriptionPhrasesMap[planName];
+function PlanDescription({ planId }: Props) {
+  const description = registeredPlanDescriptionPhrasesMap[planId];
 
   if (!description) {
     return null;

--- a/packages/console/src/pages/TenantSettings/Subscription/CurrentPlan/index.tsx
+++ b/packages/console/src/pages/TenantSettings/Subscription/CurrentPlan/index.tsx
@@ -18,7 +18,7 @@ type Props = {
 };
 
 function CurrentPlan({ subscription, subscriptionPlan, subscriptionUsage }: Props) {
-  const { name } = subscriptionPlan;
+  const { id, name } = subscriptionPlan;
 
   return (
     <FormCard title="subscription.current_plan" description="subscription.current_plan_description">
@@ -27,7 +27,7 @@ function CurrentPlan({ subscription, subscriptionPlan, subscriptionUsage }: Prop
           <PlanName name={name} />
         </div>
         <div className={styles.description}>
-          <PlanDescription planName={name} />
+          <PlanDescription planId={id} />
         </div>
       </div>
       <FormField title="subscription.plan_usage">


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Use plan id to index plan descriptions since now we have reserved plan ids, so we should not rely on the old reserved plan name to index plan descriptions.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
