### PR TITLE
refactor(core,console): filter out webhook logs from audit logs list

### DIFF
--- a/packages/console/src/components/AuditLogTable/index.tsx
+++ b/packages/console/src/components/AuditLogTable/index.tsx
@@ -6,7 +6,7 @@ import useSWR from 'swr';
 
 import ApplicationName from '@/components/ApplicationName';
 import UserName from '@/components/UserName';
-import { defaultPageSize } from '@/consts';
+import { auditLogEventTitle, defaultPageSize } from '@/consts';
 import Table from '@/ds-components/Table';
 import type { Column } from '@/ds-components/Table/types';
 import type { RequestError } from '@/hooks/use-api';
@@ -20,6 +20,11 @@ import ApplicationSelector from './components/ApplicationSelector';
 import EventName from './components/EventName';
 import EventSelector from './components/EventSelector';
 import * as styles from './index.module.scss';
+
+const auditLogEventOptions = Object.entries(auditLogEventTitle).map(([value, title]) => ({
+  value,
+  title: title ?? value,
+}));
 
 type Props = {
   userId?: string;
@@ -103,6 +108,7 @@ function AuditLogTable({ userId, className }: Props) {
           <div className={styles.eventSelector}>
             <EventSelector
               value={event}
+              options={auditLogEventOptions}
               onChange={(event) => {
                 updateSearchParameters({ event, page: undefined });
               }}

--- a/packages/console/src/consts/logs.ts
+++ b/packages/console/src/consts/logs.ts
@@ -1,7 +1,7 @@
-import type { AuditLogKey } from '@logto/schemas';
+import type { AuditLogKey, LogKey, WebhookLogKey } from '@logto/schemas';
 import { type Optional } from '@silverhand/essentials';
 
-export const logEventTitle: Record<string, Optional<string>> &
+export const auditLogEventTitle: Record<string, Optional<string>> &
   Record<AuditLogKey, Optional<string>> = Object.freeze({
   'ExchangeTokenBy.AuthorizationCode': 'Exchange token by Code',
   'ExchangeTokenBy.ClientCredentials': 'Exchange token by Client Credentials',
@@ -49,3 +49,16 @@ export const logEventTitle: Record<string, Optional<string>> &
   RevokeToken: undefined,
   Unknown: undefined,
 });
+
+// `webhookLogEventTitle` and `logEventTitle` are not used yet, keep them just in case.
+const webhookLogEventTitle: Record<string, Optional<string>> &
+  Record<WebhookLogKey, Optional<string>> = Object.freeze({
+  'TriggerHook.PostRegister': undefined,
+  'TriggerHook.PostResetPassword': undefined,
+  'TriggerHook.PostSignIn': undefined,
+});
+
+export const logEventTitle: Record<string, Optional<string>> & Record<LogKey, Optional<string>> = {
+  ...auditLogEventTitle,
+  ...webhookLogEventTitle,
+};

--- a/packages/console/src/consts/logs.ts
+++ b/packages/console/src/consts/logs.ts
@@ -1,54 +1,60 @@
 import type { LogKey } from '@logto/schemas';
 import { type Optional } from '@silverhand/essentials';
 
-export const logEventTitle: Record<string, Optional<string>> & Record<LogKey, Optional<string>> =
-  Object.freeze({
-    'ExchangeTokenBy.AuthorizationCode': 'Exchange token by Code',
-    'ExchangeTokenBy.ClientCredentials': 'Exchange token by Client Credentials',
-    'ExchangeTokenBy.RefreshToken': 'Exchange token by Refresh Token',
-    'ExchangeTokenBy.Unknown': undefined,
-    'Interaction.Create': 'Interaction started',
-    'Interaction.End': 'Interaction ended',
-    'Interaction.ForgotPassword.Identifier.Password.Submit':
-      'Submit forgot-password identifier with password',
-    'Interaction.ForgotPassword.Identifier.Social.Create': undefined,
-    'Interaction.ForgotPassword.Identifier.Social.Submit': undefined,
-    'Interaction.ForgotPassword.Identifier.VerificationCode.Create':
-      'Create and send forgot-password verification code',
-    'Interaction.ForgotPassword.Identifier.VerificationCode.Submit':
-      'Submit and verify forgot-password verification code',
-    'Interaction.ForgotPassword.Profile.Create': 'Put new forgot-password interaction profile',
-    'Interaction.ForgotPassword.Profile.Delete': 'Delete forgot-password interaction profile',
-    'Interaction.ForgotPassword.Profile.Update': 'Patch update forgot-password interaction profile',
-    'Interaction.ForgotPassword.Submit': 'Submit forgot-password interaction',
-    'Interaction.ForgotPassword.Update': 'Update forgot-password interaction',
-    'Interaction.Register.Identifier.Password.Submit': undefined,
-    'Interaction.Register.Identifier.Social.Create': undefined,
-    'Interaction.Register.Identifier.Social.Submit': undefined,
-    'Interaction.Register.Identifier.VerificationCode.Create':
-      'Create and send register identifier with verification code',
-    'Interaction.Register.Identifier.VerificationCode.Submit':
-      'Submit and verify register verification code',
-    'Interaction.Register.Profile.Create': 'Put new register interaction profile',
-    'Interaction.Register.Profile.Delete': 'Delete register interaction profile',
-    'Interaction.Register.Profile.Update': 'Patch update register interaction profile',
-    'Interaction.Register.Submit': 'Submit register interaction',
-    'Interaction.Register.Update': 'Update register interaction',
-    'Interaction.SignIn.Identifier.Password.Submit': 'Submit sign-in identifier with password',
-    'Interaction.SignIn.Identifier.Social.Create': 'Create social sign-in authorization-url',
-    'Interaction.SignIn.Identifier.Social.Submit': 'Authenticate and submit social identifier',
-    'Interaction.SignIn.Identifier.VerificationCode.Create':
-      'Create and send sign-in verification code',
-    'Interaction.SignIn.Identifier.VerificationCode.Submit':
-      'Submit and verify sign-in identifier with verification code',
-    'Interaction.SignIn.Profile.Create': 'Put new sign-in interaction profile',
-    'Interaction.SignIn.Profile.Delete': 'Delete sign-in interaction profile',
-    'Interaction.SignIn.Profile.Update': 'Patch Update sign-in interaction profile',
-    'Interaction.SignIn.Submit': 'Submit sign-in interaction',
-    'Interaction.SignIn.Update': 'Update sign-in interaction',
-    'TriggerHook.PostRegister': undefined,
-    'TriggerHook.PostResetPassword': undefined,
-    'TriggerHook.PostSignIn': undefined,
-    RevokeToken: undefined,
-    Unknown: undefined,
-  });
+/**
+ * Filter out webhook logs from the audit log list.
+ * Hence should not allow user to check webhook logs by selecting their event/log types.
+ */
+type AuditLogKeys = Exclude<
+  LogKey,
+  'TriggerHook.PostRegister' | 'TriggerHook.PostSignIn' | 'TriggerHook.PostResetPassword'
+>;
+
+export const logEventTitle: Record<string, Optional<string>> &
+  Record<AuditLogKeys, Optional<string>> = Object.freeze({
+  'ExchangeTokenBy.AuthorizationCode': 'Exchange token by Code',
+  'ExchangeTokenBy.ClientCredentials': 'Exchange token by Client Credentials',
+  'ExchangeTokenBy.RefreshToken': 'Exchange token by Refresh Token',
+  'ExchangeTokenBy.Unknown': undefined,
+  'Interaction.Create': 'Interaction started',
+  'Interaction.End': 'Interaction ended',
+  'Interaction.ForgotPassword.Identifier.Password.Submit':
+    'Submit forgot-password identifier with password',
+  'Interaction.ForgotPassword.Identifier.Social.Create': undefined,
+  'Interaction.ForgotPassword.Identifier.Social.Submit': undefined,
+  'Interaction.ForgotPassword.Identifier.VerificationCode.Create':
+    'Create and send forgot-password verification code',
+  'Interaction.ForgotPassword.Identifier.VerificationCode.Submit':
+    'Submit and verify forgot-password verification code',
+  'Interaction.ForgotPassword.Profile.Create': 'Put new forgot-password interaction profile',
+  'Interaction.ForgotPassword.Profile.Delete': 'Delete forgot-password interaction profile',
+  'Interaction.ForgotPassword.Profile.Update': 'Patch update forgot-password interaction profile',
+  'Interaction.ForgotPassword.Submit': 'Submit forgot-password interaction',
+  'Interaction.ForgotPassword.Update': 'Update forgot-password interaction',
+  'Interaction.Register.Identifier.Password.Submit': undefined,
+  'Interaction.Register.Identifier.Social.Create': undefined,
+  'Interaction.Register.Identifier.Social.Submit': undefined,
+  'Interaction.Register.Identifier.VerificationCode.Create':
+    'Create and send register identifier with verification code',
+  'Interaction.Register.Identifier.VerificationCode.Submit':
+    'Submit and verify register verification code',
+  'Interaction.Register.Profile.Create': 'Put new register interaction profile',
+  'Interaction.Register.Profile.Delete': 'Delete register interaction profile',
+  'Interaction.Register.Profile.Update': 'Patch update register interaction profile',
+  'Interaction.Register.Submit': 'Submit register interaction',
+  'Interaction.Register.Update': 'Update register interaction',
+  'Interaction.SignIn.Identifier.Password.Submit': 'Submit sign-in identifier with password',
+  'Interaction.SignIn.Identifier.Social.Create': 'Create social sign-in authorization-url',
+  'Interaction.SignIn.Identifier.Social.Submit': 'Authenticate and submit social identifier',
+  'Interaction.SignIn.Identifier.VerificationCode.Create':
+    'Create and send sign-in verification code',
+  'Interaction.SignIn.Identifier.VerificationCode.Submit':
+    'Submit and verify sign-in identifier with verification code',
+  'Interaction.SignIn.Profile.Create': 'Put new sign-in interaction profile',
+  'Interaction.SignIn.Profile.Delete': 'Delete sign-in interaction profile',
+  'Interaction.SignIn.Profile.Update': 'Patch Update sign-in interaction profile',
+  'Interaction.SignIn.Submit': 'Submit sign-in interaction',
+  'Interaction.SignIn.Update': 'Update sign-in interaction',
+  RevokeToken: undefined,
+  Unknown: undefined,
+});

--- a/packages/console/src/consts/logs.ts
+++ b/packages/console/src/consts/logs.ts
@@ -1,17 +1,8 @@
-import type { LogKey } from '@logto/schemas';
+import type { AuditLogKey } from '@logto/schemas';
 import { type Optional } from '@silverhand/essentials';
 
-/**
- * Filter out webhook logs from the audit log list.
- * Hence should not allow user to check webhook logs by selecting their event/log types.
- */
-type AuditLogKeys = Exclude<
-  LogKey,
-  'TriggerHook.PostRegister' | 'TriggerHook.PostSignIn' | 'TriggerHook.PostResetPassword'
->;
-
 export const logEventTitle: Record<string, Optional<string>> &
-  Record<AuditLogKeys, Optional<string>> = Object.freeze({
+  Record<AuditLogKey, Optional<string>> = Object.freeze({
   'ExchangeTokenBy.AuthorizationCode': 'Exchange token by Code',
   'ExchangeTokenBy.ClientCredentials': 'Exchange token by Client Credentials',
   'ExchangeTokenBy.RefreshToken': 'Exchange token by Refresh Token',

--- a/packages/core/src/routes/hook.test.ts
+++ b/packages/core/src/routes/hook.test.ts
@@ -6,6 +6,7 @@ import {
   type CreateHook,
   LogResult,
   type Log,
+  hook,
 } from '@logto/schemas';
 import { pickDefault } from '@logto/shared/esm';
 import { subDays } from 'date-fns';
@@ -61,13 +62,13 @@ const mockExecutionStats = {
 };
 
 const logs = {
-  countWebhookLogs: jest.fn().mockResolvedValue({
+  countLogs: jest.fn().mockResolvedValue({
     count: 1,
   }),
-  findWebhookLogs: jest.fn().mockResolvedValue([mockLog]),
+  findLogs: jest.fn().mockResolvedValue([mockLog]),
 };
 
-const { countWebhookLogs, findWebhookLogs } = logs;
+const { countLogs, findLogs } = logs;
 
 const mockQueries = {
   hooks,
@@ -142,7 +143,7 @@ describe('hook routes', () => {
     });
   });
 
-  it('GET /hooks/:id/recent-logs should call countWebhookLogs and findWebhookLogs with correct parameters', async () => {
+  it('GET /hooks/:id/recent-logs should call countLogs and findLogs with correct parameters', async () => {
     jest.useFakeTimers().setSystemTime(100_000);
 
     const hookId = 'foo';
@@ -155,15 +156,17 @@ describe('hook routes', () => {
     await hookRequest.get(
       `/hooks/${hookId}/recent-logs?logKey=${logKey}&page=${page}&page_size=${pageSize}`
     );
-    expect(countWebhookLogs).toHaveBeenCalledWith({
-      hookId,
+    expect(countLogs).toHaveBeenCalledWith({
+      payload: { hookId },
       logKey,
       startTimeExclusive,
+      includeKeyPrefix: [hook.Type.TriggerHook],
     });
-    expect(findWebhookLogs).toHaveBeenCalledWith(5, 0, {
-      hookId,
+    expect(findLogs).toHaveBeenCalledWith(5, 0, {
+      payload: { hookId },
       logKey,
       startTimeExclusive,
+      includeKeyPrefix: [hook.Type.TriggerHook],
     });
 
     jest.useRealTimers();

--- a/packages/core/src/routes/hook.test.ts
+++ b/packages/core/src/routes/hook.test.ts
@@ -155,8 +155,18 @@ describe('hook routes', () => {
     await hookRequest.get(
       `/hooks/${hookId}/recent-logs?logKey=${logKey}&page=${page}&page_size=${pageSize}`
     );
-    expect(countLogs).toHaveBeenCalledWith({ hookId, logKey, startTimeExclusive });
-    expect(findLogs).toHaveBeenCalledWith(5, 0, { hookId, logKey, startTimeExclusive });
+    expect(countLogs).toHaveBeenCalledWith({
+      hookId,
+      logKey,
+      startTimeExclusive,
+      includeWebhookLogs: true,
+    });
+    expect(findLogs).toHaveBeenCalledWith(5, 0, {
+      hookId,
+      logKey,
+      startTimeExclusive,
+      includeWebhookLogs: true,
+    });
 
     jest.useRealTimers();
   });

--- a/packages/core/src/routes/hook.test.ts
+++ b/packages/core/src/routes/hook.test.ts
@@ -61,13 +61,13 @@ const mockExecutionStats = {
 };
 
 const logs = {
-  countLogs: jest.fn().mockResolvedValue({
+  countWebhookLogs: jest.fn().mockResolvedValue({
     count: 1,
   }),
-  findLogs: jest.fn().mockResolvedValue([mockLog]),
+  findWebhookLogs: jest.fn().mockResolvedValue([mockLog]),
 };
 
-const { countLogs, findLogs } = logs;
+const { countWebhookLogs, findWebhookLogs } = logs;
 
 const mockQueries = {
   hooks,
@@ -142,7 +142,7 @@ describe('hook routes', () => {
     });
   });
 
-  it('GET /hooks/:id/recent-logs should call countLogs and findLogs with correct parameters', async () => {
+  it('GET /hooks/:id/recent-logs should call countWebhookLogs and findWebhookLogs with correct parameters', async () => {
     jest.useFakeTimers().setSystemTime(100_000);
 
     const hookId = 'foo';
@@ -155,17 +155,15 @@ describe('hook routes', () => {
     await hookRequest.get(
       `/hooks/${hookId}/recent-logs?logKey=${logKey}&page=${page}&page_size=${pageSize}`
     );
-    expect(countLogs).toHaveBeenCalledWith({
+    expect(countWebhookLogs).toHaveBeenCalledWith({
       hookId,
       logKey,
       startTimeExclusive,
-      includeWebhookLogs: true,
     });
-    expect(findLogs).toHaveBeenCalledWith(5, 0, {
+    expect(findWebhookLogs).toHaveBeenCalledWith(5, 0, {
       hookId,
       logKey,
       startTimeExclusive,
-      includeWebhookLogs: true,
     });
 
     jest.useRealTimers();

--- a/packages/core/src/routes/hook.ts
+++ b/packages/core/src/routes/hook.ts
@@ -117,8 +117,13 @@ export default function hookRoutes<T extends AuthedRouter>(
       const startTimeExclusive = subDays(new Date(), 1).getTime();
 
       const [{ count }, logs] = await Promise.all([
-        countLogs({ logKey, hookId: id, startTimeExclusive }),
-        findLogs(limit, offset, { logKey, hookId: id, startTimeExclusive }),
+        countLogs({ logKey, hookId: id, startTimeExclusive, includeWebhookLogs: true }),
+        findLogs(limit, offset, {
+          logKey,
+          hookId: id,
+          startTimeExclusive,
+          includeWebhookLogs: true,
+        }),
       ]);
 
       ctx.pagination.totalCount = count;

--- a/packages/core/src/routes/hook.ts
+++ b/packages/core/src/routes/hook.ts
@@ -28,7 +28,7 @@ export default function hookRoutes<T extends AuthedRouter>(
       updateHookById,
       deleteHookById,
     },
-    logs: { countLogs, findLogs },
+    logs: { countWebhookLogs, findWebhookLogs },
   } = queries;
 
   const {
@@ -117,12 +117,11 @@ export default function hookRoutes<T extends AuthedRouter>(
       const startTimeExclusive = subDays(new Date(), 1).getTime();
 
       const [{ count }, logs] = await Promise.all([
-        countLogs({ logKey, hookId: id, startTimeExclusive, includeWebhookLogs: true }),
-        findLogs(limit, offset, {
+        countWebhookLogs({ logKey, hookId: id, startTimeExclusive }),
+        findWebhookLogs(limit, offset, {
           logKey,
           hookId: id,
           startTimeExclusive,
-          includeWebhookLogs: true,
         }),
       ]);
 

--- a/packages/core/src/routes/log.test.ts
+++ b/packages/core/src/routes/log.test.ts
@@ -12,13 +12,13 @@ const mockLog: Log = { tenantId: 'fake_tenant', id: '1', ...mockBody };
 const mockLogs = [mockLog, { id: '2', ...mockBody }];
 
 const logs = {
-  countLogs: jest.fn().mockResolvedValue({
+  countAuditLogs: jest.fn().mockResolvedValue({
     count: mockLogs.length,
   }),
-  findLogs: jest.fn().mockResolvedValue(mockLogs),
+  findAuditLogs: jest.fn().mockResolvedValue(mockLogs),
   findLogById: jest.fn().mockResolvedValue(mockLog),
 };
-const { countLogs, findLogs, findLogById } = logs;
+const { countAuditLogs, findAuditLogs, findLogById } = logs;
 const logRoutes = await pickDefault(import('./log.js'));
 
 describe('logRoutes', () => {
@@ -32,7 +32,7 @@ describe('logRoutes', () => {
   });
 
   describe('GET /logs', () => {
-    it('should call countLogs and findLogs with correct parameters', async () => {
+    it('should call countAuditLogs and findAuditLogs with correct parameters', async () => {
       const userId = 'userIdValue';
       const applicationId = 'foo';
       const logKey = 'SignInUsernamePassword';
@@ -42,17 +42,15 @@ describe('logRoutes', () => {
       await logRequest.get(
         `/logs?userId=${userId}&applicationId=${applicationId}&logKey=${logKey}&page=${page}&page_size=${pageSize}`
       );
-      expect(countLogs).toHaveBeenCalledWith({
+      expect(countAuditLogs).toHaveBeenCalledWith({
         userId,
         applicationId,
         logKey,
-        includeWebhookLogs: false,
       });
-      expect(findLogs).toHaveBeenCalledWith(5, 0, {
+      expect(findAuditLogs).toHaveBeenCalledWith(5, 0, {
         userId,
         applicationId,
         logKey,
-        includeWebhookLogs: false,
       });
     });
 

--- a/packages/core/src/routes/log.test.ts
+++ b/packages/core/src/routes/log.test.ts
@@ -1,4 +1,4 @@
-import { LogResult } from '@logto/schemas';
+import { LogResult, token, interaction, LogKeyUnknown } from '@logto/schemas';
 import type { Log } from '@logto/schemas';
 import { pickDefault } from '@logto/shared/esm';
 
@@ -12,13 +12,13 @@ const mockLog: Log = { tenantId: 'fake_tenant', id: '1', ...mockBody };
 const mockLogs = [mockLog, { id: '2', ...mockBody }];
 
 const logs = {
-  countAuditLogs: jest.fn().mockResolvedValue({
+  countLogs: jest.fn().mockResolvedValue({
     count: mockLogs.length,
   }),
-  findAuditLogs: jest.fn().mockResolvedValue(mockLogs),
+  findLogs: jest.fn().mockResolvedValue(mockLogs),
   findLogById: jest.fn().mockResolvedValue(mockLog),
 };
-const { countAuditLogs, findAuditLogs, findLogById } = logs;
+const { countLogs, findLogs, findLogById } = logs;
 const logRoutes = await pickDefault(import('./log.js'));
 
 describe('logRoutes', () => {
@@ -32,7 +32,7 @@ describe('logRoutes', () => {
   });
 
   describe('GET /logs', () => {
-    it('should call countAuditLogs and findAuditLogs with correct parameters', async () => {
+    it('should call countLogs and findLogs with correct parameters', async () => {
       const userId = 'userIdValue';
       const applicationId = 'foo';
       const logKey = 'SignInUsernamePassword';
@@ -42,15 +42,25 @@ describe('logRoutes', () => {
       await logRequest.get(
         `/logs?userId=${userId}&applicationId=${applicationId}&logKey=${logKey}&page=${page}&page_size=${pageSize}`
       );
-      expect(countAuditLogs).toHaveBeenCalledWith({
-        userId,
-        applicationId,
+      expect(countLogs).toHaveBeenCalledWith({
+        payload: { userId, applicationId },
         logKey,
+        includeKeyPrefix: [
+          token.Type.ExchangeTokenBy,
+          token.Type.RevokeToken,
+          interaction.prefix,
+          LogKeyUnknown,
+        ],
       });
-      expect(findAuditLogs).toHaveBeenCalledWith(5, 0, {
-        userId,
-        applicationId,
+      expect(findLogs).toHaveBeenCalledWith(5, 0, {
+        payload: { userId, applicationId },
         logKey,
+        includeKeyPrefix: [
+          token.Type.ExchangeTokenBy,
+          token.Type.RevokeToken,
+          interaction.prefix,
+          LogKeyUnknown,
+        ],
       });
     });
 

--- a/packages/core/src/routes/log.test.ts
+++ b/packages/core/src/routes/log.test.ts
@@ -42,8 +42,18 @@ describe('logRoutes', () => {
       await logRequest.get(
         `/logs?userId=${userId}&applicationId=${applicationId}&logKey=${logKey}&page=${page}&page_size=${pageSize}`
       );
-      expect(countLogs).toHaveBeenCalledWith({ userId, applicationId, logKey });
-      expect(findLogs).toHaveBeenCalledWith(5, 0, { userId, applicationId, logKey });
+      expect(countLogs).toHaveBeenCalledWith({
+        userId,
+        applicationId,
+        logKey,
+        includeWebhookLogs: false,
+      });
+      expect(findLogs).toHaveBeenCalledWith(5, 0, {
+        userId,
+        applicationId,
+        logKey,
+        includeWebhookLogs: false,
+      });
     });
 
     it('should return correct response', async () => {

--- a/packages/core/src/routes/log.ts
+++ b/packages/core/src/routes/log.ts
@@ -1,4 +1,5 @@
 import { Logs } from '@logto/schemas';
+import { yes } from '@silverhand/essentials';
 import { object, string } from 'zod';
 
 import koaGuard from '#src/middleware/koa-guard.js';
@@ -19,6 +20,7 @@ export default function logRoutes<T extends AuthedRouter>(
         userId: string().optional(),
         applicationId: string().optional(),
         logKey: string().optional(),
+        includeWebhookLogs: string().optional(),
       }),
       response: Logs.guard.omit({ tenantId: true }).array(),
       status: 200,
@@ -26,13 +28,25 @@ export default function logRoutes<T extends AuthedRouter>(
     async (ctx, next) => {
       const { limit, offset } = ctx.pagination;
       const {
-        query: { userId, applicationId, logKey },
+        query: { userId, applicationId, logKey, includeWebhookLogs: includeWebhookLogsString },
       } = ctx.guard;
+      const includeWebhookLogs = yes(includeWebhookLogsString);
 
       // TODO: @Gao refactor like user search
+      // Filter out webhook logs from the audit log list by default.
       const [{ count }, logs] = await Promise.all([
-        countLogs({ logKey, applicationId, userId }),
-        findLogs(limit, offset, { logKey, userId, applicationId }),
+        countLogs({
+          logKey,
+          applicationId,
+          userId,
+          includeWebhookLogs,
+        }),
+        findLogs(limit, offset, {
+          logKey,
+          userId,
+          applicationId,
+          includeWebhookLogs,
+        }),
       ]);
 
       // Return totalCount to pagination middleware

--- a/packages/integration-tests/src/api/logs.ts
+++ b/packages/integration-tests/src/api/logs.ts
@@ -3,7 +3,12 @@ import { conditionalString } from '@silverhand/essentials';
 
 import { authedAdminApi } from './api.js';
 
-export const getLogs = async (params?: URLSearchParams) =>
+export const getAuditLogs = async (params?: URLSearchParams) =>
   authedAdminApi.get('logs?' + conditionalString(params?.toString())).json<Log[]>();
+
+export const getWebhookRecentLogs = async (hookId: string, params?: URLSearchParams) =>
+  authedAdminApi
+    .get(`hooks/${hookId}/recent-logs?` + conditionalString(params?.toString()))
+    .json<Log[]>();
 
 export const getLog = async (logId: string) => authedAdminApi.get(`logs/${logId}`).json<Log>();

--- a/packages/integration-tests/src/tests/api/audit-logs/index.test.ts
+++ b/packages/integration-tests/src/tests/api/audit-logs/index.test.ts
@@ -3,7 +3,7 @@ import { assert } from '@silverhand/essentials';
 
 import { deleteUser } from '#src/api/admin-user.js';
 import { putInteraction } from '#src/api/interaction.js';
-import { getLogs } from '#src/api/logs.js';
+import { getAuditLogs } from '#src/api/logs.js';
 import MockClient from '#src/client/index.js';
 import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
 import { generateNewUserProfile } from '#src/helpers/user.js';
@@ -26,7 +26,7 @@ describe('audit logs for interaction', () => {
     console.debug('Testing interaction', interactionId);
 
     // Expect interaction create log
-    const createLogs = await getLogs(
+    const createLogs = await getAuditLogs(
       new URLSearchParams({ logKey: `${interaction.prefix}.${interaction.Action.Create}` })
     );
     expect(createLogs.some((value) => value.payload.interactionId === interactionId)).toBeTruthy();
@@ -43,7 +43,7 @@ describe('audit logs for interaction', () => {
     await client.processSession(response.redirectTo);
 
     // Expect interaction end log
-    const endLogs = await getLogs(
+    const endLogs = await getAuditLogs(
       new URLSearchParams({ logKey: `${interaction.prefix}.${interaction.Action.End}` })
     );
     expect(endLogs.some((value) => value.payload.interactionId === interactionId)).toBeTruthy();

--- a/packages/integration-tests/src/tests/api/hook/hook.trigger.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.trigger.test.ts
@@ -87,7 +87,9 @@ describe('trigger hooks', () => {
     await signInWithPassword({ username, password });
 
     // Check hook trigger log
-    const logs = await getLogs(new URLSearchParams({ logKey, page_size: '100' }));
+    const logs = await getLogs(
+      new URLSearchParams({ logKey, page_size: '100', includeWebhookLogs: 'true' })
+    );
     expect(
       logs.some(
         ({ payload: { hookId, result, error } }) =>
@@ -128,7 +130,9 @@ describe('trigger hooks', () => {
     const userId = await registerNewUser(username, password);
 
     // Check hook trigger log
-    const logs = await getLogs(new URLSearchParams({ logKey, page_size: '100' }));
+    const logs = await getLogs(
+      new URLSearchParams({ logKey, page_size: '100', includeWebhookLogs: 'true' })
+    );
     expect(
       logs.some(
         ({ payload: { hookId, result, error } }) =>
@@ -222,7 +226,9 @@ describe('trigger hooks', () => {
     // Wait for the hook to be trigged
     await waitFor(1000);
 
-    const logs = await getLogs(new URLSearchParams({ logKey, page_size: '100' }));
+    const logs = await getLogs(
+      new URLSearchParams({ logKey, page_size: '100', includeWebhookLogs: 'true' })
+    );
     const relatedLogs = logs.filter(
       ({ payload: { hookId, result } }) =>
         hookId === resetPasswordHook.id && result === LogResult.Success

--- a/packages/integration-tests/src/tests/api/hook/hook.trigger.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.trigger.test.ts
@@ -90,14 +90,12 @@ describe('trigger hooks', () => {
     // Check hook trigger log
     const logs = await getWebhookRecentLogs(
       createdHook.id,
-      new URLSearchParams({ logKey, page_size: '100', includeWebhookLogs: 'true' })
+      new URLSearchParams({ logKey, page_size: '100' })
     );
     expect(
       logs.some(
-        ({ payload: { hookId, result, error } }) =>
-          hookId === createdHook.id &&
-          result === LogResult.Error &&
-          error === 'RequestError: Invalid URL'
+        ({ payload: { result, error } }) =>
+          result === LogResult.Error && error === 'RequestError: Invalid URL'
       )
     ).toBeTruthy();
 
@@ -140,14 +138,12 @@ describe('trigger hooks', () => {
       // eslint-disable-next-line no-await-in-loop
       const logs = await getWebhookRecentLogs(
         hook.id,
-        new URLSearchParams({ logKey, page_size: '100', includeWebhookLogs: 'true' })
+        new URLSearchParams({ logKey, page_size: '100' })
       );
       expect(
         logs.some(
-          ({ payload: { hookId, result, error } }) =>
-            hookId === hook.id &&
-            result === expectedResult &&
-            (!expectedError || error === expectedError)
+          ({ payload: { result, error } }) =>
+            result === expectedResult && (!expectedError || error === expectedError)
         )
       ).toBeTruthy();
     }
@@ -228,16 +224,15 @@ describe('trigger hooks', () => {
     // Wait for the hook to be trigged
     await waitFor(1000);
 
-    const logs = await getWebhookRecentLogs(
+    const relatedLogs = await getWebhookRecentLogs(
       resetPasswordHook.id,
-      new URLSearchParams({ logKey, page_size: '100', includeWebhookLogs: 'true' })
+      new URLSearchParams({ logKey, page_size: '100' })
     );
-    const relatedLogs = logs.filter(
-      ({ payload: { hookId, result } }) =>
-        hookId === resetPasswordHook.id && result === LogResult.Success
+    const succeedLogs = relatedLogs.filter(
+      ({ payload: { result } }) => result === LogResult.Success
     );
 
-    expect(relatedLogs).toHaveLength(2);
+    expect(succeedLogs).toHaveLength(2);
 
     await authedAdminApi.delete(`hooks/${resetPasswordHook.id}`);
     await deleteUser(user.id);

--- a/packages/integration-tests/src/tests/api/hook/hook.trigger.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.trigger.test.ts
@@ -134,7 +134,7 @@ describe('trigger hooks', () => {
       [hook1, LogResult.Error, 'RequestError: Invalid URL'],
       [hook2, LogResult.Success, undefined],
       [hook3, LogResult.Success, undefined],
-    ] as Array<[Hook, LogResult, Optional<string>]>) {
+    ] satisfies Array<[Hook, LogResult, Optional<string>]>) {
       // eslint-disable-next-line no-await-in-loop
       const logs = await getWebhookRecentLogs(
         hook.id,

--- a/packages/integration-tests/src/tests/api/hook/hook.trigger.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.trigger.test.ts
@@ -10,10 +10,11 @@ import {
   type Log,
   ConnectorType,
 } from '@logto/schemas';
+import { type Optional } from '@silverhand/essentials';
 
 import { deleteUser } from '#src/api/admin-user.js';
 import { authedAdminApi } from '#src/api/api.js';
-import { getLogs } from '#src/api/logs.js';
+import { getWebhookRecentLogs } from '#src/api/logs.js';
 import {
   clearConnectorsByTypes,
   setEmailConnector,
@@ -87,7 +88,8 @@ describe('trigger hooks', () => {
     await signInWithPassword({ username, password });
 
     // Check hook trigger log
-    const logs = await getLogs(
+    const logs = await getWebhookRecentLogs(
+      createdHook.id,
       new URLSearchParams({ logKey, page_size: '100', includeWebhookLogs: 'true' })
     );
     expect(
@@ -130,25 +132,25 @@ describe('trigger hooks', () => {
     const userId = await registerNewUser(username, password);
 
     // Check hook trigger log
-    const logs = await getLogs(
-      new URLSearchParams({ logKey, page_size: '100', includeWebhookLogs: 'true' })
-    );
-    expect(
-      logs.some(
-        ({ payload: { hookId, result, error } }) =>
-          hookId === hook1.id && result === LogResult.Error && error === 'RequestError: Invalid URL'
-      )
-    ).toBeTruthy();
-    expect(
-      logs.some(
-        ({ payload: { hookId, result } }) => hookId === hook2.id && result === LogResult.Success
-      )
-    ).toBeTruthy();
-    expect(
-      logs.some(
-        ({ payload: { hookId, result } }) => hookId === hook3.id && result === LogResult.Success
-      )
-    ).toBeTruthy();
+    for (const [hook, expectedResult, expectedError] of [
+      [hook1, LogResult.Error, 'RequestError: Invalid URL'],
+      [hook2, LogResult.Success, undefined],
+      [hook3, LogResult.Success, undefined],
+    ] as Array<[Hook, LogResult, Optional<string>]>) {
+      // eslint-disable-next-line no-await-in-loop
+      const logs = await getWebhookRecentLogs(
+        hook.id,
+        new URLSearchParams({ logKey, page_size: '100', includeWebhookLogs: 'true' })
+      );
+      expect(
+        logs.some(
+          ({ payload: { hookId, result, error } }) =>
+            hookId === hook.id &&
+            result === expectedResult &&
+            (!expectedError || error === expectedError)
+        )
+      ).toBeTruthy();
+    }
 
     // Clean up
     await Promise.all([
@@ -226,7 +228,8 @@ describe('trigger hooks', () => {
     // Wait for the hook to be trigged
     await waitFor(1000);
 
-    const logs = await getLogs(
+    const logs = await getWebhookRecentLogs(
+      resetPasswordHook.id,
       new URLSearchParams({ logKey, page_size: '100', includeWebhookLogs: 'true' })
     );
     const relatedLogs = logs.filter(

--- a/packages/integration-tests/src/tests/api/log.test.ts
+++ b/packages/integration-tests/src/tests/api/log.test.ts
@@ -1,15 +1,15 @@
-import { getLog, getLogs } from '#src/api/index.js';
+import { getLog, getAuditLogs } from '#src/api/index.js';
 import { createResponseWithCode } from '#src/helpers/admin-tenant.js';
 
 describe('logs', () => {
   it('should get logs successfully', async () => {
-    const logs = await getLogs();
+    const logs = await getAuditLogs();
 
     expect(logs.length).toBeGreaterThan(0);
   });
 
   it('should get log detail successfully', async () => {
-    const logs = await getLogs();
+    const logs = await getAuditLogs();
     const logId = logs[0]?.id;
 
     expect(logId).not.toBeUndefined();

--- a/packages/schemas/src/types/log/index.ts
+++ b/packages/schemas/src/types/log/index.ts
@@ -9,6 +9,9 @@ export * as hook from './hook.js';
 /** Fallback for empty or unrecognized log keys. */
 export const LogKeyUnknown = 'Unknown';
 
+export type AuditLogKey = typeof LogKeyUnknown | interaction.LogKey | token.LogKey;
+export type WebhookLogKey = hook.LogKey;
+
 /**
  * The union type of all available log keys.
  * Note duplicate keys are allowed but should be avoided.
@@ -16,4 +19,4 @@ export const LogKeyUnknown = 'Unknown';
  * @see {@link interaction.LogKey} for interaction log keys.
  * @see {@link token.LogKey} for token log keys.
  **/
-export type LogKey = typeof LogKeyUnknown | interaction.LogKey | token.LogKey | hook.LogKey;
+export type LogKey = AuditLogKey | WebhookLogKey;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
filter out webhook logs from audit logs list.
1. Separate the findLogs/countLogs methods to find(Audit|Webhook)Logs/count(Audit|Webhook)Logs, since in our use case, these two kinds of logs should be decoupled.
2. Remove all webhook event types from audit log "filter by event" dropdown option lists.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Updated UTs, ITs and also tested locally, can successfully filter out webhook logs in audit logs list and do not affect the display of webhook logs in hook detail pages.
Before: (webhook log in the list)
<img width="2129" alt="image" src="https://github.com/logto-io/logto/assets/15182327/a3f8d9f4-ddfb-4196-92fe-47dec1c78aa1">
After: (webhook log filtered out)
<img width="2277" alt="image" src="https://github.com/logto-io/logto/assets/15182327/24890c51-0c47-4e25-8b58-b8d31522eecb">

Can not find/select webhook related event type in "filter (audit log) by event" dropdown. (previously these options are presented before `RevokeToken`).
<img width="2082" alt="image" src="https://github.com/logto-io/logto/assets/15182327/e60b30f8-193a-4c0a-b7a6-8410471efdcb">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] docs

OR

- [ ] This PR is not applicable for the checklist
