### PR TITLE
chore(cli): move typescript to dev dependencies

### DIFF
--- a/.changeset/happy-bags-arrive.md
+++ b/.changeset/happy-bags-arrive.md
@@ -1,0 +1,5 @@
+---
+"@logto/cli": patch
+---
+
+move typescript to dev dependencies

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -69,7 +69,6 @@
     "slonik-interceptor-preset": "^1.2.10",
     "slonik-sql-tag-raw": "^1.1.4",
     "tar": "^6.1.11",
-    "typescript": "^5.3.3",
     "yargs": "^17.6.0",
     "zod": "^3.22.4"
   },
@@ -88,7 +87,8 @@
     "jest": "^29.7.0",
     "lint-staged": "^15.0.0",
     "prettier": "^3.0.0",
-    "sinon": "^17.0.0"
+    "sinon": "^17.0.0",
+    "typescript": "^5.3.3"
   },
   "eslintConfig": {
     "extends": "@silverhand",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,9 +181,6 @@ importers:
       tar:
         specifier: ^6.1.11
         version: 6.1.11
-      typescript:
-        specifier: ^5.3.3
-        version: 5.3.3
       yargs:
         specifier: ^17.6.0
         version: 17.6.0
@@ -236,6 +233,9 @@ importers:
       sinon:
         specifier: ^17.0.0
         version: 17.0.0
+      typescript:
+        specifier: ^5.3.3
+        version: 5.3.3
 
   packages/connectors/connector-alipay-native:
     dependencies:


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
not sure why i moved it to dependencies in [this commit](https://github.com/logto-io/logto/commit/fde330a8b31bef5c629160062cb3a08e75976625#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758). now revert it.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
n/a

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
