### PR TITLE
feat(schemas): add new scope read:member to both tenant admin and member roles

### DIFF
--- a/packages/schemas/alterations/next-1711624564-add-read-member-scope-to-tenant-roles.ts
+++ b/packages/schemas/alterations/next-1711624564-add-read-member-scope-to-tenant-roles.ts
@@ -1,0 +1,25 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      insert into organization_scopes (tenant_id, id, name, description)
+        values ('admin', 'read-member', 'read:member', 'Read members of the tenant.');
+      insert into organization_role_scope_relations (tenant_id, organization_role_id, organization_scope_id)
+        values ('admin', 'admin', 'read-member'),
+               ('admin', 'member', 'read-member');
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      delete from organization_role_scope_relations
+        where tenant_id = 'admin' and organization_scope_id = 'read-member';
+      delete from organization_scopes
+        where tenant_id = 'admin' and id = 'read-member';
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/types/tenant-organization.ts
+++ b/packages/schemas/src/types/tenant-organization.ts
@@ -55,6 +55,8 @@ export enum TenantScope {
   WriteData = 'write:data',
   /** Delete data of the tenant. */
   DeleteData = 'delete:data',
+  /** Read members of the tenant. */
+  ReadMember = 'read:member',
   /** Invite members to the tenant. */
   InviteMember = 'invite:member',
   /** Remove members from the tenant. */
@@ -97,6 +99,7 @@ const tenantScopeDescriptions: Readonly<Record<TenantScope, string>> = Object.fr
   [TenantScope.ReadData]: 'Read the tenant data.',
   [TenantScope.WriteData]: 'Write the tenant data, including creating and updating the tenant.',
   [TenantScope.DeleteData]: 'Delete data of the tenant.',
+  [TenantScope.ReadMember]: 'Read members of the tenant.',
   [TenantScope.InviteMember]: 'Invite members to the tenant.',
   [TenantScope.RemoveMember]: 'Remove members from the tenant.',
   [TenantScope.UpdateMemberRole]: 'Update the role of a member in the tenant.',
@@ -155,5 +158,10 @@ export const getTenantRole = (role: TenantRole): Readonly<OrganizationRole> =>
 export const tenantRoleScopes: Readonly<Record<TenantRole, Readonly<TenantScope[]>>> =
   Object.freeze({
     [TenantRole.Admin]: allTenantScopes,
-    [TenantRole.Member]: [TenantScope.ReadData, TenantScope.WriteData, TenantScope.DeleteData],
+    [TenantRole.Member]: [
+      TenantScope.ReadData,
+      TenantScope.WriteData,
+      TenantScope.DeleteData,
+      TenantScope.ReadMember,
+    ],
   });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add a new "read:member" scope to both tenant admin and member roles, for browsing tenant members.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
CI

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
