### PR TITLE
refactor(core): use name attribute as the default connector name

### DIFF
--- a/packages/core/src/libraries/sign-in-experience/index.test.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.test.ts
@@ -146,7 +146,8 @@ describe('getFullSignInExperience()', () => {
       wellConfiguredSsoConnector,
     ]);
 
-    const fullSignInExperience = await getFullSignInExperience();
+    const fullSignInExperience = await getFullSignInExperience('en');
+    const connectorFactory = ssoConnectorFactories[wellConfiguredSsoConnector.providerName];
 
     expect(fullSignInExperience).toStrictEqual({
       ...mockSignInExperience,
@@ -159,9 +160,9 @@ describe('getFullSignInExperience()', () => {
       ssoConnectors: [
         {
           id: wellConfiguredSsoConnector.id,
-          connectorName: wellConfiguredSsoConnector.providerName,
-          logo: ssoConnectorFactories[wellConfiguredSsoConnector.providerName].logo,
-          darkLogo: ssoConnectorFactories[wellConfiguredSsoConnector.providerName].logoDark,
+          connectorName: connectorFactory.name.en,
+          logo: connectorFactory.logo,
+          darkLogo: connectorFactory.logoDark,
         },
       ],
       isDevelopmentTenant: false,
@@ -178,14 +179,16 @@ describe('get sso connectors', () => {
       wellConfiguredSsoConnector,
     ]);
 
-    const { ssoConnectors } = await getFullSignInExperience();
+    const { ssoConnectors } = await getFullSignInExperience('jp');
+
+    const connectorFactory = ssoConnectorFactories[wellConfiguredSsoConnector.providerName];
 
     expect(ssoConnectors).toEqual([
       {
         id: wellConfiguredSsoConnector.id,
-        connectorName: wellConfiguredSsoConnector.providerName,
-        logo: ssoConnectorFactories[wellConfiguredSsoConnector.providerName].logo,
-        darkLogo: ssoConnectorFactories[wellConfiguredSsoConnector.providerName].logoDark,
+        connectorName: connectorFactory.name.en,
+        logo: connectorFactory.logo,
+        darkLogo: connectorFactory.logoDark,
       },
     ]);
   });
@@ -205,14 +208,16 @@ describe('get sso connectors', () => {
       },
     ]);
 
-    const { ssoConnectors } = await getFullSignInExperience();
+    const connectorFactory = ssoConnectorFactories[wellConfiguredSsoConnector.providerName];
+
+    const { ssoConnectors } = await getFullSignInExperience('en');
 
     expect(ssoConnectors).toEqual([
       {
         id: wellConfiguredSsoConnector.id,
         connectorName: displayName,
-        logo: ssoConnectorFactories[wellConfiguredSsoConnector.providerName].logo,
-        darkLogo: ssoConnectorFactories[wellConfiguredSsoConnector.providerName].logoDark,
+        logo: connectorFactory.logo,
+        darkLogo: connectorFactory.logoDark,
       },
     ]);
   });

--- a/packages/core/src/routes/well-known.ts
+++ b/packages/core/src/routes/well-known.ts
@@ -44,7 +44,7 @@ export default function wellKnownRoutes<T extends AnonymousRouter>(
     '/.well-known/sign-in-exp',
     koaGuard({ response: guardFullSignInExperience, status: 200 }),
     async (ctx, next) => {
-      ctx.body = await getFullSignInExperience();
+      ctx.body = await getFullSignInExperience(ctx.locale);
 
       return next();
     }

--- a/packages/core/src/utils/translation.ts
+++ b/packages/core/src/utils/translation.ts
@@ -1,3 +1,4 @@
+import { type I18nPhrases } from '@logto/connector-kit';
 import type { Translation } from '@logto/schemas';
 
 /**
@@ -23,3 +24,6 @@ export const isStrictlyPartial = (
     return typeof fullValue === typeof value;
   });
 };
+
+export const isKeyOfI18nPhrases = (key: string, phrases: I18nPhrases): key is keyof I18nPhrases =>
+  key in phrases;


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Use the new added name attribute as the default connector name for the client side. 

<img width="556" alt="image" src="https://github.com/logto-io/logto/assets/36393111/be9f8235-fde3-473c-a29f-acc1d7e74da9">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
