### PR TITLE
fix(console): upcoming billing info not updated when subscription changes

### DIFF
--- a/packages/console/src/pages/TenantSettings/Subscription/SwitchPlanActionBar/index.tsx
+++ b/packages/console/src/pages/TenantSettings/Subscription/SwitchPlanActionBar/index.tsx
@@ -23,7 +23,7 @@ import * as styles from './index.module.scss';
 type Props = {
   currentSubscriptionPlanId: string;
   subscriptionPlans: SubscriptionPlan[];
-  onSubscriptionUpdated: () => void;
+  onSubscriptionUpdated: () => Promise<void>;
 };
 
 function SwitchPlanActionBar({
@@ -67,7 +67,7 @@ function SwitchPlanActionBar({
       setCurrentLoadingPlanId(targetPlanId);
       if (targetPlanId === ReservedPlanId.Free) {
         await cancelSubscription(currentTenantId);
-        onSubscriptionUpdated();
+        await onSubscriptionUpdated();
         toast.success(
           <Trans components={{ name: <PlanName name={targetPlan.name} /> }}>
             {t('downgrade_success')}

--- a/packages/console/src/pages/TenantSettings/Subscription/index.tsx
+++ b/packages/console/src/pages/TenantSettings/Subscription/index.tsx
@@ -19,7 +19,11 @@ function Subscription() {
   const { subscriptionPlans, currentPlan, currentSubscription, onCurrentSubscriptionUpdated } =
     useContext(SubscriptionDataContext);
 
-  const { data: subscriptionUsage, isLoading } = useSubscriptionUsage(currentTenantId);
+  const {
+    data: subscriptionUsage,
+    isLoading,
+    mutate: mutateSubscriptionUsage,
+  } = useSubscriptionUsage(currentTenantId);
 
   const reservedPlans = pickupFeaturedPlans(subscriptionPlans);
 
@@ -43,7 +47,15 @@ function Subscription() {
       <SwitchPlanActionBar
         currentSubscriptionPlanId={currentSubscription.planId}
         subscriptionPlans={reservedPlans}
-        onSubscriptionUpdated={onCurrentSubscriptionUpdated}
+        onSubscriptionUpdated={async () => {
+          /**
+           * The upcoming billing info is calculated based on the current subscription usage,
+           * and the usage is based on the current subscription plan,
+           * need to manually trigger the usage update while the subscription plan is changed.
+           */
+          onCurrentSubscriptionUpdated();
+          await mutateSubscriptionUsage();
+        }}
       />
     </div>
   );


### PR DESCRIPTION


<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
upcoming billing info should be updated when the subscription changes.
<img width="2196" alt="image" src="https://github.com/logto-io/logto/assets/15182327/49b66a07-4533-4c25-a2f7-e5095d6ce3f6">
As you can see in the screenshot, the upcoming billing info is calculated based on the response of cloud `GET /:tenantId/usage` endpoint and the `cost` varies with subscription.
<img width="354" alt="image" src="https://github.com/logto-io/logto/assets/15182327/4901dcf7-2863-47c6-b5df-dcfd3bfa66c7">
Since the subscription changes, we need to revalidate the response of the `GET /:tenantId/usage` API to make sure the upcoming billing is up-to-date.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
