### PR TITLE
refactor(console): hide mfa quota content before feature launched

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -26,7 +26,7 @@
     "@fontsource/roboto-mono": "^5.0.0",
     "@jest/types": "^29.5.0",
     "@logto/app-insights": "workspace:^1.3.1",
-    "@logto/cloud": "0.2.5-71b7fea",
+    "@logto/cloud": "0.2.5-444ed49",
     "@logto/connector-kit": "workspace:^1.1.1",
     "@logto/core-kit": "workspace:^2.0.1",
     "@logto/language-kit": "workspace:^1.0.0",

--- a/packages/console/src/consts/quota-item-phrases.ts
+++ b/packages/console/src/consts/quota-item-phrases.ts
@@ -21,6 +21,7 @@ export const quotaItemPhrasesMap: Record<
   auditLogsRetentionDays: 'audit_logs_retention_days.name',
   communitySupportEnabled: 'community_support_enabled.name',
   ticketSupportResponseTime: 'customer_ticket_support.name',
+  mfaEnabled: 'mfa_enabled.name',
 };
 
 export const quotaItemUnlimitedPhrasesMap: Record<
@@ -42,6 +43,7 @@ export const quotaItemUnlimitedPhrasesMap: Record<
   auditLogsRetentionDays: 'audit_logs_retention_days.unlimited',
   communitySupportEnabled: 'community_support_enabled.unlimited',
   ticketSupportResponseTime: 'customer_ticket_support.unlimited',
+  mfaEnabled: 'mfa_enabled.unlimited',
 };
 
 export const quotaItemLimitedPhrasesMap: Record<
@@ -63,6 +65,7 @@ export const quotaItemLimitedPhrasesMap: Record<
   auditLogsRetentionDays: 'audit_logs_retention_days.limited',
   communitySupportEnabled: 'community_support_enabled.limited',
   ticketSupportResponseTime: 'customer_ticket_support.limited',
+  mfaEnabled: 'mfa_enabled.limited',
 };
 
 export const quotaItemNotEligiblePhrasesMap: Record<
@@ -84,4 +87,5 @@ export const quotaItemNotEligiblePhrasesMap: Record<
   auditLogsRetentionDays: 'audit_logs_retention_days.not_eligible',
   communitySupportEnabled: 'community_support_enabled.not_eligible',
   ticketSupportResponseTime: 'customer_ticket_support.not_eligible',
+  mfaEnabled: 'mfa_enabled.not_eligible',
 };

--- a/packages/console/src/containers/ConsoleContent/Sidebar/hook.tsx
+++ b/packages/console/src/containers/ConsoleContent/Sidebar/hook.tsx
@@ -14,7 +14,7 @@ import ResourceIcon from '@/assets/icons/resource.svg';
 import Role from '@/assets/icons/role.svg';
 import SecurityLock from '@/assets/icons/security-lock.svg';
 import Web from '@/assets/icons/web.svg';
