### PR TITLE
feat(console,phrases): implement permissions assignment modal 4-4

### DIFF
--- a/packages/console/src/components/ScopesAssignmentModal/ScopesAssignmentForm/index.module.scss
+++ b/packages/console/src/components/ScopesAssignmentModal/ScopesAssignmentForm/index.module.scss
@@ -1,0 +1,3 @@
+.scopesAssignmentForm {
+  height: 360px;
+}

--- a/packages/console/src/components/ScopesAssignmentModal/ScopesAssignmentForm/index.tsx
+++ b/packages/console/src/components/ScopesAssignmentModal/ScopesAssignmentForm/index.tsx
@@ -1,0 +1,39 @@
+import classNames from 'classnames';
+
+import * as transferLayout from '@/scss/transfer.module.scss';
+
+import SourceScopesBox from '../SourceScopesBox';
+import TargetScopesBox from '../TargetScopesBox';
+import {
+  type ScopeAssignmentScopeDataType,
+  type ScopeAssignmentResourceScopesGroupDataType,
+  type SelectedScopeAssignmentScopeDataType,
+} from '../type';
+
+import * as styles from './index.module.scss';
+
+type Props = {
+  selectedScopes: SelectedScopeAssignmentScopeDataType[];
+  setSelectedScopes: (scopes: SelectedScopeAssignmentScopeDataType[]) => void;
+  availableScopes?: ScopeAssignmentScopeDataType[];
+  groupedAvailableResourceScopes?: ScopeAssignmentResourceScopesGroupDataType[];
+};
+
+function ScopesAssignmentForm({
+  selectedScopes,
+  setSelectedScopes,
+  availableScopes,
+  groupedAvailableResourceScopes,
+}: Props) {
+  return (
+    <div className={classNames(transferLayout.container, styles.scopesAssignmentForm)}>
+      <SourceScopesBox
+        {...{ selectedScopes, setSelectedScopes, availableScopes, groupedAvailableResourceScopes }}
+      />
+      <div className={transferLayout.verticalBar} />
+      <TargetScopesBox {...{ selectedScopes, setSelectedScopes }} />
+    </div>
+  );
+}
+
+export default ScopesAssignmentForm;

--- a/packages/console/src/components/ScopesAssignmentModal/SourceResourceScopesGroupItem/index.module.scss
+++ b/packages/console/src/components/ScopesAssignmentModal/SourceResourceScopesGroupItem/index.module.scss
@@ -1,0 +1,43 @@
+@use '@/scss/underscore' as _;
+
+.resourceItem {
+  user-select: none;
+
+  .title {
+    display: flex;
+    align-items: center;
+    padding: _.unit(1.5) _.unit(4);
+
+    .resource {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      cursor: pointer;
+      overflow: hidden;
+
+      .caret {
+        margin-right: _.unit(2);
+      }
+
+      .name {
+        font: var(--font-label-2);
+        @include _.text-ellipsis;
+      }
+
+      .scopeInfo {
+        flex-shrink: 0;
+        font: var(--font-body-2);
+        color: var(--color-text-secondary);
+        margin-left: _.unit(2);
+      }
+    }
+  }
+
+  .invisible {
+    display: none;
+  }
+}
+
+.scopesGroup {
+  padding-left: _.unit(10);
+}

