### PR TITLE
fix: logo size in get sample section in app integration guide

### DIFF
--- a/packages/console/src/mdx-components-v2/Sample/index.module.scss
+++ b/packages/console/src/mdx-components-v2/Sample/index.module.scss
@@ -25,10 +25,6 @@
 }
 
 .logo {
-  padding: _.unit(2);
-
-  svg {
-    width: 32px;
-    height: 32px;
-  }
+  width: 48px;
+  height: 48px;
 }

--- a/packages/console/src/mdx-components-v2/Sample/index.tsx
+++ b/packages/console/src/mdx-components-v2/Sample/index.tsx
@@ -22,11 +22,7 @@ export default function Sample() {
 
   return (
     <aside className={styles.sample}>
-      {Logo && (
-        <div className={styles.logo}>
-          <Logo />
-        </div>
-      )}
+      {Logo && <Logo className={styles.logo} />}
       <hgroup>
         <header>Want to see a sample?</header>
         <p>Check out our repository for a sample application that uses this guide.</p>

--- a/packages/console/src/pages/Applications/components/Guide/index.tsx
+++ b/packages/console/src/pages/Applications/components/Guide/index.tsx
@@ -2,14 +2,7 @@ import { DomainStatus, type ApplicationResponse } from '@logto/schemas';
 import { MDXProvider } from '@mdx-js/react';
 import { conditional } from '@silverhand/essentials';
 import classNames from 'classnames';
-import {
-  useContext,
-  Suspense,
-  createContext,
-  useMemo,
-  type LazyExoticComponent,
-  type ComponentType,
-} from 'react';
+import { useContext, Suspense, createContext, useMemo, type LazyExoticComponent } from 'react';
 
 import guides from '@/assets/docs/guides';
 import { type GuideMetadata } from '@/assets/docs/guides/types';
@@ -27,7 +20,7 @@ import * as styles from './index.module.scss';
 
 type GuideContextType = {
   metadata: Readonly<GuideMetadata>;
-  Logo?: LazyExoticComponent<ComponentType>;
+  Logo?: LazyExoticComponent<SvgComponent>;
   app: ApplicationResponse;
   endpoint: string;
   alternativeEndpoint?: string;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix logo size

<img width="758" alt="image" src="https://github.com/logto-io/logto/assets/12833674/18e61db8-cdeb-4855-8b2b-9cca3c6f0766">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
- [x] This PR is not applicable for the checklist
