### PR TITLE
refactor(test): refactor `expectRejects` helper method to support status code checking

### DIFF
--- a/packages/integration-tests/src/helpers/admin-tenant.ts
+++ b/packages/integration-tests/src/helpers/admin-tenant.ts
@@ -27,10 +27,6 @@ import { generatePassword, generateUsername } from '#src/utils.js';
 export const resourceDefault = getManagementApiResourceIndicator(defaultTenantId);
 export const resourceMe = getManagementApiResourceIndicator(adminTenantId, 'me');
 
-export const createResponseWithCode = (statusCode: number) => ({
-  response: { statusCode },
-});
-
 const createUserWithRoles = async (roleNames: string[]) => {
   const username = generateUsername();
   const password = generatePassword();

--- a/packages/integration-tests/src/helpers/index.ts
+++ b/packages/integration-tests/src/helpers/index.ts
@@ -54,7 +54,7 @@ export const removeVerificationCode = async (): Promise<void> => {
 
 type ExpectedErrorInfo = {
   code: string;
-  statusCode?: number;
+  statusCode: number;
   messageIncludes?: string;
 };
 
@@ -86,9 +86,7 @@ export const expectRequestError = (error: unknown, expected: ExpectedErrorInfo) 
 
   expect(body.code).toEqual(code);
 
-  if (statusCode !== undefined) {
-    expect(error.response?.statusCode).toEqual(statusCode);
-  }
+  expect(error.response?.statusCode).toEqual(statusCode);
 
   if (messageIncludes) {
     expect(body.message.includes(messageIncludes)).toBeTruthy();

--- a/packages/integration-tests/src/helpers/index.ts
+++ b/packages/integration-tests/src/helpers/index.ts
@@ -52,15 +52,17 @@ export const removeVerificationCode = async (): Promise<void> => {
   }
 };
 
-export const expectRejects = async (
-  promise: Promise<unknown>,
-  code: string,
-  messageIncludes?: string
-) => {
+type ExpectedErrorInfo = {
+  code: string;
+  statusCode?: number;
+  messageIncludes?: string;
+};
+
+export const expectRejects = async (promise: Promise<unknown>, expected: ExpectedErrorInfo) => {
   try {
     await promise;
   } catch (error: unknown) {
-    expectRequestError(error, code, messageIncludes);
+    expectRequestError(error, expected);
 
     return;
   }
@@ -68,7 +70,9 @@ export const expectRejects = async (
   fail();
 };
 
-export const expectRequestError = (error: unknown, code: string, messageIncludes?: string) => {
+export const expectRequestError = (error: unknown, expected: ExpectedErrorInfo) => {
+  const { code, statusCode, messageIncludes } = expected;
+
   if (!(error instanceof RequestError)) {
     fail('Error should be an instance of RequestError');
   }
@@ -81,6 +85,10 @@ export const expectRequestError = (error: unknown, code: string, messageIncludes
   };
 
   expect(body.code).toEqual(code);
+
+  if (statusCode !== undefined) {
+    expect(error.response?.statusCode).toEqual(statusCode);
+  }
 
   if (messageIncludes) {
     expect(body.message.includes(messageIncludes)).toBeTruthy();

--- a/packages/integration-tests/src/helpers/interactions.ts
+++ b/packages/integration-tests/src/helpers/interactions.ts
@@ -78,7 +78,10 @@ export const createNewSocialUserWithUsernameAndPassword = async (connectorId: st
     connectorData: { state, redirectUri, code, userId: socialUserId },
   });
 
-  await expectRejects(client.submitInteraction(), 'user.identity_not_exist');
+  await expectRejects(client.submitInteraction(), {
+    code: 'user.identity_not_exist',
+    statusCode: 422,
+  });
   await client.successSend(patchInteractionIdentifiers, { username, password });
   await client.successSend(putInteractionProfile, { connectorId });
 

--- a/packages/integration-tests/src/tests/api/admin-user.roles.test.ts
+++ b/packages/integration-tests/src/tests/api/admin-user.roles.test.ts
@@ -2,8 +2,7 @@ import { HTTPError } from 'got';
 
 import { assignRolesToUser, getUserRoles, deleteRoleFromUser } from '#src/api/index.js';
 import { createRole } from '#src/api/role.js';
-import { createResponseWithCode } from '#src/helpers/admin-tenant.js';
-import { createUserByAdmin } from '#src/helpers/index.js';
+import { createUserByAdmin, expectRejects } from '#src/helpers/index.js';
 
 describe('admin console user management (roles)', () => {
   it('should get empty list successfully', async () => {
@@ -27,9 +26,10 @@ describe('admin console user management (roles)', () => {
     const role = await createRole();
 
     await assignRolesToUser(user.id, [role.id]);
-    await expect(assignRolesToUser(user.id, [role.id])).rejects.toMatchObject(
-      createResponseWithCode(422)
-    );
+    await expectRejects(assignRolesToUser(user.id, [role.id]), {
+      code: 'user.role_exists',
+      statusCode: 422,
+    });
   });
 
   it('should delete role from user successfully', async () => {

--- a/packages/integration-tests/src/tests/api/admin-user.search.test.ts
+++ b/packages/integration-tests/src/tests/api/admin-user.search.test.ts
@@ -178,8 +178,7 @@ describe('admin console user search params', () => {
         ['search.primaryEmail', 'jerry_swift_jr_2@geek.best'],
         ['search.primaryEmail', 'jerry_swift_jr_jr@gmail.com'],
       ]),
-      'request.invalid_input',
-      '`exact`'
+      { code: 'request.invalid_input', statusCode: 400, messageIncludes: '`exact`' }
     );
   });
 
@@ -189,8 +188,11 @@ describe('admin console user search params', () => {
         ['search.primaryEmail', ''],
         ['search', 'tom'],
       ]),
-      'request.invalid_input',
-      'cannot be empty'
+      {
+        code: 'request.invalid_input',
+        statusCode: 400,
+        messageIncludes: 'cannot be empty',
+      }
     );
   });
 
@@ -200,8 +202,11 @@ describe('admin console user search params', () => {
         ['search.primaryEmail', '%gmail%'],
         ['mode.primaryEmail', 'similar_to'],
       ]),
-      'request.invalid_input',
-      'case-insensitive'
+      {
+        code: 'request.invalid_input',
+        statusCode: 400,
+        messageIncludes: 'case-insensitive',
+      }
     );
   });
 
@@ -212,21 +217,26 @@ describe('admin console user search params', () => {
           ['search.primaryEmail', '%gmail%'],
           ['mode.primaryEmail', 'similar to'],
         ]),
-        'request.invalid_input',
-        'is not valid'
+        {
+          code: 'request.invalid_input',
+          statusCode: 400,
+          messageIncludes: 'is not valid',
+        }
       ),
-      expectRejects(
-        getUsers<User[]>([['search.email', '%gmail%']]),
-        'request.invalid_input',
-        'is not valid'
-      ),
+      expectRejects(getUsers<User[]>([['search.email', '%gmail%']]), {
+        code: 'request.invalid_input',
+        messageIncludes: 'is not valid',
+      }),
       expectRejects(
         getUsers<User[]>([
           ['search.primaryEmail', '%gmail%'],
           ['joint', 'and1'],
         ]),
-        'request.invalid_input',
-        'is not valid'
+        {
+          code: 'request.invalid_input',
+          statusCode: 400,
+          messageIncludes: 'is not valid',
+        }
       ),
     ]);
   });

