### PR TITLE
fix(console): use correct sign-out redirect uri for api hooks

### DIFF
--- a/packages/console/src/hooks/use-api.ts
+++ b/packages/console/src/hooks/use-api.ts
@@ -6,13 +6,13 @@ import ky from 'ky';
 import { useCallback, useContext, useMemo } from 'react';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
-import { useHref } from 'react-router-dom';
 
 import { requestTimeout } from '@/consts';
 import { AppDataContext } from '@/contexts/AppDataProvider';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 
 import { useConfirmModal } from './use-confirm-modal';
+import useRedirectUri from './use-redirect-uri';
 
 export class RequestError extends Error {
   constructor(
@@ -33,7 +33,7 @@ export const useStaticApi = ({ prefixUrl, hideErrorToast, resourceIndicator }: S
   const { isAuthenticated, getAccessToken, signOut } = useLogto();
   const { t, i18n } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { show } = useConfirmModal();
-  const href = useHref('/');
+  const postSignOutRedirectUri = useRedirectUri('signOut');
 
   const toastError = useCallback(
     async (response: Response) => {
@@ -51,7 +51,7 @@ export const useStaticApi = ({ prefixUrl, hideErrorToast, resourceIndicator }: S
             cancelButtonText: 'general.got_it',
           });
 
-          await signOut(href);
+          await signOut(postSignOutRedirectUri.href);
           return;
         }
 
@@ -60,7 +60,7 @@ export const useStaticApi = ({ prefixUrl, hideErrorToast, resourceIndicator }: S
         toast.error(httpCodeToMessage[response.status] ?? fallbackErrorMessage);
       }
     },
-    [show, signOut, t, href]
+    [show, signOut, t, postSignOutRedirectUri]
   );
 
   const api = useMemo(
@@ -73,7 +73,6 @@ export const useStaticApi = ({ prefixUrl, hideErrorToast, resourceIndicator }: S
             !hideErrorToast &&
               (async (error) => {
                 await toastError(error.response);
-
                 return error;
               })
           ),

--- a/packages/console/src/hooks/use-redirect-uri.ts
+++ b/packages/console/src/hooks/use-redirect-uri.ts
@@ -1,5 +1,5 @@
 import { ossConsolePath } from '@logto/schemas';
-import { conditionalArray } from '@silverhand/essentials';
+import { conditionalArray, joinPath } from '@silverhand/essentials';
 import { useHref } from 'react-router-dom';
 
 import { isCloud } from '@/consts/env';
@@ -11,7 +11,7 @@ import { isCloud } from '@/consts/env';
  */
 const useRedirectUri = (flow: 'signIn' | 'signOut' = 'signIn') => {
   const path = useHref(
-    conditionalArray(!isCloud && ossConsolePath, flow === 'signIn' && '/callback').join('')
+    joinPath(...conditionalArray(!isCloud && ossConsolePath, flow === 'signIn' ? '/callback' : '/'))
   );
 
   return new URL(path, window.location.origin);


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
a fix of #4385, explicitly use `/` for `useHref` otherwise the function will return the path of the current location instead of the root path.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
passed CI in https://github.com/logto-io/cloud/pull/250

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] This PR is not applicable for the checklist
