### PR TITLE
refactor: refactor integration test ci job

### DIFF
--- a/.github/workflows/alteration-compatibility-integration-test.yml
+++ b/.github/workflows/alteration-compatibility-integration-test.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   check-alteration-changes:
-    runs-on: ubuntu-lates
+    runs-on: ubuntu-latest
     outputs:
       has-alteration-changes: ${{ steps.changes-detection.outputs.has-alteration-changes }}
 
@@ -47,7 +47,7 @@ jobs:
   package:
     needs: check-alteration-changes
     runs-on: ubuntu-latest
-    if:
+    if: ${{needs.check-alteration-changes.outputs.has-alteration-changes == 'true'}}
     env:
       INTEGRATION_TEST: true
       DEV_FEATURES_ENABLED: false

--- a/.github/workflows/alteration-compatibility-integration-test.yml
+++ b/.github/workflows/alteration-compatibility-integration-test.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   check-alteration-changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-lates
     outputs:
       has-alteration-changes: ${{ steps.changes-detection.outputs.has-alteration-changes }}
 
@@ -37,20 +37,20 @@ jobs:
 
           if [ -n "$CHANGE_FILES" ]; then
             echo "$CHANGE_FILES"
-            echo "::set-output name=has-alteration-changes::true"
+            echo "has-alteration-changes=true" >> $GITHUB_OUTPUT
             echo "Alteration changes detected"
           else
-            echo "::set-output name=has-alteration-changes::false"
+            echo "has-alteration-changes=false" >> $GITHUB_OUTPUT
             echo "No alteration changes detected"
           fi
 
   package:
     needs: check-alteration-changes
     runs-on: ubuntu-latest
-    if: ${{needs.check-alteration-changes.outputs.has-alteration-changes == 'true'}}
+    if:
     env:
       INTEGRATION_TEST: true
-      DEV_FEATURES_ENABLED: true
+      DEV_FEATURES_ENABLED: false
     steps:
       - uses: logto-io/actions-package-logto-artifact@v2
         with:
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       INTEGRATION_TEST: true
-      DEV_FEATURES_ENABLED: true
+      DEV_FEATURES_ENABLED: false
       DB_URL: postgres://postgres:postgres@localhost:5432/postgres
 
     steps:

--- a/.github/workflows/dev-feature-disabled-integration-test.yml
+++ b/.github/workflows/dev-feature-disabled-integration-test.yml
@@ -26,6 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         target: [api, experience, console]
+    needs: package
     runs-on: ubuntu-latest
     env:
       INTEGRATION_TEST: true

--- a/.github/workflows/dev-feature-disabled-integration-test.yml
+++ b/.github/workflows/dev-feature-disabled-integration-test.yml
@@ -10,44 +10,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  detect-dev-feature-changes:
-    runs-on: ubuntu-latest
-    outputs:
-      has-dev-feature-changes: ${{ steps.changes-detection.outputs.has-dev-feature-changes }}
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      # compare the current codebase with HEAD and check if there are any new lines with isDevFeaturesEnabled
-      - name: Get the diff and filter added lines
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            BASE=$(git merge-base origin/${{github.base_ref}} HEAD)
-          else
-            BASE=${{ github.event.before }}
-          fi
-
-          git diff $BASE --unified=0 | grep -E '^\+' > added_lines.txt
-
-          sed -i '/^+++ /d' added_lines.txt
-
-      - name: Check for isDevFeaturesEnabled in added lines
-        id: changes-detection
-        run: |
-          if grep -q 'isDevFeaturesEnabled' added_lines.txt; then
-            echo "Dev features enabled changes detected"
-            echo "::set-output name=has-dev-feature-changes::true"
-          else
-            echo "No dev features enabled changes detected"
-            echo "::set-output name=has-dev-feature-changes::false"
-          fi
-
   package:
-    needs: detect-dev-feature-changes
     runs-on: ubuntu-latest
-    if: ${{needs.detect-dev-feature-changes.outputs.has-dev-feature-changes == 'true'}}
     env:
       INTEGRATION_TEST: true
       DEV_FEATURES_ENABLED: false
@@ -62,7 +26,6 @@ jobs:
       fail-fast: false
       matrix:
         target: [api, experience, console]
-    needs: package
     runs-on: ubuntu-latest
     env:
       INTEGRATION_TEST: true


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR refactors the integration test ci jobs.

1. Remove the `devFeatureEnabled` git diff detection. As it can only check a newly added dev feature code flow. For any existing dev feature code changes, the test won't be triggered.  Always trigger the dev feature disabled integration tests instead. 
2. Set the DB alteration compatibility integration tests devFeatureEnabled flag to false.  Should run the test under the dev feature disabled mode. 
3. Replace the old `set-output` command with the latest `$GITHUB_OUTPUT` syntax, as the `set-output` command is deprecated. See [github actions](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) for more details. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
ci job

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [ ] ~necessary TSDoc comments~
