### PR TITLE
fix(console): add default value for custom auth rules in protected app details

### DIFF
--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ProtectedAppSettings/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ProtectedAppSettings/index.tsx
@@ -6,7 +6,7 @@ import {
 } from '@logto/schemas';
 import { cond } from '@silverhand/essentials';
 import classNames from 'classnames';
-import { type ChangeEvent, useState } from 'react';
+import { type ChangeEvent, useState, useEffect } from 'react';
 import { Controller, useFieldArray, useFormContext } from 'react-hook-form';
 import { Trans, useTranslation } from 'react-i18next';
 import useSWR from 'swr';
@@ -56,6 +56,7 @@ function ProtectedAppSettings({ data }: Props) {
     control,
     register,
     getFieldState,
+    setValue,
     formState: { errors },
   } = useFormContext<ApplicationForm>();
 
@@ -63,6 +64,12 @@ function ProtectedAppSettings({ data }: Props) {
     control,
     name: 'protectedAppMetadata.pageRules',
   });
+
+  useEffect(() => {
+    if (fields.length === 0) {
+      setValue('protectedAppMetadata.pageRules', [{ path: '' }]);
+    }
+  }, [fields.length, setValue]);
 
   if (!data.protectedAppMetadata) {
     return null;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add defaut value for custom page rules in protected app details page on the client side, as the default values are removed from server side.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
It's back.

<img width="1225" alt="image" src="https://github.com/logto-io/logto/assets/12833674/278ba0a4-6e1f-4954-8241-07758c6d5e39">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
