### PR TITLE
fix(core): prevent uncaught promise rejection

### DIFF
--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -38,8 +38,8 @@ try {
    * The unhandled promise rejection was first observed in the TenantPool class's get method.
    * @see TenantPool
    * If the tenantId is not found, Tenant.create will throw an error.
-   * We use a trySafe block to catch the tenantPool.get error and report it.
-   * However, a unhandled promise rejection error will still be thrown randomly.
+   * We use a try-catch block to catch the error and throw it with logging.
+   * However, if the Tenant.create Promise is read from the cache, somehow the error is not caught.
    * The root cause of this error is still unknown. To avoid the app from crashing, we catch the error here.
    */
   process.on('unhandledRejection', (error) => {

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -35,12 +35,14 @@ try {
 
   /**
    * Catch unhandled promise rejections and log them to Application Insights.
-   * The unhandled promise rejection was first observed in the TenantPool class's get method.
-   * @see TenantPool
-   * If the tenantId is not found, Tenant.create will throw an error.
+   * The unhandled promise rejection was first observed in the `TenantPool.get()` method.
+   *
+   * In this method, if the `tenantId` is not found, `Tenant.create()` will throw an error.
    * We use a try-catch block to catch the error and throw it with logging.
-   * However, if the Tenant.create Promise is read from the cache, somehow the error is not caught.
+   * However, if the `Tenant.create()` Promise is read from the cache, somehow the error is not caught.
    * The root cause of this error is still unknown. To avoid the app from crashing, we catch the error here.
+   *
+   * @see TenantPool.get
    */
   process.on('unhandledRejection', (error) => {
     consoleLog.error(error);

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -33,6 +33,20 @@ try {
     SystemContext.shared.loadProviderConfigs(sharedAdminPool),
   ]);
 
+  /**
+   * Catch unhandled promise rejections and log them to Application Insights.
+   * The unhandled promise rejection was first observed in the TenantPool class's get method.
+   * @see TenantPool
+   * If the tenantId is not found, Tenant.create will throw an error.
+   * We use a trySafe block to catch the tenantPool.get error and report it.
+   * However, a unhandled promise rejection error will still be thrown randomly.
+   * The root cause of this error is still unknown. To avoid the app from crashing, we catch the error here.
+   */
+  process.on('unhandledRejection', (error) => {
+    consoleLog.error(error);
+    void appInsights.trackException(error);
+  });
+
   await initApp(app);
 } catch (error: unknown) {
   consoleLog.error('Error while initializing app:');

--- a/packages/core/src/tenants/Tenant.ts
+++ b/packages/core/src/tenants/Tenant.ts
@@ -51,7 +51,8 @@ export default class Tenant implements TenantContext {
     // Try to avoid unexpected "triggerUncaughtException" by using try-catch block
     try {
       // Treat the default database URL as the management URL
-      const envSet = new EnvSet(id, await getTenantDatabaseDsn(id));
+      const tenantDatabaseDsn = await getTenantDatabaseDsn(id);
+      const envSet = new EnvSet(id, tenantDatabaseDsn);
       // Custom endpoint is used for building OIDC issuer URL when the request is a custom domain
       await envSet.load(customDomain);
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Globally catch unhandled promise rejections and log them to Application Insights.

The unhandled promise rejection was first observed in the TenantPool class's get method. If the `tenantId` is not found, the `getTenantDatabaseDsn` method will throw a tenant not found error.  We use a try-catch block to catch the error and throw it with logging. However, if the `Tenant.create` Promise is read from the cache, somehow the error is not caught. 
An unhandled promise rejection is thrown, which will crash the app. 

The root cause of this error is still unknown. To prevent our production app from frequently crashing, we add this global catch instead. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
