### PR TITLE
fix(schemas): fix the get interation/consent api bug

### DIFF
--- a/.changeset/seven-socks-perform.md
+++ b/.changeset/seven-socks-perform.md
@@ -2,23 +2,26 @@
 "@logto/schemas": patch
 ---
 
-## Fix third-party app get /interaction/consent 500 bug
+## Resolve Third-Party App's /interaction/consent Endpoint 500 Error
 
-### Steps to reproduce
+### Reproduction Steps
 
-1. Create a organization scope with empty description, add assign the scope to a third-party app
-2. Sign in the third-party app and request for the organization scope
-3. Follow the interaction flow till the consent page
-4. A internal server error 500 is returned
+- Establish an organization scope with an empty description and assign this scope to a third-party application.
 
-### Root cause
+- Login to the third-party application and request the organization scope.
 
-For the get /interaction/consent endpoint, organization scope is returned with other resource scopes in the `missingResourceScopes` property.
+- Proceed through the interaction flow until reaching the consent page.
 
-In the `consentInfoResponseGuard`, we use the resource `Scopes` zod guard to validate the `missingResourceScopes` property. However, the description field in resource scope is required. A organization scope with empty description will fail the validation.
+- An internal server error 500 is returned.
 
-### Fix
+### Root Cause
 
-Update the `consentInfoResponseGuard`'s missingResourceScopes property. Use the organization scope zod guard which does not require the description field.
+For the /interaction/consent endpoint, the organization scope is returned alongside other resource scopes in the missingResourceScopes property.
 
-The alignment of the resource scope and organization scope type will be handled in the next release.
+In the consentInfoResponseGuard, we utilize the resource Scopes zod guard to validate the missingResourceScopes property. However, the description field in the resource scope is mandatory while organization scopes'description is optional. An organization scope with an empty description will not pass the validation.
+
+### Solution
+
+Modify the consentInfoResponseGuard's missingResourceScopes property. Use the organization scope zod guard which does not necessitate the description field.
+
+The alignment of the resource scope and organization scope types will be addressed in the next release.

--- a/.changeset/seven-socks-perform.md
+++ b/.changeset/seven-socks-perform.md
@@ -4,9 +4,9 @@
 
 ## Resolve Third-Party App's /interaction/consent Endpoint 500 Error
 
-### Reproduction Steps
+### Reproduction steps
 
-- Establish an organization scope with an empty description and assign this scope to a third-party application.
+- Create an organization scope with an empty description and assign this scope to a third-party application.
 
 - Login to the third-party application and request the organization scope.
 
@@ -16,12 +16,12 @@
 
 ### Root Cause
 
-For the /interaction/consent endpoint, the organization scope is returned alongside other resource scopes in the missingResourceScopes property.
+For the `/interaction/consent` endpoint, the organization scope is returned alongside other resource scopes in the `missingResourceScopes` property.
 
-In the consentInfoResponseGuard, we utilize the resource Scopes zod guard to validate the missingResourceScopes property. However, the description field in the resource scope is mandatory while organization scopes'description is optional. An organization scope with an empty description will not pass the validation.
+In the `consentInfoResponseGuard`, we utilize the resource Scopes zod guard to validate the `missingResourceScopes` property. However, the description field in the resource scope is mandatory while organization scopes'description is optional. An organization scope with an empty description will not pass the validation.
 
 ### Solution
 
-Modify the consentInfoResponseGuard's missingResourceScopes property. Use the organization scope zod guard which does not necessitate the description field.
+Modify the consentInfoResponseGuard's `missingResourceScopes` property. Use the organization scope zod guard which does not necessitate the description field.
 
 The alignment of the resource scope and organization scope types will be addressed in the next release.

--- a/.changeset/seven-socks-perform.md
+++ b/.changeset/seven-socks-perform.md
@@ -2,7 +2,7 @@
 "@logto/schemas": patch
 ---
 
-## Resolve Third-Party App's /interaction/consent Endpoint 500 Error
+## Resolve third-party app's /interaction/consent endpoint 500 error
 
 ### Reproduction steps
 
@@ -14,7 +14,7 @@
 
 - An internal server error 500 is returned.
 
