### PR TITLE
style(console): fix unexpected spacing under page title

### DIFF
--- a/packages/console/src/components/ListPage/index.tsx
+++ b/packages/console/src/components/ListPage/index.tsx
@@ -49,7 +49,7 @@ function ListPage<
         <CardTitle {...title} />
         {createButton && <Button icon={<Plus />} type="primary" size="large" {...createButton} />}
       </div>
-      {subHeader && <div className={pageLayout.subHeader}>{subHeader}</div>}
+      {subHeader}
       <Table className={pageLayout.table} {...table} />
       {widgets}
     </div>

--- a/packages/console/src/pages/ApiResources/index.tsx
+++ b/packages/console/src/pages/ApiResources/index.tsx
@@ -85,6 +85,7 @@ function ApiResources() {
               hasSurpassedLimit={hasSurpassedLimit}
               quotaItemPhraseKey="api_resource"
               checkedFlagKey="apiResource"
+              className={styles.chargeNotification}
             />
           )
         }

--- a/packages/console/src/pages/Connectors/SignInExperienceSetupNotice/index.module.scss
+++ b/packages/console/src/pages/Connectors/SignInExperienceSetupNotice/index.module.scss
@@ -1,9 +1,5 @@
 @use '@/scss/underscore' as _;
 
-.icon {
-  flex-shrink: 0;
-}
-
-.chargeNotification {
+.notice {
   margin-top: _.unit(4);
 }

--- a/packages/console/src/pages/Connectors/SignInExperienceSetupNotice/index.tsx
+++ b/packages/console/src/pages/Connectors/SignInExperienceSetupNotice/index.tsx
@@ -6,6 +6,8 @@ import InlineNotification from '@/ds-components/InlineNotification';
 import TextLink from '@/ds-components/TextLink';
 import useUserPreferences from '@/hooks/use-user-preferences';
 
+import * as styles from './index.module.scss';
+
 function SignInExperienceSetupNotice() {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { data: connectors } = useSWR<ConnectorResponse[]>('api/connectors');
@@ -21,6 +23,7 @@ function SignInExperienceSetupNotice() {
   return (
     <InlineNotification
       action="general.got_it"
+      className={styles.notice}
       onClick={() => {
         void update({ connectorSieNoticeConfirmed: true });
       }}

--- a/packages/console/src/scss/page-layout.module.scss
+++ b/packages/console/src/scss/page-layout.module.scss
@@ -15,10 +15,6 @@
   gap: _.unit(6);
 }
 
-.subHeader {
-  margin: _.unit(4) 0 0;
-}
-
 .table {
   flex: 1;
   margin-top: _.unit(4);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
style(console): fix unexpected spacing under page title

In #5125 , we add a common style for the `subHeader` section of the `ListPage` component, this will case the page to have an unexpected spacing under the page title.

In this PR, we revert related code changes and custom the `subHeader` style manually.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Everything works fine:
![image](https://github.com/logto-io/logto/assets/10806653/155d1b90-7fa1-4d47-9682-7c10ed610038)
![image](https://github.com/logto-io/logto/assets/10806653/60d5c9e8-47d1-4957-884a-38ae5c7ebe4a)
![image](https://github.com/logto-io/logto/assets/10806653/05b8dec8-3d6c-49db-86fd-41a966a14cd2)
![image](https://github.com/logto-io/logto/assets/10806653/cbc6f980-3d92-4d1b-a574-9f208a6d0011)


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
