### PR TITLE
fix(console): fix broken api resource guides

### DIFF
--- a/packages/console/src/assets/docs/guides/api-python/README.mdx
+++ b/packages/console/src/assets/docs/guides/api-python/README.mdx
@@ -41,12 +41,10 @@ pip install python-jose[ecdsa]
 
 ### Retrieve Logto's OIDC configurations
 
-<p>
 You will need a JWK public key set and the token issuer to verify the signature and source of the received JWS token.
-All the latest public Logto Authorization Configurations can be found at <code>{appendPath(props.endpoint, '/oidc/.well-known/openid-configuration')}</code>.
+All the latest public Logto Authorization Configurations can be found at <Code>{appendPath(props.endpoint, '/oidc/.well-known/openid-configuration')}</Code>.
 
 e.g. You can locate the following two fields in the response body if you request the above endpoint.
-</p>
 
 <Code className="language-json">
 {`{

--- a/packages/console/src/assets/docs/guides/api-spring-boot/README.mdx
+++ b/packages/console/src/assets/docs/guides/api-spring-boot/README.mdx
@@ -51,11 +51,9 @@ and signed with [JWK](https://datatracker.ietf.org/doc/html/rfc7517)
 
 Before moving on, you will need to get an issuer and a JWKS URI to verify the issuer and the signature of the Bearer Token (`access_token`).
 
-<p>
-  All the Logto Authorization server configurations can be found by requesting{' '}
-  <code>{appendPath(props.endpoint, '/oidc/.well-known/openid-configuration')}</code>, including the{' '}
-  <strong>issuer</strong>, <strong>jwks_uri</strong> and other authorization configs.
-</p>
+All the Logto Authorization server configurations can be found by requesting{' '}
+<Code>{appendPath(props.endpoint, '/oidc/.well-known/openid-configuration')}</Code>, including the{' '}
+<strong>issuer</strong>, <strong>jwks_uri</strong> and other authorization configs.
 
 An example of the response:
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix broken API resource guides: `Python` and `Springboot`.

Issue was introduced by nested `<p>` tags in mdx-generated html.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested and those guides can be rendered successfully.

<img width="849" alt="image" src="https://github.com/logto-io/logto/assets/12833674/9b9aa530-45f0-4b9c-af75-8ec8604f78ba">

<img width="838" alt="image" src="https://github.com/logto-io/logto/assets/12833674/487ad705-80d3-46ae-bb93-0120ba53573b">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
