### PR TITLE
fix(schemas): use pool.query to tolerate empty query results

### DIFF
--- a/packages/schemas/alterations/next-1688375200-sync-cloud-m2m-to-logto-config.ts
+++ b/packages/schemas/alterations/next-1688375200-sync-cloud-m2m-to-logto-config.ts
@@ -39,7 +39,7 @@ type CloudConnectionConfig = {
 
 const alteration: AlterationScript = {
   up: async (pool) => {
-    const rows = await pool.many<Application>(
+    const { rows } = await pool.query<Application>(
       sql`select * from applications where type = ${ApplicationType.MachineToMachine} and tenant_id = ${adminTenantId} and name = ${cloudServiceApplicationName}`
     );
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
use pool query to tolerate empty query results.
When users have no applicable m2m apps for cloud service in the table, `pool.many` could throw error while `pool.query` returns an empty array.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally on @charIeszhao 's local DB.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
