### PR TITLE
feat(experience): add native listener to SSO callback page

### DIFF
--- a/packages/experience/src/hooks/use-native-message-listener.ts
+++ b/packages/experience/src/hooks/use-native-message-listener.ts
@@ -35,7 +35,7 @@ const useNativeMessageListener = (bypass = false) => {
     return () => {
       window.removeEventListener('message', nativeMessageHandler);
     };
-  }, [setToast]);
+  }, [bypass, setToast]);
 };
 
 export default useNativeMessageListener;

--- a/packages/experience/src/hooks/use-native-message-listener.ts
+++ b/packages/experience/src/hooks/use-native-message-listener.ts
@@ -4,12 +4,21 @@ import { isNativeWebview } from '@/utils/native-sdk';
 
 import useToast from './use-toast';
 
-const useNativeMessageListener = () => {
+/**
+ * UseNativeMessageListener
+ *
+ * Used to monitor native error message.
+ * If native error message is sent, it will be displayed as toast.
+ * Add a bypass parameter to bypass the native error message listener.
+ *
+ * @param {boolean} bypass (default: false)
+ */
+const useNativeMessageListener = (bypass = false) => {
   const { setToast } = useToast();
 
   // Monitor Native Error Message
   useEffect(() => {
-    if (!isNativeWebview()) {
+    if (!isNativeWebview() || bypass) {
       return;
     }
 

--- a/packages/experience/src/pages/SocialSignInCallback/SingleSignOn.tsx
+++ b/packages/experience/src/pages/SocialSignInCallback/SingleSignOn.tsx
@@ -1,16 +1,25 @@
+import useNativeMessageListener from '@/hooks/use-native-message-listener';
+import { useSieMethods } from '@/hooks/use-sie';
+
 import SignIn from '../SignIn';
 
 import useSingleSignOnListener from './use-single-sign-on-listener';
 
-/**
- * Single sign-on callback page
- */
 type Props = {
   connectorId: string;
 };
 
 const SingleSignOn = ({ connectorId }: Props) => {
+  const { socialConnectors } = useSieMethods();
+
+  /* To avoid register duplicated native message listeners,
+    we only add the native message listener if there are no social connectors.
+    Set the bypass flag to true if there are social connectors.
+  */
+  useNativeMessageListener(socialConnectors.length > 0);
+
   useSingleSignOnListener(connectorId);
+
   return <SignIn />;
 };
 


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add the native message listener to the SSO callback page.

In the previous implementation, we have the native message listener being registered in two places:
1. `SocialSignIn` Container:  Listed on the SignIn/Register home page.
2. `SingleSignOnConnecters` Page.

There are two steps we need to listen to the native message:
1. when the user clicks on the connector button (Social or SSO) to init a sign-in flow
2. when IdP redirects the user back to our `sign-in/callback` page.

This PR adds the native message listener to the SSO `sign-in/callback` page. Also add a condition `bypass` parameter. Only register the new listener if there are no social connectors. As it will be registered by the `SocialSignIn` Container.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [x] necessary TSDoc comments
