### PR TITLE
refactor(console): show auto generated acs url for SAML connector

### DIFF
--- a/packages/console/src/pages/ConnectorDetails/ConnectorContent/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/ConnectorContent/index.tsx
@@ -157,7 +157,12 @@ function ConnectorContent({ isDeleted, connectorData, onConnectorUpdated }: Prop
               }
             )}
           >
-            <ConfigForm formItems={formItems} connectorId={id} connectorType={connectorType} />
+            <ConfigForm
+              formItems={formItems}
+              connectorFactoryId={connectorId}
+              connectorId={id}
+              connectorType={connectorType}
+            />
           </FormCard>
         )}
         {!isSocialConnector && (

--- a/packages/console/src/pages/Connectors/Guide/index.tsx
+++ b/packages/console/src/pages/Connectors/Guide/index.tsx
@@ -48,7 +48,7 @@ function Guide({ connector, onClose }: Props) {
   const callbackConnectorId = useRef(generateStandardId());
   const [conflictConnectorName, setConflictConnectorName] = useState<Record<string, string>>();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
-  const { type: connectorType, formItems, isStandard } = connector ?? {};
+  const { type: connectorType, formItems, isStandard, id: connectorFactoryId } = connector ?? {};
   const { language } = i18next;
 
   const isSocialConnector =
@@ -207,6 +207,7 @@ function Guide({ connector, onClose }: Props) {
                   </div>
                   <ConfigForm
                     connectorId={callbackConnectorId.current}
+                    connectorFactoryId={connectorFactoryId}
                     connectorType={connectorType}
                     formItems={formItems}
                   />

--- a/packages/phrases/src/locales/de/translation/admin-console/connectors.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/connectors.ts
@@ -78,6 +78,8 @@ const connectors = {
     callback_uri: 'Callback-URI',
     callback_uri_description:
       'Auch als Redirect-URI bezeichnet, ist die URI in Logto, zu der Benutzer nach der Social-Autorisierung zurückgesendet werden. Kopieren und fügen Sie sie in die Konfigurationsseite des Social Providers ein.',
+    /** UNTRANSLATED */
+    acs_url: 'Assertion consumer service URL',
   },
   platform: {
     universal: 'Universal',

--- a/packages/phrases/src/locales/de/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/domain.ts
@@ -51,6 +51,9 @@ const domain = {
     'Sie können den Domainnamen dieser Endpunkte anpassen, wie Sie möchten. Wählen Sie entweder "{{custom}}" oder "{{default}}".',
   custom_social_callback_url_note:
     'Sie können den Domainnamen dieser URI anpassen, um mit dem Endpunkt Ihrer Anwendung übereinzustimmen. Wählen Sie entweder "{{custom}}" oder "{{default}}".',
+  /** UNTRANSLATED */
+  custom_acs_url_note:
+    'You can customize the domain name of this URI to match your identity provider assertion consumer service URL. Choose either "{{custom}}" or "{{default}}".',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/en/translation/admin-console/connectors.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/connectors.ts
@@ -77,6 +77,7 @@ const connectors = {
     callback_uri: 'Callback URI',
     callback_uri_description:
       "Also called redirect URI, is the URI in Logto where users will be sent back after social authorization, copy and paste to the social provider's config page.",
+    acs_url: 'Assertion consumer service URL',
   },
   platform: {
     universal: 'Universal',

--- a/packages/phrases/src/locales/en/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/domain.ts
@@ -51,6 +51,8 @@ const domain = {
     'You can customize the domain name of these endpoints as your required. Choose either "{{custom}}" or "{{default}}".',
   custom_social_callback_url_note:
     'You can customize the domain name of this URI to match your application’s endpoint. Choose either "{{custom}}" or "{{default}}".',
+  custom_acs_url_note:
+    'You can customize the domain name of this URI to match your identity provider assertion consumer service URL. Choose either "{{custom}}" or "{{default}}".',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/es/translation/admin-console/connectors.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/connectors.ts
@@ -78,6 +78,8 @@ const connectors = {
     callback_uri: 'URI de devolución de llamada',
     callback_uri_description:
       'También llamado URI de redireccionamiento, es la URI en Logto a la que se enviarán los usuarios después de la autorización social, copie y pegue en la página de configuración del proveedor social.',
+    /** UNTRANSLATED */
+    acs_url: 'Assertion consumer service URL',
   },
   platform: {
     universal: 'Universal',

--- a/packages/phrases/src/locales/es/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/domain.ts
@@ -51,6 +51,9 @@ const domain = {
     'Puede personalizar el nombre de dominio de estos puntos finales según sea necesario. Elija "{{custom}}" o "{{default}}".',
   custom_social_callback_url_note:
     'Puede personalizar el nombre de dominio de esta URI para que coincida con el punto final de su aplicación. Elija "{{custom}}" o "{{default}}".',
+  /** UNTRANSLATED */
+  custom_acs_url_note:
+    'You can customize the domain name of this URI to match your identity provider assertion consumer service URL. Choose either "{{custom}}" or "{{default}}".',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/fr/translation/admin-console/connectors.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/connectors.ts
@@ -79,6 +79,8 @@ const connectors = {
     callback_uri: 'URI de rappel',
     callback_uri_description:
       "Également appelée URI de redirection, c'est l'URI dans Logto où les utilisateurs seront renvoyés après l'autorisation sociale, copiez et collez sur la page de configuration du fournisseur social.",
+    /** UNTRANSLATED */
+    acs_url: 'Assertion consumer service URL',
   },
   platform: {
     universal: 'Universel',

--- a/packages/phrases/src/locales/fr/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/domain.ts
@@ -51,6 +51,9 @@ const domain = {
     'Vous pouvez personnaliser le nom de domaine de ces points de terminaison selon vos besoins. Choisissez soit "{{custom}}" ou "{{default}}".',
   custom_social_callback_url_note:
     'Vous pouvez personnaliser le nom de domaine de cette URI pour correspondre au point de terminaison de votre application. Choisissez soit "{{custom}}" ou "{{default}}".',
+  /** UNTRANSLATED */
+  custom_acs_url_note:
+    'You can customize the domain name of this URI to match your identity provider assertion consumer service URL. Choose either "{{custom}}" or "{{default}}".',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/it/translation/admin-console/connectors.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/connectors.ts
@@ -78,6 +78,8 @@ const connectors = {
     callback_uri: 'URI di callback',
     callback_uri_description:
       "Anche chiamato URI di reindirizzamento, è l'URI in Logto dove gli utenti verranno rimandati dopo l'autorizzazione tramite social media, copia e incollalo nella pagina di configurazione del provider social media.",
+    /** UNTRANSLATED */
+    acs_url: 'Assertion consumer service URL',
   },
   platform: {
     universal: 'Universale',

--- a/packages/phrases/src/locales/it/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/domain.ts
@@ -51,6 +51,9 @@ const domain = {
     'Puoi personalizzare il nome di dominio di questi endpoint come richiesto. Scegli "{{custom}}" o "{{default}}".',
   custom_social_callback_url_note:
     'Puoi personalizzare il nome di dominio di questo URI per corrispondere all\'endpoint della tua applicazione. Scegli "{{custom}}" o "{{default}}".',
+  /** UNTRANSLATED */
+  custom_acs_url_note:
+    'You can customize the domain name of this URI to match your identity provider assertion consumer service URL. Choose either "{{custom}}" or "{{default}}".',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/ja/translation/admin-console/connectors.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/connectors.ts
@@ -75,6 +75,8 @@ const connectors = {
     callback_uri: 'Callback URI',
     callback_uri_description:
       'Redirect URIもしくはコールバックURIとも呼ばれ、Logtoに戻るURIです。コピーしてソーシャルプロバイダの構成ページに貼り付けてください。',
+    /** UNTRANSLATED */
+    acs_url: 'Assertion consumer service URL',
   },
   platform: {
     universal: 'ユニバーサル',

--- a/packages/phrases/src/locales/ja/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/domain.ts
@@ -50,6 +50,9 @@ const domain = {
     'これらのエンドポイントのドメイン名を必要に応じてカスタマイズできます。 "{{custom}}" または "{{default}}" のいずれかを選択してください。',
   custom_social_callback_url_note:
     'このURIのドメイン名をアプリケーションのエンドポイントに合わせてカスタマイズできます。 "{{custom}}" または "{{default}}" のいずれかを選択してください。',
+  /** UNTRANSLATED */
+  custom_acs_url_note:
+    'You can customize the domain name of this URI to match your identity provider assertion consumer service URL. Choose either "{{custom}}" or "{{default}}".',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/ko/translation/admin-console/connectors.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/connectors.ts
@@ -73,6 +73,8 @@ const connectors = {
     callback_uri: 'Callback URI',
     callback_uri_description:
       '리다이렉트 URI라고도 불려요. 사용자의 소셜 인증 이후 되돌아올 Logto URI예요. 소셜 공급자의 설정 페이지에 붙여넣으세요.',
+    /** UNTRANSLATED */
+    acs_url: 'Assertion consumer service URL',
   },
   platform: {
     universal: 'Universal',

--- a/packages/phrases/src/locales/ko/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/domain.ts
@@ -50,6 +50,9 @@ const domain = {
     '이 엔드포인트의 도메인 이름을 필요에 따라 사용자 정의할 수 있습니다. "{{custom}}" 또는 "{{default}}" 중 하나를 선택하세요.',
   custom_social_callback_url_note:
     '이 URI의 도메인 이름을 애플리케이션 엔드포인트와 일치하도록 사용자 정의할 수 있습니다. "{{custom}}" 또는 "{{default}}" 중 하나를 선택하세요.',
+  /** UNTRANSLATED */
+  custom_acs_url_note:
+    'You can customize the domain name of this URI to match your identity provider assertion consumer service URL. Choose either "{{custom}}" or "{{default}}".',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/connectors.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/connectors.ts
@@ -77,6 +77,8 @@ const connectors = {
     callback_uri: 'URI zwrotu (Callback)',
     callback_uri_description:
       'Nazywany także URI przekierowania, to URI w Logto, do którego użytkownicy zostaną przesłani po autoryzacji społecznej; skopiuj i wklej na stronie konfiguracyjnej dostawcy usług społecznościowych.',
+    /** UNTRANSLATED */
+    acs_url: 'Assertion consumer service URL',
   },
   platform: {
     universal: 'Uniwersalny',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/domain.ts
@@ -51,6 +51,9 @@ const domain = {
     'Możesz dostosować nazwę domeny tych punktów końcowych według swoich wymagań. Wybierz "{{custom}}" lub "{{default}}".',
   custom_social_callback_url_note:
     'Możesz dostosować nazwę domeny tego adresu URI, aby dopasować ją do punktu końcowego Twojej aplikacji. Wybierz "{{custom}}" lub "{{default}}".',
+  /** UNTRANSLATED */
+  custom_acs_url_note:
+    'You can customize the domain name of this URI to match your identity provider assertion consumer service URL. Choose either "{{custom}}" or "{{default}}".',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/connectors.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/connectors.ts
@@ -76,6 +76,8 @@ const connectors = {
     callback_uri: 'URI de retorno do chamado',
     callback_uri_description:
       'Também chamado de URI de redirecionamento, é a URI no Logto para a qual os usuários serão enviados de volta após a autorização social; copie e cole na página de configuração do provedor social.',
+    /** UNTRANSLATED */
+    acs_url: 'Assertion consumer service URL',
   },
   platform: {
     universal: 'Universal',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/domain.ts
@@ -51,6 +51,9 @@ const domain = {
     'Você pode personalizar o nome de domínio desses endpoints conforme necessário. Escolha "{{custom}}" ou "{{default}}".',
   custom_social_callback_url_note:
     'Você pode personalizar o nome de domínio desta URI para corresponder ao endpoint de seu aplicativo. Escolha "{{custom}}" ou "{{default}}".',
+  /** UNTRANSLATED */
+  custom_acs_url_note:
+    'You can customize the domain name of this URI to match your identity provider assertion consumer service URL. Choose either "{{custom}}" or "{{default}}".',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/connectors.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/connectors.ts
@@ -78,6 +78,8 @@ const connectors = {
     callback_uri: 'URI de retorno',
     callback_uri_description:
       'Também chamado de URI de redirecionamento, é a URI no Logto para onde os usuários serão enviados após a autorização social, copie e cole na página de configuração do provedor social.',
+    /** UNTRANSLATED */
+    acs_url: 'Assertion consumer service URL',
   },
   platform: {
     universal: 'Universal',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/domain.ts
@@ -51,6 +51,9 @@ const domain = {
     'Pode personalizar o nome de domínio desses endpoints conforme necessário. Escolha "{{custom}}" ou "{{default}}".',
   custom_social_callback_url_note:
     'Pode personalizar o nome de domínio deste URI para corresponder ao endpoint da sua aplicação. Escolha "{{custom}}" ou "{{default}}".',
+  /** UNTRANSLATED */
+  custom_acs_url_note:
+    'You can customize the domain name of this URI to match your identity provider assertion consumer service URL. Choose either "{{custom}}" or "{{default}}".',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/ru/translation/admin-console/connectors.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/connectors.ts
@@ -77,6 +77,8 @@ const connectors = {
     callback_uri: 'URI обратного вызова',
     callback_uri_description:
       'Также называется URI перенаправления, это URI в Logto, на который пользователи будут отправлены после социальной авторизации. Скопируйте и вставьте его на странице настройки социального провайдера.',
+    /** UNTRANSLATED */
+    acs_url: 'Assertion consumer service URL',
   },
   platform: {
     universal: 'Универсальная',

--- a/packages/phrases/src/locales/ru/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/domain.ts
@@ -50,6 +50,9 @@ const domain = {
     'Вы можете настроить имя домена этих конечных точек по своему усмотрению. Выберите "{{custom}}" или "{{default}}".',
   custom_social_callback_url_note:
     'Вы можете настроить имя домена этого URI, чтобы соответствовать конечной точке вашего приложения. Выберите "{{custom}}" или "{{default}}".',
+  /** UNTRANSLATED */
+  custom_acs_url_note:
+    'You can customize the domain name of this URI to match your identity provider assertion consumer service URL. Choose either "{{custom}}" or "{{default}}".',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/connectors.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/connectors.ts
@@ -77,6 +77,8 @@ const connectors = {
     callback_uri: 'Geri dönüş URI',
     callback_uri_description:
       "Ayrıca yönlendirme URI'si olarak adlandırılır, kullanıcıların sosyal yetkilendirmeden sonra Logto'ya geri gönderilecekleri URI'dir, ve sosyal sağlayıcının yapılandırma sayfasına kopyalayın yapıştırın.",
+    /** UNTRANSLATED */
+    acs_url: 'Assertion consumer service URL',
   },
   platform: {
     universal: 'Evrensel',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/domain.ts
@@ -51,6 +51,9 @@ const domain = {
     'Bu uç noktaların alan adını özelleştirebilirsiniz. "{{custom}}" veya "{{default}}" seçeneklerinden birini seçin.',
   custom_social_callback_url_note:
     'Bu URI\'nin alan adını uygulamanızın uç noktasıyla eşleştirmek için özelleştirebilirsiniz. "{{custom}}" veya "{{default}}" seçeneklerinden birini seçin.',
+  /** UNTRANSLATED */
+  custom_acs_url_note:
+    'You can customize the domain name of this URI to match your identity provider assertion consumer service URL. Choose either "{{custom}}" or "{{default}}".',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/connectors.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/connectors.ts
@@ -68,6 +68,8 @@ const connectors = {
     callback_uri: 'Callback URI',
     callback_uri_description:
       '也称为重定向 URI，在社交授权后，用户将被发送回 Logto 的 URI，复制并粘贴到社交提供者的配置页面中。',
+    /** UNTRANSLATED */
+    acs_url: 'Assertion consumer service URL',
   },
   platform: {
     universal: '通用',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/domain.ts
@@ -45,6 +45,9 @@ const domain = {
   custom_endpoint_note: '您可以根据需要自定义这些端点的域名。选择 "{{custom}}" 或 "{{default}}"。',
   custom_social_callback_url_note:
     '您可以根据需要自定义此 URI 的域名，以匹配您的应用程序端点。选择 "{{custom}}" 或 "{{default}}"。',
+  /** UNTRANSLATED */
+  custom_acs_url_note:
+    'You can customize the domain name of this URI to match your identity provider assertion consumer service URL. Choose either "{{custom}}" or "{{default}}".',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/connectors.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/connectors.ts
@@ -68,6 +68,8 @@ const connectors = {
     callback_uri: 'Callback URI',
     callback_uri_description:
       '也稱為重定向 URI，在社交授權後，用戶將被發送回 Logto 的 URI，復制並粘貼到社交提供者的配置頁面中。',
+    /** UNTRANSLATED */
+    acs_url: 'Assertion consumer service URL',
   },
   platform: {
     universal: '通用',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/domain.ts
@@ -45,6 +45,9 @@ const domain = {
   custom_endpoint_note: '您可以根據需要自定義這些端點的域名。選擇“{{custom}}”或“{{default}}”。',
   custom_social_callback_url_note:
     '您可以自定義此URI的域名以匹配您的應用程序端點。選擇“{{custom}}”或“{{default}}”。',
+  /** UNTRANSLATED */
+  custom_acs_url_note:
+    'You can customize the domain name of this URI to match your identity provider assertion consumer service URL. Choose either "{{custom}}" or "{{default}}".',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/connectors.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/connectors.ts
@@ -68,6 +68,8 @@ const connectors = {
     callback_uri: 'Callback URI',
     callback_uri_description:
       '也稱為重定向 URI，在社交授權後，用戶將被發送回 Logto 的 URI，複製並粘貼到社交提供者的配置頁面中。',
+    /** UNTRANSLATED */
+    acs_url: 'Assertion consumer service URL',
   },
   platform: {
     universal: '通用',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/domain.ts
@@ -45,6 +45,9 @@ const domain = {
   custom_endpoint_note: '您可以根據需要自定義這些端點的域名。選擇“{{custom}}”或“{{default}}”。',
   custom_social_callback_url_note:
     '您可以自定義此 URI 的域名以匹配您的應用程序端點。選擇“{{custom}}”或“{{default}}”。',
+  /** UNTRANSLATED */
+  custom_acs_url_note:
+    'You can customize the domain name of this URI to match your identity provider assertion consumer service URL. Choose either "{{custom}}" or "{{default}}".',
 };
 
 export default Object.freeze(domain);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
show auto-generated ACS URL for SAML connector, previously we showed a callback URL for SAML connector which makes no sense.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
1. Should show callback URL for non-SAML connector:
<img width="1560" alt="image" src="https://github.com/logto-io/logto/assets/15182327/ebc79099-999e-437d-85a8-f17441e3196e">
2. Should show ACS URL for SAML connector:
<img width="1620" alt="image" src="https://github.com/logto-io/logto/assets/15182327/9773acd5-7d13-4186-b0e4-77f672fb52f5">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
