### PR TITLE
fix(console): fix jwt test context code editor bug

### DIFF
--- a/packages/console/src/pages/JwtClaims/utils/config.tsx
+++ b/packages/console/src/pages/JwtClaims/utils/config.tsx
@@ -187,7 +187,7 @@ const standardTokenPayloadData = {
   jti: 'f1d3d2d1-1f2d-3d4e-5d6f-7d8a9d0e1d2',
   iat: 1_516_235_022,
   exp: 1_516_235_022 + 3600,
-  client_id: 'my_app',
+  clientId: 'my_app',
   scope: 'read write',
   aud: 'http://localhost:3000/api/test',
 };


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix the test context code editor bug
1. fix the field name 'client_id' using 'clientId'
2. add the logic if the updated value is the same as the defaultValue e.g. click on the reset button. Instead of saving the default value to db, simply return undefined. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
