### PR TITLE
fix(console): selected text in go sdk guide should not have shadows

### DIFF
--- a/packages/console/src/assets/docs/guides/web-go/README.mdx
+++ b/packages/console/src/assets/docs/guides/web-go/README.mdx
@@ -27,17 +27,17 @@ Add the `github.com/logto-io/go/client` package to your application code:
 package main
 
 import (
-	"github.com/gin-gonic/gin"
-	// Add dependency
-	"github.com/logto-io/go/client"
+    "github.com/gin-gonic/gin"
+    // Add dependency
+    "github.com/logto-io/go/client"
 )
 
 func main() {
-	router := gin.Default()
-	router.GET("/", func(c *gin.Context) {
-		c.String(200, "Hello Logto!")
-	})
-	router.Run(":8080")
+    router := gin.Default()
+    router.GET("/", func(c *gin.Context) {
+        c.String(200, "Hello Logto!")
+    })
+    router.Run(":8080")
 }
 ```
 
@@ -65,8 +65,8 @@ The `Storage` type in the Logto SDK is as follows:
 package client
 
 type Storage interface {
-	GetItem(key string) string
-	SetItem(key, value string)
+    GetItem(key string) string
+    SetItem(key, value string)
 }
 ```
 
@@ -80,26 +80,26 @@ Apply the [github.com/gin-contrib/sessions](https://github.com/gin-contrib/sessi
 package main
 
 import (
-	"github.com/gin-contrib/sessions"
-	"github.com/gin-contrib/sessions/memstore"
-	"github.com/gin-gonic/gin"
-	"github.com/logto-io/go/client"
+    "github.com/gin-contrib/sessions"
+    "github.com/gin-contrib/sessions/memstore"
+    "github.com/gin-gonic/gin"
+    "github.com/logto-io/go/client"
 )
 
 func main() {
-	router := gin.Default()
+    router := gin.Default()
 
-	// We use memory-based session in this example
-	store := memstore.NewStore([]byte("your session secret"))
-	router.Use(sessions.Sessions("logto-session", store))
+    // We use memory-based session in this example
+    store := memstore.NewStore([]byte("your session secret"))
+    router.Use(sessions.Sessions("logto-session", store))
 
-	router.GET("/", func(ctx *gin.Context) {
-		// Get user session
-		session := sessions.Default(ctx)
-		// ...
-		ctx.String(200, "Hello Logto!")
-	})
-	router.Run(":8080")
+    router.GET("/", func(ctx *gin.Context) {
+        // Get user session
+        session := sessions.Default(ctx)
+        // ...
+        ctx.String(200, "Hello Logto!")
+    })
+    router.Run(":8080")
 }
 ```
 
@@ -112,24 +112,24 @@ Create a `session_storage.go` file, define a `SessionStorage` and implement the 
 package main
 
 import (
-	"github.com/gin-contrib/sessions"
+    "github.com/gin-contrib/sessions"
 )
 
 type SessionStorage struct {
-	session sessions.Session
+    session sessions.Session
 }
 
 func (storage *SessionStorage) GetItem(key string) string {
-	value := storage.session.Get(key)
-	if value == nil {
-		return ""
-	}
-	return value.(string)
+    value := storage.session.Get(key)
+    if value == nil {
+        return ""
+    }
+    return value.(string)
 }
 
 func (storage *SessionStorage) SetItem(key, value string) {
-	storage.session.Set(key, value)
-	storage.session.Save()
+    storage.session.Set(key, value)
+    storage.session.Save()
 }
 ```
 
@@ -147,21 +147,21 @@ sessionStorage := &SessionStorage{session: session}
   subtitle="2 steps"
 >
 
-### Create LogtConfig
+### Create LogtoConfig
 
 <pre>
   <code className="language-go">
     {`// main.go
 func main() {
-	// ...
+    // ...
 
-	logtoConfig := &client.LogtoConfig{
-		Endpoint:           "${props.endpoint}",${props.alternativeEndpoint ? ` // or "${props.alternativeEndpoint}"` : ''}
-		AppId:              "${props.app.id}",
-		AppSecret:          "${props.app.secret}",
-	}
+    logtoConfig := &client.LogtoConfig{
+        Endpoint:           "${props.endpoint}",${props.alternativeEndpoint ? ` // or "${props.alternativeEndpoint}"` : ''}
+        AppId:              "${props.app.id}",
+        AppSecret:          "${props.app.secret}",
+    }
 
-	// ...
+    // ...
 }`}
   </code>
 </pre>
@@ -171,30 +171,30 @@ func main() {
 ```go
 // main.go
 func main() {
-	// ...
+    // ...
 
-	router.GET("/", func(ctx *gin.Context) {
-		// Init LogtoClient
-		session := sessions.Default(ctx)
-		logtoClient := client.NewLogtoClient(
-			logtoConfig,
-			&SessionStorage{session: session},
-		)
+    router.GET("/", func(ctx *gin.Context) {
+        // Init LogtoClient
+        session := sessions.Default(ctx)
+        logtoClient := client.NewLogtoClient(
+            logtoConfig,
+            &SessionStorage{session: session},
+        )
 
-		// Use Logto to control the content of the home page
-		authState := "You are not logged in to this website. :("
+        // Use Logto to control the content of the home page
+        authState := "You are not logged in to this website. :("
 
-		if logtoClient.IsAuthenticated() {
-			authState = "You are logged in to this website! :)"
-		}
+        if logtoClient.IsAuthenticated() {
+            authState = "You are logged in to this website! :)"
+        }
 
-		homePage := `<h1>Hello Logto</h1>` +
-			"<div>" + authState + "</div>"
+        homePage := `<h1>Hello Logto</h1>` +
+            "<div>" + authState + "</div>"
 
-		ctx.Data(http.StatusOK, "text/html; charset=utf-8", []byte(homePage))
-	})
+        ctx.Data(http.StatusOK, "text/html; charset=utf-8", []byte(homePage))
+    })
 
-	// ...
+    // ...
 }
 ```
 
@@ -217,40 +217,40 @@ This allows Logto to redirect the user to the `/sign-in-callback` route of your 
 ```go
 //main.go
 func main() {
-	// ...
+    // ...
 
-	// Add a link to perform a sign-in request on the home page
-	router.GET("/", func(ctx *gin.Context) {
-		// ...
-		homePage := `<h1>Hello Logto</h1>` +
-			"<div>" + authState + "</div>" +
-			// Add link
-			`<div><a href="/sign-in">Sign In</a></div>`
+    // Add a link to perform a sign-in request on the home page
+    router.GET("/", func(ctx *gin.Context) {
+        // ...
+        homePage := `<h1>Hello Logto</h1>` +
+            "<div>" + authState + "</div>" +
+            // Add link
+            `<div><a href="/sign-in">Sign In</a></div>`
 
-		ctx.Data(http.StatusOK, "text/html; charset=utf-8", []byte(homePage))
-	})
+        ctx.Data(http.StatusOK, "text/html; charset=utf-8", []byte(homePage))
+    })
 
-	// Add a route for handling sign-in requests
-	router.GET("/sign-in", func(ctx *gin.Context) {
-		session := sessions.Default(ctx)
-		logtoClient := client.NewLogtoClient(
-			logtoConfig,
-			&SessionStorage{session: session},
-		)
+    // Add a route for handling sign-in requests
+    router.GET("/sign-in", func(ctx *gin.Context) {
+        session := sessions.Default(ctx)
+        logtoClient := client.NewLogtoClient(
+            logtoConfig,
+            &SessionStorage{session: session},
+        )
 
-		// The sign-in request is handled by Logto.
-		// The user will be redirected to the Redirect URI on signed in.
-		signInUri, err := logtoClient.SignIn("http://localhost:8080/sign-in-callback")
-		if err != nil {
-			ctx.String(http.StatusInternalServerError, err.Error())
-			return
-		}
+        // The sign-in request is handled by Logto.
+        // The user will be redirected to the Redirect URI on signed in.
+        signInUri, err := logtoClient.SignIn("http://localhost:8080/sign-in-callback")
+        if err != nil {
+            ctx.String(http.StatusInternalServerError, err.Error())
+            return
+        }
 
-		// Redirect the user to the Logto sign-in page.
-		ctx.Redirect(http.StatusTemporaryRedirect, signInUri)
-	})
+        // Redirect the user to the Logto sign-in page.
+        ctx.Redirect(http.StatusTemporaryRedirect, signInUri)
+    })
 
-	// ...
+    // ...
 }
 ```
 
@@ -263,29 +263,29 @@ Since the Redirect URI is `http://localhost:8080/sign-in-callback`, we add the `
 ```go
 // main.go
 func main() {
-	// ...
+    // ...
 
-	// Add a route for handling sign-in callback requests
-	router.GET("/sign-in-callback", func(ctx *gin.Context) {
-		session := sessions.Default(ctx)
-		logtoClient := client.NewLogtoClient(
-			logtoConfig,
-			&SessionStorage{session: session},
-		)
+    // Add a route for handling sign-in callback requests
+    router.GET("/sign-in-callback", func(ctx *gin.Context) {
+        session := sessions.Default(ctx)
+        logtoClient := client.NewLogtoClient(
+            logtoConfig,
+            &SessionStorage{session: session},
+        )
 
-		// The sign-in callback request is handled by Logto
-		err := logtoClient.HandleSignInCallback(ctx.Request)
-		if err != nil {
-			ctx.String(http.StatusInternalServerError, err.Error())
-			return
-		}
+        // The sign-in callback request is handled by Logto
+        err := logtoClient.HandleSignInCallback(ctx.Request)
+        if err != nil {
+            ctx.String(http.StatusInternalServerError, err.Error())
+            return
+        }
 
-		// Jump to the page specified by the developer.
-		// This example takes the user back to the home page.
-		ctx.Redirect(http.StatusTemporaryRedirect, "/")
-	})
+        // Jump to the page specified by the developer.
+        // This example takes the user back to the home page.
+        ctx.Redirect(http.StatusTemporaryRedirect, "/")
+    })
 
-	// ...
+    // ...
 }
 ```
 
