### PR TITLE
fix(core): issue `organization_id` claim for client credentials

### DIFF
--- a/packages/core/src/oidc/extra-token-claims.ts
+++ b/packages/core/src/oidc/extra-token-claims.ts
@@ -34,7 +34,9 @@ export const getExtraTokenClaimsForOrganizationApiResource = async (
     return;
   }
 
-  const isAccessToken = token instanceof ctx.oidc.provider.AccessToken;
+  const isAccessToken =
+    token instanceof ctx.oidc.provider.AccessToken ||
+    token instanceof ctx.oidc.provider.ClientCredentials;
 
   // Only handle access tokens
   if (!isAccessToken) {

--- a/packages/integration-tests/src/tests/api/oidc/client-credentials-grant.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/client-credentials-grant.test.ts
@@ -244,6 +244,7 @@ describe('client credentials grant', () => {
       expect(returnedScope).toBe(`${scope1.name} ${scope2.name}`);
 
       const verified = await jwtVerify(accessToken, jwkSet, { audience: resource.indicator });
+      expect(verified.payload.organization_id).toBe(organization.id);
       expect(verified.payload.scope).toBe(`${scope1.name} ${scope2.name}`);
     });
 
@@ -271,6 +272,7 @@ describe('client credentials grant', () => {
       expect(returnedScope1).toBe(scope1.name);
 
       const verified1 = await jwtVerify(accessToken1, jwkSet, { audience: resource.indicator });
+      expect(verified1.payload.organization_id).toBe(organization.id);
       expect(verified1.payload.scope).toBe(scope1.name);
 
       const { access_token: accessToken2, scope: returnedScope2 } = await post({
@@ -281,6 +283,7 @@ describe('client credentials grant', () => {
       expect(returnedScope2).toBe(undefined);
 
       const verified2 = await jwtVerify(accessToken2, jwkSet, { audience: resource.indicator });
+      expect(verified1.payload.organization_id).toBe(organization.id);
       expect(verified2.payload.scope).toBe(undefined);
     });
   });


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
`getExtraTokenClaimsForOrganizationApiResource` does not recognize client credentials grant so the `organization_id` claim is missing in the token. this pull fixes the issue.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
integration tests added

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
