### PR TITLE
feat(console, phrases): implement the copy, clear and reset button

### DIFF
--- a/packages/console/src/pages/JwtClaims/MonacoCodeEditor/ActionButton/CodeClearButton.tsx
+++ b/packages/console/src/pages/JwtClaims/MonacoCodeEditor/ActionButton/CodeClearButton.tsx
@@ -1,0 +1,24 @@
+import { useTranslation } from 'react-i18next';
+
+import ClearIcon from '@/assets/icons/clear.svg';
+
+import ActionButton from './index';
+
+type Props = {
+  onClick: () => void;
+};
+
+function CodeClearButton({ onClick }: Props) {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+
+  return (
+    <ActionButton
+      actionTip={t('jwt_claims.clear')}
+      actionSuccessTip={t('jwt_claims.cleared')}
+      icon={<ClearIcon />}
+      onClick={onClick}
+    />
+  );
+}
+
+export default CodeClearButton;

--- a/packages/console/src/pages/JwtClaims/MonacoCodeEditor/ActionButton/CodeRestoreButton.tsx
+++ b/packages/console/src/pages/JwtClaims/MonacoCodeEditor/ActionButton/CodeRestoreButton.tsx
@@ -1,0 +1,24 @@
+import { useTranslation } from 'react-i18next';
+
+import RedoIcon from '@/assets/icons/redo.svg';
+
+import ActionButton from './index';
+
+type Props = {
+  onClick: () => void;
+};
+
+function CodeRestoreButton({ onClick }: Props) {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+
+  return (
+    <ActionButton
+      actionTip={t('jwt_claims.restore')}
+      actionSuccessTip={t('jwt_claims.restored')}
+      icon={<RedoIcon />}
+      onClick={onClick}
+    />
+  );
+}
+
+export default CodeRestoreButton;

--- a/packages/console/src/pages/JwtClaims/MonacoCodeEditor/ActionButton/index.tsx
+++ b/packages/console/src/pages/JwtClaims/MonacoCodeEditor/ActionButton/index.tsx
@@ -1,0 +1,61 @@
+import { useCallback, useRef, useState, type MouseEventHandler, useEffect } from 'react';
+
+import IconButton from '@/ds-components/IconButton';
+import { Tooltip } from '@/ds-components/Tip';
+
+type Props = {
+  actionTip: string;
+  actionSuccessTip: string;
+  actionLoadingTip?: string;
+  className?: string;
+  icon: React.ReactNode;
+  onClick: () => Promise<void> | void;
+};
+
+function ActionButton({
+  actionTip,
+  actionSuccessTip,
+  actionLoadingTip,
+  className,
+  icon,
+  onClick,
+}: Props) {
+  const [tipContent, setTipContent] = useState(actionTip);
+  const iconButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    const mouseLeaveHandler = () => {
+      setTipContent(actionTip);
+    };
+
+    iconButtonRef.current?.addEventListener('mouseleave', mouseLeaveHandler);
+
+    return () => {
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- iconButtonRef.current is not a dependency
+      iconButtonRef.current?.removeEventListener('mouseleave', mouseLeaveHandler);
+    };
+  });
+
+  const handleClick = useCallback<MouseEventHandler<HTMLButtonElement>>(async () => {
+    iconButtonRef.current?.blur();
+
+    if (actionLoadingTip) {
+      setTipContent(actionLoadingTip);
+    }
+
+    await onClick();
+    setTipContent(actionSuccessTip);
+  }, [actionLoadingTip, actionSuccessTip, onClick]);
+
+  return (
+    <div className={className}>
+      <Tooltip content={tipContent} isSuccessful={tipContent === actionSuccessTip}>
+        <IconButton ref={iconButtonRef} size="small" onClick={handleClick}>
+          {icon}
+        </IconButton>
+      </Tooltip>
+    </div>
+  );
+}
+
+export default ActionButton;

--- a/packages/console/src/pages/JwtClaims/MonacoCodeEditor/index.module.scss
+++ b/packages/console/src/pages/JwtClaims/MonacoCodeEditor/index.module.scss
@@ -44,7 +44,7 @@
       }
     }
 
