### PR TITLE
refactor(cloud): clarify the isTest scope

### DIFF
--- a/packages/core/src/env-set/create-pool.ts
+++ b/packages/core/src/env-set/create-pool.ts
@@ -2,9 +2,13 @@ import { assert } from '@silverhand/essentials';
 import { createMockPool, createMockQueryResult, createPool, parseDsn } from 'slonik';
 import { createInterceptors } from 'slonik-interceptor-preset';
 
-const createPoolByEnv = async (databaseDsn: string, isTest: boolean, poolSize?: number) => {
+const createPoolByEnv = async (
+  databaseDsn: string,
+  mockDatabaseConnection: boolean,
+  poolSize?: number
+) => {
   // Database connection is disabled in unit test environment
-  if (isTest) {
+  if (mockDatabaseConnection) {
     return createMockPool({ query: async () => createMockQueryResult([]) });
   }
 

--- a/packages/core/src/env-set/index.ts
+++ b/packages/core/src/env-set/index.ts
@@ -29,15 +29,15 @@ export class EnvSet {
   /** The value set for global configurations.  */
   static values = new GlobalValues();
 
-  static get isTest() {
-    return this.values.isTest;
-  }
-
   static get dbUrl() {
     return this.values.dbUrl;
   }
 
-  static sharedPool = createPoolByEnv(this.dbUrl, this.isTest, this.values.databasePoolSize);
+  static sharedPool = createPoolByEnv(
+    this.dbUrl,
+    EnvSet.values.isUnitTest,
+    this.values.databasePoolSize
+  );
 
   #pool: Optional<DatabasePool>;
   #oidc: Optional<Awaited<ReturnType<typeof loadOidcValues>>>;
@@ -66,7 +66,7 @@ export class EnvSet {
   async load() {
     const pool = await createPoolByEnv(
       this.databaseUrl,
-      EnvSet.isTest,
+      EnvSet.values.isUnitTest,
       EnvSet.values.databasePoolSize
     );
 

--- a/packages/shared/src/node/env/GlobalValues.ts
+++ b/packages/shared/src/node/env/GlobalValues.ts
@@ -5,8 +5,8 @@ import { throwErrorWithDsnMessage } from './throw-errors.js';
 
 export default class GlobalValues {
   public readonly isProduction = getEnv('NODE_ENV') === 'production';
-  public readonly isTest = getEnv('NODE_ENV') === 'test';
   public readonly isIntegrationTest = yes(getEnv('INTEGRATION_TEST'));
+  public readonly isUnitTest = getEnv('NODE_ENV') === 'test';
 
   public readonly httpsCert = process.env.HTTPS_CERT_PATH;
   public readonly httpsKey = process.env.HTTPS_KEY_PATH;


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
clarify the `isTest` scope。

We have both `isIntegrationTest` and `isTest` defined in the global envSet. 

- isIntegrationTest is used to bypass some run time guard for integration tests.
- isTest is used to mock the DB connector under the unit test env. 

This PR renames the `isTest` to `isUnitTest` for better understanding.
Also makes the EnvSet.isTest private. As it is only used when creating DB connections.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] docs

OR

- [ ] This PR is not applicable for the checklist
