### PR TITLE
feat(console): show banner when only dev tenant found

### DIFF
--- a/packages/console/src/cloud/pages/Main/TenantLandingPage/TenantLandingPageContent/index.tsx
+++ b/packages/console/src/cloud/pages/Main/TenantLandingPage/TenantLandingPageContent/index.tsx
@@ -54,11 +54,11 @@ function TenantLandingPageContent({ className }: Props) {
       <CreateTenantModal
         isOpen={isCreateModalOpen}
         onClose={async (tenant?: TenantResponse) => {
+          setIsCreateModalOpen(false);
           if (tenant) {
             prependTenant(tenant);
             navigateTenant(tenant.id);
           }
-          setIsCreateModalOpen(false);
         }}
       />
     </>

--- a/packages/console/src/components/Topbar/TenantSelector/index.tsx
+++ b/packages/console/src/components/Topbar/TenantSelector/index.tsx
@@ -103,11 +103,11 @@ export default function TenantSelector() {
       <CreateTenantModal
         isOpen={showCreateTenantModal}
         onClose={async (tenant?: TenantResponse) => {
+          setShowCreateTenantModal(false);
           if (tenant) {
             prependTenant(tenant);
             navigateTenant(tenant.id);
           }
-          setShowCreateTenantModal(false);
         }}
       />
     </>

--- a/packages/console/src/containers/AppContent/TenantNotificationContainer/CreateProductionTenantBanner/index.module.scss
+++ b/packages/console/src/containers/AppContent/TenantNotificationContainer/CreateProductionTenantBanner/index.module.scss
@@ -1,0 +1,17 @@
+@use '@/scss/underscore' as _;
+
+.banner {
+  @include _.z-index(modal);
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  top: _.unit(4);
+  font: var(--font-label-2);
+  color: var(--color-text);
+  display: flex;
+  align-items: center;
+  gap: _.unit(2.5);
+  padding: _.unit(1.5) _.unit(4);
+  background: var(--color-neutral-variant-90);
+  border-radius: _.unit(4);
+}

--- a/packages/console/src/containers/AppContent/TenantNotificationContainer/CreateProductionTenantBanner/index.tsx
+++ b/packages/console/src/containers/AppContent/TenantNotificationContainer/CreateProductionTenantBanner/index.tsx
@@ -1,5 +1,6 @@
 import { TenantTag } from '@logto/schemas';
 import { useContext, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { type TenantResponse } from '@/cloud/types/router';
 import CreateTenantModal from '@/components/CreateTenantModal';
@@ -11,6 +12,9 @@ import * as styles from './index.module.scss';
 function CreateProductionTenantBanner() {
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const { tenants, prependTenant, navigateTenant } = useContext(TenantsContext);
+  const { t } = useTranslation(undefined, {
+    keyPrefix: 'admin_console.tenants.production_tenant_notification',
+  });
 
   if (tenants.some((tenant) => tenant.tag === TenantTag.Production)) {
     return null;
@@ -28,15 +32,13 @@ function CreateProductionTenantBanner() {
           }
         }}
       />
-      <span>
-        You&apos;re in a dev tenant for free testing. Create a production tenant to go live.{' '}
-      </span>
+      <span>{t('text')}</span>
       <TextLink
         onClick={() => {
           setIsCreateModalOpen(true);
         }}
       >
-        Create tenant
+        {t('action')}
       </TextLink>
     </div>
   );

--- a/packages/console/src/containers/AppContent/TenantNotificationContainer/CreateProductionTenantBanner/index.tsx
+++ b/packages/console/src/containers/AppContent/TenantNotificationContainer/CreateProductionTenantBanner/index.tsx
@@ -1,0 +1,45 @@
+import { TenantTag } from '@logto/schemas';
+import { useContext, useState } from 'react';
+
+import { type TenantResponse } from '@/cloud/types/router';
+import CreateTenantModal from '@/components/CreateTenantModal';
+import { TenantsContext } from '@/contexts/TenantsProvider';
+import TextLink from '@/ds-components/TextLink';
+
+import * as styles from './index.module.scss';
+
+function CreateProductionTenantBanner() {
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const { tenants, prependTenant, navigateTenant } = useContext(TenantsContext);
+
+  if (tenants.some((tenant) => tenant.tag === TenantTag.Production)) {
+    return null;
+  }
+
+  return (
+    <div className={styles.banner}>
+      <CreateTenantModal
+        isOpen={isCreateModalOpen}
+        onClose={async (tenant?: TenantResponse) => {
+          setIsCreateModalOpen(false);
+          if (tenant) {
+            prependTenant(tenant);
+            navigateTenant(tenant.id);
+          }
+        }}
+      />
+      <span>
+        You&apos;re in a dev tenant for free testing. Create a production tenant to go live.{' '}
+      </span>
+      <TextLink
+        onClick={() => {
+          setIsCreateModalOpen(true);
+        }}
+      >
+        Create tenant
+      </TextLink>
+    </div>
+  );
+}
+
+export default CreateProductionTenantBanner;

--- a/packages/console/src/containers/AppContent/TenantNotificationContainer/index.tsx
+++ b/packages/console/src/containers/AppContent/TenantNotificationContainer/index.tsx
@@ -5,6 +5,7 @@ import PaymentOverdueModal from '@/components/PaymentOverdueModal';
 import { isCloud } from '@/consts/env';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 
+import CreateProductionTenantBanner from './CreateProductionTenantBanner';
 import TenantEnvMigrationModal from './TenantEnvMigrationModal';
 
 function TenantNotificationContainer() {
@@ -24,6 +25,7 @@ function TenantNotificationContainer() {
           <PaymentOverdueModal />
         </>
       )}
+      <CreateProductionTenantBanner />
       <TenantEnvMigrationModal />
     </>
   );

--- a/packages/console/src/ds-components/TextLink/index.module.scss
+++ b/packages/console/src/ds-components/TextLink/index.module.scss
@@ -4,6 +4,7 @@
   display: inline-flex;
   max-width: fit-content;
   text-decoration: none;
+  user-select: none;
   border-color: transparent;
   font: var(--font-body-2);
   color: var(--color-text-link);

--- a/packages/phrases/src/locales/en/translation/admin-console/tenants.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/tenants.ts
@@ -105,6 +105,10 @@ const tenants = {
     description_2:
       'If you require further clarification, have any concerns, or wish to restore full functionality and unblock your tenants, please do not hesitate to contact us immediately.',
   },
+  production_tenant_notification: {
+    text: "You're in a dev tenant for free testing. Create a production tenant to go live.",
+    action: 'Create tenant',
+  },
 };
 
 export default Object.freeze(tenants);


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
show a banner for guiding user to create a prod tenant when there are only dev tenants under the user's account

<img width="709" alt="image" src="https://github.com/logto-io/logto/assets/14722250/518cba6c-2dd3-49fa-9899-8de47040517d">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] tested locally, create tenant ok

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
