### PR TITLE
refactor(console): only display reserved plans in the console

### DIFF
--- a/packages/console/src/components/CreateTenantModal/SelectTenantPlanModal/index.tsx
+++ b/packages/console/src/components/CreateTenantModal/SelectTenantPlanModal/index.tsx
@@ -1,3 +1,4 @@
+import { conditional } from '@silverhand/essentials';
 import { Trans, useTranslation } from 'react-i18next';
 import Modal from 'react-modal';
 
@@ -11,6 +12,7 @@ import useSubscribe from '@/hooks/use-subscribe';
 import useSubscriptionPlans from '@/hooks/use-subscription-plans';
 import * as modalStyles from '@/scss/modal.module.scss';
 import { type SubscriptionPlan } from '@/types/subscriptions';
+import { pickupReservedPlans } from '@/utils/subscription';
 
 import { type CreateTenantData } from '../type';
 
@@ -27,7 +29,9 @@ function SelectTenantPlanModal({ tenantData, onClose }: Props) {
   const { data: subscriptionPlans } = useSubscriptionPlans();
   const { subscribe } = useSubscribe();
   const cloudApi = useCloudApi({ hideErrorToast: true });
-  if (!subscriptionPlans || !tenantData) {
+  const reservedPlans = conditional(subscriptionPlans && pickupReservedPlans(subscriptionPlans));
+
+  if (!reservedPlans || !tenantData) {
     return null;
   }
 
@@ -75,7 +79,7 @@ function SelectTenantPlanModal({ tenantData, onClose }: Props) {
         onClose={onClose}
       >
         <div className={styles.container}>
-          {subscriptionPlans.map((plan) => (
+          {reservedPlans.map((plan) => (
             <PlanCardItem
               key={plan.id}
               plan={plan}

--- a/packages/console/src/consts/subscriptions.ts
+++ b/packages/console/src/consts/subscriptions.ts
@@ -4,6 +4,8 @@ export enum ReservedPlanId {
   pro = 'pro',
 }
 
+export const reservedPlanIds: string[] = Object.values(ReservedPlanId);
+
 export const reservedPlanIdOrder: string[] = [
   ReservedPlanId.free,
   ReservedPlanId.hobby,

--- a/packages/console/src/pages/TenantSettings/Subscription/index.tsx
+++ b/packages/console/src/pages/TenantSettings/Subscription/index.tsx
@@ -1,4 +1,5 @@
 import { withAppInsights } from '@logto/app-insights/react';
+import { conditionalArray } from '@silverhand/essentials';
 import { useContext } from 'react';
 
 import PageMeta from '@/components/PageMeta';
@@ -6,6 +7,7 @@ import { TenantsContext } from '@/contexts/TenantsProvider';
 import useSubscription from '@/hooks/use-subscription';
 import useSubscriptionPlans from '@/hooks/use-subscription-plans';
 import useSubscriptionUsage from '@/hooks/use-subscription-usage';
+import { pickupReservedPlans } from '@/utils/subscription';
 
 import Skeleton from '../components/Skeleton';
 
@@ -28,6 +30,10 @@ function Subscription() {
   const isLoadingPlans = !subscriptionPlans && !fetchPlansError;
   const isLoadingSubscription = !currentSubscription && !fetchSubscriptionError;
   const isLoadingSubscriptionUsage = !subscriptionUsage && !fetchSubscriptionUsageError;
+
+  const reservedPlans = conditionalArray(
+    subscriptionPlans && pickupReservedPlans(subscriptionPlans)
+  );
 
   if (isLoadingPlans || isLoadingSubscription || isLoadingSubscriptionUsage) {
     return <Skeleton />;
@@ -53,10 +59,10 @@ function Subscription() {
         subscriptionPlan={currentSubscriptionPlan}
         subscriptionUsage={subscriptionUsage}
       />
-      <PlanQuotaTable subscriptionPlans={subscriptionPlans} />
+      <PlanQuotaTable subscriptionPlans={reservedPlans} />
       <SwitchPlanActionBar
         currentSubscriptionPlanId={currentSubscription.planId}
-        subscriptionPlans={subscriptionPlans}
+        subscriptionPlans={reservedPlans}
         onSubscriptionUpdated={mutateSubscription}
       />
     </div>

--- a/packages/console/src/utils/subscription.ts
+++ b/packages/console/src/utils/subscription.ts
@@ -8,7 +8,8 @@ import {
   organizationEnabledMap,
   ticketSupportResponseTimeMap,
 } from '@/consts/plan-quotas';
-import { reservedPlanIdOrder } from '@/consts/subscriptions';
+import { reservedPlanIdOrder, reservedPlanIds } from '@/consts/subscriptions';
+import { type SubscriptionPlan } from '@/types/subscriptions';
 
 export const addSupportQuotaToPlan = (subscriptionPlanResponse: SubscriptionPlanResponse) => {
   const { id, quota } = subscriptionPlanResponse;
@@ -60,3 +61,6 @@ export const isExceededQuotaLimitError = async (error: unknown) => {
 
   return Boolean(message?.includes('Exceeded quota limit'));
 };
+
+export const pickupReservedPlans = (plans: SubscriptionPlan[]): SubscriptionPlan[] =>
+  plans.filter(({ id }) => reservedPlanIds.includes(id));


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
We will have "dev" plan in the next cloud version. But in the console, we should only display reserved plans on subscription pages, this PR is used to filter out all invisible plans on the page.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
