### PR TITLE
fix: remove connector link from session storage

### DIFF
--- a/packages/ui/src/hooks/use-social-callback-handler.ts
+++ b/packages/ui/src/hooks/use-social-callback-handler.ts
@@ -1,7 +1,10 @@
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { getCallbackLinkFromStorage } from '@/utils/social-connectors';
+import {
+  getCallbackLinkFromStorage,
+  removeCallbackLinkFromStorage,
+} from '@/utils/social-connectors';
 
 const useSocialCallbackHandler = () => {
   const navigate = useNavigate();
@@ -19,6 +22,7 @@ const useSocialCallbackHandler = () => {
 
       // Get native callback link from storage
       const callbackLink = getCallbackLinkFromStorage(connectorId);
+      removeCallbackLinkFromStorage(connectorId);
 
       if (callbackLink) {
         window.location.replace(new URL(`${callbackLink}${search}`));

--- a/packages/ui/src/utils/social-connectors.ts
+++ b/packages/ui/src/utils/social-connectors.ts
@@ -56,6 +56,10 @@ export const getCallbackLinkFromStorage = (connectorId: string) => {
   return sessionStorage.getItem(`${storageCallbackLinkKeyPrefix}:${connectorId}`);
 };
 
+export const removeCallbackLinkFromStorage = (connectorId: string) => {
+  sessionStorage.removeItem(`${storageCallbackLinkKeyPrefix}:${connectorId}`);
+};
+
 /**
  * Social Connectors Filter Utility Methods
  */


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
This PR fixes how we handle the social connector callback storage. We do not remove the callback url from the session storage after we're done with the whole connection flow. This becomes as an issue when implementing a **Settings** page like functionality in an application & callback url is your application instead of Logto.

This is the flow:
1. Implement a settings page like the one available inside Logto cloud offering, where we have the option to connection multiple social profiles for a user
![image](https://github.com/logto-io/logto/assets/10788442/40fa48cd-6b35-4073-b775-18d7557e748d)
2. Use a custom logic for handling `link-identity` functionality using the [/api/users/:userId/identities](https://docs.logto.io/api/#tag/Users/paths/~1api~1users~1:userId~1identities/post). This also means that you need to use a different callback url that the logto callback url. This is what gets stored inside the session store of the logto instance on client side
3. Perform the operations & succeed with linking user identity
4. Logout & try to log back in, follow the authorization flow.
5. The connector authz page tries to redirect you back to the `callback url` stored within the session store of logto instance which is different than the logto callback url registered within the Logto application. This causes a behaviour where user never gets logged in.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
