### PR TITLE
feat(core): api to get protected app default domain

### DIFF
--- a/packages/core/src/__mocks__/index.ts
+++ b/packages/core/src/__mocks__/index.ts
@@ -21,6 +21,7 @@ export * from './cloud-connection.js';
 export * from './user.js';
 export * from './domain.js';
 export * from './sso.js';
+export * from './protected-app.js';
 
 export const mockApplication: Application = {
   tenantId: 'fake_tenant',

--- a/packages/core/src/__mocks__/protected-app.ts
+++ b/packages/core/src/__mocks__/protected-app.ts
@@ -1,0 +1,7 @@
+export const mockProtectedAppConfigProviderConfig = {
+  accountIdentifier: 'fake_account_id',
+  namespaceIdentifier: 'fake_namespace_id',
+  keyName: 'fake_key_name',
+  apiToken: '',
+  domain: 'protected.app',
+};

--- a/packages/core/src/libraries/protected-app.ts
+++ b/packages/core/src/libraries/protected-app.ts
@@ -34,6 +34,14 @@ const deleteRemoteAppConfigs = async (host: string): Promise<void> => {
   await deleteProtectedAppSiteConfigs(protectedAppConfigProviderConfig, host);
 };
 
+/**
+ * Get default domain from provider config, this is used for front-end display
+ */
+const getDefaultDomain = async () => {
+  const { domain } = await getProviderConfig();
+  return domain;
+};
+
 export const createProtectedAppLibrary = (queries: Queries) => {
   const {
     applications: { findApplicationById, findApplicationByProtectedAppHost },
@@ -120,5 +128,6 @@ export const createProtectedAppLibrary = (queries: Queries) => {
     syncAppConfigsToRemote,
     deleteRemoteAppConfigs,
     checkAndBuildProtectedAppData,
+    getDefaultDomain,
   };
 };

--- a/packages/core/src/routes/applications/application.test.ts
+++ b/packages/core/src/routes/applications/application.test.ts
@@ -2,7 +2,11 @@ import type { Application, CreateApplication } from '@logto/schemas';
 import { ApplicationType } from '@logto/schemas';
 import { pickDefault } from '@logto/shared/esm';
 
-import { mockApplication, mockProtectedApplication } from '#src/__mocks__/index.js';
+import {
+  mockApplication,
+  mockProtectedAppConfigProviderConfig,
+  mockProtectedApplication,
+} from '#src/__mocks__/index.js';
 import { mockId, mockIdGenerators } from '#src/test-utils/nanoid.js';
 import { createMockQuotaLibrary } from '#src/test-utils/quota.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
@@ -55,6 +59,7 @@ const tenantContext = new MockTenant(
       syncAppConfigsToRemote,
       deleteRemoteAppConfigs,
       checkAndBuildProtectedAppData,
+      getDefaultDomain: jest.fn(async () => mockProtectedAppConfigProviderConfig.domain),
     },
   }
 );

--- a/packages/core/src/routes/init.ts
+++ b/packages/core/src/routes/init.ts
@@ -33,6 +33,7 @@ import signInExperiencesRoutes from './sign-in-experience/index.js';
 import ssoConnectors from './sso-connector/index.js';
 import statusRoutes from './status.js';
 import swaggerRoutes from './swagger/index.js';
+import systemRoutes from './system.js';
 import type { AnonymousRouter, AuthedRouter } from './types.js';
 import userAssetsRoutes from './user-assets.js';
 import verificationCodeRoutes from './verification-code.js';
@@ -71,6 +72,7 @@ const createRouters = (tenant: TenantContext) => {
   domainRoutes(managementRouter, tenant);
   organizationRoutes(managementRouter, tenant);
   ssoConnectors(managementRouter, tenant);
+  systemRoutes(managementRouter, tenant);
 
   const anonymousRouter: AnonymousRouter = new Router();
   wellKnownRoutes(anonymousRouter, tenant);

--- a/packages/core/src/routes/system.openapi.json
+++ b/packages/core/src/routes/system.openapi.json
@@ -1,0 +1,21 @@
+{
+  "tags": [
+    {
+      "name": "Systems",
+      "description": "Endpoints for system constants and information."
+    }
+  ],
+  "paths": {
+    "/api/systems/application": {
+      "get": {
+        "summary": "Get the application constants.",
+        "description": "Get the application constants.",
+        "responses": {
+          "200": {
+            "description": "The application constants."
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/core/src/routes/system.test.ts
+++ b/packages/core/src/routes/system.test.ts
@@ -1,0 +1,32 @@
+import { pickDefault } from '@logto/shared/esm';
+
+import { mockProtectedAppConfigProviderConfig } from '#src/__mocks__/index.js';
+import { mockIdGenerators } from '#src/test-utils/nanoid.js';
+import { createMockQuotaLibrary } from '#src/test-utils/quota.js';
+import { MockTenant } from '#src/test-utils/tenant.js';
+
+const { jest } = import.meta;
+
+await mockIdGenerators();
+
+const tenantContext = new MockTenant(undefined, undefined, undefined, {
+  quota: createMockQuotaLibrary(),
+  protectedApps: {
+    getDefaultDomain: jest.fn(async () => mockProtectedAppConfigProviderConfig.domain),
+  },
+});
+
+const { createRequester } = await import('#src/utils/test-utils.js');
+const systemRoutes = await pickDefault(import('./system.js'));
+
+describe('system route', () => {
+  const systemRequest = createRequester({ authedRoutes: systemRoutes, tenantContext });
+
+  it('GET /systems/application', async () => {
+    const response = await systemRequest.get('/systems/application');
+    expect(response.status).toEqual(200);
+    expect(response.body).toStrictEqual({
+      protectedApps: { defaultDomain: mockProtectedAppConfigProviderConfig.domain },
+    });
+  });
+});

--- a/packages/core/src/routes/system.ts
+++ b/packages/core/src/routes/system.ts
@@ -1,0 +1,32 @@
+import { object, string } from 'zod';
+
+import { EnvSet } from '#src/env-set/index.js';
+import koaGuard from '#src/middleware/koa-guard.js';
+
+import type { AuthedRouter, RouterInitArgs } from './types.js';
+
+export default function systemRoutes<T extends AuthedRouter>(
+  ...[
+    router,
+    {
+      libraries: { protectedApps },
+    },
+  ]: RouterInitArgs<T>
+) {
+  if (EnvSet.values.isDevFeaturesEnabled) {
+    router.get(
+      '/systems/application',
+      koaGuard({
+        response: object({ protectedApps: object({ defaultDomain: string() }) }),
+        status: [200],
+      }),
+      async (ctx, next) => {
+        const defaultDomain = await protectedApps.getDefaultDomain();
+
+        ctx.body = { protectedApps: { defaultDomain } };
+
+        return next();
+      }
+    );
+  }
+}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Add api `GET /systems/application` to get protected app default domain (e.g. protected.app)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Unit tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
