### PR TITLE
fix(console): check scope only when data is ready

### DIFF
--- a/packages/console/src/containers/ConsoleContent/hooks.ts
+++ b/packages/console/src/containers/ConsoleContent/hooks.ts
@@ -22,7 +22,7 @@ const useTenantScopeListener = () => {
   const { clearAccessToken, clearAllTokens, getOrganizationTokenClaims, signIn } = useLogto();
   const [tokenClaims, setTokenClaims] = useState<string[]>();
   const redirectUri = useRedirectUri();
-  const { scopes = [], isLoading } = useCurrentTenantScopes();
+  const { scopes, isLoading } = useCurrentTenantScopes();
 
   useEffect(() => {
     (async () => {
@@ -33,20 +33,20 @@ const useTenantScopeListener = () => {
   }, [currentTenantId, getOrganizationTokenClaims]);
 
   useEffect(() => {
-    if (isCloud && !isLoading && scopes.length === 0) {
+    if (isCloud && !isLoading && scopes?.length === 0) {
       // User has no access to the current tenant. Navigate to root and it will return to the
       // last visited tenant, or fallback to the page where the user can create a new tenant.
       removeTenant(currentTenantId);
       navigateTenant('');
     }
-  }, [currentTenantId, isLoading, navigateTenant, removeTenant, scopes.length]);
+  }, [currentTenantId, isLoading, navigateTenant, removeTenant, scopes?.length]);
 
   useEffect(() => {
     if (!isCloud || isLoading || tokenClaims === undefined) {
       return;
     }
-    const hasScopesGranted = scopes.some((scope) => !tokenClaims.includes(scope));
-    const hasScopesRevoked = tokenClaims.some((claim) => !scopes.includes(claim));
+    const hasScopesGranted = scopes?.some((scope) => !tokenClaims.includes(scope));
+    const hasScopesRevoked = tokenClaims.some((claim) => !scopes?.includes(claim));
     if (hasScopesGranted) {
       (async () => {
         // User has been newly granted scopes. Need to re-consent to obtain the additional scopes.


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
the `scope` fallback will cause false positive on tenant access assertion, thus an accessible tenant will be removed from the list. sometimes `isLoading` may be `false` but the data is not loaded.

**Original**

```ts
const { scopes = [], isLoading } = useCurrentTenantScopes(); // `scopes` falls back to an empty array

useEffect(() => {
  // `scopes` may not be loaded at all, which is `undefined` in the return of `useCurrentTenantScopes()`.
  // However, the fallback value `[]` will be used here, while the fetching process is not started yet
  // (`isLoading` is `false`) which causes a false positive.
  if (isCloud && !isLoading && scopes.length === 0) {
    removeTenant(currentTenantId);
    navigateTenant('');
  }
}, [currentTenantId, isLoading, navigateTenant, removeTenant, scopes.length]);
```

**Now**

```ts
// No fallback. Everyone should be happy now.
const { scopes, isLoading } = useCurrentTenantScopes();

useEffect(() => {
  // When `scopes` is `undefined`, the `scopes?.length === 0` expression will be `false`
  if (isCloud && !isLoading && scopes?.length === 0) {
    removeTenant(currentTenantId);
    navigateTenant('');
  }
}, [currentTenantId, isLoading, navigateTenant, removeTenant, scopes?.length]);
```

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

cloud tests ok

<img width="579" alt="image" src="https://github.com/user-attachments/assets/e865fcd7-1005-484a-b5e5-e61500ac8d0b">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
