### PR TITLE
fix(console,core,test): support filter by type for GET roles and apps APIs

### DIFF
--- a/.changeset/sixty-ladybugs-exercise.md
+++ b/.changeset/sixty-ladybugs-exercise.md
@@ -1,0 +1,8 @@
+---
+"@logto/integration-tests": patch
+"@logto/console": patch
+"@logto/core": patch
+---
+
+Bug fix:
+core/console: fix 500 error when using search component in console to filter both roles and applications.

--- a/.changeset/sixty-ladybugs-exercise.md
+++ b/.changeset/sixty-ladybugs-exercise.md
@@ -4,5 +4,4 @@
 "@logto/core": patch
 ---
 
-Bug fix:
-core/console: fix 500 error when using search component in console to filter both roles and applications.
+fix 500 error when using search component in console to filter both roles and applications.

--- a/packages/console/src/components/RolesTransfer/components/SourceRolesBox/index.tsx
+++ b/packages/console/src/components/RolesTransfer/components/SourceRolesBox/index.tsx
@@ -41,8 +41,7 @@ function SourceRolesBox({ entityId, type, selectedRoles, onChange }: Props) {
   const url = buildUrl('api/roles', {
     page: String(page),
     page_size: String(pageSize),
-    'search.type': type,
-    'mode.type': 'exact',
+    type,
     [type === RoleType.User ? 'excludeUserId' : 'excludeApplicationId']: entityId,
     ...conditional(keyword && { search: `%${keyword}%` }),
   });

--- a/packages/console/src/pages/Roles/components/AssignRoleModal/index.tsx
+++ b/packages/console/src/pages/Roles/components/AssignRoleModal/index.tsx
@@ -100,7 +100,7 @@ function AssignRoleModal<T extends Application | User>({
                 excludeRoleId: roleId,
                 ...(roleType === RoleType.User
                   ? {}
-                  : { 'search.type': ApplicationType.MachineToMachine, 'mode.type': 'exact' }),
+                  : { 'types': ApplicationType.MachineToMachine }),
               },
             }}
             selectedEntities={entities}

--- a/packages/console/src/pages/Roles/components/AssignRoleModal/index.tsx
+++ b/packages/console/src/pages/Roles/components/AssignRoleModal/index.tsx
@@ -98,9 +98,7 @@ function AssignRoleModal<T extends Application | User>({
               pathname: `api/${phraseKey}`,
               parameters: {
                 excludeRoleId: roleId,
-                ...(roleType === RoleType.User
-                  ? {}
-                  : { 'types': ApplicationType.MachineToMachine }),
+                ...(roleType === RoleType.User ? {} : { types: ApplicationType.MachineToMachine }),
               },
             }}
             selectedEntities={entities}

