### PR TITLE
fix(console): hide the organization row group

### DIFF
--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Permissions/index.module.scss
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Permissions/index.module.scss
@@ -6,7 +6,10 @@
   height: _.unit(9);
 
   td {
+    font: var(--font-label-2);
     color: var(--color-text-secondary);
     background-color: var(--color-layer-light);
+    padding-top: _.unit(2);
+    padding-bottom: _.unit(2);
   }
 }

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Permissions/use-scopes-table.ts
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Permissions/use-scopes-table.ts
@@ -90,7 +90,12 @@ const useScopesTable = () => {
         })
       );
 
-      return [userScopesGroup, ...resourceScopesGroups, organizationScopesGroup];
+      return [
+        userScopesGroup,
+        ...resourceScopesGroups,
+        // Hide the organization scopes group if there is no organization scopes
+        ...(organizationScopesGroup.data.length > 0 ? [organizationScopesGroup] : []),
+      ];
     },
     [t]
   );


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Should hide the organization row group if the data is empty
Adjust the spacing of the row group header


Before:
<img width="766" alt="image" src="https://github.com/logto-io/logto/assets/36393111/58323f37-74fe-4f6d-9ceb-a1a97329dfb8">


After:
<img width="771" alt="image" src="https://github.com/logto-io/logto/assets/36393111/394d2bba-945f-4fd6-b0a7-28d687ca823a">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [ ] ~necessary TSDoc comments~
