### PR TITLE
fix(connector): always show SMTP connector TLS configurations in the admin console

### DIFF
--- a/.changeset/wet-squids-move.md
+++ b/.changeset/wet-squids-move.md
@@ -1,0 +1,5 @@
+---
+"@logto/connector-smtp": patch
+---
+
+Always show TLS configurations in the admin console.

--- a/packages/connectors/connector-smtp/src/constant.ts
+++ b/packages/connectors/connector-smtp/src/constant.ts
@@ -170,7 +170,6 @@ export const defaultMetadata: ConnectorMetadata = {
       key: 'secure',
       label: 'Secure',
       type: ConnectorConfigFormItemType.Switch,
-      required: true,
       defaultValue: false,
     },
     {
@@ -179,7 +178,6 @@ export const defaultMetadata: ConnectorMetadata = {
       type: ConnectorConfigFormItemType.Json,
       required: false,
       defaultValue: {},
-      showConditions: [{ targetKey: 'secure', expectValue: true }],
     },
     {
       key: 'servername',
@@ -187,21 +185,18 @@ export const defaultMetadata: ConnectorMetadata = {
       type: ConnectorConfigFormItemType.Text,
       required: false,
       placeholder: '<servername>',
-      showConditions: [{ targetKey: 'secure', expectValue: true }],
     },
     {
       key: 'ignoreTLS',
       label: 'Ignore TLS',
       type: ConnectorConfigFormItemType.Switch,
       required: false,
-      showConditions: [{ targetKey: 'secure', expectValue: true }],
     },
     {
       key: 'requireTLS',
       label: 'Require TLS',
       type: ConnectorConfigFormItemType.Switch,
       required: false,
-      showConditions: [{ targetKey: 'secure', expectValue: true }],
     },
   ],
 };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Always show SMTP connector TLS configurations in the admin console.
This PR fixes [discord bug reports](https://discord.com/channels/965845662535147551/1210615787820163143).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
<img width="1274" alt="image" src="https://github.com/logto-io/logto/assets/15182327/1a1c2b22-b3e1-4bbd-9897-f843b0240643">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
