### PR TITLE
fix(console): move handle social route to global anonymous route enum

### DIFF
--- a/packages/console/src/cloud/AppRoutes.tsx
+++ b/packages/console/src/cloud/AppRoutes.tsx
@@ -25,7 +25,7 @@ function AppRoutes() {
             element={<AcceptInvitation />}
           />
           <Route path={GlobalAnonymousRoute.Profile + '/*'} element={<Profile />} />
-          <Route path="/handle-social" element={<HandleSocialCallback />} />
+          <Route path={GlobalAnonymousRoute.HandleSocial} element={<HandleSocialCallback />} />
           <Route path={GlobalRoute.CheckoutSuccessCallback} element={<CheckoutSuccessCallback />} />
           <Route index element={<Main />} />
         </Route>

--- a/packages/console/src/containers/ConsoleRoutes/index.tsx
+++ b/packages/console/src/containers/ConsoleRoutes/index.tsx
@@ -14,7 +14,6 @@ import useSwrOptions from '@/hooks/use-swr-options';
 import Callback from '@/pages/Callback';
 import CheckoutSuccessCallback from '@/pages/CheckoutSuccessCallback';
 import Profile from '@/pages/Profile';
-import HandleSocialCallback from '@/pages/Profile/containers/HandleSocialCallback';
 import Welcome from '@/pages/Welcome';
 import { dropLeadingSlash } from '@/utils/url';
 
@@ -48,7 +47,6 @@ export function ConsoleRoutes() {
             path={dropLeadingSlash(GlobalAnonymousRoute.Profile) + '/*'}
             element={<Profile />}
           />
-          <Route path="handle-social" element={<HandleSocialCallback />} />
           <Route element={<TenantAccess />}>
             {isCloud && (
               <Route

--- a/packages/console/src/contexts/TenantsProvider.tsx
+++ b/packages/console/src/contexts/TenantsProvider.tsx
@@ -23,6 +23,7 @@ export enum GlobalAnonymousRoute {
   SocialDemoCallback = '/social-demo-callback',
   AcceptInvitation = '/accept',
   Profile = '/profile',
+  HandleSocial = '/handle-social',
 }
 
 /**


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Move `/handle-social` route to `GlobalAnonymousRoute` enum, in order to bypass the tenant ID check on Console loading. `/handle-social` route has been moved outside of tenant context, along with the changes made for `/profile` route.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
To be tested on Cloud dev

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
