### PR TITLE
refactor: use vite for demo app

### DIFF
--- a/packages/core/src/middleware/koa-spa-proxy.ts
+++ b/packages/core/src/middleware/koa-spa-proxy.ts
@@ -37,13 +37,15 @@ export default function koaSpaProxy<StateT, ContextT extends IRouterParamContext
         changeOrigin: true,
         logs: true,
         rewrite: (requestPath) => {
+          const fullPath = '/' + path.join(prefix, requestPath);
           // Static files
           if (requestPath.includes('.')) {
-            return '/' + path.join(prefix, requestPath);
+            return fullPath;
           }
 
           // In-app routes
-          return requestPath;
+          // We'll gradually migrate our single-page apps to use vite, which can directly return the full path
+          return packagePath === 'demo-app' ? fullPath : requestPath;
         },
       });
 

--- a/packages/demo-app/.parcelrc.arm64
+++ b/packages/demo-app/.parcelrc.arm64
@@ -1,7 +1,0 @@
-{
-  "extends": "@parcel/config-default",
-  "optimizers": {
-    // Disable optimizers in arm64 arch https://github.com/parcel-bundler/parcel/issues/7402
-    "*.{jpg,jpeg,png}": []
-  }
-}

--- a/packages/demo-app/index.html
+++ b/packages/demo-app/index.html
@@ -11,7 +11,7 @@
 <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="app"></div>
-    <script type="module" src="index.tsx"></script>
+    <script type="module" src="src/index.tsx"></script>
 </body>
 
 </html>

--- a/packages/demo-app/package.json
+++ b/packages/demo-app/package.json
@@ -5,15 +5,16 @@
   "author": "Silverhand Inc. <contact@silverhand.io>",
   "license": "MPL-2.0",
   "private": true,
+  "type": "module",
   "files": [
     "dist"
   ],
   "scripts": {
     "precommit": "lint-staged",
-    "start": "parcel src/index.html",
-    "dev": "cross-env PORT=5003 parcel src/index.html --public-url /demo-app --no-cache --hmr-port 6003",
+    "start": "vite",
+    "dev": "vite",
     "check": "tsc --noEmit",
-    "build": "pnpm check && rm -rf dist && parcel build src/index.html --no-autoinstall --no-cache --public-url /demo-app",
+    "build": "pnpm check && vite build",
     "lint": "eslint --ext .ts --ext .tsx src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "stylelint": "stylelint \"src/**/*.scss\""
@@ -24,8 +25,6 @@
     "@logto/phrases": "workspace:^1.12.0",
     "@logto/react": "^3.0.12",
     "@logto/schemas": "workspace:^1.18.0",
-    "@parcel/core": "2.9.3",
-    "@parcel/transformer-sass": "2.9.3",
     "@silverhand/eslint-config": "6.0.1",
     "@silverhand/eslint-config-react": "6.0.2",
     "@silverhand/ts-config": "6.0.0",
@@ -39,7 +38,6 @@
     "i18next-browser-languagedetector": "^8.0.0",
     "jose": "^5.6.3",
     "lint-staged": "^15.0.0",
-    "parcel": "2.9.3",
     "postcss": "^8.4.31",
     "prettier": "^3.0.0",
     "react": "^18.3.1",
@@ -47,21 +45,11 @@
     "react-i18next": "^12.3.1",
     "stylelint": "^15.0.0",
     "typescript": "^5.5.3",
+    "vite": "^5.3.4",
     "zod": "^3.23.8"
   },
   "engines": {
     "node": "^20.9.0"
-  },
-  "//": "https://github.com/parcel-bundler/parcel/issues/7636",
-  "targets": {
-    "default": {
-      "engines": {
-        "browsers": "defaults"
-      }
-    }
-  },
-  "alias": {
-    "@/*": "./src/$1"
   },
   "eslintConfig": {
     "extends": "@silverhand/react"

--- a/packages/demo-app/tsconfig.json
+++ b/packages/demo-app/tsconfig.json
@@ -2,5 +2,6 @@
   "extends": "./tsconfig.base",
   "include": [
     "src",
+    "*.config.ts"
   ]
 }

