### PR TITLE
refactor(console): update subscription plan ID

### DIFF
--- a/packages/console/src/components/CreateTenantModal/SelectTenantPlanModal/PlanCardItem/index.tsx
+++ b/packages/console/src/components/CreateTenantModal/SelectTenantPlanModal/PlanCardItem/index.tsx
@@ -92,7 +92,7 @@ function PlanCardItem({ plan, onSelect, buttonProps }: Props) {
           disabled={(isFreePlan && isFreeTenantExceeded) || buttonProps?.disabled}
         />
       </div>
-      {planId === ReservedPlanId.Hobby && (
+      {planId === ReservedPlanId.Pro && (
         <div className={styles.mostPopularTag}>{t('most_popular')}</div>
       )}
     </div>

--- a/packages/console/src/components/FeatureTag/index.tsx
+++ b/packages/console/src/components/FeatureTag/index.tsx
@@ -43,7 +43,7 @@ type Props = {
  * // both free and paid features
  * {features.map((feature) => (
  *   hasPaywall(feature) &&
- *     <FeatureTag isVisible={hasAccess(feature)} plan={ReservedPlanId.Hobby} />
+ *     <FeatureTag isVisible={hasAccess(feature)} plan={ReservedPlanId.Pro} />
  * ))}
  * ```
  */

--- a/packages/console/src/components/PlanDescription/index.tsx
+++ b/packages/console/src/components/PlanDescription/index.tsx
@@ -8,7 +8,6 @@ const registeredPlanDescriptionPhrasesMap: Record<
   TFuncKey<'translation', 'admin_console.subscription'> | undefined
 > = {
   [ReservedPlanId.Free]: 'free_plan_description',
-  [ReservedPlanId.Hobby]: 'pro_plan_description',
   [ReservedPlanId.Pro]: 'pro_plan_description',
 };
 

--- a/packages/console/src/consts/plan-quotas.ts
+++ b/packages/console/src/consts/plan-quotas.ts
@@ -7,7 +7,6 @@ import { type SubscriptionPlanQuota } from '@/types/subscriptions';
  */
 export const ticketSupportResponseTimeMap: Record<string, number> = {
   [ReservedPlanId.Free]: 0,
-  [ReservedPlanId.Hobby]: 48,
   [ReservedPlanId.Pro]: 48,
 };
 

--- a/packages/console/src/consts/subscriptions.ts
+++ b/packages/console/src/consts/subscriptions.ts
@@ -13,15 +13,11 @@ export const proPlanAuditLogsRetentionDays = 14;
 /**
  * In console, only featured plans are shown in the plan selection component.
  */
-export const featuredPlanIds: string[] = [ReservedPlanId.Free, ReservedPlanId.Hobby];
+export const featuredPlanIds: string[] = [ReservedPlanId.Free, ReservedPlanId.Pro];
 
 /**
  * The order of featured plans in the plan selection content component.
  */
-export const featuredPlanIdOrder: string[] = [
-  ReservedPlanId.Free,
-  ReservedPlanId.Hobby,
-  ReservedPlanId.Pro,
-];
+export const featuredPlanIdOrder: string[] = [ReservedPlanId.Free, ReservedPlanId.Pro];
 
 export const checkoutStateQueryKey = 'checkout-state';

--- a/packages/console/src/pages/TenantSettings/Subscription/CurrentPlan/MauLimitExceededNotification/index.tsx
+++ b/packages/console/src/pages/TenantSettings/Subscription/CurrentPlan/MauLimitExceededNotification/index.tsx
@@ -27,10 +27,7 @@ function MauLimitExceededNotification({ activeUsers, currentPlan, className }: P
 
   const [isLoading, setIsLoading] = useState(false);
   const proPlan = useMemo(
-    /**
-     * Note: now the hobby plan is treated as the new pro plan
-     */
-    () => subscriptionPlans.find(({ id }) => id === ReservedPlanId.Hobby),
+    () => subscriptionPlans.find(({ id }) => id === ReservedPlanId.Pro),
     [subscriptionPlans]
   );
 

--- a/packages/console/src/pages/TenantSettings/components/NotEligibleSwitchPlanModalContent/index.tsx
+++ b/packages/console/src/pages/TenantSettings/components/NotEligibleSwitchPlanModalContent/index.tsx
@@ -63,7 +63,7 @@ function NotEligibleSwitchPlanModalContent({
         >
           {t(isDowngrade ? 'downgrade_description' : 'upgrade_description')}
         </Trans>
-        {!isDowngrade && id === ReservedPlanId.Hobby && t('upgrade_pro_tip')}
+        {!isDowngrade && id === ReservedPlanId.Pro && t('upgrade_pro_tip')}
       </div>
       <ul className={styles.list}>
         {orderedEntries.map(([quotaKey, quotaValue]) => {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Update subscription plan ID since we now use `ReservedPlanId.Pro` for Logto pro plan subscribers (see [@logto/cloud changes](https://github.com/logto-io/cloud/pull/769), before the change, we were using `ReservedPlanId.Hobby` to represent Logto pro plan subscribers, which is counterintuitive).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
