### PR TITLE
refactor(schemas): remove invite member scope from tenant member role

### DIFF
--- a/packages/schemas/alterations/next-1711607772-remove-invite-member-scope-from-tenant-member-role.ts
+++ b/packages/schemas/alterations/next-1711607772-remove-invite-member-scope-from-tenant-member-role.ts
@@ -1,0 +1,20 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      delete from organization_role_scope_relations
+        where tenant_id = 'admin' and organization_role_id = 'member' and organization_scope_id = 'invite-member';
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      insert into organization_role_scope_relations (tenant_id, organization_role_id, organization_scope_id)
+        values ('admin', 'member', 'invite-member');
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/types/tenant-organization.ts
+++ b/packages/schemas/src/types/tenant-organization.ts
@@ -155,10 +155,5 @@ export const getTenantRole = (role: TenantRole): Readonly<OrganizationRole> =>
 export const tenantRoleScopes: Readonly<Record<TenantRole, Readonly<TenantScope[]>>> =
   Object.freeze({
     [TenantRole.Admin]: allTenantScopes,
-    [TenantRole.Member]: [
-      TenantScope.ReadData,
-      TenantScope.WriteData,
-      TenantScope.DeleteData,
-      TenantScope.InviteMember,
-    ],
+    [TenantRole.Member]: [TenantScope.ReadData, TenantScope.WriteData, TenantScope.DeleteData],
   });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Remove `invite:member` scope from tenant member role, so that only admin can invite other members

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally and CI

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
