### PR TITLE
refactor(core): use deepmerge

### DIFF
--- a/packages/app-insights/package.json
+++ b/packages/app-insights/package.json
@@ -60,7 +60,7 @@
     "@microsoft/applicationinsights-clickanalytics-js": "^3.0.2",
     "@microsoft/applicationinsights-react-js": "^17.0.0",
     "@microsoft/applicationinsights-web": "^3.0.2",
-    "@silverhand/essentials": "^2.8.8",
+    "@silverhand/essentials": "^2.9.0",
     "applicationinsights": "^2.7.0"
   },
   "peerDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,7 +50,7 @@
     "@logto/phrases-experience": "workspace:^1.5.0",
     "@logto/schemas": "workspace:1.12.0",
     "@logto/shared": "workspace:^3.0.0",
-    "@silverhand/essentials": "^2.8.8",
+    "@silverhand/essentials": "^2.9.0",
     "chalk": "^5.0.0",
     "decamelize": "^6.0.0",
     "dotenv": "^16.0.0",

--- a/packages/connectors/templates/package.json
+++ b/packages/connectors/templates/package.json
@@ -23,7 +23,7 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
-    "@silverhand/essentials": "^2.8.8",
+    "@silverhand/essentials": "^2.9.0",
     "got": "^14.0.0",
     "snakecase-keys": "^6.0.0",
     "zod": "^3.22.4"

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -44,7 +44,7 @@
     "@parcel/transformer-svg-react": "2.9.3",
     "@silverhand/eslint-config": "5.0.0",
     "@silverhand/eslint-config-react": "5.0.0",
-    "@silverhand/essentials": "^2.8.8",
+    "@silverhand/essentials": "^2.9.0",
     "@silverhand/ts-config": "5.0.0",
     "@silverhand/ts-config-react": "5.0.0",
     "@swc/core": "^1.3.52",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,7 @@
     "@logto/phrases-experience": "workspace:^1.5.0",
     "@logto/schemas": "workspace:^1.12.0",
     "@logto/shared": "workspace:^3.0.0",
-    "@silverhand/essentials": "^2.8.8",
+    "@silverhand/essentials": "^2.9.0",
     "@simplewebauthn/server": "^8.2.0",
     "@withtyped/client": "^0.7.22",
     "camelcase": "^8.0.0",

--- a/packages/core/src/utils/SchemaRouter.ts
+++ b/packages/core/src/utils/SchemaRouter.ts
@@ -1,7 +1,8 @@
 import { type SchemaLike, type GeneratedSchema } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
-import { type DeepPartial } from '@silverhand/essentials';
+import { type DeepPartial, isPlainObject } from '@silverhand/essentials';
 import camelcase from 'camelcase';
+import deepmerge from 'deepmerge';
 import { type MiddlewareType } from 'koa';
 import Router, { type IRouterParamContext } from 'koa-router';
 import { z } from 'zod';
