### PR TITLE
feat(console): display api resources in org role permission table

### DIFF
--- a/packages/console/src/components/EditScopeModal/index.tsx
+++ b/packages/console/src/components/EditScopeModal/index.tsx
@@ -1,4 +1,5 @@
-import { type ScopeResponse } from '@logto/schemas';
+import { type AdminConsoleKey } from '@logto/phrases';
+import { type Nullable } from '@silverhand/essentials';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import ReactModal from 'react-modal';
@@ -10,24 +11,43 @@ import TextInput from '@/ds-components/TextInput';
 import * as modalStyles from '@/scss/modal.module.scss';
 import { trySubmitSafe } from '@/utils/form';
 
-type Props = {
-  data: ScopeResponse;
-  onClose: () => void;
-  onSubmit: (scope: ScopeResponse) => Promise<void>;
+export type EditScopeData = {
+  /** Only `description` is editable for all kinds of scopes */
+  description: Nullable<string>;
 };
 
-function EditPermissionModal({ data, onClose, onSubmit }: Props) {
+type Props = {
+  /** The scope name displayed in the name input field */
+  scopeName: string;
+  /** The data to edit */
+  data: EditScopeData;
+  /** Determines the translation keys for texts in the editor modal */
+  text: {
+    /** The translation key of the modal title */
+    title: AdminConsoleKey;
+    /** The field name translation key for the name input */
+    nameField: AdminConsoleKey;
+    /** The field name translation key for the description input */
+    descriptionField: AdminConsoleKey;
+    /** The placeholder translation key for the description input */
+    descriptionPlaceholder: AdminConsoleKey;
+  };
+  onSubmit: (editedData: EditScopeData) => Promise<void>;
+  onClose: () => void;
+};
+
+function EditScopeModal({ scopeName, data, text, onClose, onSubmit }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
   const {
     handleSubmit,
     register,
     formState: { isSubmitting },
-  } = useForm<ScopeResponse>({ defaultValues: data });
+  } = useForm<EditScopeData>({ defaultValues: data });
 
   const onSubmitHandler = handleSubmit(
     trySubmitSafe(async (formData) => {
-      await onSubmit({ ...data, ...formData });
+      await onSubmit(formData);
       onClose();
     })
   );
@@ -43,7 +63,7 @@ function EditPermissionModal({ data, onClose, onSubmit }: Props) {
       }}
     >
       <ModalLayout
-        title="permissions.edit_title"
+        title={text.title}
         footer={
           <>
             <Button isLoading={isSubmitting} title="general.cancel" onClick={onClose} />
@@ -59,14 +79,14 @@ function EditPermissionModal({ data, onClose, onSubmit }: Props) {
         onClose={onClose}
       >
         <form>
-          <FormField title="api_resource_details.permission.name">
-            <TextInput readOnly value={data.name} />
+          <FormField title={text.nameField}>
+            <TextInput readOnly value={scopeName} />
           </FormField>
-          <FormField title="api_resource_details.permission.description">
+          <FormField title={text.descriptionField}>
             <TextInput
               // eslint-disable-next-line jsx-a11y/no-autofocus
               autoFocus
-              placeholder={t('api_resource_details.permission.description_placeholder')}
+              placeholder={String(t(text.descriptionPlaceholder))}
               {...register('description')}
             />
           </FormField>
@@ -76,4 +96,4 @@ function EditPermissionModal({ data, onClose, onSubmit }: Props) {
   );
 }
 
-export default EditPermissionModal;
+export default EditScopeModal;

--- a/packages/console/src/components/PermissionsTable/index.tsx
+++ b/packages/console/src/components/PermissionsTable/index.tsx
@@ -21,9 +21,9 @@ import useApi from '@/hooks/use-api';
 import useDocumentationUrl from '@/hooks/use-documentation-url';
 
 import ActionsButton from '../ActionsButton';
+import EditScopeModal, { type EditScopeData } from '../EditScopeModal';
 import EmptyDataPlaceholder from '../EmptyDataPlaceholder';
 
-import EditPermissionModal from './EditPermissionModal';
 import * as styles from './index.module.scss';
 
 type SearchProps = {
@@ -98,9 +98,9 @@ function PermissionsTable({
 
   const api = useApi();
 
-  const handleEdit = async (scope: ScopeResponse) => {
+  const handleEdit = async (scope: ScopeResponse, editedData: EditScopeData) => {
     const patchApiEndpoint = `api/resources/${scope.resourceId}/scopes/${scope.id}`;
-    await api.patch(patchApiEndpoint, { json: scope });
+    await api.patch(patchApiEndpoint, { json: editedData });
     toast.success(t('permissions.updated'));
     onPermissionUpdated();
   };
@@ -236,12 +236,21 @@ function PermissionsTable({
         onRetry={retryHandler}
       />
       {editingScope && (
-        <EditPermissionModal
+        <EditScopeModal
+          scopeName={editingScope.name}
           data={editingScope}
+          text={{
+            title: 'permissions.edit_title',
+            nameField: 'api_resource_details.permission.name',
+            descriptionField: 'api_resource_details.permission.description',
+            descriptionPlaceholder: 'api_resource_details.permission.description_placeholder',
+          }}
+          onSubmit={async (editedData) => {
+            await handleEdit(editingScope, editedData);
+          }}
           onClose={() => {
             setEditingScope(undefined);
           }}
-          onSubmit={handleEdit}
         />
       )}
     </>

--- a/packages/console/src/pages/OrganizationRoleDetails/Permissions/ResourceName/index.module.scss
+++ b/packages/console/src/pages/OrganizationRoleDetails/Permissions/ResourceName/index.module.scss
@@ -1,0 +1,12 @@
+@use '@/scss/underscore' as _;
+
+.container {
+  margin-left: _.unit(2);
+  color: var(--color-text-secondary);
+
+  .icon {
+    width: 16px;
+    height: 16px;
+    margin-right: _.unit(1);
+  }
+}

--- a/packages/console/src/pages/OrganizationRoleDetails/Permissions/ResourceName/index.tsx
+++ b/packages/console/src/pages/OrganizationRoleDetails/Permissions/ResourceName/index.tsx
@@ -1,0 +1,27 @@
+import { type Resource } from '@logto/schemas';
+import useSWR from 'swr';
+
+import ResourceIcon from '@/assets/icons/resource.svg';
+
+import * as styles from './index.module.scss';
+
+type Props = {
+  resourceId: string;
+};
+
+function ResourceName({ resourceId }: Props) {
+  const { data, isLoading } = useSWR<Resource>(`api/resources/${resourceId}`);
+
+  if (isLoading || !data) {
+    return null;
+  }
+
+  return (
+    <span className={styles.container}>
+      <ResourceIcon className={styles.icon} />
+      {data.name}
+    </span>
+  );
+}
+
+export default ResourceName;

--- a/packages/console/src/pages/OrganizationRoleDetails/Permissions/index.tsx
+++ b/packages/console/src/pages/OrganizationRoleDetails/Permissions/index.tsx
@@ -40,17 +40,17 @@ function Permissions({ organizationRoleId }: Props) {
     keyword: '',
   });
 
-  const filterScopes = useCallback(
+  const filterScopesByKeyword = useCallback(
     (scopes: OrganizationRoleScope[]) => scopes.filter(({ name }) => name.includes(keyword)),
     [keyword]
   );
 
-  const filteredScopes = useMemo(
+  const scopesData = useMemo(
     () =>
       keyword
-        ? [...filterScopes(resourceScopes), ...filterScopes(organizationScopes)]
+        ? [...filterScopesByKeyword(resourceScopes), ...filterScopesByKeyword(organizationScopes)]
         : [...resourceScopes, ...organizationScopes],
-    [filterScopes, keyword, organizationScopes, resourceScopes]
+    [filterScopesByKeyword, keyword, organizationScopes, resourceScopes]
   );
 
   const [editingScope, setEditingScope] = useState<OrganizationScope>();
@@ -80,7 +80,7 @@ function Permissions({ organizationRoleId }: Props) {
   return (
     <>
       <Table
-        rowGroups={[{ key: 'organizationRolePermissions', data: filteredScopes }]}
+        rowGroups={[{ key: 'organizationRolePermissions', data: scopesData }]}
         rowIndexKey="id"
         columns={[
           {

--- a/packages/console/src/pages/OrganizationRoleDetails/Permissions/use-organization-role-scopes.ts
+++ b/packages/console/src/pages/OrganizationRoleDetails/Permissions/use-organization-role-scopes.ts
@@ -1,0 +1,38 @@
+import { type Scope, type OrganizationScope } from '@logto/schemas';
+import useSWR from 'swr';
+
+import { type RequestError } from '@/hooks/use-api';
+
+/**
+ * Fetches the organization and resource scopes of an organization role.
+ */
+function useOrganizationRoleScopes(organizationRoleId: string) {
+  const organizationRolePath = `api/organization-roles/${organizationRoleId}`;
+
+  const {
+    data: organizationScopes = [],
+    error: fetchOrganizationScopesError,
+    isLoading: isOrganizationScopesLoading,
+    mutate: mutateOrganizationScopes,
+  } = useSWR<OrganizationScope[], RequestError>(`${organizationRolePath}/scopes`);
+
+  const {
+    data: resourceScopes = [],
+    error: fetchResourceScopesError,
+    isLoading: isResourceScopesLoading,
+    mutate: mutateResourceScopes,
+  } = useSWR<Scope[], RequestError>(`${organizationRolePath}/resource-scopes`);
+
+  return {
+    organizationScopes,
+    resourceScopes,
+    error: fetchOrganizationScopesError ?? fetchResourceScopesError,
+    isLoading: isOrganizationScopesLoading || isResourceScopesLoading,
+    mutate: () => {
+      void mutateOrganizationScopes();
+      void mutateResourceScopes();
+    },
+  };
+}
+
+export default useOrganizationRoleScopes;

--- a/packages/console/src/pages/OrganizationTemplate/OrganizationRoles/index.tsx
+++ b/packages/console/src/pages/OrganizationTemplate/OrganizationRoles/index.tsx
@@ -70,12 +70,14 @@ function OrganizationRoles() {
             title: <DynamicT forKey="organization_template.roles.permissions_column" />,
             dataIndex: 'scopes',
             colSpan: 12,
-            render: ({ scopes }) => {
-              return scopes.length === 0 ? (
+            render: ({ scopes, resourceScopes }) => {
+              const roleScopes = [...scopes, ...resourceScopes];
+
+              return roleScopes.length === 0 ? (
                 '-'
               ) : (
                 <div className={styles.permissions}>
-                  {scopes.map(({ id, name }) => (
+                  {roleScopes.map(({ id, name }) => (
                     <Tag key={id} variant="cell">
                       <Breakable>{name}</Breakable>
                     </Tag>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
feat(console): display api resources in org role permission table
This PR also includes the following updates:
- Extract & rename `EditPermissionModal` into `EditScopeModal` and share it between resource permissions and org role permissions page
- Support editing API resource scope on role permissions page



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

<img width="1392" alt="image" src="https://github.com/logto-io/logto/assets/10806653/453ad1b6-4ac3-4f64-946b-bb149629dc4d">

![image](https://github.com/logto-io/logto/assets/10806653/66846387-9496-4a5b-a282-79fb212ff0e3)

![image](https://github.com/logto-io/logto/assets/10806653/bf276d88-5a9a-4a93-9d04-fc05b4f5d8a3)


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
