### PR TITLE
refactor(console): remove pro tag from app category filter

### DIFF
--- a/packages/console/src/pages/Applications/components/GuideLibrary/index.tsx
+++ b/packages/console/src/pages/Applications/components/GuideLibrary/index.tsx
@@ -1,16 +1,14 @@
-import { ReservedPlanId, type Application } from '@logto/schemas';
+import { type Application } from '@logto/schemas';
 import classNames from 'classnames';
-import { useCallback, useContext, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import SearchIcon from '@/assets/icons/search.svg';
 import EmptyDataPlaceholder from '@/components/EmptyDataPlaceholder';
-import FeatureTag from '@/components/FeatureTag';
 import { type SelectedGuide } from '@/components/Guide/GuideCard';
 import GuideCardGroup from '@/components/Guide/GuideCardGroup';
 import { useAppGuideMetadata } from '@/components/Guide/hooks';
-import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
-import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
+import { isDevFeaturesEnabled } from '@/consts/env';
 import { CheckboxGroup } from '@/ds-components/Checkbox';
 import OverlayScrollbar from '@/ds-components/OverlayScrollbar';
 import TextInput from '@/ds-components/TextInput';
@@ -38,7 +36,6 @@ function GuideLibrary({ className, hasCardBorder, hasCardButton, hasFilters }: P
   const [selectedGuide, setSelectedGuide] = useState<SelectedGuide>();
   const { getFilteredAppGuideMetadata, getStructuredAppGuideMetadata } = useAppGuideMetadata();
   const [showCreateForm, setShowCreateForm] = useState<boolean>(false);
-  const { currentPlan } = useContext(SubscriptionDataContext);
 
   const structuredMetadata = useMemo(
     () => getStructuredAppGuideMetadata({ categories: filterCategories }),
@@ -111,14 +108,6 @@ function GuideLibrary({ className, hasCardBorder, hasCardButton, hasFilters }: P
                       setFilterCategories(sortedValue);
                     }}
                   />
-                  {/* TODO: must be refactored since there's no way to see the tag's intention */}
-                  {isCloud && (
-                    <FeatureTag
-                      isVisible={!currentPlan.quota.machineToMachineLimit}
-                      plan={ReservedPlanId.Pro}
-                      className={styles.proTag}
-                    />
-                  )}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Remove "Pro" tag from app category filter list, since the tag was initially trying to attach to M2M app, but later the M2M is not a "Pro" feature any more. Also, the implementation was quite confusing and we were trying to refactor it in the first place. Anyways... Now, it's gone.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested using Cloud dev env. It's gone

<img width="1465" alt="image" src="https://github.com/logto-io/logto/assets/12833674/a1c82ac7-cfba-4853-8c21-0b91986d71d6">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
