### PR TITLE
refactor(core): validate supplement openapi document

### DIFF
--- a/packages/core/src/routes/connector/authorization-uri.openapi.json
+++ b/packages/core/src/routes/connector/authorization-uri.openapi.json
@@ -1,6 +1,6 @@
 {
   "paths": {
-    "/api/connectors/{id}/authorization-uri": {
+    "/api/connectors/{connectorId}/authorization-uri": {
       "post": {
         "summary": "Get connector's authorization URI",
         "description": "Get authorization URI for specified connector by providing redirect URI and randomly generated state.",

--- a/packages/core/src/routes/connector/config-testing.openapi.json
+++ b/packages/core/src/routes/connector/config-testing.openapi.json
@@ -1,6 +1,6 @@
 {
   "paths": {
-    "/api/connectors/:factoryId/test": {
+    "/api/connectors/{factoryId}/test": {
       "post": {
         "summary": "Test passwordless connector",
         "description": "Test a passwordless (email or SMS) connector by sending a test message to the given phone number or email address.",

--- a/packages/core/src/routes/log.openapi.json
+++ b/packages/core/src/routes/log.openapi.json
@@ -1,8 +1,8 @@
 {
   "tags": [
     {
-      "name": "Logs",
-      "description": "Logs (audit logs) are used to track end-user activities in Logto sign-in experience and other flows. It does not include activities in Logto Console."
+      "name": "Audit logs",
+      "description": "Audit logs are used to track end-user activities in Logto sign-in experience and other flows. It does not include activities in Logto Console."
     }
   ],
   "paths": {

--- a/packages/core/src/routes/sign-in-experience/index.openapi.json
+++ b/packages/core/src/routes/sign-in-experience/index.openapi.json
@@ -1,7 +1,7 @@
 {
   "tags": [
     {
-      "name": "Sign in exp",
+      "name": "Sign-in experience",
       "description": "Set the Sign-in experience configuration to customize your sign-in experience."
     }
   ],
@@ -24,10 +24,10 @@
                       "description": "The language detection policy for the sign-in page."
                     },
                     "signIn": {
-                      "description": "Sign-in method settings"
+                      "description": "Sign-in method settings."
                     },
                     "signUp": {
-                      "description": "Sign-up method settings",
+                      "description": "Sign-up method settings.",
                       "properties": {
                         "identifiers": {
                           "description": "Allowed identifiers when signing-up."

--- a/packages/core/src/routes/sso-connector/index.openapi.json
+++ b/packages/core/src/routes/sso-connector/index.openapi.json
@@ -1,13 +1,16 @@
 {
   "tags": [
     {
-      "name": "Sso connectors",
-      "description": "APIs for managing single sign-on (SSO) connectors. Your sign-in experience can use these well-configured SSO connectors to authenticate users and sync user attributes from external identity providers (IdPs).\n\nSSO connectors are created by SSO connector factories."
+      "name": "SSO connectors",
+      "description": "Endpoints for managing single sign-on (SSO) connectors. Your sign-in experience can use these well-configured SSO connectors to authenticate users and sync user attributes from external identity providers (IdPs).\n\nSSO connectors are created by SSO connector factories."
+    },
+    {
+      "name": "SSO connector factories",
+      "description": "Endpoints for SSO (single sign-on) connector factories.\n\nSSO connector factories provide the metadata and configuration templates for creating SSO connectors."
     }
   ],
   "paths": {
     "/api/sso-connector-factories": {
-      "summary": "APIs for SSO (single sign-on) connector factories",
       "description": "SSO connector factories are used to create Enterprise SSO connectors. The created connectors are used to connect to external SSO providers.",
       "get": {
         "summary": "Get SSO connector factories",

--- a/packages/core/src/routes/swagger/index.ts
+++ b/packages/core/src/routes/swagger/index.ts
@@ -19,7 +19,12 @@ import { translationSchemas, zodTypeToSwagger } from '#src/utils/zod.js';
 
 import type { AnonymousRouter } from '../types.js';
 
-import { buildTag, findSupplementFiles, normalizePath } from './utils/general.js';
+import {
+  buildTag,
+  findSupplementFiles,
+  normalizePath,
+  validateSupplement,
+} from './utils/general.js';
 import {
   buildParameters,
   paginationParameters,
@@ -213,6 +218,10 @@ export default function swaggerRoutes<T extends AnonymousRouter, R extends Route
       },
       tags: [...tags].map((tag) => ({ name: tag })),
     };
+
+    for (const document of supplementDocuments) {
+      validateSupplement(baseDocument, document);
+    }
 
     const data = supplementDocuments.reduce(
       (document, supplement) => deepmerge(document, supplement, { arrayMerge: mergeParameters }),

--- a/packages/core/src/routes/well-known.openapi.json
+++ b/packages/core/src/routes/well-known.openapi.json
@@ -1,22 +1,11 @@
 {
   "tags": [
     {
-      "name": "Well-Known",
+      "name": "Well-known",
       "description": "Well-Known routes provide information and resources that can be discovered by clients without the need for authentication."
     }
   ],
   "paths": {
-    "/api/.well-known/endpoints/{tenantId}": {
-      "get": {
-        "summary": "Get tenant endpoint",
-        "description": "Get the endpoint for the specified tenant.",
-        "responses": {
-          "200": {
-            "description": "The tenant endpoint."
-          }
-        }
-      }
-    },
     "/api/.well-known/sign-in-exp": {
       "get": {
         "summary": "Get full sign-in experience",


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- prettify tag names
- forbid extra paths and tags in openapi supplement documents

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
tested various cases

<img width="695" alt="image" src="https://github.com/logto-io/logto/assets/14722250/fe6f8b23-cb0c-4a71-800d-c097dab4e49d">

<img width="685" alt="image" src="https://github.com/logto-io/logto/assets/14722250/dbd05699-1c70-4301-84ab-92c154294c0d">

<img width="634" alt="image" src="https://github.com/logto-io/logto/assets/14722250/4bd71020-0f3b-41d0-a698-0b526b3d3e11">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
