### PR TITLE
fix(console): fix wrong illustration status

### DIFF
--- a/packages/console/src/pages/EnterpriseSso/SsoConnectorLogo/index.tsx
+++ b/packages/console/src/pages/EnterpriseSso/SsoConnectorLogo/index.tsx
@@ -13,15 +13,22 @@ type Props = {
   data: Pick<SsoConnectorWithProviderConfig, 'providerLogo' | 'providerLogoDark' | 'branding'>;
 };
 
+/**
+ * Prioritize `branding` configuration:
+ *   - Even if it's in light mode and have `branding.darkLogo` configured, use `branding.darkLogo`.
+ */
 const pickLogoForCurrentTheme = (
   isDarkMode: boolean,
   { logo, logoDark }: { logo: string; logoDark: string },
   branding: SsoConnectorWithProviderConfig['branding']
 ): string => {
-  if (isDarkMode) {
-    return branding.darkLogo ?? logoDark;
-  }
-  return branding.logo ?? logo;
+  // Need to use `||` here since `??` operator can not avoid empty strings.
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  const configuredLogo = isDarkMode ? branding.darkLogo : branding.logo || branding.darkLogo;
+  const builtInLogo = isDarkMode ? logoDark : logo || logoDark;
+
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  return configuredLogo || builtInLogo;
 };
 
 function SsoConnectorLogo({ className, containerClassName, data }: Props) {

--- a/packages/console/src/pages/EnterpriseSsoDetails/Settings/index.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Settings/index.tsx
@@ -6,6 +6,7 @@ import {
 } from '@logto/schemas';
 import { generateStandardShortId } from '@logto/shared/universal';
 import { conditional, conditionalArray, conditionalString } from '@silverhand/essentials';
+import cleanDeep from 'clean-deep';
 import { t as globalTranslate } from 'i18next';
 import { HTTPError } from 'ky';
 import { useForm, Controller, FormProvider } from 'react-hook-form';
@@ -107,7 +108,10 @@ function Settings({ data, isDeleted, onUpdated }: Props) {
 
       try {
         const updatedSsoConnector = await api
-          .patch(`api/sso-connectors/${data.id}`, { json: formDataToSsoConnectorParser(formData) })
+          // Only keep non-empty values since PATCH operation performs a merge scheme.
+          .patch(`api/sso-connectors/${data.id}`, {
+            json: cleanDeep(formDataToSsoConnectorParser(formData)),
+          })
           .json<SsoConnectorWithProviderConfig>();
 
         reset(dataToFormParser(updatedSsoConnector));


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix the wrong illustration status.
Update the fallback logic of SSO connector logos.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
<img width="1208" alt="image" src="https://github.com/logto-io/logto/assets/15182327/bc433a85-6090-4136-a844-c6352101c87f">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
