### PR TITLE
refactor: allow non-http scheme in cors origin

### DIFF
--- a/.changeset/fast-shirts-switch.md
+++ b/.changeset/fast-shirts-switch.md
@@ -1,0 +1,7 @@
+---
+"@logto/console": patch
+"@logto/schemas": patch
+"@logto/core": patch
+---
+
+allow non-http origins for application CORS

--- a/packages/console/src/pages/ApplicationDetails/components/Settings.tsx
+++ b/packages/console/src/pages/ApplicationDetails/components/Settings.tsx
@@ -15,7 +15,6 @@ import {
 import TextInput from '@/ds-components/TextInput';
 import TextLink from '@/ds-components/TextLink';
 import useDocumentationUrl from '@/hooks/use-documentation-url';
-import { uriOriginValidator } from '@/utils/validator';
 
 import * as styles from '../index.module.scss';
 
@@ -160,14 +159,6 @@ function Settings({ data }: Props) {
           name="customClientMetadata.corsAllowedOrigins"
           control={control}
           defaultValue={[]}
-          rules={{
-            validate: createValidatorForRhf({
-              pattern: {
-                verify: (value) => !value || uriOriginValidator(value),
-                message: t('errors.invalid_origin_format'),
-              },
-            }),
-          }}
           render={({ field: { onChange, value }, fieldState: { error } }) => (
             <MultiTextInputField
               title="application_details.cors_allowed_origins"

--- a/packages/console/src/pages/ApplicationDetails/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/index.tsx
@@ -47,7 +47,7 @@ const mapToUriFormatArrays = (value?: string[]) =>
   value?.filter(Boolean).map((uri) => decodeURIComponent(uri));
 
 const mapToUriOriginFormatArrays = (value?: string[]) =>
-  value?.filter(Boolean).map((uri) => decodeURIComponent(new URL(uri).origin));
+  value?.filter(Boolean).map((uri) => decodeURIComponent(uri.replace(/\/*$/, '')));
 
 function ApplicationDetails() {
   const { id } = useParams();

--- a/packages/console/src/utils/validator.ts
+++ b/packages/console/src/utils/validator.ts
@@ -9,14 +9,6 @@ export const uriValidator = (value: string) => {
   return true;
 };
 
-export const uriOriginValidator = (value: string) => {
-  try {
-    return new URL(value).origin === value;
-  } catch {
-    return false;
-  }
-};
-
 export const jsonValidator = (value: string) => {
   try {
     JSON.parse(value);

--- a/packages/core/src/routes/application.test.ts
+++ b/packages/core/src/routes/application.test.ts
@@ -52,7 +52,12 @@ const { createRequester } = await import('#src/utils/test-utils.js');
 const applicationRoutes = await pickDefault(import('./application.js'));
 
 const customClientMetadata = {
-  corsAllowedOrigins: ['http://localhost:5000', 'http://localhost:5001', 'https://silverhand.com'],
+  corsAllowedOrigins: [
+    'http://localhost:5000',
+    'http://localhost:5001',
+    'https://silverhand.com',
+    'capacitor://localhost',
+  ],
   idTokenTtl: 999_999,
   refreshTokenTtl: 100_000_000,
 };

--- a/packages/schemas/src/foundations/jsonb-types.ts
+++ b/packages/schemas/src/foundations/jsonb-types.ts
@@ -88,7 +88,7 @@ export enum CustomClientMetadataKey {
 }
 
 export const customClientMetadataGuard = z.object({
-  [CustomClientMetadataKey.CorsAllowedOrigins]: z.string().url().array().optional(),
+  [CustomClientMetadataKey.CorsAllowedOrigins]: z.string().array().optional(),
   [CustomClientMetadataKey.IdTokenTtl]: z.number().optional(),
   [CustomClientMetadataKey.RefreshTokenTtl]: z.number().optional(),
   [CustomClientMetadataKey.RefreshTokenTtlInDays]: z.number().int().min(1).max(90).optional(),

--- a/packages/schemas/src/foundations/jsonb-types.ts
+++ b/packages/schemas/src/foundations/jsonb-types.ts
@@ -88,7 +88,7 @@ export enum CustomClientMetadataKey {
 }
 
 export const customClientMetadataGuard = z.object({
-  [CustomClientMetadataKey.CorsAllowedOrigins]: z.string().array().optional(),
+  [CustomClientMetadataKey.CorsAllowedOrigins]: z.string().min(1).array().optional(),
   [CustomClientMetadataKey.IdTokenTtl]: z.number().optional(),
   [CustomClientMetadataKey.RefreshTokenTtl]: z.number().optional(),
   [CustomClientMetadataKey.RefreshTokenTtlInDays]: z.number().int().min(1).max(90).optional(),


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
unlike redirect uris which may cause critical security issues, allowed cors origins can be loosen in order to enable cross-platform frameworks like CapacitorJS, which uses the URL `capacitor://localhost` for window location and request origin.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
can save cors origin `capacitor://localhost` and it worked in the simulator

![image](https://github.com/logto-io/logto/assets/14722250/90c0a51a-26fd-4de3-8932-2a872580eebe)

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] docs
