### PR TITLE
feat(console,experience,phrases): add user scopes descriptions

### DIFF
--- a/packages/console/src/i18n/init.ts
+++ b/packages/console/src/i18n/init.ts
@@ -11,7 +11,7 @@ const initI18n = async (language?: LanguageTag) => {
     .use(LanguageDetector)
     .init({
       /*
-       * I18n can not load extra namespaces with a given resources on init.
+       * I18n can not load extra namespaces with a non-empty resources value given on init.
        * In order to load experiences' namespace we need to pass empty resources on init and load them later.
        */
       resources: {},
@@ -26,12 +26,12 @@ const initI18n = async (language?: LanguageTag) => {
       },
     });
 
-  // Phrases
+  // Load phrases
   for (const [language, values] of Object.entries(resources)) {
     i18next.addResourceBundle(language, 'translation', values.translation, true);
   }
 
-  // Phrases-experience
+  // Load phrases-experience
   for (const [language, values] of Object.entries(experienceResource)) {
     i18next.addResourceBundle(language, 'experience', values.translation, true);
   }

--- a/packages/console/src/i18n/init.ts
+++ b/packages/console/src/i18n/init.ts
@@ -29,6 +29,7 @@ const initI18n = async (language?: LanguageTag) => {
   // Load phrases
   for (const [language, values] of Object.entries(resources)) {
     i18next.addResourceBundle(language, 'translation', values.translation, true);
+    i18next.addResourceBundle(language, 'errors', values.errors, true);
   }
 
   // Load phrases-experience

--- a/packages/console/src/i18n/init.ts
+++ b/packages/console/src/i18n/init.ts
@@ -1,15 +1,20 @@
 import type { LanguageTag } from '@logto/language-kit';
 import resources from '@logto/phrases';
+import experienceResource from '@logto/phrases-experience';
 import i18next from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
 
-const initI18n = async (language?: LanguageTag) =>
-  i18next
+const initI18n = async (language?: LanguageTag) => {
+  await i18next
     .use(initReactI18next)
     .use(LanguageDetector)
     .init({
-      resources,
+      /*
+       * I18n can not load extra namespaces with a given resources on init.
+       * In order to load experiences' namespace we need to pass empty resources on init and load them later.
+       */
+      resources: {},
       fallbackLng: 'en',
       interpolation: {
         escapeValue: false,
@@ -20,5 +25,16 @@ const initI18n = async (language?: LanguageTag) =>
         lookupSessionStorage: 'i18nextLogtoAcLng',
       },
     });
+
+  // Phrases
+  for (const [language, values] of Object.entries(resources)) {
+    i18next.addResourceBundle(language, 'translation', values.translation, true);
+  }
+
+  // Phrases-experience
+  for (const [language, values] of Object.entries(experienceResource)) {
+    i18next.addResourceBundle(language, 'experience', values.translation, true);
+  }
+};
 
 export default initI18n;

--- a/packages/console/src/include.d/i18next.d.ts
+++ b/packages/console/src/include.d/i18next.d.ts
@@ -1,9 +1,12 @@
 // https://react.i18next.com/latest/typescript#create-a-declaration-file
 
 import type { LocalePhrase } from '@logto/phrases';
+import type { LocalePhrase as ExperiencePhrase } from '@logto/phrases-experience';
 
 declare module 'i18next' {
   interface CustomTypeOptions {
-    resources: LocalePhrase;
+    resources: LocalePhrase & {
+      experience: ExperiencePhrase['translation'];
+    };
   }
 }

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Permissions/use-scopes-table.ts
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Permissions/use-scopes-table.ts
@@ -64,7 +64,8 @@ const useScopesTable = () => {
           type: ApplicationUserConsentScopeType.UserScopes,
           id: scope,
           name: scope,
-          description: experienceT(`descriptions.${scope}`),
+          // We have ':' in the user scope, need to change the nsSeparator to '|' to avoid i18n ns matching
+          description: experienceT(`descriptions.${scope}`, { nsSeparator: '|' }),
         })),
       };
 

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Permissions/use-scopes-table.ts
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Permissions/use-scopes-table.ts
@@ -44,6 +44,8 @@ type ScopesTableRowGroupType = {
  */
 const useScopesTable = () => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const { t: experienceT } = useTranslation('experience', { keyPrefix: 'user_scopes' });
+
   const api = useApi();
 
   const parseRowGroup = useCallback(
@@ -62,7 +64,7 @@ const useScopesTable = () => {
           type: ApplicationUserConsentScopeType.UserScopes,
           id: scope,
           name: scope,
-          // TODO: @simeng-li add user profile scopes description
+          description: experienceT(`descriptions.${scope}`),
         })),
       };
 
