### PR TITLE
fix(console): always display create org button

### DIFF
--- a/packages/console/src/pages/Organizations/index.tsx
+++ b/packages/console/src/pages/Organizations/index.tsx
@@ -81,7 +81,7 @@ function Organizations({ tab }: Props) {
             targetBlank: 'noopener',
           }}
         />
-        {!isInitialSetup && (
+        {(!isInitialSetup || isDevFeaturesEnabled) && (
           <Button
             icon={<Plus />}
             type="primary"

--- a/packages/integration-tests/src/tests/console/organizations.test.ts
+++ b/packages/integration-tests/src/tests/console/organizations.test.ts
@@ -3,12 +3,12 @@ import { cls, dcls, generateTestName } from '#src/utils.js';
 
 const expectOrg = new ExpectOrganizations(await browser.newPage());
 
-// Temporarily skipping organization tests, will add them back later with the "guide" feature
-describe.skip('organizations: create, edit, and delete organization', () => {
+// Start the test by signing in or starting the console
+await expectOrg.start();
+
+describe('organizations: create, edit, and delete organization', () => {
   it('navigates to organizations page', async () => {
-    await expectOrg.start();
     await expectOrg.gotoPage('/organizations', 'Organizations');
-    await expectOrg.toExpectTabs('Organizations', 'Settings');
   });
 
   it('should be able to see the table', async () => {
@@ -40,18 +40,17 @@ describe.skip('organizations: create, edit, and delete organization', () => {
       undefined,
       false
     );
-    await expectOrg.toClick(`${dcls('danger')}[role=menuitem]`, 'Delete organization', false);
+    await expectOrg.toClick(`${dcls('danger')}[role=menuitem]`, 'Delete', false);
     await expectOrg.toExpectModal('Reminder');
     await expectOrg.toClick(['.ReactModalPortal', `button${cls('danger')}`].join(' '), 'Delete');
     expectOrg.toMatchUrl(/\/organizations$/);
   });
 });
 
-describe.skip('organizations: search organization', () => {
+describe('organizations: search organization', () => {
   const [testName1, testName2] = [generateTestName(), generateTestName()];
 
   it('creates two organizations', async () => {
-    await expectOrg.start();
     await expectOrg.toCreateOrganization(testName1);
     await expectOrg.toCreateOrganization(testName2);
     await expectOrg.gotoPage('/organizations', 'Organizations');

--- a/packages/integration-tests/src/ui-helpers/expect-organizations.ts
+++ b/packages/integration-tests/src/ui-helpers/expect-organizations.ts
@@ -12,13 +12,13 @@ export default class ExpectOrganizations extends ExpectConsole {
    */
   async toCreateOrganization(name: string) {
     await this.gotoPage('/organizations', 'Organizations');
-    await this.toClickButton('Create organization');
+    await this.toClickButton('Create organization', false);
 
     await this.toExpectModal('Create organization');
     await this.toFillForm({
       name,
     });
-    await this.toClick(['.ReactModalPortal', `button${cls('primary')}`].join(' '), 'Create', false);
+    await this.toClick(['.ReactModalPortal', `button${cls('primary')}`].join(' '), 'Create');
     this.toMatchUrl(/\/organizations\/.+$/);
   }
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Always display create org button for new version and re-enable organization page tests.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
CI passed.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
