### PR TITLE
fix(console): display guidance on application created

### DIFF
--- a/packages/console/src/pages/ApplicationDetails/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/index.tsx
@@ -10,7 +10,7 @@ import { useEffect, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import { Trans, useTranslation } from 'react-i18next';
-import { useLocation, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import useSWR from 'swr';
 
 import Delete from '@/assets/icons/delete.svg';
@@ -51,8 +51,9 @@ const mapToUriOriginFormatArrays = (value?: string[]) =>
 
 function ApplicationDetails() {
   const { id } = useParams();
-  const { pathname } = useLocation();
-  const isGuideView = !!id && pathname === `/applications/${id}/guide`;
+  const { navigate, match } = useTenantPathname();
+  const isGuideView = id && match(`/applications/${id}/guide`);
+
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { data, error, mutate } = useSWR<ApplicationResponse, RequestError>(
     id && `api/applications/${id}`
@@ -69,7 +70,6 @@ function ApplicationDetails() {
   const [isDeleting, setIsDeleting] = useState(false);
   const [isDeleted, setIsDeleted] = useState(false);
   const api = useApi();
-  const { navigate } = useTenantPathname();
   const formMethods = useForm<Application & { isAdmin: boolean }>({
     defaultValues: { customClientMetadata: customClientMetadataDefault },
   });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The previous refactor #4191 forget to update the pathname matching method with the new `match` method, this causes the application creation guidance missing after an application is created.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
