### PR TITLE
fix(core): invitee email check should be case insensitive

### DIFF
--- a/.changeset/popular-chicken-share.md
+++ b/.changeset/popular-chicken-share.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": patch
+---
+
+fix a bug that prevents invitee from accepting the organization invitation if the email letter case is not matching

--- a/packages/core/src/libraries/organization-invitation.ts
+++ b/packages/core/src/libraries/organization-invitation.ts
@@ -157,7 +157,7 @@ export class OrganizationInvitationLibrary {
 
           const user = await userQueries.findUserById(acceptedUserId);
 
-          if (user.primaryEmail !== entity.invitee) {
+          if (user.primaryEmail?.toLowerCase() !== entity.invitee.toLowerCase()) {
             throw new RequestError({
               status: 422,
               code: 'request.invalid_input',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the bug that invitee cannot accept invitation if the email letter case is not matching

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Will update integration tests in the Cloud repo

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
