### PR TITLE
feat(core): add sso email guard to interaction endpoint

### DIFF
--- a/packages/core/src/libraries/sign-in-experience/index.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.ts
@@ -64,7 +64,7 @@ export const createSignInExperienceLibrary = (
   };
 
   const getActiveSsoConnectors = async (): Promise<SsoConnectorMetadata[]> => {
-    // TODO: @simeng-li Return empty array if dev features are not enabled
+    // TODO: @simeng-li Remove the dev feature check once SSO is fully released
     if (!EnvSet.values.isDevFeaturesEnabled) {
       return [];
     }

--- a/packages/core/src/routes/interaction/index.test.ts
+++ b/packages/core/src/routes/interaction/index.test.ts
@@ -125,6 +125,11 @@ const tenantContext = new MockTenant(
       // @ts-expect-error
       return connector as LogtoConnector;
     },
+  },
+  {
+    ssoConnectors: {
+      getAvailableSsoConnectors: jest.fn().mockResolvedValue([]),
+    },
   }
 );
 

--- a/packages/core/src/routes/interaction/index.ts
+++ b/packages/core/src/routes/interaction/index.ts
@@ -33,6 +33,7 @@ import {
   verifyIdentifierSettings,
   verifyProfileSettings,
 } from './utils/sign-in-experience-validation.js';
