### PR TITLE
fix(console): fix the jwt creation page idle bug after submit form

### DIFF
--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/index.tsx
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/index.tsx
@@ -61,9 +61,13 @@ function MainContent<T extends LogtoJwtTokenKeyType>({
 
       await mutate(updatedJwtCustomizer);
 
+      // Need to reset the form data ahead to avoid the unsaved changes alert
       reset(formatResponseDataToFormData(tokenType, updatedJwtCustomizer));
 
+      // If the form is in create mode, navigate back to the previous page
       if (action === 'create') {
+        // Need to trigger a global mutate to update the cache
+        // Keep asynchrony to avoid page idling
         void globalMutate(getApiPath());
         navigate(-1);
       }

--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/index.tsx
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/index.tsx
@@ -2,17 +2,16 @@ import { type LogtoJwtTokenKeyType } from '@logto/schemas';
 import classNames from 'classnames';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
-import { type KeyedMutator } from 'swr';
+import { useSWRConfig, type KeyedMutator } from 'swr';
 
 import SubmitFormChangesActionBar from '@/components/SubmitFormChangesActionBar';
 import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
 import useApi from '@/hooks/use-api';
+import { getApiPath } from '@/pages/CustomizeJwt/utils/path';
 import { trySubmitSafe } from '@/utils/form';
 
-import useJwtCustomizer from '../../CustomizeJwt/use-jwt-customizer';
 import { type Action, type JwtCustomizer, type JwtCustomizerForm } from '../type';
 import { formatFormDataToRequestData, formatResponseDataToFormData } from '../utils/format';
-import { getApiPath } from '../utils/path';
 
 import ScriptSection from './ScriptSection';
 import SettingsSection from './SettingsSection';
@@ -35,7 +34,7 @@ function MainContent<T extends LogtoJwtTokenKeyType>({
 }: Props<T>) {
   const api = useApi();
   const navigate = useNavigate();
-  const { mutate: mutateJwtCustomizers } = useJwtCustomizer();
+  const { mutate: globalMutate } = useSWRConfig();
 
   const methods = useForm<JwtCustomizerForm>({
     defaultValues: formatResponseDataToFormData(token, data),
@@ -64,14 +63,8 @@ function MainContent<T extends LogtoJwtTokenKeyType>({
 
       reset(formatResponseDataToFormData(tokenType, updatedJwtCustomizer));
 
-      /**
-       * Should `reset` (to set `isDirty` to false) before navigating back to the custom JWT listing page.
-       * Otherwise, the unsaved changes alert modal will be triggered on clicking `create` button, which
-       * is not expected.
-       */
       if (action === 'create') {
-        // Refresh the JWT customizers list to reflect the latest changes.
-        await mutateJwtCustomizers();
+        void globalMutate(getApiPath());
         navigate(-1);
       }
     })

--- a/packages/console/src/pages/CustomizeJwtDetails/use-data-fetch.ts
+++ b/packages/console/src/pages/CustomizeJwtDetails/use-data-fetch.ts
@@ -4,10 +4,10 @@ import useSWR from 'swr';
 
 import useApi from '@/hooks/use-api';
 import useSwrFetcher from '@/hooks/use-swr-fetcher';
+import { getApiPath } from '@/pages/CustomizeJwt/utils/path';
 import { shouldRetryOnError } from '@/utils/request';
 
 import { type Action, type JwtCustomizer } from './type';
-import { getApiPath } from './utils/path';
 
 const useDataFetch = <T extends LogtoJwtTokenKeyType>(tokenType: T, action: Action) => {
   const apiPath = getApiPath(tokenType);

--- a/packages/console/src/pages/CustomizeJwtDetails/utils/path.ts
+++ b/packages/console/src/pages/CustomizeJwtDetails/utils/path.ts
@@ -1,4 +1,0 @@
-import { type LogtoJwtTokenKeyType } from '@logto/schemas';
-
-export const getApiPath = (tokenType: LogtoJwtTokenKeyType) =>
-  `api/configs/jwt-customizer/${tokenType}`;


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix the JWT creation page idle bug after submitting the form

- replace the `useJwtCustomizer` hook using useSWR global mutate to avoid the unnecessary API fetching
- remove the duplicate `getApiPath` util method
- change the await mutate to void, so the page can navigate immediately. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [ ] ~necessary TSDoc comments~
