### PR TITLE
fix(console): should stop requesting invitations api for collaborator role

### DIFF
--- a/packages/console/src/pages/TenantSettings/TenantMembers/hooks.ts
+++ b/packages/console/src/pages/TenantSettings/TenantMembers/hooks.ts
@@ -7,11 +7,13 @@ import { type TenantInvitationResponse, type TenantMemberResponse } from '@/clou
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import { type RequestError } from '@/hooks/use-api';
+import useCurrentTenantScopes from '@/hooks/use-current-tenant-scopes';
 import { hasReachedQuotaLimit, hasSurpassedQuotaLimit } from '@/utils/quota';
 
 const useTenantMembersUsage = () => {
   const { currentPlan } = useContext(SubscriptionDataContext);
   const { currentTenantId } = useContext(TenantsContext);
+  const { canInviteMember } = useCurrentTenantScopes();
 
   const cloudApi = useAuthedCloudApi();
 
@@ -21,7 +23,7 @@ const useTenantMembersUsage = () => {
       cloudApi.get('/api/tenants/:tenantId/members', { params: { tenantId: currentTenantId } })
   );
   const { data: invitations } = useSWR<TenantInvitationResponse[], RequestError>(
-    'api/tenants/:tenantId/invitations',
+    canInviteMember && 'api/tenants/:tenantId/invitations',
     async () =>
       cloudApi.get('/api/tenants/:tenantId/invitations', { params: { tenantId: currentTenantId } })
   );


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Stop requesting `GET /invitations` API for collaborator role, since they don't have the permission to do that.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
