### PR TITLE
fix(console): fix connector post/patch error rendering

### DIFF
--- a/packages/console/src/components/ConnectorForm/ConfigForm/ConfigFormFields/index.tsx
+++ b/packages/console/src/components/ConnectorForm/ConfigForm/ConfigFormFields/index.tsx
@@ -1,6 +1,5 @@
 import type { ConnectorConfigFormItem } from '@logto/connector-kit';
 import { ConnectorConfigFormItemType } from '@logto/connector-kit';
-import { conditional } from '@silverhand/essentials';
 import { useMemo } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -49,10 +48,11 @@ function ConfigFormFields({ formItems }: Props) {
   }, [formItems, values]);
 
   const renderFormItem = (item: ConnectorConfigFormItem) => {
-    const error = conditional(
-      formConfigErrors &&
-        (formConfigErrors[item.key]?.message ?? Boolean(formConfigErrors[item.key]))
-    );
+    const errorMessage = formConfigErrors?.[item.key]?.message;
+    const error =
+      typeof errorMessage === 'string' && errorMessage.length > 0
+        ? errorMessage
+        : Boolean(formConfigErrors?.[item.key]);
 
     const buildCommonProperties = () => ({
       ...register(`formConfig.${item.key}`, {

--- a/packages/console/src/pages/Connectors/Guide/index.tsx
+++ b/packages/console/src/pages/Connectors/Guide/index.tsx
@@ -43,7 +43,7 @@ type Props = {
 };
 
 function Guide({ connector, onClose }: Props) {
-  const { createConnector } = useConnectorApi({ hideErrorToast: true });
+  const { createConnector } = useConnectorApi();
   const { navigate } = useTenantPathname();
   const callbackConnectorId = useRef(generateStandardId());
   const [conflictConnectorName, setConflictConnectorName] = useState<Record<string, string>>();


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix connector post/patch error rendering.
The previous empty-string error (RHF throws an empty string error message when a required field is not filled) will result in `Boolean(error)` being false, which will not trigger the proper error style rendering.
Also, when creating new connectors, the hook `useConnectorApi` has a configuration with `hideToastError`, this will block the toast of error message so that users have no idea how to correct the connector configuration.

This is not an ultimate fix but a hot fix, we will show error messages in-place so that users can know whether did they make wrong configuration.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally, works fine.
1. Properly render unfilled field.
<img width="2173" alt="image" src="https://github.com/logto-io/logto/assets/15182327/773fdb17-21ad-422c-b5ca-2792ff487d9f">
2. Can toast error when config is not right on creating.
<img width="2090" alt="image" src="https://github.com/logto-io/logto/assets/15182327/7e512a19-08af-44a1-8bc5-a9a82ff6f017">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