+import { verifySsoOnlyEmailIdentifier } from './utils/single-sign-on.js';
 import { validatePassword } from './utils/validate-password.js';
 import {
   verifyIdentifierPayload,
@@ -82,6 +83,7 @@ export default function interactionRoutes<T extends AnonymousRouter>(
 
       if (identifier && event !== InteractionEvent.ForgotPassword) {
         verifyIdentifierSettings(identifier, signInExperience);
+        await verifySsoOnlyEmailIdentifier(libraries.ssoConnectors, identifier);
       }
 
       if (profile && event !== InteractionEvent.ForgotPassword) {
@@ -181,6 +183,7 @@ export default function interactionRoutes<T extends AnonymousRouter>(
 
       if (interactionStorage.event !== InteractionEvent.ForgotPassword) {
         verifyIdentifierSettings(identifierPayload, signInExperience);
+        await verifySsoOnlyEmailIdentifier(libraries.ssoConnectors, identifierPayload);
       }
 
       const verifiedIdentifier = await verifyIdentifierPayload(

--- a/packages/core/src/routes/interaction/index.ts
+++ b/packages/core/src/routes/interaction/index.ts
@@ -33,7 +33,7 @@ import {
   verifyIdentifierSettings,
   verifyProfileSettings,
 } from './utils/sign-in-experience-validation.js';
-import { verifySsoOnlyEmailIdentifier } from './utils/single-sign-on.js';
+import { verifySsoOnlyEmailIdentifier } from './utils/single-sign-on-guard.js';
 import { validatePassword } from './utils/validate-password.js';
 import {
   verifyIdentifierPayload,

--- a/packages/core/src/routes/interaction/utils/single-sign-on-guard.test.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on-guard.test.ts
@@ -1,0 +1,83 @@
+import { wellConfiguredSsoConnector } from '#src/__mocks__/sso.js';
+import RequestError from '#src/errors/RequestError/index.js';
+import { type SsoConnectorLibrary } from '#src/libraries/sso-connector.js';
+
+import { verifySsoOnlyEmailIdentifier } from './single-sign-on-guard.js';
+
+const { jest } = import.meta;
+
+const getAvailableSsoConnectorsMock = jest.fn();
+
+const mockSsoConnectorLibrary: SsoConnectorLibrary = {
+  getAvailableSsoConnectors: getAvailableSsoConnectorsMock,
+  getSsoConnectors: jest.fn(),
+  getSsoConnectorById: jest.fn(),
+};
+
+describe('verifySsoOnlyEmailIdentifier tests', () => {
+  it('should return if the identifier is not an email', async () => {
+    await expect(
+      verifySsoOnlyEmailIdentifier(mockSsoConnectorLibrary, {
+        username: 'foo',
+        password: 'bar',
+      })
+    ).resolves.not.toThrow();
+  });
+  it('should return if no sso connectors found with the given email', async () => {
+    getAvailableSsoConnectorsMock.mockResolvedValueOnce([
+      {
+        ...wellConfiguredSsoConnector,
+        domains: ['example.com'],
+      },
+    ]);
+
+    await expect(
+      verifySsoOnlyEmailIdentifier(mockSsoConnectorLibrary, {
+        email: 'foo@bar.com',
+        password: 'bar',
+      })
+    ).resolves.not.toThrow();
+  });
+  it('should return if the connector is not sso only', async () => {
+    getAvailableSsoConnectorsMock.mockResolvedValueOnce([
+      {
+        ...wellConfiguredSsoConnector,
+        domains: ['example.com'],
+        ssoOnly: false,
+      },
+    ]);
+
+    await expect(
+      verifySsoOnlyEmailIdentifier(mockSsoConnectorLibrary, {
+        email: 'foo@example.com',
+        password: 'bar',
+      })
+    ).resolves.not.toThrow();
+  });
+
+  it('should throw an error if multiple sso connectors found with the given email', async () => {
+    const connector = {
+      ...wellConfiguredSsoConnector,
+      domains: ['example.com'],
+    };
+
+    getAvailableSsoConnectorsMock.mockResolvedValueOnce([connector]);
+
+    await expect(
+      verifySsoOnlyEmailIdentifier(mockSsoConnectorLibrary, {
+        email: 'foo@example.com',
+        verificationCode: 'bar',
+      })
+    ).rejects.toMatchError(
+      new RequestError(
+        {
+          code: 'session.sso_enabled',
+          status: 422,
+        },
+        {
+          ssoConnectors: [connector],
+        }
+      )
+    );
+  });
+});

--- a/packages/core/src/routes/interaction/utils/single-sign-on-guard.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on-guard.ts
@@ -1,0 +1,43 @@
+import { type IdentifierPayload } from '@logto/schemas';
+
+import { EnvSet } from '#src/env-set/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
+import { type SsoConnectorLibrary } from '#src/libraries/sso-connector.js';
+import assertThat from '#src/utils/assert-that.js';
+
+// Guard the SSO only email identifier
+export const verifySsoOnlyEmailIdentifier = async (
+  { getAvailableSsoConnectors }: SsoConnectorLibrary,
+  identifier: IdentifierPayload
+) => {
+  // TODO: @simeng-li remove the dev features check when the SSO feature is released
+  if (!('email' in identifier) || !EnvSet.values.isDevFeaturesEnabled) {
+    return;
+  }
+
+  const { email } = identifier;
+  const availableSsoConnectors = await getAvailableSsoConnectors();
+  const domain = email.split('@')[1];
+
+  // Invalid email domain
+  if (!domain) {
+    return;
+  }
+
+  const availableConnectors = availableSsoConnectors.filter(
+    ({ domains, ssoOnly }) => domains.includes(domain) && ssoOnly
+  );
+
+  assertThat(
+    availableConnectors.length === 0,
+    new RequestError(
+      {
+        code: 'session.sso_enabled',
+        status: 422,
+      },
+      {
+        ssoConnectors: availableConnectors,
+      }
+    )
+  );
+};

--- a/packages/core/src/routes/interaction/utils/single-sign-on.test.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on.test.ts
@@ -3,6 +3,7 @@ import { createMockUtils } from '@logto/shared/esm';
 import type Provider from 'oidc-provider';
 
 import { mockSsoConnector, wellConfiguredSsoConnector } from '#src/__mocks__/sso.js';
+import RequestError from '#src/errors/RequestError/index.js';
 import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
 import { OidcSsoConnector } from '#src/sso/OidcSsoConnector/index.js';
 import { ssoConnectorFactories } from '#src/sso/index.js';
@@ -26,6 +27,7 @@ const updateUserMock = jest.fn();
 const findUserByEmailMock = jest.fn();
 const insertUserMock = jest.fn();
 const storeInteractionResultMock = jest.fn();
+const getAvailableSsoConnectorsMock = jest.fn();
 
 class MockOidcSsoConnector extends OidcSsoConnector {
   override getAuthorizationUrl = getAuthorizationUrlMock;
@@ -41,9 +43,12 @@ jest
   .spyOn(ssoConnectorFactories.OIDC, 'constructor')
   .mockImplementation((data: SsoConnector) => new MockOidcSsoConnector(data));
 
-const { getSsoAuthorizationUrl, getSsoAuthentication, handleSsoAuthentication } = await import(
-  './single-sign-on.js'
-);
+const {
+  getSsoAuthorizationUrl,
+  getSsoAuthentication,
+  handleSsoAuthentication,
+  verifySsoOnlyEmailIdentifier,
+} = await import('./single-sign-on.js');
 
 describe('Single sign on util methods tests', () => {
   const mockContext: WithLogContext & WithInteractionDetailsContext = {
@@ -54,6 +59,7 @@ describe('Single sign on util methods tests', () => {
   };
 
   const mockProvider = createMockProvider();
+
   const tenant = new MockTenant(
     mockProvider,
     {
@@ -71,6 +77,9 @@ describe('Single sign on util methods tests', () => {
     {
       users: {
         insertUser: insertUserMock,
+      },
+      ssoConnectors: {
+        getAvailableSsoConnectors: getAvailableSsoConnectorsMock,
       },
     }
   );
@@ -268,6 +277,74 @@ describe('Single sign on util methods tests', () => {
         issuer: mockIssuer,
         detail: mockSsoUserInfo,
       });
+    });
+  });
+
+  describe('verifySsoOnlyEmailIdentifier tests', () => {
+    it('should return if the identifier is not an email', async () => {
+      await expect(
+        verifySsoOnlyEmailIdentifier(tenant.libraries.ssoConnectors, {
+          username: 'foo',
+          password: 'bar',
+        })
+      ).resolves.not.toThrow();
+    });
+    it('should return if no sso connectors found with the given email', async () => {
+      getAvailableSsoConnectorsMock.mockResolvedValueOnce([
+        {
+          ...wellConfiguredSsoConnector,
+          domains: ['example.com'],
+        },
+      ]);
+
+      await expect(
+        verifySsoOnlyEmailIdentifier(tenant.libraries.ssoConnectors, {
+          email: 'foo@bar.com',
+          password: 'bar',
+        })
+      ).resolves.not.toThrow();
+    });
+    it('should return if the connector is not sso only', async () => {
+      getAvailableSsoConnectorsMock.mockResolvedValueOnce([
+        {
+          ...wellConfiguredSsoConnector,
+          domains: ['example.com'],
+          ssoOnly: false,
+        },
+      ]);
+
+      await expect(
+        verifySsoOnlyEmailIdentifier(tenant.libraries.ssoConnectors, {
+          email: 'foo@example.com',
+          password: 'bar',
+        })
+      ).resolves.not.toThrow();
+    });
+
+    it('should throw an error if multiple sso connectors found with the given email', async () => {
+      const connector = {
+        ...wellConfiguredSsoConnector,
+        domains: ['example.com'],
+      };
+
+      getAvailableSsoConnectorsMock.mockResolvedValueOnce([connector]);
+
+      await expect(
+        verifySsoOnlyEmailIdentifier(tenant.libraries.ssoConnectors, {
+          email: 'foo@example.com',
+          verificationCode: 'bar',
+        })
+      ).rejects.toMatchError(
+        new RequestError(
+          {
+            code: 'session.sso_enabled',
+            status: 422,
+          },
+          {
+            ssoConnectors: [connector],
+          }
+        )
+      );
     });
   });
 });

--- a/packages/core/src/routes/interaction/utils/single-sign-on.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on.ts
@@ -1,18 +1,11 @@
 import { type ConnectorSession, ConnectorError, type SocialUserInfo } from '@logto/connector-kit';
 import { validateRedirectUrl } from '@logto/core-kit';
-import {
-  type IdentifierPayload,
-  InteractionEvent,
-  type User,
-  type UserSsoIdentity,
-} from '@logto/schemas';
+import { InteractionEvent, type User, type UserSsoIdentity } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 import { conditional } from '@silverhand/essentials';
 import { z } from 'zod';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
-import { type SsoConnectorLibrary } from '#src/libraries/sso-connector.js';
 import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
 import { type WithInteractionDetailsContext } from '#src/routes/interaction/middleware/koa-interaction-details.js';
 import OidcConnector from '#src/sso/OidcConnector/index.js';
@@ -345,41 +338,4 @@ const registerWithSsoAuthentication = async (
   });
 
   return userId;
-};
-
-// Guard the SSO only email identifier
-export const verifySsoOnlyEmailIdentifier = async (
-  { getAvailableSsoConnectors }: SsoConnectorLibrary,
-  identifier: IdentifierPayload
-) => {
-  // TODO: @simeng-li remove the dev features check when the SSO feature is released
-  if (!('email' in identifier) || !EnvSet.values.isDevFeaturesEnabled) {
-    return;
-  }
-
-  const { email } = identifier;
-  const availableSsoConnectors = await getAvailableSsoConnectors();
-  const domain = email.split('@')[1];
-
-  // Invalid email domain
-  if (!domain) {
-    return;
-  }
-
-  const availableConnectors = availableSsoConnectors.filter(
-    ({ domains, ssoOnly }) => domains.includes(domain) && ssoOnly
-  );
-
-  assertThat(
-    availableConnectors.length === 0,
-    new RequestError(
-      {
-        code: 'session.sso_enabled',
-        status: 422,
-      },
-      {
-        ssoConnectors: availableConnectors,
-      }
-    )
-  );
 };

--- a/packages/integration-tests/src/constants.ts
+++ b/packages/integration-tests/src/constants.ts
@@ -1,4 +1,4 @@
-import { SignInIdentifier, demoAppApplicationId } from '@logto/schemas';
+import { type CreateSsoConnector, SignInIdentifier, demoAppApplicationId } from '@logto/schemas';
 import { appendPath, getEnv } from '@silverhand/essentials';
 
 export const logtoUrl = getEnv('INTEGRATION_TESTS_LOGTO_URL', 'http://localhost:3001');
@@ -30,3 +30,19 @@ export const mockSocialAuthPageUrl = 'http://mock.social.com';
 export enum ProviderName {
   OIDC = 'OIDC',
 }
+
+export const newOidcSsoConnectorPayload = {
+  providerName: ProviderName.OIDC,
+  connectorName: 'test-oidc',
+  domains: ['example.io'], // Auto-generated email domain
+  ssoOnly: true,
+  branding: {
+    logo: 'https://logto.io/oidc-logo.png',
+    darkLogo: 'https://logto.io/oidc-dark-logo.png',
+  },
+  config: {
+    clientId: 'foo',
+    clientSecret: 'bar',
+    issuer: `${logtoUrl}/oidc`,
+  },
+} satisfies Partial<CreateSsoConnector>;

--- a/packages/integration-tests/src/helpers/connector.ts
+++ b/packages/integration-tests/src/helpers/connector.ts
@@ -9,11 +9,17 @@ import {
   mockSocialConnectorConfig,
 } from '#src/__mocks__/connectors-mock.js';
 import { listConnectors, deleteConnectorById, postConnector } from '#src/api/index.js';
+import { deleteSsoConnectorById, getSsoConnectors } from '#src/api/sso-connector.js';
 
 export const clearConnectorsByTypes = async (types: ConnectorType[]) => {
   const connectors = await listConnectors();
   const targetConnectors = connectors.filter((connector) => types.includes(connector.type));
   await Promise.all(targetConnectors.map(async (connector) => deleteConnectorById(connector.id)));
+};
+
+export const clearSsoConnectors = async () => {
+  const ssoConnectors = await getSsoConnectors();
+  await Promise.all(ssoConnectors.map(async (connector) => deleteSsoConnectorById(connector.id)));
 };
 
 export const clearConnectorById = async (id: string) => deleteConnectorById(id);

--- a/packages/integration-tests/src/tests/api/interaction/forgot-password/happy-path.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/forgot-password/happy-path.test.ts
@@ -94,6 +94,7 @@ describe('reset password', () => {
     await logoutClient(client);
     await deleteUser(user.id);
   });
+
   it('reset password with phone', async () => {
     const { user, userProfile } = await generateNewUser({
       primaryPhone: true,

--- a/packages/integration-tests/src/tests/api/interaction/register-with-identifier/sad-path.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/register-with-identifier/sad-path.test.ts
@@ -6,18 +6,35 @@ import {
   sendVerificationCode,
 } from '#src/api/interaction.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
+import { createSsoConnector } from '#src/api/sso-connector.js';
+import { newOidcSsoConnectorPayload } from '#src/constants.js';
 import { initClient } from '#src/helpers/client.js';
 import {
   clearConnectorsByTypes,
+  clearSsoConnectors,
   setEmailConnector,
   setSmsConnector,
 } from '#src/helpers/connector.js';
 import { expectRejects, readVerificationCode } from '#src/helpers/index.js';
-import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
+import {
+  enableAllPasswordSignInMethods,
+  enableAllVerificationCodeSignInMethods,
+} from '#src/helpers/sign-in-experience.js';
 import { generateNewUserProfile } from '#src/helpers/user.js';
-import { generatePassword, generateUsername } from '#src/utils.js';
+import { generateEmail, generatePassword, generateUsername } from '#src/utils.js';
 
 describe('Register with identifiers sad path', () => {
+  beforeAll(async () => {
+    await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);
+    await setEmailConnector();
+    await setSmsConnector();
+  });
+
+  afterAll(async () => {
+    await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);
+    await clearSsoConnectors();
+  });
+
   it('Should fail to register if sign-in mode is sign-in only', async () => {
     await updateSignInExperience({ signInMode: SignInMode.SignIn });
     const client = await initClient();
@@ -34,6 +51,39 @@ describe('Register with identifiers sad path', () => {
 
     // Reset
     await updateSignInExperience({ signInMode: SignInMode.SignInAndRegister });
+  });
+
+  it('Should fail to register with email if email domain is enabled for SSO only', async () => {
+    await enableAllVerificationCodeSignInMethods();
+    const email = generateEmail('sso-register-sad-path.io');
+
+    await createSsoConnector({
+      ...newOidcSsoConnectorPayload,
+      domains: ['sso-register-sad-path.io'],
+    });
+
+    const client = await initClient();
+
+    await client.successSend(putInteraction, {
+      event: InteractionEvent.Register,
+    });
+
+    await client.successSend(sendVerificationCode, {
+      email,
+    });
+
+    const { code: verificationCode } = await readVerificationCode();
+
+    await expectRejects(
+      client.send(patchInteractionIdentifiers, {
+        email,
+        verificationCode,
+      }),
+      {
+        code: 'session.sso_enabled',
+        statusCode: 422,
+      }
+    );
   });
 
   describe('Should fail to register with identifiers if sign-up settings are not enabled', () => {

--- a/packages/integration-tests/src/tests/api/interaction/sign-in-with-passcode-identifier/sad-path.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/sign-in-with-passcode-identifier/sad-path.test.ts
@@ -1,23 +1,26 @@
 import { ConnectorType } from '@logto/connector-kit';
 import { InteractionEvent, SignInMode } from '@logto/schemas';
 
-import { suspendUser } from '#src/api/admin-user.js';
+import { createUser, deleteUser, suspendUser } from '#src/api/admin-user.js';
 import {
   patchInteractionIdentifiers,
   putInteraction,
   sendVerificationCode,
 } from '#src/api/interaction.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
+import { createSsoConnector } from '#src/api/sso-connector.js';
+import { newOidcSsoConnectorPayload } from '#src/constants.js';
 import { initClient } from '#src/helpers/client.js';
 import {
   clearConnectorsByTypes,
+  clearSsoConnectors,
   setEmailConnector,
   setSmsConnector,
 } from '#src/helpers/connector.js';
 import { expectRejects, readVerificationCode } from '#src/helpers/index.js';
 import { enableAllVerificationCodeSignInMethods } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
-import { generateEmail, generatePhone } from '#src/utils.js';
+import { generateEmail, generatePassword, generatePhone } from '#src/utils.js';
 
 describe('Sign-in flow sad path using verification-code identifiers', () => {
   beforeAll(async () => {
@@ -29,6 +32,7 @@ describe('Sign-in flow sad path using verification-code identifiers', () => {
 
   afterAll(async () => {
     await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);
+    await clearSsoConnectors();
   });
 
   it('Should fail to sign in with passcode if sign-in mode is register only', async () => {
@@ -207,6 +211,41 @@ describe('Sign-in flow sad path using verification-code identifiers', () => {
       code: 'user.user_not_exist',
       statusCode: 404,
     });
+  });
+
+  it('Should fail to sign in with email and passcode if the email domain is enabled for SSO only', async () => {
+    const password = generatePassword();
+    const email = generateEmail('sso-sad-path.io');
+    const user = await createUser({ primaryEmail: email, password });
+
+    await createSsoConnector({
+      ...newOidcSsoConnectorPayload,
+      domains: ['sso-sad-path.io'],
+    });
+
+    const client = await initClient();
+    await client.successSend(putInteraction, {
+      event: InteractionEvent.SignIn,
+    });
+
+    await client.successSend(sendVerificationCode, {
+      email,
+    });
+
+    const { code: verificationCode } = await readVerificationCode();
+
+    await expectRejects(
+      client.send(patchInteractionIdentifiers, {
+        email,
+        verificationCode,
+      }),
+      {
+        code: 'session.sso_enabled',
+        statusCode: 422,
+      }
+    );
+
+    await deleteUser(user.id);
   });
 
   it('Should fail to sign in with phone and passcode if related user is not exist', async () => {

--- a/packages/integration-tests/src/tests/api/well-known.test.ts
+++ b/packages/integration-tests/src/tests/api/well-known.test.ts
@@ -3,7 +3,7 @@ import { HTTPError } from 'got';
 
 import api, { adminTenantApi, authedAdminApi } from '#src/api/api.js';
 import { createSsoConnector, deleteSsoConnectorById } from '#src/api/sso-connector.js';
-import { logtoUrl } from '#src/constants.js';
+import { newOidcSsoConnectorPayload } from '#src/constants.js';
 
 describe('.well-known api', () => {
   it('should return tenant endpoint URL for any given tenant id', async () => {
@@ -56,25 +56,8 @@ describe('.well-known api', () => {
   });
 
   describe('sso connectors in sign-in experience', () => {
-    const logtoIssuer = `${logtoUrl}/oidc`;
-
-    const newOIDCSsoConnector = {
-      providerName: 'OIDC',
-      connectorName: 'OIDC sso connector',
-      domains: ['logto.io'],
-      branding: {
-        logo: 'https://logto.io/oidc-logo.png',
-        darkLogo: 'https://logto.io/oidc-dark-logo.png',
-      },
-      config: {
-        clientId: 'client-id',
-        clientSecret: 'client-secret',
-        issuer: logtoIssuer,
-      },
-    };
-
     it('should get the sso connectors in sign-in experience', async () => {
-      const { id, connectorName } = await createSsoConnector(newOIDCSsoConnector);
+      const { id, connectorName } = await createSsoConnector(newOidcSsoConnectorPayload);
 
       const signInExperience = await api
         .get('.well-known/sign-in-exp')
@@ -89,8 +72,8 @@ describe('.well-known api', () => {
       expect(newCreatedConnector).toMatchObject({
         id,
         connectorName,
-        logo: newOIDCSsoConnector.branding.logo,
-        darkLogo: newOIDCSsoConnector.branding.darkLogo,
+        logo: newOidcSsoConnectorPayload.branding.logo,
+        darkLogo: newOidcSsoConnectorPayload.branding.darkLogo,
       });
 
       await deleteSsoConnectorById(id);
@@ -98,7 +81,7 @@ describe('.well-known api', () => {
 
     it('should filter out the sso connectors with invalid config', async () => {
       const { id } = await createSsoConnector({
-        ...newOIDCSsoConnector,
+        ...newOidcSsoConnectorPayload,
         config: {},
       });
 
@@ -115,7 +98,7 @@ describe('.well-known api', () => {
 
     it('should filter out the sso connectors with empty domains', async () => {
       const { id } = await createSsoConnector({
-        ...newOIDCSsoConnector,
+        ...newOidcSsoConnectorPayload,
         domains: [],
       });
 

--- a/packages/integration-tests/src/utils.ts
+++ b/packages/integration-tests/src/utils.ts
@@ -12,7 +12,8 @@ export const generatePassword = () => `pwd_${crypto.randomUUID()}`;
 
 export const generateResourceName = () => `res_${crypto.randomUUID()}`;
 export const generateResourceIndicator = () => `https://${crypto.randomUUID()}.logto.io`;
-export const generateEmail = () => `${crypto.randomUUID().toLowerCase()}@logto.io`;
+export const generateEmail = (domain = 'logto.io') =>
+  `${crypto.randomUUID().toLowerCase()}@${domain}`;
 export const generateScopeName = () => `sc:${crypto.randomUUID()}`;
 export const generateRoleName = () => `role_${crypto.randomUUID()}`;
 export const generateDomain = () => `${crypto.randomUUID().toLowerCase().slice(0, 5)}.example.com`;

--- a/packages/phrases/src/locales/de/errors/session.ts
+++ b/packages/phrases/src/locales/de/errors/session.ts
@@ -50,6 +50,8 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled:
+    'Einmaliges Anmelden ist für diese gegebene E-Mail aktiviert. Bitte melden Sie sich mit SSO an.',
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/en/errors/session.ts
+++ b/packages/phrases/src/locales/en/errors/session.ts
@@ -35,6 +35,7 @@ const session = {
     invalid_backup_code: 'Invalid backup code.',
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled: 'Single sign on is enabled for this given email. Please sign in with SSO.',
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/es/errors/session.ts
+++ b/packages/phrases/src/locales/es/errors/session.ts
@@ -51,6 +51,8 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled:
+    'El inicio de sesión único está habilitado para este correo electrónico dado. Inicie sesión con SSO, por favor.',
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/fr/errors/session.ts
+++ b/packages/phrases/src/locales/fr/errors/session.ts
@@ -52,6 +52,8 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled:
+    'La connexion unique est activée pour cet e-mail donné. Veuillez vous connecter avec SSO.',
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/it/errors/session.ts
+++ b/packages/phrases/src/locales/it/errors/session.ts
@@ -50,6 +50,7 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled: "L'accesso singolo è abilitato per questa email. Accedi con SSO.",
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/ja/errors/session.ts
+++ b/packages/phrases/src/locales/ja/errors/session.ts
@@ -48,6 +48,8 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled:
+    'このメールアドレスではシングルサインオンが有効になっています。SSOでサインインしてください。',
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/ko/errors/session.ts
+++ b/packages/phrases/src/locales/ko/errors/session.ts
@@ -47,6 +47,7 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled: '이 이메일로는 SSO가 활성화되어 있어요. SSO로 로그인해 주세요.',
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/pl-pl/errors/session.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/session.ts
@@ -49,6 +49,7 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled: 'Single sign on jest włączony dla tego adresu e-mail. Zaloguj się za pomocą SSO.',
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/pt-br/errors/session.ts
+++ b/packages/phrases/src/locales/pt-br/errors/session.ts
@@ -50,6 +50,8 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled:
+    'O login único está habilitado para este e-mail fornecido. Faça login com SSO, por favor.',
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/pt-pt/errors/session.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/session.ts
@@ -52,6 +52,8 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled:
+    'O login único está habilitado para este e-mail fornecido. Faça login com SSO, por favor.',
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/ru/errors/session.ts
+++ b/packages/phrases/src/locales/ru/errors/session.ts
@@ -48,6 +48,8 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled:
+    'Единый вход в систему включен для этого указанного адреса электронной почты. Войдите в систему с помощью SSO.',
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/tr-tr/errors/session.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/session.ts
@@ -49,6 +49,7 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled: 'Bu e-posta için tek oturum açma etkin. Lütfen SSO ile oturum açın.',
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/zh-cn/errors/session.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/session.ts
@@ -44,6 +44,7 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled: '该邮箱已开启单点登录，请使用 SSO 登录。',
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/zh-hk/errors/session.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/session.ts
@@ -44,6 +44,7 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled: '該郵箱已開啟單點登錄，請使用 SSO 登錄。',
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/zh-tw/errors/session.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/session.ts
@@ -44,6 +44,7 @@ const session = {
     /** UNTRANSLATED */
     mfa_policy_not_user_controlled: 'MFA policy is not user controlled.',
   },
+  sso_enabled: '該郵箱已開啟單點登錄，請使用 SSO 登錄。',
 };
 
 export default Object.freeze(session);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add SSO email guard to interaction endpoint when user trying to sign-in or register using a email with SSO only domain. 

If the email domain is claimed by more than one SSO connectors and mark the domain to be SSO only, we will reject the email identifier update request. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT + integration tests

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
