### PR TITLE
fix(core,ui): clear ui preload link not used warning

### DIFF
--- a/packages/core/src/middleware/koa-security-headers.ts
+++ b/packages/core/src/middleware/koa-security-headers.ts
@@ -106,7 +106,13 @@ export default function koaSecurityHeaders<StateT, ContextT, ResponseBodyT>(
           "'self'",
           ...conditionalArray(!isProduction && ["'unsafe-eval'", "'unsafe-inline'"]),
         ],
-        connectSrc: ["'self'", ...adminOrigins, ...coreOrigins, ...developmentOrigins],
+        connectSrc: [
+          "'self'",
+          ...adminOrigins,
+          ...coreOrigins,
+          ...developmentOrigins,
+          ...appInsightsOrigins,
+        ],
         // Allow Main Flow origin loaded in preview iframe
         frameSrc: ["'self'", ...adminOrigins, ...coreOrigins],
       },

--- a/packages/ui/src/index.html
+++ b/packages/ui/src/index.html
@@ -5,8 +5,24 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title></title>
-  <link rel="preload" href="/api/.well-known/sign-in-exp" as="fetch" crossorigin="anonymous">
-  <link rel="preload" href="/api/.well-known/phrases" as="fetch" crossorigin="anonymous">
+  <!--Preload well-known settings API-->
+  <script>
+    const { search } = window.location;
+    const noCache = search.includes('no_cache');
+    const isPreview = search.includes('preview');
+    // Preview mode does not query sign-in-exp and phrases
+    const preLoadLinks = isPreview ? [] : ['/api/.well-known/sign-in-exp', '/api/.well-known/phrases'];
+
+    // Append preload well-known settings API links to head
+    preLoadLinks.forEach((linkUrl) => {
+      const link = document.createElement('link');
+      link.rel = 'preload';
+      link.href = `${linkUrl}${noCache ? '?no_cache=true' : ''}`;
+      link.as = 'fetch';
+      link.crossOrigin = 'anonymous';
+      document.head.appendChild(link);
+    });
+  </script>
 </head>
 
 <body>


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR address the following legacy issues:
1. Add the app insights endpoint to the allow list of OSS AC. So you won't see the annoying CORS error event with OSS version of AC. (This should not matter for our OSS users, as they do not have a valid Azure app insights report enabled)
2. Fix the warning message in preview and demo-app, preload link were never used.
<img width="1390" alt="image" src="https://github.com/logto-io/logto/assets/36393111/c37b8c1a-693f-4409-9300-915b347420d8">

- Under preview mode, all the `SIE` settings were load from the iframe post messages directly instead of send out the query requests. So all the preload links are useless
- Demo app sign-in page come with a `no_cache` flag, which force to load the `SIE` and `phrases` request under a no-cache mode. The original preload link need to add the `no_cache` flag accordingly. 
<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
<img width="1370" alt="image" src="https://github.com/logto-io/logto/assets/36393111/ffdd8e3b-c25a-4724-8bf9-dacb4607c19e">



<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- ~~[ ] `.changeset`~~
- ~~[ ] unit tests~~
- ~~[ ] integration tests~~
- ~~[ ] docs~~

OR

- [x] This PR is not applicable for the checklist
