### PR TITLE
Fix: Correctly identify Chinese mobile numbers

### DIFF
--- a/packages/connectors/connector-aliyun-sms/src/index.ts
+++ b/packages/connectors/connector-aliyun-sms/src/index.ts
@@ -20,7 +20,7 @@ import { sendSms } from './single-send-text.js';
 import type { Template } from './types.js';
 import { aliyunSmsConfigGuard, sendSmsResponseGuard } from './types.js';
 
-const isChinaNumber = (to: string) => /^(\+86|0086|86)?\d{11}$/.test(to);
+const isChinaNumber = (to: string) => /^(\+86|0086|86)\d{11}$/.test(to);
 
 const getTemplateCode = ({ templateCode }: Template, to: string) => {
   if (typeof templateCode === 'string') {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Correctly identify Chinese mobile numbers to prevent US mobile numbers from being classified as Chinese mobile numbers.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
