### PR TITLE
refactor(console): show sso status in jit domains

### DIFF
--- a/packages/console/src/pages/OrganizationDetails/Settings/index.module.scss
+++ b/packages/console/src/pages/OrganizationDetails/Settings/index.module.scss
@@ -4,6 +4,11 @@
   margin-top: _.unit(3);
 }
 
+.ssoEnabled {
+  vertical-align: middle;
+  color: var(--color-text-link);
+}
+
 .warning {
   margin-top: _.unit(3);
 }

--- a/packages/phrases/src/locales/en/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/enterprise-sso-details.ts
@@ -9,10 +9,10 @@ const enterprise_sso_details = {
   custom_branding_title: 'Display',
   custom_branding_description:
     "Customize the name and logo displayed in the end users' Single Sign-On flow. When empty, defaults are used.",
-  email_domain_field_name: 'Enterprise email domain',
+  email_domain_field_name: 'Enterprise email domains',
   email_domain_field_description:
-    'Users with this email domain can use SSO for authentication. Please verify the domain belongs to the enterprise.',
-  email_domain_field_placeholder: 'Email domain',
+    'Users with these email domains can use SSO for authentication. Please verify the domain ownership before adding.',
+  email_domain_field_placeholder: 'Enter one or more email domains (e.g. yourcompany.com)',
   sync_profile_field_name: 'Sync profile information from the identity provider',
   sync_profile_option: {
     register_only: 'Only sync at first sign-in',

--- a/packages/phrases/src/locales/en/translation/admin-console/organization-details.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/organization-details.ts
@@ -36,6 +36,8 @@ const organization_details = {
     email_domains: 'JIT provisioning email domains',
     email_domains_placeholder: 'Enter email domains for just-in-time provisioning',
     invalid_domain: 'Invalid domain',
+    sso_email_domain_description:
+      '<Icon /> means the domain is enabled for enterprise SSO. Users who signed in through the configured IdP can automatically join the organization.',
     domain_already_added: 'Domain already added',
     organization_roles: 'Default organization roles',
     organization_roles_description:


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- display sso icon in the jit domains list per design
- update enterprise sso phrases to eliminate ambiguity

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

configured `foo.com` for enterprise sso:

<img width="861" alt="image" src="https://github.com/logto-io/logto/assets/14722250/f1eed110-76fd-458b-8378-466a2fde42e4">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