-### Root Cause
+### Root cause
 
 For the `/interaction/consent` endpoint, the organization scope is returned alongside other resource scopes in the `missingResourceScopes` property.
 
@@ -22,6 +22,4 @@ In the `consentInfoResponseGuard`, we utilize the resource Scopes zod guard to v
 
 ### Solution
 
-Modify the consentInfoResponseGuard's `missingResourceScopes` property. Use the organization scope zod guard which does not necessitate the description field.
-
-The alignment of the resource scope and organization scope types will be addressed in the next release.
+Alter the resource scopes table to make the description field nullable. Related Scope zod guard and the consentInfoResponseGuard will be updated to reflect this change. Align the resource scopes table with the organization scopes table to ensure consistency.

--- a/.changeset/seven-socks-perform.md
+++ b/.changeset/seven-socks-perform.md
@@ -1,0 +1,24 @@
+---
+"@logto/schemas": patch
+---
+
+## Fix third-party app get /interaction/consent 500 bug
+
+### Steps to reproduce
+
+1. Create a organization scope with empty description, add assign the scope to a third-party app
+2. Sign in the third-party app and request for the organization scope
+3. Follow the interaction flow till the consent page
+4. A internal server error 500 is returned
+
+### Root cause
+
+For the get /interaction/consent endpoint, organization scope is returned with other resource scopes in the `missingResourceScopes` property.
+
+In the `consentInfoResponseGuard`, we use the resource `Scopes` zod guard to validate the `missingResourceScopes` property. However, the description field in resource scope is required. A organization scope with empty description will fail the validation.
+
+### Fix
+
+Update the `consentInfoResponseGuard`'s missingResourceScopes property. Use the organization scope zod guard which does not require the description field.
+
+The alignment of the resource scope and organization scope type will be handled in the next release.

--- a/packages/console/src/pages/ApiResourceDetails/ApiResourcePermissions/components/CreatePermissionModal/index.tsx
+++ b/packages/console/src/pages/ApiResourceDetails/ApiResourcePermissions/components/CreatePermissionModal/index.tsx
@@ -1,5 +1,5 @@
 import { noSpaceRegEx } from '@logto/core-kit';
-import type { Scope } from '@logto/schemas';
+import type { Scope, CreateScope } from '@logto/schemas';
 import { useContext } from 'react';
 import { useForm } from 'react-hook-form';
 import { Trans, useTranslation } from 'react-i18next';
@@ -24,7 +24,7 @@ type Props = {
   onClose: (scope?: Scope) => void;
 };
 
