### PR TITLE
refactor(console): add missing section title and adjust card layout in get-started page

### DIFF
--- a/packages/console/src/hooks/use-window-resize.ts
+++ b/packages/console/src/hooks/use-window-resize.ts
@@ -1,0 +1,27 @@
+import { useEffect, useLayoutEffect, useRef } from 'react';
+
+type Callback = (event?: UIEvent) => void;
+
+const useWindowResize = (callback: Callback) => {
+  const callbackRef = useRef<Callback>(callback);
+
+  useEffect(() => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    callbackRef.current = callback;
+  }, [callback]);
+
+  useLayoutEffect(() => {
+    const handler: Callback = (event) => {
+      callbackRef.current(event);
+    };
+
+    handler();
+    window.addEventListener('resize', handler);
+
+    return () => {
+      window.removeEventListener('resize', handler);
+    };
+  }, []);
+};
+
+export default useWindowResize;

--- a/packages/console/src/pages/Applications/components/GuideGroup/index.tsx
+++ b/packages/console/src/pages/Applications/components/GuideGroup/index.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import { type Ref, forwardRef } from 'react';
 
 import { type Guide } from '@/assets/docs/guides/types';
 
@@ -15,20 +16,16 @@ type GuideGroupProps = {
   onClickGuide: (data: SelectedGuide) => void;
 };
 
-function GuideGroup({
-  className,
-  categoryName,
-  guides,
-  hasCardBorder,
-  isCompact,
-  onClickGuide,
-}: GuideGroupProps) {
+function GuideGroup(
+  { className, categoryName, guides, hasCardBorder, isCompact, onClickGuide }: GuideGroupProps,
+  ref: Ref<HTMLDivElement>
+) {
   if (!guides?.length) {
     return null;
   }
 
   return (
-    <div className={classNames(styles.guideGroup, className)}>
+    <div ref={ref} className={classNames(styles.guideGroup, className)}>
       {categoryName && <label>{categoryName}</label>}
       <div className={styles.grid}>
         {guides.map((guide) => (
@@ -45,4 +42,4 @@ function GuideGroup({
   );
 }
 
-export default GuideGroup;
+export default forwardRef<HTMLDivElement, GuideGroupProps>(GuideGroup);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- Add missing section titles in get-started page
- Improve responsive rules and show 2,3 or 4 guide cards in one row based on current page width

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="1523" alt="image" src="https://github.com/logto-io/logto/assets/12833674/646e3183-1823-484b-9b5b-742c94e4d729">
<img width="969" alt="image" src="https://github.com/logto-io/logto/assets/12833674/32c6cdab-5b84-4159-93d7-20d4bb625b03">
<img width="680" alt="image" src="https://github.com/logto-io/logto/assets/12833674/641e49d5-dabc-4b76-b5c3-72b66c6fdac3">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] docs~~

OR

- [x] This PR is not applicable for the checklist
