### PR TITLE
refactor(console): make long text breakable in roles page

### DIFF
--- a/packages/console/src/pages/Roles/index.module.scss
+++ b/packages/console/src/pages/Roles/index.module.scss
@@ -1,6 +1,0 @@
-@use '@/scss/underscore' as _;
-
-.type,
-.description {
-  @include _.text-ellipsis;
-}

--- a/packages/console/src/pages/Roles/index.tsx
+++ b/packages/console/src/pages/Roles/index.tsx
@@ -12,6 +12,7 @@ import UserRoleIconDark from '@/assets/icons/user-role-dark.svg';
 import UserRoleIcon from '@/assets/icons/user-role.svg';
 import RolesEmptyDark from '@/assets/images/roles-empty-dark.svg';
 import RolesEmpty from '@/assets/images/roles-empty.svg';
+import Breakable from '@/components/Breakable';
 import EmptyDataPlaceholder from '@/components/EmptyDataPlaceholder';
 import ItemPreview from '@/components/ItemPreview';
 import ListPage from '@/components/ListPage';
@@ -28,7 +29,6 @@ import { buildUrl, formatSearchKeyword } from '@/utils/url';
 
 import AssignedEntities from './components/AssignedEntities';
 import CreateRoleModal from './components/CreateRoleModal';
-import * as styles from './index.module.scss';
 
 const rolesPathname = '/roles';
 const createRolePathname = `${rolesPathname}/create`;
@@ -107,18 +107,18 @@ function Roles() {
           {
             title: t('roles.col_type'),
             dataIndex: 'type',
-            colSpan: 5,
+            colSpan: 4,
             render: ({ type }) => (
-              <div className={styles.type}>
+              <Breakable>
                 {type === RoleType.User ? t('roles.type_user') : t('roles.type_machine_to_machine')}
-              </div>
+              </Breakable>
             ),
           },
           {
             title: t('roles.col_description'),
             dataIndex: 'description',
-            colSpan: 5,
-            render: ({ description }) => <div className={styles.description}>{description}</div>,
+            colSpan: 6,
+            render: ({ description }) => <Breakable>{description}</Breakable>,
           },
           {
             title: <span>{t('roles.col_assigned_entities')}</span>,


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
In small screen, the description and type of the role will be omitted, per offline discussion, make it breakable, and also adjust the `col-span` for the role type and role description column.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Before:

![image](https://github.com/logto-io/logto/assets/10806653/8ccdaa12-87ac-494c-81a9-ae39f7325c46)

After:

![image](https://github.com/logto-io/logto/assets/10806653/b09a8e37-bd4b-45d3-b018-bb10116b4f48)


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
