### PR TITLE
refactor(schemas): regenerate dau table data from logs

### DIFF
--- a/packages/schemas/alterations/next-1709528944-regenerate-dau-data.ts
+++ b/packages/schemas/alterations/next-1709528944-regenerate-dau-data.ts
@@ -1,0 +1,49 @@
+import { generateStandardId } from '@logto/shared/universal';
+import { sql } from 'slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+type ActiveUserInteractionLog = {
+  tenantId: string;
+  userId: string;
+  createdAt: number;
+};
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    // Delete all record from `daily_active_users` table
+    await pool.query(sql`delete from daily_active_users;`);
+
+    // Retrieve all active user logs from `logs` table
+    const { rows: interactionLogs } = await pool.query<ActiveUserInteractionLog>(sql`
+      select tenant_id, payload->>'userId' as user_id, created_at
+      from logs
+      where payload->>'userId' is not null and key like 'ExchangeTokenBy.%' and payload->>'result' = 'Success'
+    `);
+
+    if (interactionLogs.length === 0) {
+      console.log('No active user interaction logs found, skip alteration');
+      return;
+    }
+
+    // Generate DAU data from active user logs
+    for (const { tenantId, userId, createdAt } of interactionLogs) {
+      /**
+       * Note: we ignore the conflict here because conflict data may be inserted when staging.
+       */
+      // eslint-disable-next-line no-await-in-loop
+      await pool.query(sql`
+        insert into daily_active_users (id, tenant_id, user_id, date)
+        values (${generateStandardId()},${tenantId}, ${userId}, ${new Date(
+          createdAt
+        ).toISOString()})
+        on conflict do nothing;
+      `);
+    }
+  },
+  down: async (pool) => {
+    // Cannot be reverted
+  },
+};
+
+export default alteration;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Regenerate `daily_active_users` table data from the `logs` table data.

### Note
🚨 This PR is a data migration and should be merged after the #5451 is launched for our cloud version, otherwise old format data will still insert into the `daily_active_users` when staging.

### Background

Currently, we retrieve DAU date from `logs` table.

Since the data in the `logs` table will be cleared, so we should not rely on it anymore, now we plan to read DAU date from the `daily_active_users` table.

But there is one problem in the `daily_active_users` table:

the original `daily_active_users` table record the active user data based on UTC date, and only record the “date” time:
```tsx

export const recordActiveUsers = async (accessToken: { accountId?: string }, queries: Queries) => {
  const { accountId } = accessToken;
  const { insertActiveUser } = queries.dailyActiveUsers;

  if (!accountId) {
    // Some kind of tokens may not have accountId, for example, the one issued for application
    return;
  }

  // Mark this user as active today
  await insertActiveUser({
    id: generateStandardId(),
    userId: accountId,
		// Only record date info
    date: getUtcStartOfTheDay(new Date()).getTime(),
  });
};

export const getUtcStartOfTheDay = (date: Date) => {
  return new Date(
    Date.UTC(
	date.getUTCFullYear(),
	date.getUTCMonth(),
	date.getUTCDate(),
	// Accurate time is removed
	0,
	0,
	0,
	0
)
  );
};
```

This implementation will lose the accurate time information, this will cause an error in the following scenario:

When we display daily new users and daily active users on the dashboard:

- For daily new users, we query the users table, with the time range from `getEndOfDayTimestamp(subDays(today, 1))` to `getEndOfDayTimestamp(today)`. This is based on the server local time.
- For daily active users, we query the logs table with the same as the daily new users data.

Now, because our logs table will be cleared, we switch to reading DAU date from the `daily_active_users` table.

The `daily_active_users` table only stores UTC-based date (only date information).
As a result, the data for daily new users and daily active users no longer match.

Since `daily_active_users` records data by UTC date, and the new users data is grouped by server local date, so there are discrepancies between different time zones.

To accurately calculate DAU and delta across different time zones, we need to store precise timestamps in the `daily_active_users` table.

So, before we retrieve DAU data from `daily_active_users` table, we need to do the following things:

- record accurate time when the user has interations with Logto (Done in #5451 )
- Regenerate `daily_active_users` table data from the `logs` table data (This PR)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested with dev data (test locally).
Before alteration (retrieve dau data from `logs` table):

![image](https://github.com/logto-io/logto/assets/10806653/2e18124d-985b-4f14-a76a-ddd295a8c545)

After alteration (retrieve dau data from `daily_active_users` table:

![image](https://github.com/logto-io/logto/assets/10806653/2072b583-cf02-45b4-8a13-2916fcd8995d)


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
- [x] necessary TSDoc comments
