### PR TITLE
fix(console): use correct logic to display refresh token switches

### DIFF
--- a/.changeset/smooth-radios-wink.md
+++ b/.changeset/smooth-radios-wink.md
@@ -1,0 +1,8 @@
+---
+"@logto/console": patch
+---
+
+fix display logic for "Always issue refresh token" and "Refresh token TTL" according to OIDC configuration
+
+- Public clients (authentication method is none) are not allowed to disable refresh token rotation;
+- Web public applications (i.e. SPA) with refresh token rotation enabled are not allowed to set refresh token TTL.

--- a/.changeset/smooth-radios-wink.md
+++ b/.changeset/smooth-radios-wink.md
@@ -2,7 +2,7 @@
 "@logto/console": patch
 ---
 
-fix display logic for "Always issue refresh token" and "Refresh token TTL" according to OIDC configuration
+fix display logic for "Rotate refresh token" and "Refresh token TTL" according to OIDC configuration
 
 - Public clients (authentication method is none) are not allowed to disable refresh token rotation;
 - Web public applications (i.e. SPA) with refresh token rotation enabled are not allowed to set refresh token TTL.

--- a/packages/console/src/pages/ApplicationDetails/components/AdvancedSettings.tsx
+++ b/packages/console/src/pages/ApplicationDetails/components/AdvancedSettings.tsx
@@ -121,54 +121,65 @@ function AdvancedSettings({ applicationType, oidcConfig }: Props) {
           />
         </FormField>
       )}
