### PR TITLE
fix(console): rotate signing-key dropdown should be visible

### DIFF
--- a/packages/console/src/components/Guide/ModalFooter/index.module.scss
+++ b/packages/console/src/components/Guide/ModalFooter/index.module.scss
@@ -7,7 +7,7 @@
   padding: _.unit(4) _.unit(6);
   background-color: var(--color-layer-1);
   box-shadow: var(--shadow-3);
-  z-index: 1;
+  @include _.z-index(front);
 
   .wrapper {
     display: flex;

--- a/packages/console/src/components/Guide/index.module.scss
+++ b/packages/console/src/components/Guide/index.module.scss
@@ -74,7 +74,7 @@
   padding: _.unit(4) _.unit(6);
   background-color: var(--color-layer-1);
   box-shadow: var(--shadow-3);
-  z-index: 1;
+  @include _.z-index(front);
 
   .layout {
     margin: 0 auto;

--- a/packages/console/src/ds-components/Button/index.module.scss
+++ b/packages/console/src/ds-components/Button/index.module.scss
@@ -257,7 +257,7 @@
         position: absolute;
         inset: 0;
         background-color: var(--color-layer-1);
-        z-index: -1;
+        @include _.z-index(behind);
       }
     }
   }

--- a/packages/console/src/ds-components/CodeEditor/index.module.scss
+++ b/packages/console/src/ds-components/CodeEditor/index.module.scss
@@ -25,7 +25,7 @@
     right: _.unit(3);
     opacity: 0%;
     transition: opacity 0.2s ease-in-out;
-    z-index: 1;
+    @include _.z-index(front);
     cursor: pointer;
   }
 

--- a/packages/console/src/ds-components/ConfirmModal/index.module.scss
+++ b/packages/console/src/ds-components/ConfirmModal/index.module.scss
@@ -1,7 +1,7 @@
 @use '@/scss/underscore' as _;
 
 .overlay {
-  z-index: 1000;
+  @include _.z-index(confirm-modal);
 }
 
 .content {

--- a/packages/console/src/ds-components/Dropdown/index.module.scss
+++ b/packages/console/src/ds-components/Dropdown/index.module.scss
@@ -28,5 +28,5 @@
   background: transparent;
   position: fixed;
   inset: 0;
-  z-index: 102;
+  @include _.z-index(dropdown);
 }

--- a/packages/console/src/ds-components/Tip/TipBubble/index.module.scss
+++ b/packages/console/src/ds-components/Tip/TipBubble/index.module.scss
@@ -10,7 +10,7 @@
   font: var(--font-body-2);
   max-width: 300px;
   white-space: pre-wrap;
-  z-index: 200;
+  @include _.z-index(tooltip);
 
   &.successful {
     background: var(--color-success-60);

--- a/packages/console/src/pages/ApiResourceDetails/components/GuideDrawer/index.module.scss
+++ b/packages/console/src/pages/ApiResourceDetails/components/GuideDrawer/index.module.scss
@@ -15,7 +15,7 @@
   font: var(--font-title-2);
   color: var(--color-text);
   box-shadow: var(--shadow-1);
-  z-index: 1;
+  @include _.z-index(front);
 
   .separator {
     border-left: 1px solid var(--color-border);

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/GuideDrawer/index.module.scss
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/GuideDrawer/index.module.scss
@@ -15,7 +15,7 @@
   font: var(--font-title-2);
   color: var(--color-text);
   box-shadow: var(--shadow-1);
-  z-index: 1;
+  @include _.z-index(front);
 
   .separator {
     border-left: 1px solid var(--color-border);

--- a/packages/console/src/pages/ApplicationDetails/components/AppGuide/index.module.scss
+++ b/packages/console/src/pages/ApplicationDetails/components/AppGuide/index.module.scss
@@ -70,7 +70,7 @@
   padding: _.unit(4) _.unit(6);
   background-color: var(--color-layer-1);
   box-shadow: var(--shadow-3);
-  z-index: 1;
+  @include _.z-index(front);
 
   .layout {
     margin: 0 auto;

--- a/packages/console/src/pages/Applications/components/GuideLibrary/index.module.scss
+++ b/packages/console/src/pages/Applications/components/GuideLibrary/index.module.scss
@@ -56,7 +56,7 @@
     position: absolute;
     right: -2px;
     bottom: 0;
-    z-index: 1;
+    @include _.z-index(front);
   }
 }
 

--- a/packages/console/src/scss/_underscore.scss
+++ b/packages/console/src/scss/_underscore.scss
@@ -96,3 +96,23 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+$allowed-z-indexes: (
+  base: 0,
+  front: 1,
+  behind: -1,
+  modal-backdrop: 100,
+  modal: 101,
+  confirm-modal: 102,
+  dropdown: 199,
+  tooltip: 200,
+);
+
+@mixin z-index($index) {
+  @if map-has-key($allowed-z-indexes, $index) {
+    z-index: map-get($allowed-z-indexes, $index);
+  }
+  @else {
+    @error 'Invalid z-index value. Allowed values are #{map-keys($allowed-z-indexes)}';
+  }
+}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- Fix the bug that rotating signing-key dropdown is not visible, caused by a mis-use of z-index values.
- Cosolidate all available z-index values into a SCSS mixin function, and limit the available options with a value map.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- Locally tested and the dropdown worked.
<img width="611" alt="image" src="https://github.com/logto-io/logto/assets/12833674/36d5433e-73a1-4f94-b196-89a7a7ee3b96">

- If I try to use a value not defined in the z-index value map, the compiler will report an error.
<img width="916" alt="image" src="https://github.com/logto-io/logto/assets/12833674/edb9170e-4fbd-43d6-9d16-cd352bba2576">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
