### PR TITLE
fix(core): should throw 500 on file upload error

### DIFF
--- a/packages/core/src/routes/user-assets.ts
+++ b/packages/core/src/routes/user-assets.ts
@@ -87,7 +87,10 @@ export default function userAssetsRoutes<T extends AuthedRouter>(...[router]: Ro
 
         ctx.body = result;
       } catch {
-        throw new RequestError('storage.upload_error');
+        throw new RequestError({
+          code: 'storage.upload_error',
+          status: 500,
+        });
       }
 
       return next();


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

When upload file to remote (for example, S3) and error occurs, the status code should be 500.

Any 4xx error should be raised before calling the final upload function.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
