### PR TITLE
feat(core,schemas): support region option for s3 storage

### DIFF
--- a/.changeset/lucky-wolves-buy.md
+++ b/.changeset/lucky-wolves-buy.md
@@ -1,0 +1,6 @@
+---
+"@logto/schemas": minor
+"@logto/core": minor
+---
+
+Support region option for s3 storage

--- a/packages/core/src/utils/storage/index.ts
+++ b/packages/core/src/utils/storage/index.ts
@@ -11,12 +11,15 @@ export const buildUploadFile = (config: StorageProviderData): UploadFile => {
     return storage.uploadFile;
   }
 
-  const storage = buildS3Storage(
-    config.endpoint,
-    config.bucket,
-    config.accessKeyId,
-    config.accessSecretKey
-  );
+  const { endpoint, bucket, accessKeyId, accessSecretKey, region } = config;
+
+  const storage = buildS3Storage({
+    endpoint,
+    bucket,
+    accessKeyId,
+    secretAccessKey: accessSecretKey,
+    region,
+  });
 
   return storage.uploadFile;
 };

--- a/packages/schemas/src/types/system.ts
+++ b/packages/schemas/src/types/system.ts
@@ -40,7 +40,8 @@ export const storageProviderDataGuard = z.discriminatedUnion('provider', [
   }),
   z.object({
     provider: z.literal(StorageProvider.S3Storage),
-    endpoint: z.string(),
+    endpoint: z.string().optional(),
+    region: z.string().optional(),
     bucket: z.string(),
     accessKeyId: z.string(),
     accessSecretKey: z.string(),


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Support region option for s3 storage.

`region` is required for s3, previously, it is derived from `endpoint`, this is not working for  other s3-compatible service which is not fit the expected endpoint format.

Now, `region` and `endpoint` are all optional, the user can choose either one.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested with real s3 service.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] docs https://github.com/logto-io/docs/pull/490

OR

- [ ] This PR is not applicable for the checklist
