### PR TITLE
refactor: generate application secret on creation

### DIFF
--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/EndpointsAndCredentials.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/EndpointsAndCredentials.tsx
@@ -1,10 +1,10 @@
 import {
   type ApplicationSecret,
-  ApplicationType,
   DomainStatus,
   type Application,
   type SnakeCaseOidcConfig,
   internalPrefix,
+  hasSecrets,
 } from '@logto/schemas';
 import { appendPath } from '@silverhand/essentials';
 import { useCallback, useContext, useMemo, useState } from 'react';
@@ -57,11 +57,7 @@ function EndpointsAndCredentials({
   const [showCreateSecretModal, setShowCreateSecretModal] = useState(false);
   const secrets = useSWR<ApplicationSecretRow[], RequestError>(`api/applications/${id}/secrets`);
   const api = useApi();
-  const shouldShowAppSecrets = [
-    ApplicationType.Traditional,
-    ApplicationType.MachineToMachine,
-    ApplicationType.Protected,
-  ].includes(type);
+  const shouldShowAppSecrets = hasSecrets(type);
 
   const toggleShowMoreEndpoints = useCallback(() => {
     setShowMoreEndpoints((previous) => !previous);

--- a/packages/core/src/__mocks__/index.ts
+++ b/packages/core/src/__mocks__/index.ts
@@ -17,6 +17,7 @@ import {
   LogtoOidcConfigKey,
   DomainStatus,
   LogtoJwtTokenKey,
+  internalPrefix,
 } from '@logto/schemas';
 
 import { protectedAppSignInCallbackUrl } from '#src/constants/index.js';
@@ -33,7 +34,7 @@ export * from './protected-app.js';
 export const mockApplication: Application = {
   tenantId: 'fake_tenant',
   id: 'foo',
-  secret: mockId,
+  secret: internalPrefix + mockId,
   name: 'foo',
   type: ApplicationType.SPA,
   description: null,

--- a/packages/core/src/routes/applications/application.test.ts
+++ b/packages/core/src/routes/applications/application.test.ts
@@ -53,6 +53,7 @@ const tenantContext = new MockTenant(
       ),
       updateApplicationById,
     },
+    applicationSecrets: { insert: jest.fn() },
   },
   undefined,
   {

--- a/packages/schemas/src/utils/application.ts
+++ b/packages/schemas/src/utils/application.ts
@@ -1,0 +1,9 @@
+import { ApplicationType } from '../db-entries/custom-types.js';
+
+/** If the application type has (or can have) secrets. */
+export const hasSecrets = (type: ApplicationType) =>
+  [
+    ApplicationType.MachineToMachine,
+    ApplicationType.Protected,
+    ApplicationType.Traditional,
+  ].includes(type);

--- a/packages/schemas/src/utils/index.ts
+++ b/packages/schemas/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './application.js';
 export * from './role.js';
 export * from './management-api.js';
 export * from './domain.js';


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- generate a default secret for certain application creations
- add `hasSecrets` util to check if an application type should have secrets

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
updated integration tests accordingly

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
