### PR TITLE
refactor(cli): use `tryThat()` to enforce exit

### DIFF
--- a/packages/cli/src/commands/translate/sync-keys/utils.ts
+++ b/packages/cli/src/commands/translate/sync-keys/utils.ts
@@ -2,7 +2,7 @@ import { readFileSync, existsSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-import { trySafe } from '@silverhand/essentials';
+import { tryThat } from '@silverhand/essentials';
 import ts from 'typescript';
 
 import { consoleLog } from '../../../utils.js';
@@ -312,7 +312,7 @@ export const syncPhraseKeysAndFileStructure = async (
     consoleLog.warn(`Cannot find ${targetLocale} entrypoint, creating one`);
   }
 
-  await trySafe(
+  await tryThat(
     traverseNode(baseline, targetObject, path.join(targetDirectory, 'index.ts'), true),
     (error) => {
       consoleLog.plain();


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
a missing commit for #4265. use `tryThat()` to enforce exit since `trySafe()` could return `undefined`

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
CI

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
