### PR TITLE
fix(console): protected app form field should have layer-1 background

### DIFF
--- a/packages/console/src/pages/Applications/components/ProtectedAppForm/index.module.scss
+++ b/packages/console/src/pages/Applications/components/ProtectedAppForm/index.module.scss
@@ -42,6 +42,10 @@ form {
   }
 }
 
+.input {
+  background: var(--color-layer-1);
+}
+
 .domainFieldWrapper {
   display: flex;
   width: 100%;

--- a/packages/console/src/pages/Applications/components/ProtectedAppForm/index.tsx
+++ b/packages/console/src/pages/Applications/components/ProtectedAppForm/index.tsx
@@ -122,6 +122,7 @@ function ProtectedAppForm({
           tip={conditional(!hasDetailedInstructions && t('protected_app.form.url_field_tooltip'))}
         >
           <TextInput
+            className={styles.input}
             {...register('origin', {
               required: true,
               validate: (value) =>
@@ -153,7 +154,7 @@ function ProtectedAppForm({
         >
           <div className={styles.domainFieldWrapper}>
             <TextInput
-              className={styles.subdomain}
+              className={classNames(styles.input, styles.subdomain)}
               {...register('subDomain', {
                 required: true,
                 validate: (value) =>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Protected app form field should have `layer-1` background

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="1201" alt="image" src="https://github.com/logto-io/logto/assets/12833674/219766d4-eb4b-484c-b31b-5581de82334f">

<img width="1201" alt="image" src="https://github.com/logto-io/logto/assets/12833674/a8b5c8c1-d2d6-4531-bb5f-03da103b6bb9">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
