### PR TITLE
refactor: deprecate staging env tag (1/2)

### DIFF
--- a/packages/console/src/components/CreateTenantModal/EnvTagOptionContent/index.tsx
+++ b/packages/console/src/components/CreateTenantModal/EnvTagOptionContent/index.tsx
@@ -16,18 +16,11 @@ type Props = {
 const descriptionMap: Record<TenantTag, AdminConsoleKey> = {
   [TenantTag.Development]: 'tenants.create_modal.development_description',
   [TenantTag.Production]: 'tenants.create_modal.production_description',
-  // Todo @xiaoyijun Remove deprecated tag
-  [TenantTag.Staging]: 'tenants.create_modal.production_description',
 };
 
 const availableProductionPlanNames = [ReservedPlanName.Free, ReservedPlanName.Pro];
 
 function EnvTagOptionContent({ tag }: Props) {
-  // Todo @xiaoyijun Deprecated tag
-  if (tag === TenantTag.Staging) {
-    return null;
-  }
-
   return (
     <div className={styles.container}>
       <TenantEnvTag isAbbreviated={false} tag={tag} size="large" className={styles.tag} />

--- a/packages/console/src/components/TenantEnvTag/index.tsx
+++ b/packages/console/src/components/TenantEnvTag/index.tsx
@@ -19,15 +19,11 @@ type TenantTagMap = {
 
 export const tenantAbbreviatedTagNameMap = Object.freeze({
   [TenantTag.Development]: 'tenants.settings.environment_tag_development',
-  // Todo @xiaoyijun Remove staging tag before release
-  [TenantTag.Staging]: 'tenants.settings.environment_tag_staging',
   [TenantTag.Production]: 'tenants.settings.environment_tag_production',
 }) satisfies TenantTagMap;
 
 const tenantTagNameMap = Object.freeze({
   [TenantTag.Development]: 'tenants.full_env_tag.development',
-  // Todo @xiaoyijun Remove staging tag before release
-  [TenantTag.Staging]: 'tenants.settings.environment_tag_staging',
   [TenantTag.Production]: 'tenants.full_env_tag.production',
 }) satisfies TenantTagMap;
 

--- a/packages/console/src/components/Topbar/TenantSelector/TenantDropdownItem/index.tsx
+++ b/packages/console/src/components/Topbar/TenantSelector/TenantDropdownItem/index.tsx
@@ -38,6 +38,7 @@ function TenantDropdownItem({ tenantData, isSelected, onClick }: Props) {
       <div className={styles.info}>
         <div className={styles.meta}>
           <div className={styles.name}>{name}</div>
+          {/* @ts-expect-error @xiaoyijun FIXME: remove this line after the @logto/cloud package is updated */}
           <TenantEnvTag tag={tag} />
           <TenantStatusTag
             tenantData={tenantData}

--- a/packages/console/src/components/Topbar/TenantSelector/index.tsx
+++ b/packages/console/src/components/Topbar/TenantSelector/index.tsx
@@ -1,3 +1,4 @@
+import { type TenantTag } from '@logto/schemas';
 import { useContext, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -50,7 +51,9 @@ export default function TenantSelector() {
         }}
       >
         <div className={styles.name}>{currentTenantInfo.name}</div>
-        <TenantEnvTag className={styles.tag} tag={currentTenantInfo.tag} />
+        {/* @xiaoyijun FIXME: remove this line after the @logto/cloud package is updated */}
+        {/* eslint-disable-next-line no-restricted-syntax */}
+        <TenantEnvTag className={styles.tag} tag={currentTenantInfo.tag as TenantTag} />
         <KeyboardArrowDown className={styles.arrowIcon} />
       </div>
       <Dropdown

--- a/packages/console/src/pages/TenantSettings/TenantBasicSettings/DeleteModal/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantBasicSettings/DeleteModal/index.tsx
@@ -1,3 +1,4 @@
+import { type TenantTag } from '@logto/schemas';
 import classNames from 'classnames';
 import { useTranslation, Trans } from 'react-i18next';
 
@@ -37,7 +38,9 @@ function DeleteModal({ isOpen, isLoading, onClose, onDelete, tenant }: Props) {
           <Trans components={{ span: <span className={styles.bold} /> }}>
             {t('tenants.delete_modal.description_line1', {
               name,
-              tag: t(tenantAbbreviatedTagNameMap[tag], {}), // Referred to the use in DynamicT component.
+              // @xiaoyijun FIXME: remove this line after the @logto/cloud package is updated */
+              // eslint-disable-next-line no-restricted-syntax
+              tag: t(tenantAbbreviatedTagNameMap[tag as TenantTag], {}), // Referred to the use in DynamicT component.
             })}
           </Trans>
         </p>

--- a/packages/console/src/pages/TenantSettings/TenantBasicSettings/ProfileForm/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantBasicSettings/ProfileForm/index.tsx
@@ -1,7 +1,4 @@
-import type { AdminConsoleKey } from '@logto/phrases';
-import { TenantTag } from '@logto/schemas';
 import { useFormContext } from 'react-hook-form';
-import { useTranslation } from 'react-i18next';
 
 import FormCard from '@/components/FormCard';
 import CopyToClipboard from '@/ds-components/CopyToClipboard';
@@ -17,28 +14,8 @@ type Props = {
   currentTenantId: string;
 };
 
-const tagOptions: Array<{
-  title: AdminConsoleKey;
-  value: TenantTag;
-}> = [
-  {
-    title: 'tenants.settings.environment_tag_development',
-    value: TenantTag.Development,
-  },
-  {
-    title: 'tenants.settings.environment_tag_staging',
-    value: TenantTag.Staging,
-  },
-  {
-    title: 'tenants.settings.environment_tag_production',
-    value: TenantTag.Production,
-  },
-];
-
 function ProfileForm({ currentTenantId }: Props) {
-  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const {
-    control,
     register,
     formState: { errors },
     getValues,

--- a/packages/console/src/pages/TenantSettings/TenantBasicSettings/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantBasicSettings/index.tsx
@@ -23,6 +23,12 @@ import { type TenantSettingsForm } from './types.js';
 
 const tenantProfileToForm = (tenant?: TenantResponse): TenantSettingsForm => {
   return {
+    /**
+     * Note:
+     * The tag type in the TenantInfo returned by the Cloud does not match the newly updated tag type, but they are compatible.
+     * However, we need to update the tenant type in the schema before we can update the type of the Cloud response.
+     */
+    /** @ts-expect-error @xiaoyijun FIXME: remove this line after the @logto/cloud package is updated */
     profile: { name: tenant?.name ?? 'My project', tag: tenant?.tag ?? TenantTag.Development },
   };
 };
@@ -61,6 +67,12 @@ function TenantBasicSettings() {
       params: { tenantId: currentTenantId },
       body: data,
     });
+    /**
+     * Note:
+     * The tag type in the TenantInfo returned by the Cloud does not match the newly updated tag type, but they are compatible.
+     * However, we need to update the tenant type in the schema before we can update the type of the Cloud response.
+     */
+    /** @ts-expect-error @xiaoyijun FIXME: remove this line after the @logto/cloud package is updated */
     reset({ profile: { name, tag } });
     toast.success(t('tenants.settings.tenant_info_saved'));
     updateTenant(currentTenantId, data);

--- a/packages/phrases/src/locales/de/translation/admin-console/tenants.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/tenants.ts
@@ -17,7 +17,6 @@ const tenants = {
     tenant_region_tip:
       'Ihre Mandantenressourcen werden in {{region}} gehostet. <a>Mehr erfahren</a>',
     environment_tag_development: 'Entw',
-    environment_tag_staging: 'Staging',
     environment_tag_production: 'Prod',
     tenant_type: 'Mandantentyp',
     development_description:

--- a/packages/phrases/src/locales/en/translation/admin-console/tenants.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/tenants.ts
@@ -15,7 +15,6 @@ const tenants = {
     tenant_region: 'Data hosted region',
     tenant_region_tip: 'Your tenant resources are hosted in {{region}}. <a>Learn more</a>',
     environment_tag_development: 'Dev',
-    environment_tag_staging: 'Staging',
     environment_tag_production: 'Prod',
     tenant_type: 'Tenant type',
     development_description:

--- a/packages/phrases/src/locales/es/translation/admin-console/tenants.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/tenants.ts
@@ -17,7 +17,6 @@ const tenants = {
     tenant_region_tip:
       'Sus recursos de inquilino se alojan en {{region}}. <a>Obtener más información</a>',
     environment_tag_development: 'Desarrollo',
-    environment_tag_staging: 'Pruebas',
     environment_tag_production: 'Producción',
     tenant_type: 'Tipo de inquilino',
     development_description:

--- a/packages/phrases/src/locales/fr/translation/admin-console/tenants.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/tenants.ts
@@ -17,7 +17,6 @@ const tenants = {
     tenant_region_tip:
       'Vos ressources de locataire sont hébergées dans {{region}}. <a>En savoir plus</a>',
     environment_tag_development: 'Dev',
-    environment_tag_staging: 'Staging',
     environment_tag_production: 'Prod',
     tenant_type: 'Type de locataire',
     development_description:

--- a/packages/phrases/src/locales/it/translation/admin-console/tenants.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/tenants.ts
@@ -18,7 +18,6 @@ const tenants = {
     tenant_region_tip:
       'Le risorse del tuo inquilino sono ospitate in {{region}}. <a>Scopri di più</a>',
     environment_tag_development: 'Svil',
-    environment_tag_staging: 'Staging',
     environment_tag_production: 'Prod',
     tenant_type: 'Tipo inquilino',
     development_description:

--- a/packages/phrases/src/locales/ja/translation/admin-console/tenants.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/tenants.ts
@@ -15,7 +15,6 @@ const tenants = {
     tenant_region: 'データがホストされている地域',
     tenant_region_tip: 'テナントのリソースは{{region}}にホストされています。 <a>詳細</a>',
     environment_tag_development: '開発',
-    environment_tag_staging: 'ステージング',
     environment_tag_production: '本番',
     tenant_type: 'テナントタイプ',
     development_description:

--- a/packages/phrases/src/locales/ko/translation/admin-console/tenants.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/tenants.ts
@@ -15,7 +15,6 @@ const tenants = {
     tenant_region: '데이터 호스팅 영역',
     tenant_region_tip: '당신의 테넌트 자원은 {{region}}에 호스팅됩니다. <a>자세히 알아보기</a>',
     environment_tag_development: '개발',
-    environment_tag_staging: '스테이징',
     environment_tag_production: '프로드',
     tenant_type: '테넌트 유형',
     development_description:

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/tenants.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/tenants.ts
@@ -17,7 +17,6 @@ const tenants = {
     tenant_region_tip:
       'Twoje zasoby najemcy są hostowane w {{region}}. <a>Uzyskaj więcej informacji</a>',
     environment_tag_development: 'Dev',
-    environment_tag_staging: 'Staging',
     environment_tag_production: 'Prod',
     tenant_type: 'Typ najemcy',
     development_description:

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/tenants.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/tenants.ts
@@ -17,7 +17,6 @@ const tenants = {
     tenant_region_tip:
       'Seus recursos do locatário estão hospedados na região {{region}}. <a>Veja mais</a>',
     environment_tag_development: 'Desenvolvimento',
-    environment_tag_staging: 'Homologação',
     environment_tag_production: 'Produção',
     tenant_type: 'Tipo de locatário',
     development_description:

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/tenants.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/tenants.ts
@@ -17,7 +17,6 @@ const tenants = {
     tenant_region_tip:
       'Os recursos do seu inquilino são hospedados na região {{region}}. <a>Learn more</a>',
     environment_tag_development: 'Dev',
-    environment_tag_staging: 'Staging',
     environment_tag_production: 'Prod',
     tenant_type: 'Tipo de inquilino',
     development_description:

--- a/packages/phrases/src/locales/ru/translation/admin-console/tenants.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/tenants.ts
@@ -16,7 +16,6 @@ const tenants = {
     tenant_region: 'Регион размещения данных',
     tenant_region_tip: 'Ваши ресурсы арендатора размещаются в {{region}}. <a>Узнайте больше</a>',
     environment_tag_development: 'Разр',
-    environment_tag_staging: 'Предпр',
     environment_tag_production: 'Прод',
     tenant_type: 'Тип арендатора',
     development_description:

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/tenants.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/tenants.ts
@@ -16,7 +16,6 @@ const tenants = {
     tenant_region_tip:
       'Kiracı kaynaklarınız {{region}} bölgesinde barındırılır. <a>Daha fazla bilgi</a>',
     environment_tag_development: 'Geliş',
-    environment_tag_staging: 'Staging',
     environment_tag_production: 'Prod',
     tenant_type: 'Kiracı türü',
     development_description:

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/tenants.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/tenants.ts
@@ -15,7 +15,6 @@ const tenants = {
     tenant_region: '数据托管地区',
     tenant_region_tip: '您的租户资源托管在 {{region}}。 <a>了解更多</a>',
     environment_tag_development: '开发',
-    environment_tag_staging: '预发布',
     environment_tag_production: '产品',
     tenant_type: '租户类型',
     development_description:

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/tenants.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/tenants.ts
@@ -15,7 +15,6 @@ const tenants = {
     tenant_region: '數據托管區域',
     tenant_region_tip: '您的租戶資源托管在{{region}}。 <a>了解更多</a>',
     environment_tag_development: '開發',
-    environment_tag_staging: '預備',
     environment_tag_production: '產品',
     tenant_type: '租戶類型',
     development_description:

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/tenants.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/tenants.ts
@@ -15,7 +15,6 @@ const tenants = {
     tenant_region: '資料托管地區',
     tenant_region_tip: '您的租戶資源托管於 {{region}}。 <a>了解更多</a>',
     environment_tag_development: '開發',
-    environment_tag_staging: '預置',
     environment_tag_production: '產品',
     tenant_type: '租戶類型',
     development_description:

--- a/packages/schemas/src/types/tenant.ts
+++ b/packages/schemas/src/types/tenant.ts
@@ -1,8 +1,6 @@
 export enum TenantTag {
   /* Development tenants are free to use but are not meant to be used as production environment. */
   Development = 'development',
-  /* @deprecated */
-  Staging = 'staging',
   /* A production tenant must have an associated subscription plan, even if it's a free plan. */
   Production = 'production',
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
refactor: deprecate staging env tag

Note:
The tag type in the TenantInfo returned by the Cloud does not match the newly updated tag type, but they are compatible. So we add some ts comments to avoid type error in this PR.
However, we need to update the tenant type in the schema before we can update the type of the Cloud response.
So we will update the `@logto/cloud` package for the console when the cloud repo get updated.

## Todo
- deprecate `staging` tag in the cloud repo & publish a new `@logto/cloud` package version (https://github.com/logto-io/cloud/pull/436)
- update the `@logto/cloud` package for the console, will be "deprecate staging env tag (2/2)"


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
- [x] necessary TSDoc comments
