### PR TITLE
ci: changeset workflow is invalid on pull_request

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
AS IS.

`BOT_PAT` is unavaiable on fork; or we may use `pull_request_target` but it seems just unrelated trigger.

Ref - https://github.com/logto-io/logto/actions/runs/5804486635/job/15734119233?pr=4302