### PR TITLE
fix(console): hide coming soon features from the downgrade plan modal

### DIFF
--- a/packages/console/src/components/PlanQuotaList/index.tsx
+++ b/packages/console/src/components/PlanQuotaList/index.tsx
@@ -2,7 +2,10 @@ import classNames from 'classnames';
 import { useMemo } from 'react';
 
 import { planQuotaItemOrder } from '@/consts/plan-quotas';
-import { type SubscriptionPlanQuota } from '@/types/subscriptions';
+import {
+  type SubscriptionPlanQuotaEntries,
+  type SubscriptionPlanQuota,
+} from '@/types/subscriptions';
 import { sortBy } from '@/utils/sort';
 
 import QuotaItem from './QuotaItem';
@@ -27,9 +30,7 @@ function PlanQuotaList({
 }: Props) {
   const items = useMemo(() => {
     // eslint-disable-next-line no-restricted-syntax
-    const entries = Object.entries(quota) as Array<
-      [keyof SubscriptionPlanQuota, SubscriptionPlanQuota[keyof SubscriptionPlanQuota]]
-    >;
+    const entries = Object.entries(quota) as SubscriptionPlanQuotaEntries;
 
     const featuredEntries = featuredQuotaKeys
       ? entries.filter(([key]) => featuredQuotaKeys.includes(key))

--- a/packages/console/src/pages/TenantSettings/Subscription/DowngradeConfirmModalContent/index.tsx
+++ b/packages/console/src/pages/TenantSettings/Subscription/DowngradeConfirmModalContent/index.tsx
@@ -3,7 +3,12 @@ import { useMemo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import PlanName from '@/components/PlanName';
-import { type SubscriptionPlan } from '@/types/subscriptions';
+import { comingSoonQuotaKeys } from '@/consts/plan-quotas';
+import {
+  type SubscriptionPlanQuota,
+  type SubscriptionPlan,
+  type SubscriptionPlanQuotaEntries,
+} from '@/types/subscriptions';
 
 import PlanQuotaDiffCard from './PlanQuotaDiffCard';
 import * as styles from './index.module.scss';
@@ -11,6 +16,14 @@ import * as styles from './index.module.scss';
 type Props = {
   currentPlan: SubscriptionPlan;
   targetPlan: SubscriptionPlan;
+};
+
+const excludeComingSoonFeatures = (
+  quotaDiff: Partial<SubscriptionPlanQuota>
+): Partial<SubscriptionPlanQuota> => {
+  // eslint-disable-next-line no-restricted-syntax
+  const entries = Object.entries(quotaDiff) as SubscriptionPlanQuotaEntries;
+  return Object.fromEntries(entries.filter(([key]) => !comingSoonQuotaKeys.includes(key)));
 };
 
 function DowngradeConfirmModalContent({ currentPlan, targetPlan }: Props) {
@@ -21,12 +34,12 @@ function DowngradeConfirmModalContent({ currentPlan, targetPlan }: Props) {
   const { quota: targetQuota, name: targetPlanName } = targetPlan;
 
   const currentQuotaDiff = useMemo(
-    () => diff(targetQuota, currentQuota),
+    () => excludeComingSoonFeatures(diff(targetQuota, currentQuota)),
     [currentQuota, targetQuota]
   );
 
   const targetQuotaDiff = useMemo(
-    () => diff(currentQuota, targetQuota),
+    () => excludeComingSoonFeatures(diff(currentQuota, targetQuota)),
     [currentQuota, targetQuota]
   );
 

--- a/packages/console/src/pages/TenantSettings/components/NotEligibleSwitchPlanModalContent/index.tsx
+++ b/packages/console/src/pages/TenantSettings/components/NotEligibleSwitchPlanModalContent/index.tsx
@@ -11,7 +11,11 @@ import {
   quotaItemNotEligiblePhrasesMap,
 } from '@/consts/quota-item-phrases';
 import DynamicT from '@/ds-components/DynamicT';
-import { type SubscriptionPlan, type SubscriptionPlanQuota } from '@/types/subscriptions';
+import {
+  type SubscriptionPlanQuotaEntries,
+  type SubscriptionPlan,
+  type SubscriptionPlanQuota,
+} from '@/types/subscriptions';
 import { sortBy } from '@/utils/sort';
 
 import * as styles from './index.module.scss';
@@ -36,9 +40,7 @@ function NotEligibleSwitchPlanModalContent({ targetPlan, isDowngrade = false }: 
 
   const orderedEntries = useMemo(() => {
     // eslint-disable-next-line no-restricted-syntax
-    const entries = Object.entries(quota) as Array<
-      [keyof SubscriptionPlanQuota, SubscriptionPlanQuota[keyof SubscriptionPlanQuota]]
-    >;
+    const entries = Object.entries(quota) as SubscriptionPlanQuotaEntries;
     return entries
       .slice()
       .sort(([preQuotaKey], [nextQuotaKey]) =>

--- a/packages/console/src/types/subscriptions.ts
+++ b/packages/console/src/types/subscriptions.ts
@@ -22,6 +22,10 @@ export type SubscriptionPlanQuota = Omit<
   ssoEnabled: boolean;
 };
 
+export type SubscriptionPlanQuotaEntries = Array<
+  [keyof SubscriptionPlanQuota, SubscriptionPlanQuota[keyof SubscriptionPlanQuota]]
+>;
+
 export type SubscriptionPlan = Omit<SubscriptionPlanResponse, 'quota'> & {
   quota: SubscriptionPlanQuota;
 };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Per offline discussion with designers, we should hide coming soon features in the downgrade plan modal.

### Updates
- Extract the `SubscriptionPlanQuotaEntries` into a type since it's used in many places.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Before:
![image](https://github.com/logto-io/logto/assets/10806653/004b79f5-410b-40cd-89a7-49377ed7ce7a)

After:
![image](https://github.com/logto-io/logto/assets/10806653/25bc7d27-9b12-4bcf-8c37-e14ef5ec3441)


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
