### PR TITLE
fix(experience): should not show error message on sign-in page

### DIFF
--- a/packages/experience/src/hooks/use-check-single-sign-on.ts
+++ b/packages/experience/src/hooks/use-check-single-sign-on.ts
@@ -46,7 +46,15 @@ const useCheckSingleSignOn = () => {
       const [error, result] = await request(email);
 
       if (error) {
-        await handleError(error);
+        // Show error message only if the user is trying to continue the single sign-on flow, otherwise, silently fail
+        if (continueSignIn) {
+          await handleError(error, {
+            'guard.invalid_input': () => {
+              setErrorMessage(t('error.invalid_email'));
+            },
+          });
+        }
+
         return;
       }
 


### PR DESCRIPTION
should not show error message on sign-in page

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Should not show the invalid query (invalid email) error message on the identifier form submit flow. Should handle silently.

Unexpected:
<img width="604" alt="image" src="https://github.com/logto-io/logto/assets/36393111/5c5f67ae-d38f-4b96-b928-2d343bf66d9a">


Show error message only on the SSO page:
<img width="548" alt="image" src="https://github.com/logto-io/logto/assets/36393111/9fdf0b53-0ce7-45ed-bc59-56a7f5d4fbdd">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [x] ~necessary TSDoc comments~
