### PR TITLE
fix(core,phrases): fix custom JWT PUT API block admin tenant logic

### DIFF
--- a/packages/core/src/routes/logto-config.ts
+++ b/packages/core/src/routes/logto-config.ts
@@ -230,11 +230,12 @@ export default function logtoConfigRoutes<T extends AuthedRouter>(
       status: [200, 201, 400, 403],
     }),
     async (ctx, next) => {
-      if (
-        tenantId !== adminTenantId &&
-        !(EnvSet.values.isUnitTest || EnvSet.values.isIntegrationTest)
-      ) {
-        throw new RequestError({ code: 'auth.forbidden', status: 403 });
+      const { isCloud, isUnitTest, isIntegrationTest } = EnvSet.values;
+      if (tenantId === adminTenantId && isCloud && !(isUnitTest || isIntegrationTest)) {
+        throw new RequestError({
+          code: 'jwt_customizer.can_not_create_for_admin_tenant',
+          status: 422,
+        });
       }
 
       const {

--- a/packages/phrases/src/locales/de/errors/jwt-customizer.ts
+++ b/packages/phrases/src/locales/de/errors/jwt-customizer.ts
@@ -1,6 +1,8 @@
 const jwt_customizer = {
   /** UNTRANSLATED */
   general: 'An error occurred while customizing the JWT token. Please try again later.',
+  /** UNTRANSLATED */
+  can_not_create_for_admin_tenant: 'Cannot create a JWT token customizer for the admin tenant.',
 };
 
 export default Object.freeze(jwt_customizer);

--- a/packages/phrases/src/locales/en/errors/jwt-customizer.ts
+++ b/packages/phrases/src/locales/en/errors/jwt-customizer.ts
@@ -1,6 +1,6 @@
 const jwt_customizer = {
-  /** UNTRANSLATED */
   general: 'An error occurred while customizing the JWT token. Please try again later.',
+  can_not_create_for_admin_tenant: 'Cannot create a JWT token customizer for the admin tenant.',
 };
 
 export default Object.freeze(jwt_customizer);

--- a/packages/phrases/src/locales/es/errors/jwt-customizer.ts
+++ b/packages/phrases/src/locales/es/errors/jwt-customizer.ts
@@ -1,6 +1,8 @@
 const jwt_customizer = {
   /** UNTRANSLATED */
   general: 'An error occurred while customizing the JWT token. Please try again later.',
+  /** UNTRANSLATED */
+  can_not_create_for_admin_tenant: 'Cannot create a JWT token customizer for the admin tenant.',
 };
 
 export default Object.freeze(jwt_customizer);

--- a/packages/phrases/src/locales/fr/errors/jwt-customizer.ts
+++ b/packages/phrases/src/locales/fr/errors/jwt-customizer.ts
@@ -1,6 +1,8 @@
 const jwt_customizer = {
   /** UNTRANSLATED */
   general: 'An error occurred while customizing the JWT token. Please try again later.',
+  /** UNTRANSLATED */
+  can_not_create_for_admin_tenant: 'Cannot create a JWT token customizer for the admin tenant.',
 };
 
 export default Object.freeze(jwt_customizer);

--- a/packages/phrases/src/locales/it/errors/jwt-customizer.ts
+++ b/packages/phrases/src/locales/it/errors/jwt-customizer.ts
@@ -1,6 +1,8 @@
 const jwt_customizer = {
   /** UNTRANSLATED */
   general: 'An error occurred while customizing the JWT token. Please try again later.',
+  /** UNTRANSLATED */
+  can_not_create_for_admin_tenant: 'Cannot create a JWT token customizer for the admin tenant.',
 };
 
 export default Object.freeze(jwt_customizer);

--- a/packages/phrases/src/locales/ja/errors/jwt-customizer.ts
+++ b/packages/phrases/src/locales/ja/errors/jwt-customizer.ts
@@ -1,6 +1,8 @@
 const jwt_customizer = {
   /** UNTRANSLATED */
   general: 'An error occurred while customizing the JWT token. Please try again later.',
+  /** UNTRANSLATED */
+  can_not_create_for_admin_tenant: 'Cannot create a JWT token customizer for the admin tenant.',
 };
 
 export default Object.freeze(jwt_customizer);

--- a/packages/phrases/src/locales/ko/errors/jwt-customizer.ts
+++ b/packages/phrases/src/locales/ko/errors/jwt-customizer.ts
@@ -1,6 +1,8 @@
 const jwt_customizer = {
   /** UNTRANSLATED */
   general: 'An error occurred while customizing the JWT token. Please try again later.',
+  /** UNTRANSLATED */
+  can_not_create_for_admin_tenant: 'Cannot create a JWT token customizer for the admin tenant.',
 };
 
 export default Object.freeze(jwt_customizer);

--- a/packages/phrases/src/locales/pl-pl/errors/jwt-customizer.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/jwt-customizer.ts
@@ -1,6 +1,8 @@
 const jwt_customizer = {
   /** UNTRANSLATED */
   general: 'An error occurred while customizing the JWT token. Please try again later.',
+  /** UNTRANSLATED */
+  can_not_create_for_admin_tenant: 'Cannot create a JWT token customizer for the admin tenant.',
 };
 
 export default Object.freeze(jwt_customizer);

--- a/packages/phrases/src/locales/pt-br/errors/jwt-customizer.ts
+++ b/packages/phrases/src/locales/pt-br/errors/jwt-customizer.ts
@@ -1,6 +1,8 @@
 const jwt_customizer = {
   /** UNTRANSLATED */
   general: 'An error occurred while customizing the JWT token. Please try again later.',
+  /** UNTRANSLATED */
+  can_not_create_for_admin_tenant: 'Cannot create a JWT token customizer for the admin tenant.',
 };
 
 export default Object.freeze(jwt_customizer);

--- a/packages/phrases/src/locales/pt-pt/errors/jwt-customizer.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/jwt-customizer.ts
@@ -1,6 +1,8 @@
 const jwt_customizer = {
   /** UNTRANSLATED */
   general: 'An error occurred while customizing the JWT token. Please try again later.',
+  /** UNTRANSLATED */
+  can_not_create_for_admin_tenant: 'Cannot create a JWT token customizer for the admin tenant.',
 };
 
 export default Object.freeze(jwt_customizer);

--- a/packages/phrases/src/locales/ru/errors/jwt-customizer.ts
+++ b/packages/phrases/src/locales/ru/errors/jwt-customizer.ts
@@ -1,6 +1,8 @@
 const jwt_customizer = {
   /** UNTRANSLATED */
   general: 'An error occurred while customizing the JWT token. Please try again later.',
+  /** UNTRANSLATED */
+  can_not_create_for_admin_tenant: 'Cannot create a JWT token customizer for the admin tenant.',
 };
 
 export default Object.freeze(jwt_customizer);

--- a/packages/phrases/src/locales/tr-tr/errors/jwt-customizer.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/jwt-customizer.ts
@@ -1,6 +1,8 @@
 const jwt_customizer = {
   /** UNTRANSLATED */
   general: 'An error occurred while customizing the JWT token. Please try again later.',
+  /** UNTRANSLATED */
+  can_not_create_for_admin_tenant: 'Cannot create a JWT token customizer for the admin tenant.',
 };
 
 export default Object.freeze(jwt_customizer);

--- a/packages/phrases/src/locales/zh-cn/errors/jwt-customizer.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/jwt-customizer.ts
@@ -1,6 +1,8 @@
 const jwt_customizer = {
   /** UNTRANSLATED */
   general: 'An error occurred while customizing the JWT token. Please try again later.',
+  /** UNTRANSLATED */
+  can_not_create_for_admin_tenant: 'Cannot create a JWT token customizer for the admin tenant.',
 };
 
 export default Object.freeze(jwt_customizer);

--- a/packages/phrases/src/locales/zh-hk/errors/jwt-customizer.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/jwt-customizer.ts
@@ -1,6 +1,8 @@
 const jwt_customizer = {
   /** UNTRANSLATED */
   general: 'An error occurred while customizing the JWT token. Please try again later.',
+  /** UNTRANSLATED */
+  can_not_create_for_admin_tenant: 'Cannot create a JWT token customizer for the admin tenant.',
 };
 
 export default Object.freeze(jwt_customizer);

--- a/packages/phrases/src/locales/zh-tw/errors/jwt-customizer.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/jwt-customizer.ts
@@ -1,6 +1,8 @@
 const jwt_customizer = {
   /** UNTRANSLATED */
   general: 'An error occurred while customizing the JWT token. Please try again later.',
+  /** UNTRANSLATED */
+  can_not_create_for_admin_tenant: 'Cannot create a JWT token customizer for the admin tenant.',
 };
 
 export default Object.freeze(jwt_customizer);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix custom JWT PUT API block admin tenant logic.
1. This custom JWT feature should be available for user tenant, which means should throw error when the current tenant id admin tenant. (previous implementation made mistake)
2. Can not use `auth.forbidden` 403 error because we will call sign out and redirect the user to login page for all console 403 error, this is not expected. Add another error instead.
3. We should bypass the error for unit tests and integration test cases since the user is admin tenant in integration test setup.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
<img width="3248" alt="image" src="https://github.com/logto-io/logto/assets/15182327/d5f8309c-63b1-4af3-9934-934c397c655d">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
