### PR TITLE
feat(console): password policy

### DIFF
--- a/packages/console/src/ds-components/TextInput/NumericInput.module.scss
+++ b/packages/console/src/ds-components/TextInput/NumericInput.module.scss
@@ -1,0 +1,39 @@
+@use '@/scss/underscore' as _;
+
+.container {
+  position: absolute;
+  // The design is 2px off from the edge of the input, while the input has 1px border.
+  right: 1px;
+  top: 1px;
+  bottom: 1px;
+
+  .button {
+    width: 32px;
+    height: 16px;
+    margin: 0;
+    padding-inline: 0;
+    padding-block: 0;
+    padding: 0 _.unit(2);
+
+    &.disabled > svg {
+      color: var(--color-disabled);
+    }
+
+    &:not(.disabled):hover {
+      cursor: pointer;
+      background: var(--color-hover);
+    }
+
+    &:not(.disabled):active {
+      background: var(--color-pressed);
+    }
+
+    &.up {
+      border-radius: 6px 6px 2px 2px;
+    }
+
+    &.down {
+      border-radius: 2px 2px 6px 6px;
+    }
+  }
+}

--- a/packages/console/src/ds-components/TextInput/NumericInput.tsx
+++ b/packages/console/src/ds-components/TextInput/NumericInput.tsx
@@ -1,0 +1,89 @@
+import classNames from 'classnames';
+import { type ComponentProps } from 'react';
+
+import CaretDown from '@/assets/icons/caret-down.svg';
+import CaretUp from '@/assets/icons/caret-up.svg';
+import { onKeyDownHandler } from '@/utils/a11y';
+
+import * as styles from './NumericInput.module.scss';
+import TextInput from './index';
+
+type ButtonProps = {
+  className?: string;
+  onTrigger?: (
+    event: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>
+  ) => void;
+  children: React.ReactNode;
+  isDisabled?: boolean;
+};
+
+function Button({ className, onTrigger, children, isDisabled }: ButtonProps) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      className={classNames(styles.button, isDisabled && styles.disabled, className)}
+      aria-disabled={isDisabled}
+      onKeyDown={onKeyDownHandler(onTrigger)}
+      onClick={(event) => {
+        event.preventDefault();
+        if (isDisabled) {
+          return;
+        }
+        onTrigger?.(event);
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+type Props = Omit<ComponentProps<typeof TextInput>, 'type' | 'suffix'> & {
+  /** The event handler for when the value is incremented by the up button. */
+  onValueUp: ButtonProps['onTrigger'];
+  /** The event handler for when the value is decremented by the down button. */
+  onValueDown: ButtonProps['onTrigger'];
+};
+
+/** A numeric text input with up and down buttons for incrementing and decrementing the value. */
+function NumericInput({ onValueUp, onValueDown, ...props }: Props) {
+  const isDisabled = Boolean(props.disabled) || Boolean(props.readOnly);
+
+  return (
+    <TextInput
+      {...props}
+      alwaysShowSuffix
+      type="number"
+      suffix={
+        <div className={styles.container}>
+          <Button
+            className={styles.up}
+            isDisabled={
+              isDisabled ||
+              (props.value !== undefined &&
+                props.max !== undefined &&
+                Number(props.value) >= Number(props.max))
+            }
+            onTrigger={onValueUp}
+          >
+            <CaretUp />
+          </Button>
+          <Button
+            className={styles.down}
+            isDisabled={
+              isDisabled ||
+              (props.value !== undefined &&
+                props.min !== undefined &&
+                Number(props.value) <= Number(props.min))
+            }
+            onTrigger={onValueDown}
+          >
+            <CaretDown />
+          </Button>
+        </div>
+      }
+    />
+  );
+}
+
+export default NumericInput;

--- a/packages/console/src/ds-components/TextInput/index.module.scss
+++ b/packages/console/src/ds-components/TextInput/index.module.scss
@@ -4,6 +4,10 @@
   width: _.unit(8);
   height: _.unit(8);
   display: none;
+
+  &.visible {
+    display: block;
+  }
 }
 
 .hideTextContainerContent {
@@ -13,6 +17,7 @@
 }
 
 .container {
+  position: relative;
   display: flex;
   align-items: center;
   border-radius: 6px;

--- a/packages/console/src/ds-components/TextInput/index.tsx
+++ b/packages/console/src/ds-components/TextInput/index.tsx
@@ -21,7 +21,14 @@ import * as styles from './index.module.scss';
 type Props = Omit<HTMLProps<HTMLInputElement>, 'size'> & {
   error?: string | boolean;
   icon?: ReactElement;
-  suffix?: ReactElement;
+  /**
+   * An element to be rendered on the right side of the input.
+   * By default, the suffix is only visible when the input is focused.
+   */
+  suffix?: ReactElement<Record<string, unknown>>;
+  /** Whether to always show the suffix. */
+  // eslint-disable-next-line react/boolean-prop-naming
+  alwaysShowSuffix?: boolean;
   isConfidential?: boolean;
 };
 
@@ -30,6 +37,7 @@ function TextInput(
     error,
     icon,
     suffix,
+    alwaysShowSuffix = false,
     disabled,
     className,
     readOnly,
@@ -95,7 +103,13 @@ function TextInput(
         <input type={type} {...rest} ref={innerRef} disabled={disabled} readOnly={readOnly} />
         {suffixIcon &&
           cloneElement(suffixIcon, {
-            className: classNames([suffixIcon.props.className, styles.suffix]),
+            className: classNames(
+              // Handle by classNames
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+              suffixIcon.props.className,
+              styles.suffix,
+              alwaysShowSuffix && styles.visible
+            ),
           })}
       </div>
       {Boolean(error) && typeof error === 'string' && (

--- a/packages/console/src/pages/SignInExperience/index.tsx
+++ b/packages/console/src/pages/SignInExperience/index.tsx
@@ -32,6 +32,7 @@ import usePreviewConfigs from './hooks/use-preview-configs';
 import * as styles from './index.module.scss';
 import Branding from './tabs/Branding';
 import Content from './tabs/Content';
+import PasswordPolicy from './tabs/PasswordPolicy';
 import SignUpAndSignIn from './tabs/SignUpAndSignIn';
 import type { SignInExperienceForm } from './types';
 import {
@@ -46,6 +47,7 @@ export enum SignInExperienceTab {
   Branding = 'branding',
   SignUpAndSignIn = 'sign-up-and-sign-in',
   Content = 'content',
+  PasswordPolicy = 'password-policy',
 }
 
 const PageTab = TabNavItem<`../${SignInExperienceTab}`>;
@@ -212,6 +214,7 @@ function SignInExperience() {
         <PageTab href="../content" errorCount={getContentErrorCount(errors)}>
           {t('sign_in_exp.tabs.content')}
         </PageTab>
+        <PageTab href="../password-policy">{t('sign_in_exp.tabs.password_policy')}</PageTab>
       </TabNav>
       {data && defaultFormData && (
         <div className={styles.content}>
@@ -221,6 +224,7 @@ function SignInExperience() {
                 <Branding isActive={tab === SignInExperienceTab.Branding} />
                 <SignUpAndSignIn isActive={tab === SignInExperienceTab.SignUpAndSignIn} />
                 <Content isActive={tab === SignInExperienceTab.Content} />
+                <PasswordPolicy isActive={tab === SignInExperienceTab.PasswordPolicy} />
               </form>
             </FormProvider>
             {formData.id && (

--- a/packages/console/src/pages/SignInExperience/index.tsx
+++ b/packages/console/src/pages/SignInExperience/index.tsx
@@ -214,7 +214,10 @@ function SignInExperience() {
         <PageTab href="../content" errorCount={getContentErrorCount(errors)}>
           {t('sign_in_exp.tabs.content')}
         </PageTab>
-        <PageTab href="../password-policy">{t('sign_in_exp.tabs.password_policy')}</PageTab>
+        {/* Uncomment until all the changes are merged */}
+        {isCloud && (
+          <PageTab href="../password-policy">{t('sign_in_exp.tabs.password_policy')}</PageTab>
+        )}
       </TabNav>
       {data && defaultFormData && (
         <div className={styles.content}>

--- a/packages/console/src/pages/SignInExperience/index.tsx
+++ b/packages/console/src/pages/SignInExperience/index.tsx
@@ -214,7 +214,7 @@ function SignInExperience() {
         <PageTab href="../content" errorCount={getContentErrorCount(errors)}>
           {t('sign_in_exp.tabs.content')}
         </PageTab>
-        {/* Uncomment until all the changes are merged */}
+        {/* Remove the `isCloud` check until all the changes are merged */}
         {isCloud && (
           <PageTab href="../password-policy">{t('sign_in_exp.tabs.password_policy')}</PageTab>
         )}

--- a/packages/console/src/pages/SignInExperience/tabs/PasswordPolicy/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/tabs/PasswordPolicy/index.module.scss
@@ -1,0 +1,34 @@
+@use '@/scss/underscore' as _;
+
+.characterTypes {
+  display: flex;
+  gap: _.unit(6);
+}
+
+.passwordOption {
+  // Every password option should be put in a `<FormField>` component, a margin
+  // is added to the component to separate it from the previous one or the title.
+  margin-top: _.unit(3);
+  font: var(--font-body-2);
+
+  > div[role='checkbox'] {
+    align-items: flex-start;
+  }
+
+  .label {
+    white-space: normal;
+
+    .title {
+      color: var(--color-text);
+    }
+
+    .description {
+      color: var(--color-text-secondary);
+      margin-top: _.unit(0.5);
+    }
+
+    .textarea {
+      margin-top: _.unit(1);
+    }
+  }
+}

--- a/packages/console/src/pages/SignInExperience/tabs/PasswordPolicy/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/tabs/PasswordPolicy/index.module.scss
@@ -1,5 +1,10 @@
 @use '@/scss/underscore' as _;
 
+.minLength > div[class*='container'] {
+  // From Figma design
+  max-width: 156px;
+}
+
 .characterTypes {
   display: flex;
   gap: _.unit(6);

--- a/packages/console/src/pages/SignInExperience/tabs/PasswordPolicy/index.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/PasswordPolicy/index.tsx
@@ -10,7 +10,7 @@ import Checkbox from '@/ds-components/Checkbox/Checkbox';
 import FormField from '@/ds-components/FormField';
 import RadioGroup, { Radio } from '@/ds-components/RadioGroup';
 import TabWrapper from '@/ds-components/TabWrapper';
-import TextInput from '@/ds-components/TextInput';
+import NumericInput from '@/ds-components/TextInput/NumericInput';
 import Textarea from '@/ds-components/Textarea';
 
 import { type SignInExperienceForm } from '../../types';
@@ -62,7 +62,7 @@ function PasswordPolicy({ isActive }: Props) {
     getValues,
     formState: { errors },
   } = useFormContext<SignInExperienceForm>();
-  const maxPasswordLength = getValues('passwordPolicy.length.max');
+  const { max } = getValues('passwordPolicy.length');
   const { t } = useTranslation(undefined, {
     keyPrefix: 'admin_console.sign_in_exp.password_policy',
   });
@@ -76,26 +76,40 @@ function PasswordPolicy({ isActive }: Props) {
         <div className={commonStyles.title}>{t('password_requirements')}</div>
         <FormField title="sign_in_exp.password_policy.minimum_length">
           <div className={commonStyles.formFieldDescription}>
-            {t('minimum_length_description', { max: maxPasswordLength })}
+            {t('minimum_length_description', { max })}
           </div>
           <Controller
             name="passwordPolicy.length.min"
             control={control}
             rules={{
               min: 1,
-              max: maxPasswordLength,
+              max,
             }}
             render={({ field: { onChange, value, name } }) => (
-              <TextInput
+              <NumericInput
+                className={styles.minLength}
                 name={name}
-                type="number"
                 value={String(value)}
+                min={1}
+                max={max}
                 error={
-                  errors.passwordPolicy?.length?.min &&
-                  t('minimum_length_error', { min: 1, max: maxPasswordLength })
+                  errors.passwordPolicy?.length?.min && t('minimum_length_error', { min: 1, max })
                 }
                 onChange={(event: ChangeEvent<HTMLInputElement>) => {
                   onChange(Number(event.target.value));
+                }}
+                onValueUp={() => {
+                  onChange(value + 1);
+                }}
+                onValueDown={() => {
+                  onChange(value - 1);
+                }}
+                onBlur={() => {
+                  if (value < 1) {
+                    onChange(1);
+                  } else if (value > max) {
+                    onChange(max);
+                  }
                 }}
               />
             )}

--- a/packages/console/src/pages/SignInExperience/tabs/PasswordPolicy/index.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/PasswordPolicy/index.tsx
@@ -1,0 +1,176 @@
+import { PasswordPolicyChecker } from '@logto/core-kit';
+import { cond } from '@silverhand/essentials';
+import { type ChangeEvent, type ReactNode } from 'react';
+import { Controller, type FieldPath, useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+
+import PageMeta from '@/components/PageMeta';
+import Card from '@/ds-components/Card';
+import Checkbox from '@/ds-components/Checkbox/Checkbox';
+import FormField from '@/ds-components/FormField';
+import RadioGroup, { Radio } from '@/ds-components/RadioGroup';
+import TabWrapper from '@/ds-components/TabWrapper';
+import TextInput from '@/ds-components/TextInput';
+import Textarea from '@/ds-components/Textarea';
+
+import { type SignInExperienceForm } from '../../types';
+import * as commonStyles from '../index.module.scss';
+
+import * as styles from './index.module.scss';
+
+type PasswordOptionProps = {
+  name: FieldPath<SignInExperienceForm>;
+  title: string;
+  description: string;
+  children?: ReactNode;
+};
+
+/** A display component for password policy options with a title and description. */
+function PasswordOption({ name, title, description, children }: PasswordOptionProps) {
+  const { control } = useFormContext<SignInExperienceForm>();
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      render={({ field: { onChange, value } }) => (
+        <Checkbox
+          className={styles.passwordOption}
+          label={
+            <div className={styles.label}>
+              <div className={styles.title}>{title}</div>
+              <div className={styles.description}>{description}</div>
+              {children}
+            </div>
+          }
+          checked={Boolean(value)}
+          onChange={onChange}
+        />
+      )}
+    />
+  );
+}
+
+type Props = {
+  isActive: boolean;
+};
+
+function PasswordPolicy({ isActive }: Props) {
+  const {
+    control,
+    register,
+    getValues,
+    formState: { errors },
+  } = useFormContext<SignInExperienceForm>();
+  const maxPasswordLength = getValues('passwordPolicy.length.max');
+  const { t } = useTranslation(undefined, {
+    keyPrefix: 'admin_console.sign_in_exp.password_policy',
+  });
+
+  return (
+    <TabWrapper isActive={isActive} className={commonStyles.tabContent}>
+      {isActive && (
+        <PageMeta titleKey={['sign_in_exp.tabs.password_policy', 'sign_in_exp.page_title']} />
+      )}
+      <Card>
+        <div className={commonStyles.title}>{t('password_requirements')}</div>
+        <FormField title="sign_in_exp.password_policy.minimum_length">
+          <div className={commonStyles.formFieldDescription}>
+            {t('minimum_length_description', { max: maxPasswordLength })}
+          </div>
+          <Controller
+            name="passwordPolicy.length.min"
+            control={control}
+            rules={{
+              min: 1,
+              max: maxPasswordLength,
+            }}
+            render={({ field: { onChange, value, name } }) => (
+              <TextInput
+                name={name}
+                type="number"
+                value={String(value)}
+                error={
+                  errors.passwordPolicy?.length?.min &&
+                  t('minimum_length_error', { min: 1, max: maxPasswordLength })
+                }
+                onChange={(event: ChangeEvent<HTMLInputElement>) => {
+                  onChange(Number(event.target.value));
+                }}
+              />
+            )}
+          />
+        </FormField>
+        <FormField title="sign_in_exp.password_policy.minimum_required_char_types">
+          <div className={commonStyles.formFieldDescription}>
+            {t('minimum_required_char_types_description', {
+              symbols: PasswordPolicyChecker.symbols,
+            })}
+          </div>
+          <Controller
+            name="passwordPolicy.characterTypes.min"
+            control={control}
+            render={({ field: { onChange, value, name } }) => (
+              <RadioGroup
+                name={name}
+                className={styles.characterTypes}
+                value={cond(value && String(value))}
+                onChange={(value) => {
+                  onChange(Number(value));
+                }}
+              >
+                {[1, 2, 3, 4].map((i) => (
+                  <Radio key={i} title={<span>{i}</span>} value={String(i)} />
+                ))}
+              </RadioGroup>
+            )}
+          />
+        </FormField>
+      </Card>
+      <Card>
+        <div className={commonStyles.title}>{t('password_rejection')}</div>
+        <FormField title="sign_in_exp.password_policy.forbidden_passwords">
+          <PasswordOption
+            name="passwordPolicy.rejects.pwned"
+            title={t('breached_passwords')}
+            description={t('breached_passwords_description')}
+          />
+        </FormField>
+        <FormField title="sign_in_exp.password_policy.restricted_phrases_in_passwords">
+          <PasswordOption
+            name="passwordPolicy.rejects.repetitionAndSequence"
+            title={t('repetitive_or_sequential_characters')}
+            description={t('repetitive_or_sequential_characters_description')}
+          />
+          <PasswordOption
+            name="passwordPolicy.rejects.personalInfo"
+            title={t('personal_information')}
+            description={t('personal_information_description')}
+          />
+          <PasswordOption
+            name="passwordPolicy.isCustomWordsEnabled"
+            title={t('custom_words')}
+            description={t('custom_words_description')}
+          >
+            {getValues('passwordPolicy.isCustomWordsEnabled') && (
+              <Textarea
+                className={styles.textarea}
+                rows={5}
+                placeholder={t('custom_words_placeholder')}
+                onClick={(event) => {
+                  event.stopPropagation();
+                }}
+                onKeyDown={(event) => {
+                  event.stopPropagation();
+                }}
+                {...register('passwordPolicy.customWords')}
+              />
+            )}
+          </PasswordOption>
+        </FormField>
+      </Card>
+    </TabWrapper>
+  );
+}
+
+export default PasswordPolicy;

--- a/packages/console/src/pages/SignInExperience/types.ts
+++ b/packages/console/src/pages/SignInExperience/types.ts
@@ -1,3 +1,4 @@
+import { type PasswordPolicy } from '@logto/core-kit';
 import type { SignInExperience, SignInIdentifier, SignUp } from '@logto/schemas';
 
 export enum SignUpIdentifier {
@@ -12,9 +13,27 @@ export type SignUpForm = Omit<SignUp, 'identifiers'> & {
   identifier: SignUpIdentifier;
 };
 
-export type SignInExperienceForm = Omit<SignInExperience, 'signUp' | 'customCss'> & {
+export type SignInExperienceForm = Omit<
+  SignInExperience,
+  'signUp' | 'customCss' | 'passwordPolicy'
+> & {
   customCss?: string; // Code editor components can not properly handle null value, manually transform null to undefined instead.
   signUp?: SignUpForm;
+  /** The parsed password policy object. All properties are required. */
+  passwordPolicy: PasswordPolicy & {
+    /**
+     * The custom words separated by line breaks.
+     *
+     * This property is only used for UI display.
+     */
+    customWords: string;
+    /**
+     * Whether the custom words feature is enabled. Default value will be true if `rejects.words` is not empty.
+     *
+     * This property is only used for UI display.
+     */
+    isCustomWordsEnabled: boolean;
+  };
   createAccountEnabled: boolean;
 };
 

--- a/packages/console/src/utils/a11y.ts
+++ b/packages/console/src/utils/a11y.ts
@@ -1,11 +1,11 @@
 import type { KeyboardEventHandler, KeyboardEvent } from 'react';
 
-type callbackHandler<T> = ((event: KeyboardEvent<T>) => void) | undefined;
+type CallbackHandler<T> = ((event: KeyboardEvent<T>) => void) | undefined;
 
-type callbackHandlerMap<T> = Record<string, callbackHandler<T>>;
+type CallbackHandlerMap<T> = Record<string, CallbackHandler<T>>;
 
 export const onKeyDownHandler =
-  <T = Element>(callback?: callbackHandler<T> | callbackHandlerMap<T>): KeyboardEventHandler<T> =>
+  <T = Element>(callback?: CallbackHandler<T> | CallbackHandlerMap<T>): KeyboardEventHandler<T> =>
   (event) => {
     const { key } = event;
 

--- a/packages/phrases/src/locales/de/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/sign-in-exp/index.ts
@@ -1,4 +1,5 @@
 import content from './content.js';
+import password_policy from './password-policy.js';
 import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
@@ -10,6 +11,7 @@ const sign_in_exp = {
     branding: 'Branding',
     sign_up_and_sign_in: 'Anmeldung und Registrierung',
     content: 'Inhalt',
+    password_policy: 'Password policy', // UNTRANSLATED
   },
   welcome: {
     title: 'Anmeldungs-Erlebnis anpassen',
@@ -53,6 +55,7 @@ const sign_in_exp = {
   },
   sign_up_and_sign_in,
   content,
+  password_policy,
   setup_warning: {
     no_connector_sms:
       'Es wurde noch kein SMS-Konnektor eingerichtet. Bevor die Konfiguration abgeschlossen werden kann, können sich Benutzer nicht mit dieser Methode anmelden. <a>{{link}}</a> in "Connectors"',

--- a/packages/phrases/src/locales/de/translation/admin-console/sign-in-exp/password-policy.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/sign-in-exp/password-policy.ts
@@ -1,0 +1,27 @@
+const password_policy = {
+  password_requirements: 'Password requirements', // UNTRANSLATED
+  minimum_length: 'Minimum length', // UNTRANSLATED
+  minimum_length_description:
+    'NIST recommends a minimum of 8 characters for web products. The maximum length is fixed at {{max}} characters.', // UNTRANSLATED
+  minimum_length_error: 'Minimum length must be between {{min}} and {{max}} (inclusive).', // UNTRANSLATED
+  minimum_required_char_types: 'Minimum required character types', // UNTRANSLATED
+  minimum_required_char_types_description:
+    'The four character types are lowercase letters (a-z), uppercase letters (A-Z), numbers (0-9), and special characters ({{symbols}}).', // UNTRANSLATED
+  password_rejection: 'Password rejection', // UNTRANSLATED
+  forbidden_passwords: 'Forbidden passwords', // UNTRANSLATED
+  breached_passwords: 'Breached passwords', // UNTRANSLATED
+  breached_passwords_description:
+    'Prevent users from using passwords that have been breached in other systems.', // UNTRANSLATED
+  restricted_phrases_in_passwords: 'Restricted phrases in passwords', // UNTRANSLATED
+  repetitive_or_sequential_characters: 'Repetitive or sequential characters', // UNTRANSLATED
+  repetitive_or_sequential_characters_description: "For example, 'aaaaa' or '12345'", // UNTRANSLATED
+  personal_information: 'Personal information', // UNTRANSLATED
+  personal_information_description:
+    'Email address, phone number, username, first name, last name, etc.', // UNTRANSLATED
+  custom_words: 'Custom words', // UNTRANSLATED
+  custom_words_description:
+    'Customize the list of words to reject. Enter one word per line. Words are case-insensitive.', // UNTRANSLATED
+  custom_words_placeholder: 'Your service name, company name, etc.', // UNTRANSLATED
+};
+
+export default Object.freeze(password_policy);

--- a/packages/phrases/src/locales/en/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/sign-in-exp/index.ts
@@ -1,4 +1,5 @@
 import content from './content.js';
+import password_policy from './password-policy.js';
 import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
@@ -9,6 +10,7 @@ const sign_in_exp = {
     branding: 'Branding',
     sign_up_and_sign_in: 'Sign-up and Sign-in',
     content: 'Content',
+    password_policy: 'Password policy',
   },
   welcome: {
     title: 'Customize sign-in experience',
@@ -52,6 +54,7 @@ const sign_in_exp = {
   },
   sign_up_and_sign_in,
   content,
+  password_policy,
   setup_warning: {
     no_connector_sms:
       'No SMS connector set-up yet. Before completing the configuration, users will not be able to sign in with this method. <a>{{link}}</a> in "Connectors"',

--- a/packages/phrases/src/locales/en/translation/admin-console/sign-in-exp/password-policy.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/sign-in-exp/password-policy.ts
@@ -1,0 +1,27 @@
+const password_policy = {
+  password_requirements: 'Password requirements',
+  minimum_length: 'Minimum length',
+  minimum_length_description:
+    'NIST recommends a minimum of 8 characters for web products. The maximum length is fixed at {{max}} characters.',
+  minimum_length_error: 'Minimum length must be between {{min}} and {{max}} (inclusive).',
+  minimum_required_char_types: 'Minimum required character types',
+  minimum_required_char_types_description:
+    'The four character types are lowercase letters (a-z), uppercase letters (A-Z), numbers (0-9), and special characters ({{symbols}}).',
+  password_rejection: 'Password rejection',
+  forbidden_passwords: 'Forbidden passwords',
+  breached_passwords: 'Breached passwords',
+  breached_passwords_description:
+    'Prevent users from using passwords that have been breached in other systems.',
+  restricted_phrases_in_passwords: 'Restricted phrases in passwords',
+  repetitive_or_sequential_characters: 'Repetitive or sequential characters',
+  repetitive_or_sequential_characters_description: "For example, 'aaaaa' or '12345'",
+  personal_information: 'Personal information',
+  personal_information_description:
+    'Email address, phone number, username, first name, last name, etc.',
+  custom_words: 'Custom words',
+  custom_words_description:
+    'Customize the list of words to reject. Enter one word per line. Words are case-insensitive.',
+  custom_words_placeholder: 'Your service name, company name, etc.',
+};
+
+export default Object.freeze(password_policy);

--- a/packages/phrases/src/locales/es/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/sign-in-exp/index.ts
@@ -1,4 +1,5 @@
 import content from './content.js';
+import password_policy from './password-policy.js';
 import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
@@ -10,6 +11,7 @@ const sign_in_exp = {
     branding: 'Branding',
     sign_up_and_sign_in: 'Registro e inicio de sesión',
     content: 'Contenido',
+    password_policy: 'Password policy', // UNTRANSLATED
   },
   welcome: {
     title: 'Personalice la experiencia de inicio de sesión',
@@ -54,6 +56,7 @@ const sign_in_exp = {
   },
   sign_up_and_sign_in,
   content,
+  password_policy,
   setup_warning: {
     no_connector_sms:
       'Aún no se ha configurado el conector SMS. Antes de completar la configuración, los usuarios no podrán iniciar sesión con este método. <a>{{link}}</a> en "Conectores"',

--- a/packages/phrases/src/locales/es/translation/admin-console/sign-in-exp/password-policy.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/sign-in-exp/password-policy.ts
@@ -1,0 +1,27 @@
+const password_policy = {
+  password_requirements: 'Password requirements', // UNTRANSLATED
+  minimum_length: 'Minimum length', // UNTRANSLATED
+  minimum_length_description:
+    'NIST recommends a minimum of 8 characters for web products. The maximum length is fixed at {{max}} characters.', // UNTRANSLATED
+  minimum_length_error: 'Minimum length must be between {{min}} and {{max}} (inclusive).', // UNTRANSLATED
+  minimum_required_char_types: 'Minimum required character types', // UNTRANSLATED
+  minimum_required_char_types_description:
+    'The four character types are lowercase letters (a-z), uppercase letters (A-Z), numbers (0-9), and special characters ({{symbols}}).', // UNTRANSLATED
+  password_rejection: 'Password rejection', // UNTRANSLATED
+  forbidden_passwords: 'Forbidden passwords', // UNTRANSLATED
+  breached_passwords: 'Breached passwords', // UNTRANSLATED
+  breached_passwords_description:
+    'Prevent users from using passwords that have been breached in other systems.', // UNTRANSLATED
+  restricted_phrases_in_passwords: 'Restricted phrases in passwords', // UNTRANSLATED
+  repetitive_or_sequential_characters: 'Repetitive or sequential characters', // UNTRANSLATED
+  repetitive_or_sequential_characters_description: "For example, 'aaaaa' or '12345'", // UNTRANSLATED
+  personal_information: 'Personal information', // UNTRANSLATED
+  personal_information_description:
+    'Email address, phone number, username, first name, last name, etc.', // UNTRANSLATED
+  custom_words: 'Custom words', // UNTRANSLATED
+  custom_words_description:
+    'Customize the list of words to reject. Enter one word per line. Words are case-insensitive.', // UNTRANSLATED
+  custom_words_placeholder: 'Your service name, company name, etc.', // UNTRANSLATED
+};
+
+export default Object.freeze(password_policy);

--- a/packages/phrases/src/locales/fr/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/sign-in-exp/index.ts
@@ -1,4 +1,5 @@
 import content from './content.js';
+import password_policy from './password-policy.js';
 import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
@@ -10,6 +11,7 @@ const sign_in_exp = {
     branding: 'Image de marque',
     sign_up_and_sign_in: 'Inscription et connexion',
     content: 'Contenu',
+    password_policy: 'Password policy', // UNTRANSLATED
   },
   welcome: {
     title: "Personnaliser l'expérience de connexion",
@@ -54,6 +56,7 @@ const sign_in_exp = {
   },
   sign_up_and_sign_in,
   content,
+  password_policy,
   setup_warning: {
     no_connector_sms:
       'Aucun connecteur SMS n\'a été configuré. Avant de terminer la configuration, les utilisateurs ne pourront pas se connecter avec cette méthode. <a>{{link}}</a> dans "Connectors"',

--- a/packages/phrases/src/locales/fr/translation/admin-console/sign-in-exp/password-policy.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/sign-in-exp/password-policy.ts
@@ -1,0 +1,27 @@
+const password_policy = {
+  password_requirements: 'Password requirements', // UNTRANSLATED
+  minimum_length: 'Minimum length', // UNTRANSLATED
+  minimum_length_description:
+    'NIST recommends a minimum of 8 characters for web products. The maximum length is fixed at {{max}} characters.', // UNTRANSLATED
+  minimum_length_error: 'Minimum length must be between {{min}} and {{max}} (inclusive).', // UNTRANSLATED
+  minimum_required_char_types: 'Minimum required character types', // UNTRANSLATED
+  minimum_required_char_types_description:
+    'The four character types are lowercase letters (a-z), uppercase letters (A-Z), numbers (0-9), and special characters ({{symbols}}).', // UNTRANSLATED
+  password_rejection: 'Password rejection', // UNTRANSLATED
+  forbidden_passwords: 'Forbidden passwords', // UNTRANSLATED
+  breached_passwords: 'Breached passwords', // UNTRANSLATED
+  breached_passwords_description:
+    'Prevent users from using passwords that have been breached in other systems.', // UNTRANSLATED
+  restricted_phrases_in_passwords: 'Restricted phrases in passwords', // UNTRANSLATED
+  repetitive_or_sequential_characters: 'Repetitive or sequential characters', // UNTRANSLATED
+  repetitive_or_sequential_characters_description: "For example, 'aaaaa' or '12345'", // UNTRANSLATED
+  personal_information: 'Personal information', // UNTRANSLATED
+  personal_information_description:
+    'Email address, phone number, username, first name, last name, etc.', // UNTRANSLATED
+  custom_words: 'Custom words', // UNTRANSLATED
+  custom_words_description:
+    'Customize the list of words to reject. Enter one word per line. Words are case-insensitive.', // UNTRANSLATED
+  custom_words_placeholder: 'Your service name, company name, etc.', // UNTRANSLATED
+};
+
+export default Object.freeze(password_policy);

--- a/packages/phrases/src/locales/it/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/sign-in-exp/index.ts
@@ -1,4 +1,5 @@
 import content from './content.js';
+import password_policy from './password-policy.js';
 import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
@@ -10,6 +11,7 @@ const sign_in_exp = {
     branding: 'Marchio',
     sign_up_and_sign_in: 'Registrazione e accesso',
     content: 'Contenuto',
+    password_policy: 'Password policy', // UNTRANSLATED
   },
   welcome: {
     title: "Personalizza l'esperienza di accesso",
@@ -53,6 +55,7 @@ const sign_in_exp = {
   },
   sign_up_and_sign_in,
   content,
+  password_policy,
   setup_warning: {
     no_connector_sms:
       'Nessun connettore SMS ancora configurato. Prima di completare la configurazione, gli utenti non saranno in grado di accedere con questo metodo. <a>{{link}}</a> in "Connettori"',

--- a/packages/phrases/src/locales/it/translation/admin-console/sign-in-exp/password-policy.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/sign-in-exp/password-policy.ts
@@ -1,0 +1,27 @@
+const password_policy = {
+  password_requirements: 'Password requirements', // UNTRANSLATED
+  minimum_length: 'Minimum length', // UNTRANSLATED
+  minimum_length_description:
+    'NIST recommends a minimum of 8 characters for web products. The maximum length is fixed at {{max}} characters.', // UNTRANSLATED
+  minimum_length_error: 'Minimum length must be between {{min}} and {{max}} (inclusive).', // UNTRANSLATED
+  minimum_required_char_types: 'Minimum required character types', // UNTRANSLATED
+  minimum_required_char_types_description:
+    'The four character types are lowercase letters (a-z), uppercase letters (A-Z), numbers (0-9), and special characters ({{symbols}}).', // UNTRANSLATED
+  password_rejection: 'Password rejection', // UNTRANSLATED
+  forbidden_passwords: 'Forbidden passwords', // UNTRANSLATED
+  breached_passwords: 'Breached passwords', // UNTRANSLATED
+  breached_passwords_description:
+    'Prevent users from using passwords that have been breached in other systems.', // UNTRANSLATED
+  restricted_phrases_in_passwords: 'Restricted phrases in passwords', // UNTRANSLATED
+  repetitive_or_sequential_characters: 'Repetitive or sequential characters', // UNTRANSLATED
+  repetitive_or_sequential_characters_description: "For example, 'aaaaa' or '12345'", // UNTRANSLATED
+  personal_information: 'Personal information', // UNTRANSLATED
+  personal_information_description:
+    'Email address, phone number, username, first name, last name, etc.', // UNTRANSLATED
+  custom_words: 'Custom words', // UNTRANSLATED
+  custom_words_description:
+    'Customize the list of words to reject. Enter one word per line. Words are case-insensitive.', // UNTRANSLATED
+  custom_words_placeholder: 'Your service name, company name, etc.', // UNTRANSLATED
+};
+
+export default Object.freeze(password_policy);

--- a/packages/phrases/src/locales/ja/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/sign-in-exp/index.ts
@@ -1,4 +1,5 @@
 import content from './content.js';
+import password_policy from './password-policy.js';
 import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
@@ -9,6 +10,7 @@ const sign_in_exp = {
     branding: 'ブランディング',
     sign_up_and_sign_in: 'サインアップとサインイン',
     content: '内容',
+    password_policy: 'Password policy', // UNTRANSLATED
   },
   welcome: {
     title: 'サインインエクスペリエンスをカスタマイズ',
@@ -52,6 +54,7 @@ const sign_in_exp = {
   },
   sign_up_and_sign_in,
   content,
+  password_policy,
   setup_warning: {
     no_connector_sms:
       'まだSMSコネクタが設定されていません。構成を完了する前に、この方法でのサインインはできません。<a>{{link}}</a>「コネクタ」に移動してください',

--- a/packages/phrases/src/locales/ja/translation/admin-console/sign-in-exp/password-policy.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/sign-in-exp/password-policy.ts
@@ -1,0 +1,27 @@
+const password_policy = {
+  password_requirements: 'Password requirements', // UNTRANSLATED
+  minimum_length: 'Minimum length', // UNTRANSLATED
+  minimum_length_description:
+    'NIST recommends a minimum of 8 characters for web products. The maximum length is fixed at {{max}} characters.', // UNTRANSLATED
+  minimum_length_error: 'Minimum length must be between {{min}} and {{max}} (inclusive).', // UNTRANSLATED
+  minimum_required_char_types: 'Minimum required character types', // UNTRANSLATED
+  minimum_required_char_types_description:
+    'The four character types are lowercase letters (a-z), uppercase letters (A-Z), numbers (0-9), and special characters ({{symbols}}).', // UNTRANSLATED
+  password_rejection: 'Password rejection', // UNTRANSLATED
+  forbidden_passwords: 'Forbidden passwords', // UNTRANSLATED
+  breached_passwords: 'Breached passwords', // UNTRANSLATED
+  breached_passwords_description:
+    'Prevent users from using passwords that have been breached in other systems.', // UNTRANSLATED
+  restricted_phrases_in_passwords: 'Restricted phrases in passwords', // UNTRANSLATED
+  repetitive_or_sequential_characters: 'Repetitive or sequential characters', // UNTRANSLATED
+  repetitive_or_sequential_characters_description: "For example, 'aaaaa' or '12345'", // UNTRANSLATED
+  personal_information: 'Personal information', // UNTRANSLATED
+  personal_information_description:
+    'Email address, phone number, username, first name, last name, etc.', // UNTRANSLATED
+  custom_words: 'Custom words', // UNTRANSLATED
+  custom_words_description:
+    'Customize the list of words to reject. Enter one word per line. Words are case-insensitive.', // UNTRANSLATED
+  custom_words_placeholder: 'Your service name, company name, etc.', // UNTRANSLATED
+};
+
+export default Object.freeze(password_policy);

--- a/packages/phrases/src/locales/ko/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/sign-in-exp/index.ts
@@ -1,4 +1,5 @@
 import content from './content.js';
+import password_policy from './password-policy.js';
 import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
@@ -9,6 +10,7 @@ const sign_in_exp = {
     branding: '브랜딩',
     sign_up_and_sign_in: '회원가입/로그인',
     content: '내용',
+    password_policy: 'Password policy', // UNTRANSLATED
   },
   welcome: {
     title: '로그인 경험 사용자화',
@@ -50,6 +52,7 @@ const sign_in_exp = {
   },
   sign_up_and_sign_in,
   content,
+  password_policy,
   setup_warning: {
     no_connector_sms:
       'SMS 연동 설정이 아직 없어요. 이 구성을 완료하기 전에는 사용자가 이 로그인 방식으로 로그인 할 수 없어요. "연동 설정"에서 <a>{{link}}</a>하세요.',

--- a/packages/phrases/src/locales/ko/translation/admin-console/sign-in-exp/password-policy.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/sign-in-exp/password-policy.ts
@@ -1,0 +1,27 @@
+const password_policy = {
+  password_requirements: 'Password requirements', // UNTRANSLATED
+  minimum_length: 'Minimum length', // UNTRANSLATED
+  minimum_length_description:
+    'NIST recommends a minimum of 8 characters for web products. The maximum length is fixed at {{max}} characters.', // UNTRANSLATED
+  minimum_length_error: 'Minimum length must be between {{min}} and {{max}} (inclusive).', // UNTRANSLATED
+  minimum_required_char_types: 'Minimum required character types', // UNTRANSLATED
+  minimum_required_char_types_description:
+    'The four character types are lowercase letters (a-z), uppercase letters (A-Z), numbers (0-9), and special characters ({{symbols}}).', // UNTRANSLATED
+  password_rejection: 'Password rejection', // UNTRANSLATED
+  forbidden_passwords: 'Forbidden passwords', // UNTRANSLATED
+  breached_passwords: 'Breached passwords', // UNTRANSLATED
+  breached_passwords_description:
+    'Prevent users from using passwords that have been breached in other systems.', // UNTRANSLATED
+  restricted_phrases_in_passwords: 'Restricted phrases in passwords', // UNTRANSLATED
+  repetitive_or_sequential_characters: 'Repetitive or sequential characters', // UNTRANSLATED
+  repetitive_or_sequential_characters_description: "For example, 'aaaaa' or '12345'", // UNTRANSLATED
+  personal_information: 'Personal information', // UNTRANSLATED
+  personal_information_description:
+    'Email address, phone number, username, first name, last name, etc.', // UNTRANSLATED
+  custom_words: 'Custom words', // UNTRANSLATED
+  custom_words_description:
+    'Customize the list of words to reject. Enter one word per line. Words are case-insensitive.', // UNTRANSLATED
+  custom_words_placeholder: 'Your service name, company name, etc.', // UNTRANSLATED
+};
+
+export default Object.freeze(password_policy);

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/sign-in-exp/index.ts
@@ -1,4 +1,5 @@
 import content from './content.js';
+import password_policy from './password-policy.js';
 import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
@@ -10,6 +11,7 @@ const sign_in_exp = {
     branding: 'Marka',
     sign_up_and_sign_in: 'Rejestracja i logowanie',
     content: 'Treść',
+    password_policy: 'Password policy', // UNTRANSLATED
   },
   welcome: {
     title: 'Dostosuj swoje doświadczenie logowania',
@@ -53,6 +55,7 @@ const sign_in_exp = {
   },
   sign_up_and_sign_in,
   content,
+  password_policy,
   setup_warning: {
     no_connector_sms:
       'Nie ustawiono jeszcze łącznika SMS. Przed zakończeniem konfiguracji użytkownicy nie będą mogli się zalogować przy użyciu tej metody. <a>{{link}}</a> w sekcji „Łączniki“',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/sign-in-exp/password-policy.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/sign-in-exp/password-policy.ts
@@ -1,0 +1,27 @@
+const password_policy = {
+  password_requirements: 'Password requirements', // UNTRANSLATED
+  minimum_length: 'Minimum length', // UNTRANSLATED
+  minimum_length_description:
+    'NIST recommends a minimum of 8 characters for web products. The maximum length is fixed at {{max}} characters.', // UNTRANSLATED
+  minimum_length_error: 'Minimum length must be between {{min}} and {{max}} (inclusive).', // UNTRANSLATED
+  minimum_required_char_types: 'Minimum required character types', // UNTRANSLATED
+  minimum_required_char_types_description:
+    'The four character types are lowercase letters (a-z), uppercase letters (A-Z), numbers (0-9), and special characters ({{symbols}}).', // UNTRANSLATED
+  password_rejection: 'Password rejection', // UNTRANSLATED
+  forbidden_passwords: 'Forbidden passwords', // UNTRANSLATED
+  breached_passwords: 'Breached passwords', // UNTRANSLATED
+  breached_passwords_description:
+    'Prevent users from using passwords that have been breached in other systems.', // UNTRANSLATED
+  restricted_phrases_in_passwords: 'Restricted phrases in passwords', // UNTRANSLATED
+  repetitive_or_sequential_characters: 'Repetitive or sequential characters', // UNTRANSLATED
+  repetitive_or_sequential_characters_description: "For example, 'aaaaa' or '12345'", // UNTRANSLATED
+  personal_information: 'Personal information', // UNTRANSLATED
+  personal_information_description:
+    'Email address, phone number, username, first name, last name, etc.', // UNTRANSLATED
+  custom_words: 'Custom words', // UNTRANSLATED
+  custom_words_description:
+    'Customize the list of words to reject. Enter one word per line. Words are case-insensitive.', // UNTRANSLATED
+  custom_words_placeholder: 'Your service name, company name, etc.', // UNTRANSLATED
+};
+
+export default Object.freeze(password_policy);

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/sign-in-exp/index.ts
@@ -1,4 +1,5 @@
 import content from './content.js';
+import password_policy from './password-policy.js';
 import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
@@ -10,6 +11,7 @@ const sign_in_exp = {
     branding: 'Marca',
     sign_up_and_sign_in: 'Inscreva-se e faça login',
     content: 'Conteúdo',
+    password_policy: 'Password policy', // UNTRANSLATED
   },
   welcome: {
     title: 'Personalize a experiência de login',
@@ -53,6 +55,7 @@ const sign_in_exp = {
   },
   sign_up_and_sign_in,
   content,
+  password_policy,
   setup_warning: {
     no_connector_sms:
       'Nenhum conector SMS configurado ainda. Até terminar de configurar seu conector SMS, seus usuários não poderão fazer login. <a>{{link}}</a> em "Conectores"',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/sign-in-exp/password-policy.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/sign-in-exp/password-policy.ts
@@ -1,0 +1,27 @@
+const password_policy = {
+  password_requirements: 'Password requirements', // UNTRANSLATED
+  minimum_length: 'Minimum length', // UNTRANSLATED
+  minimum_length_description:
+    'NIST recommends a minimum of 8 characters for web products. The maximum length is fixed at {{max}} characters.', // UNTRANSLATED
+  minimum_length_error: 'Minimum length must be between {{min}} and {{max}} (inclusive).', // UNTRANSLATED
+  minimum_required_char_types: 'Minimum required character types', // UNTRANSLATED
+  minimum_required_char_types_description:
+    'The four character types are lowercase letters (a-z), uppercase letters (A-Z), numbers (0-9), and special characters ({{symbols}}).', // UNTRANSLATED
+  password_rejection: 'Password rejection', // UNTRANSLATED
+  forbidden_passwords: 'Forbidden passwords', // UNTRANSLATED
+  breached_passwords: 'Breached passwords', // UNTRANSLATED
+  breached_passwords_description:
+    'Prevent users from using passwords that have been breached in other systems.', // UNTRANSLATED
+  restricted_phrases_in_passwords: 'Restricted phrases in passwords', // UNTRANSLATED
+  repetitive_or_sequential_characters: 'Repetitive or sequential characters', // UNTRANSLATED
+  repetitive_or_sequential_characters_description: "For example, 'aaaaa' or '12345'", // UNTRANSLATED
+  personal_information: 'Personal information', // UNTRANSLATED
+  personal_information_description:
+    'Email address, phone number, username, first name, last name, etc.', // UNTRANSLATED
+  custom_words: 'Custom words', // UNTRANSLATED
+  custom_words_description:
+    'Customize the list of words to reject. Enter one word per line. Words are case-insensitive.', // UNTRANSLATED
+  custom_words_placeholder: 'Your service name, company name, etc.', // UNTRANSLATED
+};
+
+export default Object.freeze(password_policy);

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/sign-in-exp/index.ts
@@ -1,4 +1,5 @@
 import content from './content.js';
+import password_policy from './password-policy.js';
 import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
@@ -10,6 +11,7 @@ const sign_in_exp = {
     branding: 'Marca',
     sign_up_and_sign_in: 'Registo e login',
     content: 'Conteúdo',
+    password_policy: 'Password policy', // UNTRANSLATED
   },
   welcome: {
     title: 'Personalize a experiência de início de sessão',
@@ -52,6 +54,7 @@ const sign_in_exp = {
   },
   sign_up_and_sign_in,
   content,
+  password_policy,
   setup_warning: {
     no_connector_sms:
       'Ainda não foi configurado nenhum conector SMS. Antes de concluir a configuração, os utilizadores não poderão iniciar sessão com este método. <a>{{link}}</a> em "Conectores"',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/sign-in-exp/password-policy.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/sign-in-exp/password-policy.ts
@@ -1,0 +1,27 @@
+const password_policy = {
+  password_requirements: 'Password requirements', // UNTRANSLATED
+  minimum_length: 'Minimum length', // UNTRANSLATED
+  minimum_length_description:
+    'NIST recommends a minimum of 8 characters for web products. The maximum length is fixed at {{max}} characters.', // UNTRANSLATED
+  minimum_length_error: 'Minimum length must be between {{min}} and {{max}} (inclusive).', // UNTRANSLATED
+  minimum_required_char_types: 'Minimum required character types', // UNTRANSLATED
+  minimum_required_char_types_description:
+    'The four character types are lowercase letters (a-z), uppercase letters (A-Z), numbers (0-9), and special characters ({{symbols}}).', // UNTRANSLATED
+  password_rejection: 'Password rejection', // UNTRANSLATED
+  forbidden_passwords: 'Forbidden passwords', // UNTRANSLATED
+  breached_passwords: 'Breached passwords', // UNTRANSLATED
+  breached_passwords_description:
+    'Prevent users from using passwords that have been breached in other systems.', // UNTRANSLATED
+  restricted_phrases_in_passwords: 'Restricted phrases in passwords', // UNTRANSLATED
+  repetitive_or_sequential_characters: 'Repetitive or sequential characters', // UNTRANSLATED
+  repetitive_or_sequential_characters_description: "For example, 'aaaaa' or '12345'", // UNTRANSLATED
+  personal_information: 'Personal information', // UNTRANSLATED
+  personal_information_description:
+    'Email address, phone number, username, first name, last name, etc.', // UNTRANSLATED
+  custom_words: 'Custom words', // UNTRANSLATED
+  custom_words_description:
+    'Customize the list of words to reject. Enter one word per line. Words are case-insensitive.', // UNTRANSLATED
+  custom_words_placeholder: 'Your service name, company name, etc.', // UNTRANSLATED
+};
+
+export default Object.freeze(password_policy);

--- a/packages/phrases/src/locales/ru/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/sign-in-exp/index.ts
@@ -1,4 +1,5 @@
 import content from './content.js';
+import password_policy from './password-policy.js';
 import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
@@ -10,6 +11,7 @@ const sign_in_exp = {
     branding: 'Брендирование',
     sign_up_and_sign_in: 'Регистрация и вход в систему',
     content: 'Содержание',
+    password_policy: 'Password policy', // UNTRANSLATED
   },
   welcome: {
     title: 'Настройка входа в систему',
@@ -54,6 +56,7 @@ const sign_in_exp = {
   },
   sign_up_and_sign_in,
   content,
+  password_policy,
   setup_warning: {
     no_connector_sms:
       'Еще не настроен коннектор SMS. Пока не завершено настройка, пользователи не смогут войти с помощью этого метода. <a>{{link}}</a> в «Коннекторах»',

--- a/packages/phrases/src/locales/ru/translation/admin-console/sign-in-exp/password-policy.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/sign-in-exp/password-policy.ts
@@ -1,0 +1,27 @@
+const password_policy = {
+  password_requirements: 'Password requirements', // UNTRANSLATED
+  minimum_length: 'Minimum length', // UNTRANSLATED
+  minimum_length_description:
+    'NIST recommends a minimum of 8 characters for web products. The maximum length is fixed at {{max}} characters.', // UNTRANSLATED
+  minimum_length_error: 'Minimum length must be between {{min}} and {{max}} (inclusive).', // UNTRANSLATED
+  minimum_required_char_types: 'Minimum required character types', // UNTRANSLATED
+  minimum_required_char_types_description:
+    'The four character types are lowercase letters (a-z), uppercase letters (A-Z), numbers (0-9), and special characters ({{symbols}}).', // UNTRANSLATED
+  password_rejection: 'Password rejection', // UNTRANSLATED
+  forbidden_passwords: 'Forbidden passwords', // UNTRANSLATED
+  breached_passwords: 'Breached passwords', // UNTRANSLATED
+  breached_passwords_description:
+    'Prevent users from using passwords that have been breached in other systems.', // UNTRANSLATED
+  restricted_phrases_in_passwords: 'Restricted phrases in passwords', // UNTRANSLATED
+  repetitive_or_sequential_characters: 'Repetitive or sequential characters', // UNTRANSLATED
+  repetitive_or_sequential_characters_description: "For example, 'aaaaa' or '12345'", // UNTRANSLATED
+  personal_information: 'Personal information', // UNTRANSLATED
+  personal_information_description:
+    'Email address, phone number, username, first name, last name, etc.', // UNTRANSLATED
+  custom_words: 'Custom words', // UNTRANSLATED
+  custom_words_description:
+    'Customize the list of words to reject. Enter one word per line. Words are case-insensitive.', // UNTRANSLATED
+  custom_words_placeholder: 'Your service name, company name, etc.', // UNTRANSLATED
+};
+
+export default Object.freeze(password_policy);

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/sign-in-exp/index.ts
@@ -1,4 +1,5 @@
 import content from './content.js';
+import password_policy from './password-policy.js';
 import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
@@ -10,6 +11,7 @@ const sign_in_exp = {
     branding: 'Markalaşma',
     sign_up_and_sign_in: 'Kaydol ve Oturum Aç',
     content: 'İçerik',
+    password_policy: 'Password policy', // UNTRANSLATED
   },
   welcome: {
     title: 'Oturum açma deneyimini özelleştirin',
@@ -53,6 +55,7 @@ const sign_in_exp = {
   },
   sign_up_and_sign_in,
   content,
+  password_policy,
   setup_warning: {
     no_connector_sms:
       'Henüz SMS konektörü kurulmadı. Yapılandırmayı tamamlamadan önce, kullanıcılar bu yöntemle oturum açamazlar. "Konektörler"deki <a>{{link}}</a>',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/sign-in-exp/password-policy.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/sign-in-exp/password-policy.ts
@@ -1,0 +1,27 @@
+const password_policy = {
+  password_requirements: 'Password requirements', // UNTRANSLATED
+  minimum_length: 'Minimum length', // UNTRANSLATED
+  minimum_length_description:
+    'NIST recommends a minimum of 8 characters for web products. The maximum length is fixed at {{max}} characters.', // UNTRANSLATED
+  minimum_length_error: 'Minimum length must be between {{min}} and {{max}} (inclusive).', // UNTRANSLATED
+  minimum_required_char_types: 'Minimum required character types', // UNTRANSLATED
+  minimum_required_char_types_description:
+    'The four character types are lowercase letters (a-z), uppercase letters (A-Z), numbers (0-9), and special characters ({{symbols}}).', // UNTRANSLATED
+  password_rejection: 'Password rejection', // UNTRANSLATED
+  forbidden_passwords: 'Forbidden passwords', // UNTRANSLATED
+  breached_passwords: 'Breached passwords', // UNTRANSLATED
+  breached_passwords_description:
+    'Prevent users from using passwords that have been breached in other systems.', // UNTRANSLATED
+  restricted_phrases_in_passwords: 'Restricted phrases in passwords', // UNTRANSLATED
+  repetitive_or_sequential_characters: 'Repetitive or sequential characters', // UNTRANSLATED
+  repetitive_or_sequential_characters_description: "For example, 'aaaaa' or '12345'", // UNTRANSLATED
+  personal_information: 'Personal information', // UNTRANSLATED
+  personal_information_description:
+    'Email address, phone number, username, first name, last name, etc.', // UNTRANSLATED
+  custom_words: 'Custom words', // UNTRANSLATED
+  custom_words_description:
+    'Customize the list of words to reject. Enter one word per line. Words are case-insensitive.', // UNTRANSLATED
+  custom_words_placeholder: 'Your service name, company name, etc.', // UNTRANSLATED
+};
+
+export default Object.freeze(password_policy);

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/sign-in-exp/index.ts
@@ -1,4 +1,5 @@
 import content from './content.js';
+import password_policy from './password-policy.js';
 import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
@@ -9,6 +10,7 @@ const sign_in_exp = {
     branding: '品牌',
     sign_up_and_sign_in: '注册与登录',
     content: '内容',
+    password_policy: 'Password policy', // UNTRANSLATED
   },
   welcome: {
     title: '自定义登录体验',
@@ -50,6 +52,7 @@ const sign_in_exp = {
   },
   sign_up_and_sign_in,
   content,
+  password_policy,
   setup_warning: {
     no_connector_sms:
       '尚未设置 SMS 短信连接器。在完成该配置前，用户将无法通过此登录方式登录。<a>{{link}}</a>连接器。',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/sign-in-exp/password-policy.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/sign-in-exp/password-policy.ts
@@ -1,0 +1,27 @@
+const password_policy = {
+  password_requirements: 'Password requirements', // UNTRANSLATED
+  minimum_length: 'Minimum length', // UNTRANSLATED
+  minimum_length_description:
+    'NIST recommends a minimum of 8 characters for web products. The maximum length is fixed at {{max}} characters.', // UNTRANSLATED
+  minimum_length_error: 'Minimum length must be between {{min}} and {{max}} (inclusive).', // UNTRANSLATED
+  minimum_required_char_types: 'Minimum required character types', // UNTRANSLATED
+  minimum_required_char_types_description:
+    'The four character types are lowercase letters (a-z), uppercase letters (A-Z), numbers (0-9), and special characters ({{symbols}}).', // UNTRANSLATED
+  password_rejection: 'Password rejection', // UNTRANSLATED
+  forbidden_passwords: 'Forbidden passwords', // UNTRANSLATED
+  breached_passwords: 'Breached passwords', // UNTRANSLATED
+  breached_passwords_description:
+    'Prevent users from using passwords that have been breached in other systems.', // UNTRANSLATED
+  restricted_phrases_in_passwords: 'Restricted phrases in passwords', // UNTRANSLATED
+  repetitive_or_sequential_characters: 'Repetitive or sequential characters', // UNTRANSLATED
+  repetitive_or_sequential_characters_description: "For example, 'aaaaa' or '12345'", // UNTRANSLATED
+  personal_information: 'Personal information', // UNTRANSLATED
+  personal_information_description:
+    'Email address, phone number, username, first name, last name, etc.', // UNTRANSLATED
+  custom_words: 'Custom words', // UNTRANSLATED
+  custom_words_description:
+    'Customize the list of words to reject. Enter one word per line. Words are case-insensitive.', // UNTRANSLATED
+  custom_words_placeholder: 'Your service name, company name, etc.', // UNTRANSLATED
+};
+
+export default Object.freeze(password_policy);

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/sign-in-exp/index.ts
@@ -1,4 +1,5 @@
 import content from './content.js';
+import password_policy from './password-policy.js';
 import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
@@ -9,6 +10,7 @@ const sign_in_exp = {
     branding: '品牌',
     sign_up_and_sign_in: '註冊與登錄',
     content: '內容',
+    password_policy: 'Password policy', // UNTRANSLATED
   },
   welcome: {
     title: '自定義登錄體驗',
@@ -50,6 +52,7 @@ const sign_in_exp = {
   },
   sign_up_and_sign_in,
   content,
+  password_policy,
   setup_warning: {
     no_connector_sms:
       '尚未設置 SMS 短信連接器。在完成該配置前，用戶將無法通過此登錄方式登錄。<a>{{link}}</a>連接器。',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/sign-in-exp/password-policy.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/sign-in-exp/password-policy.ts
@@ -1,0 +1,27 @@
+const password_policy = {
+  password_requirements: 'Password requirements', // UNTRANSLATED
+  minimum_length: 'Minimum length', // UNTRANSLATED
+  minimum_length_description:
+    'NIST recommends a minimum of 8 characters for web products. The maximum length is fixed at {{max}} characters.', // UNTRANSLATED
+  minimum_length_error: 'Minimum length must be between {{min}} and {{max}} (inclusive).', // UNTRANSLATED
+  minimum_required_char_types: 'Minimum required character types', // UNTRANSLATED
+  minimum_required_char_types_description:
+    'The four character types are lowercase letters (a-z), uppercase letters (A-Z), numbers (0-9), and special characters ({{symbols}}).', // UNTRANSLATED
+  password_rejection: 'Password rejection', // UNTRANSLATED
+  forbidden_passwords: 'Forbidden passwords', // UNTRANSLATED
+  breached_passwords: 'Breached passwords', // UNTRANSLATED
+  breached_passwords_description:
+    'Prevent users from using passwords that have been breached in other systems.', // UNTRANSLATED
+  restricted_phrases_in_passwords: 'Restricted phrases in passwords', // UNTRANSLATED
+  repetitive_or_sequential_characters: 'Repetitive or sequential characters', // UNTRANSLATED
+  repetitive_or_sequential_characters_description: "For example, 'aaaaa' or '12345'", // UNTRANSLATED
+  personal_information: 'Personal information', // UNTRANSLATED
+  personal_information_description:
+    'Email address, phone number, username, first name, last name, etc.', // UNTRANSLATED
+  custom_words: 'Custom words', // UNTRANSLATED
+  custom_words_description:
+    'Customize the list of words to reject. Enter one word per line. Words are case-insensitive.', // UNTRANSLATED
+  custom_words_placeholder: 'Your service name, company name, etc.', // UNTRANSLATED
+};
+
+export default Object.freeze(password_policy);

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/sign-in-exp/index.ts
@@ -1,4 +1,5 @@
 import content from './content.js';
+import password_policy from './password-policy.js';
 import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
@@ -9,6 +10,7 @@ const sign_in_exp = {
     branding: '品牌',
     sign_up_and_sign_in: '註冊與登錄',
     content: '內容',
+    password_policy: 'Password policy', // UNTRANSLATED
   },
   welcome: {
     title: '自定義登錄體驗',
@@ -50,6 +52,7 @@ const sign_in_exp = {
   },
   sign_up_and_sign_in,
   content,
+  password_policy,
   setup_warning: {
     no_connector_sms:
       '尚未設置 SMS 短信連接器。在完成該配置前，用戶將無法通過此登錄方式登錄。<a>{{link}}</a>連接器。',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/sign-in-exp/password-policy.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/sign-in-exp/password-policy.ts
@@ -1,0 +1,27 @@
+const password_policy = {
+  password_requirements: 'Password requirements', // UNTRANSLATED
+  minimum_length: 'Minimum length', // UNTRANSLATED
+  minimum_length_description:
+    'NIST recommends a minimum of 8 characters for web products. The maximum length is fixed at {{max}} characters.', // UNTRANSLATED
+  minimum_length_error: 'Minimum length must be between {{min}} and {{max}} (inclusive).', // UNTRANSLATED
+  minimum_required_char_types: 'Minimum required character types', // UNTRANSLATED
+  minimum_required_char_types_description:
+    'The four character types are lowercase letters (a-z), uppercase letters (A-Z), numbers (0-9), and special characters ({{symbols}}).', // UNTRANSLATED
+  password_rejection: 'Password rejection', // UNTRANSLATED
+  forbidden_passwords: 'Forbidden passwords', // UNTRANSLATED
+  breached_passwords: 'Breached passwords', // UNTRANSLATED
+  breached_passwords_description:
+    'Prevent users from using passwords that have been breached in other systems.', // UNTRANSLATED
+  restricted_phrases_in_passwords: 'Restricted phrases in passwords', // UNTRANSLATED
+  repetitive_or_sequential_characters: 'Repetitive or sequential characters', // UNTRANSLATED
+  repetitive_or_sequential_characters_description: "For example, 'aaaaa' or '12345'", // UNTRANSLATED
+  personal_information: 'Personal information', // UNTRANSLATED
+  personal_information_description:
+    'Email address, phone number, username, first name, last name, etc.', // UNTRANSLATED
+  custom_words: 'Custom words', // UNTRANSLATED
+  custom_words_description:
+    'Customize the list of words to reject. Enter one word per line. Words are case-insensitive.', // UNTRANSLATED
+  custom_words_placeholder: 'Your service name, company name, etc.', // UNTRANSLATED
+};
+
+export default Object.freeze(password_policy);


### PR DESCRIPTION
> **Note**
> The details like how we display character sets are not finalized yet. this PR should focus on the implementation.

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

follow-up of #4418

- implement the password policy configuration tab in Console
- implement `<NumericInput />` for number inputting

<img width="559" alt="image" src="https://github.com/logto-io/logto/assets/14722250/fdcc8727-4ab6-4180-baac-50c858a75909">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

- test numeric input, try min/max values, try numbers that are out of range
- test various combinations, can save correctly
- empty rows in custom words will be removed automatically

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset` (not this PR)
- [ ] ~~unit tests~~
- [ ] integration tests (not this PR)
- [ ] docs (not this PR)
