### PR TITLE
fix: use correct `disabled` logic for free plan

### DIFF
--- a/packages/console/src/components/CreateTenantModal/SelectTenantPlanModal/PlanCardItem/index.tsx
+++ b/packages/console/src/components/CreateTenantModal/SelectTenantPlanModal/PlanCardItem/index.tsx
@@ -85,11 +85,11 @@ function PlanCardItem({ plan, onSelect, buttonProps }: Props) {
               <Trans components={{ name: <PlanName name={planName} /> }}>{t('select_plan')}</Trans>
             </DangerousRaw>
           }
-          disabled={isFreePlan && isFreeTenantExceeded}
           type={isFreePlan ? 'outline' : 'primary'}
           size="large"
           onClick={onSelect}
           {...buttonProps}
+          disabled={(isFreePlan && isFreeTenantExceeded) || buttonProps?.disabled}
         />
       </div>
       {planId === ReservedPlanId.Hobby && (


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
`buttonProps` overrides the original `disabled` logic, which should be combined. this pull update to the correct logic.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
ci (cloud)

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
