### PR TITLE
fix(console): resolve forwardRef warning in debugger console

### DIFF
--- a/packages/console/src/mdx-components-v2/Steps/FurtherReadings.tsx
+++ b/packages/console/src/mdx-components-v2/Steps/FurtherReadings.tsx
@@ -1,10 +1,14 @@
+import { type Ref, forwardRef } from 'react';
+
 import TextLink from '@/ds-components/TextLink';
 
-import Step, { type Props } from '../Step';
+import Step, { type Props as StepProps } from '../Step';
 
-export default function FurtherReadings(props: Omit<Props, 'children'>) {
+type Props = Omit<StepProps, 'children'>;
+
+function FurtherReadings(props: Props, ref?: Ref<HTMLDivElement>) {
   return (
-    <Step {...props}>
+    <Step ref={ref} {...props}>
       <ul>
         <li>
           <TextLink
@@ -46,3 +50,5 @@ export default function FurtherReadings(props: Omit<Props, 'children'>) {
     </Step>
   );
 }
+
+export default forwardRef<HTMLDivElement, Props>(FurtherReadings);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Resolve forwardRef warning in debugger console

![image](https://github.com/logto-io/logto/assets/12833674/f1a4171a-0905-40b7-a99a-a682c1847db1)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally. Warning is gone.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
- [x] This PR is not applicable for the checklist
