### PR TITLE
fix(console): protected app creation form field should have correct error background

### DIFF
--- a/packages/console/src/pages/Applications/components/ProtectedAppForm/index.tsx
+++ b/packages/console/src/pages/Applications/components/ProtectedAppForm/index.tsx
@@ -152,7 +152,8 @@ function ProtectedAppForm({
         >
           <div className={styles.domainFieldWrapper}>
             <TextInput
-              className={classNames(styles.input, styles.subdomain)}
+              className={styles.subdomain}
+              inputContainerClassName={styles.input}
               {...register('subDomain', {
                 required: true,
                 validate: (value) =>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Protected app creation form field should have correct error background color. Previously the issue was partially fixed.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="1306" alt="image" src="https://github.com/logto-io/logto/assets/12833674/6616aef2-dbd4-4175-ac74-66c94b74b941">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
