### PR TITLE
refactor: fix experience branding fallback

### DIFF
--- a/packages/experience/src/Providers/AppBoundary/AppMeta.tsx
+++ b/packages/experience/src/Providers/AppBoundary/AppMeta.tsx
@@ -33,7 +33,8 @@ const themeToFavicon = Object.freeze({
 
 const AppMeta = () => {
   const { experienceSettings, theme, platform, isPreview } = useContext(PageContext);
-  const favicon = experienceSettings?.branding[themeToFavicon[theme]];
+  const favicon =
+    experienceSettings?.branding[themeToFavicon[theme]] ?? experienceSettings?.branding.favicon;
 
   return (
     <Helmet>

--- a/packages/integration-tests/src/ui-helpers/expect-experience.ts
+++ b/packages/integration-tests/src/ui-helpers/expect-experience.ts
@@ -300,6 +300,18 @@ export default class ExpectExperience extends ExpectPage {
     return (await userIdSpan.evaluate((element) => element.textContent)) ?? '';
   }
 
+  async findFaviconUrls() {
+    const [favicon, appleFavicon] = await Promise.all([
+      this.page.evaluate(() => {
+        return document.querySelector('link[rel="shortcut icon"]')?.getAttribute('href');
+      }),
+      this.page.evaluate(() => {
+        return document.querySelector('link[rel="apple-touch-icon"]')?.getAttribute('href');
+      }),
+    ]);
+    return { favicon, appleFavicon };
+  }
+
   /** Build a full experience URL from a pathname. */
   protected buildExperienceUrl(pathname = '') {
     return appendPath(this.options.endpoint, pathname);


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

fixes LOG-9614. favicon should be able to fall back to the light one when dark mode is on but only light favicon provided.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
added a bunch of tests for the fallback logic

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
