### PR TITLE
fix(core): fix upload file guard

### DIFF
--- a/.changeset/smart-melons-shop.md
+++ b/.changeset/smart-melons-shop.md
@@ -1,0 +1,10 @@
+---
+"@logto/phrases": patch
+"@logto/core": patch
+---
+
+Fix file upload API.
+
+The `koa-body` has been upgraded to the latest version, which caused the file upload API to break. This change fixes the issue.
+
+The `ctx.request.files.file` in the new version is an array, so the code has been updated to pick the first one.

--- a/packages/connectors/connector-feishu-web/src/index.ts
+++ b/packages/connectors/connector-feishu-web/src/index.ts
@@ -153,7 +153,7 @@ export function getUserInfo(getConfig: GetConnectorConfig): GetUserInfo {
         avatar,
         email: conditional(email),
         userId: conditional(user_id),
-        phone: conditional(mobile),
+        phone: conditional(mobile?.replace('+', '')),
         rawData: jsonGuard.parse(response.body),
       };
     } catch (error: unknown) {

--- a/packages/core/src/routes/user-assets.ts
+++ b/packages/core/src/routes/user-assets.ts
@@ -52,13 +52,15 @@ export default function userAssetsRoutes<T extends ManagementApiRouter>(
     '/user-assets',
     koaGuard({
       files: object({
-        file: uploadFileGuard,
+        file: uploadFileGuard.array().min(1),
       }),
       response: userAssetsGuard,
     }),
     async (ctx, next) => {
-      const { file } = ctx.guard.files;
+      const { file: bodyFiles } = ctx.guard.files;
 
+      const file = bodyFiles[0];
+      assertThat(file, 'guard.invalid_input');
       assertThat(file.size <= maxUploadFileSize, 'guard.file_size_exceeded');
       assertThat(
         allowUploadMimeTypes.map(String).includes(file.mimetype),


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Fix file upload API.

The `koa-body` has been upgraded to the latest version, which caused the file upload API to break. This change fixes the issue.

The `ctx.request.files.file` in the new version is an array, so the code has been updated to pick the first one.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
