### PR TITLE
fix(experience): shrink input field when autofilled by the browser

### DIFF
--- a/packages/experience/src/components/InputFields/InputField/index.module.scss
+++ b/packages/experience/src/components/InputFields/InputField/index.module.scss
@@ -44,6 +44,15 @@
         transition: background-color 999999s ease-in-out 0s;
         background-color: transparent;
       }
+
+      &:-webkit-autofill {
+        /*
+         * Define a void transition css rule on the desired <input> element once it is :-webkit-autofilled.
+         * JavaScript will then be able to hook onto the 'animationstart' event.
+         * see https://stackoverflow.com/questions/11708092/detecting-browser-autofill/41530164#41530164
+         */
+        animation-name: onAutoFillStart;
+      }
     }
 
     .suffix {
@@ -115,3 +124,18 @@
     }
   }
 }
+
+
+/*
+* Define a void transition css rule on the desired <input> element once it is :-webkit-autofilled.
+* JavaScript will then be able to hook onto the 'animationstart' event.
+* see https://stackoverflow.com/questions/11708092/detecting-browser-autofill/41530164#41530164
+*/
+@keyframes onAutoFillStart {
+  /* stylelint-disable-next-line block-no-empty */
+  from {}
+
+  /* stylelint-disable-next-line block-no-empty */
+  to {}
+}
+

--- a/packages/experience/src/components/InputFields/InputField/index.tsx
+++ b/packages/experience/src/components/InputFields/InputField/index.tsx
@@ -65,10 +65,15 @@ const InputField = (
 
   /**
    * Fix the issue that the input field doesn't have the active style when the autofill value is set.
-   * Modern browsers will trigger an animation event when the input field is autofilled.
+   * We have define a void transition css rule on the input element once it is `:-webkit-autofill`ed.
+   * Hook onto this 'animationstart' event to detect the autofill start.
+   * see https://stackoverflow.com/questions/11708092/detecting-browser-autofill/41530164#41530164
    */
   const handleAnimationStart = useCallback((event: AnimationEvent<HTMLInputElement>) => {
-    if (event.animationName === 'onautofillstart') {
+    /**
+     * Because SCSS adds some random characters to the ‘onAutoFillStart’ animation name during the build process, we can’t use the exact name here.
+     */
+    if (event.animationName.includes('onAutoFillStart')) {
       setHasValue(true);
     }
   }, []);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR addresses the issue of input field styling and behavior when browsers autofill the field. By adding specific CSS rules and corresponding JavaScript handling, it's now possible to better detect and respond to autofill events, ensuring that input fields maintain the correct style and size when autofilled.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

https://github.com/user-attachments/assets/e86d3b19-87ca-4240-8f99-7b0c4b3a5df5



<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
