### PR TITLE
refactor(experience): add hidden identifier input for browser password manager

### DIFF
--- a/packages/experience/src/containers/SetPassword/HiddenIdentifierInput.tsx
+++ b/packages/experience/src/containers/SetPassword/HiddenIdentifierInput.tsx
@@ -1,0 +1,25 @@
+import { useContext } from 'react';
+
+import UserInteractionContext from '@/Providers/UserInteractionContextProvider/UserInteractionContext';
+
+/**
+ * This component renders a hidden input field that stores the user's identifier.
+ * Its primary purpose is to assist password managers in associating the correct
+ * identifier with the password being set or changed.
+ *
+ * By including this hidden field, we enable password managers to correctly save
+ * or update the user's credentials, enhancing the user experience and security.
+ */
+const HiddenIdentifierInput = () => {
+  const { identifierInputValue } = useContext(UserInteractionContext);
+
+  if (!identifierInputValue) {
+    return null;
+  }
+
+  return (
+    <input readOnly hidden type={identifierInputValue.type} value={identifierInputValue.value} />
+  );
+};
+
+export default HiddenIdentifierInput;

--- a/packages/experience/src/containers/SetPassword/Lite.tsx
+++ b/packages/experience/src/containers/SetPassword/Lite.tsx
@@ -7,6 +7,7 @@ import Button from '@/components/Button';
 import ErrorMessage from '@/components/ErrorMessage';
 import { PasswordInputField } from '@/components/InputFields';
 
+import HiddenIdentifierInput from './HiddenIdentifierInput';
 import * as styles from './index.module.scss';
 
 type Props = {
@@ -53,6 +54,7 @@ const Lite = ({ className, autoFocus, onSubmit, errorMessage, clearErrorMessage 
 
   return (
     <form className={classNames(styles.form, className)} onSubmit={onSubmitHandler}>
+      <HiddenIdentifierInput />
       <PasswordInputField
         className={styles.inputField}
         autoComplete="new-password"

--- a/packages/experience/src/containers/SetPassword/SetPassword.tsx
+++ b/packages/experience/src/containers/SetPassword/SetPassword.tsx
@@ -9,6 +9,7 @@ import IconButton from '@/components/Button/IconButton';
 import ErrorMessage from '@/components/ErrorMessage';
 import { InputField } from '@/components/InputFields';
 
+import HiddenIdentifierInput from './HiddenIdentifierInput';
 import TogglePassword from './TogglePassword';
 import * as styles from './index.module.scss';
 
@@ -67,6 +68,7 @@ const SetPassword = ({
 
   return (
     <form className={classNames(styles.form, className)} onSubmit={onSubmitHandler}>
+      <HiddenIdentifierInput />
       <InputField
         className={styles.inputField}
         type={showPassword ? 'text' : 'password'}

--- a/packages/experience/src/types/guard.ts
+++ b/packages/experience/src/types/guard.ts
@@ -109,9 +109,12 @@ export const ssoConnectorMetadataGuard: s.Describe<SsoConnectorMetadata> = s.obj
 /**
  * Defines the type guard for user identifier input value caching.
  *
- * Purpose: cache the identifier so that when the user returns from the verification
- * page or the password page, the identifier they entered will not be cleared.
+ * Purpose:
+ * - Used in conjunction with the HiddenIdentifierInput component to assist
+ * password managers in associating the correct identifier with passwords.
  *
+ * - Cache the identifier so that when the user returns from the verification
+ *  page or the password page, the identifier they entered will not be cleared.
  */
 export const identifierInputValueGuard: s.Describe<IdentifierInputValue> = s.object({
   type: s.optional(


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR introduces a new `HiddenIdentifierInput` component to enhance the user experience with browser password managers. The component is integrated into the password setting flows, both in the standard and lite versions.

These changes ensure that browser password managers accurately store and autofill user credentials, improving user experience and security.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

For new registered user:
![image](https://github.com/logto-io/logto/assets/10806653/7497800f-89c4-4bd2-af24-9c0c563b7326)

For password reset:
![image](https://github.com/logto-io/logto/assets/10806653/936a755d-4d94-4f7d-8e03-2d91b23d305c)

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
