### PR TITLE
refactor(console,experience,test): decouple isDevFeatureEnabled with isIntegrationTest

### DIFF
--- a/.github/workflows/alteration-compatibility-integration-test.yml
+++ b/.github/workflows/alteration-compatibility-integration-test.yml
@@ -50,6 +50,7 @@ jobs:
     if: ${{needs.check-alteration-changes.outputs.has-alteration-changes == 'true'}}
     env:
       INTEGRATION_TEST: true
+      DEV_FEATURES_ENABLED: true
     steps:
       - uses: logto-io/actions-package-logto-artifact@v2
         with:
@@ -66,6 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       INTEGRATION_TEST: true
+      DEV_FEATURES_ENABLED: true
       DB_URL: postgres://postgres:postgres@localhost:5432/postgres
 
     steps:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       INTEGRATION_TEST: true
+      DEV_FEATURES_ENABLED: true
 
     steps:
       - uses: logto-io/actions-package-logto-artifact@v2
@@ -32,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       INTEGRATION_TEST: true
+      DEV_FEATURES_ENABLED: true
       DB_URL: postgres://postgres:postgres@localhost:5432/postgres
 
     steps:

--- a/packages/console/src/consts/env.ts
+++ b/packages/console/src/consts/env.ts
@@ -9,5 +9,4 @@ export const adminEndpoint = process.env.ADMIN_ENDPOINT;
 export const isDevFeaturesEnabled =
   !isProduction ||
   yes(process.env.DEV_FEATURES_ENABLED) ||
-  yes(process.env.INTEGRATION_TEST) ||
   yes(localStorage.getItem(storageKeys.isDevFeaturesEnabled));

--- a/packages/experience/src/constants/env.ts
+++ b/packages/experience/src/constants/env.ts
@@ -1,6 +1,4 @@
 import { yes } from '@silverhand/essentials';
 
 export const isDevFeaturesEnabled =
-  process.env.NODE_ENV !== 'production' ||
-  yes(process.env.DEV_FEATURES_ENABLED) ||
-  yes(process.env.INTEGRATION_TEST);
+  process.env.NODE_ENV !== 'production' || yes(process.env.DEV_FEATURES_ENABLED);

--- a/packages/integration-tests/src/constants.ts
+++ b/packages/integration-tests/src/constants.ts
@@ -48,4 +48,4 @@ export const newOidcSsoConnectorPayload = {
   },
 } satisfies Partial<CreateSsoConnector>;
 
-export const isDevFeaturesEnabled = yes(process.env.DEV_FEATURES_ENABLED);
+export const isDevFeaturesEnabled = yes(getEnv('DEV_FEATURES_ENABLED'));

--- a/packages/integration-tests/src/constants.ts
+++ b/packages/integration-tests/src/constants.ts
@@ -1,10 +1,10 @@
 import {
-  type CreateSsoConnector,
   SignInIdentifier,
   SsoProviderName,
   demoAppApplicationId,
+  type CreateSsoConnector,
 } from '@logto/schemas';
-import { appendPath, getEnv } from '@silverhand/essentials';
+import { appendPath, getEnv, yes } from '@silverhand/essentials';
 
 export const logtoUrl = getEnv('INTEGRATION_TESTS_LOGTO_URL', 'http://localhost:3001');
 export const logtoOidcUrl = appendPath(new URL(logtoUrl), 'oidc').toString();
@@ -47,3 +47,5 @@ export const newOidcSsoConnectorPayload = {
     issuer: `${logtoUrl}/oidc`,
   },
 } satisfies Partial<CreateSsoConnector>;
+
+export const isDevFeaturesEnabled = yes(process.env.DEV_FEATURES_ENABLED);

--- a/packages/integration-tests/src/tests/console/bootstrap.test.ts
+++ b/packages/integration-tests/src/tests/console/bootstrap.test.ts
@@ -5,6 +5,7 @@ import { authedAdminTenantApi } from '#src/api/api.js';
 import {
   consolePassword,
   consoleUsername,
+  isDevFeaturesEnabled,
   logtoConsoleUrl as logtoConsoleUrlString,
 } from '#src/constants.js';
 import { appendPathname, cls, dcls, expectNavigation, waitFor } from '#src/utils.js';
@@ -134,5 +135,11 @@ describe('smoke testing for console admin account creation and sign-in', () => {
       })
     );
     await expect(page).toMatchElement(activeSelector, { text: 'Dashboard', visible: true });
+  });
+
+  it(`should ${isDevFeaturesEnabled ? '' : 'not '}show the dev features label`, async () => {
+    await (isDevFeaturesEnabled
+      ? expect(page).toMatchElement('div', { text: 'Dev features enabled' })
+      : expect(page).not.toMatchElement('div', { text: 'Dev features enabled' }));
   });
 });

--- a/packages/shared/src/node/env/GlobalValues.ts
+++ b/packages/shared/src/node/env/GlobalValues.ts
@@ -7,8 +7,7 @@ export default class GlobalValues {
   public readonly isProduction = getEnv('NODE_ENV') === 'production';
   public readonly isIntegrationTest = yes(getEnv('INTEGRATION_TEST'));
   public readonly isUnitTest = getEnv('NODE_ENV') === 'test';
-  public readonly isDevFeaturesEnabled =
-    !this.isProduction || yes(getEnv('DEV_FEATURES_ENABLED')) || this.isIntegrationTest;
+  public readonly isDevFeaturesEnabled = !this.isProduction || yes(getEnv('DEV_FEATURES_ENABLED'));
 
   public readonly httpsCert = process.env.HTTPS_CERT_PATH;
   public readonly httpsKey = process.env.HTTPS_KEY_PATH;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
To improve test case coverage and protect development feature code, we need to split the existing integration tests into two separate jobs, one with the development feature enabled and one without. This ensures that the development feature code does not break our production environment.

As the first step, this PR decouples the isDevFeatureEnabled environment variable from isIntegrationTest. Previously, we had:

```js
const isDevFeatureEnabled = yes(getEnv('DEV_FEATURES_ENABLED')) || yes(getEnv('INTEGRATION_TEST'));
```

Instead of automatically enabling the development feature for the integration test environment, we now need to explicitly set the DEV_FEATURES_ENABLED flag.

```js
const isDevFeatureEnabled = yes(getEnv('DEV_FEATURES_ENABLED'));
```

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Create a new console dev feature enabled label integration test. 

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
