### PR TITLE
feat(core): get and delete org invitation by id

### DIFF
--- a/packages/core/src/routes/organization/invitations.openapi.json
+++ b/packages/core/src/routes/organization/invitations.openapi.json
@@ -17,6 +17,48 @@
           }
         }
       }
+    },
+    "/api/organization-invitations/{id}": {
+      "get": {
+        "summary": "Get organization invitation",
+        "description": "Get an organization invitation by ID.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The organization invitation ID.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The organization invitation, also contains the organization roles to be assigned to the user when they accept the invitation, and the corresponding magic link data."
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete organization invitation",
+        "description": "Delete an organization invitation by ID.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The organization invitation ID.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The organization invitation was deleted successfully."
+          }
+        }
+      }
     }
   }
 }

--- a/packages/core/src/routes/organization/invitations.ts
+++ b/packages/core/src/routes/organization/invitations.ts
@@ -1,9 +1,6 @@
-import { OrganizationInvitations, organizationInvitationEntityGuard } from '@logto/schemas';
-import Router, { type IRouterParamContext } from 'koa-router';
+import { OrganizationInvitations } from '@logto/schemas';
 
-import koaGuard from '#src/middleware/koa-guard.js';
-import koaPagination from '#src/middleware/koa-pagination.js';
-import { tableToPathname } from '#src/utils/SchemaRouter.js';
+import SchemaRouter from '#src/utils/SchemaRouter.js';
 
 import { type AuthedRouter, type RouterInitArgs } from '../types.js';
 
@@ -17,24 +14,12 @@ export default function organizationInvitationRoutes<T extends AuthedRouter>(
     },
   ]: RouterInitArgs<T>
 ) {
-  const router = new Router<unknown, IRouterParamContext>({
-    prefix: '/' + tableToPathname(OrganizationInvitations.table),
+  const router = new SchemaRouter(OrganizationInvitations, invitations, {
+    disabled: {
+      post: true,
+      patchById: true,
+    },
   });
-
-  router.get(
-    '/',
-    koaPagination(),
-    koaGuard({ response: organizationInvitationEntityGuard.array(), status: [200] }),
-    async (ctx, next) => {
-      const { limit, offset } = ctx.pagination;
-      const [count, entities] = await invitations.findAll(limit, offset);
-
-      ctx.pagination.totalCount = count;
-      ctx.body = entities;
-      ctx.status = 200;
-      return next();
-    }
-  );
 
   originalRouter.use(router.routes());
 }

--- a/packages/core/src/routes/swagger/index.ts
+++ b/packages/core/src/routes/swagger/index.ts
@@ -128,6 +128,7 @@ const identifiableEntityNames = [
   'organization',
   'organization-role',
   'organization-scope',
+  'organization-invitation',
 ];
 
 /**


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
leverage `SchemaRouter` for routing. add `GET` and `DELETE` routes for organization invitations. resolve LOG-7981, LOG-7974

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
local tested. will add full integration tests once `POST` API is implemented

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
