### PR TITLE
fix(core): should sign out user after deletion or suspension

### DIFF
--- a/.changeset/green-cougars-behave.md
+++ b/.changeset/green-cougars-behave.md
@@ -1,0 +1,7 @@
+---
+"@logto/core": patch
+---
+
+Sign out user after deletion or suspension
+
+When a user is deleted or suspended through Management API, they should be signed out immediately, including sessions and refresh tokens.

--- a/packages/core/src/libraries/user.ts
+++ b/packages/core/src/libraries/user.ts
@@ -89,6 +89,7 @@ export const createUserLibrary = (queries: Queries) => {
     rolesScopes: { findRolesScopesByRoleIds },
     scopes: { findScopesByIdsAndResourceIndicator },
     organizations,
+    oidcModelInstances: { revokeInstanceByUserId },
   } = queries;
 
   const generateUserId = async (retries = 500) =>
@@ -270,6 +271,14 @@ export const createUserLibrary = (queries: Queries) => {
     return user;
   };
 
+  const signOutUser = async (userId: string) => {
+    await Promise.all([
+      revokeInstanceByUserId('AccessToken', userId),
+      revokeInstanceByUserId('RefreshToken', userId),
+      revokeInstanceByUserId('Session', userId),
+    ]);
+  };
+
   return {
     generateUserId,
     insertUser,
@@ -279,5 +288,6 @@ export const createUserLibrary = (queries: Queries) => {
     findUserRoles,
     addUserMfaVerification,
     verifyUserPassword,
+    signOutUser,
   };
 };

--- a/packages/core/src/routes/admin-user/basics.ts
+++ b/packages/core/src/routes/admin-user/basics.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { emailRegEx, phoneRegEx, usernameRegEx } from '@logto/core-kit';
 import {
   UsersPasswordEncryptionMethod,
@@ -21,7 +22,6 @@ export default function adminUserBasicsRoutes<T extends ManagementApiRouter>(
 ) {
   const [router, { queries, libraries }] = args;
   const {
-    oidcModelInstances: { revokeInstanceByUserId },
     users: {
       deleteUserById,
       findUserById,
@@ -33,7 +33,13 @@ export default function adminUserBasicsRoutes<T extends ManagementApiRouter>(
     userSsoIdentities,
   } = queries;
   const {
-    users: { checkIdentifierCollision, generateUserId, insertUser, verifyUserPassword },
+    users: {
+      checkIdentifierCollision,
+      generateUserId,
+      insertUser,
+      verifyUserPassword,
+      signOutUser,
+    },
   } = libraries;
 
   router.get(
@@ -343,12 +349,11 @@ export default function adminUserBasicsRoutes<T extends ManagementApiRouter>(
       });
 
       if (isSuspended) {
-        await revokeInstanceByUserId('refreshToken', user.id);
+        await signOutUser(user.id);
       }
 
       ctx.body = pick(user, ...userInfoSelectFields);
 
-      // eslint-disable-next-line max-lines
       return next();
     }
   );
@@ -368,6 +373,7 @@ export default function adminUserBasicsRoutes<T extends ManagementApiRouter>(
         throw new RequestError('user.cannot_delete_self');
       }
 
+      await signOutUser(userId);
       await deleteUserById(userId);
 
       ctx.status = 204;
@@ -376,3 +382,4 @@ export default function adminUserBasicsRoutes<T extends ManagementApiRouter>(
     }
   );
 }
+/* eslint-enable max-lines */

--- a/packages/integration-tests/src/tests/api/admin-user.test.ts
+++ b/packages/integration-tests/src/tests/api/admin-user.test.ts
@@ -22,7 +22,11 @@ import {
 } from '#src/api/index.js';
 import { clearConnectorsByTypes } from '#src/helpers/connector.js';
 import { createUserByAdmin, expectRejects } from '#src/helpers/index.js';
-import { createNewSocialUserWithUsernameAndPassword } from '#src/helpers/interactions.js';
+import {
+  createNewSocialUserWithUsernameAndPassword,
+  signInWithPassword,
+} from '#src/helpers/interactions.js';
+import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
 import {
   generateUsername,
   generateEmail,
@@ -177,7 +181,9 @@ describe('admin console user management', () => {
   });
 
   it('should delete user successfully', async () => {
-    const user = await createUserByAdmin();
+    const username = generateUsername();
+    const password = 'password';
+    const user = await createUserByAdmin({ username, password });
 
     const userEntity = await getUser(user.id);
     expect(userEntity).toMatchObject(user);
@@ -186,6 +192,10 @@ describe('admin console user management', () => {
 
     const response = await getUser(user.id).catch((error: unknown) => error);
     expect(response instanceof HTTPError && response.response.status === 404).toBe(true);
+
+    await enableAllPasswordSignInMethods();
+    // Sign in with deleted user should throw error
+    await expect(signInWithPassword({ username, password })).rejects.toThrowError();
   });
 
   it('should update user password successfully', async () => {


### PR DESCRIPTION
fixed #5572

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

should sign out user after deletion or suspension:

1. delete refresh token
2. delete opaque access token
3. delete session

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested, and integration tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
