### PR TITLE
refactor(experience): hide webauthn on native webview

### DIFF
--- a/packages/experience/src/hooks/use-webauthn-operation.ts
+++ b/packages/experience/src/hooks/use-webauthn-operation.ts
@@ -5,7 +5,11 @@ import {
   type WebAuthnRegistrationOptions,
 } from '@logto/schemas';
 import { trySafe } from '@silverhand/essentials';
-import { startAuthentication, startRegistration } from '@simplewebauthn/browser';
+import {
+  browserSupportsWebAuthn,
+  startAuthentication,
+  startRegistration,
+} from '@simplewebauthn/browser';
 import type {
   RegistrationResponseJSON,
   AuthenticationResponseJSON,
@@ -108,6 +112,11 @@ const useWebAuthnOperation = (flow: UserMfaFlow) => {
   );
 
   return useCallback(async () => {
+    if (!browserSupportsWebAuthn()) {
+      setToast(t('mfa.webauthn_not_supported'));
+      return;
+    }
+
     if (!webAuthnOptions) {
       /**
        * This error message is just for program robustness; in practice, this issue is unlikely to occur.

--- a/packages/phrases-experience/src/locales/de/mfa.ts
+++ b/packages/phrases-experience/src/locales/de/mfa.ts
@@ -53,6 +53,8 @@ const mfa = {
   /** UNTRANSLATED */
   webauthn_not_ready: 'WebAuthn is not ready yet. Please try again later.',
   /** UNTRANSLATED */
+  webauthn_not_supported: 'WebAuthn is not supported in this browser.',
+  /** UNTRANSLATED */
   webauthn_failed_to_create: 'Failed to create. Please try again.',
   /** UNTRANSLATED */
   webauthn_failed_to_verify: 'Failed to verify. Please try again.',

--- a/packages/phrases-experience/src/locales/en/mfa.ts
+++ b/packages/phrases-experience/src/locales/en/mfa.ts
@@ -50,6 +50,7 @@ const mfa = {
   secret_key_copied: 'Secret key copied.',
   backup_code_copied: 'Backup code copied.',
   webauthn_not_ready: 'WebAuthn is not ready yet. Please try again later.',
+  webauthn_not_supported: 'WebAuthn is not supported in this browser.',
   webauthn_failed_to_create: 'Failed to create. Please try again.',
   webauthn_failed_to_verify: 'Failed to verify. Please try again.',
 };

--- a/packages/phrases-experience/src/locales/es/mfa.ts
+++ b/packages/phrases-experience/src/locales/es/mfa.ts
@@ -52,6 +52,8 @@ const mfa = {
   /** UNTRANSLATED */
   webauthn_not_ready: 'WebAuthn is not ready yet. Please try again later.',
   /** UNTRANSLATED */
+  webauthn_not_supported: 'WebAuthn is not supported in this browser.',
+  /** UNTRANSLATED */
   webauthn_failed_to_create: 'Failed to create. Please try again.',
   /** UNTRANSLATED */
   webauthn_failed_to_verify: 'Failed to verify. Please try again.',

--- a/packages/phrases-experience/src/locales/fr/mfa.ts
+++ b/packages/phrases-experience/src/locales/fr/mfa.ts
@@ -52,6 +52,8 @@ const mfa = {
   /** UNTRANSLATED */
   webauthn_not_ready: 'WebAuthn is not ready yet. Please try again later.',
   /** UNTRANSLATED */
+  webauthn_not_supported: 'WebAuthn is not supported in this browser.',
+  /** UNTRANSLATED */
   webauthn_failed_to_create: 'Failed to create. Please try again.',
   /** UNTRANSLATED */
   webauthn_failed_to_verify: 'Failed to verify. Please try again.',

--- a/packages/phrases-experience/src/locales/it/mfa.ts
+++ b/packages/phrases-experience/src/locales/it/mfa.ts
@@ -52,6 +52,8 @@ const mfa = {
   /** UNTRANSLATED */
   webauthn_not_ready: 'WebAuthn is not ready yet. Please try again later.',
   /** UNTRANSLATED */
+  webauthn_not_supported: 'WebAuthn is not supported in this browser.',
+  /** UNTRANSLATED */
   webauthn_failed_to_create: 'Failed to create. Please try again.',
   /** UNTRANSLATED */
   webauthn_failed_to_verify: 'Failed to verify. Please try again.',

--- a/packages/phrases-experience/src/locales/ja/mfa.ts
+++ b/packages/phrases-experience/src/locales/ja/mfa.ts
@@ -52,6 +52,8 @@ const mfa = {
   /** UNTRANSLATED */
   webauthn_not_ready: 'WebAuthn is not ready yet. Please try again later.',
   /** UNTRANSLATED */
+  webauthn_not_supported: 'WebAuthn is not supported in this browser.',
+  /** UNTRANSLATED */
   webauthn_failed_to_create: 'Failed to create. Please try again.',
   /** UNTRANSLATED */
   webauthn_failed_to_verify: 'Failed to verify. Please try again.',

--- a/packages/phrases-experience/src/locales/ko/mfa.ts
+++ b/packages/phrases-experience/src/locales/ko/mfa.ts
@@ -50,6 +50,8 @@ const mfa = {
   /** UNTRANSLATED */
   webauthn_not_ready: 'WebAuthn is not ready yet. Please try again later.',
   /** UNTRANSLATED */
+  webauthn_not_supported: 'WebAuthn is not supported in this browser.',
+  /** UNTRANSLATED */
   webauthn_failed_to_create: 'Failed to create. Please try again.',
   /** UNTRANSLATED */
   webauthn_failed_to_verify: 'Failed to verify. Please try again.',

--- a/packages/phrases-experience/src/locales/pl-pl/mfa.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/mfa.ts
@@ -52,6 +52,8 @@ const mfa = {
   /** UNTRANSLATED */
   webauthn_not_ready: 'WebAuthn is not ready yet. Please try again later.',
   /** UNTRANSLATED */
+  webauthn_not_supported: 'WebAuthn is not supported in this browser.',
+  /** UNTRANSLATED */
   webauthn_failed_to_create: 'Failed to create. Please try again.',
   /** UNTRANSLATED */
   webauthn_failed_to_verify: 'Failed to verify. Please try again.',

--- a/packages/phrases-experience/src/locales/pt-br/mfa.ts
+++ b/packages/phrases-experience/src/locales/pt-br/mfa.ts
@@ -52,6 +52,8 @@ const mfa = {
   /** UNTRANSLATED */
   webauthn_not_ready: 'WebAuthn is not ready yet. Please try again later.',
   /** UNTRANSLATED */
+  webauthn_not_supported: 'WebAuthn is not supported in this browser.',
+  /** UNTRANSLATED */
   webauthn_failed_to_create: 'Failed to create. Please try again.',
   /** UNTRANSLATED */
   webauthn_failed_to_verify: 'Failed to verify. Please try again.',

--- a/packages/phrases-experience/src/locales/pt-pt/mfa.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/mfa.ts
@@ -52,6 +52,8 @@ const mfa = {
   /** UNTRANSLATED */
   webauthn_not_ready: 'WebAuthn is not ready yet. Please try again later.',
   /** UNTRANSLATED */
+  webauthn_not_supported: 'WebAuthn is not supported in this browser.',
+  /** UNTRANSLATED */
   webauthn_failed_to_create: 'Failed to create. Please try again.',
   /** UNTRANSLATED */
   webauthn_failed_to_verify: 'Failed to verify. Please try again.',

--- a/packages/phrases-experience/src/locales/ru/mfa.ts
+++ b/packages/phrases-experience/src/locales/ru/mfa.ts
@@ -52,6 +52,8 @@ const mfa = {
   /** UNTRANSLATED */
   webauthn_not_ready: 'WebAuthn is not ready yet. Please try again later.',
   /** UNTRANSLATED */
+  webauthn_not_supported: 'WebAuthn is not supported in this browser.',
+  /** UNTRANSLATED */
   webauthn_failed_to_create: 'Failed to create. Please try again.',
   /** UNTRANSLATED */
   webauthn_failed_to_verify: 'Failed to verify. Please try again.',

--- a/packages/phrases-experience/src/locales/tr-tr/mfa.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/mfa.ts
@@ -52,6 +52,8 @@ const mfa = {
   /** UNTRANSLATED */
   webauthn_not_ready: 'WebAuthn is not ready yet. Please try again later.',
   /** UNTRANSLATED */
+  webauthn_not_supported: 'WebAuthn is not supported in this browser.',
+  /** UNTRANSLATED */
   webauthn_failed_to_create: 'Failed to create. Please try again.',
   /** UNTRANSLATED */
   webauthn_failed_to_verify: 'Failed to verify. Please try again.',

--- a/packages/phrases-experience/src/locales/zh-cn/mfa.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/mfa.ts
@@ -47,6 +47,8 @@ const mfa = {
   /** UNTRANSLATED */
   webauthn_not_ready: 'WebAuthn is not ready yet. Please try again later.',
   /** UNTRANSLATED */
+  webauthn_not_supported: 'WebAuthn is not supported in this browser.',
+  /** UNTRANSLATED */
   webauthn_failed_to_create: 'Failed to create. Please try again.',
   /** UNTRANSLATED */
   webauthn_failed_to_verify: 'Failed to verify. Please try again.',

--- a/packages/phrases-experience/src/locales/zh-hk/mfa.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/mfa.ts
@@ -47,6 +47,8 @@ const mfa = {
   /** UNTRANSLATED */
   webauthn_not_ready: 'WebAuthn is not ready yet. Please try again later.',
   /** UNTRANSLATED */
+  webauthn_not_supported: 'WebAuthn is not supported in this browser.',
+  /** UNTRANSLATED */
   webauthn_failed_to_create: 'Failed to create. Please try again.',
   /** UNTRANSLATED */
   webauthn_failed_to_verify: 'Failed to verify. Please try again.',

--- a/packages/phrases-experience/src/locales/zh-tw/mfa.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/mfa.ts
@@ -47,6 +47,8 @@ const mfa = {
   /** UNTRANSLATED */
   webauthn_not_ready: 'WebAuthn is not ready yet. Please try again later.',
   /** UNTRANSLATED */
+  webauthn_not_supported: 'WebAuthn is not supported in this browser.',
+  /** UNTRANSLATED */
   webauthn_failed_to_create: 'Failed to create. Please try again.',
   /** UNTRANSLATED */
   webauthn_failed_to_verify: 'Failed to verify. Please try again.',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Hide the webauthn factor on native webview if the user has other options, since it's not supported.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
With this config:
![image](https://github.com/logto-io/logto/assets/10806653/49753def-e4c1-43e9-ba66-4e6cfd488201)

The display content:
![image](https://github.com/logto-io/logto/assets/10806653/7c0a6659-006e-4455-ad14-8b6d0d422b1b)

Not supported message:
![image](https://github.com/logto-io/logto/assets/10806653/bed8f7e3-2f2b-4e98-9d1d-1d910711d81b)

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
