### PR TITLE
feat(console,phrases): support custom domain in protected app details

### DIFF
--- a/packages/console/src/components/DomainStatusTag/index.tsx
+++ b/packages/console/src/components/DomainStatusTag/index.tsx
@@ -1,0 +1,32 @@
+import { type AdminConsoleKey } from '@logto/phrases';
+import { DomainStatus } from '@logto/schemas';
+
+import DynamicT from '@/ds-components/DynamicT';
+import type { Props as TagProps } from '@/ds-components/Tag';
+import Tag from '@/ds-components/Tag';
+
+const domainStatusToTag: Record<
+  DomainStatus,
+  { title: AdminConsoleKey; status: TagProps['status'] }
+> = {
+  [DomainStatus.PendingVerification]: { title: 'domain.status.connecting', status: 'alert' },
+  [DomainStatus.PendingSsl]: { title: 'domain.status.connecting', status: 'alert' },
+  [DomainStatus.Active]: { title: 'domain.status.in_use', status: 'success' },
+  [DomainStatus.Error]: { title: 'domain.status.failed_to_connect', status: 'error' },
+};
+
+type Props = {
+  status: DomainStatus;
+};
+
+function DomainStatusTag({ status }: Props) {
+  const tag = domainStatusToTag[status];
+
+  return (
+    <Tag status={tag.status} type="state" variant="plain">
+      <DynamicT forKey={tag.title} />
+    </Tag>
+  );
+}
+
+export default DomainStatusTag;

--- a/packages/console/src/components/OpenExternalLink/index.tsx
+++ b/packages/console/src/components/OpenExternalLink/index.tsx
@@ -1,0 +1,27 @@
+import { useTranslation } from 'react-i18next';
+
+import ExternalLinkIcon from '@/assets/icons/external-link.svg';
+import IconButton from '@/ds-components/IconButton';
+import { Tooltip } from '@/ds-components/Tip';
+
+type Props = {
+  link: string;
+};
+
+function OpenExternalLink({ link }: Props) {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  return (
+    <Tooltip content={t('general.open')}>
+      <IconButton
+        size="small"
+        onClick={() => {
+          window.open(link, '_blank');
+        }}
+      >
+        <ExternalLinkIcon />
+      </IconButton>
+    </Tooltip>
+  );
+}
+
+export default OpenExternalLink;

