### PR TITLE
fix(console): partially check config on guide page

### DIFF
--- a/packages/console/src/pages/EnterpriseSso/Guide/index.tsx
+++ b/packages/console/src/pages/EnterpriseSso/Guide/index.tsx
@@ -89,6 +89,8 @@ function Guide<T extends SsoProviderName>({ isOpen, connector, onClose, isReadOn
       await api
         .patch(`api/sso-connectors/${ssoConnectorId}/config`, {
           json: cleanDeep(formData),
+          // Do not check whether the config is complete on guide page.
+          searchParams: new URLSearchParams({ partialValidateConfig: 'true' }),
         })
         .json<SsoConnectorWithProviderConfig>();
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
partially check `config` on the guide page.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
Can continue on guide page when leave OIDC SSO connector's form blank.
<img width="1888" alt="image" src="https://github.com/logto-io/logto/assets/15182327/333a6f13-87a9-4b35-9170-62146e3362a4">
<img width="1320" alt="image" src="https://github.com/logto-io/logto/assets/15182327/922542dd-5fef-4968-a14a-7aa89f78be22">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
