### PR TITLE
fix(console): redirectUri input error message should be displayed properly

### DIFF
--- a/packages/console/src/mdx-components/UriInputField/index.tsx
+++ b/packages/console/src/mdx-components/UriInputField/index.tsx
@@ -89,7 +89,7 @@ function UriInputField({ name, defaultValue }: Props) {
           defaultValue={defaultValueArray}
           rules={{
             validate: createValidatorForRhf({
-              required: t('errors.required_field_missing_plural', { field: title }),
+              required: t('errors.required_field_missing_plural', { field: t(title) }),
               pattern: {
                 verify: (value) => !value || uriValidator(value),
                 message: t('errors.invalid_uri_format'),


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix error message display in redirect URI input field in SDK guides

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Before:
<img width="1245" alt="image" src="https://github.com/logto-io/logto/assets/12833674/d0523031-5851-431c-b704-b2fea93fe4b8">

After:
<img width="856" alt="image" src="https://github.com/logto-io/logto/assets/12833674/dd208634-41e5-4724-99aa-149947b3d013">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] docs~~

OR

- [x] This PR is not applicable for the checklist