--- a/packages/integration-tests/src/tests/api/admin-user.search.test.ts
+++ b/packages/integration-tests/src/tests/api/admin-user.search.test.ts
@@ -225,6 +225,7 @@ describe('admin console user search params', () => {
       ),
       expectRejects(getUsers<User[]>([['search.email', '%gmail%']]), {
         code: 'request.invalid_input',
+        statusCode: 400,
         messageIncludes: 'is not valid',
       }),
       expectRejects(

--- a/packages/integration-tests/src/tests/api/dashboard.test.ts
+++ b/packages/integration-tests/src/tests/api/dashboard.test.ts
@@ -2,8 +2,7 @@ import { SignInIdentifier } from '@logto/schemas';
 
 import type { StatisticsData } from '#src/api/index.js';
 import { api, getTotalUsersCount, getNewUsersData, getActiveUsersData } from '#src/api/index.js';
-import { createResponseWithCode } from '#src/helpers/admin-tenant.js';
-import { createUserByAdmin } from '#src/helpers/index.js';
+import { createUserByAdmin, expectRejects } from '#src/helpers/index.js';
 import { registerNewUser, signInWithPassword } from '#src/helpers/interactions.js';
 import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
 import { generateUsername, generatePassword } from '#src/utils.js';
@@ -18,13 +17,18 @@ describe('admin console dashboard', () => {
   });
 
   it('non authorized request should return 401', async () => {
-    await expect(api.get('dashboard/users/total')).rejects.toMatchObject(
-      createResponseWithCode(401)
-    );
-    await expect(api.get('dashboard/users/new')).rejects.toMatchObject(createResponseWithCode(401));
-    await expect(api.get('dashboard/users/active')).rejects.toMatchObject(
-      createResponseWithCode(401)
-    );
+    await expectRejects(api.get('dashboard/users/total'), {
+      code: 'auth.authorization_header_missing',
+      statusCode: 401,
+    });
+    await expectRejects(api.get('dashboard/users/new'), {
+      code: 'auth.authorization_header_missing',
+      statusCode: 401,
+    });
+    await expectRejects(api.get('dashboard/users/active'), {
+      code: 'auth.authorization_header_missing',
+      statusCode: 401,
+    });
   });
 
   it('should get total user count successfully', async () => {

--- a/packages/integration-tests/src/tests/api/interaction/forgot-password.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/forgot-password.test.ts
@@ -62,11 +62,17 @@ describe('reset password', () => {
       verificationCode: code,
     });
 
-    await expectRejects(client.submitInteraction(), 'user.new_password_required_in_profile');
+    await expectRejects(client.submitInteraction(), {
+      code: 'user.new_password_required_in_profile',
+      statusCode: 422,
+    });
 
     await client.successSend(putInteractionProfile, { password: userProfile.password });
 
-    await expectRejects(client.submitInteraction(), 'user.same_password');
+    await expectRejects(client.submitInteraction(), {
+      code: 'user.same_password',
+      statusCode: 422,
+    });
 
     const newPasswordRecord = generatePassword();
 
@@ -115,11 +121,17 @@ describe('reset password', () => {
       verificationCode: code,
     });
 
-    await expectRejects(client.submitInteraction(), 'user.new_password_required_in_profile');
+    await expectRejects(client.submitInteraction(), {
+      code: 'user.new_password_required_in_profile',
+      statusCode: 422,
+    });
 
     await client.successSend(putInteractionProfile, { password: userProfile.password });
 
-    await expectRejects(client.submitInteraction(), 'user.same_password');
+    await expectRejects(client.submitInteraction(), {
+      code: 'user.same_password',
+      statusCode: 422,
+    });
 
     const newPasswordRecord = generatePassword();
 

--- a/packages/integration-tests/src/tests/api/interaction/register-with-identifier.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/register-with-identifier.test.ts
@@ -138,7 +138,10 @@ describe('Register with passwordless identifier', () => {
       email: primaryEmail,
     });
 
-    await expectRejects(client.submitInteraction(), 'user.missing_profile');
+    await expectRejects(client.submitInteraction(), {
+      code: 'user.missing_profile',
+      statusCode: 422,
+    });
 
     await client.successSend(patchInteractionProfile, {
       password,
@@ -240,7 +243,10 @@ describe('Register with passwordless identifier', () => {
       phone: primaryPhone,
     });
 
-    await expectRejects(client.submitInteraction(), 'user.missing_profile');
+    await expectRejects(client.submitInteraction(), {
+      code: 'user.missing_profile',
+      statusCode: 422,
+    });
 
     await client.successSend(patchInteractionProfile, {
       password,
@@ -308,7 +314,10 @@ describe('Register with passwordless identifier', () => {
       email: primaryEmail,
     });
 
-    await expectRejects(client.submitInteraction(), 'user.email_already_in_use');
+    await expectRejects(client.submitInteraction(), {
+      code: 'user.email_already_in_use',
+      statusCode: 422,
+    });
 
     await client.successSend(deleteInteractionProfile);
     await client.successSend(putInteractionEvent, { event: InteractionEvent.SignIn });
@@ -360,7 +369,10 @@ describe('Register with passwordless identifier', () => {
       phone: primaryPhone,
     });
 
-    await expectRejects(client.submitInteraction(), 'user.phone_already_in_use');
+    await expectRejects(client.submitInteraction(), {
+      code: 'user.phone_already_in_use',
+      statusCode: 422,
+    });
 
     await client.successSend(deleteInteractionProfile);
     await client.successSend(putInteractionEvent, { event: InteractionEvent.SignIn });

--- a/packages/integration-tests/src/tests/api/interaction/sign-in-with-passcode-identifier.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/sign-in-with-passcode-identifier.test.ts
@@ -124,7 +124,10 @@ describe('Sign-In flow using verification-code identifiers', () => {
       verificationCode: code,
     });
 
-    await expectRejects(client.submitInteraction(), 'user.user_not_exist');
+    await expectRejects(client.submitInteraction(), {
+      code: 'user.user_not_exist',
+      statusCode: 404,
+    });
 
     await client.successSend(putInteractionEvent, { event: InteractionEvent.Register });
     await client.successSend(putInteractionProfile, { email: newEmail });
@@ -163,7 +166,10 @@ describe('Sign-In flow using verification-code identifiers', () => {
       verificationCode: code,
     });
 
-    await expectRejects(client.submitInteraction(), 'user.user_not_exist');
+    await expectRejects(client.submitInteraction(), {
+      code: 'user.user_not_exist',
+      statusCode: 404,
+    });
 
     await client.successSend(putInteractionEvent, { event: InteractionEvent.Register });
     await client.successSend(putInteractionProfile, { phone: newPhone });
@@ -205,7 +211,10 @@ describe('Sign-In flow using verification-code identifiers', () => {
       verificationCode: code,
     });
 
-    await expectRejects(client.submitInteraction(), 'user.missing_profile');
+    await expectRejects(client.submitInteraction(), {
+      code: 'user.missing_profile',
+      statusCode: 422,
+    });
 
     // Fulfill user profile
     await client.successSend(putInteractionProfile, {
@@ -264,7 +273,10 @@ describe('Sign-In flow using verification-code identifiers', () => {
       verificationCode: code,
     });
 
-    await expectRejects(client.submitInteraction(), 'user.missing_profile');
+    await expectRejects(client.submitInteraction(), {
+      code: 'user.missing_profile',
+      statusCode: 422,
+    });
 
     // Fulfill user profile with existing password
     await client.successSend(putInteractionProfile, {
@@ -272,7 +284,10 @@ describe('Sign-In flow using verification-code identifiers', () => {
       password,
     });
 
-    await expectRejects(client.submitInteraction(), 'user.password_exists_in_profile');
+    await expectRejects(client.submitInteraction(), {
+      code: 'user.password_exists_in_profile',
+      statusCode: 400,
+    });
 
     await client.successSend(putInteractionProfile, {
       username,
@@ -315,7 +330,10 @@ describe('Sign-In flow using verification-code identifiers', () => {
       verificationCode: code,
     });
 
-    await expectRejects(client.submitInteraction(), 'user.missing_profile');
+    await expectRejects(client.submitInteraction(), {
+      code: 'user.missing_profile',
+      statusCode: 422,
+    });
 
     // Fulfill user profile with existing password
     await client.successSend(putInteractionProfile, {
@@ -323,7 +341,10 @@ describe('Sign-In flow using verification-code identifiers', () => {
       password,
     });
 
-    await expectRejects(client.submitInteraction(), 'user.username_already_in_use');
+    await expectRejects(client.submitInteraction(), {
+      code: 'user.username_already_in_use',
+      statusCode: 422,
+    });
 
     await client.successSend(putInteractionProfile, {
       username,

--- a/packages/integration-tests/src/tests/api/interaction/sign-in-with-password-identifier.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/sign-in-with-password-identifier.test.ts
@@ -112,7 +112,10 @@ describe('Sign-In flow using password identifiers', () => {
       },
     });
 
-    await expectRejects(client.submitInteraction(), 'user.missing_profile');
+    await expectRejects(client.submitInteraction(), {
+      code: 'user.missing_profile',
+      statusCode: 422,
+    });
 
     await client.successSend(sendVerificationCode, {
       email: primaryEmail,
@@ -171,7 +174,10 @@ describe('Sign-In flow using password identifiers', () => {
       },
     });
 
-    await expectRejects(client.submitInteraction(), 'user.missing_profile');
+    await expectRejects(client.submitInteraction(), {
+      code: 'user.missing_profile',
+      statusCode: 422,
+    });
 
     await client.successSend(sendVerificationCode, {
       phone: primaryPhone,

--- a/packages/integration-tests/src/tests/api/interaction/social-interaction.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/social-interaction.test.ts
@@ -63,7 +63,10 @@ describe('Social Identifier Interactions', () => {
         connectorData: { state, redirectUri, code, userId: socialUserId },
       });
 
-      await expectRejects(client.submitInteraction(), 'user.identity_not_exist');
+      await expectRejects(client.submitInteraction(), {
+        code: 'user.identity_not_exist',
+        statusCode: 422,
+      });
 
       await client.successSend(putInteractionEvent, { event: InteractionEvent.Register });
       await client.successSend(putInteractionProfile, { connectorId });
@@ -116,7 +119,10 @@ describe('Social Identifier Interactions', () => {
         connectorData: { state, redirectUri, code, userId: socialUserId, email: socialEmail },
       });
 
-      await expectRejects(client.submitInteraction(), 'user.identity_not_exist');
+      await expectRejects(client.submitInteraction(), {
+        code: 'user.identity_not_exist',
+        statusCode: 422,
+      });
 
       await client.successSend(putInteractionEvent, { event: InteractionEvent.Register });
       await client.successSend(putInteractionProfile, { connectorId });
@@ -149,7 +155,10 @@ describe('Social Identifier Interactions', () => {
         connectorData: { state, redirectUri, code, userId: socialUserId, phone: socialPhone },
       });
 
-      await expectRejects(client.submitInteraction(), 'user.identity_not_exist');
+      await expectRejects(client.submitInteraction(), {
+        code: 'user.identity_not_exist',
+        statusCode: 422,
+      });
 
       await client.successSend(putInteractionEvent, { event: InteractionEvent.Register });
       await client.successSend(putInteractionProfile, { connectorId });
@@ -192,7 +201,10 @@ describe('Social Identifier Interactions', () => {
         },
       });
 
-      await expectRejects(client.submitInteraction(), 'user.identity_not_exist');
+      await expectRejects(client.submitInteraction(), {
+        code: 'user.identity_not_exist',
+        statusCode: 422,
+      });
 
       await client.successSend(patchInteractionIdentifiers, {
         connectorId,
@@ -253,12 +265,18 @@ describe('Social Identifier Interactions', () => {
         connectorData: { state, redirectUri, code, userId: socialUserId },
       });
 
-      await expectRejects(client.submitInteraction(), 'user.identity_not_exist');
+      await expectRejects(client.submitInteraction(), {
+        code: 'user.identity_not_exist',
+        statusCode: 422,
+      });
 
       await client.successSend(putInteractionEvent, { event: InteractionEvent.Register });
       await client.successSend(putInteractionProfile, { connectorId });
 
-      await expectRejects(client.submitInteraction(), 'user.missing_profile');
+      await expectRejects(client.submitInteraction(), {
+        code: 'user.missing_profile',
+        statusCode: 422,
+      });
 
       await client.successSend(patchInteractionProfile, { username: generateUsername() });
 
@@ -291,7 +309,10 @@ describe('Social Identifier Interactions', () => {
         connectorData: { state, redirectUri, code, userId: socialUserId, email: generateEmail() },
       });
 
-      await expectRejects(client.submitInteraction(), 'user.identity_not_exist');
+      await expectRejects(client.submitInteraction(), {
+        code: 'user.identity_not_exist',
+        statusCode: 422,
+      });
 
       await client.successSend(putInteractionEvent, { event: InteractionEvent.Register });
       await client.successSend(putInteractionProfile, { connectorId });
@@ -325,7 +346,10 @@ describe('Social Identifier Interactions', () => {
         connectorData: { state, redirectUri, code, userId: socialUserId, phone: generatePhone() },
       });
 
-      await expectRejects(client.submitInteraction(), 'user.identity_not_exist');
+      await expectRejects(client.submitInteraction(), {
+        code: 'user.identity_not_exist',
+        statusCode: 422,
+      });
 
       await client.successSend(putInteractionEvent, { event: InteractionEvent.Register });
       await client.successSend(putInteractionProfile, { connectorId });

--- a/packages/integration-tests/src/tests/api/log.test.ts
+++ b/packages/integration-tests/src/tests/api/log.test.ts
@@ -1,5 +1,5 @@
 import { getLog, getAuditLogs } from '#src/api/index.js';
-import { createResponseWithCode } from '#src/helpers/admin-tenant.js';
+import { expectRejects } from '#src/helpers/index.js';
 
 describe('logs', () => {
   it('should get logs successfully', async () => {
@@ -20,6 +20,9 @@ describe('logs', () => {
   });
 
   it('should throw on getting non-exist log detail', async () => {
-    await expect(getLog('non-exist-log-id')).rejects.toMatchObject(createResponseWithCode(404));
+    await expectRejects(getLog('non-exist-log-id'), {
+      code: 'entity.not_exists_with_id',
+      statusCode: 404,
+    });
   });
 });

--- a/packages/integration-tests/src/tests/api/resource.test.ts
+++ b/packages/integration-tests/src/tests/api/resource.test.ts
@@ -9,7 +9,7 @@ import {
   deleteResource,
   setDefaultResource,
 } from '#src/api/index.js';
-import { createResponseWithCode } from '#src/helpers/admin-tenant.js';
+import { expectRejects } from '#src/helpers/index.js';
 import { generateResourceIndicator, generateResourceName } from '#src/utils.js';
 
 describe('admin console api resources', () => {
@@ -47,9 +47,10 @@ describe('admin console api resources', () => {
 
     // Create second resource with same indicator should throw
     const resourceName2 = generateResourceName();
-    await expect(createResource(resourceName2, resourceIndicator)).rejects.toMatchObject(
-      createResponseWithCode(422)
-    );
+    await expectRejects(createResource(resourceName2, resourceIndicator), {
+      code: 'resource.resource_identifier_in_use',
+      statusCode: 422,
+    });
   });
 
   it('should get resource list successfully', async () => {

--- a/packages/integration-tests/src/tests/api/sign-in-experience.test.ts
+++ b/packages/integration-tests/src/tests/api/sign-in-experience.test.ts
@@ -1,7 +1,7 @@
 import { SignInIdentifier } from '@logto/schemas';
 
 import { getSignInExperience, updateSignInExperience } from '#src/api/index.js';
-import { createResponseWithCode } from '#src/helpers/admin-tenant.js';
+import { expectRejects } from '#src/helpers/index.js';
 
 describe('admin console sign-in experience', () => {
   it('should get sign-in experience successfully', async () => {
@@ -38,8 +38,9 @@ describe('admin console sign-in experience', () => {
       },
     };
 
-    await expect(updateSignInExperience(newSignInExperience)).rejects.toMatchObject(
-      createResponseWithCode(400)
-    );
+    await expectRejects(updateSignInExperience(newSignInExperience), {
+      code: 'sign_in_experiences.username_requires_password',
+      statusCode: 400,
+    });
   });
 });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Refactor `expectRejects` helper method to support status code checking since now we need to add & test reponse status code for our core APIs.

### Update
- replace original `createResponseWithCode` logic with the new `expectRejects` helper method.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
CI Passed.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
