### PR TITLE
refactor(console,phrases): protected app origin url should not contain pathname

### DIFF
--- a/packages/console/src/pages/Applications/components/ProtectedAppForm/index.tsx
+++ b/packages/console/src/pages/Applications/components/ProtectedAppForm/index.tsx
@@ -1,4 +1,4 @@
-import { isValidUrl } from '@logto/core-kit';
+import { validateUriOrigin } from '@logto/core-kit';
 import { ApplicationType, type Application, type RequestErrorBody } from '@logto/schemas';
 import { isValidSubdomain } from '@logto/shared/universal';
 import { condString, conditional } from '@silverhand/essentials';
@@ -137,7 +137,8 @@ function ProtectedAppForm({
           <TextInput
             {...register('origin', {
               required: true,
-              validate: (value) => isValidUrl(value) || t('protected_app.form.errors.invalid_url'),
+              validate: (value) =>
+                validateUriOrigin(value) || t('protected_app.form.errors.invalid_url'),
             })}
             placeholder={t('protected_app.form.url_field_placeholder')}
             error={

--- a/packages/phrases/src/locales/de/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/application-details.ts
@@ -89,7 +89,7 @@ const application_details = {
     'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
-    "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+    "Enter primary website address of your application, excluding any '/pathname'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
   /** UNTRANSLATED */
   custom_rules: 'Custom authentication rules',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/de/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/protected-app.ts
@@ -34,7 +34,7 @@ const protected_app = {
     url_field_description: 'Enter the primary website address of your application.',
     /** UNTRANSLATED */
     url_field_tooltip:
-      "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+      "Enter primary website address of your application, excluding any '/pathname'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
     /** UNTRANSLATED */
@@ -51,7 +51,7 @@ const protected_app = {
       url_required: 'Origin URL is required.',
       /** UNTRANSLATED */
       invalid_url:
-        "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
+        "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
     },
   },
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/en/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/application-details.ts
@@ -73,7 +73,7 @@ const application_details = {
   app_domain_protected_description_2:
     'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   origin_url_tip:
-    "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+    "Enter primary website address of your application, excluding any '/pathname'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
   custom_rules: 'Custom authentication rules',
   custom_rules_placeholder: '^/(admin|privacy)/.+$',
   custom_rules_description:

--- a/packages/phrases/src/locales/en/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/protected-app.ts
@@ -19,7 +19,7 @@ const protected_app = {
     url_field_placeholder: 'https://',
     url_field_description: 'Enter the primary website address of your application.',
     url_field_tooltip:
-      "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+      "Enter primary website address of your application, excluding any '/pathname'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     create_application: 'Create application',
     create_protected_app: 'Create and experience auth protection',
     errors: {
@@ -29,7 +29,7 @@ const protected_app = {
         "Invalid subdomain format: use only lowercase letters, hyphens '-', and underscores '_'.",
       url_required: 'Origin URL is required.',
       invalid_url:
-        "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
+        "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
     },
   },
   success_message:

--- a/packages/phrases/src/locales/es/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/application-details.ts
@@ -89,7 +89,7 @@ const application_details = {
     'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
-    "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+    "Enter primary website address of your application, excluding any '/pathname'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
   /** UNTRANSLATED */
   custom_rules: 'Custom authentication rules',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/es/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/protected-app.ts
@@ -34,7 +34,7 @@ const protected_app = {
     url_field_description: 'Enter the primary website address of your application.',
     /** UNTRANSLATED */
     url_field_tooltip:
-      "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+      "Enter primary website address of your application, excluding any '/pathname'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
     /** UNTRANSLATED */
@@ -51,7 +51,7 @@ const protected_app = {
       url_required: 'Origin URL is required.',
       /** UNTRANSLATED */
       invalid_url:
-        "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
+        "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
     },
   },
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/fr/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/application-details.ts
@@ -89,7 +89,7 @@ const application_details = {
     'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
-    "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+    "Enter primary website address of your application, excluding any '/pathname'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
   /** UNTRANSLATED */
   custom_rules: 'Custom authentication rules',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/fr/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/protected-app.ts
@@ -34,7 +34,7 @@ const protected_app = {
     url_field_description: 'Enter the primary website address of your application.',
     /** UNTRANSLATED */
     url_field_tooltip:
-      "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+      "Enter primary website address of your application, excluding any '/pathname'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
     /** UNTRANSLATED */
@@ -51,7 +51,7 @@ const protected_app = {
       url_required: 'Origin URL is required.',
       /** UNTRANSLATED */
       invalid_url:
-        "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
+        "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
     },
   },
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/it/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/application-details.ts
@@ -89,7 +89,7 @@ const application_details = {
     'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
-    "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+    "Enter primary website address of your application, excluding any '/pathname'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
   /** UNTRANSLATED */
   custom_rules: 'Custom authentication rules',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/it/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/protected-app.ts
@@ -34,7 +34,7 @@ const protected_app = {
     url_field_description: 'Enter the primary website address of your application.',
     /** UNTRANSLATED */
     url_field_tooltip:
-      "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+      "Enter primary website address of your application, excluding any '/pathname'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
     /** UNTRANSLATED */
@@ -51,7 +51,7 @@ const protected_app = {
       url_required: 'Origin URL is required.',
       /** UNTRANSLATED */
       invalid_url:
-        "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
+        "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
     },
   },
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/ja/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/application-details.ts
@@ -89,7 +89,7 @@ const application_details = {
     'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
-    "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+    "Enter primary website address of your application, excluding any '/pathname'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
   /** UNTRANSLATED */
   custom_rules: 'Custom authentication rules',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/ja/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/protected-app.ts
@@ -34,7 +34,7 @@ const protected_app = {
     url_field_description: 'Enter the primary website address of your application.',
     /** UNTRANSLATED */
     url_field_tooltip:
-      "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+      "Enter primary website address of your application, excluding any '/pathname'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
     /** UNTRANSLATED */
@@ -51,7 +51,7 @@ const protected_app = {
       url_required: 'Origin URL is required.',
       /** UNTRANSLATED */
       invalid_url:
-        "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
+        "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
     },
   },
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/ko/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/application-details.ts
@@ -89,7 +89,7 @@ const application_details = {
     'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
-    "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+    "Enter primary website address of your application, excluding any '/pathname'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
   /** UNTRANSLATED */
   custom_rules: 'Custom authentication rules',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/ko/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/protected-app.ts
@@ -34,7 +34,7 @@ const protected_app = {
     url_field_description: 'Enter the primary website address of your application.',
     /** UNTRANSLATED */
     url_field_tooltip:
-      "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+      "Enter primary website address of your application, excluding any '/pathname'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
     /** UNTRANSLATED */
@@ -51,7 +51,7 @@ const protected_app = {
       url_required: 'Origin URL is required.',
       /** UNTRANSLATED */
       invalid_url:
-        "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
+        "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
     },
   },
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/application-details.ts
@@ -89,7 +89,7 @@ const application_details = {
     'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
-    "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+    "Enter primary website address of your application, excluding any '/pathname'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
   /** UNTRANSLATED */
   custom_rules: 'Custom authentication rules',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/protected-app.ts
@@ -34,7 +34,7 @@ const protected_app = {
     url_field_description: 'Enter the primary website address of your application.',
     /** UNTRANSLATED */
     url_field_tooltip:
-      "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+      "Enter primary website address of your application, excluding any '/pathname'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
     /** UNTRANSLATED */
@@ -51,7 +51,7 @@ const protected_app = {
       url_required: 'Origin URL is required.',
       /** UNTRANSLATED */
       invalid_url:
-        "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
+        "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
     },
   },
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/application-details.ts
@@ -89,7 +89,7 @@ const application_details = {
     'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
-    "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+    "Enter primary website address of your application, excluding any '/pathname'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
   /** UNTRANSLATED */
   custom_rules: 'Custom authentication rules',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/protected-app.ts
@@ -34,7 +34,7 @@ const protected_app = {
     url_field_description: 'Enter the primary website address of your application.',
     /** UNTRANSLATED */
     url_field_tooltip:
-      "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+      "Enter primary website address of your application, excluding any '/pathname'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
     /** UNTRANSLATED */
@@ -51,7 +51,7 @@ const protected_app = {
       url_required: 'Origin URL is required.',
       /** UNTRANSLATED */
       invalid_url:
-        "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
+        "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
     },
   },
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/application-details.ts
@@ -89,7 +89,7 @@ const application_details = {
     'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
-    "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+    "Enter primary website address of your application, excluding any '/pathname'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
   /** UNTRANSLATED */
   custom_rules: 'Custom authentication rules',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/protected-app.ts
@@ -34,7 +34,7 @@ const protected_app = {
     url_field_description: 'Enter the primary website address of your application.',
     /** UNTRANSLATED */
     url_field_tooltip:
-      "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+      "Enter primary website address of your application, excluding any '/pathname'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
     /** UNTRANSLATED */
@@ -51,7 +51,7 @@ const protected_app = {
       url_required: 'Origin URL is required.',
       /** UNTRANSLATED */
       invalid_url:
-        "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
+        "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
     },
   },
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/ru/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/application-details.ts
@@ -89,7 +89,7 @@ const application_details = {
     'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
-    "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+    "Enter primary website address of your application, excluding any '/pathname'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
   /** UNTRANSLATED */
   custom_rules: 'Custom authentication rules',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/ru/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/protected-app.ts
@@ -34,7 +34,7 @@ const protected_app = {
     url_field_description: 'Enter the primary website address of your application.',
     /** UNTRANSLATED */
     url_field_tooltip:
-      "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+      "Enter primary website address of your application, excluding any '/pathname'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
     /** UNTRANSLATED */
@@ -51,7 +51,7 @@ const protected_app = {
       url_required: 'Origin URL is required.',
       /** UNTRANSLATED */
       invalid_url:
-        "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
+        "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
     },
   },
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/application-details.ts
@@ -89,7 +89,7 @@ const application_details = {
     'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
-    "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+    "Enter primary website address of your application, excluding any '/pathname'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
   /** UNTRANSLATED */
   custom_rules: 'Custom authentication rules',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/protected-app.ts
@@ -34,7 +34,7 @@ const protected_app = {
     url_field_description: 'Enter the primary website address of your application.',
     /** UNTRANSLATED */
     url_field_tooltip:
-      "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+      "Enter primary website address of your application, excluding any '/pathname'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
     /** UNTRANSLATED */
@@ -51,7 +51,7 @@ const protected_app = {
       url_required: 'Origin URL is required.',
       /** UNTRANSLATED */
       invalid_url:
-        "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
+        "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
     },
   },
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/application-details.ts
@@ -87,7 +87,7 @@ const application_details = {
     'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
-    "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+    "Enter primary website address of your application, excluding any '/pathname'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
   /** UNTRANSLATED */
   custom_rules: 'Custom authentication rules',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/protected-app.ts
@@ -34,7 +34,7 @@ const protected_app = {
     url_field_description: 'Enter the primary website address of your application.',
     /** UNTRANSLATED */
     url_field_tooltip:
-      "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+      "Enter primary website address of your application, excluding any '/pathname'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
     /** UNTRANSLATED */
@@ -51,7 +51,7 @@ const protected_app = {
       url_required: 'Origin URL is required.',
       /** UNTRANSLATED */
       invalid_url:
-        "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
+        "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
     },
   },
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/application-details.ts
@@ -87,7 +87,7 @@ const application_details = {
     'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
-    "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+    "Enter primary website address of your application, excluding any '/pathname'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
   /** UNTRANSLATED */
   custom_rules: 'Custom authentication rules',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/protected-app.ts
@@ -34,7 +34,7 @@ const protected_app = {
     url_field_description: 'Enter the primary website address of your application.',
     /** UNTRANSLATED */
     url_field_tooltip:
-      "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+      "Enter primary website address of your application, excluding any '/pathname'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
     /** UNTRANSLATED */
@@ -51,7 +51,7 @@ const protected_app = {
       url_required: 'Origin URL is required.',
       /** UNTRANSLATED */
       invalid_url:
-        "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
+        "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
     },
   },
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/application-details.ts
@@ -88,7 +88,7 @@ const application_details = {
     'Feel free to utilize your domain <domain>{{domain}}</domain> which is permanently valid.',
   /** UNTRANSLATED */
   origin_url_tip:
-    "Enter primary website address of your application, excluding any '/routes'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+    "Enter primary website address of your application, excluding any '/pathname'.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
   /** UNTRANSLATED */
   custom_rules: 'Custom authentication rules',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/protected-app.ts
@@ -34,7 +34,7 @@ const protected_app = {
     url_field_description: 'Enter the primary website address of your application.',
     /** UNTRANSLATED */
     url_field_tooltip:
-      "Enter primary website address of your application, excluding any '/routes'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
+      "Enter primary website address of your application, excluding any '/pathname'. After creation, you can customize route authentication rules.\n\nNote: The Origin URL itself won't require authentication; only accesses via the added app domain will be protected.",
     /** UNTRANSLATED */
     create_application: 'Create application',
     /** UNTRANSLATED */
@@ -51,7 +51,7 @@ const protected_app = {
       url_required: 'Origin URL is required.',
       /** UNTRANSLATED */
       invalid_url:
-        "Invalid Origin URL format: Use http:// or https://. Note: '/routes' is not currently supported.",
+        "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
     },
   },
   /** UNTRANSLATED */


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Protected app's Origin URL should not allow pathnames.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="780" alt="image" src="https://github.com/logto-io/logto/assets/12833674/1e510282-2e5a-404e-8203-74c19f3a8948">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
