### PR TITLE
feat(core): add single sign on authentication api

### DIFF
--- a/packages/core/src/libraries/sign-in-experience/index.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.ts
@@ -64,7 +64,7 @@ export const createSignInExperienceLibrary = (
   };
 
   const getActiveSsoConnectors = async (): Promise<SsoConnectorMetadata[]> => {
-    // TODO: @simeng-li Return empty array if dev features are not enabled
+    // TODO: @simeng-li Remove the dev feature check once SSO is fully released
     if (!EnvSet.values.isDevFeaturesEnabled) {
       return [];
     }

--- a/packages/core/src/queries/user-sso-identities.ts
+++ b/packages/core/src/queries/user-sso-identities.ts
@@ -1,0 +1,32 @@
+import {
+  type UserSsoIdentityKeys,
+  type CreateUserSsoIdentity,
+  type UserSsoIdentity,
+  UserSsoIdentities,
+} from '@logto/schemas';
+import { type Nullable } from '@silverhand/essentials';
+import { sql, type CommonQueryMethods } from 'slonik';
+
+import SchemaQueries from '#src/utils/SchemaQueries.js';
+
+export default class UserSsoIdentityQueries extends SchemaQueries<
+  UserSsoIdentityKeys,
+  CreateUserSsoIdentity,
+  UserSsoIdentity
+> {
+  constructor(pool: CommonQueryMethods) {
+    super(pool, UserSsoIdentities);
+  }
+
+  async findUserSsoIdentityBySsoIdentityId(
+    issuer: string,
+    ssoIdentityId: string
+  ): Promise<Nullable<UserSsoIdentity>> {
+    return this.pool.maybeOne<UserSsoIdentity>(sql`
+      select user_id
+      from ${UserSsoIdentities.table}
+      where ${UserSsoIdentities.fields.issuer} = ${issuer}
+      and  ${UserSsoIdentities.fields.identityId} = ${ssoIdentityId}
+    `);
+  }
+}

--- a/packages/core/src/queries/user-sso-identities.ts
+++ b/packages/core/src/queries/user-sso-identities.ts
@@ -23,7 +23,7 @@ export default class UserSsoIdentityQueries extends SchemaQueries<
     ssoIdentityId: string
   ): Promise<Nullable<UserSsoIdentity>> {
     return this.pool.maybeOne<UserSsoIdentity>(sql`
-      select user_id
+      select *
       from ${UserSsoIdentities.table}
       where ${UserSsoIdentities.fields.issuer} = ${issuer}
       and  ${UserSsoIdentities.fields.identityId} = ${ssoIdentityId}

--- a/packages/core/src/routes/interaction/index.test.ts
+++ b/packages/core/src/routes/interaction/index.test.ts
@@ -125,6 +125,11 @@ const tenantContext = new MockTenant(
       // @ts-expect-error
       return connector as LogtoConnector;
     },
+  },
+  {
+    ssoConnectors: {
+      getAvailableSsoConnectors: jest.fn().mockResolvedValue([]),
+    },
   }
 );
 

--- a/packages/core/src/routes/interaction/index.ts
+++ b/packages/core/src/routes/interaction/index.ts
@@ -33,6 +33,7 @@ import {
   verifyIdentifierSettings,
   verifyProfileSettings,
 } from './utils/sign-in-experience-validation.js';
+import { verifySsoOnlyEmailIdentifier } from './utils/single-sign-on-guard.js';
 import { validatePassword } from './utils/validate-password.js';
 import {
   verifyIdentifierPayload,
@@ -82,6 +83,7 @@ export default function interactionRoutes<T extends AnonymousRouter>(
 
       if (identifier && event !== InteractionEvent.ForgotPassword) {
         verifyIdentifierSettings(identifier, signInExperience);
+        await verifySsoOnlyEmailIdentifier(libraries.ssoConnectors, identifier);
       }
 
       if (profile && event !== InteractionEvent.ForgotPassword) {
@@ -181,6 +183,7 @@ export default function interactionRoutes<T extends AnonymousRouter>(
 
       if (interactionStorage.event !== InteractionEvent.ForgotPassword) {
         verifyIdentifierSettings(identifierPayload, signInExperience);
+        await verifySsoOnlyEmailIdentifier(libraries.ssoConnectors, identifierPayload);
       }
 
       const verifiedIdentifier = await verifyIdentifierPayload(

--- a/packages/core/src/routes/interaction/single-sign-on.ts
+++ b/packages/core/src/routes/interaction/single-sign-on.ts
@@ -53,7 +53,7 @@ export default function singleSignOnRoutes<T extends IRouterParamContext>(
 
       /* 
         Create a new sign-in interaction directly. 
-        Unlike our existing interaction APIs, to simply the call stack, client side does not need to call the PUT interaction API ahead.
+        Unlike our existing interaction APIs, to simplify the call stack, client side does not need to call the PUT interaction API ahead.
         This step is necessary for our interaction hooks to work. As it reads the event from the interaction storage.
        */
       createLog(`Interaction.SignIn.Update`);

--- a/packages/core/src/routes/interaction/single-sign-on.ts
+++ b/packages/core/src/routes/interaction/single-sign-on.ts
@@ -1,5 +1,3 @@
-import { ConnectorError, type ConnectorSession } from '@logto/connector-kit';
-import { validateRedirectUrl } from '@logto/core-kit';
 import { InteractionEvent } from '@logto/schemas';
 import type Router from 'koa-router';
 import { type IRouterParamContext } from 'koa-router';
@@ -8,15 +6,19 @@ import { z } from 'zod';
 import RequestError from '#src/errors/RequestError/index.js';
 import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
 import koaGuard from '#src/middleware/koa-guard.js';
-import { OidcSsoConnector } from '#src/sso/OidcSsoConnector/index.js';
-import { ssoConnectorFactories } from '#src/sso/index.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 
 import { interactionPrefix, ssoPath } from './const.js';
 import type { WithInteractionDetailsContext } from './middleware/koa-interaction-details.js';
-import { getInteractionStorage } from './utils/interaction.js';
-import { assignConnectorSessionResult } from './utils/social-verification.js';
+import koaInteractionHooks from './middleware/koa-interaction-hooks.js';
+import { getInteractionStorage, storeInteractionResult } from './utils/interaction.js';
+import {
+  oidcAuthorizationUrlPayloadGuard,
+  getSsoAuthorizationUrl,
+  getSsoAuthentication,
+  signInWithSsoAuthentication,
+} from './utils/single-sign-on.js';
 
 export default function singleSignOnRoutes<T extends IRouterParamContext>(
   router: Router<unknown, WithInteractionDetailsContext<WithLogContext<T>>>,
@@ -25,8 +27,11 @@ export default function singleSignOnRoutes<T extends IRouterParamContext>(
   const {
     id: tenantId,
     provider,
-    libraries: { ssoConnector },
+    libraries,
+    queries: { userSsoIdentities: userSsoIdentitiesQueries },
   } = tenant;
+
+  const { ssoConnectors: ssoConnectorsLibrary } = libraries;
 
   // Create SSO authorization url for user interaction
   router.post(
@@ -35,69 +40,88 @@ export default function singleSignOnRoutes<T extends IRouterParamContext>(
       params: z.object({
         connectorId: z.string(),
       }),
-      body: z.object({
-        state: z.string().min(1),
-        redirectUri: z.string().refine((url) => validateRedirectUrl(url, 'web')),
-      }),
+      // Only required for OIDC
+      body: oidcAuthorizationUrlPayloadGuard.optional(),
       status: [200, 500, 404],
       response: z.object({
         redirectTo: z.string(),
       }),
     }),
     async (ctx, next) => {
-      const { interactionDetails, guard, createLog } = ctx;
-
-      // Check interaction exists
-      const { event } = getInteractionStorage(interactionDetails.result);
-
-      assertThat(
-        event !== InteractionEvent.ForgotPassword,
-        'session.not_supported_for_forgot_password'
-      );
-
-      const log = createLog(`Interaction.${event}.Identifier.SingleSignOn.Create`);
+      const { guard, createLog } = ctx;
 
       const {
         params: { connectorId },
+        body: payload,
       } = guard;
 
-      const { body: payload } = guard;
-
-      log.append({
-        connectorId,
-        ...payload,
-      });
-
-      const { state, redirectUri } = payload;
-      assertThat(state && redirectUri, 'session.insufficient_info');
+      /* 
+        Create a new sign-in interaction directly. 
+        Unlike our existing interaction APIs, to simply the call stack, client side does not need to call the PUT interaction API ahead.
+        This step is necessary for our interaction hooks to work. As it reads the event from the interaction storage.
+       */
+      createLog(`Interaction.SignIn.Update`);
+      await storeInteractionResult({ event: InteractionEvent.SignIn }, ctx, provider);
 
       // Will throw 404 if connector not found, or not supported
-      const connectorData = await ssoConnector.getSsoConnectorById(connectorId);
+      const connectorData = await ssoConnectorsLibrary.getSsoConnectorById(connectorId);
 
-      try {
-        // Will throw ConnectorError if the config is invalid
-        const factory = ssoConnectorFactories[connectorData.providerName];
-        const connectorInstance = new factory.constructor(connectorData, tenantId);
+      const redirectTo = await getSsoAuthorizationUrl(ctx, tenant, connectorData, payload);
+      ctx.body = { redirectTo };
 
-        if (connectorInstance instanceof OidcSsoConnector) {
-          const redirectTo = await connectorInstance.getAuthorizationUrl(
-            { state, redirectUri },
-            async (connectorSession: ConnectorSession) =>
-              assignConnectorSessionResult(ctx, provider, connectorSession)
-          );
+      return next();
+    }
+  );
 
-          ctx.body = { redirectTo };
-        }
+  // Verify the user's single sign on identity and sign in the user
+  router.post(
+    `${interactionPrefix}/${ssoPath}/:connectorId/authentication`,
+    koaGuard({
+      params: z.object({
+        connectorId: z.string(),
+      }),
+      body: z.record(z.unknown()),
+      status: [200, 404],
+      response: z.object({
+        redirectTo: z.string(),
+      }),
+    }),
+    koaInteractionHooks(libraries),
+    async (ctx, next) => {
+      const { guard, interactionDetails } = ctx;
 
-        // TODO: Add SAML `getSingleSignOnUrl` here
-      } catch (error: unknown) {
-        // Catch ConnectorError and re-throw as 500 RequestError
-        if (error instanceof ConnectorError) {
-          throw new RequestError({ code: `connector.${error.code}`, status: 500 }, error.data);
-        }
+      // Check SSO interaction exists
+      const { event } = getInteractionStorage(interactionDetails.result);
+      assertThat(event === InteractionEvent.SignIn, 'session.connector_session_not_found');
 
-        throw error;
+      const {
+        params: { connectorId },
+        body: data,
+      } = guard;
+
+      // Will throw 404 if connector not found, or not supported
+      const connectorData = await ssoConnectorsLibrary.getSsoConnectorById(connectorId);
+
+      // Get authenticated from the SSO provider
+      const ssoAuthentication = await getSsoAuthentication(ctx, tenant, connectorData, data);
+      const { issuer, userInfo } = ssoAuthentication;
+
+      // Get logto user info
+      const userSsoIdentity = await userSsoIdentitiesQueries.findUserSsoIdentityBySsoIdentityId(
+        issuer,
+        userInfo.id
+      );
+
+      // SignIn Flow
+      if (userSsoIdentity) {
+        await signInWithSsoAuthentication(ctx, tenant, {
+          connectorData,
+          userSsoIdentity,
+          ssoAuthentication,
+        });
       }
+
+      // Register Flow
 
       return next();
     }
@@ -120,7 +144,7 @@ export default function singleSignOnRoutes<T extends IRouterParamContext>(
     }),
     async (ctx, next) => {
       const { email } = ctx.guard.query;
-      const connectors = await ssoConnector.getAvailableSsoConnectors();
+      const connectors = await ssoConnectorsLibrary.getAvailableSsoConnectors();
 
       const domain = email.split('@')[1];
 

--- a/packages/core/src/routes/interaction/utils/single-sign-on-guard.test.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on-guard.test.ts
@@ -1,0 +1,83 @@
+import { wellConfiguredSsoConnector } from '#src/__mocks__/sso.js';
+import RequestError from '#src/errors/RequestError/index.js';
+import { type SsoConnectorLibrary } from '#src/libraries/sso-connector.js';
+
+import { verifySsoOnlyEmailIdentifier } from './single-sign-on-guard.js';
+
+const { jest } = import.meta;
+
+const getAvailableSsoConnectorsMock = jest.fn();
+
+const mockSsoConnectorLibrary: SsoConnectorLibrary = {
+  getAvailableSsoConnectors: getAvailableSsoConnectorsMock,
+  getSsoConnectors: jest.fn(),
+  getSsoConnectorById: jest.fn(),
+};
+
+describe('verifySsoOnlyEmailIdentifier tests', () => {
+  it('should return if the identifier is not an email', async () => {
+    await expect(
+      verifySsoOnlyEmailIdentifier(mockSsoConnectorLibrary, {
+        username: 'foo',
+        password: 'bar',
+      })
+    ).resolves.not.toThrow();
+  });
+  it('should return if no sso connectors found with the given email', async () => {
+    getAvailableSsoConnectorsMock.mockResolvedValueOnce([
+      {
+        ...wellConfiguredSsoConnector,
+        domains: ['example.com'],
+      },
+    ]);
+
+    await expect(
+      verifySsoOnlyEmailIdentifier(mockSsoConnectorLibrary, {
+        email: 'foo@bar.com',
+        password: 'bar',
+      })
+    ).resolves.not.toThrow();
+  });
+  it('should return if the connector is not sso only', async () => {
+    getAvailableSsoConnectorsMock.mockResolvedValueOnce([
+      {
+        ...wellConfiguredSsoConnector,
+        domains: ['example.com'],
+        ssoOnly: false,
+      },
+    ]);
+
+    await expect(
+      verifySsoOnlyEmailIdentifier(mockSsoConnectorLibrary, {
+        email: 'foo@example.com',
+        password: 'bar',
+      })
+    ).resolves.not.toThrow();
+  });
+
+  it('should throw an error if multiple sso connectors found with the given email', async () => {
+    const connector = {
+      ...wellConfiguredSsoConnector,
+      domains: ['example.com'],
+    };
+
+    getAvailableSsoConnectorsMock.mockResolvedValueOnce([connector]);
+
+    await expect(
+      verifySsoOnlyEmailIdentifier(mockSsoConnectorLibrary, {
+        email: 'foo@example.com',
+        verificationCode: 'bar',
+      })
+    ).rejects.toMatchError(
+      new RequestError(
+        {
+          code: 'session.sso_enabled',
+          status: 422,
+        },
+        {
+          ssoConnectors: [connector],
+        }
+      )
+    );
+  });
+});

--- a/packages/core/src/routes/interaction/utils/single-sign-on-guard.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on-guard.ts
@@ -1,0 +1,43 @@
+import { type IdentifierPayload } from '@logto/schemas';
+
+import { EnvSet } from '#src/env-set/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
+import { type SsoConnectorLibrary } from '#src/libraries/sso-connector.js';
+import assertThat from '#src/utils/assert-that.js';
+
+// Guard the SSO only email identifier
+export const verifySsoOnlyEmailIdentifier = async (
+  { getAvailableSsoConnectors }: SsoConnectorLibrary,
+  identifier: IdentifierPayload
+) => {
+  // TODO: @simeng-li remove the dev features check when the SSO feature is released
+  if (!('email' in identifier) || !EnvSet.values.isDevFeaturesEnabled) {
+    return;
+  }
+
+  const { email } = identifier;
+  const availableSsoConnectors = await getAvailableSsoConnectors();
+  const domain = email.split('@')[1];
+
+  // Invalid email domain
+  if (!domain) {
+    return;
+  }
+
+  const availableConnectors = availableSsoConnectors.filter(
+    ({ domains, ssoOnly }) => domains.includes(domain) && ssoOnly
+  );
+
+  assertThat(
+    availableConnectors.length === 0,
+    new RequestError(
+      {
+        code: 'session.sso_enabled',
+        status: 422,
+      },
+      {
+        ssoConnectors: availableConnectors,
+      }
+    )
+  );
+};

--- a/packages/core/src/routes/interaction/utils/single-sign-on.test.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on.test.ts
@@ -1,4 +1,5 @@
-import { type SsoConnector } from '@logto/schemas';
+import { InteractionEvent, type SsoConnector } from '@logto/schemas';
+import { createMockUtils } from '@logto/shared/esm';
 
 import { mockSsoConnector, wellConfiguredSsoConnector } from '#src/__mocks__/sso.js';
 import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
@@ -10,18 +11,36 @@ import { MockTenant } from '#src/test-utils/tenant.js';
 import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
 
 const { jest } = import.meta;
+const { mockEsm } = createMockUtils(jest);
 
 const getAuthorizationUrlMock = jest.fn();
+const getIssuerMock = jest.fn();
+const getUserInfoMock = jest.fn();
+const findUserSsoIdentityBySsoIdentityIdMock = jest.fn();
+const updateUserSsoIdentityMock = jest.fn();
+const insertUserSsoIdentityMock = jest.fn();
+const updateUserMock = jest.fn();
+const findUserByEmailMock = jest.fn();
+const insertUserMock = jest.fn();
+const storeInteractionResultMock = jest.fn();
 
 class MockOidcSsoConnector extends OidcSsoConnector {
   override getAuthorizationUrl = getAuthorizationUrlMock;
+  override getIssuer = getIssuerMock;
+  override getUserInfo = getUserInfoMock;
 }
+
+mockEsm('./interaction.js', () => ({
+  storeInteractionResult: storeInteractionResultMock,
+}));
 
 jest
   .spyOn(ssoConnectorFactories.OIDC, 'constructor')
   .mockImplementation((data: SsoConnector) => new MockOidcSsoConnector(data));
 
-const { getSsoAuthorizationUrl } = await import('./single-sign-on.js');
+const { getSsoAuthorizationUrl, getSsoAuthentication, handleSsoAuthentication } = await import(
+  './single-sign-on.js'
+);
 
 describe('Single sign on util methods tests', () => {
   const mockContext: WithLogContext = {
@@ -30,7 +49,30 @@ describe('Single sign on util methods tests', () => {
   };
 
   const mockProvider = createMockProvider();
-  const tenant = new MockTenant(mockProvider);
+  const tenant = new MockTenant(
+    mockProvider,
+    {
+      userSsoIdentities: {
+        findUserSsoIdentityBySsoIdentityId: findUserSsoIdentityBySsoIdentityIdMock,
+        updateById: updateUserSsoIdentityMock,
+        insert: insertUserSsoIdentityMock,
+      },
+      users: {
+        updateUserById: updateUserMock,
+        findUserByEmail: findUserByEmailMock,
+      },
+    },
+    undefined,
+    {
+      users: {
+        insertUser: insertUserMock,
+      },
+    }
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
   describe('getSsoAuthorizationUrl tests', () => {
     it('should throw an error if the connector config is invalid', async () => {
@@ -58,6 +100,162 @@ describe('Single sign on util methods tests', () => {
           redirectUri: 'https://example.com',
         })
       ).resolves.toBe('https://example.com');
+    });
+  });
+
+  describe('getSsoAuthentication tests', () => {
+    it('should throw an error if the connector config is invalid', async () => {
+      await expect(getSsoAuthentication(mockContext, tenant, mockSsoConnector)).rejects.toThrow(
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        expect.objectContaining({ status: 500, code: `connector.invalid_config` })
+      );
+    });
+
+    it('should return the authentication result', async () => {
+      getUserInfoMock.mockResolvedValueOnce({ id: 'id', email: 'email' });
+      getIssuerMock.mockReturnValueOnce('https://example.com');
+
+      const result = await getSsoAuthentication(mockContext, tenant, wellConfiguredSsoConnector);
+
+      expect(getIssuerMock).toBeCalled();
+      expect(getUserInfoMock).toBeCalled();
+
+      expect(result).toStrictEqual({
+        issuer: 'https://example.com',
+        userInfo: { id: 'id', email: 'email' },
+      });
+    });
+  });
+
+  describe('handleSsoAuthentication tests', () => {
+    const mockIssuer = 'https://example.com';
+    const mockSsoUserInfo = {
+      id: 'identityId',
+      email: 'foo@logto.io',
+      name: 'foo',
+      avatar: 'https://example.com',
+    };
+
+    it('should signIn directly if the user is found', async () => {
+      findUserSsoIdentityBySsoIdentityIdMock.mockResolvedValueOnce({
+        id: 'ssoIdentityId',
+        userId: 'foo',
+        issuer: mockIssuer,
+      });
+
+      const accountId = await handleSsoAuthentication(
+        mockContext,
+        tenant,
+        wellConfiguredSsoConnector,
+        {
+          issuer: mockIssuer,
+          userInfo: mockSsoUserInfo,
+        }
+      );
+
+      expect(accountId).toBe('foo');
+
+      expect(findUserSsoIdentityBySsoIdentityIdMock).toBeCalledWith(mockIssuer, mockSsoUserInfo.id);
+
+      // Should update the user sso identity
+      expect(updateUserSsoIdentityMock).toBeCalledWith('ssoIdentityId', {
+        detail: mockSsoUserInfo,
+      });
+
+      // Should update the user with syncProfile enabled
+      expect(updateUserMock).toBeCalledWith('foo', {
+        name: mockSsoUserInfo.name,
+        avatar: mockSsoUserInfo.avatar,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        lastSignInAt: expect.any(Number),
+      });
+    });
+
+    it('should signIn and link the sso identity if the user with the same email is found', async () => {
+      findUserSsoIdentityBySsoIdentityIdMock.mockResolvedValueOnce(null);
+      findUserByEmailMock.mockResolvedValueOnce({ id: 'foo', email: mockSsoUserInfo.email });
+
+      const accountId = await handleSsoAuthentication(
+        mockContext,
+        tenant,
+        {
+          ...wellConfiguredSsoConnector,
+          syncProfile: false,
+        },
+        {
+          issuer: mockIssuer,
+          userInfo: mockSsoUserInfo,
+        }
+      );
+
+      expect(accountId).toBe('foo');
+
+      expect(findUserByEmailMock).lastCalledWith(mockSsoUserInfo.email);
+
+      // Should create new user sso identity
+      expect(insertUserSsoIdentityMock).toBeCalledWith({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        id: expect.any(String),
+        userId: 'foo',
+        identityId: mockSsoUserInfo.id,
+        issuer: mockIssuer,
+        detail: mockSsoUserInfo,
+      });
+
+      // Should update the user with syncProfile enabled
+      expect(updateUserMock).toBeCalledWith('foo', {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        lastSignInAt: expect.any(Number),
+      });
+    });
+
+    it('should register if no related user account found', async () => {
+      findUserSsoIdentityBySsoIdentityIdMock.mockResolvedValueOnce(null);
+      findUserByEmailMock.mockResolvedValueOnce(null);
+      insertUserMock.mockResolvedValueOnce({ id: 'foo' });
+
+      const accountId = await handleSsoAuthentication(
+        mockContext,
+        tenant,
+        wellConfiguredSsoConnector,
+        {
+          issuer: mockIssuer,
+          userInfo: mockSsoUserInfo,
+        }
+      );
+
+      expect(accountId).toBe('foo');
+
+      // Should update the interaction session event to register
+      expect(storeInteractionResultMock).toBeCalledWith(
+        { event: InteractionEvent.Register },
+        mockContext,
+        mockProvider
+      );
+
+      // Should create new user
+      expect(insertUserMock).toBeCalledWith(
+        {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          id: expect.any(String),
+          name: mockSsoUserInfo.name,
+          avatar: mockSsoUserInfo.avatar,
+          primaryEmail: mockSsoUserInfo.email,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          lastSignInAt: expect.any(Number),
+        },
+        []
+      );
+
+      // Should create new user sso identity
+      expect(insertUserSsoIdentityMock).toBeCalledWith({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        id: expect.any(String),
+        userId: 'foo',
+        identityId: mockSsoUserInfo.id,
+        issuer: mockIssuer,
+        detail: mockSsoUserInfo,
+      });
     });
   });
 });

--- a/packages/core/src/routes/interaction/utils/single-sign-on.test.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on.test.ts
@@ -24,16 +24,15 @@ jest
 const { getSsoAuthorizationUrl } = await import('./single-sign-on.js');
 
 describe('Single sign on util methods tests', () => {
+  const mockContext: WithLogContext = {
+    ...createContextWithRouteParameters(),
+    ...createMockLogContext(),
+  };
+
+  const mockProvider = createMockProvider();
+  const tenant = new MockTenant(mockProvider);
+
   describe('getSsoAuthorizationUrl tests', () => {
-    const mockContext: WithLogContext = {
-      ...createContextWithRouteParameters(),
-      ...createMockLogContext(),
-    };
-
-    const mockProvider = createMockProvider();
-
-    const tenant = new MockTenant(mockProvider);
-
     it('should throw an error if the connector config is invalid', async () => {
       await expect(getSsoAuthorizationUrl(mockContext, tenant, mockSsoConnector)).rejects.toThrow(
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument

--- a/packages/core/src/routes/interaction/utils/single-sign-on.test.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on.test.ts
@@ -26,6 +26,7 @@ const updateUserMock = jest.fn();
 const findUserByEmailMock = jest.fn();
 const insertUserMock = jest.fn();
 const storeInteractionResultMock = jest.fn();
+const getAvailableSsoConnectorsMock = jest.fn();
 
 class MockOidcSsoConnector extends OidcSsoConnector {
   override getAuthorizationUrl = getAuthorizationUrlMock;
@@ -54,6 +55,7 @@ describe('Single sign on util methods tests', () => {
   };
 
   const mockProvider = createMockProvider();
+
   const tenant = new MockTenant(
     mockProvider,
     {
@@ -71,6 +73,9 @@ describe('Single sign on util methods tests', () => {
     {
       users: {
         insertUser: insertUserMock,
+      },
+      ssoConnectors: {
+        getAvailableSsoConnectors: getAvailableSsoConnectorsMock,
       },
     }
   );

--- a/packages/core/src/routes/interaction/utils/single-sign-on.test.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on.test.ts
@@ -1,0 +1,64 @@
+import { type SsoConnector } from '@logto/schemas';
+
+import { mockSsoConnector, wellConfiguredSsoConnector } from '#src/__mocks__/sso.js';
+import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
+import { OidcSsoConnector } from '#src/sso/OidcSsoConnector/index.js';
+import { ssoConnectorFactories } from '#src/sso/index.js';
+import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
+import { createMockProvider } from '#src/test-utils/oidc-provider.js';
+import { MockTenant } from '#src/test-utils/tenant.js';
+import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
+
+const { jest } = import.meta;
+
+const getAuthorizationUrlMock = jest.fn();
+
+class MockOidcSsoConnector extends OidcSsoConnector {
+  override getAuthorizationUrl = getAuthorizationUrlMock;
+}
+
+jest
+  .spyOn(ssoConnectorFactories.OIDC, 'constructor')
+  .mockImplementation((data: SsoConnector) => new MockOidcSsoConnector(data));
+
+const { getSsoAuthorizationUrl } = await import('./single-sign-on.js');
+
+describe('Single sign on util methods tests', () => {
+  describe('getSsoAuthorizationUrl tests', () => {
+    const mockContext: WithLogContext = {
+      ...createContextWithRouteParameters(),
+      ...createMockLogContext(),
+    };
+
+    const mockProvider = createMockProvider();
+
+    const tenant = new MockTenant(mockProvider);
+
+    it('should throw an error if the connector config is invalid', async () => {
+      await expect(getSsoAuthorizationUrl(mockContext, tenant, mockSsoConnector)).rejects.toThrow(
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        expect.objectContaining({ status: 500, code: `connector.invalid_config` })
+      );
+    });
+
+    it('should throw an error if OIDC connector is used without a proper payload', async () => {
+      await expect(
+        getSsoAuthorizationUrl(mockContext, tenant, wellConfiguredSsoConnector)
+      ).rejects.toThrow(
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        expect.objectContaining({ status: 400, code: 'session.insufficient_info' })
+      );
+    });
+
+    it('should call the connector getAuthorizationUrl method', async () => {
+      getAuthorizationUrlMock.mockResolvedValueOnce('https://example.com');
+
+      await expect(
+        getSsoAuthorizationUrl(mockContext, tenant, wellConfiguredSsoConnector, {
+          state: 'state',
+          redirectUri: 'https://example.com',
+        })
+      ).resolves.toBe('https://example.com');
+    });
+  });
+});

--- a/packages/core/src/routes/interaction/utils/single-sign-on.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on.ts
@@ -1,20 +1,22 @@
 import { type ConnectorSession, ConnectorError, type SocialUserInfo } from '@logto/connector-kit';
 import { validateRedirectUrl } from '@logto/core-kit';
-import { type UserSsoIdentity } from '@logto/schemas';
-import { conditional, trySafe } from '@silverhand/essentials';
+import { InteractionEvent, type User, type UserSsoIdentity } from '@logto/schemas';
+import { generateStandardId } from '@logto/shared';
+import { conditional } from '@silverhand/essentials';
 import { z } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
-import { assignInteractionResults } from '#src/libraries/session.js';
 import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
 import OidcConnector from '#src/sso/OidcConnector/index.js';
 import { ssoConnectorFactories } from '#src/sso/index.js';
 import { type SupportedSsoConnector } from '#src/sso/types/index.js';
+import type Queries from '#src/tenants/Queries.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 
 import { type WithInteractionHooksContext } from '../middleware/koa-interaction-hooks.js';
 
+import { storeInteractionResult } from './interaction.js';
 import { assignConnectorSessionResult, getConnectorSessionResult } from './social-verification.js';
 
 export const oidcAuthorizationUrlPayloadGuard = z.object({
@@ -24,6 +26,7 @@ export const oidcAuthorizationUrlPayloadGuard = z.object({
 
 type OidcAuthorizationUrlPayload = z.infer<typeof oidcAuthorizationUrlPayloadGuard>;
 
+// Get the authorization url for the SSO provider
 export const getSsoAuthorizationUrl = async (
   ctx: WithLogContext,
   { provider }: TenantContext,
@@ -73,6 +76,7 @@ type SsoAuthenticationResult = {
   userInfo: SocialUserInfo;
 };
 
+// Get the user authentication result from the SSO provider
 export const getSsoAuthentication = async (
   ctx: WithLogContext,
   { provider }: TenantContext,
@@ -114,12 +118,56 @@ export const getSsoAuthentication = async (
   }
 };
 
-export const signInWithSsoAuthentication = async (
+// Handle the SSO authentication result and return the user id
+export const handleSsoAuthentication = async (
   ctx: WithLogContext & WithInteractionHooksContext,
-  {
-    provider,
-    queries: { userSsoIdentities: userSsoIdentitiesQueries, users: usersQueries },
-  }: TenantContext,
+  tenant: TenantContext,
+  connectorData: SupportedSsoConnector,
+  ssoAuthentication: SsoAuthenticationResult
+): Promise<string> => {
+  const { createLog } = ctx;
+  const { provider, queries } = tenant;
+  const { userSsoIdentities: userSsoIdentitiesQueries, users: usersQueries } = queries;
+  const { issuer, userInfo } = ssoAuthentication;
+
+  // Get logto user info
+  const userSsoIdentity = await userSsoIdentitiesQueries.findUserSsoIdentityBySsoIdentityId(
+    issuer,
+    userInfo.id
+  );
+
+  // SignIn
+  if (userSsoIdentity) {
+    return signInWithSsoAuthentication(ctx, queries, {
+      connectorData,
+      userSsoIdentity,
+      ssoAuthentication,
+    });
+  }
+
+  const user = userInfo.email && (await usersQueries.findUserByEmail(userInfo.email));
+
+  // SignIn and link with existing user account with a same email
+  if (user) {
+    return signInAndLinkWithSsoAuthentication(ctx, queries, {
+      connectorData,
+      user,
+      ssoAuthentication,
+    });
+  }
+
+  // Update the interaction session event to register if no related user account found
+  const registerEventUpdateLog = createLog(`Interaction.Register.Update`);
+  registerEventUpdateLog.append({ event: 'register' });
+  await storeInteractionResult({ event: InteractionEvent.Register }, ctx, provider);
+
+  // Register
+  return registerWithSsoAuthentication(ctx, tenant, connectorData, ssoAuthentication);
+};
+
+const signInWithSsoAuthentication = async (
+  ctx: WithLogContext & WithInteractionHooksContext,
+  { userSsoIdentities: userSsoIdentitiesQueries, users: usersQueries }: Queries,
   {
     connectorData: { id: connectorId, syncProfile },
     userSsoIdentity: { id, userId },
@@ -130,18 +178,17 @@ export const signInWithSsoAuthentication = async (
     ssoAuthentication: SsoAuthenticationResult;
   }
 ) => {
-  const { createLog, assignInteractionHookResult } = ctx;
-
+  const { createLog } = ctx;
   const log = createLog(`Interaction.SignIn.Submit`);
 
-  const { userInfo } = ssoAuthentication;
+  const { userInfo, issuer } = ssoAuthentication;
 
   // Update the user's SSO identity details
   await userSsoIdentitiesQueries.updateById(id, {
     detail: userInfo,
   });
 
-  const { name, avatar } = userInfo;
+  const { name, avatar, id: identityId } = userInfo;
 
   // Sync the user name and avatar to the existing user if the connector has syncProfile enabled (sign-in)
   const syncingProfile = syncProfile
@@ -151,25 +198,135 @@ export const signInWithSsoAuthentication = async (
       }
     : undefined;
 
-  // Profile update should not block the sign-in process
-  await trySafe(async () =>
-    usersQueries.updateUserById(userId, {
-      ...syncingProfile,
-      lastSignInAt: Date.now(),
-    })
-  );
+  await usersQueries.updateUserById(userId, {
+    ...syncingProfile,
+    lastSignInAt: Date.now(),
+  });
 
   log.append({
     userId,
     interaction: {
+      event: InteractionEvent.SignIn,
       ssoIdentity: {
         connectorId,
-        ...ssoAuthentication,
+        issuer,
+        identityId,
       },
       profile: syncingProfile,
     },
   });
 
-  await assignInteractionResults(ctx, provider, { login: { accountId: userId } });
-  assignInteractionHookResult({ userId });
+  return userId;
+};
+
+const signInAndLinkWithSsoAuthentication = async (
+  ctx: WithLogContext & WithInteractionHooksContext,
+  { userSsoIdentities: userSsoIdentitiesQueries, users: usersQueries }: Queries,
+  {
+    connectorData: { id: connectorId, syncProfile },
+    user: { id: userId },
+    ssoAuthentication,
+  }: {
+    connectorData: SupportedSsoConnector;
+    user: User;
+    ssoAuthentication: SsoAuthenticationResult;
+  }
+) => {
+  const { createLog } = ctx;
+  const log = createLog(`Interaction.SignIn.Submit`);
+
+  const { issuer, userInfo } = ssoAuthentication;
+  const { name, avatar, id: identityId } = userInfo;
+
+  // Insert new user SSO identity
+  await userSsoIdentitiesQueries.insert({
+    id: generateStandardId(),
+    userId,
+    identityId,
+    issuer,
+    detail: userInfo,
+  });
+
+  // Sync the user name and avatar to the existing user if the connector has syncProfile enabled (sign-in)
+  const syncingProfile = syncProfile
+    ? {
+        ...conditional(name && { name }),
+        ...conditional(avatar && { avatar }),
+      }
+    : undefined;
+
+  await usersQueries.updateUserById(userId, {
+    ...syncingProfile,
+    lastSignInAt: Date.now(),
+  });
+
+  log.append({
+    userId,
+    interaction: {
+      event: InteractionEvent.SignIn,
+      ssoIdentity: {
+        connectorId,
+        issuer,
+        identityId,
+      },
+      profile: syncingProfile,
+    },
+  });
+
+  return userId;
+};
+
+const registerWithSsoAuthentication = async (
+  ctx: WithLogContext & WithInteractionHooksContext,
+  {
+    queries: { userSsoIdentities: userSsoIdentitiesQueries },
+    libraries: { users: usersLibrary },
+  }: TenantContext,
+  connectorData: SupportedSsoConnector,
+  ssoAuthentication: SsoAuthenticationResult
+) => {
+  const { createLog } = ctx;
+  const log = createLog(`Interaction.Register.Submit`);
+  const { issuer, userInfo } = ssoAuthentication;
+
+  // Only sync the name, avatar and email (conflict email account will be guarded ahead)
+  const syncingProfile = {
+    ...conditional(userInfo.name && { name: userInfo.name }),
+    ...conditional(userInfo.avatar && { avatar: userInfo.avatar }),
+    ...conditional(userInfo.email && { primaryEmail: userInfo.email }),
+  };
+
+  // Insert new user
+  const { id: userId } = await usersLibrary.insertUser(
+    {
+      id: generateStandardId(),
+      ...syncingProfile,
+      lastSignInAt: Date.now(),
+    },
+    []
+  );
+
+  // Insert new user SSO identity
+  await userSsoIdentitiesQueries.insert({
+    id: generateStandardId(),
+    userId,
+    identityId: userInfo.id,
+    issuer,
+    detail: userInfo,
+  });
+
+  log.append({
+    userId,
+    interaction: {
+      event: InteractionEvent.Register,
+      ssoIdentity: {
+        connectorId: connectorData.id,
+        issuer,
+        identityId: userInfo.id,
+      },
+      profile: syncingProfile,
+    },
+  });
+
+  return userId;
 };

--- a/packages/core/src/routes/interaction/utils/single-sign-on.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on.ts
@@ -1,0 +1,175 @@
+import { type ConnectorSession, ConnectorError, type SocialUserInfo } from '@logto/connector-kit';
+import { validateRedirectUrl } from '@logto/core-kit';
+import { type UserSsoIdentity } from '@logto/schemas';
+import { conditional, trySafe } from '@silverhand/essentials';
+import { z } from 'zod';
+
+import RequestError from '#src/errors/RequestError/index.js';
+import { assignInteractionResults } from '#src/libraries/session.js';
+import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
+import OidcConnector from '#src/sso/OidcConnector/index.js';
+import { ssoConnectorFactories } from '#src/sso/index.js';
+import { type SupportedSsoConnector } from '#src/sso/types/index.js';
+import type TenantContext from '#src/tenants/TenantContext.js';
+import assertThat from '#src/utils/assert-that.js';
+
+import { type WithInteractionHooksContext } from '../middleware/koa-interaction-hooks.js';
+
+import { assignConnectorSessionResult, getConnectorSessionResult } from './social-verification.js';
+
+export const oidcAuthorizationUrlPayloadGuard = z.object({
+  state: z.string().min(1),
+  redirectUri: z.string().refine((url) => validateRedirectUrl(url, 'web')),
+});
+
+type OidcAuthorizationUrlPayload = z.infer<typeof oidcAuthorizationUrlPayloadGuard>;
+
+export const getSsoAuthorizationUrl = async (
+  ctx: WithLogContext,
+  { provider }: TenantContext,
+  connectorData: SupportedSsoConnector,
+  payload?: OidcAuthorizationUrlPayload
+): Promise<string> => {
+  const { id: connectorId, providerName } = connectorData;
+
+  const { createLog } = ctx;
+
+  const log = createLog(`Interaction.SignIn.Identifier.SingleSignOn.Create`);
+  log.append({
+    connectorId,
+    payload,
+  });
+
+  try {
+    // Will throw ConnectorError if the config is invalid
+    const connectorInstance = new ssoConnectorFactories[providerName].constructor(connectorData);
+
+    if (connectorInstance instanceof OidcConnector) {
+      // Only required for OIDC
+      assertThat(payload, 'session.insufficient_info');
+
+      // Will throw ConnectorError if failed to fetch the provider's config
+      return await connectorInstance.getAuthorizationUrl(
+        payload,
+        async (connectorSession: ConnectorSession) =>
+          assignConnectorSessionResult(ctx, provider, connectorSession)
+      );
+    }
+
+    // TODO: Implement SAML SSO providers logic
+    throw new Error('Not implemented');
+  } catch (error: unknown) {
+    // Catch ConnectorError and re-throw as 500 RequestError
+    if (error instanceof ConnectorError) {
+      throw new RequestError({ code: `connector.${error.code}`, status: 500 }, error.data);
+    }
+
+    throw error;
+  }
+};
+
+type SsoAuthenticationResult = {
+  issuer: string;
+  userInfo: SocialUserInfo;
+};
+
+export const getSsoAuthentication = async (
+  ctx: WithLogContext,
+  { provider }: TenantContext,
+  connectorData: SupportedSsoConnector,
+  data?: unknown
+): Promise<SsoAuthenticationResult> => {
+  const { createLog } = ctx;
+  const { id: connectorId, providerName } = connectorData;
+
+  const log = createLog(`Interaction.SignIn.Identifier.SingleSignOn.Submit`);
+  log.append({ connectorId, data });
+
+  try {
+    // Will throw ConnectorError if the config is invalid
+    const connectorInstance = new ssoConnectorFactories[providerName].constructor(connectorData);
+
+    const issuer = connectorInstance.getIssuer();
+    const userInfo = await connectorInstance.getUserInfo(data, async () =>
+      getConnectorSessionResult(ctx, provider)
+    );
+
+    const result = {
+      issuer,
+      userInfo,
+    };
+
+    log.append({ issuer, userInfo });
+
+    return result;
+
+    // TODO: Implement SAML SSO providers logic
+  } catch (error: unknown) {
+    // Catch ConnectorError and re-throw as 500 RequestError
+    if (error instanceof ConnectorError) {
+      throw new RequestError({ code: `connector.${error.code}`, status: 500 }, error.data);
+    }
+
+    throw error;
+  }
+};
+
+export const signInWithSsoAuthentication = async (
+  ctx: WithLogContext & WithInteractionHooksContext,
+  {
+    provider,
+    queries: { userSsoIdentities: userSsoIdentitiesQueries, users: usersQueries },
+  }: TenantContext,
+  {
+    connectorData: { id: connectorId, syncProfile },
+    userSsoIdentity: { id, userId },
+    ssoAuthentication,
+  }: {
+    connectorData: SupportedSsoConnector;
+    userSsoIdentity: UserSsoIdentity;
+    ssoAuthentication: SsoAuthenticationResult;
+  }
+) => {
+  const { createLog, assignInteractionHookResult } = ctx;
+
+  const log = createLog(`Interaction.SignIn.Submit`);
+
+  const { userInfo } = ssoAuthentication;
+
+  // Update the user's SSO identity details
+  await userSsoIdentitiesQueries.updateById(id, {
+    detail: userInfo,
+  });
+
+  const { name, avatar } = userInfo;
+
+  // Sync the user name and avatar to the existing user if the connector has syncProfile enabled (sign-in)
+  const syncingProfile = syncProfile
+    ? {
+        ...conditional(name && { name }),
+        ...conditional(avatar && { avatar }),
+      }
+    : undefined;
+
+  // Profile update should not block the sign-in process
+  await trySafe(async () =>
+    usersQueries.updateUserById(userId, {
+      ...syncingProfile,
+      lastSignInAt: Date.now(),
+    })
+  );
+
+  log.append({
+    userId,
+    interaction: {
+      ssoIdentity: {
+        connectorId,
+        ...ssoAuthentication,
+      },
+      profile: syncingProfile,
+    },
+  });
+
+  await assignInteractionResults(ctx, provider, { login: { accountId: userId } });
+  assignInteractionHookResult({ userId });
+};

--- a/packages/core/src/routes/interaction/utils/single-sign-on.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on.ts
@@ -14,8 +14,6 @@ import type Queries from '#src/tenants/Queries.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 
-import { type WithInteractionHooksContext } from '../middleware/koa-interaction-hooks.js';
-
 import { storeInteractionResult } from './interaction.js';
 import { assignConnectorSessionResult, getConnectorSessionResult } from './social-verification.js';
 
@@ -120,7 +118,7 @@ export const getSsoAuthentication = async (
 
 // Handle the SSO authentication result and return the user id
 export const handleSsoAuthentication = async (
-  ctx: WithLogContext & WithInteractionHooksContext,
+  ctx: WithLogContext,
   tenant: TenantContext,
   connectorData: SupportedSsoConnector,
   ssoAuthentication: SsoAuthenticationResult
@@ -166,7 +164,7 @@ export const handleSsoAuthentication = async (
 };
 
 const signInWithSsoAuthentication = async (
-  ctx: WithLogContext & WithInteractionHooksContext,
+  ctx: WithLogContext,
   { userSsoIdentities: userSsoIdentitiesQueries, users: usersQueries }: Queries,
   {
     connectorData: { id: connectorId, syncProfile },
@@ -220,7 +218,7 @@ const signInWithSsoAuthentication = async (
 };
 
 const signInAndLinkWithSsoAuthentication = async (
-  ctx: WithLogContext & WithInteractionHooksContext,
+  ctx: WithLogContext,
   { userSsoIdentities: userSsoIdentitiesQueries, users: usersQueries }: Queries,
   {
     connectorData: { id: connectorId, syncProfile },
@@ -277,7 +275,7 @@ const signInAndLinkWithSsoAuthentication = async (
 };
 
 const registerWithSsoAuthentication = async (
-  ctx: WithLogContext & WithInteractionHooksContext,
+  ctx: WithLogContext,
   {
     queries: { userSsoIdentities: userSsoIdentitiesQueries },
     libraries: { users: usersLibrary },

--- a/packages/core/src/routes/sso-connector/index.ts
+++ b/packages/core/src/routes/sso-connector/index.ts
@@ -32,7 +32,7 @@ export default function singleSignOnRoutes<T extends AuthedRouter>(...args: Rout
       libraries: { ssoConnectors: ssoConnectorLibrary },
       queries: { ssoConnectors },
       libraries: {
-        ssoConnector: { getSsoConnectorById, getSsoConnectors },
+        ssoConnectors: { getSsoConnectorById, getSsoConnectors },
       },
     },
   ] = args;

--- a/packages/core/src/routes/sso-connector/index.ts
+++ b/packages/core/src/routes/sso-connector/index.ts
@@ -29,6 +29,7 @@ export default function singleSignOnRoutes<T extends AuthedRouter>(...args: Rout
     router,
     {
       id: tenantId,
+      libraries: { ssoConnectors: ssoConnectorLibrary },
       queries: { ssoConnectors },
       libraries: {
         ssoConnector: { getSsoConnectorById, getSsoConnectors },

--- a/packages/core/src/routes/sso-connector/index.ts
+++ b/packages/core/src/routes/sso-connector/index.ts
@@ -29,7 +29,6 @@ export default function singleSignOnRoutes<T extends AuthedRouter>(...args: Rout
     router,
     {
       id: tenantId,
-      libraries: { ssoConnectors: ssoConnectorLibrary },
       queries: { ssoConnectors },
       libraries: {
         ssoConnectors: { getSsoConnectorById, getSsoConnectors },

--- a/packages/core/src/routes/well-known.phrases.content-language.test.ts
+++ b/packages/core/src/routes/well-known.phrases.content-language.test.ts
@@ -50,6 +50,7 @@ describe('when auto-detect is not enabled', () => {
       ...mockSignInExperience,
       languageInfo: {
         autoDetect: false,
+        // @ts-expect-error
         fallbackLanguage: unsupportedLanguageX,
       },
     });
@@ -90,6 +91,7 @@ describe('when auto-detect is enabled', () => {
       ...mockSignInExperience,
       languageInfo: {
         autoDetect: true,
+        // @ts-expect-error
         fallbackLanguage: unsupportedLanguageX,
       },
     });

--- a/packages/core/src/routes/well-known.phrases.content-language.test.ts
+++ b/packages/core/src/routes/well-known.phrases.content-language.test.ts
@@ -50,7 +50,6 @@ describe('when auto-detect is not enabled', () => {
       ...mockSignInExperience,
       languageInfo: {
         autoDetect: false,
-        // @ts-expect-error
         fallbackLanguage: unsupportedLanguageX,
       },
     });
@@ -91,7 +90,6 @@ describe('when auto-detect is enabled', () => {
       ...mockSignInExperience,
       languageInfo: {
         autoDetect: true,
-        // @ts-expect-error
         fallbackLanguage: unsupportedLanguageX,
       },
     });

--- a/packages/core/src/sso/OidcConnector/index.ts
+++ b/packages/core/src/sso/OidcConnector/index.ts
@@ -83,6 +83,10 @@ class OidcConnector {
     return `${oidcConfig.authorizationEndpoint}?${queryParameters.toString()}`;
   };
 
+  get issuer() {
+    return this.config.issuer;
+  }
+
   /**
    * Handle the sign-in callback from the OIDC provider and return the user info
    *

--- a/packages/core/src/sso/OidcSsoConnector/index.ts
+++ b/packages/core/src/sso/OidcSsoConnector/index.ts
@@ -22,7 +22,7 @@ export class OidcSsoConnector extends OidcConnector implements SingleSignOn {
   }
 
   getConfig = async () => this.getOidcConfig();
-  getIssuer = () => this.issuer;
+  getIssuer = async () => this.issuer;
 }
 
 export const oidcSsoConnectorFactory: SingleSignOnFactory<SsoProviderName.OIDC> = {

--- a/packages/core/src/sso/OidcSsoConnector/index.ts
+++ b/packages/core/src/sso/OidcSsoConnector/index.ts
@@ -22,6 +22,7 @@ export class OidcSsoConnector extends OidcConnector implements SingleSignOn {
   }
 
   getConfig = async () => this.getOidcConfig();
+  getIssuer = () => this.issuer;
 }
 
 export const oidcSsoConnectorFactory: SingleSignOnFactory<SsoProviderName.OIDC> = {

--- a/packages/core/src/sso/SamlSsoConnector/index.ts
+++ b/packages/core/src/sso/SamlSsoConnector/index.ts
@@ -30,6 +30,11 @@ export class SamlSsoConnector extends SamlConnector implements SingleSignOn {
     super(parseConfigResult.data, tenantId, data.id);
   }
 
+  async getIssuer() {
+    const { entityId } = await this.getSamlConfig();
+    return entityId;
+  }
+
   /**
    * Get parsed SAML connector's config along with it's metadata. Throws error if config is invalid.
    *

--- a/packages/core/src/sso/types/index.ts
+++ b/packages/core/src/sso/types/index.ts
@@ -10,7 +10,7 @@ import { type JsonObject, type SsoConnector } from '@logto/schemas';
 export abstract class SingleSignOn {
   abstract data: SsoConnector;
   abstract getConfig: () => Promise<JsonObject>;
-  abstract getIssuer: () => string;
+  abstract getIssuer: () => Promise<string>;
 }
 
 export enum SsoProviderName {

--- a/packages/core/src/sso/types/index.ts
+++ b/packages/core/src/sso/types/index.ts
@@ -10,6 +10,7 @@ import { type JsonObject, type SsoConnector } from '@logto/schemas';
 export abstract class SingleSignOn {
   abstract data: SsoConnector;
   abstract getConfig: () => Promise<JsonObject>;
+  abstract getIssuer: () => string;
 }
 
 export enum SsoProviderName {

--- a/packages/core/src/tenants/Libraries.ts
+++ b/packages/core/src/tenants/Libraries.ts
@@ -24,11 +24,11 @@ export default class Libraries {
   verificationStatuses = createVerificationStatusLibrary(this.queries);
   domains = createDomainLibrary(this.queries);
   quota = createQuotaLibrary(this.queries, this.cloudConnection, this.connectors);
-  ssoConnector = createSsoConnectorLibrary(this.queries);
+  ssoConnectors = createSsoConnectorLibrary(this.queries);
   signInExperiences = createSignInExperienceLibrary(
     this.queries,
     this.connectors,
-    this.ssoConnector,
+    this.ssoConnectors,
     this.cloudConnection
   );
 

--- a/packages/core/src/tenants/Queries.ts
+++ b/packages/core/src/tenants/Queries.ts
@@ -19,6 +19,7 @@ import { createRolesQueries } from '#src/queries/roles.js';
 import { createScopeQueries } from '#src/queries/scope.js';
 import { createSignInExperienceQueries } from '#src/queries/sign-in-experience.js';
 import SsoConnectorQueries from '#src/queries/sso-connectors.js';
+import UserSsoIdentityQueries from '#src/queries/user-sso-identities.js';
 import { createUserQueries } from '#src/queries/user.js';
 import { createUsersRolesQueries } from '#src/queries/users-roles.js';
 import { createVerificationStatusQueries } from '#src/queries/verification-status.js';
@@ -45,6 +46,7 @@ export default class Queries {
   dailyActiveUsers = createDailyActiveUsersQueries(this.pool);
   organizations = new OrganizationQueries(this.pool);
   ssoConnectors = new SsoConnectorQueries(this.pool);
+  userSsoIdentities = new UserSsoIdentityQueries(this.pool);
 
   constructor(
     public readonly pool: CommonQueryMethods,

--- a/packages/integration-tests/src/constants.ts
+++ b/packages/integration-tests/src/constants.ts
@@ -1,4 +1,4 @@
-import { SignInIdentifier, demoAppApplicationId } from '@logto/schemas';
+import { type CreateSsoConnector, SignInIdentifier, demoAppApplicationId } from '@logto/schemas';
 import { appendPath, getEnv } from '@silverhand/essentials';
 
 export const logtoUrl = getEnv('INTEGRATION_TESTS_LOGTO_URL', 'http://localhost:3001');
@@ -30,3 +30,19 @@ export const mockSocialAuthPageUrl = 'http://mock.social.com';
 export enum ProviderName {
   OIDC = 'OIDC',
 }
+
+export const newOidcSsoConnectorPayload = {
+  providerName: ProviderName.OIDC,
+  connectorName: 'test-oidc',
+  domains: ['example.io'], // Auto-generated email domain
+  ssoOnly: true,
+  branding: {
+    logo: 'https://logto.io/oidc-logo.png',
+    darkLogo: 'https://logto.io/oidc-dark-logo.png',
+  },
+  config: {
+    clientId: 'foo',
+    clientSecret: 'bar',
+    issuer: `${logtoUrl}/oidc`,
+  },
+} satisfies Partial<CreateSsoConnector>;

--- a/packages/integration-tests/src/helpers/connector.ts
+++ b/packages/integration-tests/src/helpers/connector.ts
@@ -9,11 +9,17 @@ import {
   mockSocialConnectorConfig,
 } from '#src/__mocks__/connectors-mock.js';
 import { listConnectors, deleteConnectorById, postConnector } from '#src/api/index.js';
+import { deleteSsoConnectorById, getSsoConnectors } from '#src/api/sso-connector.js';
 
 export const clearConnectorsByTypes = async (types: ConnectorType[]) => {
   const connectors = await listConnectors();
   const targetConnectors = connectors.filter((connector) => types.includes(connector.type));
   await Promise.all(targetConnectors.map(async (connector) => deleteConnectorById(connector.id)));
+};
+
+export const clearSsoConnectors = async () => {
+  const ssoConnectors = await getSsoConnectors();
+  await Promise.all(ssoConnectors.map(async (connector) => deleteSsoConnectorById(connector.id)));
 };
 
 export const clearConnectorById = async (id: string) => deleteConnectorById(id);

--- a/packages/integration-tests/src/tests/api/interaction/forgot-password/happy-path.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/forgot-password/happy-path.test.ts
@@ -94,6 +94,7 @@ describe('reset password', () => {
     await logoutClient(client);
     await deleteUser(user.id);
   });
+
   it('reset password with phone', async () => {
     const { user, userProfile } = await generateNewUser({
       primaryPhone: true,

--- a/packages/integration-tests/src/tests/api/interaction/register-with-identifier/sad-path.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/register-with-identifier/sad-path.test.ts
@@ -6,18 +6,35 @@ import {
   sendVerificationCode,
 } from '#src/api/interaction.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
+import { createSsoConnector } from '#src/api/sso-connector.js';
+import { newOidcSsoConnectorPayload } from '#src/constants.js';
 import { initClient } from '#src/helpers/client.js';
 import {
   clearConnectorsByTypes,
+  clearSsoConnectors,
   setEmailConnector,
   setSmsConnector,
 } from '#src/helpers/connector.js';
 import { expectRejects, readVerificationCode } from '#src/helpers/index.js';
-import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
+import {
+  enableAllPasswordSignInMethods,
+  enableAllVerificationCodeSignInMethods,
+} from '#src/helpers/sign-in-experience.js';
 import { generateNewUserProfile } from '#src/helpers/user.js';
-import { generatePassword, generateUsername } from '#src/utils.js';
+import { generateEmail, generatePassword, generateUsername } from '#src/utils.js';
 
 describe('Register with identifiers sad path', () => {
+  beforeAll(async () => {
+    await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);
+    await setEmailConnector();
+    await setSmsConnector();
+  });
+
+  afterAll(async () => {
+    await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);
+    await clearSsoConnectors();
+  });
+
   it('Should fail to register if sign-in mode is sign-in only', async () => {
     await updateSignInExperience({ signInMode: SignInMode.SignIn });
     const client = await initClient();
@@ -34,6 +51,39 @@ describe('Register with identifiers sad path', () => {
 
     // Reset
     await updateSignInExperience({ signInMode: SignInMode.SignInAndRegister });
+  });
+
+  it('Should fail to register with email if email domain is enabled for SSO only', async () => {
+    await enableAllVerificationCodeSignInMethods();
+    const email = generateEmail('sso-register-sad-path.io');
+
+    await createSsoConnector({
+      ...newOidcSsoConnectorPayload,
+      domains: ['sso-register-sad-path.io'],
+    });
+
+    const client = await initClient();
+
+    await client.successSend(putInteraction, {
+      event: InteractionEvent.Register,
+    });
+
+    await client.successSend(sendVerificationCode, {
+      email,
+    });
+
+    const { code: verificationCode } = await readVerificationCode();
+
+    await expectRejects(
+      client.send(patchInteractionIdentifiers, {
+        email,
+        verificationCode,
+      }),
+      {
+        code: 'session.sso_enabled',
+        statusCode: 422,
+      }
+    );
   });
 
   describe('Should fail to register with identifiers if sign-up settings are not enabled', () => {

--- a/packages/integration-tests/src/tests/api/interaction/sign-in-with-passcode-identifier/sad-path.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/sign-in-with-passcode-identifier/sad-path.test.ts
@@ -1,23 +1,26 @@
 import { ConnectorType } from '@logto/connector-kit';
 import { InteractionEvent, SignInMode } from '@logto/schemas';
 
-import { suspendUser } from '#src/api/admin-user.js';
+import { createUser, deleteUser, suspendUser } from '#src/api/admin-user.js';
 import {
   patchInteractionIdentifiers,
   putInteraction,
   sendVerificationCode,
 } from '#src/api/interaction.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
+import { createSsoConnector } from '#src/api/sso-connector.js';
+import { newOidcSsoConnectorPayload } from '#src/constants.js';
 import { initClient } from '#src/helpers/client.js';
 import {
   clearConnectorsByTypes,
+  clearSsoConnectors,
   setEmailConnector,
   setSmsConnector,
 } from '#src/helpers/connector.js';
 import { expectRejects, readVerificationCode } from '#src/helpers/index.js';
 import { enableAllVerificationCodeSignInMethods } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
-import { generateEmail, generatePhone } from '#src/utils.js';
+import { generateEmail, generatePassword, generatePhone } from '#src/utils.js';
 
 describe('Sign-in flow sad path using verification-code identifiers', () => {
   beforeAll(async () => {
@@ -29,6 +32,7 @@ describe('Sign-in flow sad path using verification-code identifiers', () => {
 
   afterAll(async () => {
     await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);
+    await clearSsoConnectors();
   });
 
   it('Should fail to sign in with passcode if sign-in mode is register only', async () => {
@@ -207,6 +211,41 @@ describe('Sign-in flow sad path using verification-code identifiers', () => {
       code: 'user.user_not_exist',
       statusCode: 404,
     });
+  });
+
+  it('Should fail to sign in with email and passcode if the email domain is enabled for SSO only', async () => {
+    const password = generatePassword();
+    const email = generateEmail('sso-sad-path.io');
+    const user = await createUser({ primaryEmail: email, password });
+
+    await createSsoConnector({
+      ...newOidcSsoConnectorPayload,
+      domains: ['sso-sad-path.io'],
+    });
+
+    const client = await initClient();
+    await client.successSend(putInteraction, {
+      event: InteractionEvent.SignIn,
+    });
+
+    await client.successSend(sendVerificationCode, {
+      email,
+    });
+
+    const { code: verificationCode } = await readVerificationCode();
+
+    await expectRejects(
+      client.send(patchInteractionIdentifiers, {
+        email,
+        verificationCode,
+      }),
+      {
+        code: 'session.sso_enabled',
+        statusCode: 422,
+      }
+    );
+
+    await deleteUser(user.id);
   });
 
   it('Should fail to sign in with phone and passcode if related user is not exist', async () => {

--- a/packages/integration-tests/src/tests/api/interaction/single-sign-on/sad-path.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/single-sign-on/sad-path.test.ts
@@ -2,35 +2,13 @@ import { InteractionEvent } from '@logto/schemas';
 
 import { getSsoAuthorizationUrl } from '#src/api/interaction-sso.js';
 import { putInteraction } from '#src/api/interaction.js';
-import { createSsoConnector } from '#src/api/sso-connector.js';
-import { ProviderName, logtoUrl } from '#src/constants.js';
+import { createSsoConnector, deleteSsoConnectorById } from '#src/api/sso-connector.js';
+import { ProviderName } from '#src/constants.js';
 import { initClient } from '#src/helpers/client.js';
 
 describe('Single Sign On Sad Path', () => {
   const state = 'foo_state';
   const redirectUri = 'http://foo.dev/callback';
-
-  it('should throw 404 if session not found', async () => {
-    const { id } = await createSsoConnector({
-      providerName: ProviderName.OIDC,
-      connectorName: 'test-oidc',
-      config: {
-        clientId: 'foo',
-        clientSecret: 'bar',
-        issuer: `${logtoUrl}/oidc`,
-      },
-    });
-
-    const client = await initClient();
-
-    await expect(
-      client.send(getSsoAuthorizationUrl, {
-        connectorId: id,
-        state,
-        redirectUri,
-      })
-    ).rejects.toThrow();
-  });
 
   it('should throw if connector not found', async () => {
     const client = await initClient();
@@ -71,5 +49,7 @@ describe('Single Sign On Sad Path', () => {
         redirectUri,
       })
     ).rejects.toThrow();
+
+    await deleteSsoConnectorById(id);
   });
 });

--- a/packages/integration-tests/src/tests/api/well-known.test.ts
+++ b/packages/integration-tests/src/tests/api/well-known.test.ts
@@ -3,7 +3,7 @@ import { HTTPError } from 'got';
 
 import api, { adminTenantApi, authedAdminApi } from '#src/api/api.js';
 import { createSsoConnector, deleteSsoConnectorById } from '#src/api/sso-connector.js';
-import { logtoUrl } from '#src/constants.js';
+import { newOidcSsoConnectorPayload } from '#src/constants.js';
 
 describe('.well-known api', () => {
   it('should return tenant endpoint URL for any given tenant id', async () => {
@@ -56,25 +56,8 @@ describe('.well-known api', () => {
   });
 
   describe('sso connectors in sign-in experience', () => {
-    const logtoIssuer = `${logtoUrl}/oidc`;
-
-    const newOIDCSsoConnector = {
-      providerName: 'OIDC',
-      connectorName: 'OIDC sso connector',
-      domains: ['logto.io'],
-      branding: {
-        logo: 'https://logto.io/oidc-logo.png',
-        darkLogo: 'https://logto.io/oidc-dark-logo.png',
-      },
-      config: {
-        clientId: 'client-id',
-        clientSecret: 'client-secret',
-        issuer: logtoIssuer,
-      },
-    };
-
     it('should get the sso connectors in sign-in experience', async () => {
-      const { id, connectorName } = await createSsoConnector(newOIDCSsoConnector);
+      const { id, connectorName } = await createSsoConnector(newOidcSsoConnectorPayload);
 
       const signInExperience = await api
         .get('.well-known/sign-in-exp')
@@ -89,8 +72,8 @@ describe('.well-known api', () => {
       expect(newCreatedConnector).toMatchObject({
         id,
         connectorName,
-        logo: newOIDCSsoConnector.branding.logo,
-        darkLogo: newOIDCSsoConnector.branding.darkLogo,
+        logo: newOidcSsoConnectorPayload.branding.logo,
+        darkLogo: newOidcSsoConnectorPayload.branding.darkLogo,
       });
 
       await deleteSsoConnectorById(id);
@@ -98,7 +81,7 @@ describe('.well-known api', () => {
 
     it('should filter out the sso connectors with invalid config', async () => {
       const { id } = await createSsoConnector({
-        ...newOIDCSsoConnector,
+        ...newOidcSsoConnectorPayload,
         config: {},
       });
 
@@ -115,7 +98,7 @@ describe('.well-known api', () => {
 
     it('should filter out the sso connectors with empty domains', async () => {
       const { id } = await createSsoConnector({
-        ...newOIDCSsoConnector,
+        ...newOidcSsoConnectorPayload,
         domains: [],
       });
 

--- a/packages/integration-tests/src/utils.ts
+++ b/packages/integration-tests/src/utils.ts
@@ -12,7 +12,8 @@ export const generatePassword = () => `pwd_${crypto.randomUUID()}`;
 
 export const generateResourceName = () => `res_${crypto.randomUUID()}`;
 export const generateResourceIndicator = () => `https://${crypto.randomUUID()}.logto.io`;
-export const generateEmail = () => `${crypto.randomUUID().toLowerCase()}@logto.io`;
+export const generateEmail = (domain = 'logto.io') =>
+  `${crypto.randomUUID().toLowerCase()}@${domain}`;
 export const generateScopeName = () => `sc:${crypto.randomUUID()}`;
 export const generateRoleName = () => `role_${crypto.randomUUID()}`;
 export const generateDomain = () => `${crypto.randomUUID().toLowerCase().slice(0, 5)}.example.com`;

--- a/packages/phrases/src/locales/de/errors/session.ts
+++ b/packages/phrases/src/locales/de/errors/session.ts
@@ -50,6 +50,8 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled:
+    'Einmaliges Anmelden ist für diese gegebene E-Mail aktiviert. Bitte melden Sie sich mit SSO an.',
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/en/errors/session.ts
+++ b/packages/phrases/src/locales/en/errors/session.ts
@@ -35,6 +35,7 @@ const session = {
     invalid_backup_code: 'Invalid backup code.',
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled: 'Single sign on is enabled for this given email. Please sign in with SSO.',
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/es/errors/session.ts
+++ b/packages/phrases/src/locales/es/errors/session.ts
@@ -51,6 +51,8 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled:
+    'El inicio de sesión único está habilitado para este correo electrónico dado. Inicie sesión con SSO, por favor.',
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/fr/errors/session.ts
+++ b/packages/phrases/src/locales/fr/errors/session.ts
@@ -52,6 +52,8 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled:
+    'La connexion unique est activée pour cet e-mail donné. Veuillez vous connecter avec SSO.',
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/it/errors/session.ts
+++ b/packages/phrases/src/locales/it/errors/session.ts
@@ -50,6 +50,7 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled: "L'accesso singolo è abilitato per questa email. Accedi con SSO.",
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/ja/errors/session.ts
+++ b/packages/phrases/src/locales/ja/errors/session.ts
@@ -48,6 +48,8 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled:
+    'このメールアドレスではシングルサインオンが有効になっています。SSOでサインインしてください。',
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/ko/errors/session.ts
+++ b/packages/phrases/src/locales/ko/errors/session.ts
@@ -47,6 +47,7 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled: '이 이메일로는 SSO가 활성화되어 있어요. SSO로 로그인해 주세요.',
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/pl-pl/errors/session.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/session.ts
@@ -49,6 +49,7 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled: 'Single sign on jest włączony dla tego adresu e-mail. Zaloguj się za pomocą SSO.',
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/pt-br/errors/session.ts
+++ b/packages/phrases/src/locales/pt-br/errors/session.ts
@@ -50,6 +50,8 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled:
+    'O login único está habilitado para este e-mail fornecido. Faça login com SSO, por favor.',
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/pt-pt/errors/session.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/session.ts
@@ -52,6 +52,8 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled:
+    'O login único está habilitado para este e-mail fornecido. Faça login com SSO, por favor.',
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/ru/errors/session.ts
+++ b/packages/phrases/src/locales/ru/errors/session.ts
@@ -48,6 +48,8 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled:
+    'Единый вход в систему включен для этого указанного адреса электронной почты. Войдите в систему с помощью SSO.',
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/tr-tr/errors/session.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/session.ts
@@ -49,6 +49,7 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled: 'Bu e-posta için tek oturum açma etkin. Lütfen SSO ile oturum açın.',
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/zh-cn/errors/session.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/session.ts
@@ -44,6 +44,7 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled: '该邮箱已开启单点登录，请使用 SSO 登录。',
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/zh-hk/errors/session.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/session.ts
@@ -44,6 +44,7 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled: '該郵箱已開啟單點登錄，請使用 SSO 登錄。',
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/zh-tw/errors/session.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/session.ts
@@ -44,6 +44,7 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled: '該郵箱已開啟單點登錄，請使用 SSO 登錄。',
 };
 
 export default Object.freeze(session);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Implement the single sign on authentication api. Handles the following SSO specific interaction flow.
 - **sign-in with existing SSO identity** 
 - **sign-in and link SSO identity with same email**
 - **register with SSO identity**
 
This PR includes the following updates:

**Queries:**
- Create new query class for the `userSsoIdentities` table.  Including a custom query method `findUserSsoIdentityBySsoIdentityId`. By a given SSO `identityId`  and `issuers`. We should be able to uniquely identify a Logto user if exist.

**Refactors**
Refactor the `POST /interaction/sso/:connectorId/authorization-url` with following updates:

1. Update the input body guard, mark the `state` and `redirectUri` data optional, as SAML single-sign-on url generation does not request such inputs. The input body data will be guarded per connector instance. (OIDC or SAML)
2. Remove the old interaction event checking and guard logic. Intend to simplify the single sign on process. Unlike our existing interaction apis (will refactor later after the SSO implementation), no need to create a sign-in interaction by calling the `PUT /interaction` API ahead.  By calling this `POST /interaction/sso/:connectorId/authorization-url` we will automatically generate a `sign-in` interaction session with proper log and session storage. 
3. Extract the api logic in to a new created `single-sign-on.ts` util file as a util method `getSsoAuthorizationUrl`


**SSO classes**
Define a new required method for all the SSO connector classes `getIssuer()`. This method is used for fetch the unique identification of the connector's provider.  `Issuer` for OIDC connectors, IdP `entityId` for the SAML connectors.  This will be stored in the user's SSO identity data. Along with the SSO identityId, we could exclusively identify a user's SSO identity. 

**POST /interaction/sso/:connectorId/authentication**
This new API handles the final step of the Single Sign On process. The internal logic has been extracted into several utils methods:
- `getSsoAuthentication`: Using all the API provided body inputs and connector data in DB to get the full authentication info from SSO IdP using our SSO connector class.
- `handleSsoAuthentication` 
  - `signInWithSsoAuthentication`: directly sign-in if we find a matched user SSO identity 
  - `signInAndLinkWithSsoAuthentication`: Find a related email account if any. Automatically bind the new SSO identity to this matched account and sign-in.
  - `registerWithSsoAuthentication`: Create a new user account using the new SSO identity.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
It is kind of hard to implement a mock connector integration for now. Need to rely on the unit test for now. 

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
