### PR TITLE
refactor(core): migrate dashboard api data deps

### DIFF
--- a/.changeset/nice-walls-admire.md
+++ b/.changeset/nice-walls-admire.md
@@ -1,0 +1,10 @@
+---
+"@logto/core": patch
+---
+
+migrate `/dashboard` API data source
+
+Updates:
+- the responded data from `/dashboard/users/new` API is now based on UTC time
+- the responded data from `/dashboard/users/active` API is now based on UTC time
+- the query parameter `date` for `/dashboard/users/active` API is now based on UTC time

--- a/packages/core/src/event-listeners/record-active-users.ts
+++ b/packages/core/src/event-listeners/record-active-users.ts
@@ -1,7 +1,7 @@
 import { generateStandardId } from '@logto/shared';
 
-import { getUtcStartOfTheDay } from '#src/oidc/utils.js';
 import type Queries from '#src/tenants/Queries.js';
+import { getUtcStartOfTheDay } from '#src/utils/utc.js';
 
 export const recordActiveUsers = async (accessToken: { accountId?: string }, queries: Queries) => {
   const { accountId } = accessToken;
@@ -16,6 +16,6 @@ export const recordActiveUsers = async (accessToken: { accountId?: string }, que
   await insertActiveUser({
     id: generateStandardId(),
     userId: accountId,
-    date: getUtcStartOfTheDay(new Date()).getTime(),
+    date: getUtcStartOfTheDay(new Date()),
   });
 };

--- a/packages/core/src/oidc/utils.ts
+++ b/packages/core/src/oidc/utils.ts
@@ -63,9 +63,3 @@ export const isOriginAllowed = (
 
   return [...corsAllowedOrigins, ...redirectUriOrigins].includes(origin);
 };
-
-export const getUtcStartOfTheDay = (date: Date) => {
-  return new Date(
-    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0, 0, 0, 0)
-  );
-};

--- a/packages/core/src/queries/daily-active-user.ts
+++ b/packages/core/src/queries/daily-active-user.ts
@@ -1,14 +1,42 @@
 import { DailyActiveUsers } from '@logto/schemas';
-import type { CommonQueryMethods } from 'slonik';
+import { convertToIdentifiers } from '@logto/shared';
+import { sql, type CommonQueryMethods } from 'slonik';
 
 import { buildInsertIntoWithPool } from '#src/database/insert-into.js';
+
+const { table, fields } = convertToIdentifiers(DailyActiveUsers);
 
 export const createDailyActiveUsersQueries = (pool: CommonQueryMethods) => {
   const insertActiveUser = buildInsertIntoWithPool(pool)(DailyActiveUsers, {
     onConflict: { ignore: true },
   });
 
+  const getDailyActiveUserCountsByTimeInterval = async (
+    startTimeExclusive: number,
+    endTimeInclusive: number
+  ) =>
+    pool.any<{ date: string; count: number }>(sql`
+      select date(${fields.date}), count(distinct(${fields.userId}))
+      from ${table}
+      where ${fields.date} > to_timestamp(${startTimeExclusive}::double precision / 1000)
+      and ${fields.date} <= to_timestamp(${endTimeInclusive}::double precision / 1000)
+      group by date(${fields.date})
+    `);
+
+  const countActiveUsersByTimeInterval = async (
+    startTimeExclusive: number,
+    endTimeInclusive: number
+  ) =>
+    pool.one<{ count: number }>(sql`
+      select count(distinct(${fields.userId}))
+      from ${table}
+      where ${fields.date} > to_timestamp(${startTimeExclusive}::double precision / 1000)
+      and ${fields.date} <= to_timestamp(${endTimeInclusive}::double precision / 1000)
+    `);
+
   return {
     insertActiveUser,
+    getDailyActiveUserCountsByTimeInterval,
+    countActiveUsersByTimeInterval,
   };
 };

--- a/packages/core/src/queries/daily-token-usage.ts
+++ b/packages/core/src/queries/daily-token-usage.ts
@@ -3,7 +3,7 @@ import { convertToIdentifiers, generateStandardId } from '@logto/shared';
 import type { CommonQueryMethods } from 'slonik';
 import { sql } from 'slonik';
 
