### PR TITLE
refactor(core): disable org apis for non-dev envs

### DIFF
--- a/packages/core/src/routes/organization/index.ts
+++ b/packages/core/src/routes/organization/index.ts
@@ -9,6 +9,7 @@ import { type Optional, cond, yes } from '@silverhand/essentials';
 import { z } from 'zod';
 
 import { type SearchOptions } from '#src/database/utils.js';
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
@@ -23,6 +24,11 @@ import organizationScopeRoutes from './scopes.js';
 import { errorHandler } from './utils.js';
 
 export default function organizationRoutes<T extends AuthedRouter>(...args: RouterInitArgs<T>) {
+  // Remove after the feature is ready
+  if (!EnvSet.values.isDevFeaturesEnabled) {
+    return;
+  }
+
   const [
     originalRouter,
     {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
disable for non-dev envs until the feature is ready.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
setting `NODE_ENV` to `production`, organization routes return 404

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
