### PR TITLE
test: add ui tests for passwordless connectors

### DIFF
--- a/packages/integration-tests/src/tests/ui/connectors/helpers.ts
+++ b/packages/integration-tests/src/tests/ui/connectors/helpers.ts
@@ -1,0 +1,92 @@
+import { ConnectorType } from '@logto/connector-kit';
+import { type Page } from 'puppeteer';
+
+import { expectConfirmModalAndAct, waitForToaster } from '#src/ui-helpers/index.js';
+
+import {
+  passwordlessConnectorTestCases,
+  type PasswordlessConnectorCase,
+} from './passwordless-connector-test-cases.js';
+
+/**
+ * Finds the next connector of the same type adjacent to the current connector, which will be selected
+ * as the new connector when changing the current connector.
+ */
+export const findNextCompatibleConnector = (currentConnector: PasswordlessConnectorCase) => {
+  const sameTypeConnectors = passwordlessConnectorTestCases.filter(
+    (connector) => connector.isEmailConnector === currentConnector.isEmailConnector
+  );
+
+  const currentIndex = sameTypeConnectors.findIndex(
+    (connector) => connector.factoryId === currentConnector.factoryId
+  );
+
+  if (currentIndex === -1) {
+    return;
+  }
+
+  return sameTypeConnectors[(currentIndex + 1) % sameTypeConnectors.length];
+};
+
+type SelectConnectorOption = {
+  groupFactoryId?: string;
+  factoryId: string;
+  connectorType: ConnectorType;
+};
+
+export const expectToSelectConnector = async (
+  page: Page,
+  { groupFactoryId, factoryId, connectorType }: SelectConnectorOption
+) => {
+  await expect(page).toMatchElement(
+    '.ReactModalPortal div[class$=header] div[class$=titleEllipsis]',
+    {
+      text:
+        connectorType === ConnectorType.Email
+          ? 'Set up email connector'
+          : connectorType === ConnectorType.Sms
+          ? 'Set up SMS connector'
+          : 'Add Social Connector',
+    }
+  );
+
+  if (groupFactoryId) {
+    // Platform selector
+    await page.click(
+      `.ReactModalPortal div[role=radio]:has(input[name=group][value=${groupFactoryId}])`
+    );
+
+    await page.waitForSelector('.ReactModalPortal div[class$=platforms] div[class$=radioGroup]');
+
+    await page.click(
+      `.ReactModalPortal div[class$=platforms] div[role=radio]:has(input[name=connector][value=${factoryId}])`
+    );
+  } else {
+    await page.click(
+      `.ReactModalPortal div[role=radio]:has(input[name=group][value=${factoryId}])`
+    );
+  }
+
+  await expect(page).toClick('.ReactModalPortal div[class$=footer] button:not(disabled) span', {
+    text: 'Next',
+  });
+};
+
+export const waitForConnectorCreationGuide = async (page: Page, connectorName: string) => {
+  await expect(page).toMatchElement('.ReactModalPortal div[class$=titleEllipsis] span', {
+    text: connectorName,
+  });
+
+  await expect(page).toMatchElement('.ReactModalPortal div[class$=subtitle] span', {
+    text: 'A step by step guide to configure your connector',
+  });
+};
+
+export const expectToConfirmConnectorDeletion = async (page: Page) => {
+  await expectConfirmModalAndAct(page, {
+    title: 'Reminder',
+    actionText: 'Delete',
+  });
+
+  await waitForToaster(page, { text: 'The connector has been successfully deleted' });
+};

