### PR TITLE
feat(connector): can access all user email even if no public email is set

### DIFF
--- a/.changeset/pretty-mirrors-peel.md
+++ b/.changeset/pretty-mirrors-peel.md
@@ -1,0 +1,5 @@
+---
+"@logto/connector-github": minor
+---
+
+Can skip email completion step when not public email available

--- a/.changeset/pretty-mirrors-peel.md
+++ b/.changeset/pretty-mirrors-peel.md
@@ -2,4 +2,6 @@
 "@logto/connector-github": minor
 ---
 
-Can skip email completion step when not public email available
+Add email address fallback logic:
+- We add `user:email` as default scope to fetch GitHub account's private email address.
+- If the user does not choose a public email for he's GitHub account, we will pick the verified primary email among private email address list as a fallback.

--- a/.changeset/pretty-mirrors-peel.md
+++ b/.changeset/pretty-mirrors-peel.md
@@ -2,6 +2,7 @@
 "@logto/connector-github": minor
 ---
 
-Add email address fallback logic:
-- We add `user:email` as default scope to fetch GitHub account's private email address.
-- If the user does not choose a public email for he's GitHub account, we will pick the verified primary email among private email address list as a fallback.
+fetch GitHub account's private email address list and pick the verified primary email as a fallback
+
+- Add `user:email` as part of default scope to fetch GitHub account's private email address list
+- Pick the verified primary email among private email address list as a fallback if the user does not set a public email for GitHub account

--- a/packages/connectors/connector-github/package.json
+++ b/packages/connectors/connector-github/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@logto/connector-kit": "workspace:^3.0.0",
     "@silverhand/essentials": "^2.9.0",
-    "got": "^14.0.0",
+    "ky": "^1.2.3",
     "query-string": "^9.0.0",
     "snakecase-keys": "^8.0.0",
     "zod": "^3.22.4"
@@ -64,7 +64,7 @@
     "@vitest/coverage-v8": "^1.4.0",
     "eslint": "^8.56.0",
     "lint-staged": "^15.0.2",
-    "nock": "^13.3.1",
+    "nock": "14.0.0-beta.6",
     "prettier": "^3.0.0",
     "rollup": "^4.12.0",
     "rollup-plugin-output-size": "^1.3.0",

--- a/packages/connectors/connector-github/src/constant.ts
+++ b/packages/connectors/connector-github/src/constant.ts
@@ -2,9 +2,15 @@ import type { ConnectorMetadata } from '@logto/connector-kit';
 import { ConnectorPlatform, ConnectorConfigFormItemType } from '@logto/connector-kit';
 
 export const authorizationEndpoint = 'https://github.com/login/oauth/authorize';
-export const scope = 'read:user';
+/**
+ * `read:user` read user profile data; `user:email` read user email addresses (including private email addresses).
+ * Ref: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps
+ */
+export const scope = 'read:user user:email';
 export const accessTokenEndpoint = 'https://github.com/login/oauth/access_token';
 export const userInfoEndpoint = 'https://api.github.com/user';
+// Ref: https://docs.github.com/en/rest/users/emails?apiVersion=2022-11-28#list-email-addresses-for-the-authenticated-user
+export const userEmailsEndpoint = 'https://api.github.com/user/emails';
 
 export const defaultMetadata: ConnectorMetadata = {
   id: 'github-universal',

--- a/packages/connectors/connector-github/src/index.test.ts
+++ b/packages/connectors/connector-github/src/index.test.ts
@@ -1,9 +1,13 @@
 import nock from 'nock';
 
 import { ConnectorError, ConnectorErrorCodes } from '@logto/connector-kit';
-import qs from 'query-string';
 
-import { accessTokenEndpoint, authorizationEndpoint, userInfoEndpoint } from './constant.js';
+import {
+  accessTokenEndpoint,
+  authorizationEndpoint,
+  userEmailsEndpoint,
+  userInfoEndpoint,
+} from './constant.js';
 import createConnector, { getAccessToken } from './index.js';
 import { mockedConfig } from './mock.js';
 
@@ -28,7 +32,7 @@ describe('getAuthorizationUri', () => {
       vi.fn()
     );
     expect(authorizationUri).toEqual(
-      `${authorizationEndpoint}?client_id=%3Cclient-id%3E&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&state=some_state&scope=read%3Auser`
+      `${authorizationEndpoint}?client_id=%3Cclient-id%3E&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&state=some_state&scope=read%3Auser+user%3Aemail`
     );
   });
 });
