### PR TITLE
fix(console): display mfa feature item in downgrade plan modal

### DIFF
--- a/packages/console/src/pages/TenantSettings/Subscription/DowngradeConfirmModalContent/index.tsx
+++ b/packages/console/src/pages/TenantSettings/Subscription/DowngradeConfirmModalContent/index.tsx
@@ -3,7 +3,6 @@ import { useMemo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import PlanName from '@/components/PlanName';
-import { isDevFeaturesEnabled } from '@/consts/env';
 import { type SubscriptionPlan } from '@/types/subscriptions';
 
 import PlanQuotaDiffCard from './PlanQuotaDiffCard';
@@ -17,19 +16,9 @@ type Props = {
 function DowngradeConfirmModalContent({ currentPlan, targetPlan }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
-  const {
-    quota: currentFullQuota,
-    quota: { mfaEnabled: currentMfaEnabled, ...currentQuotaWithoutMfa },
-    name: currentPlanName,
-  } = currentPlan;
-  const currentQuota = isDevFeaturesEnabled ? currentFullQuota : currentQuotaWithoutMfa;
+  const { quota: currentQuota, name: currentPlanName } = currentPlan;
 
-  const {
-    quota: targetFullQuota,
-    quota: { mfaEnabled: targetMfaEnabled, ...targetQuotaWithoutMfa },
-    name: targetPlanName,
-  } = targetPlan;
-  const targetQuota = isDevFeaturesEnabled ? targetFullQuota : targetQuotaWithoutMfa;
+  const { quota: targetQuota, name: targetPlanName } = targetPlan;
 
   const currentQuotaDiff = useMemo(
     () => diff(targetQuota, currentQuota),

--- a/packages/console/src/pages/TenantSettings/components/NotEligibleSwitchPlanModalContent/index.tsx
+++ b/packages/console/src/pages/TenantSettings/components/NotEligibleSwitchPlanModalContent/index.tsx
@@ -5,7 +5,6 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import ContactUsPhraseLink from '@/components/ContactUsPhraseLink';
 import PlanName from '@/components/PlanName';
-import { isDevFeaturesEnabled } from '@/consts/env';
 import { planQuotaItemOrder } from '@/consts/plan-quotas';
 import {
   quotaItemLimitedPhrasesMap,
@@ -33,14 +32,7 @@ function NotEligibleSwitchPlanModalContent({ targetPlan, isDowngrade = false }: 
     keyPrefix: 'admin_console.subscription.not_eligible_modal',
   });
 
-  const {
-    id,
-    name,
-    quota: fullQuota,
-    quota: { mfaEnabled, ...quotaWithoutMfa },
-  } = targetPlan;
-
-  const quota = isDevFeaturesEnabled ? fullQuota : quotaWithoutMfa;
+  const { id, name, quota } = targetPlan;
 
   const orderedEntries = useMemo(() => {
     // eslint-disable-next-line no-restricted-syntax


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The MFA feature item should be displayed in downgrade plan modal.

**Note**: this bug only affect the Logto cloud.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

<img width="762" alt="image" src="https://github.com/logto-io/logto/assets/10806653/575e1eb1-09ee-4c01-87f0-d9584768ab2e">

<img width="569" alt="image" src="https://github.com/logto-io/logto/assets/10806653/3be8a3e3-803b-4094-bc67-2f3bafc8aeb3">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
