### PR TITLE
test: add sad paths for sign in with password identifier flow

### DIFF
--- a/packages/integration-tests/src/tests/api/interaction/sign-in-with-passcode-identifier/sad-path.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/sign-in-with-passcode-identifier/sad-path.test.ts
@@ -31,10 +31,6 @@ describe('Sign-in flow sad path using verification-code identifiers', () => {
     await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);
   });
 
-  afterEach(async () => {
-    await enableAllVerificationCodeSignInMethods();
-  });
-
   it('Should fail to sign in with passcode if sign-in mode is register only', async () => {
     await updateSignInExperience({ signInMode: SignInMode.Register });
     const client = await initClient();
@@ -48,6 +44,9 @@ describe('Sign-in flow sad path using verification-code identifiers', () => {
         statusCode: 403,
       }
     );
+
+    // Reset
+    await enableAllVerificationCodeSignInMethods();
   });
 
   it('Should fail to sign in if related identifiers are not enabled', async () => {
@@ -101,6 +100,9 @@ describe('Sign-in flow sad path using verification-code identifiers', () => {
         statusCode: 422,
       }
     );
+
+    // Reset
+    await enableAllVerificationCodeSignInMethods();
   });
 
   it('Should fail to update sign in email identifier if verification code is incorrect or mismatch', async () => {

--- a/packages/integration-tests/src/tests/api/interaction/sign-in-with-password-identifier/happy-path.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/sign-in-with-password-identifier/happy-path.test.ts
@@ -20,7 +20,7 @@ import {
 } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser, generateNewUserProfile } from '#src/helpers/user.js';
 
-describe('Sign-In flow using password identifiers', () => {
+describe('Sign-in flow using password identifiers', () => {
   beforeAll(async () => {
     await enableAllPasswordSignInMethods();
     await clearConnectorsByTypes([ConnectorType.Sms, ConnectorType.Email]);

--- a/packages/integration-tests/src/tests/api/interaction/sign-in-with-password-identifier/sad-path.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/sign-in-with-password-identifier/sad-path.test.ts
@@ -1,15 +1,9 @@
-import { ConnectorType } from '@logto/connector-kit';
 import { InteractionEvent, SignInMode } from '@logto/schemas';
 
 import { suspendUser } from '#src/api/admin-user.js';
 import { putInteraction } from '#src/api/interaction.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
 import { initClient } from '#src/helpers/client.js';
-import {
-  clearConnectorsByTypes,
-  setSmsConnector,
-  setEmailConnector,
-} from '#src/helpers/connector.js';
 import { expectRejects } from '#src/helpers/index.js';
 import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
@@ -17,17 +11,6 @@ import { generateName, generatePassword } from '#src/utils.js';
 
 describe('Sign-in flow sad path using password identifiers', () => {
   beforeAll(async () => {
-    await enableAllPasswordSignInMethods();
-    await clearConnectorsByTypes([ConnectorType.Sms, ConnectorType.Email]);
-    await setSmsConnector();
-    await setEmailConnector();
-  });
-
-  afterAll(async () => {
-    await clearConnectorsByTypes([ConnectorType.Sms, ConnectorType.Email]);
-  });
-
-  afterEach(async () => {
     await enableAllPasswordSignInMethods();
   });
 
@@ -82,6 +65,9 @@ describe('Sign-in flow sad path using password identifiers', () => {
         statusCode: 403,
       }
     );
+
+    // Reset
+    await enableAllPasswordSignInMethods();
   });
 
   it('Should fail to sign-in with password if related identifiers are not enabled', async () => {
@@ -135,6 +121,9 @@ describe('Sign-in flow sad path using password identifiers', () => {
         statusCode: 422,
       }
     );
+
+    // Reset
+    await enableAllPasswordSignInMethods();
   });
 
   it('Should fail to sign-in with username and password if username is not existed', async () => {

--- a/packages/integration-tests/src/tests/api/interaction/sign-in-with-password-identifier/sad-path.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/sign-in-with-password-identifier/sad-path.test.ts
@@ -1,0 +1,212 @@
+import { ConnectorType } from '@logto/connector-kit';
+import { InteractionEvent, SignInMode } from '@logto/schemas';
+
+import { suspendUser } from '#src/api/admin-user.js';
+import { putInteraction } from '#src/api/interaction.js';
+import { updateSignInExperience } from '#src/api/sign-in-experience.js';
+import { initClient } from '#src/helpers/client.js';
+import {
+  clearConnectorsByTypes,
+  setSmsConnector,
+  setEmailConnector,
+} from '#src/helpers/connector.js';
+import { expectRejects } from '#src/helpers/index.js';
+import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
+import { generateNewUser } from '#src/helpers/user.js';
+import { generateName, generatePassword } from '#src/utils.js';
+
+describe('Sign-in flow sad path using password identifiers', () => {
+  beforeAll(async () => {
+    await enableAllPasswordSignInMethods();
+    await clearConnectorsByTypes([ConnectorType.Sms, ConnectorType.Email]);
+    await setSmsConnector();
+    await setEmailConnector();
+  });
+
+  afterAll(async () => {
+    await clearConnectorsByTypes([ConnectorType.Sms, ConnectorType.Email]);
+  });
+
+  afterEach(async () => {
+    await enableAllPasswordSignInMethods();
+  });
+
+  it('Should fail to sign-in with password if sign-in mode is register only', async () => {
+    await updateSignInExperience({ signInMode: SignInMode.Register });
+    const client = await initClient();
+
+    // Username & password
+    const {
+      userProfile: { username, password: password1 },
+    } = await generateNewUser({ username: true, password: true });
+
+    await expectRejects(
+      client.send(putInteraction, {
+        event: InteractionEvent.SignIn,
+        identifier: { username, password: password1 },
+      }),
+      {
+        code: 'auth.forbidden',
+        statusCode: 403,
+      }
+    );
+
+    // Email & password
+    const {
+      userProfile: { primaryEmail, password: password2 },
+    } = await generateNewUser({ primaryEmail: true, password: true });
+
+    await expectRejects(
+      client.send(putInteraction, {
+        event: InteractionEvent.SignIn,
+        identifier: { email: primaryEmail, password: password2 },
+      }),
+      {
+        code: 'auth.forbidden',
+        statusCode: 403,
+      }
+    );
+
+    // Phone & password
+    const {
+      userProfile: { primaryPhone, password: password3 },
+    } = await generateNewUser({ primaryPhone: true, password: true });
+
+    await expectRejects(
+      client.send(putInteraction, {
+        event: InteractionEvent.SignIn,
+        identifier: { phone: primaryPhone, password: password3 },
+      }),
+      {
+        code: 'auth.forbidden',
+        statusCode: 403,
+      }
+    );
+  });
+
+  it('Should fail to sign-in with password if related identifiers are not enabled', async () => {
+    await updateSignInExperience({ signIn: { methods: [] } });
+    const client = await initClient();
+
+    // Username & password
+    const {
+      userProfile: { username, password: password1 },
+    } = await generateNewUser({ username: true, password: true });
+
+    await expectRejects(
+      client.send(putInteraction, {
+        event: InteractionEvent.SignIn,
+        identifier: { username, password: password1 },
+      }),
+      {
+        code: 'user.sign_in_method_not_enabled',
+        statusCode: 422,
+      }
+    );
+
+    // Email & password
+    const {
+      userProfile: { primaryEmail, password: password2 },
+    } = await generateNewUser({ primaryEmail: true, password: true });
+
+    await expectRejects(
+      client.send(putInteraction, {
+        event: InteractionEvent.SignIn,
+        identifier: { email: primaryEmail, password: password2 },
+      }),
+      {
+        code: 'user.sign_in_method_not_enabled',
+        statusCode: 422,
+      }
+    );
+
+    // Phone & password
+    const {
+      userProfile: { primaryPhone, password: password3 },
+    } = await generateNewUser({ primaryPhone: true, password: true });
+
+    await expectRejects(
+      client.send(putInteraction, {
+        event: InteractionEvent.SignIn,
+        identifier: { phone: primaryPhone, password: password3 },
+      }),
+      {
+        code: 'user.sign_in_method_not_enabled',
+        statusCode: 422,
+      }
+    );
+  });
+
+  it('Should fail to sign-in with username and password if username is not existed', async () => {
+    const client = await initClient();
+
+    await expectRejects(
+      client.send(putInteraction, {
+        event: InteractionEvent.SignIn,
+        identifier: { username: generateName(), password: generatePassword() },
+      }),
+      {
+        code: 'session.invalid_credentials',
+        statusCode: 422,
+      }
+    );
+  });
+
+  it('Should fail to sign-in with username and password if user password is not correct', async () => {
+    const {
+      userProfile: { username },
+    } = await generateNewUser({ username: true, password: true });
+    const client = await initClient();
+
+    await expectRejects(
+      client.send(putInteraction, {
+        event: InteractionEvent.SignIn,
+        identifier: { username, password: generatePassword() },
+      }),
+      {
+        code: 'session.invalid_credentials',
+        statusCode: 422,
+      }
+    );
+  });
+
+  it('Should fail to sign-in with username and password if user password is not set', async () => {
+    const {
+      userProfile: { username },
+    } = await generateNewUser({ username: true, primaryEmail: true });
+    const client = await initClient();
+
+    await expectRejects(
+      client.send(putInteraction, {
+        event: InteractionEvent.SignIn,
+        identifier: { username, password: generatePassword() },
+      }),
+      {
+        code: 'session.invalid_credentials',
+        statusCode: 422,
+      }
+    );
+  });
+
+  it('Should fail to sign-in with username and password if the user is suspended', async () => {
+    const {
+      user,
+      userProfile: { username, password },
+    } = await generateNewUser({ username: true, password: true });
+
+    await suspendUser(user.id, true);
+
+    const client = await initClient();
+
+    await expectRejects(
+      client.send(putInteraction, {
+        event: InteractionEvent.SignIn,
+        identifier: { username, password },
+      }),
+      {
+        code: 'user.suspended',
+        statusCode: 401,
+      }
+    );
+  });
+});


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- Add sad paths for sign in with password identifier integration tests
- refactor: align sie config reset logic for interaction api tests
### Todo
Add response status guard for all interaction related APIs, We need do that after all tests is ready since a single flow will not cover all interaction API calls.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Integration tests

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
