### PR TITLE
refactor(console): guard charge notification directly in the cloud version

### DIFF
--- a/packages/console/src/components/ChargeNotification/index.tsx
+++ b/packages/console/src/components/ChargeNotification/index.tsx
@@ -5,7 +5,6 @@ import { useContext } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { pricingLink } from '@/consts';
-import { isDevFeaturesEnabled } from '@/consts/env';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import InlineNotification from '@/ds-components/InlineNotification';
 import TextLink from '@/ds-components/TextLink';
@@ -28,11 +27,6 @@ function ChargeNotification({ hasSurpassedLimit, quotaItem, quotaLimit, classNam
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console.upsell' });
   const { currentTenantId } = useContext(TenantsContext);
   const { data: currentPlan } = useSubscriptionPlan(currentTenantId);
-
-  // Todo @xiaoyijun [Pricing] Remove feature flag
-  if (!isDevFeaturesEnabled) {
-    return null;
-  }
 
   if (
     !hasSurpassedLimit ||

--- a/packages/console/src/pages/ApiResources/index.tsx
+++ b/packages/console/src/pages/ApiResources/index.tsx
@@ -14,6 +14,7 @@ import EmptyDataPlaceholder from '@/components/EmptyDataPlaceholder';
 import ItemPreview from '@/components/ItemPreview';
 import ListPage from '@/components/ListPage';
 import { defaultPageSize } from '@/consts';
+import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
 import { ApiResourceDetailsTabs } from '@/consts/page-tabs';
 import CopyToClipboard from '@/ds-components/CopyToClipboard';
 import Tag from '@/ds-components/Tag';
@@ -79,7 +80,11 @@ function ApiResources() {
           },
         }}
         subHeader={
-          <ChargeNotification hasSurpassedLimit={hasSurpassedLimit} quotaItem="api_resource" />
+          isCloud &&
+          // Todo @xiaoyijun [Pricing] Remove feature flag
+          isDevFeaturesEnabled && (
+            <ChargeNotification hasSurpassedLimit={hasSurpassedLimit} quotaItem="api_resource" />
+          )
         }
         table={{
           rowGroups: [{ key: 'apiResources', data: apiResources }],

--- a/packages/console/src/pages/Applications/index.tsx
+++ b/packages/console/src/pages/Applications/index.tsx
@@ -10,6 +10,7 @@ import ChargeNotification from '@/components/ChargeNotification';
 import ItemPreview from '@/components/ItemPreview';
 import PageMeta from '@/components/PageMeta';
 import { defaultPageSize } from '@/consts';
+import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
 import Button from '@/ds-components/Button';
 import CardTitle from '@/ds-components/CardTitle';
 import CopyToClipboard from '@/ds-components/CopyToClipboard';
@@ -72,11 +73,14 @@ function Applications() {
           />
         )}
       </div>
-      <ChargeNotification
-        hasSurpassedLimit={hasMachineToMachineAppsSurpassedLimit}
-        quotaItem="machine_to_machine"
-        className={styles.chargeNotification}
-      />
+      {/* Todo @xiaoyijun [Pricing] Remove feature flag */}
+      {isCloud && isDevFeaturesEnabled && (
+        <ChargeNotification
+          hasSurpassedLimit={hasMachineToMachineAppsSurpassedLimit}
+          quotaItem="machine_to_machine"
+          className={styles.chargeNotification}
+        />
+      )}
       {!isLoading && !applications?.length && (
         <OverlayScrollbar className={styles.guideLibraryContainer}>
           <CardTitle


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
In the orginal implementation, we guard the `ChargeNotification` by the `hasSurpassedLimit` props, which will always `false` in the cloud version.
But this couples the `isCloud` and limit checking, which makes it hard to known if the `ChargeNotification` should be displayed or not.
So we need to guard the `ChargeNotification` directly by using `isCloud` and also avoid to add the `isDevFeaturesEnabled` guard inside the `ChargeNotification`, since they should be decoupled.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
