### PR TITLE
refactor(core,schemas): make the jwt customizer script field mandatory

### DIFF
--- a/packages/core/src/routes/logto-config/jwt-customizer.test.ts
+++ b/packages/core/src/routes/logto-config/jwt-customizer.test.ts
@@ -155,11 +155,10 @@ describe('configs JWT customizer routes', () => {
     jest.spyOn(mockCloudClient, 'post').mockResolvedValue(cloudConnectionResponse);
 
     const payload: JwtCustomizerTestRequestBody = {
-      tokenType: LogtoJwtTokenKeyType.AccessToken,
+      tokenType: LogtoJwtTokenKeyType.ClientCredentials,
+      script: mockJwtCustomizerConfigForClientCredentials.value.script,
+      environmentVariables: mockJwtCustomizerConfigForClientCredentials.value.environmentVariables,
       token: {},
-      script: mockJwtCustomizerConfigForAccessToken.value.script,
-      environmentVariables: mockJwtCustomizerConfigForAccessToken.value.environmentVariables,
-      context: mockJwtCustomizerConfigForAccessToken.value.contextSample,
     };
 
     const response = await routeRequester.post('/configs/jwt-customizer/test').send(payload);
@@ -167,7 +166,7 @@ describe('configs JWT customizer routes', () => {
     expect(mockLogtoConfigsLibrary.deployJwtCustomizerScript).toHaveBeenCalledWith(
       tenantContext.cloudConnection,
       {
-        key: LogtoJwtTokenKey.AccessToken,
+        key: LogtoJwtTokenKey.ClientCredentials,
         value: payload,
         isTest: true,
       }

--- a/packages/core/src/routes/logto-config/jwt-customizer.ts
+++ b/packages/core/src/routes/logto-config/jwt-customizer.ts
@@ -207,11 +207,6 @@ export default function logtoConfigJwtCustomizerRoutes<T extends AuthedRouter>(
   router.post(
     '/configs/jwt-customizer/test',
     koaGuard({
-      /**
-       * Early throws when:
-       * 1. no `script` provided.
-       * 2. no `tokenSample` provided.
-       */
       body: jwtCustomizerTestRequestBodyGuard,
       response: jsonObjectGuard,
       status: [200, 400, 403, 422],

--- a/packages/schemas/alterations/next-1712912361-delete-jwt-customier-with-empty-script.ts
+++ b/packages/schemas/alterations/next-1712912361-delete-jwt-customier-with-empty-script.ts
@@ -2,11 +2,6 @@ import { sql } from '@silverhand/slonik';
 
 import type { AlterationScript } from '../lib/types/alteration.js';
 
-const enum LogtoJwtTokenKey {
-  AccessToken = 'jwt.accessToken',
-  ClientCredentials = 'jwt.clientCredentials',
-}
-
 const alteration: AlterationScript = {
   // We are making the jwt-customizer script field mandatory
   // Delete the records in logto_configs where key is jwt.accessToken or jwt.clientCredentials and value jsonb's script field is undefined
@@ -14,7 +9,7 @@ const alteration: AlterationScript = {
     await pool.query(
       sql`
         delete from logto_configs 
-        where key in ('${LogtoJwtTokenKey.AccessToken}', '${LogtoJwtTokenKey.ClientCredentials}')
+        where key in ('jwt.accessToken', 'jwt.clientCredentials')
         and value->>'script' is null
       `
     );

--- a/packages/schemas/alterations/next-1712912361-delete-jwt-customier-with-empty-script.ts
+++ b/packages/schemas/alterations/next-1712912361-delete-jwt-customier-with-empty-script.ts
@@ -1,0 +1,28 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const enum LogtoJwtTokenKey {
+  AccessToken = 'jwt.accessToken',
+  ClientCredentials = 'jwt.clientCredentials',
+}
+
+const alteration: AlterationScript = {
+  // We are making the jwt-customizer script field mandatory
+  // Delete the records in logto_configs where key is jwt.accessToken or jwt.clientCredentials and value jsonb's script field is undefined
+  up: async (pool) => {
+    await pool.query(
+      sql`
+        delete from logto_configs 
+        where key in ('${LogtoJwtTokenKey.AccessToken}', '${LogtoJwtTokenKey.ClientCredentials}')
+        and value->>'script' is null
+      `
+    );
+  },
+  down: async () => {
+    // No down script available, this is a non-reversible operation
+    // It is fine since we have not released this feature yet
+  },
+};
+
+export default alteration;


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Make the JWT customizer script field mandatory. 

Since we change the user flow in the admin console to create and delete a jwt-customizer, a customizer with an empty script (undefined) value is no longer valid.  Update the guard type to be required. 
Add a db alteration to delete all the dev jwt-customizer records with undefined script. 



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
