### PR TITLE
fix(console): should not show admin console in audit log app selector

### DIFF
--- a/packages/console/src/components/AuditLogTable/components/ApplicationSelector/index.tsx
+++ b/packages/console/src/components/AuditLogTable/components/ApplicationSelector/index.tsx
@@ -1,8 +1,12 @@
 import type { Application } from '@logto/schemas';
-import { adminConsoleApplicationId } from '@logto/schemas';
+import { adminConsoleApplicationId, adminTenantId } from '@logto/schemas';
+import { conditional } from '@silverhand/essentials';
+import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 
+import { isCloud } from '@/consts/env';
+import { TenantsContext } from '@/contexts/TenantsProvider';
 import Select from '@/ds-components/Select';
 
 type Props = {
@@ -12,6 +16,7 @@ type Props = {
 
 function ApplicationSelector({ value, onChange }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const { currentTenantId } = useContext(TenantsContext);
   const { data } = useSWR<Application[]>('api/applications');
   const options =
     data?.map(({ id, name }) => ({
@@ -23,7 +28,15 @@ function ApplicationSelector({ value, onChange }: Props) {
     <Select
       isClearable
       value={value}
-      options={[{ value: adminConsoleApplicationId, title: 'Admin Console' }, ...options]}
+      options={[
+        ...(conditional(
+          isCloud &&
+            currentTenantId === adminTenantId && [
+              { value: adminConsoleApplicationId, title: 'Admin Console' },
+            ]
+        ) ?? []),
+        ...options,
+      ]}
       placeholder={t('logs.application')}
       onChange={onChange}
     />


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
should not show admin console in audit log app selector (for user tenant), only show this for admin tenant.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
