### PR TITLE
feat(cli): setup logs pruner application for admin tenant

### DIFF
--- a/packages/cli/src/commands/database/seed/cloud.ts
+++ b/packages/cli/src/commands/database/seed/cloud.ts
@@ -6,14 +6,24 @@ import {
   createAdminTenantApplicationRole,
   createCloudConnectionConfig,
   AdminTenantRole,
+  CloudScope,
+  cloudApiIndicator,
+  RoleType,
+  ApplicationType,
+  type CreateApplication,
+  type CreateRole,
+  type CreateScope,
+  type CreateApplicationsRole,
 } from '@logto/schemas';
-import { GlobalValues } from '@logto/shared';
+import { GlobalValues, generateStandardId, generateStandardSecret } from '@logto/shared';
 import { appendPath } from '@silverhand/essentials';
 import type { CommonQueryMethods } from 'slonik';
 import { sql } from 'slonik';
 
 import { insertInto } from '../../../database.js';
 import { consoleLog } from '../../../utils.js';
+
+import { assignScopesToRole } from './tenant.js';
 
 /**
  * Append Redirect URIs for the default tenant callback in cloud Admin Console.
@@ -91,4 +101,69 @@ export const seedTenantCloudServiceApplication = async (
   );
 
   consoleLog.succeed('Cloud Service Application successfully created for:', tenantId);
+};
+
+/**
+ * Setup Logs Pruner application for admin tenant
+ */
+export const setupLogsPrunerApplicationForAdminTenant = async (pool: CommonQueryMethods) => {
+  // Add CloudScope.PruneLogs scope to cloud api resource
+  const { id: cloudApiResourceId } = await pool.one<{ id: string }>(sql`
+    select id from resources
+    where indicator = ${cloudApiIndicator}
+    and tenant_id = ${adminTenantId}
+  `);
+
+  const pruneLogsScope: CreateScope = {
+    tenantId: adminTenantId,
+    id: generateStandardId(),
+    name: CloudScope.PruneLogs,
+    description:
+      'Allow pruning logs which are expired. This scope is only available to Logs Pruner M2M application.',
+    resourceId: cloudApiResourceId,
+  };
+
+  await pool.query(insertInto(pruneLogsScope, 'scopes'));
+
+  // Create logs pruner role
+  const logsPrunerRole: CreateRole = {
+    tenantId: adminTenantId,
+    id: generateStandardId(),
+    name: 'logs-pruner',
+    description: 'The role for the application that prunes logs which are expired.',
+    type: RoleType.MachineToMachine,
+  };
+  await pool.query(insertInto(logsPrunerRole, 'roles'));
+
+  // Assign CloudScope.PruneLogs to logsPruner role
+  await assignScopesToRole(pool, adminTenantId, logsPrunerRole.id, pruneLogsScope.id);
+
+  // Create Logs Pruner M2M application
+  const logsPrunerApplication: CreateApplication = {
+    tenantId: adminTenantId,
+    id: generateStandardId(),
+    name: 'Logs Pruner',
+    description: 'The application that prunes logs which are expired.',
+    type: ApplicationType.MachineToMachine,
+    secret: generateStandardSecret(),
+    oidcClientMetadata: {
+      redirectUris: [],
+      postLogoutRedirectUris: [],
+    },
+    customClientMetadata: {},
+  };
+  await pool.query(insertInto(logsPrunerApplication, 'applications'));
+
+  // Assign logs-pruner role to Logs Pruner application
+  const applicationRoleRelation: CreateApplicationsRole = {
+    id: generateStandardId(),
+    tenantId: adminTenantId,
+    applicationId: logsPrunerApplication.id,
+    roleId: logsPrunerRole.id,
+  };
+  await pool.query(insertInto(applicationRoleRelation, 'applications_roles'));
+
+  consoleLog.succeed(
+    'Logs Pruner machine-to-machine application successfully setup for admin tenant'
+  );
 };

--- a/packages/cli/src/commands/database/seed/tables.ts
+++ b/packages/cli/src/commands/database/seed/tables.ts
@@ -38,7 +38,11 @@ import { getDatabaseName } from '../../../queries/database.js';
 import { updateDatabaseTimestamp } from '../../../queries/system.js';
 import { consoleLog, getPathInModule } from '../../../utils.js';
 
-import { appendAdminConsoleRedirectUris, seedTenantCloudServiceApplication } from './cloud.js';
+import {
+  appendAdminConsoleRedirectUris,
+  setupLogsPrunerApplicationForAdminTenant,
+  seedTenantCloudServiceApplication,
+} from './cloud.js';
 import { seedOidcConfigs } from './oidc-config.js';
 import { seedTenantOrganizations } from './tenant-organizations.js';
 import {
@@ -198,6 +202,7 @@ export const seedCloud = async (connection: DatabaseTransactionConnection) => {
   await Promise.all([
     appendAdminConsoleRedirectUris(connection),
     seedTenantCloudServiceApplication(connection, adminTenantId),
+    setupLogsPrunerApplicationForAdminTenant(connection),
   ]);
 };
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
According to our tech design, we will use a m2m app to retrieve an access token for cloud API to trigger audit logs' cleanup task. So we need to setup the `Logs Pruner` application for admin tenant.

### Note

The db alteration script is available in the cloud repo. See https://github.com/logto-io/cloud/pull/513

### Basic flow:
```mermaid
flowchart TD
	A[Start] --> B[Create a `Logs Pruner` M2M app for admin tenant]
	B --> C[Create a `logs-pruner` Role]
	C --> D[Add `prune:logs` scope to cloud API resource and assign it to `logs-pruner` Role]
	D --> E[Assign `logs-pruner` to admin tenant's `Logs Pruner` M2M App]
	E --> End
```

```mermaid
sequenceDiagram
	participant Github Actions
	participant Logto Service
	participant Cloud

	loop every day
		Github Actions ->> Logto Service: Request access token via admin tenant's `Logs Pruner` M2M App with `prune:logs` scope
		Logto Service -->> Github Actions: Access token with `prune:logs` permission
		Github Actions ->> Cloud: DELETE `/logs/expired` with access token retrieved
		Cloud ->> Cloud: Prune outdated audit logs for all non-admin tenants
		Cloud -->> Github Actions: HttpCode 200
	end
```

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally and have gain the correct access with correct scope:

![image](https://github.com/logto-io/logto/assets/10806653/534c26b5-3bb8-4253-95e0-3463f273cf6c)


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