--- a/packages/demo-app/vite.config.ts
+++ b/packages/demo-app/vite.config.ts
@@ -1,0 +1,47 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  base: '/demo-app',
+  server: {
+    port: 5003,
+    hmr: {
+      port: 6003,
+    },
+  },
+  resolve: {
+    alias: [
+      {
+        find: /^@\//,
+        replacement: '/src/',
+      },
+    ],
+  },
+  optimizeDeps: {
+    include: ['@logto/phrases', '@logto/phrases-experience', '@logto/schemas'],
+  },
+  build: {
+    sourcemap: process.env.NODE_ENV === 'production',
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (/\/react[^/]*\//.test(id)) {
+            return 'react';
+          }
+
+          if (id.includes('/@logto/')) {
+            return 'logto';
+          }
+
+          if (id.includes('/node_modules/')) {
+            return 'vendors';
+          }
+
+          const match = /\/lib\/locales\/([^/]+)/.exec(id);
+          if (match?.[1]) {
+            return `phrases-${match[1]}`;
+          }
+        },
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,7 +63,7 @@ importers:
         version: 20.10.4
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -78,7 +78,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/cli:
     dependencies:
@@ -190,7 +190,7 @@ importers:
         version: 17.0.13
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       '@withtyped/server':
         specifier: ^0.13.6
         version: 0.13.6(zod@3.23.8)
@@ -208,7 +208,7 @@ importers:
         version: 18.0.0
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-alipay-native:
     dependencies:
@@ -263,7 +263,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -290,7 +290,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-alipay-web:
     dependencies:
@@ -345,7 +345,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -372,7 +372,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-aliyun-dm:
     dependencies:
@@ -418,7 +418,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -445,7 +445,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-aliyun-sms:
     dependencies:
@@ -491,7 +491,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -518,7 +518,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-apple:
     dependencies:
@@ -570,7 +570,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -597,7 +597,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-aws-ses:
     dependencies:
@@ -649,7 +649,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -676,7 +676,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-azuread:
     dependencies:
@@ -725,7 +725,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -752,7 +752,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-dingtalk-web:
     dependencies:
@@ -807,7 +807,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.12.7)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.12.7)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -834,7 +834,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.12.7)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.12.7)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-discord:
     dependencies:
@@ -880,7 +880,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -907,7 +907,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-facebook:
     dependencies:
@@ -953,7 +953,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -980,7 +980,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-feishu-web:
     dependencies:
@@ -1026,7 +1026,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -1053,7 +1053,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-github:
     dependencies:
@@ -1102,7 +1102,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -1129,7 +1129,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-google:
     dependencies:
@@ -1178,7 +1178,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -1205,7 +1205,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-huggingface:
     dependencies:
@@ -1251,7 +1251,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.12.7)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.12.7)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -1278,7 +1278,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.12.7)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.12.7)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-kakao:
     dependencies:
@@ -1324,7 +1324,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -1351,7 +1351,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-logto-email:
     dependencies:
@@ -1400,7 +1400,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -1427,7 +1427,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-logto-sms:
     dependencies:
@@ -1473,7 +1473,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -1500,7 +1500,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-logto-social-demo:
     dependencies:
@@ -1546,7 +1546,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -1573,7 +1573,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-mailgun:
     dependencies:
@@ -1619,7 +1619,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -1646,7 +1646,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-mock-email:
     dependencies:
@@ -1692,7 +1692,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -1719,7 +1719,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-mock-email-alternative:
     dependencies:
@@ -1765,7 +1765,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -1792,7 +1792,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-mock-sms:
     dependencies:
@@ -1838,7 +1838,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -1865,7 +1865,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-mock-social:
     dependencies:
@@ -1911,7 +1911,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -1938,7 +1938,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-naver:
     dependencies:
@@ -1984,7 +1984,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -2011,7 +2011,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-oauth2:
     dependencies:
@@ -2066,7 +2066,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -2093,7 +2093,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-oidc:
     dependencies:
@@ -2151,7 +2151,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -2178,7 +2178,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-saml:
     dependencies:
@@ -2230,7 +2230,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -2257,7 +2257,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-sendgrid-email:
     dependencies:
@@ -2303,7 +2303,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -2330,7 +2330,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-smsaero:
     dependencies:
@@ -2376,7 +2376,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -2403,7 +2403,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-smtp:
     dependencies:
@@ -2455,7 +2455,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -2482,7 +2482,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-tencent-sms:
     dependencies:
@@ -2528,7 +2528,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -2555,7 +2555,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-twilio-sms:
     dependencies:
@@ -2601,7 +2601,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -2628,7 +2628,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-wechat-native:
     dependencies:
@@ -2674,7 +2674,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -2701,7 +2701,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-wechat-web:
     dependencies:
@@ -2747,7 +2747,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -2774,7 +2774,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/connectors/connector-wecom:
     dependencies:
