### PR TITLE
chore(schemas): add cloud scope 'invoke:custom:jwt:workers'

### DIFF
--- a/packages/schemas/alterations/next-1713714446-add-cloud-api-scope-invoke-custom-jwt-workers.ts
+++ b/packages/schemas/alterations/next-1713714446-add-cloud-api-scope-invoke-custom-jwt-workers.ts
@@ -1,0 +1,58 @@
+import { generateStandardId } from '@logto/shared/universal';
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+type Resource = {
+  tenantId: string;
+  id: string;
+  name: string;
+  indicator: string;
+};
+
+const cloudApiIndicator = 'https://cloud.logto.io/api';
+
+const adminTenantId = 'admin';
+
+const invokeCustomJwtWorkersCloudScopeName = 'invoke:custom:jwt:workers';
+const invokeCustomJwtWorkersCloudScopeDescription =
+  'Allow accessing custom JWT workers to fetch the parsed token payload.';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    // Get the Cloud API resource
+    const cloudApiResource = await pool.one<Resource>(sql`
+      select * from resources
+      where tenant_id = ${adminTenantId}
+      and indicator = ${cloudApiIndicator}
+    `);
+
+    // Create the `invoke:custom:jwt:workers` scope
+    await pool.query(sql`
+      insert into scopes (id, tenant_id, resource_id, name, description)
+      values (${generateStandardId()}, ${adminTenantId}, ${
+        cloudApiResource.id
+      }, ${invokeCustomJwtWorkersCloudScopeName}, ${invokeCustomJwtWorkersCloudScopeDescription});
+    `);
+  },
+  down: async (pool) => {
+    // Get the Cloud API resource
+    const cloudApiResource = await pool.one<Resource>(sql`
+      select * from resources
+      where tenant_id = ${adminTenantId}
+      and indicator = ${cloudApiIndicator}
+    `);
+
+    // Remove the `invoke:custom:jwt:workers` scope
+    await pool.query(sql`
+      delete from scopes
+      where
+        tenant_id = ${adminTenantId} and
+        name = ${invokeCustomJwtWorkersCloudScopeName} and
+        description = ${invokeCustomJwtWorkersCloudScopeDescription} and
+        resource_id = ${cloudApiResource.id}
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/seeds/cloud-api.ts
+++ b/packages/schemas/src/seeds/cloud-api.ts
@@ -22,6 +22,16 @@ export enum CloudScope {
    * scripts and fetch the parsed token payload.
    */
   FetchCustomJwt = 'fetch:custom:jwt',
+  /**
+   * From current design, we have two different ways to execute JWT customizer scripts:
+   * with Azure Functions (for Dev tenants) and with Cloudflare Workers (for Pro tenants).
+   *
+   * In order to secure the Cloudflare Workers (they are publicly accessible), we decide to use Logto's internal M2M
+   * mechanism to protect the Workers.
+   *
+   * The entity (this is designed to be a M2M application scope) can invoke Cloudflare Workers to fetch custom JWT result.
+   */
+  InvokeCustomJwtWorkers = 'invoke:custom:jwt:workers',
   /** The user can see and manage affiliates, including create, update, and delete. */
   ManageAffiliate = 'manage:affiliate',
   /** The user can create new affiliates and logs. */
@@ -69,6 +79,10 @@ export const createCloudApi = (): Readonly<[UpdateAdminData, ...CreateScope[]]> 
     buildScope(
       CloudScope.FetchCustomJwt,
       'Allow accessing external resource to execute JWT payload customizer script and fetch the parsed token payload.'
+    ),
+    buildScope(
+      CloudScope.InvokeCustomJwtWorkers,
+      'Allow accessing custom JWT workers to fetch the parsed token payload.'
     ),
     buildScope(CloudScope.CreateAffiliate, 'Allow creating new affiliates and logs.'),
     buildScope(


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add cloud scope 'invoke:custom:jwt:workers`

We are using Cloudflare Workers to run custom JWT scripts for Pro tenants, but Cloudflare Workers are publicly accessible by default, we hence decide to apply Logto M2M mechanism to protect the Cloudflare Workers from being abused/attacked.

This is the first step of the implementation, there are two following steps to be done but pending on this change:
1. Add a M2M app and assign the scope added in this change (via a new M2M role), add the M2M app id/secret to cloud system for later use.
2. Get access token before CF worker request and add token verification for worker template.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
