### PR TITLE
feat(core): update application organization role apis

### DIFF
--- a/.changeset/fresh-gorillas-obey.md
+++ b/.changeset/fresh-gorillas-obey.md
@@ -1,0 +1,7 @@
+---
+"@logto/core": minor
+---
+
+pagination is now optional for `GET /api/organizations/:id/users/:userId/roles`
+
+The default pagination is now removed. This isn't considered a breaking change, but we marked it as minor to get your attention. 

--- a/packages/core/src/routes/organization-role/index.ts
+++ b/packages/core/src/routes/organization-role/index.ts
@@ -60,9 +60,7 @@ export default function organizationRoleRoutes<T extends ManagementApiRouter>(
     }),
     async (ctx, next) => {
       const { limit, offset } = ctx.pagination;
-
       const search = parseSearchOptions(organizationRoleSearchKeys, ctx.guard.query);
-
       const [count, entities] = await roles.findAll(limit, offset, search);
 
       ctx.pagination.totalCount = count;

--- a/packages/core/src/routes/organization/application/index.openapi.json
+++ b/packages/core/src/routes/organization/application/index.openapi.json
@@ -82,6 +82,37 @@
         }
       }
     },
+    "/api/organizations/{id}/applications/roles": {
+      "post": {
+        "tags": ["Dev feature"],
+        "summary": "Assign roles to applications in an organization",
+        "description": "Assign roles to applications in the specified organization.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "applicationIds": {
+                    "description": "An array of application IDs to assign roles to."
+                  },
+                  "organizationRoleIds": {
+                    "description": "An array of organization role IDs to assign to the applications."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Roles were assigned to the applications successfully."
+          },
+          "422": {
+            "description": "At least one of the IDs provided is not valid. For example, the organization ID, application ID, or organization role ID does not exist; the application is not a member of the organization; or the role type is not assignable to the application."
+          }
+        }
+      }
+    },
     "/api/organizations/{id}/applications/{applicationId}/roles": {
       "get": {
         "tags": ["Dev feature"],

--- a/packages/core/src/routes/organization/application/role-relations.ts
+++ b/packages/core/src/routes/organization/application/role-relations.ts
@@ -35,7 +35,7 @@ export default function applicationRoleRelationRoutes(
 
   router.get(
     pathname,
-    koaPagination(),
+    koaPagination({ isOptional: true }),
     koaGuard({
       params: z.object(params),
       response: OrganizationRoles.guard.array(),
@@ -49,10 +49,14 @@ export default function applicationRoleRelationRoutes(
         {
           organizationId: id,
           applicationId,
-        }
+        },
+        ctx.pagination.disabled ? undefined : ctx.pagination
       );
 
-      ctx.pagination.totalCount = totalCount;
+      if (!ctx.pagination.disabled) {
+        ctx.pagination.totalCount = totalCount;
+      }
+
       ctx.body = entities;
       return next();
     }

--- a/packages/core/src/routes/organization/user/index.openapi.json
+++ b/packages/core/src/routes/organization/user/index.openapi.json
@@ -91,7 +91,7 @@
     "/api/organizations/{id}/users/roles": {
       "post": {
         "summary": "Assign roles to organization user members",
-        "description": "Assign roles to user members of the specified organization with the given data.",
+        "description": "Assign roles to user members of the specified organization.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -113,7 +113,7 @@
             "description": "Roles were assigned to organization users successfully."
           },
           "422": {
-            "description": "At least one of the IDs provided is not valid. For example, the organization ID, user ID, or organization role ID does not exist; the user is not a member of the organization."
+            "description": "At least one of the IDs provided is not valid. For example, the organization ID, user ID, or organization role ID does not exist; the user is not a member of the organization; or the role type is not assignable to the user."
           }
         }
       }

--- a/packages/core/src/routes/organization/user/role-relations.ts
+++ b/packages/core/src/routes/organization/user/role-relations.ts
@@ -39,7 +39,7 @@ export default function userRoleRelationRoutes(
 
   router.get(
     pathname,
-    koaPagination(),
+    koaPagination({ isOptional: true }),
     koaGuard({
       params: z.object(params),
       response: OrganizationRoles.guard.array(),
@@ -54,10 +54,12 @@ export default function userRoleRelationRoutes(
           organizationId: id,
           userId,
         },
-        ctx.pagination
+        ctx.pagination.disabled ? undefined : ctx.pagination
       );
 
-      ctx.pagination.totalCount = totalCount;
+      if (!ctx.pagination.disabled) {
+        ctx.pagination.totalCount = totalCount;
+      }
       ctx.body = entities;
       return next();
     }

--- a/packages/integration-tests/src/api/organization.ts
+++ b/packages/integration-tests/src/api/organization.ts
@@ -36,6 +36,16 @@ export class OrganizationApi extends ApiFactory<Organization, Omit<CreateOrganiz
     return super.getList(query) as Promise<OrganizationWithFeatured[]>;
   }
 
+  async addApplicationsRoles(
+    id: string,
+    applicationIds: string[],
+    organizationRoleIds: string[]
+  ): Promise<void> {
+    await authedAdminApi.post(`${this.path}/${id}/applications/roles`, {
+      json: { applicationIds, organizationRoleIds },
+    });
+  }
+
   async addUsers(id: string, userIds: string[]): Promise<void> {
     await authedAdminApi.post(`${this.path}/${id}/users`, { json: { userIds } });
   }
@@ -68,9 +78,9 @@ export class OrganizationApi extends ApiFactory<Organization, Omit<CreateOrganiz
     });
   }
 
-  async getUserRoles(id: string, userId: string): Promise<OrganizationRole[]> {
+  async getUserRoles(id: string, userId: string, query?: Query): Promise<OrganizationRole[]> {
     return authedAdminApi
-      .get(`${this.path}/${id}/users/${userId}/roles`)
+      .get(`${this.path}/${id}/users/${userId}/roles`, { searchParams: query })
       .json<OrganizationRole[]>();
   }
 
@@ -98,9 +108,24 @@ export class OrganizationApi extends ApiFactory<Organization, Omit<CreateOrganiz
     });
   }
 
