### PR TITLE
refactor(console,schemas): bring back hidden get-started page

### DIFF
--- a/packages/console/src/containers/ConsoleContent/Sidebar/hook.tsx
+++ b/packages/console/src/containers/ConsoleContent/Sidebar/hook.tsx
@@ -17,7 +17,6 @@ import SecurityLock from '@/assets/icons/security-lock.svg';
 import EnterpriseSso from '@/assets/icons/single-sign-on.svg';
 import Web from '@/assets/icons/web.svg';
 import { isCloud } from '@/consts/env';
-import useUserPreferences from '@/hooks/use-user-preferences';
 
 type SidebarItem = {
   Icon: FC;
@@ -47,10 +46,6 @@ export const useSidebarMenuItems = (): {
   sections: SidebarSection[];
   firstItem: Optional<SidebarItem>;
 } => {
-  const {
-    data: { getStartedHidden },
-  } = useUserPreferences();
-
   const allSections: SidebarSection[] = [
     {
       title: 'overview',
@@ -58,7 +53,6 @@ export const useSidebarMenuItems = (): {
         {
           Icon: Bolt,
           title: 'get_started',
-          isHidden: getStartedHidden,
         },
         {
           Icon: BarGraph,

--- a/packages/console/src/containers/ConsoleContent/index.tsx
+++ b/packages/console/src/containers/ConsoleContent/index.tsx
@@ -14,7 +14,6 @@ import {
 import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import OverlayScrollbar from '@/ds-components/OverlayScrollbar';
-import useUserPreferences from '@/hooks/use-user-preferences';
 import ApiResourceDetails from '@/pages/ApiResourceDetails';
 import ApiResourcePermissions from '@/pages/ApiResourceDetails/ApiResourcePermissions';
 import ApiResourceSettings from '@/pages/ApiResourceDetails/ApiResourceSettings';
@@ -70,9 +69,6 @@ import * as styles from './index.module.scss';
 
 function ConsoleContent() {
   const { scrollableContent } = useOutletContext<AppContentOutletContext>();
-  const {
-    data: { getStartedHidden },
-  } = useUserPreferences();
   const { isDevTenant } = useContext(TenantsContext);
 
   return (
@@ -82,7 +78,7 @@ function ConsoleContent() {
         <div ref={scrollableContent} className={styles.main}>
           <Routes>
             <Route path="*" element={<NotFound />} />
-            {!getStartedHidden && <Route path="get-started" element={<GetStarted />} />}
+            <Route path="get-started" element={<GetStarted />} />
             <Route path="dashboard" element={<Dashboard />} />
             <Route path="applications">
               <Route index element={<Applications />} />

--- a/packages/console/src/hooks/use-user-preferences.ts
+++ b/packages/console/src/hooks/use-user-preferences.ts
@@ -15,7 +15,6 @@ const userPreferencesGuard = z.object({
   language: z.enum(builtInConsoleLanguages).optional(),
   appearanceMode: appearanceModeGuard.optional(),
   experienceNoticeConfirmed: z.boolean().optional(),
-  getStartedHidden: z.boolean().optional(),
   connectorSieNoticeConfirmed: z.boolean().optional(),
   managementApiAcknowledged: z.boolean().optional(),
 });

--- a/packages/schemas/alterations/next-1706512952-restore-get-started-page.ts
+++ b/packages/schemas/alterations/next-1706512952-restore-get-started-page.ts
@@ -1,0 +1,17 @@
+import { sql } from 'slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      update users
+      set custom_data = custom_data #- '{adminConsolePreferences, getStartedHidden}';
+    `);
+  },
+  down: async () => {
+    // Do nothing as the data change is not reversible
+  },
+};
+
+export default alteration;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Remove `getStartedHidden` property from user preferences, to forcefully bring back the get-started page that might be set to hidden by users.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested and the previously hidden get-started page was restored.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
