### PR TITLE
fix(console): fix domain items vertical spacing in get-started page

### DIFF
--- a/packages/console/src/pages/GetStarted/ProtectedAppCreationForm/index.module.scss
+++ b/packages/console/src/pages/GetStarted/ProtectedAppCreationForm/index.module.scss
@@ -31,7 +31,7 @@
     .list {
       display: flex;
       flex-wrap: wrap;
-      gap: _.unit(8);
+      gap: _.unit(3) _.unit(8);
     }
 
     .app {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix domain items vertical spacing in get-started page.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="1233" alt="image" src="https://github.com/logto-io/logto/assets/12833674/4b33ab3e-45ef-471c-9539-eb41f28007c3">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
