### PR TITLE
feat(console,phrases): support protected app creation in get-started page

### DIFF
--- a/packages/console/src/ds-components/FormField/index.module.scss
+++ b/packages/console/src/ds-components/FormField/index.module.scss
@@ -35,3 +35,9 @@
     color: var(--color-text-secondary);
   }
 }
+
+.description {
+  font: var(--font-body-2);
+  color: var(--color-text-secondary);
+  margin-top: _.unit(1);
+}

--- a/packages/console/src/ds-components/FormField/index.tsx
+++ b/packages/console/src/ds-components/FormField/index.tsx
@@ -16,6 +16,8 @@ import * as styles from './index.module.scss';
 
 export type Props = {
   title: AdminConsoleKey | ReactElement<typeof DangerousRaw>;
+  description?: AdminConsoleKey | ReactElement<typeof DangerousRaw>;
+  descriptionPosition?: 'top' | 'bottom';
   children: ReactNode;
   isRequired?: boolean;
   isMultiple?: boolean;
@@ -27,6 +29,8 @@ export type Props = {
 
 function FormField({
   title,
+  description,
+  descriptionPosition = 'bottom',
   children,
   isRequired,
   isMultiple,
@@ -62,7 +66,15 @@ function FormField({
         <Spacer />
         {isRequired && <div className={styles.required}>{t('general.required')}</div>}
       </div>
+      {description && descriptionPosition === 'top' && (
+        <div className={styles.description}>{descriptionPosition}</div>
+      )}
       {children}
+      {description && descriptionPosition === 'bottom' && (
+        <div className={styles.description}>
+          {typeof description === 'string' ? <DynamicT forKey={description} /> : description}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/console/src/pages/Applications/components/GuideLibrary/index.module.scss
+++ b/packages/console/src/pages/Applications/components/GuideLibrary/index.module.scss
@@ -70,6 +70,10 @@
   }
 }
 
+.protectedAppCard {
+  margin-bottom: _.unit(4);
+}
+
 .wrapper.hasFilters .groups {
   max-width: dim.$guide-main-content-max-width;
 }

--- a/packages/console/src/pages/Applications/components/GuideLibrary/index.tsx
+++ b/packages/console/src/pages/Applications/components/GuideLibrary/index.tsx
@@ -137,7 +137,9 @@ function GuideLibrary({ className, hasCardBorder, hasCardButton, hasFilters }: P
             ))}
           {!keyword && (
             <>
-              {isDevFeaturesEnabled && <ProtectedAppCard />}
+              {isDevFeaturesEnabled && (
+                <ProtectedAppCard hasLabel hasCreateButton className={styles.protectedAppCard} />
+              )}
               {(filterCategories.length > 0 ? filterCategories : allAppGuideCategories).map(
                 (category) =>
                   structuredMetadata[category].length > 0 && (

--- a/packages/console/src/pages/Applications/components/ProtectedAppCard/index.module.scss
+++ b/packages/console/src/pages/Applications/components/ProtectedAppCard/index.module.scss
@@ -5,7 +5,6 @@
   flex-direction: column;
   width: 100%;
   gap: _.unit(4);
-  margin-bottom: _.unit(4);
 
   label {
     color: var(--color-text-secondary);

--- a/packages/console/src/pages/Applications/components/ProtectedAppCard/index.tsx
+++ b/packages/console/src/pages/Applications/components/ProtectedAppCard/index.tsx
@@ -1,4 +1,5 @@
-import { Theme } from '@logto/schemas';
+import { type Application, Theme } from '@logto/schemas';
+import classNames from 'classnames';
 import { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
@@ -13,7 +14,14 @@ import ProtectedAppModal from '../ProtectedAppModal';
 
 import * as styles from './index.module.scss';
 
-function ProtectedAppCard() {
+type Props = {
+  className?: string;
+  hasLabel?: boolean;
+  hasCreateButton?: boolean;
+  onCreateSuccess?: (app: Application) => void;
+};
+
+function ProtectedAppCard({ className, hasLabel, hasCreateButton, onCreateSuccess }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console.protected_app' });
   const { documentationSiteUrl } = useDocumentationUrl();
   const [showCreateModal, setShowCreateModal] = useState<boolean>(false);
@@ -22,8 +30,8 @@ function ProtectedAppCard() {
 
   return (
     <>
-      <div className={styles.container}>
-        <label>{t('name')}</label>
+      <div className={classNames(styles.container, className)}>
+        {hasLabel && <label>{t('name')}</label>}
         <div className={styles.card}>
           <Icon className={styles.logo} />
           <div className={styles.wrapper}>
@@ -39,18 +47,23 @@ function ProtectedAppCard() {
               </Trans>
             </div>
           </div>
-          <Button
-            title="protected_app.fast_create"
-            onClick={() => {
-              setShowCreateModal(true);
-            }}
-          />
+          {hasCreateButton && (
+            <Button
+              title="protected_app.fast_create"
+              onClick={() => {
+                setShowCreateModal(true);
+              }}
+            />
+          )}
         </div>
       </div>
       {showCreateModal && (
         <ProtectedAppModal
-          onClose={() => {
+          onClose={(app) => {
             setShowCreateModal(false);
+            if (app) {
+              onCreateSuccess?.(app);
+            }
           }}
         />
       )}

--- a/packages/console/src/pages/Applications/components/ProtectedAppForm/index.module.scss
+++ b/packages/console/src/pages/Applications/components/ProtectedAppForm/index.module.scss
@@ -1,6 +1,48 @@
 @use '@/scss/underscore' as _;
 
-.fieldWrapper {
+form {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.formFieldWrapper {
+  display: flex;
+  gap: _.unit(9);
+
+  .index {
+    display: flex;
+    width: 24px;
+    height: 24px;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: var(--color-surface-5);
+    color: var(--color-text-link);
+    font: var(--font-title-3);
+    position: relative;
+  }
+
+  .withDashedLine {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    .dashedLine {
+      flex: 1;
+      border-left: 1px dashed var(--color-border);
+      margin: _.unit(1.5) 0;
+    }
+  }
+
+  .field {
+    flex: 1;
+    margin: 0;
+    padding-bottom: _.unit(6);
+  }
+}
+
+.domainFieldWrapper {
   display: flex;
   align-items: center;
   width: 100%;
@@ -25,5 +67,13 @@
     font: var(--font-body-2);
     color: var(--color-text);
     background-color: var(--color-specific-unselected-disabled);
+  }
+}
+
+.submitButton {
+  align-self: flex-end;
+
+  &.leftAligned {
+    align-self: flex-start;
   }
 }

--- a/packages/console/src/pages/Applications/components/ProtectedAppForm/index.tsx
+++ b/packages/console/src/pages/Applications/components/ProtectedAppForm/index.tsx
@@ -1,40 +1,129 @@
-import { useFormContext } from 'react-hook-form';
+import { ApplicationType, type Application } from '@logto/schemas';
+import { conditional } from '@silverhand/essentials';
+import classNames from 'classnames';
+import { useForm } from 'react-hook-form';
+import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 
+import Button, { type Props as ButtonProps } from '@/ds-components/Button';
 import FormField from '@/ds-components/FormField';
 import TextInput from '@/ds-components/TextInput';
+import useApi from '@/hooks/use-api';
+import { trySubmitSafe } from '@/utils/form';
 
 import * as styles from './index.module.scss';
 
-function ProtectedAppForm() {
-  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console.protected_app' });
+type Props = {
+  className?: string;
+  buttonAlignment?: 'left' | 'right';
+  buttonText?: ButtonProps['title'];
+  buttonSize?: ButtonProps['size'];
+  hasDetailedInstructions?: boolean;
+  hasRequiredLabel?: boolean;
+  onCreateSuccess?: (createdApp: Application) => void;
+};
+
+function ProtectedAppForm({
+  className,
+  buttonAlignment = 'right',
+  buttonSize = 'large',
+  buttonText = 'protected_app.form.create_application',
+  hasDetailedInstructions,
+  hasRequiredLabel,
+  onCreateSuccess,
+}: Props) {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const {
     register,
-    formState: { errors },
-  } = useFormContext<ProtectedAppForm>();
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<ProtectedAppForm>();
+
+  const api = useApi();
+
+  const onSubmit = handleSubmit(
+    trySubmitSafe(async (data) => {
+      if (isSubmitting) {
+        return;
+      }
+
+      const createdApp = await api
+        .post('api/applications', {
+          json: {
+            // App name is subdomain on create, but user can change it later in app details.
+            name: data.subDomain,
+            type: ApplicationType.Protected,
+            protectedAppMetadata: data,
+          },
+        })
+        .json<Application>();
+      toast.success(t('applications.application_created'));
+      onCreateSuccess?.(createdApp);
+    })
+  );
 
   return (
-    <>
-      <FormField isRequired title="protected_app.form.domain_field_label">
-        <div className={styles.fieldWrapper}>
+    <form className={className}>
+      <div className={styles.formFieldWrapper}>
+        {hasDetailedInstructions && (
+          <div className={styles.withDashedLine}>
+            <div className={styles.index}>1</div>
+            <div className={styles.dashedLine} />
+          </div>
+        )}
+        <FormField
+          isRequired={hasRequiredLabel}
+          className={styles.field}
+          title="protected_app.form.domain_field_label"
+          description={`protected_app.form.domain_field_description${
+            hasDetailedInstructions ? '' : '_short'
+          }`}
+          tip={conditional(
+            !hasDetailedInstructions && t('protected_app.form.domain_field_tooltip')
+          )}
+        >
+          <div className={styles.domainFieldWrapper}>
+            <TextInput
+              className={styles.subdomain}
+              {...register('subDomain', { required: true })}
+              placeholder={t('protected_app.form.domain_field_placeholder')}
+              error={Boolean(errors.subDomain)}
+            />
+            {/** TODO: @charles Hard-coded for now, will update to read from API later. */}
+            <div className={styles.domain}>.protected.app</div>
+          </div>
+        </FormField>
+      </div>
+      <div className={styles.formFieldWrapper}>
+        {hasDetailedInstructions && <div className={styles.index}>2</div>}
+        <FormField
+          isRequired={hasRequiredLabel}
+          className={styles.field}
+          title="protected_app.form.url_field_label"
+          description={conditional(
+            hasDetailedInstructions && 'protected_app.form.url_field_description'
+          )}
+          tip={conditional(!hasDetailedInstructions && t('protected_app.form.url_field_tooltip'))}
+        >
           <TextInput
-            className={styles.subdomain}
-            {...register('subDomain', { required: true })}
-            placeholder={t('form.domain_field_placeholder')}
-            error={Boolean(errors.subDomain)}
+            {...register('origin', { required: true })}
+            placeholder={t('protected_app.form.url_field_placeholder')}
+            error={Boolean(errors.origin)}
           />
-          {/** TODO: @charles Hard-coded for now, will update to read from API later. */}
-          <div className={styles.domain}>.protected.app</div>
-        </div>
-      </FormField>
-      <FormField isRequired title="protected_app.form.url_field_label">
-        <TextInput
-          {...register('origin', { required: true })}
-          placeholder={t('form.url_field_placeholder')}
-          error={Boolean(errors.origin)}
-        />
-      </FormField>
-    </>
+        </FormField>
+      </div>
+      <Button
+        className={classNames(
+          styles.submitButton,
+          buttonAlignment === 'left' && styles.leftAligned
+        )}
+        size={buttonSize}
+        type="primary"
+        title={buttonText}
+        isLoading={isSubmitting}
+        onClick={onSubmit}
+      />
+    </form>
   );
 }
 

--- a/packages/console/src/pages/Applications/components/ProtectedAppModal/index.tsx
+++ b/packages/console/src/pages/Applications/components/ProtectedAppModal/index.tsx
@@ -1,14 +1,8 @@
-import { ApplicationType, type Application } from '@logto/schemas';
-import { FormProvider, useForm } from 'react-hook-form';
-import { toast } from 'react-hot-toast';
-import { useTranslation } from 'react-i18next';
+import { type Application } from '@logto/schemas';
 import Modal from 'react-modal';
 
-import Button from '@/ds-components/Button';
 import ModalLayout from '@/ds-components/ModalLayout';
-import useApi from '@/hooks/use-api';
 import * as modalStyles from '@/scss/modal.module.scss';
-import { trySubmitSafe } from '@/utils/form';
 
 import ProtectedAppForm from '../ProtectedAppForm';
 
@@ -17,35 +11,6 @@ type Props = {
 };
 
 function ProtectedAppModal({ onClose }: Props) {
-  const methods = useForm<ProtectedAppForm>();
-  const {
-    handleSubmit,
-    formState: { isSubmitting },
-  } = methods;
-
-  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
-  const api = useApi();
-
-  const onSubmit = handleSubmit(
-    trySubmitSafe(async (data) => {
-      if (isSubmitting) {
-        return;
-      }
-
-      const createdApp = await api
-        .post('api/applications', {
-          json: {
-            name: data.subDomain,
-            type: ApplicationType.Protected,
-            protectedAppMetadata: data,
-          },
-        })
-        .json<Application>();
-      toast.success(t('applications.application_created'));
-      onClose?.(createdApp);
-    })
-  );
-
   return (
     <Modal
       shouldCloseOnEsc
@@ -60,20 +25,9 @@ function ProtectedAppModal({ onClose }: Props) {
         title="protected_app.modal_title"
         subtitle="protected_app.modal_subtitle"
         size="large"
-        footer={
-          <Button
-            size="large"
-            type="primary"
-            title="protected_app.form.create_application"
-            isLoading={isSubmitting}
-            onClick={onSubmit}
-          />
-        }
         onClose={onClose}
       >
-        <FormProvider {...methods}>
-          <ProtectedAppForm />
-        </FormProvider>
+        <ProtectedAppForm hasRequiredLabel onCreateSuccess={onClose} />
       </ModalLayout>
     </Modal>
   );

--- a/packages/console/src/pages/GetStarted/ProtectedAppCreationForm/index.module.scss
+++ b/packages/console/src/pages/GetStarted/ProtectedAppCreationForm/index.module.scss
@@ -1,0 +1,62 @@
+@use '@/scss/underscore' as _;
+
+.container {
+  border-radius: 12px;
+  border: 1px solid var(--color-divider);
+  overflow: hidden;
+
+  .separator {
+    border-bottom: 1px solid var(--color-divider);
+  }
+
+  .form {
+    background: var(--color-layer-1);
+    padding: _.unit(6) _.unit(8);
+  }
+
+  .protectedApps {
+    display: flex;
+    flex-direction: column;
+    gap: _.unit(3);
+    background: var(--color-success-container);
+    padding: _.unit(5) _.unit(9);
+
+    .label {
+      display: flex;
+      align-items: center;
+      font: var(--font-label-2);
+      white-space: pre;
+    }
+
+    .list {
+      display: flex;
+      flex-wrap: wrap;
+    }
+
+    .app {
+      display: flex;
+      align-items: center;
+      padding-left: _.unit(5);
+      gap: _.unit(3);
+      font: var(--font-body-2);
+
+      .status {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: var(--color-on-success-container);
+        margin-right: _.unit(-1);
+      }
+
+      .hostName {
+        margin-right: _.unit(-3);
+        color: var(--color-text);
+        text-decoration: none;
+
+        &:hover {
+          text-decoration: underline;
+        }
+      }
+    }
+  }
+}

--- a/packages/console/src/pages/GetStarted/ProtectedAppCreationForm/index.tsx
+++ b/packages/console/src/pages/GetStarted/ProtectedAppCreationForm/index.tsx
@@ -1,0 +1,75 @@
+import { type Application } from '@logto/schemas';
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import useSWR from 'swr';
+
+import ExternalLinkIcon from '@/assets/icons/external-link.svg';
+import CopyToClipboard from '@/ds-components/CopyToClipboard';
+import IconButton from '@/ds-components/IconButton';
+import { Tooltip } from '@/ds-components/Tip';
+import useTenantPathname from '@/hooks/use-tenant-pathname';
+import ProtectedAppCard from '@/pages/Applications/components/ProtectedAppCard';
+import ProtectedAppForm from '@/pages/Applications/components/ProtectedAppForm';
+
+import * as styles from './index.module.scss';
+
+function ProtectedAppCreationForm() {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const { getTo } = useTenantPathname();
+  const { data, mutate } = useSWR<Application[]>('api/applications?types=Protected');
+  const hasProtectedApps = !!data?.length;
+
+  const mutateApps = useCallback(
+    (app: Application) => {
+      void mutate([...(data ?? []), app]);
+    },
+    [data, mutate]
+  );
+
+  return (
+    <div className={styles.container}>
+      <ProtectedAppCard hasCreateButton={hasProtectedApps} onCreateSuccess={mutateApps} />
+      <div className={styles.separator} />
+      {!hasProtectedApps && (
+        <div className={styles.form}>
+          <ProtectedAppForm
+            hasDetailedInstructions
+            buttonAlignment="left"
+            buttonText="protected_app.form.create_protected_app"
+            buttonSize="medium"
+            onCreateSuccess={mutateApps}
+          />
+        </div>
+      )}
+      {hasProtectedApps && (
+        <div className={styles.protectedApps}>
+          <div className={styles.label}>{t('protected_app.success_message')}</div>
+          <div className={styles.list}>
+            {data.map((app) => {
+              const host = app.protectedAppMetadata?.host;
+              return (
+                !!host && (
+                  <div key={app.id} className={styles.app}>
+                    <div className={styles.status} />
+                    <Link className={styles.hostName} to={getTo(`/applications/${app.id}`)}>
+                      {host}
+                    </Link>
+                    <CopyToClipboard value={host} variant="icon" />
+                    <Tooltip content={t('general.open')}>
+                      <IconButton size="small">
+                        <ExternalLinkIcon />
+                      </IconButton>
+                    </Tooltip>
+                  </div>
+                )
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ProtectedAppCreationForm;

--- a/packages/console/src/pages/GetStarted/index.tsx
+++ b/packages/console/src/pages/GetStarted/index.tsx
@@ -15,7 +15,7 @@ import GuideCardGroup from '@/components/Guide/GuideCardGroup';
 import { useApiGuideMetadata, useAppGuideMetadata } from '@/components/Guide/hooks';
 import PageMeta from '@/components/PageMeta';
 import { ConnectorsTabs } from '@/consts';
-import { isCloud } from '@/consts/env';
+import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
 import { AppDataContext } from '@/contexts/AppDataProvider';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import { LinkButton } from '@/ds-components/Button';
@@ -30,6 +30,7 @@ import CreateApiForm from '../ApiResources/components/CreateForm';
 import CreateAppForm from '../Applications/components/CreateForm';
 
 import DevelopmentTenantNotification from './DevelopmentTenantNotification';
+import ProtectedAppCreationForm from './ProtectedAppCreationForm';
 import * as styles from './index.module.scss';
 
 const icons = {
@@ -112,7 +113,17 @@ function GetStarted() {
       </div>
       {isCloud && isDevTenant && <DevelopmentTenantNotification />}
       <Card className={styles.card}>
-        <div className={styles.title}>{t('get_started.develop.title')}</div>
+        <div className={styles.title}>
+          {isCloud && isDevFeaturesEnabled
+            ? t('get_started.develop.title_cloud')
+            : t('get_started.develop.title')}
+        </div>
+        {isCloud && isDevFeaturesEnabled && (
+          <>
+            <ProtectedAppCreationForm />
+            <div className={styles.subtitle}>{t('get_started.develop.subtitle_cloud')}</div>
+          </>
+        )}
         <GuideCardGroup
           ref={containerRef}
           hasCardBorder

--- a/packages/phrases/src/locales/de/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/general.ts
@@ -55,6 +55,8 @@ const general = {
   demo: 'Demo',
   unnamed: 'Unbenannt',
   view: 'Anzeigen',
+  /** UNTRANSLATED */
+  open: 'Open',
   hide: 'Verbergen',
   unknown_error: 'Unbekannter Fehler, bitte versuchen Sie es später erneut.',
   select: 'Auswählen',

--- a/packages/phrases/src/locales/de/translation/admin-console/get-started.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/get-started.ts
@@ -4,6 +4,11 @@ const get_started = {
   subtitle: 'Einige Dinge, die Sie tun können, um schnell den Wert von Logto zu erhalten',
   develop: {
     title: 'Entwicklung: Nehmen Sie sich 5 Minuten Zeit, um Ihre App zu integrieren',
+    /** UNTRANSLATED */
+    title_cloud: 'Develop: Securely integrate your app in minutes',
+    /** UNTRANSLATED */
+    subtitle_cloud:
+      'Or take 5 minutes to integrate your app with our pre-built SDKs and tutorials.',
   },
   customize: {
     title: 'Anpassen: Liefern Sie ein großartiges Anmeldeerlebnis',

--- a/packages/phrases/src/locales/de/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/protected-app.ts
@@ -19,6 +19,9 @@ const protected_app = {
     domain_field_placeholder: 'Custom subdomain',
     /** UNTRANSLATED */
     domain_field_description:
+      'Specify the app domain that will be protected by authentication and redirected to the Origin URL. Custom domain can be added after creation.',
+    /** UNTRANSLATED */
+    domain_field_description_short:
       'Specify the app domain that will be protected by authentication and redirected to the Origin URL.',
     /** UNTRANSLATED */
     domain_field_tooltip:
@@ -28,10 +31,14 @@ const protected_app = {
     /** UNTRANSLATED */
     url_field_placeholder: 'https://',
     /** UNTRANSLATED */
+    url_field_description: 'Enter the primary website address of your application.',
+    /** UNTRANSLATED */
     url_field_tooltip:
       "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
+    /** UNTRANSLATED */
+    create_protected_app: 'Create and experience auth protection',
     errors: {
       /** UNTRANSLATED */
       domain_required: 'Subdomain is required',
@@ -47,6 +54,9 @@ const protected_app = {
         "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
     },
   },
+  /** UNTRANSLATED */
+  success_message:
+    '🎉  App authentication successfully enabled! Explore the new protection of your website.',
 };
 
 export default Object.freeze(protected_app);

--- a/packages/phrases/src/locales/en/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/general.ts
@@ -54,6 +54,7 @@ const general = {
   demo: 'Demo',
   unnamed: 'Unnamed',
   view: 'View',
+  open: 'Open',
   hide: 'Hide',
   unknown_error: 'Unknown error, please try again later.',
   select: 'Select',

--- a/packages/phrases/src/locales/en/translation/admin-console/get-started.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/get-started.ts
@@ -4,6 +4,9 @@ const get_started = {
   subtitle: 'A few things you can do to quickly get value of Logto',
   develop: {
     title: 'Develop: Take 5 minutes to integrate your app',
+    title_cloud: 'Develop: Securely integrate your app in minutes',
+    subtitle_cloud:
+      'Or take 5 minutes to integrate your app with our pre-built SDKs and tutorials.',
   },
   customize: {
     title: 'Customize: Deliver a great sign-in experience',

--- a/packages/phrases/src/locales/en/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/protected-app.ts
@@ -10,14 +10,18 @@ const protected_app = {
     domain_field_label: 'App domain protected',
     domain_field_placeholder: 'Custom subdomain',
     domain_field_description:
+      'Specify the app domain that will be protected by authentication and redirected to the Origin URL. Custom domain can be added after creation.',
+    domain_field_description_short:
       'Specify the app domain that will be protected by authentication and redirected to the Origin URL.',
     domain_field_tooltip:
       "You can use a 'protected.app' subdomain powered by Logto for quick testing or online access, which remains consistently valid. After creation, your custom domain name can be added.",
     url_field_label: 'Origin URL',
     url_field_placeholder: 'https://',
+    url_field_description: 'Enter the primary website address of your application.',
     url_field_tooltip:
       "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     create_application: 'Create application',
+    create_protected_app: 'Create and experience auth protection',
     errors: {
       domain_required: 'Subdomain is required',
       domain_in_use: 'This subdomain name is already in use.',
@@ -28,6 +32,8 @@ const protected_app = {
         "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
     },
   },
+  success_message:
+    '🎉  App authentication successfully enabled! Explore the new protection of your website.',
 };
 
 export default Object.freeze(protected_app);

--- a/packages/phrases/src/locales/es/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/general.ts
@@ -55,6 +55,8 @@ const general = {
   demo: 'Demostración',
   unnamed: 'Sin nombre',
   view: 'Ver',
+  /** UNTRANSLATED */
+  open: 'Open',
   hide: 'Ocultar',
   unknown_error: 'Error desconocido, por favor inténtalo de nuevo más tarde.',
   select: 'Seleccionar',

--- a/packages/phrases/src/locales/es/translation/admin-console/get-started.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/get-started.ts
@@ -4,6 +4,11 @@ const get_started = {
   subtitle: 'Algunas cosas que puedes hacer para obtener rápidamente el valor de Logto',
   develop: {
     title: 'Develop: Dedica 5 minutos para integrar tu aplicación',
+    /** UNTRANSLATED */
+    title_cloud: 'Develop: Securely integrate your app in minutes',
+    /** UNTRANSLATED */
+    subtitle_cloud:
+      'Or take 5 minutes to integrate your app with our pre-built SDKs and tutorials.',
   },
   customize: {
     title: 'Customize: Ofrece una excelente experiencia de inicio de sesión',

--- a/packages/phrases/src/locales/es/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/protected-app.ts
@@ -19,6 +19,9 @@ const protected_app = {
     domain_field_placeholder: 'Custom subdomain',
     /** UNTRANSLATED */
     domain_field_description:
+      'Specify the app domain that will be protected by authentication and redirected to the Origin URL. Custom domain can be added after creation.',
+    /** UNTRANSLATED */
+    domain_field_description_short:
       'Specify the app domain that will be protected by authentication and redirected to the Origin URL.',
     /** UNTRANSLATED */
     domain_field_tooltip:
@@ -28,10 +31,14 @@ const protected_app = {
     /** UNTRANSLATED */
     url_field_placeholder: 'https://',
     /** UNTRANSLATED */
+    url_field_description: 'Enter the primary website address of your application.',
+    /** UNTRANSLATED */
     url_field_tooltip:
       "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
+    /** UNTRANSLATED */
+    create_protected_app: 'Create and experience auth protection',
     errors: {
       /** UNTRANSLATED */
       domain_required: 'Subdomain is required',
@@ -47,6 +54,9 @@ const protected_app = {
         "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
     },
   },
+  /** UNTRANSLATED */
+  success_message:
+    '🎉  App authentication successfully enabled! Explore the new protection of your website.',
 };
 
 export default Object.freeze(protected_app);

--- a/packages/phrases/src/locales/fr/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/general.ts
@@ -55,6 +55,8 @@ const general = {
   demo: 'Démo',
   unnamed: 'Sans nom',
   view: 'Vue',
+  /** UNTRANSLATED */
+  open: 'Open',
   hide: 'Cacher',
   unknown_error: 'Erreur inconnue, veuillez réessayer ultérieurement.',
   select: 'Sélectionner',

--- a/packages/phrases/src/locales/fr/translation/admin-console/get-started.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/get-started.ts
@@ -4,6 +4,11 @@ const get_started = {
   subtitle: 'Quelques choses que vous pouvez faire pour obtenir rapidement de la valeur de Logto',
   develop: {
     title: 'Développer: Prenez 5 minutes pour intégrer votre application',
+    /** UNTRANSLATED */
+    title_cloud: 'Develop: Securely integrate your app in minutes',
+    /** UNTRANSLATED */
+    subtitle_cloud:
+      'Or take 5 minutes to integrate your app with our pre-built SDKs and tutorials.',
   },
   customize: {
     title: 'Personnaliser: Offrez une excellente expérience de connexion',

--- a/packages/phrases/src/locales/fr/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/protected-app.ts
@@ -19,6 +19,9 @@ const protected_app = {
     domain_field_placeholder: 'Custom subdomain',
     /** UNTRANSLATED */
     domain_field_description:
+      'Specify the app domain that will be protected by authentication and redirected to the Origin URL. Custom domain can be added after creation.',
+    /** UNTRANSLATED */
+    domain_field_description_short:
       'Specify the app domain that will be protected by authentication and redirected to the Origin URL.',
     /** UNTRANSLATED */
     domain_field_tooltip:
@@ -28,10 +31,14 @@ const protected_app = {
     /** UNTRANSLATED */
     url_field_placeholder: 'https://',
     /** UNTRANSLATED */
+    url_field_description: 'Enter the primary website address of your application.',
+    /** UNTRANSLATED */
     url_field_tooltip:
       "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
+    /** UNTRANSLATED */
+    create_protected_app: 'Create and experience auth protection',
     errors: {
       /** UNTRANSLATED */
       domain_required: 'Subdomain is required',
@@ -47,6 +54,9 @@ const protected_app = {
         "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
     },
   },
+  /** UNTRANSLATED */
+  success_message:
+    '🎉  App authentication successfully enabled! Explore the new protection of your website.',
 };
 
 export default Object.freeze(protected_app);

--- a/packages/phrases/src/locales/it/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/general.ts
@@ -55,6 +55,8 @@ const general = {
   demo: 'Demo',
   unnamed: 'Senza nome',
   view: 'Vista',
+  /** UNTRANSLATED */
+  open: 'Open',
   hide: 'Nascondi',
   unknown_error: 'Errore sconosciuto, riprova più tardi.',
   select: 'Seleziona',

--- a/packages/phrases/src/locales/it/translation/admin-console/get-started.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/get-started.ts
@@ -4,6 +4,11 @@ const get_started = {
   subtitle: 'Alcune cose che puoi fare per ottenere rapidamente il valore di Logto',
   develop: {
     title: 'Sviluppa: Dedica 5 minuti per integrare la tua app',
+    /** UNTRANSLATED */
+    title_cloud: 'Develop: Securely integrate your app in minutes',
+    /** UNTRANSLATED */
+    subtitle_cloud:
+      'Or take 5 minutes to integrate your app with our pre-built SDKs and tutorials.',
   },
   customize: {
     title: "Personalizza: Offri un'ottima esperienza di accesso",

--- a/packages/phrases/src/locales/it/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/protected-app.ts
@@ -19,6 +19,9 @@ const protected_app = {
     domain_field_placeholder: 'Custom subdomain',
     /** UNTRANSLATED */
     domain_field_description:
+      'Specify the app domain that will be protected by authentication and redirected to the Origin URL. Custom domain can be added after creation.',
+    /** UNTRANSLATED */
+    domain_field_description_short:
       'Specify the app domain that will be protected by authentication and redirected to the Origin URL.',
     /** UNTRANSLATED */
     domain_field_tooltip:
@@ -28,10 +31,14 @@ const protected_app = {
     /** UNTRANSLATED */
     url_field_placeholder: 'https://',
     /** UNTRANSLATED */
+    url_field_description: 'Enter the primary website address of your application.',
+    /** UNTRANSLATED */
     url_field_tooltip:
       "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
+    /** UNTRANSLATED */
+    create_protected_app: 'Create and experience auth protection',
     errors: {
       /** UNTRANSLATED */
       domain_required: 'Subdomain is required',
@@ -47,6 +54,9 @@ const protected_app = {
         "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
     },
   },
+  /** UNTRANSLATED */
+  success_message:
+    '🎉  App authentication successfully enabled! Explore the new protection of your website.',
 };
 
 export default Object.freeze(protected_app);

--- a/packages/phrases/src/locales/ja/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/general.ts
@@ -54,6 +54,8 @@ const general = {
   demo: 'デモ',
   unnamed: '名前がありません',
   view: '表示',
+  /** UNTRANSLATED */
+  open: 'Open',
   hide: '非表示',
   unknown_error: '不明なエラーが発生しました。後で再試行してください。',
   select: '選択する',

--- a/packages/phrases/src/locales/ja/translation/admin-console/get-started.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/get-started.ts
@@ -4,6 +4,11 @@ const get_started = {
   subtitle: 'Logtoの価値を迅速に把握するための数つの方法',
   develop: {
     title: 'Develop: 5分の時間を使ってアプリを統合してみましょう',
+    /** UNTRANSLATED */
+    title_cloud: 'Develop: Securely integrate your app in minutes',
+    /** UNTRANSLATED */
+    subtitle_cloud:
+      'Or take 5 minutes to integrate your app with our pre-built SDKs and tutorials.',
   },
   customize: {
     title: 'Customize: 素晴らしいサインイン体験を提供する',

--- a/packages/phrases/src/locales/ja/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/protected-app.ts
@@ -19,6 +19,9 @@ const protected_app = {
     domain_field_placeholder: 'Custom subdomain',
     /** UNTRANSLATED */
     domain_field_description:
+      'Specify the app domain that will be protected by authentication and redirected to the Origin URL. Custom domain can be added after creation.',
+    /** UNTRANSLATED */
+    domain_field_description_short:
       'Specify the app domain that will be protected by authentication and redirected to the Origin URL.',
     /** UNTRANSLATED */
     domain_field_tooltip:
@@ -28,10 +31,14 @@ const protected_app = {
     /** UNTRANSLATED */
     url_field_placeholder: 'https://',
     /** UNTRANSLATED */
+    url_field_description: 'Enter the primary website address of your application.',
+    /** UNTRANSLATED */
     url_field_tooltip:
       "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
+    /** UNTRANSLATED */
+    create_protected_app: 'Create and experience auth protection',
     errors: {
       /** UNTRANSLATED */
       domain_required: 'Subdomain is required',
@@ -47,6 +54,9 @@ const protected_app = {
         "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
     },
   },
+  /** UNTRANSLATED */
+  success_message:
+    '🎉  App authentication successfully enabled! Explore the new protection of your website.',
 };
 
 export default Object.freeze(protected_app);

--- a/packages/phrases/src/locales/ko/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/general.ts
@@ -54,6 +54,8 @@ const general = {
   demo: '데모',
   unnamed: '이름없음',
   view: '보기',
+  /** UNTRANSLATED */
+  open: 'Open',
   hide: '숨기기',
   unknown_error: '알 수 없는 오류가 발생했습니다. 나중에 다시 시도해주세요.',
   select: '선택',

--- a/packages/phrases/src/locales/ko/translation/admin-console/get-started.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/get-started.ts
@@ -4,6 +4,11 @@ const get_started = {
   subtitle: 'Logto의 가치를 빠르게 얻을 수 있는 몇 가지 방법',
   develop: {
     title: '개발: 앱을 통합하는 데 5분이면 충분합니다',
+    /** UNTRANSLATED */
+    title_cloud: 'Develop: Securely integrate your app in minutes',
+    /** UNTRANSLATED */
+    subtitle_cloud:
+      'Or take 5 minutes to integrate your app with our pre-built SDKs and tutorials.',
   },
   customize: {
     title: '사용자 정의: 훌륭한 로그인 경험 전달하기',

--- a/packages/phrases/src/locales/ko/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/protected-app.ts
@@ -19,6 +19,9 @@ const protected_app = {
     domain_field_placeholder: 'Custom subdomain',
     /** UNTRANSLATED */
     domain_field_description:
+      'Specify the app domain that will be protected by authentication and redirected to the Origin URL. Custom domain can be added after creation.',
+    /** UNTRANSLATED */
+    domain_field_description_short:
       'Specify the app domain that will be protected by authentication and redirected to the Origin URL.',
     /** UNTRANSLATED */
     domain_field_tooltip:
@@ -28,10 +31,14 @@ const protected_app = {
     /** UNTRANSLATED */
     url_field_placeholder: 'https://',
     /** UNTRANSLATED */
+    url_field_description: 'Enter the primary website address of your application.',
+    /** UNTRANSLATED */
     url_field_tooltip:
       "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
+    /** UNTRANSLATED */
+    create_protected_app: 'Create and experience auth protection',
     errors: {
       /** UNTRANSLATED */
       domain_required: 'Subdomain is required',
@@ -47,6 +54,9 @@ const protected_app = {
         "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
     },
   },
+  /** UNTRANSLATED */
+  success_message:
+    '🎉  App authentication successfully enabled! Explore the new protection of your website.',
 };
 
 export default Object.freeze(protected_app);

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/general.ts
@@ -54,6 +54,8 @@ const general = {
   demo: 'Demo',
   unnamed: 'Bez nazwy',
   view: 'Pokaż',
+  /** UNTRANSLATED */
+  open: 'Open',
   hide: 'Ukryj',
   unknown_error: 'Nieznany błąd, spróbuj ponownie później.',
   select: 'Wybierz',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/get-started.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/get-started.ts
@@ -4,6 +4,11 @@ const get_started = {
   subtitle: 'Kilka rzeczy, które możesz zrobić, aby szybko uzyskać wartość Logto',
   develop: {
     title: 'Develop: Zajmie to 5 minut, aby zintegrować swoją aplikację',
+    /** UNTRANSLATED */
+    title_cloud: 'Develop: Securely integrate your app in minutes',
+    /** UNTRANSLATED */
+    subtitle_cloud:
+      'Or take 5 minutes to integrate your app with our pre-built SDKs and tutorials.',
   },
   customize: {
     title: 'Customize: Dostarcz świetne doświadczenie logowania',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/protected-app.ts
@@ -19,6 +19,9 @@ const protected_app = {
     domain_field_placeholder: 'Custom subdomain',
     /** UNTRANSLATED */
     domain_field_description:
+      'Specify the app domain that will be protected by authentication and redirected to the Origin URL. Custom domain can be added after creation.',
+    /** UNTRANSLATED */
+    domain_field_description_short:
       'Specify the app domain that will be protected by authentication and redirected to the Origin URL.',
     /** UNTRANSLATED */
     domain_field_tooltip:
@@ -28,10 +31,14 @@ const protected_app = {
     /** UNTRANSLATED */
     url_field_placeholder: 'https://',
     /** UNTRANSLATED */
+    url_field_description: 'Enter the primary website address of your application.',
+    /** UNTRANSLATED */
     url_field_tooltip:
       "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
+    /** UNTRANSLATED */
+    create_protected_app: 'Create and experience auth protection',
     errors: {
       /** UNTRANSLATED */
       domain_required: 'Subdomain is required',
@@ -47,6 +54,9 @@ const protected_app = {
         "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
     },
   },
+  /** UNTRANSLATED */
+  success_message:
+    '🎉  App authentication successfully enabled! Explore the new protection of your website.',
 };
 
 export default Object.freeze(protected_app);

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/general.ts
@@ -55,6 +55,8 @@ const general = {
   demo: 'Demo',
   unnamed: 'Sem nome',
   view: 'Ver',
+  /** UNTRANSLATED */
+  open: 'Open',
   hide: 'Ocultar',
   unknown_error: 'Erro desconhecido, por favor tente novamente mais tarde.',
   select: 'Selecionar',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/get-started.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/get-started.ts
@@ -4,6 +4,11 @@ const get_started = {
   subtitle: 'Algumas coisas que você pode fazer para obter rapidamente valor do Logto',
   develop: {
     title: 'Desenvolva: Dedique 5 minutos para integrar o seu aplicativo',
+    /** UNTRANSLATED */
+    title_cloud: 'Develop: Securely integrate your app in minutes',
+    /** UNTRANSLATED */
+    subtitle_cloud:
+      'Or take 5 minutes to integrate your app with our pre-built SDKs and tutorials.',
   },
   customize: {
     title: 'Personalize: Ofereça uma ótima experiência de login',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/protected-app.ts
@@ -19,6 +19,9 @@ const protected_app = {
     domain_field_placeholder: 'Custom subdomain',
     /** UNTRANSLATED */
     domain_field_description:
+      'Specify the app domain that will be protected by authentication and redirected to the Origin URL. Custom domain can be added after creation.',
+    /** UNTRANSLATED */
+    domain_field_description_short:
       'Specify the app domain that will be protected by authentication and redirected to the Origin URL.',
     /** UNTRANSLATED */
     domain_field_tooltip:
@@ -28,10 +31,14 @@ const protected_app = {
     /** UNTRANSLATED */
     url_field_placeholder: 'https://',
     /** UNTRANSLATED */
+    url_field_description: 'Enter the primary website address of your application.',
+    /** UNTRANSLATED */
     url_field_tooltip:
       "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
+    /** UNTRANSLATED */
+    create_protected_app: 'Create and experience auth protection',
     errors: {
       /** UNTRANSLATED */
       domain_required: 'Subdomain is required',
@@ -47,6 +54,9 @@ const protected_app = {
         "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
     },
   },
+  /** UNTRANSLATED */
+  success_message:
+    '🎉  App authentication successfully enabled! Explore the new protection of your website.',
 };
 
 export default Object.freeze(protected_app);

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/general.ts
@@ -54,6 +54,8 @@ const general = {
   demo: 'Demonstração',
   unnamed: 'Sem nome',
   view: 'Ver',
+  /** UNTRANSLATED */
+  open: 'Open',
   hide: 'Esconder',
   unknown_error: 'Erro desconhecido, por favor tente novamente mais tarde.',
   select: 'Selecionar',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/get-started.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/get-started.ts
@@ -4,6 +4,11 @@ const get_started = {
   subtitle: 'Algumas coisas que você pode fazer para obter rapidamente valor do Logto',
   develop: {
     title: 'Develop: Dedique 5 minutos para integrar o seu aplicativo',
+    /** UNTRANSLATED */
+    title_cloud: 'Develop: Securely integrate your app in minutes',
+    /** UNTRANSLATED */
+    subtitle_cloud:
+      'Or take 5 minutes to integrate your app with our pre-built SDKs and tutorials.',
   },
   customize: {
     title: 'Customize: Ofereça uma ótima experiência de login',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/protected-app.ts
@@ -19,6 +19,9 @@ const protected_app = {
     domain_field_placeholder: 'Custom subdomain',
     /** UNTRANSLATED */
     domain_field_description:
+      'Specify the app domain that will be protected by authentication and redirected to the Origin URL. Custom domain can be added after creation.',
+    /** UNTRANSLATED */
+    domain_field_description_short:
       'Specify the app domain that will be protected by authentication and redirected to the Origin URL.',
     /** UNTRANSLATED */
     domain_field_tooltip:
@@ -28,10 +31,14 @@ const protected_app = {
     /** UNTRANSLATED */
     url_field_placeholder: 'https://',
     /** UNTRANSLATED */
+    url_field_description: 'Enter the primary website address of your application.',
+    /** UNTRANSLATED */
     url_field_tooltip:
       "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
+    /** UNTRANSLATED */
+    create_protected_app: 'Create and experience auth protection',
     errors: {
       /** UNTRANSLATED */
       domain_required: 'Subdomain is required',
@@ -47,6 +54,9 @@ const protected_app = {
         "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
     },
   },
+  /** UNTRANSLATED */
+  success_message:
+    '🎉  App authentication successfully enabled! Explore the new protection of your website.',
 };
 
 export default Object.freeze(protected_app);

--- a/packages/phrases/src/locales/ru/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/general.ts
@@ -54,6 +54,8 @@ const general = {
   demo: 'Демо',
   unnamed: 'Без названия',
   view: 'Просмотр',
+  /** UNTRANSLATED */
+  open: 'Open',
   hide: 'Скрыть',
   unknown_error: 'Неизвестная ошибка, пожалуйста, попробуйте позже.',
   select: 'Выбрать',

--- a/packages/phrases/src/locales/ru/translation/admin-console/get-started.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/get-started.ts
@@ -4,6 +4,11 @@ const get_started = {
   subtitle: 'Несколько вещей, которые вы можете сделать, чтобы быстро получить ценность от Logto',
   develop: {
     title: 'Develop: Вам понадобится 5 минут, чтобы интегрировать ваше приложение',
+    /** UNTRANSLATED */
+    title_cloud: 'Develop: Securely integrate your app in minutes',
+    /** UNTRANSLATED */
+    subtitle_cloud:
+      'Or take 5 minutes to integrate your app with our pre-built SDKs and tutorials.',
   },
   customize: {
     title: 'Customize: Создайте отличный вариант входа в систему',

--- a/packages/phrases/src/locales/ru/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/protected-app.ts
@@ -19,6 +19,9 @@ const protected_app = {
     domain_field_placeholder: 'Custom subdomain',
     /** UNTRANSLATED */
     domain_field_description:
+      'Specify the app domain that will be protected by authentication and redirected to the Origin URL. Custom domain can be added after creation.',
+    /** UNTRANSLATED */
+    domain_field_description_short:
       'Specify the app domain that will be protected by authentication and redirected to the Origin URL.',
     /** UNTRANSLATED */
     domain_field_tooltip:
@@ -28,10 +31,14 @@ const protected_app = {
     /** UNTRANSLATED */
     url_field_placeholder: 'https://',
     /** UNTRANSLATED */
+    url_field_description: 'Enter the primary website address of your application.',
+    /** UNTRANSLATED */
     url_field_tooltip:
       "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
+    /** UNTRANSLATED */
+    create_protected_app: 'Create and experience auth protection',
     errors: {
       /** UNTRANSLATED */
       domain_required: 'Subdomain is required',
@@ -47,6 +54,9 @@ const protected_app = {
         "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
     },
   },
+  /** UNTRANSLATED */
+  success_message:
+    '🎉  App authentication successfully enabled! Explore the new protection of your website.',
 };
 
 export default Object.freeze(protected_app);

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/general.ts
@@ -55,6 +55,8 @@ const general = {
   demo: 'Demo',
   unnamed: 'İsimsiz',
   view: 'Görünüm',
+  /** UNTRANSLATED */
+  open: 'Open',
   hide: 'Gizle',
   unknown_error: 'Bilinmeyen hata, lütfen daha sonra tekrar deneyin.',
   select: 'Seç',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/get-started.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/get-started.ts
@@ -4,6 +4,11 @@ const get_started = {
   subtitle: "Logto'nun değerini hızla elde etmek için yapabileceğiniz birkaç şey",
   develop: {
     title: 'Geliştir: Uygulamanızı entegre etmek için 5 dakika ayırın',
+    /** UNTRANSLATED */
+    title_cloud: 'Develop: Securely integrate your app in minutes',
+    /** UNTRANSLATED */
+    subtitle_cloud:
+      'Or take 5 minutes to integrate your app with our pre-built SDKs and tutorials.',
   },
   customize: {
     title: 'Özelleştir: Harika bir oturum açma deneyimi sunun',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/protected-app.ts
@@ -19,6 +19,9 @@ const protected_app = {
     domain_field_placeholder: 'Custom subdomain',
     /** UNTRANSLATED */
     domain_field_description:
+      'Specify the app domain that will be protected by authentication and redirected to the Origin URL. Custom domain can be added after creation.',
+    /** UNTRANSLATED */
+    domain_field_description_short:
       'Specify the app domain that will be protected by authentication and redirected to the Origin URL.',
     /** UNTRANSLATED */
     domain_field_tooltip:
@@ -28,10 +31,14 @@ const protected_app = {
     /** UNTRANSLATED */
     url_field_placeholder: 'https://',
     /** UNTRANSLATED */
+    url_field_description: 'Enter the primary website address of your application.',
+    /** UNTRANSLATED */
     url_field_tooltip:
       "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
+    /** UNTRANSLATED */
+    create_protected_app: 'Create and experience auth protection',
     errors: {
       /** UNTRANSLATED */
       domain_required: 'Subdomain is required',
@@ -47,6 +54,9 @@ const protected_app = {
         "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
     },
   },
+  /** UNTRANSLATED */
+  success_message:
+    '🎉  App authentication successfully enabled! Explore the new protection of your website.',
 };
 
 export default Object.freeze(protected_app);

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/general.ts
@@ -54,6 +54,8 @@ const general = {
   demo: '演示',
   unnamed: '未命名',
   view: '查看',
+  /** UNTRANSLATED */
+  open: 'Open',
   hide: '隐藏',
   unknown_error: '未知错误，请稍后重试。',
   select: '选择',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/get-started.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/get-started.ts
@@ -4,6 +4,11 @@ const get_started = {
   subtitle: '一些你可以做的事情，以快速获取 Logto 的价值',
   develop: {
     title: '开发：花 5 分钟集成你的应用',
+    /** UNTRANSLATED */
+    title_cloud: 'Develop: Securely integrate your app in minutes',
+    /** UNTRANSLATED */
+    subtitle_cloud:
+      'Or take 5 minutes to integrate your app with our pre-built SDKs and tutorials.',
   },
   customize: {
     title: '自定义：提供出色的登录体验',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/protected-app.ts
@@ -19,6 +19,9 @@ const protected_app = {
     domain_field_placeholder: 'Custom subdomain',
     /** UNTRANSLATED */
     domain_field_description:
+      'Specify the app domain that will be protected by authentication and redirected to the Origin URL. Custom domain can be added after creation.',
+    /** UNTRANSLATED */
+    domain_field_description_short:
       'Specify the app domain that will be protected by authentication and redirected to the Origin URL.',
     /** UNTRANSLATED */
     domain_field_tooltip:
@@ -28,10 +31,14 @@ const protected_app = {
     /** UNTRANSLATED */
     url_field_placeholder: 'https://',
     /** UNTRANSLATED */
+    url_field_description: 'Enter the primary website address of your application.',
+    /** UNTRANSLATED */
     url_field_tooltip:
       "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
+    /** UNTRANSLATED */
+    create_protected_app: 'Create and experience auth protection',
     errors: {
       /** UNTRANSLATED */
       domain_required: 'Subdomain is required',
@@ -47,6 +54,9 @@ const protected_app = {
         "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
     },
   },
+  /** UNTRANSLATED */
+  success_message:
+    '🎉  App authentication successfully enabled! Explore the new protection of your website.',
 };
 
 export default Object.freeze(protected_app);

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/general.ts
@@ -54,6 +54,8 @@ const general = {
   demo: '演示',
   unnamed: '未命名',
   view: '查看',
+  /** UNTRANSLATED */
+  open: 'Open',
   hide: '隱藏',
   unknown_error: '未知錯誤，請稍後重試。',
   select: '選擇',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/get-started.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/get-started.ts
@@ -4,6 +4,11 @@ const get_started = {
   subtitle: '一些你可以做的事情，以快速獲取 Logto 的價值',
   develop: {
     title: '開發：花 5 分鐘將你的應用集成進來',
+    /** UNTRANSLATED */
+    title_cloud: 'Develop: Securely integrate your app in minutes',
+    /** UNTRANSLATED */
+    subtitle_cloud:
+      'Or take 5 minutes to integrate your app with our pre-built SDKs and tutorials.',
   },
   customize: {
     title: '定制：提供出色的登錄體驗',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/protected-app.ts
@@ -19,6 +19,9 @@ const protected_app = {
     domain_field_placeholder: 'Custom subdomain',
     /** UNTRANSLATED */
     domain_field_description:
+      'Specify the app domain that will be protected by authentication and redirected to the Origin URL. Custom domain can be added after creation.',
+    /** UNTRANSLATED */
+    domain_field_description_short:
       'Specify the app domain that will be protected by authentication and redirected to the Origin URL.',
     /** UNTRANSLATED */
     domain_field_tooltip:
@@ -28,10 +31,14 @@ const protected_app = {
     /** UNTRANSLATED */
     url_field_placeholder: 'https://',
     /** UNTRANSLATED */
+    url_field_description: 'Enter the primary website address of your application.',
+    /** UNTRANSLATED */
     url_field_tooltip:
       "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
+    /** UNTRANSLATED */
+    create_protected_app: 'Create and experience auth protection',
     errors: {
       /** UNTRANSLATED */
       domain_required: 'Subdomain is required',
@@ -47,6 +54,9 @@ const protected_app = {
         "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
     },
   },
+  /** UNTRANSLATED */
+  success_message:
+    '🎉  App authentication successfully enabled! Explore the new protection of your website.',
 };
 
 export default Object.freeze(protected_app);

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/general.ts
@@ -54,6 +54,8 @@ const general = {
   demo: '演示',
   unnamed: '未命名',
   view: '查看',
+  /** UNTRANSLATED */
+  open: 'Open',
   hide: '隱藏',
   unknown_error: '未知錯誤，請稍後重試。',
   select: '選擇',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/get-started.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/get-started.ts
@@ -4,6 +4,11 @@ const get_started = {
   subtitle: '一些快速獲取 Logto 價值的事情',
   develop: {
     title: '開發：花 5 分鐘集成您的應用程式',
+    /** UNTRANSLATED */
+    title_cloud: 'Develop: Securely integrate your app in minutes',
+    /** UNTRANSLATED */
+    subtitle_cloud:
+      'Or take 5 minutes to integrate your app with our pre-built SDKs and tutorials.',
   },
   customize: {
     title: '自訂：提供出色的登錄體驗',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/protected-app.ts
@@ -19,6 +19,9 @@ const protected_app = {
     domain_field_placeholder: 'Custom subdomain',
     /** UNTRANSLATED */
     domain_field_description:
+      'Specify the app domain that will be protected by authentication and redirected to the Origin URL. Custom domain can be added after creation.',
+    /** UNTRANSLATED */
+    domain_field_description_short:
       'Specify the app domain that will be protected by authentication and redirected to the Origin URL.',
     /** UNTRANSLATED */
     domain_field_tooltip:
@@ -28,10 +31,14 @@ const protected_app = {
     /** UNTRANSLATED */
     url_field_placeholder: 'https://',
     /** UNTRANSLATED */
+    url_field_description: 'Enter the primary website address of your application.',
+    /** UNTRANSLATED */
     url_field_tooltip:
       "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
+    /** UNTRANSLATED */
+    create_protected_app: 'Create and experience auth protection',
     errors: {
       /** UNTRANSLATED */
       domain_required: 'Subdomain is required',
@@ -47,6 +54,9 @@ const protected_app = {
         "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
     },
   },
+  /** UNTRANSLATED */
+  success_message:
+    '🎉  App authentication successfully enabled! Explore the new protection of your website.',
 };
 
 export default Object.freeze(protected_app);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- Add protected app creation form in get-started page.
- Refactor protected app form component in order to be re-used in both get-statted page and app creation modal.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="1511" alt="image" src="https://github.com/logto-io/logto/assets/12833674/0db1b596-6bbf-4c15-95d0-41bef9f0a64f">
<img width="1511" alt="image" src="https://github.com/logto-io/logto/assets/12833674/993a8c31-ecaf-498e-962f-3019972f73c2">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
