### PR TITLE
chore: update cloud version and the way to call cloud custom JWT API

### DIFF
--- a/packages/connectors/connector-logto-email/package.json
+++ b/packages/connectors/connector-logto-email/package.json
@@ -48,6 +48,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@logto/cloud": "0.2.5-81f06ea"
+    "@logto/cloud": "0.2.5-2a777a1"
   }
 }

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -28,7 +28,7 @@
     "@fontsource/roboto-mono": "^5.0.0",
     "@jest/types": "^29.5.0",
     "@logto/app-insights": "workspace:^1.4.0",
-    "@logto/cloud": "0.2.5-81f06ea",
+    "@logto/cloud": "0.2.5-2a777a1",
     "@logto/connector-kit": "workspace:^2.1.0",
     "@logto/core-kit": "workspace:^2.3.0",
     "@logto/language-kit": "workspace:^1.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -91,7 +91,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@logto/cloud": "0.2.5-81f06ea",
+    "@logto/cloud": "0.2.5-2a777a1",
     "@silverhand/eslint-config": "5.0.0",
     "@silverhand/ts-config": "5.0.0",
     "@types/debug": "^4.1.7",

--- a/packages/schemas/src/types/jwt-customizer.ts
+++ b/packages/schemas/src/types/jwt-customizer.ts
@@ -3,7 +3,11 @@ import { z } from 'zod';
 import { Roles, UserSsoIdentities, Organizations } from '../db-entries/index.js';
 import { jsonObjectGuard, mfaFactorsGuard } from '../foundations/index.js';
 
-import { jwtCustomizerGuard } from './logto-config/index.js';
+import {
+  jwtCustomizerGuard,
+  accessTokenJwtCustomizerGuard,
+  clientCredentialsJwtCustomizerGuard,
+} from './logto-config/index.js';
 import { scopeResponseGuard } from './scope.js';
 import { userInfoGuard } from './user.js';
 
@@ -36,6 +40,29 @@ export enum LogtoJwtTokenPath {
   AccessToken = 'access-token',
   ClientCredentials = 'client-credentials',
 }
+
+/**
+ * This guard is for the core JWT customizer testing API request body guard.
+ */
+export const jwtCustomizerTestRequestBodyGuard = z.discriminatedUnion('tokenType', [
+  z.object({
+    tokenType: z.literal(LogtoJwtTokenPath.AccessToken),
+    payload: accessTokenJwtCustomizerGuard.required({
+      script: true,
+      tokenSample: true,
+      contextSample: true,
+    }),
+  }),
+  z.object({
+    tokenType: z.literal(LogtoJwtTokenPath.ClientCredentials),
+    payload: clientCredentialsJwtCustomizerGuard.required({
+      script: true,
+      tokenSample: true,
+    }),
+  }),
+]);
+
+export type JwtCustomizerTestRequestBody = z.infer<typeof jwtCustomizerTestRequestBodyGuard>;
 
 /**
  * This guard is for cloud API use (request body guard).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1235,8 +1235,8 @@ importers:
         version: 3.22.4
     devDependencies:
       '@logto/cloud':
-        specifier: 0.2.5-81f06ea
-        version: 0.2.5-81f06ea(zod@3.22.4)
+        specifier: 0.2.5-2a777a1
+        version: 0.2.5-2a777a1(zod@3.22.4)
       '@rollup/plugin-commonjs':
         specifier: ^25.0.0
         version: 25.0.7(rollup@4.12.0)
@@ -2715,8 +2715,8 @@ importers:
         specifier: workspace:^1.4.0
         version: link:../app-insights
       '@logto/cloud':
-        specifier: 0.2.5-81f06ea
-        version: 0.2.5-81f06ea(zod@3.22.4)
+        specifier: 0.2.5-2a777a1
+        version: 0.2.5-2a777a1(zod@3.22.4)
       '@logto/connector-kit':
         specifier: workspace:^2.1.0
         version: link:../toolkit/connector-kit
@@ -3202,8 +3202,8 @@ importers:
         version: 3.22.4
     devDependencies:
       '@logto/cloud':
-        specifier: 0.2.5-81f06ea
-        version: 0.2.5-81f06ea(zod@3.22.4)
+        specifier: 0.2.5-2a777a1
+        version: 0.2.5-2a777a1(zod@3.22.4)
       '@silverhand/eslint-config':
         specifier: 5.0.0
         version: 5.0.0(eslint@8.44.0)(prettier@3.0.0)(typescript@5.3.3)
@@ -7647,8 +7647,8 @@ packages:
       jose: 5.2.2
     dev: true
 
-  /@logto/cloud@0.2.5-81f06ea(zod@3.22.4):
-    resolution: {integrity: sha512-7u2VY8qlRoaheWDEbHdoFmQP9MbloKuuCwbz1jk+Wrn2EE1v+tgixVK/MiyFaAN5mLAVLAlCVQ00JIabw+g6YA==}
+  /@logto/cloud@0.2.5-2a777a1(zod@3.22.4):
+    resolution: {integrity: sha512-RnU13Hrv5phYtIjVHDo0Ik1ZFvEOT5XBdQ0fDOHBFuGH+1Xd4X4HK79Mm5iC5JMM7KxxuH7bb6lStCvsOkUUYw==}
     engines: {node: ^20.9.0}
     dependencies:
       '@silverhand/essentials': 2.9.0
@@ -18004,6 +18004,9 @@ packages:
     resolution: {integrity: sha512-2GTVocFkwblV/TIg9AmT7TI2fO4xdWkyN8aFUEVtiVNWt96GTR3FgQyHFValfCbcj1k9Xf962Ws2hYXYUr9k1Q==}
     engines: {node: '>= 12.0.0'}
     hasBin: true
+    peerDependenciesMeta:
+      '@parcel/core':
+        optional: true
     dependencies:
       '@parcel/config-default': 2.9.3(@parcel/core@2.9.3)(postcss@8.4.31)
       '@parcel/core': 2.9.3


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
update cloud version and the way to call cloud custom JWT API.

Context: we have updated the API interface of Logto Cloud POST /services/custom-jwt API in previous PRs ([1](https://github.com/logto-io/logto/pull/5557), [2](https://github.com/logto-io/cloud/pull/567)), we need to update the cloud dependency version as well and update the API call to the POST /services/custom-jwt API.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
