### PR TITLE
feat(core): guard sso config

### DIFF
--- a/packages/core/src/routes/interaction/utils/single-sign-on.test.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on.test.ts
@@ -1,4 +1,3 @@
-import { type SsoConnector } from '@logto/schemas';
 import { createMockUtils } from '@logto/shared/esm';
 import type Provider from 'oidc-provider';
 
@@ -7,6 +6,7 @@ import RequestError from '#src/errors/RequestError/index.js';
 import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
 import { OidcSsoConnector } from '#src/sso/OidcSsoConnector/index.js';
 import { ssoConnectorFactories } from '#src/sso/index.js';
+import { type SingleSignOnConnectorData } from '#src/sso/types/index.js';
 import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
 import { createMockProvider } from '#src/test-utils/oidc-provider.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
@@ -49,7 +49,7 @@ const {
 
 jest
   .spyOn(ssoConnectorFactories.OIDC, 'constructor')
-  .mockImplementation((data: SsoConnector) => new MockOidcSsoConnector(data));
+  .mockImplementation((data: SingleSignOnConnectorData) => new MockOidcSsoConnector(data));
 
 const {
   getSsoAuthorizationUrl,

--- a/packages/core/src/routes/sso-connector/index.ts
+++ b/packages/core/src/routes/sso-connector/index.ts
@@ -122,6 +122,7 @@ export default function singleSignOnRoutes<T extends AuthedRouter>(...args: Rout
         providerName,
         connectorName,
         ...conditional(config && { config: parsedConfig }),
+        ...conditional(domains && { domains }),
         ...rest,
       });
 
@@ -239,6 +240,7 @@ export default function singleSignOnRoutes<T extends AuthedRouter>(...args: Rout
       const connector = hasValidUpdate
         ? await ssoConnectors.updateById(id, {
             ...conditional(parsedConfig && { config: parsedConfig }),
+            ...conditional(domains && { domains }),
             ...rest,
           })
         : originalConnector;

--- a/packages/core/src/routes/sso-connector/utils.test.ts
+++ b/packages/core/src/routes/sso-connector/utils.test.ts
@@ -106,12 +106,6 @@ describe('fetchConnectorProviderDetails', () => {
 });
 
 describe('validateConnectorDomains', () => {
-  it('should directly return if domains are not provided', () => {
-    expect(() => {
-      validateConnectorDomains();
-    }).not.toThrow();
-  });
-
   it('should directly return if domains are empty', () => {
     expect(() => {
       validateConnectorDomains([]);

--- a/packages/core/src/sso/GoogleWorkspaceSsoConnector/index.ts
+++ b/packages/core/src/sso/GoogleWorkspaceSsoConnector/index.ts
@@ -1,9 +1,13 @@
 import { ConnectorError, ConnectorErrorCodes } from '@logto/connector-kit';
-import { type SsoConnector, SsoProviderName } from '@logto/schemas';
+import { SsoProviderName } from '@logto/schemas';
 
 import OidcConnector from '../OidcConnector/index.js';
 import { type SingleSignOnFactory } from '../index.js';
-import { type CreateSingleSignOnSession, type SingleSignOn } from '../types/index.js';
+import {
+  type CreateSingleSignOnSession,
+  type SingleSignOn,
+  type SingleSignOnConnectorData,
+} from '../types/index.js';
 import { basicOidcConnectorConfigGuard } from '../types/oidc.js';
 
 // Google use static issue endpoint.
@@ -12,7 +16,7 @@ const googleIssuer = 'https://accounts.google.com';
 export class GoogleWorkspaceSsoConnector extends OidcConnector implements SingleSignOn {
   static googleIssuer = googleIssuer;
 
-  constructor(readonly data: SsoConnector) {
+  constructor(readonly data: SingleSignOnConnectorData) {
     const parseConfigResult = googleWorkspaceSsoConnectorConfigGuard.safeParse(data.config);
 
     if (!parseConfigResult.success) {

--- a/packages/core/src/sso/OidcConnector/index.ts
+++ b/packages/core/src/sso/OidcConnector/index.ts
@@ -1,6 +1,5 @@
-import { ConnectorError, ConnectorErrorCodes } from '@logto/connector-kit';
 import { generateStandardId } from '@logto/shared/universal';
-import { assert, conditional } from '@silverhand/essentials';
+import { conditional } from '@silverhand/essentials';
 import snakecaseKeys from 'snakecase-keys';
 
 import {
@@ -62,13 +61,6 @@ class OidcConnector {
     setSession: CreateSingleSignOnSession,
     prompt?: 'login' | 'consent' | 'none' | 'select_account'
   ) {
-    assert(
-      setSession,
-      new ConnectorError(ConnectorErrorCodes.NotImplemented, {
-        message: 'Connector session storage is not implemented.',
-      })
-    );
-
     const oidcConfig = await this.getOidcConfig();
     const nonce = generateStandardId();
 

--- a/packages/core/src/sso/OidcSsoConnector/index.test.ts
+++ b/packages/core/src/sso/OidcSsoConnector/index.test.ts
@@ -1,7 +1,12 @@
-import { ConnectorError, ConnectorErrorCodes } from '@logto/connector-kit';
 import { SsoProviderName } from '@logto/schemas';
 
 import { mockSsoConnector } from '#src/__mocks__/sso.js';
+
+import {
+  SsoConnectorError,
+  SsoConnectorErrorCodes,
+  SsoConnectorConfigErrorCodes,
+} from '../types/error.js';
 
 import { oidcSsoConnectorFactory } from './index.js';
 
@@ -23,7 +28,11 @@ describe('OidcSsoConnector', () => {
     };
 
     expect(createOidcSsoConnector).toThrow(
-      new ConnectorError(ConnectorErrorCodes.InvalidConfig, result.error)
+      new SsoConnectorError(SsoConnectorErrorCodes.InvalidConfig, {
+        config: mockSsoConnector.config,
+        message: SsoConnectorConfigErrorCodes.InvalidConnectorConfig,
+        error: result.error.flatten(),
+      })
     );
   });
 });

--- a/packages/core/src/sso/OidcSsoConnector/index.ts
+++ b/packages/core/src/sso/OidcSsoConnector/index.ts
@@ -1,17 +1,25 @@
-import { ConnectorError, ConnectorErrorCodes } from '@logto/connector-kit';
-import { type SsoConnector, SsoProviderName } from '@logto/schemas';
+import { SsoProviderName } from '@logto/schemas';
 
 import OidcConnector from '../OidcConnector/index.js';
 import { type SingleSignOnFactory } from '../index.js';
-import { type SingleSignOn } from '../types/index.js';
+import {
+  SsoConnectorError,
+  SsoConnectorErrorCodes,
+  SsoConnectorConfigErrorCodes,
+} from '../types/error.js';
+import { type SingleSignOn, type SingleSignOnConnectorData } from '../types/index.js';
 import { basicOidcConnectorConfigGuard } from '../types/oidc.js';
 
 export class OidcSsoConnector extends OidcConnector implements SingleSignOn {
-  constructor(readonly data: SsoConnector) {
+  constructor(readonly data: SingleSignOnConnectorData) {
     const parseConfigResult = basicOidcConnectorConfigGuard.safeParse(data.config);
 
     if (!parseConfigResult.success) {
-      throw new ConnectorError(ConnectorErrorCodes.InvalidConfig, parseConfigResult.error);
+      throw new SsoConnectorError(SsoConnectorErrorCodes.InvalidConfig, {
+        config: data.config,
+        message: SsoConnectorConfigErrorCodes.InvalidConnectorConfig,
+        error: parseConfigResult.error.flatten(),
+      });
     }
 
     super(parseConfigResult.data);

--- a/packages/core/src/sso/OktaSsoConnector/index.ts
+++ b/packages/core/src/sso/OktaSsoConnector/index.ts
@@ -1,4 +1,3 @@
-import { ConnectorError, ConnectorErrorCodes } from '@logto/connector-kit';
 import { SsoProviderName } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
 import camelcaseKeys from 'camelcase-keys';
@@ -8,6 +7,7 @@ import assertThat from '#src/utils/assert-that.js';
 import { fetchToken, getUserInfo, getIdTokenClaims } from '../OidcConnector/utils.js';
 import { OidcSsoConnector } from '../OidcSsoConnector/index.js';
 import { type SingleSignOnFactory } from '../index.js';
+import { SsoConnectorError, SsoConnectorErrorCodes } from '../types/error.js';
 import { basicOidcConnectorConfigGuard } from '../types/oidc.js';
 import { type ExtendedSocialUserInfo } from '../types/saml.js';
 import { type SingleSignOnConnectorSession } from '../types/session.js';
@@ -33,7 +33,9 @@ export class OktaSsoConnector extends OidcSsoConnector {
 
     assertThat(
       accessToken,
-      new ConnectorError(ConnectorErrorCodes.AuthorizationFailed, 'access_token is empty.')
+      new SsoConnectorError(SsoConnectorErrorCodes.AuthorizationFailed, {
+        message: 'The access token is missing from the response.',
+      })
     );
 
     // Verify the id token and get the user id

--- a/packages/core/src/sso/SamlSsoConnector/index.test.ts
+++ b/packages/core/src/sso/SamlSsoConnector/index.test.ts
@@ -1,8 +1,12 @@
-import { ConnectorError, ConnectorErrorCodes } from '@logto/connector-kit';
 import { SsoProviderName } from '@logto/schemas';
 
 import { mockSsoConnector as _mockSsoConnector } from '#src/__mocks__/sso.js';
 
+import {
+  SsoConnectorConfigErrorCodes,
+  SsoConnectorError,
+  SsoConnectorErrorCodes,
+} from '../types/error.js';
 import { type SamlConnectorConfig } from '../types/saml.js';
 
 import { samlSsoConnectorFactory } from './index.js';
@@ -35,7 +39,10 @@ describe('SamlSsoConnector', () => {
     const connector = new samlSsoConnectorFactory.constructor(mockSsoConnector, 'default_tenant');
 
     await expect(async () => connector.getSamlIdpMetadata()).rejects.toThrow(
-      new ConnectorError(ConnectorErrorCodes.InvalidConfig, 'config not found')
+      new SsoConnectorError(SsoConnectorErrorCodes.InvalidConfig, {
+        config: undefined,
+        message: SsoConnectorConfigErrorCodes.InvalidConnectorConfig,
+      })
     );
   });
 

--- a/packages/core/src/sso/SamlSsoConnector/index.ts
+++ b/packages/core/src/sso/SamlSsoConnector/index.ts
@@ -1,15 +1,11 @@
 import { SsoProviderName } from '@logto/schemas';
 import { conditional, trySafe } from '@silverhand/essentials';
 
+import RequestError from '#src/errors/RequestError/index.js';
 import assertThat from '#src/utils/assert-that.js';
 
 import SamlConnector from '../SamlConnector/index.js';
 import { type SingleSignOnFactory } from '../index.js';
-import {
-  SsoConnectorError,
-  SsoConnectorErrorCodes,
-  SsoConnectorSessionErrorCodes,
-} from '../types/error.js';
 import { type SingleSignOn, type SingleSignOnConnectorData } from '../types/index.js';
 import { samlConnectorConfigGuard, type SamlMetadata } from '../types/saml.js';
 import {
@@ -95,12 +91,7 @@ export class SamlSsoConnector extends SamlConnector implements SingleSignOn {
    * This method only asserts the userInfo is not null and directly return it.
    */
   async getUserInfo({ userInfo }: SingleSignOnConnectorSession) {
-    assertThat(
-      userInfo,
-      new SsoConnectorError(SsoConnectorErrorCodes.SessionNotFound, {
-        message: SsoConnectorSessionErrorCodes.SessionNotFound,
-      })
-    );
+    assertThat(userInfo, new RequestError('session.connector_session_not_found'));
 
     return userInfo;
   }

--- a/packages/core/src/sso/SamlSsoConnector/index.ts
+++ b/packages/core/src/sso/SamlSsoConnector/index.ts
@@ -1,11 +1,16 @@
-import { type SsoConnector, SsoProviderName } from '@logto/schemas';
+import { SsoProviderName } from '@logto/schemas';
 import { conditional, trySafe } from '@silverhand/essentials';
 
 import assertThat from '#src/utils/assert-that.js';
 
 import SamlConnector from '../SamlConnector/index.js';
 import { type SingleSignOnFactory } from '../index.js';
-import { type SingleSignOn } from '../types/index.js';
+import {
+  SsoConnectorError,
+  SsoConnectorErrorCodes,
+  SsoConnectorSessionErrorCodes,
+} from '../types/error.js';
+import { type SingleSignOn, type SingleSignOnConnectorData } from '../types/index.js';
 import { samlConnectorConfigGuard, type SamlMetadata } from '../types/saml.js';
 import {
   type SingleSignOnConnectorSession,
@@ -26,7 +31,7 @@ import {
  */
 export class SamlSsoConnector extends SamlConnector implements SingleSignOn {
   constructor(
-    readonly data: SsoConnector,
+    readonly data: SingleSignOnConnectorData,
     tenantId: string
   ) {
     const parseConfigResult = samlConnectorConfigGuard.safeParse(data.config);
@@ -90,7 +95,12 @@ export class SamlSsoConnector extends SamlConnector implements SingleSignOn {
    * This method only asserts the userInfo is not null and directly return it.
    */
   async getUserInfo({ userInfo }: SingleSignOnConnectorSession) {
-    assertThat(userInfo, 'session.connector_validation_session_not_found');
+    assertThat(
+      userInfo,
+      new SsoConnectorError(SsoConnectorErrorCodes.SessionNotFound, {
+        message: SsoConnectorSessionErrorCodes.SessionNotFound,
+      })
+    );
 
     return userInfo;
   }

--- a/packages/core/src/sso/index.ts
+++ b/packages/core/src/sso/index.ts
@@ -24,7 +24,7 @@ type SingleSignOnConstructor = {
   [SsoProviderName.OKTA]: typeof OktaSsoConnector;
 };
 
-type SingleSignOnConnectorConfig = {
+export type SingleSignOnConnectorConfig = {
   [SsoProviderName.OIDC]: typeof basicOidcConnectorConfigGuard;
   [SsoProviderName.SAML]: typeof samlConnectorConfigGuard;
   [SsoProviderName.AZURE_AD]: typeof samlConnectorConfigGuard;

--- a/packages/core/src/sso/types/error.ts
+++ b/packages/core/src/sso/types/error.ts
@@ -4,14 +4,9 @@ import { type JsonObject } from '@logto/schemas';
 export enum SsoConnectorErrorCodes {
   InvalidMetadata = 'invalid_metadata',
   InvalidConfig = 'invalid_config',
-  SessionNotFound = 'session_not_found',
-  InvalidResponse = 'invalid_response',
   AuthorizationFailed = 'authorization_failed',
+  InvalidResponse = 'invalid_response',
   InvalidRequestParameters = 'invalid_request_parameters',
-}
-
-export enum SsoConnectorSessionErrorCodes {
-  SessionNotFound = 'session_not_found',
 }
 
 export enum SsoConnectorConfigErrorCodes {
@@ -23,7 +18,6 @@ export enum SsoConnectorConfigErrorCodes {
 const connectorErrorCodeMap: { [key in SsoConnectorErrorCodes]: ConnectorErrorCodes } = {
   [SsoConnectorErrorCodes.InvalidMetadata]: ConnectorErrorCodes.InvalidMetadata,
   [SsoConnectorErrorCodes.InvalidConfig]: ConnectorErrorCodes.InvalidConfig,
-  [SsoConnectorErrorCodes.SessionNotFound]: ConnectorErrorCodes.NotImplemented,
   [SsoConnectorErrorCodes.InvalidResponse]: ConnectorErrorCodes.InvalidResponse,
   [SsoConnectorErrorCodes.InvalidRequestParameters]: ConnectorErrorCodes.InvalidRequestParameters,
   [SsoConnectorErrorCodes.AuthorizationFailed]: ConnectorErrorCodes.AuthorizationFailed,
@@ -59,19 +53,14 @@ export class SsoConnectorError extends ConnectorError {
   );
 
   constructor(
-    code: SsoConnectorErrorCodes.SessionNotFound,
-    data: { message: SsoConnectorSessionErrorCodes }
-  );
-
-  constructor(
     code: SsoConnectorErrorCodes.AuthorizationFailed,
     data: { message: string; response?: unknown; error?: unknown }
   );
 
-  constructor(code: SsoConnectorErrorCodes, data?: unknown) {
+  constructor(code: SsoConnectorErrorCodes, data?: Record<string, unknown>) {
     super(connectorErrorCodeMap[code], {
       ssoErrorCode: code,
-      details: data,
+      ...data,
     });
   }
 }

--- a/packages/core/src/sso/types/error.ts
+++ b/packages/core/src/sso/types/error.ts
@@ -1,0 +1,77 @@
+import { ConnectorError, ConnectorErrorCodes } from '@logto/connector-kit';
+import { type JsonObject } from '@logto/schemas';
+
+export enum SsoConnectorErrorCodes {
+  InvalidMetadata = 'invalid_metadata',
+  InvalidConfig = 'invalid_config',
+  SessionNotFound = 'session_not_found',
+  InvalidResponse = 'invalid_response',
+  AuthorizationFailed = 'authorization_failed',
+  InvalidRequestParameters = 'invalid_request_parameters',
+}
+
+export enum SsoConnectorSessionErrorCodes {
+  SessionNotFound = 'session_not_found',
+}
+
+export enum SsoConnectorConfigErrorCodes {
+  InvalidConfigResponse = 'invalid_config_response',
+  FailToFetchConfig = 'fail_to_fetch_config',
+  InvalidConnectorConfig = 'invalid_connector_config',
+}
+
+const connectorErrorCodeMap: { [key in SsoConnectorErrorCodes]: ConnectorErrorCodes } = {
+  [SsoConnectorErrorCodes.InvalidMetadata]: ConnectorErrorCodes.InvalidMetadata,
+  [SsoConnectorErrorCodes.InvalidConfig]: ConnectorErrorCodes.InvalidConfig,
+  [SsoConnectorErrorCodes.SessionNotFound]: ConnectorErrorCodes.NotImplemented,
+  [SsoConnectorErrorCodes.InvalidResponse]: ConnectorErrorCodes.InvalidResponse,
+  [SsoConnectorErrorCodes.InvalidRequestParameters]: ConnectorErrorCodes.InvalidRequestParameters,
+  [SsoConnectorErrorCodes.AuthorizationFailed]: ConnectorErrorCodes.AuthorizationFailed,
+};
+
+export class SsoConnectorError extends ConnectorError {
+  constructor(
+    code: SsoConnectorErrorCodes.InvalidMetadata,
+    data: { message: SsoConnectorConfigErrorCodes; metadata?: string | JsonObject; error?: unknown }
+  );
+
+  constructor(
+    code: SsoConnectorErrorCodes.InvalidConfig,
+    data: {
+      message: SsoConnectorConfigErrorCodes;
+      config: JsonObject | undefined;
+      error?: unknown;
+    }
+  );
+
+  constructor(
+    code: SsoConnectorErrorCodes.InvalidRequestParameters,
+    data: { url: string; params: unknown; error?: unknown }
+  );
+
+  constructor(
+    code: SsoConnectorErrorCodes.InvalidResponse,
+    data: {
+      url: string;
+      response: unknown;
+      error?: unknown;
+    }
+  );
+
+  constructor(
+    code: SsoConnectorErrorCodes.SessionNotFound,
+    data: { message: SsoConnectorSessionErrorCodes }
+  );
+
+  constructor(
+    code: SsoConnectorErrorCodes.AuthorizationFailed,
+    data: { message: string; response?: unknown; error?: unknown }
+  );
+
+  constructor(code: SsoConnectorErrorCodes, data?: unknown) {
+    super(connectorErrorCodeMap[code], {
+      ssoErrorCode: code,
+      details: data,
+    });
+  }
+}

--- a/packages/core/src/sso/types/index.ts
+++ b/packages/core/src/sso/types/index.ts
@@ -1,4 +1,4 @@
-import { type JsonObject, type SsoConnector } from '@logto/schemas';
+import { type SsoProviderName, type JsonObject, type SsoConnector } from '@logto/schemas';
 
 export * from './session.js';
 
@@ -10,7 +10,13 @@ export * from './session.js';
  * @method {getConfig} getConfig - Get the full-list of SSO config from the SSO provider
  */
 export abstract class SingleSignOn {
-  abstract data: SsoConnector;
+  abstract data: SingleSignOnConnectorData;
   abstract getConfig: () => Promise<JsonObject>;
   abstract getIssuer: () => Promise<string>;
 }
+
+// Pick the required fields from SsoConnector Schema
+// providerName must be supported by the SSO connector factories
+export type SingleSignOnConnectorData = Pick<SsoConnector, 'config' | 'id'> & {
+  providerName: SsoProviderName;
+};

--- a/packages/integration-tests/src/tests/api/interaction/single-sign-on/sad-path.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/single-sign-on/sad-path.test.ts
@@ -103,7 +103,7 @@ describe('Single Sign On Sad Path', () => {
         postSamlAssertion({ connectorId, RelayState, SAMLResponse: samlAssertion }),
         {
           code: 'connector.authorization_failed',
-          statusCode: 400,
+          statusCode: 401,
         }
       );
     });

--- a/packages/integration-tests/src/tests/api/interaction/single-sign-on/sad-path.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/single-sign-on/sad-path.test.ts
@@ -102,7 +102,7 @@ describe('Single Sign On Sad Path', () => {
       await expectRejects(
         postSamlAssertion({ connectorId, RelayState, SAMLResponse: samlAssertion }),
         {
-          code: 'connector.general',
+          code: 'connector.authorization_failed',
           statusCode: 400,
         }
       );


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Per our latest product design we need to fetch and guard the config on all the config update endpoints. (POST, PATCH).

Throws error if the config schema is invalid
Throws error if the config fetching url (issuer for OIDC, metadata URL for SAML) request failed.
Throws error if the SAML metadata file is invalid.

This PR also includes the following updates:

- Shrink the `SsoConnector` class input data type to a limited fields only usable to the SsoConnector. So we may able to create the Connector instance without actually creating a full DB schema. e.g. on the POST endpoint. 

- Define new `SsoConnectorError` class based on the `Connector` class. Refine all the exception details.
 
<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