-      {applicationType !== ApplicationType.MachineToMachine && (
-        <>
-          <FormField title="application_details.rotate_refresh_token">
-            <Switch
-              label={
-                <Trans
-                  components={{
-                    a: (
-                      <TextLink
-                        href="https://docs.logto.io/docs/references/applications/#rotate-refresh-token"
-                        target="_blank"
-                      />
-                    ),
-                  }}
-                >
-                  {t('application_details.rotate_refresh_token_label')}
-                </Trans>
-              }
-              {...register('customClientMetadata.rotateRefreshToken')}
-            />
-          </FormField>
-          <FormField
-            title="application_details.refresh_token_ttl"
-            tip={t('application_details.refresh_token_ttl_tip')}
-          >
-            <TextInput
-              {...register('customClientMetadata.refreshTokenTtlInDays', {
-                min: {
-                  value: minTtl,
-                  message: ttlErrorMessage,
-                },
-                max: {
-                  value: maxTtl,
-                  message: ttlErrorMessage,
-                },
-                valueAsNumber: true,
-                validate: (value) =>
-                  value === undefined ||
-                  Number.isInteger(value) ||
-                  t('errors.should_be_an_integer'),
-              })}
-              placeholder="14"
-              // Confirm if we need a customized message here
-              error={errors.customClientMetadata?.refreshTokenTtlInDays?.message}
-            />
-          </FormField>
-        </>
-      )}
+      {/**
+        * Public clients (authentication method is none) are not allowed to disable refresh token
+        * rotation, so we don't show the option here.
+        * 
+        * @see rotateRefreshToken() in `packages/core/src/oidc/default.ts` for more details.
+        */}
+      {[ApplicationType.Traditional, ApplicationType.MachineToMachine].includes(applicationType) && (
+        <FormField title="application_details.rotate_refresh_token">
+          <Switch
+            label={
+              <Trans
+                components={{
+                  a: (
+                    <TextLink
+                      href="https://docs.logto.io/docs/references/applications/#rotate-refresh-token"
+                      target="_blank"
+                    />
+                  ),
+                }}
+              >
+                {t('application_details.rotate_refresh_token_label')}
+              </Trans>
+            }
+            {...register('customClientMetadata.rotateRefreshToken')}
+          />
+        </FormField>)}
+      {/**
+        * Web public applications (i.e. SPA) with refresh token rotation enabled are not allowed
+        * to set refresh token TTL, so we don't show the option here.
+        * 
+        * @see refreshTokenTtl() in `packages/core/src/oidc/default.ts` for more details.
+        */}
+      {applicationType !== ApplicationType.SPA &&
+        <FormField
+          title="application_details.refresh_token_ttl"
+          tip={t('application_details.refresh_token_ttl_tip')}
+        >
+          <TextInput
+            {...register('customClientMetadata.refreshTokenTtlInDays', {
+              min: {
+                value: minTtl,
+                message: ttlErrorMessage,
+              },
+              max: {
+                value: maxTtl,
+                message: ttlErrorMessage,
+              },
+              valueAsNumber: true,
+              validate: (value) =>
+                value === undefined ||
+                Number.isInteger(value) ||
+                t('errors.should_be_an_integer'),
+            })}
+            placeholder="14"
+            // Confirm if we need a customized message here
+            error={errors.customClientMetadata?.refreshTokenTtlInDays?.message}
+          />
+        </FormField>
+      }
       {applicationType === ApplicationType.MachineToMachine && (
         <FormField title="application_details.enable_admin_access">
           <Switch

--- a/packages/console/src/pages/ApplicationDetails/components/AdvancedSettings.tsx
+++ b/packages/console/src/pages/ApplicationDetails/components/AdvancedSettings.tsx
@@ -122,12 +122,14 @@ function AdvancedSettings({ applicationType, oidcConfig }: Props) {
         </FormField>
       )}
       {/**
-        * Public clients (authentication method is none) are not allowed to disable refresh token
-        * rotation, so we don't show the option here.
-        * 
-        * @see rotateRefreshToken() in `packages/core/src/oidc/default.ts` for more details.
-        */}
-      {[ApplicationType.Traditional, ApplicationType.MachineToMachine].includes(applicationType) && (
+       * Public clients (authentication method is none) are not allowed to disable refresh token
+       * rotation, so we don't show the option here.
+       *
+       * @see rotateRefreshToken() in `packages/core/src/oidc/default.ts` for more details.
+       */}
+      {[ApplicationType.Traditional, ApplicationType.MachineToMachine].includes(
+        applicationType
+      ) && (
         <FormField title="application_details.rotate_refresh_token">
           <Switch
             label={
@@ -146,14 +148,15 @@ function AdvancedSettings({ applicationType, oidcConfig }: Props) {
             }
             {...register('customClientMetadata.rotateRefreshToken')}
           />
-        </FormField>)}
+        </FormField>
+      )}
       {/**
-        * Web public applications (i.e. SPA) with refresh token rotation enabled are not allowed
-        * to set refresh token TTL, so we don't show the option here.
-        * 
-        * @see refreshTokenTtl() in `packages/core/src/oidc/default.ts` for more details.
-        */}
-      {applicationType !== ApplicationType.SPA &&
+       * Web public applications (i.e. SPA) with refresh token rotation enabled are not allowed
+       * to set refresh token TTL, so we don't show the option here.
+       *
+       * @see refreshTokenTtl() in `packages/core/src/oidc/default.ts` for more details.
+       */}
+      {applicationType !== ApplicationType.SPA && (
         <FormField
           title="application_details.refresh_token_ttl"
           tip={t('application_details.refresh_token_ttl_tip')}
@@ -170,16 +173,14 @@ function AdvancedSettings({ applicationType, oidcConfig }: Props) {
               },
               valueAsNumber: true,
               validate: (value) =>
-                value === undefined ||
-                Number.isInteger(value) ||
-                t('errors.should_be_an_integer'),
+                value === undefined || Number.isInteger(value) || t('errors.should_be_an_integer'),
             })}
             placeholder="14"
             // Confirm if we need a customized message here
             error={errors.customClientMetadata?.refreshTokenTtlInDays?.message}
           />
         </FormField>
-      }
+      )}
       {applicationType === ApplicationType.MachineToMachine && (
         <FormField title="application_details.enable_admin_access">
           <Switch


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix display logic for "Always issue refresh token" and "Refresh token TTL" according to OIDC configuration

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
n/a

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
