### PR TITLE
feat(core,schemas): bind backup code

### DIFF
--- a/packages/core/src/__mocks__/mfa-verification.ts
+++ b/packages/core/src/__mocks__/mfa-verification.ts
@@ -1,4 +1,4 @@
-import { MfaFactor, type BindMfa, type BindWebAuthn } from '@logto/schemas';
+import { MfaFactor, type BindMfa, type BindWebAuthn, type BindBackupCode } from '@logto/schemas';
 
 export const mockTotpBind: BindMfa = {
   type: MfaFactor.TOTP,
@@ -12,4 +12,9 @@ export const mockWebAuthnBind: BindWebAuthn = {
   counter: 0,
   agent: 'agent',
   transports: [],
+};
+
+export const mockBackupCodeBind: BindBackupCode = {
+  type: MfaFactor.BackupCode,
+  codes: ['code'],
 };

--- a/packages/core/src/routes/interaction/actions/submit-interaction.ts
+++ b/packages/core/src/routes/interaction/actions/submit-interaction.ts
@@ -52,7 +52,6 @@ const parseBindMfas = ({
       };
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (bindMfa.type === MfaFactor.WebAuthn) {
       return {
         ...bindMfa,
@@ -61,8 +60,12 @@ const parseBindMfas = ({
       };
     }
 
-    // Not expected to happen, the above if statements should cover all cases
-    throw new Error('Unsupported MFA factor');
+    return {
+      id: generateStandardId(),
+      createdAt: new Date().toISOString(),
+      type: MfaFactor.BackupCode,
+      codes: bindMfa.codes.map((code) => ({ code })),
+    };
   });
 };
 

--- a/packages/core/src/routes/interaction/index.test.ts
+++ b/packages/core/src/routes/interaction/index.test.ts
@@ -54,6 +54,7 @@ const {
   verifyProfile,
   validateMandatoryUserProfile,
   validateMandatoryBindMfa,
+  validateBindMfaBackupCode,
   verifyBindMfa,
   verifyMfa,
 } = await mockEsmWithActual('./verifications/index.js', () => ({
@@ -62,6 +63,7 @@ const {
   verifyProfile: jest.fn(),
   validateMandatoryUserProfile: jest.fn(),
   validateMandatoryBindMfa: jest.fn(),
+  validateBindMfaBackupCode: jest.fn(),
   verifyBindMfa: jest.fn(),
   verifyMfa: jest.fn(),
 }));
@@ -186,6 +188,9 @@ describe('interaction routes', () => {
       validateMandatoryUserProfile.mockReturnValueOnce({
         event: InteractionEvent.SignIn,
       });
+      validateMandatoryBindMfa.mockReturnValueOnce({
+        event: InteractionEvent.SignIn,
+      });
       verifyBindMfa.mockReturnValueOnce({
         event: InteractionEvent.SignIn,
       });
@@ -201,6 +206,7 @@ describe('interaction routes', () => {
       expect(validateMandatoryUserProfile).toBeCalled();
       expect(verifyBindMfa).toBeCalled();
       expect(validateMandatoryBindMfa).toBeCalled();
+      expect(validateBindMfaBackupCode).toBeCalled();
       expect(submitInteraction).toBeCalled();
     });
 
@@ -244,6 +250,7 @@ describe('interaction routes', () => {
       expect(verifyProfile).toBeCalled();
       expect(validateMandatoryUserProfile).not.toBeCalled();
       expect(validateMandatoryBindMfa).not.toBeCalled();
+      expect(validateBindMfaBackupCode).not.toBeCalled();
       expect(submitInteraction).toBeCalled();
     });
   });

--- a/packages/core/src/routes/interaction/index.ts
+++ b/packages/core/src/routes/interaction/index.ts
@@ -41,6 +41,7 @@ import {
   validateMandatoryBindMfa,
   verifyBindMfa,
   verifyMfa,
+  validateBindMfaBackupCode,
 } from './verifications/index.js';
 
 export type RouterContext<T> = T extends Router<unknown, infer Context> ? Context : never;
@@ -354,9 +355,15 @@ export default function interactionRoutes<T extends AnonymousRouter>(
         ? mandatoryProfileVerifiedInteraction
         : await verifyBindMfa(tenant, mandatoryProfileVerifiedInteraction);
 
-      const interaction = isForgotPasswordInteractionResult(bindMfaVerifiedInteraction)
+      const mandatoryMfaVerifiedInteraction = isForgotPasswordInteractionResult(
+        bindMfaVerifiedInteraction
+      )
         ? bindMfaVerifiedInteraction
         : await validateMandatoryBindMfa(tenant, ctx, bindMfaVerifiedInteraction);
+
+      const interaction = isForgotPasswordInteractionResult(mandatoryMfaVerifiedInteraction)
+        ? mandatoryMfaVerifiedInteraction
+        : await validateBindMfaBackupCode(tenant, ctx, mandatoryMfaVerifiedInteraction, provider);
 
       await submitInteraction(interaction, ctx, tenant, log);
 

--- a/packages/core/src/routes/interaction/utils/backup-code-validation.test.ts
+++ b/packages/core/src/routes/interaction/utils/backup-code-validation.test.ts
@@ -1,0 +1,12 @@
+import { generateBackupCodes } from './backup-code-validation.js';
+
+describe('generateBackupCodes()', () => {
+  it('should generate a group of random backup codes', () => {
+    const codes = generateBackupCodes();
+    expect(codes.length).toEqual(10);
+    for (const code of codes) {
+      expect(code.length).toEqual(10);
+      expect(code).toMatch(/[\da-f]{10}/);
+    }
+  });
+});

--- a/packages/core/src/routes/interaction/utils/backup-code-validation.ts
+++ b/packages/core/src/routes/interaction/utils/backup-code-validation.ts
@@ -1,0 +1,13 @@
+import { customAlphabet } from 'nanoid';
+
+const backupCodeCount = 10;
+const alphabet = '0123456789abcdef' as const;
+
+/**
+ * Generates a group of random backup codes.
+ * The code is a 10-digit string of letters from 1 to f.
+ */
+export const generateBackupCodes = () => {
+  const codes = Array.from({ length: backupCodeCount }, () => customAlphabet(alphabet, 10)());
+  return codes;
+};

--- a/packages/core/src/routes/interaction/verifications/mfa-payload-verification.test.ts
+++ b/packages/core/src/routes/interaction/verifications/mfa-payload-verification.test.ts
@@ -181,6 +181,39 @@ describe('bindMfaPayloadVerification', () => {
       ).rejects.toEqual(new RequestError('session.mfa.webauthn_verification_failed'));
     });
   });
