### PR TITLE
fix(cli): fix unsupported signing key error when generating keys with cli

### DIFF
--- a/packages/cli/src/commands/database/config.ts
+++ b/packages/cli/src/commands/database/config.ts
@@ -66,7 +66,7 @@ const validateRotateKey: ValidateRotateKeyFunction = (key) => {
 const validatePrivateKeyType: ValidatePrivateKeyTypeFunction = (key) => {
   // Using `.includes()` will result a type error
   // eslint-disable-next-line unicorn/prefer-includes
-  if (!validPrivateKeyTypes.some((element) => element === key.toUpperCase())) {
+  if (!validPrivateKeyTypes.some((element) => element === key)) {
     consoleLog.fatal(
       `Invalid private key type ${chalk.red(
         key
@@ -177,8 +177,9 @@ const rotateConfig: CommandModule<unknown, { key: string; tenantId: string; type
         default: 'ec',
       }),
   handler: async ({ key, tenantId, type }) => {
+    const keyType = type.toUpperCase();
     validateRotateKey(key);
-    validatePrivateKeyType(type);
+    validatePrivateKeyType(keyType);
 
     const pool = await createPoolFromConfig();
     const { rows } = await getRowsByKeys(pool, tenantId, [key]);
@@ -194,7 +195,7 @@ const rotateConfig: CommandModule<unknown, { key: string; tenantId: string; type
       // No need for default. It's already exhaustive
       switch (key) {
         case LogtoOidcConfigKey.PrivateKeys: {
-          return [await generateOidcPrivateKey(type), ...original];
+          return [await generateOidcPrivateKey(keyType), ...original];
         }
 
         case LogtoOidcConfigKey.CookieKeys: {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix a bug that causes "Unsupported private key {type}" error when generating `oidc.privateKeys` or `oidc.cookieKeys` using Logto CLI.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested CLI locally and it works properly now

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