--- a/packages/integration-tests/src/tests/ui/connectors/passwordless-connector-test-cases.ts
+++ b/packages/integration-tests/src/tests/ui/connectors/passwordless-connector-test-cases.ts
@@ -1,0 +1,234 @@
+export type PasswordlessConnectorCase = {
+  factoryId: string;
+  isEmailConnector: boolean;
+  name: string;
+  initialFormData: Record<string, string>;
+  updateFormData: Record<string, string>;
+  errorFormData: Record<string, string>;
+};
+
+const awsSesMail: PasswordlessConnectorCase = {
+  factoryId: 'aws-ses-mail',
+  isEmailConnector: true,
+  name: 'AWS Direct Mail',
+  initialFormData: {
+    'formConfig.accessKeyId': 'access-key-id',
+    'formConfig.accessKeySecret': 'access-key-config',
+    'formConfig.region': 'region',
+    'formConfig.emailAddress': 'email-address',
+    'formConfig.emailAddressIdentityArn': 'email-address-identity-arn',
+    'formConfig.feedbackForwardingEmailAddress': 'feedback-forwarding-email-address',
+    'formConfig.feedbackForwardingEmailAddressIdentityArn':
+      'feedback-forwarding-email-address-identity-arn',
+    'formConfig.configurationSetName': 'configuration-set-name',
+  },
+  updateFormData: {
+    'formConfig.accessKeyId': 'new-access-key-id',
+    'formConfig.accessKeySecret': 'new-access-key-config',
+    'formConfig.region': 'new-region',
+    'formConfig.emailAddress': 'new-email-address',
+    'formConfig.emailAddressIdentityArn': 'new-email-address-identity-arn',
+    'formConfig.feedbackForwardingEmailAddress': 'new-feedback-forwarding-email-address',
+    'formConfig.feedbackForwardingEmailAddressIdentityArn':
+      'new-feedback-forwarding-email-address-identity-arn',
+    'formConfig.configurationSetName': 'new-configuration-set-name',
+  },
+  errorFormData: {
+    'formConfig.accessKeyId': '',
+    'formConfig.accessKeySecret': '',
+    'formConfig.region': '',
+  },
+};
+
+const sendGrid: PasswordlessConnectorCase = {
+  factoryId: 'sendgrid-email-service',
+  isEmailConnector: true,
+  name: 'SendGrid Email',
+  initialFormData: {
+    'formConfig.apiKey': 'api-key',
+    'formConfig.fromEmail': 'foo@example.com',
+    'formConfig.fromName': 'Logto',
+  },
+  updateFormData: {
+    'formConfig.apiKey': 'new-api-key',
+    'formConfig.fromEmail': 'new-foo@example.com',
+    'formConfig.fromName': 'new-Logto',
+  },
+  errorFormData: {
+    'formConfig.apiKey': '',
+    'formConfig.fromEmail': '',
+  },
+};
+
+const aliyunDirectMail: PasswordlessConnectorCase = {
+  factoryId: 'aliyun-direct-mail',
+  isEmailConnector: true,
+  name: 'Aliyun Direct Mail',
+  initialFormData: {
+    'formConfig.accessKeyId': 'access-key-id',
+    'formConfig.accessKeySecret': 'access-key-config',
+    'formConfig.accountName': 'account-name',
+    'formConfig.fromAlias': 'from-alias',
+  },
+  updateFormData: {
+    'formConfig.accessKeyId': 'new-access-key-id',
+    'formConfig.accessKeySecret': 'new-access-key-config',
+    'formConfig.accountName': 'new-account-name',
+    'formConfig.fromAlias': 'new-from-alias',
+  },
+  errorFormData: {
+    'formConfig.accessKeyId': '',
+    'formConfig.accessKeySecret': '',
+    'formConfig.accountName': '',
+  },
+};
+
+const mailgun: PasswordlessConnectorCase = {
+  factoryId: 'mailgun-email',
+  isEmailConnector: true,
+  name: 'Mailgun',
+  initialFormData: {
+    'formConfig.endpoint': 'https://fake.mailgun.net',
+    'formConfig.domain': 'mailgun-domain.com',
+    'formConfig.apiKey': 'api-key',
+    'formConfig.from': 'from',
+  },
+  updateFormData: {
+    'formConfig.endpoint': 'https://new-fake.mailgun.net',
+    'formConfig.domain': 'new-mailgun-domain.com',
+    'formConfig.apiKey': 'new-api-key',
+    'formConfig.from': 'new-from',
+  },
+  errorFormData: {
+    'formConfig.domain': '',
+    'formConfig.apiKey': '',
+    'formConfig.from': '',
+  },
+};
+
+const smpt: PasswordlessConnectorCase = {
+  factoryId: 'simple-mail-transfer-protocol',
+  isEmailConnector: true,
+  name: 'SMTP',
+  initialFormData: {
+    'formConfig.host': 'host',
+    'formConfig.port': '25',
+    'formConfig.fromEmail': 'from',
+  },
+  updateFormData: {
+    'formConfig.host': 'new-host',
+    'formConfig.port': '26',
+    'formConfig.fromEmail': 'new-from',
+  },
+  errorFormData: {
+    'formConfig.host': '',
+    'formConfig.port': '',
+    'formConfig.fromEmail': '',
+  },
+};
+
+const twilio: PasswordlessConnectorCase = {
+  factoryId: 'twilio-short-message-service',
+  isEmailConnector: false,
+  name: 'Twilio SMS Service',
+  initialFormData: {
+    'formConfig.accountSID': 'account-sid',
+    'formConfig.authToken': 'auth-token',
+    'formConfig.fromMessagingServiceSID': 'from-messaging-service-sid',
+  },
+  updateFormData: {
+    'formConfig.accountSID': 'new-account-sid',
+    'formConfig.authToken': 'new-auth-token',
+    'formConfig.fromMessagingServiceSID': 'new-from-messaging-service-sid',
+  },
+  errorFormData: {
+    'formConfig.accountSID': '',
+    'formConfig.authToken': '',
+    'formConfig.fromMessagingServiceSID': '',
+  },
+};
+
+const aliyunShortMessage: PasswordlessConnectorCase = {
+  factoryId: 'aliyun-short-message-service',
+  isEmailConnector: false,
+  name: 'Aliyun Short Message Service',
+  initialFormData: {
+    'formConfig.accessKeyId': 'access-key-id',
+    'formConfig.accessKeySecret': 'access-key-config',
+    'formConfig.signName': 'sign-name',
+  },
+  updateFormData: {
+    'formConfig.accessKeyId': 'new-access-key-id',
+    'formConfig.accessKeySecret': 'new-access-key-config',
+    'formConfig.signName': 'new-sign-name',
+  },
+  errorFormData: {
+    'formConfig.accessKeyId': '',
+    'formConfig.accessKeySecret': '',
+    'formConfig.signName': '',
+  },
+};
+
+// Tencent-short-message-service
+const tencentShortMessage: PasswordlessConnectorCase = {
+  factoryId: 'tencent-short-message-service',
+  isEmailConnector: false,
+  name: 'Tencent Short Message Service',
+  initialFormData: {
+    'formConfig.accessKeyId': 'access-key-id',
+    'formConfig.accessKeySecret': 'access-key-config',
+    'formConfig.signName': 'sign-name',
+    'formConfig.sdkAppId': 'sdk-app-id',
+    'formConfig.region': 'region',
+  },
+  updateFormData: {
+    'formConfig.accessKeyId': 'new-access-key-id',
+    'formConfig.accessKeySecret': 'new-access-key-config',
+    'formConfig.signName': 'new-sign-name',
+    'formConfig.sdkAppId': 'new-sdk-app-id',
+    'formConfig.region': 'new-region',
+  },
+  errorFormData: {
+    'formConfig.accessKeyId': '',
+    'formConfig.accessKeySecret': '',
+    'formConfig.signName': '',
+    'formConfig.sdkAppId': '',
+    'formConfig.region': '',
+  },
+};
+
+// Smsaero-short-message-service
+const smsaeroShortMessage: PasswordlessConnectorCase = {
+  factoryId: 'smsaero-short-message-service',
+  isEmailConnector: false,
+  name: 'SMS Aero service',
+  initialFormData: {
+    'formConfig.email': 'fake@email.com',
+    'formConfig.apiKey': 'api-key',
+    'formConfig.senderName': 'sender-name',
+  },
+  updateFormData: {
+    'formConfig.email': 'new-fake@email.com',
+    'formConfig.apiKey': 'new-api-key',
+    'formConfig.senderName': 'new-sender-name',
+  },
+  errorFormData: {
+    'formConfig.email': '',
+    'formConfig.apiKey': '',
+    'formConfig.senderName': '',
+  },
+};
+
+export const passwordlessConnectorTestCases = [
+  // Email
+  awsSesMail,
+  sendGrid,
+  aliyunDirectMail,
+  mailgun,
+  smpt,
+  // SMS
+  twilio,
+  aliyunShortMessage,
+  tencentShortMessage,
+  smsaeroShortMessage,
+];

