### PR TITLE
ci: always set conclusion for alteration tests

### DIFF
--- a/.github/workflows/alteration-compatibility-integration-test.yml
+++ b/.github/workflows/alteration-compatibility-integration-test.yml
@@ -91,3 +91,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_DEBUG: api
         run: gh workflow run rerun.yml -F run_id=${{ github.run_id }}
+
+  alteration-compatibility-conclusion:
+    needs: run-logto
+    runs-on: ubuntu-latest
+    if: always() && (needs.run-logto.result == 'success' || needs.run-logto.result == 'skipped')
+    steps:
+      - name: Conclusion
+        run: echo "Alteration compatibility integration test completed successfully"


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
using `run-logto` as the requirement may cause unexpected hang up since not all pulls have alterations

![image](https://github.com/user-attachments/assets/0fc8c0e7-cd56-4aef-af00-6200755f3f6f)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
⬇️ `alteration-compatibility-conclusion` exits successfully

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
