### PR TITLE
fix: include `tenantId` and its root param in responses

### DIFF
--- a/packages/core/src/routes/swagger/utils/parameters.ts
+++ b/packages/core/src/routes/swagger/utils/parameters.ts
@@ -257,24 +257,15 @@ export const buildPathIdParameters = (
  */
 export const customParameters = (): Record<string, OpenAPIV3.ParameterObject> => {
   const entityId = 'tenantId';
+  const shared = Object.freeze({
+    in: 'path',
+    description: 'The unique identifier of the tenant.',
+    required: true,
+    schema: { type: 'string' },
+  } as const);
+
   return Object.freeze({
-    [`${entityId}-root`]: {
-      name: 'id',
-      in: 'path',
-      description: 'The unique identifier of the tenant.',
-      required: true,
-      schema: {
-        type: 'string',
-      },
-    },
-    [entityId]: {
-      name: 'tenantId',
-      in: 'path',
-      description: 'The unique identifier of the tenant.',
-      required: true,
-      schema: {
-        type: 'string',
-      },
-    },
+    [`${entityId}-root`]: { name: 'id', ...shared },
+    [entityId]: { name: 'tenantId', ...shared },
   });
 };

--- a/packages/core/src/routes/swagger/utils/parameters.ts
+++ b/packages/core/src/routes/swagger/utils/parameters.ts
@@ -256,8 +256,18 @@ export const buildPathIdParameters = (
  * Build a parameter object with additional parameters that are not inferred from the path.
  */
 export const customParameters = (): Record<string, OpenAPIV3.ParameterObject> => {
+  const entityId = 'tenantId';
   return Object.freeze({
-    tenantId: {
+    [`${entityId}-root`]: {
+      name: 'id',
+      in: 'path',
+      description: 'The unique identifier of the tenant.',
+      required: true,
+      schema: {
+        type: 'string',
+      },
+    },
+    [entityId]: {
       name: 'tenantId',
       in: 'path',
       description: 'The unique identifier of the tenant.',

--- a/packages/core/src/utils/zod.ts
+++ b/packages/core/src/utils/zod.ts
@@ -207,9 +207,7 @@ export const zodTypeToSwagger = (
   if (config instanceof ZodObject) {
     // Type from Zod is any
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    const entries = Object.entries(config.shape)
-      // `tenantId` is not editable for all routes
-      .filter(([key]) => key !== 'tenantId');
+    const entries = Object.entries(config.shape);
     const required = entries
       .filter(([, value]) => !(value instanceof ZodOptional))
       .map(([key]) => key);


### PR DESCRIPTION
This will add `tenantId` back to responses, so that the generated Go client SDK doesn't complain about unknown JSON field being unmarshalled. This is the continuation of #6089 and (possibly completely) fixes #6043. The SDK works fine now, at least for a few routes I checked.