### PR TITLE
fix(console): avoid rendering outdated role options

### DIFF
--- a/packages/console/src/components/RolesTransfer/SourceRolesBox/index.tsx
+++ b/packages/console/src/components/RolesTransfer/SourceRolesBox/index.tsx
@@ -45,7 +45,14 @@ function SourceRolesBox({ entityId, type, selectedRoles, onChange }: Props) {
     ...conditional(keyword && { search: `%${keyword}%` }),
   });
 
-  const { data, error } = useSWR<[RoleResponse[], number], RequestError>(url);
+  const { data, error } = useSWR<[RoleResponse[], number], RequestError>(url, {
+    /**
+     * Always use the latest data to reflect the latest available roles.
+     * Using cached data before new data is loaded can result in roles that have been assigned or deleted being rendered in the list.
+     * If a deleted role is rendered in the list, it will cause the query requests for role scopes in the list items to return a 404 error.
+     */
+    keepPreviousData: false,
+  });
 
   const isLoading = !data && !error;
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Open the role assignment modal and delete the default management API role and open the role assignment modal again, we will see a resource not found error:
![image](https://github.com/logto-io/logto/assets/10806653/e8994755-9acf-4eb7-9ac0-6c8d677ed9d5)

This is because SWR cached the deleted role, and try to fetch the deleted role's information.

Solution: we should always use the latest data to reflect the latest available roles since using cached data before new data is loaded can result in roles that have been assigned or deleted being rendered in the list.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
- [x] necessary TSDoc comments
