### PR TITLE
refactor(console): search fields should auto fit its placeholder as minimum width

### DIFF
--- a/packages/console/src/components/PermissionsTable/index.module.scss
+++ b/packages/console/src/components/PermissionsTable/index.module.scss
@@ -10,10 +10,6 @@
     justify-content: space-between;
     align-items: center;
 
-    .searchInput {
-      width: 306px;
-    }
-
     .createButton {
       margin-left: _.unit(2);
     }

--- a/packages/console/src/components/PermissionsTable/index.tsx
+++ b/packages/console/src/components/PermissionsTable/index.tsx
@@ -132,7 +132,6 @@ function PermissionsTable({
       filter={
         <div className={styles.filter}>
           <Search
-            inputClassName={styles.searchInput}
             defaultValue={keyword}
             isClearable={Boolean(keyword)}
             placeholder={t(

--- a/packages/console/src/pages/ApplicationDetails/components/MachineToMachineApplicationRoles/index.module.scss
+++ b/packages/console/src/pages/ApplicationDetails/components/MachineToMachineApplicationRoles/index.module.scss
@@ -9,10 +9,6 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-
-    .searchInput {
-      width: 306px;
-    }
   }
 
   .description {

--- a/packages/console/src/pages/ApplicationDetails/components/MachineToMachineApplicationRoles/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/components/MachineToMachineApplicationRoles/index.tsx
@@ -129,7 +129,6 @@ function MachineToMachineApplicationRoles({ application }: Props) {
         filter={
           <div className={styles.filter}>
             <Search
-              inputClassName={styles.searchInput}
               defaultValue={keyword}
               isClearable={Boolean(keyword)}
               placeholder={t('application_details.roles.search')}

--- a/packages/console/src/pages/Roles/index.module.scss
+++ b/packages/console/src/pages/Roles/index.module.scss
@@ -1,9 +1,5 @@
 @use '@/scss/underscore' as _;
 
-.search {
-  width: 306px;
-}
-
 .type,
 .description {
   @include _.text-ellipsis;

--- a/packages/console/src/pages/Roles/index.tsx
+++ b/packages/console/src/pages/Roles/index.tsx
@@ -147,7 +147,6 @@ function Roles() {
         },
         filter: (
           <Search
-            inputClassName={styles.search}
             placeholder={t('roles.search')}
             defaultValue={keyword}
             isClearable={Boolean(keyword)}

--- a/packages/console/src/pages/UserDetails/UserRoles/index.module.scss
+++ b/packages/console/src/pages/UserDetails/UserRoles/index.module.scss
@@ -9,10 +9,6 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-
-    .searchInput {
-      width: 306px;
-    }
   }
 
   .description {

--- a/packages/console/src/pages/UserDetails/UserRoles/index.tsx
+++ b/packages/console/src/pages/UserDetails/UserRoles/index.tsx
@@ -125,7 +125,6 @@ function UserRoles() {
         filter={
           <div className={styles.filter}>
             <Search
-              inputClassName={styles.searchInput}
               defaultValue={keyword}
               isClearable={Boolean(keyword)}
               placeholder={t('user_details.roles.search')}

--- a/packages/console/src/pages/Users/index.module.scss
+++ b/packages/console/src/pages/Users/index.module.scss
@@ -1,3 +1,0 @@
-.searchInput {
-  width: 338px;
-}

--- a/packages/console/src/pages/Users/index.tsx
+++ b/packages/console/src/pages/Users/index.tsx
@@ -26,7 +26,6 @@ import { getUserTitle, getUserSubtitle } from '@/utils/user';
 
 import CreateForm from './components/CreateForm';
 import SuspendedTag from './components/SuspendedTag';
-import * as styles from './index.module.scss';
 
 const pageSize = defaultPageSize;
 const usersPathname = '/users';
@@ -110,7 +109,6 @@ function Users() {
         ],
         filter: (
           <Search
-            inputClassName={styles.searchInput}
             placeholder={t('users.search')}
             defaultValue={keyword}
             isClearable={Boolean(keyword)}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
In addition to #4833, remove all fixed width applied to search fields, and auto fit to its placeholder content as minimum width.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
