### PR TITLE
fix(console): remove unexpected margin top from form elements

### DIFF
--- a/packages/console/src/mdx-components-v2/UriInputField/index.module.scss
+++ b/packages/console/src/mdx-components-v2/UriInputField/index.module.scss
@@ -19,6 +19,9 @@
   }
 }
 
-form {
+/* Avoid using element selector directly in mdx components, as it will
+ * affect all elements in the entire admin console app.
+ */
+.form {
   margin: _.unit(4) 0;
 }

--- a/packages/console/src/mdx-components-v2/UriInputField/index.tsx
+++ b/packages/console/src/mdx-components-v2/UriInputField/index.tsx
@@ -86,7 +86,7 @@ function UriInputField({ name, defaultValue }: Props) {
 
   return (
     <FormProvider {...methods}>
-      <form>
+      <form className={styles.form}>
         <Controller
           name={name}
           control={control}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the issue that unexpected margin top was added to all form elements across the admin console app, which was introduced by using element selector CSS in a mdx component.

Parcel compiles SCSS from all mdx components in a separated css file and this css file will affect all DOM elements globally. We should be aware of this and avoid using globally impactful CSS selectors in mdx components.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested and unexpected form margin top is gone.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
- [x] This PR is not applicable for the checklist
