### PR TITLE
feat(core): get organizations for user api

### DIFF
--- a/packages/core/src/queries/organizations.ts
+++ b/packages/core/src/queries/organizations.ts
@@ -10,10 +10,77 @@ import {
   OrganizationUserRelations,
   OrganizationRoleUserRelations,
 } from '@logto/schemas';
-import { type CommonQueryMethods } from 'slonik';
+import { convertToIdentifiers } from '@logto/shared';
+import { sql, type CommonQueryMethods } from 'slonik';
+import { z } from 'zod';
 
 import RelationQueries from '#src/utils/RelationQueries.js';
 import SchemaQueries from '#src/utils/SchemaQueries.js';
+
+/**
+ * The simplified organization role entity that is returned in the `roles` field
+ * of the organization.
+ *
+ * @remarks
+ * The type MUST be kept in sync with the query in {@link UserRelationQueries.getOrganizationsByUserId}.
+ */
+type RoleEntity = {
+  id: string;
+  name: string;
+};
+
+/**
+ * The organization entity with the `roles` field that contains the roles of the
+ * current member of the organization.
+ */
+type OrganizationWithRoles = Organization & {
+  /** The roles of the current member of the organization. */
+  roles: RoleEntity[];
+};
+
+export const organizationWithRolesGuard: z.ZodType<OrganizationWithRoles> =
+  Organizations.guard.extend({
+    roles: z
+      .object({
+        id: z.string(),
+        name: z.string(),
+      })
+      .array(),
+  });
+
+class UserRelationQueries extends RelationQueries<[typeof Organizations, typeof Users]> {
+  constructor(pool: CommonQueryMethods) {
+    super(pool, OrganizationUserRelations.table, Organizations, Users);
+  }
+
+  async getOrganizationsByUserId(userId: string): Promise<Readonly<OrganizationWithRoles[]>> {
+    const organizationRoles = convertToIdentifiers(OrganizationRoles, true);
+    const organizations = convertToIdentifiers(Organizations, true);
+    const { fields } = convertToIdentifiers(OrganizationUserRelations, true);
+    const oruRelations = convertToIdentifiers(OrganizationRoleUserRelations, true);
+
+    return this.pool.any<OrganizationWithRoles>(sql`
+      select
+        ${organizations.table}.*,
+        json_agg(
+          json_build_object(
+            'id', ${organizationRoles.fields.id},
+            'name', ${organizationRoles.fields.name})
+          )
+        as roles
+      from ${this.table}
+      join ${organizations.table}
+        on ${fields.organizationId} = ${organizations.fields.id}
+      left join ${oruRelations.table}
+        on ${fields.userId} = ${oruRelations.fields.userId}
+        and ${fields.organizationId} = ${oruRelations.fields.organizationId}
+      left join ${organizationRoles.table}
+        on ${oruRelations.fields.organizationRoleId} = ${organizationRoles.fields.id}
+      where ${fields.userId} = ${userId}
+      group by ${organizations.table}.id
+    `);
+  }
+}
 
 export default class OrganizationQueries extends SchemaQueries<
   OrganizationKeys,
@@ -35,7 +102,7 @@ export default class OrganizationQueries extends SchemaQueries<
       OrganizationScopes
     ),
     /** Queries for organization - user relations. */
-    users: new RelationQueries(this.pool, OrganizationUserRelations.table, Organizations, Users),
+    users: new UserRelationQueries(this.pool),
     /** Queries for organization - organization role - user relations. */
     rolesUsers: new RelationQueries(
       this.pool,

--- a/packages/core/src/routes/admin-user/index.ts
+++ b/packages/core/src/routes/admin-user/index.ts
@@ -1,6 +1,7 @@
 import type { AuthedRouter, RouterInitArgs } from '../types.js';
 
 import adminUserBasicsRoutes from './basics.js';
+import adminUserOrganizationRoutes from './organization.js';
 import adminUserRoleRoutes from './role.js';
 import adminUserSearchRoutes from './search.js';
 import adminUserSocialRoutes from './social.js';
@@ -10,4 +11,5 @@ export default function adminUserRoutes<T extends AuthedRouter>(...args: RouterI
   adminUserRoleRoutes(...args);
   adminUserSearchRoutes(...args);
   adminUserSocialRoutes(...args);
+  adminUserOrganizationRoutes(...args);
 }

--- a/packages/core/src/utils/SchemaRouter.ts
+++ b/packages/core/src/utils/SchemaRouter.ts
@@ -252,7 +252,7 @@ export default class SchemaRouter<
    *
    * The routes are:
    *
-   * - `GET /:id/[pathname]`: Get the entities of the relation.
+   * - `GET /:id/[pathname]`: Get the entities of the relation with pagination.
    * - `POST /:id/[pathname]`: Add entities to the relation.
    * - `DELETE /:id/[pathname]/:relationSchemaId`: Remove an entity from the relation set.
    * The `:relationSchemaId` is the entity ID in the relation schema.

--- a/packages/integration-tests/src/api/organization.ts
+++ b/packages/integration-tests/src/api/organization.ts
@@ -3,6 +3,12 @@ import { type Role, type Organization } from '@logto/schemas';
 import { authedAdminApi } from './api.js';
 import { ApiFactory } from './factory.js';
 
+type RoleEntity = {
+  id: string;
+  name: string;
+};
+type OrganizationWithRoles = Organization & { roles: RoleEntity[] };
+
 class OrganizationApi extends ApiFactory<Organization, { name: string; description?: string }> {
   constructor() {
     super('organizations');
@@ -30,6 +36,10 @@ class OrganizationApi extends ApiFactory<Organization, { name: string; descripti
 
   async deleteUserRole(id: string, userId: string, roleId: string): Promise<void> {
     await authedAdminApi.delete(`${this.path}/${id}/users/${userId}/roles/${roleId}`);
+  }
+
+  async getUserOrganizations(userId: string): Promise<OrganizationWithRoles[]> {
+    return authedAdminApi.get(`users/${userId}/organizations`).json<OrganizationWithRoles[]>();
   }
 }
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
api to get all organizations for a user with all roles the user has for each organization. resolves LOG-7237

`GET /users/:userId/organizations`

```ts
type RoleEntity = {
  id: string;
  name: string;
};

type OrganizationWithRoles = Organization & {
  /** The roles of the current member of the organization. */
  roles: RoleEntity[];
};
```

Response body will be an array of `OrganizationWithRoles`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
added api tests accordingly

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~~`.changeset`~~
- [ ] ~~unit tests~~
- [x] integration tests
- [x] TSDoc comments