### PR TITLE
style(experience): fix the terms padding

### DIFF
--- a/packages/experience/src/pages/Consent/ScopesListCard/index.module.scss
+++ b/packages/experience/src/pages/Consent/ScopesListCard/index.module.scss
@@ -64,7 +64,7 @@
 }
 
 .terms {
-  padding: _.unit(4);
+  padding: _.unit(4)  _.unit(4) _.unit(2) _.unit(4);
   border-top: _.border(var(--color-line-divider));
   margin-top: _.unit(2);
   font: var(--font-body-3);


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix the terms section padding.

The card wrapper contains an 8px wrapping. 

<img width="440" alt="image" src="https://github.com/logto-io/logto/assets/36393111/abd37508-6f8d-4959-902c-a86c512b2c7d">

The terms section should shrink the padding-bottom space by 8px in order to make the content centralized. 

<img width="440" alt="image" src="https://github.com/logto-io/logto/assets/36393111/12c1be35-217c-421f-861c-807c49b49793">



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [ ] ~necessary TSDoc comments~
