### PR TITLE
fix(console): upsell should locate on modal footer

### DIFF
--- a/packages/console/src/pages/EnterpriseSso/index.tsx
+++ b/packages/console/src/pages/EnterpriseSso/index.tsx
@@ -1,7 +1,7 @@
 import { withAppInsights } from '@logto/app-insights/react';
 import { type SsoConnectorWithProviderConfig, ReservedPlanId } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
-import { useContext, useCallback } from 'react';
+import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import useSWR from 'swr';
@@ -13,7 +13,6 @@ import ItemPreview from '@/components/ItemPreview';
 import ListPage from '@/components/ListPage';
 import { defaultPageSize } from '@/consts';
 import { isCloud } from '@/consts/env';
-import { subscriptionPage } from '@/consts/pages';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import Button from '@/ds-components/Button';
@@ -45,10 +44,6 @@ function EnterpriseSsoConnectors() {
   });
 
   const isSsoEnabled = !isCloud || currentPlan.quota.ssoEnabled;
-
-  const handleButtonClick = useCallback(() => {
-    navigate(isSsoEnabled ? createEnterpriseSsoPathname : subscriptionPage);
-  }, [isSsoEnabled, navigate]);
 
   const url = buildUrl('api/sso-connectors', {
     page: String(page),
@@ -150,11 +145,13 @@ function EnterpriseSsoConnectors() {
             description="enterprise_sso.placeholder_description"
             action={
               <Button
-                title={isSsoEnabled ? 'enterprise_sso.create' : 'upsell.upgrade_plan'}
+                title="enterprise_sso.create"
                 type="primary"
                 size="large"
-                icon={conditional(isSsoEnabled && <Plus />)}
-                onClick={handleButtonClick}
+                icon={<Plus />}
+                onClick={() => {
+                  navigate(createEnterpriseSsoPathname);
+                }}
               />
             }
           />


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
SSO connector upsell should show on the creation modal footer (not on the create button)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
<img width="1364" alt="image" src="https://github.com/logto-io/logto/assets/15182327/660378ad-e2d1-4240-a6c0-acdaf3c33f38">
<img width="818" alt="image" src="https://github.com/logto-io/logto/assets/15182327/c6a2f7ad-0dbd-4221-9a6c-2f528110f733">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
