### PR TITLE
refactor(experience): skip non-object messages in native

### DIFF
--- a/.changeset/silent-singers-trade.md
+++ b/.changeset/silent-singers-trade.md
@@ -1,0 +1,13 @@
+---
+"@logto/experience": patch
+---
+
+skip non-object messages in the native environment
+
+In the `WKWebView` of new iOS versions, some script will constantly post messages to the
+window object with increasing numbers as the message content ("1", "2", "3", ...).
+
+Ideally, we should check the source of the message with Logto-specific identifier in the
+`event.data`; however, this change will result a breaking change for the existing
+native SDK implementations. Add the `isObject` check to prevent the crazy messages while
+keeping the backward compatibility.

--- a/packages/experience/src/hooks/use-native-message-listener.ts
+++ b/packages/experience/src/hooks/use-native-message-listener.ts
@@ -1,3 +1,4 @@
+import { isObject } from '@silverhand/essentials';
 import { useEffect } from 'react';
 
 import { isNativeWebview } from '@/utils/native-sdk';
@@ -23,7 +24,14 @@ const useNativeMessageListener = (bypass = false) => {
     }
 
     const nativeMessageHandler = (event: MessageEvent) => {
-      if (event.origin === window.location.origin) {
+      // In the `WKWebView` of new iOS versions, some script will constantly post messages to the
+      // window object with increasing numbers as the message content ("1", "2", "3", ...).
+      //
+      // Ideally, we should check the source of the message with Logto-specific identifier in the
+      // `event.data`; however, this change will result a breaking change for the existing
+      // native SDK implementations. Add the `isObject` check to prevent the crazy messages while
+      // keeping the backward compatibility.
+      if (event.origin === window.location.origin && isObject(event.data)) {
         try {
           setToast(JSON.stringify(event.data));
         } catch {}


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
see changeset - clear enough

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
tested with iOS simulator. all good (with sign-in and sign-out).

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
