### PR TITLE
refactor(core): add on conflic ignore to the Relation insert query method

### DIFF
--- a/.changeset/chilly-bobcats-doubt.md
+++ b/.changeset/chilly-bobcats-doubt.md
@@ -2,6 +2,6 @@
 "@logto/core": patch
 ---
 
-Revise the ` insert`` method within the  `RelationQueries`` class to utilize on conflict do nothing.
+Set `on conflict do nothing` for all the `RelationQueries` insert operation.
 
 - For all the relation table entities, we want to safely insert them into the database. If the relation entity already exists, instead of throwing an error, we ignore the insert operation, especially on a batch insert. Unlike other resource data entities, user does not care if the relation entity already exists. Therefore, we want to silently ignore the insert operation if the relation entity already exists.

--- a/.changeset/chilly-bobcats-doubt.md
+++ b/.changeset/chilly-bobcats-doubt.md
@@ -1,0 +1,7 @@
+---
+"@logto/core": patch
+---
+
+Revise the ` insert`` method within the  `RelationQueries`` class to utilize on conflict do nothing.
+
+- For all the relation table entities, we want to safely insert them into the database. If the relation entity already exists, instead of throwing an error, we ignore the insert operation, especially on a batch insert. Unlike other resource data entities, user does not care if the relation entity already exists. Therefore, we want to silently ignore the insert operation if the relation entity already exists.

--- a/packages/core/src/routes/organization/index.openapi.json
+++ b/packages/core/src/routes/organization/index.openapi.json
@@ -194,7 +194,7 @@
                     "description": "An array of user IDs to assign roles."
                   },
                   "organizationRoleIds": {
-                    "description": "An array of organization role IDs to assign."
+                    "description": "An array of organization role IDs to assign. User existed roles assignment will be ignored."
                   }
                 }
               }
@@ -206,7 +206,7 @@
             "description": "Roles were assigned to organization users successfully."
           },
           "422": {
-            "description": "At least one of the IDs provided is not valid. For example, the organization ID, user ID, or organization role ID does not exist; the user is not a member of the organization; or the user already has the role."
+            "description": "At least one of the IDs provided is not valid. For example, the organization ID, user ID, or organization role ID does not exist; the user is not a member of the organization."
           }
         }
       }
@@ -258,7 +258,7 @@
               "schema": {
                 "properties": {
                   "organizationRoleIds": {
-                    "description": "An array of organization role IDs to assign to the user."
+                    "description": "An array of organization role IDs to assign to the user. User existed roles assignment will be ignored."
                   }
                 }
               }
@@ -270,7 +270,7 @@
             "description": "Roles were assigned to the user successfully."
           },
           "422": {
-            "description": "The user is not a member of the organization; or at least one of the IDs provided is not valid. For example, the organization ID or organization role ID does not exist; or the user already has the role."
+            "description": "The user is not a member of the organization; or at least one of the IDs provided is not valid. For example, the organization ID or organization role ID does not exist."
           }
         }
       }

--- a/packages/core/src/routes/organization/index.openapi.json
+++ b/packages/core/src/routes/organization/index.openapi.json
@@ -109,7 +109,7 @@
               "schema": {
                 "properties": {
                   "userIds": {
-                    "description": "An array of user IDs to be added to the organization."
+                    "description": "An array of user IDs to be added to the organization. Organization existed users assignment will be ignored."
                   }
                 }
               }
@@ -121,7 +121,7 @@
             "description": "Users were added to the organization successfully."
           },
           "422": {
-            "description": "At least one of the IDs provided is not valid. For example, the organization ID or user ID does not exist; or the user is already a member of the organization."
+            "description": "At least one of the IDs provided is not valid. For example, the organization ID or user ID does not exist."
           }
         }
       },

--- a/packages/core/src/routes/organization/roles.openapi.json
+++ b/packages/core/src/routes/organization/roles.openapi.json
@@ -112,7 +112,7 @@
               "schema": {
                 "properties": {
                   "organizationScopeIds": {
-                    "description": "An array of organization scope IDs to be assigned."
+                    "description": "An array of organization scope IDs to be assigned. Existed scope IDs assignments will be ignored."
                   }
                 }
               }
@@ -124,7 +124,7 @@
             "description": "Organization scopes were assigned successfully."
           },
           "422": {
-            "description": "At least one of the IDs provided is invalid. For example, the organization scope ID does not exist; or the organization scope has already been assigned to the organization role."
+            "description": "At least one of the IDs provided is invalid. For example, the organization scope ID does not exist;"
           }
         }
       },

--- a/packages/core/src/utils/RelationQueries.ts
+++ b/packages/core/src/utils/RelationQueries.ts
@@ -93,6 +93,7 @@ export default class RelationQueries<
    *
    * Each entity must contain the same number of ids as the number of relations, and
    * the order of the ids must match the order of the relations.
+   * Insert existing relations will be ignored.
    *
    * @param data Entities to insert.
    * @returns A Promise that resolves to the query result.
@@ -124,7 +125,8 @@ export default class RelationQueries<
             )})`
         ),
         sql`, `
-      )};
+      )}
+      ${sql`on conflict do nothing`}
     `);
   }
 

--- a/packages/integration-tests/src/tests/api/organization-role.test.ts
+++ b/packages/integration-tests/src/tests/api/organization-role.test.ts
@@ -176,6 +176,31 @@ describe('organization role APIs', () => {
       );
     });
 
+    it('should safely add scopes to a role when some of them already exist', async () => {
+      const [role, scope1, scope2] = await Promise.all([
+        roleApi.create({ name: 'test' + randomId() }),
+        scopeApi.create({ name: 'test' + randomId() }),
+        scopeApi.create({ name: 'test' + randomId() }),
+      ]);
+
+      await roleApi.addScopes(role.id, [scope1.id, scope2.id]);
+
+      await expect(roleApi.addScopes(role.id, [scope2.id])).resolves.not.toThrow();
+
+      const scopes = await roleApi.getScopes(role.id);
+
+      expect(scopes).toContainEqual(
+        expect.objectContaining({
+          name: scope1.name,
+        })
+      );
+      expect(scopes).toContainEqual(
+        expect.objectContaining({
+          name: scope2.name,
+        })
+      );
+    });
+
     it('should fail when try to add non-existent scopes to a role', async () => {
       const [role, scope1, scope2] = await Promise.all([
         roleApi.create({ name: 'test' + randomId() }),


### PR DESCRIPTION


<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Set `on conflict do nothing` for the `RelationQueries` insert operation.

For all the relation table entities, we want to insert them into the database safely. If the relation entity already exists, instead of throwing an error, ignore the insert operation,

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
