### PR TITLE
feat(cli): add key type for rotating command

### DIFF
--- a/.changeset/serious-pants-beg.md
+++ b/.changeset/serious-pants-beg.md
@@ -1,0 +1,5 @@
+---
+"@logto/cli": minor
+---
+
+Add key type option for the command of rotating oidc.privateKeys

--- a/packages/cli/src/commands/database/utils.ts
+++ b/packages/cli/src/commands/database/utils.ts
@@ -3,8 +3,13 @@ import { promisify } from 'node:util';
 
 import { generateStandardId } from '@logto/shared';
 
-export const generateOidcPrivateKey = async (type: 'rsa' | 'ec' = 'ec') => {
-  if (type === 'rsa') {
+export enum PrivateKeyType {
+  RSA = 'rsa',
+  EC = 'ec',
+}
+
+export const generateOidcPrivateKey = async (type: PrivateKeyType = PrivateKeyType.EC) => {
+  if (type === PrivateKeyType.RSA) {
     const { privateKey } = await promisify(generateKeyPair)('rsa', {
       modulusLength: 4096,
       publicKeyEncoding: {
@@ -21,7 +26,7 @@ export const generateOidcPrivateKey = async (type: 'rsa' | 'ec' = 'ec') => {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  if (type === 'ec') {
+  if (type === PrivateKeyType.EC) {
     const { privateKey } = await promisify(generateKeyPair)('ec', {
       // https://security.stackexchange.com/questions/78621/which-elliptic-curve-should-i-use
       namedCurve: 'secp384r1',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add key type option for rotating command:

```sh
pnpm cli db config rotate oidc.privateKeys --type rsa 
```

Background: the Cloudflare Zero Trust only support RSA key type.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested, after running the command, the RSA key is prepended:

<img width="760" alt="截屏2023-08-10 上午11 07 32" src="https://github.com/logto-io/logto/assets/5717882/ee47563c-c732-4df7-9380-5168c8fe1b3a">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`