### PR TITLE
refactor(console): do not parameterize guide id

### DIFF
--- a/packages/console/src/utils/route.ts
+++ b/packages/console/src/utils/route.ts
@@ -18,7 +18,11 @@ export const getRoutePattern = (pathname: string, routes: RouteObject[]) => {
           }
 
           // If the path is not a parameter, or it's an ID parameter, use the path as is.
-          if (!segment.startsWith(':') || segment.endsWith('Id') || segment.endsWith('id')) {
+          // Exception: For `:guideId`, we want to use the parameter value for better analytics.
+          if (
+            segment !== ':guideId' &&
+            (!segment.startsWith(':') || segment.endsWith('Id') || segment.endsWith('id'))
+          ) {
             return segment;
           }
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
use the parameter value for guide ids since they have no PII and are good for analytics.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test online later

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
