### PR TITLE
chore(console): hide the entrance of creating SAML social connector

### DIFF
--- a/packages/console/src/components/CreateConnectorForm/index.tsx
+++ b/packages/console/src/components/CreateConnectorForm/index.tsx
@@ -8,6 +8,7 @@ import { useContext, useMemo, useState } from 'react';
 import Modal from 'react-modal';
 import useSWR from 'swr';
 
+import { isDevFeaturesEnabled } from '@/consts/env';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import DynamicT from '@/ds-components/DynamicT';
 import ModalLayout from '@/ds-components/ModalLayout';
@@ -54,7 +55,12 @@ function CreateConnectorForm({ onClose, isOpen: isFormOpen, type }: Props) {
     }
 
     const allGroups = getConnectorGroups<ConnectorFactoryResponse>(
-      factories.filter(({ type: factoryType, isDemo }) => factoryType === type && !isDemo)
+      factories
+        .filter(({ type: factoryType, isDemo }) => factoryType === type && !isDemo)
+        // TODO: should remove the `isDevFeaturesEnabled` when Enterprise SSO is ready.
+        // Hide the entrance of adding SAML social connectors, users should go to Enterprise SSO if they want to use SAML.
+        // Should not remove the SAML factory from GET /connector-factories API, since that could break the existing SAML connectors.
+        .filter(({ id }) => isDevFeaturesEnabled || id !== 'saml')
     );
 
     return allGroups


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
hide the entrance of creating SAML social connector
Should not block the use or check guide of existing SAML social connectors.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
1. The entrance of creating the SAML social connector is removed.
<img width="1255" alt="image" src="https://github.com/logto-io/logto/assets/15182327/3a2aad01-7280-4a5d-a8e3-4617eef5e3ce">
2. Can enter the existing SAML connector's details page and check the guide.
<img width="1459" alt="image" src="https://github.com/logto-io/logto/assets/15182327/80835651-5a76-40ff-a2d1-1f64d7eaf189">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
