### PR TITLE
fix(console): center align card title when subtitle is not available

### DIFF
--- a/packages/console/src/ds-components/DangerousRaw/index.tsx
+++ b/packages/console/src/ds-components/DangerousRaw/index.tsx
@@ -11,7 +11,7 @@ type Props = {
  * is intended to be translated.
  */
 function DangerousRaw({ children }: Props) {
-  return <span>{children}</span>;
+  return children ? <span>{children}</span> : null;
 }
 
 export default DangerousRaw;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Remove the unexpected 4px margin introduced by the ghost subtitle from the guide step, in order to center align the card title when the subtitle is not available.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="200" alt="image" src="https://github.com/logto-io/logto/assets/12833674/97154cbe-fbd8-4232-9683-525c9b32b26f">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
