### PR TITLE
feat(console): add SSO connector details page (settings tab)

### DIFF
--- a/packages/console/src/consts/page-tabs.ts
+++ b/packages/console/src/consts/page-tabs.ts
@@ -40,3 +40,8 @@ export enum TenantSettingsTabs {
   Subscription = 'subscription',
   BillingHistory = 'billing-history',
 }
+
+export enum EnterpriseSsoDetailsTabs {
+  Settings = 'settings',
+  Connection = 'connection',
+}

--- a/packages/console/src/containers/ConsoleContent/index.tsx
+++ b/packages/console/src/containers/ConsoleContent/index.tsx
@@ -9,6 +9,7 @@ import {
   WebhookDetailsTabs,
   TenantSettingsTabs,
   ApplicationDetailsTabs,
+  EnterpriseSsoDetailsTabs,
 } from '@/consts';
 import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
 import { TenantsContext } from '@/contexts/TenantsProvider';
@@ -26,6 +27,7 @@ import ConnectorDetails from '@/pages/ConnectorDetails';
 import Connectors from '@/pages/Connectors';
 import Dashboard from '@/pages/Dashboard';
 import EnterpriseSsoConnectors from '@/pages/EnterpriseSso';
+import EnterpriseSsoConnectorDetails from '@/pages/EnterpriseSsoDetails';
 import GetStarted from '@/pages/GetStarted';
 import Mfa from '@/pages/Mfa';
 import NotFound from '@/pages/NotFound';
@@ -119,8 +121,14 @@ function ConsoleContent() {
               <Route path="enterprise-sso">
                 <Route index element={<EnterpriseSsoConnectors />} />
                 <Route path="create" element={<EnterpriseSsoConnectors />} />
-                <Route path=":id/guide" element={<EnterpriseSsoConnectors />} />
-                <Route path=":id" element={<EnterpriseSsoConnectors />} />
+                <Route path=":ssoConnectorId/guide" element={<EnterpriseSsoConnectors />} />
+                <Route path=":ssoConnectorId">
+                  <Route
+                    index
+                    element={<Navigate replace to={EnterpriseSsoDetailsTabs.Settings} />}
+                  />
+                  <Route path=":tab" element={<EnterpriseSsoConnectorDetails />} />
+                </Route>
               </Route>
             )}
             <Route path="webhooks">

--- a/packages/console/src/ds-components/Uploader/FileUploader/index.module.scss
+++ b/packages/console/src/ds-components/Uploader/FileUploader/index.module.scss
@@ -15,6 +15,8 @@
     align-items: center;
 
     .icon {
+      width: 20px;
+      height: 20px;
       color: var(--color-text-secondary);
     }
 
@@ -26,7 +28,7 @@
 
     .actionDescription {
       margin-top: _.unit(1);
-      font: var(--font-body-2);
+      font: var(--font-body-2); // With font height to be 20px.
       user-select: none;
     }
   }

