### PR TITLE
fix(console): should use organization role tag in user details page

### DIFF
--- a/packages/console/src/pages/UserDetails/UserOrganizations/index.tsx
+++ b/packages/console/src/pages/UserDetails/UserOrganizations/index.tsx
@@ -8,6 +8,7 @@ import OrganizationIcon from '@/assets/icons/organization-preview.svg';
 import Tip from '@/assets/icons/tip.svg';
 import EmptyDataPlaceholder from '@/components/EmptyDataPlaceholder';
 import ItemPreview from '@/components/ItemPreview';
+import { RoleOption } from '@/components/OrganizationRolesSelect';
 import ThemedIcon from '@/components/ThemedIcon';
 import CopyToClipboard from '@/ds-components/CopyToClipboard';
 import IconButton from '@/ds-components/IconButton';
@@ -82,7 +83,7 @@ function UserOrganizations() {
             <div className={styles.roles}>
               {organizationRoles.map(({ id, name }) => (
                 <Tag key={id} variant="cell">
-                  {name}
+                  <RoleOption value={id} title={name} />
                 </Tag>
               ))}
             </div>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Use organization role tag instead of normal string tag for organization roles in user details page.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Using the correct UI styles now

<img width="1208" alt="image" src="https://github.com/logto-io/logto/assets/12833674/c7eaa1ad-4f6e-4ea1-b249-614fed5fb90e">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
