### PR TITLE
refactor(schemas,core,cli): init tenant organizations

### DIFF
--- a/.github/workflows/alteration-compatibility-integration-test.yml
+++ b/.github/workflows/alteration-compatibility-integration-test.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - "push-action/**"
   pull_request:
 
 concurrency:
@@ -19,8 +18,7 @@ jobs:
       has-alteration-changes: ${{ steps.changes-detection.outputs.has-alteration-changes }}
 
     steps:
-      - name: checkout head
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,7 +132,7 @@ jobs:
       # ** Setup up-to-date databases and compare (test `up`) **
       - name: Setup fresh database
         working-directory: ./fresh
-        run: pnpm cli db seed
+        run: pnpm cli db seed --test
         env:
           DB_URL: postgres://postgres:postgres@localhost:5432/fresh
 
@@ -140,7 +140,7 @@ jobs:
         working-directory: ./alteration
         run: |
           cd packages/cli
-          pnpm start db seed
+          pnpm start db seed --test
         env:
           DB_URL: postgres://postgres:postgres@localhost:5432/alteration
 
@@ -161,7 +161,7 @@ jobs:
         working-directory: ./alteration
         run: |
           cd packages/cli
-          pnpm start db seed
+          pnpm start db seed --test
         env:
           DB_URL: postgres://postgres:postgres@localhost:5432/old
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,7 +140,15 @@ jobs:
         working-directory: ./alteration
         run: |
           cd packages/cli
-          pnpm start db seed --test
+          pnpm start db seed
+        env:
+          DB_URL: postgres://postgres:postgres@localhost:5432/alteration
+
+      # FIXME: Last version of CLI doesn't support test data seeding. Here's a temporary workaround.
+      # We will remove this step when a new version of CLI is released.
+      - name: Setup alteration database test data
+        working-directory: ./fresh
+        run: pnpm cli db seed --testOnly
         env:
           DB_URL: postgres://postgres:postgres@localhost:5432/alteration
 
@@ -161,7 +169,15 @@ jobs:
         working-directory: ./alteration
         run: |
           cd packages/cli
-          pnpm start db seed --test
+          pnpm start db seed
+        env:
+          DB_URL: postgres://postgres:postgres@localhost:5432/old
+
+      # FIXME: Last version of CLI doesn't support test data seeding. Here's a temporary workaround.
+      # We will remove this step when a new version of CLI is released.
+      - name: Setup old database test data
+        working-directory: ./fresh
+        run: pnpm cli db seed --testOnly
         env:
           DB_URL: postgres://postgres:postgres@localhost:5432/old
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,7 +148,7 @@ jobs:
       # We will remove this step when a new version of CLI is released.
       - name: Setup alteration database test data
         working-directory: ./fresh
-        run: pnpm cli db seed --testOnly
+        run: pnpm cli db seed --legacy-test-data
         env:
           DB_URL: postgres://postgres:postgres@localhost:5432/alteration
 
@@ -177,7 +177,7 @@ jobs:
       # We will remove this step when a new version of CLI is released.
       - name: Setup old database test data
         working-directory: ./fresh
-        run: pnpm cli db seed --testOnly
+        run: pnpm cli db seed --legacy-test-data
         env:
           DB_URL: postgres://postgres:postgres@localhost:5432/old
 

