### PR TITLE
fix(console): default button icon should use secondary color

### DIFF
--- a/packages/console/src/ds-components/Button/index.module.scss
+++ b/packages/console/src/ds-components/Button/index.module.scss
@@ -93,6 +93,10 @@
     border-width: 1px;
     border-style: solid;
 
+    .icon {
+      color: var(--color-text-secondary);
+    }
+
     &:disabled {
       border-color: var(--color-border);
       color: var(--color-neutral-70);

--- a/packages/console/src/pages/Organizations/TemplateTable/index.module.scss
+++ b/packages/console/src/pages/Organizations/TemplateTable/index.module.scss
@@ -13,9 +13,6 @@
 
 .empty {
   font: var(--font-body-2);
-}
-
-.secondary {
   color: var(--color-text-secondary);
 }
 

--- a/packages/console/src/pages/Organizations/TemplateTable/index.tsx
+++ b/packages/console/src/pages/Organizations/TemplateTable/index.tsx
@@ -97,16 +97,11 @@ function TemplateTable<
       {onAdd && !hasData && (
         <>
           {name && (
-            <div className={classNames(styles.empty, styles.secondary)}>
+            <div className={classNames(styles.empty)}>
               {t('organizations.empty_placeholder', { entity: String(t(name)).toLowerCase() })}
             </div>
           )}
-          <Button
-            className={styles.secondary}
-            icon={<Plus />}
-            title="general.add"
-            onClick={onAdd}
-          />
+          <Button icon={<Plus />} title="general.add" onClick={onAdd} />
         </>
       )}
     </section>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The default button should have icons rendered in secondary text color. Previously it was following the color of the button text and the designers said no no.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="117" alt="image" src="https://github.com/logto-io/logto/assets/12833674/b249b435-dd2a-4b20-b1a2-89d1c2e26192">

Previously the icon was black, same as the text color. Now it's gray

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
