### PR TITLE
refactor: update organization invitation api connector payload

### DIFF
--- a/packages/core/src/libraries/organization-invitation.ts
+++ b/packages/core/src/libraries/organization-invitation.ts
@@ -14,6 +14,8 @@ import type Queries from '#src/tenants/Queries.js';
 
 import { type ConnectorLibrary } from './connector.js';
 
+const invitationLinkPath = '/invitation';
+
 /**
  * The ending statuses of an organization invitation per RFC 0003. It means that the invitation
  * status cannot be changed anymore.

--- a/packages/integration-tests/src/__mocks__/connectors-mock.ts
+++ b/packages/integration-tests/src/__mocks__/connectors-mock.ts
@@ -157,6 +157,12 @@ export const mockEmailConnectorConfig = {
       subject: 'Logto Test Template',
       content: 'This is for testing purposes only. Your passcode is {{code}}.',
     },
+    {
+      usageType: 'OrganizationInvitation',
+      type: 'text/plain',
+      subject: 'Logto Organization Invitation Template',
+      content: 'This is for organization invitation purposes only. Your link is {{link}}.',
+    },
   ],
 };
 

--- a/packages/integration-tests/src/api/organization-invitation.ts
+++ b/packages/integration-tests/src/api/organization-invitation.ts
@@ -13,7 +13,7 @@ export type PostOrganizationInvitationData = {
   organizationId: string;
   expiresAt: number;
   organizationRoleIds?: string[];
-  emailPayload?: SendMessagePayload | false;
+  messagePayload?: SendMessagePayload | false;
 };
 
 export class OrganizationInvitationApi extends ApiFactory<

--- a/packages/integration-tests/src/helpers/index.ts
+++ b/packages/integration-tests/src/helpers/index.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import { createServer, type RequestListener } from 'node:http';
 
-import { mockConnectorFilePaths } from '@logto/connector-kit';
+import { mockConnectorFilePaths, type SendMessagePayload } from '@logto/connector-kit';
 import { RequestError } from 'got';
 
 import { createUser } from '#src/api/index.js';
@@ -28,6 +28,7 @@ type ConnectorMessageRecord = {
   address?: string;
   code: string;
   type: string;
+  payload: SendMessagePayload;
 };
 
 /**


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
since we removed magic links, update the api to be more specific about connector message payload for organization invitation creation.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
updated and added api tests accordingly

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
