### PR TITLE
fix(console): fix error handling on creating protected apps

### DIFF
--- a/packages/console/src/pages/Applications/components/ProtectedAppForm/index.tsx
+++ b/packages/console/src/pages/Applications/components/ProtectedAppForm/index.tsx
@@ -74,8 +74,18 @@ function ProtectedAppForm({
 
         if (code === 'application.protected_application_subdomain_exists') {
           setError('subDomain', { type: 'custom', message });
+          return;
         }
+
+        if (error.response.status !== 401) {
+          toast.error(message);
+          return;
+        }
+
+        throw error;
       }
+
+      throw error;
     }
   });
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Improve error handling logic on creating protected apps.
- `'application.protected_application_subdomain_exists'` should be catched and inline-displayed underneath the form field
- Others non-401 errors should be "toasted" up
- 401 errors and other unknown errors should still be thrown up to the upper level error handlers. e.g. ErrorBoundary

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
