### PR TITLE
feat(core,schemas): implement social/sso link and sync logic

### DIFF
--- a/packages/connectors/connector-mock-social/src/index.ts
+++ b/packages/connectors/connector-mock-social/src/index.ts
@@ -39,6 +39,8 @@ const getUserInfo: GetUserInfo = async (data, getSession) => {
     userId: z.optional(z.string()),
     email: z.string().optional(),
     phone: z.string().optional(),
+    name: z.string().optional(),
+    avatar: z.string().optional(),
   });
   const result = dataGuard.safeParse(data);
 

--- a/packages/core/src/routes/experience/classes/utils.ts
+++ b/packages/core/src/routes/experience/classes/utils.ts
@@ -5,9 +5,11 @@ import {
   type InteractionIdentifier,
   type User,
 } from '@logto/schemas';
+import { conditional } from '@silverhand/essentials';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import type Queries from '#src/tenants/Queries.js';
+import assertThat from '#src/utils/assert-that.js';
 
 import type { InteractionProfile } from '../types.js';
 
@@ -51,6 +53,71 @@ export const getNewUserProfileFromVerificationRecord = async (
     default: {
       // Unsupported verification type for user creation, such as MFA verification.
       throw new RequestError({ code: 'session.verification_failed', status: 400 });
+    }
+  }
+};
+
+/**
+ * @throws {RequestError} -400 if the verification record type is not supported for user identification.
+ * @throws {RequestError} -400 if the verification record is not verified.
+ * @throws {RequestError} -404 if the user is not found.
+ */
+export const identifyUserByVerificationRecord = async (
+  verificationRecord: VerificationRecord,
+  linkSocialIdentity?: boolean
+): Promise<{
+  user: User;
+  /**
+   * Returns the social/enterprise SSO synced profiled if the verification record is a social/enterprise SSO verification.
+   * - For new linked identity, the synced profile will includes the new social or enterprise SSO identity.
+   * - For existing social or enterprise SSO identity, the synced profile will return the synced user profile based on connector settings.
+   */
+  syncedProfile?: Pick<
+    InteractionProfile,
+    'enterpriseSsoIdentity' | 'socialIdentity' | 'avatar' | 'name'
+  >;
+}> => {
+  // Check verification record can be used to identify a user using the `identifyUser` method.
+  // E.g. MFA verification record does not have the `identifyUser` method, cannot be used to identify a user.
+  assertThat(
+    'identifyUser' in verificationRecord,
+    new RequestError({ code: 'session.verification_failed', status: 400 })
+  );
+
+  switch (verificationRecord.type) {
+    case VerificationType.Password:
+    case VerificationType.VerificationCode: {
+      return { user: await verificationRecord.identifyUser() };
+    }
+    case VerificationType.Social: {
+      const user = linkSocialIdentity
+        ? await verificationRecord.identifyRelatedUser()
+        : await verificationRecord.identifyUser();
+
+      const syncedProfile = {
+        ...(await verificationRecord.toSyncedProfile()),
+        ...conditional(linkSocialIdentity && (await verificationRecord.toUserProfile())),
+      };
+
+      return { user, syncedProfile };
+    }
+    case VerificationType.EnterpriseSso: {
+      try {
+        const user = await verificationRecord.identifyUser();
+        const syncedProfile = await verificationRecord.toSyncedProfile();
+        return { user, syncedProfile };
+      } catch (error: unknown) {
+        // Auto fallback to identify the related user if the user does not exist for enterprise SSO.
+        if (error instanceof RequestError && error.code === 'user.identity_not_exist') {
+          const user = await verificationRecord.identifyRelatedUser();
+          const syncedProfile = {
+            ...(await verificationRecord.toUserProfile()),
+            ...(await verificationRecord.toSyncedProfile()),
+          };
+          return { user, syncedProfile };
+        }
+        throw error;
+      }
     }
   }
 };

--- a/packages/core/src/routes/experience/classes/verifications/verification-record.ts
+++ b/packages/core/src/routes/experience/classes/verifications/verification-record.ts
@@ -33,5 +33,6 @@ export abstract class IdentifierVerificationRecord<
   T extends VerificationType = IdentifierVerificationType,
   Json extends Data<T> = Data<T>,
 > extends VerificationRecord<T, Json> {
+  /** Identify the user associated with the verification record. */
   abstract identifyUser(): Promise<User>;
 }

