### PR TITLE
feat(core): sync site configs to KV for new protected app

### DIFF
--- a/packages/core/src/__mocks__/index.ts
+++ b/packages/core/src/__mocks__/index.ts
@@ -43,6 +43,32 @@ export const mockApplication: Application = {
   createdAt: 1_645_334_775_356,
 };
 
+export const mockProtectedApplication: Application = {
+  tenantId: 'fake_tenant',
+  id: 'mock-protected-app',
+  secret: mockId,
+  name: 'mock-protected-app',
+  type: ApplicationType.Protected,
+  description: null,
+  oidcClientMetadata: {
+    redirectUris: [],
+    postLogoutRedirectUris: [],
+  },
+  customClientMetadata: {
+    corsAllowedOrigins: ['http://localhost:3000', 'http://localhost:3001', 'https://logto.dev'],
+    idTokenTtl: 5000,
+    refreshTokenTtl: 6_000_000,
+  },
+  protectedAppMetadata: {
+    host: 'mock.protected.dev',
+    origin: 'https://my-blog.com',
+    sessionDuration: 1_209_600,
+    pageRules: [{ path: '^/' }],
+  },
+  isThirdParty: false,
+  createdAt: 1_645_334_775_356,
+};
+
 export const mockResource: Resource = {
   tenantId: 'fake_tenant',
   id: 'logto_api',

--- a/packages/core/src/libraries/domain.test.ts
+++ b/packages/core/src/libraries/domain.test.ts
@@ -13,9 +13,9 @@ import SystemContext from '#src/tenants/SystemContext.js';
 import { mockFallbackOrigin } from '#src/utils/cloudflare/mock.js';
 
 const { jest } = import.meta;
-const { mockEsm } = createMockUtils(jest);
+const { mockEsmWithActual } = createMockUtils(jest);
 
-const { getCustomHostname, createCustomHostname, deleteCustomHostname } = mockEsm(
+const { getCustomHostname, createCustomHostname, deleteCustomHostname } = await mockEsmWithActual(
   '#src/utils/cloudflare/index.js',
   () => ({
     createCustomHostname: jest.fn(async () => mockCloudflareData),
@@ -25,7 +25,7 @@ const { getCustomHostname, createCustomHostname, deleteCustomHostname } = mockEs
   })
 );
 
-const { clearCustomDomainCache } = mockEsm('#src/utils/tenant.js', () => ({
+const { clearCustomDomainCache } = await mockEsmWithActual('#src/utils/tenant.js', () => ({
   clearCustomDomainCache: jest.fn(),
 }));
 

--- a/packages/core/src/libraries/protected-app.test.ts
+++ b/packages/core/src/libraries/protected-app.test.ts
@@ -1,0 +1,74 @@
+import { createMockUtils } from '@logto/shared/esm';
+
+import { mockProtectedApplication } from '#src/__mocks__/index.js';
+import SystemContext from '#src/tenants/SystemContext.js';
+
+const { jest } = import.meta;
+const { mockEsmWithActual } = createMockUtils(jest);
+
+const { updateProtectedAppSiteConfigs } = await mockEsmWithActual(
+  '#src/utils/cloudflare/index.js',
+  () => ({
+    updateProtectedAppSiteConfigs: jest.fn(),
+  })
+);
+
+const { MockQueries } = await import('#src/test-utils/tenant.js');
+const { createProtectedAppLibrary } = await import('./protected-app.js');
+
+const findApplicationById = jest.fn(async () => mockProtectedApplication);
+const { syncAppConfigsToRemote } = createProtectedAppLibrary(
+  new MockQueries({ applications: { findApplicationById } })
+);
+
+const protectedAppConfigProviderConfig = {
+  accountIdentifier: 'fake_account_id',
+  namespaceIdentifier: 'fake_namespace_id',
+  keyName: 'fake_key_name',
+  apiToken: '',
+};
+
+beforeAll(() => {
+  // eslint-disable-next-line @silverhand/fp/no-mutation
+  SystemContext.shared.protectedAppConfigProviderConfig = protectedAppConfigProviderConfig;
+});
+
+afterAll(() => {
+  // eslint-disable-next-line @silverhand/fp/no-mutation
+  SystemContext.shared.protectedAppConfigProviderConfig = undefined;
+});
+
+afterEach(() => {
+  updateProtectedAppSiteConfigs.mockClear();
+});
+
+describe('syncAppConfigsToRemote()', () => {
+  it('should skip if protectedAppMetadata is missing', async () => {
+    findApplicationById.mockResolvedValueOnce({
+      ...mockProtectedApplication,
+      protectedAppMetadata: null,
+    });
+    await expect(syncAppConfigsToRemote(mockProtectedApplication.id)).resolves.not.toThrow();
+    expect(updateProtectedAppSiteConfigs).not.toBeCalled();
+  });
+
+  it('should sync configs to remote', async () => {
+    findApplicationById.mockResolvedValueOnce(mockProtectedApplication);
+    await expect(syncAppConfigsToRemote(mockProtectedApplication.id)).resolves.not.toThrow();
+    const { protectedAppMetadata, id, secret } = mockProtectedApplication;
+    expect(updateProtectedAppSiteConfigs).toHaveBeenCalledWith(
+      protectedAppConfigProviderConfig,
+      protectedAppMetadata?.host,
+      {
+        ...protectedAppMetadata,
+        sdkConfig: {
+          appId: id,
+          appSecret: secret,
+          // Avoid mocking envset
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          endpoint: expect.anything(),
+        },
+      }
+    );
+  });
+});

--- a/packages/core/src/libraries/protected-app.ts
+++ b/packages/core/src/libraries/protected-app.ts
@@ -1,0 +1,45 @@
+import { EnvSet } from '#src/env-set/index.js';
+import type Queries from '#src/tenants/Queries.js';
+import SystemContext from '#src/tenants/SystemContext.js';
+import assertThat from '#src/utils/assert-that.js';
+import { updateProtectedAppSiteConfigs } from '#src/utils/cloudflare/index.js';
+
+export type ProtectedAppLibrary = ReturnType<typeof createProtectedAppLibrary>;
+
+export const createProtectedAppLibrary = (queries: Queries) => {
+  const {
+    applications: { findApplicationById },
+  } = queries;
+
+  const syncAppConfigsToRemote = async (applicationId: string): Promise<void> => {
+    // Skip for integration test, we don't do third party call in integration test
+    if (EnvSet.values.isIntegrationTest) {
+      return;
+    }
+
+    const { protectedAppConfigProviderConfig } = SystemContext.shared;
+    assertThat(protectedAppConfigProviderConfig, 'application.protected_app_not_configured');
+
+    const { protectedAppMetadata, id, secret } = await findApplicationById(applicationId);
+    if (!protectedAppMetadata) {
+      return;
+    }
+
+    await updateProtectedAppSiteConfigs(
+      protectedAppConfigProviderConfig,
+      protectedAppMetadata.host,
+      {
+        ...protectedAppMetadata,
+        sdkConfig: {
+          appId: id,
+          appSecret: secret,
+          endpoint: EnvSet.values.endpoint.href,
+        },
+      }
+    );
+  };
+
+  return {
+    syncAppConfigsToRemote,
+  };
+};

--- a/packages/core/src/tenants/Libraries.ts
+++ b/packages/core/src/tenants/Libraries.ts
@@ -5,6 +5,7 @@ import { createDomainLibrary } from '#src/libraries/domain.js';
 import { createHookLibrary } from '#src/libraries/hook/index.js';
 import { createPasscodeLibrary } from '#src/libraries/passcode.js';
 import { createPhraseLibrary } from '#src/libraries/phrase.js';
+import { createProtectedAppLibrary } from '#src/libraries/protected-app.js';
 import { createQuotaLibrary } from '#src/libraries/quota.js';
 import { createSignInExperienceLibrary } from '#src/libraries/sign-in-experience/index.js';
 import { createSocialLibrary } from '#src/libraries/social.js';
@@ -23,6 +24,7 @@ export default class Libraries {
   applications = createApplicationLibrary(this.queries);
   verificationStatuses = createVerificationStatusLibrary(this.queries);
   domains = createDomainLibrary(this.queries);
+  protectedApps = createProtectedAppLibrary(this.queries);
   quota = createQuotaLibrary(this.queries, this.cloudConnection, this.connectors);
   ssoConnectors = createSsoConnectorLibrary(this.queries);
   signInExperiences = createSignInExperienceLibrary(

--- a/packages/core/src/tenants/SystemContext.ts
+++ b/packages/core/src/tenants/SystemContext.ts
@@ -6,6 +6,8 @@ import {
   storageProviderDataGuard,
   StorageProviderKey,
   type SystemKey,
+  type ProtectedAppConfigProviderData,
+  protectedAppConfigProviderDataGuard,
 } from '@logto/schemas';
 import type { CommonQueryMethods } from 'slonik';
 import { type ZodType } from 'zod';
@@ -17,6 +19,7 @@ export default class SystemContext {
   static shared = new SystemContext();
   public storageProviderConfig?: StorageProviderData;
   public hostnameProviderConfig?: HostnameProviderData;
+  public protectedAppConfigProviderConfig?: ProtectedAppConfigProviderData;
 
   async loadProviderConfigs(pool: CommonQueryMethods) {
     await Promise.all([
@@ -32,6 +35,13 @@ export default class SystemContext {
           pool,
           CloudflareKey.HostnameProvider,
           hostnameProviderDataGuard
+        );
+      })(),
+      (async () => {
+        this.protectedAppConfigProviderConfig = await this.loadConfig(
+          pool,
+          CloudflareKey.ProtectedAppConfigProvider,
+          protectedAppConfigProviderDataGuard
         );
       })(),
     ]);

--- a/packages/core/src/utils/cloudflare/kv.ts
+++ b/packages/core/src/utils/cloudflare/kv.ts
@@ -1,0 +1,56 @@
+import path from 'node:path';
+
+import { type ProtectedAppConfigProviderData } from '@logto/schemas';
+import { got } from 'got';
+
+import RequestError from '#src/errors/RequestError/index.js';
+
+import { baseUrl } from './consts.js';
+import { type SiteConfigs } from './types.js';
+import { buildHandleResponse } from './utils.js';
+
+const handleResponse = buildHandleResponse(() => {
+  throw new RequestError({
+    code: 'application.cloudflare_unknown_error',
+    status: 500,
+  });
+});
+
+export const updateProtectedAppSiteConfigs = async (
+  auth: ProtectedAppConfigProviderData,
+  host: string,
+  value: SiteConfigs
+) => {
+  const {
+    EnvSet: {
+      values: { isIntegrationTest },
+    },
+  } = await import('#src/env-set/index.js');
+  if (isIntegrationTest) {
+    return;
+  }
+
+  const response = await got.put(
+    new URL(
+      path.join(
+        baseUrl.pathname,
+        `/accounts/${auth.accountIdentifier}/storage/kv/namespaces/${
+          auth.namespaceIdentifier
+        }/values/${encodeURIComponent(`${auth.keyName}:${host}`)}`
+      ),
+      baseUrl
+    ),
+    {
+      headers: {
+        Authorization: `Bearer ${auth.apiToken}`,
+      },
+      throwHttpErrors: false,
+      json: {
+        metadata: {},
+        value: JSON.stringify(value),
+      },
+    }
+  );
+
+  handleResponse(response);
+};

--- a/packages/core/src/utils/cloudflare/types.ts
+++ b/packages/core/src/utils/cloudflare/types.ts
@@ -1,4 +1,6 @@
-import { z } from 'zod';
+import { type ProtectedAppMetadata } from '@logto/schemas';
+import { type Response } from 'got';
+import { type ZodType, z } from 'zod';
 
 export const cloudflareResponseGuard = z.object({
   success: z.boolean(),
@@ -10,3 +12,20 @@ export const cloudflareHostnameResponseGuard = z
     origin: z.string(),
   })
   .catchall(z.unknown());
+
+export type HandleResponse = {
+  <T>(response: Response<string>, guard: ZodType<T>): T;
+  (response: Response<string>): void;
+};
+
+export type SiteConfigs = ProtectedAppMetadata & {
+  /* The Logto SDK configuration */
+  sdkConfig: {
+    /* The client ID of the application */
+    appId: string;
+    /* The client secret of the application */
+    appSecret: string;
+    /* The Logto endpoint */
+    endpoint: string;
+  };
+};

--- a/packages/core/src/utils/cloudflare/utils.ts
+++ b/packages/core/src/utils/cloudflare/utils.ts
@@ -1,13 +1,35 @@
 import { parseJson } from '@logto/connector-kit';
+import { type Response } from 'got';
+import { type ZodType } from 'zod';
 
 import assertThat from '../assert-that.js';
 
-import { cloudflareResponseGuard } from './types.js';
+import { type HandleResponse, cloudflareResponseGuard } from './types.js';
 
-export const parseCloudflareResponse = (body: string) => {
+const parseCloudflareResponse = (body: string) => {
   const result = cloudflareResponseGuard.safeParse(parseJson(body));
 
   assertThat(result.success && result.data.success, 'domain.cloudflare_response_error');
 
   return result.data.result;
+};
+
+export const buildHandleResponse = (handleError: (statusCode: number) => never) => {
+  const handleResponse: HandleResponse = <T>(response: Response<string>, guard?: ZodType<T>) => {
+    if (!response.ok) {
+      handleError(response.statusCode);
+    }
+
+    if (!guard) {
+      return;
+    }
+
+    const result = guard.safeParse(parseCloudflareResponse(response.body));
+
+    assertThat(result.success, 'domain.cloudflare_response_error');
+
+    return result.data;
+  };
+
+  return handleResponse;
 };

--- a/packages/integration-tests/src/tests/api/application/application.test.ts
+++ b/packages/integration-tests/src/tests/api/application/application.test.ts
@@ -164,7 +164,11 @@ describe('admin console application', () => {
     const allApps = await getApplications();
     const m2mApps = await getApplications([ApplicationType.MachineToMachine]);
     const spaApps = await getApplications([ApplicationType.SPA]);
-    const otherApps = await getApplications([ApplicationType.Native, ApplicationType.Traditional]);
+    const otherApps = await getApplications([
+      ApplicationType.Native,
+      ApplicationType.Traditional,
+      ApplicationType.Protected,
+    ]);
     expect(allApps.length).toBe(m2mApps.length + spaApps.length + otherApps.length);
     const allAppNames = allApps.map(({ name }) => name);
     const spaAppNames = spaApps.map(({ name }) => name);

--- a/packages/phrases/src/locales/de/errors/application.ts
+++ b/packages/phrases/src/locales/de/errors/application.ts
@@ -8,6 +8,10 @@ const application = {
   third_party_application_only: 'Das Feature ist nur für Drittanbieter-Anwendungen verfügbar.',
   user_consent_scopes_not_found: 'Ungültige Benutzerzustimmungsbereiche.',
   protected_app_metadata_is_required: 'Geschützte App-Metadaten sind erforderlich.',
+  /** UNTRANSLATED */
+  protected_app_not_configured: 'Protected app provider is not configured.',
+  /** UNTRANSLATED */
+  cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/en/errors/application.ts
+++ b/packages/phrases/src/locales/en/errors/application.ts
@@ -7,6 +7,8 @@ const application = {
   third_party_application_only: 'The feature is only available for third-party applications.',
   user_consent_scopes_not_found: 'Invalid user consent scopes.',
   protected_app_metadata_is_required: 'Protected app metadata is required.',
+  protected_app_not_configured: 'Protected app provider is not configured.',
+  cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/es/errors/application.ts
+++ b/packages/phrases/src/locales/es/errors/application.ts
@@ -8,6 +8,10 @@ const application = {
   third_party_application_only: 'La función solo está disponible para aplicaciones de terceros.',
   user_consent_scopes_not_found: 'Ámbitos de consentimiento de usuario no válidos.',
   protected_app_metadata_is_required: 'Se requiere metadatos de aplicación protegida.',
+  /** UNTRANSLATED */
+  protected_app_not_configured: 'Protected app provider is not configured.',
+  /** UNTRANSLATED */
+  cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/fr/errors/application.ts
+++ b/packages/phrases/src/locales/fr/errors/application.ts
@@ -9,6 +9,10 @@ const application = {
     'La fonctionnalité est uniquement disponible pour les applications tierces.',
   user_consent_scopes_not_found: 'Portées de consentement utilisateur invalides.',
   protected_app_metadata_is_required: "Les métadonnées d'application protégée sont requises.",
+  /** UNTRANSLATED */
+  protected_app_not_configured: 'Protected app provider is not configured.',
+  /** UNTRANSLATED */
+  cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/it/errors/application.ts
+++ b/packages/phrases/src/locales/it/errors/application.ts
@@ -9,6 +9,10 @@ const application = {
     'La funzionalità è disponibile solo per le applicazioni di terze parti.',
   user_consent_scopes_not_found: 'Scopi di consenso utente non validi.',
   protected_app_metadata_is_required: 'Protected app metadata is required.',
+  /** UNTRANSLATED */
+  protected_app_not_configured: 'Protected app provider is not configured.',
+  /** UNTRANSLATED */
+  cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/ja/errors/application.ts
+++ b/packages/phrases/src/locales/ja/errors/application.ts
@@ -8,6 +8,10 @@ const application = {
   third_party_application_only: 'この機能はサードパーティアプリケーションにのみ利用可能です。',
   user_consent_scopes_not_found: '無効なユーザー同意スコープ。',
   protected_app_metadata_is_required: 'Protected app metadata is required.',
+  /** UNTRANSLATED */
+  protected_app_not_configured: 'Protected app provider is not configured.',
+  /** UNTRANSLATED */
+  cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/ko/errors/application.ts
+++ b/packages/phrases/src/locales/ko/errors/application.ts
@@ -7,6 +7,10 @@ const application = {
   third_party_application_only: '해당 기능은 제 3자 응용 프로그램에만 사용할 수 있습니다.',
   user_consent_scopes_not_found: '유효하지 않은 사용자 동의 범위입니다.',
   protected_app_metadata_is_required: '보호된 응용 프로그램 메타데이터가 필요합니다.',
+  /** UNTRANSLATED */
+  protected_app_not_configured: 'Protected app provider is not configured.',
+  /** UNTRANSLATED */
+  cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/pl-pl/errors/application.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/application.ts
@@ -7,6 +7,10 @@ const application = {
   third_party_application_only: 'Ta funkcja jest dostępna tylko dla aplikacji zewnętrznych.',
   user_consent_scopes_not_found: 'Nieprawidłowe zakresy zgody użytkownika.',
   protected_app_metadata_is_required: 'Wymagane jest zabezpieczone metadane aplikacji.',
+  /** UNTRANSLATED */
+  protected_app_not_configured: 'Protected app provider is not configured.',
+  /** UNTRANSLATED */
+  cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/pt-br/errors/application.ts
+++ b/packages/phrases/src/locales/pt-br/errors/application.ts
@@ -8,6 +8,10 @@ const application = {
   third_party_application_only: 'O recurso está disponível apenas para aplicativos de terceiros.',
   user_consent_scopes_not_found: 'Escopos de consentimento do usuário inválidos.',
   protected_app_metadata_is_required: 'Protegido metadados do app é necessário.',
+  /** UNTRANSLATED */
+  protected_app_not_configured: 'Protected app provider is not configured.',
+  /** UNTRANSLATED */
+  cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/pt-pt/errors/application.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/application.ts
@@ -8,6 +8,10 @@ const application = {
   third_party_application_only: 'A funcionalidade só está disponível para aplicações de terceiros.',
   user_consent_scopes_not_found: 'Escopos de consentimento de utilizador inválidos.',
   protected_app_metadata_is_required: 'Protected app metadata is required.',
+  /** UNTRANSLATED */
+  protected_app_not_configured: 'Protected app provider is not configured.',
+  /** UNTRANSLATED */
+  cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/ru/errors/application.ts
+++ b/packages/phrases/src/locales/ru/errors/application.ts
@@ -9,6 +9,10 @@ const application = {
     'Эта функция доступна только для приложений сторонних разработчиков.',
   user_consent_scopes_not_found: 'Недействительные области согласия пользователя.',
   protected_app_metadata_is_required: 'Требуется защищенная метаданные приложения.',
+  /** UNTRANSLATED */
+  protected_app_not_configured: 'Protected app provider is not configured.',
+  /** UNTRANSLATED */
+  cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/tr-tr/errors/application.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/application.ts
@@ -7,6 +7,10 @@ const application = {
   third_party_application_only: 'Bu özellik sadece üçüncü taraf uygulamalar için geçerlidir.',
   user_consent_scopes_not_found: 'Geçersiz kullanıcı onay kapsamları.',
   protected_app_metadata_is_required: 'Protected app metadata is required.',
+  /** UNTRANSLATED */
+  protected_app_not_configured: 'Protected app provider is not configured.',
+  /** UNTRANSLATED */
+  cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/zh-cn/errors/application.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/application.ts
@@ -6,6 +6,10 @@ const application = {
   third_party_application_only: '该功能仅适用于第三方应用程序。',
   user_consent_scopes_not_found: '无效的用户同意范围。',
   protected_app_metadata_is_required: '需要保护的应用程序元数据。',
+  /** UNTRANSLATED */
+  protected_app_not_configured: 'Protected app provider is not configured.',
+  /** UNTRANSLATED */
+  cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/zh-hk/errors/application.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/application.ts
@@ -6,6 +6,10 @@ const application = {
   third_party_application_only: '此功能只適用於第三方應用程式。',
   user_consent_scopes_not_found: '無效的使用者同意範圍。',
   protected_app_metadata_is_required: '保護應用程式元數據是必需的。',
+  /** UNTRANSLATED */
+  protected_app_not_configured: 'Protected app provider is not configured.',
+  /** UNTRANSLATED */
+  cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/zh-tw/errors/application.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/application.ts
@@ -6,6 +6,10 @@ const application = {
   third_party_application_only: '該功能僅適用於第三方應用程式。',
   user_consent_scopes_not_found: '無效的使用者同意範圍。',
   protected_app_metadata_is_required: '需要保護應用程式元數據。',
+  /** UNTRANSLATED */
+  protected_app_not_configured: 'Protected app provider is not configured.',
+  /** UNTRANSLATED */
+  cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
 };
 
 export default Object.freeze(application);

--- a/packages/schemas/src/types/system.ts
+++ b/packages/schemas/src/types/system.ts
@@ -149,18 +149,34 @@ export const hostnameProviderDataGuard = z.object({
 
 export type HostnameProviderData = z.infer<typeof hostnameProviderDataGuard>;
 
+// Cloudflare KV for protected app config
+export const protectedAppConfigProviderDataGuard = z.object({
+  /* Cloudflare Workers & Pages account ID */
+  accountIdentifier: z.string(),
+  /* KV namespace ID */
+  namespaceIdentifier: z.string(),
+  /* Key prefix for protected app config */
+  keyName: z.string(),
+  apiToken: z.string(), // Requires account permission for "KV Storage Edit"
+});
+
+export type ProtectedAppConfigProviderData = z.infer<typeof protectedAppConfigProviderDataGuard>;
+
 export enum CloudflareKey {
   HostnameProvider = 'cloudflareHostnameProvider',
+  ProtectedAppConfigProvider = 'cloudflareProtectedAppConfigProvider',
 }
 
 export type CloudflareType = {
   [CloudflareKey.HostnameProvider]: HostnameProviderData;
+  [CloudflareKey.ProtectedAppConfigProvider]: ProtectedAppConfigProviderData;
 };
 
 export const cloudflareGuard: Readonly<{
   [key in CloudflareKey]: ZodType<CloudflareType[key]>;
 }> = Object.freeze({
   [CloudflareKey.HostnameProvider]: hostnameProviderDataGuard,
+  [CloudflareKey.ProtectedAppConfigProvider]: protectedAppConfigProviderDataGuard,
 });
 
 // Summary


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Sync site configs to KV for new protected app:

1. new library ProtectedAppsLibrary.
2. new method for KV operations in Cloudflare utils.
3. new system configs for KV.
4. Sync configs to Cloudflare KV when creating new protected application.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Unit tests added.

No integration tests since we don't do test for outside services. There is no change in our side.

Local tested, when creating a new app, new KV record created:

<img width="631" alt="image" src="https://github.com/logto-io/logto/assets/5717882/1776393b-1b08-4e3b-b465-f205bb3d6d69">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
