### PR TITLE
feat(core,schemas): add new singleSignOnEnabled field to sie

### DIFF
--- a/packages/core/src/__mocks__/sign-in-experience.ts
+++ b/packages/core/src/__mocks__/sign-in-experience.ts
@@ -96,4 +96,5 @@ export const mockSignInExperience: SignInExperience = {
     policy: MfaPolicy.UserControlled,
     factors: [],
   },
+  singleSignOnEnabled: true,
 };

--- a/packages/core/src/libraries/sign-in-experience/index.test.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.test.ts
@@ -171,6 +171,20 @@ describe('getFullSignInExperience()', () => {
 });
 
 describe('get sso connectors', () => {
+  it('should return empty array if dev feature is disabled', async () => {
+    getLogtoConnectors.mockResolvedValueOnce(mockSocialConnectors);
+    findDefaultSignInExperience.mockResolvedValueOnce({
+      ...mockSignInExperience,
+      singleSignOnEnabled: false,
+    });
+
+    const { ssoConnectors } = await getFullSignInExperience('en');
+
+    expect(ssoConnectorLibrary.getAvailableSsoConnectors).not.toBeCalled();
+
+    expect(ssoConnectors).toEqual([]);
+  });
+
   it('should return sso connectors metadata', async () => {
     getLogtoConnectors.mockResolvedValueOnce(mockSocialConnectors);
     findDefaultSignInExperience.mockResolvedValueOnce(mockSignInExperience);

--- a/packages/core/src/libraries/sign-in-experience/index.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.ts
@@ -111,13 +111,15 @@ export const createSignInExperienceLibrary = (
   };
 
   const getFullSignInExperience = async (locale: string): Promise<FullSignInExperience> => {
-    const [signInExperience, logtoConnectors, ssoConnectors, isDevelopmentTenant] =
-      await Promise.all([
-        findDefaultSignInExperience(),
-        getLogtoConnectors(),
-        getActiveSsoConnectors(locale),
-        getIsDevelopmentTenant(),
-      ]);
+    const [signInExperience, logtoConnectors, isDevelopmentTenant] = await Promise.all([
+      findDefaultSignInExperience(),
+      getLogtoConnectors(),
+      getIsDevelopmentTenant(),
+    ]);
+
+    const ssoConnectors = signInExperience.singleSignOnEnabled
+      ? await getActiveSsoConnectors(locale)
+      : [];
 
     const forgotPassword = {
       phone: logtoConnectors.some(({ type }) => type === ConnectorType.Sms),

--- a/packages/core/src/libraries/sign-in-experience/index.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.ts
@@ -117,6 +117,7 @@ export const createSignInExperienceLibrary = (
       getIsDevelopmentTenant(),
     ]);
 
+    // Always return empty array if single-sign-on is disabled
     const ssoConnectors = signInExperience.singleSignOnEnabled
       ? await getActiveSsoConnectors(locale)
       : [];

--- a/packages/core/src/queries/sign-in-experience.test.ts
+++ b/packages/core/src/queries/sign-in-experience.test.ts
@@ -39,7 +39,7 @@ describe('sign-in-experience query', () => {
   it('findDefaultSignInExperience', async () => {
     /* eslint-disable sql/no-unsafe-query */
     const expectSql = `
-      select "tenant_id", "id", "color", "branding", "language_info", "terms_of_use_url", "privacy_policy_url", "sign_in", "sign_up", "social_sign_in_connector_targets", "sign_in_mode", "custom_css", "custom_content", "password_policy", "mfa"
+      select "tenant_id", "id", "color", "branding", "language_info", "terms_of_use_url", "privacy_policy_url", "sign_in", "sign_up", "social_sign_in_connector_targets", "sign_in_mode", "custom_css", "custom_content", "password_policy", "mfa", "single_sign_on_enabled"
       from "sign_in_experiences"
       where "id"=$1
     `;

--- a/packages/experience/src/__mocks__/logto.tsx
+++ b/packages/experience/src/__mocks__/logto.tsx
@@ -109,6 +109,7 @@ export const mockSignInExperience: SignInExperience = {
     policy: MfaPolicy.UserControlled,
     factors: [],
   },
+  singleSignOnEnabled: true,
 };
 
 export const mockSignInExperienceSettings: SignInExperienceResponse = {
@@ -140,6 +141,7 @@ export const mockSignInExperienceSettings: SignInExperienceResponse = {
     factors: [],
   },
   isDevelopmentTenant: false,
+  singleSignOnEnabled: true,
 };
 
 const usernameSettings = {

--- a/packages/integration-tests/src/tests/api/sign-in-experience.test.ts
+++ b/packages/integration-tests/src/tests/api/sign-in-experience.test.ts
@@ -27,6 +27,7 @@ describe('admin console sign-in experience', () => {
         policy: MfaPolicy.UserControlled,
         factors: [],
       },
+      singleSignOnEnabled: true,
     };
 
     const updatedSignInExperience = await updateSignInExperience(newSignInExperience);

--- a/packages/schemas/alterations/next-1701245520-add-single-sign-on-enabled-flag-to-sie.ts
+++ b/packages/schemas/alterations/next-1701245520-add-single-sign-on-enabled-flag-to-sie.ts
@@ -1,0 +1,20 @@
+import { sql } from 'slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      alter table sign_in_experiences
+        add column single_sign_on_enabled boolean not null default false;
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      alter table sign_in_experiences
+        drop column single_sign_on_enabled;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/sign_in_experiences.sql
+++ b/packages/schemas/tables/sign_in_experiences.sql
@@ -17,5 +17,6 @@ create table sign_in_experiences (
   custom_content jsonb /* @use CustomContent */ not null default '{}'::jsonb,
   password_policy jsonb /* @use PartialPasswordPolicy */ not null default '{}'::jsonb,
   mfa jsonb /* @use Mfa */ not null default '{}'::jsonb,
+  single_sign_on_enabled boolean not null default false,
   primary key (tenant_id, id)
 );


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Per latest product design we are adding a  new singleSignOnEnabled field to the sign-in-experience data. 

When ssoEnabled set to false,  no sso connectors should been enabled. sie always return empty array to the client.
The default value is false.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
