### PR TITLE
fix(core): fix some webhook api body status 404 bug

### DIFF
--- a/.changeset/fast-rats-talk.md
+++ b/.changeset/fast-rats-talk.md
@@ -2,7 +2,7 @@
 "@logto/core": patch
 ---
 
-Fix the status code 404 error in webhook events payload
+fix the status code 404 error in webhook events payload
 
 Impact webhook events:
 

--- a/.changeset/fast-rats-talk.md
+++ b/.changeset/fast-rats-talk.md
@@ -1,0 +1,14 @@
+---
+"@logto/core": patch
+---
+
+Fix the status code 404 error in webhook events payload
+
+Impact webhook events:
+
+- `Role.Scopes.Updated`
+- `Organizations.Membership.Updates`
+
+Issue: These webhook event payloads were returning a API response status code of 404 when the webhook was triggered.
+Expected: A status code of 200 should be returned, as we only trigger the webhook when the request is successful.
+Fix: All webhook event contexts should be created and inserted into the webhook pipeline after the response body and status code are properly set.

--- a/packages/core/src/routes/role.ts
+++ b/packages/core/src/routes/role.ts
@@ -182,6 +182,8 @@ export default function roleRoutes<T extends ManagementApiRouter>(
 
           ctx.appendDataHookContext('Role.Scopes.Updated', {
             ...buildManagementApiContext(ctx),
+            // Hook context was appended ahead of the response, manually set the status code to 200
+            status: 200,
             roleId: role.id,
             data: newRolesScopes,
           });

--- a/packages/core/src/utils/SchemaRouter.ts
+++ b/packages/core/src/utils/SchemaRouter.ts
@@ -1,4 +1,4 @@
-import { type SchemaLike, type GeneratedSchema, type DataHookEvent } from '@logto/schemas';
+import { type DataHookEvent, type GeneratedSchema, type SchemaLike } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 import { type DeepPartial, isPlainObject } from '@silverhand/essentials';
 import camelcase from 'camelcase';
@@ -257,8 +257,8 @@ export default class SchemaRouter<
             [columns.relationSchemaId]: relationId,
           })) ?? [])
         );
-        appendHookContext(ctx, id);
         ctx.status = 201;
+        appendHookContext(ctx, id);
         return next();
       }
     );
@@ -277,8 +277,8 @@ export default class SchemaRouter<
         } = ctx.guard;
 
         await relationQueries.replace(id, relationIds ?? []);
-        appendHookContext(ctx, id);
         ctx.status = 204;
+        appendHookContext(ctx, id);
         return next();
       }
     );
@@ -302,9 +302,10 @@ export default class SchemaRouter<
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- `koaGuard()` ensures the value is not `undefined`
           [columns.relationSchemaId]: relationId!,
         });
+
+        ctx.status = 204;
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         appendHookContext(ctx, id!);
-        ctx.status = 204;
         return next();
       }
     );

--- a/packages/integration-tests/src/tests/api/hook/WebhookMockServer.ts
+++ b/packages/integration-tests/src/tests/api/hook/WebhookMockServer.ts
@@ -76,6 +76,7 @@ export const mockHookResponseGuard = z.object({
         event: hookEventGuard,
         createdAt: z.string(),
         hookId: z.string(),
+        status: z.number().optional(),
       })
       .catchall(z.any()),
     // Use the raw payload for signature verification

--- a/packages/integration-tests/src/tests/api/hook/hook.trigger.data.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.trigger.data.test.ts
@@ -47,6 +47,7 @@ const mockHookResponseGuard = z.object({
         .optional()
         .transform((value) => value?.toUpperCase()),
       matchedRoute: z.string().optional(),
+      status: z.number().optional(),
     })
     .catchall(z.any()),
   // Keep the raw payload for signature verification
@@ -364,6 +365,7 @@ describe('data hook events coverage and signature verification', () => {
 
     const webhookResult = await getWebhookResult(key);
     expect(webhookResult).toBeDefined();
+    expect(webhookResult?.payload.status).not.toBe(404);
     assert(webhookResult, new Error('webhookResult is undefined'));
 
     const { signature, rawPayload } = webhookResult;

--- a/packages/integration-tests/src/tests/api/hook/utils.ts
+++ b/packages/integration-tests/src/tests/api/hook/utils.ts
@@ -46,6 +46,7 @@ export const assertHookLogResult = async (
     const { body } = mockHookResponseGuard.parse(payload.response);
     expect(verifySignature(body.rawPayload, signingKey, body.signature)).toBeTruthy();
     expect(body.payload).toEqual(expect.objectContaining(assertions.hookPayload));
+    expect(body.payload.status).not.toBe(404);
   }
 
   if (assertions.errorMessage) {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
We have received a report from our community indicating that the `Organizations.Membership.Updates` webhook event returns status 404 in the API response body.

The root cause is that the webhook payload was built and inserted into the webhook queue ahead of the response body and the status code is properly set. 

Fix this issue, with the integration test updated. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
