### PR TITLE
chore: normalize Logto DB region role names for DB alteration CI

### DIFF
--- a/.scripts/compare-database.js
+++ b/.scripts/compare-database.js
@@ -104,6 +104,11 @@ const queryDatabaseManifest = async (database) => {
       return { ...rest, grantee: 'logto_tenant' };
     }
 
+    // Removes the last segment of region grantee since Logto will use 'logto_region_xxx' for the role name for different regions.
+    if (grantee.startsWith('logto_region_')) {
+      return { ...rest, grantee: 'logto_region' };
+    }
+
     return { grantee, ...rest };
   };
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add Logto DB role name normalization logics for region roles.
Since we are going to enable both cloud DB connection and region DB connection in @logto/cloud DB alteration, we need to check region-role grantee as well.
The random suffix of the region role name does not really matter, so we simply remove these random suffix from region role name to normalize region role names like what we have done to tenant roles' names.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
