### PR TITLE
feature: add helm charts for logto.

### DIFF
--- a/helm/.helmignore
+++ b/helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: logto
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+appVersion: "1.6.0"
+home: https://logto.io/

--- a/helm/README.md
+++ b/helm/README.md
@@ -8,9 +8,9 @@ This Logto Chart is the best way to operate Grafana OnCall on Kubernetes.
 git clone https://github.com/lingdie/logto.git
 cd logto && git checkout helm
 
-# set env.db_url and other envs in values.yaml
+# set common.env.db_url and other envs in values.yaml
 # set core.endpoint and admin.endpoint in values.yaml if necessary
-helm install logto helm --set env.db_url='postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable'
+helm install logto helm --set common.env.db_url=${db_url}
 ```
 
 access the logto service by port-forwarding

--- a/helm/README.md
+++ b/helm/README.md
@@ -8,13 +8,14 @@ This Logto Chart is the best way to operate Grafana OnCall on Kubernetes.
 git clone https://github.com/lingdie/logto.git
 cd logto && git checkout helm
 
-# set common.env.db_url and other envs in values.yaml
+# set common.env.dbURL and other envs in values.yaml
 # set core.endpoint and admin.endpoint in values.yaml if necessary
-helm install logto helm --set common.env.db_url=${db_url}
+helm install logto helm --set common.env.dbURL=${dbURL}
 ```
 
 access the logto service by port-forwarding
 
