### PR TITLE
fix(experience): use correct callback path for native environments

### DIFF
--- a/.changeset/funny-books-sell.md
+++ b/.changeset/funny-books-sell.md
@@ -1,0 +1,9 @@
+---
+"@logto/experience": patch
+---
+
+fix native social sign-in callback
+
+In a native environment, the social sign-in callback that posts to the native container (e.g. WKWebView in iOS) was wrong.
+
+This was introduced by a refactor in #5536: It updated the callback path from `/sign-in/social/:connectorId` to `/callback/social/:connectorId`. However, the function to post the message to the native container was not updated accordingly.

--- a/packages/experience/src/containers/SocialSignInList/use-social.ts
+++ b/packages/experience/src/containers/SocialSignInList/use-social.ts
@@ -23,7 +23,7 @@ const useSocial = () => {
         : redirectTo;
 
     getLogtoNativeSdk()?.getPostMessage()({
-      callbackUri: `${window.location.origin}/sign-in/social/${connectorId}`,
+      callbackUri: `${window.location.origin}/callback/social/${connectorId}`,
       redirectTo: redirectUri,
     });
   }, []);

--- a/packages/experience/src/hooks/use-single-sign-on.ts
+++ b/packages/experience/src/hooks/use-single-sign-on.ts
@@ -25,7 +25,7 @@ const useSingleSignOn = () => {
     ).toString();
 
     getLogtoNativeSdk()?.getPostMessage()({
-      callbackUri: `${window.location.origin}/sign-in/social/${connectorId}`,
+      callbackUri: `${window.location.origin}/callback/social/${connectorId}`,
       redirectTo: redirectUri,
     });
   }, []);

--- a/packages/experience/src/pages/SocialSignInWebCallback/index.test.tsx
+++ b/packages/experience/src/pages/SocialSignInWebCallback/index.test.tsx
@@ -42,10 +42,10 @@ describe('SocialCallbackPage with code', () => {
       renderWithPageContext(
         <SettingsProvider>
           <Routes>
-            <Route path="/sign-in/social/:connectorId" element={<SocialCallback />} />
+            <Route path="/callback/social/:connectorId" element={<SocialCallback />} />
           </Routes>
         </SettingsProvider>,
-        { initialEntries: ['/sign-in/social/invalid'] }
+        { initialEntries: ['/callback/social/invalid'] }
       );
 
       await waitFor(() => {
@@ -69,10 +69,10 @@ describe('SocialCallbackPage with code', () => {
       renderWithPageContext(
         <SettingsProvider>
           <Routes>
-            <Route path="/sign-in/social/:connectorId" element={<SocialCallback />} />
+            <Route path="/callback/social/:connectorId" element={<SocialCallback />} />
           </Routes>
         </SettingsProvider>,
-        { initialEntries: [`/sign-in/social/${connectorId}`] }
+        { initialEntries: [`/callback/social/${connectorId}`] }
       );
 
       await waitFor(() => {
@@ -91,10 +91,10 @@ describe('SocialCallbackPage with code', () => {
       renderWithPageContext(
         <SettingsProvider>
           <Routes>
-            <Route path="/sign-in/social/:connectorId" element={<SocialCallback />} />
+            <Route path="/callback/social/:connectorId" element={<SocialCallback />} />
           </Routes>
         </SettingsProvider>,
-        { initialEntries: [`/sign-in/social/${connectorId}`] }
+        { initialEntries: [`/callback/social/${connectorId}`] }
       );
 
       await waitFor(() => {
@@ -122,10 +122,10 @@ describe('SocialCallbackPage with code', () => {
       renderWithPageContext(
         <SettingsProvider settings={sieSettings}>
           <Routes>
-            <Route path="/sign-in/social/:connectorId" element={<SocialCallback />} />
+            <Route path="/callback/social/:connectorId" element={<SocialCallback />} />
           </Routes>
         </SettingsProvider>,
-        { initialEntries: [`/sign-in/social/${connectorId}`] }
+        { initialEntries: [`/callback/social/${connectorId}`] }
       );
 
       await waitFor(() => {
@@ -144,10 +144,10 @@ describe('SocialCallbackPage with code', () => {
       renderWithPageContext(
         <SettingsProvider settings={sieSettings}>
           <Routes>
-            <Route path="/sign-in/social/:connectorId" element={<SocialCallback />} />
+            <Route path="/callback/social/:connectorId" element={<SocialCallback />} />
           </Routes>
         </SettingsProvider>,
-        { initialEntries: [`/sign-in/social/${connectorId}`] }
+        { initialEntries: [`/callback/social/${connectorId}`] }
       );
 
       await waitFor(() => {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
in a native environment, the social sign-in callback could not be handled due to the misconfigured callback path. this pull fixes the issue. see changeset for more details.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- tested locally, social sign-in can be complete in iOS simulator
- (next) add integration tests to cover this scenario

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
