### PR TITLE
feat(experience): experience support old browser

### DIFF
--- a/packages/experience/package.json
+++ b/packages/experience/package.json
@@ -56,6 +56,7 @@
     "camelcase-keys": "^9.0.0",
     "classnames": "^2.3.1",
     "color": "^4.2.3",
+    "core-js": "^3.34.0",
     "cross-env": "^7.0.3",
     "eslint": "^8.44.0",
     "i18next": "^22.4.15",
@@ -99,7 +100,16 @@
   "targets": {
     "default": {
       "engines": {
-        "browsers": "defaults"
+        "browsers": [
+          "defaults",
+          ">0.3%",
+          "Chrome >= 52",
+          "Firefox >= 55",
+          "Safari >= 10",
+          "Edge >= 13",
+          "iOS >= 10",
+          "Electron >= 0.36"
+        ]
       }
     }
   },

--- a/packages/experience/src/index.tsx
+++ b/packages/experience/src/index.tsx
@@ -1,3 +1,4 @@
+import 'core-js/actual';
 import { createRoot } from 'react-dom/client';
 import ReactModal from 'react-modal';
 

--- a/packages/experience/src/index.tsx
+++ b/packages/experience/src/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable-next-line import/no-unassigned-import */
 import 'core-js/actual';
 import { createRoot } from 'react-dom/client';
 import ReactModal from 'react-modal';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3626,6 +3626,9 @@ importers:
       color:
         specifier: ^4.2.3
         version: 4.2.3
+      core-js:
+        specifier: ^3.34.0
+        version: 3.34.0
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -11649,10 +11652,9 @@ packages:
       depd: 2.0.0
       keygrip: 1.1.0
 
-  /core-js@3.21.1:
-    resolution: {integrity: sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==}
+  /core-js@3.34.0:
+    resolution: {integrity: sha512-aDdvlDder8QmY91H88GzNi9EtQi2TjvQhpCX6B1v/dAZHU1AuLgHvRh54RiOerpEhEW46Tkf+vgAViB/CWC0ag==}
     requiresBuild: true
-    dev: false
 
   /cosmiconfig-typescript-loader@5.0.0(@types/node@18.19.3)(cosmiconfig@8.3.6)(typescript@5.0.2):
     resolution: {integrity: sha512-+8cK7jRAReYkMwMiG+bxhcNKiHJDM6bR9FD/nGBXOWdMLuYawjF5cGrtLilJ+LGd3ZjCXnJjR5DkfWPoIVlqJA==}
@@ -19715,7 +19717,7 @@ packages:
       slonik: '*'
     dependencies:
       camelcase: 6.3.0
-      core-js: 3.21.1
+      core-js: 3.34.0
       slonik: 22.7.1
     dev: false
 
@@ -19736,7 +19738,7 @@ packages:
     resolution: {integrity: sha512-f9jxhsu+8u0ssf2pdzLx1jSlGODkAitNbGrprJWGOjmnQzZKW4jWaq54DZGwyNv4HotOb9m4Lp0u9XQODKXyng==}
     engines: {node: '>=8.0'}
     dependencies:
-      core-js: 3.21.1
+      core-js: 3.34.0
       pg-formatter: 1.3.0
       pretty-ms: 6.0.1
       slonik: 22.7.1
@@ -19762,7 +19764,7 @@ packages:
     resolution: {integrity: sha512-TAuWVFBVnq7I5KcEY/x1JgVgIVZ0yyyeRlMTzKs+u4wRYhszQW2hMIYnDak/UUfWR1h6wp3+hODiC4gKyBOUcg==}
     engines: {node: '>=8.0'}
     dependencies:
-      core-js: 3.21.1
+      core-js: 3.34.0
       slonik: 22.7.1
     transitivePeerDependencies:
       - pg-native


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR is relative to https://github.com/logto-io/logto/issues/3878 ， https://github.com/logto-io/logto/issues/3059
Current Parcel config use 
- `Object: fromEntries` ( support by chrome >=73 )
- `Optional chaining operator` ( support by chrome >= 80 )
cover 69.72% of Chinese people.

Since described in [Parcel does not include polyfill for older browsers even when browserslist is declared in the package.json](https://github.com/parcel-bundler/parcel/issues/7419)
- Parcel only transpiles the code according to the browserslist but doesn't handle runtime polyfills.
- Parcel always pass `mode: entry` to swc, and SWC treats it similarly to `useBuiltIns: entry` in Babel.

This PR add `core-js` to the entry of the experience package, and SWC will include the required parts of it for the browserslist.

The Browserslist in package.json is also updated to support as many users as possible for login, as it uses  `ReadableStream` in the `get-stream` node modules. chrome 52 is the earliest version support it. So We choose chrome 52 as start point. Current Browserslist will cover [97.1 %](https://browsersl.ist/#q=%3E0.3%25%2C+defaults%2C+Chrome+%3E%3D+52%2C+Firefox+%3E%3D+55%2C+Safari+%3E%3D+10%2C+edge+%3E%3D+13%2C+iOS+%3E%3D+10%2C+Electron+%3E%3D+0.36) global user.

Such configuration in Parcel will output two JavaScript files. One of them, based on the aforementioned Browserslist, excludes versions of browsers that do not support ES module features. This is referred to as the 'modern' version, primarily including versions of Chrome greater than 61. The other file is the 'compatibility' version. The browser will automatically choose which version to load.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
![屏幕截图 2023-12-20 162135](https://github.com/logto-io/logto/assets/5122973/ab4c6191-4b79-4a30-84e8-1312b4eabe84)

![屏幕截图 2023-12-20 180940](https://github.com/logto-io/logto/assets/5122973/991b8928-b68b-4487-bb53-7cb819f057ab)

![屏幕截图 2023-12-20 181054](https://github.com/logto-io/logto/assets/5122973/59fbf670-863c-4f49-b84b-20d7a327606c)

![屏幕截图 2023-12-20 161944](https://github.com/logto-io/logto/assets/5122973/b158dfd4-86eb-4764-aa58-a4f83c5e216d)

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
