### PR TITLE
ci: fix release workflow trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
 
 on:
+  push:
+    branches:
+      - master
   workflow_dispatch:
 
 concurrency:
@@ -8,6 +11,7 @@ concurrency:
 
 jobs:
   dockerize:
+    if: startsWith(github.ref, 'refs/tags/')
     environment: ${{ startsWith(github.ref, 'refs/tags/') && 'release' || '' }}
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
the `publish-and-tag` job should run for every push, only `dockerize` should be constraint.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
after merge

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
