### PR TITLE
refactor(schemas,core,console): unify the usage of OIDC "keyType" in both frontend and backend

### DIFF
--- a/packages/console/src/pages/TenantSettings/TenantBasicSettings/SigningKeys/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantBasicSettings/SigningKeys/index.tsx
@@ -1,7 +1,7 @@
 import {
-  LogtoOidcConfigKey,
   SupportedSigningKeyAlgorithm,
   type OidcConfigKeysResponse,
+  LogtoOidcConfigKeyType,
 } from '@logto/schemas';
 import { condArray } from '@silverhand/essentials';
 import { useMemo, useState } from 'react';
@@ -26,9 +26,10 @@ import * as styles from './index.module.scss';
 function SigningKeys() {
   const api = useApi();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console.tenants.signing_keys' });
-  const [activeTab, setActiveTab] = useState<LogtoOidcConfigKey>(LogtoOidcConfigKey.PrivateKeys);
-  const isPrivateKey = activeTab === LogtoOidcConfigKey.PrivateKeys;
-  const keyType = isPrivateKey ? 'private-keys' : 'cookie-keys';
+  const [keyType, setKeyType] = useState<LogtoOidcConfigKeyType>(
+    LogtoOidcConfigKeyType.PrivateKeys
+  );
+  const isPrivateKey = keyType === LogtoOidcConfigKeyType.PrivateKeys;
 
   const { data, error, mutate } = useSWR<OidcConfigKeysResponse[], RequestError>(
     `api/configs/oidc/${keyType}`
@@ -97,17 +98,17 @@ function SigningKeys() {
     <FormCard title="tenants.signing_keys.title" description="tenants.signing_keys.description">
       <TabNav>
         <TabNavItem
-          isActive={activeTab === LogtoOidcConfigKey.PrivateKeys}
+          isActive={keyType === LogtoOidcConfigKeyType.PrivateKeys}
           onClick={() => {
-            setActiveTab(LogtoOidcConfigKey.PrivateKeys);
+            setKeyType(LogtoOidcConfigKeyType.PrivateKeys);
           }}
         >
           <DynamicT forKey="tenants.signing_keys.type.private_key" />
         </TabNavItem>
         <TabNavItem
-          isActive={activeTab === LogtoOidcConfigKey.CookieKeys}
+          isActive={keyType === LogtoOidcConfigKeyType.CookieKeys}
           onClick={() => {
-            setActiveTab(LogtoOidcConfigKey.CookieKeys);
+            setKeyType(LogtoOidcConfigKeyType.CookieKeys);
           }}
         >
           <DynamicT forKey="tenants.signing_keys.type.cookie_key" />

--- a/packages/core/src/routes/logto-config.ts
+++ b/packages/core/src/routes/logto-config.ts
@@ -11,6 +11,7 @@ import {
   SupportedSigningKeyAlgorithm,
   type OidcConfigKeysResponse,
   type OidcConfigKey,
+  LogtoOidcConfigKeyType,
 } from '@logto/schemas';
 import { z } from 'zod';
 
@@ -20,19 +21,11 @@ import { exportJWK } from '#src/utils/jwks.js';
 
 import type { AuthedRouter, RouterInitArgs } from './types.js';
 
-/*
- * Logto OIDC private key type used in API routes
- */
-enum LogtoOidcPrivateKeyType {
-  PrivateKeys = 'private-keys',
-  CookieKeys = 'cookie-keys',
-}
-
 /**
- * Provide a simple API router key type and DB column mapping
+ * Provide a simple API router key type and DB config key mapping
  */
-const getOidcConfigKeyDatabaseColumnName = (key: LogtoOidcPrivateKeyType): LogtoOidcConfigKey =>
-  key === LogtoOidcPrivateKeyType.PrivateKeys
+const getOidcConfigKeyDatabaseColumnName = (key: LogtoOidcConfigKeyType): LogtoOidcConfigKey =>
+  key === LogtoOidcConfigKeyType.PrivateKeys
     ? LogtoOidcConfigKey.PrivateKeys
     : LogtoOidcConfigKey.CookieKeys;
 
@@ -105,7 +98,7 @@ export default function logtoConfigRoutes<T extends AuthedRouter>(
     '/configs/oidc/:keyType',
     koaGuard({
       params: z.object({
-        keyType: z.nativeEnum(LogtoOidcPrivateKeyType),
+        keyType: z.nativeEnum(LogtoOidcConfigKeyType),
       }),
       response: z.array(oidcConfigKeysResponseGuard),
       status: [200, 404],
@@ -131,7 +124,7 @@ export default function logtoConfigRoutes<T extends AuthedRouter>(
     '/configs/oidc/:keyType/:keyId',
     koaGuard({
       params: z.object({
-        keyType: z.nativeEnum(LogtoOidcPrivateKeyType),
+        keyType: z.nativeEnum(LogtoOidcConfigKeyType),
         keyId: z.string(),
       }),
       status: [204, 404, 422],
@@ -171,7 +164,7 @@ export default function logtoConfigRoutes<T extends AuthedRouter>(
     '/configs/oidc/:keyType/rotate',
     koaGuard({
       params: z.object({
-        keyType: z.nativeEnum(LogtoOidcPrivateKeyType),
+        keyType: z.nativeEnum(LogtoOidcConfigKeyType),
       }),
       body: z.object({
         signingKeyAlgorithm: z.nativeEnum(SupportedSigningKeyAlgorithm).optional(),

--- a/packages/integration-tests/src/api/logto-config.ts
+++ b/packages/integration-tests/src/api/logto-config.ts
@@ -2,6 +2,7 @@ import {
   SupportedSigningKeyAlgorithm,
   type AdminConsoleData,
   type OidcConfigKeysResponse,
+  type LogtoOidcConfigKeyType,
 } from '@logto/schemas';
 
 import { authedAdminApi } from './api.js';
@@ -16,14 +17,14 @@ export const updateAdminConsoleConfig = async (payload: Partial<AdminConsoleData
     })
     .json<AdminConsoleData>();
 
-export const getOidcKeys = async (keyType: 'private-keys' | 'cookie-keys') =>
+export const getOidcKeys = async (keyType: LogtoOidcConfigKeyType) =>
   authedAdminApi.get(`configs/oidc/${keyType}`).json<OidcConfigKeysResponse[]>();
 
-export const deleteOidcKey = async (keyType: 'private-keys' | 'cookie-keys', id: string) =>
+export const deleteOidcKey = async (keyType: LogtoOidcConfigKeyType, id: string) =>
   authedAdminApi.delete(`configs/oidc/${keyType}/${id}`);
 
 export const rotateOidcKeys = async (
-  keyType: 'private-keys' | 'cookie-keys',
+  keyType: LogtoOidcConfigKeyType,
   signingKeyAlgorithm: SupportedSigningKeyAlgorithm = SupportedSigningKeyAlgorithm.EC
 ) =>
   authedAdminApi

--- a/packages/schemas/src/types/logto-config.ts
+++ b/packages/schemas/src/types/logto-config.ts
@@ -1,13 +1,25 @@
 import type { ZodType } from 'zod';
 import { z } from 'zod';
 
-/* --- Logto OIDC configs --- */
+/**
+ * Logto OIDC signing key types, used mainly in REST API routes.
+ */
+export enum LogtoOidcConfigKeyType {
+  PrivateKeys = 'private-keys',
+  CookieKeys = 'cookie-keys',
+}
+
+/**
+ * Value maps to config key names in `logto_configs` table. Used mainly in DB SQL related scenarios.
+ */
 export enum LogtoOidcConfigKey {
   PrivateKeys = 'oidc.privateKeys',
   CookieKeys = 'oidc.cookieKeys',
 }
 
-/* --- Logto supported JWK signing key types --- */
+/**
+ * Logto supported signing key algorithms for OIDC private keys that sign JWT tokens.
+ */
 export enum SupportedSigningKeyAlgorithm {
   RSA = 'RSA',
   EC = 'EC',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Previously when reviewing the code, @darcyYe pointed out an issue that we have duplicated OIDC `keyType` enum/union declared ini both frontend and backend, which increases the risks of inconsistence in future development.
Therefore, I decided to move it to schemas and share it across the project.

Now, when we write API rotate OIDC keys API routes or call these APIs from frontend, we should use the `LogtoOidcConfigKeyType` enum, whereas if we write DB SQL queries or execute rotate OIDC key CLI commands, we should use `LogtoOidcConfigKey` enum.

`LogtoOidcConfigKeyType` has values in kebab case and thus is suitable for API routes
```ts
export enum LogtoOidcConfigKeyType {
  PrivateKeys = 'private-keys',
  CookieKeys = 'cookie-keys',
}
```

`LogtoOidcConfigKey` has values that map to the config key names in DB `logto_configs` table, and thus is suitable for writing DB related scenarios.
```ts
export enum LogtoOidcConfigKey {
  PrivateKeys = 'oidc.privateKeys',
  CookieKeys = 'oidc.cookieKeys',
}
```

Let me know if we have a better solution for this.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
