### PR TITLE
style(console): center align `CardTitle` content for application placeholder page

### DIFF
--- a/packages/console/src/ds-components/CardTitle/index.module.scss
+++ b/packages/console/src/ds-components/CardTitle/index.module.scss
@@ -1,6 +1,8 @@
 @use '@/scss/underscore' as _;
 
 .container {
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
 
   .title {

--- a/packages/console/src/pages/Applications/index.module.scss
+++ b/packages/console/src/pages/Applications/index.module.scss
@@ -17,7 +17,7 @@
   margin: _.unit(4) 0;
 
   .title {
-    text-align: center;
+    align-items: center;
     margin-bottom: _.unit(6);
   }
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Since now, the `CardTitle` component support a `titleTag` component and we use `flex` to align the title text and the title tag. so we need to use `flext` layout for the whole `CardTitle` component. This allow us to center the card title content by using `align-items: center`.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Before:
<img width="1260" alt="image" src="https://github.com/logto-io/logto/assets/10806653/2d57940b-8694-4e97-aaee-895c91d6453b">

After:
<img width="1278" alt="image" src="https://github.com/logto-io/logto/assets/10806653/025ccd43-3f7e-4913-86d6-e6ee2a863216">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
