### PR TITLE
refactor(toolkit): update input params type of SendMessageFunction

### DIFF
--- a/packages/schemas/src/types/system.ts
+++ b/packages/schemas/src/types/system.ts
@@ -69,7 +69,7 @@ export enum EmailServiceProvider {
   SendGrid = 'SendGrid',
 }
 
-export const sendgridEmailServiceDataGuard = z.object({
+export const sendgridEmailServiceConfigGuard = z.object({
   provider: z.literal(EmailServiceProvider.SendGrid),
   apiKey: z.string(),
   templateId: z.string(),
@@ -77,26 +77,26 @@ export const sendgridEmailServiceDataGuard = z.object({
   fromEmail: z.string(),
 });
 
-export type SendgridEmailServiceData = z.infer<typeof sendgridEmailServiceDataGuard>;
+export type SendgridEmailServiceConfig = z.infer<typeof sendgridEmailServiceConfigGuard>;
 
-export const emailServiceDataGuard = z.discriminatedUnion('provider', [
-  sendgridEmailServiceDataGuard,
+export const emailServiceConfigGuard = z.discriminatedUnion('provider', [
+  sendgridEmailServiceConfigGuard,
 ]);
 
-export type EmailServiceData = z.infer<typeof emailServiceDataGuard>;
+export type EmailServiceConfig = z.infer<typeof emailServiceConfigGuard>;
 
 export enum EmailServiceProviderKey {
   EmailServiceProvider = 'emailServiceProvider',
 }
 
 export type EmailServiceProviderType = {
-  [EmailServiceProviderKey.EmailServiceProvider]: EmailServiceData;
+  [EmailServiceProviderKey.EmailServiceProvider]: EmailServiceConfig;
 };
 
 export const emailServiceProviderGuard: Readonly<{
   [key in EmailServiceProviderKey]: ZodType<EmailServiceProviderType[key]>;
 }> = Object.freeze({
-  [EmailServiceProviderKey.EmailServiceProvider]: emailServiceDataGuard,
+  [EmailServiceProviderKey.EmailServiceProvider]: emailServiceConfigGuard,
 });
 
 // Demo social connectors

--- a/packages/toolkit/connector-kit/src/types.ts
+++ b/packages/toolkit/connector-kit/src/types.ts
@@ -237,29 +237,31 @@ export const emailServiceBrandingGuard = z
 export type EmailServiceBranding = z.infer<typeof emailServiceBrandingGuard>;
 
 export type SendMessagePayload = {
-  to: string;
-  type: VerificationCodeType;
-  payload: {
-    /**
-     * The dynamic verification code to send.
-     *
-     * @example '123456'
-     */
-    code: string;
-  } & EmailServiceBranding;
+  /**
+   * The dynamic verification code to send.
+   *
+   * @example '123456'
+   */
+  code: string;
 };
 
 export const sendMessagePayloadGuard = z.object({
-  to: z.string(),
-  type: verificationCodeTypeGuard,
-  payload: z
-    .object({
-      code: z.string(),
-    })
-    .merge(emailServiceBrandingGuard),
+  code: z.string(),
 }) satisfies z.ZodType<SendMessagePayload>;
 
-export type SendMessageFunction = (data: SendMessagePayload, config?: unknown) => Promise<unknown>;
+export type SendMessageData = {
+  to: string;
+  type: VerificationCodeType;
+  payload: SendMessagePayload;
+};
+
+export const sendMessageDataGuard = z.object({
+  to: z.string(),
+  type: verificationCodeTypeGuard,
+  payload: sendMessagePayloadGuard,
+}) satisfies z.ZodType<SendMessageData>;
+
+export type SendMessageFunction = (data: SendMessageData, config?: unknown) => Promise<unknown>;
 
 export type GetUsageFunction = (startFrom?: Date) => Promise<number>;
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Update input params type of SendMessageFunction.
Previously, we included the email service branding info as optional in the params, which is not used in @logto/core. The guard used to generate the payload data type is only used by @logto/cloud send email API.
The optional branding info defined in type could confuse community developers, we hence removed the branding info part of SendMessageFunction input parameter type and will update the guard used by @logto/cloud API in upcoming PR.

Hold until the integration tests on cloud service APIs are added in [this PR](https://github.com/logto-io/cloud/pull/211).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Covered by CI.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
