### PR TITLE
chore(console,core): show invalid SSO config/metadata error message inline

### DIFF
--- a/packages/console/src/pages/EnterpriseSso/types.ts
+++ b/packages/console/src/pages/EnterpriseSso/types.ts
@@ -31,9 +31,12 @@ export type OidcGuideFormType = {
   scope?: string;
 };
 
-export type GuideFormType<T extends SsoProviderName> = T extends SsoProviderName.OIDC
+export type GuideFormType<T extends SsoProviderName> = T extends
+  | SsoProviderName.OIDC
+  | SsoProviderName.GOOGLE_WORKSPACE
+  | SsoProviderName.OKTA
   ? OidcGuideFormType
-  : T extends SsoProviderName.SAML
+  : T extends SsoProviderName.SAML | SsoProviderName.AZURE_AD
   ? SamlGuideFormType
   : never;
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,6 +55,7 @@
     "deepmerge": "^4.2.2",
     "dotenv": "^16.0.0",
     "etag": "^1.8.1",
+    "fast-xml-parser": "^4.2.5",
     "find-up": "^6.3.0",
     "got": "^13.0.0",
     "hash-wasm": "^4.9.0",

--- a/packages/core/src/sso/types/error.ts
+++ b/packages/core/src/sso/types/error.ts
@@ -11,6 +11,7 @@ export enum SsoConnectorErrorCodes {
 }
 
 export enum SsoConnectorConfigErrorCodes {
+  InvalidSamlXmlMetadata = 'invalid_saml_xml_metadata',
   InvalidConfigResponse = 'invalid_config_response',
   FailToFetchConfig = 'fail_to_fetch_config',
   InvalidConnectorConfig = 'invalid_connector_config',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3214,6 +3214,9 @@ importers:
       etag:
         specifier: ^1.8.1
         version: 1.8.1
+      fast-xml-parser:
+        specifier: ^4.2.5
+        version: 4.3.2
       find-up:
         specifier: ^6.3.0
         version: 6.3.0


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
show invalid SSO config/metadata error message inline.
1. for OIDC based SSO connectors, all invalid config error comes from invalid `issuer`, show error message inline to `issuer` input field.
2. for SAML based SSO connectors, previous XML validator swallows the error, should check explicit check the validity of XML metadata. Catch the invalid metadata error for SAML based SSO connectors and show inline. Only `metadata` or `metadataURL` fields can result in creating IdP instance with XML metadata.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
<img width="1265" alt="image" src="https://github.com/logto-io/logto/assets/15182327/5aa99901-3015-446d-9eef-6de1c881d868">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
