### PR TITLE
ci: rerun integration tests on failure

### DIFF
--- a/.github/workflows/alteration-compatibility-integration-test.yml
+++ b/.github/workflows/alteration-compatibility-integration-test.yml
@@ -78,3 +78,16 @@ jobs:
           test-target: ${{ matrix.target }}
           db-alteration-target: ${{ github.head_ref }}
           pnpm-version: 9
+
+  # Automatically rerun the workflow since the integration tests are moody
+  # From this genius: https://github.com/orgs/community/discussions/67654#discussioncomment-8038649
+  rerun-on-failure:
+    needs: run-logto
+    if: failure() && fromJSON(github.run_attempt) < 3
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          GH_DEBUG: api
+        run: gh workflow run rerun.yml -F run_id=${{ github.run_id }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -47,3 +47,16 @@ jobs:
           logto-artifact: integration-test-${{ github.sha }}-dev-features-${{ env.DEV_FEATURES_ENABLED }}
           test-target: ${{ matrix.target }}
           pnpm-version: 9
+
+  # Automatically rerun the workflow since the integration tests are moody
+  # From this genius: https://github.com/orgs/community/discussions/67654#discussioncomment-8038649
+  rerun-on-failure:
+    needs: run-logto
+    if: failure() && fromJSON(github.run_attempt) < 3
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          GH_DEBUG: api
+        run: gh workflow run rerun.yml -F run_id=${{ github.run_id }}

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -1,0 +1,18 @@
+# From this genius: https://github.com/orgs/community/discussions/67654#discussioncomment-8038649
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        required: true
+jobs:
+  rerun:
+    runs-on: ubuntu-latest
+    steps:
+      - name: rerun ${{ inputs.run_id }}
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          GH_DEBUG: api
+        run: |
+          gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
+          gh run rerun ${{ inputs.run_id }} --failed


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
add rerun logic for integration tests

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
hard to test now since the `rerun.yml` does not exists yet. the cli does not work even if `--ref` specified. will test once merged.

<img width="679" alt="image" src="https://github.com/logto-io/logto/assets/14722250/afe6f3db-54c1-404e-b0ef-fdf041cae1df">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