-    .actions {
+    .actionButtons {
       display: flex;
       gap: _.unit(2);
       align-items: center;

--- a/packages/console/src/pages/JwtClaims/MonacoCodeEditor/index.tsx
+++ b/packages/console/src/pages/JwtClaims/MonacoCodeEditor/index.tsx
@@ -26,7 +26,19 @@ type Props = {
   value?: string;
   onChange?: (value: string | undefined) => void;
 };
-
+/**
+ * Monaco code editor component.
+ * @param {Props} prop
+ * @param {string} [prop.className] - The class name of the component.
+ * @param {ActionButtonType[]} prop.enabledActions - The enabled action buttons, available values are 'clear', 'restore', 'copy'.
+ * @param {ModelSettings[]} prop.models - The static model settings (all tabs) for the code editor.
+ * @param {string} prop.activeModelName - The active model name.
+ * @param {(name: string) => void} prop.setActiveModel - The callback function to set the active model. Used to switch between tabs.
+ * @param {string} prop.value - The value of the code editor for the current active model.
+ * @param {(value: string | undefined) => void} prop.onChange - The callback function to handle the value change of the code editor.
+ *
+ * @returns
+ */
 function MonacoCodeEditor({
   className,
   enabledActions = ['copy'],

--- a/packages/console/src/pages/JwtClaims/MonacoCodeEditor/index.tsx
+++ b/packages/console/src/pages/JwtClaims/MonacoCodeEditor/index.tsx
@@ -5,8 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 
-import Copy from '@/assets/icons/copy.svg';
-import IconButton from '@/ds-components/IconButton';
+import CopyToClipboard from '@/ds-components/CopyToClipboard';
 import { onKeyDownHandler } from '@/utils/a11y';
 
 import { logtoDarkTheme, defaultOptions } from './config.js';
@@ -110,11 +109,9 @@ function MonacoCodeEditor({ className, actions, models }: Props) {
             </div>
           ))}
         </div>
-        <div className={styles.actions}>
+        <div className={styles.actionButtons}>
           {actions}
-          <IconButton size="small" onClick={handleCodeCopy}>
-            <Copy />
-          </IconButton>
+          <CopyToClipboard variant="icon" value={editorRef.current?.getValue() ?? ''} />
         </div>
       </header>
       <div ref={containerRef} className={styles.editorContainer}>

--- a/packages/console/src/pages/JwtClaims/MonacoCodeEditor/type.ts
+++ b/packages/console/src/pages/JwtClaims/MonacoCodeEditor/type.ts
@@ -4,7 +4,7 @@ export type IStandaloneThemeData = Parameters<Monaco['editor']['defineTheme']>[1
 
 export type IStandaloneCodeEditor = Parameters<OnMount>[0];
 
-export type Model = {
+export type ModelSettings = {
   /** Used as the unique key for the monaco editor model @see {@link https://github.com/suren-atoyan/monaco-react?tab=readme-ov-file#multi-model-editor} */
   name: string;
   /** The icon of the model, will be displayed on the tab */
@@ -20,4 +20,9 @@ export type Model = {
    * We use this to load the global type declarations for the active model
    */
   globalDeclarations?: string;
+};
+
+export type ModelControl = {
+  value?: string;
+  onChange?: (value: string | undefined) => void;
 };

--- a/packages/console/src/pages/JwtClaims/MonacoCodeEditor/type.ts
+++ b/packages/console/src/pages/JwtClaims/MonacoCodeEditor/type.ts
@@ -11,7 +11,13 @@ export type Model = {
   icon?: React.ReactNode;
   /** The title of the model */
   title: string;
-  defaultValue: string;
+  /** The default value of the file */
+  defaultValue?: string;
+  value?: string;
   language: string;
+  /** ExtraLibs can be loaded to the code editor
+   * @see {@link https://microsoft.github.io/monaco-editor/typedoc/interfaces/languages.typescript.LanguageServiceDefaults.html#setExtraLibs}
+   * We use this to load the global type declarations for the active model
+   */
   globalDeclarations?: string;
 };

--- a/packages/console/src/pages/JwtClaims/ScriptSection.tsx
+++ b/packages/console/src/pages/JwtClaims/ScriptSection.tsx
@@ -1,6 +1,6 @@
 /* Code Editor for the custom JWT claims script. */
 import { useMemo } from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
 import Card from '@/ds-components/Card';
@@ -15,16 +15,19 @@ const titlePhrases = Object.freeze({
   [JwtTokenType.MachineToMachineAccessToken]: 'machine_to_machine_jwt',
 });
 
+const userJwtModel = userJwtFile;
+
 function ScriptSection() {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
-  const { watch } = useFormContext<JwtClaimsFormType>();
+  const { watch, control } = useFormContext<JwtClaimsFormType>();
+
   const tokenType = watch('tokenType');
 
-  // TODO: API integration, read/write the custom claims code value
-  const activeModel = useMemo<Model>(() => {
-    return tokenType === JwtTokenType.UserAccessToken ? userJwtFile : machineToMachineJwtFile;
-  }, [tokenType]);
+  const activeModel = useMemo<Model>(
+    () => (tokenType === JwtTokenType.UserAccessToken ? userJwtFile : machineToMachineJwtFile),
+    [tokenType]
+  );
 
   return (
     <Card className={styles.codePanel}>
@@ -33,7 +36,24 @@ function ScriptSection() {
           token: t(`jwt_claims.${titlePhrases[tokenType]}`),
         })}
       </div>
-      <MonacoCodeEditor className={styles.flexGrow} models={[activeModel]} />
+      <Controller
+        shouldUnregister // Unregister the input value when the token type changes
+        control={control}
+        name="script"
+        render={({ field: { onChange, value } }) => (
+          <MonacoCodeEditor
+            className={styles.flexGrow}
+            enabledActions={['clear', 'copy']}
+            models={[
+              {
+                ...activeModel,
+                value: value ?? activeModel.defaultValue,
+              },
+            ]}
+            onChange={onChange}
+          />
+        )}
+      />
     </Card>
   );
 }

--- a/packages/console/src/pages/JwtClaims/ScriptSection.tsx
+++ b/packages/console/src/pages/JwtClaims/ScriptSection.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 import Card from '@/ds-components/Card';
 
-import MonacoCodeEditor, { type Model } from './MonacoCodeEditor';
+import MonacoCodeEditor, { type ModelSettings } from './MonacoCodeEditor';
 import { userJwtFile, machineToMachineJwtFile, JwtTokenType } from './config';
 import * as styles from './index.module.scss';
 import { type JwtClaimsFormType } from './type';
@@ -15,20 +15,16 @@ const titlePhrases = Object.freeze({
   [JwtTokenType.MachineToMachineAccessToken]: 'machine_to_machine_jwt',
 });
 
-const userJwtModel = userJwtFile;
-
 function ScriptSection() {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
   const { watch, control } = useFormContext<JwtClaimsFormType>();
-
   const tokenType = watch('tokenType');
 
-  const activeModel = useMemo<Model>(
+  const activeModel = useMemo<ModelSettings>(
     () => (tokenType === JwtTokenType.UserAccessToken ? userJwtFile : machineToMachineJwtFile),
     [tokenType]
   );
-
   return (
     <Card className={styles.codePanel}>
       <div className={styles.cardTitle}>
@@ -37,20 +33,22 @@ function ScriptSection() {
         })}
       </div>
       <Controller
-        shouldUnregister // Unregister the input value when the token type changes
+        // Force rerender the controller when the token type changes
+        // Otherwise the input field will not be updated
+        key={tokenType}
+        shouldUnregister
         control={control}
         name="script"
         render={({ field: { onChange, value } }) => (
           <MonacoCodeEditor
             className={styles.flexGrow}
             enabledActions={['clear', 'copy']}
-            models={[
-              {
-                ...activeModel,
-                value: value ?? activeModel.defaultValue,
-              },
-            ]}
-            onChange={onChange}
+            models={[activeModel]}
+            activeModelName={activeModel.name}
+            value={value}
+            onChange={(newValue) => {
+              onChange(newValue);
+            }}
           />
         )}
       />

--- a/packages/console/src/pages/JwtClaims/SettingsSection/TestTab.tsx
+++ b/packages/console/src/pages/JwtClaims/SettingsSection/TestTab.tsx
@@ -1,12 +1,12 @@
 import classNames from 'classnames';
-import { useCallback, useMemo, useState } from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useFormContext, Controller, type ControllerRenderProps } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
 import Button from '@/ds-components/Button';
 import Card from '@/ds-components/Card';
 
-import MonacoCodeEditor from '../MonacoCodeEditor/index.js';
+import MonacoCodeEditor, { type ModelControl } from '../MonacoCodeEditor/index.js';
 import {
   userTokenPayloadTestModel,
   machineToMachineTokenPayloadTestModel,
@@ -22,24 +22,61 @@ type Props = {
   isActive: boolean;
 };
 
+const userTokenModelSettings = [userTokenPayloadTestModel, userTokenContextTestModel];
+const machineToMachineTokenModelSettings = [machineToMachineTokenPayloadTestModel];
+
 function TestTab({ isActive }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console.jwt_claims' });
   const [testResult, setTestResult] = useState<TestResultData>();
+  const [activeModelName, setActiveModelName] = useState<string>();
 
-  const { watch } = useFormContext<JwtClaimsFormType>();
+  const { watch, control } = useFormContext<JwtClaimsFormType>();
   const tokenType = watch('tokenType');
 
   const editorModels = useMemo(
     () =>
       tokenType === JwtTokenType.UserAccessToken
-        ? [userTokenPayloadTestModel, userTokenContextTestModel]
-        : [machineToMachineTokenPayloadTestModel],
+        ? userTokenModelSettings
+        : machineToMachineTokenModelSettings,
     [tokenType]
   );
+
+  useEffect(() => {
+    setActiveModelName(editorModels[0]?.name);
+  }, [editorModels, tokenType]);
 
   const onTestHandler = useCallback(() => {
     // TODO: API integration, read form data and send the request to the server
   }, []);
+
+  const getModelControllerProps = useCallback(
+    ({ value, onChange }: ControllerRenderProps<JwtClaimsFormType, 'testSample'>): ModelControl => {
+      // User access token context test model (user data)
+      if (activeModelName === userTokenContextTestModel.name) {
+        return {
+          value: value?.contextSample,
+          onChange: (newValue: string | undefined) => {
+            onChange({
+              ...value,
+              contextSample: newValue,
+            });
+          },
+        };
+      }
+
+      // Token payload test model (user and machine to machine)
+      return {
+        value: value?.tokenSample,
+        onChange: (newValue: string | undefined) => {
+          onChange({
+            ...value,
+            tokenSample: newValue,
+          });
+        },
+      };
+    },
+    [activeModelName]
+  );
 
   return (
     <div className={classNames(styles.tabContent, isActive && styles.active)}>
@@ -52,7 +89,26 @@ function TestTab({ isActive }: Props) {
           <Button title="jwt_claims.tester.run_button" type="primary" onClick={onTestHandler} />
         </div>
         <div className={classNames(styles.cardContent, styles.flexColumn, styles.flexGrow)}>
-          <MonacoCodeEditor models={editorModels} className={styles.flexGrow} />
+          <Controller
+            // Force rerender the controller when the token type changes
+            // Otherwise the input field will not be updated
+            key={tokenType}
+            shouldUnregister
+            control={control}
+            name="testSample"
+            render={({ field }) => (
+              <MonacoCodeEditor
+                className={styles.flexGrow}
+                enabledActions={['restore', 'copy']}
+                models={editorModels}
+                activeModelName={activeModelName}
+                setActiveModel={setActiveModelName}
+                // Pass the value and onChange handler based on the active model
+                {...getModelControllerProps(field)}
+              />
+            )}
+          />
+
           {testResult && (
             <TestResult
               testResult={testResult}

--- a/packages/console/src/pages/JwtClaims/config.tsx
+++ b/packages/console/src/pages/JwtClaims/config.tsx
@@ -3,7 +3,7 @@ import { type EditorProps } from '@monaco-editor/react';
 import TokenFileIcon from '@/assets/icons/token-file-icon.svg';
 import UserFileIcon from '@/assets/icons/user-file-icon.svg';
 
-import type { Model } from './MonacoCodeEditor/type.js';
+import type { ModelSettings } from './MonacoCodeEditor/type.js';
 
 /**
  * JWT token types
@@ -112,7 +112,7 @@ exports.getCustomJwtClaims = async (token) => {
   return {};
 }`;
 
-export const userJwtFile: Model = {
+export const userJwtFile: ModelSettings = {
   name: 'user-jwt.ts',
   title: 'TypeScript',
   language: 'typescript',
@@ -120,7 +120,7 @@ export const userJwtFile: Model = {
   globalDeclarations: userJwtGlobalDeclarations,
 };
 
-export const machineToMachineJwtFile: Model = {
+export const machineToMachineJwtFile: ModelSettings = {
   name: 'machine-to-machine-jwt.ts',
   title: 'TypeScript',
   language: 'typescript',
@@ -266,7 +266,7 @@ const defaultUserTokenContextData = {
   },
 };
 
-export const userTokenPayloadTestModel: Model = {
+export const userTokenPayloadTestModel: ModelSettings = {
   language: 'json',
   icon: <TokenFileIcon />,
   name: 'user-token-payload.json',
@@ -274,7 +274,7 @@ export const userTokenPayloadTestModel: Model = {
   defaultValue: JSON.stringify(defaultUserTokenPayloadData, null, '\t'),
 };
 
-export const machineToMachineTokenPayloadTestModel: Model = {
+export const machineToMachineTokenPayloadTestModel: ModelSettings = {
   language: 'json',
   icon: <TokenFileIcon />,
   name: 'machine-to-machine-token-payload.json',
@@ -282,7 +282,7 @@ export const machineToMachineTokenPayloadTestModel: Model = {
   defaultValue: JSON.stringify(defaultMachineToMachineTokenPayloadData, null, '\t'),
 };
 
-export const userTokenContextTestModel: Model = {
+export const userTokenContextTestModel: ModelSettings = {
   language: 'json',
   icon: <UserFileIcon />,
   name: 'user-token-context.json',

--- a/packages/console/src/pages/JwtClaims/index.tsx
+++ b/packages/console/src/pages/JwtClaims/index.tsx
@@ -25,6 +25,7 @@ type Props = {
   tab: JwtTokenType;
 };
 
+// TODO: API integration
 function JwtClaims({ tab }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 

--- a/packages/console/src/pages/JwtClaims/type.ts
+++ b/packages/console/src/pages/JwtClaims/type.ts
@@ -4,6 +4,8 @@ export type JwtClaimsFormType = {
   tokenType: JwtTokenType;
   script?: string;
   environmentVariables?: Array<{ key: string; value: string }>;
-  contextSample?: string;
-  tokenSample?: string;
+  testSample?: {
+    contextSample?: string;
+    tokenSample?: string;
+  };
 };

--- a/packages/phrases/src/locales/de/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/jwt-claims.ts
@@ -15,6 +15,14 @@ const jwt_claims = {
   /** UNTRANSLATED */
   code_editor_title: 'Customize the {{token}} claims',
   /** UNTRANSLATED */
+  clear: 'Clear',
+  /** UNTRANSLATED */
+  cleared: 'Cleared',
+  /** UNTRANSLATED */
+  restore: 'Restore defaults',
+  /** UNTRANSLATED */
+  restored: 'Restored',
+  /** UNTRANSLATED */
   data_source_tab: 'Data source',
   /** UNTRANSLATED */
   test_tab: 'Test claim',

--- a/packages/phrases/src/locales/en/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/jwt-claims.ts
@@ -7,6 +7,10 @@ const jwt_claims = {
   user_jwt: 'user JWT',
   machine_to_machine_jwt: 'machine-to-machine JWT',
   code_editor_title: 'Customize the {{token}} claims',
+  clear: 'Clear',
+  cleared: 'Cleared',
+  restore: 'Restore defaults',
+  restored: 'Restored',
   data_source_tab: 'Data source',
   test_tab: 'Test claim',
   jwt_claims_description:

--- a/packages/phrases/src/locales/es/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/jwt-claims.ts
@@ -15,6 +15,14 @@ const jwt_claims = {
   /** UNTRANSLATED */
   code_editor_title: 'Customize the {{token}} claims',
   /** UNTRANSLATED */
+  clear: 'Clear',
+  /** UNTRANSLATED */
+  cleared: 'Cleared',
+  /** UNTRANSLATED */
+  restore: 'Restore defaults',
+  /** UNTRANSLATED */
+  restored: 'Restored',
+  /** UNTRANSLATED */
   data_source_tab: 'Data source',
   /** UNTRANSLATED */
   test_tab: 'Test claim',

--- a/packages/phrases/src/locales/fr/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/jwt-claims.ts
@@ -15,6 +15,14 @@ const jwt_claims = {
   /** UNTRANSLATED */
   code_editor_title: 'Customize the {{token}} claims',
   /** UNTRANSLATED */
+  clear: 'Clear',
+  /** UNTRANSLATED */
+  cleared: 'Cleared',
+  /** UNTRANSLATED */
+  restore: 'Restore defaults',
+  /** UNTRANSLATED */
+  restored: 'Restored',
+  /** UNTRANSLATED */
   data_source_tab: 'Data source',
   /** UNTRANSLATED */
   test_tab: 'Test claim',

--- a/packages/phrases/src/locales/it/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/jwt-claims.ts
@@ -15,6 +15,14 @@ const jwt_claims = {
   /** UNTRANSLATED */
   code_editor_title: 'Customize the {{token}} claims',
   /** UNTRANSLATED */
+  clear: 'Clear',
+  /** UNTRANSLATED */
+  cleared: 'Cleared',
+  /** UNTRANSLATED */
+  restore: 'Restore defaults',
+  /** UNTRANSLATED */
+  restored: 'Restored',
+  /** UNTRANSLATED */
   data_source_tab: 'Data source',
   /** UNTRANSLATED */
   test_tab: 'Test claim',

--- a/packages/phrases/src/locales/ja/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/jwt-claims.ts
@@ -15,6 +15,14 @@ const jwt_claims = {
   /** UNTRANSLATED */
   code_editor_title: 'Customize the {{token}} claims',
   /** UNTRANSLATED */
+  clear: 'Clear',
+  /** UNTRANSLATED */
+  cleared: 'Cleared',
+  /** UNTRANSLATED */
+  restore: 'Restore defaults',
+  /** UNTRANSLATED */
+  restored: 'Restored',
+  /** UNTRANSLATED */
   data_source_tab: 'Data source',
   /** UNTRANSLATED */
   test_tab: 'Test claim',

--- a/packages/phrases/src/locales/ko/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/jwt-claims.ts
@@ -15,6 +15,14 @@ const jwt_claims = {
   /** UNTRANSLATED */
   code_editor_title: 'Customize the {{token}} claims',
   /** UNTRANSLATED */
+  clear: 'Clear',
+  /** UNTRANSLATED */
+  cleared: 'Cleared',
+  /** UNTRANSLATED */
+  restore: 'Restore defaults',
+  /** UNTRANSLATED */
+  restored: 'Restored',
+  /** UNTRANSLATED */
   data_source_tab: 'Data source',
   /** UNTRANSLATED */
   test_tab: 'Test claim',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/jwt-claims.ts
@@ -15,6 +15,14 @@ const jwt_claims = {
   /** UNTRANSLATED */
   code_editor_title: 'Customize the {{token}} claims',
   /** UNTRANSLATED */
+  clear: 'Clear',
+  /** UNTRANSLATED */
+  cleared: 'Cleared',
+  /** UNTRANSLATED */
+  restore: 'Restore defaults',
+  /** UNTRANSLATED */
+  restored: 'Restored',
+  /** UNTRANSLATED */
   data_source_tab: 'Data source',
   /** UNTRANSLATED */
   test_tab: 'Test claim',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/jwt-claims.ts
@@ -15,6 +15,14 @@ const jwt_claims = {
   /** UNTRANSLATED */
   code_editor_title: 'Customize the {{token}} claims',
   /** UNTRANSLATED */
+  clear: 'Clear',
+  /** UNTRANSLATED */
+  cleared: 'Cleared',
+  /** UNTRANSLATED */
+  restore: 'Restore defaults',
+  /** UNTRANSLATED */
+  restored: 'Restored',
+  /** UNTRANSLATED */
   data_source_tab: 'Data source',
   /** UNTRANSLATED */
   test_tab: 'Test claim',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/jwt-claims.ts
@@ -15,6 +15,14 @@ const jwt_claims = {
   /** UNTRANSLATED */
   code_editor_title: 'Customize the {{token}} claims',
   /** UNTRANSLATED */
+  clear: 'Clear',
+  /** UNTRANSLATED */
+  cleared: 'Cleared',
+  /** UNTRANSLATED */
+  restore: 'Restore defaults',
+  /** UNTRANSLATED */
+  restored: 'Restored',
+  /** UNTRANSLATED */
   data_source_tab: 'Data source',
   /** UNTRANSLATED */
   test_tab: 'Test claim',

--- a/packages/phrases/src/locales/ru/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/jwt-claims.ts
@@ -15,6 +15,14 @@ const jwt_claims = {
   /** UNTRANSLATED */
   code_editor_title: 'Customize the {{token}} claims',
   /** UNTRANSLATED */
+  clear: 'Clear',
+  /** UNTRANSLATED */
+  cleared: 'Cleared',
+  /** UNTRANSLATED */
+  restore: 'Restore defaults',
+  /** UNTRANSLATED */
+  restored: 'Restored',
+  /** UNTRANSLATED */
   data_source_tab: 'Data source',
   /** UNTRANSLATED */
   test_tab: 'Test claim',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/jwt-claims.ts
@@ -15,6 +15,14 @@ const jwt_claims = {
   /** UNTRANSLATED */
   code_editor_title: 'Customize the {{token}} claims',
   /** UNTRANSLATED */
+  clear: 'Clear',
+  /** UNTRANSLATED */
+  cleared: 'Cleared',
+  /** UNTRANSLATED */
+  restore: 'Restore defaults',
+  /** UNTRANSLATED */
+  restored: 'Restored',
+  /** UNTRANSLATED */
   data_source_tab: 'Data source',
   /** UNTRANSLATED */
   test_tab: 'Test claim',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/jwt-claims.ts
@@ -15,6 +15,14 @@ const jwt_claims = {
   /** UNTRANSLATED */
   code_editor_title: 'Customize the {{token}} claims',
   /** UNTRANSLATED */
+  clear: 'Clear',
+  /** UNTRANSLATED */
+  cleared: 'Cleared',
+  /** UNTRANSLATED */
+  restore: 'Restore defaults',
+  /** UNTRANSLATED */
+  restored: 'Restored',
+  /** UNTRANSLATED */
   data_source_tab: 'Data source',
   /** UNTRANSLATED */
   test_tab: 'Test claim',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/jwt-claims.ts
@@ -15,6 +15,14 @@ const jwt_claims = {
   /** UNTRANSLATED */
   code_editor_title: 'Customize the {{token}} claims',
   /** UNTRANSLATED */
+  clear: 'Clear',
+  /** UNTRANSLATED */
+  cleared: 'Cleared',
+  /** UNTRANSLATED */
+  restore: 'Restore defaults',
+  /** UNTRANSLATED */
+  restored: 'Restored',
+  /** UNTRANSLATED */
   data_source_tab: 'Data source',
   /** UNTRANSLATED */
   test_tab: 'Test claim',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/jwt-claims.ts
@@ -15,6 +15,14 @@ const jwt_claims = {
   /** UNTRANSLATED */
   code_editor_title: 'Customize the {{token}} claims',
   /** UNTRANSLATED */
+  clear: 'Clear',
+  /** UNTRANSLATED */
+  cleared: 'Cleared',
+  /** UNTRANSLATED */
+  restore: 'Restore defaults',
+  /** UNTRANSLATED */
+  restored: 'Restored',
+  /** UNTRANSLATED */
   data_source_tab: 'Data source',
   /** UNTRANSLATED */
   test_tab: 'Test claim',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR includes the following updates:

1. Replace the copy icon button with AC CopyToClipboard component
2. Implement the clear and reset button
3. Wrap the CodeEditor with react-hook-form so the code content is controllable through the form state.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

<img width="1281" alt="image" src="https://github.com/logto-io/logto/assets/36393111/cd893eb8-9e81-40a9-b4cd-875d50949a11">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [x] necessary TSDoc comments
