### PR TITLE
refactor(console): hide saml social connector entrance and fix SSO creation paywall

### DIFF
--- a/packages/console/src/components/CreateConnectorForm/index.tsx
+++ b/packages/console/src/components/CreateConnectorForm/index.tsx
@@ -54,7 +54,11 @@ function CreateConnectorForm({ onClose, isOpen: isFormOpen, type }: Props) {
     }
 
     const allGroups = getConnectorGroups<ConnectorFactoryResponse>(
-      factories.filter(({ type: factoryType, isDemo }) => factoryType === type && !isDemo)
+      factories
+        .filter(({ type: factoryType, isDemo }) => factoryType === type && !isDemo)
+        // Hide the entrance of adding SAML social connectors, users should go to Enterprise SSO if they want to use SAML.
+        // Should not remove the SAML factory from GET /connector-factories API, since that could break the existing SAML connectors.
+        .filter(({ id }) => id !== 'saml')
     );
 
     return allGroups

--- a/packages/console/src/pages/EnterpriseSso/index.tsx
+++ b/packages/console/src/pages/EnterpriseSso/index.tsx
@@ -72,9 +72,10 @@ function EnterpriseSsoConnectors() {
       pageMeta={{ titleKey: 'enterprise_sso.page_title' }}
       createButton={conditional(
         ssoConnectors?.length && {
-          title: isSsoEnabled ? 'enterprise_sso.create' : 'upsell.upgrade_plan',
-          onClick: handleButtonClick,
-          icon: conditional(isSsoEnabled && <Plus />),
+          title: 'enterprise_sso.create',
+          onClick: () => {
+            navigate(createEnterpriseSsoPathname);
+          },
         }
       )}
       table={{

--- a/packages/integration-tests/src/tests/console/connectors/social-connector-test-cases.ts
+++ b/packages/integration-tests/src/tests/console/connectors/social-connector-test-cases.ts
@@ -87,35 +87,36 @@ const wechatWeb: SocialConnectorCase = {
   },
 };
 
-const saml: SocialConnectorCase = {
-  factoryId: 'saml',
-  name: 'SAML',
+const oidc: SocialConnectorCase = {
+  factoryId: 'oidc',
+  name: 'OIDC',
   initialFormData: {
-    'formConfig.entityID': 'entity-id',
-    'formConfig.signInEndpoint': 'sign-in-endpoint',
-    'formConfig.x509Certificate': 'x509-certificate',
-    'formConfig.idpMetadataXml': 'idp-metadata-xml',
-    'formConfig.assertionConsumerServiceUrl': 'assertion-consumer-service-url',
+    'formConfig.authorizationEndpoint': 'authorization-endpoint',
+    'formConfig.tokenEndpoint': 'token-endpoint',
+    'formConfig.clientId': 'client-id',
+    'formConfig.clientSecret': 'client-secret',
+    'formConfig.scope': 'scope1 scope2',
   },
   updateFormData: {
-    'formConfig.entityID': 'new-entity-id',
-    'formConfig.signInEndpoint': 'new-sign-in-endpoint',
-    'formConfig.x509Certificate': 'new-x509-certificate',
-    'formConfig.idpMetadataXml': 'new-idp-metadata-xml',
-    'formConfig.assertionConsumerServiceUrl': 'new-assertion-consumer-service-url',
+    'formConfig.authorizationEndpoint': 'new-authorization-endpoint',
+    'formConfig.tokenEndpoint': 'new-token-endpoint',
+    'formConfig.clientId': 'new-client-id',
+    'formConfig.clientSecret': 'new-client-secret',
+    'formConfig.scope': 'scope1 scope2 scope3',
   },
   errorFormData: {
-    'formConfig.entityID': '',
-    'formConfig.signInEndpoint': '',
-    'formConfig.x509Certificate': '',
-    'formConfig.idpMetadataXml': '',
-    'formConfig.assertionConsumerServiceUrl': '',
+    'formConfig.authorizationEndpoint': '',
+    'formConfig.tokenEndpoint': '',
+    'formConfig.clientId': '',
+    'formConfig.clientSecret': '',
+    'formConfig.scope': '',
   },
   standardBasicFormData: {
-    name: 'SAML',
-    target: 'saml',
+    name: 'OIDC',
+    target: 'oidc-test',
   },
 };
+
 export const socialConnectorTestCases = [
   // Universal
   google,
@@ -126,5 +127,5 @@ export const socialConnectorTestCases = [
   // Group - Web
   wechatWeb,
   // Standard
-  saml,
+  oidc,
 ];


### PR DESCRIPTION


<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
1. Hide SAML Social creation entrance (the filter has been accidentally deleted).
2. Fix SSO connector paywall, when there is existing SSO connectors, the paywall should locate at the footer of creation modal.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
<img width="2145" alt="image" src="https://github.com/logto-io/logto/assets/15182327/d5881276-514f-4612-88bf-c815f917827e">
<img width="1988" alt="image" src="https://github.com/logto-io/logto/assets/15182327/45faf68d-21d9-4f4e-a504-d28e9629e6f4">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
