### PR TITLE
fix(console): add max-width to guide card group

### DIFF
--- a/packages/console/src/pages/Applications/components/GuideLibrary/index.module.scss
+++ b/packages/console/src/pages/Applications/components/GuideLibrary/index.module.scss
@@ -46,6 +46,7 @@
   display: flex;
   flex-direction: column;
   margin: _.unit(8) _.unit(8) 0 0;
+  max-width: 1876px;
   container-type: inline-size;
 
   label {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add max-width to guide card groups.
Maximum allowed width = 4 * maximum-size-cards (460px each) + 3 aisles (12px each) = 1876px

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Card layout looks OK even on super large screens

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
- [ ] This PR is not applicable for the checklist
