### PR TITLE
fix(experience): use absolute path for password sign-in form nav

### DIFF
--- a/packages/experience/src/pages/SignIn/IdentifierSignInForm/index.test.tsx
+++ b/packages/experience/src/pages/SignIn/IdentifierSignInForm/index.test.tsx
@@ -127,7 +127,7 @@ describe('IdentifierSignInForm', () => {
           await waitFor(() => {
             expect(sendVerificationCodeApi).not.toBeCalled();
             expect(mockedNavigate).toBeCalledWith(
-              { pathname: 'password' },
+              { pathname: '/sign-in/password' },
               { state: { identifier: SignInIdentifier.Username, value } }
             );
           });
@@ -145,7 +145,7 @@ describe('IdentifierSignInForm', () => {
           await waitFor(() => {
             expect(sendVerificationCodeApi).not.toBeCalled();
             expect(mockedNavigate).toBeCalledWith(
-              { pathname: 'password' },
+              { pathname: '/sign-in/password' },
               {
                 state: {
                   identifier,
@@ -199,7 +199,7 @@ describe('IdentifierSignInForm', () => {
       await waitFor(() => {
         expect(getSingleSignOnConnectorsMock).not.toBeCalled();
         expect(mockedNavigate).toBeCalledWith(
-          { pathname: 'password' },
+          { pathname: '/sign-in/password' },
           { state: { identifier: SignInIdentifier.Username, value: username } }
         );
       });
@@ -224,7 +224,7 @@ describe('IdentifierSignInForm', () => {
       await waitFor(() => {
         expect(getSingleSignOnConnectorsMock).not.toBeCalled();
         expect(mockedNavigate).toBeCalledWith(
-          { pathname: 'password' },
+          { pathname: '/sign-in/password' },
           { state: { identifier: SignInIdentifier.Email, value: email } }
         );
       });
@@ -254,7 +254,7 @@ describe('IdentifierSignInForm', () => {
       await waitFor(() => {
         expect(getSingleSignOnConnectorsMock).toBeCalled();
         expect(mockedNavigate).toBeCalledWith(
-          { pathname: 'password' },
+          { pathname: '/sign-in/password' },
           { state: { identifier: SignInIdentifier.Email, value: email } }
         );
       });

--- a/packages/experience/src/pages/SignIn/IdentifierSignInForm/use-on-submit.ts
+++ b/packages/experience/src/pages/SignIn/IdentifierSignInForm/use-on-submit.ts
@@ -17,7 +17,7 @@ const useOnSubmit = (signInMethods: SignIn['methods']) => {
     (identifier: SignInIdentifier, value: string) => {
       navigate(
         {
-          pathname: 'password',
+          pathname: `/${UserFlow.SignIn}/password`,
         },
         { state: { identifier, value } }
       );


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
should use absolute path for the password sign-in form navigation.

On the social/SSO sign-in callback page, the location URL is specified as `/sign-in/social/:connectorId`, but shares a same page rendering logic as default `/sign-in` page. In the event of a failed social/SSO authentication, users should have the option to utilize the default sign-in form to log in using their password.

However, a previous issue arose where the navigation to the password sign-in form used a relative path, directing users to `/sign-in/social/:connectorId/password`, resulting in a 404 error.

To address this, the password sign-in form navigation now uses an absolute path, ensuring that both `/sign-in` and `/sign-in/social/:connectorId` paths should lead users to the `/sign-in/password` page. T

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
