### PR TITLE
refactor(console): imporve custom phrase fetch request error handling

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/Content/LanguagesForm/ManageLanguage/LanguageEditor/LanguageDetails.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/Content/LanguagesForm/ManageLanguage/LanguageEditor/LanguageDetails.tsx
@@ -47,7 +47,7 @@ function LanguageDetails() {
   const [isDeletionAlertOpen, setIsDeletionAlertOpen] = useState(false);
   const isBuiltIn = isBuiltInLanguageTag(selectedLanguage);
   const isDefaultLanguage = signInExperience?.languageInfo.fallbackLanguage === selectedLanguage;
-  const fetchApi = useApi({ hideErrorToast: true });
+  const fetchApi = useApi({ hideErrorToast: ['entity.not_found'] });
   const fetcher = useSwrFetcher<CustomPhraseResponse>(fetchApi);
 
   const translationData = useMemo(


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
`useApi({ hideErrorToast: true })` will disable global error handling, and now the `hideErrorToast` supports to config ignored error codes, so now we don't need to set the `hideErrorToast` to `true` when fetching custom phrases in the console, only `entity.not_found` error should be ignored.

Note: this PR only improves the robustness of the code and theoretically will not affect any users, so no changeset is needed.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
