### PR TITLE
fix(console): should hide filters from app list empty placeholder

### DIFF
--- a/packages/console/src/pages/Applications/components/GuideGroup/index.module.scss
+++ b/packages/console/src/pages/Applications/components/GuideGroup/index.module.scss
@@ -3,6 +3,7 @@
 .guideGroup {
   display: flex;
   flex-direction: column;
+  max-width: 1876px;
   container-type: inline-size;
 
   label {

--- a/packages/console/src/pages/Applications/components/GuideLibrary/index.tsx
+++ b/packages/console/src/pages/Applications/components/GuideLibrary/index.tsx
@@ -24,9 +24,10 @@ import * as styles from './index.module.scss';
 type Props = {
   className?: string;
   hasCardBorder?: boolean;
+  hasFilters?: boolean;
 };
 
-function GuideLibrary({ className, hasCardBorder }: Props) {
+function GuideLibrary({ className, hasCardBorder, hasFilters }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console.applications.guide' });
   const { navigate } = useTenantPathname();
   const [keyword, setKeyword] = useState<string>('');
@@ -68,35 +69,37 @@ function GuideLibrary({ className, hasCardBorder }: Props) {
 
   return (
     <div className={classNames(styles.container, className)}>
-      <div className={styles.filters}>
-        <label>{t('filter.title')}</label>
-        <TextInput
-          className={styles.searchInput}
-          icon={<SearchIcon />}
-          placeholder={t('filter.placeholder')}
-          value={keyword}
-          onChange={(event) => {
-            setKeyword(event.currentTarget.value);
-          }}
-        />
-        <div className={styles.checkboxGroupContainer}>
-          <CheckboxGroup
-            className={styles.checkboxGroup}
-            options={allAppGuideCategories.map((category) => ({
-              title: `applications.guide.categories.${category}`,
-              value: category,
-            }))}
-            value={filterCategories}
-            onChange={(value) => {
-              const sortedValue = allAppGuideCategories.filter((category) =>
-                value.includes(category)
-              );
-              setFilterCategories(sortedValue);
+      {hasFilters && (
+        <div className={styles.filters}>
+          <label>{t('filter.title')}</label>
+          <TextInput
+            className={styles.searchInput}
+            icon={<SearchIcon />}
+            placeholder={t('filter.placeholder')}
+            value={keyword}
+            onChange={(event) => {
+              setKeyword(event.currentTarget.value);
             }}
           />
-          {isM2mDisabledForCurrentPlan && <ProTag className={styles.proTag} />}
+          <div className={styles.checkboxGroupContainer}>
+            <CheckboxGroup
+              className={styles.checkboxGroup}
+              options={allAppGuideCategories.map((category) => ({
+                title: `applications.guide.categories.${category}`,
+                value: category,
+              }))}
+              value={filterCategories}
+              onChange={(value) => {
+                const sortedValue = allAppGuideCategories.filter((category) =>
+                  value.includes(category)
+                );
+                setFilterCategories(sortedValue);
+              }}
+            />
+            {isM2mDisabledForCurrentPlan && <ProTag className={styles.proTag} />}
+          </div>
         </div>
-      </div>
+      )}
       {keyword && (
         <GuideGroup
           className={styles.guideGroup}

--- a/packages/console/src/pages/Applications/components/GuideLibraryModal/index.tsx
+++ b/packages/console/src/pages/Applications/components/GuideLibraryModal/index.tsx
@@ -30,7 +30,7 @@ function GuideLibraryModal({ isOpen, onClose }: Props) {
     >
       <div className={styles.container}>
         <GuideHeader onClose={onClose} />
-        <GuideLibrary className={styles.content} />
+        <GuideLibrary hasFilters className={styles.content} />
         <nav className={styles.actionBar}>
           <span className={styles.text}>{t('do_not_need_tutorial')}</span>
           <Button


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Hide category filters from app list empty placeholder. Only show the filters in app creation fullscreen modal view.

<img width="1511" alt="image" src="https://github.com/logto-io/logto/assets/12833674/4a79bbdf-0508-40da-acca-d4dc71fc1139">

<img width="1511" alt="image" src="https://github.com/logto-io/logto/assets/12833674/3662a559-fecc-4b9b-82a0-38e47a0bff90">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
- [x] This PR is not applicable for the checklist
