### PR TITLE
feat(experience): block email sign-in and register

### DIFF
--- a/packages/experience/src/App.tsx
+++ b/packages/experience/src/App.tsx
@@ -49,82 +49,84 @@ const App = () => {
     <BrowserRouter>
       <PageContextProvider>
         <SettingsProvider>
-          <AppBoundary>
-            <AppInsightsBoundary cloudRole="ui">
-              <Routes>
-                <Route path="sign-in/consent" element={<Consent />} />
-                <Route element={<AppLayout />}>
-                  <Route
-                    path="unknown-session"
-                    element={<ErrorPage message="error.invalid_session" />}
-                  />
-                  <Route path="springboard" element={<Springboard />} />
+          <SingleSignOnContextProvider>
+            <AppBoundary>
+              <AppInsightsBoundary cloudRole="ui">
+                <Routes>
+                  <Route path="sign-in/consent" element={<Consent />} />
+                  <Route element={<AppLayout />}>
+                    <Route
+                      path="unknown-session"
+                      element={<ErrorPage message="error.invalid_session" />}
+                    />
+                    <Route path="springboard" element={<Springboard />} />
 
-                  <Route element={<LoadingLayerProvider />}>
-                    {/* Sign-in */}
-                    <Route path="sign-in">
-                      <Route index element={<SignIn />} />
-                      <Route path="password" element={<SignInPassword />} />
-                      <Route path="social/:connectorId" element={<SocialSignIn />} />
+                    <Route element={<LoadingLayerProvider />}>
+                      {/* Sign-in */}
+                      <Route path="sign-in">
+                        <Route index element={<SignIn />} />
+                        <Route path="password" element={<SignInPassword />} />
+                        <Route path="social/:connectorId" element={<SocialSignIn />} />
+                      </Route>
+
+                      {/* Register */}
+                      <Route path="register">
+                        <Route index element={<Register />} />
+                        <Route path="password" element={<RegisterPassword />} />
+                      </Route>
+
+                      {/* Forgot password */}
+                      <Route path="forgot-password">
+                        <Route index element={<ForgotPassword />} />
+                        <Route path="reset" element={<ResetPassword />} />
+                      </Route>
+
+                      {/* Passwordless verification code */}
+                      <Route path=":flow/verification-code" element={<VerificationCode />} />
+
+                      {/* Mfa binding */}
+                      <Route path={UserMfaFlow.MfaBinding}>
+                        <Route index element={<MfaBinding />} />
+                        <Route path={MfaFactor.TOTP} element={<TotpBinding />} />
+                        <Route path={MfaFactor.WebAuthn} element={<WebAuthnBinding />} />
+                        <Route path={MfaFactor.BackupCode} element={<BackupCodeBinding />} />
+                      </Route>
+
+                      {/* Mfa verification */}
+                      <Route path={UserMfaFlow.MfaVerification}>
+                        <Route index element={<MfaVerification />} />
+                        <Route path={MfaFactor.TOTP} element={<TotpVerification />} />
+                        <Route path={MfaFactor.WebAuthn} element={<WebAuthnVerification />} />
+                        <Route path={MfaFactor.BackupCode} element={<BackupCodeVerification />} />
+                      </Route>
+
+                      {/* Continue set up missing profile */}
+                      <Route path="continue">
+                        <Route path=":method" element={<Continue />} />
+                      </Route>
+
+                      {/* Social sign-in pages */}
+                      <Route path="social">
+                        <Route path="link/:connectorId" element={<SocialLinkAccount />} />
+                        <Route path="landing/:connectorId" element={<SocialLanding />} />
+                      </Route>
+                      <Route path="callback/:connectorId" element={<Callback />} />
                     </Route>
 
-                    {/* Register */}
-                    <Route path="register">
-                      <Route index element={<Register />} />
-                      <Route path="password" element={<RegisterPassword />} />
-                    </Route>
+                    {/* Single sign on */}
+                    {isDevelopmentFeaturesEnabled && (
+                      <Route path={singleSignOnPath}>
+                        <Route path="email" element={<SingleSignOnEmail />} />
+                        <Route path="connectors" element={<SingleSignOnConnectors />} />
+                      </Route>
+                    )}
 
-                    {/* Forgot password */}
-                    <Route path="forgot-password">
-                      <Route index element={<ForgotPassword />} />
-                      <Route path="reset" element={<ResetPassword />} />
-                    </Route>
-
-                    {/* Passwordless verification code */}
-                    <Route path=":flow/verification-code" element={<VerificationCode />} />
-
-                    {/* Mfa binding */}
-                    <Route path={UserMfaFlow.MfaBinding}>
-                      <Route index element={<MfaBinding />} />
-                      <Route path={MfaFactor.TOTP} element={<TotpBinding />} />
-                      <Route path={MfaFactor.WebAuthn} element={<WebAuthnBinding />} />
-                      <Route path={MfaFactor.BackupCode} element={<BackupCodeBinding />} />
-                    </Route>
-
-                    {/* Mfa verification */}
-                    <Route path={UserMfaFlow.MfaVerification}>
-                      <Route index element={<MfaVerification />} />
-                      <Route path={MfaFactor.TOTP} element={<TotpVerification />} />
-                      <Route path={MfaFactor.WebAuthn} element={<WebAuthnVerification />} />
-                      <Route path={MfaFactor.BackupCode} element={<BackupCodeVerification />} />
-                    </Route>
-
-                    {/* Continue set up missing profile */}
-                    <Route path="continue">
-                      <Route path=":method" element={<Continue />} />
-                    </Route>
-
-                    {/* Social sign-in pages */}
-                    <Route path="social">
-                      <Route path="link/:connectorId" element={<SocialLinkAccount />} />
-                      <Route path="landing/:connectorId" element={<SocialLanding />} />
-                    </Route>
-                    <Route path="callback/:connectorId" element={<Callback />} />
+                    <Route path="*" element={<ErrorPage />} />
                   </Route>
-
-                  {/* Single sign on */}
-                  {isDevelopmentFeaturesEnabled && (
-                    <Route path={singleSignOnPath} element={<SingleSignOnContextProvider />}>
-                      <Route path="email" element={<SingleSignOnEmail />} />
-                      <Route path="connectors" element={<SingleSignOnConnectors />} />
-                    </Route>
-                  )}
-
-                  <Route path="*" element={<ErrorPage />} />
-                </Route>
-              </Routes>
-            </AppInsightsBoundary>
-          </AppBoundary>
+                </Routes>
+              </AppInsightsBoundary>
+            </AppBoundary>
+          </SingleSignOnContextProvider>
         </SettingsProvider>
       </PageContextProvider>
     </BrowserRouter>

--- a/packages/experience/src/Providers/SingleSignOnContextProvider/index.tsx
+++ b/packages/experience/src/Providers/SingleSignOnContextProvider/index.tsx
@@ -1,13 +1,16 @@
 import { type SsoConnectorMetadata } from '@logto/schemas';
-import { useEffect, useMemo, useState } from 'react';
-import { Outlet } from 'react-router-dom';
+import { type ReactNode, useEffect, useMemo, useState } from 'react';
 
 import useSessionStorage, { StorageKeys } from '@/hooks/use-session-storages';
 import { useSieMethods } from '@/hooks/use-sie';
 
 import SingleSignOnContext, { type SingleSignOnContextType } from './SingleSignOnContext';
 
-const SingleSignOnContextProvider = () => {
+type Props = {
+  children: ReactNode;
+};
+
+const SingleSignOnContextProvider = ({ children }: Props) => {
   const { ssoConnectors } = useSieMethods();
   const { get, set, remove } = useSessionStorage();
   const [email, setEmail] = useState<string | undefined>(get(StorageKeys.SsoEmail));
@@ -51,7 +54,7 @@ const SingleSignOnContextProvider = () => {
 
   return (
     <SingleSignOnContext.Provider value={singleSignOnContext}>
-      <Outlet />
+      {children}
     </SingleSignOnContext.Provider>
   );
 };

--- a/packages/experience/src/hooks/use-check-single-sign-on.ts
+++ b/packages/experience/src/hooks/use-check-single-sign-on.ts
@@ -5,10 +5,11 @@ import { useNavigate } from 'react-router-dom';
 
 import SingleSignOnContext from '@/Providers/SingleSignOnContextProvider/SingleSignOnContext';
 import { getSingleSignOnConnectors } from '@/apis/single-sign-on';
+import { singleSignOnPath } from '@/constants/env';
 import useApi from '@/hooks/use-api';
 import useErrorHandler from '@/hooks/use-error-handler';
 
-const useOnSubmit = () => {
+const useCheckSingleSignOn = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const request = useApi(getSingleSignOnConnectors);
@@ -29,6 +30,11 @@ const useOnSubmit = () => {
     setSsoConnectors([]);
   }, [setEmail, setSsoConnectors]);
 
+  /**
+   * Check if the email is registered with any SSO connectors
+   * @param {string} email
+   * @returns {Promise<boolean>} - true if the email is registered with any SSO connectors
+   */
   const onSubmit = useCallback(
     async (email: string) => {
       clearContext();
@@ -57,7 +63,8 @@ const useOnSubmit = () => {
       setSsoConnectors(connectors);
       setEmail(email);
 
-      navigate('../connectors');
+      navigate(`/${singleSignOnPath}/connectors`);
+      return true;
     },
     [
       availableSsoConnectorsMap,
@@ -78,4 +85,4 @@ const useOnSubmit = () => {
   };
 };
 
-export default useOnSubmit;
+export default useCheckSingleSignOn;

--- a/packages/experience/src/pages/SignIn/IdentifierSignInForm/use-on-submit.ts
+++ b/packages/experience/src/pages/SignIn/IdentifierSignInForm/use-on-submit.ts
@@ -3,11 +3,15 @@ import { SignInIdentifier } from '@logto/schemas';
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import useCheckSingleSignOn from '@/hooks/use-check-single-sign-on';
 import useSendVerificationCode from '@/hooks/use-send-verification-code';
+import { useSieMethods } from '@/hooks/use-sie';
 import { UserFlow } from '@/types';
 
 const useOnSubmit = (signInMethods: SignIn['methods']) => {
   const navigate = useNavigate();
+  const { ssoConnectors } = useSieMethods();
+  const { onSubmit: checkSingleSignOn } = useCheckSingleSignOn();
 
   const signInWithPassword = useCallback(
     (identifier: SignInIdentifier, value: string) => {
@@ -27,31 +31,49 @@ const useOnSubmit = (signInMethods: SignIn['methods']) => {
     onSubmit: sendVerificationCode,
   } = useSendVerificationCode(UserFlow.SignIn);
 
-  const onSubmit = async (identifier: SignInIdentifier, value: string) => {
-    const method = signInMethods.find((method) => method.identifier === identifier);
+  const onSubmit = useCallback(
+    async (identifier: SignInIdentifier, value: string) => {
+      const method = signInMethods.find((method) => method.identifier === identifier);
 
-    if (!method) {
-      throw new Error(`Cannot find method with identifier type ${identifier}`);
-    }
+      if (!method) {
+        throw new Error(`Cannot find method with identifier type ${identifier}`);
+      }
 
-    const { password, isPasswordPrimary, verificationCode } = method;
+      const { password, isPasswordPrimary, verificationCode } = method;
 
-    if (identifier === SignInIdentifier.Username) {
-      signInWithPassword(identifier, value);
+      if (identifier === SignInIdentifier.Username) {
+        signInWithPassword(identifier, value);
 
-      return;
-    }
+        return;
+      }
 
-    if (password && (isPasswordPrimary || !verificationCode)) {
-      signInWithPassword(identifier, value);
+      // Check if the email is registered with any SSO connectors. If the email is registered with any SSO connectors, we should not proceed to the next step
+      if (identifier === SignInIdentifier.Email && ssoConnectors.length > 0) {
+        const result = await checkSingleSignOn(value);
 
-      return;
-    }
+        if (result) {
+          return;
+        }
+      }
 
-    if (verificationCode) {
-      await sendVerificationCode({ identifier, value });
-    }
-  };
+      if (password && (isPasswordPrimary || !verificationCode)) {
+        signInWithPassword(identifier, value);
+
+        return;
+      }
+
+      if (verificationCode) {
+        await sendVerificationCode({ identifier, value });
+      }
+    },
+    [
+      checkSingleSignOn,
+      sendVerificationCode,
+      signInMethods,
+      signInWithPassword,
+      ssoConnectors.length,
+    ]
+  );
 
   return {
     errorMessage,

--- a/packages/experience/src/pages/SingleSignOnEmail/index.tsx
+++ b/packages/experience/src/pages/SingleSignOnEmail/index.tsx
@@ -9,10 +9,10 @@ import ErrorMessage from '@/components/ErrorMessage';
 import SmartInputField, {
   type IdentifierInputValue,
 } from '@/components/InputFields/SmartInputField';
+import useOnSubmit from '@/hooks/use-check-single-sign-on';
 import { getGeneralIdentifierErrorMessage, validateIdentifierField } from '@/utils/form';
 
 import * as styles from './index.module.scss';
-import useOnSubmit from './use-on-submit';
 
 type FormState = {
   identifier: IdentifierInputValue;


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Block email sign-in and register if SSO is enabled for that domain address.

In the sign-in and register home page,  if the input identifier type is email and has SSO connectors enabled, check the single sign-on first. If the email is registered with some SSO connectors should directly navigate to the SSO sign-in page. 


https://github.com/logto-io/logto/assets/36393111/b891b860-ed37-440f-b31d-d232aabe3f73

This PR includes the following update:
- move the `SingleSignOnContextProvider` to the top level, so all the page can have the SSO context.
- move and rename the singleSignOn email check onSubmit hook to the shared hook level. So all the pages can call this hook to check the sso connectors for a given email input.
- call the`checkSingleSignOn` first in the `sign-in` and `register` identifier form `onSubmit` handler

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT case added.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
