### PR TITLE
fix: add id generation utils for alteration scripts

### DIFF
--- a/packages/schemas/alterations/next-1716291265-create-pre-configured-m-api-role.ts
+++ b/packages/schemas/alterations/next-1716291265-create-pre-configured-m-api-role.ts
@@ -1,8 +1,9 @@
-import { generateStandardId } from '@logto/shared/universal';
 import { yes } from '@silverhand/essentials';
 import { sql } from '@silverhand/slonik';
 
 import type { AlterationScript } from '../lib/types/alteration.js';
+
+import { generateStandardId } from './utils/1716643968-id-generation.js';
 
 const isCi = yes(process.env.CI);
 

--- a/packages/schemas/alterations/utils/1716643968-id-generation.ts
+++ b/packages/schemas/alterations/utils/1716643968-id-generation.ts
@@ -1,0 +1,46 @@
+/**
+ * This file is forked from `@logto/shared` 3.1.0 to avoid alteration scripts to depend on outer packages.
+ */
+import { customAlphabet } from 'nanoid';
+
+const lowercaseAlphabet = '0123456789abcdefghijklmnopqrstuvwxyz';
+const alphabet = `${lowercaseAlphabet}ABCDEFGHIJKLMNOPQRSTUVWXYZ` as const;
+
+type BuildIdGenerator = {
+  /**
+   * Build a nanoid generator function uses numbers (0-9), lowercase letters (a-z), and uppercase letters (A-Z) as the alphabet.
+   * @param size The default id length for the generator.
+   */
+  (size: number): ReturnType<typeof customAlphabet>;
+  /**
+   * Build a nanoid generator function uses numbers (0-9) and lowercase letters (a-z) as the alphabet.
+   * @param size The default id length for the generator.
+   */
+  // eslint-disable-next-line @typescript-eslint/unified-signatures
+  (size: number, includingUppercase: false): ReturnType<typeof customAlphabet>;
+};
+
+const buildIdGenerator: BuildIdGenerator = (size: number, includingUppercase = true) =>
+  customAlphabet(includingUppercase ? alphabet : lowercaseAlphabet, size);
+
+/**
+ * Generate a standard id with 21 characters, including lowercase letters and numbers.
+ *
+ * @see {@link lowercaseAlphabet}
+ */
+export const generateStandardId = buildIdGenerator(21, false);
+
+/**
+ * Generate a standard short id with 12 characters, including lowercase letters and numbers.
+ *
+ * @see {@link lowercaseAlphabet}
+ */
+export const generateStandardShortId = buildIdGenerator(12, false);
+
+/**
+ * Generate a standard secret with 32 characters, including uppercase letters, lowercase
+ * letters, and numbers.
+ *
+ * @see {@link alphabet}
+ */
+export const generateStandardSecret = buildIdGenerator(32);

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -84,7 +84,8 @@
     "@logto/phrases": "workspace:^1.10.1",
     "@logto/phrases-experience": "workspace:^1.6.1",
     "@logto/shared": "workspace:^3.1.1",
-    "@withtyped/server": "^0.13.6"
+    "@withtyped/server": "^0.13.6",
+    "nanoid": "^5.0.1"
   },
   "peerDependencies": {
     "zod": "^3.22.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3862,6 +3862,9 @@ importers:
       '@withtyped/server':
         specifier: ^0.13.6
         version: 0.13.6(zod@3.22.4)
+      nanoid:
+        specifier: ^5.0.1
+        version: 5.0.7
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -10360,11 +10363,6 @@ packages:
 
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
-
-  nanoid@3.3.6:
-    resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
 
   nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
@@ -21450,8 +21448,6 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
-  nanoid@3.3.6: {}
-
   nanoid@3.3.7: {}
 
   nanoid@4.0.2: {}
@@ -22114,7 +22110,7 @@ snapshots:
 
   postcss@8.4.31:
     dependencies:
-      nanoid: 3.3.6
+      nanoid: 3.3.7
       picocolors: 1.0.0
       source-map-js: 1.0.2
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
We need to add ID generation utilities for alteration scripts and import the generateStandardId functions from this utility file. 
This helps prevent missing dependencies when deploying alterations to the cloud environment. See https://github.com/logto-io/cloud/actions/runs/9222739336/job/25374687799

The issue arises because the database-alteration Azure function copies alteration scripts without installing dependencies for the schema package during deployment.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<img width="739" alt="image" src="https://github.com/logto-io/logto/assets/10806653/c5738f7c-75a1-43f5-802a-ba8c42e94503">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
