### PR TITLE
fix(toolkit): domain regex should allow short subdomain and top-level domain

### DIFF
--- a/packages/toolkit/core-kit/src/regex.test.ts
+++ b/packages/toolkit/core-kit/src/regex.test.ts
@@ -1,0 +1,18 @@
+import { domainRegEx } from './regex.js';
+
+describe('Regular expressions should work as expected', () => {
+  it('should allow valid domains that consists of 3 parts. E.g. foo.bar.com', () => {
+    expect(domainRegEx.test('foo.bar.com')).toBe(true);
+    expect(domainRegEx.test('foo1.bar.com')).toBe(true);
+    expect(domainRegEx.test('foo.bar1.com')).toBe(true);
+    expect(domainRegEx.test('1foo.bar.com')).toBe(true);
+    expect(domainRegEx.test('f.bar.co')).toBe(true);
+    expect(domainRegEx.test('f.b.com')).toBe(true);
+    expect(domainRegEx.test('1.b.tk')).toBe(true);
+  });
+
+  it('should not allow domains that consists of 2 parts. E.g. bar.com', () => {
+    expect(domainRegEx.test('bar.com')).toBe(false);
+    expect(domainRegEx.test('b.co')).toBe(false);
+  });
+});

--- a/packages/toolkit/core-kit/src/regex.ts
+++ b/packages/toolkit/core-kit/src/regex.ts
@@ -8,5 +8,4 @@ export const hexColorRegEx = /^#[\da-f]{3}([\da-f]{3})?$/i;
 export const dateRegex = /^\d{4}(-\d{2}){2}/;
 export const noSpaceRegEx = /^\S+$/;
 /** Full domain that consists of at least 3 parts, e.g. foo.bar.com */
-export const domainRegEx =
-  /^[\dA-Za-z][\dA-Za-z-]*[\dA-Za-z](\.[\dA-Za-z][\dA-Za-z-]*[\dA-Za-z]){2,}$/;
+export const domainRegEx = /^[\dA-Za-z]+(\.[\dA-Za-z]+){2,}$/;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Currently the domain regex does not allow short subdomain and top-level domain that contain only 1 character. For example, the following domains are considered invalid at this point:
- f.bar.com
- foo.b.com
- f.b.com

But they are actually valid in real life. E.g. `x.com`

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested and it works

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
- [x] unit tests
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
