### PR TITLE
fix(console): sidebar width should not be shrunk

### DIFF
--- a/packages/console/src/containers/ConsoleContent/Sidebar/index.module.scss
+++ b/packages/console/src/containers/ConsoleContent/Sidebar/index.module.scss
@@ -4,4 +4,5 @@
   width: 248px;
   overflow-y: auto;
   margin-bottom: _.unit(6);
+  flex-shrink: 0;
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Sometimes the sidebar items are shrunk, when the main content contains wider elements. This PR ensures the sidebar width is not shrunkable.

<img width="320" alt="image" src="https://github.com/user-attachments/assets/3eb38e0c-c0ab-406e-8dce-3c92bd677d63">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally

<img width="327" alt="image" src="https://github.com/user-attachments/assets/6764f4a4-b043-4984-bbbc-9d1309d4dbbe">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
