### PR TITLE
refactor(console): add tooltips for elliptical texts on table list

### DIFF
--- a/packages/console/src/components/HoverableTextWrapper/index.module.scss
+++ b/packages/console/src/components/HoverableTextWrapper/index.module.scss
@@ -1,0 +1,9 @@
+@use '@/scss/underscore' as _;
+
+.tooltipAnchor {
+  max-width: 100%;
+}
+
+.text {
+  @include _.text-ellipsis;
+}

--- a/packages/console/src/components/HoverableTextWrapper/index.tsx
+++ b/packages/console/src/components/HoverableTextWrapper/index.tsx
@@ -1,0 +1,30 @@
+import { conditional } from '@silverhand/essentials';
+import classNames from 'classnames';
+import { useRef } from 'react';
+
+import { Tooltip } from '@/ds-components/Tip';
+import useTextOverflow from '@/hooks/use-text-overflow';
+
+import * as styles from './index.module.scss';
+
+type Props = {
+  children: string;
+};
+
+function HoverableTextWrapper({ children }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const { isTextOverflow } = useTextOverflow(ref);
+
+  return (
+    <Tooltip
+      content={conditional(isTextOverflow && children)}
+      anchorClassName={styles.tooltipAnchor}
+    >
+      <div ref={ref} className={classNames(styles.text)}>
+        {children}
+      </div>
+    </Tooltip>
+  );
+}
+
+export default HoverableTextWrapper;

--- a/packages/console/src/components/ItemPreview/index.module.scss
+++ b/packages/console/src/components/ItemPreview/index.module.scss
@@ -4,6 +4,7 @@
   display: flex;
   align-items: center;
   white-space: nowrap;
