### PR TITLE
fix(console): update default tenant id on manual navigation only

### DIFF
--- a/packages/console/src/containers/AppContent/components/Topbar/TenantSelector/index.tsx
+++ b/packages/console/src/containers/AppContent/components/Topbar/TenantSelector/index.tsx
@@ -9,6 +9,7 @@ import { TenantsContext } from '@/contexts/TenantsProvider';
 import Divider from '@/ds-components/Divider';
 import Dropdown from '@/ds-components/Dropdown';
 import OverlayScrollbar from '@/ds-components/OverlayScrollbar';
+import useUserDefaultTenantId from '@/hooks/use-user-default-tenant-id';
 import { onKeyDownHandler } from '@/utils/a11y';
 
 import TenantDropdownItem from './TenantDropdownItem';
@@ -28,6 +29,7 @@ export default function TenantSelector() {
   const anchorRef = useRef<HTMLDivElement>(null);
   const [showDropdown, setShowDropdown] = useState(false);
   const [showCreateTenantModal, setShowCreateTenantModal] = useState(false);
+  const { updateDefaultTenantId } = useUserDefaultTenantId();
 
   if (tenants.length === 0 || !currentTenantInfo) {
     return null;
@@ -69,6 +71,7 @@ export default function TenantSelector() {
               isSelected={tenantData.id === currentTenantId}
               onClick={() => {
                 navigateTenant(tenantData.id);
+                void updateDefaultTenantId(tenantData.id);
                 setShowDropdown(false);
               }}
             />

--- a/packages/console/src/containers/TenantAccess/index.tsx
+++ b/packages/console/src/containers/TenantAccess/index.tsx
@@ -10,7 +10,6 @@ import AppLoading from '@/components/AppLoading';
 // eslint-disable-next-line unused-imports/no-unused-imports
 import type ProtectedRoutes from '@/containers/ProtectedRoutes';
 import { TenantsContext } from '@/contexts/TenantsProvider';
-import useUserDefaultTenantId from '@/hooks/use-user-default-tenant-id';
 
 /**
  * The container that ensures the user has access to the current tenant. When the user is
@@ -47,7 +46,6 @@ export default function TenantAccess() {
   const { getAccessToken, signIn, isAuthenticated } = useLogto();
   const { currentTenant, currentTenantId, currentTenantStatus, setCurrentTenantStatus } =
     useContext(TenantsContext);
-  const { updateIfNeeded } = useUserDefaultTenantId();
   const { mutate } = useSWRConfig();
 
   // Clean the cache when the current tenant ID changes. This is required because the
@@ -103,13 +101,6 @@ export default function TenantAccess() {
     setCurrentTenantStatus,
     signIn,
   ]);
-
-  // Update the user's default tenant ID if the current tenant is validated.
-  useEffect(() => {
-    if (currentTenantStatus === 'validated') {
-      void updateIfNeeded();
-    }
-  }, [currentTenantStatus, updateIfNeeded]);
 
   return currentTenantStatus === 'validated' ? <Outlet /> : <AppLoading />;
 }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
remove the automatic default tenant id update logic since it causes infinite loop and it's hard to debug. update on manually switching only to make it more clear and maintainable.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- manually switch tenant multiple times, default tenant id update and no infinite loop

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~~`.changeset`~~
- [ ] ~~unit tests~~
- [ ] integration tests (we may add some tests for this, not sure how)
- [ ] ~~docs~~
