### PR TITLE
style(console): fix free plan notification margin-bottom

### DIFF
--- a/packages/console/src/pages/GetStarted/FreePlanNotification/index.module.scss
+++ b/packages/console/src/pages/GetStarted/FreePlanNotification/index.module.scss
@@ -8,7 +8,7 @@
   justify-content: space-between;
   align-items: center;
   gap: _.unit(6);
-  margin-bottom: _.unit(6);
+  margin-bottom: _.unit(4);
 
   .image {
     flex-shrink: 0;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
the free plan notification's margin-bottom should be 16px, not 24px

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
