### PR TITLE
feat(core): add third-party application scopes and organizations restriction

### DIFF
--- a/packages/core/src/oidc/adapter.ts
+++ b/packages/core/src/oidc/adapter.ts
@@ -157,6 +157,7 @@ export default function postgresAdapter(
           new errors.InvalidClient(`invalid client ${id}`)
         );
 
+        // FIXME: @simeng-li Remove this check after the third-party client scope feature is released
         if (EnvSet.values.isDevFeaturesEnabled && application.isThirdParty) {
           const clientScopes = await getThirdPartyClientScopes(applications, id);
           return transpileClient(application, clientScopes);

--- a/packages/core/src/oidc/adapter.ts
+++ b/packages/core/src/oidc/adapter.ts
@@ -1,12 +1,6 @@
 import type { CreateApplication } from '@logto/schemas';
-import {
-  ApplicationType,
-  OrganizationScopes,
-  Scopes,
-  adminConsoleApplicationId,
-  demoAppApplicationId,
-} from '@logto/schemas';
-import { deduplicate, appendPath, tryThat, conditional } from '@silverhand/essentials';
+import { ApplicationType, adminConsoleApplicationId, demoAppApplicationId } from '@logto/schemas';
+import { appendPath, tryThat, conditional } from '@silverhand/essentials';
 import { addSeconds } from 'date-fns';
 import type { AdapterFactory, AllClientMetadata } from 'oidc-provider';
 import { errors } from 'oidc-provider';
@@ -59,46 +53,34 @@ const buildDemoAppClientMetadata = (envSet: EnvSet): AllClientMetadata => {
 };
 
 /**
- * Restrict third-party client scopes to the app-level enabled user consent scopes
+ * Restrict third-party client OP scopes to the app-level enabled user claims scopes
  *
- * - userScopes: app-level enabled user claim scopes
- * - resourceScopes: app-level enabled resource scopes
- * - organizationScopes app-level enabled organization scopes
+ * client OP scopes include:
+ * - OIDC scopes: openid, offline_access
+ * - custom scopes: @see {@link https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#scopes}
+ * - scopes defined in user claims: @see {@link https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#claims}
  *
  * @remark
- * We use the client scope metadata to restrict the third-party client scopes, @see {@link https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#clients}
+ * We use the client metadata scope metadata to restrict the third-party client scopes,
+ *
+ * - @see {@link https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#clients}
+ * - client metadata scope must be a valid OP scope, otherwise a invalid metadata error will be thrown. @see{@link https://github.com/panva/node-oidc-provider/blob/main/lib/helpers/client_schema.js#L626}
+ * - resource scopes (including Logto organization scopes) are not include in the OP scope, it won't be validate by the client metadata scope as well. @see {@link https://github.com/panva/node-oidc-provider/blob/main/lib/actions/authorization/check_scope.js#L47}
+ * - resource scopes (including Logto organization scopes) will be filtered in the resource server's scopes fetching method. @see {@link https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#getresourceserverinfo}
+ *
  * Auth request will be rejected if the requested scopes are not included in the client scope metadata.
  */
 const getThirdPartyClientScopes = async (
-  {
-    userConsentUserScopes,
-    userConsentResourceScopes,
-    userConsentOrganizationScopes,
-  }: Queries['applications'],
+  { userConsentUserScopes }: Queries['applications'],
   applicationId: string
 ) => {
-  const [availableUserScopes, [, resourceScopes], [, organizationScopes]] = await Promise.all([
-    userConsentUserScopes.findAllByApplicationId(applicationId),
-    userConsentResourceScopes.getEntities(Scopes, {
-      applicationId,
-    }),
-    userConsentOrganizationScopes.getEntities(OrganizationScopes, {
-      applicationId,
-    }),
-  ]);
-
-  const clientScopes = [
-    'openid',
-    'offline_access',
-    ...availableUserScopes,
-    ...resourceScopes.map(({ name }) => name),
-    ...organizationScopes.map(({ name }) => name),
-  ];
+  const availableUserScopes = await userConsentUserScopes.findAllByApplicationId(applicationId);
+  const clientScopes = ['openid', 'offline_access', ...availableUserScopes];
 
   // ClientScopes does not support prefix matching, so we need to include all the scopes.
   // Resource scopes name are not unique, we need to deduplicate them.
   // Requested resource scopes and organization scopes will be validated in resource server fetching method exclusively.
-  return deduplicate(clientScopes);
+  return clientScopes;
 };
 
 export default function postgresAdapter(
@@ -141,7 +123,7 @@ export default function postgresAdapter(
       ...transpileMetadata(client_id, snakecaseKeys(oidcClientMetadata)),
       // `node-oidc-provider` won't camelCase custom parameter keys, so we need to keep the keys camelCased
       ...customClientMetadata,
-      /* Third-party client scopes are restricted to the app-level enabled user consent scopes. @see {@link https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#clients} */
+      /* Third-party client scopes are restricted to the app-level enabled user scopes. */
       ...conditional(clientScopes && { scope: clientScopes.join(' ') }),
     });
 
@@ -157,7 +139,7 @@ export default function postgresAdapter(
           new errors.InvalidClient(`invalid client ${id}`)
         );
 
-        // FIXME: @simeng-li Remove this check after the third-party client scope feature is released
+        // FIXME: @simeng-li Remove this check after the third-party feature is released
         if (EnvSet.values.isDevFeaturesEnabled && application.isThirdParty) {
           const clientScopes = await getThirdPartyClientScopes(applications, id);
           return transpileClient(application, clientScopes);

--- a/packages/core/src/oidc/adapter.ts
+++ b/packages/core/src/oidc/adapter.ts
@@ -1,6 +1,12 @@
 import type { CreateApplication } from '@logto/schemas';
-import { ApplicationType, adminConsoleApplicationId, demoAppApplicationId } from '@logto/schemas';
-import { appendPath, tryThat } from '@silverhand/essentials';
+import {
+  ApplicationType,
+  OrganizationScopes,
+  Scopes,
+  adminConsoleApplicationId,
+  demoAppApplicationId,
+} from '@logto/schemas';
+import { deduplicate, appendPath, tryThat, conditional } from '@silverhand/essentials';
 import { addSeconds } from 'date-fns';
 import type { AdapterFactory, AllClientMetadata } from 'oidc-provider';
 import { errors } from 'oidc-provider';
@@ -22,6 +28,7 @@ const transpileMetadata = (clientId: string, data: AllClientMetadata): AllClient
   }
 
   const { adminUrlSet, cloudUrlSet } = EnvSet.values;
+
   const urls = [
     ...adminUrlSet.deduplicated().map((url) => appendPath(url, '/console')),
     ...cloudUrlSet.deduplicated(),
@@ -51,12 +58,56 @@ const buildDemoAppClientMetadata = (envSet: EnvSet): AllClientMetadata => {
   };
 };
 
+/**
+ * Restrict third-party client scopes to the app-level enabled user consent scopes
+ *
+ * - userScopes: app-level enabled user claim scopes
+ * - resourceScopes: app-level enabled resource scopes
+ * - organizationScopes app-level enabled organization scopes
+ *
+ * @remark
+ * We use the client scope metadata to restrict the third-party client scopes, @see {@link https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#clients}
+ * Auth request will be rejected if the requested scopes are not included in the client scope metadata.
+ */
+const getThirdPartyClientScopes = async (
+  {
+    userConsentUserScopes,
+    userConsentResourceScopes,
+    userConsentOrganizationScopes,
+  }: Queries['applications'],
+  applicationId: string
+) => {
+  const [availableUserScopes, [, resourceScopes], [, organizationScopes]] = await Promise.all([
+    userConsentUserScopes.findAllByApplicationId(applicationId),
+    userConsentResourceScopes.getEntities(Scopes, {
+      applicationId,
+    }),
+    userConsentOrganizationScopes.getEntities(OrganizationScopes, {
+      applicationId,
+    }),
+  ]);
+
+  const clientScopes = [
+    'openid',
+    'offline_access',
+    ...availableUserScopes,
+    ...resourceScopes.map(({ name }) => name),
+    ...organizationScopes.map(({ name }) => name),
+  ];
+
+  // ClientScopes does not support prefix matching, so we need to include all the scopes.
+  // Resource scopes name are not unique, we need to deduplicate them.
+  // Requested resource scopes and organization scopes will be validated in resource server fetching method exclusively.
+  return deduplicate(clientScopes);
+};
+
 export default function postgresAdapter(
   envSet: EnvSet,
   queries: Queries,
   modelName: string
 ): ReturnType<AdapterFactory> {
   const {
+    applications,
     applications: { findApplicationById },
     oidcModelInstances: {
       consumeInstanceById,
@@ -72,14 +123,17 @@ export default function postgresAdapter(
     const reject = async () => {
       throw new Error('Not implemented');
     };
-    const transpileClient = ({
-      id: client_id,
-      secret: client_secret,
-      name: client_name,
-      type,
-      oidcClientMetadata,
-      customClientMetadata,
-    }: CreateApplication): AllClientMetadata => ({
+    const transpileClient = (
+      {
+        id: client_id,
+        secret: client_secret,
+        name: client_name,
+        type,
+        oidcClientMetadata,
+        customClientMetadata,
+      }: CreateApplication,
+      clientScopes?: string[]
+    ): AllClientMetadata => ({
       client_id,
       client_secret,
       client_name,
@@ -87,6 +141,8 @@ export default function postgresAdapter(
       ...transpileMetadata(client_id, snakecaseKeys(oidcClientMetadata)),
       // `node-oidc-provider` won't camelCase custom parameter keys, so we need to keep the keys camelCased
       ...customClientMetadata,
+      /* Third-party client scopes are restricted to the app-level enabled user consent scopes. @see {@link https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#clients} */
+      ...conditional(clientScopes && { scope: clientScopes.join(' ') }),
     });
 
     return {
@@ -96,9 +152,17 @@ export default function postgresAdapter(
           return buildDemoAppClientMetadata(envSet);
         }
 
-        return transpileClient(
-          await tryThat(findApplicationById(id), new errors.InvalidClient(`invalid client ${id}`))
+        const application = await tryThat(
+          findApplicationById(id),
+          new errors.InvalidClient(`invalid client ${id}`)
         );
+
+        if (EnvSet.values.isDevFeaturesEnabled && application.isThirdParty) {
+          const clientScopes = await getThirdPartyClientScopes(applications, id);
+          return transpileClient(application, clientScopes);
+        }
+
+        return transpileClient(application);
       },
       findByUserCode: reject,
       findByUid: reject,

--- a/packages/core/src/oidc/grants/index.ts
+++ b/packages/core/src/oidc/grants/index.ts
@@ -21,7 +21,7 @@ export const registerGrants = (oidc: Provider, envSet: EnvSet, queries: Queries)
   // Override the default `refresh_token` grant
   oidc.registerGrantType(
     GrantType.RefreshToken,
-    refreshToken.buildHandler(envSet, queries.organizations),
+    refreshToken.buildHandler(envSet, queries),
     ...parameterConfig
   );
 };

--- a/packages/core/src/oidc/resource.ts
+++ b/packages/core/src/oidc/resource.ts
@@ -162,3 +162,18 @@ export const filterResourceScopesForTheThirdPartyApplication = async (
     )
   );
 };
+
+/**
+ * Check if the user has consented to the application for the specific organization.
+ *
+ * User will be asked to grant the organization access to the application on the consent page.
+ * User application organization grant status can be managed using management API.
+ */
+export const isOrganizationConsentedToApplication = async (
+  { applications: { userConsentOrganizations } }: Queries,
+  applicationId: string,
+  accountId: string,
+  organizationId: string
+) => {
+  return userConsentOrganizations.exists(applicationId, accountId, organizationId);
+};


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR implements the application-level user consent scopes and organization restriction logic for third-party applications. 
The restriction was added in the following flows:

### 1. client_metadata
[OIDC provider](https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#clients) supports specifying the `scope` claim in the `client_metadata`.  If provided, the authorization request will throw [`InvalidScope`](https://github.com/panva/node-oidc-provider/blob/main/lib/actions/authorization/check_scope.js#L49) error if any of the requested scope is not listed in the `metadata.scope` field. This includes `OIDC reserved scopes`,  and `user claims scopes`. 

Resource scopes (including Logto organization scopes) are [not included](https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#scopes) in this OP scope validation flow.  We will filter those scopes in the`getResourceServerInfo` method bellow. 

If the client is a third-party application, we need to add the `scope` claim to the client_metadata to restrict the scopes being requested to the following scope
- `opened, offline_access`: aways include default OIDC reserved scopes
-  `applicationUserConsentUserScopes`: only enabled user claim scopes, e.g. profile, email

changed files:
   - `packages/core/src/oidc/adapter.ts`

### 2. resourceIndicators.getResourceServerInfo
In the OIDC authorization flow, the scope is not resource-isolated, and the scope name is not unique.  So we must also filter out the resource server available scopes for third-party applications. This will ensure only application-enabled resources and organization scopes will be granted in the token. This includes

- Logto reserved organization resource indicators: filter using the application-enabled organization scopes 
- other custom resource indicators: filter using the application-enabled resource scopes

changed files:
  - `packages/core/src/oidc/init.ts`
  - `packages/core/src/oidc/resources.ts`

### 3. organization refresh_token grant
We have a customized organization `regresh_token` grant flow.  Based on the requested organizationId, user-related organization scopes will be issued to the organization access_token.  For third-party applications, we need to make sure only user-granted/consented organizations can be requested.  
A `AccessDenied` error with thrown if the requested `organizationId` has not been granted by the user.

changed files:
- packages/core/src/oidc/grants/indes.ts
- packages/core/src/oidc/grants/refresh-token.ts
- packages/core/src/oidc/resources.ts

tag @gao-sun  as required code owner review

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
integration tests will be added later

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [x] unit tests
- [ ] ~integration tests~
- [x] necessary TSDoc comments
