### PR TITLE
refactor(console): refactor error handling in Express tutorial

### DIFF
--- a/packages/console/src/assets/docs/guides/api-express/README.mdx
+++ b/packages/console/src/assets/docs/guides/api-express/README.mdx
@@ -141,7 +141,7 @@ const extractBearerTokenFromHeaders = ({ authorization }: IncomingHttpHeaders) =
   }
 
   if (!authorization.startsWith('Bearer')) {
-    throw an Error('Authorization header is not in the Bearer scheme');
+    throw new Error('Authorization header is not in the Bearer scheme');
   }
 
   return authorization.slice(7); // The length of 'Bearer ' is 7


### PR DESCRIPTION
## Summary
Refactor the error handling in the Express tutorial to use the 'new Error()' constructor instead of 'throw an Error()'.

## Testing
Test locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
