### PR TITLE
style(console): update save button styles on language editor

### DIFF
--- a/packages/console/src/pages/SignInExperience/tabs/Content/components/ManageLanguage/LanguageEditor/LanguageDetails.module.scss
+++ b/packages/console/src/pages/SignInExperience/tabs/Content/components/ManageLanguage/LanguageEditor/LanguageDetails.module.scss
@@ -109,10 +109,11 @@
     .footer {
       flex-shrink: 0;
       border-top: 1px solid var(--color-divider);
-      height: 85px;
+      height: 60px;
       display: flex;
       flex-direction: row-reverse;
-      padding: _.unit(5);
+      align-items: center;
+      padding-right: _.unit(5);
     }
   }
 }

--- a/packages/console/src/pages/SignInExperience/tabs/Content/components/ManageLanguage/LanguageEditor/LanguageDetails.tsx
+++ b/packages/console/src/pages/SignInExperience/tabs/Content/components/ManageLanguage/LanguageEditor/LanguageDetails.tsx
@@ -271,7 +271,6 @@ function LanguageDetails() {
           <Button
             isLoading={isSubmitting}
             type="primary"
-            size="large"
             title="general.save"
             onClick={async () => onSubmit()}
           />


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Per offline discussion, should change the save button to medium size and fix the language footer to `60px`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

<img width="1265" alt="image" src="https://github.com/logto-io/logto/assets/10806653/2a184644-0cb0-4a78-bd6a-6e57fd900635">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
