### PR TITLE
refactor(core): update the consent apis

### DIFF
--- a/packages/core/src/middleware/koa-auto-consent.ts
+++ b/packages/core/src/middleware/koa-auto-consent.ts
@@ -1,14 +1,18 @@
-import { trySafe } from '@silverhand/essentials';
+import { demoAppApplicationId } from '@logto/schemas';
 import { type MiddlewareType } from 'koa';
 import { type IRouterParamContext } from 'koa-router';
 import type Provider from 'oidc-provider';
+import { errors } from 'oidc-provider';
 
+import { EnvSet } from '#src/env-set/index.js';
 import { consent } from '#src/libraries/session.js';
 import type Queries from '#src/tenants/Queries.js';
+import assertThat from '#src/utils/assert-that.js';
 
 /**
  * Automatically consent for the first party apps.
  */
+
 export default function koaAutoConsent<StateT, ContextT extends IRouterParamContext, ResponseBodyT>(
   provider: Provider,
   query: Queries
@@ -17,18 +21,29 @@ export default function koaAutoConsent<StateT, ContextT extends IRouterParamCont
     const interactionDetails = await provider.interactionDetails(ctx.req, ctx.res);
     const { client_id: clientId } = interactionDetails.params;
 
-    const application = await trySafe(async () =>
-      query.applications.findApplicationById(String(clientId))
+    const {
+      applications: { findApplicationById },
+    } = query;
+
+    assertThat(
+      clientId && typeof clientId === 'string',
+      new errors.InvalidClient('client must be available')
     );
 
-    const shouldAutoConsent = !application?.isThirdParty;
+    // Demo app not in the database
+    const application =
+      clientId === demoAppApplicationId ? undefined : await findApplicationById(clientId);
 
-    if (!shouldAutoConsent) {
-      return next();
+    // FIXME: @simeng-li remove this when the IdP is ready
+    const shouldAutoConsent = !EnvSet.values.isDevFeaturesEnabled || !application?.isThirdParty;
+
+    if (shouldAutoConsent) {
+      const redirectTo = await consent(ctx, provider, query, interactionDetails);
+
+      ctx.redirect(redirectTo);
+      return;
     }
 
-    const redirectTo = await consent(ctx, provider, query, interactionDetails);
-
-    ctx.redirect(redirectTo);
+    return next();
   };
 }

--- a/packages/schemas/src/types/consent.ts
+++ b/packages/schemas/src/types/consent.ts
@@ -45,7 +45,9 @@ export const publicOrganizationGuard = Organizations.guard.pick({
   name: true,
 });
 export const missingResourceScopesGuard = z.object({
-  resource: Resources.guard.pick({ id: true, name: true }),
+  // The original resource id has a maximum length of 21 restriction. We need to make it compatible with the logto reserved organization name.
+  // use string here, as we do not care about the resource id length here.
+  resource: Resources.guard.pick({ name: true }).extend({ id: z.string() }),
   scopes: Scopes.guard.pick({ id: true, name: true, description: true }).array(),
 });
 


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Update the consent APIs. This PR includes the following updates:

1. Refactor the `koaAutoConsent`, and make it more clear.  If it is a third-party app, continue to experience the consent page. Otherwise, directly grant all the missing scopes and consent. 

2. Update the `GET /consent` API's `missingResourceScopes` data parsing logic. As logto reserved organization resource does not exist in our API resource DB. We need to treat it differently.  Fetch the scopes from organization scopes instead of resource scopes. Use the reserved resource name as the resource id. 

3. Update the old consent API. Besides consenting all the missing scope on request. If there are any user-granted organizations provided. Grant the organization access to that application ahead. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [x] necessary TSDoc comments
