### PR TITLE
fix(console): user identities table should not always be loading when no data

### DIFF
--- a/packages/console/src/pages/UserDetails/UserSettings/components/UserSocialIdentities/index.tsx
+++ b/packages/console/src/pages/UserDetails/UserSettings/components/UserSocialIdentities/index.tsx
@@ -38,7 +38,9 @@ function UserSocialIdentities({ userId, identities, onDelete }: Props) {
     keyPrefix: 'admin_console',
   });
 
-  const { data, error, mutate } = useSWR<ConnectorResponse[], RequestError>('api/connectors');
+  const { data, error, isLoading, mutate } = useSWR<ConnectorResponse[], RequestError>(
+    'api/connectors'
+  );
 
   const [deletingConnector, setDeletingConnector] = useState<DisplayConnector>();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -50,8 +52,6 @@ function UserSocialIdentities({ userId, identities, onDelete }: Props) {
 
     return getConnectorGroups(data);
   }, [data]);
-
-  const isLoading = !connectorGroups && !error;
 
   const handleDelete = async (target: string) => {
     if (isSubmitting) {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix an infinite loading issue on user social identities table, when there's no data

<img width="1227" alt="image" src="https://github.com/logto-io/logto/assets/12833674/da1b055b-8048-486d-a093-ec366843d5e8">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested.

<img width="1212" alt="image" src="https://github.com/logto-io/logto/assets/12833674/56956046-b0cd-492a-91c5-c1a1f0127655">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
