### PR TITLE
refactor(core): refactor SAML SSO idpConfig type

### DIFF
--- a/packages/core/src/sso/SamlSsoConnector/index.test.ts
+++ b/packages/core/src/sso/SamlSsoConnector/index.test.ts
@@ -3,16 +3,13 @@ import { SsoProviderName } from '@logto/schemas';
 
 import { mockSsoConnector as _mockSsoConnector } from '#src/__mocks__/sso.js';
 
+import { type SamlConnectorConfig } from '../types/saml.js';
+
 import { samlSsoConnectorFactory } from './index.js';
 
 const mockSsoConnector = { ..._mockSsoConnector, providerName: SsoProviderName.SAML };
 
 describe('SamlSsoConnector', () => {
-  it('SamlSsoConnector should contains static properties', () => {
-    expect(samlSsoConnectorFactory.providerName).toEqual(SsoProviderName.SAML);
-    expect(samlSsoConnectorFactory.configGuard).toBeDefined();
-  });
-
   it('constructor should work properly', () => {
     // eslint-disable-next-line unicorn/consistent-function-scoping
     const createSamlSsoConnector = () =>
@@ -21,20 +18,43 @@ describe('SamlSsoConnector', () => {
     expect(createSamlSsoConnector).not.toThrow();
   });
 
-  it('constructor should throw error if config is invalid', () => {
+  it('should get SP config properly without proper IdP config', async () => {
     const temporaryMockSsoConnector = { ...mockSsoConnector, config: { metadata: 123 } };
-    const result = samlSsoConnectorFactory.configGuard.safeParse(temporaryMockSsoConnector.config);
-
-    if (result.success) {
-      throw new Error('Invalid config');
-    }
-
-    const createSamlSsoConnector = () => {
-      return new samlSsoConnectorFactory.constructor(temporaryMockSsoConnector, 'default_tenant');
-    };
-
-    expect(createSamlSsoConnector).toThrow(
-      new ConnectorError(ConnectorErrorCodes.InvalidConfig, result.error)
+    const connector = new samlSsoConnectorFactory.constructor(
+      temporaryMockSsoConnector,
+      'default_tenant'
     );
+
+    const { serviceProvider, identityProvider } = await connector.getConfig();
+    expect(serviceProvider.entityId).not.toBeUndefined();
+    expect(serviceProvider.assertionConsumerServiceUrl).not.toBeUndefined();
+    expect(identityProvider).toBeUndefined();
+  });
+
+  it('should throw error on calling getIdpMetadata, if the config is invalid', async () => {
+    const connector = new samlSsoConnectorFactory.constructor(mockSsoConnector, 'default_tenant');
+
+    await expect(async () => connector.getSamlIdpMetadata()).rejects.toThrow(
+      new ConnectorError(ConnectorErrorCodes.InvalidConfig, 'config not found')
+    );
+  });
+
+  it.each([
+    { metadata: 'metadata' },
+    { metadataUrl: 'https://example.com' },
+    {
+      entityId: '123',
+      signInEndpoint: 'https://example.com',
+      x509Certificate: 'mockCert',
+    },
+  ])('should parse config with %p successfully', (config: SamlConnectorConfig) => {
+    const temporaryMockSsoConnector = { ...mockSsoConnector, config };
+
+    const connector = new samlSsoConnectorFactory.constructor(
+      temporaryMockSsoConnector,
+      'default_tenant'
+    );
+
+    expect(connector.idpConfig).toEqual(config);
   });
 });

--- a/packages/core/src/sso/types/saml.ts
+++ b/packages/core/src/sso/types/saml.ts
@@ -32,17 +32,24 @@ export const samlIdentityProviderMetadataGuard = z.object({
   signInEndpoint: z.string(),
   x509Certificate: z.string(),
 });
-
 export type SamlIdentityProviderMetadata = z.infer<typeof samlIdentityProviderMetadataGuard>;
 
-export const samlConnectorConfigGuard = samlIdentityProviderMetadataGuard
-  .extend({
-    attributeMapping: customizableAttributeMappingGuard,
-    metadata: z.string(),
+export const samlConnectorConfigGuard = z.union([
+  // Config using Metadata URL
+  z.object({
     metadataUrl: z.string(),
-  })
-  .partial();
-
+    attributeMapping: customizableAttributeMappingGuard.optional(),
+  }),
+  // Config using Metadata XML
+  z.object({
+    metadata: z.string(),
+    attributeMapping: customizableAttributeMappingGuard.optional(),
+  }),
+  // Config using Metadata detail
+  samlIdentityProviderMetadataGuard.extend({
+    attributeMapping: customizableAttributeMappingGuard.optional(),
+  }),
+]);
 export type SamlConnectorConfig = z.infer<typeof samlConnectorConfigGuard>;
 
 const samlMetadataGuard = z.object({


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
LOG-7549

### Context

@darcyYe 

Based on the previous PR #4958 we no longer allow partial SSO config to exist in DB. Either empty or safely parsed.
So in this PR we update the SAML config type to be more strict. 

Previously, all the fields are optional.

```ts
{
 metadataUrl?: string;
 metadata?: string;
 entityId?: string;
 signInEndpoint?: string;
 x509Certificate?: string;
attributeMapping?: Map
}
```

In this PR we use a strict union type to guard the config
```ts
{
 metadataUrl: string;
attributeMapping?: Map
} | {
 metadata: string;
attributeMapping?: Map
} | {
 entityId: string;
 signInEndpoint: string;
 x509Certificate: string;
attributeMapping?: Map
}
```

This refactors some of the implementation logics in the SAML connector.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