@@ -309,41 +309,41 @@ This configuration enables the user to return to the home page after signing out
 ```go
 //main.go
 func main() {
-	// ...
+    // ...
 
-	// Add a link to perform a sign-out request on the home page
-	router.GET("/", func(ctx *gin.Context) {
-		// ...
-		homePage := `<h1>Hello Logto</h1>` +
-			"<div>" + authState + "</div>" +
-			`<div><a href="/sign-in">Sign In</a></div>` +
-			// Add link
-			`<div><a href="/sign-out">Sign Out</a></div>`
+    // Add a link to perform a sign-out request on the home page
+    router.GET("/", func(ctx *gin.Context) {
+        // ...
+        homePage := `<h1>Hello Logto</h1>` +
+            "<div>" + authState + "</div>" +
+            `<div><a href="/sign-in">Sign In</a></div>` +
+            // Add link
+            `<div><a href="/sign-out">Sign Out</a></div>`
 
-		ctx.Data(http.StatusOK, "text/html; charset=utf-8", []byte(homePage))
-	})
+        ctx.Data(http.StatusOK, "text/html; charset=utf-8", []byte(homePage))
+    })
 
-	// Add a route for handling signing out requests
-	router.GET("/sign-out", func(ctx *gin.Context) {
-		session := sessions.Default(ctx)
-		logtoClient := client.NewLogtoClient(
-			logtoConfig,
-			&SessionStorage{session: session},
-		)
+    // Add a route for handling signing out requests
+    router.GET("/sign-out", func(ctx *gin.Context) {
+        session := sessions.Default(ctx)
+        logtoClient := client.NewLogtoClient(
+            logtoConfig,
+            &SessionStorage{session: session},
+        )
 
-		// The sign-out request is handled by Logto.
-		// The user will be redirected to the Post Sign-out Redirect URI on signed out.
-		signOutUri, signOutErr := logtoClient.SignOut("http://localhost:8080")
+        // The sign-out request is handled by Logto.
+        // The user will be redirected to the Post Sign-out Redirect URI on signed out.
+        signOutUri, signOutErr := logtoClient.SignOut("http://localhost:8080")
 
-		if signOutErr != nil {
-			ctx.String(http.StatusOK, signOutErr.Error())
-			return
-		}
+        if signOutErr != nil {
+            ctx.String(http.StatusOK, signOutErr.Error())
+            return
+        }
 
-		ctx.Redirect(http.StatusTemporaryRedirect, signOutUri)
-	})
+        ctx.Redirect(http.StatusTemporaryRedirect, signOutUri)
+    })
 
-	// ...
+    // ...
 }
 ```
 

--- a/packages/console/src/pages/Applications/components/Guide/index.module.scss
+++ b/packages/console/src/pages/Applications/components/Guide/index.module.scss
@@ -48,10 +48,10 @@
       }
     }
 
-    code {
+    code:not(pre > code) {
       background: var(--color-layer-2);
       font: var(--font-body-2);
-      padding: _.unit(1) _.unit(1);
+      padding: _.unit(1);
       border-radius: 4px;
     }
   }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Selected text in Go SDK guide should not have unexpected shadows.
- Replace all tabs with spaces
- Fixed a typo in Go SDK guide

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Before:
<img width="1238" alt="image" src="https://github.com/logto-io/logto/assets/12833674/114dad17-f972-4813-8de6-5f3fb3ad1899">

After:
<img width="600" alt="image" src="https://github.com/logto-io/logto/assets/12833674/01d92bb8-2162-4175-bfd4-244cced073ea">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] docs~~

OR

- [x] This PR is not applicable for the checklist
