### PR TITLE
feat(core): add last use time to user mfa verifications

### DIFF
--- a/packages/core/src/routes/interaction/mfa.test.ts
+++ b/packages/core/src/routes/interaction/mfa.test.ts
@@ -65,6 +65,8 @@ const baseProviderMock = {
   client_id: demoAppApplicationId,
 };
 
+const updateUserById = jest.fn();
+
 const tenantContext = new MockTenant(
   createMockProvider(jest.fn().mockResolvedValue(baseProviderMock)),
   {
@@ -73,6 +75,7 @@ const tenantContext = new MockTenant(
     },
     users: {
       findUserById: jest.fn().mockResolvedValue(mockUserWithMfaVerifications),
+      updateUserById,
     },
   }
 );
@@ -216,6 +219,7 @@ describe('interaction routes (MFA verification)', () => {
       expect(response.status).toEqual(204);
       expect(getInteractionStorage).toBeCalled();
       expect(verifyMfaPayloadVerification).toBeCalled();
+      expect(updateUserById).toBeCalled();
       expect(storeInteractionResult).toBeCalledWith(
         {
           verifiedMfa: {

--- a/packages/core/src/routes/interaction/mfa.ts
+++ b/packages/core/src/routes/interaction/mfa.ts
@@ -123,6 +123,21 @@ export default function mfaRoutes<T extends IRouterParamContext>(
         { accountId, rpId: hostname, origin }
       );
 
+      // Update last used time
+      const user = await queries.users.findUserById(accountId);
+      await queries.users.updateUserById(accountId, {
+        mfaVerifications: user.mfaVerifications.map((mfa) => {
+          if (mfa.id !== verifiedMfa.id) {
+            return mfa;
+          }
+
+          return {
+            ...mfa,
+            lastUsedAt: new Date().toISOString(),
+          };
+        }),
+      });
+
       await storeInteractionResult({ verifiedMfa }, ctx, provider, true);
 
       ctx.status = 204;

--- a/packages/core/src/routes/interaction/verifications/mfa-payload-verification.test.ts
+++ b/packages/core/src/routes/interaction/verifications/mfa-payload-verification.test.ts
@@ -283,11 +283,15 @@ describe('verifyMfaPayloadVerification', () => {
   });
 
   describe('webauthn', () => {
+    beforeEach(() => {
+      updateUserById.mockClear();
+    });
+
     it('should return result of VerifyMfaResult and update newCounter', async () => {
       findUserById.mockResolvedValueOnce({
         mfaVerifications: [mockUserWebAuthnMfaVerification],
       });
-      const result = { type: MfaFactor.WebAuthn, id: 'id' };
+      const result = { type: MfaFactor.WebAuthn, id: mockUserWebAuthnMfaVerification.id };
       verifyWebAuthnAuthentication.mockResolvedValueOnce({
         result,
         newCounter: 1,

--- a/packages/core/src/routes/interaction/verifications/mfa-payload-verification.ts
+++ b/packages/core/src/routes/interaction/verifications/mfa-payload-verification.ts
@@ -232,7 +232,7 @@ export async function verifyMfaPayloadVerification(
       // Update the authenticator's counter in the DB to the newest count in the authentication
       await tenant.queries.users.updateUserById(accountId, {
         mfaVerifications: user.mfaVerifications.map((mfa) => {
-          if (mfa.type !== MfaFactor.WebAuthn) {
+          if (mfa.type !== MfaFactor.WebAuthn || mfa.id !== result.id) {
             return mfa;
           }
 

--- a/packages/schemas/src/foundations/jsonb-types/users.ts
+++ b/packages/schemas/src/foundations/jsonb-types/users.ts
@@ -16,6 +16,7 @@ export type Identities = z.infer<typeof identitiesGuard>;
 export const baseMfaVerification = {
   id: z.string(),
   createdAt: z.string(),
+  lastUsedAt: z.string().optional(),
 };
 
 export const mfaVerificationTotp = z.object({


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Add `lastUsedAt` to `user.mfaVerifications`, when a auth factor is verified, it will be updated with current time.

And sort `availableFactors` when throw error.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Unit tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
