### PR TITLE
refactor(console): use organization token for management api

### DIFF
--- a/packages/console/src/contexts/TenantsProvider.tsx
+++ b/packages/console/src/contexts/TenantsProvider.tsx
@@ -58,13 +58,6 @@ type Tenants = {
   currentTenantId: string;
   currentTenant?: TenantResponse;
   isDevTenant: boolean;
-  /**
-   * Indicates if the Access Token has been validated for use. Will be reset to `pending` when the current tenant changes.
-   *
-   * @see {@link CurrentTenantStatus}
-   */
-  currentTenantStatus: CurrentTenantStatus;
-  setCurrentTenantStatus: (status: CurrentTenantStatus) => void;
   /** Navigate to the given tenant ID. */
   navigateTenant: (tenantId: string) => void;
 };
@@ -106,8 +99,6 @@ export const TenantsContext = createContext<Tenants>({
   updateTenant: noop,
   currentTenantId: '',
   isDevTenant: false,
-  currentTenantStatus: 'pending',
-  setCurrentTenantStatus: noop,
   navigateTenant: noop,
 });
 
@@ -142,13 +133,10 @@ function TenantsProvider({ children }: Props) {
 
     return match.params.tenantId ?? '';
   }, [match]);
-  const [currentTenantStatus, setCurrentTenantStatus] = useState<CurrentTenantStatus>('pending');
 
   const navigateTenant = useCallback(
     (tenantId: string) => {
       navigate(`/${tenantId}`);
-
-      setCurrentTenantStatus('pending');
     },
     [navigate]
   );
@@ -163,7 +151,6 @@ function TenantsProvider({ children }: Props) {
       tenants,
       resetTenants: (tenants: TenantResponse[]) => {
         setTenants(tenants);
-        setCurrentTenantStatus('pending');
         setIsInitComplete(true);
       },
       prependTenant: (tenant: TenantResponse) => {
@@ -181,11 +168,9 @@ function TenantsProvider({ children }: Props) {
       currentTenantId,
       isDevTenant: currentTenant?.tag === TenantTag.Development,
       currentTenant,
-      currentTenantStatus,
-      setCurrentTenantStatus,
       navigateTenant,
     }),
-    [currentTenant, currentTenantId, currentTenantStatus, isInitComplete, navigateTenant, tenants]
+    [currentTenant, currentTenantId, isInitComplete, navigateTenant, tenants]
   );
 
   return <TenantsContext.Provider value={memorizedContext}>{children}</TenantsContext.Provider>;


### PR DESCRIPTION
> [!Warning]
> this pull depends on https://github.com/logto-io/cloud/pull/398 to work properly.

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

a follow-up of #5105. uses organizations for cloud multi-tenancy, and keep the API resource method for OSS.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
tested locally with OSS and Cloud. currently no additional test is needed since it does not change business logic.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
