### PR TITLE
refactor(console): replace the field table with type definition code

### DIFF
--- a/packages/console/src/pages/JwtClaims/SettingsSection/InstructionTab.tsx
+++ b/packages/console/src/pages/JwtClaims/SettingsSection/InstructionTab.tsx
@@ -11,9 +11,9 @@ import {
   fetchExternalDataCodeExample,
 } from '../utils/config';
 import {
-  buildJwtCustomizerAccessTokenPayloadType,
-  buildJwtCustomizerClientCredentialsPayloadType,
-  buildJwtCustomizerUserContextType,
+  accessTokenPayloadTypeDefinition,
+  clientCredentialsPayloadTypeDefinition,
+  jwtCustomizerUserContextTypeDefinition,
 } from '../utils/type-definitions';
 
 import EnvironmentVariablesField from './EnvironmentVariablesField';
@@ -23,10 +23,6 @@ import * as styles from './index.module.scss';
 type Props = {
   isActive: boolean;
 };
-
-const jwtCustomizerUserContextSchema = buildJwtCustomizerUserContextType();
-const accessTokenPayloadSchema = buildJwtCustomizerAccessTokenPayloadType();
-const clientCredentialsPayloadSchema = buildJwtCustomizerClientCredentialsPayloadType();
 
 /* Instructions and environment variable settings for the custom JWT claims script. */
 function InstructionTab({ isActive }: Props) {
@@ -43,7 +39,7 @@ function InstructionTab({ isActive }: Props) {
           <Editor
             language="typescript"
             className={styles.sampleCode}
-            value={jwtCustomizerUserContextSchema}
+            value={jwtCustomizerUserContextTypeDefinition}
             height="700px"
             theme="logto-dark"
             options={typeDefinitionCodeEditorOptions}
@@ -56,10 +52,10 @@ function InstructionTab({ isActive }: Props) {
           className={styles.sampleCode}
           value={
             tokenType === LogtoJwtTokenPath.AccessToken
-              ? accessTokenPayloadSchema
-              : clientCredentialsPayloadSchema
+              ? accessTokenPayloadTypeDefinition
+              : clientCredentialsPayloadTypeDefinition
           }
-          height="400px"
+          height="350px"
           theme="logto-dark"
           options={typeDefinitionCodeEditorOptions}
         />

--- a/packages/console/src/pages/JwtClaims/SettingsSection/InstructionTab.tsx
+++ b/packages/console/src/pages/JwtClaims/SettingsSection/InstructionTab.tsx
@@ -1,19 +1,20 @@
 import { LogtoJwtTokenPath } from '@logto/schemas';
 import { Editor } from '@monaco-editor/react';
 import classNames from 'classnames';
-import { useCallback } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
-import Table from '@/ds-components/Table';
-
 import { type JwtClaimsFormType } from '../type';
 import {
-  userDataDescription,
-  tokenDataDescription,
-  fetchExternalDataEditorOptions,
+  sampleCodeEditorOptions,
+  typeDefinitionCodeEditorOptions,
   fetchExternalDataCodeExample,
 } from '../utils/config';
+import {
+  buildJwtCustomizerAccessTokenPayloadType,
+  buildJwtCustomizerClientCredentialsPayloadType,
+  buildJwtCustomizerUserContextType,
+} from '../utils/type-definitions';
 
 import EnvironmentVariablesField from './EnvironmentVariablesField';
 import GuideCard, { CardType } from './GuideCard';
@@ -23,6 +24,10 @@ type Props = {
   isActive: boolean;
 };
 
+const jwtCustomizerUserContextSchema = buildJwtCustomizerUserContextType();
+const accessTokenPayloadSchema = buildJwtCustomizerAccessTokenPayloadType();
+const clientCredentialsPayloadSchema = buildJwtCustomizerClientCredentialsPayloadType();
+
 /* Instructions and environment variable settings for the custom JWT claims script. */
 function InstructionTab({ isActive }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
@@ -30,51 +35,33 @@ function InstructionTab({ isActive }: Props) {
   const { watch } = useFormContext<JwtClaimsFormType>();
   const tokenType = watch('tokenType');
 
-  const getDataColumns = useCallback(
-    (valueColSpan = 10) => [
-      {
-        title: t('domain.custom.dns_table.value_field'),
-        dataIndex: 'value',
-        colSpan: valueColSpan,
-        render: ({ value }: (typeof userDataDescription)[0]) => (
-          <span className={styles.value}>{value}</span>
-        ),
-      },
-      {
-        title: t('general.description'),
-        dataIndex: 'description',
-        colSpan: 24 - valueColSpan,
-        render: ({ description }: (typeof userDataDescription)[0]) => (
-          <span className={styles.description}>{description}</span>
-        ),
-      },
-    ],
-    [t]
-  );
-
   return (
     <div className={classNames(styles.tabContent, isActive && styles.active)}>
       <div className={styles.description}>{t('jwt_claims.jwt_claims_description')}</div>
       {tokenType === LogtoJwtTokenPath.AccessToken && (
         <GuideCard name={CardType.UserData}>
-          <Table
-            hasBorder
-            isRowHoverEffectDisabled
-            className={styles.table}
-            rowIndexKey="value"
-            columns={getDataColumns()}
-            rowGroups={[{ key: 'user_data', data: userDataDescription }]}
+          <Editor
+            language="typescript"
+            className={styles.sampleCode}
+            value={jwtCustomizerUserContextSchema}
+            height="700px"
+            theme="logto-dark"
+            options={typeDefinitionCodeEditorOptions}
           />
         </GuideCard>
       )}
       <GuideCard name={CardType.TokenData}>
-        <Table
-          hasBorder
-          isRowHoverEffectDisabled
-          className={styles.table}
-          rowIndexKey="value"
-          columns={getDataColumns(6)}
-          rowGroups={[{ key: 'token_data', data: tokenDataDescription }]}
+        <Editor
+          language="typescript"
+          className={styles.sampleCode}
+          value={
+            tokenType === LogtoJwtTokenPath.AccessToken
+              ? accessTokenPayloadSchema
+              : clientCredentialsPayloadSchema
+          }
+          height="400px"
+          theme="logto-dark"
+          options={typeDefinitionCodeEditorOptions}
         />
       </GuideCard>
       <GuideCard name={CardType.FetchExternalData}>
@@ -85,7 +72,7 @@ function InstructionTab({ isActive }: Props) {
           value={fetchExternalDataCodeExample}
           height="300px"
           theme="logto-dark"
-          options={fetchExternalDataEditorOptions}
+          options={sampleCodeEditorOptions}
         />
       </GuideCard>
       <GuideCard name={CardType.EnvironmentVariables}>

--- a/packages/console/src/pages/JwtClaims/utils/config.tsx
+++ b/packages/console/src/pages/JwtClaims/utils/config.tsx
@@ -131,81 +131,8 @@ export const clientCredentialsModel: ModelSettings = {
 /**
  * JWT claims guide card configs
  */
-// TODO: align user properties and then i18n the descriptions
-type GuideTableData = {
-  value: string;
-  description: string;
-};
 
-export const userDataDescription: GuideTableData[] = [
-  {
-    value: 'user.id',
-    description: 'Unique identifier of the user.',
-  },
-  {
-    value: 'user.username',
-    description: 'Username for sign-in',
-  },
-  {
-    value: 'user.primary_email',
-    description: 'Primary email address of the user.',
-  },
-  {
-    value: 'user.primary_phone',
-    description: 'Primary phone number of the user.',
-  },
-  {
-    value: 'user.name',
-    description: 'Full name of the user.',
-  },
-  {
-    value: 'user.avatar',
-    description: "URL pointing to user's avatar image	",
-  },
-  {
-    value: 'user.identities',
-    description: 'User info retrieved from social sign-in',
-  },
-  {
-    value: 'user.custom_data',
-    description: 'Additional info in customizable properties	',
-  },
-];
-
-export const tokenDataDescription: GuideTableData[] = [
-  {
-    value: 'jti',
-    description:
-      '(JWT ID) Unique identifier for the JWT. Useful for tracking and preventing reuse of the token.',
-  },
-  {
-    value: 'iat',
-    description: '(issued at) Time at which the JWT was issued.',
-  },
-  {
-    value: 'exp',
-    description: '(expiration) Time after which the JWT expires.',
-  },
-  {
-    value: 'client_id',
-    description: 'Client ID of the application that requested the JWT.',
-  },
-  {
-    value: 'kind',
-    description:
-      'Type of the token. `AccessToken` for user access tokens and `ClientCredentials` for machine-to-machine access tokens.',
-  },
-  {
-    value: 'scope',
-    description: 'Scopes requested by the client joint by space.',
-  },
-  {
-    value: 'aud',
-    description: '(audience) Audience for which the JWT is intended.',
-  },
-];
-
-export const fetchExternalDataEditorOptions: EditorProps['options'] = {
+export const sampleCodeEditorOptions: EditorProps['options'] = {
   readOnly: true,
   wordWrap: 'on',
   minimap: { enabled: false },
@@ -217,6 +144,13 @@ export const fetchExternalDataEditorOptions: EditorProps['options'] = {
   lineNumbers: 'off',
   scrollbar: { vertical: 'hidden', horizontal: 'hidden', handleMouseWheel: false },
   folding: false,
+  tabSize: 2,
+};
+
+export const typeDefinitionCodeEditorOptions: EditorProps['options'] = {
+  ...sampleCodeEditorOptions,
+  scrollbar: { vertical: 'auto', horizontal: 'auto' },
+  folding: true,
 };
 
 export const fetchExternalDataCodeExample = `const response = await fetch('https://api.example.com/data', {

--- a/packages/console/src/pages/JwtClaims/utils/type-definitions.ts
+++ b/packages/console/src/pages/JwtClaims/utils/type-definitions.ts
@@ -7,7 +7,12 @@ import {
 
 import { type JwtClaimsFormType } from '../type';
 
-export { JwtCustomizerTypeDefinitionKey } from '@/consts/jwt-customizer-type-definition';
+export {
+  JwtCustomizerTypeDefinitionKey,
+  accessTokenPayloadTypeDefinition,
+  clientCredentialsPayloadTypeDefinition,
+  jwtCustomizerUserContextTypeDefinition,
+} from '@/consts/jwt-customizer-type-definition';
 
 export const buildAccessTokenJwtCustomizerContextTsDefinition = () => {
   return `declare ${jwtCustomizerUserContextTypeDefinition}
@@ -32,18 +37,3 @@ export const buildEnvironmentVariablesTypeDefinition = (
 
   return `declare type ${JwtCustomizerTypeDefinitionKey.EnvironmentVariables} = ${typeDefinition}`;
 };
-
-export const buildJwtCustomizerUserContextType = () => `type ${
-  JwtCustomizerTypeDefinitionKey.JwtCustomizerUserContext
-} = ${getJwtCustomizerUserContextTsDefinition()}
-`;
-
-export const buildJwtCustomizerAccessTokenPayloadType = () => `type ${
-  JwtCustomizerTypeDefinitionKey.AccessTokenPayload
-} = ${getAccessTokenPayloadTsDefinition()}
-`;
-
-export const buildJwtCustomizerClientCredentialsPayloadType = () => `type ${
-  JwtCustomizerTypeDefinitionKey.ClientCredentialsPayload
-} = ${getClientCredentialsPayloadTsDefinition()}
-`;

--- a/packages/console/src/pages/JwtClaims/utils/type-definitions.ts
+++ b/packages/console/src/pages/JwtClaims/utils/type-definitions.ts
@@ -32,3 +32,18 @@ export const buildEnvironmentVariablesTypeDefinition = (
 
   return `declare type ${JwtCustomizerTypeDefinitionKey.EnvironmentVariables} = ${typeDefinition}`;
 };
+
+export const buildJwtCustomizerUserContextType = () => `type ${
+  JwtCustomizerTypeDefinitionKey.JwtCustomizerUserContext
+} = ${getJwtCustomizerUserContextTsDefinition()}
+`;
+
+export const buildJwtCustomizerAccessTokenPayloadType = () => `type ${
+  JwtCustomizerTypeDefinitionKey.AccessTokenPayload
+} = ${getAccessTokenPayloadTsDefinition()}
+`;
+
+export const buildJwtCustomizerClientCredentialsPayloadType = () => `type ${
+  JwtCustomizerTypeDefinitionKey.ClientCredentialsPayload
+} = ${getClientCredentialsPayloadTsDefinition()}
+`;


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
As the original hardcoded context property table definition is not scalable and hard to maintain, replace the field table with the type definition code. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<img width="1343" alt="image" src="https://github.com/logto-io/logto/assets/36393111/a3e3bba0-2e89-44f7-8329-05a60ab89861">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [ ] ~necessary TSDoc comments~
