### PR TITLE
fix(console): highlight current tab in sidebar

### DIFF
--- a/packages/console/src/containers/ConsoleContent/Sidebar/index.tsx
+++ b/packages/console/src/containers/ConsoleContent/Sidebar/index.tsx
@@ -27,7 +27,7 @@ function Sidebar() {
                   key={title}
                   titleKey={title}
                   icon={<Icon />}
-                  isActive={match(getPath(title))}
+                  isActive={match('/' + getPath(title))}
                   modal={modal}
                   externalLink={externalLink}
                 />

--- a/packages/integration-tests/src/tests/console/bootstrap.test.ts
+++ b/packages/integration-tests/src/tests/console/bootstrap.test.ts
@@ -7,7 +7,7 @@ import {
   consoleUsername,
   logtoConsoleUrl as logtoConsoleUrlString,
 } from '#src/constants.js';
-import { appendPathname, expectNavigation } from '#src/utils.js';
+import { appendPathname, cls, dcls, expectNavigation } from '#src/utils.js';
 
 /**
  * NOTE: This test suite assumes test cases will run sequentially (which is Jest default).
@@ -120,5 +120,19 @@ describe('smoke testing for console admin account creation and sign-in', () => {
 
   it('renders SVG correctly with viewbox property', async () => {
     await page.waitForSelector('div[class$=topbar] > svg[viewbox][class$=logo]', { visible: true });
+  });
+
+  it('can highlight the current tab in the sidebar', async () => {
+    const activeSelector = [dcls('sidebar'), 'a' + cls('row') + cls('active'), dcls('title')].join(
+      ' '
+    );
+
+    await expect(page).toMatchElement(activeSelector, { text: 'Applications', visible: true });
+    await expectNavigation(
+      expect(page).toClick([dcls('sidebar'), 'a' + cls('row')].join(' '), {
+        text: 'Dashboard',
+      })
+    );
+    await expect(page).toMatchElement(activeSelector, { text: 'Dashboard', visible: true });
   });
 });


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix sidebar highlight issue and add integration test accordingly

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="280" alt="image" src="https://github.com/logto-io/logto/assets/14722250/c66b9742-db08-4287-a203-f071f8732b33">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~~`.changeset`~~
- [ ] ~~unit tests~~
- [x] integration tests
- [ ] ~~docs~~