@@ -2820,7 +2820,7 @@ importers:
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -2847,7 +2847,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/console:
     devDependencies:
@@ -3485,12 +3485,6 @@ importers:
       '@logto/schemas':
         specifier: workspace:^1.18.0
         version: link:../schemas
-      '@parcel/core':
-        specifier: 2.9.3
-        version: 2.9.3
-      '@parcel/transformer-sass':
-        specifier: 2.9.3
-        version: 2.9.3(@parcel/core@2.9.3)
       '@silverhand/eslint-config':
         specifier: 6.0.1
         version: 6.0.1(eslint@8.57.0)(prettier@3.0.0)(typescript@5.5.3)
@@ -3530,9 +3524,6 @@ importers:
       lint-staged:
         specifier: ^15.0.0
         version: 15.0.2
-      parcel:
-        specifier: 2.9.3
-        version: 2.9.3(@swc/helpers@0.5.1)(postcss@8.4.31)(srcset@4.0.0)
       postcss:
         specifier: ^8.4.31
         version: 8.4.31
@@ -3554,6 +3545,9 @@ importers:
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
+      vite:
+        specifier: ^5.3.4
+        version: 5.3.4(@types/node@20.12.7)(sass@1.77.8)
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -4041,7 +4035,7 @@ importers:
         version: 0.0.33
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       camelcase:
         specifier: ^8.0.0
         version: 8.0.0
@@ -4068,7 +4062,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/shared:
     dependencies:
@@ -4102,7 +4096,7 @@ importers:
         version: 20.10.4
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -4117,7 +4111,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/toolkit/connector-kit:
     dependencies:
@@ -4149,7 +4143,7 @@ importers:
         version: 20.10.4
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -4164,7 +4158,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/toolkit/core-kit:
     dependencies:
@@ -4208,7 +4202,7 @@ importers:
         version: 18.3.3
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -4229,7 +4223,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
   packages/toolkit/language-kit:
     optionalDependencies:
@@ -4248,7 +4242,7 @@ importers:
         version: 20.10.4
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))
+        version: 2.0.0(vitest@2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -4263,7 +4257,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+        version: 2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
 
 packages:
 
@@ -12440,6 +12434,11 @@ packages:
     engines: {node: '>=12.0.0'}
     hasBin: true
 
+  sass@1.77.8:
+    resolution: {integrity: sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
   sax@1.2.4:
     resolution: {integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==}
 
@@ -13355,6 +13354,34 @@ packages:
 
   vite@5.3.3:
     resolution: {integrity: sha512-NPQdeCU0Dv2z5fu+ULotpuq5yfCS1BzKUIPhNbP3YBfAMGJXbt2nS+sbTFu+qchaqWTD+H3JK++nRwr6XIcp6A==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vite@5.3.4:
+    resolution: {integrity: sha512-Cw+7zL3ZG9/NZBB8C+8QbQZmR54GwqIz+WMI4b3JgdYJvX+ny9AjJXqkGQlDXSXRP9rP0B4tbciRMOVEKulVOA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -14416,7 +14443,7 @@ snapshots:
       '@babel/traverse': 7.24.1
       '@babel/types': 7.24.0
       convert-source-map: 2.0.0
-      debug: 4.3.4
+      debug: 4.3.5
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -14617,7 +14644,7 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.24.4
       '@babel/types': 7.24.0
-      debug: 4.3.4
+      debug: 4.3.5
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -15403,7 +15430,7 @@ snapshots:
 
   '@koa/router@12.0.1':
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.5
       http-errors: 2.0.0
       koa-compose: 4.1.0
       methods: 1.1.2
@@ -17614,7 +17641,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.7.0(typescript@5.5.3)
       '@typescript-eslint/utils': 7.7.0(eslint@8.57.0)(typescript@5.5.3)
-      debug: 4.3.4
+      debug: 4.3.5
       eslint: 8.57.0
       ts-api-utils: 1.3.0(typescript@5.5.3)
     optionalDependencies:
@@ -17628,7 +17655,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.7.0
       '@typescript-eslint/visitor-keys': 7.7.0
-      debug: 4.3.4
+      debug: 4.3.5
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.4
@@ -17660,7 +17687,7 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vitest/coverage-v8@2.0.0(vitest@2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))':
+  '@vitest/coverage-v8@2.0.0(vitest@2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -17675,11 +17702,11 @@ snapshots:
       std-env: 3.7.0
       strip-literal: 2.1.0
       test-exclude: 7.0.1
-      vitest: 2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+      vitest: 2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))':
+  '@vitest/coverage-v8@2.0.0(vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -17694,11 +17721,11 @@ snapshots:
       std-env: 3.7.0
       strip-literal: 2.1.0
       test-exclude: 7.0.1
-      vitest: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+      vitest: 2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@2.0.0(vitest@2.0.0(@types/node@20.12.7)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1))':
+  '@vitest/coverage-v8@2.0.0(vitest@2.0.0(@types/node@20.12.7)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -17713,7 +17740,7 @@ snapshots:
       std-env: 3.7.0
       strip-literal: 2.1.0
       test-exclude: 7.0.1
