### PR TITLE
fix(console): fix input field background color

### DIFF
--- a/packages/console/src/ds-components/TextInput/index.module.scss
+++ b/packages/console/src/ds-components/TextInput/index.module.scss
@@ -28,7 +28,7 @@
   transition-duration: 0.2s;
   padding: 0 _.unit(3);
   height: 36px;
-  background-color: inherit;
+  background-color: var(--color-layer-1);
   font: var(--font-body-2);
 
   &.withIcon {
@@ -85,6 +85,7 @@
 
     &[type='number'] {
       -moz-appearance: textfield;
+      appearance: textfield;
 
       &::-webkit-outer-spin-button,
       &::-webkit-inner-spin-button {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Confirmed with our designers, the input field in console should not inherit its background color from parent element, and should be set to `--color-layer-1`.

This PR fixes the bug that form fields in organization template have different background colors, like this:
![image](https://github.com/logto-io/logto/assets/12833674/98e1c2e7-f368-48af-90d1-cc59f5446825)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested OK
<img width="900" alt="image" src="https://github.com/logto-io/logto/assets/12833674/806ebfd5-206d-420a-8706-2aabf6e26506">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
