### PR TITLE
chore: ignore the hidden file found zap alert

### DIFF
--- a/.zap/rules.conf
+++ b/.zap/rules.conf
@@ -12,3 +12,6 @@
 
 # The applicationInsights endpoint will be removed
 10055	IGNORE	(CSP - Wildcard Directive)
+
+# Experience app is rendered under the root path. No hidden files are exposed. A 404 experience page will be returned.
+40035 IGNORE (Hidden File Found - Active/release)


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
ignore the hidden file found zap alert

Since we render the experience react app under the root path, any non-existing path will be handled by the experience app. A 404 page will be returned with an HTTP status code 200. 

When running the hidden file detection, the zap pen-test receives a 200 response code， so it assumes the hidden file exists on the server side. 

Temporarily ignore the alter for now. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
ci

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [x] necessary TSDoc comments
