### PR TITLE
feat(core): add GET sso-connectors api

### DIFF
--- a/packages/core/src/routes/sso-connector/index.ts
+++ b/packages/core/src/routes/sso-connector/index.ts
@@ -1,6 +1,7 @@
-import { SsoConnectors } from '@logto/schemas';
+import { SsoConnectors, jsonObjectGuard } from '@logto/schemas';
 import { generateStandardShortId } from '@logto/shared';
 import { conditional } from '@silverhand/essentials';
+import { z } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
@@ -15,10 +16,12 @@ import {
   type ConnectorFactoryDetail,
   ssoConnectorCreateGuard,
   ssoConnectorWithProviderConfigGuard,
+  ssoConnectorPatchGuard,
 } from './type.js';
 import {
   parseFactoryDetail,
   isSupportedSsoProvider,
+  parseConnectorConfig,
   fetchConnectorProviderDetails,
 } from './utils.js';
 
@@ -32,12 +35,11 @@ export default function singleSignOnRoutes<T extends AuthedRouter>(...args: Rout
 
   const pathname = `/${tableToPathname(SsoConnectors.table)}`;
 
-  /**
-   * Get all supported single sign on connector factory details
-   *
-   * - standardConnectors: OIDC, SAML, etc.
-   * - providerConnectors: Google, Okta, etc.
-   */
+  /*
+    Get all supported single sign on connector factory details
+    - standardConnectors: OIDC, SAML, etc.
+    - providerConnectors: Google, Okta, etc.
+  */
   router.get(
     '/sso-connector-factories',
     koaGuard({
@@ -88,31 +90,11 @@ export default function singleSignOnRoutes<T extends AuthedRouter>(...args: Rout
         });
       }
 
-      const factory = ssoConnectorFactories[providerName];
-
       /* 
         Validate the connector config if it's provided.
         Allow partial config DB insert
        */
-      const parseConfig = () => {
-        if (!config) {
-          return;
-        }
-
-        const result = factory.configGuard.partial().safeParse(config);
-
-        if (!result.success) {
-          throw new RequestError({
-            code: 'connector.invalid_config',
-            status: 422,
-            details: result.error.flatten(),
-          });
-        }
-
-        return result.data;
-      };
-
-      const parsedConfig = parseConfig();
+      const parsedConfig = parseConnectorConfig(providerName, config);
       const connectorId = generateStandardShortId();
 
       const connector = await ssoConnectors.insert({
@@ -129,6 +111,7 @@ export default function singleSignOnRoutes<T extends AuthedRouter>(...args: Rout
     }
   );
 
+  /* Get all single sign on connectors */
   router.get(
     pathname,
     koaGuard({
@@ -146,6 +129,150 @@ export default function singleSignOnRoutes<T extends AuthedRouter>(...args: Rout
 
       // Filter out unsupported connectors
       ctx.body = connectorsWithProviderDetails.filter(Boolean);
+
+      return next();
+    }
+  );
+
+  /* Get a single sign on connector by id */
+  router.get(
+    `${pathname}/:id`,
+    koaGuard({
+      params: z.object({ id: z.string().min(1) }),
+      response: ssoConnectorWithProviderConfigGuard,
+      status: [200, 404],
+    }),
+    async (ctx, next) => {
+      const { id } = ctx.guard.params;
+
+      // Fetch the connector
+      const connector = await ssoConnectors.findById(id);
+
+      // Fetch provider details for the connector
+      const connectorWithProviderDetails = await fetchConnectorProviderDetails(connector);
+
+      // Return 404 if the connector is not found
+      if (!connectorWithProviderDetails) {
+        throw new RequestError({
+          code: 'connector.not_found',
+          status: 404,
+        });
+      }
+
+      ctx.body = connectorWithProviderDetails;
+
+      return next();
+    }
+  );
+
+  /* Delete a single sign on connector by id */
+  router.delete(
+    `${pathname}/:id`,
+    koaGuard({
+      params: z.object({ id: z.string().min(1) }),
+      status: [204, 404],
+    }),
+    async (ctx, next) => {
+      const { id } = ctx.guard.params;
+
+      // Delete the connector
+      await ssoConnectors.deleteById(id);
+      ctx.status = 204;
+      return next();
+    }
+  );
+
+  /* Patch update a single sign on connector by id */
+  router.patch(
+    `${pathname}/:id`,
+    koaGuard({
+      params: z.object({ id: z.string().min(1) }),
+      body: ssoConnectorPatchGuard,
+      response: ssoConnectorWithProviderConfigGuard,
+      status: [200, 404, 422],
+    }),
+    async (ctx, next) => {
+      const { id } = ctx.guard.params;
+      const { body } = ctx.guard;
+
+      // Fetch the connector
+      const originalConnector = await ssoConnectors.findById(id);
+      const { providerName } = originalConnector;
+
+      // Return 422 if the connector provider is not supported
+      if (!isSupportedSsoProvider(providerName)) {
+        throw new RequestError({
+          code: 'connector.not_found',
+          type: providerName,
+          status: 422,
+        });
+      }
+
+      const { config, ...rest } = body;
+
+      // Validate the connector config if it's provided
+      const parsedConfig = parseConnectorConfig(providerName, config);
+
+      // Check if there's any valid update
+      const hasValidUpdate = parsedConfig ?? Object.keys(rest).length > 0;
+
+      // Patch update the connector only if there's any valid update
+      const connector = hasValidUpdate
+        ? await ssoConnectors.updateById(id, {
+            ...conditional(parsedConfig && { config: parsedConfig }),
+            ...rest,
+          })
+        : originalConnector;
+
+      // Fetch provider details for the connector
+      const connectorWithProviderDetails = await fetchConnectorProviderDetails(connector);
+
+      ctx.body = connectorWithProviderDetails;
+
+      return next();
+    }
+  );
+
+  /* Patch update a single sign on connector's config by id */
+  router.patch(
+    `${pathname}/:id/config`,
+    koaGuard({
+      params: z.object({ id: z.string().min(1) }),
+      body: jsonObjectGuard,
+      response: ssoConnectorWithProviderConfigGuard,
+      status: [200, 404, 422],
+    }),
+    async (ctx, next) => {
+      const { id } = ctx.guard.params;
+      const { body } = ctx.guard;
+
+      // Fetch the connector
+      const { providerName, config } = await ssoConnectors.findById(id);
+
+      // Return 422 if the connector provider is not supported
+      if (!isSupportedSsoProvider(providerName)) {
+        throw new RequestError({
+          code: 'connector.not_found',
+          type: providerName,
+          status: 422,
+        });
+      }
+
+      // Validate the connector config
+      const parsedConfig = parseConnectorConfig(providerName, body);
+
+      // Patch update the connector config
+      const connector = await ssoConnectors.updateById(id, {
+        config: {
+          ...config,
+          ...parsedConfig,
+        },
+      });
+
+      // Fetch provider details for the connector
+      const connectorWithProviderDetails = await fetchConnectorProviderDetails(connector);
+
+      ctx.body = connectorWithProviderDetails;
 
       return next();
     }

--- a/packages/core/src/routes/sso-connector/type.ts
+++ b/packages/core/src/routes/sso-connector/type.ts
@@ -26,3 +26,12 @@ export const ssoConnectorCreateGuard = SsoConnectors.createGuard
   })
   // Provider name and connector name are required for creating a connector
   .merge(SsoConnectors.guard.pick({ providerName: true, connectorName: true }));
+
+export const ssoConnectorWithProviderConfigGuard = SsoConnectors.guard.merge(
+  z.object({
+    providerLogo: z.string(),
+    providerConfig: z.record(z.unknown()).optional(),
+  })
+);
+
+export type SsoConnectorWithProviderConfig = z.infer<typeof ssoConnectorWithProviderConfigGuard>;

--- a/packages/core/src/routes/sso-connector/type.ts
+++ b/packages/core/src/routes/sso-connector/type.ts
@@ -35,3 +35,14 @@ export const ssoConnectorWithProviderConfigGuard = SsoConnectors.guard.merge(
 );
 
 export type SsoConnectorWithProviderConfig = z.infer<typeof ssoConnectorWithProviderConfigGuard>;
+
+export const ssoConnectorPatchGuard = SsoConnectors.guard
+  .pick({
+    config: true,
+    domains: true,
+    branding: true,
+    syncProfile: true,
+    ssoOnly: true,
+    connectorName: true,
+  })
+  .partial();

--- a/packages/core/src/routes/sso-connector/utils.test.ts
+++ b/packages/core/src/routes/sso-connector/utils.test.ts
@@ -1,0 +1,112 @@
+import { createMockUtils } from '@logto/shared/esm';
+
+import { mockSsoConnector } from '#src/__mocks__/sso.js';
+import { SsoProviderName } from '#src/sso/types/index.js';
+
+const { jest } = import.meta;
+const { mockEsmWithActual } = createMockUtils(jest);
+const fetchOidcConfig = jest.fn();
+
+await mockEsmWithActual('#src/sso/OidcConnector/utils.js', () => ({
+  fetchOidcConfig,
+}));
+
+const { ssoConnectorFactories } = await import('#src/sso/index.js');
+const { isSupportedSsoProvider, parseFactoryDetail, fetchConnectorProviderDetails } = await import(
+  './utils.js'
+);
+
+describe('isSupportedSsoProvider', () => {
+  it.each(Object.values(SsoProviderName))('should return true for %s', (providerName) => {
+    expect(isSupportedSsoProvider(providerName)).toBe(true);
+  });
+
+  it('should return false for unknown provider', () => {
+    expect(isSupportedSsoProvider('unknown-provider')).toBe(false);
+  });
+});
+
+describe('parseFactoryDetail', () => {
+  it.each(Object.values(SsoProviderName))('should return correct detail for %s', (providerName) => {
+    const { logo, description } = ssoConnectorFactories[providerName];
+    const detail = parseFactoryDetail(ssoConnectorFactories[providerName], 'en');
+
+    expect(detail).toEqual({
+      providerName,
+      logo,
+      description: description.en,
+    });
+  });
+
+  it.each(Object.values(SsoProviderName))(
+    'should return correct detail for %s with unknown locale',
+    (providerName) => {
+      const { logo, description } = ssoConnectorFactories[providerName];
+      const detail = parseFactoryDetail(ssoConnectorFactories[providerName], 'zh');
+
+      expect(detail).toEqual({
+        providerName,
+        logo,
+        description: description.en,
+      });
+    }
+  );
+});
+
+describe('fetchConnectorProviderDetails', () => {
+  it('should return undefined for unsupported provider', async () => {
+    const connector = { ...mockSsoConnector, providerName: 'unknown-provider' };
+    const result = await fetchConnectorProviderDetails(connector);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('providerConfig should be undefined if connector config is invalid', async () => {
+    const connector = { ...mockSsoConnector, config: { clientId: 'foo' } };
+    const result = await fetchConnectorProviderDetails(connector);
+
+    expect(result).toEqual({
+      ...connector,
+      providerLogo: ssoConnectorFactories[connector.providerName as SsoProviderName].logo,
+    });
+
+    expect(fetchOidcConfig).not.toBeCalled();
+  });
+
+  it('providerConfig should be undefined if failed to fetch config', async () => {
+    const connector = {
+      ...mockSsoConnector,
+      config: { clientId: 'foo', clientSecret: 'bar', issuer: 'http://example.com' },
+    };
+
+    fetchOidcConfig.mockRejectedValueOnce(new Error('mock-error'));
+    const result = await fetchConnectorProviderDetails(connector);
+
+    expect(result).toEqual({
+      ...connector,
+      providerLogo: ssoConnectorFactories[connector.providerName as SsoProviderName].logo,
+    });
+
+    expect(fetchOidcConfig).toBeCalledWith(connector.config.issuer);
+  });
+
+  it('should return correct details for supported provider', async () => {
+    const connector = {
+      ...mockSsoConnector,
+      config: { clientId: 'foo', clientSecret: 'bar', issuer: 'http://example.com' },
+    };
+
+    fetchOidcConfig.mockResolvedValueOnce({ tokenEndpoint: 'http://example.com/token' });
+    const result = await fetchConnectorProviderDetails(connector);
+
+    expect(result).toEqual({
+      ...connector,
+      providerLogo: ssoConnectorFactories[connector.providerName as SsoProviderName].logo,
+      providerConfig: {
+        ...connector.config,
+        scope: 'openid', // Default scope
+        tokenEndpoint: 'http://example.com/token',
+      },
+    });
+  });
+});

--- a/packages/core/src/routes/sso-connector/utils.ts
+++ b/packages/core/src/routes/sso-connector/utils.ts
@@ -5,6 +5,8 @@ import { conditional, trySafe } from '@silverhand/essentials';
 import { type SingleSignOnFactory, ssoConnectorFactories } from '#src/sso/index.js';
 import { type SsoProviderName } from '#src/sso/types/index.js';
 
+import { type SsoConnectorWithProviderConfig } from './type.js';
+
 const isKeyOfI18nPhrases = (key: string, phrases: I18nPhrases): key is keyof I18nPhrases =>
   key in phrases;
 
@@ -25,11 +27,14 @@ export const parseFactoryDetail = (
   };
 };
 
-export const fetchConnectorProviderDetails = async (connector: SsoConnector) => {
+export const fetchConnectorProviderDetails = async (
+  connector: SsoConnector
+): Promise<SsoConnectorWithProviderConfig | undefined> => {
   const { providerName } = connector;
 
+  // Return undefined if the provider is not supported
   if (!isSupportedSsoProvider(providerName)) {
-    return connector;
+    return undefined;
   }
 
   const { logo, constructor } = ssoConnectorFactories[providerName];

--- a/packages/core/src/routes/sso-connector/utils.ts
+++ b/packages/core/src/routes/sso-connector/utils.ts
@@ -1,4 +1,6 @@
 import { type I18nPhrases } from '@logto/connector-kit';
+import { type SsoConnector } from '@logto/schemas';
+import { conditional, trySafe } from '@silverhand/essentials';
 
 import { type SingleSignOnFactory, ssoConnectorFactories } from '#src/sso/index.js';
 import { type SsoProviderName } from '#src/sso/types/index.js';
@@ -20,5 +22,30 @@ export const parseFactoryDetail = (
     logo,
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- falsy value expected
     description: (isKeyOfI18nPhrases(locale, description) && description[locale]) || description.en,
+  };
+};
+
+export const fetchConnectorProviderDetails = async (connector: SsoConnector) => {
+  const { providerName } = connector;
+
+  if (!isSupportedSsoProvider(providerName)) {
+    return connector;
+  }
+
+  const { logo, constructor } = ssoConnectorFactories[providerName];
+
+  /* 
+    Safely fetch and parse the detailed connector config from provider. 
+    Return undefined if failed to fetch or parse the config.
+  */
+  const providerConfig = await trySafe(async () => {
+    const instance = new constructor(connector);
+    return instance.getConfig();
+  });
+
+  return {
+    ...connector,
+    providerLogo: logo,
+    ...conditional(providerConfig && { providerConfig }),
   };
 };

--- a/packages/core/src/sso/types/index.ts
+++ b/packages/core/src/sso/types/index.ts
@@ -1,4 +1,4 @@
-import { type SsoConnector } from '@logto/schemas';
+import { type Json, type SsoConnector } from '@logto/schemas';
 
 /**
  * Single sign-on connector interface
@@ -9,7 +9,7 @@ import { type SsoConnector } from '@logto/schemas';
  */
 export abstract class SingleSignOn {
   abstract data: SsoConnector;
-  abstract getConfig: () => Promise<unknown>;
+  abstract getConfig: () => Promise<Json>;
 }
 
 export enum SsoProviderName {

--- a/packages/core/src/sso/types/index.ts
+++ b/packages/core/src/sso/types/index.ts
@@ -1,4 +1,4 @@
-import { type Json, type SsoConnector } from '@logto/schemas';
+import { type JsonObject, type SsoConnector } from '@logto/schemas';
 
 /**
  * Single sign-on connector interface
@@ -9,7 +9,7 @@ import { type Json, type SsoConnector } from '@logto/schemas';
  */
 export abstract class SingleSignOn {
   abstract data: SsoConnector;
-  abstract getConfig: () => Promise<Json>;
+  abstract getConfig: () => Promise<JsonObject>;
 }
 
 export enum SsoProviderName {

--- a/packages/core/src/sso/types/oidc.ts
+++ b/packages/core/src/sso/types/oidc.ts
@@ -11,7 +11,7 @@ const scopeDelimiter = /[ +]/;
  *
  * @remark Forked from @logto/oidc-connector
  */
-export const scopePostProcessor = (scope: string) => {
+export const scopePostProcessor = (scope = '') => {
   const splitScopes = scope.split(scopeDelimiter).filter(Boolean);
 
   if (!splitScopes.includes(openidScope)) {
@@ -25,7 +25,7 @@ export const basicOidcConnectorConfigGuard = z.object({
   clientId: z.string(),
   clientSecret: z.string(),
   issuer: z.string(),
-  scope: z.string().transform(scopePostProcessor),
+  scope: z.string().optional().transform(scopePostProcessor),
 });
 
 export type BasicOidcConnectorConfig = z.infer<typeof basicOidcConnectorConfigGuard>;

--- a/packages/core/src/utils/SchemaQueries.ts
+++ b/packages/core/src/utils/SchemaQueries.ts
@@ -20,7 +20,7 @@ export default class SchemaQueries<
   Schema extends SchemaLike<Key> & { id: string },
 > {
   #findTotalNumber: () => Promise<{ count: number }>;
-  #findAll: (limit: number, offset: number) => Promise<readonly Schema[]>;
+  #findAll: (limit?: number, offset?: number) => Promise<readonly Schema[]>;
   #findById: (id: string) => Promise<Readonly<Schema>>;
   #insert: (data: OmitAutoSetFields<CreateSchema>) => Promise<Readonly<Schema>>;
 
@@ -48,7 +48,7 @@ export default class SchemaQueries<
     return count;
   }
 
-  async findAll(limit: number, offset: number): Promise<readonly Schema[]> {
+  async findAll(limit?: number, offset?: number): Promise<readonly Schema[]> {
     return this.#findAll(limit, offset);
   }
 

--- a/packages/core/src/utils/SchemaRouter.ts
+++ b/packages/core/src/utils/SchemaRouter.ts
@@ -20,7 +20,7 @@ import type SchemaQueries from './SchemaQueries.js';
  * tableToPathname('organization_role') // => 'organization-role'
  * ```
  */
-const tableToPathname = (tableName: string) => tableName.replaceAll('_', '-');
+export const tableToPathname = (tableName: string) => tableName.replaceAll('_', '-');
 
 /**
  * Generate the camel case schema ID column name.

--- a/packages/integration-tests/src/api/sso-connector.ts
+++ b/packages/integration-tests/src/api/sso-connector.ts
@@ -13,6 +13,11 @@ export type ConnectorFactoryResponse = {
   providerConnectors: ConnectorFactoryDetail[];
 };
 
+export type SsoConnectorWithProviderConfig = SsoConnector & {
+  providerLogo: string;
+  providerConfig?: Record<string, unknown>;
+};
+
 export const getSsoConnectorFactories = async () =>
   authedAdminApi.get('sso-connector-factories').json<ConnectorFactoryResponse>();
 
@@ -22,3 +27,6 @@ export const createSsoConnector = async (data: Partial<CreateSsoConnector>) =>
       json: data,
     })
     .json<SsoConnector>();
+
+export const getSsoConnectors = async () =>
+  authedAdminApi.get('sso-connectors').json<SsoConnectorWithProviderConfig[]>();

--- a/packages/integration-tests/src/api/sso-connector.ts
+++ b/packages/integration-tests/src/api/sso-connector.ts
@@ -30,3 +30,23 @@ export const createSsoConnector = async (data: Partial<CreateSsoConnector>) =>
 
 export const getSsoConnectors = async () =>
   authedAdminApi.get('sso-connectors').json<SsoConnectorWithProviderConfig[]>();
+
+export const getSsoConnectorById = async (id: string) =>
+  authedAdminApi.get(`sso-connectors/${id}`).json<SsoConnectorWithProviderConfig>();
+
+export const deleteSsoConnectorById = async (id: string) =>
+  authedAdminApi.delete(`sso-connectors/${id}`).json<void>();
+
+export const patchSsoConnectorById = async (id: string, data: Partial<SsoConnector>) =>
+  authedAdminApi
+    .patch(`sso-connectors/${id}`, {
+      json: data,
+    })
+    .json<SsoConnectorWithProviderConfig>();
+
+export const patchSsoConnectorConfigById = async (id: string, data: Record<string, unknown>) =>
+  authedAdminApi
+    .patch(`sso-connectors/${id}/config`, {
+      json: data,
+    })
+    .json<SsoConnectorWithProviderConfig>();

--- a/packages/integration-tests/src/tests/api/sso-connectors.test.ts
+++ b/packages/integration-tests/src/tests/api/sso-connectors.test.ts
@@ -4,6 +4,10 @@ import {
   getSsoConnectorFactories,
   createSsoConnector,
   getSsoConnectors,
+  getSsoConnectorById,
+  deleteSsoConnectorById,
+  patchSsoConnectorById,
+  patchSsoConnectorConfigById,
 } from '#src/api/sso-connector.js';
 
 describe('sso-connector library', () => {
@@ -17,7 +21,7 @@ describe('sso-connector library', () => {
   });
 });
 
-describe('post sso-connectos', () => {
+describe('post sso-connectors', () => {
   it('should throw error when providerName is not provided', async () => {
     await expect(
       createSsoConnector({
@@ -111,5 +115,172 @@ describe('get sso-connectors', () => {
 
     // Invalid config
     expect(connector?.providerConfig).toBeUndefined();
+  });
+});
+
+describe('get sso-connector by id', () => {
+  it('should return 404 if connector is not found', async () => {
+    await expect(getSsoConnectorById('invalid-id')).rejects.toThrow(HTTPError);
+  });
+
+  it('should return sso connector', async () => {
+    const { id } = await createSsoConnector({
+      providerName: 'OIDC',
+      connectorName: 'integration_test connector',
+    });
+
+    const connector = await getSsoConnectorById(id);
+
+    expect(connector).toHaveProperty('id', id);
+    expect(connector).toHaveProperty('providerName', 'OIDC');
+    expect(connector).toHaveProperty('connectorName', 'integration_test connector');
+    expect(connector).toHaveProperty('config', {});
+    expect(connector).toHaveProperty('domains', []);
+    expect(connector).toHaveProperty('ssoOnly', false);
+    expect(connector).toHaveProperty('syncProfile', false);
+  });
+});
+
+describe('delete sso-connector by id', () => {
+  it('should return 404 if connector is not found', async () => {
+    await expect(getSsoConnectorById('invalid-id')).rejects.toThrow(HTTPError);
+  });
+
+  it('should delete sso connector', async () => {
+    const { id } = await createSsoConnector({
+      providerName: 'OIDC',
+      connectorName: 'integration_test connector',
+    });
+
+    await expect(getSsoConnectorById(id)).resolves.toBeDefined();
+
+    await deleteSsoConnectorById(id);
+
+    await expect(getSsoConnectorById(id)).rejects.toThrow(HTTPError);
+  });
+});
+
+describe('patch sso-connector by id', () => {
+  it('should return 404 if connector is not found', async () => {
+    await expect(getSsoConnectorById('invalid-id')).rejects.toThrow(HTTPError);
+  });
+
+  it('should patch sso connector without config', async () => {
+    const { id } = await createSsoConnector({
+      providerName: 'OIDC',
+      connectorName: 'integration_test connector',
+    });
+
+    const connector = await patchSsoConnectorById(id, {
+      connectorName: 'integration_test connector updated',
+      domains: ['test.com'],
+      ssoOnly: true,
+    });
+
+    expect(connector).toHaveProperty('id', id);
+    expect(connector).toHaveProperty('providerName', 'OIDC');
+    expect(connector).toHaveProperty('connectorName', 'integration_test connector updated');
+    expect(connector).toHaveProperty('config', {});
+    expect(connector).toHaveProperty('domains', ['test.com']);
+    expect(connector).toHaveProperty('ssoOnly', true);
+    expect(connector).toHaveProperty('syncProfile', false);
+  });
+
+  it('should directly return if no changes are made', async () => {
+    const { id } = await createSsoConnector({
+      providerName: 'OIDC',
+      connectorName: 'integration_test connector',
+    });
+
+    const connector = await patchSsoConnectorById(id, {
+      config: undefined,
+    });
+
+    expect(connector).toHaveProperty('id', id);
+    expect(connector).toHaveProperty('providerName', 'OIDC');
+    expect(connector).toHaveProperty('connectorName', 'integration_test connector');
+    expect(connector).toHaveProperty('config', {});
+    expect(connector).toHaveProperty('domains', []);
+    expect(connector).toHaveProperty('ssoOnly', false);
+    expect(connector).toHaveProperty('syncProfile', false);
+  });
+
+  it('should throw if invalid config is provided', async () => {
+    const { id } = await createSsoConnector({
+      providerName: 'OIDC',
+      connectorName: 'integration_test connector',
+    });
+
+    await expect(
+      patchSsoConnectorById(id, {
+        config: {
+          issuer: 23,
+        },
+      })
+    ).rejects.toThrow(HTTPError);
+  });
+
+  it('should patch sso connector with config', async () => {
+    const { id } = await createSsoConnector({
+      providerName: 'OIDC',
+      connectorName: 'integration_test connector',
+    });
+
+    const connector = await patchSsoConnectorById(id, {
+      connectorName: 'integration_test connector updated',
+      config: {
+        clientId: 'foo',
+        issuer: 'https://test.com',
+      },
+      syncProfile: true,
+    });
+
+    expect(connector).toHaveProperty('id', id);
+    expect(connector).toHaveProperty('providerName', 'OIDC');
+    expect(connector).toHaveProperty('connectorName', 'integration_test connector updated');
+    expect(connector).toHaveProperty('config', {
+      clientId: 'foo',
+      issuer: 'https://test.com',
+    });
+    expect(connector).toHaveProperty('syncProfile', true);
+  });
+});
+
+describe('patch sso-connector config by id', () => {
+  it('should return 404 if connector is not found', async () => {
+    await expect(patchSsoConnectorConfigById('invalid-id', {})).rejects.toThrow(HTTPError);
+  });
+
+  it('should throw if invalid config is provided', async () => {
+    const { id } = await createSsoConnector({
+      providerName: 'OIDC',
+      connectorName: 'integration_test connector',
+    });
+
+    await expect(
+      patchSsoConnectorConfigById(id, {
+        issuer: 23,
+      })
+    ).rejects.toThrow(HTTPError);
+  });
+
+  it('should patch sso connector config', async () => {
+    const { id } = await createSsoConnector({
+      providerName: 'OIDC',
+      connectorName: 'integration_test connector',
+    });
+
+    const connector = await patchSsoConnectorConfigById(id, {
+      clientId: 'foo',
+      issuer: 'https://test.com',
+    });
+
+    expect(connector).toHaveProperty('id', id);
+    expect(connector).toHaveProperty('providerName', 'OIDC');
+    expect(connector).toHaveProperty('connectorName', 'integration_test connector');
+    expect(connector).toHaveProperty('config', {
+      clientId: 'foo',
+      issuer: 'https://test.com',
+    });
   });
 });

--- a/packages/integration-tests/src/tests/api/sso-connectors.test.ts
+++ b/packages/integration-tests/src/tests/api/sso-connectors.test.ts
@@ -1,6 +1,10 @@
 import { HTTPError } from 'got';
 
-import { getSsoConnectorFactories, createSsoConnector } from '#src/api/sso-connector.js';
+import {
+  getSsoConnectorFactories,
+  createSsoConnector,
+  getSsoConnectors,
+} from '#src/api/sso-connector.js';
 
 describe('sso-connector library', () => {
   it('should return sso-connector-factories', async () => {
@@ -87,5 +91,29 @@ describe('post sso-connectos', () => {
     expect(response).toHaveProperty('domains', data.domains);
     expect(response).toHaveProperty('ssoOnly', data.ssoOnly);
     expect(response).toHaveProperty('syncProfile', false);
+  });
+});
+
+describe('get sso-connectors', () => {
+  it('should return sso connectors', async () => {
+    const { id } = await createSsoConnector({
+      providerName: 'OIDC',
+      connectorName: 'test',
+    });
+
+    console.log(id);
+
+    const connectors = await getSsoConnectors();
+    expect(connectors.length).toBeGreaterThan(0);
+
+    console.log(connectors);
+
+    const connector = connectors.find((connector) => connector.id === id);
+
+    expect(connector).toBeDefined();
+    expect(connector?.providerLogo).toBeDefined();
+
+    // Invalid config
+    expect(connector?.providerConfig).toBeUndefined();
   });
 });

--- a/packages/integration-tests/src/tests/api/sso-connectors.test.ts
+++ b/packages/integration-tests/src/tests/api/sso-connectors.test.ts
@@ -101,12 +101,8 @@ describe('get sso-connectors', () => {
       connectorName: 'test',
     });
 
-    console.log(id);
-
     const connectors = await getSsoConnectors();
     expect(connectors.length).toBeGreaterThan(0);
-
-    console.log(connectors);
 
     const connector = connectors.find((connector) => connector.id === id);
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add GET `sso-connectors` API.

Fetch connector configs from the connector provider e.g. fetch token endpoints from the OIDC provider, and fetch metadata details from the SAML provider. 

Return connector DB data with the fetched provider configs, if any. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="1526" alt="image" src="https://github.com/logto-io/logto/assets/36393111/ef9838e2-ce28-495a-9f2e-604e222be6c7">



<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
