### PR TITLE
feat(core): add social returned email sso guard

### DIFF
--- a/packages/core/src/routes/interaction/utils/single-sign-on-guard.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on-guard.ts
@@ -1,3 +1,4 @@
+import { type SocialUserInfo } from '@logto/connector-kit';
 import { type IdentifierPayload } from '@logto/schemas';
 import { type Context } from 'koa';
 import type Provider from 'oidc-provider';
@@ -15,10 +16,14 @@ import assertThat from '#src/utils/assert-that.js';
 // Guard the SSO only email identifier
 export const verifySsoOnlyEmailIdentifier = async (
   { getAvailableSsoConnectors }: SsoConnectorLibrary,
-  identifier: IdentifierPayload
+  identifier: IdentifierPayload | SocialUserInfo
 ) => {
   // TODO: @simeng-li remove the dev features check when the SSO feature is released
-  if (!('email' in identifier) || !EnvSet.values.isDevFeaturesEnabled) {
+  if (!EnvSet.values.isDevFeaturesEnabled) {
+    return;
+  }
+
+  if (!('email' in identifier) || !identifier.email) {
     return;
   }
 

--- a/packages/core/src/routes/interaction/verifications/identifier-payload-verification.ts
+++ b/packages/core/src/routes/interaction/verifications/identifier-payload-verification.ts
@@ -34,6 +34,7 @@ import {
   isPasswordIdentifier,
   isSocialIdentifier,
 } from '../utils/index.js';
+import { verifySsoOnlyEmailIdentifier } from '../utils/single-sign-on-guard.js';
 import { verifySocialIdentity } from '../utils/social-verification.js';
 import { verifyIdentifierByVerificationCode } from '../utils/verification-code-validation.js';
 
@@ -89,6 +90,11 @@ const verifySocialIdentifier = async (
   tenant: TenantContext
 ): Promise<SocialIdentifier> => {
   const userInfo = await verifySocialIdentity(identifier, ctx, tenant);
+
+  const {
+    libraries: { ssoConnectors },
+  } = tenant;
+  await verifySsoOnlyEmailIdentifier(ssoConnectors, userInfo);
 
   return { key: 'social', connectorId: identifier.connectorId, userInfo };
 };


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add social returned email sso guard. If the social userInfo contains a email with SSO registered domain, we should reject the social identity, and throw SSO enabled error.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
