### PR TITLE
style(console): fix the jwt details page style

### DIFF
--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/ScriptSection/index.module.scss
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/ScriptSection/index.module.scss
@@ -6,7 +6,6 @@
   min-width: 50%;
 
   .fixHeightWrapper {
-    margin-bottom: _.unit(3);
     position: absolute;
     inset: 0;
     display: flex;

--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/ScriptSection/index.module.scss
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/ScriptSection/index.module.scss
@@ -1,8 +1,7 @@
 @use '@/scss/underscore' as _;
 
 .scriptSection {
-  position: sticky;
-  top: 0;
+  position: relative;
   min-width: 50%;
 
   .fixHeightWrapper {

--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/index.module.scss
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/index.module.scss
@@ -23,7 +23,3 @@
 .envVariablesField {
   margin-bottom: _.unit(4);
 }
-
-.hint {
-  margin-bottom: _.unit(3);
-}

--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/index.module.scss
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/index.module.scss
@@ -24,7 +24,6 @@
   margin-bottom: _.unit(4);
 }
 
-.description {
-  font: var(--font-body-2);
-  color: var(--color-text-secondary);
+.hint {
+  margin-bottom: _.unit(3);
 }

--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/index.tsx
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/index.tsx
@@ -53,7 +53,7 @@ function InstructionTab({ isActive }: Props) {
               ? accessTokenPayloadTypeDefinition
               : clientCredentialsPayloadTypeDefinition
           }
-          height="350px"
+          height="320px"
           theme="logto-dark"
           options={typeDefinitionCodeEditorOptions}
         />
@@ -70,7 +70,7 @@ function InstructionTab({ isActive }: Props) {
             language="typescript"
             className={styles.sampleCode}
             value={jwtCustomizerUserContextTypeDefinition}
-            height="700px"
+            height="400px"
             theme="logto-dark"
             options={typeDefinitionCodeEditorOptions}
           />
@@ -83,7 +83,9 @@ function InstructionTab({ isActive }: Props) {
           setExpendCard(expand ? CardType.FetchExternalData : undefined);
         }}
       >
-        <div className={styles.description}>{t('jwt_claims.fetch_external_data.description')}</div>
+        <div className={tabContentStyles.description}>
+          {t('jwt_claims.fetch_external_data.description')}
+        </div>
         <Editor
           language="typescript"
           className={styles.sampleCode}
@@ -101,7 +103,7 @@ function InstructionTab({ isActive }: Props) {
         }}
       >
         <EnvironmentVariablesField className={styles.envVariablesField} />
-        <div className={styles.description}>
+        <div className={tabContentStyles.description}>
           {t('jwt_claims.environment_variables.sample_code')}
         </div>
         <Editor
@@ -113,7 +115,9 @@ function InstructionTab({ isActive }: Props) {
           options={sampleCodeEditorOptions}
         />
       </GuideCard>
-      <div className={tabContentStyles.description}>{t('jwt_claims.jwt_claims_description')}</div>
+      <div className={classNames(tabContentStyles.description, styles.hint)}>
+        {t('jwt_claims.jwt_claims_description')}
+      </div>
     </div>
   );
 }

--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/index.tsx
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/index.tsx
@@ -115,9 +115,7 @@ function InstructionTab({ isActive }: Props) {
           options={sampleCodeEditorOptions}
         />
       </GuideCard>
-      <div className={classNames(tabContentStyles.description, styles.hint)}>
-        {t('jwt_claims.jwt_claims_description')}
-      </div>
+      <div className={tabContentStyles.description}>{t('jwt_claims.jwt_claims_description')}</div>
     </div>
   );
 }

--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/TestTab/index.module.scss
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/TestTab/index.module.scss
@@ -3,3 +3,8 @@
 .error {
   color: var(--color-error);
 }
+
+.codeEditor {
+  min-height: 400px;
+  flex-grow: 1;
+}

--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/TestTab/index.tsx
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/TestTab/index.tsx
@@ -108,7 +108,7 @@ function TestTab({ isActive }: Props) {
           }}
           render={({ field }) => (
             <MonacoCodeEditor
-              className={tabContentStyles.flexGrow}
+              className={styles.codeEditor}
               enabledActions={['restore', 'copy']}
               models={editorModels}
               activeModelName={activeModelName}

--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/index.module.scss
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/index.module.scss
@@ -4,14 +4,8 @@
 .content {
   display: flex;
   flex-direction: row;
-  flex-grow: 1;
-  overflow: auto;
-  scrollbar-width: none; /* For Firefox */
-  -ms-overflow-style: none;  /* For Internet Explorer and Edge */
-
-  &::-webkit-scrollbar {
-    display: none; /* For Chrome, Safari and Opera */
-  }
+  flex: 1;
+  margin-bottom: _.unit(3);
 
   > * {
     &:first-child {

--- a/packages/console/src/pages/CustomizeJwtDetails/index.module.scss
+++ b/packages/console/src/pages/CustomizeJwtDetails/index.module.scss
@@ -1,9 +1,7 @@
 @use '@/scss/underscore' as _;
 
 .container {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
+  position: relative;
 
   .header {
     flex-shrink: 0;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR includes the following updates:

1. Remove the script section code editor sticky property. As it may cause other side-effects like IntelliSense overflow cutoff, and vertical scroll area limited to the form field instead of page container level. 
2. Instead, set a smaller constant code editor height for all the data type definition editors, so the right settings section's height is manageable.
3. Remove several duplicate styles. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [ ] ~necessary TSDoc comments~