--- a/packages/core/src/routes/experience/index.ts
+++ b/packages/core/src/routes/experience/index.ts
@@ -111,10 +111,10 @@ export default function experienceApiRoutes<T extends AnonymousRouter>(
       status: [201, 204, 400, 401, 404, 409, 422],
     }),
     async (ctx, next) => {
-      const { verificationId } = ctx.guard.body;
+      const { verificationId, linkSocialIdentity } = ctx.guard.body;
       const { experienceInteraction } = ctx;
 
-      await experienceInteraction.identifyUser(verificationId);
+      await experienceInteraction.identifyUser(verificationId, linkSocialIdentity);
 
       await experienceInteraction.save();
 

--- a/packages/integration-tests/src/api/sso-connector.ts
+++ b/packages/integration-tests/src/api/sso-connector.ts
@@ -54,6 +54,7 @@ export class SsoConnectorApi {
         clientSecret: 'bar',
         issuer: `${logtoUrl}/oidc`,
       },
+      syncProfile: true,
     });
 
     return connector;

--- a/packages/integration-tests/src/helpers/connector.ts
+++ b/packages/integration-tests/src/helpers/connector.ts
@@ -40,6 +40,7 @@ export const setSocialConnector = async () =>
   postConnector({
     connectorId: mockSocialConnectorId,
     config: mockSocialConnectorConfig,
+    syncProfile: true,
   });
 
 export const resetPasswordlessConnectors = async () => {

--- a/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/enterprise-sso.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/enterprise-sso.test.ts
@@ -4,12 +4,13 @@ import { deleteUser, getUser } from '#src/api/admin-user.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
 import { SsoConnectorApi } from '#src/api/sso-connector.js';
 import { signInWithEnterpriseSso } from '#src/helpers/experience/index.js';
+import { generateNewUser } from '#src/helpers/user.js';
 import { devFeatureTest, generateEmail } from '#src/utils.js';
 
 devFeatureTest.describe('enterprise sso sign-in and sign-up', () => {
   const ssoConnectorApi = new SsoConnectorApi();
   const domain = 'foo.com';
-  const socialUserId = generateStandardId();
+  const enterpriseSsoIdentityId = generateStandardId();
   const email = generateEmail(domain);
 
   beforeAll(async () => {
@@ -21,11 +22,11 @@ devFeatureTest.describe('enterprise sso sign-in and sign-up', () => {
     await ssoConnectorApi.cleanUp();
   });
 
-  it('should successfully sign-up with enterprise sso ans sync email', async () => {
+  it('should successfully sign-up with enterprise sso and sync email', async () => {
     const userId = await signInWithEnterpriseSso(
       ssoConnectorApi.firstConnectorId!,
       {
-        sub: socialUserId,
+        sub: enterpriseSsoIdentityId,
         email,
         email_verified: true,
       },
@@ -38,10 +39,39 @@ devFeatureTest.describe('enterprise sso sign-in and sign-up', () => {
 
   it('should successfully sign-in with enterprise sso', async () => {
     const userId = await signInWithEnterpriseSso(ssoConnectorApi.firstConnectorId!, {
-      sub: socialUserId,
+      sub: enterpriseSsoIdentityId,
       email,
       email_verified: true,
+      name: 'John Doe',
     });
+
+    const { name } = await getUser(userId);
+    expect(name).toBe('John Doe');
+
+    await deleteUser(userId);
+  });
+
+  it('should successfully sign-in and link new enterprise sso identity', async () => {
+    const { userProfile, user } = await generateNewUser({
+      primaryEmail: true,
+    });
+    const { primaryEmail } = userProfile;
+
+    const userId = await signInWithEnterpriseSso(ssoConnectorApi.firstConnectorId!, {
+      sub: enterpriseSsoIdentityId,
+      email: primaryEmail,
+      email_verified: true,
+      name: 'John Doe',
+    });
+
+    expect(userId).toBe(user.id);
+
+    const { name, ssoIdentities } = await getUser(userId, true);
+
+    expect(name).toBe('John Doe');
+    expect(ssoIdentities?.some((identity) => identity.identityId === enterpriseSsoIdentityId)).toBe(
+      true
+    );
 
     await deleteUser(userId);
   });

--- a/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/social.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/social.test.ts
@@ -1,10 +1,14 @@
 import { ConnectorType } from '@logto/connector-kit';
 import { generateStandardId } from '@logto/shared';
 
-import { mockSocialConnectorId } from '#src/__mocks__/connectors-mock.js';
+import {
+  mockSocialConnectorId,
+  mockSocialConnectorTarget,
+} from '#src/__mocks__/connectors-mock.js';
 import { deleteUser, getUser } from '#src/api/admin-user.js';
 import { clearConnectorsByTypes, setSocialConnector } from '#src/helpers/connector.js';
 import { signInWithSocial } from '#src/helpers/experience/index.js';
+import { generateNewUser } from '#src/helpers/user.js';
 import { devFeatureTest, generateEmail } from '#src/utils.js';
 
 devFeatureTest.describe('social sign-in and sign-up', () => {
@@ -30,18 +34,48 @@ devFeatureTest.describe('social sign-in and sign-up', () => {
         id: socialUserId,
         email,
       },
-      true
+      {
+        registerNewUser: true,
+      }
     );
 
     const { primaryEmail } = await getUser(userId);
     expect(primaryEmail).toBe(email);
   });
 
-  it('should successfully sign-in with social', async () => {
+  it('should successfully sign-in with social and sync name', async () => {
     const userId = await signInWithSocial(connectorIdMap.get(mockSocialConnectorId)!, {
       id: socialUserId,
       email,
+      name: 'John Doe',
     });
+
+    const { name } = await getUser(userId);
+
+    expect(name).toBe('John Doe');
+
+    await deleteUser(userId);
+  });
+
+  it('should successfully sign-in with linked email and sync name', async () => {
+    const { userProfile, user } = await generateNewUser({
+      primaryEmail: true,
+    });
+
+    const userId = await signInWithSocial(
+      connectorIdMap.get(mockSocialConnectorId)!,
+      {
+        id: socialUserId,
+        email: userProfile.primaryEmail,
+        name: 'Foo Bar',
+      },
+      { linkSocial: true }
+    );
+
+    expect(userId).toBe(user.id);
+    const { identities, name } = await getUser(userId);
+    expect(identities[mockSocialConnectorTarget]).toBeTruthy();
+    expect(name).toBe('Foo Bar');
 
     await deleteUser(userId);
   });

--- a/packages/schemas/src/types/interactions.ts
+++ b/packages/schemas/src/types/interactions.ts
@@ -140,9 +140,15 @@ export const newPasswordIdentityVerificationPayloadGuard = z.object({
 export type IdentificationApiPayload = {
   /** The ID of the verification record that is used to identify the user. */
   verificationId: string;
+  /**
+   * Link social identity to a related user account with the same email or phone.
+   * Only applicable for social verification records and a related user account is found.
+   */
+  linkSocialIdentity?: boolean;
 };
 export const identificationApiPayloadGuard = z.object({
   verificationId: z.string(),
+  linkSocialIdentity: z.boolean().optional(),
 }) satisfies ToZodObject<IdentificationApiPayload>;
 
 /** Payload type for `POST /api/experience`. */


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Implement the social and enterprise SSO identity linking and profile syncing logic:

1. Implement the social-related user linking flow.  Per RFC design, the `/experience/identification` endpoint takes an extra `linkSocialIdentity` parameter to indicate that instead of identifying the user using social identity, identify him using the related user and then link the new social identity to his profile. 

2. Implement the enterprise SSO-related user auto-linking flow.  Unlike social, the user needs to resend the identification request with a `linkSocialIdentity` parameter. EnterpriseSso verification record will auto fallback to use related user info to identify the user. SSO identity will be auto-added to the interaction profile. 

3. Also implement the social and SSO sign-in profile syncing logic. When signing using a social or SSO identity, if the sync profile is enabled, related use info will be synced to the interaction profile automatically. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
integration test added. 

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
