### PR TITLE
refactor: remove `TenantInfo` type

### DIFF
--- a/packages/cli/src/commands/database/seed/tenant.ts
+++ b/packages/cli/src/commands/database/seed/tenant.ts
@@ -1,4 +1,4 @@
-import { createTenantMetadata } from '@logto/core-kit';
+import { createTenantDatabaseMetadata } from '@logto/core-kit';
 import {
   type AdminData,
   type UpdateAdminData,
@@ -26,7 +26,7 @@ import { consoleLog } from '../../../utils.js';
 
 export const createTenant = async (pool: CommonQueryMethods, tenantId: string) => {
   const database = await getDatabaseName(pool, true);
-  const { parentRole, role, password } = createTenantMetadata(database, tenantId);
+  const { parentRole, role, password } = createTenantDatabaseMetadata(database, tenantId);
   const createTenant = {
     id: tenantId,
     dbUser: role,

--- a/packages/console/src/components/CreateTenantModal/SelectTenantPlanModal/index.tsx
+++ b/packages/console/src/components/CreateTenantModal/SelectTenantPlanModal/index.tsx
@@ -16,7 +16,7 @@ import * as modalStyles from '@/scss/modal.module.scss';
 import { type SubscriptionPlan } from '@/types/subscriptions';
 import { pickupFeaturedPlans } from '@/utils/subscription';
 
-import { type CreateTenantData } from '../type';
+import { type CreateTenantData } from '../types';
 
 import PlanCardItem from './PlanCardItem';
 import * as styles from './index.module.scss';

--- a/packages/console/src/components/CreateTenantModal/index.tsx
+++ b/packages/console/src/components/CreateTenantModal/index.tsx
@@ -1,4 +1,4 @@
-import { Theme, TenantTag } from '@logto/schemas';
+import { Theme, TenantTag, type TenantModel } from '@logto/schemas';
 import { useState } from 'react';
 import { Controller, FormProvider, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -20,7 +20,8 @@ import * as modalStyles from '@/scss/modal.module.scss';
 import EnvTagOptionContent from './EnvTagOptionContent';
 import SelectTenantPlanModal from './SelectTenantPlanModal';
 import * as styles from './index.module.scss';
-import { type CreateTenantData } from './type';
+
+type CreateTenantData = Pick<TenantModel, 'name' | 'tag'>;
 
 type Props = {
   readonly isOpen: boolean;

--- a/packages/console/src/components/CreateTenantModal/index.tsx
+++ b/packages/console/src/components/CreateTenantModal/index.tsx
@@ -1,4 +1,4 @@
-import { Theme, TenantTag, type TenantModel } from '@logto/schemas';
+import { Theme, TenantTag } from '@logto/schemas';
 import { useState } from 'react';
 import { Controller, FormProvider, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -20,8 +20,7 @@ import * as modalStyles from '@/scss/modal.module.scss';
 import EnvTagOptionContent from './EnvTagOptionContent';
 import SelectTenantPlanModal from './SelectTenantPlanModal';
 import * as styles from './index.module.scss';
-
-type CreateTenantData = Pick<TenantModel, 'name' | 'tag'>;
+import { type CreateTenantData } from './types';
 
 type Props = {
   readonly isOpen: boolean;

--- a/packages/console/src/components/CreateTenantModal/type.ts
+++ b/packages/console/src/components/CreateTenantModal/type.ts
@@ -1,3 +1,0 @@
-import { type TenantInfo } from '@logto/schemas/models';
-
-export type CreateTenantData = Pick<TenantInfo, 'name' | 'tag'>;

--- a/packages/console/src/components/CreateTenantModal/types.ts
+++ b/packages/console/src/components/CreateTenantModal/types.ts
@@ -1,0 +1,3 @@
+import { type TenantModel } from '@logto/schemas';
+
+export type CreateTenantData = Pick<TenantModel, 'name' | 'tag'>;

--- a/packages/console/src/hooks/use-subscribe.ts
+++ b/packages/console/src/hooks/use-subscribe.ts
@@ -6,7 +6,7 @@ import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 
 import { toastResponseError, useCloudApi } from '@/cloud/hooks/use-cloud-api';
-import { type CreateTenantData } from '@/components/CreateTenantModal/type';
+import { type CreateTenantData } from '@/components/CreateTenantModal/types';
 import { checkoutStateQueryKey } from '@/consts/subscriptions';
 import { GlobalRoute, TenantsContext } from '@/contexts/TenantsProvider';
 import { createLocalCheckoutSession } from '@/utils/checkout';

--- a/packages/integration-tests/src/api/tenant.ts
+++ b/packages/integration-tests/src/api/tenant.ts
@@ -1,7 +1,10 @@
 import { type TenantTag } from '@logto/schemas';
-import type { TenantInfo } from '@logto/schemas/models';
+import type { TenantModel } from '@logto/schemas/models';
 
 import { cloudApi } from './api.js';
+
+// TODO: Import from cloud package after it's created
+type TenantInfo = Pick<TenantModel, 'id' | 'name' | 'tag' | 'isSuspended' | 'createdAt'>;
 
 export const createTenant = async (
   accessToken: string,

--- a/packages/schemas/src/models/tenants.ts
+++ b/packages/schemas/src/models/tenants.ts
@@ -27,9 +27,3 @@ export const Tenants = createModel(
   .extend('createdAt', { readonly: true });
 
 export type TenantModel = InferModelType<typeof Tenants>;
-
-export const tenantInfoGuard = Tenants.guard('model')
-  .pick({ id: true, name: true, tag: true, isSuspended: true })
-  .extend({ indicator: z.string() });
-
-export type TenantInfo = z.infer<typeof tenantInfoGuard>;

--- a/packages/toolkit/core-kit/src/models/tenant.ts
+++ b/packages/toolkit/core-kit/src/models/tenant.ts
@@ -3,17 +3,17 @@ import { generateStandardId } from '@logto/shared/universal';
 // Use lowercase letters for tenant IDs to improve compatibility
 const generateTenantId = () => generateStandardId(6);
 
-export type TenantMetadata = {
+export type TenantDatabaseMetadata = {
   id: string;
   parentRole: string;
   role: string;
   password: string;
 };
 
-export const createTenantMetadata = (
+export const createTenantDatabaseMetadata = (
   databaseName: string,
   tenantId = generateTenantId()
-): TenantMetadata => {
+): TenantDatabaseMetadata => {
   const parentRole = `logto_tenant_${databaseName}`;
   const role = `logto_tenant_${databaseName}_${tenantId}`;
   const password = generateStandardId(32);


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- `TenantInfo` type should be imported from a cloud package instead of defining in schemas, as it's a pure cloud type
- update `TenantMetadata` to `TenantDatabaseMetadata` for better clarity

not marking this as a breaking change since they are for internal use only.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
n/a

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
