### PR TITLE
fix(console): fix the zod-to-ts type infer bug

### DIFF
--- a/packages/console/scripts/generate-jwt-customizer-type-definition.ts
+++ b/packages/console/scripts/generate-jwt-customizer-type-definition.ts
@@ -1,13 +1,13 @@
 import fs from 'node:fs';
 
 import {
-  jwtCustomizerUserContextGuard,
   accessTokenPayloadGuard,
   clientCredentialsPayloadGuard,
+  jwtCustomizerUserContextGuard,
 } from '@logto/schemas';
 import prettier from 'prettier';
 import { type ZodTypeAny } from 'zod';
-import { zodToTs, printNode } from 'zod-to-ts';
+import { printNode, zodToTs } from 'zod-to-ts';
 
 const filePath = 'src/consts/jwt-customizer-type-definition.ts';
 
@@ -19,7 +19,18 @@ const typeIdentifiers = `export enum JwtCustomizerTypeDefinitionKey {
 };`;
 
 const inferTsDefinitionFromZod = (zodSchema: ZodTypeAny, identifier: string): string => {
-  const { node } = zodToTs(zodSchema, identifier);
+  /**
+   * We have z.lazy() used for defining Json objects in the zod schemas.
+   * @see https://zod.dev/?id=json-type
+   * zod-to-ts does not support z.lazy() yet. It will use the root type of the lazy schema. Which will be the identifier we pass to the function.
+   * @see https://github.com/sachinraja/zod-to-ts?tab=readme-ov-file#zlazy
+   *
+   * The second argument is the root type identifier for the schema.
+   * Here we use 'Record<string, unknown>' as the root type identifier. So all the Json objects will be inferred as Record<string, unknown>.
+   * This is a limitation of zod-to-ts. We can't infer the exact type of the Json objects.
+   * This solution is hacky but it works for now. The impact is it will always define the type identifer as Record<string, unknown>.
+   */
+  const { node } = zodToTs(zodSchema, 'Record<string, unknown>', { nativeEnums: 'union' });
   const typeDefinition = printNode(node);
 
   return `type ${identifier} = ${typeDefinition};`;


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix the zod-to-ts type infer bug

zod-to-ts has multiple rare cases. We have met two issues:
1. nativeEnum. Fix with the settings `{nativeNum: 'Union'}`

   Before: 
   <img width="373" alt="image" src="https://github.com/logto-io/logto/assets/36393111/d9e2de1e-17aa-44c6-ae89-c3747d883cca">

   After:
   <img width="437" alt="image" src="https://github.com/logto-io/logto/assets/36393111/19298dfb-3c2e-4f8e-9fce-639d0bbfef79">

2. We use the z.lazy method to define the JsonObject type.  zod-to-ts can not infer the type properly. Have to set a workaround. Take the fact the it always uses the root type identifier to inder the z.lazy type field. We always set the identifier as record. 

   before:
   <img width="491" alt="image" src="https://github.com/logto-io/logto/assets/36393111/3c94fa25-47a8-4c98-bc16-e04f309999af">
   after:
   <img width="487" alt="image" src="https://github.com/logto-io/logto/assets/36393111/94eda8c7-1c57-4f4f-8468-1900f2be1745">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [x] necessary TSDoc comments
