### PR TITLE
refactor(core): cache get tenant id result

### DIFF
--- a/packages/core/src/utils/tenant.test.ts
+++ b/packages/core/src/utils/tenant.test.ts
@@ -178,4 +178,17 @@ describe('getTenantId()', () => {
     findActiveDomain.mockResolvedValueOnce({ domain: 'logto.mock.com', tenantId: 'mock' });
     await expect(getTenantIdFirstElement(new URL('https://logto.mock.com'))).resolves.toBe('mock');
   });
+
+  it('should cache the result', async () => {
+    process.env = {
+      ...backupEnv,
+      ENDPOINT: 'https://foo.*.logto.mock/app',
+      NODE_ENV: 'production',
+    };
+    findActiveDomain.mockResolvedValueOnce({ domain: 'logto.mock.com', tenantId: 'mock' });
+
+    await expect(getTenantIdFirstElement(new URL('https://logto.mock.com'))).resolves.toBe('mock');
+    await expect(getTenantIdFirstElement(new URL('https://logto.mock.com'))).resolves.toBe('mock');
+    expect(findActiveDomain).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
add a simple memory cache for the `getTenantId` result as every request will use this function - a cache can save a lot of queries

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
added unit test

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
