### PR TITLE
feat(console,core,phrases): add more organization paywalls

### DIFF
--- a/packages/console/src/pages/Organizations/index.tsx
+++ b/packages/console/src/pages/Organizations/index.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 import Plus from '@/assets/icons/plus.svg';
 import PageMeta from '@/components/PageMeta';
+import { isCloud } from '@/consts/env';
 import { subscriptionPage } from '@/consts/pages';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import Button from '@/ds-components/Button';
@@ -40,7 +41,7 @@ function Organizations({ tab }: Props) {
   const [isCreating, setIsCreating] = useState(false);
   const { configs, isLoading: isLoadingConfigs } = useConfigs();
   const isInitialSetup = !isLoadingConfigs && !configs?.organizationCreated;
-  const isOrganizationsDisabled = currentPlan?.id === ReservedPlanId.Free;
+  const isOrganizationsDisabled = isCloud && !currentPlan?.quota.organizationsEnabled;
 
   const upgradePlan = useCallback(() => {
     navigate(subscriptionPage);

--- a/packages/core/src/middleware/koa-quota-guard.ts
+++ b/packages/core/src/middleware/koa-quota-guard.ts
@@ -3,17 +3,25 @@ import type { MiddlewareType } from 'koa';
 import { type QuotaLibrary } from '#src/libraries/quota.js';
 import { type FeatureQuota } from '#src/utils/subscription/types.js';
 
+type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'COPY' | 'HEAD' | 'OPTIONS';
+
 type UsageGuardConfig = {
   key: keyof FeatureQuota;
   quota: QuotaLibrary;
+  /** Guard usage only for the specified method types. Guard all if not provided. */
+  methods?: Method[];
 };
 
 export default function koaQuotaGuard<StateT, ContextT, ResponseBodyT>({
   key,
   quota,
+  methods,
 }: UsageGuardConfig): MiddlewareType<StateT, ContextT, ResponseBodyT> {
   return async (ctx, next) => {
-    await quota.guardKey(key);
+    // eslint-disable-next-line no-restricted-syntax
+    if (!methods || methods.includes(ctx.method.toUpperCase() as Method)) {
+      await quota.guardKey(key);
+    }
     return next();
   };
 }

--- a/packages/core/src/routes/organization/index.ts
+++ b/packages/core/src/routes/organization/index.ts
@@ -11,6 +11,7 @@ import { z } from 'zod';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
+import koaQuotaGuard from '#src/middleware/koa-quota-guard.js';
 import { userSearchKeys } from '#src/queries/user.js';
 import SchemaRouter from '#src/utils/SchemaRouter.js';
 import { parseSearchOptions } from '#src/utils/search.js';
@@ -26,6 +27,7 @@ export default function organizationRoutes<T extends AuthedRouter>(...args: Rout
     originalRouter,
     {
       queries: { organizations },
+      libraries: { quota },
     },
   ] = args;
 
@@ -234,6 +236,8 @@ export default function organizationRoutes<T extends AuthedRouter>(...args: Rout
   // MARK: Mount sub-routes
   organizationRoleRoutes(...args);
   organizationScopeRoutes(...args);
+
+  router.use(koaQuotaGuard({ key: 'organizationsEnabled', quota, methods: ['POST', 'PUT'] }));
 
   // Add routes to the router
   originalRouter.use(router.routes());

--- a/packages/core/src/routes/organization/roles.ts
+++ b/packages/core/src/routes/organization/roles.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 
 import koaGuard from '#src/middleware/koa-guard.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
+import koaQuotaGuard from '#src/middleware/koa-quota-guard.js';
 import SchemaRouter from '#src/utils/SchemaRouter.js';
 
 import { type AuthedRouter, type RouterInitArgs } from '../types.js';
@@ -24,6 +25,7 @@ export default function organizationRoleRoutes<T extends AuthedRouter>(
           relations: { rolesScopes },
         },
       },
+      libraries: { quota },
     },
   ]: RouterInitArgs<T>
 ) {
@@ -86,6 +88,8 @@ export default function organizationRoleRoutes<T extends AuthedRouter>(
   );
 
   router.addRelationRoutes(rolesScopes, 'scopes');
+
+  router.use(koaQuotaGuard({ key: 'organizationsEnabled', quota, methods: ['POST', 'PUT'] }));
 
   originalRouter.use(router.routes());
 }

