### PR TITLE
fix(core): profile avatar upload should not return 400 error

### DIFF
--- a/packages/core/src/routes-me/user-assets.ts
+++ b/packages/core/src/routes-me/user-assets.ts
@@ -57,13 +57,15 @@ export default function userAssetsRoutes<T extends AuthedMeRouter>(...[router]: 
     '/user-assets',
     koaGuard({
       files: object({
-        file: uploadFileGuard,
+        file: uploadFileGuard.array().min(1),
       }),
       response: userAssetsGuard,
     }),
     async (ctx, next) => {
-      const { file } = ctx.guard.files;
+      const { file: bodyFiles } = ctx.guard.files;
 
+      const file = bodyFiles[0];
+      assertThat(file, 'guard.invalid_input');
       assertThat(file.size <= maxUploadFileSize, 'guard.file_size_exceeded');
       assertThat(
         allowUploadMimeTypes.map(String).includes(file.mimetype),


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The profile avatar upload is currently down on Logto Cloud. Need to update this body guard in order to adjust the breaking change of the `ky` lib.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Pending Cloud dev testing

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
