### PR TITLE
refactor(console): sign out user when insufficient permissions

### DIFF
--- a/packages/console/src/hooks/use-api.ts
+++ b/packages/console/src/hooks/use-api.ts
@@ -59,6 +59,16 @@ export const useStaticApi = ({
         // Clone the response to avoid "Response body is already used".
         const data = await response.clone().json<RequestErrorBody>();
 
+        // This is what will happen when the user still has the legacy refresh token without
+        // organization scope. We should sign them out and redirect to the sign in page.
+        // TODO: This is a temporary solution to prevent the user from getting stuck in Console,
+        // which can be removed after all legacy refresh tokens are expired, i.e. after Jan 10th,
+        // 2024.
+        if (response.status === 403 && data.message === 'Insufficient permissions.') {
+          await signOut(postSignOutRedirectUri.href);
+          return;
+        }
+
         // Inform and redirect un-authorized users to sign in page.
         if (data.code === 'auth.forbidden') {
           await show({


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
a temp solution to prevent users with legacy refresh tokens being stuck in Console.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
the user will be signed out automatically when organization token has insufficient permissions

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
