### PR TITLE
fix: include tenant id for `isManagementApi` util

### DIFF
--- a/.changeset/ninety-goats-cover.md
+++ b/.changeset/ninety-goats-cover.md
@@ -1,0 +1,7 @@
+---
+"@logto/console": patch
+"@logto/schemas": patch
+"@logto/core": patch
+---
+
+fix Logto Management API resource indicator validation to prevent indicators with matching formats from being erroneously categorized as read-only management APIs

--- a/packages/console/src/components/OrganizationRolePermissionsAssignmentModal/use-resource-scopes-assignment.ts
+++ b/packages/console/src/components/OrganizationRolePermissionsAssignmentModal/use-resource-scopes-assignment.ts
@@ -1,11 +1,13 @@
 import { isManagementApi, type Scope, type ResourceResponse } from '@logto/schemas';
-import { useMemo, useState } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import useSWR from 'swr';
 
+import { TenantsContext } from '@/contexts/TenantsProvider';
 import { type DataGroup } from '@/ds-components/DataTransferBox/type';
 
 function useResourceScopesAssignment(assignedScopes?: Scope[]) {
   const [selectedData, setSelectedData] = useState<Scope[]>([]);
+  const { currentTenantId } = useContext(TenantsContext);
 
   const { data: allResources } = useSWR<ResourceResponse[]>('api/resources?includeScopes=true');
 
@@ -16,7 +18,7 @@ function useResourceScopesAssignment(assignedScopes?: Scope[]) {
 
     const resourcesWithScopes = allResources
       // Filter out the management APIs
-      .filter((resource) => !isManagementApi(resource.indicator))
+      .filter((resource) => !isManagementApi(currentTenantId, resource.indicator))
       .map(({ name, scopes, id: resourceId }) => ({
         groupId: resourceId,
         groupName: name,
@@ -27,7 +29,7 @@ function useResourceScopesAssignment(assignedScopes?: Scope[]) {
 
     // Filter out the resources that have no scopes
     return resourcesWithScopes.filter(({ dataList }) => dataList.length > 0);
-  }, [allResources, assignedScopes]);
+  }, [allResources, assignedScopes, currentTenantId]);
 
   return useMemo(
     () => ({

--- a/packages/console/src/components/RoleScopesTransfer/components/SourceScopesBox/index.tsx
+++ b/packages/console/src/components/RoleScopesTransfer/components/SourceScopesBox/index.tsx
@@ -3,13 +3,14 @@ import { isManagementApi, PredefinedScope, RoleType } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
 import classNames from 'classnames';
 import type { ChangeEvent } from 'react';
-import { useMemo, useState } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 
 import Search from '@/assets/icons/search.svg';
 import EmptyDataPlaceholder from '@/components/EmptyDataPlaceholder';
 import type { DetailedResourceResponse } from '@/components/RoleScopesTransfer/types';
+import { TenantsContext } from '@/contexts/TenantsProvider';
 import TextInput from '@/ds-components/TextInput';
 import type { RequestError } from '@/hooks/use-api';
 import * as transferLayout from '@/scss/transfer.module.scss';
@@ -27,6 +28,7 @@ type Props = {
 
 function SourceScopesBox({ roleId, roleType, selectedScopes, onChange }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const { currentTenantId } = useContext(TenantsContext);
 
   const { data: allResources, error: fetchAllResourcesError } = useSWR<
     ResourceResponse[],
@@ -87,7 +89,8 @@ function SourceScopesBox({ roleId, roleType, selectedScopes, onChange }: Props) 
       .filter(
         ({ indicator, scopes }) =>
           /** Should show management API scopes for machine-to-machine roles */
-          (roleType === RoleType.MachineToMachine || !isManagementApi(indicator)) &&
+          (roleType === RoleType.MachineToMachine ||
+            !isManagementApi(currentTenantId, indicator)) &&
           scopes.some(({ id }) => !excludeScopeIds.has(id))
       )
       .map(({ scopes, ...resource }) => ({
@@ -99,7 +102,7 @@ function SourceScopesBox({ roleId, roleType, selectedScopes, onChange }: Props) 
             resource,
           })),
       }));
-  }, [allResources, roleType, roleId, roleScopes]);
+  }, [allResources, roleId, roleScopes, roleType, currentTenantId]);
 
   const dataSource = useMemo(() => {
     const lowerCasedKeyword = keyword.toLowerCase();

--- a/packages/console/src/hooks/use-api-resources-usage.ts
+++ b/packages/console/src/hooks/use-api-resources-usage.ts
@@ -5,11 +5,12 @@ import useSWR from 'swr';
 import { type ApiResource } from '@/consts';
 import { isCloud } from '@/consts/env';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
+import { TenantsContext } from '@/contexts/TenantsProvider';
 import { hasReachedQuotaLimit, hasSurpassedQuotaLimit } from '@/utils/quota';
 
 const useApiResourcesUsage = () => {
   const { currentPlan } = useContext(SubscriptionDataContext);
-
+  const { currentTenantId } = useContext(TenantsContext);
   /**
    * Note: we only need to fetch all resources when the user is in cloud environment.
    * The oss version doesn't have the quota limit.
@@ -17,8 +18,10 @@ const useApiResourcesUsage = () => {
   const { data: allResources } = useSWR<ApiResource[]>(isCloud && 'api/resources');
 
   const resourceCount = useMemo(
-    () => allResources?.filter(({ indicator }) => !isManagementApi(indicator)).length ?? 0,
-    [allResources]
+    () =>
+      allResources?.filter(({ indicator }) => !isManagementApi(currentTenantId, indicator))
+        .length ?? 0,
+    [allResources, currentTenantId]
   );
 
   const hasReachedLimit = useMemo(

--- a/packages/console/src/pages/ApiResourceDetails/index.tsx
+++ b/packages/console/src/pages/ApiResourceDetails/index.tsx
@@ -2,7 +2,7 @@ import type { Resource } from '@logto/schemas';
 import { isManagementApi, Theme } from '@logto/schemas';
 import { conditionalArray } from '@silverhand/essentials';
 import classNames from 'classnames';
-import { useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { Trans, useTranslation } from 'react-i18next';
 import { Outlet, useLocation, useParams } from 'react-router-dom';
@@ -19,6 +19,7 @@ import DetailsPageHeader, { type MenuItem } from '@/components/DetailsPage/Detai
 import Drawer from '@/components/Drawer';
 import PageMeta from '@/components/PageMeta';
 import { ApiResourceDetailsTabs } from '@/consts/page-tabs';
+import { TenantsContext } from '@/contexts/TenantsProvider';
 import DeleteConfirmModal from '@/ds-components/DeleteConfirmModal';
 import TabNav, { TabNavItem } from '@/ds-components/TabNav';
 import type { RequestError } from '@/hooks/use-api';
@@ -43,6 +44,7 @@ function ApiResourceDetails() {
   const { id, guideId } = useParams();
   const { navigate, match } = useTenantPathname();
   const { getDocumentationUrl } = useDocumentationUrl();
+  const { currentTenantId } = useContext(TenantsContext);
   const isGuideView = !!id && !!guideId && match(`/api-resources/${id}/guide/${guideId}`);
 
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
@@ -52,7 +54,7 @@ function ApiResourceDetails() {
   const { ApiIcon, ManagementApiIcon } = icons[theme];
 
   const isOnPermissionPage = pathname.endsWith(ApiResourceDetailsTabs.Permissions);
-  const isLogtoManagementApiResource = isManagementApi(data?.indicator ?? '');
+  const isLogtoManagementApiResource = isManagementApi(currentTenantId, data?.indicator ?? '');
   const Icon = isLogtoManagementApiResource ? ManagementApiIcon : ApiIcon;
 
   const [isGuideDrawerOpen, setIsGuideDrawerOpen] = useState(false);

--- a/packages/console/src/pages/ApiResources/index.tsx
+++ b/packages/console/src/pages/ApiResources/index.tsx
@@ -1,5 +1,6 @@
 import type { Resource } from '@logto/schemas';
 import { Theme, isManagementApi } from '@logto/schemas';
+import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import useSWR from 'swr';
@@ -15,6 +16,7 @@ import ListPage from '@/components/ListPage';
 import { defaultPageSize } from '@/consts';
 import { isCloud } from '@/consts/env';
 import { ApiResourceDetailsTabs } from '@/consts/page-tabs';
+import { TenantsContext } from '@/contexts/TenantsProvider';
 import CopyToClipboard from '@/ds-components/CopyToClipboard';
 import Tag from '@/ds-components/Tag';
 import type { RequestError } from '@/hooks/use-api';
@@ -41,6 +43,7 @@ const icons = {
 function ApiResources() {
   const { search } = useLocation();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const { currentTenantId } = useContext(TenantsContext);
   const { hasSurpassedLimit } = useApiResourcesUsage();
   const [{ page }, updateSearchParameters] = useSearchParametersWatcher({
     page: 1,
@@ -99,7 +102,9 @@ function ApiResources() {
               dataIndex: 'name',
               colSpan: 6,
               render: ({ id, name, isDefault, indicator }) => {
-                const Icon = isManagementApi(indicator) ? ManagementApiIcon : ApiIcon;
+                const Icon = isManagementApi(currentTenantId, indicator)
+                  ? ManagementApiIcon
+                  : ApiIcon;
                 return (
                   <ItemPreview
                     title={name}

--- a/packages/core/src/libraries/role-scope.ts
+++ b/packages/core/src/libraries/role-scope.ts
@@ -13,6 +13,7 @@ export const createRoleScopeLibrary = (queries: Queries) => {
   } = queries;
 
   const validateRoleScopeAssignment = async (
+    tenantId: string,
     scopeIds: string[],
     roleId: string,
     options: { skipScopeExistenceCheck?: boolean } = {}
@@ -50,7 +51,7 @@ export const createRoleScopeLibrary = (queries: Queries) => {
         if (role.type === RoleType.User) {
           const { indicator } = await findResourceById(resourceId);
           assertThat(
-            !isManagementApi(indicator),
+            !isManagementApi(tenantId, indicator),
             'role.management_api_scopes_not_assignable_to_user_role'
           );
         }

--- a/packages/core/src/routes/resource.scope.test.ts
+++ b/packages/core/src/routes/resource.scope.test.ts
@@ -99,7 +99,7 @@ describe('resource scope routes', () => {
     const { findResourceById } = resources;
     findResourceById.mockResolvedValueOnce({
       ...mockResource,
-      indicator: getManagementApiResourceIndicator('mock'),
+      indicator: getManagementApiResourceIndicator(tenantContext.id),
     });
     await expect(
       resourceScopeRequest
@@ -128,7 +128,7 @@ describe('resource scope routes', () => {
     const { findResourceById } = resources;
     findResourceById.mockResolvedValueOnce({
       ...mockResource,
-      indicator: getManagementApiResourceIndicator('mock'),
+      indicator: getManagementApiResourceIndicator(tenantContext.id),
     });
     await expect(
       resourceScopeRequest
@@ -148,7 +148,7 @@ describe('resource scope routes', () => {
     const { findResourceById } = resources;
     findResourceById.mockResolvedValueOnce({
       ...mockResource,
-      indicator: getManagementApiResourceIndicator('mock'),
+      indicator: getManagementApiResourceIndicator(tenantContext.id),
     });
     await expect(resourceScopeRequest.delete('/resources/foo/scopes/foz')).resolves.toHaveProperty(
       'status',

--- a/packages/core/src/routes/resource.scope.ts
+++ b/packages/core/src/routes/resource.scope.ts
@@ -15,6 +15,7 @@ export default function resourceScopeRoutes<T extends ManagementApiRouter>(
   ...[
     router,
     {
+      id: tenantId,
       queries,
       libraries: { quota },
     },
@@ -95,7 +96,7 @@ export default function resourceScopeRoutes<T extends ManagementApiRouter>(
 
       const { indicator } = await findResourceById(resourceId);
       assertThat(
-        !isManagementApi(indicator),
+        !isManagementApi(tenantId, indicator),
         new RequestError({ code: 'resource.cannot_modify_management_api' })
       );
 
@@ -135,7 +136,7 @@ export default function resourceScopeRoutes<T extends ManagementApiRouter>(
 
       const { indicator } = await findResourceById(resourceId);
       assertThat(
-        !isManagementApi(indicator),
+        !isManagementApi(tenantId, indicator),
         new RequestError({ code: 'resource.cannot_modify_management_api' })
       );
 
@@ -170,7 +171,7 @@ export default function resourceScopeRoutes<T extends ManagementApiRouter>(
 
       const { indicator } = await findResourceById(resourceId);
       assertThat(
-        !isManagementApi(indicator),
+        !isManagementApi(tenantId, indicator),
         new RequestError({ code: 'resource.cannot_modify_management_api' })
       );
 

--- a/packages/core/src/routes/resource.test.ts
+++ b/packages/core/src/routes/resource.test.ts
@@ -156,7 +156,7 @@ describe('resource routes', () => {
     const { findResourceById } = resources;
     findResourceById.mockResolvedValueOnce({
       ...mockResource,
-      indicator: getManagementApiResourceIndicator('mock'),
+      indicator: getManagementApiResourceIndicator(tenantContext.id),
     });
     await expect(resourceRequest.patch('/resources/foo')).resolves.toHaveProperty('status', 400);
   });
@@ -169,7 +169,7 @@ describe('resource routes', () => {
     const { findResourceById } = resources;
     findResourceById.mockResolvedValueOnce({
       ...mockResource,
-      indicator: getManagementApiResourceIndicator('mock'),
+      indicator: getManagementApiResourceIndicator(tenantContext.id),
     });
     await expect(resourceRequest.delete('/resources/foo')).resolves.toHaveProperty('status', 400);
   });

--- a/packages/core/src/routes/resource.ts
+++ b/packages/core/src/routes/resource.ts
@@ -16,6 +16,7 @@ export default function resourceRoutes<T extends ManagementApiRouter>(
   ...[
     router,
     {
+      id: tenantId,
       queries,
       libraries: { quota },
     },
@@ -146,7 +147,7 @@ export default function resourceRoutes<T extends ManagementApiRouter>(
 
       const { indicator } = await findResourceById(id);
       assertThat(
-        !isManagementApi(indicator),
+        !isManagementApi(tenantId, indicator),
         new RequestError({ code: 'resource.cannot_modify_management_api' })
       );
 
@@ -186,7 +187,7 @@ export default function resourceRoutes<T extends ManagementApiRouter>(
 
       const { indicator } = await findResourceById(id);
       assertThat(
-        !isManagementApi(indicator),
+        !isManagementApi(tenantId, indicator),
         new RequestError({ code: 'resource.cannot_delete_management_api' })
       );
 

--- a/packages/core/src/routes/role.scope.test.ts
+++ b/packages/core/src/routes/role.scope.test.ts
@@ -106,7 +106,11 @@ describe('role scope routes', () => {
       scopeIds: [mockScope.id],
     });
     expect(response.status).toEqual(201);
-    expect(validateRoleScopeAssignment).toHaveBeenCalledWith([mockScope.id], mockAdminUserRole.id);
+    expect(validateRoleScopeAssignment).toHaveBeenCalledWith(
+      tenantContext.id,
+      [mockScope.id],
+      mockAdminUserRole.id
+    );
     expect(insertRolesScopes).toHaveBeenCalledWith([
       { id: mockId, roleId: mockAdminUserRole.id, scopeId: mockScope.id },
     ]);

--- a/packages/core/src/routes/role.scope.ts
+++ b/packages/core/src/routes/role.scope.ts
@@ -11,7 +11,7 @@ import { parseSearchParamsForSearch } from '#src/utils/search.js';
 import type { ManagementApiRouter, RouterInitArgs } from './types.js';
 
 export default function roleScopeRoutes<T extends ManagementApiRouter>(
-  ...[router, { queries, libraries }]: RouterInitArgs<T>
+  ...[router, { queries, libraries, id: tenantId }]: RouterInitArgs<T>
 ) {
   const {
     rolesScopes: { deleteRolesScope, findRolesScopesByRoleId, insertRolesScopes },
@@ -95,7 +95,7 @@ export default function roleScopeRoutes<T extends ManagementApiRouter>(
 
       await quota.guardKey('scopesPerRoleLimit', id);
 
-      await validateRoleScopeAssignment(scopeIds, id);
+      await validateRoleScopeAssignment(tenantId, scopeIds, id);
       await insertRolesScopes(
         scopeIds.map((scopeId) => ({ id: generateStandardId(), roleId: id, scopeId }))
       );

--- a/packages/core/src/routes/role.test.ts
+++ b/packages/core/src/routes/role.test.ts
@@ -132,9 +132,14 @@ describe('role routes', () => {
     expect(response.status).toEqual(200);
     expect(response.body).toEqual(mockAdminUserRole);
     expect(findRoleByRoleName).toHaveBeenCalled();
-    expect(validateRoleScopeAssignment).toHaveBeenCalledWith([mockScope.id], response.body.id, {
-      skipScopeExistenceCheck: true,
-    });
+    expect(validateRoleScopeAssignment).toHaveBeenCalledWith(
+      tenantContext.id,
+      [mockScope.id],
+      response.body.id,
+      {
+        skipScopeExistenceCheck: true,
+      }
+    );
     expect(insertRolesScopes).toHaveBeenCalled();
   });
 

--- a/packages/core/src/routes/role.ts
+++ b/packages/core/src/routes/role.ts
@@ -19,7 +19,7 @@ import type { ManagementApiRouter, RouterInitArgs } from './types.js';
 export default function roleRoutes<T extends ManagementApiRouter>(
   ...[router, tenant]: RouterInitArgs<T>
 ) {
-  const { queries, libraries } = tenant;
+  const { queries, libraries, id: tenantId } = tenant;
   const {
     rolesScopes: { insertRolesScopes },
     scopes: { findScopesByIds },
@@ -170,7 +170,9 @@ export default function roleRoutes<T extends ManagementApiRouter>(
 
       if (scopeIds) {
         // Skip scope existence check because the role is newly created.
-        await validateRoleScopeAssignment(scopeIds, role.id, { skipScopeExistenceCheck: true });
+        await validateRoleScopeAssignment(tenantId, scopeIds, role.id, {
+          skipScopeExistenceCheck: true,
+        });
         await insertRolesScopes(
           scopeIds.map((scopeId) => ({ id: generateStandardId(), roleId: role.id, scopeId }))
         );

--- a/packages/schemas/src/seeds/management-api.ts
+++ b/packages/schemas/src/seeds/management-api.ts
@@ -12,6 +12,7 @@ import {
   AdminTenantRole,
   getMapiProxyRole,
 } from '../types/index.js';
+import { getManagementApiResourceIndicator } from '../utils/index.js';
 
 import { adminTenantId, defaultTenantId } from './tenant.js';
 
@@ -73,18 +74,6 @@ export const defaultManagementApi = Object.freeze({
     type: RoleType.MachineToMachine,
   },
 }) satisfies AdminData;
-
-export function getManagementApiResourceIndicator<TenantId extends string>(
-  tenantId: TenantId
-): `https://${TenantId}.logto.app/api`;
-export function getManagementApiResourceIndicator<TenantId extends string, Path extends string>(
-  tenantId: TenantId,
-  path: Path
-): `https://${TenantId}.logto.app/${Path}`;
-
-export function getManagementApiResourceIndicator(tenantId: string, path = 'api') {
-  return `https://${tenantId}.logto.app/${path}`;
-}
 
 /**
  * The fixed Management API user role for `default` tenant in the admin tenant. It is used for

--- a/packages/schemas/src/utils/management-api.ts
+++ b/packages/schemas/src/utils/management-api.ts
@@ -1,2 +1,15 @@
-export const isManagementApi = (indicator: string) =>
-  /^https:\/\/[^.]+\.logto\.app\/api$/.test(indicator);
+export function getManagementApiResourceIndicator<TenantId extends string>(
+  tenantId: TenantId
+): `https://${TenantId}.logto.app/api`;
+
+export function getManagementApiResourceIndicator<TenantId extends string, Path extends string>(
+  tenantId: TenantId,
+  path: Path
+): `https://${TenantId}.logto.app/${Path}`;
+
+export function getManagementApiResourceIndicator(tenantId: string, path = 'api') {
+  return `https://${tenantId}.logto.app/${path}`;
+}
+
+export const isManagementApi = (tenantId: string, indicator: string) =>
+  getManagementApiResourceIndicator(tenantId) === indicator;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

In our codebase, Logto Management API resource only checks the format of the indicator.

```typescript
export const isManagementApi = (indicator: string) =>
  /^https:\/\/[^.]+\.logto\.app\/api$/.test(indicator);
```

This will lead to the situation where if a user creates any indicator in the same format, that will be treated as a read-only management API and cannot be deleted or edited.

For example, the following is a fake Logto Management API resource:

<img width="1423" alt="image" src="https://github.com/logto-io/logto/assets/10806653/ae43db33-9e5e-4bea-9fc2-54414e97385a">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

![image](https://github.com/logto-io/logto/assets/10806653/806d678c-83b7-4202-a8e2-b16086b46aa8)

![image](https://github.com/logto-io/logto/assets/10806653/d6062d26-2fa9-41aa-b792-e3fc4f4e41df)

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
