### PR TITLE
refactor(console): hide switching tabs and invite button for collaborators

### DIFF
--- a/packages/console/src/pages/TenantSettings/TenantMembers/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantMembers/index.tsx
@@ -50,16 +50,16 @@ function TenantMembers() {
         className={styles.chargeNotification}
         checkedFlagKey="tenantMember"
       />
-      <div className={styles.tabButtons}>
-        <Button
-          className={classNames(styles.button, !isInvitationTab && styles.active)}
-          icon={<MembersIcon />}
-          title="tenant_members.members"
-          onClick={() => {
-            navigate('.');
-          }}
-        />
-        {canInviteMember && (
+      {canInviteMember && (
+        <div className={styles.tabButtons}>
+          <Button
+            className={classNames(styles.button, !isInvitationTab && styles.active)}
+            icon={<MembersIcon />}
+            title="tenant_members.members"
+            onClick={() => {
+              navigate('.');
+            }}
+          />
           <Button
             className={classNames(styles.button, isInvitationTab && styles.active)}
             icon={<InvitationIcon />}
@@ -68,9 +68,7 @@ function TenantMembers() {
               navigate('invitations');
             }}
           />
-        )}
-        <Spacer />
-        {canInviteMember && (
+          <Spacer />
           <Button
             type="primary"
             size="large"
@@ -80,8 +78,8 @@ function TenantMembers() {
               setShowInviteModal(true);
             }}
           />
-        )}
-      </div>
+        </div>
+      )}
       <Routes>
         <Route path="*" element={<NotFound />} />
         <Route index element={<Members />} />


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
For collaborator role members, hide the switching tabs since they can't invite the others and only have "Members" left.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Admin:
<img width="924" alt="image" src="https://github.com/logto-io/logto/assets/12833674/6ba4a8ca-c542-40be-8a7b-d0c1d89fd114">

Collaborator:
<img width="1054" alt="image" src="https://github.com/logto-io/logto/assets/12833674/cfdb5891-37c1-42ff-bc3b-dc047f97af9d">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
