### PR TITLE
refactor(console): remove bottom padding from compact tables

### DIFF
--- a/packages/console/src/ds-components/Table/index.module.scss
+++ b/packages/console/src/ds-components/Table/index.module.scss
@@ -113,7 +113,7 @@
     }
 
     .bodyTable {
-      padding: 0 0 _.unit(3);
+      padding: 0;
       border: 1px solid var(--color-divider);
       border-top: unset;
 

--- a/packages/console/src/pages/TenantSettings/TenantBasicSettings/SigningKeys/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantBasicSettings/SigningKeys/index.tsx
@@ -116,6 +116,7 @@ function SigningKeys() {
       <FormField title={`tenants.signing_keys.${isPrivateKey ? 'private' : 'cookie'}_keys_in_use`}>
         <Table
           hasBorder
+          isRowHoverEffectDisabled
           isLoading={isLoadingKeys || isRotating}
           errorMessage={error?.body?.message ?? error?.message}
           rowIndexKey="id"


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
[Design system update] Remove bottom padding from tables in compact view.
Also removed hover effect from "OIDC signing keys" table, as there is no row click interaction.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested
<img width="796" alt="image" src="https://github.com/logto-io/logto/assets/12833674/9652a7a4-10ea-4895-9ab5-56e94e42f799">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
