### PR TITLE
fix(console): remove 'unhandledrejection' listener from ErrorBoundary

### DIFF
--- a/packages/console/src/containers/ErrorBoundary/index.tsx
+++ b/packages/console/src/containers/ErrorBoundary/index.tsx
@@ -35,24 +35,6 @@ class ErrorBoundary extends Component<Props, State> {
 
   public state: State = {};
 
-  promiseRejectionHandler(error: unknown) {
-    this.setState(
-      ErrorBoundary.getDerivedStateFromError(
-        error instanceof Error ? error : new Error(String(error))
-      )
-    );
-  }
-
-  componentDidMount(): void {
-    window.addEventListener('unhandledrejection', (event) => {
-      this.promiseRejectionHandler(event.reason);
-    });
-  }
-
-  componentWillUnmount(): void {
-    window.removeEventListener('unhandledrejection', this.promiseRejectionHandler);
-  }
-
   render() {
     const { children, t } = this.props;
     const { error } = this.state;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Remove `unhandledrejection` event listener from `ErrorBoundary` component, in order not to show `TypeError: Failed to fetch` when any 3rd party lib or script is blocked by client or failed in prod env.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Pending Cloud prod online testing.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
- [x] This PR is not applicable for the checklist
