### PR TITLE
ci: always show logs for integration tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -112,16 +112,17 @@ jobs:
 
       # Test
       - name: Run tests
-        # continue-on-error: true # Uncomment this line to debug
         run: |
           cd tests/packages/integration-tests
           pnpm build
           pnpm run test:${{ matrix.target }}
 
       - name: Show logs
+        if: always()
         working-directory: logto/
         run: cat nohup.out
 
       - name: Show error logs
+        if: always()
         working-directory: logto/
         run: cat nohup.err


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
same as https://github.com/logto-io/cloud/pull/274

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
see this [workflow run](https://github.com/logto-io/cloud/actions/runs/6143792997/job/16668464353), failed with logs shown

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~~`.changeset`~~
- [ ] ~~unit tests~~
- [ ] ~~integration tests~~
- [ ] ~~docs~~
