### PR TITLE
fix(console): remove pro tag from m2m app creation form in oss version

### DIFF
--- a/packages/console/src/pages/Applications/components/CreateForm/index.tsx
+++ b/packages/console/src/pages/Applications/components/CreateForm/index.tsx
@@ -6,6 +6,7 @@ import { useController, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import Modal from 'react-modal';
 
+import { isCloud } from '@/consts/env';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import DynamicT from '@/ds-components/DynamicT';
 import FormField from '@/ds-components/FormField';
@@ -39,7 +40,7 @@ type Props = {
 function CreateForm({ defaultCreateType, defaultCreateFrameworkName, onClose }: Props) {
   const { currentTenantId } = useContext(TenantsContext);
   const { data: currentPlan } = useSubscriptionPlan(currentTenantId);
-  const isMachineToMachineDisabled = !currentPlan?.quota.machineToMachineLimit;
+  const isMachineToMachineDisabled = isCloud && !currentPlan?.quota.machineToMachineLimit;
   const { updateConfigs } = useConfigs();
   const {
     handleSubmit,

--- a/packages/console/src/pages/Applications/components/CreateForm/index.tsx
+++ b/packages/console/src/pages/Applications/components/CreateForm/index.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import Modal from 'react-modal';
 
 import { TenantsContext } from '@/contexts/TenantsProvider';
+import DynamicT from '@/ds-components/DynamicT';
 import FormField from '@/ds-components/FormField';
 import ModalLayout from '@/ds-components/ModalLayout';
 import RadioGroup, { Radio } from '@/ds-components/RadioGroup';
@@ -31,10 +32,11 @@ type FormData = {
 
 type Props = {
   defaultCreateType?: ApplicationType;
+  defaultCreateFrameworkName?: string;
   onClose?: (createdApp?: Application) => void;
 };
 
-function CreateForm({ defaultCreateType, onClose }: Props) {
+function CreateForm({ defaultCreateType, defaultCreateFrameworkName, onClose }: Props) {
   const { currentTenantId } = useContext(TenantsContext);
   const { data: currentPlan } = useSubscriptionPlan(currentTenantId);
   const isMachineToMachineDisabled = !currentPlan?.quota.machineToMachineLimit;
@@ -86,13 +88,21 @@ function CreateForm({ defaultCreateType, onClose }: Props) {
     >
       <ModalLayout
         title="applications.create"
-        subtitle="applications.subtitle"
+        subtitle={
+          defaultCreateFrameworkName ? (
+            <DynamicT
+              forKey="applications.subtitle_with_app_type"
+              interpolation={{ name: defaultCreateFrameworkName }}
+            />
+          ) : (
+            'applications.subtitle'
+          )
+        }
         size="large"
         footer={<Footer selectedType={value} isLoading={isSubmitting} onClickCreate={onSubmit} />}
         onClose={onClose}
       >
         <form>
-          {defaultCreateType && <input hidden {...register('type')} value={defaultCreateType} />}
           {!defaultCreateType && (
             <FormField title="applications.select_application_type">
               <RadioGroup
@@ -139,6 +149,7 @@ function CreateForm({ defaultCreateType, onClose }: Props) {
               placeholder={t('applications.application_description_placeholder')}
             />
           </FormField>
+          {defaultCreateType && <input hidden {...register('type')} value={defaultCreateType} />}
         </form>
       </ModalLayout>
     </Modal>

--- a/packages/console/src/pages/Applications/components/GuideLibrary/index.tsx
+++ b/packages/console/src/pages/Applications/components/GuideLibrary/index.tsx
@@ -126,7 +126,11 @@ function GuideLibrary({ className, hasCardBorder, hasFilters }: Props) {
         </OverlayScrollbar>
       )}
       {selectedGuide?.target !== 'API' && showCreateForm && (
-        <CreateForm defaultCreateType={selectedGuide?.target} onClose={onCloseCreateForm} />
+        <CreateForm
+          defaultCreateType={selectedGuide?.target}
+          defaultCreateFrameworkName={selectedGuide?.name}
+          onClose={onCloseCreateForm}
+        />
       )}
     </div>
   );

--- a/packages/phrases/src/locales/de/translation/admin-console/applications.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/applications.ts
@@ -3,6 +3,7 @@ const applications = {
   title: 'Anwendungen',
   subtitle:
     'Richte eine native, single page, machine to machine oder herkömmliche Anwendung ein, die Logto zur Authentifizierung nutzt.',
+  subtitle_with_app_type: 'Set up Logto authentication for your {{name}} application', // UNTRANSLATED
   create: 'Anwendung erstellen',
   application_name: 'Anwendungsname',
   application_name_placeholder: 'Meine App',

--- a/packages/phrases/src/locales/en/translation/admin-console/applications.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/applications.ts
@@ -3,6 +3,7 @@ const applications = {
   title: 'Applications',
   subtitle:
     'Set up Logto authentication for your native, single page, machine to machine, or traditional application',
+  subtitle_with_app_type: 'Set up Logto authentication for your {{name}} application',
   create: 'Create Application',
   application_name: 'Application name',
   application_name_placeholder: 'My App',

--- a/packages/phrases/src/locales/es/translation/admin-console/applications.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/applications.ts
@@ -3,6 +3,7 @@ const applications = {
   title: 'Aplicaciones',
   subtitle:
     'Configura la autenticación de Logto para tu aplicación nativa, de página única, de máquina a máquina o tradicional',
+  subtitle_with_app_type: 'Set up Logto authentication for your {{name}} application', // UNTRANSLATED
   create: 'Crear aplicación',
   application_name: 'Nombre de la aplicación',
   application_name_placeholder: 'Mi App',

--- a/packages/phrases/src/locales/fr/translation/admin-console/applications.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/applications.ts
@@ -3,6 +3,7 @@ const applications = {
   title: 'Applications',
   subtitle:
     "Configurez une application mobile, une page unique, machine to machine ou une application traditionnelle pour utiliser Logto pour l'authentification.",
+  subtitle_with_app_type: 'Set up Logto authentication for your {{name}} application', // UNTRANSLATED
   create: 'Créer une application',
   application_name: "Nom de l'application",
   application_name_placeholder: 'Mon app',

--- a/packages/phrases/src/locales/it/translation/admin-console/applications.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/applications.ts
@@ -3,6 +3,7 @@ const applications = {
   title: 'Applicazioni',
   subtitle:
     "Configura l'autenticazione Logto per la tua applicazione nativa, a singola pagina, macchina-to-macchina o tradizionale",
+  subtitle_with_app_type: 'Set up Logto authentication for your {{name}} application', // UNTRANSLATED
   create: 'Crea Applicazione',
   application_name: 'Nome applicazione',
   application_name_placeholder: 'La mia App',

--- a/packages/phrases/src/locales/ja/translation/admin-console/applications.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/applications.ts
@@ -3,6 +3,7 @@ const applications = {
   title: 'アプリケーション ',
   subtitle:
     'ネイティブ、シングルページ、マシン・トゥ・マシン、または従来のアプリケーションにLogto認証を設定する',
+  subtitle_with_app_type: 'Set up Logto authentication for your {{name}} application', // UNTRANSLATED
   create: 'アプリケーションを作成する',
   application_name: 'アプリケーション名',
   application_name_placeholder: '私のアプリ',

--- a/packages/phrases/src/locales/ko/translation/admin-console/applications.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/applications.ts
@@ -3,6 +3,7 @@ const applications = {
   title: '어플리케이션',
   subtitle:
     '인증에 Logto를 사용할 모바일, 단일 페이지, Machine-to-Machine 또는 기존 어플리케이션을 설정할 수 있어요.',
+  subtitle_with_app_type: 'Set up Logto authentication for your {{name}} application', // UNTRANSLATED
   create: '어플리케이션 생성',
   application_name: '어플리케이션 이름',
   application_name_placeholder: '나의 앱',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/applications.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/applications.ts
@@ -3,6 +3,7 @@ const applications = {
   title: 'Aplikacje',
   subtitle:
     'Skonfiguruj uwierzytelnianie Logto dla Twojej aplikacji natywnej, jednostronicowej, komunikującej się bezpośrednio z zasobami lub tradycyjnej',
+  subtitle_with_app_type: 'Set up Logto authentication for your {{name}} application', // UNTRANSLATED
   create: 'Utwórz aplikację',
   application_name: 'Nazwa aplikacji',
   application_name_placeholder: 'Moja aplikacja',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/applications.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/applications.ts
@@ -3,6 +3,7 @@ const applications = {
   title: 'Aplicativos',
   subtitle:
     'Configure um aplicativo móvel, single page, machine to machine ou tradicional para usar o Logto para autenticação',
+  subtitle_with_app_type: 'Set up Logto authentication for your {{name}} application', // UNTRANSLATED
   create: 'Criar aplicativo',
   application_name: 'Nome do Aplicativo',
   application_name_placeholder: 'Meu aplicativo',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/applications.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/applications.ts
@@ -3,6 +3,7 @@ const applications = {
   title: 'Aplicações',
   subtitle:
     'Configure um aplicativo móvel, de página única, machine to machine ou tradicional para usar o Logto para autenticação',
+  subtitle_with_app_type: 'Set up Logto authentication for your {{name}} application', // UNTRANSLATED
   create: 'Criar aplicação',
   application_name: 'Nome da aplicação',
   application_name_placeholder: 'Ex: Site Empresa',

--- a/packages/phrases/src/locales/ru/translation/admin-console/applications.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/applications.ts
@@ -3,6 +3,7 @@ const applications = {
   title: 'Заявки',
   subtitle:
     'Настроить аутентификацию Logto для вашего нативного, одностраничного, машина-машина или традиционного приложения.',
+  subtitle_with_app_type: 'Set up Logto authentication for your {{name}} application', // UNTRANSLATED
   create: 'Создать заявку',
   application_name: 'Название приложения',
   application_name_placeholder: 'Мое приложение',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/applications.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/applications.ts
@@ -3,6 +3,7 @@ const applications = {
   title: 'Uygulamalar',
   subtitle:
     'Kimlik doğrulaması için Logtoyu kullanmak üzere mobil, tek sayfa, machine to machine veya geleneksel bir uygulama ayarlayınız',
+  subtitle_with_app_type: 'Set up Logto authentication for your {{name}} application', // UNTRANSLATED
   create: 'Uygulama oluştur',
   application_name: 'Uygulama adı',
   application_name_placeholder: 'Uygulamam',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/applications.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/applications.ts
@@ -2,6 +2,7 @@ const applications = {
   page_title: '全部应用',
   title: '全部应用',
   subtitle: '创建一个移动、单页、machine-to-machine 或传统 web 应用程序，并通过 Logto 进行身份验证',
+  subtitle_with_app_type: 'Set up Logto authentication for your {{name}} application', // UNTRANSLATED
   create: '创建应用',
   application_name: '应用名称',
   application_name_placeholder: '我的应用',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/applications.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/applications.ts
@@ -2,6 +2,7 @@ const applications = {
   page_title: '全部應用',
   title: '全部應用',
   subtitle: '創建一個移動、單頁、machine to machine 或傳統 web 應用程序，並通過 Logto 進行身份驗證',
+  subtitle_with_app_type: 'Set up Logto authentication for your {{name}} application', // UNTRANSLATED
   create: '創建應用',
   application_name: '應用名稱',
   application_name_placeholder: '我的應用',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/applications.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/applications.ts
@@ -2,6 +2,7 @@ const applications = {
   page_title: '全部應用',
   title: '全部應用',
   subtitle: '創建一個移動、單頁、machine to machine 或傳統 web 應用程序，並通過 Logto 進行身份驗證',
+  subtitle_with_app_type: 'Set up Logto authentication for your {{name}} application', // UNTRANSLATED
   create: '創建應用',
   application_name: '應用名稱',
   application_name_placeholder: '我的應用',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Remove the "Pro" tag from app creation form for M2M type app in OSS version. Since we don't limit the usage of M2M in OSS distributions.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
No "Pro" tag in OSS app creation form for M2M.

<img width="813" alt="image" src="https://github.com/logto-io/logto/assets/12833674/e908ee95-0a34-4128-839e-ddff2011895d">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
- [x] This PR is not applicable for the checklist
