### PR TITLE
refactor(console): update import paths and type annotations in Python app guide

### DIFF
--- a/packages/console/src/assets/docs/guides/api-python/README.mdx
+++ b/packages/console/src/assets/docs/guides/api-python/README.mdx
@@ -1,5 +1,3 @@
-import Tabs from '@mdx/components/Tabs';
-import TabItem from '@mdx/components/TabItem';
 import InlineNotification from '@/ds-components/InlineNotification';
 import Steps from '@/mdx-components/Steps';
 import Step from '@/mdx-components/Step';

--- a/packages/console/src/assets/docs/guides/web-python/README.mdx
+++ b/packages/console/src/assets/docs/guides/web-python/README.mdx
@@ -1,7 +1,4 @@
 import UriInputField from '@/mdx-components/UriInputField';
-import Tabs from '@mdx/components/Tabs';
-import TabItem from '@mdx/components/TabItem';
-import InlineNotification from '@/ds-components/InlineNotification';
 import Steps from '@/mdx-components/Steps';
 import Step from '@/mdx-components/Step';
 
@@ -46,12 +43,13 @@ Also replace the default memory storage with a persistent storage, for example:
 ```python
 from logto import LogtoClient, LogtoConfig, Storage
 from flask import session
+from typing import Union
 
 class SessionStorage(Storage):
-    def get(self, key: str) -> str | None:
+    def get(self, key: str) -> Union[str, None]:
         return session.get(key, None)
 
-    def set(self, key: str, value: str | None) -> None:
+    def set(self, key: str, value: Union[str, None]) -> None:
         session[key] = value
 
     def delete(self, key: str) -> None:


### PR DESCRIPTION


<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
refactor(console): update import paths and type annotations in Python app guide
- Update import paths for components in `api-python` and `web-python` README files
- Remove unnecessary imports and update type annotations in `web-python` README file
- Ensure consistency and accuracy in component import paths and type annotations across relevant documentation files. Since our tutorial is based on Python 3.8 and 3.8 does not support the union type operation with `|` (should use `Union` util method).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally, content updated.
<img width="900" alt="image" src="https://github.com/logto-io/logto/assets/15182327/cb5262dc-6082-4b2b-8b78-70ff67dd2dc7">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
