### PR TITLE
fix(experience): apply agree to terms policy for sso

### DIFF
--- a/packages/experience/src/pages/Register/IdentifierRegisterForm/index.tsx
+++ b/packages/experience/src/pages/Register/IdentifierRegisterForm/index.tsx
@@ -137,8 +137,7 @@ const IdentifierRegisterForm = ({ className, autoFocus, signUpMethods }: Props) 
            * Hide the terms checkbox when the policy is set to `Automatic`.
            * In registration, the terms checkbox is always shown for `Manual` and `ManualRegistrationOnly` policies.
            */
-          (showSingleSignOnForm || agreeToTermsPolicy === AgreeToTermsPolicy.Automatic) &&
-            styles.hidden
+          agreeToTermsPolicy === AgreeToTermsPolicy.Automatic && styles.hidden
         )}
       />
 

--- a/packages/experience/src/pages/SignIn/IdentifierSignInForm/index.tsx
+++ b/packages/experience/src/pages/SignIn/IdentifierSignInForm/index.tsx
@@ -137,8 +137,7 @@ const IdentifierSignInForm = ({ className, autoFocus, signInMethods }: Props) =>
         className={classNames(
           styles.terms,
           // For sign in, only show the terms checkbox if the terms policy is manual
-          (showSingleSignOnForm || agreeToTermsPolicy !== AgreeToTermsPolicy.Manual) &&
-            styles.hidden
+          agreeToTermsPolicy !== AgreeToTermsPolicy.Manual && styles.hidden
         )}
       />
 

--- a/packages/experience/src/pages/SignIn/PasswordSignInForm/index.tsx
+++ b/packages/experience/src/pages/SignIn/PasswordSignInForm/index.tsx
@@ -160,8 +160,7 @@ const PasswordSignInForm = ({ className, autoFocus, signInMethods }: Props) => {
         className={classNames(
           styles.terms,
           // For sign in, only show the terms checkbox if the terms policy is manual
-          (showSingleSignOnForm || agreeToTermsPolicy !== AgreeToTermsPolicy.Manual) &&
-            styles.hidden
+          agreeToTermsPolicy !== AgreeToTermsPolicy.Manual && styles.hidden
         )}
       />
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
In the orginal implemantaion, the agree to terms plicy for SSO is not implemented for the lack of product design.
Now we introduce related implementation to fix the bug that agree to terms policy is not applied to for sso sign-in.

- Display agree to terms policy checkbox in SSO sign-in page when the policy is set to `Manual`
- Display agree to terms policy checkbox in SSO sing-up page when the policy is set to `Manual` or `ManualRegistrationOnly`
- Validating terms of use policy agreement before single sign-on.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test by go though all flows
<img width="671" alt="image" src="https://github.com/logto-io/logto/assets/10806653/40e49317-06f6-4abc-99ab-952705e96179">
<img width="635" alt="image" src="https://github.com/logto-io/logto/assets/10806653/e701a639-8efb-4c12-8115-51aaf76f59bf">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
- [x] necessary TSDoc comments
