### PR TITLE
fix: fix the db alter detect ci script

### DIFF
--- a/.github/workflows/alteration-compatibility-integration-test.yml
+++ b/.github/workflows/alteration-compatibility-integration-test.yml
@@ -23,11 +23,18 @@ jobs:
           fetch-depth: 0
 
       # compare the current codebase with HEAD and check if there are any changes under the alterations folder
+      # if the event is a pull request, we need to compare the merge base with HEAD, otherwise we compare the current commit with the previous commit
       - name: Check for alteration changes
         id: changes-detection
         run: |
-          MERGE_BASE=$(git merge-base origin/${{github.base_ref}} HEAD)
-          CHANGE_FILES=$(git diff --name-only $MERGE_BASE | grep 'packages/schemas/alterations/' || true)
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BASE=$(git merge-base origin/${{github.base_ref}} HEAD)
+          else
+            BASE=${{ github.event.before }}
+          fi
+
+          CHANGE_FILES=$(git diff --name-only $BASE | grep 'packages/schemas/alterations/' || true)
+
           if [ -n "$CHANGE_FILES" ]; then
             echo "$CHANGE_FILES"
             echo "::set-output name=has-alteration-changes::true"


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the DB alter detect ci script. 

<img width="464" alt="image" src="https://github.com/logto-io/logto/assets/36393111/dc5c7c69-b645-49cc-b8ed-b2950a5fa58e">


We trigger the db alteration detection ci job on both `pull_request` and `push` events. For a `push` event, no merge base exists and the `github.base_ref` is also empty.  Should conditionally set the git diff based on the event type. 




<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
ci

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
