### PR TITLE
fix(console): use correct public url

### DIFF
--- a/packages/console/vite.config.ts
+++ b/packages/console/vite.config.ts
@@ -16,7 +16,7 @@ import { defaultConfig } from '../../vite.shared.config';
 dotenv.config({ path: await findUp('.env', {}) });
 
 const buildConfig = (mode: string): UserConfig => ({
-  base: `/${process.env.CONSOLE_PUBLIC_URL ?? 'console'}`,
+  base: `${process.env.CONSOLE_PUBLIC_URL ?? '/console'}`,
   envDir: '../../',
   server: {
     port: 5002,


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
console doesn't work for cloud due to the wrong public url. this pull fixes it.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
cloud console works

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
