### PR TITLE
fix(core,schemas): use database index to prevent subdomain conflict

### DIFF
--- a/packages/core/src/libraries/protected-app.ts
+++ b/packages/core/src/libraries/protected-app.ts
@@ -62,6 +62,46 @@ const getDefaultDomain = async () => {
 };
 
 /**
+ * Build application data for protected app
+ * check if subdomain is valid
+ * generate host based on subdomain
+ * generate default protectedAppMetadata based on host and origin
+ * generate redirectUris and postLogoutRedirectUris based on host
+ */
+const buildProtectedAppData = async ({
+  subDomain,
+  origin,
+}: {
+  subDomain: string;
+  origin: string;
+}): Promise<Pick<Application, 'protectedAppMetadata' | 'oidcClientMetadata'>> => {
+  assertThat(
+    isValidSubdomain(subDomain),
+    new RequestError({
+      code: 'application.invalid_subdomain',
+      status: 422,
+    })
+  );
+
+  // Skip for integration test, use empty value instead
+  const { domain } = EnvSet.values.isIntegrationTest ? { domain: '' } : await getProviderConfig();
+  const host = `${subDomain}.${domain}`;
+
+  return {
+    protectedAppMetadata: {
+      host,
+      origin,
+      sessionDuration: defaultProtectedAppSessionDuration,
+      pageRules: defaultProtectedAppPageRules,
+    },
+    oidcClientMetadata: {
+      redirectUris: [`https://${host}/${protectedAppSignInCallbackUrl}`],
+      postLogoutRedirectUris: [`https://${host}`],
+    },
+  };
+};
+
+/**
  * Call Cloudflare API to add the domain (custom hostname) to the remote
  * and get the DNS records to be added to the DNS provider
  */
@@ -107,7 +147,7 @@ const deleteDomainFromRemote = async (id: string) => {
 
 export const createProtectedAppLibrary = (queries: Queries) => {
   const {
-    applications: { findApplicationById, findApplicationByProtectedAppHost, updateApplicationById },
+    applications: { findApplicationById, updateApplicationById },
   } = queries;
 
   const syncAppConfigsToRemote = async (applicationId: string): Promise<void> => {
@@ -152,56 +192,6 @@ export const createProtectedAppLibrary = (queries: Queries) => {
         })
       );
     }
