### PR TITLE
refactor(schemas): remove shared dependency

### DIFF
--- a/packages/schemas/alterations/1.10.1-1695647183-update-private-key-type.ts
+++ b/packages/schemas/alterations/1.10.1-1695647183-update-private-key-type.ts
@@ -1,8 +1,9 @@
-import { generateStandardId } from '@logto/shared';
 import type { DatabaseTransactionConnection } from 'slonik';
 import { sql } from 'slonik';
 
 import type { AlterationScript } from '../lib/types/alteration.js';
+
+import { generateStandardId } from './utils/1710517459-generate-standard-id.js';
 
 const targetConfigKeys = ['oidc.cookieKeys', 'oidc.privateKeys'];
 

--- a/packages/schemas/alterations/1.13.0-1702544178-sync-tenant-orgs.ts
+++ b/packages/schemas/alterations/1.13.0-1702544178-sync-tenant-orgs.ts
@@ -14,10 +14,12 @@
  * new tenants before running this script and deploying the changes.
  */
 
-import { ConsoleLog, generateStandardId } from '@logto/shared';
 import { sql } from 'slonik';
 
 import { type AlterationScript } from '../lib/types/alteration.js';
+
+import { generateStandardId } from './utils/1710517459-generate-standard-id.js';
+import ConsoleLog from './utils/1710517460-console-log.js';
 
 const adminTenantId = 'admin';
 const consoleLog = new ConsoleLog();

--- a/packages/schemas/alterations/1.13.0-1703230000-update-tenant-roles.ts
+++ b/packages/schemas/alterations/1.13.0-1703230000-update-tenant-roles.ts
@@ -1,7 +1,8 @@
-import { ConsoleLog } from '@logto/shared';
 import { sql } from 'slonik';
 
 import type { AlterationScript } from '../lib/types/alteration.js';
+
+import ConsoleLog from './utils/1710517460-console-log.js';
 
 const consoleLog = new ConsoleLog();
 

--- a/packages/schemas/alterations/1.3.0-1683292832-update-hooks.ts
+++ b/packages/schemas/alterations/1.3.0-1683292832-update-hooks.ts
@@ -1,7 +1,8 @@
-import { generateStandardId } from '@logto/shared';
 import { sql } from 'slonik';
 
 import type { AlterationScript } from '../lib/types/alteration.js';
+
+import { generateStandardId } from './utils/1710517459-generate-standard-id.js';
 
 enum HookEvent {
   PostRegister = 'PostRegister',

--- a/packages/schemas/alterations/utils/1710517459-generate-standard-id.ts
+++ b/packages/schemas/alterations/utils/1710517459-generate-standard-id.ts
@@ -1,0 +1,11 @@
+import { customAlphabet } from 'nanoid';
+
+const lowercaseAlphabet = '0123456789abcdefghijklmnopqrstuvwxyz' as const;
+
+// Edited from `@logto/shared`.
+/**
+ * Generate a standard id with 21 characters, including lowercase letters and numbers.
+ *
+ * @see {@link lowercaseAlphabet}
+ */
+export const generateStandardId = customAlphabet(lowercaseAlphabet, 21);

--- a/packages/schemas/alterations/utils/1710517460-console-log.ts
+++ b/packages/schemas/alterations/utils/1710517460-console-log.ts
@@ -1,0 +1,33 @@
+// Edited from `@logto/shared`.
+export default class ConsoleLog {
+  static prefixes = Object.freeze({
+    info: '[info]',
+    warn: '[warn]',
+    error: '[error]',
+    fatal: '[fatal]',
+  });
+
+  plain = console.log;
+
+  info: typeof console.log = (...args) => {
+    console.log(ConsoleLog.prefixes.info, ...args);
+  };
+
+  succeed: typeof console.log = (...args) => {
+    this.info('✔', ...args);
+  };
+
+  warn: typeof console.log = (...args) => {
+    console.warn(ConsoleLog.prefixes.warn, ...args);
+  };
+
+  error: typeof console.log = (...args) => {
+    console.error(ConsoleLog.prefixes.error, ...args);
+  };
+
+  fatal: (...args: Parameters<typeof console.log>) => never = (...args) => {
+    console.error(ConsoleLog.prefixes.fatal, ...args);
+    // eslint-disable-next-line unicorn/no-process-exit
+    process.exit(1);
+  };
+}

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -52,6 +52,7 @@
     "eslint": "^8.44.0",
     "jest": "^29.7.0",
     "lint-staged": "^15.0.0",
+    "nanoid": "^5.0.1",
     "pluralize": "^8.0.0",
     "prettier": "^3.0.0",
     "roarr": "^7.11.0",
@@ -85,7 +86,6 @@
     "@logto/language-kit": "workspace:^1.1.0",
     "@logto/phrases": "workspace:^1.9.0",
     "@logto/phrases-experience": "workspace:^1.6.0",
-    "@logto/shared": "workspace:^3.1.0",
     "@withtyped/server": "^0.13.3"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3996,9 +3996,6 @@ importers:
       '@logto/phrases-experience':
         specifier: workspace:^1.6.0
         version: link:../phrases-experience
-      '@logto/shared':
-        specifier: workspace:^3.1.0
-        version: link:../shared
       '@withtyped/server':
         specifier: ^0.13.3
         version: 0.13.3(zod@3.22.4)
@@ -4042,6 +4039,9 @@ importers:
       lint-staged:
         specifier: ^15.0.0
         version: 15.0.2
+      nanoid:
+        specifier: ^5.0.1
+        version: 5.0.1
       pluralize:
         specifier: ^8.0.0
         version: 8.0.0


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
remove the dependency of `@logto/shared` from `@logto/schemas` since `@logto/shared` has a dependency of `slonik` which is too large.

this is also good for keeping the alteration scripts as clean as possible.

note there's a breaking change of `1.7.0-1688613459-...` which only affects cloud, and it has a very low risk since the time has passed too long.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
ci

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
