### PR TITLE
refactor(core,experience): extract sso register api

### DIFF
--- a/packages/core/src/routes/interaction/utils/single-sign-on-guard.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on-guard.ts
@@ -1,16 +1,9 @@
 import { type SocialUserInfo } from '@logto/connector-kit';
 import { type IdentifierPayload } from '@logto/schemas';
-import { type Context } from 'koa';
-import type Provider from 'oidc-provider';
-import { z } from 'zod';
 
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { type SsoConnectorLibrary } from '#src/libraries/sso-connector.js';
-import {
-  type SingleSignOnConnectorSession,
-  singleSignOnConnectorSessionGuard,
-} from '#src/sso/types/session.js';
 import assertThat from '#src/utils/assert-that.js';
 
 // Guard the SSO only email identifier
@@ -52,36 +45,4 @@ export const verifySsoOnlyEmailIdentifier = async (
       }
     )
   );
-};
-
-/**
- * Get the single sign on session data from the oidc provider session storage.
- *
- * @remark Forked from ./social-verification.ts.
- * Use SingleSignOnSession guard instead of ConnectorSession guard.
- */
-export const getSingleSignOnSessionResult = async (
-  ctx: Context,
-  provider: Provider
-): Promise<SingleSignOnConnectorSession> => {
-  const { result } = await provider.interactionDetails(ctx.req, ctx.res);
-
-  const singleSignOnSessionResult = z
-    .object({
-      connectorSession: singleSignOnConnectorSessionGuard,
-    })
-    .safeParse(result);
-
-  assertThat(
-    result && singleSignOnSessionResult.success,
-    'session.connector_validation_session_not_found'
-  );
-
-  // Clear the session after the session data is retrieved
-  const { connectorSession, ...rest } = result;
-  await provider.interactionResult(ctx.req, ctx.res, {
-    ...rest,
-  });
-
-  return singleSignOnSessionResult.data.connectorSession;
 };

--- a/packages/core/src/routes/interaction/utils/single-sign-on-session.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on-session.ts
@@ -1,0 +1,83 @@
+import { type Context } from 'koa';
+import type Provider from 'oidc-provider';
+import { z } from 'zod';
+
+import {
+  type SingleSignOnConnectorSession,
+  singleSignOnConnectorSessionGuard,
+  singleSignOnInteractionIdentifierResultGuard,
+  type SingleSignOnInteractionIdentifierResult,
+} from '#src/sso/types/session.js';
+import assertThat from '#src/utils/assert-that.js';
+
+/**
+ * Get the single sign on session data from the oidc provider session storage.
+ *
+ * @remark Forked from ./social-verification.ts.
+ * Use SingleSignOnSession guard instead of ConnectorSession guard.
+ */
+export const getSingleSignOnSessionResult = async (
+  ctx: Context,
+  provider: Provider
+): Promise<SingleSignOnConnectorSession> => {
+  const { result } = await provider.interactionDetails(ctx.req, ctx.res);
+
+  const singleSignOnSessionResult = z
+    .object({
+      connectorSession: singleSignOnConnectorSessionGuard,
+    })
+    .safeParse(result);
+
+  assertThat(
+    result && singleSignOnSessionResult.success,
+    'session.connector_validation_session_not_found'
+  );
+
+  // Clear the session after the session data is retrieved
+  const { connectorSession, ...rest } = result;
+  await provider.interactionResult(ctx.req, ctx.res, {
+    ...rest,
+  });
+
+  return singleSignOnSessionResult.data.connectorSession;
+};
+
+export const assignSingleSignOnAuthenticationResult = async (
+  ctx: Context,
+  provider: Provider,
+  singleSignOnIdentifier: SingleSignOnInteractionIdentifierResult['singleSignOnIdentifier']
+) => {
+  const details = await provider.interactionDetails(ctx.req, ctx.res);
+
+  await provider.interactionResult(
+    ctx.req,
+    ctx.res,
+    { ...details.result, singleSignOnIdentifier },
+    { mergeWithLastSubmission: true }
+  );
+};
+
+export const getSingleSignOnAuthenticationResult = async (
+  ctx: Context,
+  provider: Provider,
+  connectorId: string
+): Promise<SingleSignOnInteractionIdentifierResult['singleSignOnIdentifier']> => {
+  const { result } = await provider.interactionDetails(ctx.req, ctx.res);
+
+  const singleSignOnInteractionIdentifierResult =
+    singleSignOnInteractionIdentifierResultGuard.safeParse(result);
+
+  assertThat(
+    singleSignOnInteractionIdentifierResult.success,
+    'session.connector_session_not_found'
+  );
+
+  const { singleSignOnIdentifier } = singleSignOnInteractionIdentifierResult.data;
+
+  assertThat(
+    singleSignOnIdentifier.connectorId === connectorId,
+    'session.connector_session_not_found'
+  );
+
+  return singleSignOnIdentifier;
+};

