### PR TITLE
test(core): add hasActiveUser test case

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,4 @@
 /packages/core @simeng-li @wangsijie @gao-sun
 /packages/console @wangsijie @charIeszhao
 /packages/ui @simeng-li @charIeszhao
-/packages/integration-tests @simeng-li
 /.changeset @gao-sun

--- a/packages/integration-tests/src/api/admin-user.ts
+++ b/packages/integration-tests/src/api/admin-user.ts
@@ -8,10 +8,9 @@ type CreateUserPayload = Partial<{
   username: string;
   password: string;
   name: string;
-  isAdmin: boolean;
 }>;
 
-export const createUser = async (payload: CreateUserPayload) =>
+export const createUser = async (payload: CreateUserPayload = {}) =>
   authedAdminApi
     .post('users', {
       json: payload,

--- a/packages/integration-tests/src/helpers/index.ts
+++ b/packages/integration-tests/src/helpers/index.ts
@@ -15,8 +15,7 @@ export const createUserByAdmin = async (
   password?: string,
   primaryEmail?: string,
   primaryPhone?: string,
-  name?: string,
-  isAdmin = false
+  name?: string
 ) => {
   return createUser({
     username: username ?? generateUsername(),
@@ -24,7 +23,6 @@ export const createUserByAdmin = async (
     name: name ?? username ?? 'John',
     primaryEmail,
     primaryPhone,
-    isAdmin,
   });
 };
 

--- a/packages/integration-tests/src/tests/api/admin-user.search.test.ts
+++ b/packages/integration-tests/src/tests/api/admin-user.search.test.ts
@@ -49,14 +49,7 @@ describe('admin console user search params', () => {
         const primaryPhone =
           phonePrefix[index % phonePrefix.length]! + index.toString().padStart(5, '0');
 
-        return createUserByAdmin(
-          prefix + username,
-          undefined,
-          primaryEmail,
-          primaryPhone,
-          name,
-          index < 3
-        );
+        return createUserByAdmin(prefix + username, undefined, primaryEmail, primaryPhone, name);
       })
     );
   });


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add hasActiveUser test case.

This PR includes two updates:

1. Remove the `isAdmin`  property from all the createUser methods.  The users' isAdmin property was dropped a long time ago. Our users' endpoints no longer read this property. Remove this legacy field in the integration test methods. 

2. Resolve the linear issue. Create two Admin console onboarding test cases to cover the `hasActiveUsers` query method. 
- if any active admin user exists, should not redirect the user to the welcome page
- if all the admin users are suspended, should treated as empty active users.  Should redirect the new user to the welcome page. 
- 
<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] docs

OR

- [ ] This PR is not applicable for the checklist
