### PR TITLE
fix(console): fix code edtior set undefined value bug

### DIFF
--- a/packages/console/src/pages/JwtClaims/MonacoCodeEditor/index.tsx
+++ b/packages/console/src/pages/JwtClaims/MonacoCodeEditor/index.tsx
@@ -155,7 +155,8 @@ function MonacoCodeEditor({
             path={activeModel.name}
             theme="logto-dark"
             options={defaultOptions}
-            value={value ?? activeModel.defaultValue}
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- empty string is falsy
+            value={value || activeModel.defaultValue}
             beforeMount={handleEditorWillMount}
             onMount={handleEditorDidMount}
             onChange={onChange}

--- a/packages/console/src/pages/JwtClaims/ScriptSection.tsx
+++ b/packages/console/src/pages/JwtClaims/ScriptSection.tsx
@@ -57,11 +57,12 @@ function ScriptSection() {
             onChange={(newValue) => {
               // If the value is the same as the default code and the original form script value is undefined, reset the value to undefined as well
               if (newValue === activeModel.defaultValue && !defaultValues?.script) {
-                onChange();
+                onChange('');
                 return;
               }
 
-              onChange(newValue);
+              // Input value should not be undefined for react-hook-form @see https://react-hook-form.com/docs/usecontroller/controller
+              onChange(newValue ?? '');
             }}
             onMountHandler={onMountHandler}
           />

--- a/packages/console/src/pages/JwtClaims/utils.ts
+++ b/packages/console/src/pages/JwtClaims/utils.ts
@@ -31,7 +31,7 @@ export const formatResponseDataToFormData = <T extends LogtoJwtTokenPath>(
     : ClientCredentialsJwtCustomizer
 ): JwtClaimsFormType => {
   return {
-    script: data?.script,
+    script: data?.script ?? '', // React-hook-form won't mutate the value if it's undefined
     tokenType,
     environmentVariables: formatEnvVariablesResponseToFormData(data?.envVars) ?? [
       { key: '', value: '' },
@@ -71,7 +71,8 @@ const formatSampleCodeStringToJson = (sampleCode?: string) => {
 
 export const formatFormDataToRequestData = (data: JwtClaimsFormType) => {
   return {
-    script: data.script,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- parse empty string as undefined
+    script: data.script || undefined,
     envVars: formatEnvVariablesFormData(data.environmentVariables),
     tokenSample: formatSampleCodeStringToJson(data.testSample?.tokenSample),
     // Technically, contextSample is always undefined for client credentials token type


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the code editor set undefined value bug.  react-hook-form does not allow set undefined value to a form field.
<img width="936" alt="image" src="https://github.com/logto-io/logto/assets/36393111/ea65e0b1-db31-40e4-a81b-8a38a673ba5d">

- Replace the undefined value with an empty string for all the setForm touch point. 
- Convert the empty string to undefined when sending the request to the logto endpoint.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [x] necessary TSDoc comments