--- a/packages/console/src/ds-components/Uploader/FileUploader/index.tsx
+++ b/packages/console/src/ds-components/Uploader/FileUploader/index.tsx
@@ -19,6 +19,7 @@ export type Props = {
   actionDescription?: string;
   onCompleted: (fileUrl: string) => void;
   onUploadErrorChange: (errorMessage?: string) => void;
+  className?: string;
 };
 
 function FileUploader({
@@ -27,6 +28,7 @@ function FileUploader({
   actionDescription,
   onCompleted,
   onUploadErrorChange,
+  className,
 }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const [isUploading, setIsUploading] = useState(false);
@@ -114,7 +116,8 @@ function FileUploader({
       className={classNames(
         styles.uploader,
         Boolean(uploadError) && styles.uploaderError,
-        isDragActive && styles.dragActive
+        isDragActive && styles.dragActive,
+        className
       )}
     >
       <input {...getInputProps()} />

--- a/packages/console/src/ds-components/Uploader/ImageUploader/index.module.scss
+++ b/packages/console/src/ds-components/Uploader/ImageUploader/index.module.scss
@@ -16,12 +16,19 @@
     bottom: _.unit(2);
   }
 
-  .image {
+  .container {
+    display: flex;
     height: 40px;
-    max-width: 100%;
-    object-fit: contain;
-    cursor: not-allowed;
+    width: 40px;
+
+    > img {
+      max-width: 100%;
+      max-height: 100%;
+      object-fit: contain;
+      cursor: not-allowed;
+    }
   }
+
 
   &:hover {
     .delete {

--- a/packages/console/src/ds-components/Uploader/ImageUploader/index.tsx
+++ b/packages/console/src/ds-components/Uploader/ImageUploader/index.tsx
@@ -1,4 +1,5 @@
 import type { AllowedUploadMimeType } from '@logto/schemas';
+import classNames from 'classnames';
 
 import Delete from '@/assets/icons/delete.svg';
 import ImageWithErrorFallback from '@/ds-components/ImageWithErrorFallback';
@@ -15,6 +16,7 @@ export type Props = Omit<FileUploaderProps, 'maxSize' | 'allowedMimeTypes'> & {
   name: string;
   value: string;
   onDelete: () => void;
+  className?: string;
 };
 
 function ImageUploader({
@@ -22,13 +24,14 @@ function ImageUploader({
   value,
   onDelete,
   allowedMimeTypes: imageMimeTypes,
+  className,
   ...rest
 }: Props) {
   const { allowedMimeTypes } = useImageMimeTypes(imageMimeTypes);
   return value ? (
-    <div className={styles.imageUploader}>
+    <div className={classNames(styles.imageUploader, className)}>
       <ImageWithErrorFallback
-        className={styles.image}
+        containerClassName={styles.container}
         src={value}
         alt={name}
         /**
@@ -48,7 +51,12 @@ function ImageUploader({
       </IconButton>
     </div>
   ) : (
-    <FileUploader allowedMimeTypes={allowedMimeTypes} maxSize={maxImageSizeLimit} {...rest} />
+    <FileUploader
+      allowedMimeTypes={allowedMimeTypes}
+      maxSize={maxImageSizeLimit}
+      className={className}
+      {...rest}
+    />
   );
 }
 

--- a/packages/console/src/pages/EnterpriseSso/index.tsx
+++ b/packages/console/src/pages/EnterpriseSso/index.tsx
@@ -37,7 +37,7 @@ function EnterpriseSsoConnectors() {
 
   const { pathname } = useLocation();
   const { navigate } = useTenantPathname();
-  const { id } = useParams();
+  const { ssoConnectorId: id } = useParams();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const [connectorForGuide, setConnectorForGuide] = useState<SsoConnectorWithProviderConfig>();
   const [{ page }, updateSearchParameters] = useSearchParametersWatcher({
@@ -99,9 +99,9 @@ function EnterpriseSsoConnectors() {
                     containerClassName={styles.container}
                     alt="logo"
                     src={
-                      theme === Theme.Dark && branding.darkLogo
+                      (theme === Theme.Dark && branding.darkLogo
                         ? branding.darkLogo
-                        : branding.logo ?? providerLogo
+                        : branding.logo) ?? providerLogo
                     }
                   />
                 }

--- a/packages/console/src/pages/EnterpriseSsoDetails/Settings/LogosUploader/index.module.scss
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Settings/LogosUploader/index.module.scss
@@ -1,0 +1,38 @@
+@use '@/scss/underscore' as _;
+
+.container {
+  display: flex;
+  flex-direction: column;
+}
+
+.uploader {
+  display: flex;
+
+  .logoUploader {
+    flex: 1;
+
+    .frame {
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+  }
+
+  .logoDarkUploader {
+    flex: 1;
+
+    .frameDark {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+    }
+  }
+}
+
+.description {
+  font: var(--font-body-2);
+  color: var(--color-text-secondary);
+  margin-top: _.unit(1);
+}
+
+.error {
+  color: var(--color-error);
+}

--- a/packages/console/src/pages/EnterpriseSsoDetails/Settings/LogosUploader/index.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Settings/LogosUploader/index.tsx
@@ -1,0 +1,78 @@
+import classNames from 'classnames';
+import { useState } from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+
+import ImageUploader from '@/ds-components/Uploader/ImageUploader';
+import useImageMimeTypes from '@/hooks/use-image-mime-types';
+
+import type { FormType } from '../index.js';
+
+import * as styles from './index.module.scss';
+
+function LogosUploader() {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const [uploadLogoError, setUploadLogoError] = useState<string>();
+  const [uploadDarkLogoError, setUploadDarkLogoError] = useState<string>();
+
+  const { control } = useFormContext<FormType>();
+  const { description } = useImageMimeTypes();
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.uploader}>
+        <div className={styles.logoUploader}>
+          <Controller
+            control={control}
+            name="branding.logo"
+            render={({ field: { onChange, value, name } }) => (
+              <ImageUploader
+                name={name}
+                className={styles.frame}
+                value={value ?? ''}
+                actionDescription={t('enterprise_sso_details.branding_logo_context')}
+                onCompleted={onChange}
+                onUploadErrorChange={setUploadLogoError}
+                onDelete={() => {
+                  onChange('');
+                }}
+              />
+            )}
+          />
+        </div>
+        <div className={styles.logoDarkUploader}>
+          <Controller
+            control={control}
+            name="branding.darkLogo"
+            render={({ field: { onChange, value, name } }) => (
+              <ImageUploader
+                name={name}
+                className={styles.frameDark}
+                value={value ?? ''}
+                actionDescription={t('enterprise_sso_details.branding_dark_logo_context')}
+                onCompleted={onChange}
+                onUploadErrorChange={setUploadDarkLogoError}
+                onDelete={() => {
+                  onChange('');
+                }}
+              />
+            )}
+          />
+        </div>
+      </div>
+      {uploadLogoError && (
+        <div className={classNames(styles.description, styles.error)}>
+          {t('enterprise_sso_details.branding_logo_error', { error: uploadLogoError })}
+        </div>
+      )}
+      {uploadDarkLogoError && (
+        <div className={classNames(styles.description, styles.error)}>
+          {t('enterprise_sso_details.branding_dark_logo_error', { error: uploadDarkLogoError })}
+        </div>
+      )}
+      <div className={styles.description}>{description}</div>
+    </div>
+  );
+}
+
+export default LogosUploader;

--- a/packages/console/src/pages/EnterpriseSsoDetails/Settings/MultiInput/index.module.scss
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Settings/MultiInput/index.module.scss
@@ -1,0 +1,73 @@
+@use '@/scss/underscore' as _;
+
+.input {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 _.unit(2) 0 _.unit(3);
+  background: var(--color-layer-1);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  outline: 3px solid transparent;
+  transition-property: outline, border;
+  transition-timing-function: ease-in-out;
+  transition-duration: 0.2s;
+  font: var(--font-body-2);
+  cursor: pointer;
+  position: relative;
+
+  &.multiple {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+    gap: _.unit(2);
+    padding: _.unit(1.5) _.unit(3);
+    cursor: text;
+
+    .tag {
+      cursor: auto;
+      display: flex;
+      align-items: center;
+      gap: _.unit(1);
+      position: relative;
+
+      &.focused::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: var(--color-overlay-default-focused);
+      }
+
+      &.info {
+        background: var(--color-error-container);
+      }
+    }
+
+    .close {
+      width: 16px;
+      height: 16px;
+    }
+
+    .delete {
+      width: 20px;
+      height: 20px;
+      margin-right: _.unit(-0.5);
+    }
+
+    input {
+      color: var(--color-text);
+      font: var(--font-body-2);
+      background: transparent;
+      flex-grow: 1;
+      padding: _.unit(0.5);
+
+      &::placeholder {
+        color: var(--color-placeholder);
+      }
+    }
+  }
+
+  &:focus-within {
+    border-color: var(--color-primary);
+    outline-color: var(--color-focused-variant);
+  }
+}

--- a/packages/console/src/pages/EnterpriseSsoDetails/Settings/MultiInput/index.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Settings/MultiInput/index.tsx
@@ -1,0 +1,154 @@
+import { type AdminConsoleKey } from '@logto/phrases';
+import { generateStandardShortId } from '@logto/shared/universal';
+import { conditional, type Nullable } from '@silverhand/essentials';
+import classNames from 'classnames';
+import { useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import Close from '@/assets/icons/close.svg';
+import IconButton from '@/ds-components/IconButton';
+import Tag, { type Props as TagProps } from '@/ds-components/Tag';
+import { onKeyDownHandler } from '@/utils/a11y';
+
+import * as styles from './index.module.scss';
+
+export type Option = {
+  /**
+   * Generate a random unique id for each option to handle deletion.
+   * Sometimes we may have options with the same value, which is allowed when inputting but prohibited when submitting.
+   */
+  id: string;
+  value: string;
+  /**
+   * The `status` is used to indicate the status of the domain item (could fall into following categories):
+   * - undefined: valid domain
+   * - 'info': duplicated domain or blocked domain, see {@link packages/schemas/src/utils/domain.ts}.
+   */
+  status?: Extract<TagProps['status'], 'info'>;
+};
+
+type Props = {
+  className?: string;
+  values: Option[];
+  onChange: (values: Option[]) => void;
+  error?: string | boolean;
+  placeholder?: AdminConsoleKey;
+};
+
+// RegExp to domain string.
+// eslint-disable-next-line prefer-regex-literals
+const domainRegExp = new RegExp('\\S+[\\.]{1}\\S+');
+
+function MultiInput({ className, values, onChange, error, placeholder }: Props) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [focusedValueId, setFocusedValueId] = useState<Nullable<string>>(null);
+  const [currentValue, setCurrentValue] = useState('');
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+
+  const isCurrentValueValidDomain = useMemo(() => {
+    return domainRegExp.test(currentValue);
+  }, [currentValue]);
+
+  const handleAdd = (value: string) => {
+    const newValues = [...values, { value, id: generateStandardShortId() }];
+    onChange(newValues);
+    setCurrentValue('');
+    inputRef.current?.focus();
+  };
+
+  const handleDelete = (option: Option) => {
+    onChange(values.filter(({ id }) => id !== option.id));
+  };
+
+  return (
+    <div
+      className={classNames(
+        styles.input,
+        styles.multiple,
+        Boolean(error) && styles.error,
+        className
+      )}
+      role="button"
+      tabIndex={0}
+      onKeyDown={onKeyDownHandler(() => {
+        inputRef.current?.focus();
+      })}
+      onClick={() => {
+        inputRef.current?.focus();
+      }}
+    >
+      {values.map((option) => {
+        return (
+          <Tag
+            key={option.id}
+            variant="cell"
+            className={classNames(
+              styles.tag,
+              option.status && styles[option.status],
+              option.id === focusedValueId && styles.focused
+            )}
+            onClick={() => {
+              inputRef.current?.focus();
+            }}
+          >
+            {option.value}
+            <IconButton
+              className={styles.delete}
+              size="small"
+              onClick={() => {
+                handleDelete(option);
+              }}
+              onKeyDown={onKeyDownHandler(() => {
+                handleDelete(option);
+              })}
+            >
+              <Close className={styles.close} />
+            </IconButton>
+          </Tag>
+        );
+      })}
+      <input
+        ref={inputRef}
+        // Need to use t() to complete the translation with prefix, use String() to convert the result to string.
+        // Should not show placeholder when there are values.
+        placeholder={conditional(values.length === 0 && placeholder && String(t(placeholder)))}
+        value={currentValue}
+        onKeyDown={(event) => {
+          if (event.key === 'Backspace' && currentValue === '') {
+            if (focusedValueId) {
+              onChange(values.filter(({ id }) => id !== focusedValueId));
+              setFocusedValueId(null);
+            } else {
+              setFocusedValueId(values.at(-1)?.id ?? null);
+            }
+            inputRef.current?.focus();
+          }
+          if (event.key === 'Space') {
+            // Do not react to "Space", since a valid domain does not contain spaces.
+            event.preventDefault();
+          }
+          if (event.key === 'Enter') {
+            // Focusing on input
+            if (isCurrentValueValidDomain && document.activeElement === inputRef.current) {
+              handleAdd(currentValue);
+            }
+            // Do not react to "Enter"
+            event.preventDefault();
+          }
+        }}
+        onChange={({ currentTarget: { value } }) => {
+          setCurrentValue(value);
+          setFocusedValueId(null);
+        }}
+        onFocus={() => {
+          inputRef.current?.focus();
+        }}
+        onBlur={() => {
+          setFocusedValueId(null);
+        }}
+      />
+    </div>
+  );
+}
+
+export default MultiInput;

--- a/packages/console/src/pages/EnterpriseSsoDetails/Settings/index.module.scss
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Settings/index.module.scss
@@ -1,0 +1,13 @@
+@use '@/scss/underscore' as _;
+
+.description {
+  color: var(--color-text-secondary);
+  font: var(--font-body-2);
+  margin-bottom: _.unit(1);
+}
+
+.errorMessage {
+  font: var(--font-body-2);
+  color: var(--color-error);
+  margin-top: _.unit(1);
+}

--- a/packages/console/src/pages/EnterpriseSsoDetails/Settings/index.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Settings/index.tsx
@@ -1,0 +1,264 @@
+import {
+  type SsoConnector,
+  type SsoConnectorWithProviderConfig,
+  type RequestErrorBody,
+  findDuplicatedOrBlockedEmailDomains,
+} from '@logto/schemas';
+import { generateStandardShortId } from '@logto/shared/universal';
+import { conditional, conditionalArray, conditionalString } from '@silverhand/essentials';
+import { t as globalTranslate } from 'i18next';
+import { HTTPError } from 'ky';
+import { useForm, Controller, FormProvider } from 'react-hook-form';
+import { toast } from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+
+import DetailsForm from '@/components/DetailsForm';
+import FormCard from '@/components/FormCard';
+import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
+import FormField from '@/ds-components/FormField';
+import Select from '@/ds-components/Select';
+import TextInput from '@/ds-components/TextInput';
+import useApi from '@/hooks/use-api';
+import useUserAssetsService from '@/hooks/use-user-assets-service';
+import { SyncProfileMode } from '@/types/connector';
+import { trySubmitSafe } from '@/utils/form';
+import { uriValidator } from '@/utils/validator';
+
+import LogosUploader from './LogosUploader';
+import MultiInput, { type Option as MultiInputOption } from './MultiInput';
+import * as styles from './index.module.scss';
+
+type Props = {
+  isDeleted: boolean;
+  data: SsoConnectorWithProviderConfig;
+  onUpdated: (data: SsoConnectorWithProviderConfig) => void;
+};
+
+export type FormType = Pick<SsoConnector, 'branding' | 'connectorName'> & {
+  syncProfile: SyncProfileMode;
+  domains: MultiInputOption[];
+};
+
+const duplicatedDomainsErrorCode = 'single_sign_on.duplicated_domains';
+const forbiddenDomainsErrorCode = 'single_sign_on.forbidden_domains';
+
+const dataToFormParser = (data: SsoConnectorWithProviderConfig) => {
+  const { branding, connectorName, domains, syncProfile } = data;
+  return {
+    branding,
+    connectorName,
+    domains: domains.map((domain) => ({ value: domain, id: generateStandardShortId() })),
+    syncProfile: syncProfile ? SyncProfileMode.EachSignIn : SyncProfileMode.OnlyAtRegister,
+  };
+};
+
+const formDataToSsoConnectorParser = (
+  formData: FormType
+): Pick<SsoConnector, 'branding' | 'connectorName' | 'domains' | 'syncProfile'> => {
+  const { branding, connectorName, domains, syncProfile } = formData;
+  return {
+    branding,
+    connectorName,
+    domains: domains.map(({ value }) => value),
+    syncProfile: syncProfile === SyncProfileMode.EachSignIn,
+  };
+};
+
+function Settings({ data, isDeleted, onUpdated }: Props) {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const { isReady: isUserAssetsServiceReady } = useUserAssetsService();
+  const api = useApi({ hideErrorToast: true });
+
+  const syncProfileOptions = [
+    {
+      value: SyncProfileMode.OnlyAtRegister,
+      title: t('enterprise_sso_details.sync_profile_option.register_only'),
+    },
+    {
+      value: SyncProfileMode.EachSignIn,
+      title: t('enterprise_sso_details.sync_profile_option.each_sign_in'),
+    },
+  ];
+
+  const formMethods = useForm<FormType>({ defaultValues: dataToFormParser(data) });
+  const {
+    control,
+    watch,
+    setValue,
+    setError,
+    clearErrors,
+    handleSubmit,
+    register,
+    formState: { isDirty, isSubmitting, errors },
+    reset,
+  } = formMethods;
+
+  const onSubmit = handleSubmit(
+    trySubmitSafe(async (formData: FormType) => {
+      if (isSubmitting) {
+        return;
+      }
+
+      try {
+        const updatedSsoConnector = await api
+          .patch(`api/sso-connectors/${data.id}`, { json: formDataToSsoConnectorParser(formData) })
+          .json<SsoConnectorWithProviderConfig>();
+
+        reset(dataToFormParser(updatedSsoConnector));
+        toast.success(t('general.saved'));
+        onUpdated(updatedSsoConnector);
+      } catch (error: unknown) {
+        /**
+         * Should render invalid domains:
+         * - show `error` tag for forbidden domains
+         * - show `info` tag for duplicated domains
+         *
+         * Also manually passed the returned error message to `setError` to show the error message in-place.
+         */
+        if (error instanceof HTTPError) {
+          const { response } = error;
+          const metadata = await response.clone().json<RequestErrorBody<{ data: string[] }>>();
+
+          setValue(
+            'domains',
+            watch('domains').map((domain) => ({
+              ...domain,
+              ...conditional(metadata.data.data.includes(domain.value) && { status: 'info' }),
+            })),
+            { shouldDirty: true }
+          );
+          setError('domains', { type: 'custom', message: metadata.message });
+        }
+      }
+    })
+  );
+
+  return (
+    <FormProvider {...formMethods}>
+      <DetailsForm
+        isDirty={isDirty}
+        isSubmitting={isSubmitting}
+        onDiscard={reset}
+        onSubmit={onSubmit}
+      >
+        <FormCard title="enterprise_sso_details.general_settings_title">
+          <FormField title="enterprise_sso_details.email_domain_field_name">
+            <div className={styles.description}>
+              {t('enterprise_sso_details.email_domain_field_description')}
+            </div>
+            <Controller
+              name="domains"
+              control={control}
+              render={({ field: { onChange, value } }) => (
+                <MultiInput
+                  values={value}
+                  // Per previous error handling on submitting, error message will be truthy.
+                  error={errors.domains?.message}
+                  placeholder="enterprise_sso_details.email_domain_field_placeholder"
+                  onChange={(values) => {
+                    const { duplicatedDomains, forbiddenDomains } =
+                      findDuplicatedOrBlockedEmailDomains(values.map((domain) => domain.value));
+
+                    // Show error message and update the inputs' status for error display.
+                    if (duplicatedDomains.size > 0 || forbiddenDomains.size > 0) {
+                      onChange(
+                        values.map(({ status, ...rest }) => ({
+                          ...rest,
+                          ...conditional(
+                            (duplicatedDomains.has(rest.value) ||
+                              forbiddenDomains.has(rest.value)) && {
+                              status: 'info',
+                            }
+                          ),
+                        }))
+                      );
+                      setError('domains', {
+                        type: 'custom',
+                        message: conditionalArray(
+                          conditionalString(
+                            duplicatedDomains.size > 0 &&
+                              globalTranslate(`errors:${duplicatedDomainsErrorCode}`)
+                          ),
+                          conditionalString(
+                            forbiddenDomains.size > 0 &&
+                              globalTranslate(`errors:${forbiddenDomainsErrorCode}`)
+                          )
+                        ).join(' '),
+                      });
+                      return;
+                    }
+
+                    // Should clear the current field's error message and clear error status for input options when there is no error.
+                    onChange(
+                      values.map((domain) => {
+                        const { status, ...rest } = domain;
+                        return rest;
+                      })
+                    );
+                    clearErrors('domains');
+                  }}
+                />
+              )}
+            />
+            {errors.domains && <div className={styles.errorMessage}>{errors.domains.message}</div>}
+          </FormField>
+          <FormField title="enterprise_sso_details.sync_profile_field_name">
+            <Controller
+              name="syncProfile"
+              control={control}
+              rules={{ required: true }}
+              render={({ field: { onChange, value } }) => (
+                <Select options={syncProfileOptions} value={value} onChange={onChange} />
+              )}
+            />
+          </FormField>
+        </FormCard>
+        <FormCard
+          title="enterprise_sso_details.custom_branding_title"
+          description="enterprise_sso_details.custom_branding_description"
+        >
+          <FormField isRequired title="enterprise_sso_details.connector_name_field_name">
+            <TextInput
+              {...register('connectorName', { required: true })}
+              error={errors.connectorName?.message}
+            />
+          </FormField>
+          {isUserAssetsServiceReady ? (
+            <FormField
+              title="enterprise_sso_details.connector_logo_field_name"
+              headlineSpacing="large"
+            >
+              <LogosUploader />
+            </FormField>
+          ) : (
+            <>
+              <FormField title="enterprise_sso_details.branding_logo_field_name">
+                <TextInput
+                  {...register('branding.logo', {
+                    validate: (value) =>
+                      !value || uriValidator(value) || t('errors.invalid_uri_format'),
+                  })}
+                  error={errors.branding?.logo?.message}
+                  placeholder={t('enterprise_sso_details.branding_logo_field_placeholder')}
+                />
+              </FormField>
+              <FormField title="enterprise_sso_details.branding_dark_logo_field_name">
+                <TextInput
+                  {...register('branding.darkLogo', {
+                    validate: (value) =>
+                      !value || uriValidator(value) || t('errors.invalid_uri_format'),
+                  })}
+                  error={errors.branding?.darkLogo?.message}
+                  placeholder={t('enterprise_sso_details.branding_dark_logo_field_placeholder')}
+                />
+              </FormField>
+            </>
+          )}
+        </FormCard>
+      </DetailsForm>
+      <UnsavedChangesAlertModal hasUnsavedChanges={!isDeleted && isDirty} />
+    </FormProvider>
+  );
+}
+
+export default Settings;

--- a/packages/console/src/pages/EnterpriseSsoDetails/index.module.scss
+++ b/packages/console/src/pages/EnterpriseSsoDetails/index.module.scss
@@ -1,0 +1,25 @@
+@use '@/scss/underscore' as _;
+
+.readme {
+  padding: 0 _.unit(6);
+  margin: _.unit(6);
+  background-color: var(--color-layer-1);
+  border-radius: 16px;
+}
+
+.container {
+  width: 60px;
+  height: 60px;
+  border-radius: 12px;
+  background-color: var(--color-hover);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.logo {
+  width: 60px;
+  height: 60px;
+  flex-shrink: 0;
+}

--- a/packages/console/src/pages/EnterpriseSsoDetails/index.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/index.tsx
@@ -1,0 +1,201 @@
+import { withAppInsights } from '@logto/app-insights/react';
+import { Theme } from '@logto/schemas';
+import type { SsoConnectorWithProviderConfig } from '@logto/schemas';
+import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+import { useLocation, useParams } from 'react-router-dom';
+import useSWR from 'swr';
+
+import Delete from '@/assets/icons/delete.svg';
+import File from '@/assets/icons/file.svg';
+import DetailsPage from '@/components/DetailsPage';
+import DetailsPageHeader from '@/components/DetailsPage/DetailsPageHeader';
+import Drawer from '@/components/Drawer';
+import Markdown from '@/components/Markdown';
+import PageMeta from '@/components/PageMeta';
+import { EnterpriseSsoDetailsTabs } from '@/consts';
+import ConfirmModal from '@/ds-components/ConfirmModal';
+import DynamicT from '@/ds-components/DynamicT';
+import ImageWithErrorFallback from '@/ds-components/ImageWithErrorFallback';
+import TabNav, { TabNavItem } from '@/ds-components/TabNav';
+import type { RequestError } from '@/hooks/use-api';
+import useApi from '@/hooks/use-api';
+import useTenantPathname from '@/hooks/use-tenant-pathname';
+import useTheme from '@/hooks/use-theme';
+
+import Settings from './Settings';
+import * as styles from './index.module.scss';
+
+const enterpriseSsoPathname = '/enterprise-sso';
+const getSsoConnectorDetailsPathname = (ssoConnectorId: string, tab: EnterpriseSsoDetailsTabs) =>
+  `${enterpriseSsoPathname}/${ssoConnectorId}/${tab}`;
+
+function EnterpriseSsoConnectorDetails() {
+  const theme = useTheme();
+
+  const { pathname } = useLocation();
+  const { ssoConnectorId, tab } = useParams();
+
+  const [isDeleted, setIsDeleted] = useState(false);
+  const [isReadmeOpen, setIsReadmeOpen] = useState(false);
+
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const {
+    data: ssoConnector,
+    error: requestError,
+    mutate,
+  } = useSWR<SsoConnectorWithProviderConfig, RequestError>(
+    ssoConnectorId && `api/sso-connectors/${ssoConnectorId}`,
+    { keepPreviousData: true }
+  );
+
+  const inUse = Boolean(ssoConnector?.providerConfig);
+  const isLoading = !ssoConnector && !requestError;
+
+  const api = useApi();
+  const { navigate } = useTenantPathname();
+
+  const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  useEffect(() => {
+    setIsDeleteAlertOpen(false);
+  }, [pathname]);
+
+  const handleDelete = useCallback(async () => {
+    if (!ssoConnectorId || isDeleting) {
+      return;
+    }
+    setIsDeleting(true);
+
+    try {
+      await api
+        .delete(`api/sso-connectors/${ssoConnectorId}`)
+        .json<SsoConnectorWithProviderConfig>();
+
+      setIsDeleted(true);
+
+      toast.success(t('enterprise_sso_details.enterprise_sso_deleted'));
+      navigate(enterpriseSsoPathname);
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [api, isDeleting, navigate, ssoConnectorId, t]);
+
+  if (!ssoConnectorId) {
+    return null;
+  }
+
+  return (
+    <DetailsPage
+      backLink={enterpriseSsoPathname}
+      backLinkTitle="enterprise_sso_details.back_to_sso_connectors"
+      isLoading={isLoading}
+      error={requestError}
+      onRetry={() => {
+        void mutate();
+      }}
+    >
+      <PageMeta titleKey="enterprise_sso_details.page_title" />
+      {ssoConnector && (
+        <>
+          <DetailsPageHeader
+            icon={
+              <ImageWithErrorFallback
+                className={styles.logo}
+                containerClassName={styles.container}
+                alt="logo"
+                src={
+                  (theme === Theme.Dark && ssoConnector.branding.darkLogo
+                    ? ssoConnector.branding.darkLogo
+                    : ssoConnector.branding.logo) ?? ssoConnector.providerLogo
+                }
+              />
+            }
+            title={ssoConnector.connectorName}
+            primaryTag={ssoConnector.providerName}
+            statusTag={{
+              status: inUse ? 'success' : 'error',
+              text: inUse
+                ? 'enterprise_sso.col_status_in_use'
+                : 'enterprise_sso.col_status_invalid',
+            }}
+            identifier={{ name: 'ID', value: ssoConnector.id }}
+            additionalActionButton={{
+              title: 'enterprise_sso_details.check_readme',
+              icon: <File />,
+              onClick: () => {
+                setIsReadmeOpen(true);
+              },
+            }}
+            actionMenuItems={[
+              {
+                type: 'danger',
+                title: 'general.delete',
+                icon: <Delete />,
+                onClick: () => {
+                  setIsDeleteAlertOpen(true);
+                },
+              },
+            ]}
+          />
+          <Drawer
+            title="enterprise_sso_details.readme_drawer_title"
+            subtitle="enterprise_sso_details.readme_drawer_subtitle"
+            isOpen={isReadmeOpen}
+            onClose={() => {
+              setIsReadmeOpen(false);
+            }}
+          >
+            {/* TODO: @darcyYe Add SSO connector README. */}
+            <Markdown className={styles.readme}>
+              {'# SSO connector guide\n\nThis is a guide for Logto Enterprise SSO connector.'}
+            </Markdown>
+          </Drawer>
+          <TabNav>
+            <TabNavItem
+              href={getSsoConnectorDetailsPathname(
+                ssoConnectorId,
+                EnterpriseSsoDetailsTabs.Settings
+              )}
+            >
+              <DynamicT forKey="enterprise_sso_details.tab_settings" />
+            </TabNavItem>
+            <TabNavItem
+              href={getSsoConnectorDetailsPathname(
+                ssoConnectorId,
+                EnterpriseSsoDetailsTabs.Connection
+              )}
+            >
+              <DynamicT forKey="enterprise_sso_details.tab_connection" />
+            </TabNavItem>
+          </TabNav>
+          {tab === EnterpriseSsoDetailsTabs.Settings && (
+            <Settings
+              data={ssoConnector}
+              isDeleted={isDeleted}
+              onUpdated={(ssoConnector) => {
+                void mutate(ssoConnector);
+              }}
+            />
+          )}
+          <ConfirmModal
+            isOpen={isDeleteAlertOpen}
+            isLoading={isDeleting}
+            confirmButtonText="general.delete"
+            title="enterprise_sso_details.delete_confirm_modal_title"
+            onCancel={async () => {
+              setIsDeleteAlertOpen(false);
+            }}
+            onConfirm={handleDelete}
+          >
+            <DynamicT forKey="enterprise_sso_details.delete_confirm_modal_content" />
+          </ConfirmModal>
+        </>
+      )}
+    </DetailsPage>
+  );
+}
+
+export default withAppInsights(EnterpriseSsoConnectorDetails);

--- a/packages/core/src/sso/SamlSsoConnector/index.ts
+++ b/packages/core/src/sso/SamlSsoConnector/index.ts
@@ -1,6 +1,5 @@
 import { ConnectorError, ConnectorErrorCodes } from '@logto/connector-kit';
-import { type SsoConnector } from '@logto/schemas';
-import { SsoProviderName } from '@logto/schemas';
+import { type SsoConnector, SsoProviderName } from '@logto/schemas';
 
 import assertThat from '#src/utils/assert-that.js';
 
@@ -39,10 +38,16 @@ export class SamlSsoConnector extends SamlConnector implements SingleSignOn {
   }
 
   async getIssuer() {
-    const {
-      identityProvider: { entityId },
-    } = await this.getSamlConfig();
-    return entityId;
+    const { identityProvider } = await this.getSamlConfig();
+
+    if (!identityProvider?.entityId) {
+      throw new ConnectorError(
+        ConnectorErrorCodes.InvalidConfig,
+        'Can not get `entityId` from metadata config!'
+      );
+    }
+
+    return identityProvider.entityId;
   }
 
   /**

--- a/packages/core/src/sso/index.ts
+++ b/packages/core/src/sso/index.ts
@@ -50,25 +50,3 @@ export const standardSsoConnectorProviders = Object.freeze([
   SsoProviderName.OIDC,
   SsoProviderName.SAML,
 ]);
-
-export const singleSignOnDomainBlackList = Object.freeze([
-  'gmail.com',
-  'yahoo.com',
-  'hotmail.com',
-  'outlook.com',
-  'live.com',
-  'icloud.com',
-  'aol.com',
-  'yandex.com',
-  'mail.com',
-  'protonmail.com',
-  'yanex.com',
-  'gmx.com',
-  'mail.ru',
-  'zoho.com',
-  'qq.com',
-  '163.com',
-  '126.com',
-  'sina.com',
-  'sohu.com',
-]);

--- a/packages/phrases/src/locales/de/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/enterprise-sso-details.ts
@@ -1,0 +1,67 @@
+const enterprise_sso_details = {
+  /** UNTRANSLATED */
+  back_to_sso_connectors: 'Back to enterprise SSO',
+  /** UNTRANSLATED */
+  page_title: 'Enterprise SSO connector details',
+  /** UNTRANSLATED */
+  readme_drawer_title: 'Enterprise SSO',
+  /** UNTRANSLATED */
+  readme_drawer_subtitle: 'Set up enterprise SSO connectors to enable end users SSO',
+  /** UNTRANSLATED */
+  tab_settings: 'Settings',
+  /** UNTRANSLATED */
+  tab_connection: 'Connection',
+  /** UNTRANSLATED */
+  general_settings_title: 'General Settings',
+  /** UNTRANSLATED */
+  custom_branding_title: 'Custom Branding',
+  /** UNTRANSLATED */
+  custom_branding_description:
+    'Customize enterprise IdP display information for sign-in button and other scenarios.',
+  /** UNTRANSLATED */
+  email_domain_field_name: 'Enterprise email domain',
+  /** UNTRANSLATED */
+  email_domain_field_description:
+    'Users with this email domain can use SSO for authentication. Please ensure the domain belongs to the enterprise.',
+  /** UNTRANSLATED */
+  email_domain_field_placeholder: 'Email domain',
+  /** UNTRANSLATED */
+  sync_profile_field_name: 'Sync profile information from the identity provider',
+  sync_profile_option: {
+    /** UNTRANSLATED */
+    register_only: 'Only sync at first sign-in',
+    /** UNTRANSLATED */
+    each_sign_in: 'Always sync at each sign-in',
+  },
+  /** UNTRANSLATED */
+  connector_name_field_name: 'Connector name',
+  /** UNTRANSLATED */
+  connector_logo_field_name: 'Connector logo',
+  /** UNTRANSLATED */
+  branding_logo_context: 'Upload logo',
+  /** UNTRANSLATED */
+  branding_logo_error: 'Upload logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_logo_field_name: 'Logo',
+  /** UNTRANSLATED */
+  branding_logo_field_placeholder: 'https://your.domain/logo.png',
+  /** UNTRANSLATED */
+  branding_dark_logo_context: 'Upload dark mode logo',
+  /** UNTRANSLATED */
+  branding_dark_logo_error: 'Upload dark mode logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_name: 'Logo (dark mode)',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_placeholder: 'https://your.domain/dark-mode-logo.png',
+  /** UNTRANSLATED */
+  check_readme: 'Check README',
+  /** UNTRANSLATED */
+  enterprise_sso_deleted: 'Enterprise SSO connector has been successfully deleted',
+  /** UNTRANSLATED */
+  delete_confirm_modal_title: 'Delete enterprise SSO connector',
+  /** UNTRANSLATED */
+  delete_confirm_modal_content:
+    'Are you sure you want to delete this enterprise connector? Users from identity providers will not utilize Single Sign-On.',
+};
+
+export default Object.freeze(enterprise_sso_details);

--- a/packages/phrases/src/locales/de/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/index.ts
@@ -9,6 +9,7 @@ import connectors from './connectors.js';
 import contact from './contact.js';
 import dashboard from './dashboard.js';
 import domain from './domain.js';
+import enterprise_sso_details from './enterprise-sso-details.js';
 import enterprise_sso from './enterprise-sso.js';
 import errors from './errors.js';
 import general from './general.js';
@@ -54,6 +55,7 @@ const admin_console = {
   connectors,
   connector_details,
   enterprise_sso,
+  enterprise_sso_details,
   get_started,
   users,
   user_details,

--- a/packages/phrases/src/locales/en/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/enterprise-sso-details.ts
@@ -1,0 +1,38 @@
+const enterprise_sso_details = {
+  back_to_sso_connectors: 'Back to enterprise SSO',
+  page_title: 'Enterprise SSO connector details',
+  readme_drawer_title: 'Enterprise SSO',
+  readme_drawer_subtitle: 'Set up enterprise SSO connectors to enable end users SSO',
+  tab_settings: 'Settings',
+  tab_connection: 'Connection',
+  general_settings_title: 'General Settings',
+  custom_branding_title: 'Custom Branding',
+  custom_branding_description:
+    'Customize enterprise IdP display information for sign-in button and other scenarios.',
+  email_domain_field_name: 'Enterprise email domain',
+  email_domain_field_description:
+    'Users with this email domain can use SSO for authentication. Please ensure the domain belongs to the enterprise.',
+  email_domain_field_placeholder: 'Email domain',
+  sync_profile_field_name: 'Sync profile information from the identity provider',
+  sync_profile_option: {
+    register_only: 'Only sync at first sign-in',
+    each_sign_in: 'Always sync at each sign-in',
+  },
+  connector_name_field_name: 'Connector name',
+  connector_logo_field_name: 'Connector logo',
+  branding_logo_context: 'Upload logo',
+  branding_logo_error: 'Upload logo error: {{error}}',
+  branding_logo_field_name: 'Logo',
+  branding_logo_field_placeholder: 'https://your.domain/logo.png',
+  branding_dark_logo_context: 'Upload dark mode logo',
+  branding_dark_logo_error: 'Upload dark mode logo error: {{error}}',
+  branding_dark_logo_field_name: 'Logo (dark mode)',
+  branding_dark_logo_field_placeholder: 'https://your.domain/dark-mode-logo.png',
+  check_readme: 'Check README',
+  enterprise_sso_deleted: 'Enterprise SSO connector has been successfully deleted',
+  delete_confirm_modal_title: 'Delete enterprise SSO connector',
+  delete_confirm_modal_content:
+    'Are you sure you want to delete this enterprise connector? Users from identity providers will not utilize Single Sign-On.',
+};
+
+export default Object.freeze(enterprise_sso_details);

--- a/packages/phrases/src/locales/en/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/index.ts
@@ -9,6 +9,7 @@ import connectors from './connectors.js';
 import contact from './contact.js';
 import dashboard from './dashboard.js';
 import domain from './domain.js';
+import enterprise_sso_details from './enterprise-sso-details.js';
 import enterprise_sso from './enterprise-sso.js';
 import errors from './errors.js';
 import general from './general.js';
@@ -54,6 +55,7 @@ const admin_console = {
   connectors,
   connector_details,
   enterprise_sso,
+  enterprise_sso_details,
   get_started,
   users,
   user_details,

--- a/packages/phrases/src/locales/es/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/enterprise-sso-details.ts
@@ -1,0 +1,67 @@
+const enterprise_sso_details = {
+  /** UNTRANSLATED */
+  back_to_sso_connectors: 'Back to enterprise SSO',
+  /** UNTRANSLATED */
+  page_title: 'Enterprise SSO connector details',
+  /** UNTRANSLATED */
+  readme_drawer_title: 'Enterprise SSO',
+  /** UNTRANSLATED */
+  readme_drawer_subtitle: 'Set up enterprise SSO connectors to enable end users SSO',
+  /** UNTRANSLATED */
+  tab_settings: 'Settings',
+  /** UNTRANSLATED */
+  tab_connection: 'Connection',
+  /** UNTRANSLATED */
+  general_settings_title: 'General Settings',
+  /** UNTRANSLATED */
+  custom_branding_title: 'Custom Branding',
+  /** UNTRANSLATED */
+  custom_branding_description:
+    'Customize enterprise IdP display information for sign-in button and other scenarios.',
+  /** UNTRANSLATED */
+  email_domain_field_name: 'Enterprise email domain',
+  /** UNTRANSLATED */
+  email_domain_field_description:
+    'Users with this email domain can use SSO for authentication. Please ensure the domain belongs to the enterprise.',
+  /** UNTRANSLATED */
+  email_domain_field_placeholder: 'Email domain',
+  /** UNTRANSLATED */
+  sync_profile_field_name: 'Sync profile information from the identity provider',
+  sync_profile_option: {
+    /** UNTRANSLATED */
+    register_only: 'Only sync at first sign-in',
+    /** UNTRANSLATED */
+    each_sign_in: 'Always sync at each sign-in',
+  },
+  /** UNTRANSLATED */
+  connector_name_field_name: 'Connector name',
+  /** UNTRANSLATED */
+  connector_logo_field_name: 'Connector logo',
+  /** UNTRANSLATED */
+  branding_logo_context: 'Upload logo',
+  /** UNTRANSLATED */
+  branding_logo_error: 'Upload logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_logo_field_name: 'Logo',
+  /** UNTRANSLATED */
+  branding_logo_field_placeholder: 'https://your.domain/logo.png',
+  /** UNTRANSLATED */
+  branding_dark_logo_context: 'Upload dark mode logo',
+  /** UNTRANSLATED */
+  branding_dark_logo_error: 'Upload dark mode logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_name: 'Logo (dark mode)',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_placeholder: 'https://your.domain/dark-mode-logo.png',
+  /** UNTRANSLATED */
+  check_readme: 'Check README',
+  /** UNTRANSLATED */
+  enterprise_sso_deleted: 'Enterprise SSO connector has been successfully deleted',
+  /** UNTRANSLATED */
+  delete_confirm_modal_title: 'Delete enterprise SSO connector',
+  /** UNTRANSLATED */
+  delete_confirm_modal_content:
+    'Are you sure you want to delete this enterprise connector? Users from identity providers will not utilize Single Sign-On.',
+};
+
+export default Object.freeze(enterprise_sso_details);

--- a/packages/phrases/src/locales/es/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/index.ts
@@ -9,6 +9,7 @@ import connectors from './connectors.js';
 import contact from './contact.js';
 import dashboard from './dashboard.js';
 import domain from './domain.js';
+import enterprise_sso_details from './enterprise-sso-details.js';
 import enterprise_sso from './enterprise-sso.js';
 import errors from './errors.js';
 import general from './general.js';
@@ -54,6 +55,7 @@ const admin_console = {
   connectors,
   connector_details,
   enterprise_sso,
+  enterprise_sso_details,
   get_started,
   users,
   user_details,

--- a/packages/phrases/src/locales/fr/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/enterprise-sso-details.ts
@@ -1,0 +1,67 @@
+const enterprise_sso_details = {
+  /** UNTRANSLATED */
+  back_to_sso_connectors: 'Back to enterprise SSO',
+  /** UNTRANSLATED */
+  page_title: 'Enterprise SSO connector details',
+  /** UNTRANSLATED */
+  readme_drawer_title: 'Enterprise SSO',
+  /** UNTRANSLATED */
+  readme_drawer_subtitle: 'Set up enterprise SSO connectors to enable end users SSO',
+  /** UNTRANSLATED */
+  tab_settings: 'Settings',
+  /** UNTRANSLATED */
+  tab_connection: 'Connection',
+  /** UNTRANSLATED */
+  general_settings_title: 'General Settings',
+  /** UNTRANSLATED */
+  custom_branding_title: 'Custom Branding',
+  /** UNTRANSLATED */
+  custom_branding_description:
+    'Customize enterprise IdP display information for sign-in button and other scenarios.',
+  /** UNTRANSLATED */
+  email_domain_field_name: 'Enterprise email domain',
+  /** UNTRANSLATED */
+  email_domain_field_description:
+    'Users with this email domain can use SSO for authentication. Please ensure the domain belongs to the enterprise.',
+  /** UNTRANSLATED */
+  email_domain_field_placeholder: 'Email domain',
+  /** UNTRANSLATED */
+  sync_profile_field_name: 'Sync profile information from the identity provider',
+  sync_profile_option: {
+    /** UNTRANSLATED */
+    register_only: 'Only sync at first sign-in',
+    /** UNTRANSLATED */
+    each_sign_in: 'Always sync at each sign-in',
+  },
+  /** UNTRANSLATED */
+  connector_name_field_name: 'Connector name',
+  /** UNTRANSLATED */
+  connector_logo_field_name: 'Connector logo',
+  /** UNTRANSLATED */
+  branding_logo_context: 'Upload logo',
+  /** UNTRANSLATED */
+  branding_logo_error: 'Upload logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_logo_field_name: 'Logo',
+  /** UNTRANSLATED */
+  branding_logo_field_placeholder: 'https://your.domain/logo.png',
+  /** UNTRANSLATED */
+  branding_dark_logo_context: 'Upload dark mode logo',
+  /** UNTRANSLATED */
+  branding_dark_logo_error: 'Upload dark mode logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_name: 'Logo (dark mode)',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_placeholder: 'https://your.domain/dark-mode-logo.png',
+  /** UNTRANSLATED */
+  check_readme: 'Check README',
+  /** UNTRANSLATED */
+  enterprise_sso_deleted: 'Enterprise SSO connector has been successfully deleted',
+  /** UNTRANSLATED */
+  delete_confirm_modal_title: 'Delete enterprise SSO connector',
+  /** UNTRANSLATED */
+  delete_confirm_modal_content:
+    'Are you sure you want to delete this enterprise connector? Users from identity providers will not utilize Single Sign-On.',
+};
+
+export default Object.freeze(enterprise_sso_details);

--- a/packages/phrases/src/locales/fr/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/index.ts
@@ -9,6 +9,7 @@ import connectors from './connectors.js';
 import contact from './contact.js';
 import dashboard from './dashboard.js';
 import domain from './domain.js';
+import enterprise_sso_details from './enterprise-sso-details.js';
 import enterprise_sso from './enterprise-sso.js';
 import errors from './errors.js';
 import general from './general.js';
@@ -54,6 +55,7 @@ const admin_console = {
   connectors,
   connector_details,
   enterprise_sso,
+  enterprise_sso_details,
   get_started,
   users,
   user_details,

--- a/packages/phrases/src/locales/it/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/enterprise-sso-details.ts
@@ -1,0 +1,67 @@
+const enterprise_sso_details = {
+  /** UNTRANSLATED */
+  back_to_sso_connectors: 'Back to enterprise SSO',
+  /** UNTRANSLATED */
+  page_title: 'Enterprise SSO connector details',
+  /** UNTRANSLATED */
+  readme_drawer_title: 'Enterprise SSO',
+  /** UNTRANSLATED */
+  readme_drawer_subtitle: 'Set up enterprise SSO connectors to enable end users SSO',
+  /** UNTRANSLATED */
+  tab_settings: 'Settings',
+  /** UNTRANSLATED */
+  tab_connection: 'Connection',
+  /** UNTRANSLATED */
+  general_settings_title: 'General Settings',
+  /** UNTRANSLATED */
+  custom_branding_title: 'Custom Branding',
+  /** UNTRANSLATED */
+  custom_branding_description:
+    'Customize enterprise IdP display information for sign-in button and other scenarios.',
+  /** UNTRANSLATED */
+  email_domain_field_name: 'Enterprise email domain',
+  /** UNTRANSLATED */
+  email_domain_field_description:
+    'Users with this email domain can use SSO for authentication. Please ensure the domain belongs to the enterprise.',
+  /** UNTRANSLATED */
+  email_domain_field_placeholder: 'Email domain',
+  /** UNTRANSLATED */
+  sync_profile_field_name: 'Sync profile information from the identity provider',
+  sync_profile_option: {
+    /** UNTRANSLATED */
+    register_only: 'Only sync at first sign-in',
+    /** UNTRANSLATED */
+    each_sign_in: 'Always sync at each sign-in',
+  },
+  /** UNTRANSLATED */
+  connector_name_field_name: 'Connector name',
+  /** UNTRANSLATED */
+  connector_logo_field_name: 'Connector logo',
+  /** UNTRANSLATED */
+  branding_logo_context: 'Upload logo',
+  /** UNTRANSLATED */
+  branding_logo_error: 'Upload logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_logo_field_name: 'Logo',
+  /** UNTRANSLATED */
+  branding_logo_field_placeholder: 'https://your.domain/logo.png',
+  /** UNTRANSLATED */
+  branding_dark_logo_context: 'Upload dark mode logo',
+  /** UNTRANSLATED */
+  branding_dark_logo_error: 'Upload dark mode logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_name: 'Logo (dark mode)',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_placeholder: 'https://your.domain/dark-mode-logo.png',
+  /** UNTRANSLATED */
+  check_readme: 'Check README',
+  /** UNTRANSLATED */
+  enterprise_sso_deleted: 'Enterprise SSO connector has been successfully deleted',
+  /** UNTRANSLATED */
+  delete_confirm_modal_title: 'Delete enterprise SSO connector',
+  /** UNTRANSLATED */
+  delete_confirm_modal_content:
+    'Are you sure you want to delete this enterprise connector? Users from identity providers will not utilize Single Sign-On.',
+};
+
+export default Object.freeze(enterprise_sso_details);

--- a/packages/phrases/src/locales/it/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/index.ts
@@ -9,6 +9,7 @@ import connectors from './connectors.js';
 import contact from './contact.js';
 import dashboard from './dashboard.js';
 import domain from './domain.js';
+import enterprise_sso_details from './enterprise-sso-details.js';
 import enterprise_sso from './enterprise-sso.js';
 import errors from './errors.js';
 import general from './general.js';
@@ -54,6 +55,7 @@ const admin_console = {
   connectors,
   connector_details,
   enterprise_sso,
+  enterprise_sso_details,
   get_started,
   users,
   user_details,

--- a/packages/phrases/src/locales/ja/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/enterprise-sso-details.ts
@@ -1,0 +1,67 @@
+const enterprise_sso_details = {
+  /** UNTRANSLATED */
+  back_to_sso_connectors: 'Back to enterprise SSO',
+  /** UNTRANSLATED */
+  page_title: 'Enterprise SSO connector details',
+  /** UNTRANSLATED */
+  readme_drawer_title: 'Enterprise SSO',
+  /** UNTRANSLATED */
+  readme_drawer_subtitle: 'Set up enterprise SSO connectors to enable end users SSO',
+  /** UNTRANSLATED */
+  tab_settings: 'Settings',
+  /** UNTRANSLATED */
+  tab_connection: 'Connection',
+  /** UNTRANSLATED */
+  general_settings_title: 'General Settings',
+  /** UNTRANSLATED */
+  custom_branding_title: 'Custom Branding',
+  /** UNTRANSLATED */
+  custom_branding_description:
+    'Customize enterprise IdP display information for sign-in button and other scenarios.',
+  /** UNTRANSLATED */
+  email_domain_field_name: 'Enterprise email domain',
+  /** UNTRANSLATED */
+  email_domain_field_description:
+    'Users with this email domain can use SSO for authentication. Please ensure the domain belongs to the enterprise.',
+  /** UNTRANSLATED */
+  email_domain_field_placeholder: 'Email domain',
+  /** UNTRANSLATED */
+  sync_profile_field_name: 'Sync profile information from the identity provider',
+  sync_profile_option: {
+    /** UNTRANSLATED */
+    register_only: 'Only sync at first sign-in',
+    /** UNTRANSLATED */
+    each_sign_in: 'Always sync at each sign-in',
+  },
+  /** UNTRANSLATED */
+  connector_name_field_name: 'Connector name',
+  /** UNTRANSLATED */
+  connector_logo_field_name: 'Connector logo',
+  /** UNTRANSLATED */
+  branding_logo_context: 'Upload logo',
+  /** UNTRANSLATED */
+  branding_logo_error: 'Upload logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_logo_field_name: 'Logo',
+  /** UNTRANSLATED */
+  branding_logo_field_placeholder: 'https://your.domain/logo.png',
+  /** UNTRANSLATED */
+  branding_dark_logo_context: 'Upload dark mode logo',
+  /** UNTRANSLATED */
+  branding_dark_logo_error: 'Upload dark mode logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_name: 'Logo (dark mode)',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_placeholder: 'https://your.domain/dark-mode-logo.png',
+  /** UNTRANSLATED */
+  check_readme: 'Check README',
+  /** UNTRANSLATED */
+  enterprise_sso_deleted: 'Enterprise SSO connector has been successfully deleted',
+  /** UNTRANSLATED */
+  delete_confirm_modal_title: 'Delete enterprise SSO connector',
+  /** UNTRANSLATED */
+  delete_confirm_modal_content:
+    'Are you sure you want to delete this enterprise connector? Users from identity providers will not utilize Single Sign-On.',
+};
+
+export default Object.freeze(enterprise_sso_details);

--- a/packages/phrases/src/locales/ja/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/index.ts
@@ -9,6 +9,7 @@ import connectors from './connectors.js';
 import contact from './contact.js';
 import dashboard from './dashboard.js';
 import domain from './domain.js';
+import enterprise_sso_details from './enterprise-sso-details.js';
 import enterprise_sso from './enterprise-sso.js';
 import errors from './errors.js';
 import general from './general.js';
@@ -54,6 +55,7 @@ const admin_console = {
   connectors,
   connector_details,
   enterprise_sso,
+  enterprise_sso_details,
   get_started,
   users,
   user_details,

--- a/packages/phrases/src/locales/ko/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/enterprise-sso-details.ts
@@ -1,0 +1,67 @@
+const enterprise_sso_details = {
+  /** UNTRANSLATED */
+  back_to_sso_connectors: 'Back to enterprise SSO',
+  /** UNTRANSLATED */
+  page_title: 'Enterprise SSO connector details',
+  /** UNTRANSLATED */
+  readme_drawer_title: 'Enterprise SSO',
+  /** UNTRANSLATED */
+  readme_drawer_subtitle: 'Set up enterprise SSO connectors to enable end users SSO',
+  /** UNTRANSLATED */
+  tab_settings: 'Settings',
+  /** UNTRANSLATED */
+  tab_connection: 'Connection',
+  /** UNTRANSLATED */
+  general_settings_title: 'General Settings',
+  /** UNTRANSLATED */
+  custom_branding_title: 'Custom Branding',
+  /** UNTRANSLATED */
+  custom_branding_description:
+    'Customize enterprise IdP display information for sign-in button and other scenarios.',
+  /** UNTRANSLATED */
+  email_domain_field_name: 'Enterprise email domain',
+  /** UNTRANSLATED */
+  email_domain_field_description:
+    'Users with this email domain can use SSO for authentication. Please ensure the domain belongs to the enterprise.',
+  /** UNTRANSLATED */
+  email_domain_field_placeholder: 'Email domain',
+  /** UNTRANSLATED */
+  sync_profile_field_name: 'Sync profile information from the identity provider',
+  sync_profile_option: {
+    /** UNTRANSLATED */
+    register_only: 'Only sync at first sign-in',
+    /** UNTRANSLATED */
+    each_sign_in: 'Always sync at each sign-in',
+  },
+  /** UNTRANSLATED */
+  connector_name_field_name: 'Connector name',
+  /** UNTRANSLATED */
+  connector_logo_field_name: 'Connector logo',
+  /** UNTRANSLATED */
+  branding_logo_context: 'Upload logo',
+  /** UNTRANSLATED */
+  branding_logo_error: 'Upload logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_logo_field_name: 'Logo',
+  /** UNTRANSLATED */
+  branding_logo_field_placeholder: 'https://your.domain/logo.png',
+  /** UNTRANSLATED */
+  branding_dark_logo_context: 'Upload dark mode logo',
+  /** UNTRANSLATED */
+  branding_dark_logo_error: 'Upload dark mode logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_name: 'Logo (dark mode)',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_placeholder: 'https://your.domain/dark-mode-logo.png',
+  /** UNTRANSLATED */
+  check_readme: 'Check README',
+  /** UNTRANSLATED */
+  enterprise_sso_deleted: 'Enterprise SSO connector has been successfully deleted',
+  /** UNTRANSLATED */
+  delete_confirm_modal_title: 'Delete enterprise SSO connector',
+  /** UNTRANSLATED */
+  delete_confirm_modal_content:
+    'Are you sure you want to delete this enterprise connector? Users from identity providers will not utilize Single Sign-On.',
+};
+
+export default Object.freeze(enterprise_sso_details);

--- a/packages/phrases/src/locales/ko/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/index.ts
@@ -9,6 +9,7 @@ import connectors from './connectors.js';
 import contact from './contact.js';
 import dashboard from './dashboard.js';
 import domain from './domain.js';
+import enterprise_sso_details from './enterprise-sso-details.js';
 import enterprise_sso from './enterprise-sso.js';
 import errors from './errors.js';
 import general from './general.js';
@@ -54,6 +55,7 @@ const admin_console = {
   connectors,
   connector_details,
   enterprise_sso,
+  enterprise_sso_details,
   get_started,
   users,
   user_details,

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/enterprise-sso-details.ts
@@ -1,0 +1,67 @@
+const enterprise_sso_details = {
+  /** UNTRANSLATED */
+  back_to_sso_connectors: 'Back to enterprise SSO',
+  /** UNTRANSLATED */
+  page_title: 'Enterprise SSO connector details',
+  /** UNTRANSLATED */
+  readme_drawer_title: 'Enterprise SSO',
+  /** UNTRANSLATED */
+  readme_drawer_subtitle: 'Set up enterprise SSO connectors to enable end users SSO',
+  /** UNTRANSLATED */
+  tab_settings: 'Settings',
+  /** UNTRANSLATED */
+  tab_connection: 'Connection',
+  /** UNTRANSLATED */
+  general_settings_title: 'General Settings',
+  /** UNTRANSLATED */
+  custom_branding_title: 'Custom Branding',
+  /** UNTRANSLATED */
+  custom_branding_description:
+    'Customize enterprise IdP display information for sign-in button and other scenarios.',
+  /** UNTRANSLATED */
+  email_domain_field_name: 'Enterprise email domain',
+  /** UNTRANSLATED */
+  email_domain_field_description:
+    'Users with this email domain can use SSO for authentication. Please ensure the domain belongs to the enterprise.',
+  /** UNTRANSLATED */
+  email_domain_field_placeholder: 'Email domain',
+  /** UNTRANSLATED */
+  sync_profile_field_name: 'Sync profile information from the identity provider',
+  sync_profile_option: {
+    /** UNTRANSLATED */
+    register_only: 'Only sync at first sign-in',
+    /** UNTRANSLATED */
+    each_sign_in: 'Always sync at each sign-in',
+  },
+  /** UNTRANSLATED */
+  connector_name_field_name: 'Connector name',
+  /** UNTRANSLATED */
+  connector_logo_field_name: 'Connector logo',
+  /** UNTRANSLATED */
+  branding_logo_context: 'Upload logo',
+  /** UNTRANSLATED */
+  branding_logo_error: 'Upload logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_logo_field_name: 'Logo',
+  /** UNTRANSLATED */
+  branding_logo_field_placeholder: 'https://your.domain/logo.png',
+  /** UNTRANSLATED */
+  branding_dark_logo_context: 'Upload dark mode logo',
+  /** UNTRANSLATED */
+  branding_dark_logo_error: 'Upload dark mode logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_name: 'Logo (dark mode)',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_placeholder: 'https://your.domain/dark-mode-logo.png',
+  /** UNTRANSLATED */
+  check_readme: 'Check README',
+  /** UNTRANSLATED */
+  enterprise_sso_deleted: 'Enterprise SSO connector has been successfully deleted',
+  /** UNTRANSLATED */
+  delete_confirm_modal_title: 'Delete enterprise SSO connector',
+  /** UNTRANSLATED */
+  delete_confirm_modal_content:
+    'Are you sure you want to delete this enterprise connector? Users from identity providers will not utilize Single Sign-On.',
+};
+
+export default Object.freeze(enterprise_sso_details);

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/index.ts
@@ -9,6 +9,7 @@ import connectors from './connectors.js';
 import contact from './contact.js';
 import dashboard from './dashboard.js';
 import domain from './domain.js';
+import enterprise_sso_details from './enterprise-sso-details.js';
 import enterprise_sso from './enterprise-sso.js';
 import errors from './errors.js';
 import general from './general.js';
@@ -54,6 +55,7 @@ const admin_console = {
   connectors,
   connector_details,
   enterprise_sso,
+  enterprise_sso_details,
   get_started,
   users,
   user_details,

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/enterprise-sso-details.ts
@@ -1,0 +1,67 @@
+const enterprise_sso_details = {
+  /** UNTRANSLATED */
+  back_to_sso_connectors: 'Back to enterprise SSO',
+  /** UNTRANSLATED */
+  page_title: 'Enterprise SSO connector details',
+  /** UNTRANSLATED */
+  readme_drawer_title: 'Enterprise SSO',
+  /** UNTRANSLATED */
+  readme_drawer_subtitle: 'Set up enterprise SSO connectors to enable end users SSO',
+  /** UNTRANSLATED */
+  tab_settings: 'Settings',
+  /** UNTRANSLATED */
+  tab_connection: 'Connection',
+  /** UNTRANSLATED */
+  general_settings_title: 'General Settings',
+  /** UNTRANSLATED */
+  custom_branding_title: 'Custom Branding',
+  /** UNTRANSLATED */
+  custom_branding_description:
+    'Customize enterprise IdP display information for sign-in button and other scenarios.',
+  /** UNTRANSLATED */
+  email_domain_field_name: 'Enterprise email domain',
+  /** UNTRANSLATED */
+  email_domain_field_description:
+    'Users with this email domain can use SSO for authentication. Please ensure the domain belongs to the enterprise.',
+  /** UNTRANSLATED */
+  email_domain_field_placeholder: 'Email domain',
+  /** UNTRANSLATED */
+  sync_profile_field_name: 'Sync profile information from the identity provider',
+  sync_profile_option: {
+    /** UNTRANSLATED */
+    register_only: 'Only sync at first sign-in',
+    /** UNTRANSLATED */
+    each_sign_in: 'Always sync at each sign-in',
+  },
+  /** UNTRANSLATED */
+  connector_name_field_name: 'Connector name',
+  /** UNTRANSLATED */
+  connector_logo_field_name: 'Connector logo',
+  /** UNTRANSLATED */
+  branding_logo_context: 'Upload logo',
+  /** UNTRANSLATED */
+  branding_logo_error: 'Upload logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_logo_field_name: 'Logo',
+  /** UNTRANSLATED */
+  branding_logo_field_placeholder: 'https://your.domain/logo.png',
+  /** UNTRANSLATED */
+  branding_dark_logo_context: 'Upload dark mode logo',
+  /** UNTRANSLATED */
+  branding_dark_logo_error: 'Upload dark mode logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_name: 'Logo (dark mode)',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_placeholder: 'https://your.domain/dark-mode-logo.png',
+  /** UNTRANSLATED */
+  check_readme: 'Check README',
+  /** UNTRANSLATED */
+  enterprise_sso_deleted: 'Enterprise SSO connector has been successfully deleted',
+  /** UNTRANSLATED */
+  delete_confirm_modal_title: 'Delete enterprise SSO connector',
+  /** UNTRANSLATED */
+  delete_confirm_modal_content:
+    'Are you sure you want to delete this enterprise connector? Users from identity providers will not utilize Single Sign-On.',
+};
+
+export default Object.freeze(enterprise_sso_details);

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/index.ts
@@ -9,6 +9,7 @@ import connectors from './connectors.js';
 import contact from './contact.js';
 import dashboard from './dashboard.js';
 import domain from './domain.js';
+import enterprise_sso_details from './enterprise-sso-details.js';
 import enterprise_sso from './enterprise-sso.js';
 import errors from './errors.js';
 import general from './general.js';
@@ -54,6 +55,7 @@ const admin_console = {
   connectors,
   connector_details,
   enterprise_sso,
+  enterprise_sso_details,
   get_started,
   users,
   user_details,

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/enterprise-sso-details.ts
@@ -1,0 +1,67 @@
+const enterprise_sso_details = {
+  /** UNTRANSLATED */
+  back_to_sso_connectors: 'Back to enterprise SSO',
+  /** UNTRANSLATED */
+  page_title: 'Enterprise SSO connector details',
+  /** UNTRANSLATED */
+  readme_drawer_title: 'Enterprise SSO',
+  /** UNTRANSLATED */
+  readme_drawer_subtitle: 'Set up enterprise SSO connectors to enable end users SSO',
+  /** UNTRANSLATED */
+  tab_settings: 'Settings',
+  /** UNTRANSLATED */
+  tab_connection: 'Connection',
+  /** UNTRANSLATED */
+  general_settings_title: 'General Settings',
+  /** UNTRANSLATED */
+  custom_branding_title: 'Custom Branding',
+  /** UNTRANSLATED */
+  custom_branding_description:
+    'Customize enterprise IdP display information for sign-in button and other scenarios.',
+  /** UNTRANSLATED */
+  email_domain_field_name: 'Enterprise email domain',
+  /** UNTRANSLATED */
+  email_domain_field_description:
+    'Users with this email domain can use SSO for authentication. Please ensure the domain belongs to the enterprise.',
+  /** UNTRANSLATED */
+  email_domain_field_placeholder: 'Email domain',
+  /** UNTRANSLATED */
+  sync_profile_field_name: 'Sync profile information from the identity provider',
+  sync_profile_option: {
+    /** UNTRANSLATED */
+    register_only: 'Only sync at first sign-in',
+    /** UNTRANSLATED */
+    each_sign_in: 'Always sync at each sign-in',
+  },
+  /** UNTRANSLATED */
+  connector_name_field_name: 'Connector name',
+  /** UNTRANSLATED */
+  connector_logo_field_name: 'Connector logo',
+  /** UNTRANSLATED */
+  branding_logo_context: 'Upload logo',
+  /** UNTRANSLATED */
+  branding_logo_error: 'Upload logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_logo_field_name: 'Logo',
+  /** UNTRANSLATED */
+  branding_logo_field_placeholder: 'https://your.domain/logo.png',
+  /** UNTRANSLATED */
+  branding_dark_logo_context: 'Upload dark mode logo',
+  /** UNTRANSLATED */
+  branding_dark_logo_error: 'Upload dark mode logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_name: 'Logo (dark mode)',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_placeholder: 'https://your.domain/dark-mode-logo.png',
+  /** UNTRANSLATED */
+  check_readme: 'Check README',
+  /** UNTRANSLATED */
+  enterprise_sso_deleted: 'Enterprise SSO connector has been successfully deleted',
+  /** UNTRANSLATED */
+  delete_confirm_modal_title: 'Delete enterprise SSO connector',
+  /** UNTRANSLATED */
+  delete_confirm_modal_content:
+    'Are you sure you want to delete this enterprise connector? Users from identity providers will not utilize Single Sign-On.',
+};
+
+export default Object.freeze(enterprise_sso_details);

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/index.ts
@@ -9,6 +9,7 @@ import connectors from './connectors.js';
 import contact from './contact.js';
 import dashboard from './dashboard.js';
 import domain from './domain.js';
+import enterprise_sso_details from './enterprise-sso-details.js';
 import enterprise_sso from './enterprise-sso.js';
 import errors from './errors.js';
 import general from './general.js';
@@ -54,6 +55,7 @@ const admin_console = {
   connectors,
   connector_details,
   enterprise_sso,
+  enterprise_sso_details,
   get_started,
   users,
   user_details,

--- a/packages/phrases/src/locales/ru/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/enterprise-sso-details.ts
@@ -1,0 +1,67 @@
+const enterprise_sso_details = {
+  /** UNTRANSLATED */
+  back_to_sso_connectors: 'Back to enterprise SSO',
+  /** UNTRANSLATED */
+  page_title: 'Enterprise SSO connector details',
+  /** UNTRANSLATED */
+  readme_drawer_title: 'Enterprise SSO',
+  /** UNTRANSLATED */
+  readme_drawer_subtitle: 'Set up enterprise SSO connectors to enable end users SSO',
+  /** UNTRANSLATED */
+  tab_settings: 'Settings',
+  /** UNTRANSLATED */
+  tab_connection: 'Connection',
+  /** UNTRANSLATED */
+  general_settings_title: 'General Settings',
+  /** UNTRANSLATED */
+  custom_branding_title: 'Custom Branding',
+  /** UNTRANSLATED */
+  custom_branding_description:
+    'Customize enterprise IdP display information for sign-in button and other scenarios.',
+  /** UNTRANSLATED */
+  email_domain_field_name: 'Enterprise email domain',
+  /** UNTRANSLATED */
+  email_domain_field_description:
+    'Users with this email domain can use SSO for authentication. Please ensure the domain belongs to the enterprise.',
+  /** UNTRANSLATED */
+  email_domain_field_placeholder: 'Email domain',
+  /** UNTRANSLATED */
+  sync_profile_field_name: 'Sync profile information from the identity provider',
+  sync_profile_option: {
+    /** UNTRANSLATED */
+    register_only: 'Only sync at first sign-in',
+    /** UNTRANSLATED */
+    each_sign_in: 'Always sync at each sign-in',
+  },
+  /** UNTRANSLATED */
+  connector_name_field_name: 'Connector name',
+  /** UNTRANSLATED */
+  connector_logo_field_name: 'Connector logo',
+  /** UNTRANSLATED */
+  branding_logo_context: 'Upload logo',
+  /** UNTRANSLATED */
+  branding_logo_error: 'Upload logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_logo_field_name: 'Logo',
+  /** UNTRANSLATED */
+  branding_logo_field_placeholder: 'https://your.domain/logo.png',
+  /** UNTRANSLATED */
+  branding_dark_logo_context: 'Upload dark mode logo',
+  /** UNTRANSLATED */
+  branding_dark_logo_error: 'Upload dark mode logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_name: 'Logo (dark mode)',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_placeholder: 'https://your.domain/dark-mode-logo.png',
+  /** UNTRANSLATED */
+  check_readme: 'Check README',
+  /** UNTRANSLATED */
+  enterprise_sso_deleted: 'Enterprise SSO connector has been successfully deleted',
+  /** UNTRANSLATED */
+  delete_confirm_modal_title: 'Delete enterprise SSO connector',
+  /** UNTRANSLATED */
+  delete_confirm_modal_content:
+    'Are you sure you want to delete this enterprise connector? Users from identity providers will not utilize Single Sign-On.',
+};
+
+export default Object.freeze(enterprise_sso_details);

--- a/packages/phrases/src/locales/ru/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/index.ts
@@ -9,6 +9,7 @@ import connectors from './connectors.js';
 import contact from './contact.js';
 import dashboard from './dashboard.js';
 import domain from './domain.js';
+import enterprise_sso_details from './enterprise-sso-details.js';
 import enterprise_sso from './enterprise-sso.js';
 import errors from './errors.js';
 import general from './general.js';
@@ -54,6 +55,7 @@ const admin_console = {
   connectors,
   connector_details,
   enterprise_sso,
+  enterprise_sso_details,
   get_started,
   users,
   user_details,

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/enterprise-sso-details.ts
@@ -1,0 +1,67 @@
+const enterprise_sso_details = {
+  /** UNTRANSLATED */
+  back_to_sso_connectors: 'Back to enterprise SSO',
+  /** UNTRANSLATED */
+  page_title: 'Enterprise SSO connector details',
+  /** UNTRANSLATED */
+  readme_drawer_title: 'Enterprise SSO',
+  /** UNTRANSLATED */
+  readme_drawer_subtitle: 'Set up enterprise SSO connectors to enable end users SSO',
+  /** UNTRANSLATED */
+  tab_settings: 'Settings',
+  /** UNTRANSLATED */
+  tab_connection: 'Connection',
+  /** UNTRANSLATED */
+  general_settings_title: 'General Settings',
+  /** UNTRANSLATED */
+  custom_branding_title: 'Custom Branding',
+  /** UNTRANSLATED */
+  custom_branding_description:
+    'Customize enterprise IdP display information for sign-in button and other scenarios.',
+  /** UNTRANSLATED */
+  email_domain_field_name: 'Enterprise email domain',
+  /** UNTRANSLATED */
+  email_domain_field_description:
+    'Users with this email domain can use SSO for authentication. Please ensure the domain belongs to the enterprise.',
+  /** UNTRANSLATED */
+  email_domain_field_placeholder: 'Email domain',
+  /** UNTRANSLATED */
+  sync_profile_field_name: 'Sync profile information from the identity provider',
+  sync_profile_option: {
+    /** UNTRANSLATED */
+    register_only: 'Only sync at first sign-in',
+    /** UNTRANSLATED */
+    each_sign_in: 'Always sync at each sign-in',
+  },
+  /** UNTRANSLATED */
+  connector_name_field_name: 'Connector name',
+  /** UNTRANSLATED */
+  connector_logo_field_name: 'Connector logo',
+  /** UNTRANSLATED */
+  branding_logo_context: 'Upload logo',
+  /** UNTRANSLATED */
+  branding_logo_error: 'Upload logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_logo_field_name: 'Logo',
+  /** UNTRANSLATED */
+  branding_logo_field_placeholder: 'https://your.domain/logo.png',
+  /** UNTRANSLATED */
+  branding_dark_logo_context: 'Upload dark mode logo',
+  /** UNTRANSLATED */
+  branding_dark_logo_error: 'Upload dark mode logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_name: 'Logo (dark mode)',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_placeholder: 'https://your.domain/dark-mode-logo.png',
+  /** UNTRANSLATED */
+  check_readme: 'Check README',
+  /** UNTRANSLATED */
+  enterprise_sso_deleted: 'Enterprise SSO connector has been successfully deleted',
+  /** UNTRANSLATED */
+  delete_confirm_modal_title: 'Delete enterprise SSO connector',
+  /** UNTRANSLATED */
+  delete_confirm_modal_content:
+    'Are you sure you want to delete this enterprise connector? Users from identity providers will not utilize Single Sign-On.',
+};
+
+export default Object.freeze(enterprise_sso_details);

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/index.ts
@@ -9,6 +9,7 @@ import connectors from './connectors.js';
 import contact from './contact.js';
 import dashboard from './dashboard.js';
 import domain from './domain.js';
+import enterprise_sso_details from './enterprise-sso-details.js';
 import enterprise_sso from './enterprise-sso.js';
 import errors from './errors.js';
 import general from './general.js';
@@ -54,6 +55,7 @@ const admin_console = {
   connectors,
   connector_details,
   enterprise_sso,
+  enterprise_sso_details,
   get_started,
   users,
   user_details,

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/enterprise-sso-details.ts
@@ -1,0 +1,67 @@
+const enterprise_sso_details = {
+  /** UNTRANSLATED */
+  back_to_sso_connectors: 'Back to enterprise SSO',
+  /** UNTRANSLATED */
+  page_title: 'Enterprise SSO connector details',
+  /** UNTRANSLATED */
+  readme_drawer_title: 'Enterprise SSO',
+  /** UNTRANSLATED */
+  readme_drawer_subtitle: 'Set up enterprise SSO connectors to enable end users SSO',
+  /** UNTRANSLATED */
+  tab_settings: 'Settings',
+  /** UNTRANSLATED */
+  tab_connection: 'Connection',
+  /** UNTRANSLATED */
+  general_settings_title: 'General Settings',
+  /** UNTRANSLATED */
+  custom_branding_title: 'Custom Branding',
+  /** UNTRANSLATED */
+  custom_branding_description:
+    'Customize enterprise IdP display information for sign-in button and other scenarios.',
+  /** UNTRANSLATED */
+  email_domain_field_name: 'Enterprise email domain',
+  /** UNTRANSLATED */
+  email_domain_field_description:
+    'Users with this email domain can use SSO for authentication. Please ensure the domain belongs to the enterprise.',
+  /** UNTRANSLATED */
+  email_domain_field_placeholder: 'Email domain',
+  /** UNTRANSLATED */
+  sync_profile_field_name: 'Sync profile information from the identity provider',
+  sync_profile_option: {
+    /** UNTRANSLATED */
+    register_only: 'Only sync at first sign-in',
+    /** UNTRANSLATED */
+    each_sign_in: 'Always sync at each sign-in',
+  },
+  /** UNTRANSLATED */
+  connector_name_field_name: 'Connector name',
+  /** UNTRANSLATED */
+  connector_logo_field_name: 'Connector logo',
+  /** UNTRANSLATED */
+  branding_logo_context: 'Upload logo',
+  /** UNTRANSLATED */
+  branding_logo_error: 'Upload logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_logo_field_name: 'Logo',
+  /** UNTRANSLATED */
+  branding_logo_field_placeholder: 'https://your.domain/logo.png',
+  /** UNTRANSLATED */
+  branding_dark_logo_context: 'Upload dark mode logo',
+  /** UNTRANSLATED */
+  branding_dark_logo_error: 'Upload dark mode logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_name: 'Logo (dark mode)',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_placeholder: 'https://your.domain/dark-mode-logo.png',
+  /** UNTRANSLATED */
+  check_readme: 'Check README',
+  /** UNTRANSLATED */
+  enterprise_sso_deleted: 'Enterprise SSO connector has been successfully deleted',
+  /** UNTRANSLATED */
+  delete_confirm_modal_title: 'Delete enterprise SSO connector',
+  /** UNTRANSLATED */
+  delete_confirm_modal_content:
+    'Are you sure you want to delete this enterprise connector? Users from identity providers will not utilize Single Sign-On.',
+};
+
+export default Object.freeze(enterprise_sso_details);

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/index.ts
@@ -9,6 +9,7 @@ import connectors from './connectors.js';
 import contact from './contact.js';
 import dashboard from './dashboard.js';
 import domain from './domain.js';
+import enterprise_sso_details from './enterprise-sso-details.js';
 import enterprise_sso from './enterprise-sso.js';
 import errors from './errors.js';
 import general from './general.js';
@@ -54,6 +55,7 @@ const admin_console = {
   connectors,
   connector_details,
   enterprise_sso,
+  enterprise_sso_details,
   get_started,
   users,
   user_details,

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/enterprise-sso-details.ts
@@ -1,0 +1,67 @@
+const enterprise_sso_details = {
+  /** UNTRANSLATED */
+  back_to_sso_connectors: 'Back to enterprise SSO',
+  /** UNTRANSLATED */
+  page_title: 'Enterprise SSO connector details',
+  /** UNTRANSLATED */
+  readme_drawer_title: 'Enterprise SSO',
+  /** UNTRANSLATED */
+  readme_drawer_subtitle: 'Set up enterprise SSO connectors to enable end users SSO',
+  /** UNTRANSLATED */
+  tab_settings: 'Settings',
+  /** UNTRANSLATED */
+  tab_connection: 'Connection',
+  /** UNTRANSLATED */
+  general_settings_title: 'General Settings',
+  /** UNTRANSLATED */
+  custom_branding_title: 'Custom Branding',
+  /** UNTRANSLATED */
+  custom_branding_description:
+    'Customize enterprise IdP display information for sign-in button and other scenarios.',
+  /** UNTRANSLATED */
+  email_domain_field_name: 'Enterprise email domain',
+  /** UNTRANSLATED */
+  email_domain_field_description:
+    'Users with this email domain can use SSO for authentication. Please ensure the domain belongs to the enterprise.',
+  /** UNTRANSLATED */
+  email_domain_field_placeholder: 'Email domain',
+  /** UNTRANSLATED */
+  sync_profile_field_name: 'Sync profile information from the identity provider',
+  sync_profile_option: {
+    /** UNTRANSLATED */
+    register_only: 'Only sync at first sign-in',
+    /** UNTRANSLATED */
+    each_sign_in: 'Always sync at each sign-in',
+  },
+  /** UNTRANSLATED */
+  connector_name_field_name: 'Connector name',
+  /** UNTRANSLATED */
+  connector_logo_field_name: 'Connector logo',
+  /** UNTRANSLATED */
+  branding_logo_context: 'Upload logo',
+  /** UNTRANSLATED */
+  branding_logo_error: 'Upload logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_logo_field_name: 'Logo',
+  /** UNTRANSLATED */
+  branding_logo_field_placeholder: 'https://your.domain/logo.png',
+  /** UNTRANSLATED */
+  branding_dark_logo_context: 'Upload dark mode logo',
+  /** UNTRANSLATED */
+  branding_dark_logo_error: 'Upload dark mode logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_name: 'Logo (dark mode)',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_placeholder: 'https://your.domain/dark-mode-logo.png',
+  /** UNTRANSLATED */
+  check_readme: 'Check README',
+  /** UNTRANSLATED */
+  enterprise_sso_deleted: 'Enterprise SSO connector has been successfully deleted',
+  /** UNTRANSLATED */
+  delete_confirm_modal_title: 'Delete enterprise SSO connector',
+  /** UNTRANSLATED */
+  delete_confirm_modal_content:
+    'Are you sure you want to delete this enterprise connector? Users from identity providers will not utilize Single Sign-On.',
+};
+
+export default Object.freeze(enterprise_sso_details);

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/index.ts
@@ -9,6 +9,7 @@ import connectors from './connectors.js';
 import contact from './contact.js';
 import dashboard from './dashboard.js';
 import domain from './domain.js';
+import enterprise_sso_details from './enterprise-sso-details.js';
 import enterprise_sso from './enterprise-sso.js';
 import errors from './errors.js';
 import general from './general.js';
@@ -54,6 +55,7 @@ const admin_console = {
   connectors,
   connector_details,
   enterprise_sso,
+  enterprise_sso_details,
   get_started,
   users,
   user_details,

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/enterprise-sso-details.ts
@@ -1,0 +1,67 @@
+const enterprise_sso_details = {
+  /** UNTRANSLATED */
+  back_to_sso_connectors: 'Back to enterprise SSO',
+  /** UNTRANSLATED */
+  page_title: 'Enterprise SSO connector details',
+  /** UNTRANSLATED */
+  readme_drawer_title: 'Enterprise SSO',
+  /** UNTRANSLATED */
+  readme_drawer_subtitle: 'Set up enterprise SSO connectors to enable end users SSO',
+  /** UNTRANSLATED */
+  tab_settings: 'Settings',
+  /** UNTRANSLATED */
+  tab_connection: 'Connection',
+  /** UNTRANSLATED */
+  general_settings_title: 'General Settings',
+  /** UNTRANSLATED */
+  custom_branding_title: 'Custom Branding',
+  /** UNTRANSLATED */
+  custom_branding_description:
+    'Customize enterprise IdP display information for sign-in button and other scenarios.',
+  /** UNTRANSLATED */
+  email_domain_field_name: 'Enterprise email domain',
+  /** UNTRANSLATED */
+  email_domain_field_description:
+    'Users with this email domain can use SSO for authentication. Please ensure the domain belongs to the enterprise.',
+  /** UNTRANSLATED */
+  email_domain_field_placeholder: 'Email domain',
+  /** UNTRANSLATED */
+  sync_profile_field_name: 'Sync profile information from the identity provider',
+  sync_profile_option: {
+    /** UNTRANSLATED */
+    register_only: 'Only sync at first sign-in',
+    /** UNTRANSLATED */
+    each_sign_in: 'Always sync at each sign-in',
+  },
+  /** UNTRANSLATED */
+  connector_name_field_name: 'Connector name',
+  /** UNTRANSLATED */
+  connector_logo_field_name: 'Connector logo',
+  /** UNTRANSLATED */
+  branding_logo_context: 'Upload logo',
+  /** UNTRANSLATED */
+  branding_logo_error: 'Upload logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_logo_field_name: 'Logo',
+  /** UNTRANSLATED */
+  branding_logo_field_placeholder: 'https://your.domain/logo.png',
+  /** UNTRANSLATED */
+  branding_dark_logo_context: 'Upload dark mode logo',
+  /** UNTRANSLATED */
+  branding_dark_logo_error: 'Upload dark mode logo error: {{error}}',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_name: 'Logo (dark mode)',
+  /** UNTRANSLATED */
+  branding_dark_logo_field_placeholder: 'https://your.domain/dark-mode-logo.png',
+  /** UNTRANSLATED */
+  check_readme: 'Check README',
+  /** UNTRANSLATED */
+  enterprise_sso_deleted: 'Enterprise SSO connector has been successfully deleted',
+  /** UNTRANSLATED */
+  delete_confirm_modal_title: 'Delete enterprise SSO connector',
+  /** UNTRANSLATED */
+  delete_confirm_modal_content:
+    'Are you sure you want to delete this enterprise connector? Users from identity providers will not utilize Single Sign-On.',
+};
+
+export default Object.freeze(enterprise_sso_details);

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/index.ts
@@ -9,6 +9,7 @@ import connectors from './connectors.js';
 import contact from './contact.js';
 import dashboard from './dashboard.js';
 import domain from './domain.js';
+import enterprise_sso_details from './enterprise-sso-details.js';
 import enterprise_sso from './enterprise-sso.js';
 import errors from './errors.js';
 import general from './general.js';
@@ -54,6 +55,7 @@ const admin_console = {
   connectors,
   connector_details,
   enterprise_sso,
+  enterprise_sso_details,
   get_started,
   users,
   user_details,

--- a/packages/schemas/src/types/sso-connector.ts
+++ b/packages/schemas/src/types/sso-connector.ts
@@ -21,6 +21,28 @@ export enum SsoProviderName {
   GOOGLE_WORKSPACE = 'GoogleWorkspace',
 }
 
+export const singleSignOnDomainBlackList = Object.freeze([
+  'gmail.com',
+  'yahoo.com',
+  'hotmail.com',
+  'outlook.com',
+  'live.com',
+  'icloud.com',
+  'aol.com',
+  'yandex.com',
+  'mail.com',
+  'protonmail.com',
+  'yanex.com',
+  'gmx.com',
+  'mail.ru',
+  'zoho.com',
+  'qq.com',
+  '163.com',
+  '126.com',
+  'sina.com',
+  'sohu.com',
+]);
+
 export type SupportedSsoConnector = Omit<SsoConnector, 'providerName'> & {
   providerName: SsoProviderName;
 };

--- a/packages/schemas/src/utils/domain.test.ts
+++ b/packages/schemas/src/utils/domain.test.ts
@@ -1,0 +1,38 @@
+import { findDuplicatedOrBlockedEmailDomains } from './domain.js';
+
+describe('findDuplicatedOrBlockedEmailDomains', () => {
+  it('should return blocked domains and duplicated domains correctly', () => {
+    const { duplicatedDomains, forbiddenDomains } = findDuplicatedOrBlockedEmailDomains([
+      'gmail.com',
+      'silverhand.io',
+      'logto.io',
+      'yahoo.com',
+      'outlook.com',
+      'logto.io',
+    ]);
+    expect(duplicatedDomains).toEqual(new Set(['logto.io']));
+    expect(forbiddenDomains).toEqual(new Set(['gmail.com', 'yahoo.com', 'outlook.com']));
+  });
+
+  it('should return empty `duplicatedDomains` and `forbiddenDomains` sets if all domains are valid', () => {
+    const { duplicatedDomains, forbiddenDomains } = findDuplicatedOrBlockedEmailDomains([
+      'silverhand.io',
+      'logto.io',
+      'metalhand.io',
+    ]);
+    expect(duplicatedDomains).toEqual(new Set());
+    expect(forbiddenDomains).toEqual(new Set());
+  });
+
+  it('should return empty `duplicatedDomains` and `forbiddenDomains` sets if input is undefined', () => {
+    const { duplicatedDomains, forbiddenDomains } = findDuplicatedOrBlockedEmailDomains();
+    expect(duplicatedDomains).toEqual(new Set());
+    expect(forbiddenDomains).toEqual(new Set());
+  });
+
+  it('should return empty `duplicatedDomains` and `forbiddenDomains` sets if input is empty array', () => {
+    const { duplicatedDomains, forbiddenDomains } = findDuplicatedOrBlockedEmailDomains([]);
+    expect(duplicatedDomains).toEqual(new Set());
+    expect(forbiddenDomains).toEqual(new Set());
+  });
+});

--- a/packages/schemas/src/utils/domain.ts
+++ b/packages/schemas/src/utils/domain.ts
@@ -1,0 +1,31 @@
+import { singleSignOnDomainBlackList } from '../types/sso-connector.js';
+
+/**
+ * Find duplicated domains and blocked domains using the domain blacklist.
+ *
+ * @param domains Array of email domains.
+ * @returns
+ */
+export const findDuplicatedOrBlockedEmailDomains = (domains?: string[]) => {
+  const blackListSet = new Set<string>(singleSignOnDomainBlackList);
+  const validDomainSet = new Set<string>();
+  const duplicatedDomains = new Set<string>();
+  const forbiddenDomains = new Set<string>();
+
+  for (const domain of domains ?? []) {
+    if (blackListSet.has(domain)) {
+      forbiddenDomains.add(domain);
+    }
+
+    if (validDomainSet.has(domain)) {
+      duplicatedDomains.add(domain);
+    } else {
+      validDomainSet.add(domain);
+    }
+  }
+
+  return {
+    duplicatedDomains,
+    forbiddenDomains,
+  };
+};

--- a/packages/schemas/src/utils/index.ts
+++ b/packages/schemas/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './role.js';
 export * from './management-api.js';
+export * from './domain.js';


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add SSO connectors' details page, including the following changes:
1. [console]: add SSO connectors' details page "settings" tab (this includes some general settings for all kinds of SSO connectors)
2. [core/schemsa]: move "email domain validator" and corresponding blacklists to schemas for console reuse (per design, we need to do real-time validation when configuring the "domains" field in the details page).
3. [console]: add a component called "MultiInput" which can input a list of string-typed values.
4. [console]: add a component called "LogosUploader" to upload SSO connectors' logos for branding configuration (both light mode logo and dark mode logo)
5. [console]: align the CSS of "ImageUploader" and "FileUploader", previously the preview of the uploaded image does not fit the height of its parent component.

TODO:
This is the "Settings" tab of the SSO connector details page, the "Connection" page which contains protocol-specific configuration reuses the form we implemented in the SSO connector guide will come right after this PR.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally, will add integration tests once the complete flow is done in the console.

Overall preview:
<img width="1149" alt="image" src="https://github.com/logto-io/logto/assets/15182327/2df76c17-6f43-4a4c-89e7-ff52d97bdbba">

Realtime domain validation:
<img width="1018" alt="image" src="https://github.com/logto-io/logto/assets/15182327/0df8041d-dcc9-44bc-be3d-1eed1c778f58">
<img width="1006" alt="image" src="https://github.com/logto-io/logto/assets/15182327/93d67280-288b-4115-85ef-adf78326eda5">

Upload logo:
<img width="1033" alt="image" src="https://github.com/logto-io/logto/assets/15182327/80379c97-7303-4723-9c21-03b4146a14be">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments (front-end components use normal comments)