--- a/packages/core/src/sso/types/session.ts
+++ b/packages/core/src/sso/types/session.ts
@@ -38,3 +38,24 @@ export const samlConnectorAssertionSessionGuard = z.object({
 export type CreateSingleSignOnSession = (storage: SingleSignOnConnectorSession) => Promise<void>;
 
 export type GetSingleSignOnSession = () => Promise<SingleSignOnConnectorSession>;
+
+/**
+ * Single sign on interaction identifier session
+ *
+ * @remark this session is used to store the authentication result from the identity provider. {@link /packages/core/src/routes/interaction/utils/single-sign-on.ts}
+ * This session is needed because we need to split the authentication process into sign in and sign up two parts.
+ * If the sso identifier is found in DB we will directly sign in the user.
+ * If the sso identifier is not found in DB we will throw an error and let the client to create a new user.
+ * In the SSO registration endpoint we will validate this session data and create a new user accordingly.
+ */
+export const singleSignOnInteractionIdentifierResultGuard = z.object({
+  singleSignOnIdentifier: z.object({
+    connectorId: z.string(),
+    issuer: z.string(),
+    userInfo: extendedSocialUserInfoGuard,
+  }),
+});
+
+export type SingleSignOnInteractionIdentifierResult = z.infer<
+  typeof singleSignOnInteractionIdentifierResultGuard
+>;

--- a/packages/core/src/sso/types/session.ts
+++ b/packages/core/src/sso/types/session.ts
@@ -44,9 +44,9 @@ export type GetSingleSignOnSession = () => Promise<SingleSignOnConnectorSession>
  *
  * @remark this session is used to store the authentication result from the identity provider. {@link /packages/core/src/routes/interaction/utils/single-sign-on.ts}
  * This session is needed because we need to split the authentication process into sign in and sign up two parts.
- * If the sso identifier is found in DB we will directly sign in the user.
- * If the sso identifier is not found in DB we will throw an error and let the client to create a new user.
- * In the SSO registration endpoint we will validate this session data and create a new user accordingly.
+ * If the SSO identity is found in DB we will directly sign in the user.
+ * If the SSO identity is not found in DB we will throw an error and let the client to create a new user.
+ * In the SSO registration endpoint, we will validate this session data and create a new user accordingly.
  */
 export const singleSignOnInteractionIdentifierResultGuard = z.object({
   singleSignOnIdentifier: z.object({

--- a/packages/experience/src/apis/single-sign-on.ts
+++ b/packages/experience/src/apis/single-sign-on.ts
@@ -38,3 +38,6 @@ export const singleSignOnAuthorization = async (connectorId: string, payload: un
       json: payload,
     })
     .json<Response>();
+
+export const singleSignOnRegistration = async (connectorId: string) =>
+  api.post(`${ssoPrefix}/${connectorId}/registration`).json<Response>();


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Extract SSO register api.

Previously the SSO authentication flow was simple and straightforward. Only two interaction APIs are designed:

- `GET /interaction/single-sign-on/:connectorId/authorization-url`:  Initiate an SSO sign-in interaction and get the authorization URL for the SSO
- `POST /interaction/single-sign-on/:connectorId/authentication`: Get authenticated by the SSO provider and try to sign in with Logto. If no related user SSO identity is found we automatically create a new account. 

In short words, the register flow is merged with the sign-in flow. 

Now per our product design, all the new users have to confirm the terms of use before actually registering a new account. Thus, we need to split the register request apart from the authentication endpoint. 

In this PR:
1. Remove the auto register logic from the ssoAuthenticationHandler. Throw a user not exist error.
2. Create a new session storage `SingleSignOnInteractionIdentifierResult` that will store the authenticated SSO user identifier.
3. Create a new API `POST /interaction/single-sign-on/:connectorId/registration` that handles the user SSO registration request.  The API relies on the SSO authentication session to proceed.
4. Update the experience ui to handle the new register flow.




https://github.com/logto-io/logto/assets/36393111/71372703-9c4d-4f77-be0e-cc8d56f6aad3



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
