### PR TITLE
style(console): adjust textarea scrollbar position

### DIFF
--- a/packages/console/src/ds-components/Textarea/index.module.scss
+++ b/packages/console/src/ds-components/Textarea/index.module.scss
@@ -30,6 +30,10 @@
     resize: none;
     padding: 0;
 
+    // Leave space for scrollbar by setting `box-sizing` and `padding-right`
+    box-sizing: content-box;
+    padding-right: 10px;
+
     &::placeholder {
       color: var(--color-placeholder);
     }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
There is a large gap between the scrollbar and the right border of the `TextArea` component, by update the textarea's box-sizing to `content-box` and add a `padding-right` for the scrollbar, the scrollbar now will be in a good place.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Before:

<img width="381" alt="image" src="https://github.com/logto-io/logto/assets/10806653/4e4493fd-489d-4118-8547-6503802522ea">


After:
<img width="363" alt="image" src="https://github.com/logto-io/logto/assets/10806653/24b1a94b-85f5-4522-ac7a-02f12b139957">



<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
- [x] necessary TSDoc comments
