### PR TITLE
refactor(console): improve app creation page empty state layout

### DIFF
--- a/packages/console/src/components/EmptyDataPlaceholder/index.module.scss
+++ b/packages/console/src/components/EmptyDataPlaceholder/index.module.scss
@@ -39,4 +39,12 @@
       height: 128px;
     }
   }
+
+  .topSpace {
+    flex: 2;
+  }
+
+  .bottomSpace {
+    flex: 3;
+  }
 }

--- a/packages/console/src/components/EmptyDataPlaceholder/index.tsx
+++ b/packages/console/src/components/EmptyDataPlaceholder/index.tsx
@@ -22,8 +22,10 @@ function EmptyDataPlaceholder({ title, size = 'medium', className }: Props) {
 
   return (
     <div className={classNames(styles.empty, styles[size], className)}>
+      <div className={styles.topSpace} />
       <EmptyImage className={styles.image} />
       <div className={styles.title}>{title ?? t('errors.empty')}</div>
+      <div className={styles.bottomSpace} />
     </div>
   );
 }

--- a/packages/console/src/pages/Applications/components/GuideLibrary/index.module.scss
+++ b/packages/console/src/pages/Applications/components/GuideLibrary/index.module.scss
@@ -7,6 +7,7 @@
 
 .wrapper {
   width: 100%;
+  min-height: 100%;
   min-width: dim.$guide-content-min-width;
   max-width: dim.$guide-content-max-width;
   margin: 0 auto;
@@ -87,10 +88,13 @@
 }
 
 .emptyPlaceholder {
-  justify-content: center;
-  position: absolute;
   width: 100%;
-  height: 70%;
+  height: calc(100vh - 188px);
+  display: flex;
+}
+
+.viewAll {
+  margin-top: _.unit(8);
 }
 
 @media screen and (max-width: dim.$guide-content-max-width) {

--- a/packages/console/src/pages/Applications/components/GuideLibraryModal/index.tsx
+++ b/packages/console/src/pages/Applications/components/GuideLibraryModal/index.tsx
@@ -36,7 +36,7 @@ function GuideLibraryModal({ isOpen, onClose }: Props) {
           requestSuccessMessage="guide.request_guide_successfully"
           onClose={onClose}
         />
-        <GuideLibrary hasFilters hasCardButton className={styles.content} />
+        <GuideLibrary hasCardButton className={styles.content} />
         <ModalFooter
           wrapperClassName={styles.footerInnerWrapper}
           content="guide.do_not_need_tutorial"

--- a/packages/console/src/pages/Applications/components/ProtectedAppCard/index.module.scss
+++ b/packages/console/src/pages/Applications/components/ProtectedAppCard/index.module.scss
@@ -21,6 +21,10 @@
     background-color: var(--color-layer-1);
     border-radius: 12px;
 
+    &.hasBorder {
+      border: 1px solid var(--color-divider);
+    }
+
     .logo {
       width: 48px;
       height: 48px;

--- a/packages/console/src/pages/Applications/components/ProtectedAppCard/index.tsx
+++ b/packages/console/src/pages/Applications/components/ProtectedAppCard/index.tsx
@@ -16,12 +16,19 @@ import * as styles from './index.module.scss';
 
 type Props = {
   className?: string;
+  hasBorder?: boolean;
   hasLabel?: boolean;
   hasCreateButton?: boolean;
   onCreateSuccess?: (app: Application) => void;
 };
 
-function ProtectedAppCard({ className, hasLabel, hasCreateButton, onCreateSuccess }: Props) {
+function ProtectedAppCard({
+  className,
+  hasBorder,
+  hasLabel,
+  hasCreateButton,
+  onCreateSuccess,
+}: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console.protected_app' });
   const { documentationSiteUrl } = useDocumentationUrl();
   const [showCreateModal, setShowCreateModal] = useState<boolean>(false);
@@ -32,7 +39,7 @@ function ProtectedAppCard({ className, hasLabel, hasCreateButton, onCreateSucces
     <>
       <div className={classNames(styles.container, className)}>
         {hasLabel && <label>{t('name')}</label>}
-        <div className={styles.card}>
+        <div className={classNames(styles.card, hasBorder && styles.hasBorder)}>
           <Icon className={styles.logo} />
           <div className={styles.wrapper}>
             <div className={styles.name}>{t('title')}</div>

--- a/packages/console/src/pages/Applications/index.module.scss
+++ b/packages/console/src/pages/Applications/index.module.scss
@@ -18,11 +18,10 @@
 
 .guideLibraryContainer {
   flex: 1;
-  overflow-y: auto;
   background: var(--color-layer-1);
   border-radius: 12px;
   padding: _.unit(6) 0;
-  margin: _.unit(4) 0;
+  margin-top: _.unit(4);
 
   .title {
     align-items: center;

--- a/packages/console/src/pages/Applications/index.tsx
+++ b/packages/console/src/pages/Applications/index.tsx
@@ -12,7 +12,6 @@ import { isDevFeaturesEnabled, isCloud } from '@/consts/env';
 import Button from '@/ds-components/Button';
 import CardTitle from '@/ds-components/CardTitle';
 import CopyToClipboard from '@/ds-components/CopyToClipboard';
-import OverlayScrollbar from '@/ds-components/OverlayScrollbar';
 import TabNav, { TabNavItem } from '@/ds-components/TabNav';
 import Table from '@/ds-components/Table';
 import useApplicationsUsage from '@/hooks/use-applications-usage';
@@ -124,14 +123,14 @@ function Applications({ tab }: Props) {
       )}
 
       {!isLoading && !applications?.length && (
-        <OverlayScrollbar className={styles.guideLibraryContainer}>
+        <div className={styles.guideLibraryContainer}>
           <CardTitle
             className={styles.title}
             title="guide.app.select_framework_or_tutorial"
             subtitle="guide.app.modal_subtitle"
           />
           <GuideLibrary hasCardBorder hasCardButton className={styles.library} />
-        </OverlayScrollbar>
+        </div>
       )}
       {(isLoading || !!applications?.length) && (
         <Table

--- a/packages/console/src/scss/page-layout.module.scss
+++ b/packages/console/src/scss/page-layout.module.scss
@@ -5,7 +5,7 @@
   display: flex;
   flex-direction: column;
   padding-bottom: _.unit(6);
-  height: 100%;
+  min-height: 100%;
 }
 
 .headline {

--- a/packages/console/src/types/applications.ts
+++ b/packages/console/src/types/applications.ts
@@ -18,12 +18,12 @@ export const applicationTypeI18nKey = Object.freeze({
  * plus the "featured" category.
  */
 export const allAppGuideCategories = Object.freeze([
+  'Protected',
   'featured',
   'Traditional',
   'SPA',
   'Native',
   'MachineToMachine',
-  'Protected',
   thirdPartyAppCategory,
 ] as const);
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Improve applications page empty state layout:
1. Protected app card should have border when it's in the empty state component
2. The empty state component should not be framed and scrolled inside the frame, but stretched out and scroll with the entire page
3. Hide protected app creation card from application gallery, if the filtered category doesn't contain protected app.
4. Add the missing "View all ->" button on the bottom

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="1511" alt="image" src="https://github.com/logto-io/logto/assets/12833674/89a578c8-219f-4cf8-8ce7-5c1932156409">

<img width="1511" alt="image" src="https://github.com/logto-io/logto/assets/12833674/019740a5-0c38-431a-8d9d-f4685111f1ef">

<img width="1410" alt="image" src="https://github.com/logto-io/logto/assets/12833674/e470dedd-1b4a-4333-a059-fe1fbd33760f">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
