### PR TITLE
feat(core): schema with search fields

### DIFF
--- a/packages/core/src/database/find-all-entities.ts
+++ b/packages/core/src/database/find-all-entities.ts
@@ -2,6 +2,8 @@ import { type GeneratedSchema, type SchemaLike } from '@logto/schemas';
 import { conditionalSql, convertToIdentifiers, manyRows } from '@logto/shared';
 import { sql, type CommonQueryMethods } from 'slonik';
 
+import { buildSearchSql, type SearchOptions } from './utils.js';
+
 export const buildFindAllEntitiesWithPool =
   (pool: CommonQueryMethods) =>
   <
@@ -17,11 +19,16 @@ export const buildFindAllEntitiesWithPool =
   ) => {
     const { table, fields } = convertToIdentifiers(schema);
 
-    return async (limit?: number, offset?: number) =>
+    return async <SearchKeys extends Keys>(
+      limit?: number,
+      offset?: number,
+      search?: SearchOptions<SearchKeys>
+    ) =>
       manyRows(
         pool.query<Schema>(sql`
           select ${sql.join(Object.values(fields), sql`, `)}
           from ${table}
+          ${buildSearchSql(search)}
           ${conditionalSql(orderBy, (orderBy) => {
             const orderBySql = orderBy.map(({ field, order }) =>
               // Note: 'desc' and 'asc' are keywords, so we don't pass them as values

--- a/packages/core/src/database/row-count.ts
+++ b/packages/core/src/database/row-count.ts
@@ -1,13 +1,17 @@
 import type { CommonQueryMethods, IdentifierSqlToken } from 'slonik';
 import { sql } from 'slonik';
 
+import { type SearchOptions, buildSearchSql } from './utils.js';
+
 export const buildGetTotalRowCountWithPool =
-  (pool: CommonQueryMethods, table: string) => async () => {
+  (pool: CommonQueryMethods, table: string) =>
+  async <SearchKeys extends string>(search?: SearchOptions<SearchKeys>) => {
     // Postgres returns a bigint for count(*), which is then converted to a string by query library.
     // We need to convert it to a number.
     const { count } = await pool.one<{ count: string }>(sql`
       select count(*)
       from ${sql.identifier([table])}
+      ${buildSearchSql(search)}
     `);
 
     return { count: Number(count) };

--- a/packages/core/src/database/utils.ts
+++ b/packages/core/src/database/utils.ts
@@ -1,0 +1,23 @@
+import { conditionalSql } from '@logto/shared';
+import { sql } from 'slonik';
+
+/**
+ * Options for searching for a string within a set of fields (case-insensitive).
+ *
+ * Note: `id` is excluded from the fields since it should be unique.
+ */
+export type SearchOptions<Keys extends string> = {
+  fields: ReadonlyArray<Exclude<Keys, 'id'>>;
+  keyword: string;
+};
+
+export const buildSearchSql = <SearchKeys extends string>(search?: SearchOptions<SearchKeys>) => {
+  return conditionalSql(search, (search) => {
+    const { fields: searchFields, keyword } = search;
+    const searchSql = sql.join(
+      searchFields.map((field) => sql`${sql.identifier([field])} ilike ${`%${keyword}%`}`),
+      sql` or `
+    );
+    return sql`where ${searchSql}`;
+  });
+};

--- a/packages/core/src/queries/organizations.ts
+++ b/packages/core/src/queries/organizations.ts
@@ -101,8 +101,11 @@ class OrganizationRolesQueries extends SchemaQueries<
   override async findAll(
     limit: number,
     offset: number
-  ): Promise<Readonly<OrganizationRoleWithScopes[]>> {
-    return this.pool.any(this.#findWithScopesSql(undefined, limit, offset));
+  ): Promise<[totalNumber: number, rows: Readonly<OrganizationRoleWithScopes[]>]> {
+    return Promise.all([
+      this.findTotalNumber(),
+      this.pool.any(this.#findWithScopesSql(undefined, limit, offset)),
+    ]);
   }
 
   #findWithScopesSql(roleId?: string, limit = 1, offset = 0) {

--- a/packages/core/src/routes/organization/index.ts
+++ b/packages/core/src/routes/organization/index.ts
@@ -21,6 +21,7 @@ export default function organizationRoutes<T extends AuthedRouter>(...args: Rout
   ] = args;
   const router = new SchemaRouter(Organizations, organizations, {
     errorHandler,
+    searchFields: ['name'],
   });
 
   router.addRelationRoutes(organizations.relations.users);

--- a/packages/core/src/routes/organization/roles.ts
+++ b/packages/core/src/routes/organization/roles.ts
@@ -21,8 +21,8 @@ export default function organizationRoleRoutes<T extends AuthedRouter>(
 ) {
   const router = new SchemaRouter(OrganizationRoles, roles, {
     errorHandler,
+    searchFields: ['name'],
   });
-
   router.addRelationRoutes(rolesScopes, 'scopes');
 
   originalRouter.use(router.routes());

--- a/packages/core/src/routes/organization/scopes.ts
+++ b/packages/core/src/routes/organization/scopes.ts
@@ -16,7 +16,10 @@ export default function organizationScopeRoutes<T extends AuthedRouter>(
     },
   ]: RouterInitArgs<T>
 ) {
-  const router = new SchemaRouter(OrganizationScopes, scopes, { errorHandler });
+  const router = new SchemaRouter(OrganizationScopes, scopes, {
+    errorHandler,
+    searchFields: ['name'],
+  });
 
   originalRouter.use(router.routes());
 }

--- a/packages/core/src/utils/SchemaRouter.test.ts
+++ b/packages/core/src/utils/SchemaRouter.test.ts
@@ -38,8 +38,7 @@ describe('SchemaRouter', () => {
   ] as const satisfies readonly Schema[];
   const queries = new SchemaQueries(createTestPool(undefined, { id: '1' }), schema);
 
-  jest.spyOn(queries, 'findTotalNumber').mockResolvedValue(entities.length);
-  jest.spyOn(queries, 'findAll').mockResolvedValue(entities);
+  jest.spyOn(queries, 'findAll').mockResolvedValue([entities.length, entities]);
   jest.spyOn(queries, 'findById').mockImplementation(async (id) => {
     const entity = entities.find((entity) => entity.id === id);
     if (!entity) {
@@ -67,16 +66,14 @@ describe('SchemaRouter', () => {
     it('should be able to get all entities', async () => {
       const response = await request.get(baseRoute);
 
-      expect(queries.findAll).toHaveBeenCalledWith(20, 0);
-      expect(queries.findTotalNumber).toHaveBeenCalled();
+      expect(queries.findAll).toHaveBeenCalledWith(20, 0, undefined);
       expect(response.body).toStrictEqual(entities);
     });
 
     it('should be able to get all entities with pagination', async () => {
       const response = await request.get(`${baseRoute}?page=1&page_size=10`);
 
-      expect(queries.findAll).toHaveBeenCalledWith(10, 0);
-      expect(queries.findTotalNumber).toHaveBeenCalled();
+      expect(queries.findAll).toHaveBeenCalledWith(10, 0, undefined);
       expect(response.body).toStrictEqual(entities);
       expect(response.header).toHaveProperty('total-number', '2');
     });


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- now `SchemaQueries.findAll` supports fuzzy search for one or multiple fields
- when initializing `SchemaRouter`, it's able to pass a `searchFields` config to specify which field(s) to search

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
permission search works

<img width="611" alt="image" src="https://github.com/logto-io/logto/assets/14722250/2e5f1c0b-adb5-4958-ab0f-c38cd9ec2b46">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
