### PR TITLE
refactor(console): reorg connector creation modal

### DIFF
--- a/packages/console/src/components/CreateConnectorForm/PlatformSelector/index.module.scss
+++ b/packages/console/src/components/CreateConnectorForm/PlatformSelector/index.module.scss
@@ -1,10 +1,17 @@
 @use '@/scss/underscore' as _;
 
 .platforms {
-  margin-top: _.unit(6);
+  padding: _.unit(4) _.unit(6);
+  background: var(--color-bg-layer-2);
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: _.unit(3);
+  margin-top: _.unit(4);
 
   .title {
     font: var(--font-label-2);
-    margin-bottom: _.unit(3);
   }
 }

--- a/packages/console/src/components/CreateConnectorForm/index.tsx
+++ b/packages/console/src/components/CreateConnectorForm/index.tsx
@@ -144,6 +144,13 @@ function CreateConnectorForm({ onClose, isOpen: isFormOpen, type }: Props) {
           size={radioGroupSize}
           onChange={handleGroupChange}
         />
+        {activeGroup && (
+          <PlatformSelector
+            connectorGroup={activeGroup}
+            connectorId={activeFactoryId}
+            onConnectorIdChange={setActiveFactoryId}
+          />
+        )}
         {standardGroups.length > 0 && (
           <>
             <div className={styles.standardLabel}>
@@ -158,13 +165,6 @@ function CreateConnectorForm({ onClose, isOpen: isFormOpen, type }: Props) {
               onChange={handleGroupChange}
             />
           </>
-        )}
-        {activeGroup && (
-          <PlatformSelector
-            connectorGroup={activeGroup}
-            connectorId={activeFactoryId}
-            onConnectorIdChange={setActiveFactoryId}
-          />
         )}
       </ModalLayout>
     </Modal>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
reorg connector creation modal.
Previously, the select on platform for some cross-platform connector located at the bottom of the modal. Since standard connectors do not need to select specific platform (they are all universal connector), we move the platform select part before standard connectors.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
<img width="1494" alt="image" src="https://github.com/logto-io/logto/assets/15182327/dab98882-6951-4021-8156-d3526a29e975">
<img width="1374" alt="image" src="https://github.com/logto-io/logto/assets/15182327/147f52ba-c9cd-4e9b-bebb-e871ac24c931">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
