### PR TITLE
feat(console): add localhost notice

### DIFF
--- a/packages/console/src/ds-components/TextInput/index.module.scss
+++ b/packages/console/src/ds-components/TextInput/index.module.scss
@@ -124,4 +124,9 @@
   font: var(--font-body-2);
   color: var(--color-error);
   margin-top: _.unit(1);
+
+  a {
+    color: var(--color-error);
+    text-decoration: underline;
+  }
 }

--- a/packages/console/src/ds-components/TextInput/index.tsx
+++ b/packages/console/src/ds-components/TextInput/index.tsx
@@ -19,7 +19,7 @@ import IconButton from '@/ds-components/IconButton';
 import * as styles from './index.module.scss';
 
 type Props = Omit<HTMLProps<HTMLInputElement>, 'size'> & {
-  error?: string | boolean;
+  error?: string | boolean | ReactElement;
   icon?: ReactElement;
   /**
    * An element to be rendered on the right side of the input.
@@ -116,7 +116,7 @@ function TextInput(
             ),
           })}
       </div>
-      {Boolean(error) && typeof error === 'string' && (
+      {Boolean(error) && typeof error !== 'boolean' && (
         <div className={styles.errorMessage}>{error}</div>
       )}
     </div>

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ProtectedAppSettings/components/SessionForm.module.scss
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ProtectedAppSettings/components/SessionForm.module.scss
@@ -1,0 +1,8 @@
+.sessionDuration {
+  width: 135px;
+
+  input {
+    width: 86px;
+    flex: unset;
+  }
+}

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ProtectedAppSettings/components/SessionForm.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ProtectedAppSettings/components/SessionForm.tsx
@@ -1,0 +1,78 @@
+import { type Application, type SnakeCaseOidcConfig } from '@logto/schemas';
+import { type ChangeEvent } from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+import useSWRImmutable from 'swr/immutable';
+
+import FormCard from '@/components/FormCard';
+import { openIdProviderConfigPath } from '@/consts/oidc';
+import FormField from '@/ds-components/FormField';
+import NumericInput from '@/ds-components/TextInput/NumericInput';
+import { type RequestError } from '@/hooks/use-api';
+
+import { type ApplicationForm } from '../../utils';
+
+import * as styles from './SessionForm.module.scss';
+
+type Props = {
+  data: Application;
+};
+
+const maxSessionDuration = 365; // 1 year
+
+function SessionForm({ data }: Props) {
+  const { data: oidcConfig } = useSWRImmutable<SnakeCaseOidcConfig, RequestError>(
+    openIdProviderConfigPath
+  );
+
+  const {
+    control,
+    formState: { errors },
+  } = useFormContext<ApplicationForm>();
+
+  if (!data.protectedAppMetadata || !oidcConfig) {
+    return null;
+  }
+
+  return (
+    <FormCard title="application_details.session">
+      <FormField title="application_details.session_duration">
+        <Controller
+          name="protectedAppMetadata.sessionDuration"
+          control={control}
+          rules={{
+            min: 1,
+          }}
+          render={({ field: { onChange, value, name } }) => (
+            <NumericInput
+              className={styles.sessionDuration}
+              name={name}
+              placeholder="14"
+              value={String(value)}
+              min={1}
+              max={maxSessionDuration}
+              error={Boolean(errors.protectedAppMetadata?.sessionDuration)}
+              onChange={({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
+                onChange(value && Number(value));
+              }}
+              onValueUp={() => {
+                onChange(value + 1);
+              }}
+              onValueDown={() => {
+                onChange(value - 1);
+              }}
+              onBlur={() => {
+                if (value < 1) {
+                  onChange(1);
+                } else if (value > maxSessionDuration) {
+                  onChange(maxSessionDuration);
+                }
+              }}
+            />
+          )}
+        />
+      </FormField>
+    </FormCard>
+  );
+}
+
+export default SessionForm;

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ProtectedAppSettings/index.module.scss
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ProtectedAppSettings/index.module.scss
@@ -98,15 +98,6 @@
   gap: _.unit(3) _.unit(6);
 }
 
-.sessionDuration {
-  width: 135px;
-
-  input {
-    width: 86px;
-    flex: unset;
-  }
-}
-
 .tip {
   ol {
     margin: 0;

--- a/packages/phrases/src/locales/de/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/protected-app.ts
@@ -57,6 +57,9 @@ const protected_app = {
       /** UNTRANSLATED */
       invalid_url:
         "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
+      /** UNTRANSLATED */
+      localhost:
+        'Please expose your local server to the internet first. Learn more about <a>local development</a>.',
     },
   },
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/en/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/protected-app.ts
@@ -34,6 +34,8 @@ const protected_app = {
       url_required: 'Origin URL is required.',
       invalid_url:
         "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
+      localhost:
+        'Please expose your local server to the internet first. Learn more about <a>local development</a>.',
     },
   },
   success_message:

