### PR TITLE
feat(console): update certificate display

### DIFF
--- a/packages/console/src/pages/EnterpriseSso/types.ts
+++ b/packages/console/src/pages/EnterpriseSso/types.ts
@@ -63,6 +63,8 @@ export type ParsedSsoIdentityProviderConfig<T extends SsoProviderName> =
           entityId: string;
           signInEndpoint: string;
           x509Certificate: string;
+          expiresAt: number;
+          isValid: boolean;
         };
       }
     : never;

--- a/packages/console/src/pages/EnterpriseSsoDetails/Connection/SamlMetadataForm/ParsedConfigPreview/index.module.scss
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Connection/SamlMetadataForm/ParsedConfigPreview/index.module.scss
@@ -19,10 +19,29 @@
       font: var(--font-body-2);
       overflow-wrap: break-word;
       word-wrap: break-word;
+      display: flex;
+      flex-direction: row;
+      align-items: center;
     }
   }
 
   > :not(:last-child) {
     margin-bottom: _.unit(6);
   }
+}
+
+.indicator {
+  width: 10px;
+  height: 10px;
+  margin-right: _.unit(2);
+  border-radius: 50%;
+  background: var(--color-on-success-container);
+}
+
+.errorStatus {
+  background: var(--color-on-error-container);
+}
+
+.copyToClipboard {
+  margin-left: _.unit(1);
 }

--- a/packages/console/src/pages/EnterpriseSsoDetails/Connection/SamlMetadataForm/ParsedConfigPreview/index.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Connection/SamlMetadataForm/ParsedConfigPreview/index.tsx
@@ -1,6 +1,12 @@
+import { isLanguageTag } from '@logto/language-kit';
 import { type SsoProviderName } from '@logto/schemas';
+import { conditional } from '@silverhand/essentials';
+import classNames from 'classnames';
+import i18next from 'i18next';
 import { useTranslation } from 'react-i18next';
 
+import CopyToClipboard from '@/ds-components/CopyToClipboard';
+import DynamicT from '@/ds-components/DynamicT';
 import { type ParsedSsoIdentityProviderConfig } from '@/pages/EnterpriseSso/types.js';
 
 import * as styles from './index.module.scss';
