### PR TITLE
style(console): add margin around input fields in app guide

### DIFF
--- a/packages/console/src/mdx-components-v2/UriInputField/index.module.scss
+++ b/packages/console/src/mdx-components-v2/UriInputField/index.module.scss
@@ -18,3 +18,7 @@
     margin: _.unit(6) 0 0 _.unit(2);
   }
 }
+
+form {
+  margin: _.unit(4) 0;
+}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add margin around URI input fields in app integration guides.

Before:
<img width="1249" alt="image" src="https://github.com/logto-io/logto/assets/12833674/0d208127-1236-415d-81cb-af617f6b26cb">

After:
<img width="770" alt="image" src="https://github.com/logto-io/logto/assets/12833674/9abcf68c-bdd7-46da-85e2-830e10cf7f31">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested OK

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
- [x] This PR is not applicable for the checklist