--- a/packages/integration-tests/src/tests/ui/connectors/passwordless-connectors.test.ts
+++ b/packages/integration-tests/src/tests/ui/connectors/passwordless-connectors.test.ts
@@ -1,0 +1,174 @@
+import { ConnectorType } from '@logto/connector-kit';
+
+import { logtoConsoleUrl as logtoConsoleUrlString } from '#src/constants.js';
+import {
+  expectToClickDetailsPageOption,
+  expectUnsavedChangesAlert,
+  goToAdminConsole,
+  trySaveChanges,
+  waitForToaster,
+} from '#src/ui-helpers/index.js';
+import { expectNavigation, appendPathname } from '#src/utils.js';
+
+import {
+  expectToConfirmConnectorDeletion,
+  expectToSelectConnector,
+  findNextCompatibleConnector,
+  waitForConnectorCreationGuide,
+} from './helpers.js';
+import {
+  type PasswordlessConnectorCase,
+  passwordlessConnectorTestCases,
+} from './passwordless-connector-test-cases.js';
+
+await page.setViewport({ width: 1920, height: 1080 });
+
+describe('passwordless connectors', () => {
+  const logtoConsoleUrl = new URL(logtoConsoleUrlString);
+
+  beforeAll(async () => {
+    await goToAdminConsole();
+  });
+
+  it('navigate to passwordless connector page', async () => {
+    // Should navigate to passwordless page when visit '/console/connectors'
+    await expectNavigation(page.goto(appendPathname('/console/connectors', logtoConsoleUrl).href));
+    expect(page.url()).toBe(new URL('/console/connectors/passwordless', logtoConsoleUrl).href);
+
+    await expectNavigation(
+      page.goto(appendPathname('/console/connectors/passwordless', logtoConsoleUrl).href)
+    );
+    expect(page.url()).toBe(new URL('/console/connectors/passwordless', logtoConsoleUrl).href);
+  });
+
+  it.each(passwordlessConnectorTestCases)(
+    'can setup and modify a(n) $factoryId connector',
+    async (connector: PasswordlessConnectorCase) => {
+      const { factoryId, isEmailConnector, name, initialFormData, updateFormData, errorFormData } =
+        connector;
+
+      const connectorItem = await expect(page).toMatchElement(
+        'div[class$=item] div[class$=previewTitle]:has(>div)',
+        {
+          text: isEmailConnector ? 'Email connector' : 'SMS connector',
+        }
+      );
+
+      const setupConnectorButton = await expect(connectorItem).toMatchElement('button span', {
+        text: 'Set Up',
+      });
+
+      await setupConnectorButton.click();
+
+      await expectToSelectConnector(page, {
+        factoryId,
+        connectorType: isEmailConnector ? ConnectorType.Email : ConnectorType.Sms,
+      });
+
+      await waitForConnectorCreationGuide(page, name);
+
+      await expect(page).toClick(
+        '.ReactModalPortal form div[class$=footer] button[type=submit] span',
+        {
+          text: 'Save and Done',
+        }
+      );
+
+      // Display error input
+      await page.waitForSelector('form div[class$=field] div[class$=error]');
+
+      await expect(page).toFillForm('.ReactModalPortal form', initialFormData);
+
+      // Try click test button
+      await expect(page).toClick('.ReactModalPortal div[class$=send] button span', {
+        text: 'Send',
+      });
+
+      // Display test input error
+      await page.waitForSelector('.ReactModalPortal div[class$=error]:has(input[name=sendTo])');
+
+      await expect(page).toClick(
+        '.ReactModalPortal form div[class$=footer] button[type=submit] span',
+        {
+          text: 'Save and Done',
+        }
+      );
+
+      await waitForToaster(page, { text: 'Saved' });
+
+      await expect(page).toMatchElement('div[class$=header] div[class$=name] span', {
+        text: name,
+      });
+
+      // Try send test
+      await expect(page).toFill(
+        'input[name=sendTo]',
+        isEmailConnector ? 'fake@email.com' : '+1 555-123-4567'
+      );
+
+      await expect(page).toClick('div[class$=fields] div[class$=send] button span', {
+        text: 'Send',
+      });
+
+      await waitForToaster(page, {
+        text: /error/i,
+        isError: true,
+      });
+
+      // Fill incorrect form
+      await expect(page).toFillForm('form', errorFormData);
+
+      await trySaveChanges(page);
+
+      await page.waitForSelector('form div[class$=field] div[class$=error]');
+
+      // Update form
+      await expect(page).toFillForm('form', updateFormData);
+
+      await expectUnsavedChangesAlert(page);
+
+      await trySaveChanges(page);
+
+      await waitForToaster(page, { text: 'Saved' });
+
+      // Change to next connector
+      const nextConnector = findNextCompatibleConnector(connector);
+
+      if (nextConnector) {
+        await expectToClickDetailsPageOption(
+          page,
+          isEmailConnector ? 'Change email connector' : 'Change SMS connector'
+        );
+
+        await expectToSelectConnector(page, {
+          factoryId: nextConnector.factoryId,
+          connectorType: isEmailConnector ? ConnectorType.Email : ConnectorType.Sms,
+        });
+
+        await waitForConnectorCreationGuide(page, nextConnector.name);
+
+        await expect(page).toFillForm('.ReactModalPortal form', nextConnector.initialFormData);
+
+        await expect(page).toClick(
+          '.ReactModalPortal form div[class$=footer] button[type=submit] span',
+          {
+            text: 'Save and Done',
+          }
+        );
+
+        await waitForToaster(page, { text: 'Saved' });
+
+        await expect(page).toMatchElement('div[class$=header] div[class$=name] span', {
+          text: nextConnector.name,
+        });
+      }
+
+      // Delete email connector
+      await expectToClickDetailsPageOption(page, 'Delete');
+
+      await expectToConfirmConnectorDeletion(page);
+
+      expect(page.url()).toBe(new URL(`console/connectors/passwordless`, logtoConsoleUrl).href);
+    }
+  );
+});


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add ui tests for passwordless connectors
### Update
- Extract common operactions into helper methods from both passwordless & social connectors tests
- Refactor `waitForToaster` to support waiting for an error toaster

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
IT

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
