### PR TITLE
fix(console): should not toast invitation sent message when creating tenant w/o invitee

### DIFF
--- a/packages/console/src/onboarding/pages/CreateTenant/index.tsx
+++ b/packages/console/src/onboarding/pages/CreateTenant/index.tsx
@@ -78,19 +78,21 @@ function CreateTenant() {
         tenantId: newTenant.id,
       });
 
-      // Should not block the onboarding flow if the invitation fails.
-      try {
-        await Promise.all(
-          collaboratorEmails.map(async (email) =>
-            tenantCloudApi.post('/api/tenants/:tenantId/invitations', {
-              params: { tenantId: newTenant.id },
-              body: { invitee: email.value, roleName: TenantRole.Collaborator },
-            })
-          )
-        );
-        toast.success(t('tenant_members.messages.invitation_sent'));
-      } catch {
-        toast.error(t('tenants.create_modal.invitation_failed', { duration: 5 }));
+      if (collaboratorEmails.length > 0) {
+        // Should not block the onboarding flow if the invitation fails.
+        try {
+          await Promise.all(
+            collaboratorEmails.map(async (email) =>
+              tenantCloudApi.post('/api/tenants/:tenantId/invitations', {
+                params: { tenantId: newTenant.id },
+                body: { invitee: email.value, roleName: TenantRole.Collaborator },
+              })
+            )
+          );
+          toast.success(t('tenant_members.messages.invitation_sent'));
+        } catch {
+          toast.error(t('tenants.create_modal.invitation_failed', { duration: 5 }));
+        }
       }
       navigate(joinPath(OnboardingRoute.Onboarding, newTenant.id, OnboardingPage.SignInExperience));
     })


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix a bug that when creating tenant without filling in any invitee emails, there's an unexpected "Invitation sent" toast message popping up.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