-type CreatePermissionFormData = Pick<Scope, 'name' | 'description'>;
+type CreatePermissionFormData = Pick<CreateScope, 'name' | 'description'>;
 
 function CreatePermissionModal({ resourceId, totalResourceCount, onClose }: Props) {
   const { currentPlan } = useContext(SubscriptionDataContext);
@@ -118,10 +118,10 @@ function CreatePermissionModal({ resourceId, totalResourceCount, onClose }: Prop
               error={errors.name?.message}
             />
           </FormField>
-          <FormField isRequired title="api_resource_details.permission.description">
+          <FormField title="api_resource_details.permission.description">
             <TextInput
               placeholder={t('api_resource_details.permission.description_placeholder')}
-              {...register('description', { required: true })}
+              {...register('description')}
               error={Boolean(errors.description)}
             />
           </FormField>

--- a/packages/experience/src/pages/Consent/ScopesListCard/index.tsx
+++ b/packages/experience/src/pages/Consent/ScopesListCard/index.tsx
@@ -21,7 +21,7 @@ type ScopeGroupProps = {
   scopes: Array<{
     id: string;
     name: string;
-    description?: Nullable<string>; // Organization scopes description is nullable
+    description?: Nullable<string>; // Organization scope description cloud be `null`
   }>;
 };
 

--- a/packages/experience/src/pages/Consent/ScopesListCard/index.tsx
+++ b/packages/experience/src/pages/Consent/ScopesListCard/index.tsx
@@ -1,5 +1,6 @@
 import { ReservedResource, UserScope } from '@logto/core-kit';
 import { type ConsentInfoResponse } from '@logto/schemas';
+import { type Nullable } from '@silverhand/essentials';
 import classNames from 'classnames';
 import { useCallback, useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
@@ -20,7 +21,7 @@ type ScopeGroupProps = {
   scopes: Array<{
     id: string;
     name: string;
-    description?: string;
+    description?: Nullable<string>; // Organization scopes description is nullable
   }>;
 };
 

--- a/packages/integration-tests/src/api/interaction.ts
+++ b/packages/integration-tests/src/api/interaction.ts
@@ -5,6 +5,7 @@ import type {
   RequestVerificationCodePayload,
   BindMfaPayload,
   VerifyMfaPayload,
+  ConsentInfoResponse,
 } from '@logto/schemas';
 import type { Got } from 'got';
 
@@ -153,6 +154,14 @@ export const consent = async (api: Got, cookie: string) =>
       followRedirect: false,
     })
     .json<RedirectResponse>();
+
+export const getConsentInfo = async (cookie: string) =>
+  api
+    .get('interaction/consent', {
+      headers: { cookie },
+      followRedirect: false,
+    })
+    .json<ConsentInfoResponse>();
 
 export const createSingleSignOnAuthorizationUri = async (
   cookie: string,

--- a/packages/integration-tests/src/client/index.ts
+++ b/packages/integration-tests/src/client/index.ts
@@ -84,7 +84,7 @@ export default class MockClient {
     assert(this.interactionCookie, new Error('Get cookie from authorization endpoint failed'));
   }
 
-  public async processSession(redirectTo: string) {
+  public async processSession(redirectTo: string, consent = true) {
     // Note: should redirect to OIDC auth endpoint
     assert(
       redirectTo.startsWith(`${this.config.endpoint}/oidc/auth`),
@@ -105,6 +105,11 @@ export default class MockClient {
     );
 
     this.rawCookies = authResponse.headers['set-cookie'] ?? [];
+
+    // Manually handle the consent flow
+    if (!consent) {
+      return;
+    }
 
     const signInCallbackUri = await this.consent();
     await this.logto.handleSignInCallback(signInCallbackUri);

--- a/packages/integration-tests/src/client/index.ts
+++ b/packages/integration-tests/src/client/index.ts
@@ -84,6 +84,11 @@ export default class MockClient {
     assert(this.interactionCookie, new Error('Get cookie from authorization endpoint failed'));
   }
 
+  /**
+   *
+   * @param {string} redirectTo the sign-in or register redirect uri
+   * @param {boolean} [consent=true] whether to automatically consent. Need to manually handle the consent flow if set to false
+   */
   public async processSession(redirectTo: string, consent = true) {
     // Note: should redirect to OIDC auth endpoint
     assert(

--- a/packages/integration-tests/src/tests/api/interaction/third-party-sign-in/happy-path.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/third-party-sign-in/happy-path.test.ts
@@ -1,0 +1,134 @@
+import { ReservedResource, UserScope } from '@logto/core-kit';
+import { type Application, InteractionEvent, ApplicationType } from '@logto/schemas';
+import { assert } from '@silverhand/essentials';
+
+import { deleteUser } from '#src/api/admin-user.js';
+import { assignUserConsentScopes } from '#src/api/application-user-consent-scope.js';
+import { createApplication, deleteApplication } from '#src/api/application.js';
+import { getConsentInfo, putInteraction } from '#src/api/interaction.js';
+import { OrganizationScopeApi } from '#src/api/organization-scope.js';
+import { initClient } from '#src/helpers/client.js';
+import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
+import { generateNewUser } from '#src/helpers/user.js';
+
+describe('consent api', () => {
+  const applications = new Map<string, Application>();
+  const thirdPartyApplicationName = 'consent-third-party-app';
+  const redirectUri = 'http://example.com';
+
+  const bootStrapApplication = async () => {
+    const thirdPartyApplication = await createApplication(
+      thirdPartyApplicationName,
+      ApplicationType.Traditional,
+      {
+        isThirdParty: true,
+        oidcClientMetadata: {
+          redirectUris: [redirectUri],
+          postLogoutRedirectUris: [],
+        },
+      }
+    );
+
+    applications.set(thirdPartyApplicationName, thirdPartyApplication);
+
+    await assignUserConsentScopes(thirdPartyApplication.id, {
+      userScopes: [UserScope.Profile],
+    });
+  };
+
+  beforeAll(async () => {
+    await Promise.all([enableAllPasswordSignInMethods(), bootStrapApplication()]);
+  });
+
+  it('get consent info', async () => {
+    const application = applications.get(thirdPartyApplicationName);
+    assert(application, new Error('application.not_found'));
+
+    const { userProfile, user } = await generateNewUser({ username: true, password: true });
+
+    const client = await initClient(
+      {
+        appId: application.id,
+        appSecret: application.secret,
+      },
+      redirectUri
+    );
+
+    await client.successSend(putInteraction, {
+      event: InteractionEvent.SignIn,
+      identifier: {
+        username: userProfile.username,
+        password: userProfile.password,
+      },
+    });
+
+    const { redirectTo } = await client.submitInteraction();
+
+    await client.processSession(redirectTo, false);
+
+    const result = await client.send(getConsentInfo);
+
+    expect(result.application.id).toBe(application.id);
+    expect(result.user.id).toBe(user.id);
+    expect(result.redirectUri).toBe(redirectUri);
+    expect(result.missingOIDCScope).toEqual([UserScope.Profile]);
+
+    await deleteUser(user.id);
+  });
+
+  it('get consent info with organization scope', async () => {
+    const application = applications.get(thirdPartyApplicationName);
+    assert(application, new Error('application.not_found'));
+
+    const organizationScopeApi = new OrganizationScopeApi();
+
+    const organizationScope = await organizationScopeApi.create({
+      name: 'organization-scope',
+    });
+
+    await assignUserConsentScopes(application.id, {
+      organizationScopes: [organizationScope.id],
+      userScopes: [UserScope.Organizations],
+    });
+
+    const { userProfile, user } = await generateNewUser({ username: true, password: true });
+
+    const client = await initClient(
+      {
+        appId: application.id,
+        appSecret: application.secret,
+        scopes: [UserScope.Organizations, UserScope.Profile, organizationScope.name],
+      },
+      redirectUri
+    );
+
+    await client.successSend(putInteraction, {
+      event: InteractionEvent.SignIn,
+      identifier: {
+        username: userProfile.username,
+        password: userProfile.password,
+      },
+    });
+
+    const { redirectTo } = await client.submitInteraction();
+
+    await client.processSession(redirectTo, false);
+
+    const result = await client.send(getConsentInfo);
+
+    expect(
+      result.missingResourceScopes?.find(
+        ({ resource }) => resource.name === ReservedResource.Organization
+      )
+    ).not.toBeUndefined();
+
+    await organizationScopeApi.delete(organizationScope.id);
+    await deleteUser(user.id);
+  });
+
+  afterAll(async () => {
+    for (const application of applications.values()) {
+      void deleteApplication(application.id);
+    }
+  });
+});

--- a/packages/integration-tests/src/tests/api/resource.scope.test.ts
+++ b/packages/integration-tests/src/tests/api/resource.scope.test.ts
@@ -5,7 +5,7 @@ import { HTTPError } from 'got';
 
 import { createResource } from '#src/api/index.js';
 import { createScope, deleteScope, getScopes, updateScope } from '#src/api/scope.js';
-import { generateScopeName } from '#src/utils.js';
+import { generateName, generateScopeName } from '#src/utils.js';
 
 describe('scopes', () => {
   it('should get management api resource scopes successfully', async () => {
@@ -63,7 +63,7 @@ describe('scopes', () => {
     expect(scope).toBeTruthy();
 
     const newScopeName = `new_${scope.name}`;
-    const newScopeDescription = `new_${scope.description}`;
+    const newScopeDescription = scope.description ? `new_${scope.description}` : generateName();
 
     const updatesScope = await updateScope(resource.id, scope.id, {
       name: newScopeName,

--- a/packages/schemas/alterations/next-1710408335-make-resource-scopes-description-nullable.ts
+++ b/packages/schemas/alterations/next-1710408335-make-resource-scopes-description-nullable.ts
@@ -1,4 +1,4 @@
-import { sql } from 'slonik';
+import { sql } from '@silverhand/slonik';
 
 import type { AlterationScript } from '../lib/types/alteration.js';
 

--- a/packages/schemas/alterations/next-1710408335-make-resource-scopes-description-nullable.ts
+++ b/packages/schemas/alterations/next-1710408335-make-resource-scopes-description-nullable.ts
@@ -1,0 +1,22 @@
+import { sql } from 'slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    // Make the resource scopes description nullable
+    await pool.query(sql`
+      alter table scopes
+      alter column description drop not null;
+    `);
+  },
+  down: async (pool) => {
+    // Revert the resource scopes description nullable
+    await pool.query(sql`
+      alter table scopes
+      alter column description set not null;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/types/consent.ts
+++ b/packages/schemas/src/types/consent.ts
@@ -7,6 +7,7 @@ import {
   Resources,
   Scopes,
   ApplicationSignInExperiences,
+  OrganizationScopes,
 } from '../db-entries/index.js';
 
 /**
@@ -44,11 +45,17 @@ export const publicOrganizationGuard = Organizations.guard.pick({
   id: true,
   name: true,
 });
+
 export const missingResourceScopesGuard = z.object({
   // The original resource id has a maximum length of 21 restriction. We need to make it compatible with the logto reserved organization name.
   // use string here, as we do not care about the resource id length here.
   resource: Resources.guard.pick({ name: true }).extend({ id: z.string() }),
-  scopes: Scopes.guard.pick({ id: true, name: true, description: true }).array(),
+  scopes: Scopes.guard
+    .pick({ id: true, name: true })
+    // The description is optional for organization scopes. Manually extend the schema to make it optional.
+    // TODO: make the resource scopes description optional at the schema level.
+    .merge(OrganizationScopes.guard.pick({ description: true }).partial())
+    .array(),
 });
 
 /**

--- a/packages/schemas/src/types/consent.ts
+++ b/packages/schemas/src/types/consent.ts
@@ -7,7 +7,6 @@ import {
   Resources,
   Scopes,
   ApplicationSignInExperiences,
-  OrganizationScopes,
 } from '../db-entries/index.js';
 
 /**
@@ -50,12 +49,7 @@ export const missingResourceScopesGuard = z.object({
   // The original resource id has a maximum length of 21 restriction. We need to make it compatible with the logto reserved organization name.
   // use string here, as we do not care about the resource id length here.
   resource: Resources.guard.pick({ name: true }).extend({ id: z.string() }),
-  scopes: Scopes.guard
-    .pick({ id: true, name: true })
-    // The description is optional for organization scopes. Manually extend the schema to make it optional.
-    // TODO: make the resource scopes description optional at the schema level.
-    .merge(OrganizationScopes.guard.pick({ description: true }).partial())
-    .array(),
+  scopes: Scopes.guard.pick({ id: true, name: true, description: true }).array(),
 });
 
 /**

--- a/packages/schemas/tables/scopes.sql
+++ b/packages/schemas/tables/scopes.sql
@@ -7,7 +7,7 @@ create table scopes (
   resource_id varchar(21) not null
     references resources (id) on update cascade on delete cascade,
   name varchar(256) not null,
-  description text not null,
+  description text,
   created_at timestamptz not null default(now()),
   primary key (id),
   constraint scopes__resource_id_name


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Resolve Third-Party App's /interaction/consent Endpoint 500 Error

### Reproduction Steps

- Create an organization scope with an empty description and assign this scope to a third-party application.

- Login to the third-party application and request the organization scope.

- Proceed through the interaction flow until reaching the consent page.

- An internal server error 500 is returned.

### Root Cause

For the /interaction/consent endpoint, the organization scope is returned alongside other resource scopes in the missingResourceScopes property.

In the consentInfoResponseGuard, we utilize the resource Scopes zod guard to validate the missingResourceScopes property. However, the description field in the resource scope is mandatory while the organization scopes' description is optional. An organization scope with an empty description will not pass the validation.

### Solution

Modify the consentInfoResponseGuard's missingResourceScopes property. Use the organization scope zod guard which does not necessitate the description field.

The alignment of the resource scope and organization scope types will be addressed in the next release.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
integration tests added

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] ~unit tests~
- [x] integration tests
- [x] necessary TSDoc comments
