### PR TITLE
chore(connector): remove legacy Test passwordless template type use case

### DIFF
--- a/packages/connectors/connector-aliyun-dm/src/index.test.ts
+++ b/packages/connectors/connector-aliyun-dm/src/index.test.ts
@@ -36,15 +36,4 @@ describe('sendMessage()', () => {
       expect.anything()
     );
   });
-
-  it('throws if template is missing', async () => {
-    const connector = await createConnector({ getConfig });
-    await expect(
-      connector.sendMessage({
-        to: 'to@email.com',
-        type: VerificationCodeType.Test,
-        payload: { code: '1234' },
-      })
-    ).rejects.toThrow();
-  });
 });

--- a/packages/connectors/connector-aliyun-sms/src/index.test.ts
+++ b/packages/connectors/connector-aliyun-sms/src/index.test.ts
@@ -73,15 +73,4 @@ describe('sendMessage()', () => {
       mockedConnectorConfig.accessKeySecret
     );
   });
-
-  it('throws if template is missing', async () => {
-    const connector = await createConnector({ getConfig });
-    await expect(
-      connector.sendMessage({
-        to: phoneTest,
-        type: VerificationCodeType.Test,
-        payload: { code: codeTest },
-      })
-    ).rejects.toThrow();
-  });
 });

--- a/packages/connectors/connector-aws-ses/src/index.test.ts
+++ b/packages/connectors/connector-aws-ses/src/index.test.ts
@@ -53,15 +53,4 @@ describe('sendMessage()', () => {
       })
     );
   });
-
-  it('throws if template is missing', async () => {
-    const connector = await createConnector({ getConfig });
-    await expect(
-      connector.sendMessage({
-        to: 'to@email.com',
-        type: VerificationCodeType.Test,
-        payload: { code: '1234' },
-      })
-    ).rejects.toThrow();
-  });
 });

--- a/packages/connectors/connector-sendgrid-email/src/mock.ts
+++ b/packages/connectors/connector-sendgrid-email/src/mock.ts
@@ -26,7 +26,7 @@ export const mockedConfig: SendGridMailConfig = {
   fromEmail: 'noreply@logto.test.io',
   templates: [
     {
-      usageType: 'Test',
+      usageType: 'Generic',
       type: ContextType.Text,
       subject: 'Logto Test Template',
       content: 'This is for testing purposes only. Your verification code is {{code}}.',

--- a/packages/connectors/connector-smsaero/src/mock.ts
+++ b/packages/connectors/connector-smsaero/src/mock.ts
@@ -10,7 +10,7 @@ export const mockedConfig: SmsAeroConfig = {
   senderName: mockedSenderName,
   templates: [
     {
-      usageType: 'Test',
+      usageType: 'Generic',
       content: 'This is for testing purposes only. Your verification code is {{code}}.',
     },
   ],

--- a/packages/connectors/connector-tencent-sms/src/index.test.ts
+++ b/packages/connectors/connector-tencent-sms/src/index.test.ts
@@ -63,15 +63,4 @@ describe('sendMessage()', () => {
       })
     );
   });
-
-  it('throws if template is missing', async () => {
-    const connector = await createConnector({ getConfig });
-    await expect(
-      connector.sendMessage({
-        to: phoneTest,
-        type: VerificationCodeType.Test,
-        payload: { code: codeTest },
-      })
-    ).rejects.toThrow();
-  });
 });

--- a/packages/connectors/connector-twilio-sms/src/mock.ts
+++ b/packages/connectors/connector-twilio-sms/src/mock.ts
@@ -10,7 +10,7 @@ export const mockedConfig: TwilioSmsConfig = {
   fromMessagingServiceSID: mockedFromMessagingServiceSID,
   templates: [
     {
-      usageType: 'Test',
+      usageType: 'Generic',
       content: 'This is for testing purposes only. Your verification code is {{code}}.',
     },
   ],


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Remove legacy `Test` passwordless template type use cases.
For now, we still keep the `Test` verification code type enum since the deprecation of this could bring breaking change.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
