### PR TITLE
refactor(schemas): update schema to fit cloud

### DIFF
--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -86,7 +86,7 @@
     "@logto/phrases": "workspace:^1.9.0",
     "@logto/phrases-experience": "workspace:^1.6.0",
     "@logto/shared": "workspace:^3.1.0",
-    "@withtyped/server": "^0.12.9"
+    "@withtyped/server": "^0.13.1"
   },
   "peerDependencies": {
     "zod": "^3.22.4"

--- a/packages/schemas/src/types/organization.ts
+++ b/packages/schemas/src/types/organization.ts
@@ -11,6 +11,10 @@ import {
 
 import { type UserInfo, type FeaturedUser, userInfoGuard } from './user.js';
 
+type ToZodObject<T> = z.ZodObject<{
+  [K in keyof T]: z.ZodType<T[K]>;
+}>;
+
 /**
  * The simplified organization scope entity that is returned for some endpoints.
  */
@@ -23,7 +27,7 @@ export type OrganizationRoleWithScopes = OrganizationRole & {
   scopes: OrganizationScopeEntity[];
 };
 
-export const organizationRoleWithScopesGuard: z.ZodType<OrganizationRoleWithScopes> =
+export const organizationRoleWithScopesGuard: ToZodObject<OrganizationRoleWithScopes> =
   OrganizationRoles.guard.extend({
     scopes: z
       .object({
@@ -42,7 +46,7 @@ export type OrganizationRoleEntity = {
   name: string;
 };
 
-const organizationRoleEntityGuard: z.ZodType<OrganizationRoleEntity> = z.object({
+const organizationRoleEntityGuard: ToZodObject<OrganizationRoleEntity> = z.object({
   id: z.string(),
   name: z.string(),
 });
@@ -56,7 +60,7 @@ export type OrganizationWithRoles = Organization & {
   organizationRoles: OrganizationRoleEntity[];
 };
 
-export const organizationWithOrganizationRolesGuard: z.ZodType<OrganizationWithRoles> =
+export const organizationWithOrganizationRolesGuard: ToZodObject<OrganizationWithRoles> =
   Organizations.guard.extend({
     organizationRoles: organizationRoleEntityGuard.array(),
   });
@@ -70,7 +74,7 @@ export type UserWithOrganizationRoles = UserInfo & {
   organizationRoles: OrganizationRoleEntity[];
 };
 
-export const userWithOrganizationRolesGuard: z.ZodType<UserWithOrganizationRoles> =
+export const userWithOrganizationRolesGuard: ToZodObject<UserWithOrganizationRoles> =
   userInfoGuard.extend({
     organizationRoles: organizationRoleEntityGuard.array(),
   });
@@ -93,7 +97,7 @@ export type OrganizationInvitationEntity = OrganizationInvitation & {
   organizationRoles: OrganizationRoleEntity[];
 };
 
-export const organizationInvitationEntityGuard: z.ZodType<OrganizationInvitationEntity> =
+export const organizationInvitationEntityGuard: ToZodObject<OrganizationInvitationEntity> =
   OrganizationInvitations.guard.extend({
     organizationRoles: organizationRoleEntityGuard.array(),
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3997,8 +3997,8 @@ importers:
         specifier: workspace:^3.1.0
         version: link:../shared
       '@withtyped/server':
-        specifier: ^0.12.9
-        version: 0.12.9(zod@3.22.4)
+        specifier: ^0.13.1
+        version: 0.13.1(zod@3.22.4)
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -10546,6 +10546,16 @@ packages:
       '@silverhand/essentials': 2.9.0
       '@withtyped/shared': 0.2.2
       zod: 3.22.4
+
+  /@withtyped/server@0.13.1(zod@3.22.4):
+    resolution: {integrity: sha512-Fmmlw/7f3oidMS2tjgOx82BIkNEDBpHbFPj4oghXbyaZ8bgskLjKoLE0Qscbua6vhWUG4EgAmfR5ijSfg3bw2Q==}
+    peerDependencies:
+      zod: ^3.19.1
+    dependencies:
+      '@silverhand/essentials': 2.9.0
+      '@withtyped/shared': 0.2.2
+      zod: 3.22.4
+    dev: false
 
   /@withtyped/shared@0.2.2:
     resolution: {integrity: sha512-Vpcj12NqaoZ8M5Z/1kffheI9FBZEm9goed0THmgTcMKXLHjXSRbMZMp0olVxovEgaTIAydshqJOQUXKZMctIZw==}


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

- upgrade `@withtyped/server` to `^0.13.1` in `@logto/schemas` (this is intentional, will upgrade other packages later)
- update `@logto/schemas` guard types to make organization type guard reusable

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
cloud can use it

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
