### PR TITLE
feat(core): add customJwt paywall guard to core API

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -28,7 +28,7 @@
     "@fontsource/roboto-mono": "^5.0.0",
     "@jest/types": "^29.5.0",
     "@logto/app-insights": "workspace:^1.4.0",
-    "@logto/cloud": "0.2.5-ab8a489",
+    "@logto/cloud": "0.2.5-94f7bcc",
     "@logto/connector-kit": "workspace:^3.0.0",
     "@logto/core-kit": "workspace:^2.4.0",
     "@logto/language-kit": "workspace:^1.1.0",

--- a/packages/console/src/consts/quota-item-phrases.ts
+++ b/packages/console/src/consts/quota-item-phrases.ts
@@ -27,6 +27,7 @@ export const quotaItemPhrasesMap: Record<
   organizationsEnabled: 'organizations_enabled.name',
   ssoEnabled: 'sso_enabled.name',
   tenantMembersLimit: 'tenant_members_limit.name',
+  customJwtEnabled: 'custom_jwt_enabled.name',
 };
 
 export const quotaItemUnlimitedPhrasesMap: Record<
@@ -54,6 +55,7 @@ export const quotaItemUnlimitedPhrasesMap: Record<
   organizationsEnabled: 'organizations_enabled.unlimited',
   ssoEnabled: 'sso_enabled.unlimited',
   tenantMembersLimit: 'tenant_members_limit.unlimited',
+  customJwtEnabled: 'custom_jwt_enabled.unlimited',
 };
 
 export const quotaItemLimitedPhrasesMap: Record<
@@ -81,6 +83,7 @@ export const quotaItemLimitedPhrasesMap: Record<
   organizationsEnabled: 'organizations_enabled.limited',
   ssoEnabled: 'sso_enabled.limited',
   tenantMembersLimit: 'tenant_members_limit.limited',
+  customJwtEnabled: 'custom_jwt_enabled.limited',
 };
 
 export const quotaItemNotEligiblePhrasesMap: Record<
@@ -108,4 +111,5 @@ export const quotaItemNotEligiblePhrasesMap: Record<
   organizationsEnabled: 'organizations_enabled.not_eligible',
   ssoEnabled: 'sso_enabled.not_eligible',
   tenantMembersLimit: 'tenant_members_limit.not_eligible',
+  customJwtEnabled: 'custom_jwt_enabled.not_eligible',
 };

--- a/packages/console/src/consts/tenants.ts
+++ b/packages/console/src/consts/tenants.ts
@@ -1,4 +1,4 @@
-import { TenantTag, ReservedPlanId, defaultManagementApi } from '@logto/schemas';
+import { ReservedPlanId, TenantTag, defaultManagementApi } from '@logto/schemas';
 import dayjs from 'dayjs';
 
 import { type TenantResponse } from '@/cloud/types/router';
@@ -67,6 +67,7 @@ export const defaultSubscriptionPlan: SubscriptionPlan = {
     ticketSupportResponseTime: 48,
     thirdPartyApplicationsLimit: null,
     tenantMembersLimit: null,
+    customJwtEnabled: true,
   },
 };
 

--- a/packages/console/src/contexts/AppConfirmModalProvider/index.tsx
+++ b/packages/console/src/contexts/AppConfirmModalProvider/index.tsx
@@ -1,9 +1,9 @@
 import type { Nullable } from '@silverhand/essentials';
 import { noop } from '@silverhand/essentials';
