### PR TITLE
refactor(console): hide the empty count on tab

### DIFF
--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Permissions/ApplicationScopesAssignmentModal/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Permissions/ApplicationScopesAssignmentModal/index.tsx
@@ -1,6 +1,6 @@
 import { type AdminConsoleKey } from '@logto/phrases';
 import { ApplicationUserConsentScopeType } from '@logto/schemas';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import ConfirmModal from '@/ds-components/ConfirmModal';
@@ -45,6 +45,26 @@ function ApplicationScopesAssignmentModal({ isOpen, onClose, applicationId }: Pr
     ({ selectedData }) => selectedData.length > 0
   );
 
+  const tabs = useMemo(
+    () =>
+      Object.values(permissionTabs).map(({ title, key }) => {
+        const selectedDataCount = scopesAssignment[key].selectedData.length;
+
+        return (
+          <TabNavItem
+            key={key}
+            isActive={key === activeTab}
+            onClick={() => {
+              setActiveTab(key);
+            }}
+          >
+            {`${t(title)}${selectedDataCount ? ` (${selectedDataCount})` : ''}`}
+          </TabNavItem>
+        );
+      }),
+    [activeTab, scopesAssignment, setActiveTab, t]
+  );
+
   return (
     <ConfirmModal
       isOpen={isOpen}
@@ -59,19 +79,7 @@ function ApplicationScopesAssignmentModal({ isOpen, onClose, applicationId }: Pr
       onCancel={onCloseHandler}
       onConfirm={onSubmitHandler}
     >
-      <TabNav>
-        {Object.values(permissionTabs).map(({ title, key }) => (
-          <TabNavItem
-            key={key}
-            isActive={key === activeTab}
-            onClick={() => {
-              setActiveTab(key);
-            }}
-          >
-            {`${t(title)}(${scopesAssignment[key].selectedData.length})`}
-          </TabNavItem>
-        ))}
-      </TabNav>
+      <TabNav>{tabs}</TabNav>
       <TabWrapper
         key={ApplicationUserConsentScopeType.UserScopes}
         isActive={ApplicationUserConsentScopeType.UserScopes === activeTab}


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
hide the selected scopes count on the tab if it is 0

Before:
<img width="758" alt="image" src="https://github.com/logto-io/logto/assets/36393111/c1cc3b02-c4b5-4e9f-b991-811078fcf958">

After:
<img width="768" alt="image" src="https://github.com/logto-io/logto/assets/36393111/4d4c426b-4ee1-4d82-a633-5aafb946971d">



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [ ] ~necessary TSDoc comments~
