### PR TITLE
fix(console): icon color on add buttons in organization template

### DIFF
--- a/packages/console/src/pages/Organizations/TemplateTable/index.module.scss
+++ b/packages/console/src/pages/Organizations/TemplateTable/index.module.scss
@@ -2,6 +2,10 @@
 
 .addButton {
   margin-top: _.unit(3);
+
+  svg {
+    color: var(--color-text-secondary);
+  }
 }
 
 .spinner {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix icon color on create buttons in organization template. Make sure the icon is using `text-secondary` color token

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="145" alt="image" src="https://github.com/logto-io/logto/assets/12833674/6ab7480a-f8b1-4376-baeb-9457dfce5f2d">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
