### PR TITLE
refactor(console): load mermaid in dev

### DIFF
--- a/packages/console/src/mdx-components/Mermaid/index.tsx
+++ b/packages/console/src/mdx-components/Mermaid/index.tsx
@@ -4,12 +4,16 @@ import { useEffect } from 'react';
 
 import useTheme from '@/hooks/use-theme';
 
+/** Load Mermaid asynchronously from jsDelivr to avoid Parcel issues. */
 const loadMermaid = async () => {
   // Define this variable to "outsmart" the detection of the dynamic import by Parcel:
   // https://github.com/parcel-bundler/parcel/issues/7064#issuecomment-942441649
   const uri = 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const imported: { default: MermaidType } = await import(uri);
+  const imported: { default: MermaidType } = await (process.env.NODE_ENV === 'development'
+    ? // eslint-disable-next-line no-eval -- https://github.com/parcel-bundler/parcel/issues/8316
+      eval(`import('${uri}')`)
+    : import(uri));
   return imported.default;
 };
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Parcel is not smart enough when building production and too smart when developing. there's a Chinese idiom for this situation: "自作聪明"

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] dev loads mermaid ok
- [x] prod build no `eval` in this function

![image](https://github.com/logto-io/logto/assets/14722250/aa76d52a-9344-4958-903f-8b9dcff84569)

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