-      vitest: 2.0.0(@types/node@20.12.7)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1)
+      vitest: 2.0.0(@types/node@20.12.7)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8)
     transitivePeerDependencies:
       - supports-color
 
@@ -17896,13 +17923,13 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
 
   agent-base@7.1.0:
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
 
@@ -19914,7 +19941,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.5
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -20017,7 +20044,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       commander: 5.1.0
-      debug: 4.3.4
+      debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
 
@@ -20227,7 +20254,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.0.3
       data-uri-to-buffer: 5.0.1
-      debug: 4.3.4
+      debug: 4.3.5
       fs-extra: 8.1.0
     transitivePeerDependencies:
       - supports-color
@@ -20588,14 +20615,14 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4
+      debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
 
@@ -20615,14 +20642,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.4:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4
+      debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
 
@@ -21028,7 +21055,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.5
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -22775,7 +22802,7 @@ snapshots:
   micromark@3.2.0:
     dependencies:
       '@types/debug': 4.1.7
-      debug: 4.3.4
+      debug: 4.3.5
       decode-named-character-reference: 1.0.1
       micromark-core-commonmark: 1.1.0
       micromark-factory-space: 1.1.0
@@ -22797,7 +22824,7 @@ snapshots:
   micromark@4.0.0:
     dependencies:
       '@types/debug': 4.1.7
-      debug: 4.3.4
+      debug: 4.3.5
       decode-named-character-reference: 1.0.1
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.0
@@ -23303,7 +23330,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.0
-      debug: 4.3.4
+      debug: 4.3.5
       get-uri: 6.0.1
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.4
@@ -23738,7 +23765,7 @@ snapshots:
   proxy-agent@6.4.0:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4
+      debug: 4.3.5
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.4
       lru-cache: 7.18.3
@@ -24236,7 +24263,7 @@ snapshots:
 
   require-in-the-middle@7.2.0:
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.5
       module-details-from-path: 1.0.3
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -24459,6 +24486,13 @@ snapshots:
       immutable: 4.1.0
       source-map-js: 1.0.2
 
+  sass@1.77.8:
+    dependencies:
+      chokidar: 3.5.3
+      immutable: 4.1.0
+      source-map-js: 1.2.0
+    optional: true
+
   sax@1.2.4: {}
 
   saxes@6.0.0:
@@ -24599,7 +24633,7 @@ snapshots:
   socks-proxy-agent@8.0.2:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4
+      debug: 4.3.5
       socks: 2.7.1
     transitivePeerDependencies:
       - supports-color
@@ -25385,7 +25419,7 @@ snapshots:
     dependencies:
       browserslist: 4.23.0
       escalade: 3.1.1
-      picocolors: 1.0.0
+      picocolors: 1.0.1
 
   uri-js@4.4.1:
     dependencies:
@@ -25447,13 +25481,13 @@ snapshots:
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
 
-  vite-node@2.0.0(@types/node@20.10.4)(sass@1.56.1):
+  vite-node@2.0.0(@types/node@20.10.4)(sass@1.77.8):
     dependencies:
       cac: 6.7.14
       debug: 4.3.5
       pathe: 1.1.2
       picocolors: 1.0.1
-      vite: 5.3.3(@types/node@20.10.4)(sass@1.56.1)
+      vite: 5.3.3(@types/node@20.10.4)(sass@1.77.8)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -25464,13 +25498,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@2.0.0(@types/node@20.11.20)(sass@1.56.1):
+  vite-node@2.0.0(@types/node@20.11.20)(sass@1.77.8):
     dependencies:
       cac: 6.7.14
       debug: 4.3.5
       pathe: 1.1.2
       picocolors: 1.0.1
