### PR TITLE
refactor(experience): add hidden identifier input for browser password managers

### DIFF
--- a/packages/experience/src/containers/SetPassword/HiddenIdentifierInput.tsx
+++ b/packages/experience/src/containers/SetPassword/HiddenIdentifierInput.tsx
@@ -1,0 +1,22 @@
+import useSessionStorage, { StorageKeys } from '@/hooks/use-session-storages';
+
+/**
+ * This component renders a hidden input field that stores the user's identifier.
+ * Its primary purpose is to assist password managers in associating the correct
+ * identifier with the password being set or changed.
+ *
+ * By including this hidden field, we enable password managers to correctly save
+ * or update the user's credentials, enhancing the user experience and security.
+ */
+const HiddenIdentifierInput = () => {
+  const { get } = useSessionStorage();
+  const identifierSession = get(StorageKeys.CurrentIdentifier);
+
+  if (!identifierSession) {
+    return null;
+  }
+
+  return <input readOnly hidden type={identifierSession.type} value={identifierSession.value} />;
+};
+
+export default HiddenIdentifierInput;

--- a/packages/experience/src/containers/SetPassword/Lite.tsx
+++ b/packages/experience/src/containers/SetPassword/Lite.tsx
@@ -7,6 +7,7 @@ import Button from '@/components/Button';
 import ErrorMessage from '@/components/ErrorMessage';
 import { PasswordInputField } from '@/components/InputFields';
 
