### PR TITLE
feat(core): add get sso-connectors by email interaction api

### DIFF
--- a/packages/core/src/__mocks__/sso.ts
+++ b/packages/core/src/__mocks__/sso.ts
@@ -14,3 +14,20 @@ export const mockSsoConnector = {
   ssoOnly: true,
   createdAt: Date.now(),
 } satisfies SsoConnector;
+
+export const wellConfiguredSsoConnector = {
+  id: 'mock-well-configured-sso-connector',
+  tenantId: 'mock-tenant',
+  providerName: SsoProviderName.OIDC,
+  connectorName: 'mock-connector-name',
+  config: {
+    clientId: 'foo',
+    clientSecret: 'bar',
+    issuer: 'https://foo.com',
+  },
+  domains: ['foo.com'],
+  branding: {},
+  syncProfile: true,
+  ssoOnly: true,
+  createdAt: Date.now(),
+} satisfies SsoConnector;

--- a/packages/core/src/libraries/sign-in-experience/index.test.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.test.ts
@@ -7,7 +7,7 @@ import {
   socialTarget02,
   mockSignInExperience,
   mockSocialConnectors,
-  mockSsoConnector,
+  wellConfiguredSsoConnector,
 } from '#src/__mocks__/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { ssoConnectorFactories } from '#src/sso/index.js';