@@ -13,12 +19,13 @@ function ParsedConfigPreview({ identityProviderConfig }: Props) {
   const { t } = useTranslation(undefined, {
     keyPrefix: 'admin_console.enterprise_sso_details.saml_preview',
   });
+  const { language } = i18next;
 
   if (!identityProviderConfig) {
     return null;
   }
 
-  const { entityId, signInEndpoint, x509Certificate } = identityProviderConfig;
+  const { entityId, signInEndpoint, x509Certificate, expiresAt, isValid } = identityProviderConfig;
   return (
     <div className={styles.container}>
       <div>
@@ -31,7 +38,29 @@ function ParsedConfigPreview({ identityProviderConfig }: Props) {
       </div>
       <div>
         <div className={styles.title}>{t('x509_certificate')}</div>
-        <div className={styles.content}>{x509Certificate}</div>
+        <div className={styles.content}>
+          <div className={classNames(styles.indicator, !isValid && styles.errorStatus)} />
+          <DynamicT
+            forKey="enterprise_sso_details.saml_preview.certificate_content"
+            interpolation={{
+              date: new Date(expiresAt).toLocaleDateString(
+                // TODO: check if Logto's language tags are compatible.
+                conditional(isLanguageTag(language) && language) ?? 'en',
+                {
+                  weekday: 'long',
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                }
+              ),
+            }}
+          />
+          <CopyToClipboard
+            className={styles.copyToClipboard}
+            variant="icon"
+            value={x509Certificate}
+          />
+        </div>
       </div>
     </div>
   );

--- a/packages/core/src/sso/SamlConnector/index.ts
+++ b/packages/core/src/sso/SamlConnector/index.ts
@@ -14,7 +14,7 @@ import {
   type ExtendedSocialUserInfo,
   type SamlServiceProviderMetadata,
   type SamlIdentityProviderMetadata,
-  samlIdentityProviderMetadataGuard,
+  manualSamlConnectorConfigGuard,
 } from '../types/saml.js';
 
 import {
@@ -213,7 +213,7 @@ class SamlConnector {
    */
   private getIdpMetadataJson() {
     // Required fields of metadata should not be undefined.
-    const result = samlIdentityProviderMetadataGuard.safeParse(this.idpConfig);
+    const result = manualSamlConnectorConfigGuard.safeParse(this.idpConfig);
 
     if (!result.success) {
       throw new SsoConnectorError(SsoConnectorErrorCodes.InvalidConfig, {

--- a/packages/core/src/sso/SamlConnector/utils.test.ts
+++ b/packages/core/src/sso/SamlConnector/utils.test.ts
@@ -1,4 +1,8 @@
-import { attributeMappingPostProcessor, getExtendedUserInfoFromRawUserProfile } from './utils.js';
+import {
+  attributeMappingPostProcessor,
+  getExtendedUserInfoFromRawUserProfile,
+  getPemCertificate,
+} from './utils.js';
 
 const expectedDefaultAttributeMapping = {
   id: 'nameID',
@@ -42,5 +46,14 @@ describe('getExtendedUserInfoFromRawUserProfile', () => {
       id: 'foo',
       avatar: 'pic.png',
     });
+  });
+});
+
+const testCertificate =
+  '-----BEGIN CERTIFICATE-----\nMIIC8DCCAdigAwIBAgIQcu5YCNUIL6JNotFNdirF2DANBgkqhkiG9w0BAQsFADA0MTIwMAYDVQQDEylNaWNyb3NvZnQgQXp1cmUgRmVkZXJhdGVkIFNTTyBDZXJ0aWZpY2F0ZTAeFw0yMzEwMjUwODAyMDNaFw0yNjEwMjUwODAyMDNaMDQxMjAwBgNVBAMTKU1pY3Jvc29mdCBBenVyZSBGZWRlcmF0ZWQgU1NPIENlcnRpZmljYXRlMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2EC5TZmW2ePPI0Od2Z3qFykouY/R8SBVJDD9xUcAIocMSqMLsxqd9ydkjaNC+QLbBUnpCvUd7+7ZyVcABbr5ixIMU+yxKIoZQdchECyasrR4HHXHXMeijQ8ziyF3Ys1yRB+iVQd2wZI+26pXlq9/bmT/keqMqdbAFD78QAYVF0LniL+sQav9Y0tsgrqXaE0GzqpTUsUfEcc1kynIQQG4ltFAkMTqaDhgw44S1GErjYC91dPEZMj4Ywwf1FIfnNJaRZoG77F3SlWUg345z/kAHBzNKjFMq3deobCHDZCZBJ6a+ABzgqdunUo4xBFG/YHNjjGkZEImALwp+P45mF5OLQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQAK7s967KnFm0d7R1HpTHhr6D+L/X2Ejmgawo2HlkFLsHXPgGkeogrXl0Fw6NImJ+Zo/ChE2Vb8ZeYoEz5mdAYc0hK4k4UWJkv3yZ0GPKOzEcIWZ8Q8WAKqqWnzaO8NmZKpdc/sk8PluKH/BJ7IjEHZUgzhmuRGuJGJhVn2EPLXFIxBubyRlyMhBEZvX4syeeiCwGzvZY9CoTUPqftlrvc1xs78GFN+8cT2+B0vjcbifMkZ1Hq0iPQLN/LotM1qGbSVu/OFhuA+8mnp3Acw3XNZPOy9dZdNiVBF8ZoUz0rAC64dKYROPEDJhBTF30UzDcq6lfLA9KAgzEzupAxB8D4N\n-----END CERTIFICATE-----';
+
+describe('getPemCertificate', () => {
+  it('should not throw error with a valid certificate', () => {
+    expect(() => getPemCertificate(testCertificate)).not.toThrow();
   });
 });

--- a/packages/core/src/sso/types/saml.ts
+++ b/packages/core/src/sso/types/saml.ts
@@ -40,8 +40,16 @@ export const samlIdentityProviderMetadataGuard = z.object({
   entityId: z.string(),
   signInEndpoint: z.string(),
   x509Certificate: z.string(),
+  expiresAt: z.number(), // Timestamp in milliseconds.
+  isValid: z.boolean(),
 });
 export type SamlIdentityProviderMetadata = z.infer<typeof samlIdentityProviderMetadataGuard>;
+
+export const manualSamlConnectorConfigGuard = samlIdentityProviderMetadataGuard.pick({
+  entityId: true,
+  signInEndpoint: true,
+  x509Certificate: true,
+});
 
 export const samlConnectorConfigGuard = z.union([
   // Config using Metadata URL
@@ -55,7 +63,7 @@ export const samlConnectorConfigGuard = z.union([
     attributeMapping: customizableAttributeMapGuard.optional(),
   }),
   // Config using Metadata detail
-  samlIdentityProviderMetadataGuard.extend({
+  manualSamlConnectorConfigGuard.extend({
     attributeMapping: customizableAttributeMapGuard.optional(),
   }),
 ]);

--- a/packages/phrases/src/locales/de/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/enterprise-sso-details.ts
@@ -110,6 +110,8 @@ const enterprise_sso_details = {
     entity_id: 'Issuer',
     /** UNTRANSLATED */
     x509_certificate: 'Signing certificate',
+    /** UNTRANSLATED */
+    certificate_content: 'Expiring {{date}}',
   },
   oidc_preview: {
     /** UNTRANSLATED */

--- a/packages/phrases/src/locales/en/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/enterprise-sso-details.ts
@@ -61,6 +61,7 @@ const enterprise_sso_details = {
     sign_on_url: 'Sign on URL',
     entity_id: 'Issuer',
     x509_certificate: 'Signing certificate',
+    certificate_content: 'Expiring {{date}}',
   },
   oidc_preview: {
     authorization_endpoint: 'Authorization endpoint',

--- a/packages/phrases/src/locales/es/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/enterprise-sso-details.ts
@@ -110,6 +110,8 @@ const enterprise_sso_details = {
     entity_id: 'Issuer',
     /** UNTRANSLATED */
     x509_certificate: 'Signing certificate',
+    /** UNTRANSLATED */
+    certificate_content: 'Expiring {{date}}',
   },
   oidc_preview: {
     /** UNTRANSLATED */

--- a/packages/phrases/src/locales/fr/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/enterprise-sso-details.ts
@@ -110,6 +110,8 @@ const enterprise_sso_details = {
     entity_id: 'Issuer',
     /** UNTRANSLATED */
     x509_certificate: 'Signing certificate',
+    /** UNTRANSLATED */
+    certificate_content: 'Expiring {{date}}',
   },
   oidc_preview: {
     /** UNTRANSLATED */

--- a/packages/phrases/src/locales/it/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/enterprise-sso-details.ts
@@ -110,6 +110,8 @@ const enterprise_sso_details = {
     entity_id: 'Issuer',
     /** UNTRANSLATED */
     x509_certificate: 'Signing certificate',
+    /** UNTRANSLATED */
+    certificate_content: 'Expiring {{date}}',
   },
   oidc_preview: {
     /** UNTRANSLATED */

--- a/packages/phrases/src/locales/ja/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/enterprise-sso-details.ts
@@ -110,6 +110,8 @@ const enterprise_sso_details = {
     entity_id: 'Issuer',
     /** UNTRANSLATED */
     x509_certificate: 'Signing certificate',
+    /** UNTRANSLATED */
+    certificate_content: 'Expiring {{date}}',
   },
   oidc_preview: {
     /** UNTRANSLATED */

--- a/packages/phrases/src/locales/ko/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/enterprise-sso-details.ts
@@ -110,6 +110,8 @@ const enterprise_sso_details = {
     entity_id: 'Issuer',
     /** UNTRANSLATED */
     x509_certificate: 'Signing certificate',
+    /** UNTRANSLATED */
+    certificate_content: 'Expiring {{date}}',
   },
   oidc_preview: {
     /** UNTRANSLATED */

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/enterprise-sso-details.ts
@@ -110,6 +110,8 @@ const enterprise_sso_details = {
     entity_id: 'Issuer',
     /** UNTRANSLATED */
     x509_certificate: 'Signing certificate',
+    /** UNTRANSLATED */
+    certificate_content: 'Expiring {{date}}',
   },
   oidc_preview: {
     /** UNTRANSLATED */

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/enterprise-sso-details.ts
@@ -110,6 +110,8 @@ const enterprise_sso_details = {
     entity_id: 'Issuer',
     /** UNTRANSLATED */
     x509_certificate: 'Signing certificate',
+    /** UNTRANSLATED */
+    certificate_content: 'Expiring {{date}}',
   },
   oidc_preview: {
     /** UNTRANSLATED */

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/enterprise-sso-details.ts
@@ -110,6 +110,8 @@ const enterprise_sso_details = {
     entity_id: 'Issuer',
     /** UNTRANSLATED */
     x509_certificate: 'Signing certificate',
+    /** UNTRANSLATED */
+    certificate_content: 'Expiring {{date}}',
   },
   oidc_preview: {
     /** UNTRANSLATED */

--- a/packages/phrases/src/locales/ru/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/enterprise-sso-details.ts
@@ -110,6 +110,8 @@ const enterprise_sso_details = {
     entity_id: 'Issuer',
     /** UNTRANSLATED */
     x509_certificate: 'Signing certificate',
+    /** UNTRANSLATED */
+    certificate_content: 'Expiring {{date}}',
   },
   oidc_preview: {
     /** UNTRANSLATED */

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/enterprise-sso-details.ts
@@ -110,6 +110,8 @@ const enterprise_sso_details = {
     entity_id: 'Issuer',
     /** UNTRANSLATED */
     x509_certificate: 'Signing certificate',
+    /** UNTRANSLATED */
+    certificate_content: 'Expiring {{date}}',
   },
   oidc_preview: {
     /** UNTRANSLATED */

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/enterprise-sso-details.ts
@@ -110,6 +110,8 @@ const enterprise_sso_details = {
     entity_id: 'Issuer',
     /** UNTRANSLATED */
     x509_certificate: 'Signing certificate',
+    /** UNTRANSLATED */
+    certificate_content: 'Expiring {{date}}',
   },
   oidc_preview: {
     /** UNTRANSLATED */

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/enterprise-sso-details.ts
@@ -110,6 +110,8 @@ const enterprise_sso_details = {
     entity_id: 'Issuer',
     /** UNTRANSLATED */
     x509_certificate: 'Signing certificate',
+    /** UNTRANSLATED */
+    certificate_content: 'Expiring {{date}}',
   },
   oidc_preview: {
     /** UNTRANSLATED */

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/enterprise-sso-details.ts
@@ -110,6 +110,8 @@ const enterprise_sso_details = {
     entity_id: 'Issuer',
     /** UNTRANSLATED */
     x509_certificate: 'Signing certificate',
+    /** UNTRANSLATED */
+    certificate_content: 'Expiring {{date}}',
   },
   oidc_preview: {
     /** UNTRANSLATED */


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
update certificate display:
For valid SAML SSO connectors' config, return the parsed result of the certificate as well (in Logto, this includes both `expirationTime` and `isValid`)
We only support PEM encoding certificates in this PR.

We hence show:
- Whether the certificate is still valid
- The expiration time of the certificate

We also provide a copy button to load the parsed PEM certificate to the clipboard.

TODO:
Support certificates in other decoding (like DER).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
<img width="1207" alt="image" src="https://github.com/logto-io/logto/assets/15182327/ab008cbd-6fb9-4944-adce-eb21ff928b4d">
Parsed certificate got via copy icon.
<img width="517" alt="image" src="https://github.com/logto-io/logto/assets/15182327/9ffc34d5-a220-4600-b41f-044ea2abe91f">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
