### PR TITLE
feat(core): add custom domain for protected app

### DIFF
--- a/packages/core/src/__mocks__/index.ts
+++ b/packages/core/src/__mocks__/index.ts
@@ -44,7 +44,9 @@ export const mockApplication: Application = {
   createdAt: 1_645_334_775_356,
 };
 
-export const mockProtectedApplication: Application = {
+export const mockProtectedApplication: Omit<Application, 'protectedAppMetadata'> & {
+  protectedAppMetadata: NonNullable<Application['protectedAppMetadata']>;
+} = {
   tenantId: 'fake_tenant',
   id: 'mock-protected-app',
   secret: mockId,

--- a/packages/core/src/libraries/application.ts
+++ b/packages/core/src/libraries/application.ts
@@ -4,6 +4,7 @@ import {
   type Scope,
   ApplicationUserConsentScopeType,
   getManagementApiResourceIndicator,
+  ApplicationType,
 } from '@logto/schemas';
 
 import RequestError from '#src/errors/RequestError/index.js';
@@ -233,6 +234,19 @@ export const createApplicationLibrary = (queries: Queries) => {
     );
   };
 
+  // Guard application exists and is a protected app
+  const validateProtectedApplicationById = async (applicationId: string) => {
+    const application = await findApplicationById(applicationId);
+
+    assertThat(
+      application.type === ApplicationType.Protected,
+      new RequestError({
+        code: 'application.protected_application_only',
+        status: 422,
+      })
+    );
+  };
+
   return {
     validateThirdPartyApplicationById,
     findApplicationScopesForResourceIndicator,
@@ -243,5 +257,6 @@ export const createApplicationLibrary = (queries: Queries) => {
     getApplicationUserConsentScopes,
     deleteApplicationUserConsentScopesByTypeAndScopeId,
     validateUserConsentOrganizationMembership,
+    validateProtectedApplicationById,
   };
 };

--- a/packages/core/src/libraries/protected-app.test.ts
+++ b/packages/core/src/libraries/protected-app.test.ts
@@ -1,3 +1,4 @@
+import { type Application } from '@logto/schemas';
 import { createMockUtils } from '@logto/shared/esm';
 
 import {
@@ -24,7 +25,7 @@ const { updateProtectedAppSiteConfigs } = await mockEsmWithActual(
 const { MockQueries } = await import('#src/test-utils/tenant.js');
 const { createProtectedAppLibrary } = await import('./protected-app.js');
 
-const findApplicationById = jest.fn(async () => mockProtectedApplication);
+const findApplicationById = jest.fn(async (): Promise<Application> => mockProtectedApplication);
 const findApplicationByProtectedAppHost = jest.fn();
 const { syncAppConfigsToRemote, checkAndBuildProtectedAppData, getDefaultDomain } =
   createProtectedAppLibrary(
@@ -61,7 +62,7 @@ describe('syncAppConfigsToRemote()', () => {
     const { protectedAppMetadata, id, secret } = mockProtectedApplication;
     expect(updateProtectedAppSiteConfigs).toHaveBeenCalledWith(
       mockProtectedAppConfigProviderConfig,
-      protectedAppMetadata?.host,
+      protectedAppMetadata.host,
       {
         ...protectedAppMetadata,
         sdkConfig: {

--- a/packages/core/src/routes/applications/application-protected-app-metadata.openapi.json
+++ b/packages/core/src/routes/applications/application-protected-app-metadata.openapi.json
@@ -1,0 +1,34 @@
+{
+  "paths": {
+    "/api/applications/{id}/protected-app-metadata/custom-domains": {
+      "post": {
+        "summary": "Add a custom domain to the protected application.",
+        "description": "Add a custom domain to the protected application. You'll need to setup DNS record later.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "domain": {
+                    "description": "The domain to be added to the application."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The domain has been added to the application."
+          },
+          "409": {
+            "description": "The domain already exists."
+          },
+          "422": {
+            "description": "Exeeded the maximum number of domains allowed or the domain is invalid."
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/core/src/routes/applications/application-protected-app-metadata.test.ts
+++ b/packages/core/src/routes/applications/application-protected-app-metadata.test.ts
@@ -1,0 +1,90 @@
+import { DomainStatus } from '@logto/schemas';
+import { pickDefault } from '@logto/shared/esm';
+
+import { mockProtectedApplication } from '#src/__mocks__/index.js';
+import { mockIdGenerators } from '#src/test-utils/nanoid.js';
+import { MockTenant } from '#src/test-utils/tenant.js';
+
+const { jest } = import.meta;
+
+const mockDomain = 'app.example.com';
+
+const updateApplicationById = jest.fn();
+const findApplicationById = jest.fn(async () => mockProtectedApplication);
+
+const mockDomainResponse = {
+  domain: mockDomain,
+  cloudflareData: null,
+  status: DomainStatus.PendingVerification,
+  error: null,
+  dnsRecords: [
+    {
+      type: 'CNAME',
+      name: mockDomain,
+      value: 'origin',
+    },
+  ],
+};
+const addDomainToRemote = jest.fn(async () => mockDomainResponse);
+
+await mockIdGenerators();
+
+const tenantContext = new MockTenant(
+  undefined,
+  {
+    applications: {
+      findApplicationById,
+      updateApplicationById,
+    },
+  },
+  undefined,
+  {
+    protectedApps: { addDomainToRemote },
+    applications: { validateProtectedApplicationById: jest.fn() },
+  }
+);
+
+const { createRequester } = await import('#src/utils/test-utils.js');
+const applicationProtectedAppMetadataRoutes = await pickDefault(
+  import('./application-protected-app-metadata.js')
+);
+
+describe('application protected app metadata routes', () => {
+  const requester = createRequester({
+    authedRoutes: applicationProtectedAppMetadataRoutes,
+    tenantContext,
+  });
+
+  describe('POST /applications/:applicationId/protected-app-metadata/custom-domains', () => {
+    it('should return 201', async () => {
+      const response = await requester
+        .post(`/applications/${mockProtectedApplication.id}/protected-app-metadata/custom-domains`)
+        .send({
+          domain: mockDomain,
+        });
+      expect(response.status).toEqual(201);
+      expect(updateApplicationById).toHaveBeenCalledWith(mockProtectedApplication.id, {
+        protectedAppMetadata: {
+          ...mockProtectedApplication.protectedAppMetadata,
+          customDomains: [mockDomainResponse],
+        },
+      });
+    });
+
+    it('throw when domain exists', async () => {
+      findApplicationById.mockResolvedValueOnce({
+        ...mockProtectedApplication,
+        protectedAppMetadata: {
+          ...mockProtectedApplication.protectedAppMetadata,
+          customDomains: [mockDomainResponse],
+        },
+      });
+      const response = await requester
+        .post(`/applications/asdf/protected-app-metadata/custom-domains`)
+        .send({
+          domain: mockDomain,
+        });
+      expect(response.status).toEqual(400);
+    });
+  });
+});

--- a/packages/core/src/routes/applications/application-protected-app-metadata.ts
+++ b/packages/core/src/routes/applications/application-protected-app-metadata.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod';
+
+import koaGuard from '#src/middleware/koa-guard.js';
+import assertThat from '#src/utils/assert-that.js';
+
+import { type AuthedRouter, type RouterInitArgs } from '../types.js';
+
+export default function applicationProtectedAppMetadataRoutes<T extends AuthedRouter>(
+  ...[
+    router,
+    {
+      queries: {
+        applications: { findApplicationById, updateApplicationById },
+      },
+      libraries: {
+        applications: { validateProtectedApplicationById },
+        protectedApps: { addDomainToRemote },
+      },
+    },
+  ]: RouterInitArgs<T>
+) {
+  const params = Object.freeze({ id: z.string().min(1) } as const);
+  const pathname = '/applications/:id/protected-app-metadata';
+  const customDomainsPathname = `${pathname}/custom-domains`;
+
+  // Guard application exists and is a protected app
+  router.use(pathname, koaGuard({ params: z.object(params) }), async (ctx, next) => {
+    const { id } = ctx.guard.params;
+
+    await validateProtectedApplicationById(id);
+
+    return next();
+  });
+
+  router.post(
+    customDomainsPathname,
+    koaGuard({
+      params: z.object(params),
+      body: z.object({ domain: z.string() }),
+      status: [201, 404, 422],
+    }),
+    async (ctx, next) => {
+      const { id } = ctx.guard.params;
+      const { domain } = ctx.guard.body;
+
+      const { protectedAppMetadata } = await findApplicationById(id);
+      assertThat(protectedAppMetadata, 'application.protected_app_not_configured');
+
+      assertThat(
+        !protectedAppMetadata.customDomains || protectedAppMetadata.customDomains.length === 0,
+        'domain.limit_to_one_domain'
+      );
+
+      // TODO: LOG-8066 check if domain is already in use
+
+      const customDomain = await addDomainToRemote(domain);
+      await updateApplicationById(id, {
+        protectedAppMetadata: { ...protectedAppMetadata, customDomains: [customDomain] },
+      });
+
+      ctx.status = 201;
+      return next();
+    }
+  );
+}

--- a/packages/core/src/routes/applications/application.test.ts
+++ b/packages/core/src/routes/applications/application.test.ts
@@ -124,7 +124,7 @@ describe('application route', () => {
       type,
       protectedAppMetadata: {
         subDomain: 'mock',
-        origin: protectedAppMetadata?.origin,
+        origin: protectedAppMetadata.origin,
       },
     });
     expect(response.status).toEqual(200);
@@ -136,8 +136,8 @@ describe('application route', () => {
       type,
       protectedAppMetadata,
       oidcClientMetadata: {
-        redirectUris: [`https://${protectedAppMetadata?.host ?? ''}/callback`],
-        postLogoutRedirectUris: [`https://${protectedAppMetadata?.host ?? ''}`],
+        redirectUris: [`https://${protectedAppMetadata.host}/callback`],
+        postLogoutRedirectUris: [`https://${protectedAppMetadata.host}`],
       },
     });
   });
@@ -329,7 +329,7 @@ describe('application route', () => {
       204
     );
     expect(deleteRemoteAppConfigs).toHaveBeenCalledWith(
-      mockProtectedApplication.protectedAppMetadata?.host
+      mockProtectedApplication.protectedAppMetadata.host
     );
   });
 

--- a/packages/core/src/routes/init.ts
+++ b/packages/core/src/routes/init.ts
@@ -11,6 +11,7 @@ import type TenantContext from '#src/tenants/TenantContext.js';
 import koaAuth from '../middleware/koa-auth/index.js';
 
 import adminUserRoutes from './admin-user/index.js';
+import applicationProtectedAppMetadataRoutes from './applications/application-protected-app-metadata.js';
 import applicationRoleRoutes from './applications/application-role.js';
 import applicationSignInExperienceRoutes from './applications/application-sign-in-experience.js';
 import applicationUserConsentOrganizationRoutes from './applications/application-user-consent-organization.js';
@@ -54,6 +55,7 @@ const createRouters = (tenant: TenantContext) => {
     applicationUserConsentScopeRoutes(managementRouter, tenant);
     applicationSignInExperienceRoutes(managementRouter, tenant);
     applicationUserConsentOrganizationRoutes(managementRouter, tenant);
+    applicationProtectedAppMetadataRoutes(managementRouter, tenant);
   }
 
   logtoConfigRoutes(managementRouter, tenant);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

New route `POST /applications/:applicationId/protected-app-metadata/custom-domains` to add custom domain for protected apps.

This route only adds domain records, the status sync will be in the next PR.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Unit tests and local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests (no tests for outer provider for now)
- [x] necessary TSDoc comments
