### PR TITLE
feat(console,phrases): add permissions tab to the application details page 4-1

### DIFF
--- a/packages/console/src/consts/page-tabs.ts
+++ b/packages/console/src/consts/page-tabs.ts
@@ -3,6 +3,7 @@ export enum ApplicationDetailsTabs {
   Roles = 'roles',
   Logs = 'logs',
   Branding = 'branding',
+  Permissions = 'permissions',
 }
 
 export enum ApiResourceDetailsTabs {

--- a/packages/console/src/pages/ApplicationDetails/components/Branding/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/components/Branding/index.tsx
@@ -102,8 +102,8 @@ function Branding({ application }: Props) {
         onSubmit={onSubmit}
       >
         <FormCard
-          title="application_details.branding.branding"
-          description="application_details.branding.branding_description"
+          title="application_details.branding.name"
+          description="application_details.branding.description"
         >
           <FormField title="application_details.branding.display_name">
             <TextInput {...register('displayName')} />

--- a/packages/console/src/pages/ApplicationDetails/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/index.tsx
@@ -232,9 +232,14 @@ function ApplicationDetails() {
               </>
             )}
             {isDevFeaturesEnabled && data.isThirdParty && (
-              <TabNavItem href={`/applications/${data.id}/${ApplicationDetailsTabs.Branding}`}>
-                {t('application_details.branding.branding')}
-              </TabNavItem>
+              <>
+                <TabNavItem href={`/applications/${data.id}/${ApplicationDetailsTabs.Permissions}`}>
+                  {t('application_details.permissions.name')}
+                </TabNavItem>
+                <TabNavItem href={`/applications/${data.id}/${ApplicationDetailsTabs.Branding}`}>
+                  {t('application_details.branding.name')}
+                </TabNavItem>
+              </>
             )}
           </TabNav>
           <TabWrapper
@@ -275,12 +280,20 @@ function ApplicationDetails() {
           )}
 
           {isDevFeaturesEnabled && data.isThirdParty && (
-            <TabWrapper
-              isActive={tab === ApplicationDetailsTabs.Branding}
-              className={styles.tabContainer}
-            >
-              <Branding application={data} />
-            </TabWrapper>
+            <>
+              <TabWrapper
+                isActive={tab === ApplicationDetailsTabs.Permissions}
+                className={styles.tabContainer}
+              >
+                <div>Permissions</div>
+              </TabWrapper>
+              <TabWrapper
+                isActive={tab === ApplicationDetailsTabs.Branding}
+                className={styles.tabContainer}
+              >
+                <Branding application={data} />
+              </TabWrapper>
+            </>
           )}
         </>
       )}

