### PR TITLE
feat(experience): add struct guard to session storage hook 

### DIFF
--- a/packages/experience/package.json
+++ b/packages/experience/package.json
@@ -45,6 +45,7 @@
     "@swc/core": "^1.3.52",
     "@swc/jest": "^0.2.26",
     "@testing-library/react": "^14.0.0",
+    "@testing-library/react-hooks": "^8.0.1",
     "@types/color": "^3.0.3",
     "@types/jest": "^29.4.0",
     "@types/react": "^18.0.31",

--- a/packages/experience/src/hooks/use-session-storages.test.ts
+++ b/packages/experience/src/hooks/use-session-storages.test.ts
@@ -1,0 +1,39 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { mockSsoConnectors } from '@/__mocks__/logto';
+
+import useSessionStorage, { StorageKeys } from './use-session-storages';
+
+describe('useSessionStorage', () => {
+  it('should set and get a email value', () => {
+    const email = 'foo@test.io';
+    const { result } = renderHook(() => useSessionStorage());
+    const { get, set, remove } = result.current;
+
+    expect(get(StorageKeys.SsoEmail)).toBeUndefined();
+    set(StorageKeys.SsoEmail, email);
+    expect(get(StorageKeys.SsoEmail)).toBe(email);
+    remove(StorageKeys.SsoEmail);
+    expect(get(StorageKeys.SsoEmail)).toBeUndefined();
+  });
+
+  it('should set and get a sso connectors value', () => {
+    const { result } = renderHook(() => useSessionStorage());
+    const { get, set, remove } = result.current;
+
+    expect(get(StorageKeys.SsoConnectors)).toBeUndefined();
+    set(StorageKeys.SsoConnectors, mockSsoConnectors);
+    expect(get(StorageKeys.SsoConnectors)).toStrictEqual(mockSsoConnectors);
+    remove(StorageKeys.SsoConnectors);
+    expect(get(StorageKeys.SsoConnectors)).toBeUndefined();
+  });
+
+  it('should return undefined if the value is invalid', () => {
+    const { result } = renderHook(() => useSessionStorage());
+    const { get, set } = result.current;
+
+    // @ts-expect-error -- we are testing invalid values
+    set(StorageKeys.SsoConnectors, 'foo');
+    expect(get(StorageKeys.SsoEmail)).toBeUndefined();
+  });
+});

--- a/packages/experience/src/types/guard.ts
+++ b/packages/experience/src/types/guard.ts
@@ -1,4 +1,9 @@
-import { SignInIdentifier, MissingProfile, MfaFactor } from '@logto/schemas';
+import {
+  SignInIdentifier,
+  MissingProfile,
+  MfaFactor,
+  type SsoConnectorMetadata,
+} from '@logto/schemas';
 import * as s from 'superstruct';
 
 import { UserFlow } from '.';
@@ -106,3 +111,11 @@ export const webAuthnStateGuard = s.assign(
 );
 
 export type WebAuthnState = s.Infer<typeof webAuthnStateGuard>;
+
+/* Single Sign On */
+export const ssoConnectorMetadataGuard: s.Describe<SsoConnectorMetadata> = s.object({
+  id: s.string(),
+  logo: s.string(),
+  darkLogo: s.optional(s.string()),
+  connectorName: s.string(),
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3584,6 +3584,9 @@ importers:
       '@testing-library/react':
         specifier: ^14.0.0
         version: 14.0.0(react-dom@18.2.0)(react@18.2.0)
+      '@testing-library/react-hooks':
+        specifier: ^8.0.1
+        version: 8.0.1(@types/react@18.0.31)(react-dom@18.2.0)(react@18.2.0)
       '@types/color':
         specifier: ^3.0.3
         version: 3.0.3
@@ -9615,6 +9618,29 @@ packages:
       dom-accessibility-api: 0.5.10
       lz-string: 1.4.4
       pretty-format: 27.5.1
+    dev: true
+
+  /@testing-library/react-hooks@8.0.1(@types/react@18.0.31)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      '@types/react': ^16.9.0 || ^17.0.0
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.9.0 || ^17.0.0
+      react-test-renderer: ^16.9.0 || ^17.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react-dom:
+        optional: true
+      react-test-renderer:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.0
+      '@types/react': 18.0.31
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-error-boundary: 3.1.4(react@18.2.0)
     dev: true
 
   /@testing-library/react@14.0.0(react-dom@18.2.0)(react@18.2.0):
@@ -18176,6 +18202,16 @@ packages:
       attr-accept: 2.2.2
       file-selector: 0.6.0
       prop-types: 15.8.1
+      react: 18.2.0
+    dev: true
+
+  /react-error-boundary@3.1.4(react@18.2.0):
+    resolution: {integrity: sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==}
+    engines: {node: '>=10', npm: '>=6'}
+    peerDependencies:
+      react: '>=16.13.1 || ^18.0.0'
+    dependencies:
+      '@babel/runtime': 7.21.0
       react: 18.2.0
     dev: true
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Based on our [discussion_r1395090089](https://github.com/logto-io/logto/pull/4865#discussion_r1395090089).

@charIeszhao 

Implement a strict return value type guard using superstruct. 
Guard the return value. Clear the storage if the value in session storage is type-incompatible and returns undefined. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
