### PR TITLE
fix(core,console): invitee emails should be case insensitive

### DIFF
--- a/.changeset/afraid-stingrays-perform.md
+++ b/.changeset/afraid-stingrays-perform.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": patch
+---
+
+Bug fix: organization invitation APIs should handle invitee emails case insensitively

--- a/packages/console/src/pages/TenantSettings/TenantMembers/InviteEmailsInput/hooks.ts
+++ b/packages/console/src/pages/TenantSettings/TenantMembers/InviteEmailsInput/hooks.ts
@@ -44,15 +44,16 @@ const useEmailInputUtils = () => {
       const validEmails = new Set<string>();
 
       const existingMemberEmails = new Set<string>(
-        existingMembers.map(({ primaryEmail }) => primaryEmail ?? '').filter(Boolean)
+        existingMembers.map(({ primaryEmail }) => primaryEmail?.toLowerCase() ?? '').filter(Boolean)
       );
       const existingInvitationEmails = new Set<string>(
         existingInvitations
           .filter(({ status }) => status === OrganizationInvitationStatus.Pending)
-          .map(({ invitee }) => invitee)
+          .map(({ invitee }) => invitee.toLowerCase())
       );
 
-      for (const email of emails) {
+      for (const userInputEmail of emails) {
+        const email = userInputEmail.toLowerCase();
         if (!emailRegEx.test(email)) {
           invalidEmails.add(email);
         }

--- a/packages/core/src/queries/organization/index.ts
+++ b/packages/core/src/queries/organization/index.ts
@@ -165,7 +165,7 @@ class OrganizationInvitationsQueries extends SchemaQueries<
         return sql`and ${fields.organizationId} = ${id}`;
       })}
       ${conditionalSql(invitee, (email) => {
-        return sql`and ${fields.invitee} = ${email}`;
+        return sql`and lower(${fields.invitee}) = lower(${email})`;
       })}
     `);
   }
@@ -220,7 +220,7 @@ class OrganizationInvitationsQueries extends SchemaQueries<
         return sql`and ${fields.inviterId} = ${id}`;
       })}
       ${conditionalSql(invitee, (email) => {
-        return sql`and ${fields.invitee} = ${email}`;
+        return sql`and lower(${fields.invitee}) = lower(${email})`;
       })}
       group by ${fields.id}
       ${conditionalSql(this.orderBy, ({ field, order }) => {

--- a/packages/integration-tests/src/tests/api/organization/organization-invitation.get.test.ts
+++ b/packages/integration-tests/src/tests/api/organization/organization-invitation.get.test.ts
@@ -61,18 +61,19 @@ describe('organization invitation creation', () => {
     await Promise.all([deleteUser(inviter.id), deleteUser(inviter2.id)]);
   });
 
-  it('should be able to get invitations by invitee', async () => {
+  it('should be able to get invitations by invitee email (case insensitive)', async () => {
     const organization = await organizationApi.create({ name: 'test' });
     const invitee = `${randomId()}@example.com`;
     await invitationApi.create({
       organizationId: organization.id,
-      invitee,
+      // Deliberately use uppercase email when creating the invitation
+      invitee: invitee.toUpperCase(),
       expiresAt: Date.now() + 1_000_000,
     });
 
     const invitations = await invitationApi.getList(new URLSearchParams({ invitee }));
     expect(invitations.length).toBe(1);
-    expect(invitations[0]?.invitee).toBe(invitee);
+    expect(invitations[0]?.invitee.toLocaleLowerCase()).toBe(invitee.toLowerCase());
   });
 
   it('should have no pagination', async () => {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the bug that invitation emails are not handled case insensitively, which blocks Cloud users from accepting invitations that are sent to their email addresses with a different letter case pattern.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
