### PR TITLE
feat(console,phrases): add inline notification if email domain not configured

### DIFF
--- a/packages/console/src/pages/EnterpriseSsoDetails/Experience/MultiInput/index.module.scss
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Experience/MultiInput/index.module.scss
@@ -71,3 +71,9 @@
     outline-color: var(--color-focused-variant);
   }
 }
+
+.error {
+  border-color: var(--color-error);
+  font: var(--font-body-2);
+  margin-top: _.unit(1);
+}

--- a/packages/console/src/pages/EnterpriseSsoDetails/Experience/index.module.scss
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Experience/index.module.scss
@@ -11,3 +11,7 @@
   color: var(--color-error);
   margin-top: _.unit(1);
 }
+
+.inlineNotification {
+  margin-top: _.unit(6);
+}

--- a/packages/console/src/pages/EnterpriseSsoDetails/Experience/index.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Experience/index.tsx
@@ -17,6 +17,7 @@ import DetailsForm from '@/components/DetailsForm';
 import FormCard from '@/components/FormCard';
 import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
 import FormField from '@/ds-components/FormField';
+import InlineNotification from '@/ds-components/InlineNotification';
 import Select from '@/ds-components/Select';
 import TextInput from '@/ds-components/TextInput';
 import useApi from '@/hooks/use-api';
@@ -98,7 +99,7 @@ function Experience({ data, isDeleted, onUpdated }: Props) {
     clearErrors,
     handleSubmit,
     register,
-    formState: { isDirty, isSubmitting, errors },
+    formState: { defaultValues, isDirty, isSubmitting, errors },
     reset,
   } = formMethods;
 
