### PR TITLE
feat(core): skippable bind mfa prompt

### DIFF
--- a/packages/integration-tests/src/helpers/sign-in-experience.ts
+++ b/packages/integration-tests/src/helpers/sign-in-experience.ts
@@ -75,6 +75,14 @@ export const enableAllVerificationCodeSignInMethods = async (
     mfa: { factors: [], policy: MfaPolicy.UserControlled },
   });
 
+export const enableUserControlledMfaWithTotp = async () =>
+  updateSignInExperience({
+    mfa: {
+      factors: [MfaFactor.TOTP],
+      policy: MfaPolicy.UserControlled,
+    },
+  });
+
 export const enableMandatoryMfaWithTotp = async () =>
   updateSignInExperience({
     mfa: {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Implement skippable bind mfa prompt: for "user-controlled" MFA policy, will prompt for user to bind MFA for only once (the user can skip).

Prompt: throw "missing_mfa" error, and auto mark as skipped.
Skip: save data in user's custom data.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Unit and integration tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
