### PR TITLE
refactor(console): display webhook test result on details page

### DIFF
--- a/packages/console/src/consts/storage.ts
+++ b/packages/console/src/consts/storage.ts
@@ -6,7 +6,8 @@ export type StorageType =
   | 'appearance_mode'
   | 'linking_social_connector'
   | 'checkout_session'
-  | 'redirect_after_sign_in';
+  | 'redirect_after_sign_in'
+  | 'webhook_test_result';
 
 export const getStorageKey = <T extends StorageType>(forType: T) =>
   `logto:admin_console:${forType}` as const;
@@ -17,4 +18,5 @@ export const storageKeys = Object.freeze({
   checkoutSession: getStorageKey('checkout_session'),
   /** The react-router redirect location after sign in. The value should be a stringified Location object. */
   redirectAfterSignIn: getStorageKey('redirect_after_sign_in'),
+  webhookTestResult: getStorageKey('webhook_test_result'),
 } satisfies Record<CamelCase<StorageType>, string>);

--- a/packages/console/src/ds-components/InlineNotification/index.tsx
+++ b/packages/console/src/ds-components/InlineNotification/index.tsx
@@ -1,6 +1,7 @@
 import type { AdminConsoleKey } from '@logto/phrases';
 import classNames from 'classnames';
-import type { ReactNode } from 'react';
+import { forwardRef } from 'react';
+import type { ReactNode, Ref } from 'react';
 
 import Info from '@/assets/icons/info.svg';
 import Error from '@/assets/icons/toast-error.svg';
@@ -24,19 +25,23 @@ type Props = {
   className?: string;
 };
 
