### PR TITLE
refactor(console,phrases): hide role type selection on creation modal by default

### DIFF
--- a/packages/console/src/ds-components/RadioGroup/Radio.module.scss
+++ b/packages/console/src/ds-components/RadioGroup/Radio.module.scss
@@ -31,13 +31,19 @@
       }
     }
 
-    .icon {
+    .icon,
+    .trailingIcon {
       margin-right: _.unit(2);
       color: var(--color-text-secondary);
 
       > svg {
         display: block;
       }
+    }
+
+    .trailingIcon {
+      margin-right: unset;
+      margin-left: _.unit(2);
     }
   }
 }
@@ -74,7 +80,8 @@
       }
     }
 
-    .icon {
+    .icon,
+    .trailingIcon {
       margin-right: _.unit(2);
       vertical-align: middle;
       color: var(--color-text-secondary);
@@ -82,6 +89,11 @@
       > svg {
         display: unset;
       }
+    }
+
+    .trailingIcon {
+      margin-right: unset;
+      margin-left: _.unit(2);
     }
 
     .disabledLabel {
@@ -122,6 +134,10 @@
 
     .icon {
       margin-right: _.unit(4);
+    }
+
+    .trailingIcon {
+      margin-left: _.unit(4);
     }
   }
 }
@@ -188,7 +204,8 @@
   background-color: var(--color-hover-variant);
 
   .content {
-    .icon {
+    .icon,
+    .trailingIcon {
       color: var(--color-primary);
     }
   }
@@ -248,7 +265,8 @@
   background-color: var(--color-layer-2);
 
   .content {
-    .icon {
+    .icon,
+    .trailingIcon {
       color: var(--color-text-secondary);
     }
   }
@@ -272,7 +290,8 @@
     border-color: var(--color-primary);
 
     .content {
-      .icon {
+      .icon,
+      .trailingIcon {
         color: var(--color-primary);
       }
     }

--- a/packages/console/src/ds-components/RadioGroup/Radio.tsx
+++ b/packages/console/src/ds-components/RadioGroup/Radio.tsx
@@ -32,6 +32,7 @@ export type Props = {
   isDisabled?: boolean;
   disabledLabel?: AdminConsoleKey;
   icon?: ReactNode;
+  trailingIcon?: ReactNode;
   hasCheckIconForCard?: boolean;
 };
 
@@ -48,6 +49,7 @@ function Radio({
   isDisabled,
   disabledLabel,
   icon,
+  trailingIcon,
   hasCheckIconForCard = true,
 }: Props) {
   const handleKeyPress: KeyboardEventHandler<HTMLDivElement> = useCallback(
@@ -90,6 +92,7 @@ function Radio({
         {type === 'plain' && <div className={styles.indicator} />}
         {icon && <span className={styles.icon}>{icon}</span>}
         {title && (typeof title === 'string' ? <DynamicT forKey={title} /> : title)}
+        {trailingIcon && <span className={styles.trailingIcon}>{trailingIcon}</span>}
         {isDisabled && disabledLabel && (
           <div className={classNames(styles.indicator, styles.disabledLabel)}>
             <DynamicT forKey={disabledLabel} />

--- a/packages/console/src/pages/Roles/components/CreateRoleForm/index.module.scss
+++ b/packages/console/src/pages/Roles/components/CreateRoleForm/index.module.scss
@@ -4,3 +4,23 @@
   display: flex;
   gap: _.unit(6);
 }
+
+.roleTypeSelectionSwitch {
+  margin-top: _.unit(2);
+}
+
+.trailingIcon {
+  width: 16px;
+  height: 16px;
+
+  > svg {
+    width: 100%;
+    height: 100%;
+  }
+}
+
+.proTag {
+  margin: 0;
+  display: flex;
+  align-items: center;
+}

--- a/packages/phrases/src/locales/de/translation/admin-console/roles.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/roles.ts
@@ -6,6 +6,10 @@ const roles = {
   create: 'Rolle erstellen',
   role_name: 'Rollenname',
   role_type: 'Rollenart',
+  /** UNTRANSLATED */
+  show_role_type_button_text: 'Show more options',
+  /** UNTRANSLATED */
+  hide_role_type_button_text: 'Hide more options',
   type_user: 'Benutzerrolle',
   type_machine_to_machine: 'Maschinen-zu-Maschinen-App-Rolle',
   role_description: 'Beschreibung',

--- a/packages/phrases/src/locales/en/translation/admin-console/roles.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/roles.ts
@@ -6,6 +6,10 @@ const roles = {
   create: 'Create Role',
   role_name: 'Role name',
   role_type: 'Role type',
+  /** UNTRANSLATED */
+  show_role_type_button_text: 'Show more options',
+  /** UNTRANSLATED */
+  hide_role_type_button_text: 'Hide more options',
   type_user: 'User role',
   type_machine_to_machine: 'Machine-to-machine app role',
   role_description: 'Description',

--- a/packages/phrases/src/locales/es/translation/admin-console/roles.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/roles.ts
@@ -6,6 +6,10 @@ const roles = {
   create: 'Crear Rol',
   role_name: 'Nombre de rol',
   role_type: 'Tipo de rol',
+  /** UNTRANSLATED */
+  show_role_type_button_text: 'Show more options',
+  /** UNTRANSLATED */
+  hide_role_type_button_text: 'Hide more options',
   type_user: 'Rol de usuario',
   type_machine_to_machine: 'Rol de aplicación de máquina a máquina',
   role_description: 'Descripción',

--- a/packages/phrases/src/locales/fr/translation/admin-console/roles.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/roles.ts
@@ -6,6 +6,10 @@ const roles = {
   create: 'Créer un rôle',
   role_name: 'Nom du rôle',
   role_type: 'Type de rôle',
+  /** UNTRANSLATED */
+  show_role_type_button_text: 'Show more options',
+  /** UNTRANSLATED */
+  hide_role_type_button_text: 'Hide more options',
   type_user: 'Rôle utilisateur',
   type_machine_to_machine: "Rôle d'application machine-à-machine",
   role_description: 'Description',

--- a/packages/phrases/src/locales/it/translation/admin-console/roles.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/roles.ts
@@ -6,6 +6,10 @@ const roles = {
   create: 'Crea Ruolo',
   role_name: 'Nome ruolo',
   role_type: 'Tipo ruolo',
+  /** UNTRANSLATED */
+  show_role_type_button_text: 'Show more options',
+  /** UNTRANSLATED */
+  hide_role_type_button_text: 'Hide more options',
   type_user: 'Ruolo utente',
   type_machine_to_machine: 'Ruolo app M2M',
   role_description: 'Descrizione',

--- a/packages/phrases/src/locales/ja/translation/admin-console/roles.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/roles.ts
@@ -6,6 +6,10 @@ const roles = {
   create: 'ロールを作成する',
   role_name: '役割名',
   role_type: '役割タイプ',
+  /** UNTRANSLATED */
+  show_role_type_button_text: 'Show more options',
+  /** UNTRANSLATED */
+  hide_role_type_button_text: 'Hide more options',
   type_user: 'ユーザーの役割',
   type_machine_to_machine: 'マシン対マシンアプリの役割',
   role_description: '説明',

--- a/packages/phrases/src/locales/ko/translation/admin-console/roles.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/roles.ts
@@ -6,6 +6,10 @@ const roles = {
   create: '역할 생성',
   role_name: '역할 이름',
   role_type: '역할 유형',
+  /** UNTRANSLATED */
+  show_role_type_button_text: 'Show more options',
+  /** UNTRANSLATED */
+  hide_role_type_button_text: 'Hide more options',
   type_user: '사용자 역할',
   type_machine_to_machine: '기계 간 앱 역할',
   role_description: '설명',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/roles.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/roles.ts
@@ -6,6 +6,10 @@ const roles = {
   create: 'Utwórz rolę',
   role_name: 'Nazwa roli',
   role_type: 'Typ roli',
+  /** UNTRANSLATED */
+  show_role_type_button_text: 'Show more options',
+  /** UNTRANSLATED */
+  hide_role_type_button_text: 'Hide more options',
   type_user: 'Rola użytkownika',
   type_machine_to_machine: 'Rola aplikacji Machine-to-Machine',
   role_description: 'Opis',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/roles.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/roles.ts
@@ -6,6 +6,10 @@ const roles = {
   create: 'Criar função',
   role_name: 'Nome da função',
   role_type: 'Tipo de função',
+  /** UNTRANSLATED */
+  show_role_type_button_text: 'Show more options',
+  /** UNTRANSLATED */
+  hide_role_type_button_text: 'Hide more options',
   type_user: 'Função do usuário',
   type_machine_to_machine: 'Função do aplicativo de máquina para máquina',
   role_description: 'Descrição',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/roles.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/roles.ts
@@ -6,6 +6,10 @@ const roles = {
   create: 'Criar papel',
   role_name: 'Nome do papel',
   role_type: 'Tipo de papel',
+  /** UNTRANSLATED */
+  show_role_type_button_text: 'Show more options',
+  /** UNTRANSLATED */
+  hide_role_type_button_text: 'Hide more options',
   type_user: 'Função de usuário',
   type_machine_to_machine: 'Função de aplicação máquina-a-máquina',
   role_description: 'Descrição',

--- a/packages/phrases/src/locales/ru/translation/admin-console/roles.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/roles.ts
@@ -6,6 +6,10 @@ const roles = {
   create: 'Создать роль',
   role_name: 'Имя роли',
   role_type: 'Тип роли',
+  /** UNTRANSLATED */
+  show_role_type_button_text: 'Show more options',
+  /** UNTRANSLATED */
+  hide_role_type_button_text: 'Hide more options',
   type_user: 'Роль пользователя',
   type_machine_to_machine: 'Роль приложения между машинами',
   role_description: 'Описание',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/roles.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/roles.ts
@@ -6,6 +6,10 @@ const roles = {
   create: 'Rol Oluştur',
   role_name: 'Rol adı',
   role_type: 'Rol tipi',
+  /** UNTRANSLATED */
+  show_role_type_button_text: 'Show more options',
+  /** UNTRANSLATED */
+  hide_role_type_button_text: 'Hide more options',
   type_user: 'Kullanıcı rolü',
   type_machine_to_machine: 'Makine-makine uygulama rolü',
   role_description: 'Açıklama',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/roles.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/roles.ts
@@ -6,6 +6,10 @@ const roles = {
   create: '创建角色',
   role_name: '角色名称',
   role_type: '角色类型',
+  /** UNTRANSLATED */
+  show_role_type_button_text: 'Show more options',
+  /** UNTRANSLATED */
+  hide_role_type_button_text: 'Hide more options',
   type_user: '用户角色',
   type_machine_to_machine: '机器对机器应用程序角色',
   role_description: '描述',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/roles.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/roles.ts
@@ -6,6 +6,10 @@ const roles = {
   create: '創建角色',
   role_name: '角色名稱',
   role_type: '角色類型',
+  /** UNTRANSLATED */
+  show_role_type_button_text: 'Show more options',
+  /** UNTRANSLATED */
+  hide_role_type_button_text: 'Hide more options',
   type_user: '用戶角色',
   type_machine_to_machine: '機器到機器應用程式角色',
   role_description: '描述',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/roles.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/roles.ts
@@ -6,6 +6,10 @@ const roles = {
   create: '建立角色',
   role_name: '角色名稱',
   role_type: '角色類型',
+  /** UNTRANSLATED */
+  show_role_type_button_text: 'Show more options',
+  /** UNTRANSLATED */
+  hide_role_type_button_text: 'Hide more options',
   type_user: '使用者角色',
   type_machine_to_machine: '機器對機器應用角色',
   role_description: '描述',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
hide role type selection on the role creation modal by default.
1. add `PRO` tag to the role type selection field on the `m2m role` options (show up for free plan).
2. when the plan is free plan and select m2m role, should pop up upsell footer.
3. fixed the footer, there will always be only ONE upsell message.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
tested locally.

1. This is a free plan, with one existing user role.
<img width="1229" alt="image" src="https://github.com/logto-io/logto/assets/15182327/853cc89a-e75f-455d-859b-205a5a20f3c5">
<img width="1246" alt="image" src="https://github.com/logto-io/logto/assets/15182327/e9a14051-4e9e-4ac6-b96b-983c56c8933f">

2. the role type selection part is hidden by default
<img width="1298" alt="image" src="https://github.com/logto-io/logto/assets/15182327/7c97dfed-062e-4361-8f42-71e4f2a39753">

3. a hobby plan without `pro` tag
<img width="1247" alt="image" src="https://github.com/logto-io/logto/assets/15182327/7bea529c-0cfe-433b-93ae-be78b9608bb2">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