-  async getApplicationRoles(id: string, applicationId: string): Promise<OrganizationRole[]> {
+  async getApplicationRoles(
+    id: string,
+    applicationId: string,
+    page?: number,
+    pageSize?: number
+  ): Promise<OrganizationRole[]> {
+    const search = new URLSearchParams();
+
+    if (page) {
+      search.set('page', String(page));
+    }
+
+    if (pageSize) {
+      search.set('page_size', String(pageSize));
+    }
+
     return authedAdminApi
-      .get(`${this.path}/${id}/applications/${applicationId}/roles`)
+      .get(`${this.path}/${id}/applications/${applicationId}/roles`, { searchParams: search })
       .json<OrganizationRole[]>();
   }
 

--- a/packages/integration-tests/src/helpers/organization.ts
+++ b/packages/integration-tests/src/helpers/organization.ts
@@ -137,10 +137,12 @@ export class OrganizationApiTest extends OrganizationApi {
    * when they are deleted by other tests.
    */
   async cleanUp(): Promise<void> {
-    await Promise.all(
+    await Promise.all([
       // Use `trySafe` to avoid error when organization is deleted by other tests.
-      this.organizations.map(async (organization) => trySafe(this.delete(organization.id)))
-    );
+      ...this.organizations.map(async (organization) => trySafe(this.delete(organization.id))),
+      this.roleApi.cleanUp(),
+      this.scopeApi.cleanUp(),
+    ]);
     this.#organizations = [];
   }
 }

--- a/packages/integration-tests/src/tests/api/hook/hook.trigger.data.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.trigger.data.test.ts
@@ -340,7 +340,7 @@ describe('organization role data hook events', () => {
   });
 
   afterAll(async () => {
-    await organizationScopeApi.cleanUp();
+    await Promise.all([organizationScopeApi.cleanUp(), roleApi.cleanUp()]);
   });
 
   it.each(organizationRoleDataHookTestCases)(

--- a/packages/integration-tests/src/tests/api/interaction/consent/happy-path.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/consent/happy-path.test.ts
@@ -152,11 +152,9 @@ describe('consent api', () => {
   });
 
   describe('get consent info with organization resource scopes', () => {
-    const roleApi = new OrganizationRoleApiTest();
     const organizationApi = new OrganizationApiTest();
 
     afterEach(async () => {
-      await roleApi.cleanUp();
       await organizationApi.cleanUp();
     });
 
@@ -167,7 +165,7 @@ describe('consent api', () => {
       const resource = await createResource(generateResourceName(), generateResourceIndicator());
       const scope = await createScope(resource.id, generateScopeName());
       const scope2 = await createScope(resource.id, generateScopeName());
-      const role = await roleApi.create({
+      const role = await organizationApi.roleApi.create({
         name: generateRoleName(),
         resourceScopeIds: [scope.id],
       });
@@ -219,7 +217,7 @@ describe('consent api', () => {
 
       const resource = await createResource(generateResourceName(), generateResourceIndicator());
       const scope = await createScope(resource.id, generateScopeName());
-      const role = await roleApi.create({
+      const role = await organizationApi.roleApi.create({
         name: generateRoleName(),
         resourceScopeIds: [scope.id],
       });
@@ -397,10 +395,12 @@ describe('consent api', () => {
       // Scope2 is removed because organization2 is not consented
       expect(getAccessTokenPayload(accessToken)).toHaveProperty('scope', scope.name);
 
-      await roleApi.cleanUp();
-      await organizationApi.cleanUp();
-      await deleteResource(resource.id);
-      await deleteUser(user.id);
+      await Promise.all([
+        roleApi.cleanUp(),
+        organizationApi.cleanUp(),
+        deleteResource(resource.id),
+        deleteUser(user.id),
+      ]);
     });
   });
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- implement `POST /api/organizations/{id}/applications/roles` for batch applications - organization roles assignment
- make pagination optional for `GET /api/organizations/:id/users/:userId/roles` and `GET /api/organizations/:id/applications/:applicationId/roles`
  - rationale: we have those pages shows organization members or applications with all their roles in that organization, thus the get roles api should be ok to have no pagination

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
integration tests added

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
