### PR TITLE
refactor: fix third-party app experience branding

### DIFF
--- a/packages/console/src/components/ImageInputs/index.tsx
+++ b/packages/console/src/components/ImageInputs/index.tsx
@@ -45,7 +45,10 @@ export type ImageField<FormContext extends FieldValues> = {
 type Props<FormContext extends FieldValues> = {
   /** The condensed title when user assets service is available. */
   readonly uploadTitle: React.ComponentProps<typeof FormField>['title'];
-  /** The tooltip to show for all the fields. */
+  /**
+   * When user assets service is available, the tip will be displayed for the `uploadTitle`;
+   * otherwise, it will be displayed for each text input.
+   */
   readonly tip?: React.ComponentProps<typeof FormField>['tip'];
   readonly control: Control<FormContext>;
   readonly register: UseFormRegister<FormContext>;

--- a/packages/core/src/libraries/sign-in-experience/index.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.ts
@@ -147,7 +147,7 @@ export const createSignInExperienceLibrary = (
       return;
     }
 
-    return pick(found, 'branding', 'color');
+    return pick(found, 'branding', 'color', 'type', 'isThirdParty');
   };
 
   const getFullSignInExperience = async ({
@@ -223,9 +223,17 @@ export const createSignInExperienceLibrary = (
       };
     };
 
+    /** Get the branding and color from the app sign-in experience if it is not a third-party app. */
+    const getAppSignInExperience = () => {
+      if (!appSignInExperience || appSignInExperience.isThirdParty) {
+        return {};
+      }
+      return pick(appSignInExperience, 'branding', 'color');
+    };
+
     return {
       ...deepmerge(
-        deepmerge(signInExperience, appSignInExperience ?? {}),
+        deepmerge(signInExperience, getAppSignInExperience()),
         organizationOverride ?? {}
       ),
       socialConnectors,

--- a/packages/core/src/queries/application-sign-in-experience.ts
+++ b/packages/core/src/queries/application-sign-in-experience.ts
@@ -1,4 +1,10 @@
-import { ApplicationSignInExperiences, type ApplicationSignInExperience } from '@logto/schemas';
+import {
+  type Application,
+  ApplicationSignInExperiences,
+  Applications,
+  type ApplicationSignInExperience,
+} from '@logto/schemas';
+import { type Nullable } from '@silverhand/essentials';
 import { sql, type CommonQueryMethods } from '@silverhand/slonik';
 
 import { buildInsertIntoWithPool } from '#src/database/insert-into.js';
@@ -10,12 +16,22 @@ const createApplicationSignInExperienceQueries = (pool: CommonQueryMethods) => {
     returning: true,
   });
 
-  const safeFindSignInExperienceByApplicationId = async (applicationId: string) => {
-    const { table, fields } = convertToIdentifiers(ApplicationSignInExperiences);
+  type ApplicationSignInExperienceReturn = ApplicationSignInExperience &
+    Pick<Application, 'type' | 'isThirdParty'>;
 
-    return pool.maybeOne<ApplicationSignInExperience>(sql`
-      select ${sql.join(Object.values(fields), sql`, `)}
+  const safeFindSignInExperienceByApplicationId = async (
+    applicationId: string
+  ): Promise<Nullable<ApplicationSignInExperienceReturn>> => {
+    const applications = convertToIdentifiers(Applications, true);
+    const { table, fields } = convertToIdentifiers(ApplicationSignInExperiences, true);
+
+    return pool.maybeOne<ApplicationSignInExperienceReturn>(sql`
+      select
+        ${sql.join(Object.values(fields), sql`, `)},
+        ${applications.fields.type},
+        ${applications.fields.isThirdParty}
       from ${table}
+      join ${applications.table} on ${fields.applicationId}=${applications.fields.id}
       where ${fields.applicationId}=${applicationId}
     `);
   };


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
resolves LOG-9599 and LOG-9596. third-party apps should not overwrite the existing experience branding.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
integration tests added

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