-import { isCloud, isProduction } from '@/consts/env';
+import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
 import useUserPreferences from '@/hooks/use-user-preferences';
 
 type SidebarItem = {
@@ -82,7 +82,7 @@ export const useSidebarMenuItems = (): {
         {
           Icon: SecurityLock,
           title: 'mfa',
-          isHidden: isProduction,
+          isHidden: !isDevFeaturesEnabled,
         },
         {
           Icon: Connection,

--- a/packages/console/src/containers/ConsoleContent/index.tsx
+++ b/packages/console/src/containers/ConsoleContent/index.tsx
@@ -9,7 +9,7 @@ import {
   TenantSettingsTabs,
   ApplicationDetailsTabs,
 } from '@/consts';
-import { isCloud, isProduction } from '@/consts/env';
+import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
 import OverlayScrollbar from '@/ds-components/OverlayScrollbar';
 import useUserPreferences from '@/hooks/use-user-preferences';
 import ApiResourceDetails from '@/pages/ApiResourceDetails';
@@ -98,7 +98,7 @@ function ConsoleContent() {
               <Route index element={<Navigate replace to={SignInExperienceTab.Branding} />} />
               <Route path=":tab" element={<SignInExperience />} />
             </Route>
-            {!isProduction && <Route path="mfa" element={<Mfa />} />}
+            {isDevFeaturesEnabled && <Route path="mfa" element={<Mfa />} />}
             <Route path="connectors">
               <Route index element={<Navigate replace to={ConnectorsTabs.Passwordless} />} />
               <Route path=":tab" element={<Connectors />} />

--- a/packages/console/src/pages/TenantSettings/Subscription/DowngradeConfirmModalContent/index.tsx
+++ b/packages/console/src/pages/TenantSettings/Subscription/DowngradeConfirmModalContent/index.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import PlanName from '@/components/PlanName';
+import { isDevFeaturesEnabled } from '@/consts/env';
 import { type SubscriptionPlan } from '@/types/subscriptions';
 
 import PlanQuotaDiffCard from './PlanQuotaDiffCard';
@@ -16,8 +17,19 @@ type Props = {
 function DowngradeConfirmModalContent({ currentPlan, targetPlan }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
-  const { quota: currentQuota, name: currentPlanName } = currentPlan;
-  const { quota: targetQuota, name: targetPlanName } = targetPlan;
+  const {
+    quota: currentFullQuota,
+    quota: { mfaEnabled: currentMfaEnabled, ...currentQuotaWithoutMfa },
+    name: currentPlanName,
+  } = currentPlan;
+  const currentQuota = isDevFeaturesEnabled ? currentFullQuota : currentQuotaWithoutMfa;
+
+  const {
+    quota: targetFullQuota,
+    quota: { mfaEnabled: targetMfaEnabled, ...targetQuotaWithoutMfa },
+    name: targetPlanName,
+  } = targetPlan;
+  const targetQuota = isDevFeaturesEnabled ? targetFullQuota : targetQuotaWithoutMfa;
 
   const currentQuotaDiff = useMemo(
     () => diff(targetQuota, currentQuota),

--- a/packages/console/src/pages/TenantSettings/Subscription/PlanQuotaTable/PlanQuotaKeyLabel/index.tsx
+++ b/packages/console/src/pages/TenantSettings/Subscription/PlanQuotaTable/PlanQuotaKeyLabel/index.tsx
@@ -28,6 +28,7 @@ const planQuotaKeyPhraseMap: {
   smsConnectorsEnabled: 'user_authn.sms_connector',
   socialConnectorsLimit: 'user_authn.social_connectors',
   standardConnectorsLimit: 'user_authn.standard_connectors',
+  mfaEnabled: 'user_authn.mfa',
   userManagementEnabled: 'user_management.user_management',
   rolesLimit: 'user_management.roles',
   scopesPerRoleLimit: 'user_management.scopes_per_role',

--- a/packages/console/src/pages/TenantSettings/components/NotEligibleSwitchPlanModalContent/index.tsx
+++ b/packages/console/src/pages/TenantSettings/components/NotEligibleSwitchPlanModalContent/index.tsx
@@ -4,6 +4,7 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import ContactUsPhraseLink from '@/components/ContactUsPhraseLink';
 import PlanName from '@/components/PlanName';
+import { isDevFeaturesEnabled } from '@/consts/env';
 import { planQuotaItemOrder } from '@/consts/plan-quotas';
 import {
   quotaItemLimitedPhrasesMap,
@@ -32,7 +33,14 @@ function NotEligibleSwitchPlanModalContent({ targetPlan, isDowngrade = false }: 
     keyPrefix: 'admin_console.subscription.not_eligible_modal',
   });
 
-  const { id, name, quota } = targetPlan;
+  const {
+    id,
+    name,
+    quota: fullQuota,
+    quota: { mfaEnabled, ...quotaWithoutMfa },
+  } = targetPlan;
+
+  const quota = isDevFeaturesEnabled ? fullQuota : quotaWithoutMfa;
 
   const orderedEntries = useMemo(() => {
     // eslint-disable-next-line no-restricted-syntax

--- a/packages/phrases/src/locales/de/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/subscription/quota-item.ts
@@ -113,6 +113,12 @@ const quota_item = {
     unlimited: 'Kundenticketsupport',
     not_eligible: 'Kein Kundenticketsupport',
   },
+  mfa_enabled: {
+    name: 'MFA',
+    limited: 'MFA',
+    unlimited: 'MFA',
+    not_eligible: 'Deaktivieren Sie Ihre MFA',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/de/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/subscription/quota-table.ts
@@ -34,6 +34,7 @@ const quota_table = {
     social_connectors: 'Social-Connectors',
     standard_connectors: 'Standard-Connectors',
     built_in_email_connector: 'Integrierter E-Mail-Connector',
+    mfa: 'MFA',
   },
   user_management: {
     title: 'Benutzerverwaltung',

--- a/packages/phrases/src/locales/en/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/subscription/quota-item.ts
@@ -113,6 +113,12 @@ const quota_item = {
     unlimited: 'Customer ticket support',
     not_eligible: 'No customer ticket support',
   },
+  mfa_enabled: {
+    name: 'MFA',
+    limited: 'MFA',
+    unlimited: 'MFA',
+    not_eligible: 'Disable your MFA',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/en/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/subscription/quota-table.ts
@@ -34,6 +34,7 @@ const quota_table = {
     social_connectors: 'Social connectors',
     standard_connectors: 'Standard connectors',
     built_in_email_connector: 'Built-in email connector',
+    mfa: 'MFA',
   },
   user_management: {
     title: 'User management',

--- a/packages/phrases/src/locales/es/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/subscription/quota-item.ts
@@ -113,6 +113,12 @@ const quota_item = {
     unlimited: 'Soporte de tickets de clientes',
     not_eligible: 'Sin soporte de tickets de clientes',
   },
+  mfa_enabled: {
+    name: 'MFA',
+    limited: 'MFA',
+    unlimited: 'MFA',
+    not_eligible: 'Desactiva tu MFA',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/es/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/subscription/quota-table.ts
@@ -34,6 +34,7 @@ const quota_table = {
     social_connectors: 'Conectores sociales',
     standard_connectors: 'Conectores estándar',
     built_in_email_connector: 'Conector de correo electrónico incorporado',
+    mfa: 'MFA',
   },
   user_management: {
     title: 'Gestión de usuarios',

--- a/packages/phrases/src/locales/fr/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/subscription/quota-item.ts
@@ -113,6 +113,12 @@ const quota_item = {
     unlimited: 'Support client de ticket',
     not_eligible: 'Pas de support client de ticket',
   },
+  mfa_enabled: {
+    name: 'MFA',
+    limited: 'MFA',
+    unlimited: 'MFA',
+    not_eligible: 'Désactivez votre MFA',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/fr/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/subscription/quota-table.ts
@@ -34,6 +34,7 @@ const quota_table = {
     social_connectors: 'Connecteurs sociaux',
     standard_connectors: 'Connecteurs standards',
     built_in_email_connector: 'Connecteur email intégré',
+    mfa: 'MFA',
   },
   user_management: {
     title: 'Gestion des utilisateurs',

--- a/packages/phrases/src/locales/it/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/subscription/quota-item.ts
@@ -113,6 +113,12 @@ const quota_item = {
     unlimited: 'Supporto tramite ticket clienti',
     not_eligible: 'Nessun supporto tramite ticket clienti',
   },
+  mfa_enabled: {
+    name: 'MFA',
+    limited: 'MFA',
+    unlimited: 'MFA',
+    not_eligible: 'Disabilita il tuo MFA',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/it/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/subscription/quota-table.ts
@@ -34,6 +34,7 @@ const quota_table = {
     social_connectors: 'Connettori sociali',
     standard_connectors: 'Connettori standard',
     built_in_email_connector: 'Connettore e-mail integrato',
+    mfa: 'MFA',
   },
   user_management: {
     title: 'Gestione utenti',

--- a/packages/phrases/src/locales/ja/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/subscription/quota-item.ts
@@ -113,6 +113,12 @@ const quota_item = {
     unlimited: '顧客チケットサポート',
     not_eligible: '顧客チケットサポートなし',
   },
+  mfa_enabled: {
+    name: 'MFA',
+    limited: 'MFA',
+    unlimited: 'MFA',
+    not_eligible: 'MFAを無効にする',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/ja/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/subscription/quota-table.ts
@@ -34,6 +34,7 @@ const quota_table = {
     social_connectors: 'ソーシャルコネクタ',
     standard_connectors: 'スタンダードコネクタ',
     built_in_email_connector: '組み込みE-mailコネクタ',
+    mfa: 'MFA',
   },
   user_management: {
     title: 'ユーザー管理',

--- a/packages/phrases/src/locales/ko/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/subscription/quota-item.ts
@@ -113,6 +113,12 @@ const quota_item = {
     unlimited: '고객 지원 티켓',
     not_eligible: '고객 지원 티켓 없음',
   },
+  mfa_enabled: {
+    name: 'MFA',
+    limited: 'MFA',
+    unlimited: 'MFA',
+    not_eligible: 'MFA 비활성화',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/ko/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/subscription/quota-table.ts
@@ -34,6 +34,7 @@ const quota_table = {
     social_connectors: '소셜 커넥터',
     standard_connectors: '표준 커넥터',
     built_in_email_connector: '내장 이메일 커넥터',
+    mfa: 'MFA',
   },
   user_management: {
     title: '사용자 관리',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/subscription/quota-item.ts
@@ -113,6 +113,12 @@ const quota_item = {
     unlimited: 'Wsparcie biletowe dla klienta',
     not_eligible: 'Brak wsparcia biletowego dla klienta',
   },
+  mfa_enabled: {
+    name: 'MFA',
+    limited: 'MFA',
+    unlimited: 'MFA',
+    not_eligible: 'Dezaktywuj MFA',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/subscription/quota-table.ts
@@ -34,6 +34,7 @@ const quota_table = {
     social_connectors: 'Podłączenia społecznościowe',
     standard_connectors: 'Standardowe podłączenia',
     built_in_email_connector: 'Wbudowane podłączenie e-mail',
+    mfa: 'MFA',
   },
   user_management: {
     title: 'Zarządzanie użytkownikami',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/subscription/quota-item.ts
@@ -113,6 +113,12 @@ const quota_item = {
     unlimited: 'Suporte de ticket de cliente',
     not_eligible: 'Nenhum suporte de ticket de cliente',
   },
+  mfa_enabled: {
+    name: 'MFA',
+    limited: 'MFA',
+    unlimited: 'MFA',
+    not_eligible: 'Desative sua MFA',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/subscription/quota-table.ts
@@ -34,6 +34,7 @@ const quota_table = {
     social_connectors: 'Conectores sociais',
     standard_connectors: 'Conectores padrão',
     built_in_email_connector: 'Conector de e-mail integrado',
+    mfa: 'MFA',
   },
   user_management: {
     title: 'Gerenciamento de usuários',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/subscription/quota-item.ts
@@ -113,6 +113,12 @@ const quota_item = {
     unlimited: 'Apoio de bilhetes de cliente',
     not_eligible: 'Sem apoio de bilhetes de cliente',
   },
+  mfa_enabled: {
+    name: 'MFA',
+    limited: 'MFA',
+    unlimited: 'MFA',
+    not_eligible: 'Desative a sua MFA',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/subscription/quota-table.ts
@@ -34,6 +34,7 @@ const quota_table = {
     social_connectors: 'Conectores sociais',
     standard_connectors: 'Conectores padrão',
     built_in_email_connector: 'Conector de e-mail incorporado',
+    mfa: 'MFA',
   },
   user_management: {
     title: 'Gestão de utilizadores',

--- a/packages/phrases/src/locales/ru/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/subscription/quota-item.ts
@@ -113,6 +113,12 @@ const quota_item = {
     unlimited: 'Поддержка клиентов по билетам',
     not_eligible: 'Без поддержки клиентов по билетам',
   },
+  mfa_enabled: {
+    name: 'MFA',
+    limited: 'MFA',
+    unlimited: 'MFA',
+    not_eligible: 'Отключите свой MFA',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/ru/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/subscription/quota-table.ts
@@ -34,6 +34,7 @@ const quota_table = {
     social_connectors: 'Социальные подключения',
     standard_connectors: 'Стандартные подключения',
     built_in_email_connector: 'Встроенное подключение электронной почты',
+    mfa: 'MFA',
   },
   user_management: {
     title: 'Управление пользователями',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/subscription/quota-item.ts
@@ -113,6 +113,12 @@ const quota_item = {
     unlimited: 'Müşteri destek bileti',
     not_eligible: 'Müşteri destek bileti yok',
   },
+  mfa_enabled: {
+    name: 'MFA',
+    limited: 'MFA',
+    unlimited: 'MFA',
+    not_eligible: "MFA'nızı devre dışı bırakın",
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/subscription/quota-table.ts
@@ -34,6 +34,7 @@ const quota_table = {
     social_connectors: 'Sosyal bağlayıcılar',
     standard_connectors: 'Standart bağlayıcılar',
     built_in_email_connector: 'Dahili e-posta bağlayıcısı',
+    mfa: 'MFA',
   },
   user_management: {
     title: 'Kullanıcı Yönetimi',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/subscription/quota-item.ts
@@ -113,6 +113,12 @@ const quota_item = {
     unlimited: '客户支持票',
     not_eligible: '无客户支持票',
   },
+  mfa_enabled: {
+    name: 'MFA',
+    limited: 'MFA',
+    unlimited: 'MFA',
+    not_eligible: '禁用你的 MFA',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/subscription/quota-table.ts
@@ -34,6 +34,7 @@ const quota_table = {
     social_connectors: '社交连接器',
     standard_connectors: '标准连接器',
     built_in_email_connector: '内置电子邮件连接器',
+    mfa: 'MFA',
   },
   user_management: {
     title: '用户管理',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/subscription/quota-item.ts
@@ -113,6 +113,12 @@ const quota_item = {
     unlimited: '客戶工單支援',
     not_eligible: '無客戶工單支援',
   },
+  mfa_enabled: {
+    name: 'MFA',
+    limited: 'MFA',
+    unlimited: 'MFA',
+    not_eligible: '停用你的 MFA',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/subscription/quota-table.ts
@@ -34,6 +34,7 @@ const quota_table = {
     social_connectors: '社交連接器',
     standard_connectors: '標準連接器',
     built_in_email_connector: '內置電子郵件連接器',
+    mfa: 'MFA',
   },
   user_management: {
     title: '用戶管理',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/subscription/quota-item.ts
@@ -113,6 +113,12 @@ const quota_item = {
     unlimited: '客戶票證支援',
     not_eligible: '無客戶票證支援',
   },
+  mfa_enabled: {
+    name: 'MFA',
+    limited: 'MFA',
+    unlimited: 'MFA',
+    not_eligible: '停用你的 MFA',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/subscription/quota-table.ts
@@ -34,6 +34,7 @@ const quota_table = {
     social_connectors: '社交連接器',
     standard_connectors: '標準連接器',
     built_in_email_connector: '內建電子郵件連接器',
+    mfa: 'MFA',
   },
   user_management: {
     title: '使用者管理',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2834,8 +2834,8 @@ importers:
         specifier: workspace:^1.3.1
         version: link:../app-insights
       '@logto/cloud':
-        specifier: 0.2.5-71b7fea
-        version: 0.2.5-71b7fea(zod@3.20.2)
+        specifier: 0.2.5-444ed49
+        version: 0.2.5-444ed49(zod@3.20.2)
       '@logto/connector-kit':
         specifier: workspace:^1.1.1
         version: link:../toolkit/connector-kit
@@ -7305,8 +7305,8 @@ packages:
       jose: 4.14.4
     dev: true
 
-  /@logto/cloud@0.2.5-71b7fea(zod@3.20.2):
-    resolution: {integrity: sha512-howllmEV6kWAgusP+2OSloG5bZQ146UiKn0PpA7xi9HcpgM6Fd1NPuNjc3BZdInJ5Qn0en6LOZL7c2EwTRx3jw==}
+  /@logto/cloud@0.2.5-444ed49(zod@3.20.2):
+    resolution: {integrity: sha512-UirssRQV8+UAG/d0amK3qSrZstYW8+VUtfRWcKN8Ka0oJbPaNQL+fW+8OCB39ikQqT39KLrClXbThu3akPUWhw==}
     engines: {node: ^18.12.0}
     dependencies:
       '@silverhand/essentials': 2.8.4


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Hide mfa quota content before feature launched.

Since the mfa quota config is merged into the cloud repo, so we need to hide the MFA-related content on the console.

This PR is used to unblock the new release of Logto.

### Updates
- Replace the `isProduction` guard with the new `isDevFeaturesEnabled` env variable.
- Add related phrases and phrases configs to make related types happy

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Since now the UI tests for plan subscription are not ready, test this PR manually.

### Before hiding MFA contents
![image](https://github.com/logto-io/logto/assets/10806653/0dd2428d-b26b-4fe8-a572-464db6c9c3d9)

![image](https://github.com/logto-io/logto/assets/10806653/2ecf1343-a994-405b-b68a-6ae59986f7b4)

### After hiding MFA contents

![image](https://github.com/logto-io/logto/assets/10806653/890ca02f-700c-459b-aee4-f1cc355ec608)

![image](https://github.com/logto-io/logto/assets/10806653/84620371-ff0f-45ab-974f-bc533d286f9f)

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
