### PR TITLE
fix(console): transfer items should all be rendered as 40px in height

### DIFF
--- a/packages/console/src/components/RoleEntitiesTransfer/components/TargetEntityItem/index.module.scss
+++ b/packages/console/src/components/RoleEntitiesTransfer/components/TargetEntityItem/index.module.scss
@@ -3,21 +3,20 @@
 .item {
   display: flex;
   align-items: center;
-  padding: _.unit(2.5) _.unit(4);
+  padding: _.unit(2) _.unit(3) _.unit(2) _.unit(4);
   user-select: none;
-
-  .icon {
-    width: 20px;
-    height: 20px;
-    border-radius: 6px;
-    color: var(--color-text-secondary);
-  }
 
   .meta {
     flex: 1;
     display: flex;
     align-items: center;
     overflow: hidden;
+
+    .icon {
+      width: 20px;
+      height: 20px;
+      border-radius: 6px;
+    }
 
     .title {
       flex: 1 1 0;

--- a/packages/console/src/components/RoleEntitiesTransfer/components/TargetEntityItem/index.tsx
+++ b/packages/console/src/components/RoleEntitiesTransfer/components/TargetEntityItem/index.tsx
@@ -31,7 +31,6 @@ function TargetEntityItem<T extends User | Application>({ entity, onDelete }: Pr
       </div>
       <IconButton
         size="small"
-        iconClassName={styles.icon}
         onClick={() => {
           onDelete();
         }}

--- a/packages/console/src/components/RoleScopesTransfer/components/ResourceItem/index.tsx
+++ b/packages/console/src/components/RoleScopesTransfer/components/ResourceItem/index.tsx
@@ -49,7 +49,7 @@ function ResourceItem({ resource, selectedScopes, onSelectResource, onSelectScop
             setIsScopesInvisible(!isScopesInvisible);
           }}
         >
-          <IconButton size="small" className={styles.caret}>
+          <IconButton size="medium" className={styles.caret}>
             {isScopesInvisible ? <CaretFolded /> : <CaretExpanded />}
           </IconButton>
           <div className={styles.name}>{name}</div>

--- a/packages/console/src/components/RoleScopesTransfer/components/TargetScopeItem/index.module.scss
+++ b/packages/console/src/components/RoleScopesTransfer/components/TargetScopeItem/index.module.scss
@@ -3,7 +3,7 @@
 .targetScopeItem {
   display: flex;
   align-items: center;
-  padding: _.unit(1.5) _.unit(4);
+  padding: _.unit(1.5) _.unit(3) _.unit(1.5) _.unit(4);
 
   .title {
     flex: 1 1 0;
@@ -26,10 +26,6 @@
       color: var(--color-text-secondary);
       @include _.text-ellipsis;
     }
-  }
-
-  .icon {
-    color: var(--color-text-secondary);
   }
 
   &:hover {

--- a/packages/console/src/components/RoleScopesTransfer/components/TargetScopeItem/index.tsx
+++ b/packages/console/src/components/RoleScopesTransfer/components/TargetScopeItem/index.tsx
@@ -24,7 +24,6 @@ function TargetScopeItem({ scope, onDelete }: Props) {
       </div>
       <IconButton
         size="small"
-        iconClassName={styles.icon}
         onClick={() => {
           onDelete(scope);
         }}

--- a/packages/console/src/components/UserRolesTransfer/components/TargetRoleItem/index.module.scss
+++ b/packages/console/src/components/UserRolesTransfer/components/TargetRoleItem/index.module.scss
@@ -3,7 +3,7 @@
 .item {
   display: flex;
   align-items: center;
-  padding: _.unit(2.5) _.unit(4);
+  padding: _.unit(2) _.unit(3) _.unit(2) _.unit(4);
   font: var(--font-body-2);
   user-select: none;
 
@@ -27,9 +27,5 @@
       margin-left: _.unit(2);
       color: var(--color-text-secondary);
     }
-  }
-
-  .icon {
-    color: var(--color-text-secondary);
   }
 }

--- a/packages/console/src/components/UserRolesTransfer/components/TargetRoleItem/index.tsx
+++ b/packages/console/src/components/UserRolesTransfer/components/TargetRoleItem/index.tsx
@@ -23,7 +23,7 @@ function TargetRoleItem({ role, onDelete }: Props) {
           ({t('user_details.roles.assigned_user_count', { value: usersCount })})
         </div>
       </div>
-      <IconButton size="small" iconClassName={styles.icon} onClick={onDelete}>
+      <IconButton size="small" onClick={onDelete}>
         <Close />
       </IconButton>
     </div>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
All source and target items in `Transfer` component should be rendered as 40px.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
1. Assign roles to user: 
<img width="769" alt="image" src="https://github.com/logto-io/logto/assets/12833674/96c8ba8b-d0e1-4684-b31f-52c18bc473d8">

2. Assign users to role:
<img width="775" alt="image" src="https://github.com/logto-io/logto/assets/12833674/6616cbe1-ca01-484a-8500-3ab567df0f4b">

3. Assign permissions to role:
<img width="783" alt="image" src="https://github.com/logto-io/logto/assets/12833674/2bde75ed-ba70-4251-af9f-afeb20fb2f13">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] docs~~

OR

- [x] This PR is not applicable for the checklist
