### PR TITLE
refactor(core,schemas): add user detail payload to User.Deleted webhook event

### DIFF
--- a/.changeset/fuzzy-eyes-add.md
+++ b/.changeset/fuzzy-eyes-add.md
@@ -2,4 +2,4 @@
 "@logto/core": patch
 ---
 
-add user detail data payload to the User.Deleted DataHook event
+add user detail data payload to the `User.Deleted` webhook event

--- a/.changeset/fuzzy-eyes-add.md
+++ b/.changeset/fuzzy-eyes-add.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": patch
+---
+
+add user detail data payload to the User.Deleted DataHook event

--- a/packages/core/src/libraries/hook/context-manager.ts
+++ b/packages/core/src/libraries/hook/context-manager.ts
@@ -16,8 +16,6 @@ import {
   hasRegisteredDataHookEvent,
 } from './utils.js';
 
-type ManagementApiHooksRegistrationKey = keyof typeof managementApiHooksRegistration;
-
 type DataHookMetadata = {
   userAgent?: string;
   ip: string;

--- a/packages/core/src/routes/admin-user/basics.test.ts
+++ b/packages/core/src/routes/admin-user/basics.test.ts
@@ -5,6 +5,7 @@ import { removeUndefinedKeys } from '@silverhand/essentials';
 
 import { mockUser, mockUserResponse } from '#src/__mocks__/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
+import { koaManagementApiHooks } from '#src/middleware/koa-management-api-hooks.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import { MockTenant, type Partial2 } from '#src/test-utils/tenant.js';
@@ -95,7 +96,11 @@ describe('adminUserRoutes', () => {
   const tenantContext = new MockTenant(undefined, mockedQueries, undefined, {
     users: usersLibraries,
   });
-  const userRequest = createRequester({ authedRoutes: adminUserRoutes, tenantContext });
+  const userRequest = createRequester({
+    middlewares: [koaManagementApiHooks(tenantContext.libraries.hooks)],
+    authedRoutes: adminUserRoutes,
+    tenantContext,
+  });
 
   afterEach(() => {
     jest.clearAllMocks();

--- a/packages/core/src/routes/admin-user/basics.ts
+++ b/packages/core/src/routes/admin-user/basics.ts
@@ -381,7 +381,7 @@ export default function adminUserBasicsRoutes<T extends ManagementApiRouter>(
 
       ctx.status = 204;
 
-      // Manually trigger the User.Deleted hook with the user data payload
+      // Manually trigger the `User.Deleted` hook since we need to send the user data in the payload
       ctx.appendDataHookContext({
         event: 'User.Deleted',
         ...buildManagementApiContext(ctx),

--- a/packages/core/src/routes/admin-user/basics.ts
+++ b/packages/core/src/routes/admin-user/basics.ts
@@ -11,6 +11,7 @@ import { conditional, pick, yes } from '@silverhand/essentials';
 import { boolean, literal, nativeEnum, object, string } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
+import { buildManagementApiContext } from '#src/libraries/hook/utils.js';
 import { encryptUserPassword } from '#src/libraries/user.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import assertThat from '#src/utils/assert-that.js';
@@ -373,10 +374,19 @@ export default function adminUserBasicsRoutes<T extends ManagementApiRouter>(
         throw new RequestError('user.cannot_delete_self');
       }
 
+      const user = await findUserById(userId);
+
       await signOutUser(userId);
       await deleteUserById(userId);
 
       ctx.status = 204;
+
+      // Manually trigger the User.Deleted hook with the user data payload
+      ctx.appendDataHookContext({
+        event: 'User.Deleted',
+        ...buildManagementApiContext(ctx),
+        data: pick(user, ...userInfoSelectFields),
+      });
 
       return next();
     }

--- a/packages/core/src/routes/well-known.test.ts
+++ b/packages/core/src/routes/well-known.test.ts
@@ -1,4 +1,4 @@
-import { pickDefault, createMockUtils } from '@logto/shared/esm';
+import { createMockUtils, pickDefault } from '@logto/shared/esm';
 
 import {
   mockAliyunDmConnector,
@@ -63,14 +63,6 @@ describe('GET /.well-known/sign-in-exp', () => {
   const sessionRequest = createRequester({
     anonymousRoutes: wellKnownRoutes,
     tenantContext,
-    middlewares: [
-      async (ctx, next) => {
-        ctx.addLogContext = jest.fn();
-        ctx.log = jest.fn();
-
-        return next();
-      },
-    ],
   });
 
   it('should return github and facebook connector instances', async () => {

--- a/packages/core/src/utils/test-utils.ts
+++ b/packages/core/src/utils/test-utils.ts
@@ -112,7 +112,7 @@ type RouteLauncher<T extends ManagementApiRouter | AnonymousRouter> = (
   tenant: TenantContext
 ) => void;
 
-export function createRequester({
+export function createRequester<StateT, ContextT extends IRouterParamContext, ResponseT>({
   anonymousRoutes,
   authedRoutes,
   middlewares,
@@ -120,7 +120,7 @@ export function createRequester({
 }: {
   anonymousRoutes?: RouteLauncher<AnonymousRouter> | Array<RouteLauncher<AnonymousRouter>>;
   authedRoutes?: RouteLauncher<ManagementApiRouter> | Array<RouteLauncher<ManagementApiRouter>>;
-  middlewares?: Middleware[];
+  middlewares?: Array<Middleware<StateT, ContextT, ResponseT>>;
   tenantContext?: TenantContext;
 }) {
   const app = new Koa();

--- a/packages/integration-tests/src/tests/api/hook/hook.trigger.custom.data.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.trigger.custom.data.test.ts
@@ -1,5 +1,7 @@
-import { hookEvents } from '@logto/schemas';
+import { hookEvents, userInfoSelectFields } from '@logto/schemas';
+import { pick } from '@silverhand/essentials';
 
+import { createUser, deleteUser } from '#src/api/admin-user.js';
 import { OrganizationRoleApi } from '#src/api/organization-role.js';
 import { OrganizationScopeApi } from '#src/api/organization-scope.js';
 import { createResource, deleteResource } from '#src/api/resource.js';
@@ -93,5 +95,19 @@ describe('trigger custom data hook events', () => {
 
     await roleApi.delete(organizationRole.id);
     await organizationScopeApi.delete(scope.id);
+  });
+
+  it('delete user should trigger User.Deleted event with selected user info', async () => {
+    const user = await createUser();
+    const hook = webHookApi.hooks.get(hookName)!;
+
+    await deleteUser(user.id);
+
+    await assertHookLogResult(hook, 'User.Deleted', {
+      hookPayload: {
+        event: 'User.Deleted',
+        data: pick(user, ...userInfoSelectFields),
+      },
+    });
   });
 });

--- a/packages/integration-tests/src/tests/api/hook/hook.trigger.data.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.trigger.data.test.ts
@@ -120,6 +120,11 @@ describe('user data hook events', () => {
       expect(hook?.payload.event).toBe(event);
     }
   );
+
+  // Clean up
+  afterAll(async () => {
+    await authedAdminApi.delete(`users/${userId}`);
+  });
 });
 
 describe('role data hook events', () => {

--- a/packages/integration-tests/src/tests/api/hook/test-cases.ts
+++ b/packages/integration-tests/src/tests/api/hook/test-cases.ts
@@ -44,13 +44,6 @@ export const userDataHookTestCases: TestCase[] = [
     endpoint: `users/{userId}/is-suspended`,
     payload: { isSuspended: true },
   },
-  {
-    route: 'DELETE /users/:userId',
-    event: 'User.Deleted',
-    method: 'delete',
-    endpoint: `users/{userId}`,
-    payload: {},
-  },
 ];
 
 export const roleDataHookTestCases: TestCase[] = [

--- a/packages/schemas/src/foundations/jsonb-types/hooks.ts
+++ b/packages/schemas/src/foundations/jsonb-types/hooks.ts
@@ -117,7 +117,7 @@ type ApiMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
  */
 export const managementApiHooksRegistration = Object.freeze({
   'POST /users': 'User.Created',
-  'DELETE /users/:userId': 'User.Deleted',
+  // `User.Deleted` event is triggered manually in the `DELETE /users/:userId` route for better payload control
   'PATCH /users/:userId': 'User.Data.Updated',
   'PATCH /users/:userId/custom-data': 'User.Data.Updated',
   'PATCH /users/:userId/profile': 'User.Data.Updated',


### PR DESCRIPTION


<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Add the user data to the `User.Deleted` webhook event payload.

- Remove the `User.Deleted` from the auto-triggered management API webhook event registration list.
- Manually trigger the event instead. 
- Fetch the user data before deleting it from DB. Insert the data in the webhook event payload


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
