### PR TITLE
refactor(console): remove min-height for readonly code editors

### DIFF
--- a/packages/console/src/ds-components/CodeEditor/index.module.scss
+++ b/packages/console/src/ds-components/CodeEditor/index.module.scss
@@ -59,10 +59,12 @@
       overflow: hidden;
     }
 
-    textarea,
-    pre {
-      display: flex;
-      min-height: 80px;
+    &:not(.readonly) {
+      textarea,
+      pre {
+        display: flex;
+        min-height: 80px;
+      }
     }
   }
 

--- a/packages/console/src/ds-components/CodeEditor/index.tsx
+++ b/packages/console/src/ds-components/CodeEditor/index.tsx
@@ -87,7 +87,7 @@ function CodeEditor({
       <div className={classNames(styles.container, className)}>
         {isShowingPlaceholder && <div className={styles.placeholder}>{placeholder}</div>}
         <CopyToClipboard value={value ?? ''} variant="icon" className={styles.copy} />
-        <div ref={editorRef} className={styles.editor}>
+        <div ref={editorRef} className={classNames(styles.editor, isReadonly && styles.readonly)}>
           {/* SyntaxHighlighter is a readonly component, so a transparent <textarea> layer is needed
       in order to support user interactions, such as code editing, copy-pasting, etc. */}
           <textarea


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
remove min-height for readonly code editors since it looks better

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="826" alt="image" src="https://github.com/logto-io/logto/assets/14722250/f844f32c-0fe5-4f85-96f5-761a397b7699">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
