### PR TITLE
fix(connector): fix GitHub connector GET /emails forbidden error

### DIFF
--- a/.changeset/olive-deers-wink.md
+++ b/.changeset/olive-deers-wink.md
@@ -1,0 +1,7 @@
+---
+"@logto/connector-github": patch
+---
+
+fix GET /users/emails API requests break social sign-in flow error
+
+Previously, the GET /users/emails API was returning a 403 Forbidden error when the endpoint is not accessible. This will break the social sign-in flow in previous version, so we handled this error and return an empty array instead. In this way, the social sign-in flow will continue but with `userEmails` as an empty array, and should provide enough information for further investigation.

--- a/.changeset/olive-deers-wink.md
+++ b/.changeset/olive-deers-wink.md
@@ -2,6 +2,6 @@
 "@logto/connector-github": patch
 ---
 
-fix GET /users/emails API requests break social sign-in flow error
+fix `GET /users/emails` API requests break social sign-in flow error
 
 Previously, the GET /users/emails API was returning a 403 Forbidden error when the endpoint is not accessible. This will break the social sign-in flow in previous version, so we handled this error and return an empty array instead. In this way, the social sign-in flow will continue but with `userEmails` as an empty array, and should provide enough information for further investigation.

--- a/packages/connectors/connector-github/src/index.test.ts
+++ b/packages/connectors/connector-github/src/index.test.ts
@@ -162,6 +162,33 @@ describe('getUserInfo', () => {
     });
   });
 
+  it('should fallback to empty array when can not access to GET /users/emails endpoint', async () => {
+    nock(userInfoEndpoint).get('').reply(200, {
+      id: 1,
+      avatar_url: 'https://github.com/images/error/octocat_happy.gif',
+      name: 'monalisa octocat',
+      foo: 'bar',
+    });
+    nock(userEmailsEndpoint).get('').reply(403, []);
+    const connector = await createConnector({ getConfig });
+    const socialUserInfo = await connector.getUserInfo({ code: 'code' }, vi.fn());
+    expect(socialUserInfo).toStrictEqual({
+      id: '1',
+      avatar: 'https://github.com/images/error/octocat_happy.gif',
+      name: 'monalisa octocat',
+      email: undefined,
+      rawData: {
+        userInfo: {
+          id: 1,
+          avatar_url: 'https://github.com/images/error/octocat_happy.gif',
+          name: 'monalisa octocat',
+          foo: 'bar',
+        },
+        userEmails: [],
+      },
+    });
+  });
+
   it('should convert `null` to `undefined` in SocialUserInfo', async () => {
     nock(userInfoEndpoint).get('').reply(200, {
       id: 1,


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix GitHub connector GET /emails forbidden error.
Some users use GitHub App instead of OAuth App to collect user permissions.
In GitHub App, you can set Account permissions that block access to Email addresses.
<img width="1076" alt="image" src="https://github.com/logto-io/logto/assets/15182327/e491debf-0ade-4405-a559-db61f26c56de">
In this situation, the server will reject the `GET /users/emails` request and cause an error. We need to try and catch this error and use an empty array as fallback to prevent the disruption of the Social sign in flow.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
When `GET /users/emails` API is not accessible, the social sign-in flow works fine, `userEmails` is set to be empty array.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
