### PR TITLE
fix(core): allow ui unsafe inline script

### DIFF
--- a/packages/core/src/middleware/koa-security-headers.ts
+++ b/packages/core/src/middleware/koa-security-headers.ts
@@ -80,7 +80,8 @@ export default function koaSecurityHeaders<StateT, ContextT, ResponseBodyT>(
         // Non-production environment allow "unsafe-eval" and "unsafe-inline" for debugging purpose
         scriptSrc: [
           "'self'",
-          ...conditionalArray(!isProduction && ["'unsafe-eval'", "'unsafe-inline'"]),
+          "'unsafe-inline'",
+          ...conditionalArray(!isProduction && "'unsafe-eval'"),
         ],
         connectSrc: ["'self'", tenantEndpointOrigin, ...developmentOrigins, ...appInsightsOrigins],
         // WARNING: high risk Need to allow self hosted terms of use page loaded in an iframe


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Allow UI unsafe inline script in the CSP header. 

<img width="1002" alt="image" src="https://github.com/logto-io/logto/assets/36393111/74e29d99-f3d3-4a8f-b09f-0415667bdf4b">

<img width="614" alt="image" src="https://github.com/logto-io/logto/assets/36393111/99462a9e-75be-455b-8df9-d50be6350046">



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
