### PR TITLE
feat(schemas): update `logto_configs` table related types

### DIFF
--- a/packages/schemas/src/types/index.ts
+++ b/packages/schemas/src/types/index.ts
@@ -2,7 +2,7 @@ export * from './connector.js';
 export * from './log/index.js';
 export * from './oidc-config.js';
 export * from './user.js';
-export * from './logto-config.js';
+export * from './logto-config/index.js';
 export * from './interactions.js';
 export * from './search.js';
 export * from './resource.js';

--- a/packages/schemas/src/types/logto-config/index.ts
+++ b/packages/schemas/src/types/logto-config/index.ts
@@ -51,14 +51,6 @@ export const logtoOidcConfigGuard: Readonly<{
   [LogtoOidcConfigKey.CookieKeys]: oidcConfigKeyGuard.array(),
 });
 
-/**
- * Logto JWT customizer token types, used in REST API routes.
- */
-export enum LogtoJwtTokenKeyType {
-  AccessToken = 'access-token',
-  ClientCredentials = 'client-credentials',
-}
-
 export enum LogtoJwtTokenKey {
   AccessToken = 'jwt.accessToken',
   ClientCredentials = 'jwt.clientCredentials',

--- a/packages/schemas/src/types/logto-config/index.ts
+++ b/packages/schemas/src/types/logto-config/index.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 import { jsonObjectGuard } from '../../foundations/index.js';
 
-import { accessTokenGuard, clientCredentialsGuard } from './oidc-provider.js';
+import { accessTokenPayloadGuard, clientCredentialsPayloadGuard } from './oidc-provider.js';
 
 export * from './oidc-provider.js';
 
@@ -66,14 +66,14 @@ const jwtCustomizerGuard = z
 
 export const jwtCustomizerAccessTokenGuard = jwtCustomizerGuard.extend({
   // Use partial token guard since users customization may not rely on all fields.
-  tokenSample: accessTokenGuard.partial().optional(),
+  tokenSample: accessTokenPayloadGuard.partial().optional(),
 });
 
 export type JwtCustomizerAccessToken = z.infer<typeof jwtCustomizerAccessTokenGuard>;
 
 export const jwtCustomizerClientCredentialsGuard = jwtCustomizerGuard.extend({
   // Use partial token guard since users customization may not rely on all fields.
-  tokenSample: clientCredentialsGuard.partial().optional(),
+  tokenSample: clientCredentialsPayloadGuard.partial().optional(),
 });
 
 export type JwtCustomizerClientCredentials = z.infer<typeof jwtCustomizerClientCredentialsGuard>;

--- a/packages/schemas/src/types/logto-config/index.ts
+++ b/packages/schemas/src/types/logto-config/index.ts
@@ -64,13 +64,11 @@ export enum LogtoJwtTokenKey {
   ClientCredentials = 'jwt.clientCredentials',
 }
 
-export const jwtCustomizerGuard = z
+const jwtCustomizerGuard = z
   .object({
     script: z.string(),
     envVars: z.record(z.string()),
     contextSample: jsonObjectGuard,
-    // This `tokenSample` field will be overridden by the `tokenSample` field once the `tokenType` is determined.
-    tokenSample: jsonObjectGuard,
   })
   .partial();
 

--- a/packages/schemas/src/types/logto-config/oidc-provider.ts
+++ b/packages/schemas/src/types/logto-config/oidc-provider.ts
@@ -1,7 +1,7 @@
 /**
  * Manually implement zod guards of some node OIDC provider types.
  *
- * Please note that we defined `accessTokenGuard` and `clientCredentialsGuard` in this file, they are used to make the user-defined token
+ * Please note that we defined `accessTokenPayloadGuard` and `clientCredentialsPayloadGuard` in this file, they are used to make the user-defined token
  * sample to be aligned with the real token payload given by the OIDC provider in a real use case.
  *
  * But these token payload is not a pure "claims" payload, it contains some OIDC provider specific fields (e.g. `kind`). These fields could
@@ -23,7 +23,7 @@ import { jsonObjectGuard } from '../../foundations/index.js';
  * https://github.com/panva/node-oidc-provider/blob/270af1da83dda4c49edb4aaab48908f737d73379/lib/models/base_model.js#L11
  * https://github.com/panva/node-oidc-provider/blob/270af1da83dda4c49edb4aaab48908f737d73379/lib/models/base_token.js#L62
  */
-const baseTokenGuardObject = {
+const baseTokenPayloadGuardObject = {
   jti: z.string(),
   iat: z.number(),
   exp: z.number().optional(),
@@ -41,8 +41,8 @@ const baseTokenGuardObject = {
  * `feature.claimsParameter`: https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#featuresclaimsparameter
  * OIDC claims parameter: https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter
  */
-export const accessTokenGuard = z.object({
-  ...baseTokenGuardObject,
+export const accessTokenPayloadGuard = z.object({
+  ...baseTokenPayloadGuardObject,
   kind: z.literal('AccessToken'),
   accountId: z.string(),
   aud: z.string().or(z.array(z.string())),
@@ -52,19 +52,19 @@ export const accessTokenGuard = z.object({
   sid: z.string().optional(),
 });
 
-export type AccessToken = z.infer<typeof accessTokenGuard>;
+export type AccessTokenPayload = z.infer<typeof accessTokenPayloadGuard>;
 
 /**
  * Ref:
  * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0b7b01b70c4c211a4f69caf05008228ac065413c/types/oidc-provider/index.d.ts#L515
  * https://github.com/panva/node-oidc-provider/blob/270af1da83dda4c49edb4aaab48908f737d73379/lib/models/client_credentials.js#L11
  */
-export const clientCredentialsGuard = z.object({
-  ...baseTokenGuardObject,
+export const clientCredentialsPayloadGuard = z.object({
+  ...baseTokenPayloadGuardObject,
   kind: z.literal('ClientCredentials'),
   aud: z.string().or(z.array(z.string())),
   extra: jsonObjectGuard.optional(),
   scope: z.string().optional(),
 });
 
-export type ClientCredentials = z.infer<typeof clientCredentialsGuard>;
+export type ClientCredentialsPayload = z.infer<typeof clientCredentialsPayloadGuard>;

--- a/packages/schemas/src/types/logto-config/oidc-provider.ts
+++ b/packages/schemas/src/types/logto-config/oidc-provider.ts
@@ -20,26 +20,15 @@ const baseTokenGuardObject = {
   kind: z.string(),
 };
 
-// Ref: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0b7b01b70c4c211a4f69caf05008228ac065413c/types/oidc-provider/index.d.ts#L144
-const claimsParameterMemberGuard = z
-  .object({
-    essential: z.boolean(),
-    value: z.string(),
-    values: z.array(z.string()),
-  })
-  .partial()
-  .catchall(jsonObjectGuard);
-
-// Ref: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0b7b01b70c4c211a4f69caf05008228ac065413c/types/oidc-provider/index.d.ts#L152
-const claimsParameterGuard = z.object({
-  id_token: z.record(claimsParameterMemberGuard.nullable()).optional(),
-  userinfo: z.record(claimsParameterMemberGuard.nullable()).optional(),
-});
-
 /**
  * Ref:
  * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0b7b01b70c4c211a4f69caf05008228ac065413c/types/oidc-provider/index.d.ts#L550
  * https://github.com/panva/node-oidc-provider/blob/270af1da83dda4c49edb4aaab48908f737d73379/lib/models/access_token.js#L17
+ *
+ * We do not include `claims` field in this guard because we did not enabled the `feature.claimsParameter` in the oidc-provider.
+ * If we enable the `feature.claimsParameter` feature in the future, we should include and implement the `claims` field guard.
+ * `feature.claimsParameter`: https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#featuresclaimsparameter
+ * OIDC claims parameter: https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter
  */
 export const accessTokenGuard = z
   .object({
@@ -47,7 +36,6 @@ export const accessTokenGuard = z
     kind: z.literal('AccessToken'),
     accountId: z.string(),
     aud: z.string().or(z.array(z.string())),
-    claims: claimsParameterGuard.optional(),
     extra: jsonObjectGuard.optional(),
     grantId: z.string(),
     scope: z.string().optional(),

--- a/packages/schemas/src/types/logto-config/oidc-provider.ts
+++ b/packages/schemas/src/types/logto-config/oidc-provider.ts
@@ -1,5 +1,16 @@
 /**
  * Manually implement zod guards of some node OIDC provider types.
+ *
+ * Please note that we defined `accessTokenGuard` and `clientCredentialsGuard` in this file, they are used to make the user-defined token
+ * sample to be aligned with the real token payload given by the OIDC provider in a real use case.
+ *
+ * But these token payload is not a pure "claims" payload, it contains some OIDC provider specific fields (e.g. `kind`). These fields could
+ * be useful when the user relies on them to make conditional logic in the customization code scripts but will be ignored when the OIDC provider
+ * processes the customized token payload to JWT token.
+ *
+ * TODO: @darcyYe LOG-8366
+ * Find a proper way to "filter" those fields that will be ignored by the OIDC provider when processing the customized token payload.
+ * So that we can make the "testing" function in the admin console to be more accurate.
  */
 import { z } from 'zod';
 
@@ -30,18 +41,16 @@ const baseTokenGuardObject = {
  * `feature.claimsParameter`: https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#featuresclaimsparameter
  * OIDC claims parameter: https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter
  */
-export const accessTokenGuard = z
-  .object({
-    ...baseTokenGuardObject,
-    kind: z.literal('AccessToken'),
-    accountId: z.string(),
-    aud: z.string().or(z.array(z.string())),
-    extra: jsonObjectGuard.optional(),
-    grantId: z.string(),
-    scope: z.string().optional(),
-    sid: z.string().optional(),
-  })
-  .catchall(jsonObjectGuard);
+export const accessTokenGuard = z.object({
+  ...baseTokenGuardObject,
+  kind: z.literal('AccessToken'),
+  accountId: z.string(),
+  aud: z.string().or(z.array(z.string())),
+  extra: jsonObjectGuard.optional(),
+  grantId: z.string(),
+  scope: z.string().optional(),
+  sid: z.string().optional(),
+});
 
 export type AccessToken = z.infer<typeof accessTokenGuard>;
 
@@ -50,14 +59,12 @@ export type AccessToken = z.infer<typeof accessTokenGuard>;
  * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0b7b01b70c4c211a4f69caf05008228ac065413c/types/oidc-provider/index.d.ts#L515
  * https://github.com/panva/node-oidc-provider/blob/270af1da83dda4c49edb4aaab48908f737d73379/lib/models/client_credentials.js#L11
  */
-export const clientCredentialsGuard = z
-  .object({
-    ...baseTokenGuardObject,
-    kind: z.literal('ClientCredentials'),
-    aud: z.string().or(z.array(z.string())),
-    extra: jsonObjectGuard.optional(),
-    scope: z.string().optional(),
-  })
-  .catchall(jsonObjectGuard);
+export const clientCredentialsGuard = z.object({
+  ...baseTokenGuardObject,
+  kind: z.literal('ClientCredentials'),
+  aud: z.string().or(z.array(z.string())),
+  extra: jsonObjectGuard.optional(),
+  scope: z.string().optional(),
+});
 
 export type ClientCredentials = z.infer<typeof clientCredentialsGuard>;

--- a/packages/schemas/src/types/logto-config/oidc-provider.ts
+++ b/packages/schemas/src/types/logto-config/oidc-provider.ts
@@ -1,0 +1,75 @@
+/**
+ * Manually implement zod guards of some node OIDC provider types.
+ */
+import { z } from 'zod';
+
+import { jsonObjectGuard } from '../../foundations/index.js';
+
+/**
+ * Does not include built-in methods.
+ * Ref:
+ * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0b7b01b70c4c211a4f69caf05008228ac065413c/types/oidc-provider/index.d.ts#L310
+ * https://github.com/panva/node-oidc-provider/blob/270af1da83dda4c49edb4aaab48908f737d73379/lib/models/base_model.js#L11
+ * https://github.com/panva/node-oidc-provider/blob/270af1da83dda4c49edb4aaab48908f737d73379/lib/models/base_token.js#L62
+ */
+const baseTokenGuardObject = {
+  jti: z.string(),
+  iat: z.number(),
+  exp: z.number().optional(),
+  clientId: z.string().optional(),
+  kind: z.string(),
+};
+
+// Ref: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0b7b01b70c4c211a4f69caf05008228ac065413c/types/oidc-provider/index.d.ts#L144
+const claimsParameterMemberGuard = z
+  .object({
+    essential: z.boolean(),
+    value: z.string(),
+    values: z.array(z.string()),
+  })
+  .partial()
+  .catchall(jsonObjectGuard);
+
+// Ref: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0b7b01b70c4c211a4f69caf05008228ac065413c/types/oidc-provider/index.d.ts#L152
+const claimsParameterGuard = z.object({
+  id_token: z.record(claimsParameterMemberGuard.nullable()).optional(),
+  userinfo: z.record(claimsParameterMemberGuard.nullable()).optional(),
+});
+
+/**
+ * Ref:
+ * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0b7b01b70c4c211a4f69caf05008228ac065413c/types/oidc-provider/index.d.ts#L550
+ * https://github.com/panva/node-oidc-provider/blob/270af1da83dda4c49edb4aaab48908f737d73379/lib/models/access_token.js#L17
+ */
+export const accessTokenGuard = z
+  .object({
+    ...baseTokenGuardObject,
+    kind: z.literal('AccessToken'),
+    accountId: z.string(),
+    aud: z.string().or(z.array(z.string())),
+    claims: claimsParameterGuard.optional(),
+    extra: jsonObjectGuard.optional(),
+    grantId: z.string(),
+    scope: z.string().optional(),
+    sid: z.string().optional(),
+  })
+  .catchall(jsonObjectGuard);
+
+export type AccessToken = z.infer<typeof accessTokenGuard>;
+
+/**
+ * Ref:
+ * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0b7b01b70c4c211a4f69caf05008228ac065413c/types/oidc-provider/index.d.ts#L515
+ * https://github.com/panva/node-oidc-provider/blob/270af1da83dda4c49edb4aaab48908f737d73379/lib/models/client_credentials.js#L11
+ */
+export const clientCredentialsGuard = z
+  .object({
+    ...baseTokenGuardObject,
+    kind: z.literal('ClientCredentials'),
+    aud: z.string().or(z.array(z.string())),
+    extra: jsonObjectGuard.optional(),
+    scope: z.string().optional(),
+  })
+  .catchall(jsonObjectGuard);
+
+export type ClientCredentials = z.infer<typeof clientCredentialsGuard>;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
We will support two custom JWT scenarios, `AccessToken` (for end-user) and `ClientCredentials` (for machine connection), Logto users can customize the logic to manipulate the raw token payload, and the result of the parsed token payload will be further processed by Logto OIDC service and then issued to the client.
For each scenario, Logto user can customize the token payload manipulation by providing a code snippet, env variables, and sample token/context (for testing purposes). This is a group of data that will be stored in `logto_config` table as a single DB record.

This PR is the preparation for upcoming custom JWT-related APIs, with the following update/refactor:
1. Enable new `key` column value `LogtoJwtTokenKey` for `logto_config` table.
2. For each `LogtoJwtTokenKey`, we provide the corresponding `data` guards (`jwtCustomizerAccessTokenGuard` and `jwtCustomizerClientCredentialsGuard`) and types (`JwtCustomizerAccessToken` and `JwtCustomizerClientCredentials`).
 - All fields in `data` guards are optional to make the data flexible. Some fields have default values, but the backend does not care what the value is. The console will handle all of the value fallback logic.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
