### PR TITLE
fix(console): revert the custom jwt forms overflow hidden

### DIFF
--- a/packages/console/src/pages/JwtClaims/SettingsSection/TestTab.tsx
+++ b/packages/console/src/pages/JwtClaims/SettingsSection/TestTab.tsx
@@ -155,9 +155,7 @@ function TestTab({ isActive }: Props) {
 
   return (
     <div className={classNames(styles.tabContent, isActive && styles.active)}>
-      <Card
-        className={classNames(styles.card, styles.flexGrow, styles.flexColumn, styles.fixHeight)}
-      >
+      <Card className={classNames(styles.card, styles.flexGrow, styles.flexColumn)}>
         <div className={styles.headerRow}>
           <div className={styles.cardHeader}>
             <div className={styles.cardTitle}>{t('tester.title')}</div>

--- a/packages/console/src/pages/JwtClaims/SettingsSection/index.module.scss
+++ b/packages/console/src/pages/JwtClaims/SettingsSection/index.module.scss
@@ -37,8 +37,6 @@
 
 .tabContent {
   display: none;
-  // restrict the height of the tab content to the height of the container
-  overflow: hidden;
 
   &.active {
     flex: 1;
@@ -84,14 +82,6 @@
 
     > *:not(:last-child) {
       margin-bottom: _.unit(4);
-    }
-  }
-
-  &.fixHeight {
-    overflow: hidden;
-
-    .cardContent {
-      overflow: hidden;
     }
   }
 

--- a/packages/console/src/pages/JwtClaims/index.module.scss
+++ b/packages/console/src/pages/JwtClaims/index.module.scss
@@ -19,15 +19,10 @@
   display: flex;
   flex-direction: row;
   flex-grow: 1;
-  // restrict the height of the tab content to the height of the container
-  overflow: hidden;
 
   > * {
     flex: 1;
     margin-bottom: _.unit(6);
-
-    // restrict the height of the tab content to the height of the container
-    overflow: hidden;
 
     &:first-child {
       margin-right: _.unit(3);


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
revert the custom jwt forms overflow hidden styles.

This PR will fix the page overflow not scrollable and IntelliSense cut-off issue. 
We will refactor the overall page layout in the following PRs. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [ ] ~necessary TSDoc comments~
