### PR TITLE
refactor(core): support `roles` scope for ID token

### DIFF
--- a/.changeset/sweet-cows-burn.md
+++ b/.changeset/sweet-cows-burn.md
@@ -1,0 +1,6 @@
+---
+"@logto/core-kit": patch
+"@logto/core": patch
+---
+
+support `roles` scope for ID token to issue `roles` claim

--- a/.changeset/sweet-cows-burn.md
+++ b/.changeset/sweet-cows-burn.md
@@ -1,6 +1,6 @@
 ---
-"@logto/core-kit": patch
-"@logto/core": patch
+"@logto/core-kit": minor
+"@logto/core": minor
 ---
 
 support `roles` scope for ID token to issue `roles` claim

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -230,16 +230,18 @@ export default function initOidc(
           return snakecaseKeys(
             {
               /**
-               * This line is required because:
+               * The manual `sub` assignment is required because:
                * 1. TypeScript will complain since `Object.fromEntries()` has a fixed key type `string`
                * 2. Scope `openid` is removed from `UserScope` enum
                */
               sub,
               ...Object.fromEntries(
-                getUserClaims(use, scope, claims, rejected).map((claim) => [
-                  claim,
-                  getUserClaimData(user, claim),
-                ])
+                await Promise.all(
+                  getUserClaims(use, scope, claims, rejected).map(
+                    async (claim) =>
+                      [claim, await getUserClaimData(user, claim, libraries.users)] as const
+                  )
+                )
               ),
             },
             {

--- a/packages/integration-tests/src/tests/api/oidc/id-token.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/id-token.test.ts
@@ -1,0 +1,51 @@
+import { Prompt } from '@logto/js';
+import { InteractionEvent, demoAppApplicationId } from '@logto/schemas';
+
+import { assignRolesToUser, putInteraction } from '#src/api/index.js';
+import { createRole } from '#src/api/role.js';
+import MockClient from '#src/client/index.js';
+import { demoAppRedirectUri } from '#src/constants.js';
+import { processSession } from '#src/helpers/client.js';
+import { createUserByAdmin } from '#src/helpers/index.js';
+import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
+import { generatePassword, generateUsername } from '#src/utils.js';
+
+describe('OpenID Connect ID token', () => {
+  const username = generateUsername();
+  const password = generatePassword();
+  // eslint-disable-next-line @silverhand/fp/no-let
+  let userId = '';
+
+  const fetchIdToken = async (scopes: string[], expectClaims: Record<string, unknown>) => {
+    const client = new MockClient({
+      appId: demoAppApplicationId,
+      prompt: Prompt.Login,
+      scopes,
+    });
+    await client.initSession(demoAppRedirectUri);
+    await client.successSend(putInteraction, {
+      event: InteractionEvent.SignIn,
+      identifier: { username, password },
+    });
+    const { redirectTo } = await client.submitInteraction();
+    await processSession(client, redirectTo);
+    const idToken = await client.getIdTokenClaims();
+    expect(idToken).toMatchObject(expectClaims);
+  };
+
+  beforeAll(async () => {
+    const { id } = await createUserByAdmin(username, password);
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    userId = id;
+    await enableAllPasswordSignInMethods();
+  });
+
+  it('should be issued with correct `username` and `roles` claims', async () => {
+    const role = await createRole({});
+    await assignRolesToUser(userId, [role.id]);
+    await fetchIdToken(['username', 'roles'], {
+      username,
+      roles: [role.name],
+    });
+  });
+});

--- a/packages/toolkit/core-kit/src/scope.ts
+++ b/packages/toolkit/core-kit/src/scope.ts
@@ -11,6 +11,7 @@ export type UserClaim =
   | 'email_verified'
   | 'phone_number'
   | 'phone_number_verified'
+  | 'roles'
   | 'custom_data'
   | 'identities';
 
@@ -48,6 +49,12 @@ export enum UserScope {
    * See {@link idTokenClaims} for mapped claims in ID Token and {@link userinfoClaims} for additional claims in Userinfo Endpoint.
    */
   Identities = 'identities',
+  /**
+   * Scope for user's roles.
+   *
+   * See {@link idTokenClaims} for mapped claims in ID Token and {@link userinfoClaims} for additional claims in Userinfo Endpoint.
+   */
+  Roles = 'roles',
 }
 
 /**
@@ -57,6 +64,7 @@ export const idTokenClaims: Readonly<Record<UserScope, UserClaim[]>> = Object.fr
   [UserScope.Profile]: ['name', 'picture', 'username'],
   [UserScope.Email]: ['email', 'email_verified'],
   [UserScope.Phone]: ['phone_number', 'phone_number_verified'],
+  [UserScope.Roles]: ['roles'],
   [UserScope.CustomData]: [],
   [UserScope.Identities]: [],
 });
@@ -68,6 +76,7 @@ export const userinfoClaims: Readonly<Record<UserScope, UserClaim[]>> = Object.f
   [UserScope.Profile]: [],
   [UserScope.Email]: [],
   [UserScope.Phone]: [],
+  [UserScope.Roles]: [],
   [UserScope.CustomData]: ['custom_data'],
   [UserScope.Identities]: ['identities'],
 });


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
create a new scope `roles` to add `roles` claim to the ID token. the claim will be an array of role names. this should resolve #3411.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
tested locally and added integration tests

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] ~~unit tests~~
- [x] integration tests
- [ ] docs (to be updated in the docs repo)
