### PR TITLE
fix(console): fix Google connector `scope` field can not be unset bug

### DIFF
--- a/.changeset/cool-otters-unite.md
+++ b/.changeset/cool-otters-unite.md
@@ -1,0 +1,5 @@
+---
+"@logto/console": patch
+---
+
+fix Google connector `scope` field can not be reset bug

--- a/packages/console/src/pages/ConnectorDetails/ConnectorContent/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/ConnectorContent/index.tsx
@@ -68,7 +68,7 @@ function ConnectorContent({ isDeleted, connectorData, onConnectorUpdated }: Prop
       const { syncProfile, name, logo, logoDark, target, rawConfig } = data;
       // Apply the raw config first to avoid losing data updated from other forms that are not
       // included in the form items.
-      const config = { ...rawConfig, ...configParser(data, formItems) };
+      const config = removeFalsyValues({ ...rawConfig, ...configParser(data, formItems) });
 
       const payload = isSocialConnector
         ? {

--- a/packages/console/src/utils/connector-form.ts
+++ b/packages/console/src/utils/connector-form.ts
@@ -27,11 +27,6 @@ export const parseFormConfig = (
   return Object.fromEntries(
     Object.entries(config)
       .map(([key, value]) => {
-        // Filter out empty input
-        if (value === '') {
-          return null;
-        }
-
         const formItem = formItems.find((item) => item.key === key);
 
         if (!formItem) {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the bug that Google connector `scope` field can not be unset.

It's because in `parseFormConfig()` method, we removed key-value pairs from form config.

Due to the changes in [PR#6034](https://github.com/logto-io/logto/pull/6034), when submitting the connector config form, the fields from `parseFormConfig()` will be used to overwrite the values in `rawConfig`, where `rawConfig` is the old connector config. In `parseFormConfig()`, if the value of `scope` is an empty string, it would be dropped in the original logic, thus failing to overwrite the old `config.scope` value.

In this fix, we no longer remove key-value pairs corresponding to falsy values in `parseFormConfig()`. Instead, we remove the falsy values after the overwrite is completed.

This PR fixes [Issue#6230](https://github.com/logto-io/logto/issues/6230) and LOG-9624.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
