### PR TITLE
refactor(console): preload subscription data for all tenants

### DIFF
--- a/packages/console/src/containers/AppContent/components/Topbar/TenantSelector/TenantDropdownItem/TenantStatusTag.tsx
+++ b/packages/console/src/containers/AppContent/components/Topbar/TenantSelector/TenantDropdownItem/TenantStatusTag.tsx
@@ -8,8 +8,6 @@ import useSubscriptionPlan from '@/hooks/use-subscription-plan';
 import useSubscriptionUsage from '@/hooks/use-subscription-usage';
 import { getLatestUnpaidInvoice } from '@/utils/subscription';
 
-import Skeleton from './Skeleton';
-
 type Props = {
   tenantId: string;
   className?: string;
@@ -30,7 +28,7 @@ function TenantStatusTag({ tenantId, className }: Props) {
   );
 
   if (isLoadingUsage || isLoadingInvoice || isLoadingSubscription) {
-    return <Skeleton />;
+    return null;
   }
 
   /**

--- a/packages/console/src/containers/ProtectedRoutes/index.tsx
+++ b/packages/console/src/containers/ProtectedRoutes/index.tsx
@@ -1,7 +1,9 @@
 import { useLogto } from '@logto/react';
-import { yes, conditional } from '@silverhand/essentials';
-import { useContext, useEffect } from 'react';
+import { type TenantInfo } from '@logto/schemas/lib/models/tenants.js';
+import { yes, conditional, trySafe } from '@silverhand/essentials';
+import { useCallback, useContext, useEffect } from 'react';
 import { Outlet, useSearchParams } from 'react-router-dom';
+import { preload } from 'swr';
 
 import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
 import AppLoading from '@/components/AppLoading';
@@ -34,6 +36,34 @@ export default function ProtectedRoutes() {
   const { isAuthenticated, isLoading, signIn } = useLogto();
   const { currentTenantId, isInitComplete, resetTenants } = useContext(TenantsContext);
 
+  const preloadSubscriptionData = useCallback(
+    async (tenants: TenantInfo[]) => {
+      await Promise.all([
+        // Preload subscription plans
+        preload('/api/subscription-plans', async () => trySafe(api.get('/api/subscription-plans'))),
+        // Preload tenants' subscriptions
+        ...tenants.map(async ({ id: tenantId }) =>
+          preload(`/api/tenants/${tenantId}/subscription`, async () =>
+            trySafe(api.get(`/api/tenants/:tenantId/subscription`, { params: { tenantId } }))
+          )
+        ),
+        // Preload tenants' subscription usages
+        ...tenants.map(async ({ id: tenantId }) =>
+          preload(`/api/tenants/${tenantId}/usage`, async () =>
+            trySafe(api.get(`/api/tenants/:tenantId/usage`, { params: { tenantId } }))
+          )
+        ),
+        // Preload tenants' invoices
+        ...tenants.map(async ({ id: tenantId }) =>
+          preload(`/api/tenants/${tenantId}/invoices`, async () =>
+            trySafe(api.get(`/api/tenants/:tenantId/invoices`, { params: { tenantId } }))
+          )
+        ),
+      ]);
+    },
+    [api]
+  );
+
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
       saveRedirect();
@@ -46,12 +76,13 @@ export default function ProtectedRoutes() {
     if (isAuthenticated && !isInitComplete) {
       const loadTenants = async () => {
         const data = await api.get('/api/tenants');
+        await preloadSubscriptionData(data);
         resetTenants(data);
       };
 
       void loadTenants();
     }
-  }, [api, isAuthenticated, isInitComplete, resetTenants]);
+  }, [api, isAuthenticated, isInitComplete, preloadSubscriptionData, resetTenants]);
 
   if (!isInitComplete || !isAuthenticated) {
     return <AppLoading />;

--- a/packages/console/src/containers/TenantAccess/index.tsx
+++ b/packages/console/src/containers/TenantAccess/index.tsx
@@ -12,6 +12,10 @@ import type ProtectedRoutes from '@/containers/ProtectedRoutes';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import useUserDefaultTenantId from '@/hooks/use-user-default-tenant-id';
 
+const tenantSubscriptionKeyRegex = /^\/api\/tenants\/[^/]+\/subscription$/;
+const tenantUsageKeyRegex = /^\/api\/tenants\/[^/]+\/usage$/;
+const tenantInvoicesKeyRegex = /^\/api\/tenants\/[^/]+\/invoices$/;
+
 /**
  * The container that ensures the user has access to the current tenant. When the user is
  * authenticated, it will run the validation by fetching an Access Token for the current
@@ -59,11 +63,19 @@ export default function TenantAccess() {
      * Exceptions:
      * - Exclude the `me` key because it's not tenant-aware. If don't, we need to manually
      * revalidate the `me` key to make console work again.
-     * - Exclude keys that include `/.well-known/` because they are usually static and
+     * - Exclude `/api/subscription-plans` and keys that include `/.well-known/` because they are usually static and
      * should not be revalidated.
+     * - Exclude `/api/tenants/:tenantId/subscription` and `/api/tenants/:tenantId/usage` because we want to keep related caches for all tenants
      */
     void mutate(
-      (key) => typeof key !== 'string' || (key !== 'me' && !key.includes('/.well-known/')),
+      (key) =>
+        typeof key !== 'string' ||
+        (key !== 'me' &&
+          !key.includes('/.well-known/') &&
+          !key.includes('/api/subscription-plans') &&
+          !tenantSubscriptionKeyRegex.test(key) &&
+          !tenantUsageKeyRegex.test(key) &&
+          !tenantInvoicesKeyRegex.test(key)),
       undefined,
       { rollbackOnError: false, throwOnError: false }
     );


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
In the original implementation, we will fetch tenants' subscription data when needed and this mechanism will cause the tenant selector to display a loading state:

<img width="268" alt="image" src="https://github.com/logto-io/logto/assets/10806653/d54e002a-d518-4667-ac21-4fc5b3f8a4f4">


This is ugly, now we preload subscription data for all tenants to avoid this ugly loading view.

### Updates
- Remove the loading skeleton for the tenant status component

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

<img width="343" alt="image" src="https://github.com/logto-io/logto/assets/10806653/52891a12-39ea-4bc9-ade9-4a2a8794509c">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
