### PR TITLE
fix(schemas): remove catchall from cloudflare data guard

### DIFF
--- a/packages/core/src/__mocks__/domain.ts
+++ b/packages/core/src/__mocks__/domain.ts
@@ -38,13 +38,6 @@ export const mockCloudflareData: CloudflareData = {
   status: 'pending',
   ssl: {
     status: 'pending',
-    txt_name: mockSslTxtName,
-    txt_value: mockSslTxtValue,
-  },
-  ownership_verification: {
-    type: 'TXT',
-    name: mockTxtName,
-    value: mockTxtValue,
   },
 };
 
@@ -53,8 +46,6 @@ export const mockCloudflareDataPendingSSL: CloudflareData = {
   status: 'active',
   ssl: {
     status: 'pending',
-    txt_name: mockSslTxtName,
-    txt_value: mockSslTxtValue,
   },
 };
 

--- a/packages/schemas/src/foundations/jsonb-types/custom-domain.ts
+++ b/packages/schemas/src/foundations/jsonb-types/custom-domain.ts
@@ -11,25 +11,20 @@ export type DomainDnsRecords = z.infer<typeof domainDnsRecordsGuard>;
 
 // https://developers.cloudflare.com/api/operations/custom-hostname-for-a-zone-list-custom-hostnames#Responses
 // Predefine the "useful" fields
-export const cloudflareDataGuard = z
-  .object({
-    id: z.string(),
+export const cloudflareDataGuard = z.object({
+  id: z.string(),
+  status: z.string(),
+  ssl: z.object({
     status: z.string(),
-    ssl: z
+    validation_errors: z
       .object({
-        status: z.string(),
-        validation_errors: z
-          .object({
-            message: z.string(),
-          })
-          .catchall(z.unknown())
-          .array()
-          .optional(),
+        message: z.string(),
       })
-      .catchall(z.unknown()),
-    verification_errors: z.string().array().optional(),
-  })
-  .catchall(z.unknown());
+      .array()
+      .optional(),
+  }),
+  verification_errors: z.string().array().optional(),
+});
 
 export type CloudflareData = z.infer<typeof cloudflareDataGuard>;
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Remove `catchall` from `cloudflareDataGuard` to simplify the type.

This change will lost the other fields of cloudflare response, but these are not useful, and can be fetched from Cloudflare in any time, so it is OK to remove.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested with existing data, the parsing is OK:

<img width="526" alt="截屏2024-01-22 下午12 54 40" src="https://github.com/logto-io/logto/assets/5717882/e25baf12-23e7-4873-939f-0fee7c57ba16">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