--- a/packages/console/src/ds-components/ActionMenu/index.tsx
+++ b/packages/console/src/ds-components/ActionMenu/index.tsx
@@ -27,6 +27,7 @@ type Props =
     })
   | (BaseProps & {
       icon: ReactNode;
+      iconSize?: 'small' | 'medium' | 'large';
     });
 
 /**
@@ -66,6 +67,8 @@ function ActionMenu(props: Props) {
       {!hasButtonProps && (
         <IconButton
           ref={anchorReference}
+          // eslint-disable-next-line unicorn/consistent-destructuring -- cannot deconstruct before checking
+          size={props.iconSize}
           onClick={() => {
             setIsOpen(true);
           }}

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ProtectedAppSettings/index.module.scss
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ProtectedAppSettings/index.module.scss
@@ -23,6 +23,62 @@
   }
 }
 
+.customDomain {
+  margin-bottom: _.unit(3);
+}
+
+.label {
+  font: var(--font-body-2);
+  color: var(--color-text-secondary);
+  margin-bottom: _.unit(1);
+}
+
+.hostInUse {
+  display: flex;
+  align-items: center;
+  gap: _.unit(6);
+  border-radius: 8px;
+  border: 1px solid var(--color-divider);
+  background: var(--color-layer-1);
+  padding: _.unit(5) _.unit(6);
+
+  .host {
+    font: var(--font-label-1);
+    white-space: nowrap;
+  }
+
+  .status {
+    display: flex;
+    align-items: center;
+    gap: _.unit(2);
+    font: var(--font-body-2);
+    white-space: nowrap;
+
+    .dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+
+      &.success {
+        background: var(--color-on-success-container);
+      }
+
+      &.connecting {
+        background: var(--color-on-alert-container);
+      }
+    }
+  }
+}
+
+.inlineCode {
+  font: var(--font-body-2);
+  font-family: 'Roboto Mono', monospace;
+  background-color: var(--color-bg-layer-2);
+  color: var(--color-text);
+  border-radius: 6px;
+  padding: _.unit(0.5) _.unit(1.5);
+}
+
 .routes {
   display: grid;
   grid-template-columns: repeat(2, 1fr);

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/utils.ts
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/utils.ts
@@ -10,7 +10,7 @@ export type ApplicationForm = {
   customClientMetadata?: ApplicationResponse['customClientMetadata'];
   isAdmin?: ApplicationResponse['isAdmin'];
   // eslint-disable-next-line @typescript-eslint/ban-types
-  protectedAppMetadata?: Omit<Exclude<ProtectedAppMetadataType, null>, 'customDomains'>;
+  protectedAppMetadata?: Omit<Exclude<ProtectedAppMetadataType, null>, 'customDomains'>; // Custom domains are handled separately
 };
 
 const mapToUriFormatArrays = (value?: string[]) =>

--- a/packages/console/src/pages/Applications/components/ProtectedAppForm/index.tsx
+++ b/packages/console/src/pages/Applications/components/ProtectedAppForm/index.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import { useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
+import useSWRImmutable from 'swr/immutable';
 
 import Button, { type Props as ButtonProps } from '@/ds-components/Button';
 import FormField from '@/ds-components/FormField';
@@ -32,6 +33,8 @@ function ProtectedAppForm({
   hasRequiredLabel,
   onCreateSuccess,
 }: Props) {
+  const { data } = useSWRImmutable<ProtectedAppsDomainConfig>('api/systems/application');
+  const defaultDomain = data?.protectedApps.defaultDomain ?? '';
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const {
     register,
@@ -89,8 +92,7 @@ function ProtectedAppForm({
               placeholder={t('protected_app.form.domain_field_placeholder')}
               error={Boolean(errors.subDomain)}
             />
-            {/** TODO: @charles Hard-coded for now, will update to read from API later. */}
-            <div className={styles.domain}>.protected.app</div>
+            {defaultDomain && <div className={styles.domain}>{defaultDomain}</div>}
           </div>
         </FormField>
       </div>

--- a/packages/console/src/pages/Applications/components/ProtectedAppForm/types.ts
+++ b/packages/console/src/pages/Applications/components/ProtectedAppForm/types.ts
@@ -2,3 +2,9 @@ type ProtectedAppForm = {
   subDomain: string;
   origin: string;
 };
+
+type ProtectedAppsDomainConfig = {
+  protectedApps: {
+    defaultDomain: string;
+  };
+};

--- a/packages/console/src/pages/GetStarted/ProtectedAppCreationForm/index.tsx
+++ b/packages/console/src/pages/GetStarted/ProtectedAppCreationForm/index.tsx
@@ -4,10 +4,8 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import useSWR from 'swr';
 
-import ExternalLinkIcon from '@/assets/icons/external-link.svg';
+import OpenExternalLink from '@/components/OpenExternalLink';
 import CopyToClipboard from '@/ds-components/CopyToClipboard';
-import IconButton from '@/ds-components/IconButton';
-import { Tooltip } from '@/ds-components/Tip';
 import useTenantPathname from '@/hooks/use-tenant-pathname';
 import ProtectedAppCard from '@/pages/Applications/components/ProtectedAppCard';
 import ProtectedAppForm from '@/pages/Applications/components/ProtectedAppForm';