--- a/packages/core/src/queries/application.ts
+++ b/packages/core/src/queries/application.ts
@@ -47,10 +47,10 @@ export const createApplicationQueries = (pool: CommonQueryMethods) => {
   /**
    * Get the number of applications that match the search conditions, conditions are joined in `and` mode.
    *
-   * @param search The search config object, can apply to `id`, `name` and `description` field for application
-   * @param excludeApplicationIds Exclude applications with these ids
-   * @param types Optional array of {@link ApplicationType}, filter applications by types, if not provided, all types will be included
-   * @returns The number of applications that match the search conditions
+   * @param search The search config object, can apply to `id`, `name` and `description` field for application.
+   * @param excludeApplicationIds Exclude applications with these ids.
+   * @param types Optional array of {@link ApplicationType}, filter applications by types, if not provided, all types will be included.
+   * @returns A Promise that resolves the number of applications that match the search conditions.
    */
   const countApplications = async (
     search: Search,
@@ -76,11 +76,11 @@ export const createApplicationQueries = (pool: CommonQueryMethods) => {
    * Get the list of applications that match the search conditions, conditions are joined in `and` mode.
    *
    * @param search The search config object, can apply to `id`, `name` and `description` field for application
-   * @param excludeApplicationIds Exclude applications with these ids
-   * @param types Optional array of {@link ApplicationType}, filter applications by types, if not provided, all types will be included
-   * @param limit limit of the number of applications in each page
-   * @param offset offset of the applications in the result
-   * @returns The list of applications that match the search conditions
+   * @param excludeApplicationIds Exclude applications with these ids.
+   * @param types Optional array of {@link ApplicationType}, filter applications by types, if not provided, all types will be included.
+   * @param limit Limit of the number of applications in each page.
+   * @param offset Offset of the applications in the result.
+   * @returns A Promise that resolves the list of applications that match the search conditions.
    */
   const findApplications = async (
     search: Search,

--- a/packages/core/src/queries/application.ts
+++ b/packages/core/src/queries/application.ts
@@ -44,6 +44,14 @@ const buildConditionArray = (conditions: SqlSqlToken[]) => {
 };
 
 export const createApplicationQueries = (pool: CommonQueryMethods) => {
+  /**
+   * Get the number of applications that match the search conditions, conditions are joined in `and` mode.
+   *
+   * @param search The search config object, can apply to `id`, `name` and `description` field for application
+   * @param excludeApplicationIds Exclude applications with these ids
+   * @param types Optional array of {@link ApplicationType}, filter applications by types, if not provided, all types will be included
+   * @returns The number of applications that match the search conditions
+   */
   const countApplications = async (
     search: Search,
     excludeApplicationIds: string[],
@@ -64,6 +72,16 @@ export const createApplicationQueries = (pool: CommonQueryMethods) => {
     return { count: Number(count) };
   };
 
+  /**
+   * Get the list of applications that match the search conditions, conditions are joined in `and` mode.
+   *
+   * @param search The search config object, can apply to `id`, `name` and `description` field for application
+   * @param excludeApplicationIds Exclude applications with these ids
+   * @param types Optional array of {@link ApplicationType}, filter applications by types, if not provided, all types will be included
+   * @param limit limit of the number of applications in each page
+   * @param offset offset of the applications in the result
+   * @returns The list of applications that match the search conditions
+   */
   const findApplications = async (
     search: Search,
     excludeApplicationIds: string[],

--- a/packages/core/src/routes/admin-user/role.ts
+++ b/packages/core/src/routes/admin-user/role.ts
@@ -44,8 +44,8 @@ export default function adminUserRoleRoutes<T extends AuthedRouter>(
           const usersRoles = await findUsersRolesByUserId(userId);
           const roleIds = usersRoles.map(({ roleId }) => roleId);
           const [{ count }, roles] = await Promise.all([
-            countRoles(search, { roleIds }),
-            findRoles(search, limit, offset, { roleIds }),
+            countRoles(search, { roleIds, type: RoleType.User }),
+            findRoles(search, limit, offset, { roleIds, type: RoleType.User }),
           ]);
 
           // Return totalCount to pagination middleware

--- a/packages/core/src/routes/application-role.ts
+++ b/packages/core/src/routes/application-role.ts
@@ -55,8 +55,8 @@ export default function applicationRoleRoutes<T extends AuthedRouter>(
           const applicationRoles = await findApplicationsRolesByApplicationId(applicationId);
           const roleIds = applicationRoles.map(({ roleId }) => roleId);
           const [{ count }, roles] = await Promise.all([
-            countRoles(search, { roleIds }),
-            findRoles(search, limit, offset, { roleIds }),
+            countRoles(search, { roleIds, type: RoleType.MachineToMachine }),
+            findRoles(search, limit, offset, { roleIds, type: RoleType.MachineToMachine }),
           ]);
 
           // Return totalCount to pagination middleware

--- a/packages/core/src/routes/application.ts
+++ b/packages/core/src/routes/application.ts
@@ -14,6 +14,7 @@ import koaGuard from '#src/middleware/koa-guard.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
 import { buildOidcClientMetadata } from '#src/oidc/utils.js';
 import assertThat from '#src/utils/assert-that.js';
+import { consoleLog } from '#src/utils/console.js';
 import { parseSearchParamsForSearch } from '#src/utils/search.js';
 
 import type { AuthedRouter, RouterInitArgs } from './types.js';
@@ -71,7 +72,9 @@ export default function applicationRoutes<T extends AuthedRouter>(
       const { searchParams } = ctx.URL;
       const { types } = ctx.guard.query;
 
+      consoleLog.info('searchParams:', searchParams);
       const search = parseSearchParamsForSearch(searchParams);
+      consoleLog.info('search:', search);
 
       const excludeRoleId = searchParams.get('excludeRoleId');
       const excludeApplicationsRoles = excludeRoleId

--- a/packages/core/src/routes/application.ts
+++ b/packages/core/src/routes/application.ts
@@ -14,7 +14,6 @@ import koaGuard from '#src/middleware/koa-guard.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
 import { buildOidcClientMetadata } from '#src/oidc/utils.js';
 import assertThat from '#src/utils/assert-that.js';
-import { consoleLog } from '#src/utils/console.js';
 import { parseSearchParamsForSearch } from '#src/utils/search.js';
 
 import type { AuthedRouter, RouterInitArgs } from './types.js';
@@ -72,9 +71,7 @@ export default function applicationRoutes<T extends AuthedRouter>(
       const { searchParams } = ctx.URL;
       const { types } = ctx.guard.query;
 
-      consoleLog.info('searchParams:', searchParams);
       const search = parseSearchParamsForSearch(searchParams);
-      consoleLog.info('search:', search);
 
       const excludeRoleId = searchParams.get('excludeRoleId');
       const excludeApplicationsRoles = excludeRoleId

--- a/packages/integration-tests/src/api/admin-user.ts
+++ b/packages/integration-tests/src/api/admin-user.ts
@@ -48,8 +48,17 @@ export const deleteUserIdentity = async (userId: string, connectorTarget: string
 export const assignRolesToUser = async (userId: string, roleIds: string[]) =>
   authedAdminApi.post(`users/${userId}/roles`, { json: { roleIds } });
 
-export const getUserRoles = async (userId: string) =>
-  authedAdminApi.get(`users/${userId}/roles`).json<Role[]>();
+/**
+ * Get roles assigned to the user.
+ *
+ * @param userId Concerned user id
+ * @param keyword Search among all roles (on `id`, `name` and `description` fields) assigned to the user with `keyword`
+ * @returns All roles which contains the keyword assigned to the user
+ */
+export const getUserRoles = async (userId: string, keyword?: string) => {
+  const searchParams = new URLSearchParams(keyword && [['search', `%${keyword}%`]]);
+  return authedAdminApi.get(`users/${userId}/roles`, { searchParams }).json<Role[]>();
+};
 
 export const deleteRoleFromUser = async (userId: string, roleId: string) =>
   authedAdminApi.delete(`users/${userId}/roles/${roleId}`);

--- a/packages/integration-tests/src/api/application.ts
+++ b/packages/integration-tests/src/api/application.ts
@@ -26,10 +26,7 @@ export const createApplication = async (
 
 export const getApplications = async (types?: ApplicationType[]) => {
   const searchParams = new URLSearchParams(
-    conditional(
-      types &&
-        types.length > 0 && [...types.map((type) => ['search.type', type]), ['mode.type', 'exact']]
-    )
+    conditional(types && types.length > 0 && types.map((type) => ['types', type]))
   );
 
   return authedAdminApi.get('applications', { searchParams }).json<Application[]>();

--- a/packages/integration-tests/src/api/application.ts
+++ b/packages/integration-tests/src/api/application.ts
@@ -24,10 +24,18 @@ export const createApplication = async (
     })
     .json<Application>();
 
-export const getApplications = async (types?: ApplicationType[]) => {
-  const searchParams = new URLSearchParams(
-    conditional(types && types.length > 0 && types.map((type) => ['types', type]))
-  );
+export const getApplications = async (
+  types?: ApplicationType[],
+  searchParameters?: Record<string, string>
+) => {
+  const searchParams = new URLSearchParams([
+    ...(conditional(types && types.length > 0 && types.map((type) => ['types', type])) ?? []),
+    ...(conditional(
+      searchParameters &&
+        Object.keys(searchParameters).length > 0 &&
+        Object.entries(searchParameters).map(([key, value]) => [key, value])
+    ) ?? []),
+  ]);
 
   return authedAdminApi.get('applications', { searchParams }).json<Application[]>();
 };

--- a/packages/integration-tests/src/api/application.ts
+++ b/packages/integration-tests/src/api/application.ts
@@ -54,8 +54,17 @@ export const updateApplication = async (
 export const deleteApplication = async (applicationId: string) =>
   authedAdminApi.delete(`applications/${applicationId}`);
 
-export const getApplicationRoles = async (applicationId: string) =>
-  authedAdminApi.get(`applications/${applicationId}/roles`).json<Role[]>();
+/**
+ * Get roles assigned to the m2m app.
+ *
+ * @param applicationId Concerned m2m app id
+ * @param keyword Search among all roles (on `id`, `name` and `description` fields) assigned to the m2m app with `keyword`
+ * @returns All roles which contains the keyword assigned to the m2m app
+ */
+export const getApplicationRoles = async (applicationId: string, keyword?: string) => {
+  const searchParams = new URLSearchParams(conditional(keyword && [['search', `%${keyword}%`]]));
+  return authedAdminApi.get(`applications/${applicationId}/roles`, { searchParams }).json<Role[]>();
+};
 
 export const assignRolesToApplication = async (applicationId: string, roleIds: string[]) =>
   authedAdminApi.post(`applications/${applicationId}/roles`, {

--- a/packages/integration-tests/src/api/role.ts
+++ b/packages/integration-tests/src/api/role.ts
@@ -5,7 +5,12 @@ import { generateRoleName } from '#src/utils.js';
 
 import { authedAdminApi } from './api.js';
 
-export type GetRoleOptions = { excludeUserId?: string; excludeApplicationId?: string };
+export type GetRoleOptions = {
+  excludeUserId?: string;
+  excludeApplicationId?: string;
+  type?: RoleType;
+  search?: string;
+};
 
 export const createRole = async ({
   name,

--- a/packages/integration-tests/src/api/role.ts
+++ b/packages/integration-tests/src/api/role.ts
@@ -58,8 +58,17 @@ export const assignScopesToRole = async (scopeIds: string[], roleId: string) =>
 export const deleteScopeFromRole = async (scopeId: string, roleId: string) =>
   authedAdminApi.delete(`roles/${roleId}/scopes/${scopeId}`);
 
-export const getRoleUsers = async (roleId: string) =>
-  authedAdminApi.get(`roles/${roleId}/users`).json<User[]>();
+/**
+ * Get users assigned to the role.
+ *
+ * @param roleId Concerned role id
+ * @param keyword Search among all users (on `id`, `name` and `description` fields) assigned to the role with `keyword`
+ * @returns All users which contains the keyword assigned to the role
+ */
+export const getRoleUsers = async (roleId: string, keyword?: string) => {
+  const searchParams = new URLSearchParams(keyword && [['search', `%${keyword}%`]]);
+  return authedAdminApi.get(`roles/${roleId}/users`, { searchParams }).json<User[]>();
+};
 
 export const assignUsersToRole = async (userIds: string[], roleId: string) =>
   authedAdminApi.post(`roles/${roleId}/users`, {
@@ -69,8 +78,17 @@ export const assignUsersToRole = async (userIds: string[], roleId: string) =>
 export const deleteUserFromRole = async (userId: string, roleId: string) =>
   authedAdminApi.delete(`roles/${roleId}/users/${userId}`);
 
-export const getRoleApplications = async (roleId: string) =>
-  authedAdminApi.get(`roles/${roleId}/applications`).json<Application[]>();
+/**
+ * Get apps assigned to the role.
+ *
+ * @param roleId Concerned role id
+ * @param keyword Search among all m2m apps (on `id`, `name` and `description` fields) assigned to the role with `keyword`
+ * @returns All m2m apps which contains the keyword assigned to the role
+ */
+export const getRoleApplications = async (roleId: string, keyword?: string) => {
+  const searchParams = new URLSearchParams(keyword && [['search', `%${keyword}%`]]);
+  return authedAdminApi.get(`roles/${roleId}/applications`, { searchParams }).json<Application[]>();
+};
 
 export const assignApplicationsToRole = async (applicationIds: string[], roleId: string) =>
   authedAdminApi.post(`roles/${roleId}/applications`, {

--- a/packages/integration-tests/src/api/role.ts
+++ b/packages/integration-tests/src/api/role.ts
@@ -61,9 +61,9 @@ export const deleteScopeFromRole = async (scopeId: string, roleId: string) =>
 /**
  * Get users assigned to the role.
  *
- * @param roleId Concerned role id
- * @param keyword Search among all users (on `id`, `name` and `description` fields) assigned to the role with `keyword`
- * @returns All users which contains the keyword assigned to the role
+ * @param roleId Concerned role id.
+ * @param keyword Search among all users (on `id`, `name` and `description` fields) assigned to the role with `keyword`.
+ * @returns A Promise that resolves all users which contains the keyword assigned to the role.
  */
 export const getRoleUsers = async (roleId: string, keyword?: string) => {
   const searchParams = new URLSearchParams(keyword && [['search', `%${keyword}%`]]);
@@ -81,9 +81,9 @@ export const deleteUserFromRole = async (userId: string, roleId: string) =>
 /**
  * Get apps assigned to the role.
  *
- * @param roleId Concerned role id
- * @param keyword Search among all m2m apps (on `id`, `name` and `description` fields) assigned to the role with `keyword`
- * @returns All m2m apps which contains the keyword assigned to the role
+ * @param roleId Concerned role id.
+ * @param keyword Search among all m2m apps (on `id`, `name` and `description` fields) assigned to the role with `keyword`.
+ * @returns A Promise that resolves all m2m apps which contains the keyword assigned to the role.
  */
 export const getRoleApplications = async (roleId: string, keyword?: string) => {
   const searchParams = new URLSearchParams(keyword && [['search', `%${keyword}%`]]);

--- a/packages/integration-tests/src/tests/api/application.roles.test.ts
+++ b/packages/integration-tests/src/tests/api/application.roles.test.ts
@@ -40,6 +40,14 @@ describe('admin console application management (roles)', () => {
     expect(roles.length).toBe(2);
     expect(roles.find(({ id }) => id === role1.id)).toBeDefined();
     expect(roles.find(({ id }) => id === role2.id)).toBeDefined();
+
+    // Empty keyword should be ignored, all assigned roles should be returned
+    await expect(getApplicationRoles(application.id, '')).resolves.toHaveLength(2);
+
+    // Get right assigned roles with search keyword
+    const rolesWithSearchParams = await getApplicationRoles(application.id, role1.name);
+    expect(rolesWithSearchParams).toHaveLength(1);
+    expect(rolesWithSearchParams.find(({ id }) => id === role2.id)).toBeUndefined();
   });
 
   it('should fail when assign duplicated role to app', async () => {

--- a/packages/integration-tests/src/tests/api/role.application.test.ts
+++ b/packages/integration-tests/src/tests/api/role.application.test.ts
@@ -32,12 +32,21 @@ describe('roles applications', () => {
 
   it('should assign applications to role successfully', async () => {
     const role = await createRole({ type: RoleType.MachineToMachine });
-    const m2mApp1 = await createApplication(generateStandardId(), ApplicationType.MachineToMachine);
-    const m2mApp2 = await createApplication(generateStandardId(), ApplicationType.MachineToMachine);
+    const m2mApp1 = await createApplication('m2m-app-001', ApplicationType.MachineToMachine);
+    const m2mApp2 = await createApplication('m2m-app-002', ApplicationType.MachineToMachine);
     await assignApplicationsToRole([m2mApp1.id, m2mApp2.id], role.id);
-    const applications = await getRoleApplications(role.id);
 
-    expect(applications.length).toBe(2);
+    // No assigned m2m apps satisfy the search keyword
+    await expect(getRoleApplications(role.id, 'not-found')).resolves.toHaveLength(0);
+
+    // Get right assigned m2m apps with search keyword
+    await expect(getRoleApplications(role.id, 'm2m-app')).resolves.toHaveLength(2);
+
+    // Empty search keyword should be ignored, all assigned m2m apps should be returned
+    await expect(getRoleApplications(role.id, '')).resolves.toHaveLength(2);
+
+    // Get all assigned m2m apps
+    await expect(getRoleApplications(role.id)).resolves.toHaveLength(2);
   });
 
   it('should fail when try to assign empty applications', async () => {

--- a/packages/integration-tests/src/tests/console/machine-to-machine-rbac/machime-to-machime-rbac.test.ts
+++ b/packages/integration-tests/src/tests/console/machine-to-machine-rbac/machime-to-machime-rbac.test.ts
@@ -34,6 +34,8 @@ describe('M2M RBAC', () => {
   const permissionDescription = 'Dummy permission description';
   const roleName = generateRoleName();
   const roleDescription = 'Dummy role description';
+  const anotherRoleName = generateRoleName();
+  const anotherRoleDescription = 'Another dummy role description';
 
   const rbacTestAppname = 'm2m-app-001';
   const m2mFramework = 'Machine-to-machine';
@@ -152,11 +154,37 @@ describe('M2M RBAC', () => {
       );
     });
 
-    it('create a m2m role and assign permissions to the role', async () => {
-      await createM2mRoleAndAssignPermissions(page, { roleName, roleDescription }, [
-        { apiResourceName, permissionName },
-        { apiResourceName: managementApiResourceName, permissionName: managementApiPermission },
-      ]);
+    it('create a m2m role and assign permissions to the role, then go back to role listing page', async () => {
+      await createM2mRoleAndAssignPermissions(
+        page,
+        { roleName, roleDescription },
+        [
+          { apiResourceName, permissionName },
+          { apiResourceName: managementApiResourceName, permissionName: managementApiPermission },
+        ],
+        true
+      );
+    });
+
+    it('create another m2m role and assign permissions to the role, then go back to role listing page', async () => {
+      await createM2mRoleAndAssignPermissions(
+        page,
+        { roleName: anotherRoleName, roleDescription: anotherRoleDescription },
+        [
+          { apiResourceName, permissionName },
+          { apiResourceName: managementApiResourceName, permissionName: managementApiPermission },
+        ],
+        true
+      );
+    });
+
+    it('search for a role and enter its details page', async () => {
+      await expect(page).toFill('div[class$=filter] input', roleName);
+      await expect(page).toClick('button', { text: 'Search' });
+
+      await expect(page).toClick('table tbody tr td div[class$=meta]:has(a[class$=title])', {
+        text: roleName,
+      });
     });
 
     it('delete a permission from a role on the role details page', async () => {
@@ -224,6 +252,7 @@ describe('M2M RBAC', () => {
 
       await expectModalWithTitle(page, 'Assign apps');
 
+      await expect(page).toFill('.ReactModalPortal input[type=text]', rbacTestAppname);
       await expect(page).toClick(
         '.ReactModalPortal div[class$=rolesTransfer] div[class$=item] div[class$=title]',
         {
@@ -243,30 +272,12 @@ describe('M2M RBAC', () => {
         }
       );
     });
-  });
 
-  describe('assign/remove a role to/from a m2m app (on m2m app details page)', () => {
-    it('remove a role form a m2m app on the app details page', async () => {
-      // Navigate to app details page
-      await expect(page).toClick('table tbody tr td a[class$=title]', {
+    it('remove m2m app from the role on the role details page', async () => {
+      const m2mAppRole = await expect(page).toMatchElement('table tbody tr:has(td div)', {
         text: rbacTestAppname,
       });
-
-      await expect(page).toMatchElement('div[class$=header] > div[class$=metadata] div', {
-        text: rbacTestAppname,
-      });
-
-      // Go to roles tab
-      await expect(page).toClick('nav div[class$=item] div[class$=link] a', {
-        text: 'Roles',
-      });
-
-      const roleRow = await expect(page).toMatchElement('table tbody tr:has(td a[class$=title])', {
-        text: roleName,
-      });
-
-      // Click remove button
-      await expect(roleRow).toClick('td:last-of-type button');
+      await expect(m2mAppRole).toClick('td > div[class$=anchor] > button');
 
       await expectConfirmModalAndAct(page, {
         title: 'Reminder',
@@ -274,11 +285,28 @@ describe('M2M RBAC', () => {
       });
 
       await waitForToast(page, {
-        text: `${roleName} was successfully removed from this user.`,
+        text: `${rbacTestAppname} was successfully removed from this role`,
+      });
+    });
+  });
+
+  describe('assign/remove a role to/from a m2m app (on m2m app details page)', () => {
+    it('navigate to application page and enter m2m app details page', async () => {
+      await expectNavigation(
+        page.goto(appendPathname('/console/applications', logtoConsoleUrl).href)
+      );
+
+      await expect(page).toClick('table tbody tr td a[class$=title]', {
+        text: rbacTestAppname,
       });
     });
 
     it('add a role to m2m app on the application details page', async () => {
+      // Go to roles tab
+      await expect(page).toClick('nav div[class$=item] div[class$=link] a', {
+        text: 'Roles',
+      });
+
       await expect(page).toClick('div[class$=filter] button span', {
         text: 'Assign roles',
       });
@@ -296,6 +324,31 @@ describe('M2M RBAC', () => {
 
       await waitForToast(page, {
         text: 'Successfully assigned role(s)',
+      });
+    });
+
+    it('remove a role form a m2m app on the app details page', async () => {
+      await expect(page).toMatchElement(
+        'div[class$=header] > div[class$=metadata] > div[class$=name]',
+        {
+          text: rbacTestAppname,
+        }
+      );
+
+      const roleRow = await expect(page).toMatchElement('table tbody tr:has(td a[class$=title])', {
+        text: roleName,
+      });
+
+      // Click remove button
+      await expect(roleRow).toClick('td:last-of-type button');
+
+      await expectConfirmModalAndAct(page, {
+        title: 'Reminder',
+        actionText: 'Remove',
+      });
+
+      await waitForToast(page, {
+        text: `${roleName} was successfully removed from this user.`,
       });
     });
   });

--- a/packages/integration-tests/src/tests/console/machine-to-machine-rbac/utils.ts
+++ b/packages/integration-tests/src/tests/console/machine-to-machine-rbac/utils.ts
@@ -1,16 +1,29 @@
 import { type Page } from 'puppeteer';
 
+import { logtoConsoleUrl } from '#src/constants.js';
 import {
   expectModalWithTitle,
   expectToClickModalAction,
   waitForToast,
 } from '#src/ui-helpers/index.js';
+import { expectNavigation, appendPathname } from '#src/utils.js';
 
+/**
+ * Create a machine-to-machine role and assign permissions to it by operating on the Web
+ *
+ * @param page The page to run the test on
+ * @param createRolePayload The payload to create the role
+ * @param apiResources The list of API resources which are going to be assigned to the role
+ * @param backToListingPage Whether to go back to the roles listing page after creating the role
+ */
 export const createM2mRoleAndAssignPermissions = async (
   page: Page,
-  { roleName, roleDescription }: { roleName: string; roleDescription: string },
-  apiResources: Array<{ apiResourceName: string; permissionName: string }>
+  createRolePayload: { roleName: string; roleDescription: string },
+  apiResources: Array<{ apiResourceName: string; permissionName: string }>,
+  backToListingPage = false
 ) => {
+  const { roleName, roleDescription } = createRolePayload;
+
   await expect(page).toClick('div[class$=headline] button span', {
     text: 'Create role',
   });
@@ -63,4 +76,17 @@ export const createM2mRoleAndAssignPermissions = async (
   await expect(page).toMatchElement('div[class$=header] div[class$=metadata] div[class$=name]', {
     text: roleName,
   });
+
+  if (backToListingPage) {
+    await expectNavigation(
+      page.goto(appendPathname('/console/roles', new URL(logtoConsoleUrl)).href)
+    );
+
+    await expect(page).toMatchElement(
+      'div[class$=main] div[class$=headline] div[class$=titleEllipsis]',
+      {
+        text: 'Roles',
+      }
+    );
+  }
 };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
support filter by type for GET roles and apps APIs and no longer reuse advanced search for both role and application filtering by type, made the following changes:
1. add optional `type` as GET /roles API's query parameter. Show all roles (including both m2m app roles and user roles if `type` is not specified)
2. add optional `types` as GET /applications API's query parameter (list all apps if not presented)
3. remove the monkey-patched `fieldsTypeMapping` input parameters when parsing query parameters for advanced search. Usually, the string values used for advanced search apply to multiple fields in DB records, and in most cases, the non-exact match mode is applied. While `type` is likely an enum type and needs an exact match mode, which means reusing advanced search for `type` filtering is not a good idea.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally and CI.

Also added the following integration test cases:

Console:
1. search role on the roles listing page.
2. search apps on the roles details page, m2m app tab.
3. unassign m2m apps from a role on the role details page.
4. unassign a role from m2m apps on the app details page.

API (add search with keyword test cases):
1. GET /applications/:appId/roles
2. GET /users/:userId/roles
3. GET /roles/:roleId/applications
4. GET /roles/:roleId/users
ONLY add API test cases for using keywords (match the use case of the console "Search" component on corresponding pages).

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
