### PR TITLE
refactor(core): add time window validation tolerance for otp authenticator

### DIFF
--- a/packages/core/src/routes/interaction/utils/totp-validation.ts
+++ b/packages/core/src/routes/interaction/utils/totp-validation.ts
@@ -1,6 +1,17 @@
 import { authenticator } from 'otplib';
 
+/**
+ * Note:
+ * Considering T1 and T2 two consecutive time steps,
+ * any token generated within T1 but checked with T2 could be considered valid according to [RFC 6238 5.2](https://datatracker.ietf.org/doc/html/rfc6238#section-5.2).
+ *
+ * FYI: https://github.com/yeojz/otplib/issues/697#issuecomment-1655749578
+ */
+// eslint-disable-next-line @silverhand/fp/no-mutation
+authenticator.options = { window: 1 };
+
 export const generateTotpSecret = () => authenticator.generateSecret();
 
-export const validateTotpToken = (secret: string, token: string) =>
-  authenticator.check(token, secret);
+export const validateTotpToken = (secret: string, token: string) => {
+  return authenticator.check(token, secret);
+};

--- a/packages/integration-tests/src/ui-helpers/expect-totp-experience.ts
+++ b/packages/integration-tests/src/ui-helpers/expect-totp-experience.ts
@@ -1,6 +1,5 @@
 import { authenticator } from 'otplib';
 
-import { demoAppUrl } from '#src/constants.js';
 import { waitFor, dcls } from '#src/utils.js';
 
 import ExpectExperience from './expect-experience.js';
@@ -35,10 +34,7 @@ export default class ExpectTotpExperience extends ExpectExperience {
 
     const code = authenticator.generate(secret);
 
-    for (const [index, char] of code.split('').entries()) {
-      // eslint-disable-next-line no-await-in-loop
-      await this.toFillInput(`totpCode_${index}`, char);
-    }
+    await this.fillTotpCode(code);
 
     // Wait for the form to commit automatically
     await waitFor(500);
@@ -64,10 +60,7 @@ export default class ExpectTotpExperience extends ExpectExperience {
 
     const code = authenticator.generate(secret);
 
-    for (const [index, char] of code.split('').entries()) {
-      // eslint-disable-next-line no-await-in-loop
-      await this.toFillInput(`totpCode_${index}`, char);
-    }
+    await this.fillTotpCode(code);
 
     // Wait for the form to commit automatically
     await waitFor(500);
@@ -76,17 +69,10 @@ export default class ExpectTotpExperience extends ExpectExperience {
     }
   }
 
-  /**
-   * Assert the page is at the demo app page and get the user ID from the page.
-   * @returns The user ID.
-   */
-  async getUserIdFromDemoAppPage() {
-    this.toMatchUrl(demoAppUrl);
-    const userIdDiv = await expect(this.page).toMatchElement([dcls('infoCard'), 'div'].join(' '), {
-      text: 'User ID: ',
-    });
-    const userIdSpan = await expect(userIdDiv).toMatchElement('span');
-
-    return (await userIdSpan.evaluate((element) => element.textContent)) ?? '';
+  private async fillTotpCode(code: string) {
+    for (const [index, char] of code.split('').entries()) {
+      // eslint-disable-next-line no-await-in-loop
+      await this.toFillInput(`totpCode_${index}`, char);
+    }
   }
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Considering T1 and T2 two consecutive time steps, any token generated within T1 but checked with T2 could be considered valid according to [RFC 6238 5.2](https://datatracker.ietf.org/doc/html/rfc6238#section-5.2).

FYI: https://github.com/yeojz/otplib/issues/697#issuecomment-1655749578

### Updates
- test: Extract filling totp code logic into a helper method
- test: Remove `getUserIdFromDemoAppPage` method from the `ExpectTotpExperience` class since it's available in the base class(`ExpectExperience`).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
IT

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
