### PR TITLE
fix(console): invalid guide url should show 404 not found

### DIFF
--- a/packages/console/src/pages/Applications/components/Guide/index.module.scss
+++ b/packages/console/src/pages/Applications/components/Guide/index.module.scss
@@ -55,6 +55,14 @@
   margin-top: _.unit(6);
 }
 
+.notFound {
+  width: 100%;
+
+  svg {
+    margin-top: 10%;
+  }
+}
+
 .actionBar {
   position: absolute;
   inset: auto 0 0 0;

--- a/packages/console/src/pages/NotFound/index.tsx
+++ b/packages/console/src/pages/NotFound/index.tsx
@@ -1,4 +1,5 @@
 import { Theme } from '@logto/schemas';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 
@@ -10,13 +11,17 @@ import useTheme from '@/hooks/use-theme';
 
 import * as styles from './index.module.scss';
 
-function NotFound() {
+type Props = {
+  className?: string;
+};
+
+function NotFound({ className }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const theme = useTheme();
   const location = useLocation();
 
   return (
-    <div className={styles.container}>
+    <div className={classNames(styles.container, className)}>
       {/* Don't track "not found" for the root path as it will be redirected. */}
       <PageMeta titleKey="errors.page_not_found" trackPageView={location.pathname !== '/'} />
       <Card className={styles.content}>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Manually visit an invalid guide URL will end up showing `404 not found` instead of error stack.

Before:
<img width="1325" alt="image" src="https://github.com/logto-io/logto/assets/12833674/7e46d8fa-1737-4df9-bff0-d2a8f886189c">

After:
<img width="1511" alt="image" src="https://github.com/logto-io/logto/assets/12833674/630c7bdf-b09a-470c-8e0e-65ffe94242dc">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Manually tested OK. See screenshot above.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
- [x] This PR is not applicable for the checklist
