### PR TITLE
chore(core,console): update error handling of testing custom JWT

### DIFF
--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/ScriptSection/ErrorContent/index.tsx
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/ScriptSection/ErrorContent/index.tsx
@@ -17,7 +17,7 @@ function ErrorContent({ testResult }: Props) {
       )}
       {testResult.payload && (
         <pre>
-          {'JWT Payload: \n'}
+          {'Extra JWT claims: \n'}
           {testResult.payload}
         </pre>
       )}

--- a/packages/console/src/pages/CustomizeJwtDetails/utils/config.tsx
+++ b/packages/console/src/pages/CustomizeJwtDetails/utils/config.tsx
@@ -209,20 +209,20 @@ export const defaultClientCredentialsPayload: ClientCredentialsPayload = {
 
 const defaultUserContext: Partial<JwtCustomizerUserContext> = {
   id: '123',
-  name: 'Foo Bar',
-  roles: [],
-  avatar: 'https://example.com/avatar.png',
-  profile: {},
   username: 'foo',
-  customData: {},
-  identities: {},
   primaryEmail: 'foo@logto.io',
   primaryPhone: '+1234567890',
+  name: 'Foo Bar',
+  avatar: 'https://example.com/avatar.png',
+  customData: {},
+  identities: {},
+  profile: {},
   applicationId: 'my-app',
-  organizations: [],
   ssoIdentities: [],
-  organizationRoles: [],
   mfaVerificationFactors: [],
+  roles: [],
+  organizations: [],
+  organizationRoles: [],
 };
 
 export const defaultUserTokenContextData = {

--- a/packages/console/src/pages/CustomizeJwtDetails/utils/format.ts
+++ b/packages/console/src/pages/CustomizeJwtDetails/utils/format.ts
@@ -1,4 +1,4 @@
-import { LogtoJwtTokenPath, type AccessTokenJwtCustomizer } from '@logto/schemas';
+import { LogtoJwtTokenPath, type AccessTokenJwtCustomizer, type Json } from '@logto/schemas';
 
 import type { JwtCustomizer, JwtCustomizerForm } from '../type';
 
@@ -36,7 +36,7 @@ const formatEnvVariablesFormDataToRequest = (
   return Object.fromEntries(entries.map(({ key, value }) => [key, value]));
 };
 
-const formatSampleCodeJsonToString = (sampleJson?: AccessTokenJwtCustomizer['contextSample']) => {
+const formatSampleCodeJsonToString = (sampleJson?: Json) => {
   if (!sampleJson) {
     return;
   }
@@ -106,15 +106,12 @@ export const formatFormDataToTestRequestPayload = ({
 }: JwtCustomizerForm) => {
   return {
     tokenType,
-    payload: {
-      script,
-      envVars: formatEnvVariablesFormDataToRequest(environmentVariables),
-      tokenSample:
-        formatSampleCodeStringToJson(testSample.tokenSample) ??
-        defaultValues[tokenType].tokenSample,
-      contextSample:
-        formatSampleCodeStringToJson(testSample.contextSample) ??
-        defaultValues[tokenType].contextSample,
-    },
+    script,
+    envVars: formatEnvVariablesFormDataToRequest(environmentVariables),
+    token:
+      formatSampleCodeStringToJson(testSample.tokenSample) ?? defaultValues[tokenType].tokenSample,
+    context:
+      formatSampleCodeStringToJson(testSample.contextSample) ??
+      defaultValues[tokenType].contextSample,
   };
 };

--- a/packages/core/src/errors/RequestError/index.ts
+++ b/packages/core/src/errors/RequestError/index.ts
@@ -5,7 +5,7 @@ import { conditional, pick } from '@silverhand/essentials';
 import i18next from 'i18next';
 import { ZodError } from 'zod';
 
-const formatZodError = ({ issues }: ZodError): string[] =>
+export const formatZodError = ({ issues }: ZodError): string[] =>
   issues.map((issue) => {
     const base = `Error in key path "${issue.path.map(String).join('.')}": (${issue.code}) `;
 

--- a/packages/schemas/src/types/index.ts
+++ b/packages/schemas/src/types/index.ts
@@ -26,5 +26,4 @@ export * from './tenant.js';
 export * from './tenant-organization.js';
 export * from './mapi-proxy.js';
 export * from './consent.js';
-export * from './jwt-customizer.js';
 export * from './onboarding.js';

--- a/packages/schemas/src/types/logto-config/index.ts
+++ b/packages/schemas/src/types/logto-config/index.ts
@@ -1,11 +1,15 @@
 import type { ZodType } from 'zod';
 import { z } from 'zod';
 
-import { jsonObjectGuard } from '../../foundations/index.js';
-
-import { accessTokenPayloadGuard, clientCredentialsPayloadGuard } from './oidc-provider.js';
+import {
+  type AccessTokenJwtCustomizer,
+  type ClientCredentialsJwtCustomizer,
+  accessTokenJwtCustomizerGuard,
+  clientCredentialsJwtCustomizerGuard,
+} from './jwt-customizer.js';
 
 export * from './oidc-provider.js';
+export * from './jwt-customizer.js';
 
 /**
  * Logto OIDC signing key types, used mainly in REST API routes.
@@ -55,28 +59,6 @@ export enum LogtoJwtTokenKey {
   AccessToken = 'jwt.accessToken',
   ClientCredentials = 'jwt.clientCredentials',
 }
-
-export const jwtCustomizerGuard = z
-  .object({
-    script: z.string(),
-    envVars: z.record(z.string()),
-    contextSample: jsonObjectGuard,
-  })
-  .partial();
-
-export const accessTokenJwtCustomizerGuard = jwtCustomizerGuard.extend({
-  // Use partial token guard since users customization may not rely on all fields.
-  tokenSample: accessTokenPayloadGuard.partial().optional(),
-});
-
-export type AccessTokenJwtCustomizer = z.infer<typeof accessTokenJwtCustomizerGuard>;
-
-export const clientCredentialsJwtCustomizerGuard = jwtCustomizerGuard.extend({
-  // Use partial token guard since users customization may not rely on all fields.
-  tokenSample: clientCredentialsPayloadGuard.partial().optional(),
-});
-
-export type ClientCredentialsJwtCustomizer = z.infer<typeof clientCredentialsJwtCustomizerGuard>;
 
 export type JwtCustomizerType = {
   [LogtoJwtTokenKey.AccessToken]: AccessTokenJwtCustomizer;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
update error handling of testing custom JWT:
1. add API request body error handling for custom JWT console when testing
2. update the custom JWT test API interface, which brings a more understandable error message (we reused zod error message formatter to compose the zod error message, previous interface is not easy to be understood by Logto user due to the nested zod variable path)
3. reorder the content of sample user context to align with the zod guard, so that clicking reset button of sample user context does not change the content in the code editor

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
<img width="1405" alt="image" src="https://github.com/logto-io/logto/assets/15182327/0c558a99-cfc2-43b6-b5ea-7b6e1a5ae64b">
Before this change, the error only show error code without detailed error message, which is hard for debugging.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
