### PR TITLE
fix(console): fix SSO connector logo fallback logic

### DIFF
--- a/packages/console/src/pages/EnterpriseSso/SsoConnectorLogo/index.tsx
+++ b/packages/console/src/pages/EnterpriseSso/SsoConnectorLogo/index.tsx
@@ -6,6 +6,7 @@ import ImageWithErrorFallback from '@/ds-components/ImageWithErrorFallback';
 import useTheme from '@/hooks/use-theme';
 
 import * as styles from './index.module.scss';
+import { pickLogoForCurrentThemeHelper } from './utils';
 
 type Props = {
   className?: string;
@@ -23,9 +24,13 @@ const pickLogoForCurrentTheme = (
   branding: SsoConnectorWithProviderConfig['branding']
 ): string => {
   // Need to use `||` here since `??` operator can not avoid empty strings.
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const configuredLogo = isDarkMode ? branding.darkLogo : branding.logo || branding.darkLogo;
-  const builtInLogo = isDarkMode ? logoDark : logo || logoDark;
+  // Since `logo` and `darkLogo` are both optional, when it is dark mode and `darkLogo` is not configured, should fallback to `logo`.
+  const configuredLogo = pickLogoForCurrentThemeHelper(
+    isDarkMode,
+    branding.logo,
+    branding.darkLogo
+  );
+  const builtInLogo = pickLogoForCurrentThemeHelper(isDarkMode, logo, logoDark);
 
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   return configuredLogo || builtInLogo;

--- a/packages/console/src/pages/EnterpriseSso/SsoConnectorLogo/utils.test.ts
+++ b/packages/console/src/pages/EnterpriseSso/SsoConnectorLogo/utils.test.ts
@@ -1,0 +1,38 @@
+import { pickLogoForCurrentThemeHelper } from './utils';
+
+describe('pickLogoForCurrentThemeHelper', () => {
+  const logo = 'logo';
+  const logoDark = 'logoDark';
+
+  it('dark mode, logo non-empty, logoDark non-empty, should get logoDark', () => {
+    expect(pickLogoForCurrentThemeHelper(true, logo, logoDark)).toBe(logoDark);
+  });
+
+  it('light mode, logo non-empty, logoDark non-empty, should get logo', () => {
+    expect(pickLogoForCurrentThemeHelper(false, logo, logoDark)).toBe(logo);
+  });
+
+  it('dark mode, logo non-empty, logoDark empty, should get logo', () => {
+    expect(pickLogoForCurrentThemeHelper(true, logo, '')).toBe(logo);
+  });
+
+  it('light mode, logo non-empty, logoDark empty, should get logo', () => {
+    expect(pickLogoForCurrentThemeHelper(false, logo, '')).toBe(logo);
+  });
+
+  it('dark mode, logo empty, logoDark non-empty, should get logoDark', () => {
+    expect(pickLogoForCurrentThemeHelper(true, '', logoDark)).toBe(logoDark);
+  });
+
+  it('light mode, logo empty, logoDark non-empty, should get logoDark', () => {
+    expect(pickLogoForCurrentThemeHelper(false, '', logoDark)).toBe(logoDark);
+  });
+
+  it('dark mode, logo empty, logoDark empty, should get empty string', () => {
+    expect(pickLogoForCurrentThemeHelper(true, '', '')).toBe('');
+  });
+
+  it('light mode, logo empty, logoDark empty, should get empty string', () => {
+    expect(pickLogoForCurrentThemeHelper(false, '', '')).toBe('');
+  });
+});

--- a/packages/console/src/pages/EnterpriseSso/SsoConnectorLogo/utils.ts
+++ b/packages/console/src/pages/EnterpriseSso/SsoConnectorLogo/utils.ts
@@ -1,0 +1,9 @@
+import { type Optional } from '@silverhand/essentials';
+
+export const pickLogoForCurrentThemeHelper = <T extends string | Optional<string>>(
+  isDarkMode: boolean,
+  logo: T,
+  logoDark: T
+): T => {
+  return (isDarkMode ? logoDark : logo) || logoDark || logo;
+};

--- a/packages/console/src/pages/UserDetails/UserSettings/components/UserSocialIdentities/index.module.scss
+++ b/packages/console/src/pages/UserDetails/UserSettings/components/UserSocialIdentities/index.module.scss
@@ -11,10 +11,14 @@
   align-items: center;
 
   .icon {
-    width: 32px;
-    height: 32px;
-    border-radius: _.unit(2);
-    flex-shrink: 0;
+    background: transparent;
+    width: 20px;
+    height: 20px;
+
+    > img {
+      width: 100%;
+      height: 100%;
+    }
   }
 
   .name {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
1. fix the SSO connector logo fallback logic, when the system was in dark mode and only the light mode logo was configured, the configured light mode logo should be displayed.
2. Add missed `branding` field to SSO identity `displayConnectors`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
<img width="1200" alt="image" src="https://github.com/logto-io/logto/assets/15182327/3462b5ed-8a55-4989-bbb4-b3dd76a50f4d">
Previously this user management page throws an error since `branding` is not passed.
<img width="1218" alt="image" src="https://github.com/logto-io/logto/assets/15182327/469064b9-e2da-4f34-9811-d5f8ed1a6725">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