-      vite: 5.3.3(@types/node@20.11.20)(sass@1.56.1)
+      vite: 5.3.3(@types/node@20.11.20)(sass@1.77.8)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -25481,13 +25515,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@2.0.0(@types/node@20.12.7)(sass@1.56.1):
+  vite-node@2.0.0(@types/node@20.12.7)(sass@1.77.8):
     dependencies:
       cac: 6.7.14
       debug: 4.3.5
       pathe: 1.1.2
       picocolors: 1.0.1
-      vite: 5.3.3(@types/node@20.12.7)(sass@1.56.1)
+      vite: 5.3.3(@types/node@20.12.7)(sass@1.77.8)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -25498,7 +25532,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.3.3(@types/node@20.10.4)(sass@1.56.1):
+  vite@5.3.3(@types/node@20.10.4)(sass@1.77.8):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.39
@@ -25506,9 +25540,9 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.10.4
       fsevents: 2.3.3
-      sass: 1.56.1
+      sass: 1.77.8
 
-  vite@5.3.3(@types/node@20.11.20)(sass@1.56.1):
+  vite@5.3.3(@types/node@20.11.20)(sass@1.77.8):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.39
@@ -25516,9 +25550,9 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.11.20
       fsevents: 2.3.3
-      sass: 1.56.1
+      sass: 1.77.8
 
-  vite@5.3.3(@types/node@20.12.7)(sass@1.56.1):
+  vite@5.3.3(@types/node@20.12.7)(sass@1.77.8):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.39
@@ -25526,9 +25560,19 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.12.7
       fsevents: 2.3.3
-      sass: 1.56.1
+      sass: 1.77.8
 
-  vitest@2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1):
+  vite@5.3.4(@types/node@20.12.7)(sass@1.77.8):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.4.39
+      rollup: 4.14.3
+    optionalDependencies:
+      '@types/node': 20.12.7
+      fsevents: 2.3.3
+      sass: 1.77.8
+
+  vitest@2.0.0(@types/node@20.10.4)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8):
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@vitest/expect': 2.0.0
@@ -25545,8 +25589,8 @@ snapshots:
       std-env: 3.7.0
       tinybench: 2.8.0
       tinypool: 1.0.0
-      vite: 5.3.3(@types/node@20.10.4)(sass@1.56.1)
-      vite-node: 2.0.0(@types/node@20.10.4)(sass@1.56.1)
+      vite: 5.3.3(@types/node@20.10.4)(sass@1.77.8)
+      vite-node: 2.0.0(@types/node@20.10.4)(sass@1.77.8)
       why-is-node-running: 2.2.2
     optionalDependencies:
       '@types/node': 20.10.4
@@ -25561,7 +25605,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1):
+  vitest@2.0.0(@types/node@20.11.20)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8):
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@vitest/expect': 2.0.0
@@ -25578,8 +25622,8 @@ snapshots:
       std-env: 3.7.0
       tinybench: 2.8.0
       tinypool: 1.0.0
-      vite: 5.3.3(@types/node@20.11.20)(sass@1.56.1)
-      vite-node: 2.0.0(@types/node@20.11.20)(sass@1.56.1)
+      vite: 5.3.3(@types/node@20.11.20)(sass@1.77.8)
+      vite-node: 2.0.0(@types/node@20.11.20)(sass@1.77.8)
       why-is-node-running: 2.2.2
     optionalDependencies:
       '@types/node': 20.11.20
@@ -25594,7 +25638,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.0.0(@types/node@20.12.7)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.56.1):
+  vitest@2.0.0(@types/node@20.12.7)(happy-dom@14.12.3)(jsdom@20.0.2)(sass@1.77.8):
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@vitest/expect': 2.0.0
@@ -25611,8 +25655,8 @@ snapshots:
       std-env: 3.7.0
       tinybench: 2.8.0
       tinypool: 1.0.0
-      vite: 5.3.3(@types/node@20.12.7)(sass@1.56.1)
-      vite-node: 2.0.0(@types/node@20.12.7)(sass@1.56.1)
+      vite: 5.3.3(@types/node@20.12.7)(sass@1.77.8)
+      vite-node: 2.0.0(@types/node@20.12.7)(sass@1.77.8)
       why-is-node-running: 2.2.2
     optionalDependencies:
       '@types/node': 20.12.7


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
[RIP parcel](https://github.com/parcel-bundler/parcel/discussions/9790) (i know the team's answer it's "not dead", but it's a duck death to us)

we loved parcel, bore its moodiness, but the latest version it can work properly stayed in 2.9.3, which released on Jun 25, 2023. after some research, i believe vite is the next cool kid's gear.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
locally tested, sign-in/out demo app ok

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset` (will update in a separate pull)
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
