### PR TITLE
fix(core): filter scopes for 3rd-party app

### DIFF
--- a/packages/core/src/oidc/resource.ts
+++ b/packages/core/src/oidc/resource.ts
@@ -120,7 +120,11 @@ export const filterResourceScopesForTheThirdPartyApplication = async (
   libraries: Libraries,
   applicationId: string,
   indicator: string,
-  scopes: ReadonlyArray<{ name: string; id: string }>
+  scopes: ReadonlyArray<{ name: string; id: string }>,
+  {
+    includeOrganizationResourceScopes = true,
+    includeResourceScopes = true,
+  }: { includeOrganizationResourceScopes?: boolean; includeResourceScopes?: boolean } = {}
 ) => {
   const {
     applications: {
@@ -154,12 +158,16 @@ export const filterResourceScopesForTheThirdPartyApplication = async (
   }
 
   // Get the API resource scopes that are enabled in the application
-  const userConsentResources = await getApplicationUserConsentResourceScopes(applicationId);
+  const userConsentResources = includeResourceScopes
+    ? await getApplicationUserConsentResourceScopes(applicationId)
+    : [];
   const userConsentResource = userConsentResources.find(
     ({ resource }) => resource.indicator === indicator
   );
   const userConsentOrganizationResources = EnvSet.values.isDevFeaturesEnabled
-    ? await getApplicationUserConsentOrganizationResourceScopes(applicationId)
+    ? includeOrganizationResourceScopes
+      ? await getApplicationUserConsentOrganizationResourceScopes(applicationId)
+      : []
     : [];
   const userConsentOrganizationResource = userConsentOrganizationResources.find(
     ({ resource }) => resource.indicator === indicator

--- a/packages/core/src/routes/interaction/consent/index.ts
+++ b/packages/core/src/routes/interaction/consent/index.ts
@@ -106,6 +106,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
         queries,
         libraries,
         userId,
+        applicationId,
       });
 
       const organizationsWithMissingResourceScopes = await Promise.all(
@@ -120,6 +121,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
             libraries,
             userId,
             organizationId: id,
+            applicationId,
           });
 
           return { name, id, missingResourceScopes };
@@ -249,6 +251,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
         queries,
         libraries,
         userId: accountId,
+        applicationId: clientId,
       });
 
       // Find the organizations if the application is requesting the organizations scope
@@ -268,6 +271,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
             libraries,
             userId: accountId,
             organizationId: id,
+            applicationId: clientId,
           });
 
           return { name, id, missingResourceScopes };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

In consent API, should always filter resource scopes for third party application.

Although the "missiongResourceScopes" from the prompt details are already filtered, there may be duplicated scopes from either resources or organization resources.

For example, if `scope1` is enabled in "personal" but not in "organizations", then it can appear in "missiongResourceScopes".

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested, and integration tests case added.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
