### PR TITLE
fix(console): fix the quota guard layout

### DIFF
--- a/packages/console/src/components/QuotaGuardFooter/index.module.scss
+++ b/packages/console/src/components/QuotaGuardFooter/index.module.scss
@@ -7,6 +7,7 @@
   padding: _.unit(6);
   background-color: var(--color-info-container);
   margin: 0 _.unit(-6) _.unit(-6);
+  flex: 1;
 
   .description {
     flex: 1;

--- a/packages/console/src/components/QuotaGuardFooter/index.module.scss
+++ b/packages/console/src/components/QuotaGuardFooter/index.module.scss
@@ -7,7 +7,7 @@
   padding: _.unit(6);
   background-color: var(--color-info-container);
   margin: 0 _.unit(-6) _.unit(-6);
-  flex: 1;
+  flex: 1; // Should display in full width
 
   .description {
     flex: 1;


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the quota guard layout.

Issue: the `QuotaGuardFooter` component is not displayed in full width under the large-size modal. 
Cause: We have a `justify-content: flex-end` style applied to all the model footer containers. 


Before:
<img width="1233" alt="image" src="https://github.com/logto-io/logto/assets/36393111/2fbf1d3d-2faa-46a7-a84f-5662b5bed186">


After:
<img width="1250" alt="image" src="https://github.com/logto-io/logto/assets/36393111/570e7ec8-8260-4447-9fff-7ca60fec13aa">



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ～`.changeset`～
- [ ] ～unit tests～
- [ ] ～integration tests～
- [x] necessary TSDoc comments
