### PR TITLE
fix(core): check user mfa when binding backup code

### DIFF
--- a/packages/core/src/routes/interaction/mfa.test.ts
+++ b/packages/core/src/routes/interaction/mfa.test.ts
@@ -149,6 +149,21 @@ describe('interaction routes (MFA verification)', () => {
       expect(response.status).toEqual(400);
     });
 
+    it('should pass when backup code is the only item in bindMfa, but is not in user mfaVerifications', async () => {
+      getInteractionStorage.mockReturnValueOnce({
+        event: InteractionEvent.SignIn,
+        bindMfas: [],
+        accountId: 'accountId',
+      });
+
+      const body = {
+        type: MfaFactor.BackupCode,
+      };
+
+      const response = await sessionRequest.post(path).send(body);
+      expect(response.status).toEqual(204);
+    });
+
     it('should return 204 for totp and backup code combination', async () => {
       getInteractionStorage.mockReturnValueOnce({
         event: InteractionEvent.SignIn,

--- a/packages/core/src/routes/interaction/mfa.ts
+++ b/packages/core/src/routes/interaction/mfa.ts
@@ -58,11 +58,15 @@ export default function mfaRoutes<T extends IRouterParamContext>(
         verifyMfaSettings(bindMfaPayload.type, signInExperience);
       }
 
-      const { bindMfas = [] } = interactionStorage;
+      const { bindMfas = [], accountId } = interactionStorage;
 
       if (bindMfaPayload.type === MfaFactor.BackupCode) {
+        const { mfaVerifications } = accountId
+          ? await queries.users.findUserById(accountId)
+          : { mfaVerifications: [] };
         assertThat(
-          bindMfas.some(({ type }) => type !== MfaFactor.BackupCode),
+          bindMfas.some(({ type }) => type !== MfaFactor.BackupCode) ||
+            mfaVerifications.some(({ type }) => type !== MfaFactor.BackupCode),
           'session.mfa.backup_code_can_not_be_alone'
         );
       } else {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

When checking if "backup code" is the user's only factor, should check both interaction's `bindMfa` and user's `mfaVerifications`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Unit tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
