### PR TITLE
fix(phrases): fix legacy sie phrases

### DIFF
--- a/packages/phrases-experience/src/locales/de/description.ts
+++ b/packages/phrases-experience/src/locales/de/description.ts
@@ -33,7 +33,7 @@ const description = {
   social_link_phone: 'Du kannst eine weitere Telefonnummer verknüpfen',
   social_link_email_or_phone: 'Du kannst eine weitere Email oder Telefonnummer verknüpfen',
   social_bind_with_existing:
-    'Wir haben eine verwandte {{method}} gefunden, die bereits registriert wurde, und Sie können sie direkt verknüpfen.',
+    'Wir haben ein verwandtes Konto gefunden, du kannst es direkt verknüpfen.',
   reset_password: 'Passwort vergessen',
   reset_password_description:
     'Gib die {{types, list(type: disjunction;)}} deines Kontos ein und wir senden dir einen Bestätigungscode um dein Passwort zurückzusetzen.',

--- a/packages/phrases-experience/src/locales/fr/description.ts
+++ b/packages/phrases-experience/src/locales/fr/description.ts
@@ -33,7 +33,7 @@ const description = {
   social_link_email_or_phone:
     'Vous pouvez lier une autre adresse e-mail ou un autre numéro de téléphone',
   social_bind_with_existing:
-    'Nous avons trouvé une {{method}} connexe qui a été enregistrée, et vous pouvez la lier directement.',
+    'Nous avons trouvé un compte associé, vous pouvez le lier directement.',
   reset_password: 'Mot de passe oublié',
   reset_password_description:
     'Entrez le {{types, list(type: disjunction;)}} associé à votre compte et nous vous enverrons le code de vérification pour réinitialiser votre mot de passe.',

--- a/packages/phrases-experience/src/locales/ko/description.ts
+++ b/packages/phrases-experience/src/locales/ko/description.ts
@@ -29,7 +29,7 @@ const description = {
   social_link_email: '다른 이메일을 연동할 수 있어요',
   social_link_phone: '다른 휴대전화를 연동할 수 있어요',
   social_link_email_or_phone: '다른 이메일이나 휴대전화를 연동할 수 있어요',
-  social_bind_with_existing: '등록된 관련 {{method}}이 있습니다. 직접 연결할 수 있습니다.',
+  social_bind_with_existing: '관련된 계정을 찾았어요. 직접 연동할 수 있어요.',
   reset_password: '비밀번호를 잊으셨나요',
   reset_password_description:
     '귀하의 계정과 연결된 {{types, list(type: disjunction;)}}를 입력하면 비밀번호 재설정을 위한 인증 코드를 보내드립니다.',


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix legacy sie phrase `social_bind_with_existing`.

Issue:
Some of the i18n translations of the phrase `social_bind_with_existing` are outdated.  We no longer pass the variable `method` to the phrase.

![image](https://github.com/logto-io/logto/assets/36393111/3e09505a-aa9d-401a-b3e7-af8e49a9a69f)

Fix: 
Sync with the latest en phrase. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [ ] ~necessary TSDoc comments~
