### PR TITLE
fix(console): block margin should be the same on get-started page

### DIFF
--- a/packages/console/src/pages/GetStarted/FreePlanNotification/index.module.scss
+++ b/packages/console/src/pages/GetStarted/FreePlanNotification/index.module.scss
@@ -8,7 +8,6 @@
   justify-content: space-between;
   align-items: center;
   gap: _.unit(6);
-  margin-bottom: _.unit(4);
 
   .image {
     flex-shrink: 0;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Remove unnecessary margin space on get-started page.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Before:
![image](https://github.com/logto-io/logto/assets/12833674/6a78dca2-0405-4d87-8282-fdf02a3dc8a9)

After:
<img width="1201" alt="image" src="https://github.com/logto-io/logto/assets/12833674/8605fbe4-e3d5-41db-bf70-79ff7df7e43c">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] docs~~

OR

- [x] This PR is not applicable for the checklist
