### PR TITLE
refactor(core): implement verification records map

### DIFF
--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -103,7 +103,7 @@ export default class ExperienceInteraction {
 
     for (const record of verificationRecords) {
       const instance = buildVerificationRecord(libraries, queries, record);
-      this.verificationRecords.set(instance.type, instance);
+      this.verificationRecords.setValue(instance);
     }
   }
 
@@ -192,8 +192,8 @@ export default class ExperienceInteraction {
   public getVerificationRecordByTypeAndId<K extends keyof VerificationRecordMap>(
     type: K,
     verificationId: string
-  ) {
-    const record = this.verificationRecords.get(type);
+  ): VerificationRecordMap[K] {
+    const record = this.verificationRecords.getValue(type);
 
     assertThat(
       record?.id === verificationId,

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -184,16 +184,14 @@ export default class ExperienceInteraction {
    * If a record with the same type already exists, it will be replaced.
    */
   public setVerificationRecord(record: VerificationRecord) {
-    const { type } = record;
-
-    this.verificationRecords.set(type, record);
+    this.verificationRecords.setValue(record);
   }
 
   public getVerificationRecordByTypeAndId<K extends keyof VerificationRecordMap>(
     type: K,
     verificationId: string
   ): VerificationRecordMap[K] {
-    const record = this.verificationRecords.getValue(type);
+    const record = this.verificationRecords.get(type);
 
     assertThat(
       record?.id === verificationId,
@@ -310,7 +308,7 @@ export default class ExperienceInteraction {
   }
 
   private get verificationRecordsArray() {
-    return this.verificationRecords.toArray();
+    return this.verificationRecords.array();
   }
 
   /**

--- a/packages/core/src/routes/experience/classes/helpers.ts
+++ b/packages/core/src/routes/experience/classes/helpers.ts
@@ -32,7 +32,9 @@ export const getNewUserProfileFromVerificationRecord = async (
     case VerificationType.Social: {
       const [identityProfile, syncedProfile] = await Promise.all([
         verificationRecord.toUserProfile(),
-        verificationRecord.toSyncedProfile(),
+        // Set `isNewUser` to true to specify syncing profile from the
+        // social/enterprise SSO identity for a new user.
+        verificationRecord.toSyncedProfile(true),
       ]);
 
       return { ...identityProfile, ...syncedProfile };

--- a/packages/core/src/routes/experience/classes/helpers.ts
+++ b/packages/core/src/routes/experience/classes/helpers.ts
@@ -30,8 +30,11 @@ export const getNewUserProfileFromVerificationRecord = async (
     }
     case VerificationType.EnterpriseSso:
     case VerificationType.Social: {
-      const identityProfile = await verificationRecord.toUserProfile();
-      const syncedProfile = await verificationRecord.toSyncedProfile(true);
+      const [identityProfile, syncedProfile] = await Promise.all([
+        verificationRecord.toUserProfile(),
+        verificationRecord.toSyncedProfile(),
+      ]);
+
       return { ...identityProfile, ...syncedProfile };
     }
     default: {
@@ -95,8 +98,9 @@ export const identifyUserByVerificationRecord = async (
         // Auto fallback to identify the related user if the user does not exist for enterprise SSO.
         if (error instanceof RequestError && error.code === 'user.identity_not_exist') {
           const user = await verificationRecord.identifyRelatedUser();
+
           const syncedProfile = {
-            ...(await verificationRecord.toUserProfile()),
+            ...verificationRecord.toUserProfile(),
             ...(await verificationRecord.toSyncedProfile()),
           };
           return { user, syncedProfile };

--- a/packages/core/src/routes/experience/classes/helpers.ts
+++ b/packages/core/src/routes/experience/classes/helpers.ts
@@ -16,8 +16,8 @@ import type { InteractionProfile } from '../types.js';
 import { type VerificationRecord } from './verifications/index.js';
 
 /**
- * @throws {RequestError} -400 if the verification record type is not supported for user creation.
- * @throws {RequestError} -400 if the verification record is not verified.
+ * @throws {RequestError} with status 400 if the verification record type is not supported for user creation.
+ * @throws {RequestError} with status 400 if the verification record is not verified.
  */
 export const getNewUserProfileFromVerificationRecord = async (
   verificationRecord: VerificationRecord

--- a/packages/core/src/routes/experience/classes/validators/provision-library.ts
+++ b/packages/core/src/routes/experience/classes/validators/provision-library.ts
@@ -43,7 +43,7 @@ export class ProvisionLibrary {
   /**
    * Insert a new user into the Logto database using the provided profile.
    *
-   * - provision the organization for the new user based on the profile
+   * - Provision the organization for the new user based on the profile
    * - OSS only, new user provisioning
    */
   async provisionNewUser(profile: InteractionProfile) {

--- a/packages/core/src/routes/experience/classes/verifications/enterprise-sso-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/enterprise-sso-verification.ts
@@ -173,7 +173,7 @@ export class EnterpriseSsoVerification
   /**
    * Returns the use SSO identity as a new user profile.
    */
-  async toUserProfile(): Promise<Required<Pick<InteractionProfile, 'enterpriseSsoIdentity'>>> {
+  toUserProfile(): Required<Pick<InteractionProfile, 'enterpriseSsoIdentity'>> {
     assertThat(
       this.enterpriseSsoUserInfo && this.issuer,
       new RequestError({ code: 'session.verification_failed', status: 400 })

--- a/packages/core/src/routes/experience/classes/verifications/index.ts
+++ b/packages/core/src/routes/experience/classes/verifications/index.ts
@@ -60,15 +60,19 @@ export type VerificationRecordData =
  * This union type is used to narrow down the type of the verification record.
  * Used in the ExperienceInteraction class to store and manage all the verification records. With a given verification type, we can narrow down the type of the verification record.
  */
-export type VerificationRecord =
-  | PasswordVerification
-  | EmailCodeVerification
-  | PhoneCodeVerification
-  | SocialVerification
-  | EnterpriseSsoVerification
-  | TotpVerification
-  | BackupCodeVerification
-  | NewPasswordIdentityVerification;
+export type VerificationRecordMap = {
+  [VerificationType.Password]: PasswordVerification;
+  [VerificationType.EmailVerificationCode]: EmailCodeVerification;
+  [VerificationType.PhoneVerificationCode]: PhoneCodeVerification;
+  [VerificationType.Social]: SocialVerification;
+  [VerificationType.EnterpriseSso]: EnterpriseSsoVerification;
+  [VerificationType.TOTP]: TotpVerification;
+  [VerificationType.BackupCode]: BackupCodeVerification;
+  [VerificationType.NewPasswordIdentity]: NewPasswordIdentityVerification;
+};
+type ValueOf<T> = T[keyof T];
+
+export type VerificationRecord = ValueOf<VerificationRecordMap>;
 
 export const verificationRecordDataGuard = z.discriminatedUnion('type', [
   passwordVerificationRecordDataGuard,

--- a/packages/core/src/routes/experience/classes/verifications/index.ts
+++ b/packages/core/src/routes/experience/classes/verifications/index.ts
@@ -41,6 +41,7 @@ import {
   totpVerificationRecordDataGuard,
   type TotpVerificationRecordData,
 } from './totp-verification.js';
+import { type VerificationRecord as GenericVerificationRecord } from './verification-record.js';
 
 export type VerificationRecordData =
   | PasswordVerificationRecordData
@@ -52,15 +53,13 @@ export type VerificationRecordData =
   | BackupCodeVerificationRecordData
   | NewPasswordIdentityVerificationRecordData;
 
-/**
- * Union type for all verification record types
- *
- * @remark This is a discriminated union type.
- * The VerificationRecord generic class can not narrow down the type of a verification record instance by its type property.
- * This union type is used to narrow down the type of the verification record.
- * Used in the ExperienceInteraction class to store and manage all the verification records. With a given verification type, we can narrow down the type of the verification record.
- */
-export type VerificationRecordMap = {
+// This is to ensure the keys of the map are the same as the type of the verification record
+type VerificationRecordInterfaceMap = {
+  [K in VerificationType]?: GenericVerificationRecord<K>;
+};
+type AssertVerificationMap<T extends VerificationRecordInterfaceMap> = T;
+
+export type VerificationRecordMap = AssertVerificationMap<{
   [VerificationType.Password]: PasswordVerification;
   [VerificationType.EmailVerificationCode]: EmailCodeVerification;
   [VerificationType.PhoneVerificationCode]: PhoneCodeVerification;
@@ -69,9 +68,17 @@ export type VerificationRecordMap = {
   [VerificationType.TOTP]: TotpVerification;
   [VerificationType.BackupCode]: BackupCodeVerification;
   [VerificationType.NewPasswordIdentity]: NewPasswordIdentityVerification;
-};
-type ValueOf<T> = T[keyof T];
+}>;
 
+type ValueOf<T> = T[keyof T];
+/**
+ * Union type for all verification record types
+ *
+ * @remarks This is a discriminated union type.
+ * The VerificationRecord generic class can not narrow down the type of a verification record instance by its type property.
+ * This union type is used to narrow down the type of the verification record.
+ * Used in the ExperienceInteraction class to store and manage all the verification records. With a given verification type, we can narrow down the type of the verification record.
+ */
 export type VerificationRecord = ValueOf<VerificationRecordMap>;
 
 export const verificationRecordDataGuard = z.discriminatedUnion('type', [

--- a/packages/core/src/routes/experience/classes/verifications/index.ts
+++ b/packages/core/src/routes/experience/classes/verifications/index.ts
@@ -75,9 +75,9 @@ type ValueOf<T> = T[keyof T];
  * Union type for all verification record types
  *
  * @remarks This is a discriminated union type.
- * The VerificationRecord generic class can not narrow down the type of a verification record instance by its type property.
+ * The `VerificationRecord` generic class can not narrow down the type of a verification record instance by its type property.
  * This union type is used to narrow down the type of the verification record.
- * Used in the ExperienceInteraction class to store and manage all the verification records. With a given verification type, we can narrow down the type of the verification record.
+ * Used in the `ExperienceInteraction` class to store and manage all the verification records. With a given verification type, we can narrow down the type of the verification record.
  */
 export type VerificationRecord = ValueOf<VerificationRecordMap>;
 

--- a/packages/core/src/routes/experience/classes/verifications/verification-records-map.ts
+++ b/packages/core/src/routes/experience/classes/verifications/verification-records-map.ts
@@ -1,38 +1,41 @@
 /**
- * @overview Since map in TS does not support strict key value type checking, we have to manually define the key value type.
+ * @fileoverview
+ *
+ * Since map in TS does not support  key value type mapping,
+ * we have to manually define a `setValue` method to ensure the key value type mapping.
  * This class is used to store and manage all the verification records.
- * We override the set and get methods to ensure the type safety of the verification record.
+ *
+ * Extends the Map class and adds a `setValue` method to ensure the key value type mapping.
  */
 
 import { type VerificationType } from '@logto/schemas';
 
-import RequestError from '#src/errors/RequestError/index.js';
 import assertThat from '#src/utils/assert-that.js';
 
 import { type VerificationRecord, type VerificationRecordMap } from './index.js';
 
-type VerificationRecordKey<T extends VerificationRecord> = T['type'];
-
-export class VerificationRecordsMap {
-  readonly #map = new Map<VerificationType, VerificationRecord>();
-
-  set<V extends VerificationRecord>(key: VerificationRecordKey<V>, value: V): void {
-    this.#map.set(key, value);
+export class VerificationRecordsMap extends Map<VerificationType, VerificationRecord> {
+  setValue(value: VerificationRecord) {
+    return this.set(value.type, value);
   }
 
-  get<K extends keyof VerificationRecordMap>(key: K): VerificationRecordMap[K] | undefined {
-    const record = this.#map.get(key);
+  getValue<K extends keyof VerificationRecordMap>(key: K): VerificationRecordMap[K] | undefined {
+    const record = super.get(key);
+
+    if (!record) {
+      return undefined;
+    }
 
     assertThat(
-      record?.type === key,
-      new RequestError({ code: 'session.verification_session_not_found', status: 404 })
+      record.type === key,
+      new TypeError(`Verification record type mismatch. Expected ${key}, but got ${record.type}.`)
     );
 
-    // eslint-disable-next-line no-restricted-syntax -- We are sure that the record is of type K
-    return this.#map.get(key) as VerificationRecordMap[K];
+    // eslint-disable-next-line no-restricted-syntax -- Type assertion above ensures the type safety
+    return record as VerificationRecordMap[K];
   }
 
   toArray(): VerificationRecord[] {
-    return [...this.#map.values()];
+    return [...this.values()];
   }
 }

--- a/packages/core/src/routes/experience/classes/verifications/verification-records-map.ts
+++ b/packages/core/src/routes/experience/classes/verifications/verification-records-map.ts
@@ -1,8 +1,8 @@
 /**
  * @fileoverview
  *
- * Since map in TS does not support  key value type mapping,
- * we have to manually define a `setValue` method to ensure the key value type mapping.
+ * Since `Map` in TS does not support  key value type mapping,
+ * we have to manually define a `setValue` method to ensure correct key will be set
  * This class is used to store and manage all the verification records.
  *
  * Extends the Map class and adds a `setValue` method to ensure the key value type mapping.
@@ -10,32 +10,26 @@
 
 import { type VerificationType } from '@logto/schemas';
 
-import assertThat from '#src/utils/assert-that.js';
-
 import { type VerificationRecord, type VerificationRecordMap } from './index.js';
 
 export class VerificationRecordsMap extends Map<VerificationType, VerificationRecord> {
   setValue(value: VerificationRecord) {
-    return this.set(value.type, value);
+    return super.set(value.type, value);
   }
 
-  getValue<K extends keyof VerificationRecordMap>(key: K): VerificationRecordMap[K] | undefined {
-    const record = super.get(key);
-
-    if (!record) {
-      return undefined;
-    }
-
-    assertThat(
-      record.type === key,
-      new TypeError(`Verification record type mismatch. Expected ${key}, but got ${record.type}.`)
-    );
-
-    // eslint-disable-next-line no-restricted-syntax -- Type assertion above ensures the type safety
-    return record as VerificationRecordMap[K];
+  override get<K extends keyof VerificationRecordMap>(
+    key: K
+  ): VerificationRecordMap[K] | undefined {
+    // eslint-disable-next-line no-restricted-syntax
+    return super.get(key) as VerificationRecordMap[K] | undefined;
   }
 
-  toArray(): VerificationRecord[] {
+  // @ts-expect-error - Override the set method to throw an error
+  override set() {
+    throw new Error('Use `setValue` method to set the value');
+  }
+
+  array(): VerificationRecord[] {
     return [...this.values()];
   }
 }

--- a/packages/core/src/routes/experience/classes/verifications/verification-records-map.ts
+++ b/packages/core/src/routes/experience/classes/verifications/verification-records-map.ts
@@ -6,6 +6,7 @@
 
 import { type VerificationType } from '@logto/schemas';
 
+import RequestError from '#src/errors/RequestError/index.js';
 import assertThat from '#src/utils/assert-that.js';
 
 import { type VerificationRecord, type VerificationRecordMap } from './index.js';
@@ -22,7 +23,10 @@ export class VerificationRecordsMap {
   get<K extends keyof VerificationRecordMap>(key: K): VerificationRecordMap[K] | undefined {
     const record = this.#map.get(key);
 
-    assertThat(record?.type === key, new TypeError('Invalid verification record type'));
+    assertThat(
+      record?.type === key,
+      new RequestError({ code: 'session.verification_session_not_found', status: 404 })
+    );
 
     // eslint-disable-next-line no-restricted-syntax -- We are sure that the record is of type K
     return this.#map.get(key) as VerificationRecordMap[K];

--- a/packages/core/src/routes/experience/classes/verifications/verification-records-map.ts
+++ b/packages/core/src/routes/experience/classes/verifications/verification-records-map.ts
@@ -1,0 +1,34 @@
+/**
+ * @overview Since map in TS does not support strict key value type checking, we have to manually define the key value type.
+ * This class is used to store and manage all the verification records.
+ * We override the set and get methods to ensure the type safety of the verification record.
+ */
+
+import { type VerificationType } from '@logto/schemas';
+
+import assertThat from '#src/utils/assert-that.js';
+
+import { type VerificationRecord, type VerificationRecordMap } from './index.js';
+
+type VerificationRecordKey<T extends VerificationRecord> = T['type'];
+
+export class VerificationRecordsMap {
+  readonly #map = new Map<VerificationType, VerificationRecord>();
+
+  set<V extends VerificationRecord>(key: VerificationRecordKey<V>, value: V): void {
+    this.#map.set(key, value);
+  }
+
+  get<K extends keyof VerificationRecordMap>(key: K): VerificationRecordMap[K] | undefined {
+    const record = this.#map.get(key);
+
+    assertThat(record?.type === key, new TypeError('Invalid verification record type'));
+
+    // eslint-disable-next-line no-restricted-syntax -- We are sure that the record is of type K
+    return this.#map.get(key) as VerificationRecordMap[K];
+  }
+
+  toArray(): VerificationRecord[] {
+    return [...this.#map.values()];
+  }
+}

--- a/packages/core/src/routes/experience/classes/verifications/verification-records-map.ts
+++ b/packages/core/src/routes/experience/classes/verifications/verification-records-map.ts
@@ -24,8 +24,7 @@ export class VerificationRecordsMap extends Map<VerificationType, VerificationRe
     return super.get(key) as VerificationRecordMap[K] | undefined;
   }
 
-  // @ts-expect-error - Override the set method to throw an error
-  override set() {
+  override set(): never {
     throw new Error('Use `setValue` method to set the value');
   }
 

--- a/packages/core/src/routes/experience/verification-routes/enterprise-sso-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/enterprise-sso-verification.ts
@@ -80,12 +80,13 @@ export default function enterpriseSsoVerificationRoutes<T extends WithLogContext
       const { connectorData, verificationId } = ctx.guard.body;
 
       const enterpriseSsoVerificationRecord =
-        ctx.experienceInteraction.getVerificationRecordById(verificationId);
+        ctx.experienceInteraction.getVerificationRecordByTypeAndId(
+          VerificationType.EnterpriseSso,
+          verificationId
+        );
 
       assertThat(
-        enterpriseSsoVerificationRecord &&
-          enterpriseSsoVerificationRecord.type === VerificationType.EnterpriseSso &&
-          enterpriseSsoVerificationRecord.connectorId === connectorId,
+        enterpriseSsoVerificationRecord.connectorId === connectorId,
         new RequestError({ code: 'session.verification_session_not_found', status: 404 })
       );
 

--- a/packages/core/src/routes/experience/verification-routes/social-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/social-verification.ts
@@ -75,13 +75,13 @@ export default function socialVerificationRoutes<T extends WithLogContext>(
       const { connectorId } = ctx.params;
       const { connectorData, verificationId } = ctx.guard.body;
 
-      const socialVerificationRecord =
-        ctx.experienceInteraction.getVerificationRecordById(verificationId);
+      const socialVerificationRecord = ctx.experienceInteraction.getVerificationRecordByTypeAndId(
+        VerificationType.Social,
+        verificationId
+      );
 
       assertThat(
-        socialVerificationRecord &&
-          socialVerificationRecord.type === VerificationType.Social &&
-          socialVerificationRecord.connectorId === connectorId,
+        socialVerificationRecord.connectorId === connectorId,
         new RequestError({ code: 'session.verification_session_not_found', status: 404 })
       );
 

--- a/packages/core/src/routes/experience/verification-routes/totp-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/totp-verification.ts
@@ -75,13 +75,13 @@ export default function totpVerificationRoutes<T extends WithLogContext>(
 
       // Verify new generated secret
       if (verificationId) {
-        const totpVerificationRecord =
-          experienceInteraction.getVerificationRecordById(verificationId);
+        const totpVerificationRecord = experienceInteraction.getVerificationRecordByTypeAndId(
+          VerificationType.TOTP,
+          verificationId
+        );
 
         assertThat(
-          totpVerificationRecord &&
-            totpVerificationRecord.type === VerificationType.TOTP &&
-            totpVerificationRecord.userId === experienceInteraction.identifiedUserId,
+          totpVerificationRecord.userId === experienceInteraction.identifiedUserId,
           new RequestError({
             code: 'session.verification_session_not_found',
             status: 404,

--- a/packages/core/src/routes/experience/verification-routes/verification-code.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code.ts
@@ -2,11 +2,9 @@ import { InteractionEvent, verificationCodeIdentifierGuard } from '@logto/schema
 import type Router from 'koa-router';
 import { z } from 'zod';
 
-import RequestError from '#src/errors/RequestError/index.js';
 import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
-import assertThat from '#src/utils/assert-that.js';
 
 import { codeVerificationIdentifierRecordTypeMap } from '../classes/utils.js';
 import { createNewCodeVerificationRecord } from '../classes/verifications/code-verification.js';
@@ -71,14 +69,9 @@ export default function verificationCodeRoutes<T extends WithLogContext>(
     async (ctx, next) => {
       const { verificationId, code, identifier } = ctx.guard.body;
 
-      const codeVerificationRecord =
-        ctx.experienceInteraction.getVerificationRecordById(verificationId);
-
-      assertThat(
-        codeVerificationRecord &&
-          // Make the Verification type checker happy
-          codeVerificationRecord.type === codeVerificationIdentifierRecordTypeMap[identifier.type],
-        new RequestError({ code: 'session.verification_session_not_found', status: 404 })
+      const codeVerificationRecord = ctx.experienceInteraction.getVerificationRecordByTypeAndId(
+        codeVerificationIdentifierRecordTypeMap[identifier.type],
+        verificationId
       );
 
       await codeVerificationRecord.verify(identifier, code);


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Implement verification records map.

Originally we used TS native `Map`  to store the interaction verification records. However, a map variable can not strictly guard the value type by its key. So in this PR, we implement a `VerificationRecordsMap` wrapper class with key value getter and setter method redefined. 

Also implement a new `getVerificationRecordByTypeAndId` method, which will get the verification record with verification type and id assertions. 



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
integration test covered

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
