### PR TITLE
fix(core): add devFeature guard for DataHooks

### DIFF
--- a/packages/core/src/middleware/koa-management-api-hooks.ts
+++ b/packages/core/src/middleware/koa-management-api-hooks.ts
@@ -30,7 +30,7 @@ export const koaManagementApiHooks = <StateT, ContextT extends IRouterParamConte
     // TODO: Remove dev feature guard
     const { isDevFeaturesEnabled } = EnvSet.values;
     if (!isDevFeaturesEnabled) {
-      return;
+      return next();
     }
 
     const {

--- a/packages/core/src/routes/hook.ts
+++ b/packages/core/src/routes/hook.ts
@@ -7,7 +7,6 @@ import {
   hookEventsGuard,
   hookResponseGuard,
   interactionHookEventGuard,
-  interactionHookEventsGuard,
   type Hook,
   type HookResponse,
 } from '@logto/schemas';
@@ -28,7 +27,9 @@ import type { ManagementApiRouter, RouterInitArgs } from './types.js';
 
 const { isDevFeaturesEnabled } = EnvSet.values;
 // TODO: remove dev features guard
-const webhookEventsGuard = isDevFeaturesEnabled ? hookEventsGuard : interactionHookEventsGuard;
+const webhookEventsGuard = isDevFeaturesEnabled
+  ? hookEventsGuard
+  : interactionHookEventGuard.array();
 const nonemptyUniqueHookEventsGuard = webhookEventsGuard
   .nonempty()
   .transform((events) => deduplicate(events));

--- a/packages/schemas/src/foundations/jsonb-types/hooks.ts
+++ b/packages/schemas/src/foundations/jsonb-types/hooks.ts
@@ -82,6 +82,9 @@ export const hookEventsGuard = hookEventGuard.array();
 
 export type HookEvents = z.infer<typeof hookEventsGuard>;
 
+export const interactionHookEventGuard = z.nativeEnum(InteractionHookEvent);
+export const interactionHookEventsGuard = interactionHookEventGuard.array();
+
 /**
  * Hook configuration for web hook.
  */

--- a/packages/schemas/src/foundations/jsonb-types/hooks.ts
+++ b/packages/schemas/src/foundations/jsonb-types/hooks.ts
@@ -83,7 +83,6 @@ export const hookEventsGuard = hookEventGuard.array();
 export type HookEvents = z.infer<typeof hookEventsGuard>;
 
 export const interactionHookEventGuard = z.nativeEnum(InteractionHookEvent);
-export const interactionHookEventsGuard = interactionHookEventGuard.array();
 
 /**
  * Hook configuration for web hook.


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- add devFeature guard DataHooks to the hook management API
- fix bug `koaManagementApi` will throw 404 on all management APIs is devFeature is off. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<img width="966" alt="image" src="https://github.com/logto-io/logto/assets/36393111/36a51b17-2ca6-48b6-a122-065693007910">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
