### PR TITLE
refactor(experience): generate webauthn options before switching to the webauthn page

### DIFF
--- a/packages/experience/src/hooks/use-start-webauthn-processing.ts
+++ b/packages/experience/src/hooks/use-start-webauthn-processing.ts
@@ -1,0 +1,50 @@
+import { MfaFactor } from '@logto/schemas';
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import {
+  createWebAuthnRegistrationOptions,
+  generateWebAuthnAuthnOptions,
+} from '@/apis/interaction';
+import { UserMfaFlow } from '@/types';
+import { type WebAuthnState, type MfaFlowState } from '@/types/guard';
+
+import useApi from './use-api';
+import useErrorHandler from './use-error-handler';
+
+type Options = {
+  replace?: boolean;
+};
+
+const useStartWebAuthnProcessing = ({ replace }: Options = {}) => {
+  const navigate = useNavigate();
+  const asyncCreateRegistrationOptions = useApi(createWebAuthnRegistrationOptions);
+  const asyncGenerateAuthnOptions = useApi(generateWebAuthnAuthnOptions);
+  const handleError = useErrorHandler();
+
+  return useCallback(
+    async (flow: UserMfaFlow, flowState: MfaFlowState) => {
+      const [error, options] =
+        flow === UserMfaFlow.MfaBinding
+          ? await asyncCreateRegistrationOptions()
+          : await asyncGenerateAuthnOptions();
+
+      if (error) {
+        await handleError(error);
+        return;
+      }
+
+      if (options) {
+        const state: WebAuthnState = {
+          options,
+          ...flowState,
+        };
+
+        navigate({ pathname: `/${flow}/${MfaFactor.WebAuthn}` }, { replace, state });
+      }
+    },
+    [asyncCreateRegistrationOptions, asyncGenerateAuthnOptions, handleError, navigate, replace]
+  );
+};
+
+export default useStartWebAuthnProcessing;

--- a/packages/experience/src/hooks/use-webauthn-operation.ts
+++ b/packages/experience/src/hooks/use-webauthn-operation.ts
@@ -14,19 +14,15 @@ import type {
   RegistrationResponseJSON,
   AuthenticationResponseJSON,
 } from '@simplewebauthn/typescript-types';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import {
-  createWebAuthnRegistrationOptions,
-  generateWebAuthnAuthnOptions,
-} from '@/apis/interaction';
 import { UserMfaFlow } from '@/types';
 
-import useApi from './use-api';
-import useErrorHandler from './use-error-handler';
 import useSendMfaPayload from './use-send-mfa-payload';
 import useToast from './use-toast';
