### PR TITLE
feat(core,schemas): introduce new PUT experience API

### DIFF
--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -38,14 +38,14 @@ const interactionStorageGuard = z.object({
  * @see {@link https://github.com/logto-io/rfcs | Logto RFCs} for more information about RFC 0004.
  */
 export default class ExperienceInteraction {
-  /** The interaction event for the current interaction. */
-  private _interactionEvent?: InteractionEvent;
   /** The user verification record list for the current interaction. */
   private readonly verificationRecords = new Map<VerificationType, VerificationRecord>();
   /** The userId of the user for the current interaction. Only available once the user is identified. */
   private userId?: string;
   /** The user provided profile data in the current interaction that needs to be stored to database. */
   private readonly profile?: Record<string, unknown>; // TODO: Fix the type
+  /** The interaction event for the current interaction. */
+  #interactionEvent?: InteractionEvent;
 
   /**
    * Create a new `ExperienceInteraction` instance.
@@ -73,7 +73,7 @@ export default class ExperienceInteraction {
 
     const { verificationRecords = [], profile, userId, interactionEvent } = result.data;
 
-    this._interactionEvent = interactionEvent;
+    this.#interactionEvent = interactionEvent;
     this.userId = userId;
     this.profile = profile;
 
@@ -88,13 +88,13 @@ export default class ExperienceInteraction {
   }
 
   get interactionEvent() {
-    return this._interactionEvent;
+    return this.#interactionEvent;
   }
 
   /** Set the interaction event for the current interaction */
   public setInteractionEvent(interactionEvent: InteractionEvent) {
     // TODO: conflict event check (e.g. reset password session can't be used for sign in)
-    this._interactionEvent = interactionEvent;
+    this.#interactionEvent = interactionEvent;
   }
 
   /**

--- a/packages/core/src/routes/experience/index.ts
+++ b/packages/core/src/routes/experience/index.ts
@@ -46,9 +46,6 @@ export default function experienceApiRoutes<T extends AnonymousRouter>(
       koaExperienceInteraction(tenant)
     );
 
-  /**
-   * @api {post} /experience Create a new interaction
-   */
   router.put(
     experienceRoutes.prefix,
     koaGuard({
@@ -68,6 +65,7 @@ export default function experienceApiRoutes<T extends AnonymousRouter>(
 
       await experienceInteraction.save();
 
+      ctx.experienceInteraction = experienceInteraction;
       ctx.status = 204;
 
       return next();

--- a/packages/core/src/routes/experience/index.ts
+++ b/packages/core/src/routes/experience/index.ts
@@ -10,7 +10,7 @@
  * The experience APIs can be used by developers to build custom user interaction experiences.
  */
 
-import { identificationApiPayloadGuard } from '@logto/schemas';
+import { identificationApiPayloadGuard, InteractionEvent } from '@logto/schemas';
 import type Router from 'koa-router';
 import { z } from 'zod';
 
@@ -19,6 +19,7 @@ import koaGuard from '#src/middleware/koa-guard.js';
 
 import { type AnonymousRouter, type RouterInitArgs } from '../types.js';
 
+import ExperienceInteraction from './classes/experience-interaction.js';
 import { experienceRoutes } from './const.js';
 import koaExperienceInteraction, {
   type WithExperienceInteractionContext,
@@ -45,6 +46,64 @@ export default function experienceApiRoutes<T extends AnonymousRouter>(
       koaExperienceInteraction(tenant)
     );
 
+  /**
+   * @api {post} /experience Create a new interaction
+   */
+  router.put(
+    experienceRoutes.prefix,
+    koaGuard({
+      body: z.object({
+        interactionEvent: z.nativeEnum(InteractionEvent),
+      }),
+      status: [204],
+    }),
+    async (ctx, next) => {
+      const { interactionEvent } = ctx.guard.body;
+      const { createLog } = ctx;
+
+      createLog(`Interaction.${interactionEvent}.Update`);
+
+      const experienceInteraction = new ExperienceInteraction(ctx, tenant);
+      experienceInteraction.setInteractionEvent(interactionEvent);
+
+      await experienceInteraction.save();
+
+      ctx.status = 204;
+
+      return next();
+    }
+  );
+
+  router.put(
+    `${experienceRoutes.prefix}/interaction-event`,
+    koaGuard({
+      body: z.object({
+        interactionEvent: z.nativeEnum(InteractionEvent),
+      }),
+      status: [204],
+    }),
+    async (ctx, next) => {
+      const { interactionEvent } = ctx.guard.body;
+      const { createLog, experienceInteraction } = ctx;
+
+      const eventLog = createLog(
+        `Interaction.${experienceInteraction.interactionEvent ?? interactionEvent}.Update`
+      );
+
+      experienceInteraction.setInteractionEvent(interactionEvent);
+
+      eventLog.append({
+        interactionEvent,
+      });
+
+      await experienceInteraction.save();
+
+      ctx.status = 204;
+
+      return next();
+    }
+  );
+
   router.post(
     experienceRoutes.identification,
     koaGuard({
@@ -52,10 +111,7 @@ export default function experienceApiRoutes<T extends AnonymousRouter>(
       status: [204, 400, 401, 404],
     }),
     async (ctx, next) => {
-      const { interactionEvent, verificationId } = ctx.guard.body;
-
-      // TODO: implement a separate POST interaction route to handle the initiation of the interaction event
-      ctx.experienceInteraction.setInteractionEvent(interactionEvent);
+      const { verificationId } = ctx.guard.body;
 
       await ctx.experienceInteraction.identifyUser(verificationId);
 

--- a/packages/core/src/routes/experience/middleware/koa-experience-interaction.ts
+++ b/packages/core/src/routes/experience/middleware/koa-experience-interaction.ts
@@ -25,7 +25,10 @@ export default function koaExperienceInteraction<
   tenant: TenantContext
 ): MiddlewareType<StateT, WithExperienceInteractionContext<ContextT>, ResponseT> {
   return async (ctx, next) => {
-    ctx.experienceInteraction = await ExperienceInteraction.create(ctx, tenant);
+    const { provider } = tenant;
+    const interactionDetails = await provider.interactionDetails(ctx.req, ctx.res);
+
+    ctx.experienceInteraction = new ExperienceInteraction(ctx, tenant, interactionDetails);
 
     return next();
   };

--- a/packages/integration-tests/src/client/experience/index.ts
+++ b/packages/integration-tests/src/client/experience/index.ts
@@ -1,4 +1,5 @@
 import {
+  type CreateExperienceApiPayload,
   type IdentificationApiPayload,
   type InteractionEvent,
   type PasswordVerificationPayload,
@@ -27,6 +28,24 @@ export class ExperienceClient extends MockClient {
   public async identifyUser(payload: IdentificationApiPayload) {
     return api
       .post(experienceRoutes.identification, {
+        headers: { cookie: this.interactionCookie },
+        json: payload,
+      })
+      .json();
+  }
+
+  public async updateInteractionEvent(payload: { interactionEvent: InteractionEvent }) {
+    return api
+      .put(`${experienceRoutes.prefix}/interaction-event`, {
+        headers: { cookie: this.interactionCookie },
+        json: payload,
+      })
+      .json();
+  }
+
+  public async initInteraction(payload: CreateExperienceApiPayload) {
+    return api
+      .put(experienceRoutes.prefix, {
         headers: { cookie: this.interactionCookie },
         json: payload,
       })

--- a/packages/integration-tests/src/helpers/experience/index.ts
+++ b/packages/integration-tests/src/helpers/experience/index.ts
@@ -27,13 +27,14 @@ export const signInWithPassword = async ({
 }) => {
   const client = await initExperienceClient();
 
+  await client.initInteraction({ interactionEvent: InteractionEvent.SignIn });
+
   const { verificationId } = await client.verifyPassword({
     identifier,
     password,
   });
 
   await client.identifyUser({
-    interactionEvent: InteractionEvent.SignIn,
     verificationId,
   });
 
@@ -45,6 +46,8 @@ export const signInWithPassword = async ({
 
 export const signInWithVerificationCode = async (identifier: VerificationCodeIdentifier) => {
   const client = await initExperienceClient();
+
+  await client.initInteraction({ interactionEvent: InteractionEvent.SignIn });
 
   const { verificationId, code } = await successfullySendVerificationCode(client, {
     identifier,
@@ -58,7 +61,6 @@ export const signInWithVerificationCode = async (identifier: VerificationCodeIde
   });
 
   await client.identifyUser({
-    interactionEvent: InteractionEvent.SignIn,
     verificationId: verifiedVerificationId,
   });
 
@@ -80,6 +82,8 @@ export const identifyUserWithUsernamePassword = async (
   username: string,
   password: string
 ) => {
+  await client.initInteraction({ interactionEvent: InteractionEvent.SignIn });
+
   const { verificationId } = await client.verifyPassword({
     identifier: {
       type: InteractionIdentifierType.Username,
@@ -88,7 +92,7 @@ export const identifyUserWithUsernamePassword = async (
     password,
   });
 
-  await client.identifyUser({ interactionEvent: InteractionEvent.SignIn, verificationId });
+  await client.identifyUser({ verificationId });
 
   return { verificationId };
 };

--- a/packages/integration-tests/src/tests/api/experience-api/interaction.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/interaction.test.ts
@@ -1,0 +1,34 @@
+import { InteractionEvent, InteractionIdentifierType } from '@logto/schemas';
+
+import { initExperienceClient } from '#src/helpers/client.js';
+import { expectRejects } from '#src/helpers/index.js';
+import { generateNewUserProfile, UserApiTest } from '#src/helpers/user.js';
+import { devFeatureTest } from '#src/utils.js';
+
+devFeatureTest.describe('PUT /experience API', () => {
+  const userApi = new UserApiTest();
+
+  afterAll(async () => {
+    await userApi.cleanUp();
+  });
+
+  it('PUT new experience API should reset all existing verification records', async () => {
+    const { username, password } = generateNewUserProfile({ username: true, password: true });
+    const user = await userApi.create({ username, password });
+
+    const client = await initExperienceClient();
+    await client.initInteraction({ interactionEvent: InteractionEvent.SignIn });
+    const { verificationId } = await client.verifyPassword({
+      identifier: { type: InteractionIdentifierType.Username, value: username },
+      password,
+    });
+
+    // PUT /experience
+    await client.initInteraction({ interactionEvent: InteractionEvent.SignIn });
+
+    await expectRejects(client.identifyUser({ verificationId }), {
+      code: 'session.verification_session_not_found',
+      status: 404,
+    });
+  });
+});

--- a/packages/schemas/src/types/interactions.ts
+++ b/packages/schemas/src/types/interactions.ts
@@ -117,13 +117,20 @@ export const backupCodeVerificationVerifyPayloadGuard = z.object({
 
 /** Payload type for `POST /api/experience/identification`. */
 export type IdentificationApiPayload = {
-  interactionEvent: InteractionEvent;
+  /** The ID of the verification record that is used to identify the user. */
   verificationId: string;
 };
 export const identificationApiPayloadGuard = z.object({
-  interactionEvent: z.nativeEnum(InteractionEvent),
   verificationId: z.string(),
 }) satisfies ToZodObject<IdentificationApiPayload>;
+
+/** Payload type for `POST /api/experience`. */
+export type CreateExperienceApiPayload = {
+  interactionEvent: InteractionEvent;
+};
+export const CreateExperienceApiPayloadGuard = z.object({
+  interactionEvent: z.nativeEnum(InteractionEvent),
+}) satisfies ToZodObject<CreateExperienceApiPayload>;
 
 // ====== Experience API payload guard and types definitions end ======
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Introduce new PUT experience API. See [RFC update](https://github.com/logto-io/rfcs/pull/11) for more details.

This PR adds two new experience root-level endpoints:
- `PUT /experience`: Init a brand new interaction with a given interaction event. A new interaction instance will be created and overwrite any existing interaction data in the session. 
- `PUT /experience/interaction-event`: Interchange between `Register` and `SignIn`.

Also includes the following refactoring:
1. Update the identification endpoint payload. `InteractionEvent` is removed from the body. Per our latest design, the interaction event should be specified ahead by calling the newly added `PUT /experience` API.
2. Update the `ExperienceInteraction` class constructor. Make the `interactionDetails` input optional.  If no `interactionDetails` value is provided, create a brand new empty instance. 
3. Append the "interaction-data" to all the `logEntries` on save.  This can attach the latest interaction status context to all the audit logs created during the interaction. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Interaction case added.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
