### PR TITLE
refactor(core): refactor post connector endpoint

### DIFF
--- a/packages/cli/src/connector/factories.ts
+++ b/packages/cli/src/connector/factories.ts
@@ -23,11 +23,13 @@ export const loadConnectorFactories = async (
       try {
         const createConnector = await loadConnector(packagePath, ignoreVersionMismatch);
         const rawConnector = await createConnector({ getConfig: notImplemented });
+
         validateConnectorModule(rawConnector);
 
         return {
           metadata: await parseMetadata(rawConnector.metadata, packagePath),
           type: rawConnector.type,
+          configGuard: rawConnector.configGuard,
           createConnector,
           path: packagePath,
         };

--- a/packages/cli/src/connector/types.ts
+++ b/packages/cli/src/connector/types.ts
@@ -8,7 +8,7 @@ export type ConnectorFactory<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   T extends Router<any, BaseRoutes, string>,
   U extends AllConnector = AllConnector,
-> = Pick<U, 'type' | 'metadata'> & {
+> = Pick<U, 'type' | 'metadata' | 'configGuard'> & {
   createConnector: CreateConnector<U, T>;
   path: string;
 };

--- a/packages/core/src/__mocks__/connector.ts
+++ b/packages/core/src/__mocks__/connector.ts
@@ -59,6 +59,7 @@ export const mockConnectorFactory: ConnectorFactory<typeof router> = {
   metadata: mockMetadata,
   type: ConnectorType.Social,
   path: 'random_path',
+  configGuard: any(),
   createConnector: jest.fn(),
 };
 

--- a/packages/core/src/libraries/connector.ts
+++ b/packages/core/src/libraries/connector.ts
@@ -1,7 +1,7 @@
 import { buildRawConnector, defaultConnectorMethods } from '@logto/cli/lib/connector/index.js';
-import type { AllConnector } from '@logto/connector-kit';
-import { validateConfig, ServiceConnector } from '@logto/connector-kit';
-import { conditional, pick, trySafe } from '@silverhand/essentials';
+import type { AllConnector, ConnectorPlatform } from '@logto/connector-kit';
+import { validateConfig, ServiceConnector, ConnectorType } from '@logto/connector-kit';
+import { type Nullable, conditional, pick, trySafe } from '@silverhand/essentials';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import type Queries from '#src/tenants/Queries.js';
@@ -119,10 +119,26 @@ export const createConnectorLibrary = (
     return pickedConnector;
   };
 
+  const getLogtoConnectorByTargetAndPlatform = async (
+    target: string,
+    platform: Nullable<ConnectorPlatform>
+  ) => {
+    const connectors = await getLogtoConnectors();
+
+    return connectors.find(({ type, metadata }) => {
+      return (
+        type === ConnectorType.Social &&
+        metadata.target === target &&
+        metadata.platform === platform
+      );
+    });
+  };
+
   return {
     getConnectorConfig,
     getLogtoConnectors,
     getLogtoConnectorsWellKnown,
     getLogtoConnectorById,
+    getLogtoConnectorByTargetAndPlatform,
   };
 };

--- a/packages/core/src/routes/connector/index.post.test.ts
+++ b/packages/core/src/routes/connector/index.post.test.ts
@@ -2,6 +2,7 @@ import { ConnectorPlatform } from '@logto/connector-kit';
 import type { Connector } from '@logto/schemas';
 import { ConnectorType } from '@logto/schemas';
 import { pickDefault, createMockUtils } from '@logto/shared/esm';
+import { type Nullable } from '@silverhand/essentials';
 import { any } from 'zod';
 
 import {
@@ -64,6 +65,20 @@ const tenantContext = new MockTenant(
       );
 
       return connector;
+    },
+    getLogtoConnectorByTargetAndPlatform: async (
+      target: string,
+      platform: Nullable<ConnectorPlatform>
+    ) => {
+      const connectors = await getLogtoConnectors();
+
+      return connectors.find(({ type, metadata }) => {
+        return (
+          type === ConnectorType.Social &&
+          metadata.target === target &&
+          metadata.platform === platform
+        );
+      });
     },
   },
   {


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Refactor the POST /connectors endpoint.

This PR includes the following updates:
1. Return the `configGuard` directly in the `connectorFactory`. No need to rebuild the connector to validate the config data. 
2. Extract the fide duplicate social connector with the given `target` and `platform` into a library method. 
3. Move all the social-only validation statements into the `ConnectorType === 'Social'` block.



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [ ] ~necessary TSDoc comments~
