### PR TITLE
fix: generate valid OpenAPI spec

### DIFF
--- a/.changeset/heavy-badgers-jog.md
+++ b/.changeset/heavy-badgers-jog.md
@@ -1,0 +1,8 @@
+---
+"@logto/core": patch
+---
+
+fix OpenAPI schema returned by the `GET /api/swagger.json` endpoint
+
+1. The `:` character is invalid in parameter names, such as `organizationId:root`. These characters have been replaced with `-`.
+2. The `tenantId` parameter of the `/api/.well-known/endpoints/{tenantId}` route was missing from the generated OpenAPI spec document, resulting in validation errors. This has been fixed.

--- a/packages/core/src/routes/swagger/index.test.ts
+++ b/packages/core/src/routes/swagger/index.test.ts
@@ -120,7 +120,7 @@ describe('GET /swagger.json', () => {
         get: {
           parameters: [
             {
-              $ref: '#/components/parameters/mockId:root',
+              $ref: '#/components/parameters/mockId-root',
             },
             {
               name: 'field',
@@ -135,7 +135,7 @@ describe('GET /swagger.json', () => {
         get: {
           parameters: [
             {
-              $ref: '#/components/parameters/mockId:root',
+              $ref: '#/components/parameters/mockId-root',
             },
             {
               name: 'field',

--- a/packages/core/src/routes/swagger/index.ts
+++ b/packages/core/src/routes/swagger/index.ts
@@ -236,9 +236,8 @@ export default function swaggerRoutes<T extends AnonymousRouter, R extends Route
           (previous, entityName) => ({
             ...previous,
             ...buildPathIdParameters(entityName),
-            ...customParameters(),
           }),
-          {}
+          customParameters()
         ),
       },
       tags: [...tags, ...additionalTags].map((tag) => ({ name: tag })),

--- a/packages/core/src/routes/swagger/index.ts
+++ b/packages/core/src/routes/swagger/index.ts
@@ -34,6 +34,7 @@ import {
   paginationParameters,
   buildPathIdParameters,
   mergeParameters,
+  customParameters,
 } from './utils/parameters.js';
 
 type RouteObject = {
@@ -232,7 +233,11 @@ export default function swaggerRoutes<T extends AnonymousRouter, R extends Route
       components: {
         schemas: translationSchemas,
         parameters: identifiableEntityNames.reduce(
-          (previous, entityName) => ({ ...previous, ...buildPathIdParameters(entityName) }),
+          (previous, entityName) => ({
+            ...previous,
+            ...buildPathIdParameters(entityName),
+            ...customParameters(),
+          }),
           {}
         ),
       },

--- a/packages/core/src/routes/swagger/utils/parameters.ts
+++ b/packages/core/src/routes/swagger/utils/parameters.ts
@@ -91,7 +91,7 @@ export const buildParameters: BuildParameters = (
       if (key === 'id') {
         if (rootComponent) {
           return {
-            $ref: `#/components/parameters/${pluralize(rootComponent, 1)}Id:root`,
+            $ref: `#/components/parameters/${pluralize(rootComponent, 1)}Id-root`,
           };
         }
 
@@ -241,13 +241,31 @@ export const buildPathIdParameters = (
   // Need to duplicate the object because OpenAPI does not support partial reference.
   // See https://github.com/OAI/OpenAPI-Specification/issues/2026
   return {
-    [`${entityId}:root`]: {
+    [`${entityId}-root`]: {
       ...shared,
       name: 'id',
     },
     [entityId]: {
       ...shared,
       name: entityId,
+    },
+  };
+};
+
+/**
+ * Build a parameter object for the `tenantId` parameter.
+ * @returns The parameter object for the `tenantId` parameter.
+ */
+export const customParameters = (): Record<string, OpenAPIV3.ParameterObject> => {
+  return {
+    tenantId: {
+      name: 'tenantId',
+      in: 'path',
+      description: 'The unique identifier of the tenant.',
+      required: true,
+      schema: {
+        type: 'string',
+      },
     },
   };
 };

--- a/packages/core/src/routes/swagger/utils/parameters.ts
+++ b/packages/core/src/routes/swagger/utils/parameters.ts
@@ -253,11 +253,10 @@ export const buildPathIdParameters = (
 };
 
 /**
- * Build a parameter object for the `tenantId` parameter.
- * @returns The parameter object for the `tenantId` parameter.
+ * Build a parameter object with additional parameters that are not inferred from the path.
  */
 export const customParameters = (): Record<string, OpenAPIV3.ParameterObject> => {
-  return {
+  return Object.freeze({
     tenantId: {
       name: 'tenantId',
       in: 'path',
@@ -267,5 +266,5 @@ export const customParameters = (): Record<string, OpenAPIV3.ParameterObject> =>
         type: 'string',
       },
     },
-  };
+  });
 };

--- a/packages/core/src/routes/swagger/utils/parameters.ts
+++ b/packages/core/src/routes/swagger/utils/parameters.ts
@@ -48,7 +48,7 @@ type BuildParameters = {
    * For path parameters, this function will try to match reusable ID parameters:
    *
    * - If the parameter name is `id`, and the path is `/organizations/{id}/users`, the parameter
-   *   `id` will be a reference to `#/components/parameters/organizationId:root`.
+   *   `id` will be a reference to `#/components/parameters/organizationId-root`.
    * - If the parameter name ends with `Id`, and the path is `/organizations/{id}/users/{userId}`,
    *   the parameter `userId` will be a reference to `#/components/parameters/userId`.
    *
@@ -206,7 +206,7 @@ export const mergeParameters = (destination: unknown[], source: unknown[]) => {
  *       type: 'string',
  *     },
  *   },
- *   'organizationId:root': {
+ *   'organizationId-root': {
  *     name: 'id',
  *     // ... same as above
  *   },
@@ -216,7 +216,7 @@ export const mergeParameters = (destination: unknown[], source: unknown[]) => {
  * @remarks
  * The root path component is the first path component in the path. For example, the root path
  * component of `/organizations/{id}/users` is `organizations`. Since the name of the parameter is
- * same for all root path components, we need to add an additional key with the `:root` suffix to
+ * same for all root path components, we need to add an additional key with the `-root` suffix to
  * distinguish them.
  *
  * @param rootComponent The root path component in kebab case (`foo-bar`).


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
This PR partially addresses an issue reported in #6043 that caused OpenAPI tooling to fail when validating the generated OpenAPI specification document from `http://ip:port/api/swagger.json`. This fix aims to resolve two problems identified during the investigation:

1. The `:` character is invalid in parameter names, such as `organizationId:root`. These characters have been replaced with `-`.
2. The `tenantId` parameter of the `/api/.well-known/endpoints/{tenantId}` route was missing from the generated OpenAPI spec document, resulting in validation errors. This has been fixed.

> [!NOTE]
> ~Although the above steps result in a valid OpenAPI being generated, the Go client stubs produced by `openapi-generator-cli` (`go` extension) are still invalid. I believe the duplication of parameters (for `id` and `-root` variants) causes the generation of duplicate `struct`s of the same type within the same Go package, leading to compilation errors. This effectively prevents generating a Go client SDK for Logto.~ If you run Logto in development mode, the `Dev Features` tag will cause certain endpoints on organizations and security to be duplicated in the resulting OpenAPI spec doc, hence resulting in duplicate structs in Go output. The resulting code has some minor issues that can be fixed manually when one runs `gofmt` on the codebase. This means that the resulting Go Client SDK is usable now (with some minor issues).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Retrieve the generated OpenAPI spec doc and validate it using Swagger [Editor](https://editor.swagger.io/) or [Validator](https://validator.swagger.io/).

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
