### PR TITLE
feat(core): handle oidc scopes for token exchange

### DIFF
--- a/packages/core/src/oidc/grants/index.ts
+++ b/packages/core/src/oidc/grants/index.ts
@@ -39,15 +39,4 @@ export const registerGrants = (oidc: Provider, envSet: EnvSet, queries: Queries)
     tokenExchange.buildHandler(envSet, queries),
     ...getParameterConfig(tokenExchange.parameters)
   );
-
-  // Token exchange grant
-  const tokenExchangeParameterConfig: [parameters: string[], duplicates: string[]] =
-    resourceIndicators.enabled
-      ? [[...tokenExchange.parameters, 'resource'], ['resource']]
-      : [[...tokenExchange.parameters], []];
-  oidc.registerGrantType(
-    GrantType.TokenExchange,
-    tokenExchange.buildHandler(envSet, queries),
-    ...tokenExchangeParameterConfig
-  );
 };

--- a/packages/core/src/oidc/grants/index.ts
+++ b/packages/core/src/oidc/grants/index.ts
@@ -39,4 +39,15 @@ export const registerGrants = (oidc: Provider, envSet: EnvSet, queries: Queries)
     tokenExchange.buildHandler(envSet, queries),
     ...getParameterConfig(tokenExchange.parameters)
   );
+
+  // Token exchange grant
+  const tokenExchangeParameterConfig: [parameters: string[], duplicates: string[]] =
+    resourceIndicators.enabled
+      ? [[...tokenExchange.parameters, 'resource'], ['resource']]
+      : [[...tokenExchange.parameters], []];
+  oidc.registerGrantType(
+    GrantType.TokenExchange,
+    tokenExchange.buildHandler(envSet, queries),
+    ...tokenExchangeParameterConfig
+  );
 };

--- a/packages/core/src/oidc/grants/token-exchange.ts
+++ b/packages/core/src/oidc/grants/token-exchange.ts
@@ -73,6 +73,7 @@ export const buildHandler: (
   const providerInstance = instance(provider);
   const {
     features: { userinfo, resourceIndicators },
+    scopes: oidcScopes,
   } = providerInstance.configuration();
 
   const subjectToken = await trySafe(async () => findSubjectToken(String(params.subject_token)));
@@ -186,9 +187,15 @@ export const buildHandler: (
       .filter(Set.prototype.has.bind(accessToken.resourceServer.scopes))
       .join(' ');
   } else {
-    // TODO: (LOG-9166) Check claims and scopes
     accessToken.claims = ctx.oidc.claims;
-    accessToken.scope = Array.from(scope).join(' ');
+    // Filter scopes from `oidcScopes`,
+    // in other grants, this is done by `Grant` class
+    // See https://github.com/panva/node-oidc-provider/blob/0c569cf5c36dd5faa105fb931a43b2e587530def/lib/helpers/oidc_context.js#L159
+    accessToken.scope = Array.from(scope)
+      // Wrong typing for oidc-provider, `oidcScopes` is actully a Set,
+      // wrap it with `new Set` to make it work
+      .filter((name) => new Set(oidcScopes).has(name))
+      .join(' ');
   }
   /* eslint-enable @silverhand/fp/no-mutation, @typescript-eslint/no-unsafe-assignment */
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

In token exchange grant: filter out non-oidc scopes when resource is not present (the audience is OP).

In other grant type flow, this is done by `Grant` class. But there is no `Grant` instance in token exchange, so we have to do it manually. The `oidcScopes` list comes from `oidc.provider`, SSOT is ensured. https://github.com/panva/node-oidc-provider/blob/0c569cf5c36dd5faa105fb931a43b2e587530def/lib/helpers/oidc_context.js#L159

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Integration tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests (hard to implement)
- [x] integration tests
- [x] necessary TSDoc comments
