### PR TITLE
fix(schemas): specify function db schema of check_role_type

### DIFF
--- a/packages/schemas/alterations/next-1694418765-specify-check-role-type-function-to-be-public-schema.ts
+++ b/packages/schemas/alterations/next-1694418765-specify-check-role-type-function-to-be-public-schema.ts
@@ -1,0 +1,54 @@
+import { sql } from 'slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+/**
+ * This alteration is a fix on `check_role_type` function, since this function could be called by
+ * cloud (at the time the DB schema is `cloud` and can not find `public` functions/tables).
+ *
+ * As a result, we need to specify the function to be with `public` schema.
+ */
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(
+      sql`alter table applications_roles drop constraint applications_roles__role_type;`
+    );
+    await pool.query(sql`alter table users_roles drop constraint users_roles__role_type;`);
+    await pool.query(sql`drop function check_role_type;`);
+    await pool.query(sql`
+      create function public.check_role_type(role_id varchar(21), target_type role_type) returns boolean as
+      $$ begin
+        return (select type from public.roles where id = role_id) = target_type;
+      end; $$ language plpgsql;
+    `);
+    await pool.query(sql`
+      alter table users_roles add constraint users_roles__role_type
+          check (public.check_role_type(role_id, 'User'));
+    `);
+    await pool.query(
+      sql`alter table applications_roles add constraint applications_roles__role_type check (public.check_role_type(role_id, 'MachineToMachine'));`
+    );
+  },
+  down: async (pool) => {
+    await pool.query(
+      sql`alter table applications_roles drop constraint applications_roles__role_type;`
+    );
+    await pool.query(sql`alter table users_roles drop constraint users_roles__role_type;`);
+    await pool.query(sql`drop function public.check_role_type;`);
+    await pool.query(sql`
+      create function check_role_type(role_id varchar(21), target_type role_type) returns boolean as
+      $$ begin
+        return (select type from roles where id = role_id) = target_type;
+      end; $$ language plpgsql;
+    `);
+    await pool.query(sql`
+      alter table users_roles add constraint users_roles__role_type
+          check (check_role_type(role_id, 'User'));
+    `);
+    await pool.query(
+      sql`alter table applications_roles add constraint applications_roles__role_type check (check_role_type(role_id, 'MachineToMachine'));`
+    );
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/applications_roles.sql
+++ b/packages/schemas/tables/applications_roles.sql
@@ -12,7 +12,7 @@ create table applications_roles (
   constraint applications_roles__application_id_role_id
     unique (tenant_id, application_id, role_id),
   constraint applications_roles__role_type
-    check (check_role_type(role_id, 'MachineToMachine'))
+    check (public.check_role_type(role_id, 'MachineToMachine'))
 );
 
 create index applications_roles__id

--- a/packages/schemas/tables/roles.sql
+++ b/packages/schemas/tables/roles.sql
@@ -17,7 +17,7 @@ create table roles (
 create index roles__id
   on roles (tenant_id, id);
 
-create function check_role_type(role_id varchar(21), target_type role_type) returns boolean as
+create function public.check_role_type(role_id varchar(21), target_type role_type) returns boolean as
 $$ begin
-  return (select type from roles where id = role_id) = target_type;
+  return (select type from public.roles where id = role_id) = target_type;
 end; $$ language plpgsql;

--- a/packages/schemas/tables/users_roles.sql
+++ b/packages/schemas/tables/users_roles.sql
@@ -12,7 +12,7 @@ create table users_roles (
   constraint users_roles__user_id_role_id
     unique (tenant_id, user_id, role_id),
   constraint users_roles__role_type
-    check (check_role_type(role_id, 'User'))
+    check (public.check_role_type(role_id, 'User'))
 );
 
 create index users_roles__id


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix check role type fucntion's db schema.
Previously, we did not specify the DB schema of the function `check_role_type`. The fact is, cloud may call this function under `cloud` DB schema and can not find out `public.check_role_type`. We hence should specify the DB schema of this function.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
