### PR TITLE
fix(console): hide the guide button for third-party app

### DIFF
--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/index.tsx
@@ -4,6 +4,7 @@ import {
   type ApplicationResponse,
   type SnakeCaseOidcConfig,
 } from '@logto/schemas';
+import { conditional } from '@silverhand/essentials';
 import { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
@@ -110,13 +111,15 @@ function ApplicationDetailsContent({ data, oidcConfig, onApplicationUpdated }: P
         title={data.name}
         primaryTag={t(`${applicationTypeI18nKey[data.type]}.title`)}
         identifier={{ name: 'App ID', value: data.id }}
-        additionalActionButton={{
-          title: 'application_details.check_guide',
-          icon: <File />,
-          onClick: () => {
-            setIsReadmeOpen(true);
-          },
-        }}
+        additionalActionButton={conditional(
+          data.isThirdParty && {
+            title: 'application_details.check_guide',
+            icon: <File />,
+            onClick: () => {
+              setIsReadmeOpen(true);
+            },
+          }
+        )}
         actionMenuItems={[
           {
             type: 'danger',

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/index.tsx
@@ -112,7 +112,7 @@ function ApplicationDetailsContent({ data, oidcConfig, onApplicationUpdated }: P
         primaryTag={t(`${applicationTypeI18nKey[data.type]}.title`)}
         identifier={{ name: 'App ID', value: data.id }}
         additionalActionButton={conditional(
-          data.isThirdParty && {
+          !data.isThirdParty && {
             title: 'application_details.check_guide',
             icon: <File />,
             onClick: () => {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Hide the guide button on the application detail page's header if the current application is a third-party app. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [ ] ~necessary TSDoc comments~