+  overflow: hidden;
 
   > div:not(:first-child) {
     margin-left: _.unit(3);
@@ -14,8 +15,6 @@
     overflow: hidden;
     display: flex;
     align-items: center;
-    // Note: add an offset to visually center the element.
-    margin-top: _.unit(-1);
 
     > div:not(:last-child) {
       margin-right: _.unit(2);
@@ -23,6 +22,10 @@
 
     .meta {
       overflow: hidden;
+
+      .tooltipAnchor {
+        max-width: 100%;
+      }
 
       .title {
         display: block;

--- a/packages/console/src/components/ItemPreview/index.tsx
+++ b/packages/console/src/components/ItemPreview/index.tsx
@@ -1,9 +1,12 @@
+import { conditional } from '@silverhand/essentials';
 import classNames from 'classnames';
-import type { ReactNode } from 'react';
+import { useRef, type ReactNode } from 'react';
 import type { To } from 'react-router-dom';
 import { Link } from 'react-router-dom';
 
+import { Tooltip } from '@/ds-components/Tip';
 import useTenantPathname from '@/hooks/use-tenant-pathname';
+import useTextOverflow from '@/hooks/use-text-overflow';
 
 import * as styles from './index.module.scss';
 
@@ -19,6 +22,10 @@ type Props = {
 
 function ItemPreview({ title, subtitle, icon, to, size = 'default', suffix, toTarget }: Props) {
   const { getTo } = useTenantPathname();
+  const linkRef = useRef<HTMLAnchorElement>(null);
+  const titleRef = useRef<HTMLDivElement>(null);
+  const { isTextOverflow: isLinkOverflow } = useTextOverflow(linkRef);
+  const { isTextOverflow } = useTextOverflow(linkRef);
 
   return (
     <div className={classNames(styles.item, styles[size])}>
@@ -26,18 +33,33 @@ function ItemPreview({ title, subtitle, icon, to, size = 'default', suffix, toTa
       <div className={styles.content}>
         <div className={styles.meta}>
           {to && (
-            <Link
-              className={styles.title}
-              to={getTo(to)}
-              target={toTarget}
-              onClick={(event) => {
-                event.stopPropagation();
-              }}
+            <Tooltip
+              content={conditional(isLinkOverflow && title)}
+              anchorClassName={styles.tooltipAnchor}
             >
-              {title}
-            </Link>
+              <Link
+                ref={linkRef}
+                className={styles.title}
+                to={getTo(to)}
+                target={toTarget}
+                onClick={(event) => {
+                  event.stopPropagation();
+                }}
+              >
+                {title}
+              </Link>
+            </Tooltip>
           )}
-          {!to && <div className={styles.title}>{title}</div>}
+          {!to && (
+            <Tooltip
+              content={conditional(isTextOverflow && title)}
+              anchorClassName={styles.tooltipAnchor}
+            >
+              <div ref={titleRef} className={styles.title}>
+                {title}
+              </div>
+            </Tooltip>
+          )}
           {subtitle && <div className={styles.subtitle}>{subtitle}</div>}
         </div>
         {suffix}

--- a/packages/console/src/components/PermissionsTable/index.module.scss
+++ b/packages/console/src/components/PermissionsTable/index.module.scss
@@ -29,10 +29,6 @@
     @include _.text-ellipsis;
   }
 
-  .description {
-    @include _.text-ellipsis;
-  }
-
   .link {
     display: block;
     @include _.text-ellipsis;

--- a/packages/console/src/components/PermissionsTable/index.tsx
+++ b/packages/console/src/components/PermissionsTable/index.tsx
@@ -7,6 +7,8 @@ import Delete from '@/assets/icons/delete.svg';
 import Plus from '@/assets/icons/plus.svg';
 import PermissionsEmptyDark from '@/assets/images/permissions-empty-dark.svg';
 import PermissionsEmpty from '@/assets/images/permissions-empty.svg';
+import EmptyDataPlaceholder from '@/components/EmptyDataPlaceholder';
+import HoverableTextWrapper from '@/components/HoverableTextWrapper';
 import { ApiResourceDetailsTabs } from '@/consts/page-tabs';
 import Button from '@/ds-components/Button';
 import DynamicT from '@/ds-components/DynamicT';
@@ -19,8 +21,6 @@ import type { Column } from '@/ds-components/Table/types';
 import TextLink from '@/ds-components/TextLink';
 import { Tooltip } from '@/ds-components/Tip';
 import useDocumentationUrl from '@/hooks/use-documentation-url';
-
-import EmptyDataPlaceholder from '../EmptyDataPlaceholder';
 
 import * as styles from './index.module.scss';
 
@@ -75,7 +75,7 @@ function PermissionsTable({
     title: t('permissions.description_column'),
     dataIndex: 'description',
     colSpan: isApiColumnVisible ? 5 : 9,
-    render: ({ description }) => <div className={styles.description}>{description}</div>,
+    render: ({ description }) => <HoverableTextWrapper>{description}</HoverableTextWrapper>,
   };
 
   const apiColumn: Column<ScopeResponse> = {

--- a/packages/console/src/ds-components/Tip/TipBubble/index.module.scss
+++ b/packages/console/src/ds-components/Tip/TipBubble/index.module.scss
@@ -10,6 +10,7 @@
   font: var(--font-body-2);
   max-width: 300px;
   z-index: 200;
+  overflow-wrap: break-word;
 
   &.successful {
     background: var(--color-success-60);

--- a/packages/console/src/hooks/use-text-overflow.ts
+++ b/packages/console/src/hooks/use-text-overflow.ts
@@ -1,0 +1,31 @@
+import { useState, type RefObject, useEffect } from 'react';
+
+const useTextOverflow = (textRef: RefObject<HTMLDivElement | HTMLAnchorElement>) => {
+  const [isTextOverflow, setIsTextOverflow] = useState(false);
+
+  useEffect(() => {
+    if (!textRef.current) {
+      return;
+    }
+
+    const text = textRef.current;
+
+    setIsTextOverflow(text.scrollWidth > text.offsetWidth);
+
+    const handleResize = () => {
+      setIsTextOverflow(text.scrollWidth > text.offsetWidth);
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [textRef]);
+
+  return {
+    isTextOverflow,
+  };
+};
+
+export default useTextOverflow;

--- a/packages/console/src/pages/Connectors/ConnectorName/index.module.scss
+++ b/packages/console/src/pages/Connectors/ConnectorName/index.module.scss
@@ -3,6 +3,7 @@
 .container {
   display: flex;
   align-items: center;
+  overflow: hidden;
 }
 
 .logoContainer {

--- a/packages/console/src/pages/Roles/index.module.scss
+++ b/packages/console/src/pages/Roles/index.module.scss
@@ -1,9 +1,4 @@
-@use '@/scss/underscore' as _;
-
 .search {
   width: 306px;
 }
 
-.description {
-  @include _.text-ellipsis;
-}

--- a/packages/console/src/pages/Roles/index.tsx
+++ b/packages/console/src/pages/Roles/index.tsx
@@ -8,6 +8,7 @@ import useSWR from 'swr';
 import Plus from '@/assets/icons/plus.svg';
 import RolesEmptyDark from '@/assets/images/roles-empty-dark.svg';
 import RolesEmpty from '@/assets/images/roles-empty.svg';
+import HoverableTextWrapper from '@/components/HoverableTextWrapper';
 import ItemPreview from '@/components/ItemPreview';
 import ListPage from '@/components/ListPage';
 import { defaultPageSize } from '@/consts';
@@ -85,7 +86,7 @@ function Roles() {
             title: t('roles.role_description'),
             dataIndex: 'description',
             colSpan: 6,
-            render: ({ description }) => <div className={styles.description}>{description}</div>,
+            render: ({ description }) => <HoverableTextWrapper>{description}</HoverableTextWrapper>,
           },
           {
             title: <span>{t('roles.assigned_users')}</span>,


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add tooltips for elliptical texts on table list.

<img width="643" alt="image" src="https://github.com/logto-io/logto/assets/10806653/61f47e58-b254-4390-9f8f-ea0b27fe1b3a">

### Updates
- Add an `useTextOverflow` hook to know if a text is overflow or not.
- Add a `HoverableTextWrapper` component to add a tooltip for a text(if it is elliptical).
- Add tooltips for `ItemPreview` title if needed.

### Style fixes
- Remove `margin-top: _.unit(-1)` from `ItemPreview` content, because initially it was thought that the content was not visually centered, after a review by the designer, it was found that the effect of not adding any offset is better. Therefore, it is no longer needed.

- Add `overflow: hidden` style to the `ConnectorName` component since it's a flex container and wraps another flex container, `ItemPreview` as its children, we need to add overflow rule to make the `ItemPreview` display correctly.

Before:
<img width="1214" alt="image" src="https://github.com/logto-io/logto/assets/10806653/58b782c8-5fde-40eb-9064-df9688d9fe67">

After:
<img width="529" alt="image" src="https://github.com/logto-io/logto/assets/10806653/6aebf39b-2f97-4542-bf79-d9f74849db83">



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

![image](https://github.com/logto-io/logto/assets/10806653/813f855c-27db-415b-b914-b75235e3e7c6)

![image](https://github.com/logto-io/logto/assets/10806653/3c161642-cced-4087-bce2-5bd7609c6caf)

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
