### PR TITLE
fix(console): fix test result panel overflow bug

### DIFF
--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/MonacoCodeEditor/index.module.scss
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/MonacoCodeEditor/index.module.scss
@@ -71,23 +71,17 @@
     }
   }
 
-  .body {
-    display: flex;
-    flex-direction: column;
+  .editorContainer {
+    position: relative;
     flex-grow: 1;
 
-    .editorContainer {
-      position: relative;
-      flex-grow: 1;
-
-      &.dashboardOpen {
-        flex-grow: 0;
-        height: 50%;
-      }
+    &.dashboardOpen {
+      flex-grow: 0;
+      height: calc(50% - 64px); // 64px = header height
     }
+  }
 
-    .resultPanel {
-      border-radius: 0 0 8px 8px;
-    }
+  .resultPanel {
+    border-radius: 0 0 8px 8px;
   }
 }

--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/MonacoCodeEditor/index.tsx
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/MonacoCodeEditor/index.tsx
@@ -176,30 +176,28 @@ function MonacoCodeEditor({
           {actionButtons}
         </div>
       </header>
-      <div className={styles.body}>
-        <div
-          ref={containerRef}
-          className={classNames(styles.editorContainer, dashboard && styles.dashboardOpen)}
-        >
-          {activeModel && (
-            <Editor
-              height={editorHeight}
-              language={activeModel.language}
-              path={activeModel.name}
-              theme="logto-dark"
-              options={{
-                ...defaultOptions,
-                ...activeModel.options,
-              }}
-              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- empty string is falsy
-              value={value || activeModel.defaultValue}
-              onMount={handleEditorDidMount}
-              onChange={onChange}
-            />
-          )}
-        </div>
-        {dashboard && <DashBoard {...dashboard} className={styles.resultPanel} />}
+      <div
+        ref={containerRef}
+        className={classNames(styles.editorContainer, dashboard && styles.dashboardOpen)}
+      >
+        {activeModel && (
+          <Editor
+            height={editorHeight}
+            language={activeModel.language}
+            path={activeModel.name}
+            theme="logto-dark"
+            options={{
+              ...defaultOptions,
+              ...activeModel.options,
+            }}
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- empty string is falsy
+            value={value || activeModel.defaultValue}
+            onMount={handleEditorDidMount}
+            onChange={onChange}
+          />
+        )}
       </div>
+      {dashboard && <DashBoard {...dashboard} className={styles.resultPanel} />}
     </div>
   );
 }


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This OR fixes the test result panel overflow bug. If the test result content size is huge it will cause the parent flexbox element height to overflow.

Rever the [PR ](https://github.com/logto-io/logto/pull/5625/files#diff-c9494caa1840bf25eda109bf4a77c91edcdc263fe5eeb80e337dc8c37be04d16)

Use CSS to adjust the panel size. 

<img width="812" alt="image" src="https://github.com/logto-io/logto/assets/36393111/cc4349e3-2ce2-4f80-85e1-66f295553091">



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [ ] ~necessary TSDoc comments~
