### PR TITLE
fix(experience): use forgot password identifier in related flow

### DIFF
--- a/packages/experience/src/pages/VerificationCode/index.tsx
+++ b/packages/experience/src/pages/VerificationCode/index.tsx
@@ -21,15 +21,19 @@ const VerificationCode = () => {
   const { flow } = useParams<Parameters>();
   const { signInMethods } = useSieMethods();
 
-  const { identifierInputValue } = useContext(UserInteractionContext);
+  const { identifierInputValue, forgotPasswordIdentifierInputValue } =
+    useContext(UserInteractionContext);
 
-  const [, useFlow] = validate(flow, userFlowGuard);
+  const [, userFlow] = validate(flow, userFlowGuard);
 
-  if (!useFlow) {
+  if (!userFlow) {
     return <ErrorPage />;
   }
 
-  const { type, value } = identifierInputValue ?? {};
+  const cachedIdentifierInputValue =
+    flow === UserFlow.ForgotPassword ? forgotPasswordIdentifierInputValue : identifierInputValue;
+
+  const { type, value } = cachedIdentifierInputValue ?? {};
 
   if (!type || type === SignInIdentifier.Username || !value) {
     return <ErrorPage title="error.invalid_session" />;
@@ -53,10 +57,10 @@ const VerificationCode = () => {
       }}
     >
       <VerificationCodeContainer
-        flow={useFlow}
+        flow={userFlow}
         identifier={type}
         target={value}
-        hasPasswordButton={useFlow === UserFlow.SignIn && methodSettings?.password}
+        hasPasswordButton={userFlow === UserFlow.SignIn && methodSettings?.password}
       />
     </SecondaryPageLayout>
   );


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
In the verfication code page, if the flow is forgot password, we should read the forgot password input identifier.

Updates:
- fix typo `useFlow` -> `userFlow`

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
