### PR TITLE
feat(schemas,cli): apply `cleanup:outdated-logs` scope

### DIFF
--- a/packages/cli/src/commands/database/seed/tables.ts
+++ b/packages/cli/src/commands/database/seed/tables.ts
@@ -156,13 +156,19 @@ export const seedTables = async (
   // Create tenant application role
   const applicationRole = createTenantApplicationRole();
   await connection.query(insertInto(applicationRole, Roles.table));
+
+  const m2mAppOnlyScopes = new Set<string>([
+    CloudScope.SendSms,
+    CloudScope.SendEmail,
+    CloudScope.CleanupOutdatedLogs,
+  ]);
+
+  // Assign scopes which are only available for M2M applications to the tenant application role
   await assignScopesToRole(
     connection,
     adminTenantId,
     applicationRole.id,
-    ...cloudAdditionalScopes
-      .filter(({ name }) => name === CloudScope.SendSms || name === CloudScope.SendEmail)
-      .map(({ id }) => id)
+    ...cloudAdditionalScopes.filter(({ name }) => m2mAppOnlyScopes.has(name)).map(({ id }) => id)
   );
 
   await Promise.all([

--- a/packages/schemas/alterations/next-1707121558-add-cleanup-outdated-logs-scope.ts
+++ b/packages/schemas/alterations/next-1707121558-add-cleanup-outdated-logs-scope.ts
@@ -1,0 +1,100 @@
+/**
+ * @fileoverview A preparation for the audit log cleanup task.
+ *
+ * This scripts will do the following things:
+ * 1. Add a new scope `cleanup:outdated-logs` to the cloud api resource.
+ * 2. Assign the new scope to the `tenantApplication` role, which is the role for cloud service M2M application.
+ *
+ * The `cleanup:outdated-logs` scope is used to control the access to the audit log cleanup task provided by the cloud api.
+ *
+ * The `down` script will remove the role-scope assignment and the scope itself.
+ */
+import { generateStandardId } from '@logto/shared/universal';
+import { sql } from 'slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const adminTenantId = 'admin';
+const cloudApiIndicator = 'https://cloud.logto.io/api';
+
+const cleanupOutdatedLogsScopeName = 'cleanup:outdated-logs';
+const cleanupOutdatedLogsScopeDescription =
+  'Allow cleaning up outdated logs. This scope is only available to M2M application.';
+
+const tenantApplicationRole = 'tenantApplication';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    const scopeId = generateStandardId();
+
+    const { id: resourceId } = await pool.one<{ id: string }>(sql`
+      select id from resources
+      where tenant_id = ${adminTenantId}
+      and indicator = ${cloudApiIndicator}
+    `);
+
+    // Add scope to cloud api resource
+    await pool.query(sql`
+      insert into scopes (tenant_id, id, name, description, resource_id)
+        values (
+          ${adminTenantId},
+          ${scopeId},
+          ${cleanupOutdatedLogsScopeName},
+          ${cleanupOutdatedLogsScopeDescription},
+          ${resourceId}
+        );
+    `);
+
+    // Assign scope to the tenant application role
+    const { id: tenantAppRoleId } = await pool.one<{ id: string }>(sql`
+      select id from roles where tenant_id = ${adminTenantId} and name = ${tenantApplicationRole}
+    `);
+    await pool.query(sql`
+      insert into roles_scopes (tenant_id, id, role_id, scope_id)
+        values (
+          ${adminTenantId},
+          ${generateStandardId()},
+          ${tenantAppRoleId},
+          ${scopeId}
+        );
+    `);
+  },
+  down: async (pool) => {
+    const { id: resourceId } = await pool.one<{ id: string }>(sql`
+      select id from resources
+      where tenant_id = ${adminTenantId}
+      and indicator = ${cloudApiIndicator}
+    `);
+
+    const { id: scopeId } = await pool.one<{ id: string }>(sql`
+      select id from scopes
+      where tenant_id = ${adminTenantId}
+      and name = ${cleanupOutdatedLogsScopeName}
+      and resource_id = ${resourceId}
+    `);
+
+    const { id: tenantAppRoleId } = await pool.one<{ id: string }>(sql`
+      select id from roles where tenant_id = ${adminTenantId} and name = ${tenantApplicationRole}
+    `);
+
+    // Remove scope from tenant application role
+    await pool.query(sql`
+      delete from roles_scopes
+      where
+        tenant_id = ${adminTenantId}
+        and role_id = ${tenantAppRoleId}
+        and scope_id = ${scopeId}
+    `);
+
+    // Remove scope
+    await pool.query(sql`
+      delete from scopes
+      where
+        tenant_id = ${adminTenantId}
+        and id = ${scopeId}
+        and resource_id = ${resourceId};
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/seeds/cloud-api.ts
+++ b/packages/schemas/src/seeds/cloud-api.ts
@@ -21,6 +21,8 @@ export enum CloudScope {
   ManageAffiliate = 'manage:affiliate',
   /** The user can create new affiliates and logs. */
   CreateAffiliate = 'create:affiliate',
+  /** The user can cleanup outdated logs. */
+  CleanupOutdatedLogs = 'cleanup:outdated-logs',
 }
 
 export const createCloudApi = (): Readonly<[UpdateAdminData, ...CreateScope[]]> => {

--- a/packages/schemas/src/seeds/cloud-api.ts
+++ b/packages/schemas/src/seeds/cloud-api.ts
@@ -68,6 +68,10 @@ export const createCloudApi = (): Readonly<[UpdateAdminData, ...CreateScope[]]> 
       CloudScope.ManageAffiliate,
       'Allow managing affiliates, including create, update, and delete.'
     ),
+    buildScope(
+      CloudScope.CleanupOutdatedLogs,
+      'Allow cleaning up outdated logs. This scope is only available to M2M application.'
+    ),
   ]);
 };
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Apply `cleanup:outdated-logs` scope to cloud service app, we will request `cleanup:outdated-logs` scope when trying to execute the cleanup outdated logs task by the cloud service m2m app.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested by requesting an access token from the cloud service with the given scope (note: the scope name is `delete:outdated-logs` in the picture, but renamed to `cleanup:outdated-logs` in this PR):
![image](https://github.com/logto-io/logto/assets/10806653/59268818-43d3-4471-a413-8e0e11f3abdc)


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
