### PR TITLE
fix(console): pagination bar should be fully visible

### DIFF
--- a/packages/console/src/pages/TenantSettings/TenantMembers/EditMemberModal/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantMembers/EditMemberModal/index.tsx
@@ -15,6 +15,8 @@ import { useConfirmModal } from '@/hooks/use-confirm-modal';
 import useCurrentTenantScopes from '@/hooks/use-current-tenant-scopes';
 import * as modalStyles from '@/scss/modal.module.scss';
 
+import * as styles from '../index.module.scss';
+
 type Props = {
   readonly user: TenantMemberResponse;
   readonly isOpen: boolean;
@@ -43,7 +45,9 @@ function EditMemberModal({ user, isOpen, onClose }: Props) {
     if (role === TenantRole.Admin) {
       const [result] = await show({
         ModalContent: () => (
-          <Trans components={{ ul: <ul />, li: <li /> }}>{t('assign_admin_confirm')}</Trans>
+          <Trans components={{ ul: <ul className={styles.list} />, li: <li /> }}>
+            {t('assign_admin_confirm')}
+          </Trans>
         ),
         confirmButtonText: 'general.confirm',
       });

--- a/packages/console/src/pages/TenantSettings/TenantMembers/InviteMemberModal/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantMembers/InviteMemberModal/index.tsx
@@ -15,6 +15,7 @@ import * as modalStyles from '@/scss/modal.module.scss';
 
 import InviteEmailsInput from '../InviteEmailsInput';
 import useEmailInputUtils from '../InviteEmailsInput/hooks';
+import * as styles from '../index.module.scss';
 import { type InviteMemberForm } from '../types';
 
 import Footer from './Footer';
@@ -66,7 +67,9 @@ function InviteMemberModal({ isOpen, onClose }: Props) {
     if (role === TenantRole.Admin) {
       const [result] = await show({
         ModalContent: () => (
-          <Trans components={{ ul: <ul />, li: <li /> }}>{t('assign_admin_confirm')}</Trans>
+          <Trans components={{ ul: <ul className={styles.list} />, li: <li /> }}>
+            {t('assign_admin_confirm')}
+          </Trans>
         ),
         confirmButtonText: 'general.confirm',
       });

--- a/packages/console/src/pages/TenantSettings/TenantMembers/index.module.scss
+++ b/packages/console/src/pages/TenantSettings/TenantMembers/index.module.scss
@@ -53,7 +53,7 @@
   }
 }
 
-ul {
+.list {
   padding-inline-start: _.unit(6);
 
   > li {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the bug that pagination bar is not fully visible, caused by unexpected applying global styles to `<ul />` elements.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Before
<img width="353" alt="image" src="https://github.com/logto-io/logto/assets/12833674/872b5c50-b33d-47c4-8c37-ad6160950798">

After
<img width="250" alt="image" src="https://github.com/logto-io/logto/assets/12833674/b3c92262-09ad-4af4-8bc7-3c30c9c94cad">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
