### PR TITLE
feat(schemas): add unique constrain to the SSO connectorName field

### DIFF
--- a/packages/schemas/alterations/next-1701054133-add-unique-constraint-to-the-sso-connector-name.ts
+++ b/packages/schemas/alterations/next-1701054133-add-unique-constraint-to-the-sso-connector-name.ts
@@ -1,0 +1,21 @@
+import { sql } from 'slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      alter table sso_connectors
+        add constraint sso_connectors__connector_name__unique 
+          unique (tenant_id, connector_name);
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      alter table sso_connectors
+        drop constraint sso_connectors__connector_name__unique;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/sso_connectors.sql
+++ b/packages/schemas/tables/sso_connectors.sql
@@ -18,7 +18,9 @@ create table sso_connectors (
   sync_profile boolean not null default FALSE,
   /** When the SSO connector was created. */
   created_at timestamptz not null default(now()),
-  primary key (id)
+  primary key (id),
+  constraint sso_connectors__connector_name__unique
+    unique (tenant_id, connector_name)
 );
 
 create index sso_connectors__id


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add unique constrain to the SSO connectorName field.

This PR is part of the implementation of #4969.

We need to create this separate PR in order to pass the alteration integration tests. 
In #4969 we update the integration tests to generate connectorName randomly. So after the unique constrain rule is added to the DB, the test won't fail. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
