### PR TITLE
fix(console): fix AuditLogTable components application selector

### DIFF
--- a/packages/console/src/components/AuditLogTable/index.tsx
+++ b/packages/console/src/components/AuditLogTable/index.tsx
@@ -40,11 +40,13 @@ function AuditLogTable({ applicationId, userId, className }: Props) {
     useSearchParametersWatcher({
       page: 1,
       event: '',
-      ...conditional(applicationId && { applicationId: '' }),
+      // If `applicationId` not specified when init this component, then search parameter of `applicationId` can be accepted.
+      ...conditional(!applicationId && { applicationId: '' }),
     });
 
   // TODO: LOG-7135, revisit this fallback logic and see whether this should be done outside of this component.
-  const searchApplicationId = applicationId ?? applicationIdFromSearch;
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  const searchApplicationId = applicationId || applicationIdFromSearch;
   const { data: specifiedApplication } = useSWR<ApplicationResponse>(
     applicationId && `api/applications/${applicationId}`
   );
@@ -127,9 +129,12 @@ function AuditLogTable({ applicationId, userId, className }: Props) {
           {!applicationId && (
             <div className={styles.applicationSelector}>
               <ApplicationSelector
-                value={applicationId}
-                onChange={(applicationId) => {
-                  updateSearchParameters({ applicationId, page: undefined });
+                value={applicationIdFromSearch}
+                onChange={(applicationIdFromSearch) => {
+                  updateSearchParameters({
+                    applicationId: applicationIdFromSearch,
+                    page: undefined,
+                  });
                 }}
               />
             </div>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix AuditLogTable components application selector.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
tested locally.
1. can successfully filter by application and add its corresponding `applicationId` to search parameters.
<img width="1716" alt="image" src="https://github.com/logto-io/logto/assets/15182327/9180d1fc-1f47-4cbf-8721-17b3c9405e3f">
<img width="1659" alt="image" src="https://github.com/logto-io/logto/assets/15182327/14f9eb91-81fc-4d36-b065-f798fad65a37">
2. can correctly get audit logs of specific application (characterized by `applicationId`) and hide application selector
<img width="1223" alt="image" src="https://github.com/logto-io/logto/assets/15182327/f8795738-b19a-479f-8e78-95d8ab65fb2e">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
