### PR TITLE
feat(console): reuse existing oidc/saml form for OOTB SSO connector config

### DIFF
--- a/packages/console/src/pages/EnterpriseSso/Guide/BasicInfo/index.tsx
+++ b/packages/console/src/pages/EnterpriseSso/Guide/BasicInfo/index.tsx
@@ -29,7 +29,11 @@ function BasicInfo({ ssoConnectorId, providerName, providerConfig }: Props) {
   const { tenantEndpoint } = useContext(AppDataContext);
   const { applyDomain: applyCustomDomain } = useCustomDomain();
 
-  if (providerName === SsoProviderName.OIDC) {
+  if (
+    [SsoProviderName.OIDC, SsoProviderName.GOOGLE_WORKSPACE, SsoProviderName.OKTA].includes(
+      providerName
+    )
+  ) {
     return (
       <FormField title="enterprise_sso.basic_info.oidc.redirect_uri_field_name">
         {/* Generated and passed in by Admin console. */}

--- a/packages/console/src/pages/EnterpriseSso/Guide/OidcMetadataForm/ParsedConfigPreview/index.tsx
+++ b/packages/console/src/pages/EnterpriseSso/Guide/OidcMetadataForm/ParsedConfigPreview/index.tsx
@@ -1,4 +1,5 @@
 import { type SsoProviderName } from '@logto/schemas';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 
 import { type ParsedSsoIdentityProviderConfig } from '@/pages/EnterpriseSso/types.js';
@@ -7,16 +8,17 @@ import * as styles from './index.module.scss';
 
 type Props = {
   providerConfig: ParsedSsoIdentityProviderConfig<SsoProviderName.OIDC>;
+  className?: string;
 };
 
-function ParsedConfigPreview({ providerConfig }: Props) {
+function ParsedConfigPreview({ providerConfig, className }: Props) {
   const { t } = useTranslation(undefined, {
     keyPrefix: 'admin_console.enterprise_sso_details.oidc_preview',
   });
   const { authorizationEndpoint, tokenEndpoint, userinfoEndpoint, jwksUri, issuer } =
     providerConfig;
   return (
-    <div className={styles.container}>
+    <div className={classNames(styles.container, className)}>
       <div>
         <div className={styles.title}>{t('authorization_endpoint')}</div>
         <div className={styles.content}>{authorizationEndpoint}</div>

--- a/packages/console/src/pages/EnterpriseSso/Guide/OidcMetadataForm/index.module.scss
+++ b/packages/console/src/pages/EnterpriseSso/Guide/OidcMetadataForm/index.module.scss
@@ -1,0 +1,9 @@
+@use '@/scss/underscore' as _;
+
+.copyToClipboard {
+  display: block;
+}
+
+.oidcConfigPreview {
+  margin-top: _.unit(3);
+}

--- a/packages/console/src/pages/EnterpriseSso/Guide/index.tsx
+++ b/packages/console/src/pages/EnterpriseSso/Guide/index.tsx
@@ -30,7 +30,6 @@ type Props<T extends SsoProviderName> = {
   isOpen: boolean;
   connector: SsoConnectorWithProviderConfigWithGeneric<T>;
   onClose: (ssoConnectorId?: string) => void;
-  isReadOnly?: boolean;
 };
 
 type GuideCardProps = {
@@ -58,7 +57,7 @@ function GuideCard({ cardOrder, title, description, children, className }: Guide
   );
 }
 
-function Guide<T extends SsoProviderName>({ isOpen, connector, onClose, isReadOnly }: Props<T>) {
+function Guide<T extends SsoProviderName>({ isOpen, connector, onClose }: Props<T>) {
   const {
     id: ssoConnectorId,
     connectorName: ssoConnectorName,
@@ -143,13 +142,17 @@ function Guide<T extends SsoProviderName>({ isOpen, connector, onClose, isReadOn
                     providerConfig={providerConfig}
                   />
                 </GuideCard>
-                {providerName === SsoProviderName.OIDC ? (
+                {[
+                  SsoProviderName.OIDC,
+                  SsoProviderName.GOOGLE_WORKSPACE,
+                  SsoProviderName.OKTA,
+                ].includes(providerName) ? (
                   <GuideCard
                     cardOrder={2}
                     title="enterprise_sso.metadata.title"
                     description="enterprise_sso.metadata.description"
                   >
-                    <OidcMetadataForm isGuidePage />
+                    <OidcMetadataForm isGuidePage providerName={providerName} />
                   </GuideCard>
                 ) : (
                   <>
@@ -158,7 +161,7 @@ function Guide<T extends SsoProviderName>({ isOpen, connector, onClose, isReadOn
                       title="enterprise_sso.attribute_mapping.title"
                       description="enterprise_sso.attribute_mapping.description"
                     >
-                      <SamlAttributeMapping isReadOnly={isReadOnly} />
+                      <SamlAttributeMapping />
                     </GuideCard>
                     <GuideCard
                       cardOrder={3}

--- a/packages/console/src/pages/EnterpriseSso/index.tsx
+++ b/packages/console/src/pages/EnterpriseSso/index.tsx
@@ -139,10 +139,13 @@ function EnterpriseSsoConnectors() {
             dataIndex: 'status',
             colSpan: 186,
             render: ({ providerConfig, providerName }) => {
-              const inUse =
-                providerName === SsoProviderName.OIDC
-                  ? Boolean(providerConfig)
-                  : Boolean(providerConfig?.identityProvider);
+              const inUse = [
+                SsoProviderName.OIDC,
+                SsoProviderName.GOOGLE_WORKSPACE,
+                SsoProviderName.OKTA,
+              ].includes(providerName)
+                ? Boolean(providerConfig)
+                : Boolean(providerConfig?.identityProvider);
               return (
                 <Tag type="state" status={inUse ? 'success' : 'error'} variant="plain">
                   {t(
@@ -208,7 +211,6 @@ function EnterpriseSsoConnectors() {
                   // eslint-disable-next-line no-restricted-syntax
                   connectorForGuide as SsoConnectorWithProviderConfigWithGeneric<SsoProviderName>
                 }
-                isReadOnly={connectorForGuide.providerName !== 'SAML'}
                 onClose={async (connectorId) => {
                   if (connectorId) {
                     navigate(buildDetailsPathname(connectorId), { replace: true });

--- a/packages/console/src/pages/EnterpriseSsoDetails/Connection/index.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Connection/index.tsx
@@ -86,10 +86,13 @@ function Connection<T extends SsoProviderName>({ isDeleted, data, onUpdated }: P
           title="enterprise_sso_details.upload_idp_metadata_title"
           description="enterprise_sso_details.upload_idp_metadata_description"
         >
-          {providerName === SsoProviderName.OIDC ? (
+          {[SsoProviderName.OIDC, SsoProviderName.GOOGLE_WORKSPACE, SsoProviderName.OKTA].includes(
+            providerName
+          ) ? (
             // Can not infer the type by narrowing down the value of `providerName`, so we need to cast it.
             <OidcMetadataForm
               isGuidePage={false}
+              providerName={providerName}
               // eslint-disable-next-line no-restricted-syntax
               config={config as SsoConnectorConfig<SsoProviderName.OIDC>}
               providerConfig={
@@ -127,7 +130,7 @@ function Connection<T extends SsoProviderName>({ isDeleted, data, onUpdated }: P
             providerConfig={providerConfig}
           />
         </FormCard>
-        {providerName === SsoProviderName.SAML && (
+        {[SsoProviderName.SAML, SsoProviderName.AZURE_AD].includes(providerName) && (
           <FormCard
             title="enterprise_sso_details.attribute_mapping_title"
             description="enterprise_sso_details.attribute_mapping_description"

--- a/packages/console/src/pages/EnterpriseSsoDetails/index.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/index.tsx
@@ -57,7 +57,9 @@ function EnterpriseSsoConnectorDetails<T extends SsoProviderName>() {
 
   const inUse =
     ssoConnector &&
-    (ssoConnector.providerName === SsoProviderName.OIDC
+    ([SsoProviderName.OIDC, SsoProviderName.GOOGLE_WORKSPACE, SsoProviderName.OKTA].includes(
+      ssoConnector.providerName
+    )
       ? Boolean(ssoConnector.providerConfig)
       : Boolean(
           ssoConnector.providerConfig &&


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
1. Map out-of-the-box SSO connectors' form to either SAML or OIDC form according to the protocol the SSO connector is based on.
2. Remove the isReadonly flag for SAML attribute mapping component, edit on attribute mapping is always allowed.
3. For SAML protocol-based SSO connectors (SAML and AAD), it should pass default attribute mapping.
4. Update the SSO connectors' isUse check logic.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
