### PR TITLE
fix(core): get hostname from ctx for webauthn

### DIFF
--- a/packages/core/src/routes/interaction/additional.ts
+++ b/packages/core/src/routes/interaction/additional.ts
@@ -10,7 +10,6 @@ import { type IRouterParamContext } from 'koa-router';
 import qrcode from 'qrcode';
 import { z } from 'zod';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
 import koaGuard from '#src/middleware/koa-guard.js';
@@ -162,7 +161,7 @@ export default function additionalRoutes<T extends IRouterParamContext>(
         const newAccountId = await generateUserId();
         const newUserProfile = await parseUserProfile(tenant, profileVerifiedInteraction);
         const options = await generateWebAuthnRegistrationOptions({
-          rpId: EnvSet.values.endpoint.hostname,
+          rpId: ctx.URL.hostname,
           user: {
             id: newAccountId,
             username: newUserProfile.username ?? newAccountId,
@@ -193,7 +192,7 @@ export default function additionalRoutes<T extends IRouterParamContext>(
           accountId
         );
         const options = await generateWebAuthnRegistrationOptions({
-          rpId: EnvSet.values.endpoint.hostname,
+          rpId: ctx.URL.hostname,
           user: {
             id,
             username,
@@ -240,7 +239,7 @@ export default function additionalRoutes<T extends IRouterParamContext>(
 
       const { mfaVerifications } = await findUserById(accountId);
       const options = await generateWebAuthnAuthenticationOptions({
-        rpId: EnvSet.values.endpoint.hostname,
+        rpId: ctx.URL.hostname,
         mfaVerifications,
       });
 

--- a/packages/core/src/routes/interaction/mfa.ts
+++ b/packages/core/src/routes/interaction/mfa.ts
@@ -114,7 +114,7 @@ export default function mfaRoutes<T extends IRouterParamContext>(
         })
       );
 
-      const { hostname, origin } = EnvSet.values.endpoint;
+      const { hostname, origin } = ctx.URL;
       const verifiedMfa = await verifyMfaPayloadVerification(
         tenant,
         verifyMfaPayloadGuard,


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

For MFA (WebAuthn and TOTP) hostname, use `ctx.URL` to replace `EnvSet.values.endpoint`:

1. `ctx.URL` is more accurate if the user is using custom domain.
2. `EnvSet.values.endpoint` will not contain tenantId in the cloud, this is a bug.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
