### PR TITLE
feat(core): add isDevelopmentTenant to SIE well-known api

### DIFF
--- a/packages/core/src/libraries/sign-in-experience/types.ts
+++ b/packages/core/src/libraries/sign-in-experience/types.ts
@@ -18,6 +18,7 @@ export type FullSignInExperience = SignInExperience & {
   socialConnectors: ConnectorMetadataWithId[];
   ssoConnectors: SsoConnectorMetadata[];
   forgotPassword: ForgotPassword;
+  isDevelopmentTenant: boolean;
 };
 
 export const guardFullSignInExperience: z.ZodType<FullSignInExperience> =
@@ -25,4 +26,5 @@ export const guardFullSignInExperience: z.ZodType<FullSignInExperience> =
     socialConnectors: connectorMetadataGuard.extend({ id: z.string() }).array(),
     ssoConnectors: ssoConnectorMetadataGuard.array(),
     forgotPassword: z.object({ phone: z.boolean(), email: z.boolean() }),
+    isDevelopmentTenant: z.boolean(),
   });

--- a/packages/core/src/tenants/Libraries.ts
+++ b/packages/core/src/tenants/Libraries.ts
@@ -28,7 +28,8 @@ export default class Libraries {
   signInExperiences = createSignInExperienceLibrary(
     this.queries,
     this.connectors,
-    this.ssoConnector
+    this.ssoConnector,
+    this.cloudConnection
   );
 
   constructor(


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Add `isDevelopmentTenant` to `/.well-known/sign-in-exp`, the front-end will use this to show the banner.

Notice that there is no integration tests, because we are unable to test "cloud" related features for now.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Unit tests and local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
