### PR TITLE
chore(core): rename SSO connectors management API routes

### DIFF
--- a/packages/core/src/routes/sso-connector/index.ts
+++ b/packages/core/src/routes/sso-connector/index.ts
@@ -27,7 +27,9 @@ import {
   validateConnectorConfigConnectionStatus,
 } from './utils.js';
 
-export default function singleSignOnRoutes<T extends AuthedRouter>(...args: RouterInitArgs<T>) {
+export default function singleSignOnConnectorsRoutes<T extends AuthedRouter>(
+  ...args: RouterInitArgs<T>
+) {
   const [
     router,
     {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
rename SSO connectors management API routes.
Both interaction-related SSO APIs and SSO connectors management APIs routes are both called `singleSignOnRoutes`, which can lead to confusion. Rename the SSO connector management API routes to be `singleSignOnConnectorsRoutes` to avoid repeated names. cc @xiaoyijun 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
