### PR TITLE
fix(console): grouped avatars should stack on each other

### DIFF
--- a/packages/console/src/components/UserAvatar/index.module.scss
+++ b/packages/console/src/components/UserAvatar/index.module.scss
@@ -7,32 +7,32 @@
   border-radius: 8px;
   overflow: hidden;
   flex-shrink: 0;
+}
 
-  &.micro {
-    width: 20px;
-    height: 20px;
-    border-radius: 6px;
-  }
+.micro {
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+}
 
-  &.small {
-    width: 24px;
-    height: 24px;
-  }
+.small {
+  width: 24px;
+  height: 24px;
+}
 
-  &.medium {
-    width: 32px;
-    height: 32px;
-  }
+.medium {
+  width: 32px;
+  height: 32px;
+}
 
-  &.large {
-    width: 40px;
-    height: 40px;
-  }
+.large {
+  width: 40px;
+  height: 40px;
+}
 
-  &.xlarge {
-    width: 60px;
-    height: 60px;
-  }
+.xlarge {
+  width: 60px;
+  height: 60px;
 }
 
 .avatar {

--- a/packages/console/src/components/UserAvatar/index.tsx
+++ b/packages/console/src/components/UserAvatar/index.tsx
@@ -92,16 +92,17 @@ function UserAvatar({ className, size = 'medium', user, hasTooltip = false }: Pr
   );
 
   return (
-    <Tooltip
-      className={styles.tooltip}
-      content={conditional(hasTooltip && user && <UserInfoTipContent user={user} />)}
-    >
-      <div className={wrapperClassName}>
+    <div className={wrapperClassName}>
+      <Tooltip
+        className={styles.tooltip}
+        anchorClassName={styles[size]}
+        content={conditional(hasTooltip && user && <UserInfoTipContent user={user} />)}
+      >
         <div className={avatarClassName} style={{ backgroundColor: color }}>
           {nameToDisplay ? nameToDisplay.charAt(0) : <DefaultAvatar />}
         </div>
-      </div>
-    </Tooltip>
+      </Tooltip>
+    </div>
   );
 }
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Avatars should stack on each other in the avatar group

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="765" alt="image" src="https://github.com/logto-io/logto/assets/12833674/ac90ef73-df65-4b6f-aab1-18fcf629966a">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] docs~~

OR

- [x] This PR is not applicable for the checklist
