### PR TITLE
refactor(core): generate shared id parameters definition for swagger

### DIFF
--- a/.changeset/warm-tips-attack.md
+++ b/.changeset/warm-tips-attack.md
@@ -1,0 +1,9 @@
+---
+"@logto/core": patch
+---
+
+refactored swagger json api
+
+- reuse parameter definitions, which reduces the size of the swagger response.
+- tags are now in sentence case.
+- path parameters now follow the swagger convention, using `{foo}` instead of `:foo`.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,7 +29,7 @@
   "json.schemas": [
     {
       "fileMatch": [
-        "packages/core/src/routes/*.openapi.json"
+        "packages/core/src/routes/**/*.openapi.json"
       ],
       "url": "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.0/schema.json"
     }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,7 @@
     "precommit": "lint-staged",
     "copyfiles": "copyfiles -u 1 src/routes/**/*.openapi.json build/",
     "build": "rm -rf build/ && tsc -p tsconfig.build.json && pnpm run copyfiles",
-    "build:test": "rm -rf build/ && tsc -p tsconfig.test.json --sourcemap",
+    "build:test": "rm -rf build/ && tsc -p tsconfig.test.json --sourcemap && pnpm run copyfiles",
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "dev": "rm -rf build/ && pnpm run copyfiles && nodemon",

--- a/packages/core/src/routes/init.ts
+++ b/packages/core/src/routes/init.ts
@@ -29,7 +29,7 @@ import roleScopeRoutes from './role.scope.js';
 import signInExperiencesRoutes from './sign-in-experience/index.js';
 import ssoConnectors from './sso-connector/index.js';
 import statusRoutes from './status.js';
-import swaggerRoutes from './swagger.js';
+import swaggerRoutes from './swagger/index.js';
 import type { AnonymousRouter, AuthedRouter } from './types.js';
 import userAssetsRoutes from './user-assets.js';
 import verificationCodeRoutes from './verification-code.js';

--- a/packages/core/src/routes/swagger/index.test.ts
+++ b/packages/core/src/routes/swagger/index.test.ts
@@ -101,19 +101,41 @@ describe('GET /swagger.json', () => {
 
     const response = await swaggerRequest.get('/swagger.json');
     expect(response.body.paths).toMatchObject({
-      '/api/mock/:id/:field': {
-        parameters: [
-          {
-            $ref: '#/components/parameters/mocId:root',
+      '/api/mock/{id}/{field}': {
+        get: {
+          parameters: [
+            {
+              $ref: '#/components/parameters/mocId:root',
+            },
+            {
+              name: 'field',
+              in: 'path',
+              required: true,
+              schema: { type: 'string' },
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it('should be able to find supplement files and merge them', async () => {
+    const swaggerRequest = createSwaggerRequest([mockRouter]);
+    const response = await swaggerRequest.get('/swagger.json');
+    // Partially match one of the supplement files `status.openapi.json`. Should update this test
+    // when the file is updated.
+    expect(response.body).toMatchObject({
+      paths: {
+        '/api/status': {
+          get: {
+            summary: 'Health check',
+            responses: {
+              '204': {
+                description: 'The Logto core service is healthy.',
+              },
+            },
           },
-          {
-            name: 'field',
-            in: 'path',
-            required: true,
-            schema: { type: 'string' },
-          },
-        ],
-        get: {},
+        },
       },
     });
   });

--- a/packages/core/src/routes/swagger/index.test.ts
+++ b/packages/core/src/routes/swagger/index.test.ts
@@ -8,7 +8,8 @@ import koaGuard from '#src/middleware/koa-guard.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
 import type { AnonymousRouter } from '#src/routes/types.js';
 
-const { default: swaggerRoutes, paginationParameters } = await import('./index.js');
+const { default: swaggerRoutes } = await import('./index.js');
+const { paginationParameters } = await import('./utils/parameters.js');
 
 const createSwaggerRequest = (
   allRouters: Router[],
@@ -79,7 +80,7 @@ describe('GET /swagger.json', () => {
         get: { tags: ['Mock'] },
       },
       '/api/.well-known': {
-        put: { tags: ['.well-known'] },
+        put: { tags: ['Well known'] },
       },
     });
   });
@@ -101,22 +102,18 @@ describe('GET /swagger.json', () => {
     const response = await swaggerRequest.get('/swagger.json');
     expect(response.body.paths).toMatchObject({
       '/api/mock/:id/:field': {
-        get: {
-          parameters: [
-            {
-              name: 'id',
-              in: 'path',
-              required: true,
-              schema: { type: 'number' },
-            },
-            {
-              name: 'field',
-              in: 'path',
-              required: true,
-              schema: { type: 'string' },
-            },
-          ],
-        },
+        parameters: [
+          {
+            $ref: '#/components/parameters/mocId:root',
+          },
+          {
+            name: 'field',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        get: {},
       },
     });
   });

--- a/packages/core/src/routes/swagger/index.test.ts
+++ b/packages/core/src/routes/swagger/index.test.ts
@@ -8,7 +8,7 @@ import koaGuard from '#src/middleware/koa-guard.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
 import type { AnonymousRouter } from '#src/routes/types.js';
 
-const { default: swaggerRoutes, paginationParameters } = await import('./swagger.js');
+const { default: swaggerRoutes, paginationParameters } = await import('./index.js');
 
 const createSwaggerRequest = (
   allRouters: Router[],

--- a/packages/core/src/routes/swagger/utils/general.ts
+++ b/packages/core/src/routes/swagger/utils/general.ts
@@ -14,8 +14,12 @@ export const getRootComponent = (path?: string) => path?.split('/')[1];
  * component name.
  * @example '/organization-roles' -> 'Organization roles'
  */
-export const buildTag = (path: string) =>
-  capitalize((getRootComponent(path) ?? 'General').replaceAll('-', ' '));
+export const buildTag = (path: string) => {
+  const rootComponent = (getRootComponent(path) ?? 'General').replaceAll('-', ' ');
+  return rootComponent.startsWith('.')
+    ? capitalize(rootComponent.slice(1))
+    : capitalize(rootComponent);
+};
 
 /**
  * Recursively find all supplement files (files end with `.openapi.json`) for the given
@@ -37,3 +41,16 @@ export const findSupplementFiles = async (directory: string) => {
   return result;
 };
 /* eslint-enable @silverhand/fp/no-mutating-methods, no-await-in-loop */
+
+/**
+ * Normalize the path to the OpenAPI path by adding `/api` prefix and replacing the path parameters
+ * with OpenAPI path parameters.
+ *
+ * @example
+ * normalizePath('/organization/:id') -> '/api/organization/{id}'
+ */
+export const normalizePath = (path: string) =>
+  `/api${path}`
+    .split('/')
+    .map((part) => (part.startsWith(':') ? `{${part.slice(1)}}` : part))
+    .join('/');

--- a/packages/core/src/routes/swagger/utils/general.ts
+++ b/packages/core/src/routes/swagger/utils/general.ts
@@ -1,0 +1,39 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const capitalize = (value: string) => value.charAt(0).toUpperCase() + value.slice(1);
+
+/**
+ * Get the root component name from the given absolute path.
+ * @example '/organization/:id' -> 'organization'
+ */
+export const getRootComponent = (path?: string) => path?.split('/')[1];
+
+/**
+ * Build a tag name from the given absolute path. The tag name is the sentence case of the root
+ * component name.
+ * @example '/organization-roles' -> 'Organization roles'
+ */
+export const buildTag = (path: string) =>
+  capitalize((getRootComponent(path) ?? 'General').replaceAll('-', ' '));
+
+/**
+ * Recursively find all supplement files (files end with `.openapi.json`) for the given
+ * directory.
+ */
+/* eslint-disable @silverhand/fp/no-mutating-methods, no-await-in-loop */
+export const findSupplementFiles = async (directory: string) => {
+  const result: string[] = [];
+
+  for (const file of await fs.readdir(directory)) {
+    const stats = await fs.stat(path.join(directory, file));
+    if (stats.isDirectory()) {
+      result.push(...(await findSupplementFiles(path.join(directory, file))));
+    } else if (file.endsWith('.openapi.json')) {
+      result.push(path.join(directory, file));
+    }
+  }
+
+  return result;
+};
+/* eslint-enable @silverhand/fp/no-mutating-methods, no-await-in-loop */

--- a/packages/core/src/routes/swagger/utils/parameters.ts
+++ b/packages/core/src/routes/swagger/utils/parameters.ts
@@ -1,0 +1,230 @@
+import camelcase from 'camelcase';
+import deepmerge from 'deepmerge';
+import { type OpenAPIV3 } from 'openapi-types';
+import { z } from 'zod';
+
+import { fallbackDefaultPageSize } from '#src/middleware/koa-pagination.js';
+import assertThat from '#src/utils/assert-that.js';
+import { zodTypeToSwagger } from '#src/utils/zod.js';
+
+import { getRootComponent } from './general.js';
+
+export type ParameterArray = Array<OpenAPIV3.ReferenceObject | OpenAPIV3.ParameterObject>;
+
+// TODO: Generate pagination parameters according to the config.
+export const paginationParameters: OpenAPIV3.ParameterObject[] = [
+  {
+    name: 'page',
+    in: 'query',
+    description: 'Page number (starts from 1).',
+    required: false,
+    schema: {
+      type: 'integer',
+      minimum: 1,
+      default: 1,
+    },
+  },
+  {
+    name: 'page_size',
+    in: 'query',
+    description: 'Entries per page.',
+    required: false,
+    schema: {
+      type: 'integer',
+      minimum: 1,
+      default: fallbackDefaultPageSize,
+    },
+  },
+];
+
+type BuildParameters = {
+  /**
+   * Build a parameter array for the given `ZodObject`.
+   *
+   * For path parameters, this function will try to match reusable ID parameters:
+   *
+   * - If the parameter name is `id`, and the path is `/organizations/{id}/users`, the parameter
+   *   `id` will be a reference to `#/components/parameters/organizationId:root`.
+   * - If the parameter name ends with `Id`, and the path is `/organizations/{id}/users/{userId}`,
+   *   the parameter `userId` will be a reference to `#/components/parameters/userId`.
+   *
+   * @param zodParameters The `ZodObject` to build parameters from. The keys of the object are the
+   * parameter names.
+   * @param inWhere The parameters are in a path, for example, `/users/:id`.
+   * @param path The path of the route. Only required when `inWhere` is `path`.
+   * @returns The built parameter array for OpenAPI.
+   * @see {@link buildPathIdParameters} for reusable ID parameters.
+   */
+  (zodParameters: unknown, inWhere: 'path', path: string): ParameterArray;
+  /**
+   * Build a parameter array for the given `ZodObject`.
+   * @param zodParameters The `ZodObject` to build parameters from. The keys of the object are the
+   * parameter names.
+   * @param inWhere The parameters are in a query, for example, `/users?name=foo`.
+   * @returns The built parameter array for OpenAPI.
+   */
+  (zodParameters: unknown, inWhere: 'query'): ParameterArray;
+};
+
+// Parameter serialization: https://swagger.io/docs/specification/serialization
+export const buildParameters: BuildParameters = (
+  zodParameters: unknown,
+  inWhere: 'path' | 'query',
+  path?: string
+): ParameterArray => {
+  if (!zodParameters) {
+    return [];
+  }
+
+  assertThat(zodParameters instanceof z.ZodObject, 'swagger.not_supported_zod_type_for_params');
+
+  const rootComponent = camelcase(getRootComponent(path) ?? '');
+
+  // Type from Zod is any
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  return Object.entries(zodParameters.shape).map(([key, value]) => {
+    if (inWhere === 'path') {
+      if (key === 'id') {
+        if (rootComponent) {
+          return {
+            $ref: `#/components/parameters/${rootComponent.slice(0, -1)}Id:root`,
+          };
+        }
+
+        throw new Error(
+          'Cannot find root path component for `:id` in path `' +
+            (path ?? '') +
+            '`. This is probably not expected.'
+        );
+      } else if (key.endsWith('Id')) {
+        return {
+          $ref: `#/components/parameters/${key}`,
+        };
+      }
+    }
+
+    return {
+      name: key,
+      in: inWhere,
+      required: !(value instanceof z.ZodOptional),
+      schema: zodTypeToSwagger(value),
+    };
+  });
+};
+
+const isObjectArray = (value: unknown): value is Array<Record<string, unknown>> =>
+  Array.isArray(value) && value.every((item) => typeof item === 'object' && item !== null);
+
+/**
+ * Merge two arrays. If the two arrays are both object arrays, merge them with the following
+ * rules:
+ *
+ * - If the source array has an item with `name` and `in` properties, and the destination array
+ *  also has an item with the same `name` and `in` properties, merge the two items with
+ * `deepmerge`.
+ * - Otherwise, append the item to the destination array (the default behavior of
+ * `deepmerge`).
+ *
+ * Otherwise, use `deepmerge` to merge the two arrays.
+ *
+ * @param destination The destination array.
+ * @param source The source array.
+ * @returns The merged array.
+ */
+export const mergeParameters = (destination: unknown[], source: unknown[]) => {
+  if (!isObjectArray(destination) || !isObjectArray(source)) {
+    return deepmerge(destination, source);
+  }
+
+  const result = destination.slice();
+
+  for (const item of source) {
+    if (!('name' in item) || !('in' in item)) {
+      // eslint-disable-next-line @silverhand/fp/no-mutating-methods
+      result.push(item);
+      continue;
+    }
+
+    const index = result.findIndex(
+      (resultItem) => resultItem.name === item.name && resultItem.in === item.in
+    );
+
+    if (index === -1) {
+      // eslint-disable-next-line @silverhand/fp/no-mutating-methods
+      result.push(item);
+    } else {
+      // eslint-disable-next-line @silverhand/fp/no-mutation, @typescript-eslint/no-non-null-assertion
+      result[index] = deepmerge(result[index]!, item);
+    }
+  }
+
+  return result;
+};
+
+/**
+ * Given a root path component, build a reusable parameter object for the entity ID in path with
+ * two properties, one for the root path component, and one for other path components.
+ *
+ * @example
+ * ```ts
+ * buildPathIdParameters('organization');
+ * ```
+ *
+ * Will generate the following object:
+ *
+ * ```ts
+ * {
+ *   organizationId: {
+ *     name: 'organizationId',
+ *     in: 'path',
+ *     description: 'The unique identifier of the organization.',
+ *     required: true,
+ *     schema: {
+ *       type: 'string',
+ *     },
+ *   },
+ *   'organizationId:root': {
+ *     name: 'id',
+ *     // ... same as above
+ *   },
+ * }
+ * ```
+ *
+ * @remarks
+ * The root path component is the first path component in the path. For example, the root path
+ * component of `/organizations/{id}/users` is `organizations`. Since the name of the parameter is
+ * same for all root path components, we need to add an additional key with the `:root` suffix to
+ * distinguish them.
+ *
+ * @param rootComponent The root path component in kebab case (`foo-bar`).
+ * @returns The parameter object for the entity ID in path.
+ */
+export const buildPathIdParameters = (
+  rootComponent: string
+): Record<string, OpenAPIV3.ParameterObject> => {
+  const entityId = `${camelcase(rootComponent)}Id`;
+  const shared = {
+    in: 'path',
+    description: `The unique identifier of the ${rootComponent
+      .split('-')
+      .join(' ')
+      .toLowerCase()}.`,
+    required: true,
+    schema: {
+      type: 'string',
+    },
+  } as const;
+
+  // Need to duplicate the object because OpenAPI does not support partial reference.
+  // See https://github.com/OAI/OpenAPI-Specification/issues/2026
+  return {
+    [`${entityId}:root`]: {
+      ...shared,
+      name: 'id',
+    },
+    [entityId]: {
+      ...shared,
+      name: entityId,
+    },
+  };
+};

--- a/packages/core/src/utils/SchemaRouter.ts
+++ b/packages/core/src/utils/SchemaRouter.ts
@@ -254,10 +254,11 @@ export default class SchemaRouter<
     { disabled }: Partial<RelationRoutesConfig> = {}
   ) {
     const relationSchema = relationQueries.schemas[1];
+    const relationSchemaId = camelCaseSchemaId(relationSchema);
     const columns = {
       schemaId: camelCaseSchemaId(this.schema),
-      relationSchemaId: camelCaseSchemaId(relationSchema),
-      relationSchemaIds: camelCaseSchemaId(relationSchema) + 's',
+      relationSchemaId,
+      relationSchemaIds: relationSchemaId + 's',
     };
 
     if (!disabled?.get) {
@@ -332,20 +333,20 @@ export default class SchemaRouter<
     );
 
     this.delete(
-      `/:id/${pathname}/:relationId`,
+      `/:id/${pathname}/:${camelCaseSchemaId(relationSchema)}`,
       koaGuard({
-        params: z.object({ id: z.string().min(1), relationId: z.string().min(1) }),
+        params: z.object({ id: z.string().min(1), [relationSchemaId]: z.string().min(1) }),
         // Should be 422 if the relation doesn't exist, update until we change the error handling
         status: [204, 404],
       }),
       async (ctx, next) => {
         const {
-          params: { id, relationId },
+          params: { id, [relationSchemaId]: relationId },
         } = ctx.guard;
 
         await relationQueries.delete({
-          [columns.schemaId]: id,
-          [columns.relationSchemaId]: relationId,
+          [columns.schemaId]: id!,
+          [columns.relationSchemaId]: relationId!,
         });
 
         ctx.status = 204;

--- a/packages/core/src/utils/SchemaRouter.ts
+++ b/packages/core/src/utils/SchemaRouter.ts
@@ -336,8 +336,7 @@ export default class SchemaRouter<
       `/:id/${pathname}/:${camelCaseSchemaId(relationSchema)}`,
       koaGuard({
         params: z.object({ id: z.string().min(1), [relationSchemaId]: z.string().min(1) }),
-        // Should be 422 if the relation doesn't exist, update until we change the error handling
-        status: [204, 404],
+        status: [204, 422],
       }),
       async (ctx, next) => {
         const {
@@ -345,7 +344,9 @@ export default class SchemaRouter<
         } = ctx.guard;
 
         await relationQueries.delete({
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- `koaGuard()` ensures the value is not `undefined`
           [columns.schemaId]: id!,
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- `koaGuard()` ensures the value is not `undefined`
           [columns.relationSchemaId]: relationId!,
         });
 

--- a/packages/core/src/utils/zod.ts
+++ b/packages/core/src/utils/zod.ts
@@ -204,7 +204,9 @@ export const zodTypeToSwagger = (
   if (config instanceof ZodObject) {
     // Type from Zod is any
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    const entries = Object.entries(config.shape);
+    const entries = Object.entries(config.shape)
+      // `tenantId` is not editable for all routes
+      .filter(([key]) => key !== 'tenantId');
     const required = entries
       .filter(([, value]) => !(value instanceof ZodOptional))
       .map(([key]) => key);


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

refactor the swagger (openapi) json generator.

### Reuse `:id` and `:entityId` path parameters

generate components to reuse `:id` and `:entityId` path parameters. for example:

- path `/users/:id` and `/users/:id/roles/:roleId` can reuse the `:id` parameter.
- path `/roles/:id/users/:userId` and `/organizations/:id/users/:userId` can reuse the `:userId` parameter.

since different `:id` parameters may have different types, we'll generate two parameters for each entity:

```jsonc
{
  "components": {
    "parameters": {
      "userId": { "name": "userId", "in": "path", /* ... */ },
      "userId:root": { "name": "id", "in": "path", /* ... */ },
      "roleId": { "name": "roleId", "in": "path", /* ... */ },
      "roleId:root": { "name": "id", "in": "path", /* ... */ }
    }
  }
}
```

the entity needs to specify in the `identifiableEntityNames` variable in the `routes/swagger/index.ts` file.

following this rule, the swagger json generator will automatically generate `:id` and `:entityId` parameters for the path. for example:

```jsonc
{
  "/users/{id}": {
    "parameters": [{ "$ref": "#/components/parameters/userId:root" }],
    /* ... */
  },
  "/users/{id}/roles/{roleId}": {
    "parameters": [
      { "$ref": "#/components/parameters/userId:root" },
      { "$ref": "#/components/parameters/roleId" }
    ],
    /* ... */
  }
}
```

### Other changes

- slightly change the tag generation logic. now we use sentence case, and `.well-known` will produce `Well known`.
- path parameters now follow the swagger convention, using `{foo}` instead of `:foo`.
- better merge logic for supplementary files. it will recognize the parameters and try to find the same parameters in the array, instead of just appending the array.
- filter out `tenantId` since they are not usable.
- relation routes use the camel case schema name for `DELETE` method instead of `:entityId` which is not friendly to everyone.

### Deprecated changes

<details>
<summary>Reuse path parameters for different methods of the same path</summary>

---

> **Note**
> This is deprecated since we are likely to use bump.sh to host our APIs, which does not support this format yet.

reuse path parameters for different methods of the same path. for example, path `/users/:id` may have GET and PUT methods, originally we'll generate the `id` parameter under each method:

```jsonc
{
  "/users/{id}": {
    "get": {
      "parameters": [{ "name": "id", "in": "path", /* ... */ }]
    },
    "put": {
      "parameters": [{ "name": "id", "in": "path", /* ... */ }]
    }
  }
}
```

now we'll generate the `id` parameter under the path:

```jsonc
{
  "/users/{id}": {
    "parameters": [{ "name": "id", "in": "path", /* ... */ }],
    "get": { /* ... */ },
    "put": { /* ... */ }
  }
}
```

it will make the swagger json smaller.
</details>

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

a preview for the changes in the next pr, which benefits from this one:

<img width="1340" alt="image" src="https://github.com/logto-io/logto/assets/14722250/2f5aebb5-5e7d-4511-b758-c3276405bdad">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