+import HiddenIdentifierInput from './HiddenIdentifierInput';
 import * as styles from './index.module.scss';
 
 type Props = {
@@ -53,6 +54,7 @@ const Lite = ({ className, autoFocus, onSubmit, errorMessage, clearErrorMessage 
 
   return (
     <form className={classNames(styles.form, className)} onSubmit={onSubmitHandler}>
+      <HiddenIdentifierInput />
       <PasswordInputField
         className={styles.inputField}
         autoComplete="new-password"

--- a/packages/experience/src/containers/SetPassword/SetPassword.tsx
+++ b/packages/experience/src/containers/SetPassword/SetPassword.tsx
@@ -9,6 +9,7 @@ import IconButton from '@/components/Button/IconButton';
 import ErrorMessage from '@/components/ErrorMessage';
 import { InputField } from '@/components/InputFields';
 
+import HiddenIdentifierInput from './HiddenIdentifierInput';
 import TogglePassword from './TogglePassword';
 import * as styles from './index.module.scss';
 
@@ -67,6 +68,7 @@ const SetPassword = ({
 
   return (
     <form className={classNames(styles.form, className)} onSubmit={onSubmitHandler}>
+      <HiddenIdentifierInput />
       <InputField
         className={styles.inputField}
         type={showPassword ? 'text' : 'password'}

--- a/packages/experience/src/hooks/use-session-storages.ts
+++ b/packages/experience/src/hooks/use-session-storages.ts
@@ -4,18 +4,20 @@
 import { useCallback } from 'react';
 import * as s from 'superstruct';
 
-import { ssoConnectorMetadataGuard } from '@/types/guard';
+import { identifierSessionGuard, ssoConnectorMetadataGuard } from '@/types/guard';
 
 const logtoStorageKeyPrefix = `logto:${window.location.origin}`;
 
 export enum StorageKeys {
   SsoEmail = 'sso-email',
   SsoConnectors = 'sso-connectors',
+  CurrentIdentifier = 'current-identifier',
 }
 
 const valueGuard = Object.freeze({
   [StorageKeys.SsoEmail]: s.string(),
   [StorageKeys.SsoConnectors]: s.array(ssoConnectorMetadataGuard),
+  [StorageKeys.CurrentIdentifier]: identifierSessionGuard,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- we  don't care about the superstruct details
 } satisfies { [key in StorageKeys]: s.Struct<any> });
 

--- a/packages/experience/src/pages/Register/IdentifierRegisterForm/use-on-submit.ts
+++ b/packages/experience/src/pages/Register/IdentifierRegisterForm/use-on-submit.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 
 import useCheckSingleSignOn from '@/hooks/use-check-single-sign-on';
 import useSendVerificationCode from '@/hooks/use-send-verification-code';
+import useSessionStorage, { StorageKeys } from '@/hooks/use-session-storages';
 import { useSieMethods } from '@/hooks/use-sie';
 import { UserFlow } from '@/types';
 
@@ -11,6 +12,7 @@ import useRegisterWithUsername from './use-register-with-username';
 const useOnSubmit = () => {
   const { ssoConnectors } = useSieMethods();
   const { onSubmit: checkSingleSignOn } = useCheckSingleSignOn();
+  const { set } = useSessionStorage();
 
   const {
     errorMessage: usernameRegisterErrorMessage,
@@ -31,6 +33,12 @@ const useOnSubmit = () => {
 
   const onSubmit = useCallback(
     async (identifier: SignInIdentifier, value: string) => {
+      // Set the current identifier to the session storage
+      set(StorageKeys.CurrentIdentifier, {
+        type: identifier,
+        value,
+      });
+
       if (identifier === SignInIdentifier.Username) {
         await registerWithUsername(value);
 

--- a/packages/experience/src/pages/SignIn/IdentifierSignInForm/use-on-submit.ts
+++ b/packages/experience/src/pages/SignIn/IdentifierSignInForm/use-on-submit.ts
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 
 import useCheckSingleSignOn from '@/hooks/use-check-single-sign-on';
 import useSendVerificationCode from '@/hooks/use-send-verification-code';
+import useSessionStorage, { StorageKeys } from '@/hooks/use-session-storages';
 import { useSieMethods } from '@/hooks/use-sie';
 import { UserFlow } from '@/types';
 
@@ -12,6 +13,7 @@ const useOnSubmit = (signInMethods: SignIn['methods']) => {
   const navigate = useNavigate();
   const { ssoConnectors } = useSieMethods();
   const { onSubmit: checkSingleSignOn } = useCheckSingleSignOn();
+  const { set } = useSessionStorage();
 
   const signInWithPassword = useCallback(
     (identifier: SignInIdentifier, value: string) => {
@@ -38,6 +40,12 @@ const useOnSubmit = (signInMethods: SignIn['methods']) => {
       if (!method) {
         throw new Error(`Cannot find method with identifier type ${identifier}`);
       }
+
+      // Set the current identifier to the session storage
+      set(StorageKeys.CurrentIdentifier, {
+        type: identifier,
+        value,
+      });
 
       const { password, isPasswordPrimary, verificationCode } = method;
 
@@ -69,6 +77,7 @@ const useOnSubmit = (signInMethods: SignIn['methods']) => {
     [
       checkSingleSignOn,
       sendVerificationCode,
+      set,
       signInMethods,
       signInWithPassword,
       ssoConnectors.length,

--- a/packages/experience/src/types/guard.ts
+++ b/packages/experience/src/types/guard.ts
@@ -119,3 +119,13 @@ export const ssoConnectorMetadataGuard: s.Describe<SsoConnectorMetadata> = s.obj
   darkLogo: s.optional(s.string()),
   connectorName: s.string(),
 });
+
+/**
+ * Defines the structure for caching the current user's identifier.
+ * Used in conjunction with the HiddenIdentifierInput component to assist
+ * password managers in associating the correct identifier with passwords.
+ */
+export const identifierSessionGuard = s.object({
+  type: s.enums([SignInIdentifier.Email, SignInIdentifier.Phone, SignInIdentifier.Username]),
+  value: s.string(),
+});


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR introduces a mechanism to enhance browser password managers’ compatibility by adding hidden identifier input fields in SetPassword components.
- A new HiddenIdentifierInput component is created to store user identifiers in hidden fields.
- Session storage hooks are updated to cache identifier data.
- Form submission hooks (use-on-submit) are modified to store current identifiers data into session storage.

These changes ensure that browser password managers accurately store and autofill user credentials, improving user experience and security.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
For new registered user:
![image](https://github.com/logto-io/logto/assets/10806653/7497800f-89c4-4bd2-af24-9c0c563b7326)

For password reset:
![image](https://github.com/logto-io/logto/assets/10806653/936a755d-4d94-4f7d-8e03-2d91b23d305c)

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
