### PR TITLE
fix(core): skip iss validation for azure oidc sso

### DIFF
--- a/packages/core/src/sso/AzureOidcSsoConnector/index.ts
+++ b/packages/core/src/sso/AzureOidcSsoConnector/index.ts
@@ -44,7 +44,8 @@ export class AzureOidcSsoConnector extends OidcSsoConnector {
     );
 
     // Verify the id token and get the user id
-    const { sub: id } = await getIdTokenClaims(idToken, oidcConfig, nonce);
+    // Skip the issuer check as the issuer may vary depending on the authenticated user`s tenantId
+    const { sub: id } = await getIdTokenClaims(idToken, oidcConfig, nonce, true);
 
     // Fetch user info from the userinfo endpoint
     const { sub, name, picture, email, email_verified, phone, phone_verified, ...rest } =

--- a/packages/core/src/sso/OidcConnector/utils.ts
+++ b/packages/core/src/sso/OidcConnector/utils.ts
@@ -2,22 +2,22 @@ import { parseJson } from '@logto/connector-kit';
 import { assert } from '@silverhand/essentials';
 import camelcaseKeys, { type CamelCaseKeys } from 'camelcase-keys';
 import { got, HTTPError } from 'got';
-import { jwtVerify, createRemoteJWKSet } from 'jose';
+import { createRemoteJWKSet, jwtVerify } from 'jose';
 import { z } from 'zod';
 
 import {
+  SsoConnectorConfigErrorCodes,
   SsoConnectorError,
   SsoConnectorErrorCodes,
-  SsoConnectorConfigErrorCodes,
 } from '../types/error.js';
 import {
+  idTokenProfileStandardClaimsGuard,
+  oidcAuthorizationResponseGuard,
+  oidcConfigResponseGuard,
+  oidcTokenResponseGuard,
   type BaseOidcConfig,
   type OidcConfigResponse,
-  oidcConfigResponseGuard,
-  oidcAuthorizationResponseGuard,
-  oidcTokenResponseGuard,
   type OidcTokenResponse,
-  idTokenProfileStandardClaimsGuard,
 } from '../types/oidc.js';
 
 export const fetchOidcConfig = async (
@@ -109,11 +109,12 @@ const issuedAtTimeTolerance = 600; // 10 minutes
 export const getIdTokenClaims = async (
   idToken: string,
   config: BaseOidcConfig,
-  nonceFromSession?: string
+  nonceFromSession: string | undefined,
+  skipIssuerCheck = false
 ) => {
   try {
     const { payload } = await jwtVerify(idToken, createRemoteJWKSet(new URL(config.jwksUri)), {
-      issuer: config.issuer,
+      issuer: skipIssuerCheck ? undefined : config.issuer,
       audience: config.clientId,
     });
 


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Skip the issuer validation for Azure OIDC SSO connector. 

For multi-tenant audience connectors, the issuer value in idToken may vary depending on the authenticated user's tenantId. Thus, unable to varify the exact value of the issuer. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
