### PR TITLE
fix(core,phrases): add notice that protected app is cloud only

### DIFF
--- a/packages/core/src/routes/applications/application-protected-app-metadata.openapi.json
+++ b/packages/core/src/routes/applications/application-protected-app-metadata.openapi.json
@@ -3,7 +3,7 @@
     "/api/applications/{id}/protected-app-metadata/custom-domains": {
       "get": {
         "summary": "Get the list of custom domains of the protected application.",
-        "description": "Get the list of custom domains of the protected application.",
+        "description": "Get the list of custom domains of the protected application. This feature is not available for open source version.",
         "responses": {
           "200": {
             "description": "The domain list of the protected application."
@@ -15,7 +15,7 @@
       },
       "post": {
         "summary": "Add a custom domain to the protected application.",
-        "description": "Add a custom domain to the protected application. You'll need to setup DNS record later.",
+        "description": "Add a custom domain to the protected application. You'll need to setup DNS record later. This feature is not available for open source version.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -45,7 +45,7 @@
     "/api/applications/{id}/protected-app-metadata/custom-domains/{domain}": {
       "delete": {
         "summary": "Delete a custom domain.",
-        "description": "Add a custom domain.",
+        "description": "Add a custom domain. This feature is not available for open source version.",
         "responses": {
           "204": {
             "description": "The domain has been deleted."

--- a/packages/core/src/routes/applications/application.openapi.json
+++ b/packages/core/src/routes/applications/application.openapi.json
@@ -32,7 +32,7 @@
               "schema": {
                 "properties": {
                   "protectedAppMetadata": {
-                    "description": "The data for protected app.",
+                    "description": "The data for protected app, this feature is not available for open source version.",
                     "properties": {
                       "subDomain": {
                         "description": "The subdomain prefix, e.g., my-site."

--- a/packages/core/src/routes/init.ts
+++ b/packages/core/src/routes/init.ts
@@ -57,7 +57,7 @@ const createRouters = (tenant: TenantContext) => {
   applicationUserConsentOrganizationRoutes(managementRouter, tenant);
 
   // FIXME: @wangsijie: remove this after the feature is enabled by default
-  if (EnvSet.values.isDevFeaturesEnabled) {
+  if (!EnvSet.values.isCloud) {
     applicationProtectedAppMetadataRoutes(managementRouter, tenant);
   }
 

--- a/packages/phrases/src/locales/de/errors/application.ts
+++ b/packages/phrases/src/locales/de/errors/application.ts
@@ -11,7 +11,8 @@ const application = {
   consent_management_api_scopes_not_allowed: 'Management API scopes are not allowed.',
   protected_app_metadata_is_required: 'Geschützte App-Metadaten sind erforderlich.',
   /** UNTRANSLATED */
-  protected_app_not_configured: 'Protected app provider is not configured.',
+  protected_app_not_configured:
+    'Protected app provider is not configured. This feature is not available for open source version.',
   /** UNTRANSLATED */
   cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/en/errors/application.ts
+++ b/packages/phrases/src/locales/en/errors/application.ts
@@ -8,7 +8,8 @@ const application = {
   user_consent_scopes_not_found: 'Invalid user consent scopes.',
   consent_management_api_scopes_not_allowed: 'Management API scopes are not allowed.',
   protected_app_metadata_is_required: 'Protected app metadata is required.',
-  protected_app_not_configured: 'Protected app provider is not configured.',
+  protected_app_not_configured:
+    'Protected app provider is not configured. This feature is not available for open source version.',
   cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
   protected_application_only: 'The feature is only available for protected applications.',
   protected_application_misconfigured: 'Protected application is misconfigured.',

--- a/packages/phrases/src/locales/es/errors/application.ts
+++ b/packages/phrases/src/locales/es/errors/application.ts
@@ -11,7 +11,8 @@ const application = {
   consent_management_api_scopes_not_allowed: 'Management API scopes are not allowed.',
   protected_app_metadata_is_required: 'Se requiere metadatos de aplicación protegida.',
   /** UNTRANSLATED */
-  protected_app_not_configured: 'Protected app provider is not configured.',
+  protected_app_not_configured:
+    'Protected app provider is not configured. This feature is not available for open source version.',
   /** UNTRANSLATED */
   cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/fr/errors/application.ts
+++ b/packages/phrases/src/locales/fr/errors/application.ts
@@ -12,7 +12,8 @@ const application = {
   consent_management_api_scopes_not_allowed: 'Management API scopes are not allowed.',
   protected_app_metadata_is_required: "Les métadonnées d'application protégée sont requises.",
   /** UNTRANSLATED */
-  protected_app_not_configured: 'Protected app provider is not configured.',
+  protected_app_not_configured:
+    'Protected app provider is not configured. This feature is not available for open source version.',
   /** UNTRANSLATED */
   cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/it/errors/application.ts
+++ b/packages/phrases/src/locales/it/errors/application.ts
@@ -12,7 +12,8 @@ const application = {
   consent_management_api_scopes_not_allowed: 'Management API scopes are not allowed.',
   protected_app_metadata_is_required: 'Protected app metadata is required.',
   /** UNTRANSLATED */
-  protected_app_not_configured: 'Protected app provider is not configured.',
+  protected_app_not_configured:
+    'Protected app provider is not configured. This feature is not available for open source version.',
   /** UNTRANSLATED */
   cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/ja/errors/application.ts
+++ b/packages/phrases/src/locales/ja/errors/application.ts
@@ -11,7 +11,8 @@ const application = {
   consent_management_api_scopes_not_allowed: 'Management API scopes are not allowed.',
   protected_app_metadata_is_required: 'Protected app metadata is required.',
   /** UNTRANSLATED */
-  protected_app_not_configured: 'Protected app provider is not configured.',
+  protected_app_not_configured:
+    'Protected app provider is not configured. This feature is not available for open source version.',
   /** UNTRANSLATED */
   cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/ko/errors/application.ts
+++ b/packages/phrases/src/locales/ko/errors/application.ts
@@ -10,7 +10,8 @@ const application = {
   consent_management_api_scopes_not_allowed: 'Management API scopes are not allowed.',
   protected_app_metadata_is_required: '보호된 응용 프로그램 메타데이터가 필요합니다.',
   /** UNTRANSLATED */
-  protected_app_not_configured: 'Protected app provider is not configured.',
+  protected_app_not_configured:
+    'Protected app provider is not configured. This feature is not available for open source version.',
   /** UNTRANSLATED */
   cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/pl-pl/errors/application.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/application.ts
@@ -10,7 +10,8 @@ const application = {
   consent_management_api_scopes_not_allowed: 'Management API scopes are not allowed.',
   protected_app_metadata_is_required: 'Wymagane jest zabezpieczone metadane aplikacji.',
   /** UNTRANSLATED */
-  protected_app_not_configured: 'Protected app provider is not configured.',
+  protected_app_not_configured:
+    'Protected app provider is not configured. This feature is not available for open source version.',
   /** UNTRANSLATED */
   cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/pt-br/errors/application.ts
+++ b/packages/phrases/src/locales/pt-br/errors/application.ts
@@ -11,7 +11,8 @@ const application = {
   consent_management_api_scopes_not_allowed: 'Management API scopes are not allowed.',
   protected_app_metadata_is_required: 'Protegido metadados do app é necessário.',
   /** UNTRANSLATED */
-  protected_app_not_configured: 'Protected app provider is not configured.',
+  protected_app_not_configured:
+    'Protected app provider is not configured. This feature is not available for open source version.',
   /** UNTRANSLATED */
   cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/pt-pt/errors/application.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/application.ts
@@ -11,7 +11,8 @@ const application = {
   consent_management_api_scopes_not_allowed: 'Management API scopes are not allowed.',
   protected_app_metadata_is_required: 'Protected app metadata is required.',
   /** UNTRANSLATED */
-  protected_app_not_configured: 'Protected app provider is not configured.',
+  protected_app_not_configured:
+    'Protected app provider is not configured. This feature is not available for open source version.',
   /** UNTRANSLATED */
   cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/ru/errors/application.ts
+++ b/packages/phrases/src/locales/ru/errors/application.ts
@@ -12,7 +12,8 @@ const application = {
   consent_management_api_scopes_not_allowed: 'Management API scopes are not allowed.',
   protected_app_metadata_is_required: 'Требуется защищенная метаданные приложения.',
   /** UNTRANSLATED */
-  protected_app_not_configured: 'Protected app provider is not configured.',
+  protected_app_not_configured:
+    'Protected app provider is not configured. This feature is not available for open source version.',
   /** UNTRANSLATED */
   cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/tr-tr/errors/application.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/application.ts
@@ -10,7 +10,8 @@ const application = {
   consent_management_api_scopes_not_allowed: 'Management API scopes are not allowed.',
   protected_app_metadata_is_required: 'Protected app metadata is required.',
   /** UNTRANSLATED */
-  protected_app_not_configured: 'Protected app provider is not configured.',
+  protected_app_not_configured:
+    'Protected app provider is not configured. This feature is not available for open source version.',
   /** UNTRANSLATED */
   cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/zh-cn/errors/application.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/application.ts
@@ -9,7 +9,8 @@ const application = {
   consent_management_api_scopes_not_allowed: 'Management API scopes are not allowed.',
   protected_app_metadata_is_required: '需要保护的应用程序元数据。',
   /** UNTRANSLATED */
-  protected_app_not_configured: 'Protected app provider is not configured.',
+  protected_app_not_configured:
+    'Protected app provider is not configured. This feature is not available for open source version.',
   /** UNTRANSLATED */
   cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/zh-hk/errors/application.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/application.ts
@@ -9,7 +9,8 @@ const application = {
   consent_management_api_scopes_not_allowed: 'Management API scopes are not allowed.',
   protected_app_metadata_is_required: '保護應用程式元數據是必需的。',
   /** UNTRANSLATED */
-  protected_app_not_configured: 'Protected app provider is not configured.',
+  protected_app_not_configured:
+    'Protected app provider is not configured. This feature is not available for open source version.',
   /** UNTRANSLATED */
   cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/zh-tw/errors/application.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/application.ts
@@ -9,7 +9,8 @@ const application = {
   consent_management_api_scopes_not_allowed: 'Management API scopes are not allowed.',
   protected_app_metadata_is_required: '需要保護應用程式元數據。',
   /** UNTRANSLATED */
-  protected_app_not_configured: 'Protected app provider is not configured.',
+  protected_app_not_configured:
+    'Protected app provider is not configured. This feature is not available for open source version.',
   /** UNTRANSLATED */
   cloudflare_unknown_error: 'Got unknown error when requesting Cloudflare API',
   /** UNTRANSLATED */


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Protected App is not available in open source version, add this notice in openapi docs and error messages.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
