### PR TITLE
feat(core): add scopes and resource scopes to org role detail api

### DIFF
--- a/packages/integration-tests/src/tests/api/organization/organization-role.test.ts
+++ b/packages/integration-tests/src/tests/api/organization/organization-role.test.ts
@@ -40,6 +40,13 @@ describe('organization role APIs', () => {
       expect(isKeyInObject(body, 'code') && body.code).toBe('entity.unique_integrity_violation');
     });
 
+    it('should get organization role by id successfully', async () => {
+      const createdRole = await roleApi.create({ name: 'test' + randomId() });
+      const role = await roleApi.get(createdRole.id);
+
+      expect(role).toHaveProperty('name', createdRole.name);
+    });
+
     it('should get organization roles successfully', async () => {
       const [name1, name2] = ['test' + randomId(), 'test' + randomId()];
       await Promise.all([
@@ -86,11 +93,14 @@ describe('organization role APIs', () => {
       expect(roles[0]).toHaveProperty('name', name1);
     });
 
-    it('should be able to create and get organization roles by id', async () => {
+    it('should be able to create and get organization role by id', async () => {
       const createdRole = await roleApi.create({ name: 'test' + randomId() });
-      const { scopes, ...role } = await roleApi.get(createdRole.id);
+      const role = await roleApi.get(createdRole.id);
 
-      expect(role).toStrictEqual(createdRole);
+      expect(role).toMatchObject({
+        ...createdRole,
+        resourceScopes: [],
+      });
     });
 
     it('should be able to create a new organization with initial organization scopes and resource scopes', async () => {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Update `GET /organization-roles/:id`, add "scopes" and "resourceScopes", to align the response type with `GET /organization-roles`

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Integrationt tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
