### PR TITLE
refactor(core): remove the sso only property from the sso connectors response guard

### DIFF
--- a/packages/core/src/libraries/sign-in-experience/types.ts
+++ b/packages/core/src/libraries/sign-in-experience/types.ts
@@ -16,7 +16,7 @@ type ConnectorMetadataWithId = ConnectorMetadata & { id: string };
 
 export type FullSignInExperience = SignInExperience & {
   socialConnectors: ConnectorMetadataWithId[];
-  ssoConnectors: SsoConnectorMetadata[];
+  ssoConnectors: Array<Omit<SsoConnectorMetadata, 'ssoOnly'>>;
   forgotPassword: ForgotPassword;
   isDevelopmentTenant: boolean;
 };
@@ -24,7 +24,7 @@ export type FullSignInExperience = SignInExperience & {
 export const guardFullSignInExperience: z.ZodType<FullSignInExperience> =
   SignInExperiences.guard.extend({
     socialConnectors: connectorMetadataGuard.extend({ id: z.string() }).array(),
-    ssoConnectors: ssoConnectorMetadataGuard.array(),
+    ssoConnectors: ssoConnectorMetadataGuard.omit({ ssoOnly: true }).array(),
     forgotPassword: z.object({ phone: z.boolean(), email: z.boolean() }),
     isDevelopmentTenant: z.boolean(),
   });

--- a/packages/core/src/routes/sso-connector/index.ts
+++ b/packages/core/src/routes/sso-connector/index.ts
@@ -77,7 +77,7 @@ export default function singleSignOnRoutes<T extends AuthedRouter>(...args: Rout
     pathname,
     koaGuard({
       body: ssoConnectorCreateGuard,
-      response: SsoConnectors.guard,
+      response: SsoConnectors.guard.omit({ ssoOnly: true }),
       status: [200, 422],
     }),
     async (ctx, next) => {

--- a/packages/core/src/routes/sso-connector/type.ts
+++ b/packages/core/src/routes/sso-connector/type.ts
@@ -27,12 +27,14 @@ export const ssoConnectorCreateGuard = SsoConnectors.createGuard
   // Provider name and connector name are required for creating a connector
   .merge(SsoConnectors.guard.pick({ providerName: true, connectorName: true }));
 
-export const ssoConnectorWithProviderConfigGuard = SsoConnectors.guard.merge(
-  z.object({
-    providerLogo: z.string(),
-    providerConfig: z.record(z.unknown()).optional(),
-  })
-);
+export const ssoConnectorWithProviderConfigGuard = SsoConnectors.guard
+  .merge(
+    z.object({
+      providerLogo: z.string(),
+      providerConfig: z.record(z.unknown()).optional(),
+    })
+  )
+  .omit({ ssoOnly: true });
 
 export type SsoConnectorWithProviderConfig = z.infer<typeof ssoConnectorWithProviderConfigGuard>;
 


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Related PR #4856 

We are going to remove the  ssoOnly property from SSO connectors per product decisions.  However the db alteration compatibility test will fail, as previous version API has a strict guard on the return type of the sso connectors. 

To make the migration process flawless. This PR first remove the ssoOnly property assertion from the API response guard. So the db alteration script won't fail the api request. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
ci

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
