### PR TITLE
fix(console): allow image/x-icon mime type

### DIFF
--- a/packages/console/src/consts/user-assets.ts
+++ b/packages/console/src/consts/user-assets.ts
@@ -9,6 +9,7 @@ export const mimeTypeToFileExtensionMappings: MimeTypeToFileExtensionMappings = 
   'image/png': ['png'],
   'image/gif': ['gif'],
   'image/vnd.microsoft.icon': ['ico'],
+  'image/x-icon': ['ico'],
   'image/svg+xml': ['svg'],
   'image/tiff': ['tif', 'tiff'],
   'image/webp': ['webp'],

--- a/packages/console/src/hooks/use-image-mime-types.ts
+++ b/packages/console/src/hooks/use-image-mime-types.ts
@@ -11,6 +11,7 @@ const allowedImageMimeTypes: AllowedUploadMimeType[] = [
   'image/png',
   'image/jpeg',
   'image/vnd.microsoft.icon',
+  'image/x-icon',
 ];
 
 const useImageMimeTypes = (

--- a/packages/console/src/utils/uploader.ts
+++ b/packages/console/src/utils/uploader.ts
@@ -1,8 +1,11 @@
 import type { AllowedUploadMimeType } from '@logto/schemas';
+import { deduplicate } from '@silverhand/essentials';
 
 import { mimeTypeToFileExtensionMappings } from '@/consts/user-assets';
 
 export const convertToFileExtensionArray = (mimeTypes: AllowedUploadMimeType[]) =>
-  mimeTypes
-    .flatMap((type) => mimeTypeToFileExtensionMappings[type])
-    .map((extension) => extension.toUpperCase());
+  deduplicate(
+    mimeTypes
+      .flatMap((type) => mimeTypeToFileExtensionMappings[type])
+      .map((extension) => extension.toUpperCase())
+  );

--- a/packages/schemas/src/types/user-assets.ts
+++ b/packages/schemas/src/types/user-assets.ts
@@ -8,6 +8,7 @@ export const allowUploadMimeTypes = [
   'image/png',
   'image/gif',
   'image/vnd.microsoft.icon',
+  'image/x-icon',
   'image/svg+xml',
   'image/tiff',
   'image/webp',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Since the `.ico` file's mime type will may be treated as `image/x-icon` in some browser, so we need to add support for this mime type or this may cause a bug when uploading a `.icon` file:

<img width="304" alt="image" src="https://github.com/logto-io/logto/assets/10806653/aa24ca69-d59a-46f4-abfb-7abdbd3005f1">

Refer to: https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types#ico_microsoft_windows_icon

<img width="799" alt="image" src="https://github.com/logto-io/logto/assets/10806653/6d56d220-fa5b-4b3f-b874-d508f6cbdf17">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
