### PR TITLE
feat(core): case insensitive usernames

### DIFF
--- a/packages/shared/src/node/env/GlobalValues.ts
+++ b/packages/shared/src/node/env/GlobalValues.ts
@@ -104,6 +104,9 @@ export default class GlobalValues {
   /** Maximum number of clients to keep in a single database pool (i.e. per `Tenant` class). */
   public readonly databasePoolSize = Number(getEnv('DATABASE_POOL_SIZE', '20'));
 
+  /** Case insensitive username */
+  public readonly isCaseInsensitiveUsername = yes(getEnv('CASE_INSENSITIVE_USERNAME'));
+
   /**
    * The Redis endpoint (optional). If it's set, the central cache mechanism will be automatically enabled.
    *


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This is a (bit overdue) contribution stemming from https://discord.com/channels/965845662535147551/1118601345038037083/1118601345038037083

This PR adds a new env variable: `CASE_INSENSITIVE_USERNAME` that when set to `1` will treat usernames the same as email addresses. For example, username `john` will be accepted, as well as `John` and `JOHN`, as the same user.

I am still new to this workflow, let me know if I missed anything!

(Also let me know if there is a better way to handle sql conditional query stuff, I couldn't find a good way to do that :sweat_smile: )

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local testing. All case variations of `john` are accepted. It is not possible to create a duplicate user with the same or different case.

This probably needs unit tests as well, but I have no experience making them and this seems a bit daunting (needs to spin up a separate instance with different envs)

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
