### PR TITLE
feat(connector,toolkit): define new sso-oidc connector type

### DIFF
--- a/.changeset/wet-lies-wash.md
+++ b/.changeset/wet-lies-wash.md
@@ -1,0 +1,6 @@
+---
+"@logto/connector-kit": minor
+---
+
+- Introduce new SsoOidc connector type.
+- Define shared OIDC standard data guards and types

--- a/.changeset/wet-lies-wash.md
+++ b/.changeset/wet-lies-wash.md
@@ -1,6 +1,8 @@
 ---
 "@logto/connector-kit": minor
+"@logto/connector-oidc": minor
 ---
 
-- Introduce new SsoOidc connector type.
+- Introduce new `SsoOidc`` connector type.
 - Define shared OIDC standard data guards and types
+- Update `@logto/connector-oidc` package to reference shared OIDC types and guards from `@logto/connector-kit` package.

--- a/packages/connectors/connector-oidc/src/index.ts
+++ b/packages/connectors/connector-oidc/src/index.ts
@@ -14,12 +14,13 @@ import {
   ConnectorErrorCodes,
   validateConfig,
   ConnectorType,
+  idTokenProfileStandardClaimsGuard,
 } from '@logto/connector-kit';
 import { generateStandardId } from '@logto/shared/universal';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
 
 import { defaultMetadata } from './constant.js';
-import { idTokenProfileStandardClaimsGuard, oidcConfigGuard } from './types.js';
+import { oidcConfigGuard } from './types.js';
 import { getIdToken } from './utils.js';
 
 const generateNonce = () => generateStandardId();

--- a/packages/connectors/connector-oidc/src/types.ts
+++ b/packages/connectors/connector-oidc/src/types.ts
@@ -1,42 +1,6 @@
 import { z } from 'zod';
 
-const scopeOpenid = 'openid' as const;
-export const delimiter = /[ +]/;
-
-// Space-delimited 'scope' MUST contain 'openid', see https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth
-export const scopePostProcessor = (scope: string) => {
-  const splitScopes = scope.split(delimiter).filter(Boolean);
-
-  if (!splitScopes.includes(scopeOpenid)) {
-    return [...splitScopes, scopeOpenid].join(' ');
-  }
-
-  return scope;
-};
-
-// See https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims.
-// We only concern a subset of them, and social identity provider usually does not provide a complete set of them.
-export const idTokenProfileStandardClaimsGuard = z.object({
-  sub: z.string(),
-  name: z.string().nullish(),
-  email: z.string().nullish(),
-  email_verified: z.boolean().nullish(),
-  phone: z.string().nullish(),
-  phone_verified: z.boolean().nullish(),
-  picture: z.string().nullish(),
-  profile: z.string().nullish(),
-  nonce: z.string().nullish(),
-});
-
-export const userProfileGuard = z.object({
-  id: z.preprocess(String, z.string()),
-  email: z.string().optional(),
-  phone: z.string().optional(),
-  name: z.string().optional(),
-  avatar: z.string().optional(),
-});
-
-export type UserProfile = z.infer<typeof userProfileGuard>;
+import { scopePostProcessor } from '@logto/connector-kit';
 
 const endpointConfigObject = {
   authorizationEndpoint: z.string(),
@@ -96,24 +60,3 @@ export const oidcConfigGuard = z.object({
 });
 
 export type OidcConfig = z.infer<typeof oidcConfigGuard>;
-
-export const authResponseGuard = z
-  .object({
-    code: z.string(),
-    state: z.string().optional(),
-  })
-  .catchall(z.string());
-
-export type AuthResponse = z.infer<typeof authResponseGuard>;
-
-export const accessTokenResponseGuard = z.object({
-  id_token: z.string(),
-  access_token: z.string().optional(),
-  token_type: z.string().optional(),
-  expires_in: z.number().optional(),
-  refresh_token: z.string().optional(),
-  scope: z.string().optional(),
-  code: z.string().optional(),
-});
-
-export type AccessTokenResponse = z.infer<typeof accessTokenResponseGuard>;

--- a/packages/toolkit/connector-kit/src/index.ts
+++ b/packages/toolkit/connector-kit/src/index.ts
@@ -3,6 +3,7 @@ import type { ZodType, ZodTypeDef } from 'zod';
 import { ConnectorError, ConnectorErrorCodes } from './types/index.js';
 
 export * from './types/index.js';
+export * from './utils/oidc.js';
 
 export function validateConfig<Output, Input = Output>(
   config: unknown,

--- a/packages/toolkit/connector-kit/src/types/foundation.ts
+++ b/packages/toolkit/connector-kit/src/types/foundation.ts
@@ -6,14 +6,19 @@ export enum ConnectorType {
   Email = 'Email',
   Sms = 'Sms',
   Social = 'Social',
+  SsoOidc = 'SsoOidc',
+  SsoSaml = 'SsoSaml',
 }
 
 /* 
   SocialConnector, EmailConnector, SmsConnector has dependency on BaseConnector,
   so BaseConnector need be defined separately.
 */
-export type BaseConnector<Type extends ConnectorType> = {
+export type BaseConnector<
+  Type extends ConnectorType,
+  MetadataType extends ConnectorMetadata = ConnectorMetadata,
+> = {
   type: Type;
-  metadata: ConnectorMetadata;
+  metadata: MetadataType;
   configGuard: ZodType;
 };

--- a/packages/toolkit/connector-kit/src/types/index.ts
+++ b/packages/toolkit/connector-kit/src/types/index.ts
@@ -3,6 +3,7 @@ import type { BaseRoutes, Router } from '@withtyped/server';
 
 import { type SmsConnector, type EmailConnector } from './passwordless.js';
 import { type SocialConnector } from './social.js';
+import { type SsoOidcConnector } from './sso.js';
 
 export * from './config-form.js';
 export * from './error.js';
@@ -10,6 +11,8 @@ export * from './metadata.js';
 export * from './foundation.js';
 export * from './passwordless.js';
 export * from './social.js';
+export * from './sso.js';
+export * from './oidc.js';
 
 export type GetConnectorConfig = (id: string) => Promise<unknown>;
 
@@ -27,7 +30,7 @@ export type CreateConnector<
   getCloudServiceClient?: GetCloudServiceClient<U>;
 }) => Promise<T>;
 
-export type AllConnector = SmsConnector | EmailConnector | SocialConnector;
+export type AllConnector = SmsConnector | EmailConnector | SocialConnector | SsoOidcConnector;
 
 export enum DemoConnector {
   Sms = 'logto-sms',

--- a/packages/toolkit/connector-kit/src/types/metadata.ts
+++ b/packages/toolkit/connector-kit/src/types/metadata.ts
@@ -41,6 +41,11 @@ export const socialConnectorMetadataGuard = z.object({
   isStandard: z.boolean().optional(),
 });
 
+export const ssoConnectorMetadataGuard = z.object({
+  restrictedSignInMethod: z.boolean(),
+  domains: z.array(z.string()),
+});
+
 export const connectorMetadataGuard = z
   .object({
     // Unique connector factory id
@@ -59,6 +64,7 @@ export const connectorMetadataGuard = z
     formItems: connectorConfigFormItemGuard.array().optional(),
   })
   .merge(socialConnectorMetadataGuard)
+  .merge(ssoConnectorMetadataGuard.partial())
   .catchall(z.unknown());
 
 export type ConnectorMetadata = z.infer<typeof connectorMetadataGuard>;
@@ -70,6 +76,8 @@ export const configurableConnectorMetadataGuard = connectorMetadataGuard
     name: true,
     logo: true,
     logoDark: true,
+    restrictedSignInMethod: true,
+    domains: true,
   })
   .partial();
 

--- a/packages/toolkit/connector-kit/src/types/oidc.ts
+++ b/packages/toolkit/connector-kit/src/types/oidc.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod';
+
+export const basicOidcConnectorConfigGuard = z.object({
+  issuer: z.string(),
+  clientId: z.string(),
+  clientSecret: z.string(),
+});
+
+export const oidcConnectorConfigGuard = basicOidcConnectorConfigGuard.merge(
+  z.object({
+    authorizationEndpoint: z.string(),
+    tokenEndpoint: z.string(),
+    userinfoEndpoint: z.string(),
+    jwksUri: z.string(),
+    scope: z.string().optional(),
+  })
+);
+
+export type OidcConfig = z.infer<typeof oidcConnectorConfigGuard>;
+
+export type GetOidcConfig = () => Promise<OidcConfig>;
+
+export const oidcConfigResponseGuard = z.object({
+  authorization_endpoint: z.string(),
+  token_endpoint: z.string(),
+  userinfo_endpoint: z.string(),
+  jwks_uri: z.string(),
+  issuer: z.string(),
+});
+
+export const oidcAuthorizationResponseGuard = z.object({
+  code: z.string(),
+  state: z.string(),
+});
+export type OidcAuthorizationResponse = z.infer<typeof oidcAuthorizationResponseGuard>;
+
+export const oidcTokenResponseGuard = z.object({
+  id_token: z.string(),
+  access_token: z.string().optional(),
+  token_type: z.string().optional(),
+  expires_in: z.number().optional(),
+  refresh_token: z.string().optional(),
+  scope: z.string().optional(),
+  code: z.string().optional(),
+});
+
+export type OidcTokenResponse = z.infer<typeof oidcTokenResponseGuard>;
+
+// See https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims.
+export const idTokenProfileStandardClaimsGuard = z.object({
+  sub: z.string(),
+  name: z.string().nullish(),
+  email: z.string().nullish(),
+  email_verified: z.boolean().nullish(),
+  phone: z.string().nullish(),
+  phone_verified: z.boolean().nullish(),
+  picture: z.string().nullish(),
+  profile: z.string().nullish(),
+  nonce: z.string().nullish(),
+});

--- a/packages/toolkit/connector-kit/src/types/sso.ts
+++ b/packages/toolkit/connector-kit/src/types/sso.ts
@@ -1,0 +1,23 @@
+import { type z } from 'zod';
+
+import { type ConnectorType, type BaseConnector } from './foundation.js';
+import { type ConnectorMetadata, type ssoConnectorMetadataGuard } from './metadata.js';
+import { type GetOidcConfig } from './oidc.js';
+import { type GetAuthorizationUri, type GetUserInfo } from './social.js';
+
+type ssoConnectorOnlyMetadata = z.infer<typeof ssoConnectorMetadataGuard>;
+
+// Domains and restrictedSignInMethod are mandatory for SSO connectors
+export type SsoConnectorMetadata = ConnectorMetadata & ssoConnectorOnlyMetadata;
+
+export type SsoOidcConnector = BaseConnector<
+  ConnectorType.SsoOidc,
+  ConnectorMetadata & ssoConnectorOnlyMetadata
+> & {
+  /* Indicates if the connector config is valid */
+  isConfigValid: boolean;
+  getAuthorizationUri: GetAuthorizationUri;
+  getUserInfo: GetUserInfo;
+  /* Get full OIDC config from the connector provider */
+  getOidcConfig: GetOidcConfig;
+};

--- a/packages/toolkit/connector-kit/src/types/sso.ts
+++ b/packages/toolkit/connector-kit/src/types/sso.ts
@@ -14,8 +14,6 @@ export type SsoOidcConnector = BaseConnector<
   ConnectorType.SsoOidc,
   ConnectorMetadata & ssoConnectorOnlyMetadata
 > & {
-  /* Indicates if the connector config is valid */
-  isConfigValid: boolean;
   getAuthorizationUri: GetAuthorizationUri;
   getUserInfo: GetUserInfo;
   /* Get full OIDC config from the connector provider */

--- a/packages/toolkit/connector-kit/src/utils/oidc.test.ts
+++ b/packages/toolkit/connector-kit/src/utils/oidc.test.ts
@@ -1,4 +1,4 @@
-import { scopePostProcessor } from './types.js';
+import { scopePostProcessor } from './oidc.js';
 
 describe('scopePostProcessor', () => {
   it('`openid` will be added if not exists (with empty string)', () => {

--- a/packages/toolkit/connector-kit/src/utils/oidc.ts
+++ b/packages/toolkit/connector-kit/src/utils/oidc.ts
@@ -1,0 +1,18 @@
+const scopeOpenid = 'openid' as const;
+const delimiter = /[ +]/;
+
+/**
+ * Scope config processor for OIDC connector. openid scope is required to retrieve id_token
+ * @see https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth
+ * @param scope
+ * @returns
+ */
+export const scopePostProcessor = (scope: string) => {
+  const splitScopes = scope.split(delimiter).filter(Boolean);
+
+  if (!splitScopes.includes(scopeOpenid)) {
+    return [...splitScopes, scopeOpenid].join(' ');
+  }
+
+  return scope;
+};


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR includes the following update:

1. Introduce two new connector types `SsoOidc` and `SsoSaml`.   Both have different metadata and connector factory properties compared to our existing social connectors. 

- new metadata: `restrictedSignInMethod` and `domains`. Undefined for social connectors but required for SSO connectors.
- new connector property method: `getOidcConfig`.  Fetch the full OIDC configuration from IDP.

2. Extract shared OIDC-specific types, guards, and util methods from the `oidc-connector` to the `connector-kit`. So they can be shared across all OIDC-based connectors.

3. Remove useless validation method in oidc-connector
- isIdTokenInResponseType method
- access_token response assertion


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
exiting ci

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] ~unit tests~
- [ ] ~integration tests~
- [ ] ~necessary TSDoc comments~