@@ -40,16 +44,11 @@ describe('getAccessToken', () => {
   });
 
   it('should get an accessToken by exchanging with code', async () => {
-    nock(accessTokenEndpoint)
-      .post('')
-      .reply(
-        200,
-        qs.stringify({
-          access_token: 'access_token',
-          scope: 'scope',
-          token_type: 'token_type',
-        })
-      );
+    nock(accessTokenEndpoint).post('').reply(200, {
+      access_token: 'access_token',
+      scope: 'scope',
+      token_type: 'token_type',
+    });
     const { accessToken } = await getAccessToken(mockedConfig, { code: 'code' });
     expect(accessToken).toEqual('access_token');
   });
@@ -57,7 +56,7 @@ describe('getAccessToken', () => {
   it('throws SocialAuthCodeInvalid error if accessToken not found in response', async () => {
     nock(accessTokenEndpoint)
       .post('')
-      .reply(200, qs.stringify({ access_token: '', scope: 'scope', token_type: 'token_type' }));
+      .reply(200, { access_token: '', scope: 'scope', token_type: 'token_type' });
     await expect(getAccessToken(mockedConfig, { code: 'code' })).rejects.toStrictEqual(
       new ConnectorError(ConnectorErrorCodes.SocialAuthCodeInvalid)
     );
@@ -66,16 +65,11 @@ describe('getAccessToken', () => {
 
 describe('getUserInfo', () => {
   beforeEach(() => {
-    nock(accessTokenEndpoint)
-      .post('')
-      .reply(
-        200,
-        qs.stringify({
-          access_token: 'access_token',
-          scope: 'scope',
-          token_type: 'token_type',
-        })
-      );
+    nock(accessTokenEndpoint).post('').query(true).reply(200, {
+      access_token: 'access_token',
+      scope: 'scope',
+      token_type: 'token_type',
+    });
   });
 
   afterEach(() => {
@@ -91,6 +85,7 @@ describe('getUserInfo', () => {
       email: 'octocat@github.com',
       foo: 'bar',
     });
+    nock(userEmailsEndpoint).get('').reply(200, []);
     const connector = await createConnector({ getConfig });
     const socialUserInfo = await connector.getUserInfo({ code: 'code' }, vi.fn());
     expect(socialUserInfo).toStrictEqual({
@@ -99,11 +94,70 @@ describe('getUserInfo', () => {
       name: 'monalisa octocat',
       email: 'octocat@github.com',
       rawData: {
-        id: 1,
-        avatar_url: 'https://github.com/images/error/octocat_happy.gif',
-        name: 'monalisa octocat',
-        email: 'octocat@github.com',
-        foo: 'bar',
+        userInfo: {
+          id: 1,
+          avatar_url: 'https://github.com/images/error/octocat_happy.gif',
+          name: 'monalisa octocat',
+          email: 'octocat@github.com',
+          foo: 'bar',
+        },
+        userEmails: [],
+      },
+    });
+  });
+
+  it('should fallback to verified primary email if not public is available', async () => {
+    nock(userInfoEndpoint).get('').reply(200, {
+      id: 1,
+      avatar_url: 'https://github.com/images/error/octocat_happy.gif',
+      name: 'monalisa octocat',
+      email: undefined,
+      foo: 'bar',
+    });
+    nock(userEmailsEndpoint)
+      .get('')
+      .reply(200, [
+        {
+          email: 'foo@logto.io',
+          verified: true,
+          primary: true,
+          visibility: 'public',
+        },
+        {
+          email: 'foo1@logto.io',
+          verified: true,
+          primary: false,
+          visibility: null,
+        },
+      ]);
+    const connector = await createConnector({ getConfig });
+    const socialUserInfo = await connector.getUserInfo({ code: 'code' }, vi.fn());
+    expect(socialUserInfo).toStrictEqual({
+      id: '1',
+      avatar: 'https://github.com/images/error/octocat_happy.gif',
+      name: 'monalisa octocat',
+      email: 'foo@logto.io',
+      rawData: {
+        userInfo: {
+          id: 1,
+          avatar_url: 'https://github.com/images/error/octocat_happy.gif',
+          name: 'monalisa octocat',
+          foo: 'bar',
+        },
+        userEmails: [
+          {
+            email: 'foo@logto.io',
+            verified: true,
+            primary: true,
+            visibility: 'public',
+          },
+          {
+            email: 'foo1@logto.io',
+            verified: true,
+            primary: false,
+            visibility: null,
+          },
+        ],
       },
     });
   });
@@ -115,15 +169,14 @@ describe('getUserInfo', () => {
       name: null,
       email: null,
     });
+    nock(userEmailsEndpoint).get('').reply(200, []);
     const connector = await createConnector({ getConfig });
     const socialUserInfo = await connector.getUserInfo({ code: 'code' }, vi.fn());
     expect(socialUserInfo).toMatchObject({
       id: '1',
       rawData: {
-        id: 1,
-        avatar_url: null,
-        name: null,
-        email: null,
+        userInfo: { id: 1, avatar_url: null, name: null, email: null },
+        userEmails: [],
       },
     });
   });

--- a/packages/connectors/connector-github/src/types.ts
+++ b/packages/connectors/connector-github/src/types.ts
@@ -8,6 +8,17 @@ export const githubConfigGuard = z.object({
 
 export type GithubConfig = z.infer<typeof githubConfigGuard>;
 
+/**
+ * This guard is used to validate the response from the GitHub API when requesting the user's email addresses.
+ * Ref: https://docs.github.com/en/rest/users/emails?apiVersion=2022-11-28#list-email-addresses-for-the-authenticated-user
+ */
+export const emailAddressGuard = z.object({
+  email: z.string(),
+  primary: z.boolean(),
+  verified: z.boolean(),
+  visibility: z.string().nullable(),
+});
+
 export const accessTokenResponseGuard = z.object({
   access_token: z.string(),
   scope: z.string(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -981,9 +981,9 @@ importers:
       '@silverhand/essentials':
         specifier: ^2.9.0
         version: 2.9.0
-      got:
-        specifier: ^14.0.0
-        version: 14.0.0
+      ky:
+        specifier: ^1.2.3
+        version: 1.2.3
       query-string:
         specifier: ^9.0.0
         version: 9.0.0
@@ -1028,8 +1028,8 @@ importers:
         specifier: ^15.0.2
         version: 15.0.2
       nock:
-        specifier: ^13.3.1
-        version: 13.3.1
+        specifier: 14.0.0-beta.6
+        version: 14.0.0-beta.6
       prettier:
         specifier: ^3.0.0
         version: 3.0.0
@@ -10186,7 +10186,7 @@ packages:
       strip-literal: 2.0.0
       test-exclude: 6.0.0
       v8-to-istanbul: 9.2.0
-      vitest: 1.4.0(@types/node@20.12.7)
+      vitest: 1.4.0(@types/node@20.10.4)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11930,17 +11930,6 @@ packages:
   /dayjs@1.11.6:
     resolution: {integrity: sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ==}
 
-  /debug@3.2.7:
-    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.3
-    dev: true
-
   /debug@3.2.7(supports-color@5.5.0):
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -12705,7 +12694,7 @@ packages:
   /eslint-import-resolver-node@0.3.9:
     resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
     dependencies:
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@5.5.0)
       is-core-module: 2.13.1
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -12757,7 +12746,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/parser': 7.7.0(eslint@8.57.0)(typescript@5.3.3)
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@5.5.0)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.7.0)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
@@ -12811,7 +12800,7 @@ packages:
       array.prototype.findlastindex: 1.2.5
       array.prototype.flat: 1.3.2
       array.prototype.flatmap: 1.3.2
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@5.5.0)
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
@@ -18004,6 +17993,9 @@ packages:
     resolution: {integrity: sha512-2GTVocFkwblV/TIg9AmT7TI2fO4xdWkyN8aFUEVtiVNWt96GTR3FgQyHFValfCbcj1k9Xf962Ws2hYXYUr9k1Q==}
     engines: {node: '>= 12.0.0'}
     hasBin: true
+    peerDependenciesMeta:
+      '@parcel/core':
+        optional: true
     dependencies:
       '@parcel/config-default': 2.9.3(@parcel/core@2.9.3)(postcss@8.4.31)
       '@parcel/core': 2.9.3


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Sometimes, GitHub users do not set a public email. In previous implementation, Logto users who sign in with GitHub account need to manually add their email address.
In this change, we add default scope `user:email` which can be used to access GitHub accounts' private emails. And Logto will fallback to the verified primary email address in the GitHub account private email address list. This change can make GitHub social sign-in smoother.

What's more, we also migrate from `got` to `ky` for the GitHub connector and upgrade `nock` to a new version to update the unit test as well (old `nock` version can not successfully mock the HTTP requests made by `ky`).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally, removed my GitHub account public email, and as you can see no email is available but we can successfully fallback to a verified & primary email address attached to your GitHub account.
<img width="665" alt="image" src="https://github.com/logto-io/logto/assets/15182327/89993cd4-6125-4bd4-90f8-0e1f12df78c9">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
