### PR TITLE
fix(console): should not parse phone number if it is empty

### DIFF
--- a/packages/console/src/pages/UserDetails/UserSettings/index.tsx
+++ b/packages/console/src/pages/UserDetails/UserSettings/index.tsx
@@ -1,7 +1,7 @@
 import { emailRegEx, usernameRegEx } from '@logto/core-kit';
 import type { User } from '@logto/schemas';
 import { parsePhoneNumber } from '@logto/shared/universal';
-import { trySafe } from '@silverhand/essentials';
+import { conditionalString, trySafe } from '@silverhand/essentials';
 import { parsePhoneNumberWithError } from 'libphonenumber-js';
 import { useForm, useController } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
@@ -79,7 +79,7 @@ function UserSettings() {
 
       const payload: Partial<User> = {
         ...formData,
-        primaryPhone: parsePhoneNumber(primaryPhone),
+        primaryPhone: conditionalString(primaryPhone && parsePhoneNumber(primaryPhone)),
         customData: parseResult.data,
       };
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Should not try to parse phone number if it's empty. Otherwise the util method will report an unexpected error in browser console.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