@@ -92,7 +94,7 @@ const useScopesTable = () => {
 
       return [userScopesGroup, ...resourceScopesGroups, organizationScopesGroup];
     },
-    [t]
+    [experienceT, t]
   );
 
   const deleteScope = useCallback(

--- a/packages/experience/src/pages/Consent/ScopesListCard/index.tsx
+++ b/packages/experience/src/pages/Consent/ScopesListCard/index.tsx
@@ -1,4 +1,4 @@
-import { ReservedResource } from '@logto/core-kit';
+import { ReservedResource, UserScope } from '@logto/core-kit';
 import { type ConsentInfoResponse } from '@logto/schemas';
 import classNames from 'classnames';
 import { useCallback, useMemo, useState } from 'react';
@@ -11,6 +11,9 @@ import TermsLinks from '@/components/TermsLinks';
 import { onKeyDownHandler } from '@/utils/a11y';
 
 import * as styles from './index.module.scss';
+
+const isUserScope = (scope: string): scope is UserScope =>
+  Object.values<string>(UserScope).includes(scope);
 
 type ScopeGroupProps = {
   groupName: string;
@@ -77,14 +80,14 @@ const ScopesListCard = ({
 }: Props) => {
   const { t } = useTranslation();
 
-  // TODO: implement the userScopes description
   const userScopesData = useMemo(
     () =>
       userScopes?.map((scope) => ({
         id: scope,
         name: scope,
+        description: isUserScope(scope) ? t(`user_scopes.descriptions.${scope}`) : undefined,
       })),
-    [userScopes]
+    [t, userScopes]
   );
 
   const showTerms = Boolean(termsUrl ?? privacyUrl);

--- a/packages/experience/src/pages/Consent/ScopesListCard/index.tsx
+++ b/packages/experience/src/pages/Consent/ScopesListCard/index.tsx
@@ -85,7 +85,10 @@ const ScopesListCard = ({
       userScopes?.map((scope) => ({
         id: scope,
         name: scope,
-        description: isUserScope(scope) ? t(`user_scopes.descriptions.${scope}`) : undefined,
+        description: isUserScope(scope)
+          ? // We have ':' in the user scope, need to change the nsSeparator to '|' to avoid i18n ns matching
+            t(`user_scopes.descriptions.${scope}`, { nsSeparator: '|' })
+          : undefined,
       })),
     [t, userScopes]
   );

--- a/packages/phrases-experience/src/locales/de/index.ts
+++ b/packages/phrases-experience/src/locales/de/index.ts
@@ -8,6 +8,7 @@ import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
 import secondary from './secondary.js';
+import user_scopes from './user-scopes.js';
 
 const de = {
   translation: {
@@ -19,6 +20,7 @@ const de = {
     list,
     mfa,
     development_tenant,
+    user_scopes,
   },
 } satisfies LocalePhrase;
 

--- a/packages/phrases-experience/src/locales/de/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/de/user-scopes.ts
@@ -1,0 +1,24 @@
+import { UserScope } from '@logto/core-kit';
+
+const user_scopes = {
+  descriptions: {
+    /** UNTRANSLATED */
+    [UserScope.CustomData]: 'Your custom data',
+    /** UNTRANSLATED */
+    [UserScope.Email]: 'Your email address',
+    /** UNTRANSLATED */
+    [UserScope.Phone]: 'Your phone number',
+    /** UNTRANSLATED */
+    [UserScope.Profile]: 'Your name and avatar',
+    /** UNTRANSLATED */
+    [UserScope.Roles]: 'Your roles',
+    /** UNTRANSLATED */
+    [UserScope.Identities]: 'Your linked social identities',
+    /** UNTRANSLATED */
+    [UserScope.Organizations]: 'Your organizations info',
+    /** UNTRANSLATED */
+    [UserScope.OrganizationRoles]: 'Your organization roles',
+  },
+};
+
+export default Object.freeze(user_scopes);

--- a/packages/phrases-experience/src/locales/en/index.ts
+++ b/packages/phrases-experience/src/locales/en/index.ts
@@ -6,6 +6,7 @@ import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
 import secondary from './secondary.js';
+import user_scopes from './user-scopes.js';
 
 const en = {
   translation: {
@@ -17,6 +18,7 @@ const en = {
     list,
     mfa,
     development_tenant,
+    user_scopes,
   },
 };
 

--- a/packages/phrases-experience/src/locales/en/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/en/user-scopes.ts
@@ -1,0 +1,16 @@
+import { UserScope } from '@logto/core-kit';
+
+const user_scopes = {
+  descriptions: {
+    [UserScope.CustomData]: 'Your custom data',
+    [UserScope.Email]: 'Your email address',
+    [UserScope.Phone]: 'Your phone number',
+    [UserScope.Profile]: 'Your name and avatar',
+    [UserScope.Roles]: 'Your roles',
+    [UserScope.Identities]: 'Your linked social identities',
+    [UserScope.Organizations]: 'Your organizations info',
+    [UserScope.OrganizationRoles]: 'Your organization roles',
+  },
+};
+
+export default Object.freeze(user_scopes);

--- a/packages/phrases-experience/src/locales/es/index.ts
+++ b/packages/phrases-experience/src/locales/es/index.ts
@@ -8,6 +8,7 @@ import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
 import secondary from './secondary.js';
+import user_scopes from './user-scopes.js';
 
 const es = {
   translation: {
@@ -19,6 +20,7 @@ const es = {
     list,
     mfa,
     development_tenant,
+    user_scopes,
   },
 } satisfies LocalePhrase;
 

--- a/packages/phrases-experience/src/locales/es/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/es/user-scopes.ts
@@ -1,0 +1,24 @@
+import { UserScope } from '@logto/core-kit';
+
+const user_scopes = {
+  descriptions: {
+    /** UNTRANSLATED */
+    [UserScope.CustomData]: 'Your custom data',
+    /** UNTRANSLATED */
+    [UserScope.Email]: 'Your email address',
+    /** UNTRANSLATED */
+    [UserScope.Phone]: 'Your phone number',
+    /** UNTRANSLATED */
+    [UserScope.Profile]: 'Your name and avatar',
+    /** UNTRANSLATED */
+    [UserScope.Roles]: 'Your roles',
+    /** UNTRANSLATED */
+    [UserScope.Identities]: 'Your linked social identities',
+    /** UNTRANSLATED */
+    [UserScope.Organizations]: 'Your organizations info',
+    /** UNTRANSLATED */
+    [UserScope.OrganizationRoles]: 'Your organization roles',
+  },
+};
+
+export default Object.freeze(user_scopes);

--- a/packages/phrases-experience/src/locales/fr/index.ts
+++ b/packages/phrases-experience/src/locales/fr/index.ts
@@ -8,6 +8,7 @@ import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
 import secondary from './secondary.js';
+import user_scopes from './user-scopes.js';
 
 const fr = {
   translation: {
@@ -19,6 +20,7 @@ const fr = {
     list,
     mfa,
     development_tenant,
+    user_scopes,
   },
 } satisfies LocalePhrase;
 

--- a/packages/phrases-experience/src/locales/fr/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/fr/user-scopes.ts
@@ -1,0 +1,24 @@
+import { UserScope } from '@logto/core-kit';
+
+const user_scopes = {
+  descriptions: {
+    /** UNTRANSLATED */
+    [UserScope.CustomData]: 'Your custom data',
+    /** UNTRANSLATED */
+    [UserScope.Email]: 'Your email address',
+    /** UNTRANSLATED */
+    [UserScope.Phone]: 'Your phone number',
+    /** UNTRANSLATED */
+    [UserScope.Profile]: 'Your name and avatar',
+    /** UNTRANSLATED */
+    [UserScope.Roles]: 'Your roles',
+    /** UNTRANSLATED */
+    [UserScope.Identities]: 'Your linked social identities',
+    /** UNTRANSLATED */
+    [UserScope.Organizations]: 'Your organizations info',
+    /** UNTRANSLATED */
+    [UserScope.OrganizationRoles]: 'Your organization roles',
+  },
+};
+
+export default Object.freeze(user_scopes);

--- a/packages/phrases-experience/src/locales/it/index.ts
+++ b/packages/phrases-experience/src/locales/it/index.ts
@@ -8,6 +8,7 @@ import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
 import secondary from './secondary.js';
+import user_scopes from './user-scopes.js';
 
 const it = {
   translation: {
@@ -19,6 +20,7 @@ const it = {
     list,
     mfa,
     development_tenant,
+    user_scopes,
   },
 } satisfies LocalePhrase;
 

--- a/packages/phrases-experience/src/locales/it/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/it/user-scopes.ts
@@ -1,0 +1,24 @@
+import { UserScope } from '@logto/core-kit';
+
+const user_scopes = {
+  descriptions: {
+    /** UNTRANSLATED */
+    [UserScope.CustomData]: 'Your custom data',
+    /** UNTRANSLATED */
+    [UserScope.Email]: 'Your email address',
+    /** UNTRANSLATED */
+    [UserScope.Phone]: 'Your phone number',
+    /** UNTRANSLATED */
+    [UserScope.Profile]: 'Your name and avatar',
+    /** UNTRANSLATED */
+    [UserScope.Roles]: 'Your roles',
+    /** UNTRANSLATED */
+    [UserScope.Identities]: 'Your linked social identities',
+    /** UNTRANSLATED */
+    [UserScope.Organizations]: 'Your organizations info',
+    /** UNTRANSLATED */
+    [UserScope.OrganizationRoles]: 'Your organization roles',
+  },
+};
+
+export default Object.freeze(user_scopes);

--- a/packages/phrases-experience/src/locales/ja/index.ts
+++ b/packages/phrases-experience/src/locales/ja/index.ts
@@ -8,6 +8,7 @@ import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
 import secondary from './secondary.js';
+import user_scopes from './user-scopes.js';
 
 const ja = {
   translation: {
@@ -19,6 +20,7 @@ const ja = {
     list,
     mfa,
     development_tenant,
+    user_scopes,
   },
 } satisfies LocalePhrase;
 

--- a/packages/phrases-experience/src/locales/ja/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/ja/user-scopes.ts
@@ -1,0 +1,24 @@
+import { UserScope } from '@logto/core-kit';
+
+const user_scopes = {
+  descriptions: {
+    /** UNTRANSLATED */
+    [UserScope.CustomData]: 'Your custom data',
+    /** UNTRANSLATED */
+    [UserScope.Email]: 'Your email address',
+    /** UNTRANSLATED */
+    [UserScope.Phone]: 'Your phone number',
+    /** UNTRANSLATED */
+    [UserScope.Profile]: 'Your name and avatar',
+    /** UNTRANSLATED */
+    [UserScope.Roles]: 'Your roles',
+    /** UNTRANSLATED */
+    [UserScope.Identities]: 'Your linked social identities',
+    /** UNTRANSLATED */
+    [UserScope.Organizations]: 'Your organizations info',
+    /** UNTRANSLATED */
+    [UserScope.OrganizationRoles]: 'Your organization roles',
+  },
+};
+
+export default Object.freeze(user_scopes);

--- a/packages/phrases-experience/src/locales/ko/index.ts
+++ b/packages/phrases-experience/src/locales/ko/index.ts
@@ -8,6 +8,7 @@ import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
 import secondary from './secondary.js';
+import user_scopes from './user-scopes.js';
 
 const ko = {
   translation: {
@@ -19,6 +20,7 @@ const ko = {
     list,
     mfa,
     development_tenant,
+    user_scopes,
   },
 } satisfies LocalePhrase;
 

--- a/packages/phrases-experience/src/locales/ko/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/ko/user-scopes.ts
@@ -1,0 +1,24 @@
+import { UserScope } from '@logto/core-kit';
+
+const user_scopes = {
+  descriptions: {
+    /** UNTRANSLATED */
+    [UserScope.CustomData]: 'Your custom data',
+    /** UNTRANSLATED */
+    [UserScope.Email]: 'Your email address',
+    /** UNTRANSLATED */
+    [UserScope.Phone]: 'Your phone number',
+    /** UNTRANSLATED */
+    [UserScope.Profile]: 'Your name and avatar',
+    /** UNTRANSLATED */
+    [UserScope.Roles]: 'Your roles',
+    /** UNTRANSLATED */
+    [UserScope.Identities]: 'Your linked social identities',
+    /** UNTRANSLATED */
+    [UserScope.Organizations]: 'Your organizations info',
+    /** UNTRANSLATED */
+    [UserScope.OrganizationRoles]: 'Your organization roles',
+  },
+};
+
+export default Object.freeze(user_scopes);

--- a/packages/phrases-experience/src/locales/pl-pl/index.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/index.ts
@@ -8,6 +8,7 @@ import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
 import secondary from './secondary.js';
+import user_scopes from './user-scopes.js';
 
 const pl_pl = {
   translation: {
@@ -19,6 +20,7 @@ const pl_pl = {
     list,
     mfa,
     development_tenant,
+    user_scopes,
   },
 } satisfies LocalePhrase;
 

--- a/packages/phrases-experience/src/locales/pl-pl/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/user-scopes.ts
@@ -1,0 +1,24 @@
+import { UserScope } from '@logto/core-kit';
+
+const user_scopes = {
+  descriptions: {
+    /** UNTRANSLATED */
+    [UserScope.CustomData]: 'Your custom data',
+    /** UNTRANSLATED */
+    [UserScope.Email]: 'Your email address',
+    /** UNTRANSLATED */
+    [UserScope.Phone]: 'Your phone number',
+    /** UNTRANSLATED */
+    [UserScope.Profile]: 'Your name and avatar',
+    /** UNTRANSLATED */
+    [UserScope.Roles]: 'Your roles',
+    /** UNTRANSLATED */
+    [UserScope.Identities]: 'Your linked social identities',
+    /** UNTRANSLATED */
+    [UserScope.Organizations]: 'Your organizations info',
+    /** UNTRANSLATED */
+    [UserScope.OrganizationRoles]: 'Your organization roles',
+  },
+};
+
+export default Object.freeze(user_scopes);

--- a/packages/phrases-experience/src/locales/pt-br/index.ts
+++ b/packages/phrases-experience/src/locales/pt-br/index.ts
@@ -8,6 +8,7 @@ import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
 import secondary from './secondary.js';
+import user_scopes from './user-scopes.js';
 
 const pt_br = {
   translation: {
@@ -19,6 +20,7 @@ const pt_br = {
     list,
     mfa,
     development_tenant,
+    user_scopes,
   },
 } satisfies LocalePhrase;
 

--- a/packages/phrases-experience/src/locales/pt-br/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/pt-br/user-scopes.ts
@@ -1,0 +1,24 @@
+import { UserScope } from '@logto/core-kit';
+
+const user_scopes = {
+  descriptions: {
+    /** UNTRANSLATED */
+    [UserScope.CustomData]: 'Your custom data',
+    /** UNTRANSLATED */
+    [UserScope.Email]: 'Your email address',
+    /** UNTRANSLATED */
+    [UserScope.Phone]: 'Your phone number',
+    /** UNTRANSLATED */
+    [UserScope.Profile]: 'Your name and avatar',
+    /** UNTRANSLATED */
+    [UserScope.Roles]: 'Your roles',
+    /** UNTRANSLATED */
+    [UserScope.Identities]: 'Your linked social identities',
+    /** UNTRANSLATED */
+    [UserScope.Organizations]: 'Your organizations info',
+    /** UNTRANSLATED */
+    [UserScope.OrganizationRoles]: 'Your organization roles',
+  },
+};
+
+export default Object.freeze(user_scopes);

--- a/packages/phrases-experience/src/locales/pt-pt/index.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/index.ts
@@ -8,6 +8,7 @@ import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
 import secondary from './secondary.js';
+import user_scopes from './user-scopes.js';
 
 const pt_pt = {
   translation: {
@@ -19,6 +20,7 @@ const pt_pt = {
     list,
     mfa,
     development_tenant,
+    user_scopes,
   },
 } satisfies LocalePhrase;
 

--- a/packages/phrases-experience/src/locales/pt-pt/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/user-scopes.ts
@@ -1,0 +1,24 @@
+import { UserScope } from '@logto/core-kit';
+
+const user_scopes = {
+  descriptions: {
+    /** UNTRANSLATED */
+    [UserScope.CustomData]: 'Your custom data',
+    /** UNTRANSLATED */
+    [UserScope.Email]: 'Your email address',
+    /** UNTRANSLATED */
+    [UserScope.Phone]: 'Your phone number',
+    /** UNTRANSLATED */
+    [UserScope.Profile]: 'Your name and avatar',
+    /** UNTRANSLATED */
+    [UserScope.Roles]: 'Your roles',
+    /** UNTRANSLATED */
+    [UserScope.Identities]: 'Your linked social identities',
+    /** UNTRANSLATED */
+    [UserScope.Organizations]: 'Your organizations info',
+    /** UNTRANSLATED */
+    [UserScope.OrganizationRoles]: 'Your organization roles',
+  },
+};
+
+export default Object.freeze(user_scopes);

--- a/packages/phrases-experience/src/locales/ru/index.ts
+++ b/packages/phrases-experience/src/locales/ru/index.ts
@@ -8,6 +8,7 @@ import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
 import secondary from './secondary.js';
+import user_scopes from './user-scopes.js';
 
 const ru = {
   translation: {
@@ -19,6 +20,7 @@ const ru = {
     list,
     mfa,
     development_tenant,
+    user_scopes,
   },
 } satisfies LocalePhrase;
 

--- a/packages/phrases-experience/src/locales/ru/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/ru/user-scopes.ts
@@ -1,0 +1,24 @@
+import { UserScope } from '@logto/core-kit';
+
+const user_scopes = {
+  descriptions: {
+    /** UNTRANSLATED */
+    [UserScope.CustomData]: 'Your custom data',
+    /** UNTRANSLATED */
+    [UserScope.Email]: 'Your email address',
+    /** UNTRANSLATED */
+    [UserScope.Phone]: 'Your phone number',
+    /** UNTRANSLATED */
+    [UserScope.Profile]: 'Your name and avatar',
+    /** UNTRANSLATED */
+    [UserScope.Roles]: 'Your roles',
+    /** UNTRANSLATED */
+    [UserScope.Identities]: 'Your linked social identities',
+    /** UNTRANSLATED */
+    [UserScope.Organizations]: 'Your organizations info',
+    /** UNTRANSLATED */
+    [UserScope.OrganizationRoles]: 'Your organization roles',
+  },
+};
+
+export default Object.freeze(user_scopes);

--- a/packages/phrases-experience/src/locales/tr-tr/index.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/index.ts
@@ -8,6 +8,7 @@ import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
 import secondary from './secondary.js';
+import user_scopes from './user-scopes.js';
 
 const tr_tr = {
   translation: {
@@ -19,6 +20,7 @@ const tr_tr = {
     list,
     mfa,
     development_tenant,
+    user_scopes,
   },
 } satisfies LocalePhrase;
 

--- a/packages/phrases-experience/src/locales/tr-tr/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/user-scopes.ts
@@ -1,0 +1,24 @@
+import { UserScope } from '@logto/core-kit';
+
+const user_scopes = {
+  descriptions: {
+    /** UNTRANSLATED */
+    [UserScope.CustomData]: 'Your custom data',
+    /** UNTRANSLATED */
+    [UserScope.Email]: 'Your email address',
+    /** UNTRANSLATED */
+    [UserScope.Phone]: 'Your phone number',
+    /** UNTRANSLATED */
+    [UserScope.Profile]: 'Your name and avatar',
+    /** UNTRANSLATED */
+    [UserScope.Roles]: 'Your roles',
+    /** UNTRANSLATED */
+    [UserScope.Identities]: 'Your linked social identities',
+    /** UNTRANSLATED */
+    [UserScope.Organizations]: 'Your organizations info',
+    /** UNTRANSLATED */
+    [UserScope.OrganizationRoles]: 'Your organization roles',
+  },
+};
+
+export default Object.freeze(user_scopes);

--- a/packages/phrases-experience/src/locales/zh-cn/index.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/index.ts
@@ -8,6 +8,7 @@ import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
 import secondary from './secondary.js';
+import user_scopes from './user-scopes.js';
 
 const zh_cn = {
   translation: {
@@ -19,6 +20,7 @@ const zh_cn = {
     list,
     mfa,
     development_tenant,
+    user_scopes,
   },
 } satisfies LocalePhrase;
 

--- a/packages/phrases-experience/src/locales/zh-cn/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/user-scopes.ts
@@ -1,0 +1,24 @@
+import { UserScope } from '@logto/core-kit';
+
+const user_scopes = {
+  descriptions: {
+    /** UNTRANSLATED */
+    [UserScope.CustomData]: 'Your custom data',
+    /** UNTRANSLATED */
+    [UserScope.Email]: 'Your email address',
+    /** UNTRANSLATED */
+    [UserScope.Phone]: 'Your phone number',
+    /** UNTRANSLATED */
+    [UserScope.Profile]: 'Your name and avatar',
+    /** UNTRANSLATED */
+    [UserScope.Roles]: 'Your roles',
+    /** UNTRANSLATED */
+    [UserScope.Identities]: 'Your linked social identities',
+    /** UNTRANSLATED */
+    [UserScope.Organizations]: 'Your organizations info',
+    /** UNTRANSLATED */
+    [UserScope.OrganizationRoles]: 'Your organization roles',
+  },
+};
+
+export default Object.freeze(user_scopes);

--- a/packages/phrases-experience/src/locales/zh-hk/index.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/index.ts
@@ -8,6 +8,7 @@ import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
 import secondary from './secondary.js';
+import user_scopes from './user-scopes.js';
 
 const zh_hk = {
   translation: {
@@ -19,6 +20,7 @@ const zh_hk = {
     list,
     mfa,
     development_tenant,
+    user_scopes,
   },
 } satisfies LocalePhrase;
 

--- a/packages/phrases-experience/src/locales/zh-hk/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/user-scopes.ts
@@ -1,0 +1,24 @@
+import { UserScope } from '@logto/core-kit';
+
+const user_scopes = {
+  descriptions: {
+    /** UNTRANSLATED */
+    [UserScope.CustomData]: 'Your custom data',
+    /** UNTRANSLATED */
+    [UserScope.Email]: 'Your email address',
+    /** UNTRANSLATED */
+    [UserScope.Phone]: 'Your phone number',
+    /** UNTRANSLATED */
+    [UserScope.Profile]: 'Your name and avatar',
+    /** UNTRANSLATED */
+    [UserScope.Roles]: 'Your roles',
+    /** UNTRANSLATED */
+    [UserScope.Identities]: 'Your linked social identities',
+    /** UNTRANSLATED */
+    [UserScope.Organizations]: 'Your organizations info',
+    /** UNTRANSLATED */
+    [UserScope.OrganizationRoles]: 'Your organization roles',
+  },
+};
+
+export default Object.freeze(user_scopes);

--- a/packages/phrases-experience/src/locales/zh-tw/index.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/index.ts
@@ -8,6 +8,7 @@ import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
 import secondary from './secondary.js';
+import user_scopes from './user-scopes.js';
 
 const zh_tw = {
   translation: {
@@ -19,6 +20,7 @@ const zh_tw = {
     list,
     mfa,
     development_tenant,
+    user_scopes,
   },
 } satisfies LocalePhrase;
 

--- a/packages/phrases-experience/src/locales/zh-tw/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/user-scopes.ts
@@ -1,0 +1,24 @@
+import { UserScope } from '@logto/core-kit';
+
+const user_scopes = {
+  descriptions: {
+    /** UNTRANSLATED */
+    [UserScope.CustomData]: 'Your custom data',
+    /** UNTRANSLATED */
+    [UserScope.Email]: 'Your email address',
+    /** UNTRANSLATED */
+    [UserScope.Phone]: 'Your phone number',
+    /** UNTRANSLATED */
+    [UserScope.Profile]: 'Your name and avatar',
+    /** UNTRANSLATED */
+    [UserScope.Roles]: 'Your roles',
+    /** UNTRANSLATED */
+    [UserScope.Identities]: 'Your linked social identities',
+    /** UNTRANSLATED */
+    [UserScope.Organizations]: 'Your organizations info',
+    /** UNTRANSLATED */
+    [UserScope.OrganizationRoles]: 'Your organization roles',
+  },
+};
+
+export default Object.freeze(user_scopes);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add user scope descriptions using i18n.

- load experience phrase on the console using a separate namespace 'experience'
- update the console permission table to display user scope descriptions
- update the consent page to display user scope descriptions.

<img width="777" alt="image" src="https://github.com/logto-io/logto/assets/36393111/c17a3a67-f318-4676-9de5-3f917ebf5503">

<img width="440" alt="image" src="https://github.com/logto-io/logto/assets/36393111/ea410812-7db4-4b9a-b956-654640ca4f45">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test  locally
test locally


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [x] necessary TSDoc comments
