### PR TITLE
fix(console): hide feature tag when standard connectors is unlimited

### DIFF
--- a/packages/console/src/components/CreateConnectorForm/index.tsx
+++ b/packages/console/src/components/CreateConnectorForm/index.tsx
@@ -48,7 +48,11 @@ function CreateConnectorForm({ onClose, isOpen: isFormOpen, type }: Props) {
   const { currentTenantId } = useContext(TenantsContext);
   const { data: currentPlan } = useSubscriptionPlan(currentTenantId);
 
-  const isStandardConnectorDisabled = !currentPlan?.quota.standardConnectorsLimit;
+  const {
+    quota: { standardConnectorsLimit },
+  } = currentPlan ?? { quota: { standardConnectorsLimit: 0 } };
+
+  const isStandardConnectorDisabled = isCloud && standardConnectorsLimit === 0;
 
   const groups = useMemo(() => {
     if (!factories || !existingConnectors) {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

`null` value stands for 'unlimited' in our plan quota, so we need to check if the quota value is `0` to determine the standard connectos feature is enabled or not.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="671" alt="image" src="https://github.com/logto-io/logto/assets/10806653/ef32934d-dc9b-4063-984c-21d4c56ad363">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
