### PR TITLE
feat(schemas, core): init organization invitation apis

### DIFF
--- a/packages/core/src/database/utils.ts
+++ b/packages/core/src/database/utils.ts
@@ -1,5 +1,11 @@
 import { type GeneratedSchema } from '@logto/schemas';
-import { type SchemaLike, conditionalSql, convertToIdentifiers, type Table } from '@logto/shared';
+import {
+  type SchemaLike,
+  conditionalSql,
+  convertToIdentifiers,
+  type Table,
+  type FieldIdentifiers,
+} from '@logto/shared';
 import { type SqlSqlToken, sql } from 'slonik';
 
 /**
@@ -56,3 +62,48 @@ export const expandFields = <Keys extends string>(schema: Table<Keys>, tablePref
   const { fields } = convertToIdentifiers(schema, tablePrefix);
   return sql.join(Object.values(fields), sql`, `);
 };
+
+/**
+ * Given a set of identifiers, build a SQL that converts them into a JSON object by mapping
+ * the keys to the values.
+ *
+ * @example
+ * ```ts
+ * buildJsonObjectSql({
+ *   id: sql.identifier(['id']),
+ *   firstName: sql.identifier(['first_name']),
+ *   lastName: sql.identifier(['last_name']),
+ *   createdAt: sql.identifier(['created_at']),
+ * );
+ * ```
+ *
+ * will generate
+ *
+ * ```sql
+ * json_build_object(
+ *   'id', "id",
+ *   'firstName', "first_name",
+ *   'lastName', "last_name",
+ *   'createdAt', trunc(extract(epoch from "created_at") * 1000)
+ * )
+ * ```
+ *
+ * @remarks The values will be converted to epoch milliseconds if the key ends with `At` since
+ * slonik has a default parser that converts timestamps to epoch milliseconds, but it does not
+ * work for JSON objects.
+ */
+export const buildJsonObjectSql = <Identifiers extends FieldIdentifiers<string>>(
+  identifiers: Identifiers
+) => sql`
+  json_build_object(
+    ${sql.join(
+      Object.entries(identifiers).map(
+        ([key, value]) =>
+          sql`${sql.literalValue(key)}, ${
+            key.endsWith('At') ? sql`trunc(extract(epoch from ${value}) * 1000)` : value
+          }`
+      ),
+      sql`, `
+    )}
+  )
+`;

