### PR TITLE
refactor(toolkit,schemas,console): use loose redirect url check for native apps

### DIFF
--- a/.changeset/spicy-rats-repair.md
+++ b/.changeset/spicy-rats-repair.md
@@ -1,0 +1,7 @@
+---
+"@logto/core-kit": patch
+"@logto/console": patch
+"@logto/schemas": patch
+---
+
+Update `validateRedirectUrl` util, changing `mobile` type to `native` and loosen the regex check for native app URL schemes.

--- a/packages/console/src/pages/ApplicationDetails/components/Settings.tsx
+++ b/packages/console/src/pages/ApplicationDetails/components/Settings.tsx
@@ -35,7 +35,7 @@ function Settings({ data }: Props) {
   const isNativeApp = applicationType === ApplicationType.Native;
   const uriPatternRules: MultiTextInputRule = {
     pattern: {
-      verify: (value) => !value || validateRedirectUrl(value, isNativeApp ? 'mobile' : 'web'),
+      verify: (value) => !value || validateRedirectUrl(value, isNativeApp ? 'native' : 'web'),
       message: t('errors.invalid_uri_format'),
     },
   };

--- a/packages/schemas/src/foundations/jsonb-types/oidc-module.ts
+++ b/packages/schemas/src/foundations/jsonb-types/oidc-module.ts
@@ -19,7 +19,7 @@ export const oidcClientMetadataGuard = z.object({
   redirectUris: z
     .string()
     .refine((url) => validateRedirectUrl(url, 'web'))
-    .or(z.string().refine((url) => validateRedirectUrl(url, 'mobile')))
+    .or(z.string().refine((url) => validateRedirectUrl(url, 'native')))
     .array(),
   postLogoutRedirectUris: z.string().url().array(),
   logoUri: z.string().optional(),

--- a/packages/toolkit/core-kit/src/regex.ts
+++ b/packages/toolkit/core-kit/src/regex.ts
@@ -4,6 +4,7 @@ export const phoneInputRegEx = /^\+?[\d-( )]+$/;
 export const usernameRegEx = /^[A-Z_a-z]\w*$/;
 export const webRedirectUriProtocolRegEx = /^https?:$/;
 export const mobileUriSchemeProtocolRegEx = /^[a-z][\d+_a-z-]*(\.[\d+_a-z-]+)+:$/;
+export const looseNativeUriSchemeProtocolRegEx = /^\S*:$/;
 export const hexColorRegEx = /^#[\da-f]{3}([\da-f]{3})?$/i;
 export const dateRegex = /^\d{4}(-\d{2}){2}/;
 export const noSpaceRegEx = /^\S+$/;

--- a/packages/toolkit/core-kit/src/regex.ts
+++ b/packages/toolkit/core-kit/src/regex.ts
@@ -3,7 +3,15 @@ export const phoneRegEx = /^\d+$/;
 export const phoneInputRegEx = /^\+?[\d-( )]+$/;
 export const usernameRegEx = /^[A-Z_a-z]\w*$/;
 export const webRedirectUriProtocolRegEx = /^https?:$/;
+/**
+ * Strict custom URI scheme check that matches the OIDC recommended pattern: a reversed domain name followed by a colon.
+ * E.g. `com.myapp://callback` is a valid redirect URI, but `myapp://callback` is not.
+ */
 export const mobileUriSchemeProtocolRegEx = /^[a-z][\d+_a-z-]*(\.[\d+_a-z-]+)+:$/;
+/**
+ * Loose custom URI scheme check that matches any non-whitespace character followed by a colon, for better compatibility.
+ * Community reports that some windows native apps use this scheme pattern. E.g. `myapp://callback`
+ */
 export const looseNativeUriSchemeProtocolRegEx = /^\S*:$/;
 export const hexColorRegEx = /^#[\da-f]{3}([\da-f]{3})?$/i;
 export const dateRegex = /^\d{4}(-\d{2}){2}/;

--- a/packages/toolkit/core-kit/src/utils/url.test.ts
+++ b/packages/toolkit/core-kit/src/utils/url.test.ts
@@ -6,20 +6,22 @@ describe('url utilities', () => {
     expect(validateRedirectUrl('https://logto.dev/callback', 'web')).toBeTruthy();
     expect(validateRedirectUrl('https://my-company.com/callback?test=123', 'web')).toBeTruthy();
     expect(validateRedirectUrl('https://abc.com/callback?test=123#param=hash', 'web')).toBeTruthy();
-    expect(validateRedirectUrl('io.logto://my-app/callback', 'mobile')).toBeTruthy();
-    expect(validateRedirectUrl('com.company://myDemoApp/callback', 'mobile')).toBeTruthy();
-    expect(validateRedirectUrl('com.company://demo:1234', 'mobile')).toBeTruthy();
-    expect(validateRedirectUrl('io.logto.SwiftUI-Demo://callback', 'mobile')).toBeTruthy();
-    expect(validateRedirectUrl('io.logto.SwiftUI+Demo://callback', 'mobile')).toBeTruthy();
+    expect(validateRedirectUrl('io.logto://my-app/callback', 'native')).toBeTruthy();
+    expect(validateRedirectUrl('com.company://myDemoApp/callback', 'native')).toBeTruthy();
+    expect(validateRedirectUrl('com.company://demo:1234', 'native')).toBeTruthy();
+    expect(validateRedirectUrl('io.logto.SwiftUI-Demo://callback', 'native')).toBeTruthy();
+    expect(validateRedirectUrl('io.logto.SwiftUI+Demo://callback', 'native')).toBeTruthy();
+    // Native apps on Windows might use this type of custom URI scheme.
+    expect(validateRedirectUrl('servicesstudiox11://auth', 'native')).toBeTruthy();
   });
 
   it('should detect invalid redirect URIs', () => {
     expect(validateRedirectUrl('io.logto://my-app/callback', 'web')).toBeFalsy();
     expect(validateRedirectUrl('ws://com.company://demo:1234', 'web')).toBeFalsy();
     expect(validateRedirectUrl('abc.com', 'web')).toBeFalsy();
-    expect(validateRedirectUrl('abc.com', 'mobile')).toBeFalsy();
-    expect(validateRedirectUrl('http://localhost:3001', 'mobile')).toBeFalsy();
-    expect(validateRedirectUrl('https://logto.dev/callback', 'mobile')).toBeFalsy();
-    expect(validateRedirectUrl('demoApp/callback', 'mobile')).toBeFalsy();
+    expect(validateRedirectUrl('abc.com', 'native')).toBeFalsy();
+    expect(validateRedirectUrl('http://localhost:3001', 'native')).toBeFalsy();
+    expect(validateRedirectUrl('https://logto.dev/callback', 'native')).toBeFalsy();
+    expect(validateRedirectUrl('demoApp/callback', 'native')).toBeFalsy();
   });
 });

--- a/packages/toolkit/core-kit/src/utils/url.test.ts
+++ b/packages/toolkit/core-kit/src/utils/url.test.ts
@@ -17,11 +17,10 @@ describe('url utilities', () => {
 
   it('should detect invalid redirect URIs', () => {
     expect(validateRedirectUrl('io.logto://my-app/callback', 'web')).toBeFalsy();
-    expect(validateRedirectUrl('ws://com.company://demo:1234', 'web')).toBeFalsy();
     expect(validateRedirectUrl('abc.com', 'web')).toBeFalsy();
-    expect(validateRedirectUrl('abc.com', 'native')).toBeFalsy();
-    expect(validateRedirectUrl('http://localhost:3001', 'native')).toBeFalsy();
-    expect(validateRedirectUrl('https://logto.dev/callback', 'native')).toBeFalsy();
+    // Does not have colon.
     expect(validateRedirectUrl('demoApp/callback', 'native')).toBeFalsy();
+    // Does not have non-whitespace characters before colon.
+    expect(validateRedirectUrl('://callback', 'native')).toBeFalsy();
   });
 });

--- a/packages/toolkit/core-kit/src/utils/url.ts
+++ b/packages/toolkit/core-kit/src/utils/url.ts
@@ -1,10 +1,10 @@
-import { mobileUriSchemeProtocolRegEx, webRedirectUriProtocolRegEx } from '../regex.js';
+import { looseNativeUriSchemeProtocolRegEx, webRedirectUriProtocolRegEx } from '../regex.js';
 
-export const validateRedirectUrl = (url: string, type: 'web' | 'mobile') => {
+export const validateRedirectUrl = (url: string, type: 'web' | 'native') => {
   try {
     const { protocol } = new URL(url);
     const protocolRegEx =
-      type === 'mobile' ? mobileUriSchemeProtocolRegEx : webRedirectUriProtocolRegEx;
+      type === 'native' ? looseNativeUriSchemeProtocolRegEx : webRedirectUriProtocolRegEx;
 
     return protocolRegEx.test(protocol);
   } catch {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Use loose URL check for native apps, since native apps on Windows platform usually do not comply with the OIDC recommendation of using backward domain (containing at least a dot `.`) in URI schemes, e.g. `com.company.myapp://callback`. Windows native apps usually use custom schemes like `servicestudiov11://auth`.

Fixes: #4995

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally in native app details page, worked fine.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
