### PR TITLE
feat(core): actor token

### DIFF
--- a/packages/core/src/oidc/grants/index.ts
+++ b/packages/core/src/oidc/grants/index.ts
@@ -7,7 +7,7 @@ import type Queries from '#src/tenants/Queries.js';
 
 import * as clientCredentials from './client-credentials.js';
 import * as refreshToken from './refresh-token.js';
-import * as tokenExchange from './token-exchange.js';
+import * as tokenExchange from './token-exchange/index.js';
 
 export const registerGrants = (oidc: Provider, envSet: EnvSet, queries: Queries) => {
   const {

--- a/packages/core/src/oidc/grants/token-exchange/actor-token.test.ts
+++ b/packages/core/src/oidc/grants/token-exchange/actor-token.test.ts
@@ -1,0 +1,69 @@
+import { errors, type KoaContextWithOIDC } from 'oidc-provider';
+import Sinon from 'sinon';
+
+import { createOidcContext } from '#src/test-utils/oidc-provider.js';
+
+import { handleActorToken } from './actor-token.js';
+import { TokenExchangeTokenType } from './types.js';
+
+const { InvalidGrant } = errors;
+
+const actorId = 'some_account_id';
+
+const validOidcContext: Partial<KoaContextWithOIDC['oidc']> = {
+  params: {
+    actor_token: 'some_actor_token',
+    actor_token_type: TokenExchangeTokenType.AccessToken,
+  },
+};
+
+beforeAll(() => {
+  // `oidc-provider` will warn for dev interactions
+  Sinon.stub(console, 'warn');
+});
+
+afterAll(() => {
+  Sinon.restore();
+});
+
+describe('handleActorToken', () => {
+  it('should return actorId', async () => {
+    const ctx = createOidcContext(validOidcContext);
+    Sinon.stub(ctx.oidc.provider.AccessToken, 'find').resolves({
+      accountId: actorId,
+      scope: 'openid',
+    });
+
+    await expect(handleActorToken(ctx)).resolves.toStrictEqual({
+      actorId,
+    });
+  });
+
+  it('should return empty actorId when params are not present', async () => {
+    const ctx = createOidcContext({ params: {} });
+
+    await expect(handleActorToken(ctx)).resolves.toStrictEqual({
+      actorId: undefined,
+    });
+  });
+
+  it('should throw if actor_token_type is invalid', async () => {
+    const ctx = createOidcContext({
+      params: {
+        actor_token: 'some_actor_token',
+        actor_token_type: 'invalid',
+      },
+    });
+
+    await expect(handleActorToken(ctx)).rejects.toThrow(
+      new InvalidGrant('unsupported actor token type')
+    );
+  });
+
+  it('should throw if actor_token is invalid', async () => {
+    const ctx = createOidcContext(validOidcContext);
+    Sinon.stub(ctx.oidc.provider.AccessToken, 'find').rejects();
+
+    await expect(handleActorToken(ctx)).rejects.toThrow(new InvalidGrant('invalid actor token'));
+  });
+});

--- a/packages/core/src/oidc/grants/token-exchange/actor-token.ts
+++ b/packages/core/src/oidc/grants/token-exchange/actor-token.ts
@@ -1,0 +1,38 @@
+import { trySafe } from '@silverhand/essentials';
+import { type KoaContextWithOIDC, errors } from 'oidc-provider';
+
+import assertThat from '#src/utils/assert-that.js';
+
+import { TokenExchangeTokenType } from './types.js';
+
+const { InvalidGrant } = errors;
+
+/**
+ * Handles the `actor_token` and `actor_token_type` parameters,
+ * if both are present and valid, the `accountId` of the actor token is returned.
+ */
+export const handleActorToken = async (ctx: KoaContextWithOIDC): Promise<{ actorId?: string }> => {
+  const { params, provider } = ctx.oidc;
+  const { AccessToken } = provider;
+
+  assertThat(params, new InvalidGrant('parameters must be available'));
+  assertThat(
+    !params.actor_token || params.actor_token_type === TokenExchangeTokenType.AccessToken,
+    new InvalidGrant('unsupported actor token type')
+  );
+
+  if (!params.actor_token) {
+    return { actorId: undefined };
+  }
+
+  // The actor token should have `openid` scope (RFC 0005), and a token with this scope is an opaque token.
+  // We can use `AccessToken.find` to handle the token, no need to handle JWT tokens.
+  const actorToken = await trySafe(async () => AccessToken.find(String(params.actor_token)));
+  assertThat(actorToken?.accountId, new InvalidGrant('invalid actor token'));
+  assertThat(
+    actorToken.scope?.includes('openid'),
+    new InvalidGrant('actor token must have openid scope')
+  );
+
+  return { actorId: actorToken.accountId };
+};

--- a/packages/core/src/oidc/grants/token-exchange/index.test.ts
+++ b/packages/core/src/oidc/grants/token-exchange/index.test.ts
@@ -1,4 +1,5 @@
 import { type SubjectToken } from '@logto/schemas';
+import { createMockUtils } from '@logto/shared/esm';
 import { type KoaContextWithOIDC, errors } from 'oidc-provider';
 import Sinon from 'sinon';
 
@@ -6,9 +7,16 @@ import { mockApplication } from '#src/__mocks__/index.js';
 import { createOidcContext } from '#src/test-utils/oidc-provider.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
 
-import { buildHandler } from './token-exchange.js';
+import { TokenExchangeTokenType } from './types.js';
 
 const { jest } = import.meta;
+const { mockEsm } = createMockUtils(jest);
+
+const { handleActorToken } = mockEsm('./actor-token.js', () => ({
+  handleActorToken: jest.fn().mockResolvedValue({ accountId: undefined }),
+}));
+
+const { buildHandler } = await import('./index.js');
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = async () => {};
@@ -57,7 +65,7 @@ const validSubjectToken: SubjectToken = {
 const validOidcContext: Partial<KoaContextWithOIDC['oidc']> = {
   params: {
     subject_token: 'some_subject_token',
-    subject_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+    subject_token_type: TokenExchangeTokenType.AccessToken,
   },
   entities: {
     Client: validClient,

--- a/packages/core/src/oidc/grants/token-exchange/types.ts
+++ b/packages/core/src/oidc/grants/token-exchange/types.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const tokenExchangeActGuard = z.object({
+  act: z.object({
+    sub: z.string(),
+  }),
+});
+
+export type TokenExchangeAct = z.infer<typeof tokenExchangeActGuard>;
+
+export enum TokenExchangeTokenType {
+  AccessToken = 'urn:ietf:params:oauth:token-type:access_token',
+}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Implement "actor token" feature in token exchange according to the [RFC](https://github.com/logto-io/rfcs/blob/master/draft/0005-impersonation.md).

If `actor_token` is present, will add an extra claim `act` to the response access token.

Because the class `AccessToken` can only accept a list of predefined claims, so we have to set the `act` claim to `extra` first, and then extract it to the outside in `extraTokenClaims` option of `node-oidc-provider`.

This PR also includes the refactor of `token-exchange.ts`, it is now splited into a folder of files.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Unit and integration tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
