### PR TITLE
refactor(core,schemas): refactor `CodeVerification`

### DIFF
--- a/packages/core/src/routes/experience/classes/experience-interaction.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.test.ts
@@ -77,7 +77,7 @@ describe('ExperienceInteraction class', () => {
 
   const emailVerificationRecord = new EmailCodeVerification(libraries, queries, {
     id: 'mock_email_verification_id',
-    type: VerificationType.VerificationCode,
+    type: VerificationType.EmailVerificationCode,
     identifier: {
       type: SignInIdentifier.Email,
       value: mockEmail,

--- a/packages/core/src/routes/experience/classes/experience-interaction.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.test.ts
@@ -17,7 +17,7 @@ import { createMockProvider } from '#src/test-utils/oidc-provider.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
 import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
 
-import { CodeVerification } from './verifications/code-verification.js';
+import { EmailCodeVerification } from './verifications/code-verification.js';
 
 const { jest } = import.meta;
 const { mockEsm } = createMockUtils(jest);
@@ -75,7 +75,7 @@ describe('ExperienceInteraction class', () => {
   };
   const { libraries, queries } = tenant;
 
-  const emailVerificationRecord = new CodeVerification(libraries, queries, {
+  const emailVerificationRecord = new EmailCodeVerification(libraries, queries, {
     id: 'mock_email_verification_id',
     type: VerificationType.VerificationCode,
     identifier: {

--- a/packages/core/src/routes/experience/classes/utils.ts
+++ b/packages/core/src/routes/experience/classes/utils.ts
@@ -4,6 +4,7 @@ import {
   VerificationType,
   type InteractionIdentifier,
   type User,
+  type VerificationCodeSignInIdentifier,
 } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
 
@@ -41,7 +42,8 @@ export const getNewUserProfileFromVerificationRecord = async (
 ): Promise<InteractionProfile> => {
   switch (verificationRecord.type) {
     case VerificationType.NewPasswordIdentity:
-    case VerificationType.VerificationCode: {
+    case VerificationType.EmailVerificationCode:
+    case VerificationType.PhoneVerificationCode: {
       return verificationRecord.toUserProfile();
     }
     case VerificationType.EnterpriseSso:
@@ -86,7 +88,8 @@ export const identifyUserByVerificationRecord = async (
 
   switch (verificationRecord.type) {
     case VerificationType.Password:
-    case VerificationType.VerificationCode: {
+    case VerificationType.EmailVerificationCode:
+    case VerificationType.PhoneVerificationCode: {
       return { user: await verificationRecord.identifyUser() };
     }
     case VerificationType.Social: {
@@ -171,3 +174,8 @@ export function profileToUserInfo(
     phoneNumber: primaryPhone ?? undefined,
   };
 }
+
+export const codeVerificationIdentifierRecordTypeMap = Object.freeze({
+  [SignInIdentifier.Email]: VerificationType.EmailVerificationCode,
+  [SignInIdentifier.Phone]: VerificationType.PhoneVerificationCode,
+}) satisfies Record<VerificationCodeSignInIdentifier, VerificationType>;

--- a/packages/core/src/routes/experience/classes/validators/sign-in-experience-validator.test.ts
+++ b/packages/core/src/routes/experience/classes/validators/sign-in-experience-validator.test.ts
@@ -11,7 +11,7 @@ import { mockSignInExperience } from '#src/__mocks__/sign-in-experience.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
 
-import { CodeVerification } from '../verifications/code-verification.js';
+import { createNewCodeVerificationRecord } from '../verifications/code-verification.js';
 import { EnterpriseSsoVerification } from '../verifications/enterprise-sso-verification.js';
 import { type VerificationRecord } from '../verifications/index.js';
 import { NewPasswordIdentityVerification } from '../verifications/new-password-identity-verification.js';
@@ -53,7 +53,7 @@ const passwordVerificationRecords = Object.fromEntries(
 ) as Record<SignInIdentifier, PasswordVerification>;
 
 const verificationCodeVerificationRecords = Object.freeze({
-  [SignInIdentifier.Email]: CodeVerification.create(
+  [SignInIdentifier.Email]: createNewCodeVerificationRecord(
     mockTenant.libraries,
     mockTenant.queries,
     {
@@ -62,7 +62,7 @@ const verificationCodeVerificationRecords = Object.freeze({
     },
     InteractionEvent.SignIn
   ),
-  [SignInIdentifier.Phone]: CodeVerification.create(
+  [SignInIdentifier.Phone]: createNewCodeVerificationRecord(
     mockTenant.libraries,
     mockTenant.queries,
     {

--- a/packages/core/src/routes/experience/classes/validators/sign-in-experience-validator.ts
+++ b/packages/core/src/routes/experience/classes/validators/sign-in-experience-validator.ts
@@ -4,6 +4,7 @@ import { PasswordPolicyChecker } from '@logto/core-kit';
 import {
   InteractionEvent,
   type SignInExperience,
+  SignInIdentifier,
   SignInMode,
   VerificationType,
 } from '@logto/schemas';
@@ -18,12 +19,13 @@ import { type VerificationRecord } from '../verifications/index.js';
 const getEmailIdentifierFromVerificationRecord = (verificationRecord: VerificationRecord) => {
   switch (verificationRecord.type) {
     case VerificationType.Password:
-    case VerificationType.VerificationCode: {
+    case VerificationType.EmailVerificationCode:
+    case VerificationType.PhoneVerificationCode: {
       const {
         identifier: { type, value },
       } = verificationRecord;
 
-      return type === 'email' ? value : undefined;
+      return type === SignInIdentifier.Email ? value : undefined;
     }
     case VerificationType.Social: {
       const { socialUserInfo } = verificationRecord;
@@ -174,7 +176,8 @@ export class SignInExperienceValidator {
 
     switch (verificationRecord.type) {
       case VerificationType.Password:
-      case VerificationType.VerificationCode: {
+      case VerificationType.EmailVerificationCode:
+      case VerificationType.PhoneVerificationCode: {
         const {
           identifier: { type },
         } = verificationRecord;
@@ -224,7 +227,8 @@ export class SignInExperienceValidator {
         );
         break;
       }
-      case VerificationType.VerificationCode: {
+      case VerificationType.EmailVerificationCode:
+      case VerificationType.PhoneVerificationCode: {
         const {
           identifier: { type },
         } = verificationRecord;
@@ -255,7 +259,8 @@ export class SignInExperienceValidator {
   /** Forgot password only supports verification code type verification record */
   private guardForgotPasswordVerificationMethod(verificationRecord: VerificationRecord) {
     assertThat(
-      verificationRecord.type === VerificationType.VerificationCode,
+      verificationRecord.type === VerificationType.EmailVerificationCode ||
+        verificationRecord.type === VerificationType.PhoneVerificationCode,
       new RequestError({ code: 'session.not_supported_for_forgot_password', status: 422 })
     );
   }

--- a/packages/core/src/routes/experience/classes/verifications/index.ts
+++ b/packages/core/src/routes/experience/classes/verifications/index.ts
@@ -10,11 +10,10 @@ import {
   type BackupCodeVerificationRecordData,
 } from './backup-code-verification.js';
 import {
-  assertEmailCodeVerificationData,
-  assertPhoneCodeVerificationData,
-  codeVerificationRecordDataGuard,
   EmailCodeVerification,
+  emailCodeVerificationRecordDataGuard,
   PhoneCodeVerification,
+  phoneCodeVerificationRecordDataGuard,
   type CodeVerificationRecordData,
 } from './code-verification.js';
 import {
@@ -45,7 +44,8 @@ import {
 
 export type VerificationRecordData =
   | PasswordVerificationRecordData
-  | CodeVerificationRecordData
+  | CodeVerificationRecordData<VerificationType.EmailVerificationCode>
+  | CodeVerificationRecordData<VerificationType.PhoneVerificationCode>
   | SocialVerificationRecordData
   | EnterpriseSsoVerificationRecordData
   | TotpVerificationRecordData
@@ -72,7 +72,8 @@ export type VerificationRecord =
 
 export const verificationRecordDataGuard = z.discriminatedUnion('type', [
   passwordVerificationRecordDataGuard,
-  codeVerificationRecordDataGuard,
+  emailCodeVerificationRecordDataGuard,
+  phoneCodeVerificationRecordDataGuard,
   socialVerificationRecordDataGuard,
   enterPriseSsoVerificationRecordDataGuard,
   totpVerificationRecordDataGuard,
@@ -92,17 +93,11 @@ export const buildVerificationRecord = (
     case VerificationType.Password: {
       return new PasswordVerification(libraries, queries, data);
     }
-    case VerificationType.VerificationCode: {
-      // TS can't distribute the CodeVerificationRecordData type directly
-      // so we need to assert the data type here
-      if (assertEmailCodeVerificationData(data)) {
-        return new EmailCodeVerification(libraries, queries, data);
-      }
-      if (assertPhoneCodeVerificationData(data)) {
-        return new PhoneCodeVerification(libraries, queries, data);
-      }
-      // Make the type checker happy
-      throw new Error('Invalid code verification data');
+    case VerificationType.EmailVerificationCode: {
+      return new EmailCodeVerification(libraries, queries, data);
+    }
+    case VerificationType.PhoneVerificationCode: {
+      return new PhoneCodeVerification(libraries, queries, data);
     }
     case VerificationType.Social: {
       return new SocialVerification(libraries, queries, data);

--- a/packages/core/src/routes/experience/classes/verifications/index.ts
+++ b/packages/core/src/routes/experience/classes/verifications/index.ts
@@ -10,8 +10,11 @@ import {
   type BackupCodeVerificationRecordData,
 } from './backup-code-verification.js';
 import {
-  CodeVerification,
+  assertEmailCodeVerificationData,
+  assertPhoneCodeVerificationData,
   codeVerificationRecordDataGuard,
+  EmailCodeVerification,
+  PhoneCodeVerification,
   type CodeVerificationRecordData,
 } from './code-verification.js';
 import {
@@ -59,7 +62,8 @@ export type VerificationRecordData =
  */
 export type VerificationRecord =
   | PasswordVerification
-  | CodeVerification
+  | EmailCodeVerification
+  | PhoneCodeVerification
   | SocialVerification
   | EnterpriseSsoVerification
   | TotpVerification
@@ -89,7 +93,16 @@ export const buildVerificationRecord = (
       return new PasswordVerification(libraries, queries, data);
     }
     case VerificationType.VerificationCode: {
-      return new CodeVerification(libraries, queries, data);
+      // TS can't distribute the CodeVerificationRecordData type directly
+      // so we need to assert the data type here
+      if (assertEmailCodeVerificationData(data)) {
+        return new EmailCodeVerification(libraries, queries, data);
+      }
+      if (assertPhoneCodeVerificationData(data)) {
+        return new PhoneCodeVerification(libraries, queries, data);
+      }
+      // Make the type checker happy
+      throw new Error('Invalid code verification data');
     }
     case VerificationType.Social: {
       return new SocialVerification(libraries, queries, data);

--- a/packages/core/src/routes/experience/classes/verifications/verification-record.ts
+++ b/packages/core/src/routes/experience/classes/verifications/verification-record.ts
@@ -19,7 +19,8 @@ export abstract class VerificationRecord<
 }
 
 type IdentifierVerificationType =
-  | VerificationType.VerificationCode
+  | VerificationType.EmailVerificationCode
+  | VerificationType.PhoneVerificationCode
   | VerificationType.Password
   | VerificationType.Social
   | VerificationType.EnterpriseSso;

--- a/packages/core/src/routes/experience/verification-routes/verification-code.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code.ts
@@ -12,7 +12,7 @@ import koaGuard from '#src/middleware/koa-guard.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 
-import { CodeVerification } from '../classes/verifications/code-verification.js';
+import { createNewCodeVerificationRecord } from '../classes/verifications/code-verification.js';
 import { experienceRoutes } from '../const.js';
 import { type WithExperienceInteractionContext } from '../middleware/koa-experience-interaction.js';
 
@@ -36,7 +36,7 @@ export default function verificationCodeRoutes<T extends WithLogContext>(
     async (ctx, next) => {
       const { identifier, interactionEvent } = ctx.guard.body;
 
-      const codeVerification = CodeVerification.create(
+      const codeVerification = createNewCodeVerificationRecord(
         libraries,
         queries,
         identifier,
@@ -80,7 +80,8 @@ export default function verificationCodeRoutes<T extends WithLogContext>(
       assertThat(
         codeVerificationRecord &&
           // Make the Verification type checker happy
-          codeVerificationRecord.type === VerificationType.VerificationCode,
+          codeVerificationRecord.type === VerificationType.VerificationCode &&
+          codeVerificationRecord.identifier.type === identifier.type,
         new RequestError({ code: 'session.verification_session_not_found', status: 404 })
       );
 

--- a/packages/core/src/routes/experience/verification-routes/verification-code.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code.ts
@@ -1,8 +1,4 @@
-import {
-  InteractionEvent,
-  VerificationType,
-  verificationCodeIdentifierGuard,
-} from '@logto/schemas';
+import { InteractionEvent, verificationCodeIdentifierGuard } from '@logto/schemas';
 import type Router from 'koa-router';
 import { z } from 'zod';
 
@@ -12,6 +8,7 @@ import koaGuard from '#src/middleware/koa-guard.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 
+import { codeVerificationIdentifierRecordTypeMap } from '../classes/utils.js';
 import { createNewCodeVerificationRecord } from '../classes/verifications/code-verification.js';
 import { experienceRoutes } from '../const.js';
 import { type WithExperienceInteractionContext } from '../middleware/koa-experience-interaction.js';
@@ -80,8 +77,7 @@ export default function verificationCodeRoutes<T extends WithLogContext>(
       assertThat(
         codeVerificationRecord &&
           // Make the Verification type checker happy
-          codeVerificationRecord.type === VerificationType.VerificationCode &&
-          codeVerificationRecord.identifier.type === identifier.type,
+          codeVerificationRecord.type === codeVerificationIdentifierRecordTypeMap[identifier.type],
         new RequestError({ code: 'session.verification_session_not_found', status: 404 })
       );
 

--- a/packages/schemas/src/types/interactions.ts
+++ b/packages/schemas/src/types/interactions.ts
@@ -58,7 +58,8 @@ export const verificationCodeIdentifierGuard = z.object({
 /** Logto supported interaction verification types. */
 export enum VerificationType {
   Password = 'Password',
-  VerificationCode = 'VerificationCode',
+  EmailVerificationCode = 'EmailVerificationCode',
+  PhoneVerificationCode = 'PhoneVerificationCode',
   Social = 'Social',
   EnterpriseSso = 'EnterpriseSso',
   TOTP = 'Totp',

--- a/packages/schemas/src/types/interactions.ts
+++ b/packages/schemas/src/types/interactions.ts
@@ -41,12 +41,15 @@ export const interactionIdentifierGuard = z.object({
   value: z.string(),
 }) satisfies ToZodObject<InteractionIdentifier>;
 
+export type VerificationCodeSignInIdentifier = SignInIdentifier.Email | SignInIdentifier.Phone;
+
 /** Currently only email and phone are supported for verification code validation. */
-export type VerificationCodeIdentifier = {
-  type: SignInIdentifier.Email | SignInIdentifier.Phone;
+export type VerificationCodeIdentifier<
+  T extends VerificationCodeSignInIdentifier = VerificationCodeSignInIdentifier,
+> = {
+  type: T;
   value: string;
 };
-
 export const verificationCodeIdentifierGuard = z.object({
   type: z.enum([SignInIdentifier.Email, SignInIdentifier.Phone]),
   value: z.string(),


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
To better infer the return type of the `toUserProfile` method for email or phone identifier type, we split the original `CodeVerification` class into `EmailCodeVerification` and `PhoneCodeVerification`.

- The old `CodeVerification` class has become an internal parent class that is no longer publicly visible. 
- The old `CodeVerification` type has been split into `EmailCodeVerification` and `PhoneCodeVerificaiton` as well. 

Note: By default, ts can not infer the return type correctly based on a given `identifier` with a generic type. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
integration test covered. 

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
