### PR TITLE
fix(console): block subsequent requests on deleting apps

### DIFF
--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/index.tsx
@@ -84,18 +84,14 @@ function ApplicationDetailsContent({ data, oidcConfig, onApplicationUpdated }: P
   );
 
   const onDelete = async () => {
-    if (isDeleting) {
-      return;
-    }
-
+    setIsDeleting(true);
     try {
       await api.delete(`api/applications/${data.id}`);
       setIsDeleted(true);
-      setIsDeleting(false);
       setIsDeleteFormOpen(false);
       toast.success(t('application_details.application_deleted', { name: data.name }));
       navigate(`/applications`);
-    } catch {
+    } finally {
       setIsDeleting(false);
     }
   };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the bug that the delete button does not turn to loading & disabled state when deleting applications, potentially causing making subsequent deleting requests to the server.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Works as expected on my local machine. You can only make one delete request now on deleting apps

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
