### PR TITLE
feat: add content schema to HTTP 201 CREATED messages

### DIFF
--- a/packages/core/src/routes/swagger/index.ts
+++ b/packages/core/src/routes/swagger/index.ts
@@ -93,7 +93,7 @@ const buildOperation = (
         throw new Error(`Invalid status code ${status}.`);
       }
 
-      if (status === 200) {
+      if (status === 200 || status === 201) {
         return [
           status,
           {


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
When creating a new organization using the Go SDK that I generated from the OpenAPI spec doc, [go-api-client](https://github.com/mostafa/go-api-client), the `CreateOrganization` endpoint returns a `201 CREATED` HTTP status code and an `Organization` instance with a populated ID field (of the new org). However, the schema doesn't exist in the content key of the response:

![image](https://github.com/user-attachments/assets/1fe71df5-eb9f-4576-a0f5-57af03b54f29)

This results in a normal `http.Response` object to be returned in Go, instead of an instance of a struct, which is unlike other endpoints that return a processed schema as an object. If the `content` key is added to the response of 201 status codes, it'll result in the processing of the `resp` (below) into a separate instance of the (generated) `Organization` struct and I can access the `newOrg` like an object: `newOrg.GetId()`. In the existing case, I need to unmarshal the body of the response into a `map[string]any` (JSON) object to be able to access the ID field.

```diff
- resp, err := client.OrganizationsAPI.CreateOrganization(ctx).CreateOrganizationRequest(createOrgReq).Execute()
+ newOrg, _, err := client.OrganizationsAPI.CreateOrganization(ctx).CreateOrganizationRequest(createOrgReq).Execute()
```

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Access the `swagger.json` endpoint and see if the 201 status of the POST request of the `/api/organizations` has `response.content`.

## Note to Reviewer

1. I was able to test the updated response with 201 HTTP status code and this is the result:

![image](https://github.com/user-attachments/assets/d96cb84b-0677-433a-adc9-da0fe2c7cafb)

2. I'd be happy to donate `go-api-client` to you, if you want. I just need to make some changes after transferring the project.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
