### PR TITLE
refactor(experience): display secret code first when binding totp on mobile devices

### DIFF
--- a/packages/experience/src/pages/MfaBinding/TotpBinding/SecretSection/index.tsx
+++ b/packages/experience/src/pages/MfaBinding/TotpBinding/SecretSection/index.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import SectionLayout from '@/Layout/SectionLayout';
 import Button from '@/components/Button';
 import TextLink from '@/components/TextLink';
+import usePlatform from '@/hooks/use-platform';
 import useTextHandler from '@/hooks/use-text-handler';
 import { type TotpBindingState } from '@/types/guard';
 
@@ -11,7 +12,8 @@ import * as styles from './index.module.scss';
 
 const SecretSection = ({ secret, secretQrCode }: TotpBindingState) => {
   const { t } = useTranslation();
-  const [isQrCodeFormat, setIsQrCodeFormat] = useState(true);
+  const { isMobile } = usePlatform();
+  const [isQrCodeFormat, setIsQrCodeFormat] = useState(!isMobile);
   const { copyText } = useTextHandler();
 
   return (


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
refactor(experience): display secret code first when bindning totp on mobile devices

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="405" alt="image" src="https://github.com/logto-io/logto/assets/10806653/5cbc6972-ebbc-4717-86c6-f47b953061f0">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
