### PR TITLE
refactor(console): remove alternative endpoint from app guides

### DIFF
--- a/packages/console/src/assets/docs/guides/m2m-general/README.mdx
+++ b/packages/console/src/assets/docs/guides/m2m-general/README.mdx
@@ -37,7 +37,7 @@ If you want to use this m2m app for accessing Logto [Management API](https://doc
 
 In the API Resource tab, find the API identifier that the app needs to access. If you haven't added the API Resource in Logto or don't know what API Resource is, see [API Resource](https://docs.logto.io/docs/references/resources).
 
-<img alt="API identifier" src={AppIdentifierSrc} width="600px" style={{ paddingBottom: '12px' }} />
+<img alt="API identifier" src={AppIdentifierSrc} width="600px" style={{ borderRadius: '6px' }} />
 
 </Step>
 <Step title="Compose and send request">

--- a/packages/console/src/assets/docs/guides/m2m-general/README.mdx
+++ b/packages/console/src/assets/docs/guides/m2m-general/README.mdx
@@ -46,7 +46,7 @@ In the API Resource tab, find the API identifier that the app needs to access. I
 
 <ul>
   <li>
-    Use Token Endpoint <code>{`${appendPath(props.alternativeEndpoint ?? props.endpoint), '/oidc/token'}`}</code> as the request endpoint, and
+    Use Token Endpoint <code>{`${appendPath(props.endpoint), '/oidc/token'}`}</code> as the request endpoint, and
     use POST as the method.
   </li>
   <li>
@@ -75,7 +75,7 @@ If you are using cURL:
 <pre>
   <code className="language-bash">
     {`curl --location
-  --request POST '${appendPath(props.alternativeEndpoint ?? props.endpoint, '/oidc/token')}'
+  --request POST '${appendPath(props.endpoint, '/oidc/token')}'
   --header 'Authorization: Basic ${Buffer.from(`${props.app.id}:${props.app.secret}`).toString('base64')}'
   --header 'Content-Type: application/x-www-form-urlencoded'
   --data-urlencode 'grant_type=client_credentials'
@@ -98,7 +98,7 @@ A successful response body would be like:
 ```
 
 </Step>
-<Step title="Access resource using Access Token">
+<Step title="Access resource using access token">
 
 You may notice the token response has a `token_type` field, which it's fixed to `Bearer`. Thus you should put the Access Token in the Authorization field of HTTP headers with the Bearer format (`Bearer YOUR_TOKEN`).
 
@@ -107,8 +107,8 @@ For example, if you have requested an Access Token with the resource `https://ap
 <pre>
   <code className="language-bash">
     {`curl --location
-  --request GET '${appendPath(props.alternativeEndpoint ?? props.endpoint, '/api/applications')}'
-  --header 'Authorization: Bearer eyJhbG...2g' # Access Token
+  --request GET '${appendPath(props.endpoint, '/api/applications')}'
+  --header 'Authorization: Bearer eyJhbG...2g' # Access token
 `}
   </code>
 </pre>

--- a/packages/console/src/assets/docs/guides/native-android-java/README.mdx
+++ b/packages/console/src/assets/docs/guides/native-android-java/README.mdx
@@ -49,7 +49,7 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
 
         LogtoConfig logtoConfig = new LogtoConfig(
-            "${props.endpoint}",${props.alternativeEndpoint ? ` // or "${props.alternativeEndpoint}"` : ''}
+            "${props.endpoint}",
             "${props.app.id}",
             null,
             null,

--- a/packages/console/src/assets/docs/guides/native-android-kt/README.mdx
+++ b/packages/console/src/assets/docs/guides/native-android-kt/README.mdx
@@ -42,7 +42,7 @@ import io.logto.sdk.android.type.LogtoConfig
 
 class MainActivity : AppCompatActivity() {
     val logtoConfig = LogtoConfig(
-        endpoint = "${props.endpoint}",${props.alternativeEndpoint ? ` // or "${props.alternativeEndpoint}"` : ''}
+        endpoint = "${props.endpoint}",
         appId = "${props.app.id}",
         scopes = null,
         resources = null,

--- a/packages/console/src/assets/docs/guides/native-capacitor/README.mdx
+++ b/packages/console/src/assets/docs/guides/native-capacitor/README.mdx
@@ -32,7 +32,7 @@ Add the following code to your Capacitor project:
     {`import LogtoClient from '@logto/capacitor';
 
 const logtoClient = new LogtoClient({
-  endpoint: '${props.endpoint}',${props.alternativeEndpoint ? ` // or '${props.alternativeEndpoint}'` : ''}
+  endpoint: '${props.endpoint}',
   appId: '${props.app.id}',
 });`}
   </code>

--- a/packages/console/src/assets/docs/guides/native-flutter/README.mdx
+++ b/packages/console/src/assets/docs/guides/native-flutter/README.mdx
@@ -139,9 +139,7 @@ late LogtoClient logtoClient;
 
 // LogtoConfig
 final logtoConfig = const LogtoConfig(
-  endpoint: '${props.endpoint}',${
-    props.alternativeEndpoint ? ` // or "${props.alternativeEndpoint}"` : ''
-  }
+  endpoint: '${props.endpoint}',
   appId: '${props.app.id}',
 );
 

--- a/packages/console/src/assets/docs/guides/native-ios-swift/README.mdx
+++ b/packages/console/src/assets/docs/guides/native-ios-swift/README.mdx
@@ -50,7 +50,7 @@ CocoaPods [does not support local dependency](https://github.com/CocoaPods/Cocoa
 import LogtoClient
 
 let config = try? LogtoConfig(
-  endpoint: "${props.endpoint}",${props.alternativeEndpoint ? ` // or "${props.alternativeEndpoint}"` : ''}
+  endpoint: "${props.endpoint}",
   appId: "${props.app.id}"
 )
 let logtoClient = LogtoClient(useConfig: config)`}

--- a/packages/console/src/assets/docs/guides/spa-react/README.mdx
+++ b/packages/console/src/assets/docs/guides/spa-react/README.mdx
@@ -48,7 +48,7 @@ Import and use `LogtoProvider` to provide a Logto context:
     {`import { LogtoProvider, LogtoConfig } from '@logto/react';
 
 const config: LogtoConfig = {
-  endpoint: '${props.endpoint}',${props.alternativeEndpoint ? ` // or "${props.alternativeEndpoint}"` : ''}
+  endpoint: '${props.endpoint}',
   appId: '${props.app.id}',
 };
 

--- a/packages/console/src/assets/docs/guides/spa-vanilla/README.mdx
+++ b/packages/console/src/assets/docs/guides/spa-vanilla/README.mdx
@@ -48,7 +48,7 @@ Import and init `LogtoClient` by passing config:
     {`import LogtoClient from '@logto/browser';
 
 const logtoClient = new LogtoClient({
-  endpoint: '${props.endpoint}',${props.alternativeEndpoint ? ` // or "${props.alternativeEndpoint}"` : ''}
+  endpoint: '${props.endpoint}',
   appId: '${props.app.id}',
 });`}
   </code>

--- a/packages/console/src/assets/docs/guides/spa-vue/README.mdx
+++ b/packages/console/src/assets/docs/guides/spa-vue/README.mdx
@@ -53,7 +53,7 @@ Import and use `createLogto` to install Logto plugin:
     {`import { createLogto, LogtoConfig } from '@logto/vue';
 
 const config: LogtoConfig = {
-  endpoint: '${props.endpoint}',${props.alternativeEndpoint ? ` // or "${props.alternativeEndpoint}"` : ''}
+  endpoint: '${props.endpoint}',
   appId: '${props.app.id}',
 };
 

--- a/packages/console/src/assets/docs/guides/web-asp-net-core-mvc/README.mdx
+++ b/packages/console/src/assets/docs/guides/web-asp-net-core-mvc/README.mdx
@@ -36,7 +36,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddLogtoAuthentication(options =>
 {
-  options.Endpoint = "${props.endpoint}";${props.alternativeEndpoint ? ' // or "${props.alternativeEndpoint}"' : ''}
+  options.Endpoint = "${props.endpoint}";
   options.AppId = "${props.app.id}";
   options.AppSecret = "${props.app.secret}";
 });

--- a/packages/console/src/assets/docs/guides/web-asp-net-core/README.mdx
+++ b/packages/console/src/assets/docs/guides/web-asp-net-core/README.mdx
@@ -36,7 +36,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddLogtoAuthentication(options =>
 {
-  options.Endpoint = "${props.endpoint}";${props.alternativeEndpoint ? ' // or "${props.alternativeEndpoint}"' : ''}
+  options.Endpoint = "${props.endpoint}";
   options.AppId = "${props.app.id}";
   options.AppSecret = "${props.app.secret}";
 });

--- a/packages/console/src/assets/docs/guides/web-express/README.mdx
+++ b/packages/console/src/assets/docs/guides/web-express/README.mdx
@@ -54,7 +54,7 @@ Import and initialize LogtoClient:
     {`import LogtoClient from '@logto/express';
 
 export const logtoClient = new LogtoClient({
-  endpoint: '${props.endpoint}',${props.alternativeEndpoint ? ` // or "${props.alternativeEndpoint}"` : ''}
+  endpoint: '${props.endpoint}',
   appId: '${props.app.id}',
   appSecret: '${props.app.secret}',
   baseUrl: 'http://localhost:3000', // Change to your own base URL

--- a/packages/console/src/assets/docs/guides/web-go/README.mdx
+++ b/packages/console/src/assets/docs/guides/web-go/README.mdx
@@ -156,7 +156,7 @@ func main() {
     // ...
 
     logtoConfig := &client.LogtoConfig{
-        Endpoint:           "${props.endpoint}",${props.alternativeEndpoint ? ` // or "${props.alternativeEndpoint}"` : ''}
+        Endpoint:           "${props.endpoint}",
         AppId:              "${props.app.id}",
         AppSecret:          "${props.app.secret}",
     }

--- a/packages/console/src/assets/docs/guides/web-gpt-plugin/README.mdx
+++ b/packages/console/src/assets/docs/guides/web-gpt-plugin/README.mdx
@@ -37,7 +37,7 @@ Remember to click Save. To help ChatGPT maintain the authentication state, you c
 
 When setting up your plugin with ChatGPT, you will need to provide your OAuth Client ID and Client Secret.
 
-<img alt="ChatGPT plugin OAuth credentials" src={chatgptPluginOauthCredentials} width="560" />
+<img alt="ChatGPT plugin OAuth credentials" src={chatgptPluginOauthCredentials} width="560" style={{ borderRadius: '6px' }} />
 
 These correspond to the “App ID” and “App Secret” below (you can copy and paste):
 
@@ -57,11 +57,11 @@ Remember to replace the `verification_tokens.openai` value with the actual one.
 
 The ChatGPT UI will automatically prompt you to install the plugin. Once successful, you will see a dialog with a button that says "Log in with [your plugin name]."
 
-<img alt="ChatGPT plugin login" src={chatgptPluginLogin} width="560" />
+<img alt="ChatGPT plugin login" src={chatgptPluginLogin} width="560" style={{ borderRadius: '6px' }} />
 
 Click on the button, and you will be directed to the Logto sign-in experience.
 
-<img alt="Logto sign-in experience" src={logtoSignInExperience} width="560" />
+<img alt="Logto sign-in experience" src={logtoSignInExperience} width="560" style={{ borderRadius: '6px' }} />
 
 If everything is configured correctly, once you complete the sign-in or registration process in Logto, you will be redirected back to ChatGPT. From now on, every request sent by ChatGPT to your plugin server will carry the Authorization header, allowing you to decode and verify the token in your API.
 

--- a/packages/console/src/assets/docs/guides/web-next-app-router/README.mdx
+++ b/packages/console/src/assets/docs/guides/web-next-app-router/README.mdx
@@ -54,9 +54,7 @@ Import and initialize LogtoClient:
 import LogtoClient from '@logto/next/edge';
 
 export const logtoClient = new LogtoClient({
-  endpoint: '${props.endpoint}',${
-    props.alternativeEndpoint ? ` // or "${props.alternativeEndpoint}"` : ''
-  }
+  endpoint: '${props.endpoint}',
   appId: '${props.app.id}',
   appSecret: '${props.app.secret}',
   baseUrl: 'http://localhost:3000', // Change to your own base URL

--- a/packages/console/src/assets/docs/guides/web-next/README.mdx
+++ b/packages/console/src/assets/docs/guides/web-next/README.mdx
@@ -54,7 +54,7 @@ Import and initialize LogtoClient:
 import LogtoClient from '@logto/next';
 
 export const logtoClient = new LogtoClient({
-  endpoint: '${props.endpoint}',${props.alternativeEndpoint ? ` // or "${props.alternativeEndpoint}"` : ''}
+  endpoint: '${props.endpoint}',
   appId: '${props.app.id}',
   appSecret: '${props.app.secret}',
   baseUrl: 'http://localhost:3000', // Change to your own base URL

--- a/packages/console/src/assets/docs/guides/web-outline/README.mdx
+++ b/packages/console/src/assets/docs/guides/web-outline/README.mdx
@@ -57,15 +57,15 @@ See [Passwordless sign-in by adding connectors](https://docs.logto.io/docs/tutor
 
 Start the Outline instance and access its endpoint. You should see a button in the center labeled "Continue with OpenID Connect"; it can be customized by setting the `OIDC_DISPLAY_NAME` environment variable.
 
-<img alt="Outline sign-in page" src={outlineSignIn} width="360" />
+<img alt="Outline sign-in page" src={outlineSignIn} width="360" style={{ borderRadius: '6px' }} />
 
 Click on the button, and you will be directed to the Logto sign-in experience.
 
-<img alt="Logto sign-in experience" src={logtoSignInExperience} width="360" />
+<img alt="Logto sign-in experience" src={logtoSignInExperience} width="360" style={{ borderRadius: '6px' }} />
 
 If everything has been configured correctly, once you complete the sign-in or registration process in Logto, you will be redirected back to Outline. You can then see your personal information displayed in the bottom left corner of the page.
 
-<img alt="Outline home" src={outlineHome} width="660" />
+<img alt="Outline home" src={outlineHome} width="660" style={{ borderRadius: '6px' }} />
 
 </Step>
 

--- a/packages/console/src/assets/docs/guides/web-php/README.mdx
+++ b/packages/console/src/assets/docs/guides/web-php/README.mdx
@@ -34,7 +34,7 @@ use Logto\Sdk\LogtoConfig;
 
 $client = new LogtoClient(
   new LogtoConfig(
-    endpoint: "${props.endpoint}",${props.alternativeEndpoint ? ' // or "${props.alternativeEndpoint}"' : ''}
+    endpoint: "${props.endpoint}",
     appId: "${props.app.id}",
     appSecret: "${props.app.secret}",
   ),

--- a/packages/console/src/assets/docs/guides/web-python/README.mdx
+++ b/packages/console/src/assets/docs/guides/web-python/README.mdx
@@ -34,7 +34,7 @@ Insert the following code into your Python file:
 
 client = LogtoClient(
     LogtoConfig(
-        endpoint="${props.endpoint}",${props.alternativeEndpoint ? ' # or "${props.alternativeEndpoint}"' : ''}
+        endpoint="${props.endpoint}",
         appId="${props.app.id}",
         appSecret="${props.app.secret}",
     )

--- a/packages/console/src/assets/docs/guides/web-remix/README.mdx
+++ b/packages/console/src/assets/docs/guides/web-remix/README.mdx
@@ -78,9 +78,7 @@ import { makeLogtoRemix } from "@logto/remix";
 
 export const logto = makeLogtoRemix(
   {
-    endpoint: '${props.endpoint}',${
-      props.alternativeEndpoint ? ` // or "${props.alternativeEndpoint}"` : ''
-    }
+    endpoint: '${props.endpoint}',
     appId: '${props.app.id}',
     appSecret: '${props.app.secret}',
     baseUrl: 'http://localhost:3000', // Change to your own base URL

--- a/packages/console/src/components/Guide/index.tsx
+++ b/packages/console/src/components/Guide/index.tsx
@@ -21,7 +21,6 @@ export type GuideContextType = {
   isCompact: boolean;
   app?: ApplicationResponse;
   endpoint?: string;
-  alternativeEndpoint?: string;
   redirectUris?: string[];
   postLogoutRedirectUris?: string[];
   sampleUrls?: {

--- a/packages/console/src/pages/ApplicationDetails/components/AppGuide/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/components/AppGuide/index.tsx
@@ -17,7 +17,7 @@ type Props = {
 
 function AppGuide({ className, guideId, app, isCompact, onClose }: Props) {
   const { tenantEndpoint } = useContext(AppDataContext);
-  const { data: customDomain, applyDomain: applyCustomDomain } = useCustomDomain();
+  const { applyDomain: applyCustomDomain } = useCustomDomain();
   const guide = guides.find(({ id }) => id === guideId);
 
   const memorizedContext = useMemo(
@@ -28,10 +28,7 @@ function AppGuide({ className, guideId, app, isCompact, onClose }: Props) {
             metadata: guide.metadata,
             Logo: guide.Logo,
             app,
-            endpoint: tenantEndpoint?.href ?? '',
-            alternativeEndpoint: conditional(
-              customDomain && applyCustomDomain(tenantEndpoint?.href ?? '')
-            ),
+            endpoint: applyCustomDomain(tenantEndpoint?.href ?? ''),
             redirectUris: app.oidcClientMetadata.redirectUris,
             postLogoutRedirectUris: app.oidcClientMetadata.postLogoutRedirectUris,
             isCompact: Boolean(isCompact),
@@ -41,7 +38,7 @@ function AppGuide({ className, guideId, app, isCompact, onClose }: Props) {
             },
           }
       ) satisfies GuideContextType | undefined,
-    [guide, app, tenantEndpoint?.href, customDomain, applyCustomDomain, isCompact]
+    [guide, app, tenantEndpoint?.href, applyCustomDomain, isCompact]
   );
 
   return memorizedContext ? (


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- Remove `alternativeEndpoint` from all app guides and apply custom domain to `endpoint` directly
- Add border radius effect to some screenshots used in guides

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested OK, pending online test for custom domain display

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] docs~~

OR

- [x] This PR is not applicable for the checklist
