### PR TITLE
fix(console): should be able to remove the zip on upload error

### DIFF
--- a/packages/console/src/components/CustomUiAssetsUploader/index.tsx
+++ b/packages/console/src/components/CustomUiAssetsUploader/index.tsx
@@ -1,4 +1,5 @@
 import { type CustomUiAssets, maxUploadFileSize, type AllowedUploadMimeType } from '@logto/schemas';
+import { type Nullable } from '@silverhand/essentials';
 import { format } from 'date-fns/fp';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -13,15 +14,15 @@ import FileIcon from '../FileIcon';
 import * as styles from './index.module.scss';
 
 type Props = {
-  readonly value?: CustomUiAssets;
-  readonly onChange: (value: CustomUiAssets) => void;
   // eslint-disable-next-line react/boolean-prop-naming
   readonly disabled?: boolean;
+  readonly value: Nullable<CustomUiAssets>;
+  readonly onChange: (value: Nullable<CustomUiAssets>) => void;
 };
 
 const allowedMimeTypes: AllowedUploadMimeType[] = ['application/zip'];
 
-function CustomUiAssetsUploader({ value, onChange, disabled }: Props) {
+function CustomUiAssetsUploader({ disabled, value, onChange }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const [file, setFile] = useState<File>();
   const [error, setError] = useState<string>();
@@ -79,7 +80,7 @@ function CustomUiAssetsUploader({ value, onChange, disabled }: Props) {
         onClick={() => {
           setFile(undefined);
           setError(undefined);
-          onChange({ id: '', createdAt: 0 });
+          onChange(null);
         }}
       >
         <DeleteIcon />

--- a/packages/console/src/pages/SignInExperience/PageContent/utils/parser.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/utils/parser.ts
@@ -49,14 +49,13 @@ export const signUpFormDataParser = {
 
 export const sieFormDataParser = {
   fromSignInExperience: (data: SignInExperience): SignInExperienceForm => {
-    const { signUp, signInMode, customCss, customUiAssets, branding, passwordPolicy } = data;
+    const { signUp, signInMode, customCss, branding, passwordPolicy } = data;
 
     return {
       ...data,
       signUp: signUpFormDataParser.fromSignUp(signUp),
       createAccountEnabled: signInMode !== SignInMode.SignIn,
       customCss: customCss ?? undefined,
-      customUiAssets: customUiAssets ?? undefined,
       branding: {
         ...emptyBranding,
         ...branding,
@@ -86,7 +85,6 @@ export const sieFormDataParser = {
       signUp: signUpFormDataParser.toSignUp(signUp),
       signInMode: createAccountEnabled ? SignInMode.SignInAndRegister : SignInMode.SignIn,
       customCss: customCss?.length ? customCss : null,
-      customUiAssets: customUiAssets?.id ? customUiAssets : null,
       passwordPolicy: {
         ...passwordPolicy,
         rejects: {

--- a/packages/console/src/pages/SignInExperience/types.ts
+++ b/packages/console/src/pages/SignInExperience/types.ts
@@ -1,10 +1,5 @@
 import { type PasswordPolicy } from '@logto/core-kit';
-import {
-  type SignUp,
-  type SignInExperience,
-  type SignInIdentifier,
-  type CustomUiAssets,
-} from '@logto/schemas';
+import { type SignUp, type SignInExperience, type SignInIdentifier } from '@logto/schemas';
 
 export enum SignInExperienceTab {
   Branding = 'branding',
@@ -27,10 +22,9 @@ export type SignUpForm = Omit<SignUp, 'identifiers'> & {
 
 export type SignInExperienceForm = Omit<
   SignInExperience,
-  'signUp' | 'customCss' | 'customUiAssets' | 'passwordPolicy'
+  'signUp' | 'customCss' | 'passwordPolicy'
 > & {
   customCss?: string; // Code editor components can not properly handle null value, manually transform null to undefined instead.
-  customUiAssets?: CustomUiAssets;
   signUp: SignUpForm;
   /** The parsed password policy object. All properties are required. */
   passwordPolicy: PasswordPolicy & {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Should be able to remove the uploaded zip on error occurred, and removing the zip should not dirty the form.

Previously, I used the parser functions to transform the DB data from and to the form data type, but it seems it's not necessary and causing issues, since setting the form value to `undefined` does not clear the value change in React Hook Form. Therefore, changing it back to its original type definition `CustomUiAssets | null` and it solves the issue naturally.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
