### PR TITLE
feat(console): add the user permission tooltips

### DIFF
--- a/packages/console/src/ds-components/Button/index.module.scss
+++ b/packages/console/src/ds-components/Button/index.module.scss
@@ -49,10 +49,6 @@
   .trailingIcon {
     display: flex;
     align-items: center;
-
-    &:not(:first-child) {
-      margin-left: _.unit(2);
-    }
   }
 
   &.small {

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Permissions/index.module.scss
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Permissions/index.module.scss
@@ -13,3 +13,9 @@
     padding-bottom: _.unit(2);
   }
 }
+
+.label {
+  display: flex;
+  gap: _.unit(1);
+  align-items: center;
+}

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Permissions/use-scopes-table.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Permissions/use-scopes-table.tsx
@@ -1,10 +1,15 @@
+/* eslint-disable consistent-default-export-name/default-export-match-filename */
+// We need to return a ReactNode property in the parseRowGroup function
 import {
   type ApplicationUserConsentScopesResponse,
   ApplicationUserConsentScopeType,
 } from '@logto/schemas';
-import { useCallback } from 'react';
+import { useCallback, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import Tip from '@/assets/icons/tip.svg';
+import IconButton from '@/ds-components/IconButton';
+import { ToggleTip } from '@/ds-components/Tip';
 import useApi from '@/hooks/use-api';
 
 import * as styles from './index.module.scss';
@@ -34,7 +39,7 @@ export type ScopesTableRowDataType =
 
 type ScopesTableRowGroupType = {
   key: string;
-  label: string;
+  label: string | ReactNode;
   labelRowClassName?: string;
   data: ScopesTableRowDataType[];
 };
@@ -58,7 +63,18 @@ const useScopesTable = () => {
 
       const userScopesGroup: ScopesTableRowGroupType = {
         key: ApplicationUserConsentScopeType.UserScopes,
-        label: t('application_details.permissions.user_permissions'),
+        label: (
+          <div className={styles.label}>
+            {t('application_details.permissions.user_permissions')}
+            <ToggleTip
+              content={t('application_details.permissions.user_data_permission_description_tips')}
+            >
+              <IconButton size="small">
+                <Tip />
+              </IconButton>
+            </ToggleTip>
+          </div>
+        ),
         labelRowClassName: styles.sectionTitleRow,
         data: userScopes.map((scope) => ({
           type: ApplicationUserConsentScopeType.UserScopes,
@@ -145,3 +161,4 @@ const useScopesTable = () => {
 };
 
 export default useScopesTable;
+/* eslint-enable consistent-default-export-name/default-export-match-filename */

--- a/packages/phrases/src/locales/de/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/application-details.ts
@@ -170,6 +170,9 @@ const application_details = {
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
     /** UNTRANSLATED */
+    user_data_permission_description_tips:
+      'You can modify the description of the personal user data permissions via "Sign-in Experience > Content > Manage Language"',
+    /** UNTRANSLATED */
     permission_description_tips:
       'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },

--- a/packages/phrases/src/locales/en/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/application-details.ts
@@ -119,6 +119,8 @@ const application_details = {
     user_permissions_assignment_form_title: 'Add the user profile permissions',
     organization_permissions_assignment_form_title: 'Add the organization permissions',
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
+    user_data_permission_description_tips:
+      'You can modify the description of the personal user data permissions via "Sign-in Experience > Content > Manage Language"',
     permission_description_tips:
       'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },

--- a/packages/phrases/src/locales/es/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/application-details.ts
@@ -170,6 +170,9 @@ const application_details = {
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
     /** UNTRANSLATED */
+    user_data_permission_description_tips:
+      'You can modify the description of the personal user data permissions via "Sign-in Experience > Content > Manage Language"',
+    /** UNTRANSLATED */
     permission_description_tips:
       'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },

--- a/packages/phrases/src/locales/fr/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/application-details.ts
@@ -170,6 +170,9 @@ const application_details = {
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
     /** UNTRANSLATED */
+    user_data_permission_description_tips:
+      'You can modify the description of the personal user data permissions via "Sign-in Experience > Content > Manage Language"',
+    /** UNTRANSLATED */
     permission_description_tips:
       'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },

--- a/packages/phrases/src/locales/it/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/application-details.ts
@@ -170,6 +170,9 @@ const application_details = {
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
     /** UNTRANSLATED */
+    user_data_permission_description_tips:
+      'You can modify the description of the personal user data permissions via "Sign-in Experience > Content > Manage Language"',
+    /** UNTRANSLATED */
     permission_description_tips:
       'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },

--- a/packages/phrases/src/locales/ja/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/application-details.ts
@@ -170,6 +170,9 @@ const application_details = {
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
     /** UNTRANSLATED */
+    user_data_permission_description_tips:
+      'You can modify the description of the personal user data permissions via "Sign-in Experience > Content > Manage Language"',
+    /** UNTRANSLATED */
     permission_description_tips:
       'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },

--- a/packages/phrases/src/locales/ko/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/application-details.ts
@@ -170,6 +170,9 @@ const application_details = {
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
     /** UNTRANSLATED */
+    user_data_permission_description_tips:
+      'You can modify the description of the personal user data permissions via "Sign-in Experience > Content > Manage Language"',
+    /** UNTRANSLATED */
     permission_description_tips:
       'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/application-details.ts
@@ -170,6 +170,9 @@ const application_details = {
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
     /** UNTRANSLATED */
+    user_data_permission_description_tips:
+      'You can modify the description of the personal user data permissions via "Sign-in Experience > Content > Manage Language"',
+    /** UNTRANSLATED */
     permission_description_tips:
       'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/application-details.ts
@@ -170,6 +170,9 @@ const application_details = {
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
     /** UNTRANSLATED */
+    user_data_permission_description_tips:
+      'You can modify the description of the personal user data permissions via "Sign-in Experience > Content > Manage Language"',
+    /** UNTRANSLATED */
     permission_description_tips:
       'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/application-details.ts
@@ -170,6 +170,9 @@ const application_details = {
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
     /** UNTRANSLATED */
+    user_data_permission_description_tips:
+      'You can modify the description of the personal user data permissions via "Sign-in Experience > Content > Manage Language"',
+    /** UNTRANSLATED */
     permission_description_tips:
       'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },

--- a/packages/phrases/src/locales/ru/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/application-details.ts
@@ -170,6 +170,9 @@ const application_details = {
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
     /** UNTRANSLATED */
+    user_data_permission_description_tips:
+      'You can modify the description of the personal user data permissions via "Sign-in Experience > Content > Manage Language"',
+    /** UNTRANSLATED */
     permission_description_tips:
       'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/application-details.ts
@@ -170,6 +170,9 @@ const application_details = {
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
     /** UNTRANSLATED */
+    user_data_permission_description_tips:
+      'You can modify the description of the personal user data permissions via "Sign-in Experience > Content > Manage Language"',
+    /** UNTRANSLATED */
     permission_description_tips:
       'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/application-details.ts
@@ -167,6 +167,9 @@ const application_details = {
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
     /** UNTRANSLATED */
+    user_data_permission_description_tips:
+      'You can modify the description of the personal user data permissions via "Sign-in Experience > Content > Manage Language"',
+    /** UNTRANSLATED */
     permission_description_tips:
       'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/application-details.ts
@@ -167,6 +167,9 @@ const application_details = {
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
     /** UNTRANSLATED */
+    user_data_permission_description_tips:
+      'You can modify the description of the personal user data permissions via "Sign-in Experience > Content > Manage Language"',
+    /** UNTRANSLATED */
     permission_description_tips:
       'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/application-details.ts
@@ -168,6 +168,9 @@ const application_details = {
     /** UNTRANSLATED */
     api_resource_permissions_assignment_form_title: 'Add the API resource permissions',
     /** UNTRANSLATED */
+    user_data_permission_description_tips:
+      'You can modify the description of the personal user data permissions via "Sign-in Experience > Content > Manage Language"',
+    /** UNTRANSLATED */
     permission_description_tips:
       'When Logto is used as an Identity Provider (IdP) for authentication in third-party apps, and users are asked for authorization, this description appears on the consent screen.',
   },


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add the user permission tooltips.


- Fix the button trailing icon style
- Add a tooltip button on the user data permission's table header

<img width="803" alt="image" src="https://github.com/logto-io/logto/assets/36393111/063dfe60-961d-4fd8-881c-e80502857e99">



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [ ] ~necessary TSDoc comments~
