### PR TITLE
fix(experience): fix the organization selector position

### DIFF
--- a/packages/experience/src/pages/Consent/OrganizationSelector/OrganizationSelectorModal/index.tsx
+++ b/packages/experience/src/pages/Consent/OrganizationSelector/OrganizationSelectorModal/index.tsx
@@ -31,26 +31,38 @@ const OrganizationSelectorModal = ({
   const updatePosition = useCallback(() => {
     const parent = parentElementRef.current;
 
-    if (!parent || isMobile) {
+    if (!parent || isMobile || !isOpen) {
       setPosition({});
       return;
     }
 
-    const offset = 8;
     const { top, left, height, width } = parent.getBoundingClientRect();
-    setPosition({ top: top + height + offset, left, width });
-  }, [isMobile, parentElementRef]);
+
+    // Offset the modal from the parent element
+    const offset = 8;
+
+    // The height of each organization item
+    const organizationItemHeight = 40;
+    // The padding around the modal content
+    const organizationModalPadding = 8;
+
+    // Calculate the max top position so that the modal doesn't go off the screen
+    const modalContentHeight =
+      organizations.length * organizationItemHeight + organizationModalPadding * 2;
+    const windowHeight = window.innerHeight;
+    const maxTop = windowHeight - modalContentHeight;
+
+    setPosition({ top: Math.min(top + height + offset, maxTop), left, width });
+  }, [isMobile, isOpen, organizations.length, parentElementRef]);
 
   useLayoutEffect(() => {
     updatePosition();
     window.addEventListener('resize', updatePosition);
-    window.addEventListener('scroll', updatePosition);
 
     return () => {
       window.removeEventListener('resize', updatePosition);
-      window.removeEventListener('scroll', updatePosition);
     };
-  }, [updatePosition]);
+  }, [updatePosition, isOpen]);
 
   return (
     <ReactModal


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the organization selector position.

This PR includes the following fix:

Based on the current page layout, all the page-level overflow scroll event is triggered on a `view-box`  div element instead of the window.  So the original `window.onScroll` event won't be triggered. This organization selector modal pos can not be recalculated properly. 

![image](https://github.com/logto-io/logto/assets/36393111/a73cf214-7720-4a1d-b98d-9736d75c3ab3)

To fix this: 
1. Remove the window on scroll event listener, as it is useless
2. Add the 'isOpen' property as the `useEffect` dependency, so the dropdown pos may be recalculated whenever the modal is opened. 
3. Calculate the modal height and provide a min Top threshold to make sure the drop-down menu won't go off the screen

<img width="560" alt="image" src="https://github.com/logto-io/logto/assets/36393111/8fe36854-bf9a-4294-824e-54b6c379f0d5">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [x] necessary TSDoc comments
