### PR TITLE
fix(core): exclude standard connectors when compute social connector usage

### DIFF
--- a/packages/core/src/libraries/quota.ts
+++ b/packages/core/src/libraries/quota.ts
@@ -56,7 +56,8 @@ export const createQuotaLibrary = (
     socialConnectorsLimit: async () => {
       const connectors = await getLogtoConnectors();
       const count = connectors.filter(
-        ({ type, metadata: { id } }) => type === ConnectorType.Social && id !== DemoConnector.Social
+        ({ type, metadata: { id, isStandard } }) =>
+          type === ConnectorType.Social && !isStandard && id !== DemoConnector.Social
       ).length;
       return { count };
     },


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The usage of social connectors should not include standard connectors.
Sync with the update of [@logto/cloud](https://github.com/logto-io/cloud/pull/198) to keep accordance for now. Will remove the quota calculation in @logto/core and rely on @logto/cloud, which will be the SSOT.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
