### PR TITLE
chore(core): deprecate unused query methods for logs table

### DIFF
--- a/packages/core/src/queries/log.ts
+++ b/packages/core/src/queries/log.ts
@@ -1,5 +1,5 @@
 import {
-  token,
+  type token,
   type hook,
   Logs,
   type HookExecutionStats,
@@ -77,33 +77,6 @@ export const createLogQueries = (pool: CommonQueryMethods) => {
 
   const findLogById = buildFindEntityByIdWithPool(pool)(Logs);
 
-  const getDailyActiveUserCountsByTimeInterval = async (
-    startTimeExclusive: number,
-    endTimeInclusive: number
-  ) =>
-    pool.any<{ date: string; count: number }>(sql`
-      select date(${fields.createdAt}), count(distinct(${fields.payload}->>'userId'))
-      from ${table}
-      where ${fields.createdAt} > to_timestamp(${startTimeExclusive}::double precision / 1000)
-      and ${fields.createdAt} <= to_timestamp(${endTimeInclusive}::double precision / 1000)
-      and ${fields.key} like ${`${token.Type.ExchangeTokenBy}.%`}
-      and ${fields.payload}->>'result' = 'Success'
-      group by date(${fields.createdAt})
-    `);
-
-  const countActiveUsersByTimeInterval = async (
-    startTimeExclusive: number,
-    endTimeInclusive: number
-  ) =>
-    pool.one<{ count: number }>(sql`
-      select count(distinct(${fields.payload}->>'userId'))
-      from ${table}
-      where ${fields.createdAt} > to_timestamp(${startTimeExclusive}::double precision / 1000)
-      and ${fields.createdAt} <= to_timestamp(${endTimeInclusive}::double precision / 1000)
-      and ${fields.key} like ${`${token.Type.ExchangeTokenBy}.%`}
-      and ${fields.payload}->>'result' = 'Success'
-    `);
-
   const getHookExecutionStatsByHookId = async (hookId: string) => {
     const startTimeExclusive = subDays(new Date(), 1).getTime();
     return pool.one<HookExecutionStats>(sql`
@@ -120,8 +93,6 @@ export const createLogQueries = (pool: CommonQueryMethods) => {
     countLogs,
     findLogs,
     findLogById,
-    getDailyActiveUserCountsByTimeInterval,
-    countActiveUsersByTimeInterval,
     getHookExecutionStatsByHookId,
   };
 };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
deprecate unused `countActiveUsersByTimeInterval` and `getDailyActiveUserCountsByTimeInterval` methods from `LogQueries`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
