### PR TITLE
fix: type instantiation is excessively deep and possibly infinite

### DIFF
--- a/packages/phrases-experience/src/types.ts
+++ b/packages/phrases-experience/src/types.ts
@@ -1,10 +1,17 @@
 import type en from './locales/en/index.js';
 
-type FlattenKeys<T, Prefix extends string = ''> = {
-  [K in keyof T]: T[K] extends Record<string, unknown>
-    ? `${Prefix}${string & K}.${FlattenKeys<T[K]>}`
-    : `${Prefix}${string & K}`;
-}[keyof T];
+type FlattenKeys<
+  T,
+  Prefix extends string = '',
+  D extends number = 11, // Depth limit is actually 10, since the initial value of A is [0]
+  A extends unknown[] = [0],
+> = A['length'] extends D
+  ? never
+  : {
+      [K in keyof T]: T[K] extends Record<string, unknown>
+        ? `${Prefix}${string & K}.${FlattenKeys<T[K], '', D, [0, ...A]>}`
+        : `${Prefix}${string & K}`;
+    }[keyof T];
 
 export type LocalePhrase = typeof en;
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix a typescript recursive type inference issue, which seems only to happen on typescript 5.4.x and above.

![image](https://github.com/user-attachments/assets/cc30fb60-9de9-480b-9c4f-98b7e4ad324c)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
