### PR TITLE
feat(experience): auto expand the scopes list

### DIFF
--- a/packages/experience/src/pages/Consent/ScopesListCard/index.tsx
+++ b/packages/experience/src/pages/Consent/ScopesListCard/index.tsx
@@ -15,6 +15,7 @@ import * as styles from './index.module.scss';
 
 type ScopeGroupProps = {
   groupName: string;
+  isAutoExpand?: boolean;
   scopes: Array<{
     id: string;
     name: string;
@@ -22,8 +23,8 @@ type ScopeGroupProps = {
   }>;
 };
 
-const ScopeGroup = ({ groupName, scopes }: ScopeGroupProps) => {
-  const [expanded, setExpanded] = useState(false);
+const ScopeGroup = ({ groupName, scopes, isAutoExpand = false }: ScopeGroupProps) => {
+  const [expanded, setExpanded] = useState(isAutoExpand);
 
   const toggle = useCallback(() => {
     setExpanded((previous) => !previous);
@@ -97,7 +98,12 @@ const ScopesListCard = ({
       <div className={styles.title}>{t('description.request_permission', { name: appName })}</div>
       <div className={styles.cardWrapper}>
         {userScopesData && userScopesData.length > 0 && (
-          <ScopeGroup groupName="User Scopes" scopes={userScopesData} />
+          <ScopeGroup
+            groupName="User Scopes"
+            scopes={userScopesData}
+            // If there is no resource scopes, we should auto expand the user scopes
+            isAutoExpand={!resourceScopes?.length}
+          />
         )}
         {resourceScopes?.map(({ resource, scopes }) => (
           <ScopeGroup
@@ -108,6 +114,8 @@ const ScopesListCard = ({
                 : resource.name
             }
             scopes={scopes}
+            // If there is no user scopes, we should auto expand the resource scopes
+            isAutoExpand={!userScopesData?.length && resourceScopes.length === 1}
           />
         ))}
         {showTerms && (


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Auto expands the scopes list if there are only user scopes or only one group of resource scopes is being requested.

| user scopes | resource scopes |
| ------------ | ---------------- |
| ![WX20240124-135247@2x](https://github.com/logto-io/logto/assets/36393111/ecda3e03-8428-4cf3-98c2-77b23ca60484) | ![WX20240124-135350@2x](https://github.com/logto-io/logto/assets/36393111/7fcf4c53-095b-44c3-a0bd-7fdb79c51130) |




<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [ ] ~necessary TSDoc comments~