--- a/packages/phrases/src/locales/es/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/protected-app.ts
@@ -57,6 +57,9 @@ const protected_app = {
       /** UNTRANSLATED */
       invalid_url:
         "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
+      /** UNTRANSLATED */
+      localhost:
+        'Please expose your local server to the internet first. Learn more about <a>local development</a>.',
     },
   },
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/fr/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/protected-app.ts
@@ -57,6 +57,9 @@ const protected_app = {
       /** UNTRANSLATED */
       invalid_url:
         "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
+      /** UNTRANSLATED */
+      localhost:
+        'Please expose your local server to the internet first. Learn more about <a>local development</a>.',
     },
   },
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/it/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/protected-app.ts
@@ -57,6 +57,9 @@ const protected_app = {
       /** UNTRANSLATED */
       invalid_url:
         "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
+      /** UNTRANSLATED */
+      localhost:
+        'Please expose your local server to the internet first. Learn more about <a>local development</a>.',
     },
   },
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/ja/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/protected-app.ts
@@ -57,6 +57,9 @@ const protected_app = {
       /** UNTRANSLATED */
       invalid_url:
         "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
+      /** UNTRANSLATED */
+      localhost:
+        'Please expose your local server to the internet first. Learn more about <a>local development</a>.',
     },
   },
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/ko/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/protected-app.ts
@@ -57,6 +57,9 @@ const protected_app = {
       /** UNTRANSLATED */
       invalid_url:
         "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
+      /** UNTRANSLATED */
+      localhost:
+        'Please expose your local server to the internet first. Learn more about <a>local development</a>.',
     },
   },
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/protected-app.ts
@@ -57,6 +57,9 @@ const protected_app = {
       /** UNTRANSLATED */
       invalid_url:
         "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
+      /** UNTRANSLATED */
+      localhost:
+        'Please expose your local server to the internet first. Learn more about <a>local development</a>.',
     },
   },
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/protected-app.ts
@@ -57,6 +57,9 @@ const protected_app = {
       /** UNTRANSLATED */
       invalid_url:
         "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
+      /** UNTRANSLATED */
+      localhost:
+        'Please expose your local server to the internet first. Learn more about <a>local development</a>.',
     },
   },
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/protected-app.ts
@@ -57,6 +57,9 @@ const protected_app = {
       /** UNTRANSLATED */
       invalid_url:
         "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
+      /** UNTRANSLATED */
+      localhost:
+        'Please expose your local server to the internet first. Learn more about <a>local development</a>.',
     },
   },
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/ru/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/protected-app.ts
@@ -57,6 +57,9 @@ const protected_app = {
       /** UNTRANSLATED */
       invalid_url:
         "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
+      /** UNTRANSLATED */
+      localhost:
+        'Please expose your local server to the internet first. Learn more about <a>local development</a>.',
     },
   },
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/protected-app.ts
@@ -57,6 +57,9 @@ const protected_app = {
       /** UNTRANSLATED */
       invalid_url:
         "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
+      /** UNTRANSLATED */
+      localhost:
+        'Please expose your local server to the internet first. Learn more about <a>local development</a>.',
     },
   },
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/protected-app.ts
@@ -57,6 +57,9 @@ const protected_app = {
       /** UNTRANSLATED */
       invalid_url:
         "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
+      /** UNTRANSLATED */
+      localhost:
+        'Please expose your local server to the internet first. Learn more about <a>local development</a>.',
     },
   },
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/protected-app.ts
@@ -57,6 +57,9 @@ const protected_app = {
       /** UNTRANSLATED */
       invalid_url:
         "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
+      /** UNTRANSLATED */
+      localhost:
+        'Please expose your local server to the internet first. Learn more about <a>local development</a>.',
     },
   },
   /** UNTRANSLATED */

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/protected-app.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/protected-app.ts
@@ -57,6 +57,9 @@ const protected_app = {
       /** UNTRANSLATED */
       invalid_url:
         "Invalid Origin URL format: Use http:// or https://. Note: '/pathname' is not currently supported.",
+      /** UNTRANSLATED */
+      localhost:
+        'Please expose your local server to the internet first. Learn more about <a>local development</a>.',
     },
   },
   /** UNTRANSLATED */

