### PR TITLE
feat(core,schemas): add CRUD for consent organization resource scopes

### DIFF
--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Permissions/ApplicationScopesAssignmentModal/constants.ts
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Permissions/ApplicationScopesAssignmentModal/constants.ts
@@ -10,6 +10,11 @@ export const permissionTabs = Object.freeze({
     title: 'application_details.permissions.api_resource',
     key: ApplicationUserConsentScopeType.ResourceScopes,
   },
+  [ApplicationUserConsentScopeType.OrganizationResourceScopes]: {
+    // TODO @xiaoyijun: update the title
+    title: 'application_details.permissions.api_resource',
+    key: ApplicationUserConsentScopeType.OrganizationResourceScopes,
+  },
   [ApplicationUserConsentScopeType.OrganizationScopes]: {
     title: 'application_details.permissions.organization',
     key: ApplicationUserConsentScopeType.OrganizationScopes,

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Permissions/ApplicationScopesAssignmentModal/use-application-scopes-assignment.ts
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Permissions/ApplicationScopesAssignmentModal/use-application-scopes-assignment.ts
@@ -72,6 +72,8 @@ const useApplicationScopesAssignment = (applicationId: string) => {
       [ApplicationUserConsentScopeType.UserScopes]: userScopesAssignment,
       [ApplicationUserConsentScopeType.OrganizationScopes]: organizationScopesAssignment,
       [ApplicationUserConsentScopeType.ResourceScopes]: resourceScopesAssignment,
+      // TODO @xiaoyijun: Replace with correct scopes
+      [ApplicationUserConsentScopeType.OrganizationResourceScopes]: resourceScopesAssignment,
     }),
     [organizationScopesAssignment, resourceScopesAssignment, userScopesAssignment]
   );

--- a/packages/core/src/queries/application-user-consent-scopes.ts
+++ b/packages/core/src/queries/application-user-consent-scopes.ts
@@ -2,6 +2,7 @@ import { type UserScope } from '@logto/core-kit';
 import {
   ApplicationUserConsentOrganizationScopes,
   ApplicationUserConsentResourceScopes,
+  ApplicationUserConsentOrganizationResourceScopes,
   ApplicationUserConsentUserScopes,
   Applications,
   OrganizationScopes,
@@ -29,6 +30,15 @@ export class ApplicationUserConsentResourceScopeQueries extends TwoRelationsQuer
 > {
   constructor(pool: CommonQueryMethods) {
     super(pool, ApplicationUserConsentResourceScopes.table, Applications, Scopes);
+  }
+}
+
+export class ApplicationUserConsentOrganizationResourceScopeQueries extends TwoRelationsQueries<
+  typeof Applications,
+  typeof Scopes
+> {
+  constructor(pool: CommonQueryMethods) {
+    super(pool, ApplicationUserConsentOrganizationResourceScopes.table, Applications, Scopes);
   }
 }
 

--- a/packages/core/src/queries/application.ts
+++ b/packages/core/src/queries/application.ts
@@ -15,6 +15,7 @@ import type { OmitAutoSetFields } from '#src/utils/sql.js';
 
 import ApplicationUserConsentOrganizationsQuery from './application-user-consent-organizations.js';
 import {
+  ApplicationUserConsentOrganizationResourceScopeQueries,
   ApplicationUserConsentOrganizationScopeQueries,
   ApplicationUserConsentResourceScopeQueries,
   createApplicationUserConsentUserScopeQueries,
@@ -253,6 +254,8 @@ export const createApplicationQueries = (pool: CommonQueryMethods) => {
     deleteApplicationById,
     userConsentOrganizationScopes: new ApplicationUserConsentOrganizationScopeQueries(pool),
     userConsentResourceScopes: new ApplicationUserConsentResourceScopeQueries(pool),
+    userConsentOrganizationResourceScopes:
+      new ApplicationUserConsentOrganizationResourceScopeQueries(pool),
     userConsentUserScopes: createApplicationUserConsentUserScopeQueries(pool),
     userConsentOrganizations: new ApplicationUserConsentOrganizationsQuery(pool),
   };

--- a/packages/core/src/routes/applications/application-user-consent-scope.openapi.json
+++ b/packages/core/src/routes/applications/application-user-consent-scope.openapi.json
@@ -15,6 +15,9 @@
                   "resourceScopes": {
                     "description": "A list of resource scope id to assign to the application. Throws error if any given resource scope is not found."
                   },
+                  "organizationResourceScopes": {
+                    "description": "A list of organization resource scope id to assign to the application. Throws error if any given resource scope is not found."
+                  },
                   "userScopes": {
                     "description": "A list of user scope enum value to assign to the application."
                   }
@@ -50,6 +53,9 @@
                     },
                     "resourceScopes": {
                       "description": "A list of resource scope details grouped by resource id assigned to the application."
+                    },
+                    "organizationResourceScopes": {
+                      "description": "A list of organization resource scope details grouped by resource id assigned to the application."
                     },
                     "userScopes": {
                       "description": "A list of user scope enum value assigned to the application."

--- a/packages/integration-tests/src/api/application-user-consent-scope.ts
+++ b/packages/integration-tests/src/api/application-user-consent-scope.ts
@@ -11,6 +11,7 @@ export const assignUserConsentScopes = async (
   payload: {
     organizationScopes?: string[];
     resourceScopes?: string[];
+    organizationResourceScopes?: string[];
     userScopes?: UserScope[];
   }
 ) => authedAdminApi.post(`applications/${applicationId}/user-consent-scopes`, { json: payload });

--- a/packages/schemas/src/types/application.ts
+++ b/packages/schemas/src/types/application.ts
@@ -40,22 +40,26 @@ export const applicationPatchGuard = applicationCreateGuard.partial().omit({
   isThirdParty: true,
 });
 
+const resourceScopesGuard = z.array(
+  z.object({
+    resource: Resources.guard.pick({ id: true, name: true, indicator: true }),
+    scopes: z.array(Scopes.guard.pick({ id: true, name: true, description: true })),
+  })
+);
+
 export const applicationUserConsentScopesResponseGuard = z.object({
   organizationScopes: z.array(
     OrganizationScopes.guard.pick({ id: true, name: true, description: true })
   ),
-  resourceScopes: z.array(
-    z.object({
-      resource: Resources.guard.pick({ id: true, name: true, indicator: true }),
-      scopes: z.array(Scopes.guard.pick({ id: true, name: true, description: true })),
-    })
-  ),
+  resourceScopes: resourceScopesGuard,
+  organizationResourceScopes: resourceScopesGuard,
   userScopes: z.array(z.nativeEnum(UserScope)),
 });
 
 export enum ApplicationUserConsentScopeType {
   OrganizationScopes = 'organization-scopes',
   ResourceScopes = 'resource-scopes',
+  OrganizationResourceScopes = 'organization-resource-scopes',
   UserScopes = 'user-scopes',
 }
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Implement the new field `ApplicationUserConsentOrganizationResourceScopes` in the following APIs:

- `GET /applications/:applicationId/user-consent-scopes`
- `POST /applications/:applicationId/user-consent-scopes`
- `DELETE /applications/:applicationId/user-consent-scopes/:scopeType/:scopeId`

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Integration tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
