### PR TITLE
fix(core): remove the COOP policy

### DIFF
--- a/packages/core/src/middleware/koa-security-headers.ts
+++ b/packages/core/src/middleware/koa-security-headers.ts
@@ -56,6 +56,7 @@ export default function koaSecurityHeaders<StateT, ContextT, ResponseBodyT>(
 
   const basicSecurityHeaderSettings: HelmetOptions = {
     contentSecurityPolicy: false, // Exclusively set per app
+    crossOriginOpenerPolicy: false, // Allow cross origin opener, as some apps rely on popup window for the sign-in flow
     crossOriginEmbedderPolicy: { policy: 'credentialless' },
     dnsPrefetchControl: false,
     referrerPolicy: {


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Remove the COOP policy.

Based on the use case of the issue https://github.com/logto-io/logto/issues/5109,  it is a common use case for web apps using a popup window to handle their sign-in interaction flow.  
Per offline discussion remove the COOP policy for now, as it will block all the cross-origin pop-up window's opener communication. 



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally

<img width="891" alt="image" src="https://github.com/logto-io/logto/assets/36393111/73e60566-ec7f-4530-a5fc-a6f06d12ed63">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
