### PR TITLE
feat(core): implement application user consent organizations api 

### DIFF
--- a/packages/core/src/queries/application-user-consent-organizations.ts
+++ b/packages/core/src/queries/application-user-consent-organizations.ts
@@ -1,0 +1,61 @@
+import {
+  ApplicationUserConsentOrganizations,
+  Applications,
+  Organizations,
+  Users,
+} from '@logto/schemas';
+import { convertToIdentifiers } from '@logto/shared';
+import { sql, type CommonQueryMethods } from 'slonik';
+
+import RelationQueries from '#src/utils/RelationQueries.js';
+
+class ApplicationUserConsentOrganizationsQuery extends RelationQueries<
+  [typeof Applications, typeof Users, typeof Organizations]
+> {
+  constructor(pool: CommonQueryMethods) {
+    super(pool, ApplicationUserConsentOrganizations.table, Applications, Users, Organizations);
+  }
+
+  /** Replace the organizations of a user consented for the application */
+  async replace(applicationId: string, userId: string, organizationIds: string[]) {
+    const users = convertToIdentifiers(Users);
+    const relations = convertToIdentifiers(ApplicationUserConsentOrganizations);
+
+    return this.pool.transaction(async (transaction) => {
+      // Lock user
+      await transaction.query(sql`
+        select id
+        from ${users.table}
+        where ${users.fields.id} = ${userId}
+        for update
+      `);
+
+      // Delete existing relations
+      await transaction.query(sql`
+        delete from ${relations.table}
+        where ${relations.fields.applicationId} = ${applicationId}
+        and ${relations.fields.userId} = ${userId}
+      `);
+
+      // Insert new relations
+      if (organizationIds.length === 0) {
+        return;
+      }
+
+      await transaction.query(sql`
+        insert into ${relations.table} (
+          ${relations.fields.applicationId},
+          ${relations.fields.organizationId},
+          ${relations.fields.userId}
+        ) values ${sql.join(
+          organizationIds.map(
+            (organizationId) => sql`(${applicationId}, ${organizationId}, ${userId})`
+          ),
+          sql`, `
+        )}
+      `);
+    });
+  }
+}
+
+export default ApplicationUserConsentOrganizationsQuery;

--- a/packages/core/src/queries/application.ts
+++ b/packages/core/src/queries/application.ts
@@ -13,6 +13,7 @@ import { DeletionError } from '#src/errors/SlonikError/index.js';
 import { buildConditionsFromSearch } from '#src/utils/search.js';
 import type { Search } from '#src/utils/search.js';
 
+import ApplicationUserConsentOrganizationsQuery from './application-user-consent-organizations.js';
 import {
   ApplicationUserConsentOrganizationScopeQueries,
   ApplicationUserConsentResourceScopeQueries,
@@ -241,6 +242,7 @@ export const createApplicationQueries = (pool: CommonQueryMethods) => {
     deleteApplicationById,
     userConsentOrganizationScopes: new ApplicationUserConsentOrganizationScopeQueries(pool),
     userConsentResourceScopes: new ApplicationUserConsentResourceScopeQueries(pool),
-    useConsentUserScopes: createApplicationUserConsentUserScopeQueries(pool),
+    userConsentUserScopes: createApplicationUserConsentUserScopeQueries(pool),
+    userConsentOrganizations: new ApplicationUserConsentOrganizationsQuery(pool),
   };
 };

