### PR TITLE
fix(console): hide error toast for non-existed application in audit logs

### DIFF
--- a/.changeset/good-shrimps-cover.md
+++ b/.changeset/good-shrimps-cover.md
@@ -1,0 +1,5 @@
+---
+"@logto/console": patch
+---
+
+fix a regression bug that error toasts pop up in audit log when logs are associated with deleted applications

--- a/packages/console/src/components/ApplicationName/index.tsx
+++ b/packages/console/src/components/ApplicationName/index.tsx
@@ -20,7 +20,7 @@ type Props = {
 function ApplicationName({ applicationId, isLink = false }: Props) {
   const isAdminConsole = applicationId === adminConsoleApplicationId;
 
-  const fetchApi = useApi({ hideErrorToast: ['entity.not_found'] });
+  const fetchApi = useApi({ hideErrorToast: ['entity.not_exists_with_id'] });
   const fetcher = useSwrFetcher<Application>(fetchApi);
   const { data, error } = useSWR<Application, RequestError>(
     !isAdminConsole && `api/applications/${applicationId}`,


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
A patch fix to #6021. It seems the error code used in the previous PR was wrong for the scenario that showing deleted application ID in audit logs.

And it has a regression bug that the console keeps popping up the error toast again for deleted application ID.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally with a deleted application record in Audit logs, and the error toast did not show up again.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
