### PR TITLE
fix(console,core): fix application count bug

### DIFF
--- a/packages/console/src/pages/Applications/hooks/use-application-data.ts
+++ b/packages/console/src/pages/Applications/hooks/use-application-data.ts
@@ -64,6 +64,7 @@ const useApplicationsData = (isThirdParty = false) => {
       buildUrl(applicationsEndpoint, {
         page: String(firstPartyApplicationPage),
         page_size: String(pageSize),
+        isThirdParty: 'false',
       }),
     [firstPartyApplicationPage]
   );

--- a/packages/core/src/queries/application.ts
+++ b/packages/core/src/queries/application.ts
@@ -73,7 +73,7 @@ export const createApplicationQueries = (pool: CommonQueryMethods) => {
           ? sql`${fields.id} not in (${sql.join(excludeApplicationIds, sql`, `)})`
           : sql``,
         types && types.length > 0 ? sql`${fields.type} in (${sql.join(types, sql`, `)})` : sql``,
-        isThirdParty ? sql`${fields.isThirdParty} = true` : sql`${fields.isThirdParty} = false`,
+        typeof isThirdParty === 'boolean' ? sql`${fields.isThirdParty} = ${isThirdParty}` : sql``,
         buildApplicationConditions(search),
       ])}
     `);
@@ -118,7 +118,7 @@ export const createApplicationQueries = (pool: CommonQueryMethods) => {
           ? sql`${fields.id} not in (${sql.join(excludeApplicationIds, sql`, `)})`
           : sql``,
         types && types.length > 0 ? sql`${fields.type} in (${sql.join(types, sql`, `)})` : sql``,
-        isThirdParty ? sql`${fields.isThirdParty} = true` : sql`${fields.isThirdParty} = false`,
+        typeof isThirdParty === 'boolean' ? sql`${fields.isThirdParty} = ${isThirdParty}` : sql``,
         buildApplicationConditions(search),
       ])}
       order by ${fields.createdAt} desc

--- a/packages/integration-tests/src/api/application.ts
+++ b/packages/integration-tests/src/api/application.ts
@@ -28,7 +28,7 @@ export const createApplication = async (
 export const getApplications = async (
   types?: ApplicationType[],
   searchParameters?: Record<string, string>,
-  isThirdParty?: boolean
+  isThirdParty?: 'true' | 'false'
 ) => {
   const searchParams = new URLSearchParams([
     ...(conditional(types && types.length > 0 && types.map((type) => ['types', type])) ?? []),
@@ -37,7 +37,7 @@ export const getApplications = async (
         Object.keys(searchParameters).length > 0 &&
         Object.entries(searchParameters).map(([key, value]) => [key, value])
     ) ?? []),
-    ...(conditional(isThirdParty && [['isThirdParty', 'true']]) ?? []),
+    ...(conditional(isThirdParty && [['isThirdParty', isThirdParty]]) ?? []),
   ]);
 
   return authedAdminApi.get('applications', { searchParams }).json<Application[]>();

--- a/packages/integration-tests/src/tests/api/application/application.test.ts
+++ b/packages/integration-tests/src/tests/api/application/application.test.ts
@@ -176,7 +176,7 @@ describe('admin console application', () => {
   });
 
   it('should fetch all non-third party applications created above', async () => {
-    const applications = await getApplications();
+    const applications = await getApplications(undefined, undefined, 'false');
 
     const applicationNames = applications.map(({ name }) => name);
     expect(applicationNames).toContain('test-create-app');
@@ -194,10 +194,29 @@ describe('admin console application', () => {
       }
     );
 
-    const applications = await getApplications(undefined, undefined, true);
+    const applications = await getApplications(undefined, undefined, 'true');
 
     expect(applications.find(({ id }) => id === application.id)).toEqual(application);
     expect(applications.some(({ isThirdParty }) => !isThirdParty)).toBe(false);
+    await deleteApplication(application.id);
+  });
+
+  it('should fetch all applications including third party applications', async () => {
+    const application = await createApplication(
+      'test-third-party-app',
+      ApplicationType.Traditional,
+      {
+        isThirdParty: true,
+      }
+    );
+
+    const applications = await getApplications();
+    const applicationNames = applications.map(({ name }) => name);
+
+    expect(applicationNames).toContain('test-create-app');
+    expect(applicationNames).toContain('test-update-app');
+    expect(applicationNames).toContain('test-third-party-app');
+
     await deleteApplication(application.id);
   });
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the application count bug.

Bug description:
With the thrid-party application implemented. previously we added a new query parameter `isThirdParty` to the `GET /applications` API. 
To make it compatible with the existing online behavior, the logic was if the `isThirdParty` query parameter is absent, return all the first-party apps. Otherwise, return third-party applications.  However, we use the same API to get the total count of the applications in the console. Including first-party and third-party apps.  

Fix:
To make the API precise, update the query logic, if the `isThirdParty` query parameter is not provided return all the applications without filtering.  
Filter the first-party or third-party applications exclusively based on the `isThirdParty`'s exact value. 'true' | 'false'.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [x] integration tests
- [ ] ~necessary TSDoc comments~