--- a/packages/toolkit/core-kit/src/utils/url.test.ts
+++ b/packages/toolkit/core-kit/src/utils/url.test.ts
@@ -1,4 +1,4 @@
-import { isValidUrl, validateRedirectUrl } from './url.js';
+import { isLocalhost, isValidUrl, validateRedirectUrl } from './url.js';
 
 describe('url utilities', () => {
   it('should allow valid redirect URIs', () => {
@@ -39,5 +39,20 @@ describe('url utilities', () => {
     expect(isValidUrl('abc.com/callback')).toBeFalsy();
     expect(isValidUrl('abc.com/callback?test=123')).toBeFalsy();
     expect(isValidUrl('abc.com/callback#test=123')).toBeFalsy();
+  });
+});
+
+describe('isLocalhost()', () => {
+  it('should return true for localhost', () => {
+    expect(isLocalhost('http://localhost')).toBeTruthy();
+    expect(isLocalhost('http://localhost:3001')).toBeTruthy();
+    expect(isLocalhost('https://localhost:3001')).toBeTruthy();
+    expect(isLocalhost('http://localhost:3001/callback')).toBeTruthy();
+  });
+
+  it('should return false for non-localhost', () => {
+    expect(isLocalhost('https://localhost.dev/callback')).toBeFalsy();
+    expect(isLocalhost('https://my-company.com/callback?test=123')).toBeFalsy();
+    expect(isLocalhost('https://abc.com/callback?test=123#param=hash')).toBeFalsy();
   });
 });

--- a/packages/toolkit/core-kit/src/utils/url.ts
+++ b/packages/toolkit/core-kit/src/utils/url.ts
@@ -27,3 +27,12 @@ export const isValidUrl = (url?: string) => {
     return false;
   }
 };
+
+/**
+ * Check if the given URL is localhost
+ */
+export const isLocalhost = (url: string) => {
+  const parsedUrl = new URL(url);
+
+  return ['localhost', '127.0.0.1', '::1'].includes(parsedUrl.hostname);
+};


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

In protected app form, if the origin url is localhost, the validation will fail with a link to the docs site.

The "message" in react-hook-form can only be string, so I have to render the error message manually, to add the link.

Refactored "SessionForm" because the file is too long.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

<img width="889" alt="截屏2024-02-19 下午7 37 21" src="https://github.com/logto-io/logto/assets/5717882/0a07e555-00a7-4472-a606-6b0427179410">

<img width="750" alt="截屏2024-02-19 下午7 43 59" src="https://github.com/logto-io/logto/assets/5717882/bc327c07-470c-4f18-94ee-c32f7ea4392e">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
