### PR TITLE
feat(core,schemas): add org resource scopes to consent get

### DIFF
--- a/packages/core/src/libraries/user.ts
+++ b/packages/core/src/libraries/user.ts
@@ -175,15 +175,18 @@ export const createUserLibrary = (queries: Queries) => {
   const findUserScopesForResourceIndicator = async (
     userId: string,
     resourceIndicator: string,
+    findFromOrganizations = false,
     organizationId?: string
   ): Promise<readonly Scope[]> => {
     const usersRoles = await findUsersRolesByUserId(userId);
     const rolesScopes = await findRolesScopesByRoleIds(usersRoles.map(({ roleId }) => roleId));
-    const organizationScopes = await organizations.relations.rolesUsers.getUserResourceScopes(
-      userId,
-      resourceIndicator,
-      organizationId
-    );
+    const organizationScopes = findFromOrganizations
+      ? await organizations.relations.rolesUsers.getUserResourceScopes(
+          userId,
+          resourceIndicator,
+          organizationId
+        )
+      : [];
 
     const scopes = await findScopesByIdsAndResourceIndicator(
       [...rolesScopes.map(({ scopeId }) => scopeId), ...organizationScopes.map(({ id }) => id)],

--- a/packages/integration-tests/src/tests/api/interaction/third-party-sign-in/happy-path.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/third-party-sign-in/happy-path.test.ts
@@ -7,9 +7,18 @@ import { assignUserConsentScopes } from '#src/api/application-user-consent-scope
 import { createApplication, deleteApplication } from '#src/api/application.js';
 import { getConsentInfo, putInteraction } from '#src/api/interaction.js';
 import { OrganizationScopeApi } from '#src/api/organization-scope.js';
+import { createResource, deleteResource } from '#src/api/resource.js';
+import { createScope } from '#src/api/scope.js';
 import { initClient } from '#src/helpers/client.js';
+import { OrganizationApiTest, OrganizationRoleApiTest } from '#src/helpers/organization.js';
 import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
+import {
+  generateResourceIndicator,
+  generateResourceName,
+  generateRoleName,
+  generateScopeName,
+} from '#src/utils.js';
 
 describe('consent api', () => {
   const applications = new Map<string, Application>();
@@ -123,6 +132,63 @@ describe('consent api', () => {
     ).not.toBeUndefined();
 
     await organizationScopeApi.delete(organizationScope.id);
+    await deleteUser(user.id);
+  });
+
+  it('get consent info with organization resource scopes', async () => {
+    const application = applications.get(thirdPartyApplicationName);
+    assert(application, new Error('application.not_found'));
+
+    const resource = await createResource(generateResourceName(), generateResourceIndicator());
+    const scope = await createScope(resource.id, generateScopeName());
+    const scope2 = await createScope(resource.id, generateScopeName());
+    const roleApi = new OrganizationRoleApiTest();
+    const role = await roleApi.create({
+      name: generateRoleName(),
+      resourceScopeIds: [scope.id],
+    });
+    const organizationApi = new OrganizationApiTest();
+    const organization = await organizationApi.create({ name: 'test_org' });
+    const { userProfile, user } = await generateNewUser({ username: true, password: true });
+    await organizationApi.addUsers(organization.id, [user.id]);
+    await organizationApi.addUserRoles(organization.id, user.id, [role.id]);
+
+    await assignUserConsentScopes(application.id, {
+      organizationResourceScopes: [scope.id],
+      userScopes: [UserScope.Organizations],
+    });
+
+    const client = await initClient(
+      {
+        appId: application.id,
+        appSecret: application.secret,
+        scopes: [UserScope.Organizations, UserScope.Profile, scope.name, scope2.name],
+        resources: [resource.indicator],
+      },
+      redirectUri
+    );
+
+    await client.successSend(putInteraction, {
+      event: InteractionEvent.SignIn,
+      identifier: {
+        username: userProfile.username,
+        password: userProfile.password,
+      },
+    });
+
+    const { redirectTo } = await client.submitInteraction();
+
+    await client.processSession(redirectTo, false);
+
+    const result = await client.send(getConsentInfo);
+
+    expect(result.missingResourceScopes).toHaveLength(0);
+    // Only scope1, scope2 is removed
+    expect(result.organizations?.[0]?.missingResourceScopes).toHaveLength(1);
+
+    await roleApi.cleanUp();
+    await organizationApi.cleanUp();
+    await deleteResource(resource.id);
     await deleteUser(user.id);
   });
 

--- a/packages/schemas/src/types/consent.ts
+++ b/packages/schemas/src/types/consent.ts
@@ -37,14 +37,6 @@ export const applicationSignInExperienceGuard = ApplicationSignInExperiences.gua
   termsOfUseUrl: true,
 });
 
-/**
- * Define the public organization info that can be exposed to the public. e.g. on the user consent page.
- */
-export const publicOrganizationGuard = Organizations.guard.pick({
-  id: true,
-  name: true,
-});
-
 export const missingResourceScopesGuard = z.object({
   // The original resource id has a maximum length of 21 restriction. We need to make it compatible with the logto reserved organization name.
   // use string here, as we do not care about the resource id length here.
@@ -56,6 +48,20 @@ export const missingResourceScopesGuard = z.object({
  * Define the missing resource scopes for the consent page.
  */
 export type MissingResourceScopes = z.infer<typeof missingResourceScopesGuard>;
+
+/**
+ * Define the public organization info that can be exposed to the public. e.g. on the user consent page.
+ */
+export const publicOrganizationGuard = Organizations.guard
+  .pick({
+    id: true,
+    name: true,
+  })
+  .extend({
+    missingResourceScopes: missingResourceScopesGuard.array().optional(),
+  });
+
+export type PublicOrganization = z.infer<typeof publicOrganizationGuard>;
 
 export const consentInfoResponseGuard = z.object({
   application: publicApplicationGuard.merge(applicationSignInExperienceGuard.partial()),


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Add organization resource scopes info to `GET /interaction/consent`:

1. Filter out organizations-only resource scopes from `missingResourceScopes`.
2. Add `missingResourceScopes` to `organizations`.

To implement it, this PR includes:

1. Split `filterResourceScopesForTheThirdPartyApplication` into 2 functions, one for non-organizations, another for organizations. This helps the "filter out" operation in consetn GET.
2. Rebuild the scopes list in this API route. Because `missingResourceScopes` contains only scope name, without id. So I copied some of the code lines from `getResourceServerInfo` where the original `missingResourceScopes` comes from.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Integration tests and local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
