### PR TITLE
feat(core): filter scopes assigned to organization roles

### DIFF
--- a/.changeset/afraid-buckets-accept.md
+++ b/.changeset/afraid-buckets-accept.md
@@ -1,0 +1,7 @@
+---
+"@logto/core": minor
+---
+
+filter scopes assigned to organization roles
+
+For api `GET /resources`, extend the query parameter `includeScopes` with new value `assignedByOrganizations` to filter scopes assigned by organization roles only.

--- a/packages/core/src/queries/organization/index.ts
+++ b/packages/core/src/queries/organization/index.ts
@@ -45,8 +45,8 @@ class OrganizationRolesQueries extends SchemaQueries<
   }
 
   override async findAll(
-    limit: number,
-    offset: number,
+    limit?: number,
+    offset?: number,
     search?: SearchOptions<OrganizationRoleKeys>
   ): Promise<[totalNumber: number, rows: Readonly<OrganizationRoleWithScopes[]>]> {
     return Promise.all([

--- a/packages/core/src/routes/resource.openapi.json
+++ b/packages/core/src/routes/resource.openapi.json
@@ -12,7 +12,7 @@
           {
             "in": "query",
             "name": "includeScopes",
-            "description": "If it's provided with a truthy value (`true`, `1`, `yes`), the scopes of each resource will be included in the response."
+            "description": "If it's provided with a truthy value (`true`, `1`, `yes`) or `assignedByOrganizations`, the scopes of each resource will be included in the response. And if it is set to `assignedByOrganizations`, only the scopes assigned by organizations will be included."
           }
         ],
         "responses": {

--- a/packages/core/src/utils/resource.ts
+++ b/packages/core/src/utils/resource.ts
@@ -1,10 +1,23 @@
-import { type Resource, type ResourceResponse } from '@logto/schemas';
+import {
+  type OrganizationRoleWithScopes,
+  type Resource,
+  type ResourceResponse,
+} from '@logto/schemas';
 
 import type Queries from '#src/tenants/Queries.js';
 
+/**
+ * Query and attach scopes to resources.
+ *
+ * @param resources list of resources
+ * @param scopeQueries queries
+ * @param organizationRoles when provided, only the scopes that are assigned to the organization roles
+ * @returns
+ */
 export const attachScopesToResources = async (
   resources: readonly Resource[],
-  scopeQueries: Queries['scopes']
+  scopeQueries: Queries['scopes'],
+  organizationRoles?: readonly OrganizationRoleWithScopes[]
 ): Promise<ResourceResponse[]> => {
   const { findScopesByResourceIds } = scopeQueries;
   const resourceIds = resources.map(({ id }) => id);
@@ -12,6 +25,14 @@ export const attachScopesToResources = async (
 
   return resources.map((resource) => ({
     ...resource,
-    scopes: scopes.filter(({ resourceId }) => resourceId === resource.id),
+    scopes: scopes
+      .filter(({ resourceId }) => resourceId === resource.id)
+      .filter(
+        ({ id }) =>
+          !organizationRoles ||
+          organizationRoles.some(({ resourceScopes }) =>
+            resourceScopes.some((scope) => scope.id === id)
+          )
+      ),
   }));
 };

--- a/packages/integration-tests/src/api/resource.ts
+++ b/packages/integration-tests/src/api/resource.ts
@@ -1,4 +1,5 @@
-import type { Resource, CreateResource } from '@logto/schemas';
+import type { Resource, CreateResource, Scope } from '@logto/schemas';
+import { conditionalString } from '@silverhand/essentials';
 import { type Options } from 'ky';
 
 import { generateResourceIndicator, generateResourceName } from '#src/utils.js';
@@ -15,7 +16,14 @@ export const createResource = async (name?: string, indicator?: string) =>
     })
     .json<Resource>();
 
-export const getResources = async () => authedAdminApi.get('resources').json<Resource[]>();
+export const getResources = async (query?: string) =>
+  authedAdminApi.get(`resources${conditionalString(query && `?${query}`)}`).json<
+    Array<
+      Resource & {
+        scopes?: Scope[];
+      }
+    >
+  >();
 
 export const getResource = async (resourceId: string, options?: Options) =>
   authedAdminApi.get(`resources/${resourceId}`, options).json<Resource>();


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Filter scopes assigned to organization roles.

For api `GET /resources`, add a query parameter `assignedByOrganizations` to filter scopes assigned by organization roles only. This is only useful when `includeScopes` is set to `true`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Integration tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
