### PR TITLE
fix(core): update google SSO connector prompt always select-account

### DIFF
--- a/packages/core/src/sso/GoogleWorkspaceSsoConnector/index.ts
+++ b/packages/core/src/sso/GoogleWorkspaceSsoConnector/index.ts
@@ -3,7 +3,7 @@ import { type SsoConnector, SsoProviderName } from '@logto/schemas';
 
 import OidcConnector from '../OidcConnector/index.js';
 import { type SingleSignOnFactory } from '../index.js';
-import { type SingleSignOn } from '../types/index.js';
+import { type CreateSingleSignOnSession, type SingleSignOn } from '../types/index.js';
 import { basicOidcConnectorConfigGuard } from '../types/oidc.js';
 
 // Google use static issue endpoint.
@@ -23,6 +23,13 @@ export class GoogleWorkspaceSsoConnector extends OidcConnector implements Single
       ...parseConfigResult.data,
       issuer: googleIssuer,
     });
+  }
+
+  override async getAuthorizationUrl(
+    payload: { state: string; redirectUri: string; connectorId: string },
+    setSession: CreateSingleSignOnSession
+  ) {
+    return super.getAuthorizationUrl(payload, setSession, 'select_account');
   }
 
   async getConfig() {

--- a/packages/core/src/sso/GoogleWorkspaceSsoConnector/index.ts
+++ b/packages/core/src/sso/GoogleWorkspaceSsoConnector/index.ts
@@ -25,6 +25,7 @@ export class GoogleWorkspaceSsoConnector extends OidcConnector implements Single
     });
   }
 
+  // Always use select_account prompt for Google Workspace SSO.
   override async getAuthorizationUrl(
     payload: { state: string; redirectUri: string; connectorId: string },
     setSession: CreateSingleSignOnSession

--- a/packages/core/src/sso/OidcConnector/index.ts
+++ b/packages/core/src/sso/OidcConnector/index.ts
@@ -54,7 +54,8 @@ class OidcConnector {
       redirectUri,
       connectorId,
     }: { state: string; redirectUri: string; connectorId: string },
-    setSession: CreateSingleSignOnSession
+    setSession: CreateSingleSignOnSession,
+    prompt?: 'login' | 'consent' | 'none' | 'select_account'
   ) {
     assert(
       setSession,
@@ -76,6 +77,7 @@ class OidcConnector {
         responseType: 'code',
         redirectUri,
       }),
+      ...conditional(prompt && { prompt }),
       scope: oidcConfig.scope,
     });
 


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Set google SSO connector prompt always select-account.

This PR fix the following situation:

Local browser has a personal google account sign-in session.
Sign-in to Logto using a workspace account specific google sso connector.
Unable to select/sign-in to another workspace google account. 


Fix: Set the prompt to select_account for google




<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally 
<img width="589" alt="image" src="https://github.com/logto-io/logto/assets/36393111/4f259a0e-fc7d-411c-9b85-9c3a97f98e71">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
