### PR TITLE
refactor(console): deprecate original organization template page

### DIFF
--- a/packages/console/src/containers/ConsoleContent/index.tsx
+++ b/packages/console/src/containers/ConsoleContent/index.tsx
@@ -202,10 +202,14 @@ function ConsoleContent() {
             <Route path="organizations">
               <Route index element={<Organizations />} />
               <Route path="create" element={<Organizations />} />
-              <Route path="template" element={<Organizations tab="template" />} />
+              {!isDevFeaturesEnabled && (
+                <Route path="template" element={<Organizations tab="template" />} />
+              )}
               <Route path=":id/*" element={<OrganizationDetails />} />
             </Route>
-            <Route path="organization-guide/*" element={<OrganizationGuide />} />
+            {!isDevFeaturesEnabled && (
+              <Route path="organization-guide/*" element={<OrganizationGuide />} />
+            )}
             <Route path="profile">
               <Route index element={<Profile />} />
               <Route path="verify-password" element={<VerifyPasswordModal />} />

--- a/packages/console/src/pages/Organizations/index.tsx
+++ b/packages/console/src/pages/Organizations/index.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import Plus from '@/assets/icons/plus.svg';
 import PageMeta from '@/components/PageMeta';
 import { organizationsFeatureLink } from '@/consts';
-import { isCloud } from '@/consts/env';
+import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
 import { subscriptionPage } from '@/consts/pages';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import { TenantsContext } from '@/contexts/TenantsProvider';
@@ -51,7 +51,7 @@ function Organizations({ tab }: Props) {
   }, [navigate]);
 
   const handleCreate = useCallback(() => {
-    if (isInitialSetup) {
+    if (isInitialSetup && !isDevFeaturesEnabled) {
       navigate(guidePathname);
       return;
     }
@@ -91,7 +91,7 @@ function Organizations({ tab }: Props) {
           />
         )}
       </div>
-      {isInitialSetup && (
+      {isInitialSetup && !isDevFeaturesEnabled && (
         <Card className={styles.emptyCardContainer}>
           <EmptyDataPlaceholder
             buttonProps={{
@@ -104,7 +104,7 @@ function Organizations({ tab }: Props) {
           />
         </Card>
       )}
-      {!isInitialSetup && (
+      {!isInitialSetup && !isDevFeaturesEnabled && (
         <>
           <TabNav className={styles.tabs}>
             <TabNavItem href="/organizations" isActive={!tab}>
@@ -120,6 +120,21 @@ function Organizations({ tab }: Props) {
           {!tab && <OrganizationsTable isLoading={isLoadingConfigs} onCreate={handleCreate} />}
           {tab === 'template' && <Settings />}
         </>
+      )}
+      {isDevFeaturesEnabled && isOrganizationsDisabled && (
+        <Card className={styles.emptyCardContainer}>
+          <EmptyDataPlaceholder
+            buttonProps={{
+              title: 'upsell.upgrade_plan',
+              onClick: upgradePlan,
+              // Set to `undefined` to override the default icon
+              icon: undefined,
+            }}
+          />
+        </Card>
+      )}
+      {isDevFeaturesEnabled && !isOrganizationsDisabled && (
+        <OrganizationsTable isLoading={isLoadingConfigs} onCreate={handleCreate} />
       )}
     </div>
   );


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Deprecate original organization template page since it has been moved to a single page.
This PR also deprecate the original guide when creating a organization, since the guide has simplified and displayed on the organizaion template page.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

![image](https://github.com/logto-io/logto/assets/10806653/309c9ba7-31bf-4557-8836-da2bbefcf5bb)


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