--- a/packages/core/src/routes/organization/index.ts
+++ b/packages/core/src/routes/organization/index.ts
@@ -8,6 +8,7 @@ import {
 import { yes } from '@silverhand/essentials';
 import { z } from 'zod';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
@@ -18,6 +19,7 @@ import { parseSearchOptions } from '#src/utils/search.js';
 
 import { type AuthedRouter, type RouterInitArgs } from '../types.js';
 
+import organizationInvitationRoutes from './invitations.js';
 import organizationRoleRoutes from './roles.js';
 import organizationScopeRoutes from './scopes.js';
 import { errorHandler } from './utils.js';
@@ -236,6 +238,10 @@ export default function organizationRoutes<T extends AuthedRouter>(...args: Rout
   // MARK: Mount sub-routes
   organizationRoleRoutes(...args);
   organizationScopeRoutes(...args);
+
+  if (EnvSet.values.isDevFeaturesEnabled) {
+    organizationInvitationRoutes(...args);
+  }
 
   router.use(koaQuotaGuard({ key: 'organizationsEnabled', quota, methods: ['POST', 'PUT'] }));
 

--- a/packages/core/src/routes/organization/invitations.openapi.json
+++ b/packages/core/src/routes/organization/invitations.openapi.json
@@ -1,0 +1,22 @@
+{
+  "tags": [
+    {
+      "name": "Organization invitations",
+      "description": "Organization invitations are used to invite users to join an organization. They are sent via email and contain a link that the user can click to accept the invitation and join the organization."
+    }
+  ],
+  "paths": {
+    "/api/organization-invitations": {
+      "get": {
+        "summary": "Get organization invitations",
+        "description": "Get organization invitations with pagination.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "A list of organization invitations, each item also contains the organization roles to be assigned to the user when they accept the invitation, and the corresponding magic link data."
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/core/src/routes/organization/invitations.ts
+++ b/packages/core/src/routes/organization/invitations.ts
@@ -1,0 +1,40 @@
+import { OrganizationInvitations, organizationInvitationEntityGuard } from '@logto/schemas';
+import Router, { type IRouterParamContext } from 'koa-router';
+
+import koaGuard from '#src/middleware/koa-guard.js';
+import koaPagination from '#src/middleware/koa-pagination.js';
+import { tableToPathname } from '#src/utils/SchemaRouter.js';
+
+import { type AuthedRouter, type RouterInitArgs } from '../types.js';
+
+export default function organizationInvitationRoutes<T extends AuthedRouter>(
+  ...[
+    originalRouter,
+    {
+      queries: {
+        organizations: { invitations },
+      },
+    },
+  ]: RouterInitArgs<T>
+) {
+  const router = new Router<unknown, IRouterParamContext>({
+    prefix: '/' + tableToPathname(OrganizationInvitations.table),
+  });
+
+  router.get(
+    '/',
+    koaPagination(),
+    koaGuard({ response: organizationInvitationEntityGuard.array(), status: [200] }),
+    async (ctx, next) => {
+      const { limit, offset } = ctx.pagination;
+      const [count, entities] = await invitations.findAll(limit, offset);
+
+      ctx.pagination.totalCount = count;
+      ctx.body = entities;
+      ctx.status = 200;
+      return next();
+    }
+  );
+
+  originalRouter.use(router.routes());
+}

--- a/packages/schemas/src/types/organization.ts
+++ b/packages/schemas/src/types/organization.ts
@@ -5,6 +5,10 @@ import {
   OrganizationRoles,
   type Organization,
   Organizations,
+  type OrganizationInvitation,
+  type MagicLink,
+  OrganizationInvitations,
+  MagicLinks,
 } from '../db-entries/index.js';
 
 import { type UserInfo, type FeaturedUser, userInfoGuard } from './user.js';
@@ -81,3 +85,20 @@ export type OrganizationWithFeatured = Organization & {
   usersCount?: number;
   featuredUsers?: FeaturedUser[];
 };
+
+/**
+ * The organization invitation with additional fields:
+ *
+ * - `magicLink`: The magic link that can be used to accept the invitation.
+ * - `organizationRoles`: The roles to be assigned to the user when accepting the invitation.
+ */
+export type OrganizationInvitationEntity = OrganizationInvitation & {
+  magicLink: MagicLink;
+  organizationRoles: OrganizationRoleEntity[];
+};
+
+export const organizationInvitationEntityGuard: z.ZodType<OrganizationInvitationEntity> =
+  OrganizationInvitations.guard.extend({
+    magicLink: MagicLinks.guard,
+    organizationRoles: organizationRoleEntityGuard.array(),
+  });

--- a/packages/schemas/tables/magic_links.sql
+++ b/packages/schemas/tables/magic_links.sql
@@ -1,10 +1,6 @@
 /* init_order = 1 */
 
-/** 
- * Link that can be used to perform certain actions by verifying the token. The expiration time
- * of the link should be determined by the action it performs, thus there is no `expires_at`
- * column in this table.
- */
+/** Link that can be used to perform certain actions by verifying the token. The expiration time of the link should be determined by the action it performs, thus there is no `expires_at` column in this table. */
 create table magic_links (
   tenant_id varchar(21) not null
     references tenants (id) on update cascade on delete cascade,


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
resolves LOG-7976.

- init organization invitation queries
- implement `GET /organization-invitations`

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

local tested the get api, organization roles and magic links can be correctly aggregated. integration tests will be added once mutation methods (e.g. `POST`) are implemented.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
