### PR TITLE
fix(console): fix passwordless connector tester send failed bug

### DIFF
--- a/packages/console/src/hooks/use-connector-form-config-parser.tsx
+++ b/packages/console/src/hooks/use-connector-form-config-parser.tsx
@@ -31,9 +31,13 @@ const useJsonStringConfigParser = () => {
 export const useConnectorFormConfigParser = () => {
   const parseJsonConfig = useJsonStringConfigParser();
 
-  return (data: ConnectorFormType, formItems: ConnectorResponse['formItems']) => {
+  return (
+    data: ConnectorFormType,
+    formItems: ConnectorResponse['formItems'],
+    skipFalsyValuesRemoval = false
+  ) => {
     return formItems
-      ? parseFormConfig(data.formConfig, formItems)
+      ? parseFormConfig(data.formConfig, formItems, skipFalsyValuesRemoval)
       : parseJsonConfig(data.jsonConfig);
   };
 };

--- a/packages/console/src/pages/ConnectorDetails/ConnectorContent/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/ConnectorContent/index.tsx
@@ -68,7 +68,11 @@ function ConnectorContent({ isDeleted, connectorData, onConnectorUpdated }: Prop
       const { syncProfile, name, logo, logoDark, target, rawConfig } = data;
       // Apply the raw config first to avoid losing data updated from other forms that are not
       // included in the form items.
-      const config = removeFalsyValues({ ...rawConfig, ...configParser(data, formItems) });
+      // Explicitly SKIP falsy values removal logic (the last argument of `configParser()` method) for social connectors.
+      const config = removeFalsyValues({
+        ...rawConfig,
+        ...configParser(data, formItems, isSocialConnector),
+      });
 
       const payload = isSocialConnector
         ? {

--- a/packages/console/src/utils/connector-form.ts
+++ b/packages/console/src/utils/connector-form.ts
@@ -22,11 +22,17 @@ const initFormData = (formItems: ConnectorConfigFormItem[], config?: Record<stri
 
 export const parseFormConfig = (
   config: Record<string, unknown>,
-  formItems: ConnectorConfigFormItem[]
+  formItems: ConnectorConfigFormItem[],
+  skipFalsyValuesRemoval = false
 ) => {
   return Object.fromEntries(
     Object.entries(config)
       .map(([key, value]) => {
+        // Filter out empty input
+        if (!skipFalsyValuesRemoval && value === '') {
+          return null;
+        }
+
         const formItem = formItems.find((item) => item.key === key);
 
         if (!formItem) {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix passwordless connector tester send failed bug.

This bug was brought in [PR#6254](https://github.com/logto-io/logto/pull/6254), we do not apply falsy key-value pairs removal logics in `parseFormConfig()` (which is a branch of `useConnectorFormConfigParser()` method). Hence we need to manually remove falsy key-values pairs for cases that we explicitly skip this logic.

In order to make the code easier to maintain, we add a switch to control whether we want to skip this falsy value removal logic, and the default value is false. So that this could keep the original logic of other `useConnectorFormConfigParser()` use cases.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally and thru cloud UI integration tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
