### PR TITLE
refactor(console): avoid nested modal content for role creation

### DIFF
--- a/packages/console/src/pages/Roles/components/CreateRoleModal/index.tsx
+++ b/packages/console/src/pages/Roles/components/CreateRoleModal/index.tsx
@@ -32,6 +32,20 @@ function CreateRoleModal({ onClose }: Props) {
     onClose();
   };
 
+  // Show assign role modal after role is created
+  if (createdRole) {
+    return (
+      <AssignRoleModal
+        isRemindSkip
+        roleId={createdRole.id}
+        roleType={createdRole.type}
+        onClose={() => {
+          navigate(`/roles/${createdRole.id}`, { replace: true });
+        }}
+      />
+    );
+  }
+
   return (
     <ReactModal
       isOpen
@@ -40,18 +54,7 @@ function CreateRoleModal({ onClose }: Props) {
       overlayClassName={modalStyles.overlay}
       onRequestClose={onClose}
     >
-      {createdRole ? (
-        <AssignRoleModal
-          isRemindSkip
-          roleId={createdRole.id}
-          roleType={createdRole.type}
-          onClose={() => {
-            navigate(`/roles/${createdRole.id}`, { replace: true });
-          }}
-        />
-      ) : (
-        <CreateRoleForm onClose={onCreateFormClose} />
-      )}
+      <CreateRoleForm onClose={onCreateFormClose} />
     </ReactModal>
   );
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The `AssignRoleModal` and `CreateRoleForm` should not nested in one modal layout.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally and IT passed

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
