### PR TITLE
fix(experience): add empty scopes fallback layout

### DIFF
--- a/packages/experience/src/pages/Consent/ScopesListCard/index.tsx
+++ b/packages/experience/src/pages/Consent/ScopesListCard/index.tsx
@@ -1,7 +1,6 @@
 import { ReservedResource } from '@logto/core-kit';
 import { type ConsentInfoResponse } from '@logto/schemas';
 import classNames from 'classnames';
-import type React from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
@@ -64,7 +63,6 @@ type Props = {
   resourceScopes: ConsentInfoResponse['missingResourceScopes'];
   appName: string;
   className?: string;
-  children?: React.ReactNode;
   termsUrl?: string;
   privacyUrl?: string;
 };
@@ -76,7 +74,6 @@ const ScopesListCard = ({
   termsUrl,
   privacyUrl,
   className,
-  children,
 }: Props) => {
   const { t } = useTranslation();
 
@@ -91,6 +88,22 @@ const ScopesListCard = ({
   );
 
   const showTerms = Boolean(termsUrl ?? privacyUrl);
+
+  // If there is no user scopes and resource scopes, we don't need to show the scopes list.
+  // This is a fallback for the corner case that all the scopes are already granted.
+  if (!userScopesData?.length && !resourceScopes?.length) {
+    return showTerms ? (
+      <div className={className}>
+        <Trans
+          components={{
+            link: <TermsLinks inline termsOfUseUrl={termsUrl} privacyPolicyUrl={privacyUrl} />,
+          }}
+        >
+          {t('description.authorize_agreement', { name: appName })}
+        </Trans>
+      </div>
+    ) : null;
+  }
 
   return (
     <div className={className}>


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add empty scopes fallback layout. This is a fallback layout of the consent page for corner cases like:
- no user scopes and resource scopes are requested e.g. only 'openid' and 'offline_access';
- all the requested scopes are granted previously. 

<img width="564" alt="image" src="https://github.com/logto-io/logto/assets/36393111/342ed145-e95c-49fb-a667-27c133b252b9">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [ ] ~necessary TSDoc comments~
