### PR TITLE
refactor(core): add the isSupportedSsoConnector type assertion

### DIFF
--- a/packages/core/src/__mocks__/sso.ts
+++ b/packages/core/src/__mocks__/sso.ts
@@ -1,9 +1,11 @@
 import { type SsoConnector } from '@logto/schemas';
 
-export const mockSsoConnector: SsoConnector = {
+import { SsoProviderName } from '#src/sso/types/index.js';
+
+export const mockSsoConnector = {
   id: 'mock-sso-connector',
   tenantId: 'mock-tenant',
-  providerName: 'OIDC',
+  providerName: SsoProviderName.OIDC,
   connectorName: 'mock-connector-name',
   config: {},
   domains: [],
@@ -11,4 +13,4 @@ export const mockSsoConnector: SsoConnector = {
   syncProfile: true,
   ssoOnly: true,
   createdAt: Date.now(),
-};
+} satisfies SsoConnector;

--- a/packages/core/src/libraries/sso-connector.test.ts
+++ b/packages/core/src/libraries/sso-connector.test.ts
@@ -1,0 +1,63 @@
+import { mockSsoConnector } from '#src/__mocks__/sso.js';
+import RequestError from '#src/errors/RequestError/index.js';
+import { MockQueries } from '#src/test-utils/tenant.js';
+
+import { createSsoConnectorLibrary } from './sso-connector.js';
+
+const { jest } = import.meta;
+
+const findAllSsoConnectors = jest.fn();
+const geConnectorById = jest.fn();
+
+const queries = new MockQueries({
+  ssoConnectors: { findAll: findAllSsoConnectors, findById: geConnectorById },
+});
+
+describe('SsoConnectorLibrary', () => {
+  const ssoConnectorLibrary = createSsoConnectorLibrary(queries);
+
+  it('getSsoConnectors() should filter unsupported sso connectors', async () => {
+    const { getSsoConnectors } = ssoConnectorLibrary;
+
+    findAllSsoConnectors.mockResolvedValueOnce([
+      2,
+      [
+        mockSsoConnector,
+        {
+          ...mockSsoConnector,
+          providerName: 'unsupported',
+        },
+      ],
+    ]);
+
+    const connectors = await getSsoConnectors();
+
+    expect(connectors).toEqual([mockSsoConnector]);
+  });
+
+  it('getSsoConnectorById() should throw 404 if the connector is not supported', async () => {
+    const { getSsoConnectorById } = ssoConnectorLibrary;
+
+    geConnectorById.mockResolvedValueOnce({
+      ...mockSsoConnector,
+      providerName: 'unsupported',
+    });
+
+    await expect(getSsoConnectorById('id')).rejects.toMatchError(
+      new RequestError({
+        code: 'connector.not_found',
+        status: 404,
+      })
+    );
+  });
+
+  it('getSsoConnectorById() should return the connector if it is supported', async () => {
+    const { getSsoConnectorById } = ssoConnectorLibrary;
+
+    geConnectorById.mockResolvedValueOnce(mockSsoConnector);
+
+    const connector = await getSsoConnectorById('id');
+
+    expect(connector).toEqual(mockSsoConnector);
+  });
+});

--- a/packages/core/src/libraries/sso-connector.ts
+++ b/packages/core/src/libraries/sso-connector.ts
@@ -1,0 +1,38 @@
+import { assert } from '@silverhand/essentials';
+
+import RequestError from '#src/errors/RequestError/index.js';
+import { type SupportedSsoConnector } from '#src/sso/types/index.js';
+import { isSupportedSsoConnector } from '#src/sso/utils.js';
+import type Queries from '#src/tenants/Queries.js';
+
+export const createSsoConnectorLibrary = (queries: Queries) => {
+  const { ssoConnectors } = queries;
+
+  const getSsoConnectors = async () => {
+    const [_, entities] = await ssoConnectors.findAll();
+
+    return entities.filter((connector): connector is SupportedSsoConnector =>
+      isSupportedSsoConnector(connector)
+    );
+  };
+
+  const getSsoConnectorById = async (id: string) => {
+    const connector = await ssoConnectors.findById(id);
+
+    // Return 404 if the connector is not supported
+    assert(
+      isSupportedSsoConnector(connector),
+      new RequestError({
+        code: 'connector.not_found',
+        status: 404,
+      })
+    );
+
+    return connector;
+  };
+
+  return {
+    getSsoConnectors,
+    getSsoConnectorById,
+  };
+};

--- a/packages/core/src/routes/sso-connector/index.ts
+++ b/packages/core/src/routes/sso-connector/index.ts
@@ -121,7 +121,6 @@ export default function singleSignOnRoutes<T extends AuthedRouter>(...args: Rout
       status: [200],
     }),
     async (ctx, next) => {
-      // Query all connectors
       const [_, entities] = await ssoConnectors.findAll();
 
       // Filter out unsupported connectors
@@ -134,7 +133,6 @@ export default function singleSignOnRoutes<T extends AuthedRouter>(...args: Rout
         filerSupportedConnectors.map(async (connector) => fetchConnectorProviderDetails(connector))
       );
 
-      // Filter out unsupported connectors
       ctx.body = connectorsWithProviderDetails;
 
       return next();
@@ -152,7 +150,6 @@ export default function singleSignOnRoutes<T extends AuthedRouter>(...args: Rout
     async (ctx, next) => {
       const { id } = ctx.guard.params;
 
-      // Fetch the connector
       const connector = await ssoConnectors.findById(id);
 
       // Return 404 if the connector is not supported
@@ -183,7 +180,6 @@ export default function singleSignOnRoutes<T extends AuthedRouter>(...args: Rout
     async (ctx, next) => {
       const { id } = ctx.guard.params;
 
-      // Delete the connector
       await ssoConnectors.deleteById(id);
       ctx.status = 204;
       return next();
@@ -203,11 +199,9 @@ export default function singleSignOnRoutes<T extends AuthedRouter>(...args: Rout
       const { id } = ctx.guard.params;
       const { body } = ctx.guard;
 
-      // Fetch the connector
       const originalConnector = await ssoConnectors.findById(id);
       const { providerName } = originalConnector;
 
-      // Return 404 if the connector is not supported
       assert(
         isSupportedSsoProvider(providerName),
         new RequestError({
@@ -238,7 +232,6 @@ export default function singleSignOnRoutes<T extends AuthedRouter>(...args: Rout
         new RequestError({ code: 'connector.not_found', status: 404 })
       );
 
-      // Fetch provider details for the connector
       const connectorWithProviderDetails = await fetchConnectorProviderDetails(connector);
 
       ctx.body = connectorWithProviderDetails;
@@ -260,7 +253,6 @@ export default function singleSignOnRoutes<T extends AuthedRouter>(...args: Rout
       const { id } = ctx.guard.params;
       const { body } = ctx.guard;
 
-      // Fetch the connector
       const { providerName, config } = await ssoConnectors.findById(id);
 
       // Return 422 if the connector provider is not supported
@@ -278,7 +270,6 @@ export default function singleSignOnRoutes<T extends AuthedRouter>(...args: Rout
         ...body,
       });
 
-      // Patch update the connector config
       const connector = await ssoConnectors.updateById(id, {
         config: parsedConfig,
       });

--- a/packages/core/src/routes/sso-connector/type.ts
+++ b/packages/core/src/routes/sso-connector/type.ts
@@ -1,4 +1,4 @@
-import { SsoConnectors } from '@logto/schemas';
+import { SsoConnectors, type SsoConnector } from '@logto/schemas';
 import { z } from 'zod';
 
 import { SsoProviderName } from '#src/sso/types/index.js';
@@ -46,3 +46,7 @@ export const ssoConnectorPatchGuard = SsoConnectors.guard
     connectorName: true,
   })
   .partial();
+
+export type SupportedSsoConnector = Omit<SsoConnector, 'providerName'> & {
+  providerName: SsoProviderName;
+};

--- a/packages/core/src/routes/sso-connector/type.ts
+++ b/packages/core/src/routes/sso-connector/type.ts
@@ -1,4 +1,4 @@
-import { SsoConnectors, type SsoConnector } from '@logto/schemas';
+import { SsoConnectors } from '@logto/schemas';
 import { z } from 'zod';
 
 import { SsoProviderName } from '#src/sso/types/index.js';
@@ -46,7 +46,3 @@ export const ssoConnectorPatchGuard = SsoConnectors.guard
     connectorName: true,
   })
   .partial();
-
-export type SupportedSsoConnector = Omit<SsoConnector, 'providerName'> & {
-  providerName: SsoProviderName;
-};

--- a/packages/core/src/routes/sso-connector/utils.test.ts
+++ b/packages/core/src/routes/sso-connector/utils.test.ts
@@ -12,19 +12,7 @@ await mockEsmWithActual('#src/sso/OidcConnector/utils.js', () => ({
 }));
 
 const { ssoConnectorFactories } = await import('#src/sso/index.js');
-const { isSupportedSsoProvider, parseFactoryDetail, fetchConnectorProviderDetails } = await import(
-  './utils.js'
-);
-
-describe('isSupportedSsoProvider', () => {
-  it.each(Object.values(SsoProviderName))('should return true for %s', (providerName) => {
-    expect(isSupportedSsoProvider(providerName)).toBe(true);
-  });
-
-  it('should return false for unknown provider', () => {
-    expect(isSupportedSsoProvider('unknown-provider')).toBe(false);
-  });
-});
+const { parseFactoryDetail, fetchConnectorProviderDetails } = await import('./utils.js');
 
 describe('parseFactoryDetail', () => {
   it.each(Object.values(SsoProviderName))('should return correct detail for %s', (providerName) => {

--- a/packages/core/src/routes/sso-connector/utils.test.ts
+++ b/packages/core/src/routes/sso-connector/utils.test.ts
@@ -54,15 +54,11 @@ describe('parseFactoryDetail', () => {
 });
 
 describe('fetchConnectorProviderDetails', () => {
-  it('should return undefined for unsupported provider', async () => {
-    const connector = { ...mockSsoConnector, providerName: 'unknown-provider' };
-    const result = await fetchConnectorProviderDetails(connector);
-
-    expect(result).toBeUndefined();
-  });
-
   it('providerConfig should be undefined if connector config is invalid', async () => {
-    const connector = { ...mockSsoConnector, config: { clientId: 'foo' } };
+    const connector = {
+      ...mockSsoConnector,
+      config: { clientId: 'foo' },
+    };
     const result = await fetchConnectorProviderDetails(connector);
 
     expect(result).toEqual({

--- a/packages/core/src/routes/sso-connector/utils.ts
+++ b/packages/core/src/routes/sso-connector/utils.ts
@@ -1,22 +1,15 @@
 import { type I18nPhrases } from '@logto/connector-kit';
-import { type JsonObject, type SsoConnector } from '@logto/schemas';
+import { type JsonObject } from '@logto/schemas';
 import { conditional, trySafe } from '@silverhand/essentials';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import { type SingleSignOnFactory, ssoConnectorFactories } from '#src/sso/index.js';
-import { type SsoProviderName } from '#src/sso/types/index.js';
+import { type SsoProviderName, type SupportedSsoConnector } from '#src/sso/types/index.js';
 
-import { type SsoConnectorWithProviderConfig, type SupportedSsoConnector } from './type.js';
+import { type SsoConnectorWithProviderConfig } from './type.js';
 
 const isKeyOfI18nPhrases = (key: string, phrases: I18nPhrases): key is keyof I18nPhrases =>
   key in phrases;
-
-export const isSupportedSsoProvider = (providerName: string): providerName is SsoProviderName =>
-  providerName in ssoConnectorFactories;
-
-export const isSupportedSsoConnector = (
-  connector: SsoConnector
-): connector is SupportedSsoConnector => isSupportedSsoProvider(connector.providerName);
 
 export const parseFactoryDetail = (
   factory: SingleSignOnFactory<SsoProviderName>,

--- a/packages/core/src/sso/index.ts
+++ b/packages/core/src/sso/index.ts
@@ -25,3 +25,5 @@ export const ssoConnectorFactories: {
 } = {
   [SsoProviderName.OIDC]: oidcSsoConnectorFactory,
 };
+
+export const standardSsoConnectorProviders = Object.freeze([SsoProviderName.OIDC]);

--- a/packages/core/src/sso/types/index.ts
+++ b/packages/core/src/sso/types/index.ts
@@ -15,3 +15,7 @@ export abstract class SingleSignOn {
 export enum SsoProviderName {
   OIDC = 'OIDC',
 }
+
+export type SupportedSsoConnector = Omit<SsoConnector, 'providerName'> & {
+  providerName: SsoProviderName;
+};

--- a/packages/core/src/sso/utils.test.ts
+++ b/packages/core/src/sso/utils.test.ts
@@ -1,0 +1,12 @@
+import { SsoProviderName } from './types/index.js';
+import { isSupportedSsoProvider } from './utils.js';
+
+describe('isSupportedSsoProvider', () => {
+  it.each(Object.values(SsoProviderName))('should return true for %s', (providerName) => {
+    expect(isSupportedSsoProvider(providerName)).toBe(true);
+  });
+
+  it('should return false for unknown provider', () => {
+    expect(isSupportedSsoProvider('unknown-provider')).toBe(false);
+  });
+});

--- a/packages/core/src/sso/utils.ts
+++ b/packages/core/src/sso/utils.ts
@@ -1,0 +1,11 @@
+import { type SsoConnector } from '@logto/schemas';
+
+import { ssoConnectorFactories } from './index.js';
+import { type SupportedSsoConnector, type SsoProviderName } from './types/index.js';
+
+export const isSupportedSsoProvider = (providerName: string): providerName is SsoProviderName =>
+  providerName in ssoConnectorFactories;
+
+export const isSupportedSsoConnector = (
+  connector: SsoConnector
+): connector is SupportedSsoConnector => isSupportedSsoProvider(connector.providerName);

--- a/packages/core/src/tenants/Libraries.ts
+++ b/packages/core/src/tenants/Libraries.ts
@@ -8,6 +8,7 @@ import { createPhraseLibrary } from '#src/libraries/phrase.js';
 import { createQuotaLibrary } from '#src/libraries/quota.js';
 import { createSignInExperienceLibrary } from '#src/libraries/sign-in-experience/index.js';
 import { createSocialLibrary } from '#src/libraries/social.js';
+import { createSsoConnectorLibrary } from '#src/libraries/sso-connector.js';
 import { createUserLibrary } from '#src/libraries/user.js';
 import { createVerificationStatusLibrary } from '#src/libraries/verification-status.js';
 
@@ -24,6 +25,7 @@ export default class Libraries {
   verificationStatuses = createVerificationStatusLibrary(this.queries);
   domains = createDomainLibrary(this.queries);
   quota = createQuotaLibrary(this.queries, this.cloudConnection, this.connectors);
+  ssoConnector = createSsoConnectorLibrary(this.queries);
 
   constructor(
     public readonly tenantId: string,


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
In DB schema `providerName` type is string.  But in practice, for most of the use cases of the connector data, we need to ensure the `providerName` is one of the Logto-provided SsoConnector provider types.  Assert `providerName` is the `SsoProviderName` type.

Define a new type assertion helper function to clarify the input connector is `SupportedSsoConnector`. This may simplify some of the internal logic with a strict output type guard.  

Also extract those common connector's get queries into a library, with the `SupportedSsoConnector` assertion added. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT updated

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
