### PR TITLE
chore(core): remove redundant types in openapi json

### DIFF
--- a/packages/core/src/routes/authn.openapi.json
+++ b/packages/core/src/routes/authn.openapi.json
@@ -31,14 +31,11 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
                 "properties": {
                   "SAMLResponse": {
-                    "type": "string",
                     "description": "The SAML assertion response from the identity provider (IdP)."
                   },
                   "RelayState": {
-                    "type": "string",
                     "description": "SAML standard parameter that will be transmitted between the identity provider and the service provider. It will be used as the session ID (jti) of the user's Logto authentication session. This API will use this session ID to retrieve the SSO connector authentication session from the database."
                   }
                 }

--- a/packages/core/src/routes/hooks.openapi.json
+++ b/packages/core/src/routes/hooks.openapi.json
@@ -32,15 +32,10 @@
               "schema": {
                 "properties": {
                   "name": {
-                    "type": "string",
                     "description": "The name of the hook."
                   },
                   "events": {
-                    "type": "array",
-                    "description": "An array of hook events.",
-                    "items": {
-                      "type": "string"
-                    }
+                    "description": "An array of hook events."
                   }
                 }
               }
@@ -80,15 +75,10 @@
               "schema": {
                 "properties": {
                   "name": {
-                    "type": "string",
                     "description": "The updated name of the hook."
                   },
                   "events": {
-                    "type": "array",
-                    "description": "An array of updated hook events.",
-                    "items": {
-                      "type": "string"
-                    }
+                    "description": "An array of updated hook events."
                   }
                 }
               }
@@ -139,11 +129,7 @@
               "schema": {
                 "properties": {
                   "events": {
-                    "type": "array",
-                    "description": "An array of hook events for testing.",
-                    "items": {
-                      "type": "string"
-                    }
+                    "description": "An array of hook events for testing."
                   },
                   "config": {
                     "description": "The hook configuration for testing."


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
we have auto-generated ones

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
didn't blow up. the api still responds types (if defined in the route)

<img width="196" alt="image" src="https://github.com/logto-io/logto/assets/14722250/a80f76a6-41b1-419c-b4c7-8649b86ade07">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
