### PR TITLE
fix(console): getPathname() could result in duplicated tenant id segments

### DIFF
--- a/packages/console/src/hooks/use-tenant-pathname.ts
+++ b/packages/console/src/hooks/use-tenant-pathname.ts
@@ -73,7 +73,7 @@ function useTenantPathname(): TenantPathname {
   /** Returns the pathname with the current tenant ID prepended. */
   const getPathname = useCallback(
     (pathname: string) => {
-      if (pathname.startsWith('/')) {
+      if (pathname.startsWith('/') && !pathname.startsWith(`/${tenantSegment}`)) {
         return joinPath(tenantSegment, pathname);
       }
       // Directly return the pathname if it's a relative pathname


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
getPathname() could result in duplicated tenant id segments and lead to an empty console page.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
Can now successfully go use the backlink button to go back.
https://github.com/logto-io/logto/assets/15182327/d469688d-7beb-480b-a8be-460b54fc6d99

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
