### PR TITLE
refactor(console): get real time email service usage

### DIFF
--- a/packages/console/src/pages/ConnectorDetails/ConnectorContent/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/ConnectorContent/index.tsx
@@ -116,7 +116,7 @@ function ConnectorContent({ isDeleted, connectorData, onConnectorUpdated }: Prop
     if (connectorData.usage === undefined) {
       return;
     }
-    onConnectorUpdated({ ...connectorData, usage: connectorData.usage + 1 });
+    onConnectorUpdated();
   }, [connectorData, onConnectorUpdated]);
 
   return (

--- a/packages/console/src/pages/ConnectorDetails/EmailUsage/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/EmailUsage/index.tsx
@@ -16,6 +16,7 @@ import * as styles from './index.module.scss';
 type Props = {
   usage: number;
 };
+
 function EmailUsage({ usage }: Props) {
   const theme = useTheme();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });

--- a/packages/console/src/pages/ConnectorDetails/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/index.tsx
@@ -51,12 +51,9 @@ function ConnectorDetails() {
   const [isReadMeOpen, setIsReadMeOpen] = useState(false);
   const [isSetupOpen, setIsSetupOpen] = useState(false);
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
-  /**
-   * TODO: Can add `keepPreviousData` option to useSWR to avoid the flash on `Skeleton`
-   * component when manually trigger `mutate` function. This change is available in `swr@v2.0` or above.
-   */
   const { data, error, mutate } = useSWR<ConnectorResponse, RequestError>(
-    connectorId && `api/connectors/${connectorId}`
+    connectorId && `api/connectors/${connectorId}`,
+    { keepPreviousData: true }
   );
   const {
     data: connectorFactory,


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
get real-time email service usage.

Previously we manually add the usage by 1 when users are testing with the config in the logto email service configuration form. This implementation is not good enough since the current usage on the front-end is not up-to-date, and the manual increment of the usage by 1 also leads to out-of-date display.

We hence manually trigger the GET API to get the real-time email service usage. W/o the `useSWR` config of `keepPreviousData` will cause the data used to render the email service connector detail page cleared and reloaded, which will trigger the page rerender by our current console implementation. This `keepPreviousData` config is brought by swr@v2 and we just have SWR upgraded from v1 and have this config available.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
With the change, we are able to get the updated email service usage for console users without the rerender/refresh of the console page. (Refresh is bad, the email input text box will be cleared by a page refresh, which is annoying.)
https://github.com/logto-io/logto/assets/15182327/fd5760f9-de8e-405d-b02e-e83c083ae320


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