+
+  describe('backup code', () => {
+    it('should return result of BindMfa', async () => {
+      await expect(
+        bindMfaPayloadVerification(
+          baseCtx,
+          { type: MfaFactor.BackupCode },
+          {
+            ...interaction,
+            pendingMfa: {
+              type: MfaFactor.BackupCode,
+              codes: ['code'],
+            },
+          },
+          additionalParameters
+        )
+      ).resolves.toMatchObject({
+        type: MfaFactor.BackupCode,
+        codes: ['code'],
+      });
+    });
+
+    it('should reject when pendingMfa is missing', async () => {
+      await expect(
+        bindMfaPayloadVerification(
+          baseCtx,
+          { type: MfaFactor.BackupCode },
+          interaction,
+          additionalParameters
+        )
+      ).rejects.toEqual(new RequestError('session.mfa.pending_info_not_found'));
+    });
+  });
 });
 
 describe('verifyMfaPayloadVerification', () => {

--- a/packages/core/src/utils/user.ts
+++ b/packages/core/src/utils/user.ts
@@ -7,10 +7,9 @@ export const transpileUserMfaVerifications = (
     const { id, createdAt, type } = verification;
 
     if (type === MfaFactor.BackupCode) {
-      const { usedAt } = verification;
-      const used = Boolean(usedAt);
+      const { codes } = verification;
 
-      return { id, createdAt, type, used };
+      return { id, createdAt, type, remainCodes: codes.filter((code) => !code.usedAt).length };
     }
 
     if (type === MfaFactor.WebAuthn) {

--- a/packages/schemas/src/foundations/jsonb-types/users.ts
+++ b/packages/schemas/src/foundations/jsonb-types/users.ts
@@ -51,8 +51,7 @@ export type MfaVerificationWebAuthn = z.infer<typeof mfaVerificationWebAuthn>;
 export const mfaVerificationBackupCode = z.object({
   type: z.literal(MfaFactor.BackupCode),
   ...baseMfaVerification,
-  code: z.string(),
-  usedAt: z.string().optional(),
+  codes: z.object({ code: z.string(), usedAt: z.string().optional() }).array(),
 });
 
 export type MfaVerificationBackupCode = z.infer<typeof mfaVerificationBackupCode>;

--- a/packages/schemas/src/types/interactions.ts
+++ b/packages/schemas/src/types/interactions.ts
@@ -141,9 +141,16 @@ export const bindWebAuthnPayloadGuard = z.object({
 
 export type BindWebAuthnPayload = z.infer<typeof bindWebAuthnPayloadGuard>;
 
+export const bindBackupCodePayloadGuard = z.object({
+  type: z.literal(MfaFactor.BackupCode),
+});
+
+export type BindBackupCodePayload = z.infer<typeof bindBackupCodePayloadGuard>;
+
 export const bindMfaPayloadGuard = z.discriminatedUnion('type', [
   bindTotpPayloadGuard,
   bindWebAuthnPayloadGuard,
+  bindBackupCodePayloadGuard,
 ]);
 
 export type BindMfaPayload = z.infer<typeof bindMfaPayloadGuard>;
@@ -186,11 +193,19 @@ export const pendingWebAuthnGuard = z.object({
 
 export type PendingWebAuthn = z.infer<typeof pendingWebAuthnGuard>;
 
+export const pendingBackupCodeGuard = z.object({
+  type: z.literal(MfaFactor.BackupCode),
+  codes: z.array(z.string()),
+});
+
+export type PendingBackupCode = z.infer<typeof pendingBackupCodeGuard>;
+
 // Some information like TOTP secret should be generated in the backend
 // and stored in the interaction temporarily.
 export const pendingMfaGuard = z.discriminatedUnion('type', [
   pendingTotpGuard,
   pendingWebAuthnGuard,
+  pendingBackupCodeGuard,
 ]);
 
 export type PendingMfa = z.infer<typeof pendingMfaGuard>;
@@ -210,8 +225,16 @@ export const bindWebAuthnGuard = z.object({
 
 export type BindWebAuthn = z.infer<typeof bindWebAuthnGuard>;
 
+export const bindBackupCodeGuard = pendingBackupCodeGuard;
+
+export type BindBackupCode = z.infer<typeof bindBackupCodeGuard>;
+
 // The type for binding new mfa verification to a user, not always equals to the pending type.
-export const bindMfaGuard = z.discriminatedUnion('type', [bindTotpGuard, bindWebAuthnGuard]);
+export const bindMfaGuard = z.discriminatedUnion('type', [
+  bindTotpGuard,
+  bindWebAuthnGuard,
+  bindBackupCodeGuard,
+]);
 
 export type BindMfa = z.infer<typeof bindMfaGuard>;
 

--- a/packages/schemas/src/types/user.ts
+++ b/packages/schemas/src/types/user.ts
@@ -36,7 +36,7 @@ export const userMfaVerificationResponseGuard = z
     createdAt: z.string(),
     type: z.nativeEnum(MfaFactor),
     agent: z.string().optional(),
-    used: z.boolean().optional(),
+    remainCodes: z.number().optional(),
   })
   .array();
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Implement the feature: bind backup code:

If "backup code" is enabled in Console, then if a user want to bind a new MFA, backup code should be added together. The process is:

1. Submit interaction with new `bindMfa`.
2. Return error of missing backup code, and generate codes to session, send to front end with error, the front end can then show backup codes to the user.
3. Resubmit the interaction to "confirm" backup code.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Unit tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
- [x] unit tests
~~- [ ] integration tests~~ will add in "verify backup code" PR
- [x] necessary TSDoc comments
