### PR TITLE
fix: should hide upsell tag for standard connectors in OSS version

### DIFF
--- a/.changeset/tame-crabs-breathe.md
+++ b/.changeset/tame-crabs-breathe.md
@@ -1,0 +1,5 @@
+---
+"@logto/console": patch
+---
+
+Remove the upsell tag on social connectors creation modal in OSS version.

--- a/packages/console/src/components/CreateConnectorForm/index.tsx
+++ b/packages/console/src/components/CreateConnectorForm/index.tsx
@@ -8,6 +8,7 @@ import { useContext, useMemo, useState } from 'react';
 import Modal from 'react-modal';
 import useSWR from 'swr';
 
+import { isCloud } from '@/consts/env';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import DynamicT from '@/ds-components/DynamicT';
 import ModalLayout from '@/ds-components/ModalLayout';
@@ -46,6 +47,7 @@ function CreateConnectorForm({ onClose, isOpen: isFormOpen, type }: Props) {
   const isCreatingSocialConnector = type === ConnectorType.Social;
   const { currentTenantId } = useContext(TenantsContext);
   const { data: currentPlan } = useSubscriptionPlan(currentTenantId);
+
   const isStandardConnectorDisabled = !currentPlan?.quota.standardConnectorsLimit;
 
   const groups = useMemo(() => {
@@ -160,11 +162,13 @@ function CreateConnectorForm({ onClose, isOpen: isFormOpen, type }: Props) {
           <>
             <div className={styles.standardLabel}>
               <DynamicT forKey="connectors.standard_connectors" />
-              <FeatureTag
-                isVisible={isStandardConnectorDisabled}
-                for="upsell"
-                plan={ReservedPlanId.Hobby}
-              />
+              {isCloud && (
+                <FeatureTag
+                  isVisible={isStandardConnectorDisabled}
+                  for="upsell"
+                  plan={ReservedPlanId.Hobby}
+                />
+              )}
             </div>
             <ConnectorRadioGroup
               name="group"


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
should hide upsell tag for standard connectors in OSS version.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
1. Upsell tag not showing up in OSS version.
<img width="2134" alt="image" src="https://github.com/logto-io/logto/assets/15182327/a1a70be1-fa0a-4ec5-8f06-67e576cdca8f">
2. Upsell tag should be visible for the cloud version.
<img width="1823" alt="image" src="https://github.com/logto-io/logto/assets/15182327/38937b06-2d38-43c4-b234-bd4df73bea8a">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
