### PR TITLE
fix(console): organization guide should check required fields on navigation

### DIFF
--- a/packages/console/src/pages/Organizations/Guide/CreatePermissions/index.tsx
+++ b/packages/console/src/pages/Organizations/Guide/CreatePermissions/index.tsx
@@ -68,29 +68,28 @@ function CreatePermissions() {
 
   const { fields, append, remove } = useFieldArray({ control, name: 'permissions' });
 
-  const onSubmit = () => {
-    if (!isDirty) {
-      navigate(`../${steps.createRoles}`);
-      return;
-    }
-
-    void handleSubmit(
-      trySubmitSafe(async ({ permissions }) => {
-        if (data?.length) {
-          await Promise.all(
-            data.map(async ({ id }) => api.delete(`${organizationScopesPath}/${id}`))
-          );
-        }
-        await Promise.all(
-          permissions.map(async ({ name, description }) => {
-            await api.post(organizationScopesPath, { json: { name, description } });
-          })
-        );
-
+  const onSubmit = handleSubmit(
+    trySubmitSafe(async ({ permissions }) => {
+      // If user has pre-saved data and no changes, skip submit and go directly to next step
+      if (data?.length && !isDirty) {
         navigate(`../${steps.createRoles}`);
-      })
-    )();
-  };
+        return;
+      }
+
+      if (data?.length) {
+        await Promise.all(
+          data.map(async ({ id }) => api.delete(`${organizationScopesPath}/${id}`))
+        );
+      }
+      await Promise.all(
+        permissions.map(async ({ name, description }) => {
+          await api.post(organizationScopesPath, { json: { name, description } });
+        })
+      );
+
+      navigate(`../${steps.createRoles}`);
+    })
+  );
 
   return (
     <>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the issue that organization guide should check required field input before navigation, when there's no pre-saved data available.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
