### PR TITLE
fix(console): only show m2m role notification for m2m roles

### DIFF
--- a/packages/console/src/pages/RoleDetails/index.tsx
+++ b/packages/console/src/pages/RoleDetails/index.tsx
@@ -61,6 +61,8 @@ function RoleDetails() {
     ? Boolean(m2mRoleNotificationAcknowledged)
     : true;
 
+  const isM2mRole = data?.type === RoleType.MachineToMachine;
+
   const [isDeletionAlertOpen, setIsDeletionAlertOpen] = useState(false);
 
   useEffect(() => {
@@ -98,7 +100,7 @@ function RoleDetails() {
       onRetry={mutate}
     >
       {/* Todo @xiaoyijun remove dev feature flag */}
-      {isDevFeaturesEnabled && !isM2mRoleNotificationAcknowledged && (
+      {isDevFeaturesEnabled && isM2mRole && !isM2mRoleNotificationAcknowledged && (
         <InlineNotification
           action="general.got_it"
           onClick={() => {
@@ -119,12 +121,10 @@ function RoleDetails() {
       {data && (
         <>
           <DetailsPageHeader
-            icon={data.type === RoleType.User ? <UserIcon /> : <MachineToMachineIcon />}
+            icon={isM2mRole ? <MachineToMachineIcon /> : <UserIcon />}
             title={data.name}
             primaryTag={t(
-              data.type === RoleType.User
-                ? 'role_details.type_user_role_tag'
-                : 'role_details.type_m2m_role_tag'
+              isM2mRole ? 'role_details.type_m2m_role_tag' : 'role_details.type_user_role_tag'
             )}
             identifier={{ name: 'ID', value: data.id }}
             actionMenuItems={[
@@ -155,12 +155,10 @@ function RoleDetails() {
             </TabNavItem>
             <TabNavItem
               href={`/roles/${data.id}/${
-                data.type === RoleType.User ? RoleDetailsTabs.Users : RoleDetailsTabs.M2mApps
+                isM2mRole ? RoleDetailsTabs.M2mApps : RoleDetailsTabs.Users
               }`}
             >
-              {t(
-                data.type === RoleType.User ? 'role_details.users_tab' : 'role_details.m2m_apps_tab'
-              )}
+              {t(isM2mRole ? 'role_details.m2m_apps_tab' : 'role_details.users_tab')}
             </TabNavItem>
             <TabNavItem href={`/roles/${data.id}/${RoleDetailsTabs.General}`}>
               {t('role_details.general_tab')}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
M2M role notification should not be displayed on user roles page.

Bug:
![image](https://github.com/logto-io/logto/assets/10806653/beeb3437-d713-4808-b8fc-fa55ad856cad)


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

<img width="1388" alt="image" src="https://github.com/logto-io/logto/assets/10806653/ee91ab9b-6a33-47c5-a5ee-dbc644791280">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
