### PR TITLE
fix(core): update expired invitation to expired before inserting a new one

### DIFF
--- a/packages/core/src/libraries/organization-invitation.ts
+++ b/packages/core/src/libraries/organization-invitation.ts
@@ -66,6 +66,11 @@ export class OrganizationInvitationLibrary {
 
     return this.queries.pool.transaction(async (connection) => {
       const organizationQueries = new OrganizationQueries(connection);
+      // Check if any pending invitation has expired, if yes, update the invitation status to "Expired" first
+      // Note: Even if the status may appear to be "Expired", the actual data in DB may still be "Pending".
+      // Check `findEntities` in `OrganizationQueries` for more details.
+      await organizationQueries.invitations.updateExpiredEntities({ invitee, organizationId });
+      // Insert the new invitation
       const invitation = await organizationQueries.invitations.insert({
         id: generateStandardId(),
         inviterId,


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
When inserting a new invitation entity, check if the invitee has expired invitations first. If yes, update the invitation status to "Expired" first, in order to avoid the "unique_integrity_violation".

Root cause:
- The invitation table has a unique index based on "pending invitation status + invitee + org id"
<img width="1051" alt="image" src="https://github.com/logto-io/logto/assets/12833674/1bda031a-94c5-47db-b140-a0b7925f3b1b">

- Also, when fetching invitation entities, the `findEntity` query "fakes" the expired status but not being able to update it
<img width="729" alt="image" src="https://github.com/logto-io/logto/assets/12833674/0defb00e-68bd-4f78-bb92-bc7e15afb43e">


Therefore, we can only update the invitation status to expired before inserting a new one to the same invitee. This seems to be the best opportunity to do it.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested with cloud API locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~ Integration test will be covered in Cloud repo
- [x] necessary TSDoc comments