@@ -130,28 +130,21 @@ describe('remove unavailable social connector targets', () => {
 });
 
 describe('get sso connectors', () => {
-  it('should return sso connectors with valid config', async () => {
+  it('should return sso connectors metadata', async () => {
     getLogtoConnectors.mockResolvedValueOnce(mockSocialConnectors);
     findDefaultSignInExperience.mockResolvedValueOnce(mockSignInExperience);
 
-    const ssoConnector = {
-      ...mockSsoConnector,
-      config: {
-        clientId: 'mockClientId',
-        clientSecret: 'mockClientSecret',
-        issuer: 'mockIssuer',
-      },
-    };
-
-    ssoConnectorLibrary.getAvailableSsoConnectors.mockResolvedValueOnce([ssoConnector]);
+    ssoConnectorLibrary.getAvailableSsoConnectors.mockResolvedValueOnce([
+      wellConfiguredSsoConnector,
+    ]);
 
     const { ssoConnectors } = await getFullSignInExperience();
 
     expect(ssoConnectors).toEqual([
       {
-        id: ssoConnector.id,
-        connectorName: ssoConnector.connectorName,
-        logo: ssoConnectorFactories[ssoConnector.providerName].logo,
+        id: wellConfiguredSsoConnector.id,
+        connectorName: wellConfiguredSsoConnector.connectorName,
+        logo: ssoConnectorFactories[wellConfiguredSsoConnector.providerName].logo,
         darkLogo: undefined,
       },
     ]);

--- a/packages/core/src/libraries/sign-in-experience/index.test.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.test.ts
@@ -37,6 +37,7 @@ const { findDefaultSignInExperience, updateDefaultSignInExperience } = signInExp
 const ssoConnectorLibrary = {
   getSsoConnectors: jest.fn(),
   getSsoConnectorById: jest.fn(),
+  getAvailableSsoConnectors: jest.fn(),
 };
 
 const { MockQueries } = await import('#src/test-utils/tenant.js');
@@ -129,15 +130,6 @@ describe('remove unavailable social connector targets', () => {
 });
 
 describe('get sso connectors', () => {
-  it('should filter out sso connectors that has invalid config', async () => {
-    ssoConnectorLibrary.getSsoConnectors.mockResolvedValueOnce([mockSsoConnector]);
-    getLogtoConnectors.mockResolvedValueOnce(mockSocialConnectors);
-    findDefaultSignInExperience.mockResolvedValueOnce(mockSignInExperience);
-
-    const { ssoConnectors } = await getFullSignInExperience();
-    expect(ssoConnectors).toEqual([]);
-  });
-
   it('should return sso connectors with valid config', async () => {
     getLogtoConnectors.mockResolvedValueOnce(mockSocialConnectors);
     findDefaultSignInExperience.mockResolvedValueOnce(mockSignInExperience);
@@ -151,7 +143,7 @@ describe('get sso connectors', () => {
       },
     };
 
-    ssoConnectorLibrary.getSsoConnectors.mockResolvedValueOnce([ssoConnector]);
+    ssoConnectorLibrary.getAvailableSsoConnectors.mockResolvedValueOnce([ssoConnector]);
 
     const { ssoConnectors } = await getFullSignInExperience();
 
@@ -159,7 +151,6 @@ describe('get sso connectors', () => {
       {
         id: ssoConnector.id,
         connectorName: ssoConnector.connectorName,
-        domains: ssoConnector.domains,
         logo: ssoConnectorFactories[ssoConnector.providerName].logo,
         darkLogo: undefined,
       },

--- a/packages/core/src/libraries/sign-in-experience/index.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.ts
@@ -67,7 +67,7 @@ export const createSignInExperienceLibrary = (
 
     return ssoConnectors.reduce<SsoConnectorMetadata[]>(
       (previous, connector): SsoConnectorMetadata[] => {
-        const { providerName, connectorName, config, id, branding, domains } = connector;
+        const { providerName, connectorName, config, id, branding } = connector;
         const factory = ssoConnectorFactories[providerName];
 
         // Filter out sso connectors that has invalid config
@@ -81,7 +81,6 @@ export const createSignInExperienceLibrary = (
         const connectorMetadata: SsoConnectorMetadata = {
           id,
           connectorName,
-          domains,
           logo: branding.logo ?? factory.logo,
           darkLogo: branding.darkLogo,
         };

--- a/packages/core/src/libraries/sso-connector.test.ts
+++ b/packages/core/src/libraries/sso-connector.test.ts
@@ -1,4 +1,4 @@
-import { mockSsoConnector } from '#src/__mocks__/sso.js';
+import { mockSsoConnector, wellConfiguredSsoConnector } from '#src/__mocks__/sso.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { MockQueries } from '#src/test-utils/tenant.js';
 
@@ -38,20 +38,39 @@ describe('SsoConnectorLibrary', () => {
   it('getAvailableSsoConnectors() should filter sso connectors with invalid config', async () => {
     const { getAvailableSsoConnectors } = ssoConnectorLibrary;
 
-    const wellSetSsoConnectors = {
-      ...mockSsoConnector,
-      config: {
-        clientId: 'foo',
-        clientSecret: 'bar',
-        issuer: 'https://foo.com',
-      },
-    };
-
-    findAllSsoConnectors.mockResolvedValueOnce([2, [mockSsoConnector, wellSetSsoConnectors]]);
+    findAllSsoConnectors.mockResolvedValueOnce([
+      2,
+      [
+        {
+          ...mockSsoConnector,
+          domains: ['foo.com'],
+        },
+        wellConfiguredSsoConnector,
+      ],
+    ]);
 
     const connectors = await getAvailableSsoConnectors();
 
-    expect(connectors).toEqual([wellSetSsoConnectors]);
+    expect(connectors).toEqual([wellConfiguredSsoConnector]);
+  });
+
+  it('getAvailableSsoConnectors() should filter sso connectors with empty domains', async () => {
+    const { getAvailableSsoConnectors } = ssoConnectorLibrary;
+
+    findAllSsoConnectors.mockResolvedValueOnce([
+      2,
+      [
+        {
+          ...mockSsoConnector,
+          config: wellConfiguredSsoConnector.config,
+        },
+        wellConfiguredSsoConnector,
+      ],
+    ]);
+
+    const connectors = await getAvailableSsoConnectors();
+
+    expect(connectors).toEqual([wellConfiguredSsoConnector]);
   });
 
   it('getSsoConnectorById() should throw 404 if the connector is not supported', async () => {

--- a/packages/core/src/libraries/sso-connector.test.ts
+++ b/packages/core/src/libraries/sso-connector.test.ts
@@ -35,6 +35,25 @@ describe('SsoConnectorLibrary', () => {
     expect(connectors).toEqual([mockSsoConnector]);
   });
 
+  it('getAvailableSsoConnectors() should filter sso connectors with invalid config', async () => {
+    const { getAvailableSsoConnectors } = ssoConnectorLibrary;
+
+    const wellSetSsoConnectors = {
+      ...mockSsoConnector,
+      config: {
+        clientId: 'foo',
+        clientSecret: 'bar',
+        issuer: 'https://foo.com',
+      },
+    };
+
+    findAllSsoConnectors.mockResolvedValueOnce([2, [mockSsoConnector, wellSetSsoConnectors]]);
+
+    const connectors = await getAvailableSsoConnectors();
+
+    expect(connectors).toEqual([wellSetSsoConnectors]);
+  });
+
   it('getSsoConnectorById() should throw 404 if the connector is not supported', async () => {
     const { getSsoConnectorById } = ssoConnectorLibrary;
 

--- a/packages/core/src/libraries/sso-connector.ts
+++ b/packages/core/src/libraries/sso-connector.ts
@@ -22,10 +22,12 @@ export const createSsoConnectorLibrary = (queries: Queries) => {
   const getAvailableSsoConnectors = async () => {
     const connectors = await getSsoConnectors();
 
-    return connectors.filter(({ providerName, config }) => {
+    return connectors.filter(({ providerName, config, domains }) => {
       const factory = ssoConnectorFactories[providerName];
+      const hasValidConfig = factory.configGuard.safeParse(config).success;
+      const hasValidDomains = domains.length > 0;
 
-      return factory.configGuard.safeParse(config).success;
+      return hasValidConfig && hasValidDomains;
     });
   };
 

--- a/packages/core/src/libraries/sso-connector.ts
+++ b/packages/core/src/libraries/sso-connector.ts
@@ -1,6 +1,7 @@
 import { assert } from '@silverhand/essentials';
 
 import RequestError from '#src/errors/RequestError/index.js';
+import { ssoConnectorFactories } from '#src/sso/index.js';
 import { type SupportedSsoConnector } from '#src/sso/types/index.js';
 import { isSupportedSsoConnector } from '#src/sso/utils.js';
 import type Queries from '#src/tenants/Queries.js';
@@ -16,6 +17,16 @@ export const createSsoConnectorLibrary = (queries: Queries) => {
     return entities.filter((connector): connector is SupportedSsoConnector =>
       isSupportedSsoConnector(connector)
     );
+  };
+
+  const getAvailableSsoConnectors = async () => {
+    const connectors = await getSsoConnectors();
+
+    return connectors.filter(({ providerName, config }) => {
+      const factory = ssoConnectorFactories[providerName];
+
+      return factory.configGuard.safeParse(config).success;
+    });
   };
 
   const getSsoConnectorById = async (id: string) => {
@@ -35,6 +46,7 @@ export const createSsoConnectorLibrary = (queries: Queries) => {
 
   return {
     getSsoConnectors,
+    getAvailableSsoConnectors,
     getSsoConnectorById,
   };
 };

--- a/packages/core/src/routes/interaction/single-sign-on.ts
+++ b/packages/core/src/routes/interaction/single-sign-on.ts
@@ -26,7 +26,7 @@ export default function singleSignOnRoutes<T extends IRouterParamContext>(
     libraries: { ssoConnector },
   } = tenant;
 
-  // Create Sso authorization url for user interaction
+  // Create SSO authorization url for user interaction
   router.post(
     `${interactionPrefix}/${ssoPath}/:connectorId/authentication`,
     koaGuard({
@@ -101,7 +101,7 @@ export default function singleSignOnRoutes<T extends IRouterParamContext>(
     }
   );
 
-  // Get the available Sso connectors for the user to choose from
+  // Get the available SSO connectors for the user to choose from by a given email
   router.get(
     `${interactionPrefix}/${ssoPath}/connectors`,
     koaGuard({

--- a/packages/integration-tests/src/api/interaction-sso.ts
+++ b/packages/integration-tests/src/api/interaction-sso.ts
@@ -19,3 +19,19 @@ export const getSsoAuthorizationUrl = async (
     })
     .json<{ redirectTo: string }>();
 };
+
+export const getSsoConnectorsByEmail = async (
+  cookie: string,
+  data: {
+    email: string;
+  }
+) => {
+  return api
+    .get(`interaction/${ssoPath}/connectors`, {
+      headers: { cookie },
+      searchParams: {
+        email: data.email,
+      },
+    })
+    .json<Array<{ id: string; ssoOnly: boolean }>>();
+};

--- a/packages/integration-tests/src/tests/api/interaction/single-sign-on/happy-path.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/single-sign-on/happy-path.test.ts
@@ -13,7 +13,7 @@ describe('Single Sign On Happy Path', () => {
   const redirectUri = 'http://foo.dev/callback';
 
   beforeAll(async () => {
-    const { id, connectorName, domains } = await createSsoConnector({
+    const { id, connectorName } = await createSsoConnector({
       providerName: ProviderName.OIDC,
       connectorName: 'test-oidc',
       config: {
@@ -23,7 +23,7 @@ describe('Single Sign On Happy Path', () => {
       },
     });
 
-    connectorIdMap.set(id, { id, connectorName, domains, logo: '' });
+    connectorIdMap.set(id, { id, connectorName, logo: '' });
   });
 
   afterAll(async () => {

--- a/packages/integration-tests/src/tests/api/well-known.test.ts
+++ b/packages/integration-tests/src/tests/api/well-known.test.ts
@@ -61,6 +61,7 @@ describe('.well-known api', () => {
     const newOIDCSsoConnector = {
       providerName: 'OIDC',
       connectorName: 'OIDC sso connector',
+      domains: ['logto.io'],
       branding: {
         logo: 'https://logto.io/oidc-logo.png',
         darkLogo: 'https://logto.io/oidc-dark-logo.png',

--- a/packages/integration-tests/src/tests/api/well-known.test.ts
+++ b/packages/integration-tests/src/tests/api/well-known.test.ts
@@ -73,7 +73,7 @@ describe('.well-known api', () => {
     };
 
     it('should get the sso connectors in sign-in experience', async () => {
-      const { id, connectorName, domains } = await createSsoConnector(newOIDCSsoConnector);
+      const { id, connectorName } = await createSsoConnector(newOIDCSsoConnector);
 
       const signInExperience = await api
         .get('.well-known/sign-in-exp')
@@ -88,7 +88,6 @@ describe('.well-known api', () => {
       expect(newCreatedConnector).toMatchObject({
         id,
         connectorName,
-        domains,
         logo: newOIDCSsoConnector.branding.logo,
         darkLogo: newOIDCSsoConnector.branding.darkLogo,
       });

--- a/packages/integration-tests/src/tests/api/well-known.test.ts
+++ b/packages/integration-tests/src/tests/api/well-known.test.ts
@@ -95,5 +95,39 @@ describe('.well-known api', () => {
 
       await deleteSsoConnectorById(id);
     });
+
+    it('should filter out the sso connectors with invalid config', async () => {
+      const { id } = await createSsoConnector({
+        ...newOIDCSsoConnector,
+        config: {},
+      });
+
+      const signInExperience = await api
+        .get('.well-known/sign-in-exp')
+        .json<SignInExperience & { ssoConnectors: SsoConnectorMetadata[] }>();
+
+      const { ssoConnectors } = signInExperience;
+
+      expect(ssoConnectors.find((connector) => connector.id === id)).toBeUndefined();
+
+      await deleteSsoConnectorById(id);
+    });
+
+    it('should filter out the sso connectors with empty domains', async () => {
+      const { id } = await createSsoConnector({
+        ...newOIDCSsoConnector,
+        domains: [],
+      });
+
+      const signInExperience = await api
+        .get('.well-known/sign-in-exp')
+        .json<SignInExperience & { ssoConnectors: SsoConnectorMetadata[] }>();
+
+      const { ssoConnectors } = signInExperience;
+
+      expect(ssoConnectors.find((connector) => connector.id === id)).toBeUndefined();
+
+      await deleteSsoConnectorById(id);
+    });
   });
 });

--- a/packages/schemas/src/types/sso-connector.ts
+++ b/packages/schemas/src/types/sso-connector.ts
@@ -6,7 +6,6 @@ import { z } from 'zod';
 export const ssoConnectorMetadataGuard = z.object({
   id: z.string(),
   connectorName: z.string(),
-  domains: z.array(z.string()),
   logo: z.string(),
   darkLogo: z.string().optional(),
 });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
 Add get sso-connectors by email interaction api.

This PR includes the following update:

- extract a new sso connector library method `getAvailableSsoConnectors`. This method should query sso connectors from the DB and filter out those with invalid connector configs or empty domain settings.
- remove the `domains` property from the `ssoConnectorMetadata`. All the `domains` mapping and validation logic should kept in backend, instead of return everything to the client side.
- add a new interaction api: `GET /interaction/sso/connectors?email=XXX`. Allow the client side to fetch available connectors by a given email address.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
ut + integration test

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
