### PR TITLE
refactor(console): fix switch styles

### DIFF
--- a/packages/console/src/components/ConnectorForm/GoogleOneTapCard/index.module.scss
+++ b/packages/console/src/components/ConnectorForm/GoogleOneTapCard/index.module.scss
@@ -4,6 +4,12 @@
   width: 200px;
 }
 
+.oneTapSwitch {
+  display: flex;
+  gap: _.unit(6);
+  align-items: center;
+}
+
 .oneTapConfig {
   display: flex;
   gap: _.unit(2);

--- a/packages/console/src/components/ConnectorForm/GoogleOneTapCard/index.tsx
+++ b/packages/console/src/components/ConnectorForm/GoogleOneTapCard/index.tsx
@@ -41,14 +41,14 @@ function GoogleOneTapCard() {
       <FormField title="connector_details.google_one_tap.enable_google_one_tap">
         <Switch
           description={
-            <>
+            <div className={styles.oneTapSwitch}>
               <img
                 className={styles.figure}
                 src={themeToFigure[theme]}
                 alt="Google One Tap figure"
               />
               {t('enable_google_one_tap_description')}
-            </>
+            </div>
           }
           {...register('rawConfig.oneTap.isEnabled')}
         />

--- a/packages/console/src/ds-components/Switch/index.module.scss
+++ b/packages/console/src/ds-components/Switch/index.module.scss
@@ -63,9 +63,6 @@
   .label {
     flex: 1;
     font: var(--font-body-2);
-    display: flex;
-    gap: _.unit(6);
-    align-items: center;
   }
 
   &.error {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
one tap should be a special case for the switch component, since in other cases a "Learn more" link may need to show at the end of the sentence.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
locally previewed, both google one tap and text with learn more link worked as expected

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