--- a/packages/phrases/src/locales/de/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/application-details.ts
@@ -69,10 +69,9 @@ const application_details = {
   redirect_uri_required: 'Gib mindestens eine Umleitungs-URI an',
   branding: {
     /** UNTRANSLATED */
-    branding: 'Branding',
+    name: 'Branding',
     /** UNTRANSLATED */
-    branding_description:
-      "Customize your application's display name and logo on the consent screen.",
+    description: "Customize your application's display name and logo on the consent screen.",
     /** UNTRANSLATED */
     more_info: 'More info',
     /** UNTRANSLATED */
@@ -87,6 +86,13 @@ const application_details = {
     terms_of_use_url: 'Application terms of use URL',
     /** UNTRANSLATED */
     privacy_policy_url: 'Application privacy policy URL',
+  },
+  permissions: {
+    /** UNTRANSLATED */
+    name: 'Permissions',
+    /** UNTRANSLATED */
+    description:
+      'Select the permissions that the third-party application requires for user authorization to access specific data types.',
   },
   roles: {
     name_column: 'Rolle',

--- a/packages/phrases/src/locales/en/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/application-details.ts
@@ -62,9 +62,8 @@ const application_details = {
   application_deleted: 'Application {{name}} has been successfully deleted',
   redirect_uri_required: 'You must enter at least one redirect URI',
   branding: {
-    branding: 'Branding',
-    branding_description:
-      "Customize your application's display name and logo on the consent screen.",
+    name: 'Branding',
+    description: "Customize your application's display name and logo on the consent screen.",
     more_info: 'More info',
     more_info_description: 'Offer users more details about your application on the consent screen.',
     display_name: 'Display name',
@@ -72,6 +71,11 @@ const application_details = {
     display_logo_dark: 'Display logo (dark)',
     terms_of_use_url: 'Application terms of use URL',
     privacy_policy_url: 'Application privacy policy URL',
+  },
+  permissions: {
+    name: 'Permissions',
+    description:
+      'Select the permissions that the third-party application requires for user authorization to access specific data types.',
   },
   roles: {
     name_column: 'Role',

--- a/packages/phrases/src/locales/es/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/application-details.ts
@@ -69,10 +69,9 @@ const application_details = {
   redirect_uri_required: 'Debes ingresar al menos un URI de Redireccionamiento',
   branding: {
     /** UNTRANSLATED */
-    branding: 'Branding',
+    name: 'Branding',
     /** UNTRANSLATED */
-    branding_description:
-      "Customize your application's display name and logo on the consent screen.",
+    description: "Customize your application's display name and logo on the consent screen.",
     /** UNTRANSLATED */
     more_info: 'More info',
     /** UNTRANSLATED */
@@ -87,6 +86,13 @@ const application_details = {
     terms_of_use_url: 'Application terms of use URL',
     /** UNTRANSLATED */
     privacy_policy_url: 'Application privacy policy URL',
+  },
+  permissions: {
+    /** UNTRANSLATED */
+    name: 'Permissions',
+    /** UNTRANSLATED */
+    description:
+      'Select the permissions that the third-party application requires for user authorization to access specific data types.',
   },
   roles: {
     name_column: 'Rol',

--- a/packages/phrases/src/locales/fr/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/application-details.ts
@@ -69,10 +69,9 @@ const application_details = {
   redirect_uri_required: 'Vous devez entrer au moins un URI de redirection.',
   branding: {
     /** UNTRANSLATED */
-    branding: 'Branding',
+    name: 'Branding',
     /** UNTRANSLATED */
-    branding_description:
-      "Customize your application's display name and logo on the consent screen.",
+    description: "Customize your application's display name and logo on the consent screen.",
     /** UNTRANSLATED */
     more_info: 'More info',
     /** UNTRANSLATED */
@@ -87,6 +86,13 @@ const application_details = {
     terms_of_use_url: 'Application terms of use URL',
     /** UNTRANSLATED */
     privacy_policy_url: 'Application privacy policy URL',
+  },
+  permissions: {
+    /** UNTRANSLATED */
+    name: 'Permissions',
+    /** UNTRANSLATED */
+    description:
+      'Select the permissions that the third-party application requires for user authorization to access specific data types.',
   },
   roles: {
     name_column: 'Rôle',

--- a/packages/phrases/src/locales/it/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/application-details.ts
@@ -69,10 +69,9 @@ const application_details = {
   redirect_uri_required: 'Devi inserire almeno un URI di reindirizzamento',
   branding: {
     /** UNTRANSLATED */
-    branding: 'Branding',
+    name: 'Branding',
     /** UNTRANSLATED */
-    branding_description:
-      "Customize your application's display name and logo on the consent screen.",
+    description: "Customize your application's display name and logo on the consent screen.",
     /** UNTRANSLATED */
     more_info: 'More info',
     /** UNTRANSLATED */
@@ -87,6 +86,13 @@ const application_details = {
     terms_of_use_url: 'Application terms of use URL',
     /** UNTRANSLATED */
     privacy_policy_url: 'Application privacy policy URL',
+  },
+  permissions: {
+    /** UNTRANSLATED */
+    name: 'Permissions',
+    /** UNTRANSLATED */
+    description:
+      'Select the permissions that the third-party application requires for user authorization to access specific data types.',
   },
   roles: {
     name_column: 'Ruolo',

--- a/packages/phrases/src/locales/ja/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/application-details.ts
@@ -69,10 +69,9 @@ const application_details = {
   redirect_uri_required: 'リダイレクトURIを少なくとも1つ入力する必要があります',
   branding: {
     /** UNTRANSLATED */
-    branding: 'Branding',
+    name: 'Branding',
     /** UNTRANSLATED */
-    branding_description:
-      "Customize your application's display name and logo on the consent screen.",
+    description: "Customize your application's display name and logo on the consent screen.",
     /** UNTRANSLATED */
     more_info: 'More info',
     /** UNTRANSLATED */
@@ -87,6 +86,13 @@ const application_details = {
     terms_of_use_url: 'Application terms of use URL',
     /** UNTRANSLATED */
     privacy_policy_url: 'Application privacy policy URL',
+  },
+  permissions: {
+    /** UNTRANSLATED */
+    name: 'Permissions',
+    /** UNTRANSLATED */
+    description:
+      'Select the permissions that the third-party application requires for user authorization to access specific data types.',
   },
   roles: {
     name_column: '役割',

--- a/packages/phrases/src/locales/ko/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/application-details.ts
@@ -69,10 +69,9 @@ const application_details = {
   redirect_uri_required: '반드시 최소 하나의 Redirect URI 를 입력해야 해요.',
   branding: {
     /** UNTRANSLATED */
-    branding: 'Branding',
+    name: 'Branding',
     /** UNTRANSLATED */
-    branding_description:
-      "Customize your application's display name and logo on the consent screen.",
+    description: "Customize your application's display name and logo on the consent screen.",
     /** UNTRANSLATED */
     more_info: 'More info',
     /** UNTRANSLATED */
@@ -87,6 +86,13 @@ const application_details = {
     terms_of_use_url: 'Application terms of use URL',
     /** UNTRANSLATED */
     privacy_policy_url: 'Application privacy policy URL',
+  },
+  permissions: {
+    /** UNTRANSLATED */
+    name: 'Permissions',
+    /** UNTRANSLATED */
+    description:
+      'Select the permissions that the third-party application requires for user authorization to access specific data types.',
   },
   roles: {
     name_column: '역할',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/application-details.ts
@@ -69,10 +69,9 @@ const application_details = {
   redirect_uri_required: 'Musisz wpisać co najmniej jeden adres URL przekierowania',
   branding: {
     /** UNTRANSLATED */
-    branding: 'Branding',
+    name: 'Branding',
     /** UNTRANSLATED */
-    branding_description:
-      "Customize your application's display name and logo on the consent screen.",
+    description: "Customize your application's display name and logo on the consent screen.",
     /** UNTRANSLATED */
     more_info: 'More info',
     /** UNTRANSLATED */
@@ -87,6 +86,13 @@ const application_details = {
     terms_of_use_url: 'Application terms of use URL',
     /** UNTRANSLATED */
     privacy_policy_url: 'Application privacy policy URL',
+  },
+  permissions: {
+    /** UNTRANSLATED */
+    name: 'Permissions',
+    /** UNTRANSLATED */
+    description:
+      'Select the permissions that the third-party application requires for user authorization to access specific data types.',
   },
   roles: {
     name_column: 'Role',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/application-details.ts
@@ -69,10 +69,9 @@ const application_details = {
   redirect_uri_required: 'Você deve inserir pelo menos um URI de redirecionamento',
   branding: {
     /** UNTRANSLATED */
-    branding: 'Branding',
+    name: 'Branding',
     /** UNTRANSLATED */
-    branding_description:
-      "Customize your application's display name and logo on the consent screen.",
+    description: "Customize your application's display name and logo on the consent screen.",
     /** UNTRANSLATED */
     more_info: 'More info',
     /** UNTRANSLATED */
@@ -87,6 +86,13 @@ const application_details = {
     terms_of_use_url: 'Application terms of use URL',
     /** UNTRANSLATED */
     privacy_policy_url: 'Application privacy policy URL',
+  },
+  permissions: {
+    /** UNTRANSLATED */
+    name: 'Permissions',
+    /** UNTRANSLATED */
+    description:
+      'Select the permissions that the third-party application requires for user authorization to access specific data types.',
   },
   roles: {
     name_column: 'Função',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/application-details.ts
@@ -69,10 +69,9 @@ const application_details = {
   redirect_uri_required: 'Deve inserir pelo menos um URI de redirecionamento',
   branding: {
     /** UNTRANSLATED */
-    branding: 'Branding',
+    name: 'Branding',
     /** UNTRANSLATED */
-    branding_description:
-      "Customize your application's display name and logo on the consent screen.",
+    description: "Customize your application's display name and logo on the consent screen.",
     /** UNTRANSLATED */
     more_info: 'More info',
     /** UNTRANSLATED */
@@ -87,6 +86,13 @@ const application_details = {
     terms_of_use_url: 'Application terms of use URL',
     /** UNTRANSLATED */
     privacy_policy_url: 'Application privacy policy URL',
+  },
+  permissions: {
+    /** UNTRANSLATED */
+    name: 'Permissions',
+    /** UNTRANSLATED */
+    description:
+      'Select the permissions that the third-party application requires for user authorization to access specific data types.',
   },
   roles: {
     name_column: 'Nome da função',

--- a/packages/phrases/src/locales/ru/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/application-details.ts
@@ -69,10 +69,9 @@ const application_details = {
   redirect_uri_required: 'Вы должны ввести по крайней мере один URI перенаправления',
   branding: {
     /** UNTRANSLATED */
-    branding: 'Branding',
+    name: 'Branding',
     /** UNTRANSLATED */
-    branding_description:
-      "Customize your application's display name and logo on the consent screen.",
+    description: "Customize your application's display name and logo on the consent screen.",
     /** UNTRANSLATED */
     more_info: 'More info',
     /** UNTRANSLATED */
@@ -87,6 +86,13 @@ const application_details = {
     terms_of_use_url: 'Application terms of use URL',
     /** UNTRANSLATED */
     privacy_policy_url: 'Application privacy policy URL',
+  },
+  permissions: {
+    /** UNTRANSLATED */
+    name: 'Permissions',
+    /** UNTRANSLATED */
+    description:
+      'Select the permissions that the third-party application requires for user authorization to access specific data types.',
   },
   roles: {
     name_column: 'Роль',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/application-details.ts
@@ -69,10 +69,9 @@ const application_details = {
   redirect_uri_required: 'En az 1 yönlendirme URIı girmelisiniz',
   branding: {
     /** UNTRANSLATED */
-    branding: 'Branding',
+    name: 'Branding',
     /** UNTRANSLATED */
-    branding_description:
-      "Customize your application's display name and logo on the consent screen.",
+    description: "Customize your application's display name and logo on the consent screen.",
     /** UNTRANSLATED */
     more_info: 'More info',
     /** UNTRANSLATED */
@@ -87,6 +86,13 @@ const application_details = {
     terms_of_use_url: 'Application terms of use URL',
     /** UNTRANSLATED */
     privacy_policy_url: 'Application privacy policy URL',
+  },
+  permissions: {
+    /** UNTRANSLATED */
+    name: 'Permissions',
+    /** UNTRANSLATED */
+    description:
+      'Select the permissions that the third-party application requires for user authorization to access specific data types.',
   },
   roles: {
     name_column: 'Rol',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/application-details.ts
@@ -66,10 +66,9 @@ const application_details = {
   redirect_uri_required: '至少需要输入一个重定向 URI。',
   branding: {
     /** UNTRANSLATED */
-    branding: 'Branding',
+    name: 'Branding',
     /** UNTRANSLATED */
-    branding_description:
-      "Customize your application's display name and logo on the consent screen.",
+    description: "Customize your application's display name and logo on the consent screen.",
     /** UNTRANSLATED */
     more_info: 'More info',
     /** UNTRANSLATED */
@@ -84,6 +83,13 @@ const application_details = {
     terms_of_use_url: 'Application terms of use URL',
     /** UNTRANSLATED */
     privacy_policy_url: 'Application privacy policy URL',
+  },
+  permissions: {
+    /** UNTRANSLATED */
+    name: 'Permissions',
+    /** UNTRANSLATED */
+    description:
+      'Select the permissions that the third-party application requires for user authorization to access specific data types.',
   },
   roles: {
     name_column: '角色',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/application-details.ts
@@ -66,10 +66,9 @@ const application_details = {
   redirect_uri_required: '至少需要輸入一個重定向 URL。',
   branding: {
     /** UNTRANSLATED */
-    branding: 'Branding',
+    name: 'Branding',
     /** UNTRANSLATED */
-    branding_description:
-      "Customize your application's display name and logo on the consent screen.",
+    description: "Customize your application's display name and logo on the consent screen.",
     /** UNTRANSLATED */
     more_info: 'More info',
     /** UNTRANSLATED */
@@ -84,6 +83,13 @@ const application_details = {
     terms_of_use_url: 'Application terms of use URL',
     /** UNTRANSLATED */
     privacy_policy_url: 'Application privacy policy URL',
+  },
+  permissions: {
+    /** UNTRANSLATED */
+    name: 'Permissions',
+    /** UNTRANSLATED */
+    description:
+      'Select the permissions that the third-party application requires for user authorization to access specific data types.',
   },
   roles: {
     name_column: '角色',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/application-details.ts
@@ -67,10 +67,9 @@ const application_details = {
   redirect_uri_required: '至少需要輸入一個重定向 URL。',
   branding: {
     /** UNTRANSLATED */
-    branding: 'Branding',
+    name: 'Branding',
     /** UNTRANSLATED */
-    branding_description:
-      "Customize your application's display name and logo on the consent screen.",
+    description: "Customize your application's display name and logo on the consent screen.",
     /** UNTRANSLATED */
     more_info: 'More info',
     /** UNTRANSLATED */
@@ -85,6 +84,13 @@ const application_details = {
     terms_of_use_url: 'Application terms of use URL',
     /** UNTRANSLATED */
     privacy_policy_url: 'Application privacy policy URL',
+  },
+  permissions: {
+    /** UNTRANSLATED */
+    name: 'Permissions',
+    /** UNTRANSLATED */
+    description:
+      'Select the permissions that the third-party application requires for user authorization to access specific data types.',
   },
   roles: {
     name_column: '角色',


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add the permissions tab to the application details page. 

Split the feature into 4 subsequent PRs. This the PR 4-1.

<img width="1262" alt="image" src="https://github.com/logto-io/logto/assets/36393111/b4180840-4715-4c76-86fe-e2499a6f669c">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally. Integration tests will be added later


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [ ] ~necessary TSDoc comments~
