### PR TITLE
fix(console): protected app form field background should exclude error message

### DIFF
--- a/packages/console/src/ds-components/TextInput/index.tsx
+++ b/packages/console/src/ds-components/TextInput/index.tsx
@@ -30,6 +30,7 @@ type Props = Omit<HTMLProps<HTMLInputElement>, 'size'> & {
   // eslint-disable-next-line react/boolean-prop-naming
   alwaysShowSuffix?: boolean;
   isConfidential?: boolean;
+  inputContainerClassName?: string;
 };
 
 function TextInput(
@@ -43,6 +44,7 @@ function TextInput(
     readOnly,
     type = 'text',
     isConfidential = false,
+    inputContainerClassName,
     ...rest
   }: Props,
   reference: Ref<Nullable<HTMLInputElement>>
@@ -96,7 +98,8 @@ function TextInput(
           isConfidential && isContentHidden && type === 'text' && styles.hideTextContainerContent,
           icon && styles.withIcon,
           disabled && styles.disabled,
-          readOnly && styles.readOnly
+          readOnly && styles.readOnly,
+          inputContainerClassName
         )}
       >
         {icon && <span className={styles.icon}>{icon}</span>}

--- a/packages/console/src/pages/Applications/components/ProtectedAppForm/index.tsx
+++ b/packages/console/src/pages/Applications/components/ProtectedAppForm/index.tsx
@@ -122,7 +122,7 @@ function ProtectedAppForm({
           tip={conditional(!hasDetailedInstructions && t('protected_app.form.url_field_tooltip'))}
         >
           <TextInput
-            className={styles.input}
+            inputContainerClassName={styles.input}
             {...register('origin', {
               required: true,
               validate: (value) =>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Protected app creation form field should not render background color on error messages.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="1111" alt="image" src="https://github.com/logto-io/logto/assets/12833674/cd54ac32-2624-46aa-ab3a-2c97f10f8819">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