@@ -172,6 +173,11 @@ function Experience({ data, isDeleted, onUpdated }: Props) {
               error={errors.connectorName?.message}
             />
           </FormField>
+          {!defaultValues?.domains?.length && (
+            <InlineNotification className={styles.inlineNotification} severity="alert">
+              {t('enterprise_sso_details.configure_domain_field_info_text')}
+            </InlineNotification>
+          )}
           <FormField title="enterprise_sso_details.email_domain_field_name">
             <div className={styles.description}>
               {t('enterprise_sso_details.email_domain_field_description')}
@@ -179,6 +185,14 @@ function Experience({ data, isDeleted, onUpdated }: Props) {
             <Controller
               name="domains"
               control={control}
+              rules={{
+                validate: (value) => {
+                  if (value.length === 0) {
+                    return t('enterprise_sso_details.email_domain_field_required');
+                  }
+                  return true;
+                },
+              }}
               render={({ field: { onChange, value } }) => (
                 <MultiInput
                   values={value}

--- a/packages/phrases/src/locales/de/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/enterprise-sso-details.ts
@@ -71,6 +71,11 @@ const enterprise_sso_details = {
   /** UNTRANSLATED */
   upload_idp_metadata_button_text: 'Upload metadata XML file',
   /** UNTRANSLATED */
+  configure_domain_field_info_text:
+    'Add email domain to guide enterprise users to their identity provider for Single Sign-on.',
+  /** UNTRANSLATED */
+  email_domain_field_required: 'Email domain is required to enable enterprise SSO.',
+  /** UNTRANSLATED */
   upload_saml_idp_metadata_info_text_url:
     'Paste the metadata URL from the identity provider to connect.',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/en/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/enterprise-sso-details.ts
@@ -37,6 +37,9 @@ const enterprise_sso_details = {
   upload_idp_metadata_title: 'Upload IdP metadata',
   upload_idp_metadata_description: 'Configure the metadata copied from the identity provider.',
   upload_idp_metadata_button_text: 'Upload metadata XML file',
+  configure_domain_field_info_text:
+    'Add email domain to guide enterprise users to their identity provider for Single Sign-on.',
+  email_domain_field_required: 'Email domain is required to enable enterprise SSO.',
   upload_saml_idp_metadata_info_text_url:
     'Paste the metadata URL from the identity provider to connect.',
   upload_saml_idp_metadata_info_text_xml:

--- a/packages/phrases/src/locales/es/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/enterprise-sso-details.ts
@@ -71,6 +71,11 @@ const enterprise_sso_details = {
   /** UNTRANSLATED */
   upload_idp_metadata_button_text: 'Upload metadata XML file',
   /** UNTRANSLATED */
+  configure_domain_field_info_text:
+    'Add email domain to guide enterprise users to their identity provider for Single Sign-on.',
+  /** UNTRANSLATED */
+  email_domain_field_required: 'Email domain is required to enable enterprise SSO.',
+  /** UNTRANSLATED */
   upload_saml_idp_metadata_info_text_url:
     'Paste the metadata URL from the identity provider to connect.',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/fr/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/enterprise-sso-details.ts
@@ -71,6 +71,11 @@ const enterprise_sso_details = {
   /** UNTRANSLATED */
   upload_idp_metadata_button_text: 'Upload metadata XML file',
   /** UNTRANSLATED */
+  configure_domain_field_info_text:
+    'Add email domain to guide enterprise users to their identity provider for Single Sign-on.',
+  /** UNTRANSLATED */
+  email_domain_field_required: 'Email domain is required to enable enterprise SSO.',
+  /** UNTRANSLATED */
   upload_saml_idp_metadata_info_text_url:
     'Paste the metadata URL from the identity provider to connect.',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/it/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/enterprise-sso-details.ts
@@ -71,6 +71,11 @@ const enterprise_sso_details = {
   /** UNTRANSLATED */
   upload_idp_metadata_button_text: 'Upload metadata XML file',
   /** UNTRANSLATED */
+  configure_domain_field_info_text:
+    'Add email domain to guide enterprise users to their identity provider for Single Sign-on.',
+  /** UNTRANSLATED */
+  email_domain_field_required: 'Email domain is required to enable enterprise SSO.',
+  /** UNTRANSLATED */
   upload_saml_idp_metadata_info_text_url:
     'Paste the metadata URL from the identity provider to connect.',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/ja/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/enterprise-sso-details.ts
@@ -71,6 +71,11 @@ const enterprise_sso_details = {
   /** UNTRANSLATED */
   upload_idp_metadata_button_text: 'Upload metadata XML file',
   /** UNTRANSLATED */
+  configure_domain_field_info_text:
+    'Add email domain to guide enterprise users to their identity provider for Single Sign-on.',
+  /** UNTRANSLATED */
+  email_domain_field_required: 'Email domain is required to enable enterprise SSO.',
+  /** UNTRANSLATED */
   upload_saml_idp_metadata_info_text_url:
     'Paste the metadata URL from the identity provider to connect.',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/ko/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/enterprise-sso-details.ts
@@ -71,6 +71,11 @@ const enterprise_sso_details = {
   /** UNTRANSLATED */
   upload_idp_metadata_button_text: 'Upload metadata XML file',
   /** UNTRANSLATED */
+  configure_domain_field_info_text:
+    'Add email domain to guide enterprise users to their identity provider for Single Sign-on.',
+  /** UNTRANSLATED */
+  email_domain_field_required: 'Email domain is required to enable enterprise SSO.',
+  /** UNTRANSLATED */
   upload_saml_idp_metadata_info_text_url:
     'Paste the metadata URL from the identity provider to connect.',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/enterprise-sso-details.ts
@@ -71,6 +71,11 @@ const enterprise_sso_details = {
   /** UNTRANSLATED */
   upload_idp_metadata_button_text: 'Upload metadata XML file',
   /** UNTRANSLATED */
+  configure_domain_field_info_text:
+    'Add email domain to guide enterprise users to their identity provider for Single Sign-on.',
+  /** UNTRANSLATED */
+  email_domain_field_required: 'Email domain is required to enable enterprise SSO.',
+  /** UNTRANSLATED */
   upload_saml_idp_metadata_info_text_url:
     'Paste the metadata URL from the identity provider to connect.',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/enterprise-sso-details.ts
@@ -71,6 +71,11 @@ const enterprise_sso_details = {
   /** UNTRANSLATED */
   upload_idp_metadata_button_text: 'Upload metadata XML file',
   /** UNTRANSLATED */
+  configure_domain_field_info_text:
+    'Add email domain to guide enterprise users to their identity provider for Single Sign-on.',
+  /** UNTRANSLATED */
+  email_domain_field_required: 'Email domain is required to enable enterprise SSO.',
+  /** UNTRANSLATED */
   upload_saml_idp_metadata_info_text_url:
     'Paste the metadata URL from the identity provider to connect.',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/enterprise-sso-details.ts
@@ -71,6 +71,11 @@ const enterprise_sso_details = {
   /** UNTRANSLATED */
   upload_idp_metadata_button_text: 'Upload metadata XML file',
   /** UNTRANSLATED */
+  configure_domain_field_info_text:
+    'Add email domain to guide enterprise users to their identity provider for Single Sign-on.',
+  /** UNTRANSLATED */
+  email_domain_field_required: 'Email domain is required to enable enterprise SSO.',
+  /** UNTRANSLATED */
   upload_saml_idp_metadata_info_text_url:
     'Paste the metadata URL from the identity provider to connect.',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/ru/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/enterprise-sso-details.ts
@@ -71,6 +71,11 @@ const enterprise_sso_details = {
   /** UNTRANSLATED */
   upload_idp_metadata_button_text: 'Upload metadata XML file',
   /** UNTRANSLATED */
+  configure_domain_field_info_text:
+    'Add email domain to guide enterprise users to their identity provider for Single Sign-on.',
+  /** UNTRANSLATED */
+  email_domain_field_required: 'Email domain is required to enable enterprise SSO.',
+  /** UNTRANSLATED */
   upload_saml_idp_metadata_info_text_url:
     'Paste the metadata URL from the identity provider to connect.',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/enterprise-sso-details.ts
@@ -71,6 +71,11 @@ const enterprise_sso_details = {
   /** UNTRANSLATED */
   upload_idp_metadata_button_text: 'Upload metadata XML file',
   /** UNTRANSLATED */
+  configure_domain_field_info_text:
+    'Add email domain to guide enterprise users to their identity provider for Single Sign-on.',
+  /** UNTRANSLATED */
+  email_domain_field_required: 'Email domain is required to enable enterprise SSO.',
+  /** UNTRANSLATED */
   upload_saml_idp_metadata_info_text_url:
     'Paste the metadata URL from the identity provider to connect.',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/enterprise-sso-details.ts
@@ -71,6 +71,11 @@ const enterprise_sso_details = {
   /** UNTRANSLATED */
   upload_idp_metadata_button_text: 'Upload metadata XML file',
   /** UNTRANSLATED */
+  configure_domain_field_info_text:
+    'Add email domain to guide enterprise users to their identity provider for Single Sign-on.',
+  /** UNTRANSLATED */
+  email_domain_field_required: 'Email domain is required to enable enterprise SSO.',
+  /** UNTRANSLATED */
   upload_saml_idp_metadata_info_text_url:
     'Paste the metadata URL from the identity provider to connect.',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/enterprise-sso-details.ts
@@ -71,6 +71,11 @@ const enterprise_sso_details = {
   /** UNTRANSLATED */
   upload_idp_metadata_button_text: 'Upload metadata XML file',
   /** UNTRANSLATED */
+  configure_domain_field_info_text:
+    'Add email domain to guide enterprise users to their identity provider for Single Sign-on.',
+  /** UNTRANSLATED */
+  email_domain_field_required: 'Email domain is required to enable enterprise SSO.',
+  /** UNTRANSLATED */
   upload_saml_idp_metadata_info_text_url:
     'Paste the metadata URL from the identity provider to connect.',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/enterprise-sso-details.ts
@@ -71,6 +71,11 @@ const enterprise_sso_details = {
   /** UNTRANSLATED */
   upload_idp_metadata_button_text: 'Upload metadata XML file',
   /** UNTRANSLATED */
+  configure_domain_field_info_text:
+    'Add email domain to guide enterprise users to their identity provider for Single Sign-on.',
+  /** UNTRANSLATED */
+  email_domain_field_required: 'Email domain is required to enable enterprise SSO.',
+  /** UNTRANSLATED */
   upload_saml_idp_metadata_info_text_url:
     'Paste the metadata URL from the identity provider to connect.',
   /** UNTRANSLATED */


### PR DESCRIPTION


<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
1. Add email domain fields inline notification when not configured.
2. Add error style for email domain field

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
Save with email domain not configured.
<img width="1274" alt="image" src="https://github.com/logto-io/logto/assets/15182327/0f21fab1-109d-4113-8429-62e581a77640">
Inline notification disappears after email domain is not empty.
<img width="1253" alt="image" src="https://github.com/logto-io/logto/assets/15182327/d0d8473f-219c-4994-b67c-7b89e7b48879">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