--- a/packages/console/src/components/ScopesAssignmentModal/SourceResourceScopesGroupItem/index.tsx
+++ b/packages/console/src/components/ScopesAssignmentModal/SourceResourceScopesGroupItem/index.tsx
@@ -1,0 +1,89 @@
+import classNames from 'classnames';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import CaretExpanded from '@/assets/icons/caret-expanded.svg';
+import CaretFolded from '@/assets/icons/caret-folded.svg';
+import Checkbox from '@/ds-components/Checkbox';
+import IconButton from '@/ds-components/IconButton';
+import { onKeyDownHandler } from '@/utils/a11y';
+
+import SourceScopeItem from '../SourceScopeItem';
+import {
+  type ScopeAssignmentResourceScopesGroupDataType,
+  type SelectedScopeAssignmentScopeDataType,
+} from '../type';
+
+import * as styles from './index.module.scss';
+
+type Props = {
+  resourceGroup: ScopeAssignmentResourceScopesGroupDataType;
+  resourceSelectedScopes: SelectedScopeAssignmentScopeDataType[];
+  onSelectResource: (resource: ScopeAssignmentResourceScopesGroupDataType) => void;
+  onSelectScope: (scope: SelectedScopeAssignmentScopeDataType) => void;
+};
+
+function SourceResourceScopesGroupItem({
+  resourceGroup,
+  resourceSelectedScopes,
+  onSelectResource,
+  onSelectScope,
+}: Props) {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const { resourceName, scopes } = resourceGroup;
+  const selectedScopesIdsSet = new Set(resourceSelectedScopes.map(({ id }) => id));
+  const selectedScopesCount = selectedScopesIdsSet.size;
+  const totalScopesCount = scopes.length;
+
+  const [isScopesInvisible, setIsScopesInvisible] = useState(true);
+
+  return (
+    <div className={styles.resourceItem}>
+      <div className={styles.title}>
+        <Checkbox
+          checked={selectedScopesCount === totalScopesCount}
+          indeterminate={selectedScopesCount > 0 && selectedScopesCount < totalScopesCount}
+          onChange={() => {
+            onSelectResource(resourceGroup);
+          }}
+        />
+        <div
+          role="button"
+          tabIndex={0}
+          className={styles.resource}
+          onKeyDown={onKeyDownHandler(() => {
+            setIsScopesInvisible(!isScopesInvisible);
+          })}
+          onClick={() => {
+            setIsScopesInvisible(!isScopesInvisible);
+          }}
+        >
+          <IconButton size="medium" className={styles.caret}>
+            {isScopesInvisible ? <CaretFolded /> : <CaretExpanded />}
+          </IconButton>
+          <div className={styles.name}>{resourceName}</div>
+          <div className={styles.scopeInfo}>
+            ({t('role_details.permission.api_permission_count', { count: scopes.length })})
+          </div>
+        </div>
+      </div>
+      <div className={classNames(isScopesInvisible && styles.invisible, styles.scopesGroup)}>
+        {scopes.map((scope) => (
+          <SourceScopeItem
+            key={scope.id}
+            scope={scope}
+            isSelected={selectedScopesIdsSet.has(scope.id)}
+            onSelect={(scope) => {
+              onSelectScope({
+                ...scope,
+                resourceName,
+              });
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default SourceResourceScopesGroupItem;

--- a/packages/console/src/components/ScopesAssignmentModal/SourceScopeItem/index.module.scss
+++ b/packages/console/src/components/ScopesAssignmentModal/SourceScopeItem/index.module.scss
@@ -1,0 +1,20 @@
+@use '@/scss/underscore' as _;
+
+.sourceScopeItem {
+  display: flex;
+  align-items: center;
+  padding: _.unit(1.5) _.unit(4);
+
+  .name {
+    font: var(--font-body-2);
+    padding: _.unit(1) _.unit(2);
+    border-radius: 6px;
+    background: var(--color-neutral-95);
+    @include _.text-ellipsis;
+    cursor: pointer;
+  }
+
+  .icon {
+    color: var(--color-text-secondary);
+  }
+}

--- a/packages/console/src/components/ScopesAssignmentModal/SourceScopeItem/index.tsx
+++ b/packages/console/src/components/ScopesAssignmentModal/SourceScopeItem/index.tsx
@@ -1,0 +1,40 @@
+import Checkbox from '@/ds-components/Checkbox';
+import { onKeyDownHandler } from '@/utils/a11y';
+
+import type { ScopeAssignmentScopeDataType } from '../type';
+
+import * as styles from './index.module.scss';
+
+type Props = {
+  scope: ScopeAssignmentScopeDataType;
+  isSelected: boolean;
+  onSelect: (scope: ScopeAssignmentScopeDataType) => void;
+};
+
+function SourceScopeItem({ scope, scope: { name }, isSelected, onSelect }: Props) {
+  return (
+    <div className={styles.sourceScopeItem}>
+      <Checkbox
+        checked={isSelected}
+        onChange={() => {
+          onSelect(scope);
+        }}
+      />
+      <div
+        className={styles.name}
+        role="button"
+        tabIndex={0}
+        onKeyDown={onKeyDownHandler(() => {
+          onSelect(scope);
+        })}
+        onClick={() => {
+          onSelect(scope);
+        }}
+      >
+        {name}
+      </div>
+    </div>
+  );
+}
+
+export default SourceScopeItem;

--- a/packages/console/src/components/ScopesAssignmentModal/SourceScopesBox/index.module.scss
+++ b/packages/console/src/components/ScopesAssignmentModal/SourceScopesBox/index.module.scss
@@ -1,0 +1,9 @@
+@use '@/scss/underscore' as _;
+
+.search {
+  width: 100%;
+}
+
+.icon {
+  color: var(--color-text-secondary);
+}

--- a/packages/console/src/components/ScopesAssignmentModal/SourceScopesBox/index.tsx
+++ b/packages/console/src/components/ScopesAssignmentModal/SourceScopesBox/index.tsx
@@ -1,0 +1,184 @@
+import classNames from 'classnames';
+import { useState, type ChangeEvent, useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import Search from '@/assets/icons/search.svg';
+import EmptyDataPlaceholder from '@/components/EmptyDataPlaceholder';
+import TextInput from '@/ds-components/TextInput';
+import * as transferLayout from '@/scss/transfer.module.scss';
+
+import SourceResourceScopesGroupItem from '../SourceResourceScopesGroupItem';
+import SourceScopeItem from '../SourceScopeItem';
+import {
+  type SelectedScopeAssignmentScopeDataType,
+  type ScopeAssignmentResourceScopesGroupDataType,
+  type ScopeAssignmentScopeDataType,
+} from '../type';
+
+import * as styles from './index.module.scss';
+
+type Props = {
+  selectedScopes: SelectedScopeAssignmentScopeDataType[];
+  setSelectedScopes: (scopes: SelectedScopeAssignmentScopeDataType[]) => void;
+  availableScopes?: ScopeAssignmentScopeDataType[];
+  groupedAvailableResourceScopes?: ScopeAssignmentResourceScopesGroupDataType[];
+};
+
+function SourceScopesBox({
+  selectedScopes,
+  setSelectedScopes,
+  availableScopes,
+  groupedAvailableResourceScopes,
+}: Props) {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+
+  // Keyword search
+  const [keyword, setKeyword] = useState('');
+  const handleSearchInput = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setKeyword(event.target.value);
+  }, []);
+
+  const isScopeSelected = useCallback(
+    (scope: ScopeAssignmentScopeDataType) =>
+      selectedScopes.findIndex(({ id }) => id === scope.id) >= 0,
+    [selectedScopes]
+  );
+
+  // Get the selected scopes by resource
+  const getSelectedScopesByResource = useCallback(
+    (resourceGroupScopes: ScopeAssignmentScopeDataType[]) =>
+      selectedScopes.filter(({ id }) => resourceGroupScopes.some((scope) => scope.id === id)),
+    [selectedScopes]
+  );
+
+  // Toggle the scope selection status
+  const onSelectScope = useCallback(
+    (scope: SelectedScopeAssignmentScopeDataType) => {
+      if (isScopeSelected(scope)) {
+        setSelectedScopes(selectedScopes.filter(({ id }) => id !== scope.id));
+        return;
+      }
+
+      setSelectedScopes([...selectedScopes, scope]);
+    },
+    [isScopeSelected, selectedScopes, setSelectedScopes]
+  );
+
+  // Toggle the resource group selection status
+  const onSelectResource = useCallback(
+    ({ resourceName, scopes: resourceScopes }: ScopeAssignmentResourceScopesGroupDataType) => {
+      const isAllSelected = resourceScopes.every((scope) => isScopeSelected(scope));
+
+      // Filter out the scopes that are selected and belong to the resource group
+      if (isAllSelected) {
+        setSelectedScopes(
+          selectedScopes.filter(
+            ({ id: selectedScopeId }) =>
+              !resourceScopes.some(({ id: resourceScopeId }) => resourceScopeId === selectedScopeId)
+          )
+        );
+        return;
+      }
+
+      // Add the scopes that belong to the resource group
+      setSelectedScopes([
+        ...selectedScopes,
+        ...resourceScopes.map((scope) => ({
+          ...scope,
+          resourceName,
+        })),
+      ]);
+    },
+    [isScopeSelected, selectedScopes, setSelectedScopes]
+  );
+
+  // Get the keyword filtered available scopes
+  const filteredAvailableScopes = useMemo(() => {
+    if (!availableScopes) {
+      return;
+    }
+
+    const lowerCasedKeyword = keyword.toLowerCase();
+
+    return availableScopes.filter(({ name }) =>
+      lowerCasedKeyword ? name.toLowerCase().includes(lowerCasedKeyword) : true
+    );
+  }, [availableScopes, keyword]);
+
+  // Get the keyword filtered available resource group
+  const filteredAvailableResourceGroup = useMemo(() => {
+    if (!groupedAvailableResourceScopes) {
+      return;
+    }
+
+    const lowerCasedKeyword = keyword.toLowerCase();
+
+    return (
+      groupedAvailableResourceScopes
+        .map((resourceGroup) => {
+          // If the resource name matches the keyword, return all the original scopes
+          if (resourceGroup.resourceName.toLowerCase().includes(lowerCasedKeyword)) {
+            return resourceGroup;
+          }
+
+          // If the resource name doesn't match the keyword, return the filtered scopes
+          return {
+            ...resourceGroup,
+            scopes: resourceGroup.scopes.filter(({ name }) =>
+              lowerCasedKeyword ? name.toLowerCase().includes(lowerCasedKeyword) : true
+            ),
+          };
+        })
+        // Filter out the resources if the resource name doesn't match the keyword and none of the scopes matches the keyword
+        .filter(
+          (resourceGroup) =>
+            resourceGroup.resourceName.toLowerCase().includes(lowerCasedKeyword) ||
+            resourceGroup.scopes.length > 0
+        )
+    );
+  }, [groupedAvailableResourceScopes, keyword]);
+
+  const isEmpty = !filteredAvailableScopes?.length && !filteredAvailableResourceGroup?.length;
+
+  return (
+    <div className={transferLayout.box}>
+      <div className={transferLayout.boxTopBar}>
+        <TextInput
+          className={styles.search}
+          icon={<Search className={styles.icon} />}
+          placeholder={t('general.search_placeholder')}
+          onChange={handleSearchInput}
+        />
+      </div>
+      <div
+        className={classNames(transferLayout.boxContent, isEmpty && transferLayout.emptyBoxContent)}
+      >
+        {isEmpty ? (
+          <EmptyDataPlaceholder size="small" title={t('role_details.permission.empty')} />
+        ) : (
+          <>
+            {filteredAvailableResourceGroup?.map((resourceGroup) => (
+              <SourceResourceScopesGroupItem
+                key={resourceGroup.resourceId}
+                resourceGroup={resourceGroup}
+                resourceSelectedScopes={getSelectedScopesByResource(resourceGroup.scopes)}
+                onSelectScope={onSelectScope}
+                onSelectResource={onSelectResource}
+              />
+            ))}
+            {filteredAvailableScopes?.map((scope) => (
+              <SourceScopeItem
+                key={scope.id}
+                scope={scope}
+                isSelected={isScopeSelected(scope)}
+                onSelect={onSelectScope}
+              />
+            ))}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default SourceScopesBox;

--- a/packages/console/src/components/ScopesAssignmentModal/TargetScopeItem/index.module.scss
+++ b/packages/console/src/components/ScopesAssignmentModal/TargetScopeItem/index.module.scss
@@ -1,0 +1,34 @@
+@use '@/scss/underscore' as _;
+
+.targetScopeItem {
+  display: flex;
+  align-items: center;
+  padding: _.unit(1.5) _.unit(3) _.unit(1.5) _.unit(4);
+
+  .title {
+    flex: 1 1 0;
+    display: flex;
+    align-items: center;
+    font: var(--font-body-2);
+    overflow: hidden;
+
+    .name {
+      flex-shrink: 0;
+      max-width: 204px;
+      padding: _.unit(1) _.unit(2);
+      border-radius: 6px;
+      background: var(--color-neutral-95);
+      @include _.text-ellipsis;
+    }
+
+    .resourceName {
+      margin: 0 _.unit(2);
+      color: var(--color-text-secondary);
+      @include _.text-ellipsis;
+    }
+  }
+
+  &:hover {
+    background: var(--color-hover);
+  }
+}

--- a/packages/console/src/components/ScopesAssignmentModal/TargetScopeItem/index.tsx
+++ b/packages/console/src/components/ScopesAssignmentModal/TargetScopeItem/index.tsx
@@ -1,0 +1,35 @@
+import Close from '@/assets/icons/close.svg';
+import IconButton from '@/ds-components/IconButton';
+
+import { type SelectedScopeAssignmentScopeDataType } from '../type';
+
+import * as styles from './index.module.scss';
+
+type Props = {
+  // ResourceName is only used by the resource scope assignment form
+  scope: SelectedScopeAssignmentScopeDataType;
+  onDelete: (scope: SelectedScopeAssignmentScopeDataType) => void;
+};
+
+function TargetScopeItem({ scope, onDelete }: Props) {
+  const { name, resourceName } = scope;
+
+  return (
+    <div className={styles.targetScopeItem}>
+      <div className={styles.title}>
+        <div className={styles.name}>{name}</div>
+        {resourceName && <div className={styles.resourceName}>{resourceName}</div>}
+      </div>
+      <IconButton
+        size="small"
+        onClick={() => {
+          onDelete(scope);
+        }}
+      >
+        <Close />
+      </IconButton>
+    </div>
+  );
+}
+
+export default TargetScopeItem;

--- a/packages/console/src/components/ScopesAssignmentModal/TargetScopesBox/index.module.scss
+++ b/packages/console/src/components/ScopesAssignmentModal/TargetScopesBox/index.module.scss
@@ -1,0 +1,3 @@
+.added {
+  font: var(--font-label-2);
+}

--- a/packages/console/src/components/ScopesAssignmentModal/TargetScopesBox/index.tsx
+++ b/packages/console/src/components/ScopesAssignmentModal/TargetScopesBox/index.tsx
@@ -1,0 +1,45 @@
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import * as transferLayout from '@/scss/transfer.module.scss';
+
+import TargetScopeItem from '../TargetScopeItem';
+import {
+  type SelectedScopeAssignmentScopeDataType,
+  type ScopeAssignmentScopeDataType,
+} from '../type';
+
+import * as styles from './index.module.scss';
+
+type Props = {
+  selectedScopes: SelectedScopeAssignmentScopeDataType[];
+  setSelectedScopes: (scopes: SelectedScopeAssignmentScopeDataType[]) => void;
+};
+
+function TargetScopesBox({ selectedScopes, setSelectedScopes }: Props) {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+
+  const onDeleteScope = useCallback(
+    ({ id }: ScopeAssignmentScopeDataType) => {
+      setSelectedScopes(selectedScopes.filter(({ id: scopeId }) => scopeId !== id));
+    },
+    [selectedScopes, setSelectedScopes]
+  );
+
+  return (
+    <div className={transferLayout.box}>
+      <div className={transferLayout.boxTopBar}>
+        <span className={styles.added}>
+          {t('role_details.permission.added_text', { count: selectedScopes.length })}
+        </span>
+      </div>
+      <div className={transferLayout.boxContent}>
+        {selectedScopes.map((scope) => (
+          <TargetScopeItem key={scope.id} scope={scope} onDelete={onDeleteScope} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default TargetScopesBox;

--- a/packages/console/src/components/ScopesAssignmentModal/index.tsx
+++ b/packages/console/src/components/ScopesAssignmentModal/index.tsx
@@ -7,6 +7,8 @@ import FormField from '@/ds-components/FormField';
 import ModalLayout from '@/ds-components/ModalLayout';
 import * as modalStyles from '@/scss/modal.module.scss';
 
+export { default as ScopesAssignmentForm } from './ScopesAssignmentForm';
+
 type ModalTextConfig = {
   title: AdminConsoleKey;
   subtitle: AdminConsoleKey;

--- a/packages/console/src/components/ScopesAssignmentModal/index.tsx
+++ b/packages/console/src/components/ScopesAssignmentModal/index.tsx
@@ -1,0 +1,71 @@
+import { type AdminConsoleKey } from '@logto/phrases';
+import type React from 'react';
+import ReactModal from 'react-modal';
+
+import Button from '@/ds-components/Button';
+import FormField from '@/ds-components/FormField';
+import ModalLayout from '@/ds-components/ModalLayout';
+import * as modalStyles from '@/scss/modal.module.scss';
+
+type ModalTextConfig = {
+  title: AdminConsoleKey;
+  subtitle: AdminConsoleKey;
+  saveBtn: AdminConsoleKey;
+};
+
+type Props = {
+  isOpen: boolean;
+  modalText: ModalTextConfig;
+  onSubmit: () => void;
+  onClose: () => void;
+  isSubmitDisabled?: boolean;
+  isLoading?: boolean;
+  tabElement?: React.ReactNode;
+  children?: React.ReactNode;
+};
+
+function ScopesAssignmentModal({
+  isOpen,
+  modalText,
+  onClose,
+  children,
+  onSubmit,
+  isSubmitDisabled,
+  isLoading = false,
+  tabElement,
+}: Props) {
+  return (
+    <ReactModal
+      shouldCloseOnEsc
+      isOpen={isOpen}
+      className={modalStyles.content}
+      overlayClassName={modalStyles.overlay}
+      onRequestClose={onClose}
+    >
+      <ModalLayout
+        title={modalText.title}
+        subtitle={modalText.subtitle}
+        size="large"
+        footer={
+          <Button
+            isLoading={isLoading}
+            disabled={isSubmitDisabled}
+            htmlType="submit"
+            title={modalText.saveBtn}
+            size="large"
+            type="primary"
+            onClick={onSubmit}
+          />
+        }
+        onClose={onClose}
+      >
+        {tabElement}
+        <FormField title="application_details.permissions.permissions_assignment_form_title">
+          {children}
+        </FormField>
+      </ModalLayout>
+    </ReactModal>
+  );
+}
+
+export default ScopesAssignmentModal;

--- a/packages/console/src/components/ScopesAssignmentModal/type.ts
+++ b/packages/console/src/components/ScopesAssignmentModal/type.ts
@@ -1,0 +1,14 @@
+export type ScopeAssignmentScopeDataType = {
+  id: string;
+  name: string;
+};
+
+export type ScopeAssignmentResourceScopesGroupDataType = {
+  resourceId: string;
+  resourceName: string;
+  scopes: ScopeAssignmentScopeDataType[];
+};
+
+export type SelectedScopeAssignmentScopeDataType = ScopeAssignmentScopeDataType & {
+  resourceName?: string;
+};

--- a/packages/console/src/components/TemplateTable/index.tsx
+++ b/packages/console/src/components/TemplateTable/index.tsx
@@ -27,6 +27,7 @@ type Props<TFieldValues extends FieldValues, TName extends FieldPath<TFieldValue
   };
   isLoading?: boolean;
   onAdd?: () => void;
+  errorMessage?: string;
 };
 
 export const pageSize = 10;
@@ -46,6 +47,7 @@ function TemplateTable<
   pagination,
   isLoading,
   onAdd,
+  errorMessage,
 }: Props<TFieldValues, TName>) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
@@ -61,7 +63,7 @@ function TemplateTable<
           <DynamicT forKey={name} interpolation={{ count: 2 }} />
         </header>
       )}
-      {onAdd && noData && (
+      {onAdd && noData && !errorMessage && (
         <>
           {name && (
             <div className={styles.empty}>
@@ -71,6 +73,7 @@ function TemplateTable<
           <Button icon={<Plus />} title="general.add" onClick={onAdd} />
         </>
       )}
+      {noData && errorMessage && <div className={styles.empty}>{errorMessage}</div>}
       {!noData && (
         <Table
           hasBorder

--- a/packages/console/src/pages/ApplicationDetails/components/Permissions/ApplicationScopesAssignmentModal/constants.ts
+++ b/packages/console/src/pages/ApplicationDetails/components/Permissions/ApplicationScopesAssignmentModal/constants.ts
@@ -1,0 +1,22 @@
+import { type AdminConsoleKey } from '@logto/phrases';
+import { ApplicationUserConsentScopeType } from '@logto/schemas';
+
+export const permissionTabs = Object.freeze({
+  [ApplicationUserConsentScopeType.UserScopes]: {
+    title: 'application_details.permissions.user_profile',
+    key: ApplicationUserConsentScopeType.UserScopes,
+  },
+  [ApplicationUserConsentScopeType.ResourceScopes]: {
+    title: 'application_details.permissions.api_resource',
+    key: ApplicationUserConsentScopeType.ResourceScopes,
+  },
+  [ApplicationUserConsentScopeType.OrganizationScopes]: {
+    title: 'application_details.permissions.organization',
+    key: ApplicationUserConsentScopeType.OrganizationScopes,
+  },
+}) satisfies {
+  [key in ApplicationUserConsentScopeType]: {
+    title: AdminConsoleKey;
+    key: key;
+  };
+};

--- a/packages/console/src/pages/ApplicationDetails/components/Permissions/ApplicationScopesAssignmentModal/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/components/Permissions/ApplicationScopesAssignmentModal/index.tsx
@@ -1,0 +1,81 @@
+import { type AdminConsoleKey } from '@logto/phrases';
+import { ApplicationUserConsentScopeType } from '@logto/schemas';
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import ScopesAssignmentModal from '@/components/ScopesAssignmentModal';
+import ScopesAssignmentForm from '@/components/ScopesAssignmentModal/ScopesAssignmentForm';
+import TabNav, { TabNavItem } from '@/ds-components/TabNav';
+import TabWrapper from '@/ds-components/TabWrapper';
+
+import { permissionTabs } from './constants';
+import useApplicationScopesAssignment from './use-application-scopes-assignment';
+
+const modalText = Object.freeze({
+  title: 'application_details.permissions.table_name',
+  subtitle: 'application_details.permissions.permissions_assignment_description',
+  saveBtn: 'general.save',
+}) satisfies Record<string, AdminConsoleKey>;
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  applicationId: string;
+};
+
+function ApplicationScopesAssignmentModal({ isOpen, onClose, applicationId }: Props) {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+
+  const { activeTab, setActiveTab, scopesAssignment, clearSelectedData, onSubmit, isLoading } =
+    useApplicationScopesAssignment(applicationId);
+
+  const onCloseHandler = useCallback(() => {
+    onClose();
+    clearSelectedData();
+    setActiveTab(ApplicationUserConsentScopeType.UserScopes);
+  }, [clearSelectedData, onClose, setActiveTab]);
+
+  const onSubmitHandler = useCallback(async () => {
+    await onSubmit();
+    onCloseHandler();
+  }, [onCloseHandler, onSubmit]);
+
+  // If any of the tabs has selected scopes, the modal is dirty
+  const isDirty = Object.values(scopesAssignment).some(
+    ({ selectedScopes }) => selectedScopes.length > 0
+  );
+
+  return (
+    <ScopesAssignmentModal
+      isOpen={isOpen}
+      isLoading={isLoading}
+      modalText={modalText}
+      isSubmitDisabled={!isDirty}
+      tabElement={
+        <TabNav>
+          {Object.values(permissionTabs).map(({ title, key }) => (
+            <TabNavItem
+              key={key}
+              isActive={key === activeTab}
+              onClick={() => {
+                setActiveTab(key);
+              }}
+            >
+              {`${t(title)}(${scopesAssignment[key].selectedScopes.length})`}
+            </TabNavItem>
+          ))}
+        </TabNav>
+      }
+      onClose={onCloseHandler}
+      onSubmit={onSubmitHandler}
+    >
+      {Object.values(scopesAssignment).map(({ scopeType, ...reset }) => (
+        <TabWrapper key={scopeType} isActive={scopeType === activeTab}>
+          <ScopesAssignmentForm {...reset} />
+        </TabWrapper>
+      ))}
+    </ScopesAssignmentModal>
+  );
+}
+
+export default ApplicationScopesAssignmentModal;

--- a/packages/console/src/pages/ApplicationDetails/components/Permissions/ApplicationScopesAssignmentModal/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/components/Permissions/ApplicationScopesAssignmentModal/index.tsx
@@ -3,8 +3,7 @@ import { ApplicationUserConsentScopeType } from '@logto/schemas';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import ScopesAssignmentModal from '@/components/ScopesAssignmentModal';
-import ScopesAssignmentForm from '@/components/ScopesAssignmentModal/ScopesAssignmentForm';
+import ScopesAssignmentModal, { ScopesAssignmentForm } from '@/components/ScopesAssignmentModal';
 import TabNav, { TabNavItem } from '@/ds-components/TabNav';
 import TabWrapper from '@/ds-components/TabWrapper';
 

--- a/packages/console/src/pages/ApplicationDetails/components/Permissions/ApplicationScopesAssignmentModal/type.ts
+++ b/packages/console/src/pages/ApplicationDetails/components/Permissions/ApplicationScopesAssignmentModal/type.ts
@@ -1,0 +1,24 @@
+import {
+  type ApplicationUserConsentScopesResponse,
+  type ApplicationUserConsentScopeType,
+} from '@logto/schemas';
+
+import {
+  type ScopeAssignmentScopeDataType,
+  type ScopeAssignmentResourceScopesGroupDataType,
+  type SelectedScopeAssignmentScopeDataType,
+} from '@/components/ScopesAssignmentModal/type';
+
+type ScopeAssignmentHookReturnType<T extends ApplicationUserConsentScopeType> = {
+  scopeType: T;
+  selectedScopes: SelectedScopeAssignmentScopeDataType[];
+  setSelectedScopes: (selectedScopes: SelectedScopeAssignmentScopeDataType[]) => void;
+  availableScopes?: ScopeAssignmentScopeDataType[];
+  groupedAvailableResourceScopes?: ScopeAssignmentResourceScopesGroupDataType[];
+};
+
+// This is used to parse the ApplicationUserConsentScopeType to the response key
+type CamelCase<T> = T extends `${infer A}-${infer B}` ? `${A}${Capitalize<CamelCase<B>>}` : T;
+export type ScopeAssignmentHook<T extends ApplicationUserConsentScopeType> = (
+  assignedScopes?: ApplicationUserConsentScopesResponse[CamelCase<T>]
+) => ScopeAssignmentHookReturnType<T>;

--- a/packages/console/src/pages/ApplicationDetails/components/Permissions/ApplicationScopesAssignmentModal/use-application-scopes-assignment.ts
+++ b/packages/console/src/pages/ApplicationDetails/components/Permissions/ApplicationScopesAssignmentModal/use-application-scopes-assignment.ts
@@ -1,0 +1,89 @@
+import {
+  ApplicationUserConsentScopeType,
+  type ApplicationUserConsentScopesResponse,
+} from '@logto/schemas';
+import { conditional } from '@silverhand/essentials';
+import { useState, useCallback, useMemo } from 'react';
+import useSWR from 'swr';
+
+import useApi, { type RequestError } from '@/hooks/use-api';
+
+import useOrganizationScopesAssignment from './use-organization-scopes-assignment';
+import useResourceScopesAssignment from './use-resource-scopes-assignment';
+import useUserScopesAssignment from './use-user-scopes-assignment';
+
+const useApplicationScopesAssignment = (applicationId: string) => {
+  const [activeTab, setActiveTab] = useState<ApplicationUserConsentScopeType>(
+    ApplicationUserConsentScopeType.UserScopes
+  );
+  const [isLoading, setIsLoading] = useState(false);
+
+  const api = useApi();
+
+  const { data, mutate } = useSWR<ApplicationUserConsentScopesResponse, RequestError>(
+    `api/applications/${applicationId}/user-consent-scopes`
+  );
+
+  const userScopesAssignment = useUserScopesAssignment(data?.userScopes);
+  const organizationScopesAssignment = useOrganizationScopesAssignment(data?.organizationScopes);
+  const resourceScopesAssignment = useResourceScopesAssignment(data?.resourceScopes);
+
+  const clearSelectedData = useCallback(() => {
+    userScopesAssignment.setSelectedScopes([]);
+    organizationScopesAssignment.setSelectedScopes([]);
+    resourceScopesAssignment.setSelectedScopes([]);
+  }, [organizationScopesAssignment, resourceScopesAssignment, userScopesAssignment]);
+
+  const onSubmit = useCallback(async () => {
+    setIsLoading(true);
+    const newUserScopes = userScopesAssignment.selectedScopes.map(({ id }) => id);
+    const newOrganizationScopes = organizationScopesAssignment.selectedScopes.map(({ id }) => id);
+    const newResourceScopes = resourceScopesAssignment.selectedScopes.map(({ id }) => id);
+
+    await api
+      .post(`api/applications/${applicationId}/user-consent-scopes`, {
+        json: {
+          ...conditional(newUserScopes.length > 0 && { userScopes: newUserScopes }),
+          ...conditional(
+            newOrganizationScopes.length > 0 && {
+              organizationScopes: newOrganizationScopes,
+            }
+          ),
+          ...conditional(newResourceScopes.length > 0 && { resourceScopes: newResourceScopes }),
+        },
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+
+    void mutate();
+  }, [
+    api,
+    applicationId,
+    mutate,
+    organizationScopesAssignment.selectedScopes,
+    resourceScopesAssignment.selectedScopes,
+    userScopesAssignment.selectedScopes,
+  ]);
+
+  // Return selectedScopes and setSelectedScopes based on the active tab
+  const scopesAssignment = useMemo(
+    () => ({
+      [ApplicationUserConsentScopeType.UserScopes]: userScopesAssignment,
+      [ApplicationUserConsentScopeType.OrganizationScopes]: organizationScopesAssignment,
+      [ApplicationUserConsentScopeType.ResourceScopes]: resourceScopesAssignment,
+    }),
+    [organizationScopesAssignment, resourceScopesAssignment, userScopesAssignment]
+  );
+
+  return {
+    isLoading,
+    activeTab,
+    setActiveTab,
+    scopesAssignment,
+    clearSelectedData,
+    onSubmit,
+  };
+};
+
+export default useApplicationScopesAssignment;

--- a/packages/console/src/pages/ApplicationDetails/components/Permissions/ApplicationScopesAssignmentModal/use-organization-scopes-assignment.ts
+++ b/packages/console/src/pages/ApplicationDetails/components/Permissions/ApplicationScopesAssignmentModal/use-organization-scopes-assignment.ts
@@ -1,0 +1,35 @@
+import { ApplicationUserConsentScopeType, type OrganizationScope } from '@logto/schemas';
+import { useState, useMemo } from 'react';
+import useSWR from 'swr';
+
+import { type SelectedScopeAssignmentScopeDataType } from '@/components/ScopesAssignmentModal/type';
+import { type RequestError } from '@/hooks/use-api';
+
+import { type ScopeAssignmentHook } from './type';
+
+const useOrganizationScopesAssignment: ScopeAssignmentHook<
+  ApplicationUserConsentScopeType.OrganizationScopes
+> = (assignedOrganizationScopes = []) => {
+  const [selectedScopes, setSelectedScopes] = useState<SelectedScopeAssignmentScopeDataType[]>([]);
+
+  const { data: organizationScopes } = useSWR<OrganizationScope[], RequestError>(
+    'api/organization-scopes'
+  );
+
+  const availableScopes = useMemo(
+    () =>
+      (organizationScopes ?? [])
+        .map(({ id, name }) => ({ id, name }))
+        .filter(({ id }) => !assignedOrganizationScopes.some((scope) => scope.id === id)),
+    [organizationScopes, assignedOrganizationScopes]
+  );
+
+  return {
+    scopeType: ApplicationUserConsentScopeType.OrganizationScopes,
+    selectedScopes,
+    setSelectedScopes,
+    availableScopes,
+  };
+};
+
+export default useOrganizationScopesAssignment;

--- a/packages/console/src/pages/ApplicationDetails/components/Permissions/ApplicationScopesAssignmentModal/use-resource-scopes-assignment.ts
+++ b/packages/console/src/pages/ApplicationDetails/components/Permissions/ApplicationScopesAssignmentModal/use-resource-scopes-assignment.ts
@@ -1,0 +1,67 @@
+import { type ResourceResponse, ApplicationUserConsentScopeType } from '@logto/schemas';
+import { isManagementApi } from '@logto/schemas';
+import { useState, useMemo } from 'react';
+import useSWR from 'swr';
+
+import {
+  type SelectedScopeAssignmentScopeDataType,
+  type ScopeAssignmentResourceScopesGroupDataType,
+} from '@/components/ScopesAssignmentModal/type';
+import { type RequestError } from '@/hooks/use-api';
+
+import { type ScopeAssignmentHook } from './type';
+
+const useResourceScopesAssignment: ScopeAssignmentHook<
+  ApplicationUserConsentScopeType.ResourceScopes
+> = (assignedResourceScopes) => {
+  const [selectedScopes, setSelectedScopes] = useState<SelectedScopeAssignmentScopeDataType[]>([]);
+
+  const { data: allResources } = useSWR<ResourceResponse[], RequestError>(
+    'api/resources?includeScopes=true'
+  );
+
+  const availableScopes = useMemo(() => {
+    if (!allResources) {
+      return [];
+    }
+
+    const resourcesWithScopes: ScopeAssignmentResourceScopesGroupDataType[] = allResources
+      // Filter out the management APIs
+      .filter((resource) => !isManagementApi(resource.indicator))
+      .map(({ name, scopes, id }) => {
+        const assignedResource = assignedResourceScopes?.find(({ resource }) => resource.id === id);
+
+        return {
+          resourceId: id,
+          resourceName: name,
+          scopes: scopes
+            // Filter out the scopes that have been assigned
+            .filter(({ id: scopeId }) => {
+              if (!assignedResourceScopes) {
+                return true;
+              }
+
+              return assignedResource
+                ? !assignedResource.scopes.some((scope) => scope.id === scopeId)
+                : true;
+            })
+            .map(({ id, name }) => ({
+              id,
+              name,
+            })),
+        };
+      });
+
+    // Filter out the resources that have no scopes
+    return resourcesWithScopes.filter(({ scopes }) => scopes.length > 0);
+  }, [allResources, assignedResourceScopes]);
+
+  return {
+    scopeType: ApplicationUserConsentScopeType.ResourceScopes,
+    selectedScopes,
+    setSelectedScopes,
+    groupedAvailableResourceScopes: availableScopes,
+  };
+};
+
+export default useResourceScopesAssignment;

--- a/packages/console/src/pages/ApplicationDetails/components/Permissions/ApplicationScopesAssignmentModal/use-user-scopes-assignment.ts
+++ b/packages/console/src/pages/ApplicationDetails/components/Permissions/ApplicationScopesAssignmentModal/use-user-scopes-assignment.ts
@@ -1,0 +1,34 @@
+import { UserScope } from '@logto/core-kit';
+import { ApplicationUserConsentScopeType } from '@logto/schemas';
+import { useState, useMemo } from 'react';
+
+import { type SelectedScopeAssignmentScopeDataType } from '@/components/ScopesAssignmentModal/type';
+
+import { type ScopeAssignmentHook } from './type';
+
+const useUserScopesAssignment: ScopeAssignmentHook<ApplicationUserConsentScopeType.UserScopes> = (
+  assignedUserScopes = []
+) => {
+  const [selectedScopes, setSelectedScopes] = useState<SelectedScopeAssignmentScopeDataType[]>([]);
+
+  const availableScopes = useMemo(
+    () =>
+      Object.values(UserScope)
+        .map((name) => ({
+          name,
+          id: name,
+        }))
+        // Filter out the scopes that have been assigned
+        .filter(({ id }) => !assignedUserScopes.includes(id)),
+    [assignedUserScopes]
+  );
+
+  return {
+    scopeType: ApplicationUserConsentScopeType.UserScopes,
+    selectedScopes,
+    setSelectedScopes,
+    availableScopes,
+  };
+};
+
+export default useUserScopesAssignment;

--- a/packages/console/src/pages/ApplicationDetails/components/Permissions/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/components/Permissions/index.tsx
@@ -10,7 +10,8 @@ import TemplateTable from '@/components/TemplateTable';
 import Tag from '@/ds-components/Tag';
 import { type RequestError } from '@/hooks/use-api';
 
-import usePermissionsTable from './use-permissions-table';
+import ApplicationScopesAssignmentModal from './ApplicationScopesAssignmentModal';
+import useScopesTable from './use-scopes-table';
 
 type Props = {
   application: Application;
@@ -20,7 +21,7 @@ function Permissions({ application }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
   const [isAssignScopesModalOpen, setIsAssignScopesModalOpen] = useState(false);
-  const { parseRowGroup, deletePermission } = usePermissionsTable();
+  const { parseRowGroup, deleteScope } = useScopesTable();
 
   const { data, error, mutate } = useSWR<ApplicationUserConsentScopesResponse, RequestError>(
     `api/applications/${application.id}/user-consent-scopes`
@@ -30,61 +31,74 @@ function Permissions({ application }: Props) {
   const rowGroups = useMemo(() => parseRowGroup(data), [data, parseRowGroup]);
 
   return (
-    <FormCard
-      title="application_details.permissions.name"
-      description="application_details.permissions.description"
-    >
-      <TemplateTable
-        name="application_details.permissions.table_name"
-        rowIndexKey="id"
-        isLoading={isLoading}
-        rowGroups={rowGroups}
-        columns={[
-          {
-            title: t('application_details.permissions.field_name'),
-            dataIndex: 'name',
-            colSpan: 5,
-            render: ({ name }) => (
-              <Tag variant="cell">
-                <Breakable>{name}</Breakable>
-              </Tag>
-            ),
-          },
-          {
-            title: `${t('general.description')} (${t(
-              'application_details.permissions.field_description'
-            )})`,
-            dataIndex: 'description',
-            colSpan: 5,
-            render: ({ description }) => <Breakable>{description ?? '-'}</Breakable>,
-          },
-          {
-            title: null,
-            dataIndex: 'delete',
-            render: (data) => (
-              <ActionsButton
-                fieldName="application_details.permissions.name"
-                deleteConfirmation="application_details.permissions.permission_delete_confirm"
-                textOverrides={{
-                  delete: 'application_details.permissions.delete_text',
-                  deleteConfirmation: 'general.remove',
-                }}
-                onEdit={() => {
-                  // TODO: Implement edit permission
-                }}
-                onDelete={async () => {
-                  await deletePermission(data, application.id);
-                  void mutate();
-                }}
-              />
-            ),
-          },
-        ]}
-        onAdd={() => {
-          setIsAssignScopesModalOpen(true);
-        }}
-      />
-    </FormCard>
+    <>
+      <FormCard
+        title="application_details.permissions.name"
+        description="application_details.permissions.description"
+      >
+        <TemplateTable
+          name="application_details.permissions.table_name"
+          rowIndexKey="id"
+          errorMessage={error?.body?.message ?? error?.message}
+          isLoading={isLoading}
+          rowGroups={rowGroups}
+          columns={[
+            {
+              title: t('application_details.permissions.field_name'),
+              dataIndex: 'name',
+              colSpan: 5,
+              render: ({ name }) => (
+                <Tag variant="cell">
+                  <Breakable>{name}</Breakable>
+                </Tag>
+              ),
+            },
+            {
+              title: `${t('general.description')} (${t(
+                'application_details.permissions.field_description'
+              )})`,
+              dataIndex: 'description',
+              colSpan: 5,
+              render: ({ description }) => <Breakable>{description ?? '-'}</Breakable>,
+            },
+            {
+              title: null,
+              dataIndex: 'delete',
+              render: (data) => (
+                <ActionsButton
+                  fieldName="application_details.permissions.name"
+                  deleteConfirmation="application_details.permissions.permission_delete_confirm"
+                  textOverrides={{
+                    delete: 'application_details.permissions.delete_text',
+                    deleteConfirmation: 'general.remove',
+                  }}
+                  onEdit={() => {
+                    // TODO: Implement edit permission
+                  }}
+                  onDelete={async () => {
+                    await deleteScope(data, application.id);
+                    void mutate();
+                  }}
+                />
+              ),
+            },
+          ]}
+          onAdd={() => {
+            setIsAssignScopesModalOpen(true);
+          }}
+        />
+      </FormCard>
+      {/* Render the permissions assignment modal only if the data is fetched properly */}
+      {data && (
+        <ApplicationScopesAssignmentModal
+          applicationId={application.id}
+          isOpen={isAssignScopesModalOpen}
+          onClose={() => {
+            setIsAssignScopesModalOpen(false);
+          }}
+        />
+      )}
+    </>
   );
 }
 

--- a/packages/console/src/pages/ApplicationDetails/components/Permissions/use-scopes-table.ts
+++ b/packages/console/src/pages/ApplicationDetails/components/Permissions/use-scopes-table.ts
@@ -9,36 +9,36 @@ import useApi from '@/hooks/use-api';
 
 import * as styles from './index.module.scss';
 
-type PermissionsTableRowDataType = {
+type ScopesTableRowDataType = {
   type: ApplicationUserConsentScopeType;
   id: string;
   name: string;
   description?: string;
 };
 
-type PermissionsTableFieldGroupType = {
+type ScopesTableRowGroupType = {
   key: string;
   label: string;
   labelRowClassName?: string;
-  data: PermissionsTableRowDataType[];
+  data: ScopesTableRowDataType[];
 };
 
 /**
  * - parseRowGroup: parse the application user consent scopes response data to table field group data
  */
-const usePermissionsTable = () => {
+const useScopesTable = () => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const api = useApi();
 
   const parseRowGroup = useCallback(
-    (data?: ApplicationUserConsentScopesResponse): PermissionsTableFieldGroupType[] => {
+    (data?: ApplicationUserConsentScopesResponse): ScopesTableRowGroupType[] => {
       if (!data) {
         return [];
       }
 
       const { organizationScopes, userScopes, resourceScopes } = data;
 
-      const userScopesGroup: PermissionsTableFieldGroupType = {
+      const userScopesGroup: ScopesTableRowGroupType = {
         key: ApplicationUserConsentScopeType.UserScopes,
         label: t('application_details.permissions.user_permissions'),
         labelRowClassName: styles.sectionTitleRow,
@@ -50,7 +50,7 @@ const usePermissionsTable = () => {
         })),
       };
 
-      const organizationScopesGroup: PermissionsTableFieldGroupType = {
+      const organizationScopesGroup: ScopesTableRowGroupType = {
         key: ApplicationUserConsentScopeType.OrganizationScopes,
         label: t('application_details.permissions.organization_permissions'),
         labelRowClassName: styles.sectionTitleRow,
@@ -62,7 +62,7 @@ const usePermissionsTable = () => {
         })),
       };
 
-      const resourceScopesGroups = resourceScopes.map<PermissionsTableFieldGroupType>(
+      const resourceScopesGroups = resourceScopes.map<ScopesTableRowGroupType>(
         ({ resource, scopes }) => ({
           key: resource.indicator,
           label: resource.name,
@@ -81,16 +81,16 @@ const usePermissionsTable = () => {
     [t]
   );
 
-  const deletePermission = useCallback(
-    async (scope: PermissionsTableRowDataType, applicationId: string) =>
+  const deleteScope = useCallback(
+    async (scope: ScopesTableRowDataType, applicationId: string) =>
       api.delete(`api/applications/${applicationId}/user-consent-scopes/${scope.type}/${scope.id}`),
     [api]
   );
 
   return {
     parseRowGroup,
-    deletePermission,
+    deleteScope,
   };
 };
 
-export default usePermissionsTable;
+export default useScopesTable;

--- a/packages/phrases/src/locales/de/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/application-details.ts
@@ -108,6 +108,17 @@ const application_details = {
     /** UNTRANSLATED */
     permission_delete_confirm:
       'This action will withdraw the permissions granted to the third-party app, preventing it from requesting user authorization for specific data types. Are you sure you want to continue?',
+    /** UNTRANSLATED */
+    permissions_assignment_description:
+      'Select the permissions the third-party application requests for user authorization to access specific data types.',
+    /** UNTRANSLATED */
+    user_profile: 'User profile',
+    /** UNTRANSLATED */
+    api_resource: 'API resource',
+    /** UNTRANSLATED */
+    organization: 'Organization',
+    /** UNTRANSLATED */
+    permissions_assignment_form_title: 'Add profile permissions',
   },
   roles: {
     name_column: 'Rolle',

--- a/packages/phrases/src/locales/en/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/application-details.ts
@@ -84,6 +84,12 @@ const application_details = {
     delete_text: 'Remove permission',
     permission_delete_confirm:
       'This action will withdraw the permissions granted to the third-party app, preventing it from requesting user authorization for specific data types. Are you sure you want to continue?',
+    permissions_assignment_description:
+      'Select the permissions the third-party application requests for user authorization to access specific data types.',
+    user_profile: 'User profile',
+    api_resource: 'API resource',
+    organization: 'Organization',
+    permissions_assignment_form_title: 'Add profile permissions',
   },
   roles: {
     name_column: 'Role',

--- a/packages/phrases/src/locales/es/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/application-details.ts
@@ -108,6 +108,17 @@ const application_details = {
     /** UNTRANSLATED */
     permission_delete_confirm:
       'This action will withdraw the permissions granted to the third-party app, preventing it from requesting user authorization for specific data types. Are you sure you want to continue?',
+    /** UNTRANSLATED */
+    permissions_assignment_description:
+      'Select the permissions the third-party application requests for user authorization to access specific data types.',
+    /** UNTRANSLATED */
+    user_profile: 'User profile',
+    /** UNTRANSLATED */
+    api_resource: 'API resource',
+    /** UNTRANSLATED */
+    organization: 'Organization',
+    /** UNTRANSLATED */
+    permissions_assignment_form_title: 'Add profile permissions',
   },
   roles: {
     name_column: 'Rol',

--- a/packages/phrases/src/locales/fr/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/application-details.ts
@@ -108,6 +108,17 @@ const application_details = {
     /** UNTRANSLATED */
     permission_delete_confirm:
       'This action will withdraw the permissions granted to the third-party app, preventing it from requesting user authorization for specific data types. Are you sure you want to continue?',
+    /** UNTRANSLATED */
+    permissions_assignment_description:
+      'Select the permissions the third-party application requests for user authorization to access specific data types.',
+    /** UNTRANSLATED */
+    user_profile: 'User profile',
+    /** UNTRANSLATED */
+    api_resource: 'API resource',
+    /** UNTRANSLATED */
+    organization: 'Organization',
+    /** UNTRANSLATED */
+    permissions_assignment_form_title: 'Add profile permissions',
   },
   roles: {
     name_column: 'Rôle',

--- a/packages/phrases/src/locales/it/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/application-details.ts
@@ -108,6 +108,17 @@ const application_details = {
     /** UNTRANSLATED */
     permission_delete_confirm:
       'This action will withdraw the permissions granted to the third-party app, preventing it from requesting user authorization for specific data types. Are you sure you want to continue?',
+    /** UNTRANSLATED */
+    permissions_assignment_description:
+      'Select the permissions the third-party application requests for user authorization to access specific data types.',
+    /** UNTRANSLATED */
+    user_profile: 'User profile',
+    /** UNTRANSLATED */
+    api_resource: 'API resource',
+    /** UNTRANSLATED */
+    organization: 'Organization',
+    /** UNTRANSLATED */
+    permissions_assignment_form_title: 'Add profile permissions',
   },
   roles: {
     name_column: 'Ruolo',

--- a/packages/phrases/src/locales/ja/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/application-details.ts
@@ -108,6 +108,17 @@ const application_details = {
     /** UNTRANSLATED */
     permission_delete_confirm:
       'This action will withdraw the permissions granted to the third-party app, preventing it from requesting user authorization for specific data types. Are you sure you want to continue?',
+    /** UNTRANSLATED */
+    permissions_assignment_description:
+      'Select the permissions the third-party application requests for user authorization to access specific data types.',
+    /** UNTRANSLATED */
+    user_profile: 'User profile',
+    /** UNTRANSLATED */
+    api_resource: 'API resource',
+    /** UNTRANSLATED */
+    organization: 'Organization',
+    /** UNTRANSLATED */
+    permissions_assignment_form_title: 'Add profile permissions',
   },
   roles: {
     name_column: '役割',

--- a/packages/phrases/src/locales/ko/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/application-details.ts
@@ -108,6 +108,17 @@ const application_details = {
     /** UNTRANSLATED */
     permission_delete_confirm:
       'This action will withdraw the permissions granted to the third-party app, preventing it from requesting user authorization for specific data types. Are you sure you want to continue?',
+    /** UNTRANSLATED */
+    permissions_assignment_description:
+      'Select the permissions the third-party application requests for user authorization to access specific data types.',
+    /** UNTRANSLATED */
+    user_profile: 'User profile',
+    /** UNTRANSLATED */
+    api_resource: 'API resource',
+    /** UNTRANSLATED */
+    organization: 'Organization',
+    /** UNTRANSLATED */
+    permissions_assignment_form_title: 'Add profile permissions',
   },
   roles: {
     name_column: '역할',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/application-details.ts
@@ -108,6 +108,17 @@ const application_details = {
     /** UNTRANSLATED */
     permission_delete_confirm:
       'This action will withdraw the permissions granted to the third-party app, preventing it from requesting user authorization for specific data types. Are you sure you want to continue?',
+    /** UNTRANSLATED */
+    permissions_assignment_description:
+      'Select the permissions the third-party application requests for user authorization to access specific data types.',
+    /** UNTRANSLATED */
+    user_profile: 'User profile',
+    /** UNTRANSLATED */
+    api_resource: 'API resource',
+    /** UNTRANSLATED */
+    organization: 'Organization',
+    /** UNTRANSLATED */
+    permissions_assignment_form_title: 'Add profile permissions',
   },
   roles: {
     name_column: 'Role',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/application-details.ts
@@ -108,6 +108,17 @@ const application_details = {
     /** UNTRANSLATED */
     permission_delete_confirm:
       'This action will withdraw the permissions granted to the third-party app, preventing it from requesting user authorization for specific data types. Are you sure you want to continue?',
+    /** UNTRANSLATED */
+    permissions_assignment_description:
+      'Select the permissions the third-party application requests for user authorization to access specific data types.',
+    /** UNTRANSLATED */
+    user_profile: 'User profile',
+    /** UNTRANSLATED */
+    api_resource: 'API resource',
+    /** UNTRANSLATED */
+    organization: 'Organization',
+    /** UNTRANSLATED */
+    permissions_assignment_form_title: 'Add profile permissions',
   },
   roles: {
     name_column: 'Função',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/application-details.ts
@@ -108,6 +108,17 @@ const application_details = {
     /** UNTRANSLATED */
     permission_delete_confirm:
       'This action will withdraw the permissions granted to the third-party app, preventing it from requesting user authorization for specific data types. Are you sure you want to continue?',
+    /** UNTRANSLATED */
+    permissions_assignment_description:
+      'Select the permissions the third-party application requests for user authorization to access specific data types.',
+    /** UNTRANSLATED */
+    user_profile: 'User profile',
+    /** UNTRANSLATED */
+    api_resource: 'API resource',
+    /** UNTRANSLATED */
+    organization: 'Organization',
+    /** UNTRANSLATED */
+    permissions_assignment_form_title: 'Add profile permissions',
   },
   roles: {
     name_column: 'Nome da função',

--- a/packages/phrases/src/locales/ru/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/application-details.ts
@@ -108,6 +108,17 @@ const application_details = {
     /** UNTRANSLATED */
     permission_delete_confirm:
       'This action will withdraw the permissions granted to the third-party app, preventing it from requesting user authorization for specific data types. Are you sure you want to continue?',
+    /** UNTRANSLATED */
+    permissions_assignment_description:
+      'Select the permissions the third-party application requests for user authorization to access specific data types.',
+    /** UNTRANSLATED */
+    user_profile: 'User profile',
+    /** UNTRANSLATED */
+    api_resource: 'API resource',
+    /** UNTRANSLATED */
+    organization: 'Organization',
+    /** UNTRANSLATED */
+    permissions_assignment_form_title: 'Add profile permissions',
   },
   roles: {
     name_column: 'Роль',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/application-details.ts
@@ -108,6 +108,17 @@ const application_details = {
     /** UNTRANSLATED */
     permission_delete_confirm:
       'This action will withdraw the permissions granted to the third-party app, preventing it from requesting user authorization for specific data types. Are you sure you want to continue?',
+    /** UNTRANSLATED */
+    permissions_assignment_description:
+      'Select the permissions the third-party application requests for user authorization to access specific data types.',
+    /** UNTRANSLATED */
+    user_profile: 'User profile',
+    /** UNTRANSLATED */
+    api_resource: 'API resource',
+    /** UNTRANSLATED */
+    organization: 'Organization',
+    /** UNTRANSLATED */
+    permissions_assignment_form_title: 'Add profile permissions',
   },
   roles: {
     name_column: 'Rol',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/application-details.ts
@@ -105,6 +105,17 @@ const application_details = {
     /** UNTRANSLATED */
     permission_delete_confirm:
       'This action will withdraw the permissions granted to the third-party app, preventing it from requesting user authorization for specific data types. Are you sure you want to continue?',
+    /** UNTRANSLATED */
+    permissions_assignment_description:
+      'Select the permissions the third-party application requests for user authorization to access specific data types.',
+    /** UNTRANSLATED */
+    user_profile: 'User profile',
+    /** UNTRANSLATED */
+    api_resource: 'API resource',
+    /** UNTRANSLATED */
+    organization: 'Organization',
+    /** UNTRANSLATED */
+    permissions_assignment_form_title: 'Add profile permissions',
   },
   roles: {
     name_column: '角色',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/application-details.ts
@@ -105,6 +105,17 @@ const application_details = {
     /** UNTRANSLATED */
     permission_delete_confirm:
       'This action will withdraw the permissions granted to the third-party app, preventing it from requesting user authorization for specific data types. Are you sure you want to continue?',
+    /** UNTRANSLATED */
+    permissions_assignment_description:
+      'Select the permissions the third-party application requests for user authorization to access specific data types.',
+    /** UNTRANSLATED */
+    user_profile: 'User profile',
+    /** UNTRANSLATED */
+    api_resource: 'API resource',
+    /** UNTRANSLATED */
+    organization: 'Organization',
+    /** UNTRANSLATED */
+    permissions_assignment_form_title: 'Add profile permissions',
   },
   roles: {
     name_column: '角色',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/application-details.ts
@@ -106,6 +106,17 @@ const application_details = {
     /** UNTRANSLATED */
     permission_delete_confirm:
       'This action will withdraw the permissions granted to the third-party app, preventing it from requesting user authorization for specific data types. Are you sure you want to continue?',
+    /** UNTRANSLATED */
+    permissions_assignment_description:
+      'Select the permissions the third-party application requests for user authorization to access specific data types.',
+    /** UNTRANSLATED */
+    user_profile: 'User profile',
+    /** UNTRANSLATED */
+    api_resource: 'API resource',
+    /** UNTRANSLATED */
+    organization: 'Organization',
+    /** UNTRANSLATED */
+    permissions_assignment_form_title: 'Add profile permissions',
   },
   roles: {
     name_column: '角色',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Implement new Scopes assignment modal.

Apologies for the huge PR, the component is complicated, and hard to decouple some of the updates. 

This PR includes the following update:
1. Replace all the `Permissions` words under the ApplicationDetailsPage using `Scopes`.
2.  [Major]: Implement a new `ScopesAssignmentModal` component groups
 - these components are forked and refactored directly from the `RolePermissions` and `RoleScopesTransfer` related components. 
 - The original `RoleScopesTransfer` has the role scopes data processing logic deeply embedded in each layer of the components. It is impossible to be reused by other pages.
 - The original `RolePermissionsModal` component does not support multi-tab permissions selections. 
 - New components decoupled the data process logic with UI. 
 
An issue has been created to migrate the old permission transfer components under the roles detail page using the newly added one. 




<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.
Will add the integration tests after the project is well developed. 

<img width="991" alt="image" src="https://github.com/logto-io/logto/assets/36393111/443e7b4b-f630-4f41-8a6f-110cd050a543">
 
<img width="848" alt="image" src="https://github.com/logto-io/logto/assets/36393111/7c1779bd-ebf2-4e5d-b278-c373bdb92fe8">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [x] necessary TSDoc comments
