### PR TITLE
fix(console): app guard cards in drawer view should not have buttons

### DIFF
--- a/packages/console/src/pages/Applications/components/GuideCard/index.tsx
+++ b/packages/console/src/pages/Applications/components/GuideCard/index.tsx
@@ -27,10 +27,6 @@ type Props = {
   isCompact?: boolean;
 };
 
-function LogoSkeleton() {
-  return <div className={styles.logoSkeleton} />;
-}
-
 function GuideCard({ data, onClick, hasBorder, isCompact }: Props) {
   const { navigate } = useTenantPathname();
   const { currentTenantId } = useContext(TenantsContext);
@@ -68,7 +64,7 @@ function GuideCard({ data, onClick, hasBorder, isCompact }: Props) {
       })}
     >
       <div className={styles.header}>
-        <Suspense fallback={<LogoSkeleton />}>
+        <Suspense fallback={<div className={styles.logoSkeleton} />}>
           <Logo className={styles.logo} />
         </Suspense>
         <div className={styles.infoWrapper}>
@@ -79,17 +75,21 @@ function GuideCard({ data, onClick, hasBorder, isCompact }: Props) {
           <div className={styles.description}>{description}</div>
         </div>
       </div>
-      <Button
-        title={isSubscriptionRequired ? 'upsell.upgrade_plan' : 'applications.guide.start_building'}
-        size="small"
-        onClick={() => {
-          if (isSubscriptionRequired) {
-            navigate(subscriptionPage);
-          } else {
-            onClick({ id, target, name });
+      {!isCompact && (
+        <Button
+          title={
+            isSubscriptionRequired ? 'upsell.upgrade_plan' : 'applications.guide.start_building'
           }
-        }}
-      />
+          size="small"
+          onClick={() => {
+            if (isSubscriptionRequired) {
+              navigate(subscriptionPage);
+            } else {
+              onClick({ id, target, name });
+            }
+          }}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
App guard cards in drawer view should not have "Start building" buttons

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

BEFORE:
<img width="1259" alt="image" src="https://github.com/logto-io/logto/assets/12833674/0d496c40-8b5d-48da-b8f6-f997d3eb74ab">

AFTER:
<img width="1563" alt="image" src="https://github.com/logto-io/logto/assets/12833674/301225b0-a1e2-42d5-9f15-4368ec951871">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
- [x] This PR is not applicable for the checklist
