### PR TITLE
fix(core): fix azure oidc sso connector authorization error

### DIFF
--- a/.changeset/serious-geese-admire.md
+++ b/.changeset/serious-geese-admire.md
@@ -1,0 +1,11 @@
+---
+"@logto/core": patch
+---
+
+fix Microsoft EntraID OIDC SSO connector invalid authorization code response bug
+
+- For public organizations access EntraID OIDC applications, the token endpoint returns `expires_in` value type in number.
+- For private organization access only applications, the token endpoint returns `expires_in` value type in string.
+
+String type `expires_in` value is not supported by the OIDC connector, a invalid authorization response error will be thrown.
+Update the token response guard to handle both number and string type `expires_in` value. Make the SSO connector more robust.

--- a/.changeset/serious-geese-admire.md
+++ b/.changeset/serious-geese-admire.md
@@ -6,6 +6,7 @@ fix Microsoft EntraID OIDC SSO connector invalid authorization code response bug
 
 - For public organizations access EntraID OIDC applications, the token endpoint returns `expires_in` value type in number.
 - For private organization access only applications, the token endpoint returns `expires_in` value type in string.
+- Expected `expires_in` value type is number. (See [v2-oauth2-auth-code-flow](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow#successful-response-2) for reference)
 
-String type `expires_in` value is not supported by the OIDC connector, a invalid authorization response error will be thrown.
+String type `expires_in` value is not supported by the current Microsoft EntraID OIDC connector, a invalid authorization response error will be thrown.
 Update the token response guard to handle both number and string type `expires_in` value. Make the SSO connector more robust.

--- a/packages/core/src/routes/interaction/single-sign-on.ts
+++ b/packages/core/src/routes/interaction/single-sign-on.ts
@@ -79,7 +79,7 @@ export default function singleSignOnRoutes<T extends IRouterParamContext>(
         connectorId: z.string(),
       }),
       body: z.record(z.unknown()),
-      status: [200, 404, 422],
+      status: [200, 404, 422, 500],
       response: z.object({
         redirectTo: z.string(),
       }),
@@ -125,7 +125,7 @@ export default function singleSignOnRoutes<T extends IRouterParamContext>(
       params: z.object({
         connectorId: z.string(),
       }),
-      status: [200, 404, 403],
+      status: [200, 404, 403, 500],
       response: z.object({
         redirectTo: z.string(),
       }),

--- a/packages/core/src/sso/types/oidc.ts
+++ b/packages/core/src/sso/types/oidc.ts
@@ -57,7 +57,8 @@ export const oidcTokenResponseGuard = z.object({
   id_token: z.string(),
   access_token: z.string().optional(),
   token_type: z.string().optional(),
-  expires_in: z.number().optional(),
+  // Microsoft EntraID may return string type for expires_in
+  expires_in: z.number().or(z.string()).optional(),
   refresh_token: z.string().optional(),
   scope: z.string().optional(),
 });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

This PR fix a online azure SSO invalid authentication error:
<img width="754" alt="image" src="https://github.com/logto-io/logto/assets/36393111/e05d1aba-68b9-4095-83d5-025acf00e34e">


- For public organizations access EntraID OIDC applications, the token endpoint returns `expires_in` value type in number.
- For private organization access only applications, the token endpoint returns `expires_in` value type in string.

String type `expires_in` value is not supported by the OIDC connector, a invalid authorization response error will be thrown.
Update the token response guard to handle both number and string type `expires_in` value. Make the SSO connector more robust.

Also, update the response code guard for SSO routes. So the error detail won't lost. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
