### PR TITLE
fix(core): fix quota guard for schema routers

### DIFF
--- a/packages/core/src/routes/organization/index.ts
+++ b/packages/core/src/routes/organization/index.ts
@@ -34,6 +34,7 @@ export default function organizationRoutes<T extends AuthedRouter>(...args: Rout
   ] = args;
 
   const router = new SchemaRouter(Organizations, organizations, {
+    middlewares: [koaQuotaGuard({ key: 'organizationsEnabled', quota, methods: ['POST', 'PUT'] })],
     errorHandler,
     searchFields: ['name'],
     disabled: { get: true },
@@ -242,8 +243,6 @@ export default function organizationRoutes<T extends AuthedRouter>(...args: Rout
   if (EnvSet.values.isDevFeaturesEnabled) {
     organizationInvitationRoutes(...args);
   }
-
-  router.use(koaQuotaGuard({ key: 'organizationsEnabled', quota, methods: ['POST', 'PUT'] }));
 
   // Add routes to the router
   originalRouter.use(router.routes());

--- a/packages/core/src/routes/organization/roles.ts
+++ b/packages/core/src/routes/organization/roles.ts
@@ -30,6 +30,7 @@ export default function organizationRoleRoutes<T extends AuthedRouter>(
   ]: RouterInitArgs<T>
 ) {
   const router = new SchemaRouter(OrganizationRoles, roles, {
+    middlewares: [koaQuotaGuard({ key: 'organizationsEnabled', quota, methods: ['POST', 'PUT'] })],
     disabled: { get: true, post: true },
     errorHandler,
     searchFields: ['name'],
@@ -88,8 +89,6 @@ export default function organizationRoleRoutes<T extends AuthedRouter>(
   );
 
   router.addRelationRoutes(rolesScopes, 'scopes');
-
-  router.use(koaQuotaGuard({ key: 'organizationsEnabled', quota, methods: ['POST', 'PUT'] }));
 
   originalRouter.use(router.routes());
 }

--- a/packages/core/src/routes/organization/scopes.ts
+++ b/packages/core/src/routes/organization/scopes.ts
@@ -19,11 +19,10 @@ export default function organizationScopeRoutes<T extends AuthedRouter>(
   ]: RouterInitArgs<T>
 ) {
   const router = new SchemaRouter(OrganizationScopes, scopes, {
+    middlewares: [koaQuotaGuard({ key: 'organizationsEnabled', quota, methods: ['POST', 'PUT'] })],
     errorHandler,
     searchFields: ['name'],
   });
-
-  router.use(koaQuotaGuard({ key: 'organizationsEnabled', quota, methods: ['POST', 'PUT'] }));
 
   originalRouter.use(router.routes());
 }

--- a/packages/core/src/utils/SchemaRouter.ts
+++ b/packages/core/src/utils/SchemaRouter.ts
@@ -3,6 +3,7 @@ import { generateStandardId } from '@logto/shared';
 import { type DeepPartial } from '@silverhand/essentials';
 import camelcase from 'camelcase';
 import deepmerge from 'deepmerge';
+import { type MiddlewareType } from 'koa';
 import Router, { type IRouterParamContext } from 'koa-router';
 import { z } from 'zod';
 
@@ -50,6 +51,7 @@ type SchemaRouterConfig<Key extends string> = {
     /** Disable `DELETE /:id` route. */
     deleteById: boolean;
   };
+  middlewares?: MiddlewareType[];
   /** A custom error handler for the router before throwing the error. */
   errorHandler?: (error: unknown) => void;
   /** The fields that can be searched for the `GET /` route. */
@@ -112,6 +114,10 @@ export default class SchemaRouter<
       },
       config
     );
+
+    if (this.config.middlewares?.length) {
+      this.use(...this.config.middlewares);
+    }
 
     if (this.config.errorHandler) {
       this.use(async (_, next) => {

--- a/packages/core/src/utils/SchemaRouter.ts
+++ b/packages/core/src/utils/SchemaRouter.ts
@@ -51,6 +51,7 @@ type SchemaRouterConfig<Key extends string> = {
     /** Disable `DELETE /:id` route. */
     deleteById: boolean;
   };
+  /** Middlewares that are used before creating API routes */
   middlewares?: MiddlewareType[];
   /** A custom error handler for the router before throwing the error. */
   errorHandler?: (error: unknown) => void;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add pre-middlewares to SchemRouter configs, in order to apply quota guard before generating actual routes. This fix can guarantee the quota guard is executed before going into API routes.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally, quota guard protected API returns 403 and the post data was not persisted in DB

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
