### PR TITLE
style(console): inherit background-color for text input

### DIFF
--- a/packages/console/src/ds-components/TextInput/index.module.scss
+++ b/packages/console/src/ds-components/TextInput/index.module.scss
@@ -28,7 +28,7 @@
   transition-duration: 0.2s;
   padding: 0 _.unit(3);
   height: 36px;
-  background: var(--color-layer-1);
+  background-color: inherit;
   font: var(--font-body-2);
 
   &.withIcon {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The background color of `TextInput` should be inherit from its parent.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
