### PR TITLE
fix(console): detail form tabs should not have unexpected margin-top

### DIFF
--- a/packages/console/src/components/DetailsForm/index.module.scss
+++ b/packages/console/src/components/DetailsForm/index.module.scss
@@ -5,20 +5,16 @@
   display: flex;
   flex-direction: column;
   padding-bottom: _.unit(2);
+  gap: _.unit(4);
 
   &.withSubmitActionBar {
     padding-bottom: 0;
   }
 
-  >:not(:first-child) {
-    margin-top: _.unit(4);
-  }
-
   .fields {
-    flex-grow: 1;
-
-    > :not(:first-child) {
-      margin-top: _.unit(4);
-    }
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: _.unit(4);
   }
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Tabs in details form should not have unexpected margin-top. Use flex `gap` instead of `:not(:first-child)` + `margin-top` in CSS to solve the issue.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Before:
<img width="1302" alt="image" src="https://github.com/logto-io/logto/assets/12833674/d2328cd9-8e25-40e7-a4cf-862413dea716">

Now:
GREAT AGAIN!
<img width="1302" alt="image" src="https://github.com/logto-io/logto/assets/12833674/5db3fa48-e9b4-4f03-a310-ff0ab1cd8691">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] docs~~

OR

- [x] This PR is not applicable for the checklist
