### PR TITLE
feat(experience): enable SSO auto watch to the sign-in and register form

### DIFF
--- a/packages/experience/src/Providers/SingleSignOnFormModeContextProvider/SingleSignOnFormModeContext.tsx
+++ b/packages/experience/src/Providers/SingleSignOnFormModeContextProvider/SingleSignOnFormModeContext.tsx
@@ -1,0 +1,18 @@
+import { noop } from '@silverhand/essentials';
+import { createContext } from 'react';
+
+export type SingleSignOnFormModeContextType = {
+  showSingleSignOnForm: boolean;
+  setShowSingleSignOnForm: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+/**
+ * This context is used to share the single sign on identifier status cross the page and form components.
+ * If the user has entered an identifier that is associated with a single sign on method, we will show the single sign on form.
+ */
+const SingleSignOnFormModeContext = createContext<SingleSignOnFormModeContextType>({
+  showSingleSignOnForm: false,
+  setShowSingleSignOnForm: noop,
+});
+
+export default SingleSignOnFormModeContext;

--- a/packages/experience/src/Providers/SingleSignOnFormModeContextProvider/index.tsx
+++ b/packages/experience/src/Providers/SingleSignOnFormModeContextProvider/index.tsx
@@ -1,0 +1,23 @@
+import { useState, useMemo, type ReactNode } from 'react';
+
+import SingleSignOnFormModeContext from './SingleSignOnFormModeContext';
+
+const SingleSignOnFormModeContextProvider = ({ children }: { children: ReactNode }) => {
+  const [showSingleSignOnForm, setShowSingleSignOnForm] = useState<boolean>(false);
+
+  const contextValue = useMemo(
+    () => ({
+      showSingleSignOnForm,
+      setShowSingleSignOnForm,
+    }),
+    [showSingleSignOnForm]
+  );
+
+  return (
+    <SingleSignOnFormModeContext.Provider value={contextValue}>
+      {children}
+    </SingleSignOnFormModeContext.Provider>
+  );
+};
+
+export default SingleSignOnFormModeContextProvider;

--- a/packages/experience/src/components/InputFields/SmartInputField/index.tsx
+++ b/packages/experience/src/components/InputFields/SmartInputField/index.tsx
@@ -66,8 +66,8 @@ const SmartInputField = (
 
   return (
     <AnimatedInputField
-      {...rest}
       {...getInputHtmlProps(enabledTypes, identifierType)}
+      {...rest}
       ref={innerRef}
       isSuffixFocusVisible={Boolean(inputValue)}
       style={{ zIndex: 1, paddingLeft }} // Give <input /> z-index to override country selector

--- a/packages/experience/src/containers/TermsAndPrivacy/index.module.scss
+++ b/packages/experience/src/containers/TermsAndPrivacy/index.module.scss
@@ -13,10 +13,6 @@
   cursor: pointer;
 }
 
-.hidden {
-  display: none;
-}
-
 .content {
   @include _.text-hint;
   font: var(--font-body-3);

--- a/packages/experience/src/containers/TermsAndPrivacy/index.module.scss
+++ b/packages/experience/src/containers/TermsAndPrivacy/index.module.scss
@@ -13,6 +13,10 @@
   cursor: pointer;
 }
 
+.hidden {
+  display: none;
+}
+
 .content {
   @include _.text-hint;
   font: var(--font-body-3);

--- a/packages/experience/src/hooks/use-sie.ts
+++ b/packages/experience/src/hooks/use-sie.ts
@@ -5,6 +5,7 @@ import { useContext, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import PageContext from '@/Providers/PageContextProvider/PageContext';
+import { isDevFeaturesEnabled } from '@/constants/env';
 import { type VerificationCodeIdentifier } from '@/types';
 
 export const useSieMethods = () => {
@@ -24,7 +25,8 @@ export const useSieMethods = () => {
     signInMode: experienceSettings?.signInMode,
     forgotPassword: experienceSettings?.forgotPassword,
     customContent: experienceSettings?.customContent,
-    singleSignOnEnabled: experienceSettings?.singleSignOnEnabled,
+    // TODO: remove the dev feature check once SSO is ready
+    singleSignOnEnabled: isDevFeaturesEnabled && experienceSettings?.singleSignOnEnabled,
   };
 };
 

--- a/packages/experience/src/pages/Register/IdentifierRegisterForm/index.module.scss
+++ b/packages/experience/src/pages/Register/IdentifierRegisterForm/index.module.scss
@@ -9,12 +9,21 @@
 
   .inputField,
   .terms,
-  .formErrors {
+  .formErrors,
+  .message {
     margin-bottom: _.unit(4);
+  }
+
+  .message {
+    @include _.text-hint;
   }
 
   .formErrors {
     margin-left: _.unit(0.5);
     margin-top: _.unit(-3);
+  }
+
+  .hidden {
+    display: none;
   }
 }

--- a/packages/experience/src/pages/Register/index.test.tsx
+++ b/packages/experience/src/pages/Register/index.test.tsx
@@ -83,7 +83,7 @@ describe('<Register />', () => {
     expect(queryByText('action.single_sign_on')).not.toBeNull();
   });
 
-  test('should  render single sign on link with single sign on enabled but empty list', () => {
+  test('should render single sign on link with single sign on enabled but empty list', () => {
     const { queryByText } = renderRegisterPage({
       ssoConnectors: [],
       singleSignOnEnabled: true,

--- a/packages/experience/src/pages/Register/index.tsx
+++ b/packages/experience/src/pages/Register/index.tsx
@@ -1,11 +1,13 @@
 import { SignInMode } from '@logto/schemas';
+import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Navigate } from 'react-router-dom';
 
 import LandingPageLayout from '@/Layout/LandingPageLayout';
+import SingleSignOnFormModeContextProvider from '@/Providers/SingleSignOnFormModeContextProvider';
+import SingleSignOnFormModeContext from '@/Providers/SingleSignOnFormModeContextProvider/SingleSignOnFormModeContext';
 import Divider from '@/components/Divider';
 import TextLink from '@/components/TextLink';
-import { isDevFeaturesEnabled } from '@/constants/env';
 import SocialSignInList from '@/containers/SocialSignInList';
 import TermsAndPrivacy from '@/containers/TermsAndPrivacy';
 import { useSieMethods } from '@/hooks/use-sie';
@@ -15,33 +17,24 @@ import ErrorPage from '../ErrorPage';
 import IdentifierRegisterForm from './IdentifierRegisterForm';
 import * as styles from './index.module.scss';
 
-const Register = () => {
+const RegisterFooter = () => {
   const { signUpMethods, socialConnectors, signInMode, signInMethods, singleSignOnEnabled } =
     useSieMethods();
+
   const { t } = useTranslation();
 
-  if (!signInMode) {
-    return <ErrorPage />;
-  }
+  const { showSingleSignOnForm } = useContext(SingleSignOnFormModeContext);
 
-  if (signInMode === SignInMode.SignIn) {
-    return <Navigate to="/sign-in" />;
+  /* Hide footers when showing Single Sign On form */
+  if (showSingleSignOnForm) {
+    return null;
   }
 
   return (
-    <LandingPageLayout title="description.create_your_account">
-      {signUpMethods.length > 0 && (
-        <IdentifierRegisterForm signUpMethods={signUpMethods} className={styles.main} />
-      )}
-      {signUpMethods.length === 0 && socialConnectors.length > 0 && (
-        <>
-          <TermsAndPrivacy className={styles.terms} />
-          <SocialSignInList className={styles.main} socialConnectors={socialConnectors} />
-        </>
-      )}
+    <>
       {
-        // Single Sign On footer TODO: remove the dev feature check once SSO is ready
-        isDevFeaturesEnabled && singleSignOnEnabled && (
+        // Single Sign On footer
+        singleSignOnEnabled && (
           <div className={styles.singleSignOn}>
             {t('description.use')}{' '}
             <TextLink to="/single-sign-on/email" text="action.single_sign_on" />
@@ -65,6 +58,37 @@ const Register = () => {
           </>
         )
       }
+    </>
+  );
+};
+
+const Register = () => {
+  const { signUpMethods, socialConnectors, signInMode } = useSieMethods();
+
+  if (!signInMode) {
+    return <ErrorPage />;
+  }
+
+  if (signInMode === SignInMode.SignIn) {
+    return <Navigate to="/sign-in" />;
+  }
+
+  return (
+    <LandingPageLayout title="description.create_your_account">
+      <SingleSignOnFormModeContextProvider>
+        {signUpMethods.length > 0 && (
+          <IdentifierRegisterForm signUpMethods={signUpMethods} className={styles.main} />
+        )}
+        {signUpMethods.length === 0 && socialConnectors.length > 0 && (
+          <>
+            <TermsAndPrivacy className={styles.terms} />
+            <SocialSignInList className={styles.main} socialConnectors={socialConnectors} />
+          </>
+        )}
+        <RegisterFooter />
+      </SingleSignOnFormModeContextProvider>
+
+      {/* Hide footer elements when showing Single Sign On form */}
     </LandingPageLayout>
   );
 };

--- a/packages/experience/src/pages/SignIn/IdentifierSignInForm/index.module.scss
+++ b/packages/experience/src/pages/SignIn/IdentifierSignInForm/index.module.scss
@@ -8,8 +8,13 @@
   }
 
   .inputField,
-  .formErrors {
+  .formErrors,
+  .message {
     margin-bottom: _.unit(4);
+  }
+
+  .message {
+    @include _.text-hint;
   }
 
   .formErrors {

--- a/packages/experience/src/pages/SignIn/PasswordSignInForm/index.test.tsx
+++ b/packages/experience/src/pages/SignIn/PasswordSignInForm/index.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, waitFor } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 
 import SingleSignOnContextProvider from '@/Providers/SingleSignOnContextProvider';
+import SingleSignOnFormModeContextProvider from '@/Providers/SingleSignOnFormModeContextProvider';
 import renderWithPageContext from '@/__mocks__/RenderWithPageContext';
 import SettingsProvider from '@/__mocks__/RenderWithPageContext/SettingsProvider';
 import { mockSignInExperienceSettings, mockSsoConnectors } from '@/__mocks__/logto';
@@ -51,7 +52,9 @@ describe('UsernamePasswordSignInForm', () => {
     renderWithPageContext(
       <SettingsProvider settings={{ ...mockSignInExperienceSettings, ...settings }}>
         <SingleSignOnContextProvider>
-          <PasswordSignInForm signInMethods={signInMethods} />
+          <SingleSignOnFormModeContextProvider>
+            <PasswordSignInForm signInMethods={signInMethods} />
+          </SingleSignOnFormModeContextProvider>
         </SingleSignOnContextProvider>
       </SettingsProvider>
     );

--- a/packages/experience/src/pages/SignIn/PasswordSignInForm/index.tsx
+++ b/packages/experience/src/pages/SignIn/PasswordSignInForm/index.tsx
@@ -12,10 +12,10 @@ import type { IdentifierInputValue } from '@/components/InputFields/SmartInputFi
 import ForgotPasswordLink from '@/containers/ForgotPasswordLink';
 import usePasswordSignIn from '@/hooks/use-password-sign-in';
 import { useForgotPasswordSettings } from '@/hooks/use-sie';
+import useSingleSignOnWatch from '@/hooks/use-single-sign-on-watch';
 import { getGeneralIdentifierErrorMessage, validateIdentifierField } from '@/utils/form';
 
 import * as styles from './index.module.scss';
-import useSingleSignOnWatch from './use-single-sign-on-watch';
 
 type Props = {
   className?: string;
@@ -49,7 +49,9 @@ const PasswordSignInForm = ({ className, autoFocus, signInMethods }: Props) => {
     },
   });
 
-  const { showSingleSignOn, navigateToSingleSignOn } = useSingleSignOnWatch(control);
+  const { showSingleSignOnForm, navigateToSingleSignOn } = useSingleSignOnWatch(
+    watch('identifier')
+  );
 
   const onSubmitHandler = useCallback(
     async (event?: React.FormEvent<HTMLFormElement>) => {
@@ -60,7 +62,7 @@ const PasswordSignInForm = ({ className, autoFocus, signInMethods }: Props) => {
           return;
         }
 
-        if (showSingleSignOn) {
+        if (showSingleSignOnForm) {
           await navigateToSingleSignOn();
           return;
         }
@@ -71,7 +73,7 @@ const PasswordSignInForm = ({ className, autoFocus, signInMethods }: Props) => {
         });
       })(event);
     },
-    [clearErrorMessage, handleSubmit, navigateToSingleSignOn, onSubmit, showSingleSignOn]
+    [clearErrorMessage, handleSubmit, navigateToSingleSignOn, onSubmit, showSingleSignOnForm]
   );
 
   useEffect(() => {
@@ -107,11 +109,11 @@ const PasswordSignInForm = ({ className, autoFocus, signInMethods }: Props) => {
           />
         )}
       />
-      {showSingleSignOn && (
+      {showSingleSignOnForm && (
         <div className={styles.message}>{t('description.single_sign_on_enabled')}</div>
       )}
 
-      {!showSingleSignOn && (
+      {!showSingleSignOnForm && (
         <PasswordInputField
           className={styles.inputField}
           autoComplete="current-password"
@@ -124,7 +126,7 @@ const PasswordSignInForm = ({ className, autoFocus, signInMethods }: Props) => {
 
       {errorMessage && <ErrorMessage className={styles.formErrors}>{errorMessage}</ErrorMessage>}
 
-      {isForgotPasswordEnabled && !showSingleSignOn && (
+      {isForgotPasswordEnabled && !showSingleSignOnForm && (
         <ForgotPasswordLink
           className={styles.link}
           identifier={watch('identifier').type}
@@ -134,8 +136,8 @@ const PasswordSignInForm = ({ className, autoFocus, signInMethods }: Props) => {
 
       <Button
         name="submit"
-        title={showSingleSignOn ? 'action.single_sign_on' : 'action.sign_in'}
-        icon={showSingleSignOn ? <LockIcon /> : undefined}
+        title={showSingleSignOnForm ? 'action.single_sign_on' : 'action.sign_in'}
+        icon={showSingleSignOnForm ? <LockIcon /> : undefined}
         htmlType="submit"
       />
 

--- a/packages/experience/src/pages/SignIn/index.tsx
+++ b/packages/experience/src/pages/SignIn/index.tsx
@@ -1,11 +1,13 @@
 import { SignInMode } from '@logto/schemas';
+import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Navigate } from 'react-router-dom';
 
 import LandingPageLayout from '@/Layout/LandingPageLayout';
+import SingleSignOnFormModeContextProvider from '@/Providers/SingleSignOnFormModeContextProvider';
+import SingleSignOnFormModeContext from '@/Providers/SingleSignOnFormModeContextProvider/SingleSignOnFormModeContext';
 import Divider from '@/components/Divider';
 import TextLink from '@/components/TextLink';
-import { isDevFeaturesEnabled } from '@/constants/env';
 import SocialSignInList from '@/containers/SocialSignInList';
 import TermsAndPrivacyLinks from '@/containers/TermsAndPrivacyLinks';
 import { useSieMethods } from '@/hooks/use-sie';
@@ -15,25 +17,24 @@ import ErrorPage from '../ErrorPage';
 import Main from './Main';
 import * as styles from './index.module.scss';
 
-const SignIn = () => {
-  const { signInMethods, signUpMethods, socialConnectors, signInMode, singleSignOnEnabled } =
-    useSieMethods();
+const SignInFooters = () => {
   const { t } = useTranslation();
 
-  if (!signInMode) {
-    return <ErrorPage />;
-  }
+  const { signInMethods, signUpMethods, socialConnectors, signInMode, singleSignOnEnabled } =
+    useSieMethods();
 
-  if (signInMode === SignInMode.Register) {
-    return <Navigate to="/register" />;
+  const { showSingleSignOnForm } = useContext(SingleSignOnFormModeContext);
+
+  /* Hide footers when showing Single Sign On form */
+  if (showSingleSignOnForm) {
+    return null;
   }
 
   return (
-    <LandingPageLayout title="description.sign_in_to_your_account">
-      <Main signInMethods={signInMethods} socialConnectors={socialConnectors} />
+    <>
       {
-        // Single Sign On footer TODO: remove the dev feature check once SSO is ready
-        isDevFeaturesEnabled && singleSignOnEnabled && (
+        // Single Sign On footer
+        singleSignOnEnabled && (
           <div className={styles.singleSignOn}>
             {t('description.use')}{' '}
             <TextLink to="/single-sign-on/email" text="action.single_sign_on" />
@@ -58,6 +59,28 @@ const SignIn = () => {
           </>
         )
       }
+    </>
+  );
+};
+
+const SignIn = () => {
+  const { signInMethods, socialConnectors, signInMode } = useSieMethods();
+
+  if (!signInMode) {
+    return <ErrorPage />;
+  }
+
+  if (signInMode === SignInMode.Register) {
+    return <Navigate to="/register" />;
+  }
+
+  return (
+    <LandingPageLayout title="description.sign_in_to_your_account">
+      <SingleSignOnFormModeContextProvider>
+        <Main signInMethods={signInMethods} socialConnectors={socialConnectors} />
+        <SignInFooters />
+      </SingleSignOnFormModeContextProvider>
+
       <TermsAndPrivacyLinks className={styles.terms} />
     </LandingPageLayout>
   );


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Enable SSO auto watch to the sign-in and register form.

Previously we have SSO auto detect feature enabled for the password sign-in form only. If a input email is detected as SSO enabled, auto switch the form to SSO mode. 

Base on latest design, apply this flow to all the sign-in and register forms.


https://github.com/logto-io/logto/assets/36393111/00af7326-62b8-435a-b2f8-e0b2f9d08831


Major updates:

- introduce a page level `SingleSignOnFormModeContextProvider`. This is used to share the single sign on form visibility between the child form component with its parent component. If the form is switch to SSO mode, should hide all related footer elements. 
- Move the `useSingleSignOnWatch` to the shared `hooks` directory, and apply it to the `sign-in-identifier` form and `register-identifier` form.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
