### PR TITLE
refactor(console): navigate to plan & billing page on paywall button clicked

### DIFF
--- a/packages/console/src/pages/ApiResources/components/CreateForm/Footer.tsx
+++ b/packages/console/src/pages/ApiResources/components/CreateForm/Footer.tsx
@@ -1,5 +1,4 @@
 import { ReservedPlanId } from '@logto/schemas';
-import { cond } from '@silverhand/essentials';
 import { useContext } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
@@ -10,7 +9,6 @@ import { isDevFeaturesEnabled } from '@/consts/env';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import Button from '@/ds-components/Button';
 import useApiResourcesUsage from '@/hooks/use-api-resources-usage';
-import useSubscribe from '@/hooks/use-subscribe';
 import useSubscriptionPlan from '@/hooks/use-subscription-plan';
 
 type Props = {
@@ -23,7 +21,6 @@ function Footer({ isCreationLoading, onClickCreate }: Props) {
   const { currentTenantId } = useContext(TenantsContext);
   const { data: currentPlan } = useSubscriptionPlan(currentTenantId);
   const { hasReachedLimit } = useApiResourcesUsage();
-  const { subscribe, isSubscribeLoading } = useSubscribe();
 
   if (
     currentPlan &&
@@ -35,20 +32,7 @@ function Footer({ isCreationLoading, onClickCreate }: Props) {
     (!isDevFeaturesEnabled || currentPlan.id === ReservedPlanId.Free)
   ) {
     return (
-      <QuotaGuardFooter
-        isLoading={isSubscribeLoading}
-        onClickUpgrade={cond(
-          isDevFeaturesEnabled &&
-            (() => {
-              void subscribe({
-                // Todo @xiaoyijun [Pricing] Replace 'Hobby' with 'Pro' when pricing is ready, in MVP, we use 'Hobby' as the new pro plan id
-                planId: ReservedPlanId.Hobby,
-                tenantId: currentTenantId,
-                callbackPage: '/api-resources/create',
-              });
-            })
-        )}
-      >
+      <QuotaGuardFooter>
         <Trans
           components={{
             a: <ContactUsPhraseLink />,

--- a/packages/console/src/pages/Applications/components/CreateForm/Footer/index.tsx
+++ b/packages/console/src/pages/Applications/components/CreateForm/Footer/index.tsx
@@ -9,7 +9,6 @@ import { isDevFeaturesEnabled } from '@/consts/env';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import Button from '@/ds-components/Button';
 import useApplicationsUsage from '@/hooks/use-applications-usage';
-import useSubscribe from '@/hooks/use-subscribe';
 import useSubscriptionPlan from '@/hooks/use-subscription-plan';
 
 type Props = {
@@ -22,7 +21,6 @@ function Footer({ selectedType, isLoading, onClickCreate }: Props) {
   const { currentTenantId } = useContext(TenantsContext);
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console.upsell.paywall' });
   const { data: currentPlan } = useSubscriptionPlan(currentTenantId);
-  const { subscribe, isSubscribeLoading } = useSubscribe();
   const { hasAppsReachedLimit, hasMachineToMachineAppsReachedLimit } = useApplicationsUsage();
 
   if (currentPlan && selectedType) {
@@ -32,17 +30,7 @@ function Footer({ selectedType, isLoading, onClickCreate }: Props) {
       // Todo @xiaoyijun [Pricing] Remove feature flag
       if (isDevFeaturesEnabled && planId === ReservedPlanId.Free) {
         return (
-          <QuotaGuardFooter
-            isLoading={isSubscribeLoading}
-            onClickUpgrade={() => {
-              void subscribe({
-                // Todo @xiaoyijun [Pricing] Replace 'Hobby' with 'Pro' when pricing is ready, in MVP, we use 'Hobby' as the new pro plan id
-                planId: ReservedPlanId.Hobby,
-                tenantId: currentTenantId,
-                callbackPage: '/applications/create',
-              });
-            }}
-          >
+          <QuotaGuardFooter>
             <Trans
               components={{
                 a: <ContactUsPhraseLink />,


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Per offline discussion, we won't navigate to the stripe checkout page directly when the paywall button is clicked, since the user may need to know the actrual price, but in our MVP pricing version, the prices is not settled, and the stripe page will not display the price. So navigate to the 'plan & billing page' as usual.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
