### PR TITLE
style(experience): add margin-bottom for terms checkbox on sign-in page

### DIFF
--- a/packages/experience/src/pages/SignIn/IdentifierSignInForm/index.module.scss
+++ b/packages/experience/src/pages/SignIn/IdentifierSignInForm/index.module.scss
@@ -9,6 +9,7 @@
 
   .inputField,
   .formErrors,
+  .terms,
   .message {
     margin-bottom: _.unit(4);
   }

--- a/packages/experience/src/pages/SignIn/IdentifierSignInForm/index.tsx
+++ b/packages/experience/src/pages/SignIn/IdentifierSignInForm/index.tsx
@@ -135,6 +135,7 @@ const IdentifierSignInForm = ({ className, autoFocus, signInMethods }: Props) =>
        */}
       <TermsAndPrivacyCheckbox
         className={classNames(
+          styles.terms,
           // For sign in, only show the terms checkbox if the terms policy is manual
           (showSingleSignOnForm || agreeToTermsPolicy !== AgreeToTermsPolicy.Manual) &&
             styles.hidden


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
style(experience): add margin-bottom for terms checkbox on sign-in page

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Before
<img width="340" alt="image" src="https://github.com/logto-io/logto/assets/10806653/002f1d4f-a4ac-4db5-a29e-123ddfa64f82">

### After
<img width="617" alt="image" src="https://github.com/logto-io/logto/assets/10806653/452f1647-67fd-4bd3-84a1-50228b2e2e25">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
