### PR TITLE
fix(console): details page header text should not overflow its container

### DIFF
--- a/packages/console/src/components/DetailsPage/DetailsPageHeader/index.module.scss
+++ b/packages/console/src/components/DetailsPage/DetailsPageHeader/index.module.scss
@@ -30,10 +30,12 @@
 
   .metadata {
     flex: 1;
+    overflow: hidden;
 
     .name {
       font: var(--font-title-1);
       color: var(--color-text);
+      @include _.text-ellipsis;
     }
 
     .row {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Details page header text should not overflow its container. Ellipsis should be appended and text content should be cut off.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="989" alt="image" src="https://github.com/logto-io/logto/assets/12833674/5af07837-8dc8-4805-a5a3-cfc988ce9aec">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
