### PR TITLE
fix: replace INFO with IGNORE in zap rules

### DIFF
--- a/.zap/rules.conf
+++ b/.zap/rules.conf
@@ -5,10 +5,10 @@
 
 # Not applicable to the cloud appliaction
 10096	IGNORE	(Timestamp Disclosure - Passive/release)
+40039	IGNORE	(Web Cache Deception)
 
-# TODO
+# TODO 
 10063	IGNORE	(Permissions Policy Header Not Set - Passive/beta)
 
 # The applicationInsights endpoint will be removed
 10055	IGNORE	(CSP - Wildcard Directive)
-40039	IGNORE	(Web Cache Deception)

--- a/.zap/rules.conf
+++ b/.zap/rules.conf
@@ -1,9 +1,14 @@
-# Mark the following rules as INFO
+# Mark the following rules as IGNORE
 
 # CloudFlare will block the metadata endpoint access
-90034	INFO	(Cloud Metadata Potentially Exposed - Active/release)
+90034	IGNORE	(Cloud Metadata Potentially Exposed - Active/release)
 
-10096	INFO	(Timestamp Disclosure - Passive/release)
-10063-1	INFO	(Permissions Policy Header Not Set - Passive/beta)
-10055-4	INFO	(CSP - Wildcard Directive)
-40039	INFO	(Web Cache Deception)
+# Not applicable to the cloud appliaction
+10096	IGNORE	(Timestamp Disclosure - Passive/release)
+
+# TODO
+10063	IGNORE	(Permissions Policy Header Not Set - Passive/beta)
+
+# The applicationInsights endpoint will be removed
+10055	IGNORE	(CSP - Wildcard Directive)
+40039	IGNORE	(Web Cache Deception)


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
replace INFO with IGNORE for the ZAP scanning rules. 

Looks like the INFO setting does not prevent the alert from being thrown. Replace with IGNORE.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally using Zap Docker run on cloud dev. 

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