-import { getUtcStartOfTheDay } from '#src/oidc/utils.js';
+import { getUtcStartOfTheDay } from '#src/utils/utc.js';
 
 const { table, fields } = convertToIdentifiers(DailyTokenUsage);
 const { fields: fieldsWithPrefix } = convertToIdentifiers(DailyTokenUsage, true);
@@ -33,7 +33,7 @@ export const createDailyTokenUsageQueries = (pool: CommonQueryMethods) => {
       insert into ${table} (${fields.id}, ${fields.date}, ${fields.usage})
       values (${generateStandardId()}, to_timestamp(${getUtcStartOfTheDay(
         date
-      ).getTime()}::double precision / 1000), 1)
+      )}::double precision / 1000), 1)
       on conflict (${fields.date}, ${fields.tenantId}) do update set ${fields.usage} = ${
         fieldsWithPrefix.usage
       } + 1

--- a/packages/core/src/queries/log.ts
+++ b/packages/core/src/queries/log.ts
@@ -1,5 +1,5 @@
 import {
-  token,
+  type token,
   type hook,
   Logs,
   type HookExecutionStats,
@@ -77,33 +77,6 @@ export const createLogQueries = (pool: CommonQueryMethods) => {
 
   const findLogById = buildFindEntityByIdWithPool(pool)(Logs);
 
-  const getDailyActiveUserCountsByTimeInterval = async (
-    startTimeExclusive: number,
-    endTimeInclusive: number
-  ) =>
-    pool.any<{ date: string; count: number }>(sql`
-      select date(${fields.createdAt}), count(distinct(${fields.payload}->>'userId'))
-      from ${table}
-      where ${fields.createdAt} > to_timestamp(${startTimeExclusive}::double precision / 1000)
-      and ${fields.createdAt} <= to_timestamp(${endTimeInclusive}::double precision / 1000)
-      and ${fields.key} like ${`${token.Type.ExchangeTokenBy}.%`}
-      and ${fields.payload}->>'result' = 'Success'
-      group by date(${fields.createdAt})
-    `);
-
-  const countActiveUsersByTimeInterval = async (
-    startTimeExclusive: number,
-    endTimeInclusive: number
-  ) =>
-    pool.one<{ count: number }>(sql`
-      select count(distinct(${fields.payload}->>'userId'))
-      from ${table}
-      where ${fields.createdAt} > to_timestamp(${startTimeExclusive}::double precision / 1000)
-      and ${fields.createdAt} <= to_timestamp(${endTimeInclusive}::double precision / 1000)
-      and ${fields.key} like ${`${token.Type.ExchangeTokenBy}.%`}
-      and ${fields.payload}->>'result' = 'Success'
-    `);
-
   const getHookExecutionStatsByHookId = async (hookId: string) => {
     const startTimeExclusive = subDays(new Date(), 1).getTime();
     return pool.one<HookExecutionStats>(sql`
@@ -120,8 +93,6 @@ export const createLogQueries = (pool: CommonQueryMethods) => {
     countLogs,
     findLogs,
     findLogById,
-    getDailyActiveUserCountsByTimeInterval,
-    countActiveUsersByTimeInterval,
     getHookExecutionStatsByHookId,
   };
 };

--- a/packages/core/src/routes/dashboard.openapi.json
+++ b/packages/core/src/routes/dashboard.openapi.json
@@ -21,7 +21,7 @@
     "/api/dashboard/users/new": {
       "get": {
         "summary": "Get new user count",
-        "description": "Get new user count in the past 7 days.",
+        "description": "Get new user count in the past 7 days. Based on UTC time.",
         "parameters": [],
         "responses": {
           "200": {
@@ -33,12 +33,12 @@
     "/api/dashboard/users/active": {
       "get": {
         "summary": "Get active user data",
-        "description": "Get active user data, including daily active user (DAU), weekly active user (WAU) and monthly active user (MAU). It also includes an array of DAU in the past 30 days.",
+        "description": "Get active user data, including daily active user (DAU), weekly active user (WAU) and monthly active user (MAU). It also includes an array of DAU in the past 30 days. Based on UTC time.",
         "parameters": [
           {
             "in": "query",
             "name": "date",
-            "description": "The date to get active user data."
+            "description": "The date (based on UTC) to get active user data."
           }
         ],
         "responses": {

--- a/packages/core/src/routes/dashboard.ts
+++ b/packages/core/src/routes/dashboard.ts
@@ -1,24 +1,21 @@
 import { dateRegex } from '@logto/core-kit';
 import { getNewUsersResponseGuard, getActiveUsersResponseGuard } from '@logto/schemas';
-import { endOfDay, format, subDays } from 'date-fns';
+import { subDays } from 'date-fns';
 import { number, object, string } from 'zod';
 
 import koaGuard from '#src/middleware/koa-guard.js';
+import { getUtcDateString, getUtcEndOfTheDay } from '#src/utils/utc.js';
 
 import type { AuthedRouter, RouterInitArgs } from './types.js';
 
-const getDateString = (date: Date | number) => format(date, 'yyyy-MM-dd');
-
 const indices = (length: number) => [...Array.from({ length }).keys()];
-
-const getEndOfDayTimestamp = (date: Date | number) => endOfDay(date).valueOf();
 
 export default function dashboardRoutes<T extends AuthedRouter>(
   ...[router, { queries }]: RouterInitArgs<T>
 ) {
   const {
-    logs: { countActiveUsersByTimeInterval, getDailyActiveUserCountsByTimeInterval },
     users: { countUsers, getDailyNewUserCountsByTimeInterval },
+    dailyActiveUsers: { getDailyActiveUserCountsByTimeInterval, countActiveUsersByTimeInterval },
   } = queries;
 
   router.get(
@@ -47,24 +44,24 @@ export default function dashboardRoutes<T extends AuthedRouter>(
       const today = Date.now();
       const dailyNewUserCounts = await getDailyNewUserCountsByTimeInterval(
         // (14 days ago 23:59:59.999, today 23:59:59.999]
-        getEndOfDayTimestamp(subDays(today, 14)),
-        getEndOfDayTimestamp(today)
+        getUtcEndOfTheDay(subDays(today, 14)),
+        getUtcEndOfTheDay(today)
       );
 
       const last14DaysNewUserCounts = new Map(
         dailyNewUserCounts.map(({ date, count }) => [date, count])
       );
 
-      const todayNewUserCount = last14DaysNewUserCounts.get(getDateString(today)) ?? 0;
+      const todayNewUserCount = last14DaysNewUserCounts.get(getUtcDateString(today)) ?? 0;
       const yesterday = subDays(today, 1);
-      const yesterdayNewUserCount = last14DaysNewUserCounts.get(getDateString(yesterday)) ?? 0;
+      const yesterdayNewUserCount = last14DaysNewUserCounts.get(getUtcDateString(yesterday)) ?? 0;
       const todayDelta = todayNewUserCount - yesterdayNewUserCount;
 
       const last7DaysNewUserCount = indices(7)
-        .map((index) => getDateString(subDays(today, index)))
+        .map((index) => getUtcDateString(subDays(today, index)))
         .reduce((sum, date) => sum + (last14DaysNewUserCounts.get(date) ?? 0), 0);
       const newUserCountFrom13DaysAgoTo7DaysAgo = indices(7)
-        .map((index) => getDateString(subDays(today, index + 7)))
+        .map((index) => getUtcDateString(subDays(today, index + 7)))
         .reduce((sum, date) => sum + (last14DaysNewUserCounts.get(date) ?? 0), 0);
       const last7DaysDelta = last7DaysNewUserCount - newUserCountFrom13DaysAgoTo7DaysAgo;
 
@@ -108,39 +105,39 @@ export default function dashboardRoutes<T extends AuthedRouter>(
       ] = await Promise.all([
         getDailyActiveUserCountsByTimeInterval(
           // (30 days ago 23:59:59.999, target day 23:59:59.999]
-          getEndOfDayTimestamp(subDays(targetDay, 30)),
-          getEndOfDayTimestamp(targetDay)
+          getUtcEndOfTheDay(subDays(targetDay, 30)),
+          getUtcEndOfTheDay(targetDay)
         ),
         countActiveUsersByTimeInterval(
           // (14 days ago 23:59:59.999, 7 days ago 23:59:59.999]
-          getEndOfDayTimestamp(subDays(targetDay, 14)),
-          getEndOfDayTimestamp(subDays(targetDay, 7))
+          getUtcEndOfTheDay(subDays(targetDay, 14)),
+          getUtcEndOfTheDay(subDays(targetDay, 7))
         ),
         countActiveUsersByTimeInterval(
           // (7 days ago 23:59:59.999, target day 23:59:59.999]
-          getEndOfDayTimestamp(subDays(targetDay, 7)),
-          getEndOfDayTimestamp(targetDay)
+          getUtcEndOfTheDay(subDays(targetDay, 7)),
+          getUtcEndOfTheDay(targetDay)
         ),
         countActiveUsersByTimeInterval(
           // (60 days ago 23:59:59.999, 30 days ago 23:59:59.999]
-          getEndOfDayTimestamp(subDays(targetDay, 60)),
-          getEndOfDayTimestamp(subDays(targetDay, 30))
+          getUtcEndOfTheDay(subDays(targetDay, 60)),
+          getUtcEndOfTheDay(subDays(targetDay, 30))
         ),
         countActiveUsersByTimeInterval(
           // (30 days ago 23:59:59.999, target day 23:59:59.999]
-          getEndOfDayTimestamp(subDays(targetDay, 30)),
-          getEndOfDayTimestamp(targetDay)
+          getUtcEndOfTheDay(subDays(targetDay, 30)),
+          getUtcEndOfTheDay(targetDay)
         ),
       ]);
 
-      const previousDate = getDateString(subDays(targetDay, 1));
-      const targetDate = getDateString(targetDay);
+      const previousDate = getUtcDateString(subDays(targetDay, 1));
+      const targetDate = getUtcDateString(targetDay);
 
       const previousDAU = last30DauCounts.find(({ date }) => date === previousDate)?.count ?? 0;
       const dau = last30DauCounts.find(({ date }) => date === targetDate)?.count ?? 0;
 
       const dauCurve = indices(30).map((index) => {
-        const dateString = getDateString(subDays(targetDay, 29 - index));
+        const dateString = getUtcDateString(subDays(targetDay, 29 - index));
         const count = last30DauCounts.find(({ date }) => date === dateString)?.count ?? 0;
 
         return { date: dateString, count };

--- a/packages/core/src/utils/utc.ts
+++ b/packages/core/src/utils/utc.ts
@@ -1,0 +1,28 @@
+const getUtcDate = (date: Date | number) => {
+  const _date = new Date(date);
+  return new Date(Date.UTC(_date.getUTCFullYear(), _date.getUTCMonth(), _date.getUTCDate()));
+};
+
+/**
+ * Get the start timestamp of the day in UTC, with time set to 00:00:00.000
+ * @param date date
+ * @returns timestamp in milliseconds
+ */
+export const getUtcStartOfTheDay = (date: Date | number) =>
+  new Date(getUtcDate(date).setUTCHours(0, 0, 0, 0)).getTime();
+
+/**
+ * Get the end timestamp of the day in UTC, with time set to 23:59:59.999
+ * @param date date
+ * @returns timestamp in milliseconds
+ */
+export const getUtcEndOfTheDay = (date: Date | number) =>
+  new Date(getUtcDate(date).setUTCHours(23, 59, 59, 999)).getTime();
+
+/**
+ * Get date string in yyyy-MM-dd format in UTC
+ * @param date
+ * @returns date string in yyyy-MM-dd format
+ */
+export const getUtcDateString = (date: Date | number) =>
+  getUtcDate(date).toISOString().slice(0, 'yyyy-MM-dd'.length);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
In the near future, outdated audit logs will be cleared, so we need to refactor the dashboard api to read the DAU statistics data from the `active_daily_users` table.

This PR also update the `/dashboard/users/new` api, since in the original implementation, it's based on local time, and now it should align with the active data, and should based on UTC time.

This PR includs following updates:
- Read dau staticstics data from the `active_daily_users` table rather than `logs` table
- Update the API doc since the statistics data from `active_daily_users` table is based on UTC time, so we need to update the api description to mention this.
- Add a changeset file since this change will have impact to users.
- Update `/dashboard` API UTs since now they're based on UTC time.
- Extract UTC utils into a util file.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT passed and test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
