### PR TITLE
fix(core,phrases): ignore cloudflare not found when deleting domain

### DIFF
--- a/packages/core/src/utils/cloudflare/index.ts
+++ b/packages/core/src/utils/cloudflare/index.ts
@@ -24,6 +24,10 @@ const handleResponse: HandleResponse = <T>(response: Response<string>, guard?: Z
       throw new RequestError('domain.hostname_already_exists');
     }
 
+    if (response.statusCode === 404) {
+      throw new RequestError('domain.cloudflare_not_found');
+    }
+
     throw new RequestError(
       {
         code: 'domain.cloudflare_unknown_error',

--- a/packages/phrases/src/locales/de/errors/domain.ts
+++ b/packages/phrases/src/locales/de/errors/domain.ts
@@ -6,6 +6,7 @@ const domain = {
   cloudflare_response_error: 'Vom Cloudflare wurde eine unerwartete Antwort erhalten.',
   limit_to_one_domain: 'Sie können nur eine benutzerdefinierte Domain haben.',
   hostname_already_exists: 'Diese Domain existiert bereits auf unserem Server.',
+  cloudflare_not_found: 'Hostname in Cloudflare nicht gefunden',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/en/errors/domain.ts
+++ b/packages/phrases/src/locales/en/errors/domain.ts
@@ -5,6 +5,7 @@ const domain = {
   cloudflare_response_error: 'Got unexpected response from Cloudflare.',
   limit_to_one_domain: 'You can only have one custom domain.',
   hostname_already_exists: 'This domain already exists in our server.',
+  cloudflare_not_found: 'Can not find hostname in Cloudflare',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/es/errors/domain.ts
+++ b/packages/phrases/src/locales/es/errors/domain.ts
@@ -5,6 +5,7 @@ const domain = {
   cloudflare_response_error: 'Recibió una respuesta inesperada de Cloudflare.',
   limit_to_one_domain: 'Solo puedes tener un dominio personalizado.',
   hostname_already_exists: 'Este dominio ya existe en nuestro servidor.',
+  cloudflare_not_found: 'No se puede encontrar el nombre de host en Cloudflare',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/fr/errors/domain.ts
+++ b/packages/phrases/src/locales/fr/errors/domain.ts
@@ -5,6 +5,7 @@ const domain = {
   cloudflare_response_error: 'Réponse inattendue de Cloudflare',
   limit_to_one_domain: "Vous ne pouvez avoir qu'un seul domaine personnalisé",
   hostname_already_exists: 'Ce domaine existe déjà sur notre serveur.',
+  cloudflare_not_found: "Impossible de trouver le nom d'hôte dans Cloudflare",
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/it/errors/domain.ts
+++ b/packages/phrases/src/locales/it/errors/domain.ts
@@ -5,6 +5,7 @@ const domain = {
   cloudflare_response_error: 'Ricevuta una risposta non prevista da Cloudflare.',
   limit_to_one_domain: 'Puoi avere solo un dominio personalizzato.',
   hostname_already_exists: 'Questo dominio esiste già nel nostro server.',
+  cloudflare_not_found: 'Impossibile trovare il nome host in Cloudflare.',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/ja/errors/domain.ts
+++ b/packages/phrases/src/locales/ja/errors/domain.ts
@@ -5,6 +5,7 @@ const domain = {
   cloudflare_response_error: 'Cloudflare から予期しない応答がありました。',
   limit_to_one_domain: 'カスタムドメインは1つしか持てません。',
   hostname_already_exists: 'サーバーには既にこのドメインが存在しています。',
+  cloudflare_not_found: 'Cloudflare からホスト名が見つかりませんでした。',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/ko/errors/domain.ts
+++ b/packages/phrases/src/locales/ko/errors/domain.ts
@@ -5,6 +5,7 @@ const domain = {
   cloudflare_response_error: 'Cloudflare 로부터 예상치 못한 응답을 받았습니다.',
   limit_to_one_domain: '하나의 맞춤 도메인만 사용할 수 있습니다.',
   hostname_already_exists: '이 도메인은 이미 서버에 존재합니다.',
+  cloudflare_not_found: 'Cloudflare에서 호스트 이름을 찾을 수 없습니다.', // UNTRANSLATED
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/pl-pl/errors/domain.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/domain.ts
@@ -5,6 +5,7 @@ const domain = {
   cloudflare_response_error: 'Otrzymano nieoczekiwaną odpowiedź od Cloudflare.',
   limit_to_one_domain: 'Możesz mieć tylko jedną niestandardową domenę.',
   hostname_already_exists: 'Ta domena już istnieje na naszym serwerze.',
+  cloudflare_not_found: 'Nie można znaleźć nazwy hosta w Cloudflare',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/pt-br/errors/domain.ts
+++ b/packages/phrases/src/locales/pt-br/errors/domain.ts
@@ -5,6 +5,7 @@ const domain = {
   cloudflare_response_error: 'Recebido resposta inesperada do Cloudflare.',
   limit_to_one_domain: 'Você só pode ter um domínio personalizado.',
   hostname_already_exists: 'Este domínio já existe em nosso servidor.',
+  cloudflare_not_found: 'Não é possível encontrar o nome do host no Cloudflare',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/pt-pt/errors/domain.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/domain.ts
@@ -5,6 +5,7 @@ const domain = {
   cloudflare_response_error: 'Obteve uma resposta inesperada da Cloudflare.',
   limit_to_one_domain: 'Você só pode ter um domínio personalizado.',
   hostname_already_exists: 'Este domínio já existe em nosso servidor.',
+  cloudflare_not_found: 'Não é possível encontrar o nome de host no Cloudflare',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/ru/errors/domain.ts
+++ b/packages/phrases/src/locales/ru/errors/domain.ts
@@ -5,6 +5,7 @@ const domain = {
   cloudflare_response_error: 'Получен неожиданный ответ от Cloudflare.',
   limit_to_one_domain: 'Вы можете использовать только один пользовательский домен.',
   hostname_already_exists: 'Этот домен уже существует на нашем сервере.',
+  cloudflare_not_found: 'Не удается найти имя хоста в Cloudflare',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/tr-tr/errors/domain.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/domain.ts
@@ -5,6 +5,7 @@ const domain = {
   cloudflare_response_error: 'Cloudflare’dan beklenmeyen bir yanıt alındı.',
   limit_to_one_domain: 'Sadece bir özel alan adınız olabilir.',
   hostname_already_exists: 'Bu alan adı sunucumuzda zaten mevcut.',
+  cloudflare_not_found: "Cloudflare'da alan adı bulunamadı.",
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/zh-cn/errors/domain.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/domain.ts
@@ -5,6 +5,7 @@ const domain = {
   cloudflare_response_error: '从 Cloudflare 得到意外的响应。',
   limit_to_one_domain: '仅限一个自定义域名。',
   hostname_already_exists: '该域名在我们的服务器中已存在。',
+  cloudflare_not_found: '在 Cloudflare 中找不到主机名',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/zh-hk/errors/domain.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/domain.ts
@@ -5,6 +5,7 @@ const domain = {
   cloudflare_response_error: '從 Cloudflare 獲取到意外的響應',
   limit_to_one_domain: '您只能擁有一個自定義域名。',
   hostname_already_exists: '此域名已存在於我們的伺服器中。',
+  cloudflare_not_found: '無法在 Cloudflare 中找到主機名',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/zh-tw/errors/domain.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/domain.ts
@@ -5,6 +5,7 @@ const domain = {
   cloudflare_response_error: '從 Cloudflare 收到意外回應',
   limit_to_one_domain: '您只能擁有一個自訂網域。',
   hostname_already_exists: '此網域名稱已經存在我們的伺服器中。',
+  cloudflare_not_found: '無法找到 Cloudflare 中的主機名',
 };
 
 export default Object.freeze(domain);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
When deleting custom domain, ignore the 404 error returned by Cloudflare API, since we are deleting the domain anyway.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
