### PR TITLE
feat: add the new dockerize-edge job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   dockerize:
     if: startsWith(github.ref, 'refs/tags/')
-    environment: "release"
+    environment: release
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -64,18 +64,19 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
   # Build and push the edge image on every master push
-  # Use docker to build and push the amd64 image directly.
-  # No need to use depot without arm64 support
-  dockerize-edge-image:
+  # Use official docker workflows since we only need to build amd64 images.
+  dockerize-edge:
     if: ${{ !startsWith(github.ref, 'refs/tags/')}}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
+
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -85,11 +86,13 @@ jobs:
             svhd/logto
           tags: |
             type=edge
+
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -97,8 +100,10 @@ jobs:
             ghcr.io
           username: silverhand-bot
           password: ${{ secrets.BOT_PAT }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Build and push docker image
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   dockerize:
     if: startsWith(github.ref, 'refs/tags/')
-    environment: ${{ startsWith(github.ref, 'refs/tags/') && 'release' || '' }}
+    environment: "release"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -58,6 +58,51 @@ jobs:
         with:
           platforms: linux/amd64, linux/arm64
           project: g902cp6dvv
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  # Build and push the edge image on every master push
+  # Use docker to build and push the amd64 image directly.
+  # No need to use depot without arm64 support
+  dockerize-ghcr-edge:
+    if: ${{ !startsWith(github.ref, 'refs/tags/')}}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/logto-io/logto
+            svhd/logto
+          tags: |
+            type=edge
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: |
+            ghcr.io
+          username: silverhand-bot
+          password: ${{ secrets.BOT_PAT }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push docker image
+        uses: docker/build-push-action@v5
+        with:
+          platforms: linux/amd64
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
   # Build and push the edge image on every master push
   # Use docker to build and push the amd64 image directly.
   # No need to use depot without arm64 support
-  dockerize-ghcr-edge:
+  dockerize-edge-image:
     if: ${{ !startsWith(github.ref, 'refs/tags/')}}
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->


### Background
When running a pen-test diagnosis, we noticed that our edge docker image hadn't been updated for a few months. Related PR #5398. 
GitHub does not provide a proper container environment for the `arm64` platform docker image build. We have to use the depot instead. But, we do not want to use the depot build quota on every edge image build.

### Solution
Add the new dockerize-edge-image job.  Build `amd64` platform only edge image, using the default local docker build. Triggers on every master push. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
ci workflow

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [x] necessary TSDoc comments
