### PR TITLE
fix(console): input verification code in profile page should not crash the app

### DIFF
--- a/.changeset/mean-jeans-clap.md
+++ b/.changeset/mean-jeans-clap.md
@@ -1,0 +1,5 @@
+---
+"@logto/console": patch
+---
+
+fix the app crash when inputting verification code in Console profile page

--- a/packages/console/src/hooks/use-redirect-uri.ts
+++ b/packages/console/src/hooks/use-redirect-uri.ts
@@ -1,5 +1,6 @@
 import { ossConsolePath } from '@logto/schemas';
 import { conditionalArray, joinPath } from '@silverhand/essentials';
+import { useMemo } from 'react';
 import { useHref } from 'react-router-dom';
 
 import { isCloud } from '@/consts/env';
@@ -13,8 +14,9 @@ const useRedirectUri = (flow: 'signIn' | 'signOut' = 'signIn') => {
   const path = useHref(
     joinPath(...conditionalArray(!isCloud && ossConsolePath, flow === 'signIn' ? '/callback' : '/'))
   );
+  const url = useMemo(() => new URL(path, window.location.origin), [path]);
 
-  return new URL(path, window.location.origin);
+  return url;
 };
 
 export default useRedirectUri;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Hot fix: The app should not crash when inputting verification code in user profile page in admin console.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested OK

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] docs~~

OR

~~- [] This PR is not applicable for the checklist~~