-import { useState, useRef, useMemo, createContext, useCallback, useEffect } from 'react';
+import { createContext, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import ConfirmModal from '@/ds-components/ConfirmModal';
 import type { ConfirmModalProps } from '@/ds-components/ConfirmModal';
+import ConfirmModal from '@/ds-components/ConfirmModal';
 
 type ModalContentRenderProps = {
   confirm: (data?: unknown) => void;
@@ -108,13 +108,7 @@ function AppConfirmModalProvider({ children }: Props) {
       {children}
       <ConfirmModal
         {...restProps}
-        onConfirm={
-          type === 'confirm'
-            ? () => {
-                handleConfirm();
-              }
-            : undefined
-        }
+        onConfirm={type === 'confirm' ? handleConfirm : undefined}
         onCancel={() => {
           handleCancel();
         }}

--- a/packages/console/src/pages/CustomizeJwt/CreateButton/index.tsx
+++ b/packages/console/src/pages/CustomizeJwt/CreateButton/index.tsx
@@ -1,6 +1,11 @@
 import { type LogtoJwtTokenKeyType } from '@logto/schemas';
+import { useCallback, useContext } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
 
+import ContactUsPhraseLink from '@/components/ContactUsPhraseLink';
+import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import Button from '@/ds-components/Button';
+import { useConfirmModal } from '@/hooks/use-confirm-modal';
 import useTenantPathname from '@/hooks/use-tenant-pathname';
 import { getPagePath } from '@/pages/CustomizeJwt/utils/path';
 
@@ -11,14 +16,47 @@ type Props = {
 function CreateButton({ tokenType }: Props) {
   const link = getPagePath(tokenType, 'create');
   const { navigate } = useTenantPathname();
+  const { show } = useConfirmModal();
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+
+  const { currentPlan } = useContext(SubscriptionDataContext);
+  const {
+    quota: { customJwtEnabled },
+  } = currentPlan;
+
+  const onCreateButtonClick = useCallback(async () => {
+    if (customJwtEnabled) {
+      navigate(link);
+      return;
+    }
+
+    const [confirm] = await show({
+      title: 'upsell.paywall.custom_jwt.title',
+      ModalContent: () => (
+        <Trans
+          components={{
+            a: <ContactUsPhraseLink />,
+          }}
+        >
+          {t('upsell.paywall.custom_jwt.description')}
+        </Trans>
+      ),
+      confirmButtonText: 'upsell.upgrade_plan',
+      confirmButtonType: 'primary',
+      isCancelButtonVisible: false,
+    });
+
+    if (confirm) {
+      // Navigate to subscription page by default
+      navigate('/tenant-settings/subscription');
+    }
+  }, [customJwtEnabled, link, navigate, show, t]);
 
   return (
     <Button
       type="primary"
       title="jwt_claims.custom_jwt_create_button"
-      onClick={() => {
-        navigate(link);
-      }}
+      onClick={onCreateButtonClick}
     />
   );
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -92,7 +92,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@logto/cloud": "0.2.5-749cae5",
+    "@logto/cloud": "0.2.5-94f7bcc",
     "@silverhand/eslint-config": "5.0.0",
     "@silverhand/ts-config": "5.0.0",
     "@types/debug": "^4.1.7",

--- a/packages/core/src/libraries/quota.ts
+++ b/packages/core/src/libraries/quota.ts
@@ -1,5 +1,5 @@
 import { ConnectorType, DemoConnector } from '@logto/connector-kit';
-import { RoleType, ReservedPlanId } from '@logto/schemas';
+import { ReservedPlanId, RoleType } from '@logto/schemas';
 
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
@@ -72,6 +72,7 @@ export const createQuotaLibrary = (
     ssoEnabled: notNumber,
     omniSignInEnabled: notNumber, // No limit for now
     builtInEmailConnectorEnabled: notNumber, // No limit for now
+    customJwtEnabled: notNumber, // No limit for now
   };
 
   const getTenantUsage = async (key: keyof FeatureQuota, queryKey?: string): Promise<number> => {

--- a/packages/phrases/src/locales/de/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/subscription/quota-item.ts
@@ -163,6 +163,16 @@ const quota_item = {
     /** UNTRANSLATED */
     not_eligible: 'Remove your tenant members',
   },
+  custom_jwt_enabled: {
+    /** UNTRANSLATED */
+    name: 'Custom JWT',
+    /** UNTRANSLATED */
+    limited: 'Custom JWT',
+    /** UNTRANSLATED */
+    unlimited: 'Custom JWT',
+    /** UNTRANSLATED */
+    not_eligible: 'Remove your JWT claims customizer',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/de/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/tabs.ts
@@ -15,7 +15,7 @@ const tabs = {
   tenant_settings: 'Einstellungen',
   mfa: 'Multi-Faktor-Authentifizierung',
   /** UNTRANSLATED */
-  customize_jwt: 'JWT Claims',
+  customize_jwt: 'Custom JWT',
   signing_keys: 'Signierschlüssel',
   organization_template: 'Organisationstemplate',
 };

--- a/packages/phrases/src/locales/de/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/upsell/paywall.ts
@@ -64,6 +64,13 @@ const paywall = {
   /** UNTRANSLATED */
   tenant_members_dev_plan:
     "You've reached your {{limit}}-member limit. Release a member or revoke a pending invitation to add someone new. Need more seats? Feel free to contact us.",
+  custom_jwt: {
+    /** UNTRANSLATED */
+    title: 'Add custom claims',
+    /** UNTRANSLATED */
+    description:
+      "Upgrade to a paid plan for custom JWT functionality and premium benefits. Don't hesitate to <a>contact us</a> if you have any questions.",
+  },
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/en/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/subscription/quota-item.ts
@@ -153,6 +153,12 @@ const quota_item = {
     unlimited: 'Unlimited tenant members',
     not_eligible: 'Remove your tenant members',
   },
+  custom_jwt_enabled: {
+    name: 'Custom JWT',
+    limited: 'Custom JWT',
+    unlimited: 'Custom JWT',
+    not_eligible: 'Remove your JWT claims customizer',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/en/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/tabs.ts
@@ -14,7 +14,7 @@ const tabs = {
   docs: 'Docs',
   tenant_settings: 'Settings',
   mfa: 'Multi-factor auth',
-  customize_jwt: 'JWT Claims',
+  customize_jwt: 'Custom JWT',
   signing_keys: 'Signing keys',
   organization_template: 'Organization template',
 };

--- a/packages/phrases/src/locales/en/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/upsell/paywall.ts
@@ -60,6 +60,11 @@ const paywall = {
     'Unlock collaboration feature by upgrading to a paid plan. For any assistance, feel free to <a>contact us</a>.',
   tenant_members_dev_plan:
     "You've reached your {{limit}}-member limit. Release a member or revoke a pending invitation to add someone new. Need more seats? Feel free to contact us.",
+  custom_jwt: {
+    title: 'Add custom claims',
+    description:
+      "Upgrade to a paid plan for custom JWT functionality and premium benefits. Don't hesitate to <a>contact us</a> if you have any questions.",
+  },
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/es/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/subscription/quota-item.ts
@@ -163,6 +163,16 @@ const quota_item = {
     /** UNTRANSLATED */
     not_eligible: 'Remove your tenant members',
   },
+  custom_jwt_enabled: {
+    /** UNTRANSLATED */
+    name: 'Custom JWT',
+    /** UNTRANSLATED */
+    limited: 'Custom JWT',
+    /** UNTRANSLATED */
+    unlimited: 'Custom JWT',
+    /** UNTRANSLATED */
+    not_eligible: 'Remove your JWT claims customizer',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/es/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/tabs.ts
@@ -15,7 +15,7 @@ const tabs = {
   tenant_settings: 'Configuraciones del inquilino',
   mfa: 'Autenticación multifactor',
   /** UNTRANSLATED */
-  customize_jwt: 'JWT Claims',
+  customize_jwt: 'Custom JWT',
   signing_keys: 'Claves de firma',
   organization_template: 'Plantilla de organización',
 };

--- a/packages/phrases/src/locales/es/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/upsell/paywall.ts
@@ -64,6 +64,13 @@ const paywall = {
   /** UNTRANSLATED */
   tenant_members_dev_plan:
     "You've reached your {{limit}}-member limit. Release a member or revoke a pending invitation to add someone new. Need more seats? Feel free to contact us.",
+  custom_jwt: {
+    /** UNTRANSLATED */
+    title: 'Add custom claims',
+    /** UNTRANSLATED */
+    description:
+      "Upgrade to a paid plan for custom JWT functionality and premium benefits. Don't hesitate to <a>contact us</a> if you have any questions.",
+  },
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/fr/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/subscription/quota-item.ts
@@ -163,6 +163,16 @@ const quota_item = {
     /** UNTRANSLATED */
     not_eligible: 'Remove your tenant members',
   },
+  custom_jwt_enabled: {
+    /** UNTRANSLATED */
+    name: 'Custom JWT',
+    /** UNTRANSLATED */
+    limited: 'Custom JWT',
+    /** UNTRANSLATED */
+    unlimited: 'Custom JWT',
+    /** UNTRANSLATED */
+    not_eligible: 'Remove your JWT claims customizer',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/fr/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/tabs.ts
@@ -15,7 +15,7 @@ const tabs = {
   tenant_settings: 'Paramètres du locataire',
   mfa: 'Authentification multi-facteur',
   /** UNTRANSLATED */
-  customize_jwt: 'JWT Claims',
+  customize_jwt: 'Custom JWT',
   signing_keys: 'Clés de signature',
   organization_template: "Modèle d'organisation",
 };

--- a/packages/phrases/src/locales/fr/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/upsell/paywall.ts
@@ -64,6 +64,13 @@ const paywall = {
   /** UNTRANSLATED */
   tenant_members_dev_plan:
     "You've reached your {{limit}}-member limit. Release a member or revoke a pending invitation to add someone new. Need more seats? Feel free to contact us.",
+  custom_jwt: {
+    /** UNTRANSLATED */
+    title: 'Add custom claims',
+    /** UNTRANSLATED */
+    description:
+      "Upgrade to a paid plan for custom JWT functionality and premium benefits. Don't hesitate to <a>contact us</a> if you have any questions.",
+  },
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/it/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/subscription/quota-item.ts
@@ -163,6 +163,16 @@ const quota_item = {
     /** UNTRANSLATED */
     not_eligible: 'Remove your tenant members',
   },
+  custom_jwt_enabled: {
+    /** UNTRANSLATED */
+    name: 'Custom JWT',
+    /** UNTRANSLATED */
+    limited: 'Custom JWT',
+    /** UNTRANSLATED */
+    unlimited: 'Custom JWT',
+    /** UNTRANSLATED */
+    not_eligible: 'Remove your JWT claims customizer',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/it/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/tabs.ts
@@ -15,7 +15,7 @@ const tabs = {
   tenant_settings: 'Impostazioni',
   mfa: 'Autenticazione multi-fattore',
   /** UNTRANSLATED */
-  customize_jwt: 'JWT Claims',
+  customize_jwt: 'Custom JWT',
   signing_keys: 'Chiavi di firma',
   organization_template: 'Modello di organizzazione',
 };

--- a/packages/phrases/src/locales/it/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/upsell/paywall.ts
@@ -64,6 +64,13 @@ const paywall = {
   /** UNTRANSLATED */
   tenant_members_dev_plan:
     "You've reached your {{limit}}-member limit. Release a member or revoke a pending invitation to add someone new. Need more seats? Feel free to contact us.",
+  custom_jwt: {
+    /** UNTRANSLATED */
+    title: 'Add custom claims',
+    /** UNTRANSLATED */
+    description:
+      "Upgrade to a paid plan for custom JWT functionality and premium benefits. Don't hesitate to <a>contact us</a> if you have any questions.",
+  },
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/ja/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/subscription/quota-item.ts
@@ -163,6 +163,16 @@ const quota_item = {
     /** UNTRANSLATED */
     not_eligible: 'Remove your tenant members',
   },
+  custom_jwt_enabled: {
+    /** UNTRANSLATED */
+    name: 'Custom JWT',
+    /** UNTRANSLATED */
+    limited: 'Custom JWT',
+    /** UNTRANSLATED */
+    unlimited: 'Custom JWT',
+    /** UNTRANSLATED */
+    not_eligible: 'Remove your JWT claims customizer',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/ja/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/tabs.ts
@@ -15,7 +15,7 @@ const tabs = {
   tenant_settings: '設定',
   mfa: 'Multi-factor auth',
   /** UNTRANSLATED */
-  customize_jwt: 'JWT Claims',
+  customize_jwt: 'Custom JWT',
   signing_keys: '署名キー',
   organization_template: '組織テンプレート',
 };

--- a/packages/phrases/src/locales/ja/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/upsell/paywall.ts
@@ -64,6 +64,13 @@ const paywall = {
   /** UNTRANSLATED */
   tenant_members_dev_plan:
     "You've reached your {{limit}}-member limit. Release a member or revoke a pending invitation to add someone new. Need more seats? Feel free to contact us.",
+  custom_jwt: {
+    /** UNTRANSLATED */
+    title: 'Add custom claims',
+    /** UNTRANSLATED */
+    description:
+      "Upgrade to a paid plan for custom JWT functionality and premium benefits. Don't hesitate to <a>contact us</a> if you have any questions.",
+  },
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/ko/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/subscription/quota-item.ts
@@ -163,6 +163,16 @@ const quota_item = {
     /** UNTRANSLATED */
     not_eligible: 'Remove your tenant members',
   },
+  custom_jwt_enabled: {
+    /** UNTRANSLATED */
+    name: 'Custom JWT',
+    /** UNTRANSLATED */
+    limited: 'Custom JWT',
+    /** UNTRANSLATED */
+    unlimited: 'Custom JWT',
+    /** UNTRANSLATED */
+    not_eligible: 'Remove your JWT claims customizer',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/ko/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/tabs.ts
@@ -15,7 +15,7 @@ const tabs = {
   tenant_settings: '테넌트 설정',
   mfa: '다중 요소 인증',
   /** UNTRANSLATED */
-  customize_jwt: 'JWT Claims',
+  customize_jwt: 'Custom JWT',
   signing_keys: '서명 키',
   organization_template: '조직 템플릿',
 };

--- a/packages/phrases/src/locales/ko/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/upsell/paywall.ts
@@ -64,6 +64,13 @@ const paywall = {
   /** UNTRANSLATED */
   tenant_members_dev_plan:
     "You've reached your {{limit}}-member limit. Release a member or revoke a pending invitation to add someone new. Need more seats? Feel free to contact us.",
+  custom_jwt: {
+    /** UNTRANSLATED */
+    title: 'Add custom claims',
+    /** UNTRANSLATED */
+    description:
+      "Upgrade to a paid plan for custom JWT functionality and premium benefits. Don't hesitate to <a>contact us</a> if you have any questions.",
+  },
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/subscription/quota-item.ts
@@ -163,6 +163,16 @@ const quota_item = {
     /** UNTRANSLATED */
     not_eligible: 'Remove your tenant members',
   },
+  custom_jwt_enabled: {
+    /** UNTRANSLATED */
+    name: 'Custom JWT',
+    /** UNTRANSLATED */
+    limited: 'Custom JWT',
+    /** UNTRANSLATED */
+    unlimited: 'Custom JWT',
+    /** UNTRANSLATED */
+    not_eligible: 'Remove your JWT claims customizer',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/tabs.ts
@@ -15,7 +15,7 @@ const tabs = {
   tenant_settings: 'Ustawienia',
   mfa: 'Multi-factor auth',
   /** UNTRANSLATED */
-  customize_jwt: 'JWT Claims',
+  customize_jwt: 'Custom JWT',
   signing_keys: 'Klucze do podpisu',
   organization_template: 'Szablon organizacji',
 };

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/upsell/paywall.ts
@@ -64,6 +64,13 @@ const paywall = {
   /** UNTRANSLATED */
   tenant_members_dev_plan:
     "You've reached your {{limit}}-member limit. Release a member or revoke a pending invitation to add someone new. Need more seats? Feel free to contact us.",
+  custom_jwt: {
+    /** UNTRANSLATED */
+    title: 'Add custom claims',
+    /** UNTRANSLATED */
+    description:
+      "Upgrade to a paid plan for custom JWT functionality and premium benefits. Don't hesitate to <a>contact us</a> if you have any questions.",
+  },
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/subscription/quota-item.ts
@@ -163,6 +163,16 @@ const quota_item = {
     /** UNTRANSLATED */
     not_eligible: 'Remove your tenant members',
   },
+  custom_jwt_enabled: {
+    /** UNTRANSLATED */
+    name: 'Custom JWT',
+    /** UNTRANSLATED */
+    limited: 'Custom JWT',
+    /** UNTRANSLATED */
+    unlimited: 'Custom JWT',
+    /** UNTRANSLATED */
+    not_eligible: 'Remove your JWT claims customizer',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/tabs.ts
@@ -15,7 +15,7 @@ const tabs = {
   tenant_settings: 'Configurações',
   mfa: 'Autenticação de multi-fator',
   /** UNTRANSLATED */
-  customize_jwt: 'JWT Claims',
+  customize_jwt: 'Custom JWT',
   signing_keys: 'Chaves de assinatura',
   organization_template: 'Modelo de organização',
 };

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/upsell/paywall.ts
@@ -64,6 +64,13 @@ const paywall = {
   /** UNTRANSLATED */
   tenant_members_dev_plan:
     "You've reached your {{limit}}-member limit. Release a member or revoke a pending invitation to add someone new. Need more seats? Feel free to contact us.",
+  custom_jwt: {
+    /** UNTRANSLATED */
+    title: 'Add custom claims',
+    /** UNTRANSLATED */
+    description:
+      "Upgrade to a paid plan for custom JWT functionality and premium benefits. Don't hesitate to <a>contact us</a> if you have any questions.",
+  },
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/subscription/quota-item.ts
@@ -163,6 +163,16 @@ const quota_item = {
     /** UNTRANSLATED */
     not_eligible: 'Remove your tenant members',
   },
+  custom_jwt_enabled: {
+    /** UNTRANSLATED */
+    name: 'Custom JWT',
+    /** UNTRANSLATED */
+    limited: 'Custom JWT',
+    /** UNTRANSLATED */
+    unlimited: 'Custom JWT',
+    /** UNTRANSLATED */
+    not_eligible: 'Remove your JWT claims customizer',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/tabs.ts
@@ -15,7 +15,7 @@ const tabs = {
   tenant_settings: 'Definições do inquilino',
   mfa: 'Autenticação multi-fator',
   /** UNTRANSLATED */
-  customize_jwt: 'JWT Claims',
+  customize_jwt: 'Custom JWT',
   signing_keys: 'Chaves de assinatura',
   organization_template: 'Modelo de organização',
 };

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/upsell/paywall.ts
@@ -64,6 +64,13 @@ const paywall = {
   /** UNTRANSLATED */
   tenant_members_dev_plan:
     "You've reached your {{limit}}-member limit. Release a member or revoke a pending invitation to add someone new. Need more seats? Feel free to contact us.",
+  custom_jwt: {
+    /** UNTRANSLATED */
+    title: 'Add custom claims',
+    /** UNTRANSLATED */
+    description:
+      "Upgrade to a paid plan for custom JWT functionality and premium benefits. Don't hesitate to <a>contact us</a> if you have any questions.",
+  },
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/ru/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/subscription/quota-item.ts
@@ -163,6 +163,16 @@ const quota_item = {
     /** UNTRANSLATED */
     not_eligible: 'Remove your tenant members',
   },
+  custom_jwt_enabled: {
+    /** UNTRANSLATED */
+    name: 'Custom JWT',
+    /** UNTRANSLATED */
+    limited: 'Custom JWT',
+    /** UNTRANSLATED */
+    unlimited: 'Custom JWT',
+    /** UNTRANSLATED */
+    not_eligible: 'Remove your JWT claims customizer',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/ru/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/tabs.ts
@@ -15,7 +15,7 @@ const tabs = {
   tenant_settings: 'Настройки',
   mfa: 'Multi-factor auth',
   /** UNTRANSLATED */
-  customize_jwt: 'JWT Claims',
+  customize_jwt: 'Custom JWT',
   signing_keys: 'Ключи подписи',
   organization_template: 'Шаблон организации',
 };

--- a/packages/phrases/src/locales/ru/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/upsell/paywall.ts
@@ -64,6 +64,13 @@ const paywall = {
   /** UNTRANSLATED */
   tenant_members_dev_plan:
     "You've reached your {{limit}}-member limit. Release a member or revoke a pending invitation to add someone new. Need more seats? Feel free to contact us.",
+  custom_jwt: {
+    /** UNTRANSLATED */
+    title: 'Add custom claims',
+    /** UNTRANSLATED */
+    description:
+      "Upgrade to a paid plan for custom JWT functionality and premium benefits. Don't hesitate to <a>contact us</a> if you have any questions.",
+  },
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/subscription/quota-item.ts
@@ -163,6 +163,16 @@ const quota_item = {
     /** UNTRANSLATED */
     not_eligible: 'Remove your tenant members',
   },
+  custom_jwt_enabled: {
+    /** UNTRANSLATED */
+    name: 'Custom JWT',
+    /** UNTRANSLATED */
+    limited: 'Custom JWT',
+    /** UNTRANSLATED */
+    unlimited: 'Custom JWT',
+    /** UNTRANSLATED */
+    not_eligible: 'Remove your JWT claims customizer',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/tabs.ts
@@ -15,7 +15,7 @@ const tabs = {
   tenant_settings: 'Ayarlar',
   mfa: 'Çoklu faktörlü kimlik doğrulama',
   /** UNTRANSLATED */
-  customize_jwt: 'JWT Claims',
+  customize_jwt: 'Custom JWT',
   signing_keys: 'İmza anahtarları',
   organization_template: 'Kuruluş şablonu',
 };

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/upsell/paywall.ts
@@ -64,6 +64,13 @@ const paywall = {
   /** UNTRANSLATED */
   tenant_members_dev_plan:
     "You've reached your {{limit}}-member limit. Release a member or revoke a pending invitation to add someone new. Need more seats? Feel free to contact us.",
+  custom_jwt: {
+    /** UNTRANSLATED */
+    title: 'Add custom claims',
+    /** UNTRANSLATED */
+    description:
+      "Upgrade to a paid plan for custom JWT functionality and premium benefits. Don't hesitate to <a>contact us</a> if you have any questions.",
+  },
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/subscription/quota-item.ts
@@ -163,6 +163,16 @@ const quota_item = {
     /** UNTRANSLATED */
     not_eligible: 'Remove your tenant members',
   },
+  custom_jwt_enabled: {
+    /** UNTRANSLATED */
+    name: 'Custom JWT',
+    /** UNTRANSLATED */
+    limited: 'Custom JWT',
+    /** UNTRANSLATED */
+    unlimited: 'Custom JWT',
+    /** UNTRANSLATED */
+    not_eligible: 'Remove your JWT claims customizer',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/tabs.ts
@@ -15,7 +15,7 @@ const tabs = {
   tenant_settings: '租户设置',
   mfa: '多因素认证',
   /** UNTRANSLATED */
-  customize_jwt: 'JWT Claims',
+  customize_jwt: 'Custom JWT',
   signing_keys: '签名密钥',
   organization_template: '组织模板',
 };

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/upsell/paywall.ts
@@ -63,6 +63,13 @@ const paywall = {
   /** UNTRANSLATED */
   tenant_members_dev_plan:
     "You've reached your {{limit}}-member limit. Release a member or revoke a pending invitation to add someone new. Need more seats? Feel free to contact us.",
+  custom_jwt: {
+    /** UNTRANSLATED */
+    title: 'Add custom claims',
+    /** UNTRANSLATED */
+    description:
+      "Upgrade to a paid plan for custom JWT functionality and premium benefits. Don't hesitate to <a>contact us</a> if you have any questions.",
+  },
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/subscription/quota-item.ts
@@ -163,6 +163,16 @@ const quota_item = {
     /** UNTRANSLATED */
     not_eligible: 'Remove your tenant members',
   },
+  custom_jwt_enabled: {
+    /** UNTRANSLATED */
+    name: 'Custom JWT',
+    /** UNTRANSLATED */
+    limited: 'Custom JWT',
+    /** UNTRANSLATED */
+    unlimited: 'Custom JWT',
+    /** UNTRANSLATED */
+    not_eligible: 'Remove your JWT claims customizer',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/tabs.ts
@@ -15,7 +15,7 @@ const tabs = {
   tenant_settings: '租戶設置',
   mfa: '多重認證',
   /** UNTRANSLATED */
-  customize_jwt: 'JWT Claims',
+  customize_jwt: 'Custom JWT',
   signing_keys: '簽署密鑰',
   organization_template: '組織模板',
 };

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/upsell/paywall.ts
@@ -63,6 +63,13 @@ const paywall = {
   /** UNTRANSLATED */
   tenant_members_dev_plan:
     "You've reached your {{limit}}-member limit. Release a member or revoke a pending invitation to add someone new. Need more seats? Feel free to contact us.",
+  custom_jwt: {
+    /** UNTRANSLATED */
+    title: 'Add custom claims',
+    /** UNTRANSLATED */
+    description:
+      "Upgrade to a paid plan for custom JWT functionality and premium benefits. Don't hesitate to <a>contact us</a> if you have any questions.",
+  },
 };
 
 export default Object.freeze(paywall);

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/subscription/quota-item.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/subscription/quota-item.ts
@@ -163,6 +163,16 @@ const quota_item = {
     /** UNTRANSLATED */
     not_eligible: 'Remove your tenant members',
   },
+  custom_jwt_enabled: {
+    /** UNTRANSLATED */
+    name: 'Custom JWT',
+    /** UNTRANSLATED */
+    limited: 'Custom JWT',
+    /** UNTRANSLATED */
+    unlimited: 'Custom JWT',
+    /** UNTRANSLATED */
+    not_eligible: 'Remove your JWT claims customizer',
+  },
 };
 
 export default Object.freeze(quota_item);

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/tabs.ts
@@ -15,7 +15,7 @@ const tabs = {
   tenant_settings: '租戶設定',
   mfa: '多重認證',
   /** UNTRANSLATED */
-  customize_jwt: 'JWT Claims',
+  customize_jwt: 'Custom JWT',
   signing_keys: '簽署密鑰',
   organization_template: '組織模板',
 };

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/upsell/paywall.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/upsell/paywall.ts
@@ -63,6 +63,13 @@ const paywall = {
   /** UNTRANSLATED */
   tenant_members_dev_plan:
     "You've reached your {{limit}}-member limit. Release a member or revoke a pending invitation to add someone new. Need more seats? Feel free to contact us.",
+  custom_jwt: {
+    /** UNTRANSLATED */
+    title: 'Add custom claims',
+    /** UNTRANSLATED */
+    description:
+      "Upgrade to a paid plan for custom JWT functionality and premium benefits. Don't hesitate to <a>contact us</a> if you have any questions.",
+  },
 };
 
 export default Object.freeze(paywall);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2715,8 +2715,8 @@ importers:
         specifier: workspace:^1.4.0
         version: link:../app-insights
       '@logto/cloud':
-        specifier: 0.2.5-ab8a489
-        version: 0.2.5-ab8a489(zod@3.22.4)
+        specifier: 0.2.5-94f7bcc
+        version: 0.2.5-94f7bcc(zod@3.22.4)
       '@logto/connector-kit':
         specifier: workspace:^3.0.0
         version: link:../toolkit/connector-kit

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3205,8 +3205,8 @@ importers:
         version: 3.22.4
     devDependencies:
       '@logto/cloud':
-        specifier: 0.2.5-749cae5
-        version: 0.2.5-749cae5(zod@3.22.4)
+        specifier: 0.2.5-94f7bcc
+        version: 0.2.5-94f7bcc(zod@3.22.4)
       '@silverhand/eslint-config':
         specifier: 5.0.0
         version: 5.0.0(eslint@8.44.0)(prettier@3.0.0)(typescript@5.3.3)
@@ -7647,8 +7647,8 @@ packages:
       jose: 5.2.2
     dev: true
 
-  /@logto/cloud@0.2.5-749cae5(zod@3.22.4):
-    resolution: {integrity: sha512-QzebHRSBShQwOsKAvYlVd7QF43RlrHOt/nmwrlRNW4F9U0DUEFaeLZujYS56oxjQ49GRdsOPKSQCE97wRB7NNQ==}
+  /@logto/cloud@0.2.5-94f7bcc(zod@3.22.4):
+    resolution: {integrity: sha512-1nY3o1/gXgEIqgvjel2no0X3rR+BGnfozB7Vev+FY2qTkDyQIWRtHAnx+kkv4iEIIFcZW86LRNlvfjDUqR2yIg==}
     engines: {node: ^20.9.0}
     dependencies:
       '@silverhand/essentials': 2.9.0


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add customJwt paywall guard to core API

- bump the cloud version to pick up the latest plan quota schema
- guard the `logtoConfigJwtCustomizerRoutes` with the quota key


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [ ] ~necessary TSDoc comments~
