### PR TITLE
fix(schemas): explicitly set search path

### DIFF
--- a/packages/schemas/alterations/next-1719221205-fix-functions.ts
+++ b/packages/schemas/alterations/next-1719221205-fix-functions.ts
@@ -1,0 +1,25 @@
+/**
+ * In Logto Cloud, we have multiple schemas and the default search behavior will be problematic.
+ * This alteration script will fix it by setting the search path to public for the functions.
+ */
+
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      alter function check_application_type set search_path = public;
+      alter function check_organization_role_type set search_path = public;
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      alter function check_application_type reset search_path;
+      alter function check_organization_role_type reset search_path;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/applications.sql
+++ b/packages/schemas/tables/applications.sql
@@ -37,4 +37,4 @@ create unique index applications__protected_app_metadata_custom_domain
 create function check_application_type(application_id varchar(21), target_type application_type) returns boolean as
 $$ begin
   return (select type from applications where id = application_id) = target_type;
-end; $$ language plpgsql;
+end; $$ language plpgsql set search_path = public;

--- a/packages/schemas/tables/organization_roles.sql
+++ b/packages/schemas/tables/organization_roles.sql
@@ -23,4 +23,4 @@ create index organization_roles__id
 create function check_organization_role_type(role_id varchar(21), target_type role_type) returns boolean as
 $$ begin
   return (select type from organization_roles where id = role_id) = target_type;
-end; $$ language plpgsql;
+end; $$ language plpgsql set search_path = public;


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
In Logto Cloud, we have multiple schemas and the default search behavior will be problematic. This alteration script will fix it by setting the search path to public for the functions.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
locally ran a cloud test set, no error

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
