### PR TITLE
feat(core): undeploy worker scripts when jwt customizer is deleted

### DIFF
--- a/packages/core/src/libraries/cloud-connection.test.ts
+++ b/packages/core/src/libraries/cloud-connection.test.ts
@@ -2,6 +2,8 @@ import { GlobalValues } from '@logto/shared';
 import { createMockUtils } from '@logto/shared/esm';
 import nock from 'nock';
 
+import { mockLogtoConfigsLibrary } from '#src/test-utils/mock-libraries.js';
+
 import { type LogtoConfigLibrary } from './logto-config.js';
 
 const { jest } = import.meta;
@@ -28,17 +30,12 @@ await mockEsmWithActual('#src/env-set/index.js', () => ({
 const { createCloudConnectionLibrary } = await import('./cloud-connection.js');
 
 const logtoConfigs: LogtoConfigLibrary = {
+  ...mockLogtoConfigsLibrary,
   getCloudConnectionData: jest.fn().mockResolvedValue({
     appId: 'appId',
     appSecret: 'appSecret',
     resource: 'resource',
   }),
-  getOidcConfigs: jest.fn(),
-  upsertJwtCustomizer: jest.fn(),
-  getJwtCustomizer: jest.fn(),
-  getJwtCustomizers: jest.fn(),
-  updateJwtCustomizer: jest.fn(),
-  deployJwtCustomizerScript: jest.fn(),
 };
 
 describe('getAccessToken()', () => {

--- a/packages/core/src/libraries/sign-in-experience/index.test.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.test.ts
@@ -11,6 +11,7 @@ import {
 } from '#src/__mocks__/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { ssoConnectorFactories } from '#src/sso/index.js';
+import { mockLogtoConfigsLibrary } from '#src/test-utils/mock-libraries.js';
 
 import { createCloudConnectionLibrary } from '../cloud-connection.js';
 import { createConnectorLibrary } from '../connector.js';
@@ -51,17 +52,12 @@ const connectorLibrary = createConnectorLibrary(queries, {
   getClient: jest.fn(),
 });
 const cloudConnection = createCloudConnectionLibrary({
+  ...mockLogtoConfigsLibrary,
   getCloudConnectionData: jest.fn().mockResolvedValue({
     appId: 'appId',
     appSecret: 'appSecret',
     resource: 'resource',
   }),
-  getOidcConfigs: jest.fn(),
-  upsertJwtCustomizer: jest.fn(),
-  getJwtCustomizer: jest.fn(),
-  getJwtCustomizers: jest.fn(),
-  updateJwtCustomizer: jest.fn(),
-  deployJwtCustomizerScript: jest.fn(),
 });
 
 const getLogtoConnectors = jest.spyOn(connectorLibrary, 'getLogtoConnectors');

--- a/packages/core/src/routes/logto-config/jwt-customizer.test.ts
+++ b/packages/core/src/routes/logto-config/jwt-customizer.test.ts
@@ -24,6 +24,7 @@ const logtoConfigLibraries = {
   getJwtCustomizers: jest.fn(),
   updateJwtCustomizer: jest.fn(),
   deployJwtCustomizerScript: jest.fn(),
+  undeployJwtCustomizerScript: jest.fn(),
 };
 
 const settingRoutes = await pickDefault(import('./index.js'));
@@ -126,6 +127,10 @@ describe('configs JWT customizer routes', () => {
 
   it('DELETE /configs/jwt-customizer/:tokenType should delete the record', async () => {
     const response = await routeRequester.delete('/configs/jwt-customizer/client-credentials');
+    expect(logtoConfigLibraries.undeployJwtCustomizerScript).toHaveBeenCalledWith(
+      tenantContext.cloudConnection,
+      LogtoJwtTokenKey.ClientCredentials
+    );
     expect(logtoConfigQueries.deleteJwtCustomizer).toHaveBeenCalledWith(
       LogtoJwtTokenKey.ClientCredentials
     );

--- a/packages/core/src/test-utils/mock-libraries.ts
+++ b/packages/core/src/test-utils/mock-libraries.ts
@@ -1,0 +1,14 @@
+import { type LogtoConfigLibrary } from '#src/libraries/logto-config.js';
+
+const { jest } = import.meta;
+
+export const mockLogtoConfigsLibrary: LogtoConfigLibrary = {
+  getCloudConnectionData: jest.fn(),
+  getOidcConfigs: jest.fn(),
+  upsertJwtCustomizer: jest.fn(),
+  getJwtCustomizer: jest.fn(),
+  getJwtCustomizers: jest.fn(),
+  updateJwtCustomizer: jest.fn(),
+  deployJwtCustomizerScript: jest.fn(),
+  undeployJwtCustomizerScript: jest.fn(),
+};


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Undeloy the worker script when the JWT customizer is deleted.

Add new method to:
1. call the delete worker cloud service if the only JWT customizer has been deleted
2. call the put worker cloud service to redeploy the worker with the deleted token customizer script being removed. 

<img width="767" alt="image" src="https://github.com/logto-io/logto/assets/36393111/ae4d0f56-af32-4e51-a8b9-a59fbe9f4663">
<img width="842" alt="image" src="https://github.com/logto-io/logto/assets/36393111/03c4d88f-42ed-49c0-8e2d-df1cd5392c5e">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [x] unit tests
- [ ] ~integration tests~
- [x] necessary TSDoc comments
