### PR TITLE
fix(core): fix cloudflare hostname not found error handler

### DIFF
--- a/packages/core/src/libraries/domain.test.ts
+++ b/packages/core/src/libraries/domain.test.ts
@@ -149,4 +149,14 @@ describe('deleteDomain()', () => {
     expect(clearCustomDomainCache).toBeCalledTimes(1);
     expect(deleteDomainById).toBeCalledTimes(1);
   });
+
+  it('should delete local record even if the record is not found in remote', async () => {
+    findDomainById.mockResolvedValueOnce(mockDomainWithCloudflareData);
+    deleteCustomHostname.mockRejectedValueOnce(
+      new RequestError({ code: 'domain.cloudflare_not_found' })
+    );
+    await expect(deleteDomain(mockDomain.id)).resolves.not.toThrow();
+    expect(clearCustomDomainCache).toBeCalledTimes(1);
+    expect(deleteDomainById).toBeCalledTimes(1);
+  });
 });

--- a/packages/core/src/libraries/domain.ts
+++ b/packages/core/src/libraries/domain.ts
@@ -103,12 +103,10 @@ export const createDomainLibrary = (queries: Queries) => {
       try {
         await deleteCustomHostname(hostnameProviderConfig, domain.cloudflareData.id);
       } catch (error: unknown) {
-        if (error instanceof RequestError && error.code === 'domain.cloudflare_not_found') {
-          // Ignore not found error, since we are deleting the domain anyway
-          return;
+        // Ignore not found error, since we are deleting the domain anyway
+        if (!(error instanceof RequestError) || error.code !== 'domain.cloudflare_not_found') {
+          throw error;
         }
-
-        throw error;
       }
     }
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix Cloudflare hostname not found error handler, when 404 error occurs, the remaining code need to be run, so a “return” is not correct.

Also add unit test to cover this.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Unit test

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] unit tests