### PR TITLE
fix(console): should show user initial letter avatar in roles

### DIFF
--- a/packages/core/src/routes/role.test.ts
+++ b/packages/core/src/routes/role.test.ts
@@ -101,6 +101,8 @@ describe('role routes', () => {
             id: mockUser.id,
             avatar: mockUser.avatar,
             name: mockUser.name,
+            username: mockUser.username,
+            primaryEmail: mockUser.primaryEmail,
           },
         ],
         applicationsCount: 0,

--- a/packages/core/src/routes/role.ts
+++ b/packages/core/src/routes/role.ts
@@ -99,7 +99,13 @@ export default function roleRoutes<T extends AuthedRouter>(...[router, tenant]: 
               return {
                 ...role,
                 usersCount,
-                featuredUsers: users.map(({ id, avatar, name }) => ({ id, avatar, name })),
+                featuredUsers: users.map(({ id, avatar, name, username, primaryEmail }) => ({
+                  id,
+                  avatar,
+                  name,
+                  username,
+                  primaryEmail,
+                })),
                 applicationsCount,
                 featuredApplications: applications.map(({ id, name }) => ({ id, name })),
               };

--- a/packages/schemas/src/types/role.ts
+++ b/packages/schemas/src/types/role.ts
@@ -2,7 +2,7 @@ import type { Application, Role, User } from '../db-entries/index.js';
 
 export type RoleResponse = Role & {
   usersCount: number;
-  featuredUsers: Array<Pick<User, 'avatar' | 'id' | 'name'>>;
+  featuredUsers: Array<Pick<User, 'avatar' | 'id' | 'name' | 'username' | 'primaryEmail'>>;
   applicationsCount: number;
   featuredApplications: Array<Pick<Application, 'id' | 'name'>>;
 };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Should show user initials as avatar in roles, even if the user doesn't have name (display name). Should fallback the display logic to username and email initials to construct the initial avatar.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Before:
<img width="1142" alt="sss" src="https://github.com/logto-io/logto/assets/12833674/ff14163e-84d8-4e64-b9dd-9f640bf00d64">

After:
<img width="1131" alt="image" src="https://github.com/logto-io/logto/assets/12833674/1ac43084-5570-4137-83f1-de4e16e97915">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] docs~~

OR

- [x] This PR is not applicable for the checklist
