### PR TITLE
chore(core): add supplementary openapi json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,10 @@
       "source.fixAll.stylelint": true
     }
   },
-  "stylelint.validate": ["css", "scss"],
+  "stylelint.validate": [
+    "css",
+    "scss"
+  ],
   "eslint.workingDirectories": [
     {
       "pattern": "./packages/*",
@@ -23,6 +26,14 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true,
   },
+  "json.schemas": [
+    {
+      "fileMatch": [
+        "packages/core/src/routes/*.openapi.json"
+      ],
+      "url": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.0/schema.json"
+    }
+  ],
   "cSpell.words": [
     "Alipay",
     "CIAM",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "precommit": "lint-staged",
-    "copyfiles": "copyfiles -u 1 src/**/*.md build",
+    "copyfiles": "copyfiles -u 1 src/routes/**/*.openapi.json build/",
     "build": "rm -rf build/ && tsc -p tsconfig.build.json && pnpm run copyfiles",
     "build:test": "rm -rf build/ && tsc -p tsconfig.test.json --sourcemap",
     "lint": "eslint --ext .ts src",

--- a/packages/core/src/routes/status.openapi.json
+++ b/packages/core/src/routes/status.openapi.json
@@ -1,0 +1,15 @@
+{
+  "paths": {
+    "/api/status": {
+      "get": {
+        "summary": "Health check",
+        "description": "The traditional health check API. No authentication needed.\n\n> **Note**\n> Even if 204 is returned, it does not guarantee all the APIs are working properly since they may depend on additional resources or external services.",
+        "responses": {
+          "204": {
+            "description": "The Logto core service is healthy."
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/core/src/routes/swagger.test.ts
+++ b/packages/core/src/routes/swagger.test.ts
@@ -51,8 +51,6 @@ describe('GET /swagger.json', () => {
 
   it('should contain the specific paths', async () => {
     const response = await mockSwaggerRequest.get('/swagger.json');
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    expect(Object.entries(response.body.paths)).toHaveLength(2);
     expect(response.body.paths).toMatchObject({
       /* eslint-disable @typescript-eslint/no-unsafe-assignment */
       '/api/mock': {

--- a/packages/core/src/routes/swagger.ts
+++ b/packages/core/src/routes/swagger.ts
@@ -1,4 +1,3 @@
-import assert from 'node:assert';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -6,7 +5,6 @@ import { fileURLToPath } from 'node:url';
 import { httpCodeToMessage } from '@logto/core-kit';
 import { conditionalArray, deduplicate, toTitle } from '@silverhand/essentials';
 import deepmerge from 'deepmerge';
-import { findUp } from 'find-up';
 import type { IMiddleware } from 'koa-router';
 import type Router from 'koa-router';
 import type { OpenAPIV3 } from 'openapi-types';
@@ -213,15 +211,8 @@ export default function swaggerRoutes<T extends AnonymousRouter, R extends Route
       pathMap.set(path, { ...pathMap.get(path), [method]: operation });
     }
 
-    const sourcePath = await findUp('src', {
-      type: 'directory',
-      cwd: path.dirname(fileURLToPath(import.meta.url)),
-    });
-    assert(
-      sourcePath,
-      'Cannot find the `src` directory, please make sure you downloaded the full distribution.'
-    );
-    const supplementPaths = await findSupplementFiles(path.join(sourcePath, 'routes'));
+    // Current path should be the root directory of routes files.
+    const supplementPaths = await findSupplementFiles(path.dirname(fileURLToPath(import.meta.url)));
     const supplementDocuments = await Promise.all(
       supplementPaths.map(
         // eslint-disable-next-line no-restricted-syntax


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
support supplementary openapi json files (ends with `.openapi.json`) under `packages/core/src/routes`. the file content will be deeply merged to the generated data.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
looks good

<img width="1655" alt="image" src="https://github.com/logto-io/logto/assets/14722250/b94f9d7f-f002-44e5-b1f6-2d68a6bddf25">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~~`.changeset`~~
- [ ] ~~unit tests~~
- [ ] ~~integration tests~~
- [ ] ~~docs~~