### PR TITLE
refactor(console): show dynamic region info in tenant settings

### DIFF
--- a/packages/console/src/pages/TenantSettings/TenantBasicSettings/ProfileForm/TenantRegion/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantBasicSettings/ProfileForm/TenantRegion/index.tsx
@@ -1,25 +1,32 @@
+import { useContext } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
-import Region, { RegionName } from '@/components/Region';
+import Region from '@/components/Region';
 import { trustAndSecurityLink } from '@/consts';
+import { TenantsContext } from '@/contexts/TenantsProvider';
 import TextLink from '@/ds-components/TextLink';
 
 import * as styles from './index.module.scss';
 
 function TenantRegion() {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const { currentTenant } = useContext(TenantsContext);
+  const regionName = currentTenant?.regionName;
+
+  if (!regionName) {
+    return null;
+  }
 
   return (
     <div className={styles.container}>
-      {/* TODO: Read the value from the tenant */}
-      <Region className={styles.region} regionName={RegionName.EU} />
+      <Region className={styles.region} regionName={regionName} />
       <div className={styles.regionTip}>
         <Trans
           components={{
             a: <TextLink targetBlank="noopener" href={trustAndSecurityLink} />,
           }}
         >
-          {t('tenants.settings.tenant_region_tip', { region: 'EU' })}
+          {t('tenants.settings.tenant_region_tip', { region: regionName })}
         </Trans>
       </div>
     </div>

--- a/packages/console/src/pages/TenantSettings/TenantBasicSettings/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantBasicSettings/index.tsx
@@ -1,4 +1,4 @@
-import { ReservedPlanId, TenantTag } from '@logto/schemas';
+import { ReservedPlanId, type TenantTag } from '@logto/schemas';
 import classNames from 'classnames';
 import { useContext, useEffect, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
@@ -6,7 +6,6 @@ import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 
 import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
-import { type TenantResponse } from '@/cloud/types/router';
 import PageMeta from '@/components/PageMeta';
 import SubmitFormChangesActionBar from '@/components/SubmitFormChangesActionBar';
 import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
@@ -21,12 +20,6 @@ import LeaveCard from './LeaveCard';
 import ProfileForm from './ProfileForm';
 import * as styles from './index.module.scss';
 import { type TenantSettingsForm } from './types.js';
-
-const tenantProfileToForm = (tenant?: TenantResponse): TenantSettingsForm => {
-  return {
-    profile: { name: tenant?.name ?? 'My project', tag: tenant?.tag ?? TenantTag.Development },
-  };
-};
 
 function TenantBasicSettings() {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
@@ -47,7 +40,7 @@ function TenantBasicSettings() {
   const { show: showModal } = useConfirmModal();
 
   const methods = useForm<TenantSettingsForm>({
-    defaultValues: tenantProfileToForm(currentTenant),
+    defaultValues: { profile: currentTenant },
   });
   const {
     watch,
@@ -57,7 +50,7 @@ function TenantBasicSettings() {
   } = methods;
 
   useEffect(() => {
-    reset(tenantProfileToForm(currentTenant));
+    reset({ profile: currentTenant });
   }, [currentTenant, reset]);
 
   const saveData = async (data: { name?: string; tag?: TenantTag }) => {

--- a/packages/console/src/pages/TenantSettings/TenantBasicSettings/types.ts
+++ b/packages/console/src/pages/TenantSettings/TenantBasicSettings/types.ts
@@ -1,5 +1,9 @@
 import { type TenantModel } from '@logto/schemas/models';
 
+import { type RegionName } from '@/components/Region';
+
 export type TenantSettingsForm = {
-  profile: Pick<TenantModel, 'name' | 'tag'>;
+  profile: Pick<TenantModel, 'name' | 'tag'> & {
+    regionName: RegionName;
+  };
 };


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
read region info from api response and dynamically display it

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
tested locally, the page shows the info according to the api response

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
