### PR TITLE
fix(console): discard application settings changes when switching tabs

### DIFF
--- a/packages/console/src/components/UnsavedChangesAlertModal/index.tsx
+++ b/packages/console/src/components/UnsavedChangesAlertModal/index.tsx
@@ -7,9 +7,10 @@ import ConfirmModal from '@/ds-components/ConfirmModal';
 type Props = {
   hasUnsavedChanges: boolean;
   parentPath?: string;
+  onConfirm?: () => void;
 };
 
-function UnsavedChangesAlertModal({ hasUnsavedChanges, parentPath }: Props) {
+function UnsavedChangesAlertModal({ hasUnsavedChanges, parentPath, onConfirm }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { pathname } = useLocation();
   const blocker = useBlocker(hasUnsavedChanges);
@@ -36,7 +37,10 @@ function UnsavedChangesAlertModal({ hasUnsavedChanges, parentPath }: Props) {
       confirmButtonText="general.leave_page"
       cancelButtonText="general.stay_on_page"
       onCancel={blocker.reset}
-      onConfirm={blocker.proceed}
+      onConfirm={() => {
+        onConfirm?.();
+        blocker.proceed?.();
+      }}
     >
       {t('general.unsaved_changes_warning')}
     </ConfirmModal>

--- a/packages/console/src/pages/ApplicationDetails/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/index.tsx
@@ -259,7 +259,7 @@ function ApplicationDetails() {
           </FormProvider>
         </>
       )}
-      <UnsavedChangesAlertModal hasUnsavedChanges={!isDeleted && isDirty} />
+      <UnsavedChangesAlertModal hasUnsavedChanges={!isDeleted && isDirty} onConfirm={reset} />
     </DetailsPage>
   );
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix: discard applicaiton settings changes when switching tabs.

- Support add confirmation callback to the `UnsavedChangesAlert` modal
- Add reset data callback to the `UnsavedChangesAlert` on the application settings page


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