+
+type WebAuthnOptions = WebAuthnRegistrationOptions | WebAuthnAuthenticationOptions;
 
 const isAuthenticationResponseJSON = (
   responseJson: RegistrationResponseJSON | AuthenticationResponseJSON
@@ -34,114 +30,58 @@ const isAuthenticationResponseJSON = (
   return 'signature' in responseJson.response;
 };
 
-const useWebAuthnOperation = (flow: UserMfaFlow) => {
+const useWebAuthnOperation = () => {
   const { t } = useTranslation();
   const { setToast } = useToast();
-  const [webAuthnOptions, setWebAuthnOptions] = useState<
-    WebAuthnRegistrationOptions | WebAuthnAuthenticationOptions
-  >();
-
-  const asyncCreateRegistrationOptions = useApi(createWebAuthnRegistrationOptions);
-  const asyncGenerateAuthnOptions = useApi(generateWebAuthnAuthnOptions);
-
   const sendMfaPayload = useSendMfaPayload();
 
-  const handleError = useErrorHandler();
-  const handleRawWebAuthnError = useCallback(() => {
-    setToast(
-      t(
-        flow === UserMfaFlow.MfaBinding
-          ? 'mfa.webauthn_failed_to_create'
-          : 'mfa.webauthn_failed_to_verify'
-      )
-    );
-  }, [flow, setToast, t]);
-
-  /**
-   * Note:
-   * Due to limitations in the iOS system, user interaction is required for the use of the WebAuthn API.
-   * Therefore, we should avoid asynchronous operations before invoking the WebAuthn API.
-   * Otherwise, the operating system may consider the WebAuthn authorization is not initiated by the user.
-   * So, we need to prepare the necessary WebAuthn options before calling the WebAuthn API.
-   */
-  const prepareWebAuthnOptions = useCallback(async () => {
-    if (webAuthnOptions) {
-      return;
-    }
-
-    const [error, options] =
-      flow === UserMfaFlow.MfaBinding
-        ? await asyncCreateRegistrationOptions()
-        : await asyncGenerateAuthnOptions();
-
-    if (error) {
-      await handleError(error);
-      return;
-    }
-
-    setWebAuthnOptions(options);
-  }, [
-    asyncCreateRegistrationOptions,
-    asyncGenerateAuthnOptions,
-    flow,
-    handleError,
-    webAuthnOptions,
-  ]);
-
-  useEffect(() => {
-    if (webAuthnOptions) {
-      return;
-    }
-
-    void prepareWebAuthnOptions();
-  }, [prepareWebAuthnOptions, webAuthnOptions]);
-
-  const handleWebAuthnProcess = useCallback(
-    async (options: WebAuthnRegistrationOptions | WebAuthnAuthenticationOptions) => {
-      const parsedOptions = webAuthnRegistrationOptionsGuard.safeParse(options);
-
-      return trySafe(
-        async () =>
-          parsedOptions.success
-            ? startRegistration(parsedOptions.data)
-            : startAuthentication(options),
-        handleRawWebAuthnError
-      );
-    },
-    [handleRawWebAuthnError]
-  );
-
-  return useCallback(async () => {
-    if (!browserSupportsWebAuthn()) {
-      setToast(t('mfa.webauthn_not_supported'));
-      return;
-    }
-
-    if (!webAuthnOptions) {
-      /**
-       * This error message is just for program robustness; in practice, this issue is unlikely to occur.
-       */
-      setToast(t('mfa.webauthn_not_ready'));
-      void prepareWebAuthnOptions();
-
-      return;
-    }
-
-    const response = await handleWebAuthnProcess(webAuthnOptions);
-
-    if (!response) {
-      return;
-    }
-
+  return useCallback(
     /**
-     * Assert type manually to get the correct type
+     * Note:
+     * Due to limitations in the iOS system, user interaction is required for the use of the WebAuthn API.
+     * Therefore, we should avoid asynchronous operations before invoking the WebAuthn API or the os may consider the WebAuthn authorization is not initiated by the user.
+     * So, we need to prepare the necessary WebAuthn options before calling the WebAuthn API, this is why we don't generate the options in this function.
      */
-    void sendMfaPayload(
-      isAuthenticationResponseJSON(response)
-        ? { flow: UserMfaFlow.MfaVerification, payload: { ...response, type: MfaFactor.WebAuthn } }
-        : { flow: UserMfaFlow.MfaBinding, payload: { ...response, type: MfaFactor.WebAuthn } }
-    );
-  }, [handleWebAuthnProcess, prepareWebAuthnOptions, sendMfaPayload, setToast, t, webAuthnOptions]);
+    async (options: WebAuthnOptions) => {
+      if (!browserSupportsWebAuthn()) {
+        setToast(t('mfa.webauthn_not_supported'));
+        return;
+      }
+
+      const parsedRegistrationOptions = webAuthnRegistrationOptionsGuard.safeParse(options);
+
+      const response = await trySafe(
+        async () =>
+          parsedRegistrationOptions.success
+            ? startRegistration(parsedRegistrationOptions.data)
+            : startAuthentication(options),
+        () => {
+          setToast(
+            t(
+              parsedRegistrationOptions.success
+                ? 'mfa.webauthn_failed_to_create'
+                : 'mfa.webauthn_failed_to_verify'
+            )
+          );
+        }
+      );
+
+      if (response) {
+        /**
+         * Assert type manually to get the correct type
+         */
+        void sendMfaPayload(
+          isAuthenticationResponseJSON(response)
+            ? {
+                flow: UserMfaFlow.MfaVerification,
+                payload: { ...response, type: MfaFactor.WebAuthn },
+              }
+            : { flow: UserMfaFlow.MfaBinding, payload: { ...response, type: MfaFactor.WebAuthn } }
+        );
+      }
+    },
+    [sendMfaPayload, setToast, t]
+  );
 };
 
 export default useWebAuthnOperation;

--- a/packages/experience/src/pages/MfaBinding/WebAuthnBinding/index.tsx
+++ b/packages/experience/src/pages/MfaBinding/WebAuthnBinding/index.tsx
@@ -1,26 +1,34 @@
 import { conditional } from '@silverhand/essentials';
+import { useLocation } from 'react-router-dom';
+import { validate } from 'superstruct';
 
 import SecondaryPageLayout from '@/Layout/SecondaryPageLayout';
 import Button from '@/components/Button';
 import SwitchMfaFactorsLink from '@/components/SwitchMfaFactorsLink';
-import useMfaFlowState from '@/hooks/use-mfa-factors-state';
 import useSkipMfa from '@/hooks/use-skip-mfa';
 import useWebAuthnOperation from '@/hooks/use-webauthn-operation';
 import ErrorPage from '@/pages/ErrorPage';
 import { UserMfaFlow } from '@/types';
+import { webAuthnStateGuard } from '@/types/guard';
+import { isWebAuthnOptions } from '@/utils/webauthn';
 
 import * as styles from './index.module.scss';
 
 const WebAuthnBinding = () => {
-  const flowState = useMfaFlowState();
-  const bindWebAuthn = useWebAuthnOperation(UserMfaFlow.MfaBinding);
+  const { state } = useLocation();
+  const [, webAuthnState] = validate(state, webAuthnStateGuard);
+  const handleWebAuthn = useWebAuthnOperation();
   const skipMfa = useSkipMfa();
 
-  if (!flowState) {
+  if (!webAuthnState) {
     return <ErrorPage title="error.invalid_session" />;
   }
 
-  const { skippable } = flowState;
+  const { options, availableFactors, skippable } = webAuthnState;
+
+  if (!isWebAuthnOptions(options)) {
+    return <ErrorPage title="error.invalid_session" />;
+  }
 
   return (
     <SecondaryPageLayout
@@ -28,10 +36,15 @@ const WebAuthnBinding = () => {
       description="mfa.create_passkey_description"
       onSkip={conditional(skippable && skipMfa)}
     >
-      <Button title="mfa.create_a_passkey" onClick={bindWebAuthn} />
+      <Button
+        title="mfa.create_a_passkey"
+        onClick={() => {
+          void handleWebAuthn(options);
+        }}
+      />
       <SwitchMfaFactorsLink
         flow={UserMfaFlow.MfaBinding}
-        flowState={flowState}
+        flowState={{ availableFactors, skippable }}
         className={styles.switchLink}
       />
     </SecondaryPageLayout>

--- a/packages/experience/src/types/guard.ts
+++ b/packages/experience/src/types/guard.ts
@@ -97,3 +97,12 @@ export const backupCodeErrorDataGuard = s.object({
 export const backupCodeBindingStateGuard = backupCodeErrorDataGuard;
 
 export type BackupCodeBindingState = s.Infer<typeof backupCodeBindingStateGuard>;
+
+export const webAuthnStateGuard = s.assign(
+  s.object({
+    options: s.record(s.string(), s.unknown()),
+  }),
+  mfaFlowStateGuard
+);
+
+export type WebAuthnState = s.Infer<typeof webAuthnStateGuard>;

--- a/packages/experience/src/types/index.ts
+++ b/packages/experience/src/types/index.ts
@@ -1,4 +1,11 @@
-import type { SignInExperience, ConnectorMetadata, SignInIdentifier, Theme } from '@logto/schemas';
+import type {
+  SignInExperience,
+  ConnectorMetadata,
+  SignInIdentifier,
+  Theme,
+  WebAuthnRegistrationOptions,
+  WebAuthnAuthenticationOptions,
+} from '@logto/schemas';
 
 export enum UserFlow {
   SignIn = 'sign-in',
@@ -45,3 +52,5 @@ export type ArrayElement<ArrayType extends readonly unknown[]> = ArrayType exten
 >
   ? ElementType
   : never;
+
+export type WebAuthnOptions = WebAuthnRegistrationOptions | WebAuthnAuthenticationOptions;

--- a/packages/experience/src/utils/webauthn.ts
+++ b/packages/experience/src/utils/webauthn.ts
@@ -1,0 +1,10 @@
+import {
+  webAuthnRegistrationOptionsGuard,
+  webAuthnAuthenticationOptionsGuard,
+} from '@logto/schemas';
+
+import { type WebAuthnOptions } from '@/types';
+
+export const isWebAuthnOptions = (options: Record<string, unknown>): options is WebAuthnOptions =>
+  webAuthnRegistrationOptionsGuard.safeParse(options).success ||
+  webAuthnAuthenticationOptionsGuard.safeParse(options).success;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
In the original implementation, WebAuthn options will be generated on the WebAuthn page, it will cause an unexpected loading state on the page.
This time, we need to generate WebAuthn options before we navigating the page to the WebAuthn page.

To achieve this goal, we do following things:

- add an `useStartWebAuthnProcessing` hook to generate WebAuthn options and pass generated options to the WebAuthn page via the navigation state
- add a `WebAuthnState` type to guard the navigation state
- add an `isWebAuthnOptions` function to assert the options' type before we calling the native WebAuthn API, since the WebAuthn options is a complex object and is already guarded by the backend API, so we don't add a navigation state guard for the options ( use `Record<string, unkonwn>` instead).

### Updates
- Since before navigation, we should not allow users to do other things, so we make all related function calls async in this PR.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally & all UI tests passed.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
