### PR TITLE
feat(console,phrases): add application permissions edit modal

### DIFF
--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Permissions/ApplicationScopesManagementModal/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Permissions/ApplicationScopesManagementModal/index.tsx
@@ -1,0 +1,135 @@
+import { ApplicationUserConsentScopeType } from '@logto/schemas';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import ReactModal from 'react-modal';
+
+import Button from '@/ds-components/Button';
+import DangerousRaw from '@/ds-components/DangerousRaw';
+import FormField from '@/ds-components/FormField';
+import ModalLayout from '@/ds-components/ModalLayout';
+import TextInput from '@/ds-components/TextInput';
+import useActionTranslation from '@/hooks/use-action-translation';
+import useApi from '@/hooks/use-api';
+import * as modalStyles from '@/scss/modal.module.scss';
+import { trySubmitSafe } from '@/utils/form';
+
+import { type ScopesTableRowDataType, type UserScopeTableRowDataType } from '../use-scopes-table';
+
+/**
+ * ApplicationScopesManagementModal
+ *
+ * This modal is used to edit the resource and organization scopes' descriptions.
+ */
+export type EditableScopeData = Exclude<ScopesTableRowDataType, UserScopeTableRowDataType>;
+
+type Props = {
+  scope?: EditableScopeData;
+  onClose: () => void;
+  onSubmit: (scope: EditableScopeData) => void;
+};
+
+function ApplicationScopesManagementModal({ scope, onClose, onSubmit }: Props) {
+  const api = useApi();
+
+  const {
+    reset,
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<EditableScopeData>();
+
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const tAction = useActionTranslation();
+
+  const onSubmitHandler = handleSubmit(trySubmitSafe(onSubmit));
+
+  // Reset form on open
+  useEffect(() => {
+    if (scope) {
+      reset(scope);
+    }
+  }, [reset, scope]);
+
+  return (
+    <ReactModal
+      isOpen={Boolean(scope)}
+      className={modalStyles.content}
+      overlayClassName={modalStyles.overlay}
+      onRequestClose={onClose}
+    >
+      {scope && (
+        <ModalLayout
+          title={
+            scope.type === ApplicationUserConsentScopeType.ResourceScopes ? (
+              'api_resource_details.permission.edit_title'
+            ) : (
+              <DangerousRaw>
+                {tAction('edit', 'organizations.organization_permission')}
+              </DangerousRaw>
+            )
+          }
+          subtitle={
+            scope.type === ApplicationUserConsentScopeType.ResourceScopes ? (
+              <DangerousRaw>
+                {t('api_resource_details.permission.edit_subtitle', {
+                  resourceName: scope.resourceName,
+                })}
+              </DangerousRaw>
+            ) : undefined
+          }
+          learnMoreLink={
+            scope.type === ApplicationUserConsentScopeType.ResourceScopes
+              ? {
+                  href: 'https://docs.logto.io/docs/recipes/rbac/manage-permissions-and-roles#manage-role-permissions',
+                  targetBlank: 'noopener',
+                }
+              : undefined
+          }
+          footer={
+            <Button
+              isLoading={isSubmitting}
+              htmlType="submit"
+              type="primary"
+              size="large"
+              title="general.save"
+              onClick={onSubmitHandler}
+            />
+          }
+          onClose={onClose}
+        >
+          <form>
+            <FormField isRequired title="general.name">
+              <TextInput
+                disabled
+                error={Boolean(errors.name)}
+                {...register('name', { required: true })}
+              />
+            </FormField>
+            <FormField
+              title="general.description"
+              isRequired={scope.type === ApplicationUserConsentScopeType.ResourceScopes}
+              tip={t('application_details.permissions.permission_description_tips')}
+            >
+              <TextInput
+                // eslint-disable-next-line jsx-a11y/no-autofocus
+                autoFocus
+                placeholder={
+                  scope.type === ApplicationUserConsentScopeType.ResourceScopes
+                    ? t('api_resource_details.permission.description_placeholder')
+                    : t('organizations.create_permission_placeholder')
+                }
+                error={Boolean(errors.description)}
+                {...register('description', {
+                  required: scope.type === ApplicationUserConsentScopeType.ResourceScopes,
+                })}
+              />
+            </FormField>
+          </form>
+        </ModalLayout>
+      )}
+    </ReactModal>
+  );
+}
+
+export default ApplicationScopesManagementModal;

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Permissions/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Permissions/index.tsx
@@ -29,7 +29,7 @@ function Permissions({ application }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
   const [isAssignScopesModalOpen, setIsAssignScopesModalOpen] = useState(false);
-  const [editScopeModalData, setEditScopeModalData] = useState<EditableScopeData | undefined>();
+  const [editScopeModalData, setEditScopeModalData] = useState<EditableScopeData>();
 
   const { parseRowGroup, deleteScope, editScope } = useScopesTable();
 

--- a/packages/phrases/src/locales/de/translation/admin-console/api-resource-details.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/api-resource-details.ts
@@ -21,6 +21,10 @@ const api_resource_details = {
     create_title: 'Berechtigung erstellen',
     create_subtitle: 'Definieren Sie die benötigten Berechtigungen (Bereiche) für diese API.',
     confirm_create: 'Berechtigung erstellen',
+    /** UNTRANSLATED */
+    edit_title: 'Edit API permission',
+    /** UNTRANSLATED */
+    edit_subtitle: 'Define the permissions (scopes) needed by the {{resourceName}} API.',
     name: 'Berechtigungsname',
     name_placeholder: 'read:resource',
     forbidden_space_in_name: 'Der Berechtigungsname darf keine Leerzeichen enthalten.',

--- a/packages/phrases/src/locales/de/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/application-details.ts
@@ -166,6 +166,9 @@ const application_details = {
     organization_permissions_assignment_form_title: 'Add the organization permissions',
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
+    /** UNTRANSLATED */
+    permission_description_tips:
+      'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },
   roles: {
     name_column: 'Rolle',

--- a/packages/phrases/src/locales/en/translation/admin-console/api-resource-details.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/api-resource-details.ts
@@ -21,6 +21,8 @@ const api_resource_details = {
     create_title: 'Create permission',
     create_subtitle: 'Define the permissions (scopes) needed by this API.',
     confirm_create: 'Create permission',
+    edit_title: 'Edit API permission',
+    edit_subtitle: 'Define the permissions (scopes) needed by the {{resourceName}} API.',
     name: 'Permission name',
     name_placeholder: 'read:resource',
     forbidden_space_in_name: 'The permission name must not contain any spaces.',

--- a/packages/phrases/src/locales/en/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/application-details.ts
@@ -117,6 +117,8 @@ const application_details = {
     user_permissions_assignment_form_title: 'Add the user profile permissions',
     organization_permissions_assignment_form_title: 'Add the organization permissions',
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
+    permission_description_tips:
+      'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },
   roles: {
     name_column: 'Role',

--- a/packages/phrases/src/locales/es/translation/admin-console/api-resource-details.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/api-resource-details.ts
@@ -21,6 +21,10 @@ const api_resource_details = {
     create_title: 'Crear permiso',
     create_subtitle: 'Define los permisos (scopes) necesarios para esta API.',
     confirm_create: 'Crear permiso',
+    /** UNTRANSLATED */
+    edit_title: 'Edit API permission',
+    /** UNTRANSLATED */
+    edit_subtitle: 'Define the permissions (scopes) needed by the {{resourceName}} API.',
     name: 'Nombre del permiso',
     name_placeholder: 'leer:recurso',
     forbidden_space_in_name: 'El nombre del permiso no debe contener espacios.',

--- a/packages/phrases/src/locales/es/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/application-details.ts
@@ -166,6 +166,9 @@ const application_details = {
     organization_permissions_assignment_form_title: 'Add the organization permissions',
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
+    /** UNTRANSLATED */
+    permission_description_tips:
+      'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },
   roles: {
     name_column: 'Rol',

--- a/packages/phrases/src/locales/fr/translation/admin-console/api-resource-details.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/api-resource-details.ts
@@ -21,6 +21,10 @@ const api_resource_details = {
     create_title: 'Créer une autorisation',
     create_subtitle: 'Définir les autorisations (scopes) requises pour cette API.',
     confirm_create: 'Créer une autorisation',
+    /** UNTRANSLATED */
+    edit_title: 'Edit API permission',
+    /** UNTRANSLATED */
+    edit_subtitle: 'Define the permissions (scopes) needed by the {{resourceName}} API.',
     name: "Nom de l'autorisation",
     name_placeholder: 'lecture:ressource',
     forbidden_space_in_name: "Le nom de l'autorisation ne doit pas contenir d'espaces.",

--- a/packages/phrases/src/locales/fr/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/application-details.ts
@@ -166,6 +166,9 @@ const application_details = {
     organization_permissions_assignment_form_title: 'Add the organization permissions',
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
+    /** UNTRANSLATED */
+    permission_description_tips:
+      'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },
   roles: {
     name_column: 'Rôle',

--- a/packages/phrases/src/locales/it/translation/admin-console/api-resource-details.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/api-resource-details.ts
@@ -21,6 +21,10 @@ const api_resource_details = {
     create_title: 'crea autorizzazione',
     create_subtitle: 'Definire le autorizzazioni (ambiti) necessarie per questa API.',
     confirm_create: 'Crea autorizzazione',
+    /** UNTRANSLATED */
+    edit_title: 'Edit API permission',
+    /** UNTRANSLATED */
+    edit_subtitle: 'Define the permissions (scopes) needed by the {{resourceName}} API.',
     name: 'Nome autorizzazione',
     name_placeholder: 'lettura:risorsa',
     forbidden_space_in_name: "Il nome dell'autorizzazione non deve contenere spazi.",

--- a/packages/phrases/src/locales/it/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/application-details.ts
@@ -166,6 +166,9 @@ const application_details = {
     organization_permissions_assignment_form_title: 'Add the organization permissions',
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
+    /** UNTRANSLATED */
+    permission_description_tips:
+      'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },
   roles: {
     name_column: 'Ruolo',

--- a/packages/phrases/src/locales/ja/translation/admin-console/api-resource-details.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/api-resource-details.ts
@@ -21,6 +21,10 @@ const api_resource_details = {
     create_title: '権限の作成',
     create_subtitle: 'このAPIで必要な権限（スコープ）を定義します。',
     confirm_create: '権限を作成',
+    /** UNTRANSLATED */
+    edit_title: 'Edit API permission',
+    /** UNTRANSLATED */
+    edit_subtitle: 'Define the permissions (scopes) needed by the {{resourceName}} API.',
     name: '権限名',
     name_placeholder: 'read:resource',
     forbidden_space_in_name: '権限名にはスペースを含めることはできません。',

--- a/packages/phrases/src/locales/ja/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/application-details.ts
@@ -166,6 +166,9 @@ const application_details = {
     organization_permissions_assignment_form_title: 'Add the organization permissions',
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
+    /** UNTRANSLATED */
+    permission_description_tips:
+      'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },
   roles: {
     name_column: '役割',

--- a/packages/phrases/src/locales/ko/translation/admin-console/api-resource-details.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/api-resource-details.ts
@@ -21,6 +21,10 @@ const api_resource_details = {
     create_title: '권한 생성',
     create_subtitle: '이 API에 필요한 권한을 정의합니다.',
     confirm_create: '권한 생성',
+    /** UNTRANSLATED */
+    edit_title: 'Edit API permission',
+    /** UNTRANSLATED */
+    edit_subtitle: 'Define the permissions (scopes) needed by the {{resourceName}} API.',
     name: '권한 이름',
     name_placeholder: 'read:resource',
     forbidden_space_in_name: '권한 이름에는 공백을 포함할 수 없습니다.',

--- a/packages/phrases/src/locales/ko/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/application-details.ts
@@ -166,6 +166,9 @@ const application_details = {
     organization_permissions_assignment_form_title: 'Add the organization permissions',
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
+    /** UNTRANSLATED */
+    permission_description_tips:
+      'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },
   roles: {
     name_column: '역할',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/api-resource-details.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/api-resource-details.ts
@@ -21,6 +21,10 @@ const api_resource_details = {
     create_title: 'Utwórz uprawnienie',
     create_subtitle: 'Zdefiniuj uprawnienia (zakresy) wymagane przez to API.',
     confirm_create: 'Utwórz uprawnienie',
+    /** UNTRANSLATED */
+    edit_title: 'Edit API permission',
+    /** UNTRANSLATED */
+    edit_subtitle: 'Define the permissions (scopes) needed by the {{resourceName}} API.',
     name: 'Nazwa uprawnienia',
     name_placeholder: 'ready:resource',
     forbidden_space_in_name: 'Nazwa uprawnienia nie może zawierać spacji.',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/application-details.ts
@@ -166,6 +166,9 @@ const application_details = {
     organization_permissions_assignment_form_title: 'Add the organization permissions',
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
+    /** UNTRANSLATED */
+    permission_description_tips:
+      'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },
   roles: {
     name_column: 'Role',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/api-resource-details.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/api-resource-details.ts
@@ -21,6 +21,10 @@ const api_resource_details = {
     create_title: 'Criar permissão',
     create_subtitle: 'Define as permissões (escopos) necessárias para esta API.',
     confirm_create: 'Criar permissão',
+    /** UNTRANSLATED */
+    edit_title: 'Edit API permission',
+    /** UNTRANSLATED */
+    edit_subtitle: 'Define the permissions (scopes) needed by the {{resourceName}} API.',
     name: 'Nome da permissão',
     name_placeholder: 'ler:recurso',
     forbidden_space_in_name: 'O nome da permissão não deve conter espaços.',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/application-details.ts
@@ -166,6 +166,9 @@ const application_details = {
     organization_permissions_assignment_form_title: 'Add the organization permissions',
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
+    /** UNTRANSLATED */
+    permission_description_tips:
+      'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },
   roles: {
     name_column: 'Função',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/api-resource-details.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/api-resource-details.ts
@@ -21,6 +21,10 @@ const api_resource_details = {
     create_title: 'Criar permissão',
     create_subtitle: 'Define as permissões (escopos) necessários para essa API.',
     confirm_create: 'Criar permissão',
+    /** UNTRANSLATED */
+    edit_title: 'Edit API permission',
+    /** UNTRANSLATED */
+    edit_subtitle: 'Define the permissions (scopes) needed by the {{resourceName}} API.',
     name: 'Nome da permissão',
     name_placeholder: 'leitura:recurso',
     forbidden_space_in_name: 'O nome da permissão não pode conter espaços.',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/application-details.ts
@@ -166,6 +166,9 @@ const application_details = {
     organization_permissions_assignment_form_title: 'Add the organization permissions',
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
+    /** UNTRANSLATED */
+    permission_description_tips:
+      'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },
   roles: {
     name_column: 'Nome da função',

--- a/packages/phrases/src/locales/ru/translation/admin-console/api-resource-details.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/api-resource-details.ts
@@ -21,6 +21,10 @@ const api_resource_details = {
     create_title: 'Создать разрешение',
     create_subtitle: 'Определите необходимые разрешения (области) для этого API.',
     confirm_create: 'Создать разрешение',
+    /** UNTRANSLATED */
+    edit_title: 'Edit API permission',
+    /** UNTRANSLATED */
+    edit_subtitle: 'Define the permissions (scopes) needed by the {{resourceName}} API.',
     name: 'Название разрешения',
     name_placeholder: 'read:resource',
     forbidden_space_in_name: 'Название разрешения не должно содержать пробелов.',

--- a/packages/phrases/src/locales/ru/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/application-details.ts
@@ -166,6 +166,9 @@ const application_details = {
     organization_permissions_assignment_form_title: 'Add the organization permissions',
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
+    /** UNTRANSLATED */
+    permission_description_tips:
+      'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },
   roles: {
     name_column: 'Роль',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/api-resource-details.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/api-resource-details.ts
@@ -21,6 +21,10 @@ const api_resource_details = {
     create_title: 'İzin Oluştur',
     create_subtitle: 'Bu API tarafından gerektirilen izinleri (kapsamları) tanımlayın.',
     confirm_create: 'İzin Oluştur',
+    /** UNTRANSLATED */
+    edit_title: 'Edit API permission',
+    /** UNTRANSLATED */
+    edit_subtitle: 'Define the permissions (scopes) needed by the {{resourceName}} API.',
     name: 'İzin adı',
     name_placeholder: 'read:kaynak',
     forbidden_space_in_name: 'İzin adı boşluk içermemelidir.',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/application-details.ts
@@ -166,6 +166,9 @@ const application_details = {
     organization_permissions_assignment_form_title: 'Add the organization permissions',
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
+    /** UNTRANSLATED */
+    permission_description_tips:
+      'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },
   roles: {
     name_column: 'Rol',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/api-resource-details.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/api-resource-details.ts
@@ -21,6 +21,10 @@ const api_resource_details = {
     create_title: '创建权限',
     create_subtitle: '定义此 API 所需的权限 (scope)。',
     confirm_create: '创建权限',
+    /** UNTRANSLATED */
+    edit_title: 'Edit API permission',
+    /** UNTRANSLATED */
+    edit_subtitle: 'Define the permissions (scopes) needed by the {{resourceName}} API.',
     name: '权限名称',
     name_placeholder: 'read:resource',
     forbidden_space_in_name: '权限名称不能包含空格。',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/application-details.ts
@@ -163,6 +163,9 @@ const application_details = {
     organization_permissions_assignment_form_title: 'Add the organization permissions',
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
+    /** UNTRANSLATED */
+    permission_description_tips:
+      'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },
   roles: {
     name_column: '角色',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/api-resource-details.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/api-resource-details.ts
@@ -21,6 +21,10 @@ const api_resource_details = {
     create_title: '創建權限',
     create_subtitle: '定義此 API 所需的權限 (scope)。',
     confirm_create: '創建權限',
+    /** UNTRANSLATED */
+    edit_title: 'Edit API permission',
+    /** UNTRANSLATED */
+    edit_subtitle: 'Define the permissions (scopes) needed by the {{resourceName}} API.',
     name: '權限名稱',
     name_placeholder: 'read:resource',
     forbidden_space_in_name: '權限名稱不能包含空格。',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/application-details.ts
@@ -163,6 +163,9 @@ const application_details = {
     organization_permissions_assignment_form_title: 'Add the organization permissions',
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
+    /** UNTRANSLATED */
+    permission_description_tips:
+      'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },
   roles: {
     name_column: '角色',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/api-resource-details.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/api-resource-details.ts
@@ -21,6 +21,10 @@ const api_resource_details = {
     create_title: '建立權限',
     create_subtitle: '定義此 API 所需的權限 (scope)。',
     confirm_create: '建立權限',
+    /** UNTRANSLATED */
+    edit_title: 'Edit API permission',
+    /** UNTRANSLATED */
+    edit_subtitle: 'Define the permissions (scopes) needed by the {{resourceName}} API.',
     name: '權限名稱',
     name_placeholder: 'read:resource',
     forbidden_space_in_name: '權限名稱不能包含空格。',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/application-details.ts
@@ -164,6 +164,9 @@ const application_details = {
     organization_permissions_assignment_form_title: 'Add the organization permissions',
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
+    /** UNTRANSLATED */
+    permission_description_tips:
+      'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },
   roles: {
     name_column: '角色',


### PR DESCRIPTION


<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add the application permissions edit modal.

Resource scopes and organization scope descriptions can be directly editable through the third-party permissions management page. 

<img width="703" alt="image" src="https://github.com/logto-io/logto/assets/36393111/0825b62d-ddba-48f5-a496-b2305b2b49c8">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [x] necessary TSDoc comments
