### PR TITLE
fix(test): make m2m RBAC console integration test stable

### DIFF
--- a/packages/integration-tests/src/tests/console/machine-to-machine-rbac/machime-to-machime-rbac.test.ts
+++ b/packages/integration-tests/src/tests/console/machine-to-machine-rbac/machime-to-machime-rbac.test.ts
@@ -180,6 +180,11 @@ describe('M2M RBAC', () => {
     });
 
     it('assign a permission to a role on the role details page', async () => {
+      // Wait for the deletion confirmation modal to disappear.
+      await page.waitForSelector('.ReactModalPortal div[class$=header] div[class$=titleEllipsis]', {
+        hidden: true,
+      });
+
       await expect(page).toClick('div[class$=filter] button span', {
         text: 'Assign Permissions',
       });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
make M2M RBAC console integration test stable.
The test case "assign permission to an m2m role app on app details page" occasionally fails because the previous permission deletion operation will idle for a while until the DB is updated. Before this, the deletion confirmation modal still exists and the "add permission" button is not clickable.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
CI.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
