### PR TITLE
fix(core): fix dev tenant migration data guard

### DIFF
--- a/packages/schemas/src/types/logto-config.ts
+++ b/packages/schemas/src/types/logto-config.ts
@@ -1,8 +1,6 @@
 import type { ZodType } from 'zod';
 import { z } from 'zod';
 
-import { TenantTag } from './tenant.js';
-
 /**
  * Logto OIDC signing key types, used mainly in REST API routes.
  */
@@ -54,7 +52,11 @@ export const adminConsoleDataGuard = z.object({
   developmentTenantMigrationNotification: z
     .object({
       isPaidTenant: z.boolean(),
-      tag: z.nativeEnum(TenantTag),
+      /**
+       * Tag is used to store the original tenant tag before dev tenant migration.
+       * This field is only used for DB rollback and because the `TenantTag` may change, so we don't guard it as the `TenantTag` type.
+       */
+      tag: z.string(),
       readAt: z.number().optional(),
     })
     .optional(),


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Now we've deprecated the `staging` tag from `TenantTag`, but the tenant migration data, which is stored in the admin console data, saves the tenant's original tenant tag, when the tenant's original tenant is `staging`, it will cause an API type guard error, so we need to update the type guard for the `AdminConsoleData`.

![image](https://github.com/logto-io/logto/assets/10806653/5537f9d3-568b-46a4-879e-ee2faa672d66)



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Construct migration data with a `staging` tenant tag:

<img width="692" alt="image" src="https://github.com/logto-io/logto/assets/10806653/89ad00d0-e9d4-494f-9260-4c7e692d7180">

Tested in the admin console:

<img width="1129" alt="image" src="https://github.com/logto-io/logto/assets/10806653/349a2029-df3f-490a-8a69-5ed003350245">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
- [x] necessary TSDoc comments
