### PR TITLE
refactor(console): retrieve latest invoice id from stripe

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -26,7 +26,7 @@
     "@fontsource/roboto-mono": "^5.0.0",
     "@jest/types": "^29.5.0",
     "@logto/app-insights": "workspace:^1.3.1",
-    "@logto/cloud": "0.2.5-444ed49",
+    "@logto/cloud": "0.2.5-d434baa",
     "@logto/connector-kit": "workspace:^1.1.1",
     "@logto/core-kit": "workspace:^2.1.0",
     "@logto/language-kit": "workspace:^1.0.0",

--- a/packages/console/src/hooks/use-invoices.ts
+++ b/packages/console/src/hooks/use-invoices.ts
@@ -2,12 +2,12 @@ import useSWR from 'swr';
 
 import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
 import { type InvoicesResponse } from '@/cloud/types/router';
-import { isCloud } from '@/consts/env';
 
 const useInvoices = (tenantId: string) => {
   const cloudApi = useCloudApi();
+
   const swrResponse = useSWR<InvoicesResponse, Error>(
-    isCloud && `/api/tenants/${tenantId}/invoices`,
+    `/api/tenants/${tenantId}/invoices`,
     async () => cloudApi.get('/api/tenants/:tenantId/invoices', { params: { tenantId } })
   );
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2834,8 +2834,8 @@ importers:
         specifier: workspace:^1.3.1
         version: link:../app-insights
       '@logto/cloud':
-        specifier: 0.2.5-444ed49
-        version: 0.2.5-444ed49(zod@3.20.2)
+        specifier: 0.2.5-d434baa
+        version: 0.2.5-d434baa(zod@3.20.2)
       '@logto/connector-kit':
         specifier: workspace:^1.1.1
         version: link:../toolkit/connector-kit
@@ -7312,6 +7312,16 @@ packages:
 
   /@logto/cloud@0.2.5-a3e852f(zod@3.20.2):
     resolution: {integrity: sha512-dIrEUW7gi477HQpNsq/HT1gdvPK2ZmVuV73u2rH9LXGEIFIVGqmmIaaK3IcOPG110jKCBhTzF0+hKsW9Y3Pjmw==}
+    engines: {node: ^18.12.0}
+    dependencies:
+      '@silverhand/essentials': 2.8.4
+      '@withtyped/server': 0.12.9(zod@3.20.2)
+    transitivePeerDependencies:
+      - zod
+    dev: true
+
+  /@logto/cloud@0.2.5-d434baa(zod@3.20.2):
+    resolution: {integrity: sha512-VmWpqFzpWBrzJPQLvfe0bb7/XjF3lxs/rPbLt3zqBjGPtDXM9FAUn1m/gPbTwzXi5PxGOjlbD7jTl+3+1u4/NQ==}
     engines: {node: ^18.12.0}
     dependencies:
       '@silverhand/essentials': 2.8.4


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Previously we had an issue on expired invoice links.  When is invoice is finalized or overdue, the original stripe-hosted invoice page URL will expire in 30 days.  
So we need to retrieve a new one from Stripe every time, just to make sure the URL is not expired. Please check [cloud#298](https://github.com/logto-io/cloud/pull/298) for more details.

Instead of using the hostedInvoiceUrl link from invoice DB, we call the Logto cloud endpoint to retrieve a new invoice url. 


- update the cloud dependency to pick up the latest GET `/api/tenants/:tenantId/invoices/:invoiceId/hosted-invoice-url` API
- Remove the URL link, and implement an onClick callback method instead. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
(The invoice page integration test in still in the todo list)

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
