### PR TITLE
feat(core): organization apis

### DIFF
--- a/packages/core/src/database/find-all-entities.ts
+++ b/packages/core/src/database/find-all-entities.ts
@@ -28,7 +28,7 @@ export const buildFindAllEntitiesWithPool =
         pool.query<Schema>(sql`
           select ${sql.join(Object.values(fields), sql`, `)}
           from ${table}
-          ${buildSearchSql(search)}
+          ${buildSearchSql(schema, search)}
           ${conditionalSql(orderBy, (orderBy) => {
             const orderBySql = orderBy.map(({ field, order }) =>
               // Note: 'desc' and 'asc' are keywords, so we don't pass them as values

--- a/packages/core/src/database/row-count.ts
+++ b/packages/core/src/database/row-count.ts
@@ -1,17 +1,26 @@
+import { type GeneratedSchema } from '@logto/schemas';
+import { type SchemaLike } from '@logto/shared';
 import type { CommonQueryMethods, IdentifierSqlToken } from 'slonik';
 import { sql } from 'slonik';
 
 import { type SearchOptions, buildSearchSql } from './utils.js';
 
 export const buildGetTotalRowCountWithPool =
-  (pool: CommonQueryMethods, table: string) =>
-  async <SearchKeys extends string>(search?: SearchOptions<SearchKeys>) => {
+  <
+    Keys extends string,
+    CreateSchema extends Partial<SchemaLike<Keys>>,
+    Schema extends SchemaLike<Keys>,
+  >(
+    pool: CommonQueryMethods,
+    schema: GeneratedSchema<Keys, CreateSchema, Schema>
+  ) =>
+  async <SearchKeys extends Keys>(search?: SearchOptions<SearchKeys>) => {
     // Postgres returns a bigint for count(*), which is then converted to a string by query library.
     // We need to convert it to a number.
     const { count } = await pool.one<{ count: string }>(sql`
       select count(*)
-      from ${sql.identifier([table])}
-      ${buildSearchSql(search)}
+      from ${sql.identifier([schema.table])}
+      ${buildSearchSql(schema, search)}
     `);
 
     return { count: Number(count) };

--- a/packages/core/src/database/utils.ts
+++ b/packages/core/src/database/utils.ts
@@ -10,6 +10,19 @@ export type SearchOptions<Keys extends string> = {
   keyword: string;
 };
 
+/**
+ * Build the SQL for searching for a string within a set of fields (case-insensitive) of a
+ * schema.
+ *
+ * - If `search` is `undefined`, it will return an empty SQL.
+ * - If `search` is defined, it will return a SQL that is wrapped in a pair of parentheses.
+ *
+ * @param schema The schema to search.
+ * @param search The search options.
+ * @param prefixSql The SQL to prefix the generated SQL. Defaults to `where `. Ignored if
+ * `search` is `undefined`.
+ * @returns The generated SQL.
+ */
 export const buildSearchSql = <
   Keys extends string,
   CreateSchema extends Partial<SchemaLike<Keys>>,

--- a/packages/core/src/database/utils.ts
+++ b/packages/core/src/database/utils.ts
@@ -1,23 +1,33 @@
-import { conditionalSql } from '@logto/shared';
-import { sql } from 'slonik';
+import { type GeneratedSchema } from '@logto/schemas';
+import { type SchemaLike, conditionalSql, convertToIdentifiers } from '@logto/shared';
+import { type SqlSqlToken, sql } from 'slonik';
 
 /**
  * Options for searching for a string within a set of fields (case-insensitive).
- *
- * Note: `id` is excluded from the fields since it should be unique.
  */
 export type SearchOptions<Keys extends string> = {
-  fields: ReadonlyArray<Exclude<Keys, 'id'>>;
+  fields: readonly Keys[];
   keyword: string;
 };
 
-export const buildSearchSql = <SearchKeys extends string>(search?: SearchOptions<SearchKeys>) => {
+export const buildSearchSql = <
+  Keys extends string,
+  CreateSchema extends Partial<SchemaLike<Keys>>,
+  Schema extends SchemaLike<Keys>,
+  SearchKeys extends Keys,
+>(
+  schema: GeneratedSchema<Keys, CreateSchema, Schema>,
+  search?: SearchOptions<SearchKeys>,
+  prefixSql: SqlSqlToken = sql`where `
+) => {
+  const { fields } = convertToIdentifiers(schema, true);
+
   return conditionalSql(search, (search) => {
     const { fields: searchFields, keyword } = search;
     const searchSql = sql.join(
-      searchFields.map((field) => sql`${sql.identifier([field])} ilike ${`%${keyword}%`}`),
+      searchFields.map((field) => sql`${fields[field]} ilike ${`%${keyword}%`}`),
       sql` or `
     );
-    return sql`where ${searchSql}`;
+    return sql`${prefixSql}(${searchSql})`;
   });
 };

--- a/packages/core/src/include.d/koa-router.d.ts
+++ b/packages/core/src/include.d/koa-router.d.ts
@@ -203,6 +203,11 @@ declare module 'koa-router' {
       path: string | string[] | RegExp,
       ...middleware: Array<Router.IMiddleware<StateT, CustomT>>
     ): Router<StateT, CustomT>;
+    use<T, U>(
+      path: string | RegExp | Array<string | RegExp>,
+      middleware: Koa.Middleware<T, U>,
+      routeHandler: Router.IMiddleware<StateT & T, CustomT & U>
+    ): Router<StateT & T, CustomT & U>;
 
     /**
      * HTTP get method

--- a/packages/core/src/queries/organizations.ts
+++ b/packages/core/src/queries/organizations.ts
@@ -68,7 +68,7 @@ class UserRelationQueries extends TwoRelationsQueries<typeof Organizations, type
     return this.pool.any<UserWithOrganizationRoles>(sql`
       select
         ${users.table}.*,
-        ${this.#aggregateRoles('organization_roles')}
+        ${this.#aggregateRoles()}
       from ${this.table}
       left join ${users.table}
         on ${fields.userId} = ${users.fields.id}
@@ -87,9 +87,9 @@ class UserRelationQueries extends TwoRelationsQueries<typeof Organizations, type
    * Build the SQL for aggregating the organization roles with basic information (id and name)
    * into a JSON array.
    *
-   * @param as The alias of the aggregated roles. Defaults to `roles`.
+   * @param as The alias of the aggregated roles. Defaults to `organizationRoles`.
    */
-  #aggregateRoles(as = 'roles') {
+  #aggregateRoles(as = 'organizationRoles') {
     const roles = convertToIdentifiers(OrganizationRoles, true);
 
     return sql`

--- a/packages/core/src/queries/organizations.ts
+++ b/packages/core/src/queries/organizations.ts
@@ -55,6 +55,7 @@ class UserRelationQueries extends TwoRelationsQueries<typeof Organizations, type
     `);
   }
 
+  /** Get the users in an organization and their roles. */
   async getUsersByOrganizationId(
     organizationId: string,
     search?: SearchOptions<(typeof userSearchKeys)[number]>
@@ -82,6 +83,12 @@ class UserRelationQueries extends TwoRelationsQueries<typeof Organizations, type
     `);
   }
 
+  /**
+   * Build the SQL for aggregating the organization roles with basic information (id and name)
+   * into a JSON array.
+   *
+   * @param as The alias of the aggregated roles. Defaults to `roles`.
+   */
   #aggregateRoles(as = 'roles') {
     const roles = convertToIdentifiers(OrganizationRoles, true);
 

--- a/packages/core/src/queries/organizations.ts
+++ b/packages/core/src/queries/organizations.ts
@@ -13,45 +13,19 @@ import {
   type CreateOrganizationRole,
   type OrganizationRole,
   type OrganizationRoleWithScopes,
+  type OrganizationWithRoles,
+  type UserWithOrganizationRoles,
 } from '@logto/schemas';
 import { conditionalSql, convertToIdentifiers } from '@logto/shared';
 import { sql, type CommonQueryMethods } from 'slonik';
-import { z } from 'zod';
 
+import { type SearchOptions, buildSearchSql } from '#src/database/utils.js';
 import RelationQueries, { TwoRelationsQueries } from '#src/utils/RelationQueries.js';
 import SchemaQueries from '#src/utils/SchemaQueries.js';
 
-/**
- * The simplified organization role entity that is returned in the `roles` field
- * of the organization.
- *
- * @remarks
- * The type MUST be kept in sync with the query in {@link UserRelationQueries.getOrganizationsByUserId}.
- */
-type RoleEntity = {
-  id: string;
-  name: string;
-};
+import { type userSearchKeys } from './user.js';
 
-/**
- * The organization entity with the `roles` field that contains the roles of the
- * current member of the organization.
- */
-type OrganizationWithRoles = Organization & {
-  /** The roles of the current member of the organization. */
-  roles: RoleEntity[];
-};
-
-export const organizationWithRolesGuard: z.ZodType<OrganizationWithRoles> =
-  Organizations.guard.extend({
-    roles: z
-      .object({
-        id: z.string(),
-        name: z.string(),
-      })
-      .array(),
-  });
-
+/** The query class for the organization - user relation. */
 class UserRelationQueries extends TwoRelationsQueries<typeof Organizations, typeof Users> {
   constructor(pool: CommonQueryMethods) {
     super(pool, OrganizationUserRelations.table, Organizations, Users);
@@ -63,18 +37,11 @@ class UserRelationQueries extends TwoRelationsQueries<typeof Organizations, type
     const { fields } = convertToIdentifiers(OrganizationUserRelations, true);
     const relations = convertToIdentifiers(OrganizationRoleUserRelations, true);
 
+    // TODO: replace `.*` with explicit fields
     return this.pool.any<OrganizationWithRoles>(sql`
       select
         ${organizations.table}.*,
-        coalesce(
-          json_agg(
-            json_build_object(
-              'id', ${roles.fields.id},
-              'name', ${roles.fields.name}
-            )
-          ) filter (where ${roles.fields.id} is not null), -- left join could produce nulls
-          '[]'
-        ) as roles
+        ${this.#aggregateRoles()}
       from ${this.table}
       left join ${organizations.table}
         on ${fields.organizationId} = ${organizations.fields.id}
@@ -86,6 +53,49 @@ class UserRelationQueries extends TwoRelationsQueries<typeof Organizations, type
       where ${fields.userId} = ${userId}
       group by ${organizations.table}.id
     `);
+  }
+
+  async getUsersByOrganizationId(
+    organizationId: string,
+    search?: SearchOptions<(typeof userSearchKeys)[number]>
+  ): Promise<Readonly<UserWithOrganizationRoles[]>> {
+    const roles = convertToIdentifiers(OrganizationRoles, true);
+    const users = convertToIdentifiers(Users, true);
+    const { fields } = convertToIdentifiers(OrganizationUserRelations, true);
+    const relations = convertToIdentifiers(OrganizationRoleUserRelations, true);
+
+    return this.pool.any<UserWithOrganizationRoles>(sql`
+      select
+        ${users.table}.*,
+        ${this.#aggregateRoles('organization_roles')}
+      from ${this.table}
+      left join ${users.table}
+        on ${fields.userId} = ${users.fields.id}
+      left join ${relations.table}
+        on ${fields.userId} = ${relations.fields.userId}
+        and ${fields.organizationId} = ${relations.fields.organizationId}
+      left join ${roles.table}
+        on ${relations.fields.organizationRoleId} = ${roles.fields.id}
+      where ${fields.organizationId} = ${organizationId}
+      ${buildSearchSql(Users, search, sql`and `)}
+      group by ${users.table}.id
+    `);
+  }
+
+  #aggregateRoles(as = 'roles') {
+    const roles = convertToIdentifiers(OrganizationRoles, true);
+
+    return sql`
+      coalesce(
+        json_agg(
+          json_build_object(
+            'id', ${roles.fields.id},
+            'name', ${roles.fields.name}
+          ) order by ${roles.fields.name}
+        ) filter (where ${roles.fields.id} is not null), -- left join could produce nulls as roles
+        '[]'
+      ) as ${sql.identifier([as])}
+    `;
   }
 }
 
@@ -100,15 +110,21 @@ class OrganizationRolesQueries extends SchemaQueries<
 
   override async findAll(
     limit: number,
-    offset: number
+    offset: number,
+    search?: SearchOptions<OrganizationRoleKeys>
   ): Promise<[totalNumber: number, rows: Readonly<OrganizationRoleWithScopes[]>]> {
     return Promise.all([
-      this.findTotalNumber(),
-      this.pool.any(this.#findWithScopesSql(undefined, limit, offset)),
+      this.findTotalNumber(search),
+      this.pool.any(this.#findWithScopesSql(undefined, limit, offset, search)),
     ]);
   }
 
-  #findWithScopesSql(roleId?: string, limit = 1, offset = 0) {
+  #findWithScopesSql(
+    roleId?: string,
+    limit = 1,
+    offset = 0,
+    search?: SearchOptions<OrganizationRoleKeys>
+  ) {
     const { table, fields } = convertToIdentifiers(OrganizationRoles, true);
     const relations = convertToIdentifiers(OrganizationRoleScopeRelations, true);
     const scopes = convertToIdentifiers(OrganizationScopes, true);
@@ -133,6 +149,7 @@ class OrganizationRolesQueries extends SchemaQueries<
       ${conditionalSql(roleId, (id) => {
         return sql`where ${fields.id} = ${id}`;
       })}
+      ${buildSearchSql(OrganizationRoles, search)}
       group by ${fields.id}
       ${conditionalSql(this.orderBy, ({ field, order }) => {
         return sql`order by ${fields[field]} ${order === 'desc' ? sql`desc` : sql`asc`}`;
@@ -140,6 +157,54 @@ class OrganizationRolesQueries extends SchemaQueries<
       limit ${limit}
       offset ${offset}
     `;
+  }
+}
+
+class RoleUserRelationQueries extends RelationQueries<
+  [typeof Organizations, typeof OrganizationRoles, typeof Users]
+> {
+  constructor(pool: CommonQueryMethods) {
+    super(pool, OrganizationRoleUserRelations.table, Organizations, OrganizationRoles, Users);
+  }
+
+  /** Replace the roles of a user in an organization. */
+  async replace(organizationId: string, userId: string, roleIds: string[]) {
+    const users = convertToIdentifiers(Users);
+    const relations = convertToIdentifiers(OrganizationRoleUserRelations);
+
+    return this.pool.transaction(async (transaction) => {
+      // Lock user
+      await transaction.query(sql`
+        select id
+        from ${users.table}
+        where ${users.fields.id} = ${userId}
+        for update
+      `);
+
+      // Delete old relations
+      await transaction.query(sql`
+        delete from ${relations.table}
+        where ${relations.fields.userId} = ${userId}
+        and ${relations.fields.organizationId} = ${organizationId}
+      `);
+
+      // Insert new relations
+      if (roleIds.length === 0) {
+        return;
+      }
+
+      await transaction.query(sql`
+        insert into ${relations.table} (
+          ${relations.fields.userId},
+          ${relations.fields.organizationId},
+          ${relations.fields.organizationRoleId}
+        )
+         values ${sql.join(
+           roleIds.map((roleId) => sql`(${userId}, ${organizationId}, ${roleId})`),
+           sql`, `
+         )}
+      `);
+    });
   }
 }
 
@@ -169,13 +234,7 @@ export default class OrganizationQueries extends SchemaQueries<
     /** Queries for organization - user relations. */
     users: new UserRelationQueries(this.pool),
     /** Queries for organization - organization role - user relations. */
-    rolesUsers: new RelationQueries(
-      this.pool,
-      OrganizationRoleUserRelations.table,
-      Organizations,
-      OrganizationRoles,
-      Users
-    ),
+    rolesUsers: new RoleUserRelationQueries(this.pool),
   };
 
   constructor(pool: CommonQueryMethods) {

--- a/packages/core/src/queries/user.ts
+++ b/packages/core/src/queries/user.ts
@@ -13,6 +13,23 @@ import { buildConditionsFromSearch } from '#src/utils/search.js';
 
 const { table, fields } = convertToIdentifiers(Users);
 
+/**
+ * The conditions that connected with `and` operator for finding users. It supports the
+ * following:
+ *
+ * - `search`: The search conditions. It can be combined with various search fields and
+ * match modes.
+ * - `relation`: The relation conditions. It can be used to find users that have or don't
+ * have a relation with another table. Note that the relation field is the raw field name
+ * in the database, not the camel case one.
+ *
+ * @example
+ * ```ts
+ * // Find users that have a relation with the table `foo` and the field `bar` is `baz`.
+ * { relation: { table: 'foo', field: 'bar', value: 'baz', type: 'exists' } }
+ * ```
+ * @see {@link Search} for more information about the search conditions.
+ */
 export type UserConditions = {
   search?: Search;
   relation?: {
@@ -23,6 +40,10 @@ export type UserConditions = {
   };
 };
 
+/**
+ * The schema field keys that can be used for searching users. For the actual field names,
+ * see {@link Users.fields} and {@link userSearchFields}.
+ */
 export const userSearchKeys = Object.freeze([
   'id',
   'primaryEmail',
@@ -31,6 +52,10 @@ export const userSearchKeys = Object.freeze([
   'name',
 ] as const);
 
+/**
+ * The actual database field names that can be used for searching users. For the schema field
+ * keys, see {@link userSearchKeys}.
+ */
 export const userSearchFields = Object.freeze(Object.values(pick(Users.fields, ...userSearchKeys)));
 
 export const createUserQueries = (pool: CommonQueryMethods) => {
@@ -112,6 +137,11 @@ export const createUserQueries = (pool: CommonQueryMethods) => {
       `
     );
 
+  /**
+   * Build the `where` clause for finding users with the given conditions joined with `and`.
+   *
+   * @see {@link UserConditions} for more information about the conditions.
+   */
   const buildUserConditions = ({ search, relation }: UserConditions) => {
     const hasSearch = search?.matches.length;
     const id = sql.identifier;

--- a/packages/core/src/routes/admin-user/organization.ts
+++ b/packages/core/src/routes/admin-user/organization.ts
@@ -1,7 +1,7 @@
+import { organizationWithOrganizationRolesGuard } from '@logto/schemas';
 import { z } from 'zod';
 
 import koaGuard from '#src/middleware/koa-guard.js';
-import { organizationWithRolesGuard } from '#src/queries/organizations.js';
 
 import { type AuthedRouter, type RouterInitArgs } from '../types.js';
 
@@ -12,7 +12,7 @@ export default function adminUserOrganizationRoutes<T extends AuthedRouter>(
     '/users/:userId/organizations',
     koaGuard({
       params: z.object({ userId: z.string() }),
-      response: organizationWithRolesGuard.array(),
+      response: organizationWithOrganizationRolesGuard.array(),
       status: [200, 404],
     }),
     async (ctx, next) => {

--- a/packages/core/src/routes/admin-user/search.test.ts
+++ b/packages/core/src/routes/admin-user/search.test.ts
@@ -20,15 +20,13 @@ const filterUsersWithSearch = (users: User[], search: string) =>
 
 const mockedQueries = {
   users: {
-    countUsers: jest.fn(async (search) => ({
+    countUsers: jest.fn(async ({ search }) => ({
       count: search
         ? filterUsersWithSearch(mockUserList, String(search)).length
         : mockUserList.length,
     })),
     findUsers: jest.fn(
-      async (limit, offset, search): Promise<User[]> =>
-        // For testing, type should be `Search` but we use `string` in `filterUsersWithSearch()` here
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      async (limit, offset, { search }): Promise<User[]> =>
         search ? filterUsersWithSearch(mockUserList, String(search)) : mockUserList
     ),
   },

--- a/packages/core/src/routes/dashboard.test.ts
+++ b/packages/core/src/routes/dashboard.test.ts
@@ -60,7 +60,7 @@ describe('dashboardRoutes', () => {
   describe('GET /dashboard/users/total', () => {
     it('should call countUsers with no parameters', async () => {
       await logRequest.get('/dashboard/users/total');
-      expect(countUsers).toHaveBeenCalledWith();
+      expect(countUsers).toHaveBeenCalledWith({});
     });
 
     it('/dashboard/users/total should return correct response', async () => {

--- a/packages/core/src/routes/dashboard.ts
+++ b/packages/core/src/routes/dashboard.ts
@@ -30,7 +30,7 @@ export default function dashboardRoutes<T extends AuthedRouter>(
       status: [200],
     }),
     async (ctx, next) => {
-      const { count: totalUserCount } = await countUsers();
+      const { count: totalUserCount } = await countUsers({});
       ctx.body = { totalUserCount };
 
       return next();

--- a/packages/core/src/routes/organization/index.ts
+++ b/packages/core/src/routes/organization/index.ts
@@ -32,7 +32,7 @@ export default function organizationRoutes<T extends AuthedRouter>(...args: Rout
 
   router.get(
     '/:id/users',
-    // KoaPagination(),
+    // TODO: support pagination
     koaGuard({
       query: z.object({ q: z.string().optional() }),
       params: z.object({ id: z.string().min(1) }),

--- a/packages/core/src/routes/organization/utils.ts
+++ b/packages/core/src/routes/organization/utils.ts
@@ -7,7 +7,7 @@ import RequestError from '#src/errors/RequestError/index.js';
 
 export const errorHandler = (error: unknown) => {
   if (error instanceof UniqueIntegrityConstraintViolationError) {
-    throw new RequestError({ code: 'entity.duplicate_value_of_unique_field', field: 'name' });
+    throw new RequestError({ code: 'entity.duplicate_value_of_unique_field', field: 'name' }); // TODO: specify field
   }
 
   if (error instanceof ForeignKeyIntegrityConstraintViolationError) {

--- a/packages/core/src/utils/SchemaQueries.ts
+++ b/packages/core/src/utils/SchemaQueries.ts
@@ -44,7 +44,7 @@ export default class SchemaQueries<
     public readonly schema: GeneratedSchema<Key | 'id', CreateSchema, Schema>,
     protected readonly orderBy?: { field: Key | 'id'; order: 'asc' | 'desc' }
   ) {
-    this.#findTotalNumber = buildGetTotalRowCountWithPool(this.pool, this.schema.table);
+    this.#findTotalNumber = buildGetTotalRowCountWithPool(this.pool, this.schema);
     this.#findAll = buildFindAllEntitiesWithPool(this.pool)(this.schema, orderBy && [orderBy]);
     this.#findById = buildFindEntityByIdWithPool(this.pool)(this.schema);
     this.#insert = buildInsertIntoWithPool(this.pool)(this.schema, { returning: true });

--- a/packages/core/src/utils/search.ts
+++ b/packages/core/src/utils/search.ts
@@ -239,8 +239,8 @@ const showLowercase = (
  */
 export const buildConditionsFromSearch = (
   search: Search,
-  searchFields: string[],
-  fieldsTypeMapping?: Record<string, string>
+  searchFields: readonly string[],
+  fieldsTypeMapping?: Readonly<Record<string, string>>
 ) => {
   assertThat(searchFields.length > 0, new TypeError('No search field found.'));
 

--- a/packages/integration-tests/src/api/organization.ts
+++ b/packages/integration-tests/src/api/organization.ts
@@ -1,13 +1,7 @@
-import { type Role, type Organization } from '@logto/schemas';
+import { type Role, type Organization, type OrganizationWithRoles } from '@logto/schemas';
 
 import { authedAdminApi } from './api.js';
 import { ApiFactory } from './factory.js';
-
-type RoleEntity = {
-  id: string;
-  name: string;
-};
-type OrganizationWithRoles = Organization & { roles: RoleEntity[] };
 
 class OrganizationApi extends ApiFactory<Organization, { name: string; description?: string }> {
   constructor() {
@@ -26,8 +20,10 @@ class OrganizationApi extends ApiFactory<Organization, { name: string; descripti
     await authedAdminApi.delete(`${this.path}/${id}/users/${userId}`);
   }
 
-  async addUserRoles(id: string, userId: string, roleIds: string[]): Promise<void> {
-    await authedAdminApi.post(`${this.path}/${id}/users/${userId}/roles`, { json: { roleIds } });
+  async addUserRoles(id: string, userId: string, organizationRoleIds: string[]): Promise<void> {
+    await authedAdminApi.post(`${this.path}/${id}/users/${userId}/roles`, {
+      json: { organizationRoleIds },
+    });
   }
 
   async getUserRoles(id: string, userId: string): Promise<Role[]> {

--- a/packages/integration-tests/src/tests/api/organization.test.ts
+++ b/packages/integration-tests/src/tests/api/organization.test.ts
@@ -205,10 +205,10 @@ describe('organization APIs', () => {
       const organization1WithRoles = organizations.find((org) => org.id === organization1.id);
       assert(organization1WithRoles);
       expect(organization1WithRoles.id).toBe(organization1.id);
-      expect(organization1WithRoles.roles).toContainEqual(
+      expect(organization1WithRoles.organizationRoles).toContainEqual(
         expect.objectContaining({ id: role1.id })
       );
-      expect(organization1WithRoles.roles).not.toContainEqual(
+      expect(organization1WithRoles.organizationRoles).not.toContainEqual(
         expect.objectContaining({ id: role2.id })
       );
 
@@ -216,10 +216,10 @@ describe('organization APIs', () => {
       const organization2WithRoles = organizations.find((org) => org.id === organization2.id);
       assert(organization2WithRoles);
       expect(organization2WithRoles.id).toBe(organization2.id);
-      expect(organization2WithRoles.roles).toContainEqual(
+      expect(organization2WithRoles.organizationRoles).toContainEqual(
         expect.objectContaining({ id: role1.id })
       );
-      expect(organization2WithRoles.roles).toContainEqual(
+      expect(organization2WithRoles.organizationRoles).toContainEqual(
         expect.objectContaining({ id: role2.id })
       );
 

--- a/packages/schemas/src/types/organization.ts
+++ b/packages/schemas/src/types/organization.ts
@@ -1,6 +1,13 @@
 import { z } from 'zod';
 
-import { type OrganizationRole, OrganizationRoles } from '../db-entries/index.js';
+import {
+  type OrganizationRole,
+  OrganizationRoles,
+  type Organization,
+  type User,
+  Organizations,
+  Users,
+} from '../db-entries/index.js';
 
 export type OrganizationRoleWithScopes = OrganizationRole & {
   scopes: Array<{
@@ -17,4 +24,46 @@ export const organizationRoleWithScopesGuard: z.ZodType<OrganizationRoleWithScop
         name: z.string(),
       })
       .array(),
+  });
+
+/**
+ * The simplified organization role entity that is returned in the `roles` field
+ * of the organization.
+ */
+export type OrganizationRoleEntity = {
+  id: string;
+  name: string;
+};
+
+const organizationRoleEntityGuard: z.ZodType<OrganizationRoleEntity> = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+
+/**
+ * The organization entity with the `organizationRoles` field that contains the
+ * roles of the current member of the organization.
+ */
+export type OrganizationWithRoles = Organization & {
+  /** The roles of the current member of the organization. */
+  organizationRoles: OrganizationRoleEntity[];
+};
+
+export const organizationWithOrganizationRolesGuard: z.ZodType<OrganizationWithRoles> =
+  Organizations.guard.extend({
+    organizationRoles: organizationRoleEntityGuard.array(),
+  });
+
+/**
+ * The user entity with the `organizationRoles` field that contains the roles of
+ * the user in a specific organization.
+ */
+export type UserWithOrganizationRoles = User & {
+  /** The roles of the user in a specific organization. */
+  organizationRoles: OrganizationRoleEntity[];
+};
+
+export const userWithOrganizationRolesGuard: z.ZodType<UserWithOrganizationRoles> =
+  Users.guard.extend({
+    organizationRoles: organizationRoleEntityGuard.array(),
   });


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- add and update necessary organization APIs for console implementation.
  - `GET /users` now supports `excludeOrganizationId` for excluding users that have membership in an organization
  - `GET /organizations/:id/users` now attaches user roles in the response
  - add `POST /organizations/:id/users/roles` for assigning multiple users with organization roles in batch
- refactor user search with subquery

since this PR is already large, i left several inline to-dos in the change set. integration tests for the new APIs will also be added later.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
original tests

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
