### PR TITLE
feat(schemas): add table for app org resource scope consent

### DIFF
--- a/packages/schemas/alterations/next-1714270244-application-org-resource-scope.ts
+++ b/packages/schemas/alterations/next-1714270244-application-org-resource-scope.ts
@@ -1,0 +1,32 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+import { applyTableRls, dropTableRls } from './utils/1704934999-tables.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      create table application_user_consent_organization_resource_scopes (
+        tenant_id varchar(21) not null
+          references tenants (id) on update cascade on delete cascade,
+        /** The globally unique identifier of the application. */
+        application_id varchar(21) not null
+          references applications (id) on update cascade on delete cascade,
+        /** The globally unique identifier of the resource scope. */
+        scope_id varchar(21) not null
+          references scopes (id) on update cascade on delete cascade,
+        primary key (application_id, scope_id)
+      );
+    `);
+    await applyTableRls(pool, 'application_user_consent_organization_resource_scopes');
+  },
+  down: async (pool) => {
+    await dropTableRls(pool, 'application_user_consent_organization_resource_scopes');
+    await pool.query(sql`
+      drop table application_user_consent_organization_resource_scopes
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/application_user_consent_organization_resource_scopes.sql
+++ b/packages/schemas/tables/application_user_consent_organization_resource_scopes.sql
@@ -1,0 +1,18 @@
+/* init_order = 3 */
+
+/**
+  The organization resource scopes (permissions) assigned to an application's consent request.
+  This is different from the application_user_consent_resource_scopes table, scopes in this table
+  is granted by the organization roles.
+*/
+create table application_user_consent_organization_resource_scopes (
+  tenant_id varchar(21) not null
+    references tenants (id) on update cascade on delete cascade,
+  /** The globally unique identifier of the application. */
+  application_id varchar(21) not null
+    references applications (id) on update cascade on delete cascade,
+  /** The globally unique identifier of the resource scope. */
+  scope_id varchar(21) not null
+    references scopes (id) on update cascade on delete cascade,
+  primary key (application_id, scope_id)
+);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Add new table `application_user_consent_organization_resource_scopes`.

This table will be used to store "organization resource scopes" for third-party applications.

Similar to `application_user_consent_resource_scopes`, but different relations, we need to filter out some organizations.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Existing tests should pass.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
