### PR TITLE
refactor(console): hide backchannel for m2m apps

### DIFF
--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/index.tsx
@@ -205,7 +205,7 @@ function ApplicationDetailsContent({ data, oidcConfig, onApplicationUpdated }: P
             {![ApplicationType.MachineToMachine, ApplicationType.Protected].includes(data.type) && (
               <RefreshTokenSettings data={data} />
             )}
-            <BackchannelLogout />
+            {data.type !== ApplicationType.MachineToMachine && <BackchannelLogout />}
           </DetailsForm>
         </FormProvider>
         {tab === ApplicationDetailsTabs.Settings && (


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
currently there's no way to trigger backchannel logout within a m2m app. hide it first.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
n/a

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