+** If you want to use another port or domain, please set value `admin.endpoint` **
 ```bash
 kubectl port-forward svc/logto-admin 3002:3002
 ```

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,20 @@
+# Logto helm charts
+
+This Logto Chart is the best way to operate Grafana OnCall on Kubernetes.
+
+## Usage (before release)
+
+```bash
+git clone https://github.com/lingdie/logto.git
+cd logto && git checkout helm
+
+# set env.db_url and other envs in values.yaml
+# set core.endpoint and admin.endpoint in values.yaml if necessary
+helm install logto helm --set env.db_url='postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable'
+```
+
+access the logto service by port-forwarding
+
+```bash
+kubectl port-forward svc/logto-admin 3002:3002
+```

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "logto.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "logto.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "logto.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "logto.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -17,8 +17,8 @@
 {{- else if contains "ClusterIP" .Values.admin.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "logto.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+  echo "Visit http://127.0.0.1:3002 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 3002:$CONTAINER_PORT
 {{- end }}
 
 2. Get the core application URL by running these commands:
@@ -40,6 +40,6 @@
 {{- else if contains "ClusterIP" .Values.core.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "logto.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+  echo "Visit http://127.0.0.1:3001 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 3001:$CONTAINER_PORT
 {{- end }}

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,20 +1,43 @@
-1. Get the application URL by running these commands:
-{{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
+1. Get the admin application URL by running these commands:
+{{- if .Values.admin.ingress.enabled }}
+{{- range $host := .Values.admin.ingress.hosts }}
   {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  http{{ if $.Values.admin.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
-{{- else if contains "NodePort" .Values.service.type }}
+{{- else if contains "NodePort" .Values.admin.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "logto.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
+{{- else if contains "LoadBalancer" .Values.admin.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "logto.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "logto.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
-{{- else if contains "ClusterIP" .Values.service.type }}
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "logto.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.admin.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.admin.service.port }}
+{{- else if contains "ClusterIP" .Values.admin.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "logto.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}
+
+2. Get the core application URL by running these commands:
+{{- if .Values.core.ingress.enabled }}
+{{- range $host := .Values.core.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.core.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.core.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "logto.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.core.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "logto.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "logto.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.core.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.core.service.port }}
+{{- else if contains "ClusterIP" .Values.core.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "logto.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "logto.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "logto.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "logto.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "logto.labels" -}}
+helm.sh/chart: {{ include "logto.chart" . }}
+{{ include "logto.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "logto.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "logto.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "logto.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "logto.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -56,10 +56,10 @@ spec:
               containerPort: {{ .Values.admin.port }}
               protocol: TCP
           env:
+            {{- if .Values.common.env.trustProxyHeader }}
             - name: TRUST_PROXY_HEADER
-              {{- if .Values.common.env.trustProxyHeader }}
               value: "1"
-              {{- end }}
+            {{- end }}
             - name: NODE_ENV
               value: {{ .Values.common.env.nodeEnv }}
             - name: ENDPOINT
@@ -68,14 +68,35 @@ spec:
               value: {{ .Values.admin.endpoint }}
             - name: DB_URL
               value: {{ .Values.common.env.db_url }}
+            {{- if .Values.common.tls.enabled }}
+            - name: TLS_CERT_FILE
+              value: /etc/tls/tls.crt
+            - name: TLS_KEY_FILE
+              value: /etc/tls/tls.key
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
+            {{- if .Values.common.tls.enabled }}
+            - name: tls-secret
+              mountPath: /etc/tls
+              subPath: tls.crt
+              readOnly: true
+            - name: tls-secret
+              mountPath: /etc/tls
+              subPath: tls.key
+              readOnly: true
+            {{- end }}
             - name: connectors
               mountPath: /etc/logto/packages/core/connectors
       volumes:
         - name: connectors
           emptyDir: {}
+        {{- if .Values.common.tls.enabled }}
+        - name: tls-secret
+          secret:
+            secretName: {{ .Values.common.tls.secretName }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -49,21 +49,25 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            - name: http
-              containerPort: 3001
+            - name: core
+              containerPort: {{ .Values.core.port }}
               protocol: TCP
-            - name: api
-              containerPort: 3002
+            - name: admin
+              containerPort: {{ .Values.admin.port }}
               protocol: TCP
           env:
             - name: TRUST_PROXY_HEADER
-              {{- if .Values.env.trustProxyHeader }}
+              {{- if .Values.common.env.trustProxyHeader }}
               value: "1"
               {{- end }}
+            - name: NODE_ENV
+              value: {{ .Values.common.env.nodeEnv }}
             - name: ENDPOINT
-              value: {{ .Values.env.endpoint }}
+              value: {{ .Values.core.endpoint }}
             - name: ADMIN_ENDPOINT
-              value: {{ .Values.env.adminEndpoint }}
+              value: {{ .Values.admin.endpoint }}
+            - name: DB_URL
+              value: {{ .Values.common.env.db_url }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -55,6 +55,11 @@ spec:
             - name: admin
               containerPort: {{ .Values.admin.port }}
               protocol: TCP
+          command:
+            - /bin/sh
+          args:
+            - '-c'
+            - 'npm run cli db seed -- --swe && npm start'
           env:
             {{- if .Values.common.env.trustProxyHeader }}
             - name: TRUST_PROXY_HEADER
@@ -67,7 +72,7 @@ spec:
             - name: ADMIN_ENDPOINT
               value: {{ .Values.admin.endpoint }}
             - name: DB_URL
-              value: {{ .Values.common.env.db_url }}
+              value: {{ .Values.common.env.dbURL }}
             {{- if .Values.common.tls.enabled }}
             - name: TLS_CERT_FILE
               value: /etc/tls/tls.crt

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "logto.fullname" . }}
+  labels:
+    {{- include "logto.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "logto.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "logto.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "logto.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: init
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          command:
+            - /bin/sh
+          args:
+            - '-c'
+            - 'npm run cli connector add -- --official'
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: connectors
+              mountPath: /etc/logto/packages/core/connectors
+      containers:
+        - name: logto
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3001
+              protocol: TCP
+            - name: api
+              containerPort: 3002
+              protocol: TCP
+          env:
+            - name: TRUST_PROXY_HEADER
+              {{- if .Values.env.trustProxyHeader }}
+              value: "1"
+              {{- end }}
+            - name: ENDPOINT
+              value: {{ .Values.env.endpoint }}
+            - name: ADMIN_ENDPOINT
+              value: {{ .Values.env.adminEndpoint }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: connectors
+              mountPath: /etc/logto/packages/core/connectors
+      volumes:
+        - name: connectors
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/templates/hpa.yaml
+++ b/helm/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "logto.fullname" . }}
+  labels:
+    {{- include "logto.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "logto.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,9 +1,8 @@
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.admin.ingress.enabled -}}
 {{- $fullName := include "logto.fullname" . -}}
-{{- $svcPort := .Values.service.port.http -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+{{- if and .Values.admin.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.admin.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.admin.ingress.annotations "kubernetes.io/ingress.class" .Values.admin.ingress.className}}
   {{- end }}
 {{- end }}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
@@ -18,17 +17,17 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "logto.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- with .Values.admin.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
+  {{- if and .Values.admin.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.admin.ingress.className }}
   {{- end }}
-  {{- if .Values.ingress.tls }}
+  {{- if .Values.admin.ingress.tls }}
   tls:
-    {{- range .Values.ingress.tls }}
+    {{- range .Values.admin.ingress.tls }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
@@ -37,7 +36,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.ingress.hosts }}
+    {{- range .Values.admin.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
@@ -49,13 +48,75 @@ spec:
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{ $fullName }}
+                name: {{ $fullName }}-admin
                 port:
-                  number: {{ $svcPort }}
+                  name: http
               {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              serviceName: {{ $fullName }}-admin
+              servicePort: http
               {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}
+---
+{{- if .Values.core.ingress.enabled -}}
+{{- $fullName := include "logto.fullname" . -}}
+{{- if and .Values.core.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.core.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.core.ingress.annotations "kubernetes.io/ingress.class" .Values.core.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "logto.labels" . | nindent 4 }}
+  {{- with .Values.core.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.core.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.core.ingress.className }}
+  {{- end }}
+  {{- if .Values.core.ingress.tls }}
+  tls:
+    {{- range .Values.core.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.core.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}-core
+                port:
+                  name: http
+              {{- else }}
+              serviceName: {{ $fullName }}-core
+              servicePort: http
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}
+

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "logto.fullname" . -}}
+{{- $svcPort := .Values.service.port.http -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "logto.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "logto.fullname" . }}
+  labels:
+    {{- include "logto.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port.http }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: {{ .Values.service.port.api }}
+      targetPort: api
+      protocol: TCP
+      name: api
+  selector:
+    {{- include "logto.selectorLabels" . | nindent 4 }}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,19 +1,32 @@
+# core service
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "logto.fullname" . }}
+  name: {{ include "logto.fullname" . }}-core
   labels:
     {{- include "logto.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ .Values.core.service.type }}
   ports:
-    - port: {{ .Values.service.port.http }}
-      targetPort: http
+    - port: {{ .Values.core.service.port }}
+      targetPort: core
       protocol: TCP
       name: http
-    - port: {{ .Values.service.port.api }}
-      targetPort: api
+  selector:
+    {{- include "logto.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "logto.fullname" . }}-admin
+  labels:
+    {{- include "logto.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.admin.service.type }}
+  ports:
+    - port: {{ .Values.admin.service.port }}
+      targetPort: admin
       protocol: TCP
-      name: api
+      name: http
   selector:
     {{- include "logto.selectorLabels" . | nindent 4 }}

--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "logto.serviceAccountName" . }}
+  labels:
+    {{- include "logto.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/templates/tests/test-connection.yaml
+++ b/helm/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "logto.fullname" . }}-test-connection"
+  labels:
+    {{- include "logto.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "logto.fullname" . }}:{{ .Values.service.port.http }}']
+  restartPolicy: Never

--- a/helm/templates/tests/test-connection.yaml
+++ b/helm/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "logto.fullname" . }}:{{ .Values.service.port.http }}']
+      args: ['{{ include "logto.fullname" . }}:{{ .Values.core.service.port }}']
   restartPolicy: Never

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -15,7 +15,7 @@ common:
     secretName: ""
   env:
     nodeEnv: ""
-    db_url: ""
+    dbURL: ""
     adminDisableLocalhost: false
     trustProxyHeader: true
 
@@ -34,6 +34,10 @@ core:
         paths:
           - path: /
             pathType: Prefix
+#    tls:
+#      - hosts:
+#          - logto.io
+#        secretName: logto-tls
     tls: []
 
 admin:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -9,16 +9,49 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-database:
-  enabled: true
-  type: postgres
-  password: ""
+common:
+  tls:
+    enabled: false
+    secretName: ""
+  env:
+    nodeEnv: ""
+    db_url: postgres://postgres:p0stgr3s@postgres:5432/logto
+    adminDisableLocalhost: false
+    trustProxyHeader: true
 
-env:
-  trustProxyHeader: true
-  db_url: ""
+core:
   endpoint: ""
-  adminEndpoint: ""
+  port: 3001
+  service:
+    type: ClusterIP
+    port: 3001
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      - host: logto.io
+        paths:
+          - path: /
+            pathType: Prefix
+    tls: []
+
+admin:
+  endpoint: ""
+  port: 3002
+  service:
+    type: ClusterIP
+    port: 3002
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      - host: admin.logto.io
+        paths:
+          - path: /
+            pathType: Prefix
+    tls: []
 
 serviceAccount:
   create: true
@@ -31,36 +64,14 @@ podSecurityContext: {}
 
 securityContext: {}
 
-service:
-  type: ClusterIP
-  port:
-    http: 3001
-    api: 3002
-
-ingress:
-  enabled: false
-  className: ""
-  annotations: {}
-  hosts:
-    - host: logto.io
-      paths:
-        - path: /
-          pathType: Prefix
-  tls: []
-
 resources: {}
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
 
 autoscaling:
   enabled: false
   minReplicas: 1
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
 
 nodeSelector: {}
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -15,7 +15,7 @@ common:
     secretName: ""
   env:
     nodeEnv: ""
-    db_url: postgres://postgres:p0stgr3s@postgres:5432/logto
+    db_url: ""
     adminDisableLocalhost: false
     trustProxyHeader: true
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,69 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/logto-io/logto
+  pullPolicy: IfNotPresent
+  tag: "1.6.0"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+database:
+  enabled: true
+  type: postgres
+  password: ""
+
+env:
+  trustProxyHeader: true
+  db_url: ""
+  endpoint: ""
+  adminEndpoint: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+service:
+  type: ClusterIP
+  port:
+    http: 3001
+    api: 3002
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: logto.io
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
Add helm charts to deploy logto on kubernetes.


Roadmap for logto helm charts

Task | Completed
-- | --
Init helm charts | ✅
Use Bitnami/postgresql as subcharts | no need seems?
Encrypt database url to secret | ☐
Test and bug fix | ☐
Release | ☐