-function InlineNotification({
-  children,
-  action,
-  href,
-  onClick,
-  severity = 'info',
-  variant = 'plain',
-  hasIcon = true,
-  isActionLoading = false,
-  className,
-}: Props) {
+function InlineNotification(
+  {
+    children,
+    action,
+    href,
+    onClick,
+    severity = 'info',
+    variant = 'plain',
+    hasIcon = true,
+    isActionLoading = false,
+    className,
+  }: Props,
+  ref?: Ref<HTMLDivElement>
+) {
   return (
     <div
+      ref={ref}
       className={classNames(
         styles.inlineNotification,
         styles[severity],
@@ -72,4 +77,4 @@ function InlineNotification({
   );
 }
 
-export default InlineNotification;
+export default forwardRef(InlineNotification);

--- a/packages/console/src/pages/WebhookDetails/WebhookSettings/TestWebhook/index.module.scss
+++ b/packages/console/src/pages/WebhookDetails/WebhookSettings/TestWebhook/index.module.scss
@@ -12,3 +12,7 @@
   font: var(--font-body-2);
   margin-right: _.unit(3);
 }
+
+.result {
+  margin-top: _.unit(3);
+}

--- a/packages/console/src/pages/WebhookDetails/WebhookSettings/TestWebhook/index.tsx
+++ b/packages/console/src/pages/WebhookDetails/WebhookSettings/TestWebhook/index.tsx
@@ -93,6 +93,7 @@ function TestWebhook({ hookId }: Props) {
       throw error;
     } finally {
       setIsSendingPayload(false);
+      // Set timeout to wait for the notification to be rendered
       setTimeout(() => {
         testResultRef.current?.scrollIntoView({ behavior: 'smooth' });
       }, 50);

--- a/packages/console/src/pages/WebhookDetails/WebhookSettings/TestWebhook/index.tsx
+++ b/packages/console/src/pages/WebhookDetails/WebhookSettings/TestWebhook/index.tsx
@@ -1,4 +1,8 @@
-import { useState } from 'react';
+import { hookTestErrorResponseDataGuard, type RequestErrorBody } from '@logto/schemas';
+import { trySafe } from '@silverhand/essentials';
+import dayjs from 'dayjs';
+import { HTTPError } from 'ky';
+import { useRef, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
@@ -6,11 +10,13 @@ import { useTranslation } from 'react-i18next';
 import Button from '@/ds-components/Button';
 import DynamicT from '@/ds-components/DynamicT';
 import FormField from '@/ds-components/FormField';
+import InlineNotification from '@/ds-components/InlineNotification';
 import useApi from '@/hooks/use-api';
 import { type WebhookDetailsFormType } from '@/pages/WebhookDetails/types';
 import { webhookDetailsParser } from '@/pages/WebhookDetails/utils';
 
 import * as styles from './index.module.scss';
+import useWebhookTestResult from './use-webhook-test-result';
 
 type Props = {
   hookId: string;
@@ -22,9 +28,12 @@ function TestWebhook({ hookId }: Props) {
     getValues,
     formState: { isValid },
   } = useFormContext<WebhookDetailsFormType>();
+  const testResultRef = useRef<HTMLDivElement>(null);
+
+  const { result, setResult } = useWebhookTestResult();
 
   const [isSendingPayload, setIsSendingPayload] = useState(false);
-  const api = useApi();
+  const api = useApi({ hideErrorToast: true });
 
   const sendTestPayload = async () => {
     if (isSendingPayload) {
@@ -33,13 +42,60 @@ function TestWebhook({ hookId }: Props) {
 
     setIsSendingPayload(true);
 
+    const endpointUrl = getValues('url');
+    const requestTime = Date.now();
+
     try {
       const formData = getValues();
       const { events, config } = webhookDetailsParser.toRemoteModel(formData);
       await api.post(`api/hooks/${hookId}/test`, { json: { events, config } });
-      toast.success(t('webhook_details.settings.test_payload_sent'));
+
+      setResult({
+        result: 'success',
+        endpointUrl,
+        message: t('webhook_details.settings.test_result.test_success'),
+        requestTime,
+      });
+    } catch (error: unknown) {
+      if (!(error instanceof HTTPError)) {
+        toast.error(error instanceof Error ? String(error) : t('general.unknown_error'));
+        return;
+      }
+
+      const { code, data, message } = await error.response.clone().json<RequestErrorBody>();
+
+      if (code === 'hook.send_test_payload_failed') {
+        setResult({
+          result: 'error',
+          endpointUrl,
+          requestTime,
+          message,
+        });
+        return;
+      }
+
+      if (code === 'hook.endpoint_responded_with_error') {
+        const { responseStatus, responseBody } =
+          trySafe(() => hookTestErrorResponseDataGuard.parse(data)) ?? {};
+
+        setResult({
+          result: 'error',
+          endpointUrl,
+          requestTime,
+          message,
+          responseStatus,
+          responseBody,
+        });
+
+        return;
+      }
+
+      throw error;
     } finally {
       setIsSendingPayload(false);
+      setTimeout(() => {
+        testResultRef.current?.scrollIntoView({ behavior: 'smooth' });
+      }, 50);
     }
   };
 
@@ -59,6 +115,55 @@ function TestWebhook({ hookId }: Props) {
           }}
         />
       </div>
+      {result && (
+        <InlineNotification
+          ref={testResultRef}
+          hasIcon
+          severity={result.result}
+          action="general.got_it"
+          className={styles.result}
+          onClick={() => {
+            setResult(undefined);
+          }}
+        >
+          <div>
+            <DynamicT
+              forKey="webhook_details.settings.test_result.endpoint_url"
+              interpolation={{ url: result.endpointUrl }}
+            />
+          </div>
+          {result.message && (
+            <div>
+              <DynamicT
+                forKey="webhook_details.settings.test_result.message"
+                interpolation={{ message: result.message }}
+              />
+            </div>
+          )}
+          {result.responseStatus && (
+            <div>
+              <DynamicT
+                forKey="webhook_details.settings.test_result.response_status"
+                interpolation={{ status: result.responseStatus }}
+              />
+            </div>
+          )}
+          {result.responseBody && (
+            <div>
+              <DynamicT
+                forKey="webhook_details.settings.test_result.response_body"
+                interpolation={{ body: result.responseBody }}
+              />
+            </div>
+          )}
+          <div>
+            <DynamicT
+              forKey="webhook_details.settings.test_result.request_time"
+              interpolation={{ time: dayjs(result.requestTime).format('MM/DD/YYYY, hh:mm:ss A') }}
+            />
+          </div>
+        </InlineNotification>
+      )}
     </FormField>
   );
 }

--- a/packages/console/src/pages/WebhookDetails/WebhookSettings/TestWebhook/use-webhook-test-result.ts
+++ b/packages/console/src/pages/WebhookDetails/WebhookSettings/TestWebhook/use-webhook-test-result.ts
@@ -1,0 +1,48 @@
+import { conditionalString } from '@silverhand/essentials';
+import { useState } from 'react';
+import { z } from 'zod';
+
+import { storageKeys } from '@/consts';
+import { safeParseJson } from '@/utils/json';
+
+const webhookTestResultGuard = z.object({
+  result: z.enum(['success', 'error']),
+  endpointUrl: z.string(),
+  requestTime: z.number(),
+  message: z.string().optional(),
+  responseStatus: z.number().optional(),
+  responseBody: z.string().optional(),
+});
+
+type WebhookTestResult = z.infer<typeof webhookTestResultGuard>;
+
+const readResult = () => {
+  const parsedJson = safeParseJson(
+    conditionalString(sessionStorage.getItem(storageKeys.webhookTestResult))
+  );
+
+  if (!parsedJson.success) {
+    return;
+  }
+  console.log('parsedJson', parsedJson);
+
+  return webhookTestResultGuard.parse(parsedJson.data);
+};
+
+const useWebhookTestResult = () => {
+  const [testResult, setTestResult] = useState<WebhookTestResult | undefined>(readResult());
+
+  return {
+    result: testResult,
+    setResult: (result?: WebhookTestResult) => {
+      setTestResult(result);
+      if (result) {
+        sessionStorage.setItem(storageKeys.webhookTestResult, JSON.stringify(result));
+      } else {
+        sessionStorage.removeItem(storageKeys.webhookTestResult);
+      }
+    },
+  };
+};
+
+export default useWebhookTestResult;

--- a/packages/console/src/pages/WebhookDetails/WebhookSettings/TestWebhook/use-webhook-test-result.ts
+++ b/packages/console/src/pages/WebhookDetails/WebhookSettings/TestWebhook/use-webhook-test-result.ts
@@ -1,4 +1,4 @@
-import { conditionalString } from '@silverhand/essentials';
+import { conditional, conditionalString } from '@silverhand/essentials';
 import { useState } from 'react';
 import { z } from 'zod';
 
@@ -21,12 +21,7 @@ const readResult = () => {
     conditionalString(sessionStorage.getItem(storageKeys.webhookTestResult))
   );
 
-  if (!parsedJson.success) {
-    return;
-  }
-  console.log('parsedJson', parsedJson);
-
-  return webhookTestResultGuard.parse(parsedJson.data);
+  return conditional(parsedJson.success && webhookTestResultGuard.parse(parsedJson.data));
 };
 
 const useWebhookTestResult = () => {

--- a/packages/integration-tests/src/tests/ui/webhooks/helpers.ts
+++ b/packages/integration-tests/src/tests/ui/webhooks/helpers.ts
@@ -1,0 +1,11 @@
+import { type Page } from 'puppeteer';
+
+export const expectToCreateWebhook = async (page: Page) => {
+  await expect(page).toClick('div[class$=main] div[class$=headline] > button');
+  await expect(page).toClick('span[class$=label]', { text: 'Create new account' });
+  await expect(page).toClick('span[class$=label]', { text: 'Sign in' });
+  await expect(page).toFill('input[name=name]', 'hook_name');
+  await expect(page).toFill('input[name=url]', 'https://example.com/webhook');
+  await expect(page).toClick('button[type=submit]');
+  await page.waitForSelector('div[class$=header] div[class$=metadata] div[class$=title]');
+};

--- a/packages/integration-tests/src/ui-helpers/index.ts
+++ b/packages/integration-tests/src/ui-helpers/index.ts
@@ -129,3 +129,13 @@ export const expectToOpenNewPage = async (browser: Browser, url: string) => {
 
   await newPage?.close();
 };
+
+export const expectMainPageWithTitle = async (page: Page, title: string) => {
+  await expect(page).toMatchElement(
+    'div[class$=main] div[class$=headline] div[class$=titleEllipsis]',
+    {
+      text: title,
+      timeout: 2000,
+    }
+  );
+};

--- a/packages/phrases/src/locales/de/errors/hook.ts
+++ b/packages/phrases/src/locales/de/errors/hook.ts
@@ -1,6 +1,7 @@
 const hook = {
   missing_events: 'Sie müssen mindestens ein Ereignis angeben.',
   send_test_payload_failed: 'Fehler beim Senden des Testpayloads: {{message}}',
+  endpoint_responded_with_error: 'Endpunkt antwortete mit Fehler.',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/de/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/webhook-details.ts
@@ -46,7 +46,14 @@ const webhook_details = {
     test_webhook_description:
       'Konfigurieren Sie den Webhook und testen Sie ihn mit Beispieldaten für jede ausgewählte Ereigniskategorie, um eine korrekte Empfangs- und Verarbeitungsfunktion zu überprüfen.',
     send_test_payload: 'Testnutzlast senden',
-    test_payload_sent: 'Die Nutzlast wurde erfolgreich gesendet.',
+    test_result: {
+      endpoint_url: 'Endpunkt-URL: {{url}}',
+      message: 'Nachricht: {{message}}',
+      response_status: 'Antwortstatus: {{status, number}}',
+      response_body: 'Antwortkörper: {{body}}',
+      request_time: 'Anforderungszeit: {{time}}',
+      test_success: 'Der Webhook-Test zum Endpunkt war erfolgreich.',
+    },
   },
 };
 

--- a/packages/phrases/src/locales/en/errors/hook.ts
+++ b/packages/phrases/src/locales/en/errors/hook.ts
@@ -1,6 +1,7 @@
 const hook = {
   missing_events: 'You need to provide at least one event.',
   send_test_payload_failed: 'Failed to send test payload: {{message}}',
+  endpoint_responded_with_error: 'Endpoint responded with error.',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/en/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/webhook-details.ts
@@ -45,7 +45,14 @@ const webhook_details = {
     test_webhook_description:
       'Configure the webhook, and test it with payload examples for each selected event to verify correct reception and processing.',
     send_test_payload: 'Send test payload',
-    test_payload_sent: 'The payload has been sent successfully.',
+    test_result: {
+      endpoint_url: 'Endpoint URL: {{url}}',
+      message: 'Message: {{message}}',
+      response_status: 'Response status: {{status, number}}',
+      response_body: 'Response body: {{body}}',
+      request_time: 'Request time: {{time}}',
+      test_success: 'The webhook test to the endpoint was successful.',
+    },
   },
 };
 

--- a/packages/phrases/src/locales/es/errors/hook.ts
+++ b/packages/phrases/src/locales/es/errors/hook.ts
@@ -1,6 +1,7 @@
 const hook = {
   missing_events: 'Necesita proporcionar al menos un evento.',
   send_test_payload_failed: 'Error al enviar carga útil de prueba: {{message}}',
+  endpoint_responded_with_error: 'El punto de enlace respondió con un error.',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/es/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/webhook-details.ts
@@ -46,7 +46,14 @@ const webhook_details = {
     test_webhook_description:
       'Configure el webhook y pruébelo con ejemplos de carga útil para cada evento seleccionado para verificar la recepción y el procesamiento correcto.',
     send_test_payload: 'Enviar carga útil de prueba',
-    test_payload_sent: 'La carga útil se ha enviado con éxito.',
+    test_result: {
+      endpoint_url: 'URL del punto final: {{url}}',
+      message: 'Mensaje: {{message}}',
+      response_status: 'Estado de la respuesta: {{status, number}}',
+      response_body: 'Cuerpo de la respuesta: {{body}}',
+      request_time: 'Tiempo de solicitud: {{time}}',
+      test_success: 'La prueba del webhook en el punto final fue exitosa.',
+    },
   },
 };
 

--- a/packages/phrases/src/locales/fr/errors/hook.ts
+++ b/packages/phrases/src/locales/fr/errors/hook.ts
@@ -1,6 +1,7 @@
 const hook = {
   missing_events: 'Vous devez fournir au moins un événement.',
   send_test_payload_failed: "Échec de l'envoi de la charge utile de test : {{message}}",
+  endpoint_responded_with_error: 'Le point de terminaison a répondu avec une erreur.',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/fr/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/webhook-details.ts
@@ -46,7 +46,14 @@ const webhook_details = {
     test_webhook_description:
       'Configurez le webhook, et testez-le avec des exemples de payload pour chaque événement sélectionné pour vérifier la réception et le traitement corrects.',
     send_test_payload: 'Envoyer une charge utile de test',
-    test_payload_sent: 'La charge utile a été envoyée avec succès.',
+    test_result: {
+      endpoint_url: 'URL du point de terminaison : {{url}}',
+      message: 'Message : {{message}}',
+      response_status: 'Statut de la réponse : {{status, number}}',
+      response_body: 'Corps de la réponse : {{body}}',
+      request_time: 'Temps de la demande : {{time}}',
+      test_success: 'Le test du webhook vers le point de terminaison a réussi.',
+    },
   },
 };
 

--- a/packages/phrases/src/locales/it/errors/hook.ts
+++ b/packages/phrases/src/locales/it/errors/hook.ts
@@ -1,6 +1,7 @@
 const hook = {
   missing_events: 'È necessario fornire almeno un evento.',
   send_test_payload_failed: 'Impossibile inviare il payload di prova: {{message}}',
+  endpoint_responded_with_error: 'Il punto di accesso ha risposto con un errore.',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/it/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/webhook-details.ts
@@ -45,7 +45,14 @@ const webhook_details = {
     test_webhook_description:
       'Configurare il webhook e testarlo con esempi di payload per ciascun evento selezionato al fine di verificare la corretta ricezione e elaborazione.',
     send_test_payload: 'Invia Payload di Test',
-    test_payload_sent: 'Il payload è stato inviato con successo.',
+    test_result: {
+      endpoint_url: 'URL del punto di arrivo: {{url}}',
+      message: 'Messaggio: {{message}}',
+      response_status: 'Stato della risposta: {{status, number}}',
+      response_body: 'Corpo della risposta: {{body}}',
+      request_time: 'Tempo di richiesta: {{time}}',
+      test_success: 'Il test del webhook al punto di arrivo è stato eseguito con successo.',
+    },
   },
 };
 

--- a/packages/phrases/src/locales/ja/errors/hook.ts
+++ b/packages/phrases/src/locales/ja/errors/hook.ts
@@ -1,6 +1,7 @@
 const hook = {
   missing_events: '少なくとも1つのイベントを提供する必要があります。',
   send_test_payload_failed: 'テストペイロードの送信に失敗しました：{{message}}',
+  endpoint_responded_with_error: 'エンドポイントがエラーで応答しました：{{message}}。',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/ja/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/webhook-details.ts
@@ -45,7 +45,14 @@ const webhook_details = {
     test_webhook_description:
       'Webhookを設定し、各選択したイベントのペイロード例を使用してテストして、正しい受信と処理を確認してください。',
     send_test_payload: 'テストペイロードを送信する',
-    test_payload_sent: 'ペイロードが正常に送信されました。',
+    test_result: {
+      endpoint_url: 'エンドポイントURL：{{url}}',
+      message: 'メッセージ：{{message}}',
+      response_status: 'レスポンスステータス：{{status, number}}',
+      response_body: 'レスポンスボディ：{{body}}',
+      request_time: 'リクエスト時間：{{time}}',
+      test_success: 'エンドポイントへのWebhookテストは成功しました。',
+    },
   },
 };
 

--- a/packages/phrases/src/locales/ko/errors/hook.ts
+++ b/packages/phrases/src/locales/ko/errors/hook.ts
@@ -1,6 +1,7 @@
 const hook = {
   missing_events: '최소한 하나의 이벤트를 제공해야 합니다.',
   send_test_payload_failed: '테스트 페이로드 보내기 실패: {{message}}',
+  endpoint_responded_with_error: '엔드포인트가 오류로 응답했습니다.',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/ko/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/webhook-details.ts
@@ -44,7 +44,14 @@ const webhook_details = {
     test_webhook_description:
       '웹훅을 구성하고 각 선택한 이벤트의 페이로드 예제로 검증하여 올바른 수신 및 처리를 확인하세요.',
     send_test_payload: '테스트 페이로드 보내기',
-    test_payload_sent: '페이로드가 성공적으로 보내졌습니다.',
+    test_result: {
+      endpoint_url: '엔드포인트 URL: {{url}}',
+      message: '메시지: {{message}}',
+      response_status: '응답 상태: {{status, number}}',
+      response_body: '응답 본문: {{body}}',
+      request_time: '요청 시간: {{time}}',
+      test_success: '엔드포인트로의 웹훅 테스트가 성공했습니다.',
+    },
   },
 };
 

--- a/packages/phrases/src/locales/pl-pl/errors/hook.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/hook.ts
@@ -1,6 +1,7 @@
 const hook = {
   missing_events: 'Musisz podać przynajmniej jedno zdarzenie.',
   send_test_payload_failed: 'Błąd podczas wysyłania testowego ładunku: {{message}}',
+  endpoint_responded_with_error: 'Punkt końcowy odpowiedział błędem.',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/webhook-details.ts
@@ -45,7 +45,14 @@ const webhook_details = {
     test_webhook_description:
       'Skonfiguruj webhooka i przetestuj go przy użyciu przykładów ładunku dla każdego wybranego zdarzenia, aby sprawdzić poprawne odbieranie i przetwarzanie.',
     send_test_payload: 'Wyślij testowy ładunek',
-    test_payload_sent: 'Ladunek został pomyślnie wysłany.',
+    test_result: {
+      endpoint_url: 'URL punktu końcowego: {{url}}',
+      message: 'Wiadomość: {{message}}',
+      response_status: 'Status odpowiedzi: {{status, number}}',
+      response_body: 'Treść odpowiedzi: {{body}}',
+      request_time: 'Czas żądania: {{time}}',
+      test_success: 'Test webhooka do punktu końcowego zakończył się powodzeniem.',
+    },
   },
 };
 

--- a/packages/phrases/src/locales/pt-br/errors/hook.ts
+++ b/packages/phrases/src/locales/pt-br/errors/hook.ts
@@ -1,6 +1,7 @@
 const hook = {
   missing_events: 'Você precisa fornecer pelo menos um evento.',
   send_test_payload_failed: 'Falha ao enviar uma carga de teste: {{message}}',
+  endpoint_responded_with_error: 'O ponto de extremidade respondeu com erro.',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/webhook-details.ts
@@ -45,7 +45,14 @@ const webhook_details = {
     test_webhook_description:
       'Configure o webhook e teste-o com exemplos de carga para cada evento selecionado para verificação da recepção e processamento corretos.',
     send_test_payload: 'Enviar carga de teste',
-    test_payload_sent: 'A carga foi enviada com sucesso.',
+    test_result: {
+      endpoint_url: 'URL do ponto de extremidade: {{url}}',
+      message: 'Mensagem: {{message}}',
+      response_status: 'Status da resposta: {{status, number}}',
+      response_body: 'Corpo da resposta: {{body}}',
+      request_time: 'Tempo da solicitação: {{time}}',
+      test_success: 'O teste de webhook para o ponto de extremidade foi bem-sucedido.',
+    },
   },
 };
 

--- a/packages/phrases/src/locales/pt-pt/errors/hook.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/hook.ts
@@ -1,6 +1,7 @@
 const hook = {
   missing_events: 'Você precisa fornecer pelo menos um evento.',
   send_test_payload_failed: 'Falha ao enviar carga de teste: {{message}}',
+  endpoint_responded_with_error: 'O ponto de extremidade respondeu com erro.',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/webhook-details.ts
@@ -45,7 +45,14 @@ const webhook_details = {
     test_webhook_description:
       'Configure o webhook e teste-o com exemplos de carga útil para cada evento selecionado para verificar a recepção e o processamento corretos.',
     send_test_payload: 'Enviar carga de teste',
-    test_payload_sent: 'A carga foi enviada com sucesso.',
+    test_result: {
+      endpoint_url: 'URL do ponto de extremidade: {{url}}',
+      message: 'Mensagem: {{message}}',
+      response_status: 'Estado da resposta: {{status, number}}',
+      response_body: 'Corpo da resposta: {{body}}',
+      request_time: 'Tempo da solicitação: {{time}}',
+      test_success: 'O teste de webhook para o ponto de extremidade foi bem-sucedido.',
+    },
   },
 };
 

--- a/packages/phrases/src/locales/ru/errors/hook.ts
+++ b/packages/phrases/src/locales/ru/errors/hook.ts
@@ -1,6 +1,7 @@
 const hook = {
   missing_events: 'Вы должны предоставить как минимум одно событие.',
   send_test_payload_failed: 'Не удалось отправить тестовую нагрузку: {{message}}',
+  endpoint_responded_with_error: 'Конечная точка ответила ошибкой.',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/ru/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/webhook-details.ts
@@ -45,7 +45,14 @@ const webhook_details = {
     test_webhook_description:
       'Настройте вебхук и протестируйте его с примерами нагрузки для каждого выбранного события, чтобы проверить правильный прием и обработку.',
     send_test_payload: 'Отправить тестовую нагрузку',
-    test_payload_sent: 'Нагрузка успешно отправлена.',
+    test_result: {
+      endpoint_url: 'URL конечной точки: {{url}}',
+      message: 'Сообщение: {{message}}',
+      response_status: 'Статус ответа: {{status, number}}',
+      response_body: 'Тело ответа: {{body}}',
+      request_time: 'Время запроса: {{time}}',
+      test_success: 'Тест вебхука на конечную точку прошел успешно.',
+    },
   },
 };
 

--- a/packages/phrases/src/locales/tr-tr/errors/hook.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/hook.ts
@@ -1,6 +1,7 @@
 const hook = {
   missing_events: 'En az bir etkinlik sağlamanız gerekiyor.',
   send_test_payload_failed: 'Test yükü gönderilemedi: {{message}}',
+  endpoint_responded_with_error: 'Nokta yanıt verdi hatayla.',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/webhook-details.ts
@@ -44,7 +44,14 @@ const webhook_details = {
     test_webhook_description:
       'Webhook’u yapılandırın ve her seçilen olay için yük örnekleriyle test ederek doğru alma ve işleme işlemini doğrulayın.',
     send_test_payload: 'Test yükünü gönder',
-    test_payload_sent: 'Yük başarıyla gönderildi.',
+    test_result: {
+      endpoint_url: 'Son nokta URL: {{url}}',
+      message: 'Mesaj: {{message}}',
+      response_status: 'Yanıt durumu: {{status, number}}',
+      response_body: 'Yanıt gövdesi: {{body}}',
+      request_time: 'İstek zamanı: {{time}}',
+      test_success: 'Son noktaya yapılan webhook testi başarılı oldu.',
+    },
   },
 };
 

--- a/packages/phrases/src/locales/zh-cn/errors/hook.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/hook.ts
@@ -1,6 +1,7 @@
 const hook = {
   missing_events: '你需要提供至少一个事件。',
   send_test_payload_failed: '无法发送测试内容：{{message}}',
+  endpoint_responded_with_error: '端点返回了错误。',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/webhook-details.ts
@@ -42,7 +42,14 @@ const webhook_details = {
     test_webhook_description:
       '配置 Webhook，并使用每个选定事件的负载示例进行测试，以验证正确的接收和处理。',
     send_test_payload: '发送测试负载',
-    test_payload_sent: '负载已成功发送。',
+    test_result: {
+      endpoint_url: '端点 URL：{{url}}',
+      message: '消息：{{message}}',
+      response_status: '响应状态：{{status, number}}',
+      response_body: '响应主体：{{body}}',
+      request_time: '请求时间：{{time}}',
+      test_success: '向端点发起的 webhook 测试成功。',
+    },
   },
 };
 

--- a/packages/phrases/src/locales/zh-hk/errors/hook.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/hook.ts
@@ -1,6 +1,7 @@
 const hook = {
   missing_events: '你需要至少提供一個事件。',
   send_test_payload_failed: '無法發送測試内容：{{message}}',
+  endpoint_responded_with_error: '端點返回了錯誤。',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/webhook-details.ts
@@ -42,7 +42,14 @@ const webhook_details = {
     test_webhook_description:
       '配置 webhook，並使用每個選定事件的負載示例進行測試，以驗證正確接收和處理。',
     send_test_payload: '發送測試負載',
-    test_payload_sent: '負載已成功發送。',
+    test_result: {
+      endpoint_url: '端點URL：{{url}}',
+      message: '消息：{{message}}',
+      response_status: '響應狀態：{{status, number}}',
+      response_body: '響應主體：{{body}}',
+      request_time: '請求時間：{{time}}',
+      test_success: '向端點發起的 webhook 測試成功。',
+    },
   },
 };
 

--- a/packages/phrases/src/locales/zh-tw/errors/hook.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/hook.ts
@@ -1,6 +1,7 @@
 const hook = {
   missing_events: '你需要至少提供一個事件。',
   send_test_payload_failed: '無法发送測試内容：{{message}}',
+  endpoint_responded_with_error: '端點返回了錯誤。',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/webhook-details.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/webhook-details.ts
@@ -42,7 +42,14 @@ const webhook_details = {
     test_webhook_description:
       '配置 Webhook，並使用每個選定事件的有效載荷示例進行測試，以驗證正確的接收和處理。',
     send_test_payload: '發送測試有效載荷',
-    test_payload_sent: '有效載荷已成功發送。',
+    test_result: {
+      endpoint_url: '端點URL：{{url}}',
+      message: '訊息：{{message}}',
+      response_status: '回應狀態：{{status, number}}',
+      response_body: '回應主體：{{body}}',
+      request_time: '請求時間：{{time}}',
+      test_success: '向端點發起的 webhook 測試成功。',
+    },
   },
 };
 

--- a/packages/schemas/src/types/hook.ts
+++ b/packages/schemas/src/types/hook.ts
@@ -28,3 +28,10 @@ export const hookResponseGuard = Hooks.guard.extend({
 });
 
 export type HookResponse = z.infer<typeof hookResponseGuard>;
+
+export const hookTestErrorResponseDataGuard = z.object({
+  responseStatus: z.number(),
+  responseBody: z.string(),
+});
+
+export type HookTestErrorResponseData = z.infer<typeof hookTestErrorResponseDataGuard>;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Display webhook test result on details page.
- Add an `use-webhook-test-result` hook to store the test result in the session storage, since per design requirements, the result info should not disappear unless the `Got it` button have been clicked.
- Handle HTTP errors from the webhook endpoint URL when testing a webhook, since now we need to display the error info in the front-end.

### Update
- Forward reference for the `InlineNotification` component

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
API test & UI test & Test locally & Align with designers.
![image](https://github.com/logto-io/logto/assets/10806653/08b7d1fc-a657-48bf-b6b2-b9093ab4e6f8)

![image](https://github.com/logto-io/logto/assets/10806653/99363eb7-2f55-423d-a4ca-f9fcf524aa2c)

![image](https://github.com/logto-io/logto/assets/10806653/5eec59fc-98d7-44e6-878a-e758c10bb790)


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [] unit tests
- [x] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
