### PR TITLE
fix(console): guide navigation anchors should be clickable and jump to the step

### DIFF
--- a/packages/console/src/mdx-components-v2/Steps/index.module.scss
+++ b/packages/console/src/mdx-components-v2/Steps/index.module.scss
@@ -40,8 +40,14 @@
   border-radius: 12px;
   border: 1px solid var(--color-surface-5);
   padding: _.unit(3) _.unit(4);
+  user-select: none;
+  cursor: pointer;
+
+  &:hover {
+    background: var(--color-surface-5);
+  }
 
   &.active {
-    background: var(--color-surface-1);
+    background: var(--color-focused-variant);
   }
 }

--- a/packages/console/src/mdx-components-v2/Steps/index.tsx
+++ b/packages/console/src/mdx-components-v2/Steps/index.tsx
@@ -4,6 +4,7 @@ import React, { useRef, type ReactElement, useEffect, useState, useMemo, useCont
 
 import useScroll from '@/hooks/use-scroll';
 import { GuideContext } from '@/pages/Applications/components/Guide';
+import { onKeyDownHandler } from '@/utils/a11y';
 
 import Sample from '../Sample';
 import { type Props as StepProps } from '../Step';
@@ -76,6 +77,13 @@ export default function Steps({ children: reactChildren }: Props) {
     setActiveIndex(reversedActiveIndex === -1 ? -1 : children.length - reversedActiveIndex - 1);
   }, [children.length, scrollTop]);
 
+  const navigateToStep = (index: number) => {
+    const stepRef = stepReferences.current[index];
+    if (stepRef) {
+      stepRef.scrollIntoView({ behavior: 'smooth' });
+    }
+  };
+
   return (
     <div className={classNames(styles.wrapper, isCompact && styles.fullWidth)}>
       {!isCompact && (
@@ -84,7 +92,15 @@ export default function Steps({ children: reactChildren }: Props) {
             {children.map((component, index) => (
               <div
                 key={component.props.title}
+                role="button"
+                tabIndex={0}
                 className={classNames(styles.stepper, index === activeIndex && styles.active)}
+                onKeyDown={onKeyDownHandler(() => {
+                  navigateToStep(index);
+                })}
+                onClick={() => {
+                  navigateToStep(index);
+                }}
               >
                 {index + 1}. {component.props.title}
               </div>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Click the navigation anchors in each guide should be navigated to the specified step.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested OK

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
- [x] This PR is not applicable for the checklist
