### PR TITLE
fix(console): fix m2m guide curl code syntax error

### DIFF
--- a/packages/console/src/assets/docs/guides/m2m-general/README.mdx
+++ b/packages/console/src/assets/docs/guides/m2m-general/README.mdx
@@ -68,16 +68,16 @@ If you are using cURL:
 
 <pre>
   <code className="language-bash">
-    {`curl --location
-  --request POST '${appendPath(props.endpoint, '/oidc/token')}'
+    {`curl --location '${appendPath(props.endpoint, '/oidc/token')}' \\
+  --request POST \\
   # Credentials are constructed by "<app-id>:<app-secret>" and encoded in base64
   --header 'Authorization: Basic ${Buffer.from(`${props.app.id}:${props.app.secret}`).toString(
     'base64'
-  )}'
-  --header 'Content-Type: application/x-www-form-urlencoded'
-  --data-urlencode 'grant_type=client_credentials'
-  --data-urlencode 'resource=https://shopping.api'
-  --data-urlencode 'scope=scope_1 scope_2'
+  )}' \\
+  --header 'Content-Type: application/x-www-form-urlencoded' \\
+  --data-urlencode 'grant_type=client_credentials' \\
+  --data-urlencode 'resource=https://shopping.api' \\
+  --data-urlencode 'scope=scope_1 scope_2' # Optional scope(s)
 `}
   </code>
 </pre>
@@ -115,27 +115,31 @@ Here is an example of using cURL to send a GET request to get items in your shop
 </Step>
 <Step title="Enable admin access" subtitle="(optional)">
 
-  ### Accessing Logto Management API
+### Accessing Logto Management API
 
-  If you want to use this m2m app to access Logto [Management API](https://docs.logto.io/docs/references/core/#management-api).
+If you want to use this m2m app to access Logto [Management API](https://docs.logto.io/docs/references/core/#management-api).
 
-  You should go to "Roles" tab and create a new machine-to-machine role with the permission of management API.
+You should go to "Roles" tab and create a new machine-to-machine role with the permission of management API.
 
-  <img
-    alt="Create m2m management API role"
-    src={CreateM2mManagementApiRole}
-    width="600px"
-    style={{ borderRadius: '6px' }}
-  />
+{' '}
 
-  And then go to the "Roles" tab under machine to machine app detail page, and assign the role you just created to the app.
+<img
+  alt="Create m2m management API role"
+  src={CreateM2mManagementApiRole}
+  width="600px"
+  style={{ borderRadius: '6px' }}
+/>
 
-  <img
-    alt="Assign m2m management API role to app"
-    src={AssignManagementApiRole}
-    width="600px"
-    style={{ borderRadius: '6px' }}
-  />
+And then go to the "Roles" tab under machine to machine app detail page, and assign the role you just created to the app.
+
+{' '}
+
+<img
+  alt="Assign m2m management API role to app"
+  src={AssignManagementApiRole}
+  width="600px"
+  style={{ borderRadius: '6px' }}
+/>
 
 </Step>
 </Steps>


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

fix m2m guide curl code syntax error

- endpoint should be placed after `--location`
- add trailing `/` at the end of lines

<img width="904" alt="image" src="https://github.com/logto-io/logto/assets/36393111/4396660b-3f59-4e3f-adb0-7127cd103c70">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