--- a/packages/core/src/routes/applications/application-user-consent-organization.openapi.json
+++ b/packages/core/src/routes/applications/application-user-consent-organization.openapi.json
@@ -1,0 +1,96 @@
+{
+  "paths": {
+    "/api/applications/{id}/users/{userId}/consent-organizations": {
+      "get": {
+        "summary": "List all the user consented organizations of a application.",
+        "description": "List all the user consented organizations for a application by application id and user id.",
+        "responses": {
+          "200": {
+            "description": "List of organization entities granted by the user for the application.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "organizations": {
+                      "description": "A list of organization entities granted by the user for the application."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Grant a list of organization access of a user for a application.",
+        "description": "Grant a list of organization access of a user for a application by application id and user id. <br/> The user must be a member of all the organizations. <br/> Only third-party application needs to be granted access to organizations, all the other applications can request for all the organizations' access by default.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "organizationIds": {
+                    "description": "A list of organization ids to be granted."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "All the request organizations's access are granted to the user for the application."
+          },
+          "404": {
+            "description": "The application or user is not found."
+          },
+          "422": {
+            "description": "The user is not a member of one of the organizations, or the application is not a third-party application."
+          }
+        }
+      },
+      "put": {
+        "summary": "Grant a list of organization access of a user for a application.",
+        "description": "Grant a list of organization access of a user for a application by application id and user id. <br/> The user must be a member of all the organizations. <br/> Only third-party application needs to be granted access to organizations, all the other applications can request for all the organizations' access by default.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "organizationIds": {
+                    "description": "A list of organization ids to be granted. <br/> All the existing organizations' access will be revoked if not in the list. <br/> If the list is empty, all the organizations' access will be revoked."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "All the request organizations's access are granted to the user for the application. "
+          },
+          "404": {
+            "description": "The application or user is not found."
+          },
+          "422": {
+            "description": "The user is not a member of one of the organizations, or the application is not a third-party application."
+          }
+        }
+      }
+    },
+    "/api/applications/{id}/users/{userId}/consent-organizations/{organizationId}": {
+      "delete": {
+        "summary": "Revoke a user's access to an organization for a application.",
+        "description": "Revoke a user's access to an organization for a application by application id, user id and organization id.",
+        "responses": {
+          "204": {
+            "description": "The user's access to the organization is revoked for the application."
+          },
+          "404": {
+            "description": "The application, user or organization is not found."
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/core/src/routes/applications/application-user-consent-organization.ts
+++ b/packages/core/src/routes/applications/application-user-consent-organization.ts
@@ -1,0 +1,138 @@
+import { Organizations } from '@logto/schemas';
+import { z } from 'zod';
+
+import koaGuard from '#src/middleware/koa-guard.js';
+import koaPagination from '#src/middleware/koa-pagination.js';
+
+import { type AuthedRouter, type RouterInitArgs } from '../types.js';
+
+export default function applicationUserConsentOrganizationRoutes<T extends AuthedRouter>(
+  ...[
+    router,
+    {
+      queries: { applications, users },
+      libraries: {
+        applications: {
+          validateThirdPartyApplicationById,
+          validateUserConsentOrganizationMembership,
+        },
+      },
+    },
+  ]: RouterInitArgs<T>
+) {
+  // Allow application level user consent organization management
+  const params = Object.freeze({ id: z.string().min(1), userId: z.string().min(1) } as const);
+  const pathname = '/applications/:id/users/:userId/consent-organizations';
+
+  // Guard application exists and is a third party application
+  router.use(pathname, koaGuard({ params: z.object(params) }), async (ctx, next) => {
+    const { id, userId } = ctx.guard.params;
+
+    await validateThirdPartyApplicationById(id);
+
+    // Ensure that the user exists.
+    await users.findUserById(userId);
+
+    return next();
+  });
+
+  router.get(
+    pathname,
+    koaPagination(),
+    koaGuard({
+      params: z.object(params),
+      response: z.object({
+        organizations: Organizations.guard.array(),
+      }),
+      status: [200, 404, 422],
+    }),
+    async (ctx, next) => {
+      const { id, userId } = ctx.guard.params;
+
+      const [totalCount, entities] = await applications.userConsentOrganizations.getEntities(
+        Organizations,
+        {
+          applicationId: id,
+          userId,
+        },
+        ctx.pagination
+      );
+
+      ctx.pagination.totalCount = totalCount;
+      ctx.body = { organizations: entities };
+
+      return next();
+    }
+  );
+
+  router.put(
+    pathname,
+    koaGuard({
+      params: z.object(params),
+      body: z.object({ organizationIds: z.string().min(1).array() }),
+      status: [204, 404, 422],
+    }),
+    async (ctx, next) => {
+      const { id, userId } = ctx.guard.params;
+      const { organizationIds } = ctx.guard.body;
+
+      // Assert that user is a member of all organizations
+      await validateUserConsentOrganizationMembership(userId, organizationIds);
+
+      await applications.userConsentOrganizations.replace(id, userId, organizationIds);
+
+      ctx.status = 204;
+      return next();
+    }
+  );
+
+  router.post(
+    pathname,
+    koaGuard({
+      params: z.object(params),
+      body: z.object({ organizationIds: z.string().min(1).array().nonempty() }),
+      status: [201, 404, 422],
+    }),
+    async (ctx, next) => {
+      const { id, userId } = ctx.guard.params;
+      const { organizationIds } = ctx.guard.body;
+
+      // Assert that user is a member of all organizations
+      await validateUserConsentOrganizationMembership(userId, organizationIds);
+
+      await applications.userConsentOrganizations.insert(
+        ...organizationIds.map<[string, string, string]>((organizationId) => [
+          id,
+          userId,
+          organizationId,
+        ])
+      );
+
+      ctx.status = 201;
+      return next();
+    }
+  );
+
+  router.delete(
+    `${pathname}/:organizationId`,
+    koaGuard({
+      params: z.object({
+        ...params,
+        organizationId: z.string().min(1),
+      }),
+      status: [204, 404, 422],
+    }),
+    async (ctx, next) => {
+      const { id, organizationId, userId } = ctx.guard.params;
+
+      await applications.userConsentOrganizations.delete({
+        applicationId: id,
+        organizationId,
+        userId,
+      });
+
+      ctx.status = 204;
+      return next();
+    }
+  );
+}

--- a/packages/core/src/routes/init.ts
+++ b/packages/core/src/routes/init.ts
@@ -13,6 +13,7 @@ import koaAuth from '../middleware/koa-auth/index.js';
 import adminUserRoutes from './admin-user/index.js';
 import applicationRoleRoutes from './applications/application-role.js';
 import applicationSignInExperienceRoutes from './applications/application-sign-in-experience.js';
+import applicationUserConsentOrganizationRoutes from './applications/application-user-consent-organization.js';
 import applicationUserConsentScopeRoutes from './applications/application-user-consent-scope.js';
 import applicationRoutes from './applications/application.js';
 import authnRoutes from './authn.js';
@@ -51,6 +52,7 @@ const createRouters = (tenant: TenantContext) => {
   if (EnvSet.values.isDevFeaturesEnabled) {
     applicationUserConsentScopeRoutes(managementRouter, tenant);
     applicationSignInExperienceRoutes(managementRouter, tenant);
+    applicationUserConsentOrganizationRoutes(managementRouter, tenant);
   }
 
   logtoConfigRoutes(managementRouter, tenant);

--- a/packages/integration-tests/src/api/application-user-consent-organization.ts
+++ b/packages/integration-tests/src/api/application-user-consent-organization.ts
@@ -1,0 +1,42 @@
+import { type Organization } from '@logto/schemas';
+
+import { authedAdminApi } from './api.js';
+
+export const postApplicationUserConsentOrganization = async (
+  applicationId: string,
+  userId: string,
+  payload: {
+    organizationIds: string[];
+  }
+) =>
+  authedAdminApi.post(`applications/${applicationId}/users/${userId}/consent-organizations`, {
+    json: payload,
+  });
+
+export const putApplicationUserConsentOrganization = async (
+  applicationId: string,
+  userId: string,
+  payload: {
+    organizationIds: string[];
+  }
+) =>
+  authedAdminApi.put(`applications/${applicationId}/users/${userId}/consent-organizations`, {
+    json: payload,
+  });
+
+export const getApplicationUserConsentOrganization = async (
+  applicationId: string,
+  userId: string
+) =>
+  authedAdminApi.get(`applications/${applicationId}/users/${userId}/consent-organizations`).json<{
+    organizations: Organization[];
+  }>();
+
+export const deleteApplicationUserConsentOrganization = async (
+  applicationId: string,
+  userId: string,
+  organizationId: string
+) =>
+  authedAdminApi.delete(
+    `applications/${applicationId}/users/${userId}/consent-organizations/${organizationId}`
+  );

--- a/packages/integration-tests/src/tests/api/application/application-sign-in-experience.test.ts
+++ b/packages/integration-tests/src/tests/api/application/application-sign-in-experience.test.ts
@@ -64,7 +64,7 @@ describe('application sign in experience', () => {
       ),
       {
         code: 'application.third_party_application_only',
-        statusCode: 400,
+        statusCode: 422,
       }
     );
   });

--- a/packages/integration-tests/src/tests/api/application/application-user-consent-organization.test.ts
+++ b/packages/integration-tests/src/tests/api/application/application-user-consent-organization.test.ts
@@ -1,0 +1,216 @@
+import { ApplicationType, type Organization } from '@logto/schemas';
+
+import {
+  postApplicationUserConsentOrganization,
+  getApplicationUserConsentOrganization,
+  putApplicationUserConsentOrganization,
+  deleteApplicationUserConsentOrganization,
+} from '#src/api/application-user-consent-organization.js';
+import { createApplication, deleteApplication } from '#src/api/application.js';
+import { OrganizationApi } from '#src/api/organization.js';
+import { expectRejects } from '#src/helpers/index.js';
+import { UserApiTest } from '#src/helpers/user.js';
+
+const testPrefix = 'application-user-consent-organization';
+
+describe('assign user consent organizations to application', () => {
+  const applicationIds = new Map<string, string>();
+  const organizations = new Map<string, Organization>();
+  const userIds = new Map<string, string>();
+
+  const userApiTest = new UserApiTest();
+  const organizationApi = new OrganizationApi();
+
+  beforeAll(async () => {
+    const [firstPartyApp, thirdPartyApp] = await Promise.all([
+      createApplication('first-party-application', ApplicationType.SPA),
+      createApplication('third-party-application', ApplicationType.Traditional, {
+        isThirdParty: true,
+      }),
+    ]);
+
+    applicationIds.set('firstPartyApp', firstPartyApp.id);
+    applicationIds.set('thirdPartyApp', thirdPartyApp.id);
+
+    const [adminOrganization, guestOrganization] = await Promise.all([
+      organizationApi.create({
+        name: `${testPrefix}:admin-organization`,
+      }),
+      organizationApi.create({
+        name: `${testPrefix}:guest-organization`,
+      }),
+    ]);
+
+    organizations.set('adminOrganization', adminOrganization);
+    organizations.set('guestOrganization', guestOrganization);
+
+    const [adminUser, guestUser] = await Promise.all([
+      userApiTest.create({ name: `${testPrefix}:admin-user` }),
+      userApiTest.create({ name: `${testPrefix}:guest-user` }),
+    ]);
+
+    userIds.set('adminUser', adminUser.id);
+    userIds.set('guestUser', guestUser.id);
+
+    await Promise.all([
+      organizationApi.addUsers(adminOrganization.id, [adminUser.id]),
+      organizationApi.addUsers(guestOrganization.id, [adminUser.id, guestUser.id]),
+    ]);
+  });
+
+  afterAll(async () => {
+    await Promise.all([
+      ...Array.from(applicationIds.values()).map(async (applicationId) =>
+        deleteApplication(applicationId)
+      ),
+      ...Array.from(organizations.values()).map(async ({ id }) => organizationApi.delete(id)),
+      userApiTest.cleanUp(),
+    ]);
+  });
+
+  describe('assign user consent organizations to application', () => {
+    it('should throw 404 if application not found', async () => {
+      await expectRejects(
+        postApplicationUserConsentOrganization('not-found', userIds.get('adminUser')!, {
+          organizationIds: [],
+        }),
+        {
+          code: 'entity.not_exists_with_id',
+          statusCode: 404,
+        }
+      );
+    });
+
+    it('should throw 404 if user not found', async () => {
+      await expectRejects(
+        postApplicationUserConsentOrganization(applicationIds.get('thirdPartyApp')!, 'not-found', {
+          organizationIds: [],
+        }),
+        {
+          code: 'entity.not_found',
+          statusCode: 404,
+        }
+      );
+    });
+
+    it('should throw 422 if application is not third-party', async () => {
+      await expectRejects(
+        postApplicationUserConsentOrganization(
+          applicationIds.get('firstPartyApp')!,
+          userIds.get('adminUser')!,
+          {
+            organizationIds: [],
+          }
+        ),
+        {
+          code: 'application.third_party_application_only',
+          statusCode: 422,
+        }
+      );
+    });
+
+    it('should throw 422 if user is not a member of the organization', async () => {
+      await expectRejects(
+        postApplicationUserConsentOrganization(
+          applicationIds.get('thirdPartyApp')!,
+          userIds.get('guestUser')!,
+          {
+            organizationIds: [organizations.get('adminOrganization')!.id],
+          }
+        ),
+        {
+          code: 'organization.require_membership',
+          statusCode: 422,
+        }
+      );
+    });
+
+    it('should assign user consent organizations to application', async () => {
+      const applicationId = applicationIds.get('thirdPartyApp')!;
+      const adminUser = userIds.get('adminUser')!;
+      const adminOrganization = organizations.get('adminOrganization')!;
+      const guestOrganization = organizations.get('guestOrganization')!;
+
+      await postApplicationUserConsentOrganization(applicationId, adminUser, {
+        organizationIds: [adminOrganization.id, guestOrganization.id],
+      });
+
+      const { organizations: consentOrganizations } = await getApplicationUserConsentOrganization(
+        applicationId,
+        adminUser
+      );
+
+      expect(consentOrganizations).toHaveLength(2);
+      expect(consentOrganizations.find(({ id }) => id === adminOrganization.id)).toMatchObject(
+        adminOrganization
+      );
+      expect(consentOrganizations.find(({ id }) => id === guestOrganization.id)).toMatchObject(
+        guestOrganization
+      );
+    });
+
+    it('should update user consent organizations to application', async () => {
+      const applicationId = applicationIds.get('thirdPartyApp')!;
+      const adminUser = userIds.get('adminUser')!;
+      const adminOrganization = organizations.get('adminOrganization')!;
+
+      await putApplicationUserConsentOrganization(applicationId, adminUser, {
+        organizationIds: [adminOrganization.id],
+      });
+
+      const { organizations: consentOrganizations } = await getApplicationUserConsentOrganization(
+        applicationId,
+        adminUser
+      );
+
+      expect(consentOrganizations).toHaveLength(1);
+      expect(consentOrganizations.find(({ id }) => id === adminOrganization.id)).toMatchObject(
+        adminOrganization
+      );
+    });
+
+    it('should delete user consent organizations to application', async () => {
+      const applicationId = applicationIds.get('thirdPartyApp')!;
+      const adminUser = userIds.get('adminUser')!;
+
+      await putApplicationUserConsentOrganization(applicationId, adminUser, {
+        organizationIds: [],
+      });
+
+      const { organizations: consentOrganizations } = await getApplicationUserConsentOrganization(
+        applicationId,
+        adminUser
+      );
+
+      expect(consentOrganizations).toHaveLength(0);
+    });
+
+    it('should delete a user consent organization to application by id', async () => {
+      const applicationId = applicationIds.get('thirdPartyApp')!;
+      const guestUser = userIds.get('guestUser')!;
+      const guestOrganization = organizations.get('guestOrganization')!;
+
+      await postApplicationUserConsentOrganization(applicationId, guestUser, {
+        organizationIds: [guestOrganization.id],
+      });
+
+      const { organizations: consentOrganizations } = await getApplicationUserConsentOrganization(
+        applicationId,
+        guestUser
+      );
+
+      expect(consentOrganizations).toHaveLength(1);
+
+      await deleteApplicationUserConsentOrganization(
+        applicationId,
+        guestUser,
+        guestOrganization.id
+      );
+
+      const { organizations: consentOrganizationsAfterDelete } =
+        await getApplicationUserConsentOrganization(applicationId, guestUser);
+
+      expect(consentOrganizationsAfterDelete).toHaveLength(0);
+    });
+  });
+});

--- a/packages/integration-tests/src/tests/api/application/application-user-consent-scope.test.ts
+++ b/packages/integration-tests/src/tests/api/application/application-user-consent-scope.test.ts
@@ -78,7 +78,7 @@ describe('assign user consent scopes to application', () => {
       }),
       {
         code: 'application.third_party_application_only',
-        statusCode: 400,
+        statusCode: 422,
       }
     );
   });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Implement application user consent organizations management API.
Users will be able to grant organizations access to the third-party consent page. Those grant statuses can be managed throw these APIs. 

- POST /applications/:id/users/:userId/consent-organizations
- PUT /applications/:id/users/:userId/consent-organizations
- GET /applications/:id/users/:userId/consent-organizations
- DELETE /applications/:id/users/:userId/consent-organizations/:organizationId

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally using postman
integration tests added

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [x] ~integration tests~
- [x] ~necessary TSDoc comments~
