### PR TITLE
refactor: deprecate staging env tag (2/2)

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -26,7 +26,7 @@
     "@fontsource/roboto-mono": "^5.0.0",
     "@jest/types": "^29.5.0",
     "@logto/app-insights": "workspace:^1.3.1",
-    "@logto/cloud": "0.2.5-d28a065",
+    "@logto/cloud": "0.2.5-c6ed487",
     "@logto/connector-kit": "workspace:^2.0.0",
     "@logto/core-kit": "workspace:^2.2.1",
     "@logto/language-kit": "workspace:^1.0.0",

--- a/packages/console/src/components/Topbar/TenantSelector/TenantDropdownItem/index.tsx
+++ b/packages/console/src/components/Topbar/TenantSelector/TenantDropdownItem/index.tsx
@@ -41,7 +41,6 @@ function TenantDropdownItem({ tenantData, isSelected, onClick }: Props) {
       <div className={styles.info}>
         <div className={styles.meta}>
           <div className={styles.name}>{name}</div>
-          {/* @ts-expect-error @xiaoyijun FIXME: remove this line after the @logto/cloud package is updated */}
           <TenantEnvTag tag={tag} />
           <TenantStatusTag
             tenantData={tenantData}

--- a/packages/console/src/components/Topbar/TenantSelector/index.tsx
+++ b/packages/console/src/components/Topbar/TenantSelector/index.tsx
@@ -1,4 +1,3 @@
-import { type TenantTag } from '@logto/schemas';
 import { useContext, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -51,9 +50,7 @@ export default function TenantSelector() {
         }}
       >
         <div className={styles.name}>{currentTenantInfo.name}</div>
-        {/* @xiaoyijun FIXME: remove this line after the @logto/cloud package is updated */}
-        {/* eslint-disable-next-line no-restricted-syntax */}
-        <TenantEnvTag className={styles.tag} tag={currentTenantInfo.tag as TenantTag} />
+        <TenantEnvTag className={styles.tag} tag={currentTenantInfo.tag} />
         <KeyboardArrowDown className={styles.arrowIcon} />
       </div>
       <Dropdown

--- a/packages/console/src/pages/TenantSettings/TenantBasicSettings/DeleteModal/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantBasicSettings/DeleteModal/index.tsx
@@ -1,4 +1,3 @@
-import { type TenantTag } from '@logto/schemas';
 import classNames from 'classnames';
 import { useTranslation, Trans } from 'react-i18next';
 
@@ -38,9 +37,7 @@ function DeleteModal({ isOpen, isLoading, onClose, onDelete, tenant }: Props) {
           <Trans components={{ span: <span className={styles.bold} /> }}>
             {t('tenants.delete_modal.description_line1', {
               name,
-              // @xiaoyijun FIXME: remove this line after the @logto/cloud package is updated */
-              // eslint-disable-next-line no-restricted-syntax
-              tag: t(tenantAbbreviatedTagNameMap[tag as TenantTag], {}), // Referred to the use in DynamicT component.
+              tag: t(tenantAbbreviatedTagNameMap[tag], {}), // Referred to the use in DynamicT component.
             })}
           </Trans>
         </p>

--- a/packages/console/src/pages/TenantSettings/TenantBasicSettings/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantBasicSettings/index.tsx
@@ -23,12 +23,6 @@ import { type TenantSettingsForm } from './types.js';
 
 const tenantProfileToForm = (tenant?: TenantResponse): TenantSettingsForm => {
   return {
-    /**
-     * Note:
-     * The tag type in the TenantInfo returned by the Cloud does not match the newly updated tag type, but they are compatible.
-     * However, we need to update the tenant type in the schema before we can update the type of the Cloud response.
-     */
-    /** @ts-expect-error @xiaoyijun FIXME: remove this line after the @logto/cloud package is updated */
     profile: { name: tenant?.name ?? 'My project', tag: tenant?.tag ?? TenantTag.Development },
   };
 };
@@ -67,12 +61,6 @@ function TenantBasicSettings() {
       params: { tenantId: currentTenantId },
       body: data,
     });
-    /**
-     * Note:
-     * The tag type in the TenantInfo returned by the Cloud does not match the newly updated tag type, but they are compatible.
-     * However, we need to update the tenant type in the schema before we can update the type of the Cloud response.
-     */
-    /** @ts-expect-error @xiaoyijun FIXME: remove this line after the @logto/cloud package is updated */
     reset({ profile: { name, tag } });
     toast.success(t('tenants.settings.tenant_info_saved'));
     updateTenant(currentTenantId, data);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -93,7 +93,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@logto/cloud": "0.2.5-5deb133",
+    "@logto/cloud": "0.2.5-c6ed487",
     "@silverhand/eslint-config": "5.0.0",
     "@silverhand/ts-config": "5.0.0",
     "@types/debug": "^4.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2840,8 +2840,8 @@ importers:
         specifier: workspace:^1.3.1
         version: link:../app-insights
       '@logto/cloud':
-        specifier: 0.2.5-d28a065
-        version: 0.2.5-d28a065(zod@3.22.4)
+        specifier: 0.2.5-c6ed487
+        version: 0.2.5-c6ed487(zod@3.22.4)
       '@logto/connector-kit':
         specifier: workspace:^2.0.0
         version: link:../toolkit/connector-kit
@@ -3327,8 +3327,8 @@ importers:
         version: 3.22.4
     devDependencies:
       '@logto/cloud':
-        specifier: 0.2.5-5deb133
-        version: 0.2.5-5deb133(zod@3.22.4)
+        specifier: 0.2.5-c6ed487
+        version: 0.2.5-c6ed487(zod@3.22.4)
       '@silverhand/eslint-config':
         specifier: 5.0.0
         version: 5.0.0(eslint@8.44.0)(prettier@3.0.0)(typescript@5.3.3)
@@ -7597,8 +7597,8 @@ packages:
       - zod
     dev: true
 
-  /@logto/cloud@0.2.5-d28a065(zod@3.22.4):
-    resolution: {integrity: sha512-04uwAaE9bIixt4nHAeqQsOzXxB0yFNDUYArJWjTo8xcmTQGBQttq8xyVKWVWCWPp7hSEZhb74h5b45my0IOMPA==}
+  /@logto/cloud@0.2.5-c6ed487(zod@3.22.4):
+    resolution: {integrity: sha512-cDKxCBFeZcG0CiGIa6mBY1Zgu3+tuvhYxs/qN0nQcj7MLSQ0AXHK9m1GeSJQH+Nu/jspggLmg27Ks8gdCHQUcg==}
     engines: {node: ^20.9.0}
     dependencies:
       '@silverhand/essentials': 2.8.6


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Deprecate staging env tag (2/2)
see the previous PR: https://github.com/logto-io/logto/pull/5180

This PR upgrade the `@logto/cloud` to the latest version and remove redunant type infers and comments.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally and all tests passed.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
