### PR TITLE
feat(schemas): add util method to convert admin tenant org id to user tenant id

### DIFF
--- a/packages/schemas/src/types/tenant-organization.ts
+++ b/packages/schemas/src/types/tenant-organization.ts
@@ -17,6 +17,15 @@ import { adminTenantId } from '../seeds/tenant.js';
 /** Given a tenant ID, return the corresponding organization ID in the admin tenant. */
 export const getTenantOrganizationId = (tenantId: string) => `t-${tenantId}`;
 
+/** Given an admin tenant organization ID, check the format and return the corresponding user tenant ID. */
+export const getTenantIdFromOrganizationId = (organizationId: string) => {
+  if (!organizationId.startsWith('t-')) {
+    throw new Error(`Invalid admin tenant organization ID: ${organizationId}`);
+  }
+
+  return organizationId.slice(2);
+};
+
 /**
  * Given a tenant ID, return the organization create data for the admin tenant. It follows a
  * convention to generate the organization ID and name which can be used across the system.


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Logto Cloud multi-tenancy is built on top of organizations feature, and each user tenant is an associated organization that has ID starts with `t-` and followed by the user tenant ID.

This PR provides a util method to check and convert a given admin tenant organization ID to a user tenant ID.
E.g. `t-abcdef` => `abcdef`

* This util is intended for Logto Cloud features only.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