--- a/packages/core/src/routes/organization/scopes.ts
+++ b/packages/core/src/routes/organization/scopes.ts
@@ -1,5 +1,6 @@
 import { OrganizationScopes } from '@logto/schemas';
 
+import koaQuotaGuard from '#src/middleware/koa-quota-guard.js';
 import SchemaRouter from '#src/utils/SchemaRouter.js';
 
 import { type AuthedRouter, type RouterInitArgs } from '../types.js';
@@ -13,6 +14,7 @@ export default function organizationScopeRoutes<T extends AuthedRouter>(
       queries: {
         organizations: { scopes },
       },
+      libraries: { quota },
     },
   ]: RouterInitArgs<T>
 ) {
@@ -20,6 +22,8 @@ export default function organizationScopeRoutes<T extends AuthedRouter>(
     errorHandler,
     searchFields: ['name'],
   });
+
+  router.use(koaQuotaGuard({ key: 'organizationsEnabled', quota, methods: ['POST', 'PUT'] }));
 
   originalRouter.use(router.routes());
 }

--- a/packages/phrases/src/locales/de/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/upsell/paywall.ts
@@ -46,6 +46,9 @@ const paywall = {
   hooks_other:
     'Sie haben das Limit von {{count, number}} <planName/>-Webhooks erreicht. Upgraden Sie Ihren Plan, um mehr Webhooks zu erstellen. Zögern Sie nicht, <a>Kontaktieren Sie uns</a>, wenn Sie Hilfe benötigen.',
   mfa: 'Schalten Sie MFA zur Sicherheitsüberprüfung frei, indem Sie auf einen kostenpflichtigen Plan aktualisieren. Zögern Sie nicht, uns zu <a>kontaktieren</a>, wenn Sie Unterstützung benötigen.',
+  /** UNTRANSLATED */
+  organizations:
+    'Unlock organizations by upgrading to a paid plan. Don’t hesitate to <a>contact us</a> if you need any assistance.',
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/en/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/upsell/paywall.ts
@@ -46,6 +46,8 @@ const paywall = {
   hooks_other:
     '{{count, number}} webhooks of <planName/> limit reached. Upgrade plan to create more webhooks. Feel free to <a>contact us</a> if you need any assistance.',
   mfa: 'Unlock MFA to verification security by upgrading to a paid plan. Don’t hesitate to <a>contact us</a> if you need any assistance.',
+  organizations:
+    'Unlock organizations by upgrading to a paid plan. Don’t hesitate to <a>contact us</a> if you need any assistance.',
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/es/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/upsell/paywall.ts
@@ -46,6 +46,9 @@ const paywall = {
   hooks_other:
     'Has alcanzado el límite de {{count, number}} webhooks de <planName/>. Actualiza el plan para crear más webhooks. Si necesitas ayuda, no dudes en <a>contactarnos</a>.',
   mfa: 'Desbloquea MFA para verificar la seguridad al actualizar a un plan pago. No dudes en <a>contactarnos</a> si necesitas ayuda.',
+  /** UNTRANSLATED */
+  organizations:
+    'Unlock organizations by upgrading to a paid plan. Don’t hesitate to <a>contact us</a> if you need any assistance.',
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/fr/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/upsell/paywall.ts
@@ -46,6 +46,9 @@ const paywall = {
   hooks_other:
     "Vous avez atteint la limite de {{count, number}} webhooks de <planName/>. Mettez à niveau votre plan pour créer plus de webhooks. N'hésitez pas à <a>nous contacter</a> si vous avez besoin d'aide.",
   mfa: "Déverrouillez MFA pour vérifier la sécurité en passant à un plan payant. N'hésitez pas à <a>nous contacter</a> si vous avez besoin d'aide.",
+  /** UNTRANSLATED */
+  organizations:
+    'Unlock organizations by upgrading to a paid plan. Don’t hesitate to <a>contact us</a> if you need any assistance.',
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/it/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/upsell/paywall.ts
@@ -46,6 +46,9 @@ const paywall = {
   hooks_other:
     'Hai raggiunto il limite di {{count, number}} webhook di <planName/>. Aggiorna il piano per creare altri webhook. Non esitare a <a>contattarci</a> se hai bisogno di assistenza.',
   mfa: 'Sblocca MFA per verificare la sicurezza passando a un piano a pagamento. Non esitare a <a>contattarci</a> se hai bisogno di assistenza.',
+  /** UNTRANSLATED */
+  organizations:
+    'Unlock organizations by upgrading to a paid plan. Don’t hesitate to <a>contact us</a> if you need any assistance.',
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/ja/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/upsell/paywall.ts
@@ -46,6 +46,9 @@ const paywall = {
   hooks_other:
     '{{count, number}}の<planName/>ウェブフック制限に達しました。追加のウェブフックを作成するにはプランをアップグレードしてください。<a>お問い合わせ</a>は何かお手伝いが必要な場合はお気軽にどうぞ。',
   mfa: 'セキュリティを確認するためにMFAを解除して有料プランにアップグレードしてください。ご質問があれば、<a>お問い合わせください</a>。',
+  /** UNTRANSLATED */
+  organizations:
+    'Unlock organizations by upgrading to a paid plan. Don’t hesitate to <a>contact us</a> if you need any assistance.',
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/ko/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/upsell/paywall.ts
@@ -46,6 +46,9 @@ const paywall = {
   hooks_other:
     '<planName/>의 {{count, number}}개 웹훅 한도에 도달했습니다. 더 많은 웹훅을 생성하려면 플랜을 업그레이드하세요. 도움이 필요하면 <a>문의하기</a>로 연락 주세요.',
   mfa: '보안을 확인하기 위해 MFA를 잠금 해제하여 유료 플랜으로 업그레이드하세요. 궁금한 점이 있으면 <a>문의하세요</a>.',
+  /** UNTRANSLATED */
+  organizations:
+    'Unlock organizations by upgrading to a paid plan. Don’t hesitate to <a>contact us</a> if you need any assistance.',
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/upsell/paywall.ts
@@ -46,6 +46,9 @@ const paywall = {
   hooks_other:
     'Osiągnięto limit {{count, number}} webhooków w planie <planName/>. Ulepsz plan, aby tworzyć więcej webhooków. Jeśli potrzebujesz pomocy, nie wahaj się <a>skontaktować z nami</a>.',
   mfa: 'Odblokuj MFA, aby zweryfikować bezpieczeństwo, przechodząc na płatny plan. Nie wahaj się <a>skontaktować z nami</a>, jeśli potrzebujesz pomocy.',
+  /** UNTRANSLATED */
+  organizations:
+    'Unlock organizations by upgrading to a paid plan. Don’t hesitate to <a>contact us</a> if you need any assistance.',
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/upsell/paywall.ts
@@ -46,6 +46,9 @@ const paywall = {
   hooks_other:
     'Atingiu o limite de {{count, number}} webhooks de <planName/>. Atualize o plano para criar mais webhooks. Não hesite em <a>Contacte-nos</a> se precisar de ajuda.',
   mfa: 'Desbloqueie o MFA para verificar a segurança, fazendo upgrade para um plano pago. Não hesite em <a>nos contatar</a> se precisar de alguma assistência.',
+  /** UNTRANSLATED */
+  organizations:
+    'Unlock organizations by upgrading to a paid plan. Don’t hesitate to <a>contact us</a> if you need any assistance.',
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/upsell/paywall.ts
@@ -46,6 +46,9 @@ const paywall = {
   hooks_other:
     'Atingiu o limite de {{count, number}} webhooks de <planName/>. Atualize o plano para criar mais webhooks. Não hesite em <a>Contacte-nos</a> se precisar de ajuda.',
   mfa: 'Desbloqueie o MFA para a verificação de segurança ao atualizar para um plano pago. Não hesite em <a>entrar em contato conosco</a> se precisar de assistência.',
+  /** UNTRANSLATED */
+  organizations:
+    'Unlock organizations by upgrading to a paid plan. Don’t hesitate to <a>contact us</a> if you need any assistance.',
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/ru/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/upsell/paywall.ts
@@ -46,6 +46,9 @@ const paywall = {
   hooks_other:
     'Достигнут лимит {{count, number}} вебхуков в плане <planName/>. Повысьте план, чтобы создать больше вебхуков. Если вам нужна помощь, не стесняйтесь <a>связаться с нами</a>.',
   mfa: 'Разблокируйте MFA для повышения безопасности с помощью перехода на платный план. Не стесняйтесь <a>связаться с нами</a>, если вам нужна помощь.',
+  /** UNTRANSLATED */
+  organizations:
+    'Unlock organizations by upgrading to a paid plan. Don’t hesitate to <a>contact us</a> if you need any assistance.',
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/upsell/paywall.ts
@@ -46,6 +46,9 @@ const paywall = {
   hooks_other:
     '{{count, number}} <planName/> webhook sınırına ulaşıldı. Daha fazla webhook oluşturmak için planı yükseltin. Yardıma ihtiyacınız olursa, <a>iletişime geçin</a>.',
   mfa: "Güvenliği kontrol etmek için MFA'yı bir ücretli plana geçerek kilidini açın. Yardıma ihtiyacınız olursa bize <a>iletişim kurmaktan</a> çekinmeyin.",
+  /** UNTRANSLATED */
+  organizations:
+    'Unlock organizations by upgrading to a paid plan. Don’t hesitate to <a>contact us</a> if you need any assistance.',
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/upsell/paywall.ts
@@ -46,6 +46,9 @@ const paywall = {
   hooks_other:
     '已达到<planName/>的{{count, number}}个 Webhook 限制。升级计划以创建更多 Webhook。如需任何帮助，请<a>联系我们</a>。',
   mfa: '升级到付费计划以解锁MFA进行安全验证。如果需要任何帮助，请随时<a>联系我们</a>。',
+  /** UNTRANSLATED */
+  organizations:
+    'Unlock organizations by upgrading to a paid plan. Don’t hesitate to <a>contact us</a> if you need any assistance.',
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/upsell/paywall.ts
@@ -46,6 +46,9 @@ const paywall = {
   hooks_other:
     '已達到<planName/>的{{count, number}}個 Webhook 限制。升級計劃以創建更多 Webhook。如需任何幫助，請<a>聯繫我們</a>。',
   mfa: '升級到付費計劃以解鎖MFA以提高安全性。如果需要任何協助，請隨時<a>聯繫我們</a>。',
+  /** UNTRANSLATED */
+  organizations:
+    'Unlock organizations by upgrading to a paid plan. Don’t hesitate to <a>contact us</a> if you need any assistance.',
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/upsell/paywall.ts
@@ -46,6 +46,9 @@ const paywall = {
   hooks_other:
     '已達到<planName/>的{{count, number}}個 Webhook 限制。升級計劃以創建更多 Webhook。如需任何幫助，請<a>聯繫我們</a>。',
   mfa: '升級到付費計劃以解鎖MFA以提高安全性。如果需要任何協助，請隨時<a>聯繫我們</a>。',
+  /** UNTRANSLATED */
+  organizations:
+    'Unlock organizations by upgrading to a paid plan. Don’t hesitate to <a>contact us</a> if you need any assistance.',
 };
 
 export default Object.freeze(paywall);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add paywalls to organization APIs and create modal in console.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

Call organization APIs from Free plan tenant will end up with an error:
<img width="967" alt="image" src="https://github.com/logto-io/logto/assets/12833674/98723402-6be1-4aaa-a278-7ed3f83aa2e1">

If the Free plan somehow has pre-existed organizations (dev testing data), you will not be able to create more organizations through the UI, either.
<img width="905" alt="image" src="https://github.com/logto-io/logto/assets/12833674/e974dbb2-572b-449c-b126-5ca563a88546">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
