### PR TITLE
feat(core,phrases): update applications api to support third-party app

### DIFF
--- a/packages/core/src/queries/application.test.ts
+++ b/packages/core/src/queries/application.test.ts
@@ -21,7 +21,6 @@ const pool = createMockPool({
 const { createApplicationQueries } = await import('./application.js');
 const {
   findTotalNumberOfApplications,
-  findAllApplications,
   findApplicationById,
   insertApplication,
   updateApplicationById,
@@ -45,29 +44,6 @@ describe('application query', () => {
     });
 
     await expect(findTotalNumberOfApplications()).resolves.toEqual({ count: 10 });
-  });
-
-  it('findAllApplications', async () => {
-    const limit = 10;
-    const offset = 1;
-    const rowData = { id: 'foo' };
-
-    const expectSql = sql`
-      select ${sql.join(Object.values(fields), sql`, `)}
-      from ${table}
-      order by "created_at" desc
-      limit $1
-      offset $2
-    `;
-
-    mockQuery.mockImplementationOnce(async (sql, values) => {
-      expectSqlAssert(sql, expectSql.sql);
-      expect(values).toEqual([limit, offset]);
-
-      return createMockQueryResult([rowData]);
-    });
-
-    await expect(findAllApplications(limit, offset)).resolves.toEqual([rowData]);
   });
 
   it('findApplicationById', async () => {

--- a/packages/core/src/routes/applications/types.ts
+++ b/packages/core/src/routes/applications/types.ts
@@ -6,10 +6,14 @@ import {
 import { EnvSet } from '#src/env-set/index.js';
 
 // FIXME:  @simeng-li Remove this guard once Logto as IdP is ready
-export const applicationResponseGuard = EnvSet.values.isDevFeaturesEnabled
+// @ts-expect-error -- hide the dev feature field from the guard type, but always return the full type to make the api logic simpler
+export const applicationResponseGuard: typeof Applications.guard = EnvSet.values
+  .isDevFeaturesEnabled
   ? Applications.guard
   : Applications.guard.omit({ isThirdParty: true });
 
-export const applicationCreateGuard = EnvSet.values.isDevFeaturesEnabled
+// @ts-expect-error -- hide the dev feature field from the guard type, but always return the full type to make the api logic simpler
+export const applicationCreateGuard: typeof originalApplicationCreateGuard = EnvSet.values
+  .isDevFeaturesEnabled
   ? originalApplicationCreateGuard
   : originalApplicationCreateGuard.omit({ isThirdParty: true });

--- a/packages/integration-tests/src/api/application.ts
+++ b/packages/integration-tests/src/api/application.ts
@@ -26,7 +26,8 @@ export const createApplication = async (
 
 export const getApplications = async (
   types?: ApplicationType[],
-  searchParameters?: Record<string, string>
+  searchParameters?: Record<string, string>,
+  isThirdParty?: boolean
 ) => {
   const searchParams = new URLSearchParams([
     ...(conditional(types && types.length > 0 && types.map((type) => ['types', type])) ?? []),
@@ -35,6 +36,7 @@ export const getApplications = async (
         Object.keys(searchParameters).length > 0 &&
         Object.entries(searchParameters).map(([key, value]) => [key, value])
     ) ?? []),
+    ...(conditional(isThirdParty && [['isThirdParty', 'true']]) ?? []),
   ]);
 
   return authedAdminApi.get('applications', { searchParams }).json<Application[]>();

--- a/packages/phrases/src/locales/de/errors/application.ts
+++ b/packages/phrases/src/locales/de/errors/application.ts
@@ -3,6 +3,9 @@ const application = {
   role_exists: 'Die Rolle mit der ID {{roleId}} wurde bereits dieser Anwendung hinzugefügt.',
   invalid_role_type:
     'Es ist nicht möglich, einer Maschinen-zu-Maschinen-Anwendung eine Benutzertyp-Rolle zuzuweisen.',
+  /** UNTRANSLATED */
+  invalid_third_party_application_type:
+    'Only traditional web applications can be marked as a third-party app.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/en/errors/application.ts
+++ b/packages/phrases/src/locales/en/errors/application.ts
@@ -2,6 +2,8 @@ const application = {
   invalid_type: 'Only machine to machine applications can have associated roles.',
   role_exists: 'The role id {{roleId}} is already been added to this application.',
   invalid_role_type: 'Can not assign user type role to machine to machine application.',
+  invalid_third_party_application_type:
+    'Only traditional web applications can be marked as a third-party app.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/es/errors/application.ts
+++ b/packages/phrases/src/locales/es/errors/application.ts
@@ -3,6 +3,9 @@ const application = {
   role_exists: 'La identificación del rol {{roleId}} ya se ha agregado a esta aplicación.',
   invalid_role_type:
     'No se puede asignar un rol de tipo usuario a una aplicación de máquina a máquina.',
+  /** UNTRANSLATED */
+  invalid_third_party_application_type:
+    'Only traditional web applications can be marked as a third-party app.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/fr/errors/application.ts
+++ b/packages/phrases/src/locales/fr/errors/application.ts
@@ -3,6 +3,9 @@ const application = {
   role_exists: "Le rôle d'identifiant {{roleId}} a déjà été ajouté à cette application.",
   invalid_role_type:
     "Impossible d'assigner un rôle de type utilisateur à une application machine à machine.",
+  /** UNTRANSLATED */
+  invalid_third_party_application_type:
+    'Only traditional web applications can be marked as a third-party app.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/it/errors/application.ts
+++ b/packages/phrases/src/locales/it/errors/application.ts
@@ -3,6 +3,9 @@ const application = {
   role_exists: "L'ID ruolo {{roleId}} è già stato aggiunto a questa applicazione.",
   invalid_role_type:
     "Impossibile assegnare un ruolo di tipo utente all'applicazione da macchina a macchina.",
+  /** UNTRANSLATED */
+  invalid_third_party_application_type:
+    'Only traditional web applications can be marked as a third-party app.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/ja/errors/application.ts
+++ b/packages/phrases/src/locales/ja/errors/application.ts
@@ -3,6 +3,9 @@ const application = {
   role_exists: 'ロールID {{roleId}} は、すでにこのアプリケーションに追加されています。',
   invalid_role_type:
     'ユーザータイプのロールをマシン間アプリケーションに割り当てることはできません。',
+  /** UNTRANSLATED */
+  invalid_third_party_application_type:
+    'Only traditional web applications can be marked as a third-party app.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/ko/errors/application.ts
+++ b/packages/phrases/src/locales/ko/errors/application.ts
@@ -2,6 +2,9 @@ const application = {
   invalid_type: '관련 역할을 가질 수 있는 것은 기계 대 기계 응용 프로그램만 가능합니다.',
   role_exists: '역할 ID {{roleId}} 가 이미이 응용 프로그램에 추가되었습니다.',
   invalid_role_type: '사용자 유형 역할을 기계 대 기계 응용 프로그램에 할당할 수 없습니다.',
+  /** UNTRANSLATED */
+  invalid_third_party_application_type:
+    'Only traditional web applications can be marked as a third-party app.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/pl-pl/errors/application.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/application.ts
@@ -2,6 +2,9 @@ const application = {
   invalid_type: 'Tylko aplikacje maszyna-do-maszyny mogą mieć przypisane role.',
   role_exists: 'Rola o identyfikatorze {{roleId}} została już dodana do tej aplikacji.',
   invalid_role_type: 'Nie można przypisać roli typu użytkownika do aplikacji maszyna-do-maszyny.',
+  /** UNTRANSLATED */
+  invalid_third_party_application_type:
+    'Only traditional web applications can be marked as a third-party app.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/pt-br/errors/application.ts
+++ b/packages/phrases/src/locales/pt-br/errors/application.ts
@@ -3,6 +3,9 @@ const application = {
   role_exists: 'O id da função {{roleId}} já foi adicionado a este aplicativo.',
   invalid_role_type:
     'Não é possível atribuir uma função de tipo de usuário a um aplicativo de máquina para máquina.',
+  /** UNTRANSLATED */
+  invalid_third_party_application_type:
+    'Only traditional web applications can be marked as a third-party app.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/pt-pt/errors/application.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/application.ts
@@ -3,6 +3,9 @@ const application = {
   role_exists: 'O id da função {{roleId}} já foi adicionado a esta aplicação.',
   invalid_role_type:
     'Não é possível atribuir uma função de tipo de utilizador a uma aplicação máquina a máquina.',
+  /** UNTRANSLATED */
+  invalid_third_party_application_type:
+    'Only traditional web applications can be marked as a third-party app.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/ru/errors/application.ts
+++ b/packages/phrases/src/locales/ru/errors/application.ts
@@ -3,6 +3,9 @@ const application = {
   role_exists: 'Роль с идентификатором {{roleId}} уже добавлена в это приложение.',
   invalid_role_type:
     'Невозможно назначить роль типа "пользователь" для приложения типа "от машины к машине".',
+  /** UNTRANSLATED */
+  invalid_third_party_application_type:
+    'Only traditional web applications can be marked as a third-party app.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/tr-tr/errors/application.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/application.ts
@@ -2,6 +2,9 @@ const application = {
   invalid_type: 'Sadece makine ile makine uygulamaları rollerle ilişkilendirilebilir.',
   role_exists: 'Bu uygulamaya zaten {{roleId}} kimlikli bir rol eklenmiş.',
   invalid_role_type: 'Kullanıcı tipi rolü makine ile makine uygulamasına atayamaz.',
+  /** UNTRANSLATED */
+  invalid_third_party_application_type:
+    'Only traditional web applications can be marked as a third-party app.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/zh-cn/errors/application.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/application.ts
@@ -2,6 +2,9 @@ const application = {
   invalid_type: '只有机器对机器应用程序可以有关联角色。',
   role_exists: '角色 ID {{roleId}} 已添加到此应用程序。',
   invalid_role_type: '无法将用户类型角色分配给机器对机器应用程序。',
+  /** UNTRANSLATED */
+  invalid_third_party_application_type:
+    'Only traditional web applications can be marked as a third-party app.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/zh-hk/errors/application.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/application.ts
@@ -2,6 +2,9 @@ const application = {
   invalid_type: '只有機器對機器應用程式才能有相關職能。',
   role_exists: '角色 ID {{roleId}} 已經被添加到此應用程式中。',
   invalid_role_type: '無法將使用者類型的角色分配給機器對機器應用程式。',
+  /** UNTRANSLATED */
+  invalid_third_party_application_type:
+    'Only traditional web applications can be marked as a third-party app.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/zh-tw/errors/application.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/application.ts
@@ -2,6 +2,9 @@ const application = {
   invalid_type: '僅允許機器對機器應用程式附加角色。',
   role_exists: '該角色 ID {{roleId}} 已被添加至此應用程式。',
   invalid_role_type: '無法將使用者類型的角色指派給機器對機器應用程式。',
+  /** UNTRANSLATED */
+  invalid_third_party_application_type:
+    'Only traditional web applications can be marked as a third-party app.',
 };
 
 export default Object.freeze(application);


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Update applications API to support third-party apps.

This PR includes the following updates:

- Delete the `findAllApplications` query as it is no longer used.
- Update the `getApplications` query method to filter by isThirdParty field
- Update the `GET /applications` API. By default should return only `isThirdParty=false` applications. And return third-party applications only `isThirdParty` flag is present in the query parameters.
- Update the `POST /applications` API. Add application type guard for third-party applications.  All the third-party applications must be Traditional. 
- Also fix a bug `excludeRoleId` should be listed in the query guard, instead of directly read from raw search parameters. @darcyYe 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
