### PR TITLE
fix(console): fix Laravel misspelling

### DIFF
--- a/packages/console/src/assets/docs/guides/web-php/index.ts
+++ b/packages/console/src/assets/docs/guides/web-php/index.ts
@@ -4,7 +4,7 @@ import { type GuideMetadata } from '../types';
 
 const metadata: Readonly<GuideMetadata> = Object.freeze({
   name: 'PHP',
-  description: 'Integrate Logto into your PHP web app, such as Lavarel.',
+  description: 'Integrate Logto into your PHP web app, such as Laravel.',
   target: ApplicationType.Traditional,
   sample: {
     repo: 'php',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
In the description for the PHP SDK, the word "Laravel" is misspelled.

<img width="388" alt="image" src="https://github.com/logto-io/logto/assets/140933866/a9630447-b119-48c2-8df9-fdbbaef83bee">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
