### PR TITLE
fix(core): fix SSO quota guard

### DIFF
--- a/packages/core/src/routes/sso-connector/index.ts
+++ b/packages/core/src/routes/sso-connector/index.ts
@@ -40,8 +40,6 @@ export default function singleSignOnRoutes<T extends AuthedRouter>(...args: Rout
     },
   ] = args;
 
-  router.use(koaQuotaGuard({ key: 'ssoEnabled', quota, methods: ['POST', 'PUT'] }));
-
   const pathname = `/${tableToPathname(SsoConnectors.table)}`;
 
   /*
@@ -68,6 +66,7 @@ export default function singleSignOnRoutes<T extends AuthedRouter>(...args: Rout
   /* Create a new single sign on connector */
   router.post(
     pathname,
+    koaQuotaGuard({ key: 'ssoEnabled', quota }),
     koaGuard({
       body: ssoConnectorCreateGuard,
       response: SsoConnectors.guard,


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix SSO quota guard.
The guard should directly apply to the route instead of using router.use() (this could affect all APIs.)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
Does not block other POST/PUT APIs.
<img width="1707" alt="image" src="https://github.com/logto-io/logto/assets/15182327/384f53bb-a493-44f9-8d78-0ebd76feae79">
Also `POST /sso-connectors` API is guarded:
<img width="1120" alt="image" src="https://github.com/logto-io/logto/assets/15182327/741d01f8-090f-410a-97bc-8c1b800ae8cb">
`GET /sso-connectors` API works fine:
<img width="1129" alt="image" src="https://github.com/logto-io/logto/assets/15182327/7c5511c9-1e21-4e0c-ac9c-a3d5ca3b58e1">

TODO:
Add quota guard tests for APIs.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