--- a/.scripts/compare-database.js
+++ b/.scripts/compare-database.js
@@ -7,6 +7,15 @@ const omitArray = (arrayOfObjects, ...keys) => arrayOfObjects.map((value) => omi
 const schemas = ['cloud', 'public'];
 const schemasArray = `(${schemas.map((schema) => `'${schema}'`).join(', ')})`;
 
+const tryCompare = (a, b) => {
+  try {
+    assert.deepStrictEqual(a, b);
+  } catch (error) {
+    console.error(error.toString());
+    process.exit(1);
+  }
+};
+
 const queryDatabaseManifest = async (database) => {
   const pool = new pg.Pool({ database, user: 'postgres', password: 'postgres' });
 
@@ -150,7 +159,7 @@ const manifests = [
   await queryDatabaseManifest(database2),
 ];
 
-assert.deepStrictEqual(...manifests);
+tryCompare(...manifests);
 
 const autoCompare = (a, b) => {
   if (typeof a !== typeof b) {
@@ -200,7 +209,4 @@ const queryDatabaseData = async (database) => {
 
 console.log('Compare database data between', database1, 'and', database2);
 
-assert.deepStrictEqual(
-  await queryDatabaseData(database1),
-  await queryDatabaseData(database2),
-);
+tryCompare(await queryDatabaseData(database1), await queryDatabaseData(database2));

--- a/packages/cli/src/commands/database/seed/tenant-organizations.ts
+++ b/packages/cli/src/commands/database/seed/tenant-organizations.ts
@@ -33,17 +33,14 @@ import { consoleLog } from '../../../utils.js';
  * - Organization roles and scopes for tenant management.
  * - Create tenant organizations for the initial tenants (`default` and `admin`).
  *
- * If it is a cloud deployment, it will also seed the following:
+ * The following data are used for Logto Cloud, we seed them anyway for the sake of simplicity:
  *
  * - Machine-to-machine roles for Management API proxy.
  * - Assign the corresponding Management API scopes to the machine-to-machine roles.
  * - Machine-to-machine applications for Management API proxy.
  * - Assign the roles to the corresponding applications.
  */
-export const seedTenantOrganizations = async (
-  connection: DatabaseTransactionConnection,
-  isCloud: boolean
-) => {
+export const seedTenantOrganizations = async (connection: DatabaseTransactionConnection) => {
   const tenantIds = [defaultTenantId, adminTenantId];
 
   // Init organization template
@@ -87,10 +84,7 @@ export const seedTenantOrganizations = async (
   );
   consoleLog.succeed('Created tenant organizations');
 
-  if (!isCloud) {
-    return;
-  }
-
+  /* === Cloud-specific data === */
   // Init Management API proxy roles
   await connection.query(
     insertInto(
@@ -101,8 +95,8 @@ export const seedTenantOrganizations = async (
   consoleLog.succeed('Created Management API proxy roles');
 
   // Prepare Management API scopes
-  const scopes = convertToIdentifiers(Scopes);
-  const resources = convertToIdentifiers(Resources);
+  const scopes = convertToIdentifiers(Scopes, true);
+  const resources = convertToIdentifiers(Resources, true);
   /** Scopes with the name {@link PredefinedScope.All} in all Management API resources. */
   const allScopes = await connection.any<{ id: string; indicator: string }>(sql`
     select ${scopes.fields.id}, ${resources.fields.indicator}

--- a/packages/cli/src/commands/database/seed/tenant-organizations.ts
+++ b/packages/cli/src/commands/database/seed/tenant-organizations.ts
@@ -1,0 +1,161 @@
+import {
+  defaultTenantId,
+  adminTenantId,
+  Roles,
+  Applications,
+  OrganizationRoles,
+  TenantRole,
+  getTenantScope,
+  OrganizationScopes,
+  TenantScope,
+  getTenantRole,
+  OrganizationRoleScopeRelations,
+  tenantRoleScopes,
+  getTenantOrganizationCreateData,
+  Organizations,
+  Scopes,
+  Resources,
+  PredefinedScope,
+  RolesScopes,
+  ApplicationsRoles,
+} from '@logto/schemas';
+import { getMapiProxyM2mApp, getMapiProxyRole } from '@logto/schemas/lib/types/mapi-proxy.js';
+import { convertToIdentifiers, generateStandardId } from '@logto/shared';
+import type { DatabaseTransactionConnection } from 'slonik';
+import { sql } from 'slonik';
+
+import { insertInto } from '../../../database.js';
+import { consoleLog } from '../../../utils.js';
+
+/**
+ * Seed initial data in the admin tenant for tenant organizations:
+ *
+ * - Organization roles and scopes for tenant management.
+ * - Create tenant organizations for the initial tenants (`default` and `admin`).
+ *
+ * If it is a cloud deployment, it will also seed the following:
+ *
+ * - Machine-to-machine roles for Management API proxy.
+ * - Assign the corresponding Management API scopes to the machine-to-machine roles.
+ * - Machine-to-machine applications for Management API proxy.
+ * - Assign the roles to the corresponding applications.
+ */
+export const seedTenantOrganizations = async (
+  connection: DatabaseTransactionConnection,
+  isCloud: boolean
+) => {
+  const tenantIds = [defaultTenantId, adminTenantId];
+
+  // Init organization template
+  await Promise.all([
+    connection.query(
+      insertInto(
+        Object.values(TenantRole).map((role) => getTenantRole(role)),
+        OrganizationRoles.table
+      )
+    ),
+    connection.query(
+      insertInto(
+        Object.values(TenantScope).map((scope) => getTenantScope(scope)),
+        OrganizationScopes.table
+      )
+    ),
+  ]);
+
+  // Link organization roles and scopes
+  await connection.query(
+    insertInto(
+      Object.entries(tenantRoleScopes).flatMap(([role, scopes]) =>
+        scopes.map((scope) => ({
+          tenantId: adminTenantId,
+          // eslint-disable-next-line no-restricted-syntax -- `Object.entries` converts the enum to string
+          organizationRoleId: getTenantRole(role as TenantRole).id,
+          organizationScopeId: getTenantScope(scope).id,
+        }))
+      ),
+      OrganizationRoleScopeRelations.table
+    )
+  );
+  consoleLog.succeed('Initialized tenant organization template');
+
+  // Init tenant organizations
+  await connection.query(
+    insertInto(
+      tenantIds.map((id) => getTenantOrganizationCreateData(id)),
+      Organizations.table
+    )
+  );
+  consoleLog.succeed('Created tenant organizations');
+
+  if (!isCloud) {
+    return;
+  }
+
+  // Init Management API proxy roles
+  await connection.query(
+    insertInto(
+      tenantIds.map((tenantId) => getMapiProxyRole(tenantId)),
+      Roles.table
+    )
+  );
+  consoleLog.succeed('Created Management API proxy roles');
+
+  // Prepare Management API scopes
+  const scopes = convertToIdentifiers(Scopes);
+  const resources = convertToIdentifiers(Resources);
+  /** Scopes with the name {@link PredefinedScope.All} in all Management API resources. */
+  const allScopes = await connection.any<{ id: string; indicator: string }>(sql`
+    select ${scopes.fields.id}, ${resources.fields.indicator}
+    from ${resources.table}
+    join ${scopes.table} on ${scopes.fields.resourceId} = ${resources.fields.id}
+    where ${resources.fields.indicator} like 'https://%.logto.app/api'
+    and ${scopes.fields.name} = ${PredefinedScope.All}
+    and ${resources.fields.tenantId} = ${adminTenantId}
+  `);
+  const assertScopeId = (forTenantId: string) => {
+    const scope = allScopes.find(
+      (scope) => scope.indicator === `https://${forTenantId}.logto.app/api`
+    );
+    if (!scope) {
+      throw new Error(`Cannot find Management API scope for tenant '${forTenantId}'.`);
+    }
+    return scope.id;
+  };
+
+  // Assign Management API scopes to the proxy roles
+  await connection.query(
+    insertInto(
+      tenantIds.map((tenantId) => ({
+        tenantId: adminTenantId,
+        id: generateStandardId(),
+        roleId: getMapiProxyRole(tenantId).id,
+        scopeId: assertScopeId(tenantId),
+      })),
+      RolesScopes.table
+    )
+  );
+  consoleLog.succeed('Assigned Management API scopes to the proxy roles');
+
+  // Create machine-to-machine applications for Management API proxy
+  await connection.query(
+    insertInto(
+      tenantIds.map((tenantId) => getMapiProxyM2mApp(tenantId)),
+      Applications.table
+    )
+  );
+  consoleLog.succeed('Created machine-to-machine applications for Management API proxy');
+
+  // Assign the proxy roles to the applications
+  await connection.query(
+    insertInto(
+      tenantIds.map((tenantId) => ({
+        tenantId: adminTenantId,
+        id: generateStandardId(),
+        applicationId: getMapiProxyM2mApp(tenantId).id,
+        roleId: getMapiProxyRole(tenantId).id,
+      })),
+      ApplicationsRoles.table
+    )
+  );
+  consoleLog.succeed('Assigned the proxy roles to the applications');
+};

--- a/packages/schemas/alterations/next-1702544178-sync-tenant-orgs.ts
+++ b/packages/schemas/alterations/next-1702544178-sync-tenant-orgs.ts
@@ -1,0 +1,298 @@
+/**
+ * @fileoverview A preparation for the update of using organizations to manage tenants in the admin
+ * tenant. This script will do the following in the admin tenant:
+ *
+ * 1. Disable registration.
+ * 2. Create organization template roles and scopes.
+ * 3. Create organizations for existing tenants.
+ * 4. Add membership records and assign organization roles to existing users.
+ * 5. Create machine-to-machine Management API role for each tenant.
+ * 6. Create the corresponding machine-to-machine app for each tenant, and assign the Management API role to it.
+ *
+ * The `down` script will revert the changes.
+ */
+
+import { ConsoleLog, generateStandardId } from '@logto/shared';
+import { sql } from 'slonik';
+
+import { type AlterationScript } from '../lib/types/alteration.js';
+
+const adminTenantId = 'admin';
+const consoleLog = new ConsoleLog();
+
+const alteration: AlterationScript = {
+  up: async (transaction) => {
+    consoleLog.info('=== Sync tenant organizations ===');
+    consoleLog.info('Disable registration');
+    await transaction.query(sql`
+      update public.sign_in_experiences
+      set sign_in_mode = 'SignIn'
+      where tenant_id = ${adminTenantId};
+    `);
+
+    consoleLog.info('Create organization template roles and scopes');
+    await transaction.query(sql`
+      insert into public.organization_roles (id, tenant_id, name, description)
+      values
+        ('owner', ${adminTenantId}, 'owner', 'Owner of the tenant, who has all permissions.'),
+        ('admin', ${adminTenantId}, 'admin', 'Admin of the tenant, who has all permissions except deleting the tenant.'),
+        ('member', ${adminTenantId}, 'member', 'Member of the tenant, who has limited permissions.');
+    `);
+    await transaction.query(sql`
+      insert into public.organization_scopes (id, tenant_id, name, description)
+      values
+        ('read-tenant', ${adminTenantId}, 'read:tenant', 'Read the tenant data.'),
+        ('write-tenant', ${adminTenantId}, 'write:tenant', 'Write the tenant data, including creating and updating the tenant.'),
+        ('delete-tenant', ${adminTenantId}, 'delete:tenant', 'Delete data of the tenant.'),
+        ('invite-member', ${adminTenantId}, 'invite:member', 'Invite members to the tenant.'),
+        ('remove-member', ${adminTenantId}, 'remove:member', 'Remove members from the tenant.'),
+        ('update-member-role', ${adminTenantId}, 'update:member:role', 'Update the role of a member in the tenant.'),
+        ('manage-tenant', ${adminTenantId}, 'manage:tenant', 'Manage the tenant settings, including name, billing, etc.');
+    `);
+    await transaction.query(sql`
+      insert into public.organization_role_scope_relations (tenant_id, organization_role_id, organization_scope_id)
+      values
+        (${adminTenantId}, 'owner', 'read-tenant'),
+        (${adminTenantId}, 'owner', 'write-tenant'),
+        (${adminTenantId}, 'owner', 'delete-tenant'),
+        (${adminTenantId}, 'owner', 'invite-member'),
+        (${adminTenantId}, 'owner', 'remove-member'),
+        (${adminTenantId}, 'owner', 'update-member-role'),
+        (${adminTenantId}, 'owner', 'manage-tenant'),
+        (${adminTenantId}, 'admin', 'read-tenant'),
+        (${adminTenantId}, 'admin', 'write-tenant'),
+        (${adminTenantId}, 'admin', 'delete-tenant'),
+        (${adminTenantId}, 'admin', 'invite-member'),
+        (${adminTenantId}, 'admin', 'remove-member'),
+        (${adminTenantId}, 'admin', 'update-member-role'),
+        (${adminTenantId}, 'member', 'read-tenant'),
+        (${adminTenantId}, 'member', 'write-tenant'),
+        (${adminTenantId}, 'member', 'invite-member')
+    `);
+
+    consoleLog.info('Create organizations for existing tenants');
+    const tenants = await transaction.any<{ id: string }>(sql`
+      select id
+      from public.tenants;
+    `);
+    await transaction.query(sql`
+      insert into public.organizations (id, tenant_id, name)
+      values 
+        ${sql.join(
+          tenants.map(
+            (tenant) => sql`(${`t-${tenant.id}`}, ${adminTenantId}, ${`Tenant ${tenant.id}`})`
+          ),
+          sql`, `
+        )};
+    `);
+
+    consoleLog.info('Add membership records and assign organization roles to existing users');
+    const usersRoles = await transaction.any<{ userId: string; roleName: string }>(sql`
+      select
+        public.users.id as "userId",
+        public.roles.name as "roleName"
+      from public.users
+      join public.users_roles on public.users_roles.user_id = public.users.id
+      join public.roles on public.roles.id = public.users_roles.role_id
+      where public.roles.tenant_id = ${adminTenantId}
+      and public.roles.name like '%:admin';
+    `);
+
+    // Add membership records
+    await transaction.query(sql`
+      insert into public.organization_user_relations (tenant_id, organization_id, user_id)
+      values 
+        ${sql.join(
+          usersRoles.map(
+            (userRole) =>
+              sql`(${adminTenantId}, ${`t-${userRole.roleName.slice(0, -6)}`}, ${userRole.userId})`
+          ),
+          sql`, `
+        )};
+    `);
+    // We treat all existing users as the owner of the tenant
+    await transaction.query(sql`
+      insert into public.organization_role_user_relations (tenant_id, organization_id, user_id, organization_role_id)
+      values 
+        ${sql.join(
+          usersRoles.map(
+            (userRole) =>
+              sql`
+                (
+                  ${adminTenantId},
+                  ${`t-${userRole.roleName.slice(0, -6)}`},
+                  ${userRole.userId},
+                  'owner'
+                )
+              `
+          ),
+          sql`, `
+        )};
+    `);
+
+    consoleLog.info('Create machine-to-machine Management API role for each tenant');
+    await transaction.query(sql`
+      insert into public.roles (id, tenant_id, name, description, type)
+      values
+        ${sql.join(
+          tenants.map(
+            (tenant) =>
+              sql`
+                (
+                  ${`m-${tenant.id}`},
+                  ${adminTenantId},
+                  ${`machine:mapi:${tenant.id}`},
+                  ${`Machine-to-machine role for accessing Management API of tenant '${tenant.id}'.`},
+                  'MachineToMachine'
+                )
+              `
+          ),
+          sql`, `
+        )};
+    `);
+
+    const managementApiScopes = await transaction.any<{ id: string; indicator: string }>(sql`
+      select public.scopes.id, public.resources.indicator
+      from public.resources
+      join public.scopes on public.scopes.resource_id = public.resources.id
+      where public.resources.indicator like 'https://%.logto.app/api'
+      and public.scopes.name = 'all'
+      and public.resources.tenant_id = ${adminTenantId};
+    `);
+
+    const assertScopeId = (forTenantId: string) => {
+      const scope = managementApiScopes.find(
+        (scope) => scope.indicator === `https://${forTenantId}.logto.app/api`
+      );
+      if (!scope) {
+        throw new Error(`Cannot find Management API scope for tenant '${forTenantId}'.`);
+      }
+      return scope.id;
+    };
+
+    // Insert role - scope relations
+    await transaction.query(sql`
+      insert into public.roles_scopes (tenant_id, id, role_id, scope_id)
+      values 
+        ${sql.join(
+          tenants.map(
+            (tenant) =>
+              sql`
+                (
+                  ${adminTenantId},
+                  ${generateStandardId()},
+                  ${`m-${tenant.id}`},
+                  ${assertScopeId(tenant.id)}
+                )
+              `
+          ),
+          sql`, `
+        )};
+    `);
+
+    consoleLog.info(
+      'Create the corresponding machine-to-machine app for each tenant, and assign the Management API role to it'
+    );
+    await transaction.query(sql`
+      insert into public.applications (id, tenant_id, secret, name, description, type, oidc_client_metadata)
+      values 
+        ${sql.join(
+          tenants.map(
+            (tenant) =>
+              sql`
+                (
+                  ${`m-${tenant.id}`},
+                  ${adminTenantId},
+                  ${generateStandardId(32)},
+                  ${`Management API access for ${tenant.id}`},
+                  ${`Machine-to-machine app for accessing Management API of tenant '${tenant.id}'.`},
+                  'MachineToMachine',
+                  ${sql.jsonb({
+                    redirectUris: [],
+                    postLogoutRedirectUris: [],
+                  })}
+                )
+              `
+          ),
+          sql`, `
+        )};
+    `);
+    await transaction.query(sql`
+      insert into public.applications_roles (tenant_id, id, application_id, role_id)
+      values 
+        ${sql.join(
+          tenants.map(
+            (tenant) =>
+              sql`
+                (
+                  ${adminTenantId},
+                  ${generateStandardId()},
+                  ${`m-${tenant.id}`},
+                  ${`m-${tenant.id}`}
+                )
+              `
+          ),
+          sql`, `
+        )};
+    `);
+
+    consoleLog.info('=== Sync tenant organizations done ===');
+  },
+  down: async (transaction) => {
+    consoleLog.info('=== Revert sync tenant organizations ===');
+
+    consoleLog.info('Remove machine-to-machine apps');
+    await transaction.query(sql`
+      delete from public.applications
+      where public.applications.tenant_id = ${adminTenantId}
+      and public.applications.id like 'm-%';
+    `);
+
+    consoleLog.info('Remove machine-to-machine roles');
+    await transaction.query(sql`
+      delete from public.roles
+      where public.roles.tenant_id = ${adminTenantId}
+      and public.roles.id like 'm-%';
+    `);
+
+    consoleLog.info('Remove organizations');
+    await transaction.query(sql`
+      delete from public.organizations
+      where public.organizations.tenant_id = ${adminTenantId}
+      and public.organizations.id like 't-%';
+    `);
+
+    consoleLog.info('Remove organization roles');
+    await transaction.query(sql`
+      delete from public.organization_roles
+      where public.organization_roles.tenant_id = ${adminTenantId}
+      and public.organization_roles.id in ('owner', 'admin', 'member');
+    `);
+
+    consoleLog.info('Remove organization scopes');
+    await transaction.query(sql`
+      delete from public.organization_scopes
+      where public.organization_scopes.tenant_id = ${adminTenantId}
+      and public.organization_scopes.id in (
+        'read-tenant',
+        'write-tenant',
+        'delete-tenant',
+        'invite-member',
+        'remove-member',
+        'update-member-role',
+        'manage-tenant'
+      );
+    `);
+
+    consoleLog.info('Enable registration');
+    await transaction.query(sql`
+      update public.sign_in_experiences
+      set sign_in_mode = 'SignInAndRegister'
+      where tenant_id = ${adminTenantId};
+    `);
+
+    consoleLog.info('=== Revert sync tenant organizations done ===');
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/seeds/application.ts
+++ b/packages/schemas/src/seeds/application.ts
@@ -61,7 +61,7 @@ export const createTenantMachineToMachineApplication = (
     },
   });
 
-/** Create role for "tenant application (M2M)" in admin tenant */
+/** Create an entry to assign a role to an application in the admin tenant. */
 export const createAdminTenantApplicationRole = (
   applicationId: string,
   roleId: string

--- a/packages/schemas/src/types/index.ts
+++ b/packages/schemas/src/types/index.ts
@@ -23,3 +23,4 @@ export * from './mfa.js';
 export * from './organization.js';
 export * from './sso-connector.js';
 export * from './tenant.js';
+export * from './tenant-organization.js';

--- a/packages/schemas/src/types/mapi-proxy.ts
+++ b/packages/schemas/src/types/mapi-proxy.ts
@@ -1,0 +1,60 @@
+/**
+ * @fileoverview
+ * Mapi (Management API) proxy is an endpoint in Logto Cloud that proxies the requests to the
+ * corresponding Management API. It has the following benefits:
+ *
+ * - When we migrate the tenant management from API resources to tenant organizations, we can
+ *   migrate Console to use the mapi proxy endpoint by changing only the base URL.
+ * - It decouples the access control of Cloud user collaboration from the machine-to-machine access
+ *   control of the Management API.
+ * - The mapi proxy endpoint shares the same domain with Logto Cloud, so it can be used in the
+ *   browser without CORS.
+ *
+ * This module provides utilities to manage mapi proxy.
+ */
+
+import { generateStandardSecret } from '@logto/shared';
+
+import {
+  RoleType,
+  type Role,
+  type CreateApplication,
+  ApplicationType,
+} from '../db-entries/index.js';
+import { adminTenantId } from '../index.js';
+
+/**
+ * Given a tenant ID, return the role data for the mapi proxy.
+ *
+ * It follows a convention to generate all the fields which can be used across the system. See
+ * source code for details.
+ */
+export const getMapiProxyRole = (tenantId: string): Readonly<Role> =>
+  Object.freeze({
+    tenantId: adminTenantId,
+    id: `m-${tenantId}`,
+    name: `machine:mapi:${tenantId}`,
+    description: `Machine-to-machine role for accessing Management API of tenant '${tenantId}'.`,
+    type: RoleType.MachineToMachine,
+  });
+
+/**
+ * Given a tenant ID, return the application create data for the mapi proxy. The proxy will use the
+ * application to access the Management API.
+ *
+ * It follows a convention to generate all the fields which can be used across the system. See
+ * source code for details.
+ */
+export const getMapiProxyM2mApp = (tenantId: string): Readonly<CreateApplication> =>
+  Object.freeze({
+    tenantId: adminTenantId,
+    id: `m-${tenantId}`,
+    secret: generateStandardSecret(32),
+    name: `Management API access for ${tenantId}`,
+    description: `Machine-to-machine app for accessing Management API of tenant '${tenantId}'.`,
+    type: ApplicationType.MachineToMachine,
+    oidcClientMetadata: {
+      redirectUris: [],
+      postLogoutRedirectUris: [],
+    },
+  });

--- a/packages/schemas/src/types/tenant-organization.ts
+++ b/packages/schemas/src/types/tenant-organization.ts
@@ -1,0 +1,164 @@
+/**
+ * @fileoverview
+ * Tenant organizations are organizations in the admin tenant that represent tenants. They are
+ * created when a tenant is created, and are used to define the roles and scopes for the users in
+ * the tenant.
+ *
+ * This module provides utilities to manage tenant organizations.
+ */
+
+import {
+  type CreateOrganization,
+  type OrganizationRole,
+  type OrganizationScope,
+} from '../db-entries/index.js';
+import { adminTenantId } from '../seeds/tenant.js';
+
+/** Given a tenant ID, return the corresponding organization ID in the admin tenant. */
+export const getTenantOrganizationId = (tenantId: string) => `t-${tenantId}`;
+
+/**
+ * Given a tenant ID, return the organization create data for the admin tenant. It follows a
+ * convention to generate the organization ID and name which can be used across the system.
+ *
+ * @example
+ * ```ts
+ * const tenantId = 'test-tenant';
+ * const createData = getCreateData(tenantId);
+ *
+ * expect(createData).toEqual({
+ *   tenantId: 'admin',
+ *   id: 't-test-tenant',
+ *   name: 'Tenant test-tenant',
+ * });
+ * ```
+ *
+ * @see {@link getId} for the convention of generating the organization ID.
+ */
+export const getTenantOrganizationCreateData = (tenantId: string): Readonly<CreateOrganization> =>
+  Object.freeze({
+    tenantId: adminTenantId,
+    id: getTenantOrganizationId(tenantId),
+    name: `Tenant ${tenantId}`,
+  });
+
+/**
+ * Scope names in organization template for managing tenants.
+ *
+ * @remarks
+ * Should sync JSDoc descriptions with {@link tenantScopeDescriptions}.
+ */
+export enum TenantScope {
+  /** Read the tenant data. */
+  ReadData = 'read:data',
+  /** Write the tenant data, including creating and updating the tenant. */
+  WriteData = 'write:data',
+  /** Delete data of the tenant. */
+  DeleteData = 'delete:data',
+  /** Invite members to the tenant. */
+  InviteMember = 'invite:member',
+  /** Remove members from the tenant. */
+  RemoveMember = 'remove:member',
+  /** Update the role of a member in the tenant. */
+  UpdateMemberRole = 'update:member:role',
+  /** Manage the tenant settings, including name, billing, etc. */
+  ManageTenant = 'manage:tenant',
+}
+
+const allTenantScopes = Object.freeze(Object.values(TenantScope));
+
+/**
+ * Given a tenant scope, return the corresponding organization scope data in the admin tenant.
+ *
+ * @example
+ * ```ts
+ * const scope = TenantScope.ReadData; // 'read:data'
+ * const scopeData = getTenantScope(scope);
+ *
+ * expect(scopeData).toEqual({
+ *   tenantId: 'admin',
+ *   id: 'read-data',
+ *   name: 'read:data',
+ *   description: 'Read the tenant data.',
+ * });
+ * ```
+ *
+ * @see {@link tenantScopeDescriptions} for scope descriptions of each scope.
+ */
+export const getTenantScope = (scope: TenantScope): Readonly<OrganizationScope> =>
+  Object.freeze({
+    tenantId: adminTenantId,
+    id: scope.replaceAll(':', '-'),
+    name: scope,
+    description: tenantScopeDescriptions[scope],
+  });
+
+const tenantScopeDescriptions: Readonly<Record<TenantScope, string>> = Object.freeze({
+  [TenantScope.ReadData]: 'Read the tenant data.',
+  [TenantScope.WriteData]: 'Write the tenant data, including creating and updating the tenant.',
+  [TenantScope.DeleteData]: 'Delete data of the tenant.',
+  [TenantScope.InviteMember]: 'Invite members to the tenant.',
+  [TenantScope.RemoveMember]: 'Remove members from the tenant.',
+  [TenantScope.UpdateMemberRole]: 'Update the role of a member in the tenant.',
+  [TenantScope.ManageTenant]: 'Manage the tenant settings, including name, billing, etc.',
+});
+
+/**
+ * Role names in organization template for managing tenants.
+ *
+ * @remarks
+ * Should sync JSDoc descriptions with {@link tenantRoleDescriptions}.
+ */
+export enum TenantRole {
+  /** Owner of the tenant, who has all permissions. */
+  Owner = 'owner',
+  /** Admin of the tenant, who has all permissions except managing the tenant settings. */
+  Admin = 'admin',
+  /** Member of the tenant, who has limited permissions on reading and writing the tenant data. */
+  Member = 'member',
+}
+
+const tenantRoleDescriptions: Readonly<Record<TenantRole, string>> = Object.freeze({
+  [TenantRole.Owner]: 'Owner of the tenant, who has all permissions.',
+  [TenantRole.Admin]:
+    'Admin of the tenant, who has all permissions except managing the tenant settings.',
+  [TenantRole.Member]:
+    'Member of the tenant, who has limited permissions on reading and writing the tenant data.',
+});
+
+/**
+ * Given a tenant role, return the corresponding organization role data in the admin tenant.
+ *
+ * @example
+ * ```ts
+ * const role = TenantRole.Member; // 'member'
+ * const roleData = getTenantRole(role);
+ *
+ * expect(roleData).toEqual({
+ *   tenantId: 'admin',
+ *   id: 'member',
+ *   name: 'member',
+ *   description: 'Member of the tenant, who has limited permissions on reading and writing the tenant data.',
+ * });
+ * ```
+ *
+ * @see {@link tenantRoleDescriptions} for scope descriptions of each role.
+ */
+export const getTenantRole = (role: TenantRole): Readonly<OrganizationRole> =>
+  Object.freeze({
+    tenantId: adminTenantId,
+    id: role,
+    name: role,
+    description: tenantRoleDescriptions[role],
+  });
+
+/**
+ * The dictionary of tenant roles and their corresponding scopes.
+ * @see {TenantRole} for scope descriptions of each role.
+ */
+export const tenantRoleScopes: Readonly<Record<TenantRole, Readonly<TenantScope[]>>> =
+  Object.freeze({
+    [TenantRole.Owner]: allTenantScopes,
+    [TenantRole.Admin]: allTenantScopes.filter((scope) => scope !== TenantScope.ManageTenant),
+    [TenantRole.Member]: [TenantScope.ReadData, TenantScope.WriteData, TenantScope.InviteMember],
+  });

--- a/packages/schemas/src/types/tenant.ts
+++ b/packages/schemas/src/types/tenant.ts
@@ -6,30 +6,3 @@ export enum TenantTag {
   /* A production tenant must have an associated subscription plan, even if it's a free plan. */
   Production = 'production',
 }
-
-/** Tenant roles that are used in organization template of admin tenant. */
-export enum TenantRole {
-  /* A tenant admin can manage all resources in the tenant. */
-  Admin = 'admin',
-  /* A tenant member can manage resources without deleting them. */
-  Member = 'member',
-}
-
-/** Tenant scopes that are used in organization template of admin tenant. */
-export enum TenantScope {
-  /** Read tenant data. */
-  ReadTenant = 'read:tenant',
-  /** Create or update tenant data. */
-  WriteTenant = 'write:tenant',
-  /** Delete tenant data. */
-  DeleteTenant = 'delete:tenant',
-  /** Invite a new member to the tenant. */
-  InviteMember = 'invite:member',
-  /** Remove a member from the tenant. */
-  RemoveMember = 'remove:member',
-  /** Update a member's role in the tenant. */
-  UpdateMemberRole = 'update:member:role',
-}
-
-/** The prefix that applies to all organization IDs that are created to represent a tenant. */
-export const tenantOrganizationIdPrefix = 't-';


### PR DESCRIPTION
## Summary
<!-- Provide detailed PR description below -->
This is the beginning of the tenant organization series.

The main goal of this series is to leverage Logto Organizations for managing user tenants, replacing the current API resource-based approach. This will allow us to provide a better user experience for Logto Cloud, and it is also the foundation for collaboration features.

### Terms

- Tenant organization: An organization that represents a user tenant in the admin tenant.
- Management API proxy: An endpoint in Logto Cloud that proxies all requests to the corresponding tenant's Management API.

### Outline

- Database alteration script
- Common types, enums, and utils for tenant organizations
- CLI now supports only seeding test data for legacy versions

### How it works

When creating a new tenant (e.g. `foo`), the following resources will be created in the admin tenant:

```mermaid
graph LR
  subgraph Admin tenant
    subgraph Organizations
      foo("foo (i.e. tenant organization)")
    end
    subgraph API resources
      subgraph "http://foo.logto.app/api"
        scope(scope `all`)
      end
    end
    subgraph Applications
      app(Machine-to-machine app for tenant `foo`)
    end
    subgraph Roles
      role(Machine-to-machine role for tenant `foo`)
    end
  end

  app -.- role
  role -.- scope
```

Unlike the original RBAC approach, the user will now join the tenant organization `foo` for accessing the Management API proxy.

> [!Note]
> We still use the admin tenant issued access token to access user tenant. The subject changed from user to machine-to-machine app in the admin tenant.

The following diagram shows how Management API proxy works:

```mermaid
sequenceDiagram
  participant console as Logto Console
  participant cloud as Management API proxy (Logto Cloud)
  participant tenant as User tenant (Management API)
  participant admin as Admin tenant (Management API)

  console->>cloud: Request to get applications (GET /applications) for tenant `foo`
  break when user has not effective tenant organization permissions
    cloud->>console: Access denied
  end
  alt access token has expired
    cloud->>cloud: Get the machine-to-machine application for tenant `foo`
    cloud->>admin: Request access token for tenant `foo`
    admin->>cloud: Return access token
  end
  cloud->>tenant: Request `GET /applications` with access token
  tenant->>cloud: Return response
  cloud->>console: Return response
```

### Plan

The migration can have no downtime, with the following steps:

1. Temporarily disable registration for Logto Cloud. (manual)
2. Deploy database changes for tenant organizations.
3. Deploy the core and cloud services with the new changes.
4. Clean up the outdated user roles for tenant management.
5. Enable registration for Logto Cloud. (manual)

This pull request contains the changes for step 2.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
added test data for alteration scripts. should be good.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
