### PR TITLE
feat(schemas): custom ui assets db update

### DIFF
--- a/packages/core/src/__mocks__/sign-in-experience.ts
+++ b/packages/core/src/__mocks__/sign-in-experience.ts
@@ -92,6 +92,7 @@ export const mockSignInExperience: SignInExperience = {
   customCss: null,
   customContent: {},
   agreeToTermsPolicy: AgreeToTermsPolicy.Automatic,
+  customUiAssetId: null,
   passwordPolicy: {},
   mfa: {
     policy: MfaPolicy.UserControlled,

--- a/packages/core/src/queries/sign-in-experience.test.ts
+++ b/packages/core/src/queries/sign-in-experience.test.ts
@@ -40,7 +40,7 @@ describe('sign-in-experience query', () => {
   it('findDefaultSignInExperience', async () => {
     /* eslint-disable sql/no-unsafe-query */
     const expectSql = `
-      select "tenant_id", "id", "color", "branding", "language_info", "terms_of_use_url", "privacy_policy_url", "agree_to_terms_policy", "sign_in", "sign_up", "social_sign_in", "social_sign_in_connector_targets", "sign_in_mode", "custom_css", "custom_content", "password_policy", "mfa", "single_sign_on_enabled"
+      select "tenant_id", "id", "color", "branding", "language_info", "terms_of_use_url", "privacy_policy_url", "agree_to_terms_policy", "sign_in", "sign_up", "social_sign_in", "social_sign_in_connector_targets", "sign_in_mode", "custom_css", "custom_content", "custom_ui_asset_id", "password_policy", "mfa", "single_sign_on_enabled"
       from "sign_in_experiences"
       where "id"=$1
     `;

--- a/packages/experience/src/__mocks__/logto.tsx
+++ b/packages/experience/src/__mocks__/logto.tsx
@@ -106,6 +106,7 @@ export const mockSignInExperience: SignInExperience = {
   customCss: null,
   customContent: {},
   agreeToTermsPolicy: AgreeToTermsPolicy.ManualRegistrationOnly,
+  customUiAssetId: null,
   passwordPolicy: {},
   mfa: {
     policy: MfaPolicy.UserControlled,
@@ -139,6 +140,7 @@ export const mockSignInExperienceSettings: SignInExperienceResponse = {
   customCss: null,
   customContent: {},
   agreeToTermsPolicy: mockSignInExperience.agreeToTermsPolicy,
+  customUiAssetId: null,
   passwordPolicy: {},
   mfa: {
     policy: MfaPolicy.UserControlled,

--- a/packages/schemas/alterations/next-1719312694-custom-ui-assets.ts
+++ b/packages/schemas/alterations/next-1719312694-custom-ui-assets.ts
@@ -1,0 +1,18 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      alter table sign_in_experiences add column custom_ui_asset_id varchar(21);
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      alter table sign_in_experiences drop column custom_ui_asset_id;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/seeds/sign-in-experience.ts
+++ b/packages/schemas/src/seeds/sign-in-experience.ts
@@ -49,6 +49,7 @@ export const createDefaultSignInExperience = (
     signInMode: SignInMode.SignInAndRegister,
     customCss: null,
     customContent: {},
+    customUiAssetId: null,
     passwordPolicy: {},
     mfa: {
       factors: [],

--- a/packages/schemas/tables/sign_in_experiences.sql
+++ b/packages/schemas/tables/sign_in_experiences.sql
@@ -19,6 +19,7 @@ create table sign_in_experiences (
   sign_in_mode sign_in_mode not null default 'SignInAndRegister',
   custom_css text,
   custom_content jsonb /* @use CustomContent */ not null default '{}'::jsonb,
+  custom_ui_asset_id varchar(21),
   password_policy jsonb /* @use PartialPasswordPolicy */ not null default '{}'::jsonb,
   mfa jsonb /* @use Mfa */ not null default '{}'::jsonb,
   single_sign_on_enabled boolean not null default false,


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Update DB for "bring your own UI" feature. Added new "custom_ui_asset_id" column in "sign_in_experiences" table.

The "custom_ui_asset_id" will be generated when user uploads the assets to Logto storage, and will be used as part of its CDN storage key.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Alteration scripts executes successfully

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
