### PR TITLE
refactor(cli): keep alteration scripts folder writable by gid 0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN rm -rf .scripts pnpm-*.yaml packages/cloud
 FROM node:20-alpine as app
 WORKDIR /etc/logto
 COPY --from=builder /etc/logto .
+RUN mkdir -p /etc/logto/packages/cli/alteration-scripts && chmod g+w /etc/logto/packages/cli/alteration-scripts
 EXPOSE 3001
 ENTRYPOINT ["npm", "run"]
 CMD ["start"]


### PR DESCRIPTION
## Summary
One possible approach to address #6327.

Ensures that /etc/logto/packages/cli/alteration-scripts is present and writable by gid 0.
Does not remove/replace this directory each time, just removes the contents. This ensures that
the writabiliy remains (and also allows this to be a separately-mounted directory.

The reasons for doing this are described in #6327, but briefly, the desire is to let logto be
run from within docker as a non-root user (although gid 0 would still be required unless
the alteration-scripts are on a separately-mounted directory with appropriate permissions).

I propose this approach rather than making all of /etc/logto/packages/cli as writable by gid 0 since keeping more things read-only just seems safer overall.

## Testing
So far I have only tested by running with a custom docker-compose.yml that is modified to have `user: 1001:0` for the app container, and it does apply seeding as desired. I have not tested
on openshift/k8s yet (will need to build a container image accessible to my openshift cluster
to do that), but wanted to put this out there for possible discussion.


## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments

Not sure which of these you would want for this type of change (I think this may qualify at most as a `@logto/cli: minimal` under .changeset, but accept input on that).