### PR TITLE
style(console): update space size for table placeholder

### DIFF
--- a/packages/console/src/ds-components/Table/TableEmptyWrapper.module.scss
+++ b/packages/console/src/ds-components/Table/TableEmptyWrapper.module.scss
@@ -9,6 +9,13 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    padding-bottom: _.unit(25);
+
+    .topSpace {
+      flex: 2;
+    }
+
+    .bottomSpace {
+      flex: 3;
+    }
   }
 }

--- a/packages/console/src/ds-components/Table/TableEmptyWrapper.tsx
+++ b/packages/console/src/ds-components/Table/TableEmptyWrapper.tsx
@@ -11,7 +11,12 @@ function TableEmptyWrapper({ columns, children }: Props) {
   return (
     <tr>
       <td colSpan={columns} className={styles.tableEmptyWrapper}>
-        <div className={styles.content}>{children}</div>
+        <div className={styles.content}>
+          {/* Per design requirement, the empty placeholder should have a top and bottom spacing, and the space height aspect ratio is 2:3. */}
+          <div className={styles.topSpace} />
+          {children}
+          <div className={styles.bottomSpace} />
+        </div>
       </td>
     </tr>
   );


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Per design requirement, the empty placeholder should have a top and bottom spacing, and the space height aspect ratio is 2:3.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
