### PR TITLE
refactor: eliminate connector kit dependency on cloud

### DIFF
--- a/packages/cli/src/connector/utils.ts
+++ b/packages/cli/src/connector/utils.ts
@@ -7,7 +7,7 @@ import type {
   BaseConnector,
   ConnectorMetadata,
   GetConnectorConfig,
-  GetCloudServiceClient,
+  GetAuthedCloudServiceApi,
 } from '@logto/connector-kit';
 import { ConnectorError, ConnectorErrorCodes, ConnectorType } from '@logto/connector-kit';
 
@@ -93,12 +93,12 @@ export const parseMetadata = async (
 export const buildRawConnector = async <T extends AllConnector = AllConnector>(
   connectorFactory: ConnectorFactory<T>,
   getConnectorConfig?: GetConnectorConfig,
-  getCloudServiceClient?: GetCloudServiceClient
+  getAuthedCloudServiceApi?: GetAuthedCloudServiceApi
 ): Promise<{ rawConnector: T; rawMetadata: ConnectorMetadata }> => {
   const { createConnector, path: packagePath } = connectorFactory;
   const rawConnector = await createConnector({
     getConfig: getConnectorConfig ?? notImplemented,
-    getCloudServiceClient,
+    getAuthedCloudServiceApi,
   });
   validateConnectorModule(rawConnector);
   const rawMetadata = await parseMetadata(rawConnector.metadata, packagePath);

--- a/packages/connectors/connector-logto-email/src/constant.ts
+++ b/packages/connectors/connector-logto-email/src/constant.ts
@@ -104,6 +104,6 @@ export const scope = ['send:email'];
 
 export const defaultTimeout = 5000;
 
-export const emailEndpoint = '/services/mails';
+export const emailEndpoint = 'services/mails';
 
-export const usageEndpoint = '/services/mails/usage';
+export const usageEndpoint = 'services/mails/usage';

--- a/packages/core/src/libraries/connector.test.ts
+++ b/packages/core/src/libraries/connector.test.ts
@@ -20,7 +20,7 @@ const connectors: Connector[] = [
 const { createConnectorLibrary } = await import('./connector.js');
 const { getConnectorConfig } = createConnectorLibrary(
   new MockQueries({ connectors: { findAllConnectors: async () => connectors } }),
-  { getClient: jest.fn() }
+  { getAuthedCloudApi: jest.fn() }
 );
 
 it('getConnectorConfig() should return right config', async () => {

--- a/packages/core/src/libraries/connector.ts
+++ b/packages/core/src/libraries/connector.ts
@@ -15,10 +15,10 @@ export type ConnectorLibrary = ReturnType<typeof createConnectorLibrary>;
 
 export const createConnectorLibrary = (
   queries: Queries,
-  cloudConnection: Pick<CloudConnectionLibrary, 'getClient'>
+  cloudConnection: Pick<CloudConnectionLibrary, 'getAuthedCloudApi'>
 ) => {
   const { findAllConnectors, findAllConnectorsWellKnown } = queries.connectors;
-  const { getClient } = cloudConnection;
+  const { getAuthedCloudApi } = cloudConnection;
 
   const getConnectorConfig = async (id: string): Promise<unknown> => {
     const connectors = await findAllConnectors();
@@ -78,7 +78,9 @@ export const createConnectorLibrary = (
           const { rawConnector, rawMetadata } = await buildRawConnector(
             connectorFactory,
             async () => getConnectorConfig(id),
-            conditional(connectorFactory.metadata.id === ServiceConnector.Email && getClient)
+            conditional(
+              connectorFactory.metadata.id === ServiceConnector.Email && getAuthedCloudApi
+            )
           );
 
           const connector: AllConnector = {

--- a/packages/core/src/libraries/sign-in-experience/index.test.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.test.ts
@@ -38,7 +38,7 @@ const queries = new MockQueries({
   signInExperiences,
 });
 const connectorLibrary = createConnectorLibrary(queries, {
-  getClient: jest.fn(),
+  getAuthedCloudApi: jest.fn(),
 });
 const getLogtoConnectors = jest.spyOn(connectorLibrary, 'getLogtoConnectors');
 

--- a/packages/core/src/routes/connector/config-testing.ts
+++ b/packages/core/src/routes/connector/config-testing.ts
@@ -22,7 +22,7 @@ import type { AuthedRouter, RouterInitArgs } from '../types.js';
 export default function connectorConfigTestingRoutes<T extends AuthedRouter>(
   ...[router, { cloudConnection }]: RouterInitArgs<T>
 ) {
-  const { getClient } = cloudConnection;
+  const { getAuthedCloudApi } = cloudConnection;
 
   router.post(
     '/connectors/:factoryId/test',
@@ -69,7 +69,7 @@ export default function connectorConfigTestingRoutes<T extends AuthedRouter>(
       } = await buildRawConnector<SmsConnector | EmailConnector>(
         connectorFactory,
         notImplemented,
-        conditional(ServiceConnector.Email === connectorFactory.metadata.id && getClient)
+        conditional(ServiceConnector.Email === connectorFactory.metadata.id && getAuthedCloudApi)
       );
 
       await sendMessage(

--- a/packages/toolkit/connector-kit/package.json
+++ b/packages/toolkit/connector-kit/package.json
@@ -37,8 +37,7 @@
   },
   "dependencies": {
     "@logto/language-kit": "workspace:^1.0.0",
-    "@silverhand/essentials": "^2.8.4",
-    "@withtyped/client": "^0.7.22"
+    "@silverhand/essentials": "^2.8.4"
   },
   "optionalDependencies": {
     "zod": "^3.20.2"
@@ -51,6 +50,7 @@
     "@types/jest": "^29.4.0",
     "@types/node": "^18.11.18",
     "eslint": "^8.44.0",
+    "got": "^13.0.0",
     "jest": "^29.5.0",
     "lint-staged": "^14.0.0",
     "prettier": "^3.0.0",

--- a/packages/toolkit/connector-kit/src/types.ts
+++ b/packages/toolkit/connector-kit/src/types.ts
@@ -1,7 +1,6 @@
-import type router from '@logto/cloud/routes';
 import type { LanguageTag } from '@logto/language-kit';
 import { isLanguageTag } from '@logto/language-kit';
-import type Client from '@withtyped/client';
+import type { Got } from 'got';
 import type { ZodType } from 'zod';
 import { z } from 'zod';
 
@@ -201,12 +200,12 @@ export type BaseConnector<Type extends ConnectorType> = {
 
 export type CreateConnector<T extends AllConnector> = (options: {
   getConfig: GetConnectorConfig;
-  getCloudServiceClient?: GetCloudServiceClient;
+  getAuthedCloudServiceApi?: GetAuthedCloudServiceApi;
 }) => Promise<T>;
 
 export type GetConnectorConfig = (id: string) => Promise<unknown>;
 
-export type GetCloudServiceClient = () => Promise<Client<typeof router>>;
+export type GetAuthedCloudServiceApi = () => Promise<Got>;
 
 export type AllConnector = SmsConnector | EmailConnector | SocialConnector;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3756,9 +3756,6 @@ importers:
       '@silverhand/essentials':
         specifier: ^2.8.4
         version: 2.8.4
-      '@withtyped/client':
-        specifier: ^0.7.22
-        version: 0.7.22(zod@3.20.2)
     optionalDependencies:
       zod:
         specifier: ^3.20.2
@@ -3785,6 +3782,9 @@ importers:
       eslint:
         specifier: ^8.44.0
         version: 8.44.0
+      got:
+        specifier: ^13.0.0
+        version: 13.0.0
       jest:
         specifier: ^29.5.0
         version: 29.5.0(@types/node@18.11.18)(ts-node@10.9.1)


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Eliminate connector kit dependency on the cloud.
Previously, the logto email connector depended on cloud connection and the route type from logto cloud.
In order to reuse the access token and cloud endpoint provided by cloud connection library, we add a `getAuthedCloudApi` method for the cloud connection library and use this to send request to logto cloud service.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
