### PR TITLE
fix(console): update SSO connector logo uploader file types

### DIFF
--- a/packages/console/src/pages/EnterpriseSsoDetails/Settings/LogosUploader/index.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Settings/LogosUploader/index.tsx
@@ -1,3 +1,4 @@
+import type { AllowedUploadMimeType } from '@logto/schemas';
 import classNames from 'classnames';
 import { useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
@@ -10,13 +11,15 @@ import type { FormType } from '../index.js';
 
 import * as styles from './index.module.scss';
 
+const allowedMimeTypes: AllowedUploadMimeType[] = ['image/png', 'image/jpeg', 'image/svg+xml']; // Only allow `svg`, `png`, `jpg` and `jpeg` files.
+
 function LogosUploader() {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const [uploadLogoError, setUploadLogoError] = useState<string>();
   const [uploadDarkLogoError, setUploadDarkLogoError] = useState<string>();
 
   const { control } = useFormContext<FormType>();
-  const { description } = useImageMimeTypes();
+  const { description } = useImageMimeTypes(allowedMimeTypes);
 
   return (
     <div className={styles.container}>
@@ -31,6 +34,7 @@ function LogosUploader() {
                 className={styles.frame}
                 value={value ?? ''}
                 actionDescription={t('enterprise_sso_details.branding_logo_context')}
+                allowedMimeTypes={allowedMimeTypes}
                 onCompleted={onChange}
                 onUploadErrorChange={setUploadLogoError}
                 onDelete={() => {
@@ -50,6 +54,7 @@ function LogosUploader() {
                 className={styles.frameDark}
                 value={value ?? ''}
                 actionDescription={t('enterprise_sso_details.branding_dark_logo_context')}
+                allowedMimeTypes={allowedMimeTypes}
                 onCompleted={onChange}
                 onUploadErrorChange={setUploadDarkLogoError}
                 onDelete={() => {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
update SSO connector logo uploader file types, only allow PNG, JPG and SVG file types.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
tested locally.
<img width="1211" alt="image" src="https://github.com/logto-io/logto/assets/15182327/7ad13b6b-f254-4311-80a9-ef7bde9a1b02">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
