### PR TITLE
fix(console): code editor text background

### DIFF
--- a/packages/console/src/pages/Applications/components/Guide/index.module.scss
+++ b/packages/console/src/pages/Applications/components/Guide/index.module.scss
@@ -48,10 +48,10 @@
       }
     }
 
-    code {
+    code:not(pre > code) {
       background: var(--color-layer-2);
       font: var(--font-body-2);
-      padding: _.unit(1) _.unit(1);
+      padding: _.unit(1);
       border-radius: 4px;
     }
   }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the issue that code editor text background is weird in light theme mode.

<img width="613" alt="image" src="https://github.com/logto-io/logto/assets/12833674/8f4ffd60-7429-4be2-9c65-1ef51f3f9a46">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Looks normal now

<img width="759" alt="image" src="https://github.com/logto-io/logto/assets/12833674/ba1575e7-7749-4a91-ba56-95870e43ad50">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] docs~~

OR

- [x] This PR is not applicable for the checklist
