### PR TITLE
chore: fix typo in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ const languages = ['Deutsch', 'English', 'Español', 'Français', 'Italiano', '�
 
 ## Web compatibility
 
-Logto uses the [default browserlist config](https://github.com/browserslist/browserslist#full-list) to compile frontend projects, which is:
+Logto uses the [default browserslist config](https://github.com/browserslist/browserslist#full-list) to compile frontend projects, which is:
 
 ```
 > 0.5%, last 2 versions, Firefox ESR, not dead


### PR DESCRIPTION
TRIVIAL AS IS.

@gao-sun I'm curious where we pull in the browserslist dependency? I don't find one in package.json.