@@ -47,25 +45,17 @@ function ProtectedAppCreationForm() {
           <div className={styles.label}>{t('protected_app.success_message')}</div>
           <div className={styles.list}>
             {data.map((app) => {
-              const host = app.protectedAppMetadata?.host;
+              const { host, customDomains } = app.protectedAppMetadata ?? {};
+              const domain = customDomains?.[0]?.domain ?? host;
               return (
-                !!host && (
+                !!domain && (
                   <div key={app.id} className={styles.app}>
                     <div className={styles.status} />
                     <Link className={styles.hostName} to={getTo(`/applications/${app.id}`)}>
-                      {host}
+                      {domain}
                     </Link>
-                    <CopyToClipboard value={host} variant="icon" />
-                    <Tooltip content={t('general.open')}>
-                      <IconButton
-                        size="small"
-                        onClick={() => {
-                          window.open(`https://${host}`, '_blank');
-                        }}
-                      >
-                        <ExternalLinkIcon />
-                      </IconButton>
-                    </Tooltip>
+                    <CopyToClipboard value={domain} variant="icon" />
+                    <OpenExternalLink link={`https://${domain}`} />
                   </div>
                 )
               );

--- a/packages/console/src/pages/TenantSettings/TenantDomainSettings/AddDomainForm/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantDomainSettings/AddDomainForm/index.tsx
@@ -1,26 +1,25 @@
-import { type Domain } from '@logto/schemas';
+import { domainRegEx } from '@logto/core-kit';
+import classNames from 'classnames';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
 import Button from '@/ds-components/Button';
 import TextInput from '@/ds-components/TextInput';
-import useApi from '@/hooks/use-api';
 import { onKeyDownHandler } from '@/utils/a11y';
 import { trySubmitSafe } from '@/utils/form';
 
 import * as styles from './index.module.scss';
-
-const subdomainRegex = /^[\dA-Za-z][\dA-Za-z-]*[\dA-Za-z](\.[\dA-Za-z][\dA-Za-z-]*[\dA-Za-z]){2,}$/;
 
 type FormData = {
   domain: string;
 };
 
 type Props = {
-  onCustomDomainAdded: (domain: Domain) => void;
+  className?: string;
+  onSubmitCustomDomain: (data: FormData) => Promise<void>;
 };
 
-function AddDomainForm({ onCustomDomainAdded }: Props) {
+function AddDomainForm({ className, onSubmitCustomDomain }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const {
     register,
@@ -35,17 +34,14 @@ function AddDomainForm({ onCustomDomainAdded }: Props) {
 
   const domainInput = watch('domain');
 
-  const api = useApi();
-
   const onSubmit = handleSubmit(
     trySubmitSafe(async (formData) => {
-      const createdDomain = await api.post('api/domains', { json: formData }).json<Domain>();
-      onCustomDomainAdded(createdDomain);
+      await onSubmitCustomDomain(formData);
     })
   );
 
   return (
-    <div className={styles.addDomain}>
+    <div className={classNames(styles.addDomain, className)}>
       <TextInput
         className={styles.textInput}
         placeholder={t('domain.custom.custom_domain_placeholder')}
@@ -54,7 +50,7 @@ function AddDomainForm({ onCustomDomainAdded }: Props) {
         {...register('domain', {
           required: true,
           pattern: {
-            value: subdomainRegex,
+            value: domainRegEx,
             message: t('domain.custom.invalid_domain_format'),
           },
         })}

--- a/packages/console/src/pages/TenantSettings/TenantDomainSettings/CustomDomain/ActivationProcess/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantDomainSettings/CustomDomain/ActivationProcess/index.tsx
@@ -1,4 +1,4 @@
-import { type Domain } from '@logto/schemas';
+import { type CustomDomain } from '@logto/schemas';
 
 import { customDomainSyncInterval } from '@/consts/custom-domain';
 import DynamicT from '@/ds-components/DynamicT';
@@ -9,7 +9,7 @@ import Step from './Step';
 import * as styles from './index.module.scss';
 
 type Props = {
-  customDomain: Domain;
+  customDomain: CustomDomain;
 };
 
 function ActivationProcess({ customDomain }: Props) {

--- a/packages/console/src/pages/TenantSettings/TenantDomainSettings/CustomDomain/CustomDomainHeader/index.module.scss
+++ b/packages/console/src/pages/TenantSettings/TenantDomainSettings/CustomDomain/CustomDomainHeader/index.module.scss
@@ -2,21 +2,18 @@
 
 .header {
   display: flex;
-  justify-content: space-between;
   align-items: center;
   padding: _.unit(5) _.unit(6);
+  gap: _.unit(6);
 
-  .domainInfo {
-    display: flex;
-    flex-direction: column;
-    gap: _.unit(1);
 
-    .domain {
-      font: var(--font-title-2);
-    }
+  .domain {
+    font: var(--font-title-2);
   }
 
   .icon {
+    width: 16px;
+    height: 16px;
     color: var(--color-text-secondary);
   }
 }

--- a/packages/console/src/pages/TenantSettings/TenantDomainSettings/CustomDomain/index.module.scss
+++ b/packages/console/src/pages/TenantSettings/TenantDomainSettings/CustomDomain/index.module.scss
@@ -4,9 +4,3 @@
   border: 1px solid var(--color-divider);
   border-radius: 12px;
 }
-
-.notes {
-  font: var(--font-body-2);
-  color: var(--color-text-secondary);
-  margin-top: _.unit(3);
-}

--- a/packages/console/src/pages/TenantSettings/TenantDomainSettings/CustomDomain/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantDomainSettings/CustomDomain/index.tsx
@@ -1,50 +1,37 @@
-import { type Domain, DomainStatus } from '@logto/schemas';
-import { Trans, useTranslation } from 'react-i18next';
-
-import TextLink from '@/ds-components/TextLink';
-import useDocumentationUrl from '@/hooks/use-documentation-url';
+import { type CustomDomain as CustomDomainType, DomainStatus } from '@logto/schemas';
+import classNames from 'classnames';
 
 import ActivationProcess from './ActivationProcess';
 import CustomDomainHeader from './CustomDomainHeader';
 import * as styles from './index.module.scss';
 
 type Props = {
-  customDomain: Domain;
-  onDeleteCustomDomain: () => void;
+  className?: string;
+  customDomain: CustomDomainType;
+  hasExtraTipsOnDelete?: boolean;
+  hasOpenExternalLink?: boolean;
+  onDeleteCustomDomain: () => Promise<void>;
 };
 
-function CustomDomain({ customDomain, onDeleteCustomDomain }: Props) {
-  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
-  const { getDocumentationUrl } = useDocumentationUrl();
-
+function CustomDomain({
+  className,
+  customDomain,
+  hasExtraTipsOnDelete,
+  hasOpenExternalLink,
+  onDeleteCustomDomain,
+}: Props) {
   return (
-    <>
-      <div className={styles.container}>
-        <CustomDomainHeader
-          customDomain={customDomain}
-          onDeleteCustomDomain={onDeleteCustomDomain}
-        />
-        {customDomain.status !== DomainStatus.Active && (
-          <ActivationProcess customDomain={customDomain} />
-        )}
-      </div>
-      {customDomain.status === DomainStatus.Active && (
-        <div className={styles.notes}>
-          <Trans
-            components={{
-              a: (
-                <TextLink
-                  targetBlank="noopener"
-                  to={getDocumentationUrl('docs/recipes/custom-domain/use-custom-domain')}
-                />
-              ),
-            }}
-          >
-            {t('domain.update_endpoint_notice', { link: t('general.learn_more') })}
-          </Trans>
-        </div>
+    <div className={classNames(styles.container, className)}>
+      <CustomDomainHeader
+        customDomain={customDomain}
+        hasExtraTipsOnDelete={hasExtraTipsOnDelete}
+        hasOpenExternalLink={hasOpenExternalLink}
+        onDeleteCustomDomain={onDeleteCustomDomain}
+      />
+      {customDomain.status !== DomainStatus.Active && (
+        <ActivationProcess customDomain={customDomain} />
       )}
-    </>
+    </div>
   );
 }
 

--- a/packages/console/src/pages/TenantSettings/TenantDomainSettings/DefaultDomain/index.module.scss
+++ b/packages/console/src/pages/TenantSettings/TenantDomainSettings/DefaultDomain/index.module.scss
@@ -5,11 +5,10 @@
   border: 1px solid var(--color-divider);
   border-radius: 8px;
   display: flex;
-  flex-direction: column;
-  gap: _.unit(1);
+  align-items: center;
+  gap: _.unit(6);
 
   .domain {
     font: var(--font-title-2);
-    max-width: max-content;
   }
 }

--- a/packages/console/src/pages/TenantSettings/TenantDomainSettings/DefaultDomain/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantDomainSettings/DefaultDomain/index.tsx
@@ -3,6 +3,7 @@ import { useContext } from 'react';
 import { AppDataContext } from '@/contexts/AppDataProvider';
 import CopyToClipboard from '@/ds-components/CopyToClipboard';
 import DynamicT from '@/ds-components/DynamicT';
+import Spacer from '@/ds-components/Spacer';
 import Tag from '@/ds-components/Tag';
 
 import * as styles from './index.module.scss';
@@ -14,12 +15,16 @@ function DefaultDomain() {
     return null;
   }
 
+  const { host } = tenantEndpoint;
+
   return (
     <div className={styles.container}>
-      <CopyToClipboard className={styles.domain} value={tenantEndpoint.host} variant="text" />
+      <div className={styles.domain}>{host}</div>
       <Tag status="success" type="state" variant="plain">
-        <DynamicT forKey="domain.status.in_used" />
+        <DynamicT forKey="domain.status.in_use" />
       </Tag>
+      <Spacer />
+      <CopyToClipboard value={host} variant="icon" />
     </div>
   );
 }

--- a/packages/console/src/pages/TenantSettings/TenantDomainSettings/index.module.scss
+++ b/packages/console/src/pages/TenantSettings/TenantDomainSettings/index.module.scss
@@ -6,6 +6,12 @@
   }
 }
 
+.notes {
+  font: var(--font-body-2);
+  color: var(--color-text-secondary);
+  margin-top: _.unit(3);
+}
+
 .upsellNotification {
   margin-top: _.unit(4);
 }

--- a/packages/phrases/src/locales/de/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/application-details.ts
@@ -81,8 +81,11 @@ const application_details = {
   /** UNTRANSLATED */
   app_domain_protected: 'App domain protected',
   /** UNTRANSLATED */
-  app_domain_protected_description:
-    'Feel free to utilize your domain <domain></domain> which is consistently valid.',
+  app_domain_protected_description_1:
+    'Feel free to use your subdomain with protected.app powered by Logto, which is permanently valid.',
+  /** UNTRANSLATED */
+  app_domain_protected_description_2:
+    'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
     "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",

--- a/packages/phrases/src/locales/de/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/domain.ts
@@ -1,7 +1,7 @@
 const domain = {
   status: {
-    connecting: 'Verbindung wird hergestellt',
-    in_used: 'In Benutzung',
+    connecting: 'Verbindung wird hergestellt...',
+    in_use: 'In Benutzung',
     failed_to_connect: 'Verbindung fehlgeschlagen',
   },
   update_endpoint_notice:

--- a/packages/phrases/src/locales/en/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/application-details.ts
@@ -68,8 +68,10 @@ const application_details = {
   application_deleted: 'Application {{name}} has been successfully deleted',
   redirect_uri_required: 'You must enter at least one redirect URI',
   app_domain_protected: 'App domain protected',
-  app_domain_protected_description:
-    'Feel free to utilize your domain <domain></domain> which is consistently valid.',
+  app_domain_protected_description_1:
+    'Feel free to use your subdomain with protected.app powered by Logto, which is permanently valid.',
+  app_domain_protected_description_2:
+    'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   origin_url_tip:
     "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
   custom_rules: 'Custom authentication rules',

--- a/packages/phrases/src/locales/en/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/domain.ts
@@ -1,7 +1,7 @@
 const domain = {
   status: {
-    connecting: 'Connecting',
-    in_used: 'In use',
+    connecting: 'Connecting...',
+    in_use: 'In use',
     failed_to_connect: 'Failed to connect',
   },
   update_endpoint_notice:

--- a/packages/phrases/src/locales/es/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/application-details.ts
@@ -81,8 +81,11 @@ const application_details = {
   /** UNTRANSLATED */
   app_domain_protected: 'App domain protected',
   /** UNTRANSLATED */
-  app_domain_protected_description:
-    'Feel free to utilize your domain <domain></domain> which is consistently valid.',
+  app_domain_protected_description_1:
+    'Feel free to use your subdomain with protected.app powered by Logto, which is permanently valid.',
+  /** UNTRANSLATED */
+  app_domain_protected_description_2:
+    'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
     "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",

--- a/packages/phrases/src/locales/es/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/domain.ts
@@ -1,7 +1,7 @@
 const domain = {
   status: {
-    connecting: 'Conectando',
-    in_used: 'En uso',
+    connecting: 'Conectando...',
+    in_use: 'En uso',
     failed_to_connect: 'Error de conexión',
   },
   update_endpoint_notice:

--- a/packages/phrases/src/locales/fr/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/application-details.ts
@@ -81,8 +81,11 @@ const application_details = {
   /** UNTRANSLATED */
   app_domain_protected: 'App domain protected',
   /** UNTRANSLATED */
-  app_domain_protected_description:
-    'Feel free to utilize your domain <domain></domain> which is consistently valid.',
+  app_domain_protected_description_1:
+    'Feel free to use your subdomain with protected.app powered by Logto, which is permanently valid.',
+  /** UNTRANSLATED */
+  app_domain_protected_description_2:
+    'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
     "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",

--- a/packages/phrases/src/locales/fr/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/domain.ts
@@ -1,7 +1,7 @@
 const domain = {
   status: {
-    connecting: 'Connexion',
-    in_used: 'Utilisé',
+    connecting: 'Connexion...',
+    in_use: 'Utilisé',
     failed_to_connect: 'Échec de la connexion',
   },
   update_endpoint_notice:

--- a/packages/phrases/src/locales/it/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/application-details.ts
@@ -81,8 +81,11 @@ const application_details = {
   /** UNTRANSLATED */
   app_domain_protected: 'App domain protected',
   /** UNTRANSLATED */
-  app_domain_protected_description:
-    'Feel free to utilize your domain <domain></domain> which is consistently valid.',
+  app_domain_protected_description_1:
+    'Feel free to use your subdomain with protected.app powered by Logto, which is permanently valid.',
+  /** UNTRANSLATED */
+  app_domain_protected_description_2:
+    'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
     "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",

--- a/packages/phrases/src/locales/it/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/domain.ts
@@ -1,7 +1,7 @@
 const domain = {
   status: {
-    connecting: 'Connessione in corso',
-    in_used: 'In uso',
+    connecting: 'Connessione in corso...',
+    in_use: 'In uso',
     failed_to_connect: 'Connessione fallita',
   },
   update_endpoint_notice:

--- a/packages/phrases/src/locales/ja/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/application-details.ts
@@ -81,8 +81,11 @@ const application_details = {
   /** UNTRANSLATED */
   app_domain_protected: 'App domain protected',
   /** UNTRANSLATED */
-  app_domain_protected_description:
-    'Feel free to utilize your domain <domain></domain> which is consistently valid.',
+  app_domain_protected_description_1:
+    'Feel free to use your subdomain with protected.app powered by Logto, which is permanently valid.',
+  /** UNTRANSLATED */
+  app_domain_protected_description_2:
+    'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
     "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",

--- a/packages/phrases/src/locales/ja/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/domain.ts
@@ -1,7 +1,7 @@
 const domain = {
   status: {
-    connecting: '接続中',
-    in_used: '使用中',
+    connecting: '接続中...',
+    in_use: '使用中',
     failed_to_connect: '接続に失敗しました',
   },
   update_endpoint_notice:

--- a/packages/phrases/src/locales/ko/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/application-details.ts
@@ -81,8 +81,11 @@ const application_details = {
   /** UNTRANSLATED */
   app_domain_protected: 'App domain protected',
   /** UNTRANSLATED */
-  app_domain_protected_description:
-    'Feel free to utilize your domain <domain></domain> which is consistently valid.',
+  app_domain_protected_description_1:
+    'Feel free to use your subdomain with protected.app powered by Logto, which is permanently valid.',
+  /** UNTRANSLATED */
+  app_domain_protected_description_2:
+    'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
     "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",

--- a/packages/phrases/src/locales/ko/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/domain.ts
@@ -1,7 +1,7 @@
 const domain = {
   status: {
-    connecting: '연결 중',
-    in_used: '사용 중',
+    connecting: '연결 중...',
+    in_use: '사용 중',
     failed_to_connect: '연결 실패',
   },
   update_endpoint_notice:

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/application-details.ts
@@ -81,8 +81,11 @@ const application_details = {
   /** UNTRANSLATED */
   app_domain_protected: 'App domain protected',
   /** UNTRANSLATED */
-  app_domain_protected_description:
-    'Feel free to utilize your domain <domain></domain> which is consistently valid.',
+  app_domain_protected_description_1:
+    'Feel free to use your subdomain with protected.app powered by Logto, which is permanently valid.',
+  /** UNTRANSLATED */
+  app_domain_protected_description_2:
+    'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
     "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/domain.ts
@@ -1,7 +1,7 @@
 const domain = {
   status: {
-    connecting: 'Łączenie',
-    in_used: 'W użyciu',
+    connecting: 'Łączenie...',
+    in_use: 'W użyciu',
     failed_to_connect: 'Nieudane połączenie',
   },
   update_endpoint_notice:

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/application-details.ts
@@ -81,8 +81,11 @@ const application_details = {
   /** UNTRANSLATED */
   app_domain_protected: 'App domain protected',
   /** UNTRANSLATED */
-  app_domain_protected_description:
-    'Feel free to utilize your domain <domain></domain> which is consistently valid.',
+  app_domain_protected_description_1:
+    'Feel free to use your subdomain with protected.app powered by Logto, which is permanently valid.',
+  /** UNTRANSLATED */
+  app_domain_protected_description_2:
+    'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
     "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/domain.ts
@@ -1,7 +1,7 @@
 const domain = {
   status: {
-    connecting: 'Conectando',
-    in_used: 'Em uso',
+    connecting: 'Conectando...',
+    in_use: 'Em uso',
     failed_to_connect: 'Falha na conexão',
   },
   update_endpoint_notice:

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/application-details.ts
@@ -81,8 +81,11 @@ const application_details = {
   /** UNTRANSLATED */
   app_domain_protected: 'App domain protected',
   /** UNTRANSLATED */
-  app_domain_protected_description:
-    'Feel free to utilize your domain <domain></domain> which is consistently valid.',
+  app_domain_protected_description_1:
+    'Feel free to use your subdomain with protected.app powered by Logto, which is permanently valid.',
+  /** UNTRANSLATED */
+  app_domain_protected_description_2:
+    'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
     "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/domain.ts
@@ -1,7 +1,7 @@
 const domain = {
   status: {
-    connecting: 'A conectar',
-    in_used: 'Em uso',
+    connecting: 'A conectar...',
+    in_use: 'Em uso',
     failed_to_connect: 'Falha ao conectar',
   },
   update_endpoint_notice:

--- a/packages/phrases/src/locales/ru/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/application-details.ts
@@ -81,8 +81,11 @@ const application_details = {
   /** UNTRANSLATED */
   app_domain_protected: 'App domain protected',
   /** UNTRANSLATED */
-  app_domain_protected_description:
-    'Feel free to utilize your domain <domain></domain> which is consistently valid.',
+  app_domain_protected_description_1:
+    'Feel free to use your subdomain with protected.app powered by Logto, which is permanently valid.',
+  /** UNTRANSLATED */
+  app_domain_protected_description_2:
+    'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
     "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",

--- a/packages/phrases/src/locales/ru/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/domain.ts
@@ -1,7 +1,7 @@
 const domain = {
   status: {
-    connecting: 'Соединение',
-    in_used: 'Используется',
+    connecting: 'Соединение...',
+    in_use: 'Используется',
     failed_to_connect: 'Не удалось соединиться',
   },
   update_endpoint_notice:

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/application-details.ts
@@ -81,8 +81,11 @@ const application_details = {
   /** UNTRANSLATED */
   app_domain_protected: 'App domain protected',
   /** UNTRANSLATED */
-  app_domain_protected_description:
-    'Feel free to utilize your domain <domain></domain> which is consistently valid.',
+  app_domain_protected_description_1:
+    'Feel free to use your subdomain with protected.app powered by Logto, which is permanently valid.',
+  /** UNTRANSLATED */
+  app_domain_protected_description_2:
+    'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
     "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/domain.ts
@@ -1,7 +1,7 @@
 const domain = {
   status: {
-    connecting: 'Bağlanıyor',
-    in_used: 'Kullanımda',
+    connecting: 'Bağlanıyor...',
+    in_use: 'Kullanımda',
     failed_to_connect: 'Bağlantı başarısız oldu',
   },
   update_endpoint_notice:

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/application-details.ts
@@ -78,8 +78,11 @@ const application_details = {
   /** UNTRANSLATED */
   app_domain_protected: 'App domain protected',
   /** UNTRANSLATED */
-  app_domain_protected_description:
-    'Feel free to utilize your domain <domain></domain> which is consistently valid.',
+  app_domain_protected_description_1:
+    'Feel free to use your subdomain with protected.app powered by Logto, which is permanently valid.',
+  /** UNTRANSLATED */
+  app_domain_protected_description_2:
+    'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
     "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/domain.ts
@@ -1,7 +1,7 @@
 const domain = {
   status: {
-    connecting: '连接中',
-    in_used: '使用中',
+    connecting: '连接中...',
+    in_use: '使用中',
     failed_to_connect: '连接失败',
   },
   update_endpoint_notice:

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/application-details.ts
@@ -78,8 +78,11 @@ const application_details = {
   /** UNTRANSLATED */
   app_domain_protected: 'App domain protected',
   /** UNTRANSLATED */
-  app_domain_protected_description:
-    'Feel free to utilize your domain <domain></domain> which is consistently valid.',
+  app_domain_protected_description_1:
+    'Feel free to use your subdomain with protected.app powered by Logto, which is permanently valid.',
+  /** UNTRANSLATED */
+  app_domain_protected_description_2:
+    'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
     "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/domain.ts
@@ -1,7 +1,7 @@
 const domain = {
   status: {
-    connecting: '正在連接',
-    in_used: '使用中',
+    connecting: '正在連接...',
+    in_use: '使用中',
     failed_to_connect: '連接失敗',
   },
   update_endpoint_notice:

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/application-details.ts
@@ -79,8 +79,11 @@ const application_details = {
   /** UNTRANSLATED */
   app_domain_protected: 'App domain protected',
   /** UNTRANSLATED */
-  app_domain_protected_description:
-    'Feel free to utilize your domain <domain></domain> which is consistently valid.',
+  app_domain_protected_description_1:
+    'Feel free to use your subdomain with protected.app powered by Logto, which is permanently valid.',
+  /** UNTRANSLATED */
+  app_domain_protected_description_2:
+    'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
     "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/domain.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/domain.ts
@@ -1,7 +1,7 @@
 const domain = {
   status: {
-    connecting: '連線中',
-    in_used: '使用中',
+    connecting: '連線中...',
+    in_use: '使用中',
     failed_to_connect: '連線失敗',
   },
   update_endpoint_notice:

--- a/packages/toolkit/core-kit/src/regex.ts
+++ b/packages/toolkit/core-kit/src/regex.ts
@@ -7,3 +7,6 @@ export const mobileUriSchemeProtocolRegEx = /^[a-z][\d+_a-z-]*(\.[\d+_a-z-]+)+:$
 export const hexColorRegEx = /^#[\da-f]{3}([\da-f]{3})?$/i;
 export const dateRegex = /^\d{4}(-\d{2}){2}/;
 export const noSpaceRegEx = /^\S+$/;
+/** Full domain that consists of at least 3 parts, e.g. foo.bar.com */
+export const domainRegEx =
+  /^[\dA-Za-z][\dA-Za-z-]*[\dA-Za-z](\.[\dA-Za-z][\dA-Za-z-]*[\dA-Za-z]){2,}$/;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Support custom domain in protected app details page:
1. Refactored tenant custom domain components, in order to make them re-usable in protected app details page.
2. Add custom domain field in protected app details page.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="1511" alt="image" src="https://github.com/logto-io/logto/assets/12833674/c019b735-9272-478b-802b-f7fa26262394">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
