### PR TITLE
feat(core): add custom jwt worker deploy

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -91,7 +91,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@logto/cloud": "0.2.5-ab8a489",
+    "@logto/cloud": "0.2.5-749cae5",
     "@silverhand/eslint-config": "5.0.0",
     "@silverhand/ts-config": "5.0.0",
     "@types/debug": "^4.1.7",

--- a/packages/core/src/libraries/cloud-connection.test.ts
+++ b/packages/core/src/libraries/cloud-connection.test.ts
@@ -38,6 +38,7 @@ const logtoConfigs: LogtoConfigLibrary = {
   getJwtCustomizer: jest.fn(),
   getJwtCustomizers: jest.fn(),
   updateJwtCustomizer: jest.fn(),
+  deployJwtCustomizerScript: jest.fn(),
 };
 
 describe('getAccessToken()', () => {

--- a/packages/core/src/libraries/sign-in-experience/index.test.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.test.ts
@@ -3,10 +3,10 @@ import { builtInLanguages } from '@logto/phrases-experience';
 import type { CreateSignInExperience, SignInExperience } from '@logto/schemas';
 
 import {
-  socialTarget01,
-  socialTarget02,
   mockSignInExperience,
   mockSocialConnectors,
+  socialTarget01,
+  socialTarget02,
   wellConfiguredSsoConnector,
 } from '#src/__mocks__/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
@@ -61,6 +61,7 @@ const cloudConnection = createCloudConnectionLibrary({
   getJwtCustomizer: jest.fn(),
   getJwtCustomizers: jest.fn(),
   updateJwtCustomizer: jest.fn(),
+  deployJwtCustomizerScript: jest.fn(),
 });
 
 const getLogtoConnectors = jest.spyOn(connectorLibrary, 'getLogtoConnectors');

--- a/packages/core/src/routes/logto-config/jwt-customizer.test.ts
+++ b/packages/core/src/routes/logto-config/jwt-customizer.test.ts
@@ -4,9 +4,9 @@ import { pick } from '@silverhand/essentials';
 import Sinon from 'sinon';
 
 import {
-  mockLogtoConfigRows,
   mockJwtCustomizerConfigForAccessToken,
   mockJwtCustomizerConfigForClientCredentials,
+  mockLogtoConfigRows,
 } from '#src/__mocks__/index.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
 import { createRequester } from '#src/utils/test-utils.js';
@@ -23,6 +23,7 @@ const logtoConfigLibraries = {
   getJwtCustomizer: jest.fn(),
   getJwtCustomizers: jest.fn(),
   updateJwtCustomizer: jest.fn(),
+  deployJwtCustomizerScript: jest.fn(),
 };
 
 const settingRoutes = await pickDefault(import('./index.js'));
@@ -52,6 +53,9 @@ describe('configs JWT customizer routes', () => {
     const response = await routeRequester
       .put(`/configs/jwt-customizer/access-token`)
       .send(mockJwtCustomizerConfigForAccessToken.value);
+
+    expect(logtoConfigLibraries.upsertJwtCustomizer).toHaveBeenCalled();
+
     expect(logtoConfigLibraries.upsertJwtCustomizer).toHaveBeenCalledWith(
       LogtoJwtTokenKey.AccessToken,
       mockJwtCustomizerConfigForAccessToken.value
@@ -87,6 +91,9 @@ describe('configs JWT customizer routes', () => {
     const response = await routeRequester
       .patch('/configs/jwt-customizer/access-token')
       .send(mockJwtCustomizerConfigForAccessToken.value);
+
+    expect(logtoConfigLibraries.deployJwtCustomizerScript).toHaveBeenCalled();
+
     expect(logtoConfigLibraries.updateJwtCustomizer).toHaveBeenCalledWith(
       LogtoJwtTokenKey.AccessToken,
       mockJwtCustomizerConfigForAccessToken.value

--- a/packages/core/src/utils/custom-jwt.ts
+++ b/packages/core/src/utils/custom-jwt.ts
@@ -1,0 +1,8 @@
+import { LogtoJwtTokenKey, type JwtCustomizerType } from '@logto/schemas';
+
+export const getJwtCustomizerScripts = (jwtCustomizers: Partial<JwtCustomizerType>) => {
+  // eslint-disable-next-line no-restricted-syntax -- enable to infer the type using `Object.fromEntries`
+  return Object.fromEntries(
+    Object.values(LogtoJwtTokenKey).map((key) => [key, jwtCustomizers[key]?.script])
+  ) as { [key in LogtoJwtTokenKey]?: string };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3202,8 +3202,8 @@ importers:
         version: 3.22.4
     devDependencies:
       '@logto/cloud':
-        specifier: 0.2.5-ab8a489
-        version: 0.2.5-ab8a489(zod@3.22.4)
+        specifier: 0.2.5-749cae5
+        version: 0.2.5-749cae5(zod@3.22.4)
       '@silverhand/eslint-config':
         specifier: 5.0.0
         version: 5.0.0(eslint@8.44.0)(prettier@3.0.0)(typescript@5.3.3)
@@ -7642,6 +7642,16 @@ packages:
       '@silverhand/essentials': 2.9.0
       camelcase-keys: 7.0.2
       jose: 5.2.2
+    dev: true
+
+  /@logto/cloud@0.2.5-749cae5(zod@3.22.4):
+    resolution: {integrity: sha512-QzebHRSBShQwOsKAvYlVd7QF43RlrHOt/nmwrlRNW4F9U0DUEFaeLZujYS56oxjQ49GRdsOPKSQCE97wRB7NNQ==}
+    engines: {node: ^20.9.0}
+    dependencies:
+      '@silverhand/essentials': 2.9.0
+      '@withtyped/server': 0.13.3(zod@3.22.4)
+    transitivePeerDependencies:
+      - zod
     dev: true
 
   /@logto/cloud@0.2.5-ab8a489(zod@3.22.4):


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Call the custom JWT cloud's worker deployment service when upsert a new jwt-customizer.

This PR includes the following changes:
1. bump the @logto/cloud package version to pick up the latest cloud /service/custom-jwt/worker endpoints
2. Define a new `deployJwtCustomizerScript` library method. It takes the latest jwt-customizer data as input merges with the values stored in DB and deploys to the external worker service. 
3. Update the PUT/PATCH `/logto-configs/jwt-cuszomizer/:tokenTypePath` endpoints to call the deploy method before insert into DB. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
UT added

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [x] necessary TSDoc comments
