### PR TITLE
chore(schemas): add legacy-pro tag to reserved plan ID

### DIFF
--- a/packages/schemas/src/consts/subscriptions.ts
+++ b/packages/schemas/src/consts/subscriptions.ts
@@ -17,14 +17,12 @@ export enum ReservedPlanId {
    * - LOG-8339: Migrate legacy Stripe data
    */
   Hobby = 'hobby',
+  Pro = 'pro',
   /**
    * @deprecated
-   * Now this `pro` ID is not used anymore, we use `hobby` as the `pro` plan ID.
-   * Only use this `pro` value when displaying the plan ID to the user.
-   *
-   * Todo @darcyYe see `Hobby` todo
+   * Should not use this plan ID, we only use this tag as a record for the legacy `pro` plan since we will rename the `hobby` plan to be `pro`.
    */
-  Pro = 'pro',
+  LegacyPro = 'legacy-pro',
   Development = 'dev',
   /**
    * This plan ID is reserved for Admin tenant.


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
add legacy-pro tag to reserved plan ID.
This change is the prerequisite of migrate `hobby` plan ID to `pro` plan ID since we want to keep legacy records.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
