### PR TITLE
fix(console): avoid skipping m2m role assignment after switching browser tabs

### DIFF
--- a/packages/console/src/components/ApplicationCreation/CreateForm/index.tsx
+++ b/packages/console/src/components/ApplicationCreation/CreateForm/index.tsx
@@ -6,6 +6,7 @@ import { useController, useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import Modal from 'react-modal';
+import { useSWRConfig } from 'swr';
 
 import { GtagConversionId, reportConversion } from '@/components/Conversion/utils';
 import DynamicT from '@/ds-components/DynamicT';
@@ -52,6 +53,7 @@ function CreateForm({
     defaultValues: { type: defaultCreateType, isThirdParty: isDefaultCreateThirdParty },
   });
   const { user } = useCurrentUser();
+  const { mutate: mutateGlobal } = useSWRConfig();
 
   const {
     field: { onChange, value, name, ref },
@@ -77,6 +79,8 @@ function CreateForm({
       reportConversion({ gtagId: GtagConversionId.CreateFirstApp, transactionId: user?.id });
 
       toast.success(t('applications.application_created'));
+      // Trigger a refetch of the applications list
+      void mutateGlobal((key) => typeof key === 'string' && key.startsWith('api/applications'));
       onClose?.(createdApp);
     })
   );

--- a/packages/console/src/pages/Applications/components/GuideLibrary/index.tsx
+++ b/packages/console/src/pages/Applications/components/GuideLibrary/index.tsx
@@ -1,4 +1,4 @@
-import { ApplicationType, type Application, ReservedPlanId } from '@logto/schemas';
+import { ApplicationType, ReservedPlanId } from '@logto/schemas';
 import { cond } from '@silverhand/essentials';
 import classNames from 'classnames';
 import { useCallback, useContext, useMemo, useState } from 'react';
@@ -6,7 +6,6 @@ import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 
 import SearchIcon from '@/assets/icons/search.svg';
-import ApplicationCreation from '@/components/ApplicationCreation';
 import EmptyDataPlaceholder from '@/components/EmptyDataPlaceholder';
 import FeatureTag from '@/components/FeatureTag';
 import { type SelectedGuide } from '@/components/Guide/GuideCard';
@@ -18,7 +17,6 @@ import { CheckboxGroup } from '@/ds-components/Checkbox';
 import OverlayScrollbar from '@/ds-components/OverlayScrollbar';
 import TextInput from '@/ds-components/TextInput';
 import TextLink from '@/ds-components/TextLink';
-import useTenantPathname from '@/hooks/use-tenant-pathname';
 import { allAppGuideCategories, type AppGuideCategory } from '@/types/applications';
 import { thirdPartyAppCategory } from '@/types/applications';
 
@@ -30,17 +28,15 @@ type Props = {
   readonly className?: string;
   readonly hasCardBorder?: boolean;
   readonly hasCardButton?: boolean;
+  readonly onSelectGuide: (data?: SelectedGuide) => void;
 };
 
-function GuideLibrary({ className, hasCardBorder, hasCardButton }: Props) {
+function GuideLibrary({ className, hasCardBorder, hasCardButton, onSelectGuide }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
-  const { navigate } = useTenantPathname();
   const { pathname } = useLocation();
   const [keyword, setKeyword] = useState<string>('');
   const [filterCategories, setFilterCategories] = useState<AppGuideCategory[]>([]);
-  const [selectedGuide, setSelectedGuide] = useState<SelectedGuide>();
   const { getFilteredAppGuideMetadata, getStructuredAppGuideMetadata } = useAppGuideMetadata();
-  const [showCreateForm, setShowCreateForm] = useState<boolean>(false);
   const isApplicationCreateModal = pathname.includes('/applications/create');
   const { currentPlan } = useContext(SubscriptionDataContext);
 
@@ -65,27 +61,11 @@ function GuideLibrary({ className, hasCardBorder, hasCardButton }: Props) {
     );
   }, [isApplicationCreateModal]);
 
-  const onClickGuide = useCallback((data: SelectedGuide) => {
-    setShowCreateForm(true);
-    setSelectedGuide(data);
-  }, []);
-
-  const onAppCreationCompleted = useCallback(
-    (newApp?: Application) => {
-      if (newApp && selectedGuide) {
-        navigate(
-          // Third party app directly goes to the app detail page
-          selectedGuide.isThirdParty
-            ? `/applications/${newApp.id}`
-            : `/applications/${newApp.id}/guide/${selectedGuide.id}`,
-          { replace: true }
-        );
-        return;
-      }
-      setShowCreateForm(false);
-      setSelectedGuide(undefined);
+  const onClickGuide = useCallback(
+    (data: SelectedGuide) => {
+      onSelectGuide(data);
     },
-    [navigate, selectedGuide]
+    [onSelectGuide]
   );
 
   return (
@@ -184,14 +164,6 @@ function GuideLibrary({ className, hasCardBorder, hasCardButton }: Props) {
           )}
         </div>
       </div>
-      {selectedGuide?.target !== 'API' && showCreateForm && (
-        <ApplicationCreation
-          defaultCreateType={selectedGuide?.target}
-          defaultCreateFrameworkName={selectedGuide?.name}
-          isDefaultCreateThirdParty={selectedGuide?.isThirdParty}
-          onCompleted={onAppCreationCompleted}
-        />
-      )}
     </OverlayScrollbar>
   );
 }

--- a/packages/console/src/pages/Applications/components/GuideLibraryModal/index.tsx
+++ b/packages/console/src/pages/Applications/components/GuideLibraryModal/index.tsx
@@ -1,10 +1,9 @@
-import { useState } from 'react';
+import { type Nullable } from '@silverhand/essentials';
 import Modal from 'react-modal';
 
-import ApplicationCreation from '@/components/ApplicationCreation';
+import { type SelectedGuide } from '@/components/Guide/GuideCard';
 import ModalFooter from '@/components/Guide/ModalFooter';
 import ModalHeader from '@/components/Guide/ModalHeader';
-import useTenantPathname from '@/hooks/use-tenant-pathname';
 import * as modalStyles from '@/scss/modal.module.scss';
 
 import GuideLibrary from '../GuideLibrary';
@@ -14,11 +13,17 @@ import * as styles from './index.module.scss';
 type Props = {
   readonly isOpen: boolean;
   readonly onClose: () => void;
+  /**
+   * The callback function when a guide is selected
+   * For the parameter:
+   * - `undefined`: No guide is selected
+   * - `null`: Create application without a framework
+   * - `selectedGuide`: The selected guide
+   */
+  readonly onSelectGuide: (guide?: Nullable<SelectedGuide>) => void;
 };
 
-function GuideLibraryModal({ isOpen, onClose }: Props) {
-  const { navigate } = useTenantPathname();
-  const [showCreateForm, setShowCreateForm] = useState(false);
+function GuideLibraryModal({ isOpen, onClose, onSelectGuide }: Props) {
   return (
     <Modal
       shouldCloseOnEsc
@@ -36,26 +41,17 @@ function GuideLibraryModal({ isOpen, onClose }: Props) {
           requestSuccessMessage="guide.request_guide_successfully"
           onClose={onClose}
         />
-        <GuideLibrary hasCardButton className={styles.content} />
+        <GuideLibrary hasCardButton className={styles.content} onSelectGuide={onSelectGuide} />
         <ModalFooter
           wrapperClassName={styles.footerInnerWrapper}
           content="guide.do_not_need_tutorial"
           buttonText="guide.app.continue_without_framework"
           onClick={() => {
-            setShowCreateForm(true);
+            // Create application without a framework
+            onSelectGuide(null);
           }}
         />
       </div>
-      {showCreateForm && (
-        <ApplicationCreation
-          onCompleted={(newApp) => {
-            if (newApp) {
-              navigate(`/applications/${newApp.id}`);
-            }
-            setShowCreateForm(false);
-          }}
-        />
-      )}
     </Modal>
   );
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
If we switch browser tabs when the m2m role assignment modal is opened during the application creation flow for the first app, the m2m role assignment modal will be skipped:

https://github.com/logto-io/logto/assets/10806653/0aac046e-d8c9-462e-9a57-5e10bfbf3703

This is because when no application data in the table, the table will display a placeholder to show applicaiton guide items, and when we open the `ApplicationCreation` component from the guide items, the creation component will be rendered in the placeholder component, after the first app is created, table list will not empty (list refreshed by SWR when we switch browser tab), and this cause the placeholder with the role assignment modal to disappeared.

### Solution
- render the `ApplicationCreation` component in the list page, rather than the table placeholder
- refresh the application data once an application is created to avoid displaying the table placeholder evenif the application data is not empty.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally and all integration passed.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
- [x] necessary TSDoc comments
