### PR TITLE
refactor: allow unknown keys in send message payload

### DIFF
--- a/.changeset/witty-moose-kick.md
+++ b/.changeset/witty-moose-kick.md
@@ -1,0 +1,5 @@
+---
+"@logto/connector-kit": patch
+---
+
+allow unknown properties in send message payload

--- a/packages/core/src/utils/zod.ts
+++ b/packages/core/src/utils/zod.ts
@@ -21,6 +21,7 @@ import {
   ZodUnion,
   ZodUnknown,
   ZodDefault,
+  ZodIntersection,
 } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
@@ -276,6 +277,12 @@ export const zodTypeToSwagger = (
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       default: config._def.defaultValue(),
       ...zodTypeToSwagger(config._def.innerType),
+    };
+  }
+
+  if (config instanceof ZodIntersection) {
+    return {
+      allOf: [zodTypeToSwagger(config._def.left), zodTypeToSwagger(config._def.right)],
     };
   }
 

--- a/packages/toolkit/connector-kit/src/index.test.ts
+++ b/packages/toolkit/connector-kit/src/index.test.ts
@@ -59,15 +59,25 @@ describe('replaceSendMessageHandlebars', () => {
     );
   });
 
-  it('should replace handlebars with empty string if payload does not contain the key', () => {
+  it('should not replace handlebars if payload does not contain the key', () => {
     const template = 'Your verification code is {{code}}';
     const payload = {};
-    expect(replaceSendMessageHandlebars(template, payload)).toEqual('Your verification code is ');
+    expect(replaceSendMessageHandlebars(template, payload)).toEqual(
+      'Your verification code is {{code}}'
+    );
   });
 
-  it('should ignore handlebars that are not in the predefined list for both template and payload', () => {
+  it('should replace all handlebars even they are not in the predefined list for payload', () => {
     const template = 'Your verification code is {{code}} and {{foo}}';
     const payload = { code: '123456', foo: 'bar' };
+    expect(replaceSendMessageHandlebars(template, payload)).toEqual(
+      'Your verification code is 123456 and bar'
+    );
+  });
+
+  it('should ignore handlebars that are not in the payload', () => {
+    const template = 'Your verification code is {{code}} and {{foo}}';
+    const payload = { code: '123456' };
     expect(replaceSendMessageHandlebars(template, payload)).toEqual(
       'Your verification code is 123456 and {{foo}}'
     );

--- a/packages/toolkit/connector-kit/src/index.ts
+++ b/packages/toolkit/connector-kit/src/index.ts
@@ -3,7 +3,6 @@ import type { ZodType, ZodTypeDef } from 'zod';
 import {
   ConnectorError,
   ConnectorErrorCodes,
-  sendMessagePayloadKeys,
   type SendMessagePayload,
   ConnectorType,
 } from './types/index.js';
@@ -96,7 +95,7 @@ export const replaceSendMessageHandlebars = (
   template: string,
   payload: SendMessagePayload
 ): string => {
-  return sendMessagePayloadKeys.reduce(
+  return Object.keys(payload).reduce(
     (accumulator, key) =>
       accumulator.replaceAll(new RegExp(`{{\\s*${key}\\s*}}`, 'g'), payload[key] ?? ''),
     template

--- a/packages/toolkit/connector-kit/src/types/passwordless.ts
+++ b/packages/toolkit/connector-kit/src/types/passwordless.ts
@@ -32,6 +32,7 @@ export enum TemplateType {
 
 export const templateTypeGuard = z.nativeEnum(TemplateType);
 
+/** The payload for sending email or sms. */
 export type SendMessagePayload = {
   /**
    * The dynamic verification code to send. It will replace the `{{code}}` handlebars in the
@@ -44,16 +45,15 @@ export type SendMessagePayload = {
    * @example 'https://example.com'
    */
   link?: string;
-};
+} & Record<string, string>;
 
-export const sendMessagePayloadKeys = ['code', 'link'] as const satisfies Array<
-  keyof SendMessagePayload
->;
-
-export const sendMessagePayloadGuard = z.object({
-  code: z.string().optional(),
-  link: z.string().optional(),
-}) satisfies z.ZodType<SendMessagePayload>;
+/** The guard for {@link SendMessagePayload}. */
+export const sendMessagePayloadGuard = z
+  .object({
+    code: z.string().optional(),
+    link: z.string().optional(),
+  })
+  .and(z.record(z.string())) satisfies z.ZodType<SendMessagePayload>;
 
 export const urlRegEx =
   /(https?:\/\/)?(?:www\.)?[\w#%+.:=@~-]{1,256}\.[\d()A-Za-z]{1,6}\b[\w#%&()+./:=?@~-]*/;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
the limitation brings more trouble than benefit. the payload type should be guidance instead of enforcement.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
added test cases

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
