### PR TITLE
fix(core,phrases): prevent application deletion for custom domain

### DIFF
--- a/packages/core/src/__mocks__/index.ts
+++ b/packages/core/src/__mocks__/index.ts
@@ -75,7 +75,7 @@ export const mockProtectedApplication: Omit<Application, 'protectedAppMetadata'>
 export const mockCustomDomain = {
   domain: 'mock.blog.com',
   status: DomainStatus.PendingVerification,
-  error: null,
+  errorMessage: null,
   dnsRecords: [],
   cloudflareData: {
     id: 'cloudflare-id',

--- a/packages/core/src/libraries/protected-app.ts
+++ b/packages/core/src/libraries/protected-app.ts
@@ -85,7 +85,7 @@ const addDomainToRemote = async (
     domain: hostname,
     cloudflareData,
     status: DomainStatus.PendingVerification,
-    error: null,
+    errorMessage: null,
     dnsRecords: [
       {
         type: 'CNAME',
@@ -252,7 +252,7 @@ export const createProtectedAppLibrary = (queries: Queries) => {
         return {
           ...domain,
           cloudflareData,
-          errorMessage,
+          errorMessage: errorMessage || null,
           status,
         };
       })

--- a/packages/core/src/routes/applications/application-protected-app-metadata.test.ts
+++ b/packages/core/src/routes/applications/application-protected-app-metadata.test.ts
@@ -20,7 +20,7 @@ const mockDomainResponse = {
   domain: mockDomain,
   cloudflareData: null,
   status: DomainStatus.PendingVerification,
-  error: null,
+  errorMessage: null,
   dnsRecords: [
     {
       type: 'CNAME',

--- a/packages/core/src/routes/applications/application.test.ts
+++ b/packages/core/src/routes/applications/application.test.ts
@@ -5,6 +5,7 @@ import { pickDefault } from '@logto/shared/esm';
 import {
   mockApplication,
   mockProtectedAppConfigProviderConfig,
+  mockCustomDomain,
   mockProtectedApplication,
 } from '#src/__mocks__/index.js';
 import { mockId, mockIdGenerators } from '#src/test-utils/nanoid.js';
@@ -339,6 +340,20 @@ describe('application route', () => {
     await expect(applicationRequest.delete('/applications/foo')).resolves.toHaveProperty(
       'status',
       500
+    );
+  });
+
+  it('DELETE /applications/:applicationId should throw if custom domains are not empty', async () => {
+    findApplicationById.mockResolvedValueOnce({
+      ...mockProtectedApplication,
+      protectedAppMetadata: {
+        ...mockProtectedApplication.protectedAppMetadata,
+        customDomains: [mockCustomDomain],
+      },
+    });
+    await expect(applicationRequest.delete('/applications/foo')).resolves.toHaveProperty(
+      'status',
+      400
     );
   });
 });

--- a/packages/core/src/routes/applications/application.ts
+++ b/packages/core/src/routes/applications/application.ts
@@ -320,6 +320,10 @@ export default function applicationRoutes<T extends AuthedRouter>(
       const { id } = ctx.guard.params;
       const { type, protectedAppMetadata } = await findApplicationById(id);
       if (type === ApplicationType.Protected && protectedAppMetadata) {
+        assertThat(
+          !protectedAppMetadata.customDomains || protectedAppMetadata.customDomains.length === 0,
+          'application.should_delete_custom_domains_first'
+        );
         await protectedApps.deleteRemoteAppConfigs(protectedAppMetadata.host);
       }
       // Note: will need delete cascade when application is joint with other tables

--- a/packages/phrases/src/locales/de/errors/application.ts
+++ b/packages/phrases/src/locales/de/errors/application.ts
@@ -25,6 +25,8 @@ const application = {
   invalid_subdomain: 'Invalid subdomain.',
   /** UNTRANSLATED */
   custom_domain_not_found: 'Custom domain not found.',
+  /** UNTRANSLATED */
+  should_delete_custom_domains_first: 'Should delete custom domains first.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/en/errors/application.ts
+++ b/packages/phrases/src/locales/en/errors/application.ts
@@ -16,6 +16,7 @@ const application = {
     'The subdomain of Protected application is already in use.',
   invalid_subdomain: 'Invalid subdomain.',
   custom_domain_not_found: 'Custom domain not found.',
+  should_delete_custom_domains_first: 'Should delete custom domains first.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/es/errors/application.ts
+++ b/packages/phrases/src/locales/es/errors/application.ts
@@ -25,6 +25,8 @@ const application = {
   invalid_subdomain: 'Invalid subdomain.',
   /** UNTRANSLATED */
   custom_domain_not_found: 'Custom domain not found.',
+  /** UNTRANSLATED */
+  should_delete_custom_domains_first: 'Should delete custom domains first.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/fr/errors/application.ts
+++ b/packages/phrases/src/locales/fr/errors/application.ts
@@ -26,6 +26,8 @@ const application = {
   invalid_subdomain: 'Invalid subdomain.',
   /** UNTRANSLATED */
   custom_domain_not_found: 'Custom domain not found.',
+  /** UNTRANSLATED */
+  should_delete_custom_domains_first: 'Should delete custom domains first.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/it/errors/application.ts
+++ b/packages/phrases/src/locales/it/errors/application.ts
@@ -26,6 +26,8 @@ const application = {
   invalid_subdomain: 'Invalid subdomain.',
   /** UNTRANSLATED */
   custom_domain_not_found: 'Custom domain not found.',
+  /** UNTRANSLATED */
+  should_delete_custom_domains_first: 'Should delete custom domains first.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/ja/errors/application.ts
+++ b/packages/phrases/src/locales/ja/errors/application.ts
@@ -25,6 +25,8 @@ const application = {
   invalid_subdomain: 'Invalid subdomain.',
   /** UNTRANSLATED */
   custom_domain_not_found: 'Custom domain not found.',
+  /** UNTRANSLATED */
+  should_delete_custom_domains_first: 'Should delete custom domains first.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/ko/errors/application.ts
+++ b/packages/phrases/src/locales/ko/errors/application.ts
@@ -24,6 +24,8 @@ const application = {
   invalid_subdomain: 'Invalid subdomain.',
   /** UNTRANSLATED */
   custom_domain_not_found: 'Custom domain not found.',
+  /** UNTRANSLATED */
+  should_delete_custom_domains_first: 'Should delete custom domains first.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/pl-pl/errors/application.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/application.ts
@@ -24,6 +24,8 @@ const application = {
   invalid_subdomain: 'Invalid subdomain.',
   /** UNTRANSLATED */
   custom_domain_not_found: 'Custom domain not found.',
+  /** UNTRANSLATED */
+  should_delete_custom_domains_first: 'Should delete custom domains first.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/pt-br/errors/application.ts
+++ b/packages/phrases/src/locales/pt-br/errors/application.ts
@@ -25,6 +25,8 @@ const application = {
   invalid_subdomain: 'Invalid subdomain.',
   /** UNTRANSLATED */
   custom_domain_not_found: 'Custom domain not found.',
+  /** UNTRANSLATED */
+  should_delete_custom_domains_first: 'Should delete custom domains first.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/pt-pt/errors/application.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/application.ts
@@ -25,6 +25,8 @@ const application = {
   invalid_subdomain: 'Invalid subdomain.',
   /** UNTRANSLATED */
   custom_domain_not_found: 'Custom domain not found.',
+  /** UNTRANSLATED */
+  should_delete_custom_domains_first: 'Should delete custom domains first.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/ru/errors/application.ts
+++ b/packages/phrases/src/locales/ru/errors/application.ts
@@ -26,6 +26,8 @@ const application = {
   invalid_subdomain: 'Invalid subdomain.',
   /** UNTRANSLATED */
   custom_domain_not_found: 'Custom domain not found.',
+  /** UNTRANSLATED */
+  should_delete_custom_domains_first: 'Should delete custom domains first.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/tr-tr/errors/application.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/application.ts
@@ -24,6 +24,8 @@ const application = {
   invalid_subdomain: 'Invalid subdomain.',
   /** UNTRANSLATED */
   custom_domain_not_found: 'Custom domain not found.',
+  /** UNTRANSLATED */
+  should_delete_custom_domains_first: 'Should delete custom domains first.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/zh-cn/errors/application.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/application.ts
@@ -23,6 +23,8 @@ const application = {
   invalid_subdomain: 'Invalid subdomain.',
   /** UNTRANSLATED */
   custom_domain_not_found: 'Custom domain not found.',
+  /** UNTRANSLATED */
+  should_delete_custom_domains_first: 'Should delete custom domains first.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/zh-hk/errors/application.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/application.ts
@@ -23,6 +23,8 @@ const application = {
   invalid_subdomain: 'Invalid subdomain.',
   /** UNTRANSLATED */
   custom_domain_not_found: 'Custom domain not found.',
+  /** UNTRANSLATED */
+  should_delete_custom_domains_first: 'Should delete custom domains first.',
 };
 
 export default Object.freeze(application);

--- a/packages/phrases/src/locales/zh-tw/errors/application.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/application.ts
@@ -23,6 +23,8 @@ const application = {
   invalid_subdomain: 'Invalid subdomain.',
   /** UNTRANSLATED */
   custom_domain_not_found: 'Custom domain not found.',
+  /** UNTRANSLATED */
+  should_delete_custom_domains_first: 'Should delete custom domains first.',
 };
 
 export default Object.freeze(application);

--- a/packages/schemas/src/foundations/jsonb-types/applications.ts
+++ b/packages/schemas/src/foundations/jsonb-types/applications.ts
@@ -8,7 +8,7 @@ export const customDomainGuard = z.object({
   /* The status of the domain in Cloudflare */
   status: domainStatusGuard,
   /* The error message if any */
-  error: z.string().nullable(),
+  errorMessage: z.string().nullable(),
   /* The DNS records of the domain */
   dnsRecords: domainDnsRecordsGuard,
   /* The remote Cloudflare data */


### PR DESCRIPTION
…ists

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

In `DELETE /applications/:applicationId`, check if custom domains are deleted.

Users should delete custom domains before they can delete an application.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Unit tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
