### PR TITLE
fix(console): remove inspire me phone as identifier options

### DIFF
--- a/packages/console/src/onboarding/pages/SignInExperience/sie-config-templates.ts
+++ b/packages/console/src/onboarding/pages/SignInExperience/sie-config-templates.ts
@@ -20,52 +20,31 @@ const configTemplate1: OnboardingSieConfig = {
 };
 
 const configTemplate2: OnboardingSieConfig = {
-  logo: `${assetsUrl}/kvCN1Z2a/logo2.png`,
-  color: '#F47346',
-  identifier: SignInIdentifier.Phone,
-  authentications: [Authentication.Password, Authentication.VerificationCode],
-};
-
-const configTemplate3: OnboardingSieConfig = {
   logo: `${assetsUrl}/IcI0snBP/logo3.png`,
   color: '#FF5449',
   identifier: SignInIdentifier.Username,
   authentications: [Authentication.Password],
 };
 
-const configTemplate4: OnboardingSieConfig = {
+const configTemplate3: OnboardingSieConfig = {
   logo: `${assetsUrl}/7UQyvuFc/logo4.png`,
   color: '#CA4E96',
   identifier: SignInIdentifier.Email,
   authentications: [Authentication.Password],
 };
 
-const configTemplate5: OnboardingSieConfig = {
+const configTemplate4: OnboardingSieConfig = {
   logo: `${assetsUrl}/zB2merH1/logo5.png`,
   color: '#F07EFF',
   identifier: SignInIdentifier.Email,
   authentications: [Authentication.VerificationCode],
 };
 
-const configTemplate6: OnboardingSieConfig = {
-  logo: `${assetsUrl}/CX51jxXS/logo6.png`,
-  color: '#9E65F8',
-  identifier: SignInIdentifier.Phone,
-  authentications: [Authentication.VerificationCode],
-};
-
-const configTemplate7: OnboardingSieConfig = {
+const configTemplate5: OnboardingSieConfig = {
   logo: `${assetsUrl}/uLoMzrlz/logo7.png`,
   color: '#FF5449',
   identifier: SignInIdentifier.Email,
   authentications: [Authentication.Password, Authentication.VerificationCode],
-};
-
-const configTemplate8: OnboardingSieConfig = {
-  logo: `${assetsUrl}/dIz8UHEh/logo8.png`,
-  color: '#5D34F2',
-  identifier: SignInIdentifier.Phone,
-  authentications: [Authentication.VerificationCode],
 };
 
 const sieConfigTemplates: OnboardingSieConfig[] = [
@@ -74,9 +53,6 @@ const sieConfigTemplates: OnboardingSieConfig[] = [
   configTemplate3,
   configTemplate4,
   configTemplate5,
-  configTemplate6,
-  configTemplate7,
-  configTemplate8,
 ];
 
 export const randomSieConfigTemplate = (


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
remove inspire me the phone as identifier option.
Since we removed the phone as identifier option before, the randomly generated SIE can not contain this option either.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