@@ -122,16 +123,7 @@ export default class SchemaRouter<
   ) {
     super({ prefix: '/' + tableToPathname(schema.table) });
 
-    const { disabled, ...rest } = config;
-
-    this.config = {
-      ...defaultConfig,
-      disabled: {
-        ...defaultConfig.disabled,
-        ...disabled,
-      },
-      ...rest,
-    };
+    this.config = deepmerge(defaultConfig, config, { isMergeableObject: isPlainObject });
 
     if (this.config.middlewares?.length) {
       this.use(...this.config.middlewares);

--- a/packages/experience/package.json
+++ b/packages/experience/package.json
@@ -37,7 +37,7 @@
     "@react-spring/web": "^9.6.1",
     "@silverhand/eslint-config": "5.0.0",
     "@silverhand/eslint-config-react": "5.0.0",
-    "@silverhand/essentials": "^2.8.8",
+    "@silverhand/essentials": "^2.9.0",
     "@silverhand/ts-config": "5.0.0",
     "@silverhand/ts-config-react": "5.0.0",
     "@simplewebauthn/browser": "^8.3.1",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -31,7 +31,7 @@
     "@logto/schemas": "workspace:^1.12.0",
     "@logto/shared": "workspace:^3.0.0",
     "@silverhand/eslint-config": "5.0.0",
-    "@silverhand/essentials": "^2.8.8",
+    "@silverhand/essentials": "^2.9.0",
     "@silverhand/ts-config": "5.0.0",
     "@types/jest": "^29.4.0",
     "@types/node": "^20.9.5",

--- a/packages/phrases-experience/package.json
+++ b/packages/phrases-experience/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@logto/core-kit": "workspace:^2.2.1",
     "@logto/language-kit": "workspace:^1.0.0",
-    "@silverhand/essentials": "^2.8.8"
+    "@silverhand/essentials": "^2.9.0"
   },
   "peerDependencies": {
     "zod": "^3.22.4"

--- a/packages/phrases/package.json
+++ b/packages/phrases/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@logto/language-kit": "workspace:^1.0.0",
-    "@silverhand/essentials": "^2.8.8"
+    "@silverhand/essentials": "^2.9.0"
   },
   "peerDependencies": {
     "zod": "^3.22.4"

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@silverhand/eslint-config": "5.0.0",
-    "@silverhand/essentials": "^2.8.8",
+    "@silverhand/essentials": "^2.9.0",
     "@silverhand/ts-config": "5.0.0",
     "@types/inquirer": "^9.0.0",
     "@types/jest": "^29.4.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -60,7 +60,7 @@
   },
   "prettier": "@silverhand/eslint-config/.prettierrc",
   "dependencies": {
-    "@silverhand/essentials": "^2.8.8",
+    "@silverhand/essentials": "^2.9.0",
     "chalk": "^5.0.0",
     "find-up": "^7.0.0",
     "libphonenumber-js": "^1.9.49",

--- a/packages/toolkit/connector-kit/package.json
+++ b/packages/toolkit/connector-kit/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@logto/language-kit": "workspace:^1.0.0",
-    "@silverhand/essentials": "^2.8.8",
+    "@silverhand/essentials": "^2.9.0",
     "@withtyped/client": "^0.7.22",
     "@withtyped/server": "^0.12.9"
   },

--- a/packages/toolkit/core-kit/package.json
+++ b/packages/toolkit/core-kit/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@jest/types": "^29.0.3",
     "@silverhand/eslint-config": "5.0.0",
-    "@silverhand/essentials": "^2.8.8",
+    "@silverhand/essentials": "^2.9.0",
     "@silverhand/ts-config": "5.0.0",
     "@silverhand/ts-config-react": "5.0.0",
     "@types/color": "^3.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2(tslib@2.4.1)(typescript@5.3.3)
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       applicationinsights:
         specifier: ^2.7.0
         version: 2.7.0
@@ -125,8 +125,8 @@ importers:
         specifier: workspace:^3.0.0
         version: link:../shared
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       chalk:
         specifier: ^5.0.0
         version: 5.1.2
@@ -243,8 +243,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       dayjs:
         specifier: ^1.10.5
         version: 1.11.6
@@ -331,8 +331,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       dayjs:
         specifier: ^1.10.5
         version: 1.11.6
@@ -419,8 +419,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -498,8 +498,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -580,8 +580,8 @@ importers:
         specifier: workspace:^3.0.0
         version: link:../../shared
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -668,8 +668,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -750,8 +750,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -829,8 +829,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -908,8 +908,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -987,8 +987,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -1066,8 +1066,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -1148,8 +1148,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -1227,8 +1227,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -1306,8 +1306,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -1388,8 +1388,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -1467,8 +1467,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -1546,8 +1546,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -1625,8 +1625,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -1704,8 +1704,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -1783,8 +1783,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -1862,8 +1862,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -1941,8 +1941,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -2020,8 +2020,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -2105,8 +2105,8 @@ importers:
         specifier: workspace:^3.0.0
         version: link:../../shared
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -2190,8 +2190,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       fast-xml-parser:
         specifier: ^4.2.5
         version: 4.2.5
@@ -2275,8 +2275,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -2354,8 +2354,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -2433,8 +2433,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -2518,8 +2518,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -2597,8 +2597,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -2676,8 +2676,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -2755,8 +2755,8 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../../toolkit/connector-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       got:
         specifier: ^14.0.0
         version: 14.0.0
@@ -2894,8 +2894,8 @@ importers:
         specifier: 5.0.0
         version: 5.0.0(eslint@8.44.0)(postcss@8.4.31)(prettier@3.0.0)(stylelint@15.0.0)(typescript@5.3.3)
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       '@silverhand/ts-config':
         specifier: 5.0.0
         version: 5.0.0(typescript@5.3.3)
@@ -3182,8 +3182,8 @@ importers:
         specifier: workspace:^3.0.0
         version: link:../shared
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       '@simplewebauthn/server':
         specifier: ^8.2.0
         version: 8.2.0
@@ -3570,8 +3570,8 @@ importers:
         specifier: 5.0.0
         version: 5.0.0(eslint@8.44.0)(postcss@8.4.31)(prettier@3.0.0)(stylelint@15.0.0)(typescript@5.3.3)
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       '@silverhand/ts-config':
         specifier: 5.0.0
         version: 5.0.0(typescript@5.3.3)
@@ -3772,8 +3772,8 @@ importers:
         specifier: 5.0.0
         version: 5.0.0(eslint@8.44.0)(prettier@3.0.0)(typescript@5.3.3)
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       '@silverhand/ts-config':
         specifier: 5.0.0
         version: 5.0.0(typescript@5.3.3)
@@ -3835,8 +3835,8 @@ importers:
         specifier: workspace:^1.0.0
         version: link:../toolkit/language-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -3869,8 +3869,8 @@ importers:
         specifier: workspace:^1.0.0
         version: link:../toolkit/language-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -3928,8 +3928,8 @@ importers:
         specifier: 5.0.0
         version: 5.0.0(eslint@8.44.0)(prettier@3.0.0)(typescript@5.3.3)
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       '@silverhand/ts-config':
         specifier: 5.0.0
         version: 5.0.0(typescript@5.3.3)
@@ -3982,8 +3982,8 @@ importers:
   packages/shared:
     dependencies:
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       chalk:
         specifier: ^5.0.0
         version: 5.1.2
@@ -4037,8 +4037,8 @@ importers:
         specifier: workspace:^1.0.0
         version: link:../language-kit
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       '@withtyped/client':
         specifier: ^0.7.22
         version: 0.7.22(zod@3.22.4)
@@ -4107,8 +4107,8 @@ importers:
         specifier: 5.0.0
         version: 5.0.0(eslint@8.44.0)(prettier@3.0.0)(typescript@5.3.3)
       '@silverhand/essentials':
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^2.9.0
+        version: 2.9.0
       '@silverhand/ts-config':
         specifier: 5.0.0
         version: 5.0.0(typescript@5.3.3)
@@ -7569,7 +7569,7 @@ packages:
     resolution: {integrity: sha512-yDWSZMI2Qo/xoYU92tnwSP/gnSvq8+CLK5DqD/4brO42QJa7xjt7eA+HSyuMmSUrKffY2nP3riU81gs+nR8DkA==}
     engines: {node: ^18.12.0}
     dependencies:
-      '@silverhand/essentials': 2.8.8
+      '@silverhand/essentials': 2.9.0
       tiny-cookie: 2.4.1
     dev: false
 
@@ -7577,7 +7577,7 @@ packages:
     resolution: {integrity: sha512-8kKh1EcAm19smnEMvw0M51d2EQXEEH77G1JEKh1iLifUScmxD+c7HcN/5mLekaBz36MUVNiA2gE7s9L2GOpWrg==}
     dependencies:
       '@logto/client': 2.3.0
-      '@silverhand/essentials': 2.8.8
+      '@silverhand/essentials': 2.9.0
       js-base64: 3.7.5
     dev: true
 
@@ -7585,7 +7585,7 @@ packages:
     resolution: {integrity: sha512-VrzsF+QtnrVXnDFbsdYTeGatjThlTFwtjTT/jJMaFdyRg0lno8vHxsjuyG8ba4wVSu22tSmJAr7okpAwRyhtcg==}
     dependencies:
       '@logto/js': 3.0.1
-      '@silverhand/essentials': 2.8.8
+      '@silverhand/essentials': 2.9.0
       camelcase-keys: 7.0.2
       jose: 5.0.1
     dev: true
@@ -7594,7 +7594,7 @@ packages:
     resolution: {integrity: sha512-cDKxCBFeZcG0CiGIa6mBY1Zgu3+tuvhYxs/qN0nQcj7MLSQ0AXHK9m1GeSJQH+Nu/jspggLmg27Ks8gdCHQUcg==}
     engines: {node: ^20.9.0}
     dependencies:
-      '@silverhand/essentials': 2.8.8
+      '@silverhand/essentials': 2.9.0
       '@withtyped/server': 0.12.9(zod@3.22.4)
     transitivePeerDependencies:
       - zod
@@ -7604,7 +7604,7 @@ packages:
     resolution: {integrity: sha512-hUiuzOPd4bKIV6fIKZLQW2Fc8JYmwKWWps7gZoxGbL3uLmAYYci5JHIP+vM7nbNS+oK1V141sy3JjNS1vAkvGA==}
     engines: {node: ^20.9.0}
     dependencies:
-      '@silverhand/essentials': 2.8.8
+      '@silverhand/essentials': 2.9.0
       '@withtyped/server': 0.12.9(zod@3.22.4)
     transitivePeerDependencies:
       - zod
@@ -7613,7 +7613,7 @@ packages:
   /@logto/js@3.0.1:
     resolution: {integrity: sha512-vsU6mH5oiiW3k00pMyVA4V31K2Bd0rOT9qWch2l5e5o1yCQLJ3zUIOjGjChu3m2TRu1d920iiUpZU3Lzf6Pwdw==}
     dependencies:
-      '@silverhand/essentials': 2.8.8
+      '@silverhand/essentials': 2.9.0
       camelcase-keys: 7.0.2
       jose: 5.0.1
     dev: true
@@ -7622,7 +7622,7 @@ packages:
     resolution: {integrity: sha512-xzVCnlrev/bqLtXOAw9I35h7njU1bed1jt6fL/VZfY4RUUJVZ36LG7fq2b7GsGg5xGRLchJ//+/VP1ac3+27YA==}
     dependencies:
       '@logto/client': 2.3.0
-      '@silverhand/essentials': 2.8.8
+      '@silverhand/essentials': 2.9.0
       js-base64: 3.7.5
       node-fetch: 2.7.0
     transitivePeerDependencies:
@@ -7635,7 +7635,7 @@ packages:
       react: '>=16.8.0 || ^18.0.0'
     dependencies:
       '@logto/browser': 2.2.0
-      '@silverhand/essentials': 2.8.8
+      '@silverhand/essentials': 2.9.0
       react: 18.2.0
     dev: true
 
@@ -9308,8 +9308,8 @@ packages:
       lodash: 4.17.21
     dev: true
 
-  /@silverhand/essentials@2.8.8:
-    resolution: {integrity: sha512-JCiNjdF9IcsF/7Gd4ZMAL3ykdujKrIvEpKa2Iz6YqUaoCSJEeyLwspE5xAHo38a0oT55Qa2pC+wLjEEgWAD8zA==}
+  /@silverhand/essentials@2.9.0:
+    resolution: {integrity: sha512-n9mSO/gsLj0GRFXBRNhaQLRK6qbn6pBnKjMQdFwweKgT12ODBXpgkpXohpOBqSofnoaCQWqiDAT6xpCy/5dMIg==}
     engines: {node: ^18.12.0 || ^20.9.0, pnpm: ^8.0.0}
 
   /@silverhand/ts-config-react@5.0.0(typescript@5.3.3):
@@ -10472,7 +10472,7 @@ packages:
     peerDependencies:
       zod: ^3.19.1
     dependencies:
-      '@silverhand/essentials': 2.8.8
+      '@silverhand/essentials': 2.9.0
       '@withtyped/shared': 0.2.2
       zod: 3.22.4
 
@@ -15511,7 +15511,7 @@ packages:
       jest: ^28.1.0 || ^29.1.2
       react: ^17.0.0 || ^18.0.0
     dependencies:
-      jest: 29.7.0(@types/node@18.19.3)
+      jest: 29.7.0(@types/node@20.10.4)(ts-node@10.9.2)
       react: 18.2.0
     dev: true
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
use deepmerge for config. leveraging `isPlainObject()` thus we can keep the zod guard in config unchanged

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
ci (fail without `isPlainObject()`)

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