-  };
-
-  /**
-   * Build application data for protected app
-   * check if subdomain is valid
-   * generate host based on subdomain
-   * generate default protectedAppMetadata based on host and origin
-   * generate redirectUris and postLogoutRedirectUris based on host
-   */
-  const checkAndBuildProtectedAppData = async ({
-    subDomain,
-    origin,
-  }: {
-    subDomain: string;
-    origin: string;
-  }): Promise<Pick<Application, 'protectedAppMetadata' | 'oidcClientMetadata'>> => {
-    assertThat(
-      isValidSubdomain(subDomain),
-      new RequestError({
-        code: 'application.invalid_subdomain',
-        status: 422,
-      })
-    );
-
-    // Skip for integration test, use empty value instead
-    const { domain } = EnvSet.values.isIntegrationTest ? { domain: '' } : await getProviderConfig();
-    const host = `${subDomain}.${domain}`;
-
-    const application = await findApplicationByProtectedAppHost(host);
-
-    assertThat(
-      !application,
-      new RequestError({
-        code: 'application.protected_application_subdomain_exists',
-        status: 422,
-      })
-    );
-
-    return {
-      protectedAppMetadata: {
-        host,
-        origin,
-        sessionDuration: defaultProtectedAppSessionDuration,
-        pageRules: defaultProtectedAppPageRules,
-      },
-      oidcClientMetadata: {
-        redirectUris: [`https://${host}/${protectedAppSignInCallbackUrl}`],
-        postLogoutRedirectUris: [`https://${host}`],
-      },
-    };
   };
 
   /**
@@ -280,7 +270,7 @@ export const createProtectedAppLibrary = (queries: Queries) => {
   return {
     syncAppConfigsToRemote,
     deleteRemoteAppConfigs,
-    checkAndBuildProtectedAppData,
+    buildProtectedAppData,
     getDefaultDomain,
     addDomainToRemote,
     syncAppCustomDomainStatus,

--- a/packages/core/src/middleware/koa-slonik-error-handler.test.ts
+++ b/packages/core/src/middleware/koa-slonik-error-handler.test.ts
@@ -1,5 +1,5 @@
 import { Users } from '@logto/schemas';
-import { NotFoundError, SlonikError } from 'slonik';
+import { NotFoundError, SlonikError, UniqueIntegrityConstraintViolationError } from 'slonik';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import { DeletionError, InsertionError, UpdateError } from '#src/errors/SlonikError/index.js';
@@ -95,6 +95,23 @@ describe('koaSlonikErrorHandler middleware', () => {
       new RequestError({
         code: 'entity.not_found',
         status: 404,
+      })
+    );
+  });
+
+  it('UniqueIntegrityConstraintViolationError for protected application', async () => {
+    const error = new UniqueIntegrityConstraintViolationError(
+      new Error(' '),
+      'applications__protected_app_metadata_host'
+    );
+    next.mockImplementationOnce(() => {
+      throw error;
+    });
+
+    await expect(koaSlonikErrorHandler()(ctx, next)).rejects.toMatchError(
+      new RequestError({
+        code: 'application.protected_application_subdomain_exists',
+        status: 422,
       })
     );
   });

--- a/packages/core/src/middleware/koa-slonik-error-handler.ts
+++ b/packages/core/src/middleware/koa-slonik-error-handler.ts
@@ -5,6 +5,7 @@ import {
   NotFoundError,
   InvalidInputError,
   CheckIntegrityConstraintViolationError,
+  UniqueIntegrityConstraintViolationError,
 } from 'slonik';
 
 import RequestError from '#src/errors/RequestError/index.js';
@@ -22,6 +23,16 @@ export default function koaSlonikErrorHandler<StateT, ContextT>(): Middleware<St
       if (error instanceof InvalidInputError) {
         throw new RequestError({
           code: 'entity.invalid_input',
+          status: 422,
+        });
+      }
+
+      if (
+        error instanceof UniqueIntegrityConstraintViolationError &&
+        error.constraint === 'applications__protected_app_metadata_host'
+      ) {
+        throw new RequestError({
+          code: 'application.protected_application_subdomain_exists',
           status: 422,
         });
       }

--- a/packages/core/src/queries/application.test.ts
+++ b/packages/core/src/queries/application.test.ts
@@ -22,7 +22,6 @@ const { createApplicationQueries } = await import('./application.js');
 const {
   findTotalNumberOfApplications,
   findApplicationById,
-  findApplicationByProtectedAppHost,
   findApplicationByProtectedAppCustomDomain,
   insertApplication,
   updateApplicationById,
@@ -66,27 +65,6 @@ describe('application query', () => {
     });
 
     await findApplicationById(id);
-  });
-
-  it('findApplicationByProtectedAppHost', async () => {
-    const host = 'host.protected.app';
-    const rowData = { host };
-
-    const expectSql = sql`
-      select ${sql.join(Object.values(fields), sql`, `)}
-      from ${table}
-      where ${fields.protectedAppMetadata}->>'host' = $1
-      and ${fields.type} = $2
-    `;
-
-    mockQuery.mockImplementationOnce(async (sql, values) => {
-      expectSqlAssert(sql, expectSql.sql);
-      expect(values).toEqual([host, ApplicationType.Protected]);
-
-      return createMockQueryResult([rowData]);
-    });
-
-    await findApplicationByProtectedAppHost(host);
   });
 
   it('findApplicationByProtectedAppCustomDomain', async () => {

--- a/packages/core/src/queries/application.ts
+++ b/packages/core/src/queries/application.ts
@@ -130,14 +130,6 @@ export const createApplicationQueries = (pool: CommonQueryMethods) => {
 
   const findApplicationById = buildFindEntityByIdWithPool(pool)(Applications);
 
-  const findApplicationByProtectedAppHost = async (host: string) =>
-    pool.maybeOne<Application>(sql`
-      select ${sql.join(Object.values(fields), sql`, `)}
-      from ${table}
-      where ${fields.protectedAppMetadata}->>'host' = ${host}
-      and ${fields.type} = ${ApplicationType.Protected}
-    `);
-
   /**
    * Find an protected application by its custom domain.
    * the domain is stored in the `customDomains` field of the `protectedAppMetadata` field.
@@ -252,7 +244,6 @@ export const createApplicationQueries = (pool: CommonQueryMethods) => {
     findApplications,
     findTotalNumberOfApplications,
     findApplicationById,
-    findApplicationByProtectedAppHost,
     findApplicationByProtectedAppCustomDomain,
     insertApplication,
     updateApplication,

--- a/packages/core/src/routes/applications/application.test.ts
+++ b/packages/core/src/routes/applications/application.test.ts
@@ -19,7 +19,7 @@ const findApplicationById = jest.fn(async () => mockApplication);
 const deleteApplicationById = jest.fn();
 const syncAppConfigsToRemote = jest.fn();
 const deleteRemoteAppConfigs = jest.fn();
-const checkAndBuildProtectedAppData = jest.fn(async () => {
+const buildProtectedAppData = jest.fn(async () => {
   const { oidcClientMetadata, protectedAppMetadata } = mockProtectedApplication;
 
   return { oidcClientMetadata, protectedAppMetadata };
@@ -60,7 +60,7 @@ const tenantContext = new MockTenant(
     protectedApps: {
       syncAppConfigsToRemote,
       deleteRemoteAppConfigs,
-      checkAndBuildProtectedAppData,
+      buildProtectedAppData,
       getDefaultDomain: jest.fn(async () => mockProtectedAppConfigProviderConfig.domain),
     },
   }

--- a/packages/core/src/routes/applications/application.ts
+++ b/packages/core/src/routes/applications/application.ts
@@ -173,7 +173,7 @@ export default function applicationRoutes<T extends AuthedRouter>(
         ...conditional(
           rest.type === ApplicationType.Protected &&
             protectedAppMetadata &&
-            (await protectedApps.checkAndBuildProtectedAppData(protectedAppMetadata))
+            (await protectedApps.buildProtectedAppData(protectedAppMetadata))
         ),
         ...rest,
       });

--- a/packages/schemas/alterations/next-1706510290-protected-app-host-index.ts
+++ b/packages/schemas/alterations/next-1706510290-protected-app-host-index.ts
@@ -1,0 +1,21 @@
+import { sql } from 'slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      create unique index applications__protected_app_metadata_host
+      on applications (
+        (protected_app_metadata->>'host')
+      );
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      drop index applications__protected_app_metadata_host;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/applications.sql
+++ b/packages/schemas/tables/applications.sql
@@ -23,3 +23,8 @@ create index applications__id
 
 create index applications__is_third_party
   on applications (tenant_id, is_third_party);
+
+create unique index applications__protected_app_metadata_host
+  on applications (
+    (protected_app_metadata->>'host')
+  );


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Create an unique index for protected app's free subdomain, to ensure that domains will not conflict.

The previous solution won't work because of RLS.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested and unit tests.

<img width="691" alt="截屏2024-01-29 下午2 31 25" src="https://github.com/logto-io/logto/assets/5717882/eb1b7fb2-6b26-4d1e-a33d-74d3eba43b53">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
