### PR TITLE
chore(core): mark `event` and `retries` as deprecated for hooks api doc

### DIFF
--- a/packages/core/src/routes/hooks.openapi.json
+++ b/packages/core/src/routes/hooks.openapi.json
@@ -34,8 +34,20 @@
                   "name": {
                     "description": "The name of the hook."
                   },
+                  "event": {
+                    "deprecated": true,
+                    "description": "Use `events` instead."
+                  },
                   "events": {
                     "description": "An array of hook events."
+                  },
+                  "config": {
+                    "properties": {
+                      "retries": {
+                        "deprecated": true,
+                        "description": "Now the retry times is fixed to 3. Keep for backward compatibility."
+                      }
+                    }
                   }
                 }
               }
@@ -77,8 +89,20 @@
                   "name": {
                     "description": "The updated name of the hook."
                   },
+                  "event": {
+                    "deprecated": true,
+                    "description": "Use `events` instead."
+                  },
                   "events": {
                     "description": "An array of updated hook events."
+                  },
+                  "config": {
+                    "properties": {
+                      "retries": {
+                        "deprecated": true,
+                        "description": "Now the retry times is fixed to 3. Keep for backward compatibility."
+                      }
+                    }
                   }
                 }
               }
@@ -128,11 +152,21 @@
             "application/json": {
               "schema": {
                 "properties": {
+                  "event": {
+                    "deprecated": true,
+                    "description": "Use `events` instead."
+                  },
                   "events": {
                     "description": "An array of hook events for testing."
                   },
                   "config": {
-                    "description": "The hook configuration for testing."
+                    "description": "The hook configuration for testing.",
+                    "properties": {
+                      "retries": {
+                        "deprecated": true,
+                        "description": "Now the retry times is fixed to 3. Keep for backward compatibility."
+                      }
+                    }
                   }
                 }
               }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
chore(core): mark `event` and `retries` as deprecated for hooks api doc

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="769" alt="image" src="https://github.com/logto-io/logto/assets/10806653/3363d907-f078-4d4c-b980-be1214b3d738">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
