### PR TITLE
refactor: remove service log fkey

### DIFF
--- a/packages/schemas/alterations/next-1717148078-remove-service-log-reference.ts
+++ b/packages/schemas/alterations/next-1717148078-remove-service-log-reference.ts
@@ -1,0 +1,19 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      alter table service_logs drop constraint service_logs_tenant_id_fkey;
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      alter table service_logs add constraint service_logs_tenant_id_fkey 
+        foreign key (tenant_id) references tenants(id) on update cascade on delete cascade;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/service_logs.sql
+++ b/packages/schemas/tables/service_logs.sql
@@ -1,7 +1,6 @@
 create table service_logs (
   id varchar(21) not null,
-  tenant_id varchar(21) not null
-    references tenants (id) on update cascade on delete cascade,
+  tenant_id varchar(21) not null,
   type varchar(64) not null,
   payload jsonb /* @use JsonObject */ not null default '{}'::jsonb,
   created_at timestamptz not null default(now()),


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
remove the `tenant_id` fkey in the `service_logs` table since it should be a cloud table with no fkey

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
ci

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
