### PR TITLE
refactor(console): allow view and update `user.profile` in settings

### DIFF
--- a/.changeset/gold-bulldogs-draw.md
+++ b/.changeset/gold-bulldogs-draw.md
@@ -1,0 +1,6 @@
+---
+"@logto/console": patch
+"@logto/phrases": patch
+---
+
+view and update user's `profile` property in the user settings page

--- a/packages/console/src/consts/external-links.ts
+++ b/packages/console/src/consts/external-links.ts
@@ -26,3 +26,4 @@ export const organizationRoleLink =
   '/docs/recipes/organizations/understand-how-it-works/#organization-role';
 export const organizationPermissionLink =
   '/docs/recipes/organizations/understand-how-it-works/#organization-permission';
+export const profilePropertyReferenceLink = '/docs/references/users/#profile-1';

--- a/packages/console/src/pages/UserDetails/types.ts
+++ b/packages/console/src/pages/UserDetails/types.ts
@@ -7,6 +7,7 @@ export type UserDetailsForm = {
   name: string;
   avatar: string;
   customData: string;
+  profile: string;
 };
 
 export type UserDetailsOutletContext = {

--- a/packages/console/src/pages/UserDetails/utils.ts
+++ b/packages/console/src/pages/UserDetails/utils.ts
@@ -6,7 +6,7 @@ import type { UserDetailsForm } from './types';
 
 export const userDetailsParser = {
   toLocalForm: (data: UserProfileResponse): UserDetailsForm => {
-    const { primaryEmail, primaryPhone, username, name, avatar, customData } = data;
+    const { primaryEmail, primaryPhone, username, name, avatar, customData, profile } = data;
     const parsedPhoneNumber = conditional(
       primaryPhone && formatToInternationalPhoneNumber(primaryPhone)
     );
@@ -18,6 +18,7 @@ export const userDetailsParser = {
       name: name ?? '',
       avatar: avatar ?? '',
       customData: JSON.stringify(customData, null, 2),
+      profile: JSON.stringify(profile, null, 2),
     };
   },
 };

--- a/packages/phrases/src/locales/en/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/user-details.ts
@@ -34,9 +34,13 @@ const user_details = {
   field_custom_data: 'Custom data',
   field_custom_data_tip:
     'Additional user info not listed in the pre-defined user properties, such as user-preferred color and language.',
+  field_profile: 'Profile',
+  field_profile_tip:
+    "Additional OpenID Connect standard claims that are not included in user's properties. Note that all unknown properties will be stripped. Please refer to <a>profile property reference</a> for more information.",
   field_connectors: 'Social connections',
   field_sso_connectors: 'Enterprise connections',
   custom_data_invalid: 'Custom data must be a valid JSON object',
+  profile_invalid: 'Profile must be a valid JSON object',
   connectors: {
     connectors: 'Connectors',
     user_id: 'User ID',


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
we've add the support of `user.profile` via Management API but the user settings page in Console is missing the capability. this pull add it to Console.

> [!Note]
> The docs link will be available once https://github.com/logto-io/docs/pull/697 merged.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] can update `user.profile`

<img width="891" alt="image" src="https://github.com/logto-io/logto/assets/14722250/5e348755-5261-420c-a7d8-f4d2e542f2cd">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
