### PR TITLE
fix(console): improve protected app loading state in get started page

### DIFF
--- a/packages/console/src/pages/GetStarted/ProtectedAppCreationForm/index.tsx
+++ b/packages/console/src/pages/GetStarted/ProtectedAppCreationForm/index.tsx
@@ -19,7 +19,7 @@ function ProtectedAppCreationForm() {
   const { getTo } = useTenantPathname();
   const { data, isLoading, mutate } = useSWR<Application[]>('api/applications?types=Protected');
   const { hasAppsReachedLimit } = useApplicationsUsage();
-  const hasProtectedApps = !!data?.length;
+  const hasProtectedApps = !isLoading && !!data?.length;
   const showCreationForm = !hasProtectedApps && !hasAppsReachedLimit;
 
   const mutateApps = useCallback(


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Improve protected app form loading state in get started page. Previously when you have created 3 or more apps in Free plan, you will notice the protected form show up in protected app after the initial loading, then the form disappears, as it has reached the quota limit of total app count.

This fix improve the process and you will not be able to see the form, even not in a blink of eye.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested with slow 3G network throttling. Works fine.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
