### PR TITLE
fix(console): hide org resource scopes tab from 3rd-party app modal

### DIFF
--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Permissions/ApplicationScopesAssignmentModal/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Permissions/ApplicationScopesAssignmentModal/index.tsx
@@ -47,21 +47,28 @@ function ApplicationScopesAssignmentModal({ isOpen, onClose, applicationId }: Pr
 
   const tabs = useMemo(
     () =>
-      Object.values(permissionTabs).map(({ title, key }) => {
-        const selectedDataCount = scopesAssignment[key].selectedData.length;
+      Object.values(permissionTabs)
+        /**
+         * Hide the organization resource scopes tab since the feature is not ready.
+         * We don't need the `isDevFeaturesEnabled` flag since the feature will change the UI.
+         * Todo @xiaoyijun Implement the new organization resource scopes feature. LOG-8823
+         */
+        .filter(({ key }) => key !== ApplicationUserConsentScopeType.OrganizationResourceScopes)
+        .map(({ title, key }) => {
+          const selectedDataCount = scopesAssignment[key].selectedData.length;
 
-        return (
-          <TabNavItem
-            key={key}
-            isActive={key === activeTab}
-            onClick={() => {
-              setActiveTab(key);
-            }}
-          >
-            {`${t(title)}${selectedDataCount ? ` (${selectedDataCount})` : ''}`}
-          </TabNavItem>
-        );
-      }),
+          return (
+            <TabNavItem
+              key={key}
+              isActive={key === activeTab}
+              onClick={() => {
+                setActiveTab(key);
+              }}
+            >
+              {`${t(title)}${selectedDataCount ? ` (${selectedDataCount})` : ''}`}
+            </TabNavItem>
+          );
+        }),
     [activeTab, scopesAssignment, setActiveTab, t]
   );
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
hide org resource scopes tab from 3rd-party app modal

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Before
<img width="886" alt="image" src="https://github.com/logto-io/logto/assets/10806653/01b2c903-642f-41b2-bf81-1ca7441104e7">

### After
<img width="831" alt="image" src="https://github.com/logto-io/logto/assets/10806653/3b5f8361-4f30-4c5b-98b1-08a20920072f">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
- [x] necessary TSDoc comments
