### PR TITLE
feat(cli): support sync array keys

### DIFF
--- a/.changeset/empty-buttons-ring.md
+++ b/.changeset/empty-buttons-ring.md
@@ -1,0 +1,7 @@
+---
+"@logto/cli": minor
+---
+
+support sync phrases array keys and update concurrency to 5
+
+as the new model works with more concurrency.

--- a/packages/cli/src/commands/translate/sync.ts
+++ b/packages/cli/src/commands/translate/sync.ts
@@ -13,7 +13,7 @@ const sync: CommandModule<{ path?: string }, { path?: string }> = {
   describe:
     'Translate all untranslated phrases using ChatGPT. Note the environment variable `OPENAI_API_KEY` is required to work.',
   handler: async ({ path: inputPath }) => {
-    const queue = new PQueue({ concurrency: 1 });
+    const queue = new PQueue({ concurrency: 5 });
     const instancePath = await inquireInstancePath(inputPath);
 
     for (const languageTag of Object.keys(languages)) {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
support sync array keys with string and nested objects:

```ts
{
  foo: ['bar', { baz: 'baz' }]
}
```

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
tested with website phrases. works as expected

<img width="373" alt="image" src="https://github.com/logto-io/logto/assets/14722250/1609c71a-b8ea-4218-ae3f-591d2265b4bf">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
