### PR TITLE
fix(console): fix the invalid_target error block console consent issue

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -32,7 +32,7 @@
     "@logto/language-kit": "workspace:^1.0.0",
     "@logto/phrases": "workspace:^1.5.0",
     "@logto/phrases-experience": "workspace:^1.3.1",
-    "@logto/react": "^2.1.0",
+    "@logto/react": "^2.1.2",
     "@logto/schemas": "workspace:^1.9.1",
     "@logto/shared": "workspace:^2.0.1",
     "@mdx-js/react": "^1.6.22",

--- a/packages/console/src/containers/ErrorBoundary/index.tsx
+++ b/packages/console/src/containers/ErrorBoundary/index.tsx
@@ -1,4 +1,4 @@
-import { LogtoClientError, LogtoError, OidcError } from '@logto/react';
+import { LogtoClientError, LogtoError, OidcError, LogtoRequestError } from '@logto/react';
 import { conditional } from '@silverhand/essentials';
 import { ResponseError } from '@withtyped/client';
 import { type TFunction } from 'i18next';
@@ -10,6 +10,23 @@ import { withTranslation } from 'react-i18next';
 import AppError from '@/components/AppError';
 import SessionExpired from '@/components/SessionExpired';
 import { isInCallback } from '@/utils/url';
+
+/**
+ * Returns true if the error is an OIDC invalid_grant error.
+ *
+ * OIDC request error is globally converted to the LogtoRequestError.
+ * @see {@link @logto/core/packages/core/src/middleware/koa-oidc-error-handler.ts}
+ * We need to check the error code to determine if it is an OIDC invalid_grant error.
+ */
+const isOidcInvalidGrantError = (error: Error) => {
+  const oidcGrantErrors = ['oidc.invalid_grant', 'oidc.invalid_target'];
+
+  if (!(error instanceof LogtoRequestError)) {
+    return false;
+  }
+
+  return oidcGrantErrors.includes(error.code);
+};
 
 type Props = {
   children: ReactNode;
@@ -70,6 +87,7 @@ class ErrorBoundary extends Component<Props, State> {
     if (
       error instanceof LogtoError ||
       error instanceof LogtoClientError ||
+      isOidcInvalidGrantError(error) ||
       (error instanceof HTTPError && error.response.status === 401) ||
       (error instanceof ResponseError && error.status === 401)
     ) {

--- a/packages/console/src/containers/ErrorBoundary/index.tsx
+++ b/packages/console/src/containers/ErrorBoundary/index.tsx
@@ -19,11 +19,11 @@ import { isInCallback } from '@/utils/url';
  * We need to check the error code to determine if it is an OIDC invalid_grant error.
  */
 const isOidcInvalidGrantError = (error: Error) => {
-  const oidcGrantErrors = ['oidc.invalid_grant', 'oidc.invalid_target'];
-
   if (!(error instanceof LogtoRequestError)) {
     return false;
   }
+
+  const oidcGrantErrors = ['oidc.invalid_grant', 'oidc.invalid_target'];
 
   return oidcGrantErrors.includes(error.code);
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2852,8 +2852,8 @@ importers:
         specifier: workspace:^1.3.1
         version: link:../phrases-experience
       '@logto/react':
-        specifier: ^2.1.0
-        version: 2.1.0(react@18.2.0)
+        specifier: ^2.1.2
+        version: 2.1.2(react@18.2.0)
       '@logto/schemas':
         specifier: workspace:^1.9.1
         version: link:../schemas
@@ -7289,6 +7289,14 @@ packages:
       js-base64: 3.7.5
     dev: true
 
+  /@logto/browser@2.1.2:
+    resolution: {integrity: sha512-LADZHT7LTyiWDwWmBwh3qAtOg+IVEjfaFKBTB/RQBc5T9xYO4q4JcyW1XgpMlkc0uLqOtW3uOGztUVs0ugi6/g==}
+    dependencies:
+      '@logto/client': 2.2.3
+      '@silverhand/essentials': 2.8.4
+      js-base64: 3.7.5
+    dev: true
+
   /@logto/client@2.1.0:
     resolution: {integrity: sha512-vw8xDW8k38/58Q1r592z/9JdsmUh4+LMmoVm/Nu7LbWKlT32eD3H9hZDkFK9XEHpriifhI0hP7asGWEmhrEUuQ==}
     dependencies:
@@ -7302,6 +7310,15 @@ packages:
     resolution: {integrity: sha512-7I2ELo5UWIJsFCYK/gX465l0+QhXTdyYWkgb2CcdPu5KbaPBNpASedm+fEV2NREYe2svbNODFhog6UMA/xGQnQ==}
     dependencies:
       '@logto/js': 2.1.1
+      '@silverhand/essentials': 2.8.4
+      camelcase-keys: 7.0.2
+      jose: 4.14.4
+    dev: true
+
+  /@logto/client@2.2.3:
+    resolution: {integrity: sha512-xq4LhQ6ItbukAHgsMDcgfspTpdpO5sSfSEugpOrGP/nLwzGTfBO78OSUfMdBQEDr5+3SRmONuSjUBBwssOLINA==}
+    dependencies:
+      '@logto/js': 2.1.3
       '@silverhand/essentials': 2.8.4
       camelcase-keys: 7.0.2
       jose: 4.14.4
@@ -7345,6 +7362,14 @@ packages:
       jose: 4.14.2
     dev: true
 
+  /@logto/js@2.1.3:
+    resolution: {integrity: sha512-TOuoC5gHx/SfY5gcGSBfw63x5TpM6Lm/9J5y0Jy003Z1DZARUlpz0KbzyCVAIC/+6qIefkmNPHKl1rq9MB/hog==}
+    dependencies:
+      '@silverhand/essentials': 2.8.4
+      camelcase-keys: 7.0.2
+      jose: 4.14.4
+    dev: true
+
   /@logto/node@2.1.1:
     resolution: {integrity: sha512-joSzzAqaRKeEquRenoFrIXXkNxkJci5zSkk4afywz1P8tTcTysnV4eXaBmwXNpmDfQdtHBwRdSACZPLgeF8JiQ==}
     dependencies:
@@ -7362,6 +7387,16 @@ packages:
       react: '>=16.8.0 || ^18.0.0'
     dependencies:
       '@logto/browser': 2.1.0
+      '@silverhand/essentials': 2.8.4
+      react: 18.2.0
+    dev: true
+
+  /@logto/react@2.1.2(react@18.2.0):
+    resolution: {integrity: sha512-4Fz5GG5N7y9ynYVutuLZgBornkVccaxG1vmAOxt233wfFPmNzESJ+TlYGe2FbngC7z9xfT6c7f9Q+1LZQmrzVg==}
+    peerDependencies:
+      react: '>=16.8.0 || ^18.0.0'
+    dependencies:
+      '@logto/browser': 2.1.2
       '@silverhand/essentials': 2.8.4
       react: 18.2.0
     dev: true


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the invalid_target error block console consent issue.


### Context
In PR #4573 we aligned the error response format of all OIDC thrown errors. Including errors like `invalid_grant` and `invalid_target`. Aligned with our  LogtoRequestError data structure.
- before response body: {error: 'invalid_grant', error_description: 'The resource indicator is missing or unknown'}.
- after response body: {code: 'oidc.invalid_grant', message: 'Invalid resource indicator'， error: 'invalid_grant', error_description: 'The resource indicator is missing or unknown' }

In AC we have an exclusive logic to handle the multi-tenant token exchanging flow. If an `invalid_target` or `invalid_grant` error is thrown, should treated as an unknown session and redirect the user to re-consent. 

- before: oidc error is not recognizable by our React SDK, since its body does not follow our `LogtoRequestError` convention. The error will be thrown as a `LogtoError` in the SDK. console will redirect to the unknown session page for all `LogtoError` as well. 
- after: oidc error is aligned with our `LogtoRequestError`. The error is recognized as a normal Logto API request error. An error is thrown instead of redirecting the user to re-authenticate. 

### Fix
Detect and identify the `oidc.invalid_grant` and `oidc.invalid_target` error. Redirect to the unknown session page. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] docs

OR

- [ ] This PR is not applicable for the checklist
