### PR TITLE
fix: bring back docker edge build

### DIFF
--- a/.github/workflows/pen-tests.yml
+++ b/.github/workflows/pen-tests.yml
@@ -16,7 +16,6 @@ concurrency:
 
 jobs:
   zap-scan:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Bring back the docker edge build on the master push.

When investigating our pen-test job, I noticed the `svhd/logto:edge` container has not been updated for months. 
Lead back to the PR #5398.
In this PR, the tag releases event constrained the dockerize job.  Normal master push will no-longer trigger the dockerize job.
Remove the contains, and bring back the docker build with the `edge` tab on every master push. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
ci

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [ ] ~necessary TSDoc comments~
