### PR TITLE
refactor: update compare DB alteration scripts

### DIFF
--- a/.scripts/compare-database.js
+++ b/.scripts/compare-database.js
@@ -131,6 +131,8 @@ const queryDatabaseManifest = async (database) => {
     const prefix = 'allow_';
     const suffix = '_access';
     if (policyname && policyname.startsWith(prefix) && policyname.endsWith(suffix)) {
+      // This is a naming convention in Logto cloud, it is formatted as `allow_{role_name}_access`, we need to normalize the role name part for the convenience of comparing DB updates.
+      // Ref: https://github.com/logto-io/cloud/pull/738
       return { policyname: `${prefix}${normalizeRoleName(policyname.slice(prefix.length, -suffix.length))}${suffix}`, ...rest };
     }
 

--- a/.scripts/compare-database.js
+++ b/.scripts/compare-database.js
@@ -99,24 +99,42 @@ const queryDatabaseManifest = async (database) => {
   `);
 
   // This function removes the last segment of grantee since Logto will use 'logto_tenant_fresh/alteration' for the role name.
-  const normalizeGrantee = ({ grantee, ...rest }) => {
-    if (grantee.startsWith('logto_tenant_')) {
-      return { ...rest, grantee: 'logto_tenant' };
+  const normalizeRoleName = (roleName) => {
+    if (roleName.startsWith('logto_tenant_')) {
+      return 'logto_tenant';
     }
 
     // Removes the last segment of region grantee since Logto will use 'logto_region_xxx' for the role name for different regions.
-    if (grantee.startsWith('logto_region_')) {
-      return { ...rest, grantee: 'logto_region' };
+    if (roleName.startsWith('logto_region_')) {
+      return 'logto_region';
     }
 
-    return { grantee, ...rest };
+    return roleName;
   };
+
+  const normalizeGrantee = ({ grantee, ...rest }) => ({
+    ...rest,
+    grantee: normalizeRoleName(grantee),
+  });
 
   // Ditto.
   const normalizeRoles = ({ roles: raw, ...rest }) => {
-    const roles = raw.slice(1, -1).split(',').map((name) => name.startsWith('logto_tenant_') ? 'logto_tenant' : name);
+    const roles = raw
+      .slice(1, -1)
+      .split(',')
+      .map((name) => normalizeRoleName(name));
 
     return { roles, ...rest };
+  };
+
+  const normalizePolicyname = ({ policyname, ...rest }) => {
+    const prefix = 'allow_';
+    const suffix = '_access';
+    if (policyname && policyname.startsWith(prefix) && policyname.endsWith(suffix)) {
+      return { policyname: `${prefix}${normalizeRoleName(policyname.slice(prefix.length, -suffix.length))}${suffix}`, ...rest };
+    }
+
+    return { policyname, ...rest };
   };
 
   // Omit generated ids and values
@@ -149,7 +167,7 @@ const queryDatabaseManifest = async (database) => {
     indexes,
     funcs,
     triggers: omitArray(triggers, 'trigger_catalog', 'event_object_catalog'),
-    policies: policies.map(normalizeRoles),
+    policies: policies.map(normalizeRoles).map(normalizePolicyname),
     columnGrants: omitArray(columnGrants, 'table_catalog').map(normalizeGrantee),
     tableGrants: omitArray(tableGrants, 'table_catalog').map(normalizeGrantee),
   };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
When we create region role, we also create a corresponding `policy` (see [PR#738](https://github.com/logto-io/cloud/pull/738)). We hence extract `nomalizeRoleName()` as a reusable method and refactored the DB alteration compare logic.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Need to test on cloud CI.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
