### PR TITLE
fix(console): adjust the app guide order

### DIFF
--- a/packages/console/src/assets/docs/guides/index.ts
+++ b/packages/console/src/assets/docs/guides/index.ts
@@ -12,11 +12,9 @@ import spaReact from './spa-react/index';
 import spaVanilla from './spa-vanilla/index';
 import spaVue from './spa-vue/index';
 import { type Guide } from './types';
-import webCsharp from './web-csharp/index';
 import webExpress from './web-express/index';
 import webGo from './web-go/index';
 import webGptPlugin from './web-gpt-plugin/index';
-import webJava from './web-java/index';
 import webNext from './web-next/index';
 import webNextAppRouter from './web-next-app-router/index';
 import webOutline from './web-outline/index';
@@ -26,10 +24,88 @@ import webRemix from './web-remix/index';
 
 const guides: Readonly<Guide[]> = Object.freeze([
   {
+    id: 'web-next',
+    Logo: lazy(async () => import('./web-next/logo.svg')),
+    Component: lazy(async () => import('./web-next/README.mdx')),
+    metadata: webNext,
+  },
+  {
+    id: 'web-next-app-router',
+    Logo: lazy(async () => import('./web-next-app-router/logo.svg')),
+    Component: lazy(async () => import('./web-next-app-router/README.mdx')),
+    metadata: webNextAppRouter,
+  },
+  {
+    id: 'web-express',
+    Logo: lazy(async () => import('./web-express/logo.svg')),
+    Component: lazy(async () => import('./web-express/README.mdx')),
+    metadata: webExpress,
+  },
+  {
+    id: 'web-go',
+    Logo: lazy(async () => import('./web-go/logo.svg')),
+    Component: lazy(async () => import('./web-go/README.mdx')),
+    metadata: webGo,
+  },
+  {
+    id: 'web-php',
+    Logo: lazy(async () => import('./web-php/logo.svg')),
+    Component: lazy(async () => import('./web-php/README.mdx')),
+    metadata: webPhp,
+  },
+  {
+    id: 'web-python',
+    Logo: lazy(async () => import('./web-python/logo.svg')),
+    Component: lazy(async () => import('./web-python/README.mdx')),
+    metadata: webPython,
+  },
+  {
+    id: 'web-remix',
+    Logo: lazy(async () => import('./web-remix/logo.svg')),
+    Component: lazy(async () => import('./web-remix/README.mdx')),
+    metadata: webRemix,
+  },
+  {
+    id: 'web-outline',
+    Logo: lazy(async () => import('./web-outline/logo.svg')),
+    Component: lazy(async () => import('./web-outline/README.mdx')),
+    metadata: webOutline,
+  },
+  {
+    id: 'spa-react',
+    Logo: lazy(async () => import('./spa-react/logo.svg')),
+    Component: lazy(async () => import('./spa-react/README.mdx')),
+    metadata: spaReact,
+  },
+  {
     id: 'm2m-general',
     Logo: lazy(async () => import('./m2m-general/logo.svg')),
     Component: lazy(async () => import('./m2m-general/README.mdx')),
     metadata: m2mGeneral,
+  },
+  {
+    id: 'web-gpt-plugin',
+    Logo: lazy(async () => import('./web-gpt-plugin/logo.svg')),
+    Component: lazy(async () => import('./web-gpt-plugin/README.mdx')),
+    metadata: webGptPlugin,
+  },
+  {
+    id: 'spa-vue',
+    Logo: lazy(async () => import('./spa-vue/logo.svg')),
+    Component: lazy(async () => import('./spa-vue/README.mdx')),
+    metadata: spaVue,
+  },
+  {
+    id: 'spa-vanilla',
+    Logo: lazy(async () => import('./spa-vanilla/logo.svg')),
+    Component: lazy(async () => import('./spa-vanilla/README.mdx')),
+    metadata: spaVanilla,
+  },
+  {
+    id: 'native-ios-swift',
+    Logo: lazy(async () => import('./native-ios-swift/logo.svg')),
+    Component: lazy(async () => import('./native-ios-swift/README.mdx')),
+    metadata: nativeIosSwift,
   },
   {
     id: 'native-android-java',
@@ -54,96 +130,6 @@ const guides: Readonly<Guide[]> = Object.freeze([
     Logo: lazy(async () => import('./native-flutter/logo.svg')),
     Component: lazy(async () => import('./native-flutter/README.mdx')),
     metadata: nativeFlutter,
-  },
-  {
-    id: 'native-ios-swift',
-    Logo: lazy(async () => import('./native-ios-swift/logo.svg')),
-    Component: lazy(async () => import('./native-ios-swift/README.mdx')),
-    metadata: nativeIosSwift,
-  },
-  {
-    id: 'spa-react',
-    Logo: lazy(async () => import('./spa-react/logo.svg')),
-    Component: lazy(async () => import('./spa-react/README.mdx')),
-    metadata: spaReact,
-  },
-  {
-    id: 'spa-vanilla',
-    Logo: lazy(async () => import('./spa-vanilla/logo.svg')),
-    Component: lazy(async () => import('./spa-vanilla/README.mdx')),
-    metadata: spaVanilla,
-  },
-  {
-    id: 'spa-vue',
-    Logo: lazy(async () => import('./spa-vue/logo.svg')),
-    Component: lazy(async () => import('./spa-vue/README.mdx')),
-    metadata: spaVue,
-  },
-  {
-    id: 'web-csharp',
-    Logo: lazy(async () => import('./web-csharp/logo.svg')),
-    Component: lazy(async () => import('./web-csharp/README.mdx')),
-    metadata: webCsharp,
-  },
-  {
-    id: 'web-express',
-    Logo: lazy(async () => import('./web-express/logo.svg')),
-    Component: lazy(async () => import('./web-express/README.mdx')),
-    metadata: webExpress,
-  },
-  {
-    id: 'web-go',
-    Logo: lazy(async () => import('./web-go/logo.svg')),
-    Component: lazy(async () => import('./web-go/README.mdx')),
-    metadata: webGo,
-  },
-  {
-    id: 'web-gpt-plugin',
-    Logo: lazy(async () => import('./web-gpt-plugin/logo.svg')),
-    Component: lazy(async () => import('./web-gpt-plugin/README.mdx')),
-    metadata: webGptPlugin,
-  },
-  {
-    id: 'web-java',
-    Logo: lazy(async () => import('./web-java/logo.svg')),
-    Component: lazy(async () => import('./web-java/README.mdx')),
-    metadata: webJava,
-  },
-  {
-    id: 'web-next',
-    Logo: lazy(async () => import('./web-next/logo.svg')),
-    Component: lazy(async () => import('./web-next/README.mdx')),
-    metadata: webNext,
-  },
-  {
-    id: 'web-next-app-router',
-    Logo: lazy(async () => import('./web-next-app-router/logo.svg')),
-    Component: lazy(async () => import('./web-next-app-router/README.mdx')),
-    metadata: webNextAppRouter,
-  },
-  {
-    id: 'web-outline',
-    Logo: lazy(async () => import('./web-outline/logo.svg')),
-    Component: lazy(async () => import('./web-outline/README.mdx')),
-    metadata: webOutline,
-  },
-  {
-    id: 'web-php',
-    Logo: lazy(async () => import('./web-php/logo.svg')),
-    Component: lazy(async () => import('./web-php/README.mdx')),
-    metadata: webPhp,
-  },
-  {
-    id: 'web-python',
-    Logo: lazy(async () => import('./web-python/logo.svg')),
-    Component: lazy(async () => import('./web-python/README.mdx')),
-    metadata: webPython,
-  },
-  {
-    id: 'web-remix',
-    Logo: lazy(async () => import('./web-remix/logo.svg')),
-    Component: lazy(async () => import('./web-remix/README.mdx')),
-    metadata: webRemix,
   },
 ]);
 


### PR DESCRIPTION
adjust the app guide order

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Adjust the app guide order, also remove the web-java and web-csharp two guide entrance. 

<img width="1706" alt="image" src="https://github.com/logto-io/logto/assets/36393111/4872b9ca-49b7-44c3-8495-daaf58a57dee">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
