### PR TITLE
refactor(core): make the interaction event mandatory

### DIFF
--- a/packages/core/src/routes/experience/classes/experience-interaction.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.test.ts
@@ -92,9 +92,12 @@ describe('ExperienceInteraction class', () => {
 
   describe('new user registration', () => {
     it('First admin user provisioning', async () => {
-      const experienceInteraction = new ExperienceInteraction(ctx, tenant);
+      const experienceInteraction = new ExperienceInteraction(
+        ctx,
+        tenant,
+        InteractionEvent.Register
+      );
 
-      await experienceInteraction.setInteractionEvent(InteractionEvent.Register);
       experienceInteraction.setVerificationRecord(emailVerificationRecord);
       await experienceInteraction.identifyUser(emailVerificationRecord.id);
 

--- a/packages/core/src/routes/experience/index.ts
+++ b/packages/core/src/routes/experience/index.ts
@@ -41,11 +41,15 @@ export default function experienceApiRoutes<T extends AnonymousRouter>(
 ) {
   const { queries } = tenant;
 
-  const routerWithLogs = anonymousRouter.use(koaAuditLog(queries));
+  const experienceRouter =
+    // @ts-expect-error for good koa types
+    // eslint-disable-next-line no-restricted-syntax
+    (anonymousRouter as Router<unknown, WithExperienceInteractionContext<RouterContext<T>>>).use(
+      koaAuditLog(queries),
+      koaExperienceInteraction(tenant)
+    );
 
-  // Should not apply the koaExperienceInteraction middleware to this route.
-  // New ExperienceInteraction instance will be created.
-  routerWithLogs.put(
+  experienceRouter.put(
     experienceRoutes.prefix,
     koaGuard({
       body: z.object({
@@ -70,13 +74,6 @@ export default function experienceApiRoutes<T extends AnonymousRouter>(
       return next();
     }
   );
-
-  const experienceRouter =
-    // @ts-expect-error for good koa types
-    // eslint-disable-next-line no-restricted-syntax
-    (routerWithLogs as Router<unknown, WithExperienceInteractionContext<RouterContext<T>>>).use(
-      koaExperienceInteraction(tenant)
-    );
 
   experienceRouter.put(
     `${experienceRoutes.prefix}/interaction-event`,

--- a/packages/core/src/routes/experience/middleware/koa-experience-interaction.ts
+++ b/packages/core/src/routes/experience/middleware/koa-experience-interaction.ts
@@ -4,6 +4,7 @@ import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 
 import ExperienceInteraction from '../classes/experience-interaction.js';
+import { experienceRoutes } from '../const.js';
 
 export type WithExperienceInteractionContext<ContextT extends WithLogContext = WithLogContext> =
   ContextT & {
@@ -25,6 +26,14 @@ export default function koaExperienceInteraction<
   tenant: TenantContext
 ): MiddlewareType<StateT, WithExperienceInteractionContext<ContextT>, ResponseT> {
   return async (ctx, next) => {
+    const { method, path } = ctx.request;
+
+    // Should not apply the koaExperienceInteraction middleware to the PUT /experience route.
+    // New ExperienceInteraction instance are supposed to be created in the PUT /experience route.
+    if (method === 'PUT' && path === `${experienceRoutes.prefix}`) {
+      return next();
+    }
+
     const { provider } = tenant;
     const interactionDetails = await provider.interactionDetails(ctx.req, ctx.res);
 

--- a/packages/core/src/routes/experience/verification-routes/backup-code-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/backup-code-verification.ts
@@ -17,6 +17,30 @@ export default function backupCodeVerificationRoutes<T extends WithLogContext>(
 ) {
   const { libraries, queries } = tenantContext;
 
+  router.post(`${experienceRoutes.verification}/backup-code/generate`, async (ctx, next) => {
+    const { experienceInteraction } = ctx;
+
+    assertThat(experienceInteraction.identifiedUserId, 'session.identifier_not_found');
+
+    const backupCodeVerificationRecord = BackupCodeVerification.create(
+      libraries,
+      queries,
+      experienceInteraction.identifiedUserId
+    );
+
+    backupCodeVerificationRecord.generate();
+
+    ctx.experienceInteraction.setVerificationRecord(backupCodeVerificationRecord);
+
+    await ctx.experienceInteraction.save();
+
+    ctx.body = {
+      verificationId: backupCodeVerificationRecord.id,
+    };
+
+    return next();
+  });
+
   router.post(
     `${experienceRoutes.verification}/backup-code/generate`,
     koaGuard({

--- a/packages/core/src/routes/experience/verification-routes/backup-code-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/backup-code-verification.ts
@@ -53,41 +53,6 @@ export default function backupCodeVerificationRoutes<T extends WithLogContext>(
   );
 
   router.post(
-    `${experienceRoutes.verification}/backup-code/generate`,
-    koaGuard({
-      status: [200, 400],
-      response: z.object({
-        verificationId: z.string(),
-        codes: z.array(z.string()),
-      }),
-    }),
-    async (ctx, next) => {
-      const { experienceInteraction } = ctx;
-
-      assertThat(experienceInteraction.identifiedUserId, 'session.identifier_not_found');
-
-      const backupCodeVerificationRecord = BackupCodeVerification.create(
-        libraries,
-        queries,
-        experienceInteraction.identifiedUserId
-      );
-
-      const codes = backupCodeVerificationRecord.generate();
-
-      ctx.experienceInteraction.setVerificationRecord(backupCodeVerificationRecord);
-
-      await ctx.experienceInteraction.save();
-
-      ctx.body = {
-        verificationId: backupCodeVerificationRecord.id,
-        codes,
-      };
-
-      return next();
-    }
-  );
-
-  router.post(
     `${experienceRoutes.verification}/backup-code/verify`,
     koaGuard({
       body: backupCodeVerificationVerifyPayloadGuard,

--- a/packages/core/src/routes/experience/verification-routes/backup-code-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/backup-code-verification.ts
@@ -17,29 +17,40 @@ export default function backupCodeVerificationRoutes<T extends WithLogContext>(
 ) {
   const { libraries, queries } = tenantContext;
 
-  router.post(`${experienceRoutes.verification}/backup-code/generate`, async (ctx, next) => {
-    const { experienceInteraction } = ctx;
+  router.post(
+    `${experienceRoutes.verification}/backup-code/generate`,
+    koaGuard({
+      status: [200, 400],
+      response: z.object({
+        verificationId: z.string(),
+        codes: z.array(z.string()),
+      }),
+    }),
+    async (ctx, next) => {
+      const { experienceInteraction } = ctx;
 
-    assertThat(experienceInteraction.identifiedUserId, 'session.identifier_not_found');
+      assertThat(experienceInteraction.identifiedUserId, 'session.identifier_not_found');
 
-    const backupCodeVerificationRecord = BackupCodeVerification.create(
-      libraries,
-      queries,
-      experienceInteraction.identifiedUserId
-    );
+      const backupCodeVerificationRecord = BackupCodeVerification.create(
+        libraries,
+        queries,
+        experienceInteraction.identifiedUserId
+      );
 
-    backupCodeVerificationRecord.generate();
+      const codes = backupCodeVerificationRecord.generate();
 
-    ctx.experienceInteraction.setVerificationRecord(backupCodeVerificationRecord);
+      ctx.experienceInteraction.setVerificationRecord(backupCodeVerificationRecord);
 
-    await ctx.experienceInteraction.save();
+      await ctx.experienceInteraction.save();
 
-    ctx.body = {
-      verificationId: backupCodeVerificationRecord.id,
-    };
+      ctx.body = {
+        verificationId: backupCodeVerificationRecord.id,
+        codes,
+      };
 
-    return next();
-  });
+      return next();
+    }
+  );
 
   router.post(
     `${experienceRoutes.verification}/backup-code/generate`,

--- a/packages/integration-tests/src/helpers/client.ts
+++ b/packages/integration-tests/src/helpers/client.ts
@@ -1,4 +1,5 @@
 import type { LogtoConfig, SignInOptions } from '@logto/node';
+import { InteractionEvent } from '@logto/schemas';
 import { assert } from '@silverhand/essentials';
 
 import { ExperienceClient } from '#src/client/experience/index.js';
@@ -17,6 +18,7 @@ export const initClient = async (
 };
 
 export const initExperienceClient = async (
+  interactionEvent: InteractionEvent = InteractionEvent.SignIn,
   config?: Partial<LogtoConfig>,
   redirectUri?: string,
   options: Omit<SignInOptions, 'redirectUri'> = {}
@@ -24,6 +26,7 @@ export const initExperienceClient = async (
   const client = new ExperienceClient(config);
   await client.initSession(redirectUri, options);
   assert(client.interactionCookie, new Error('Session not found'));
+  await client.initInteraction({ interactionEvent });
 
   return client;
 };

--- a/packages/integration-tests/src/helpers/experience/index.ts
+++ b/packages/integration-tests/src/helpers/experience/index.ts
@@ -34,8 +34,6 @@ export const signInWithPassword = async ({
 }) => {
   const client = await initExperienceClient();
 
-  await client.initInteraction({ interactionEvent: InteractionEvent.SignIn });
-
   const { verificationId } = await client.verifyPassword({
     identifier,
     password,
@@ -53,8 +51,6 @@ export const signInWithPassword = async ({
 
 export const signInWithVerificationCode = async (identifier: VerificationCodeIdentifier) => {
   const client = await initExperienceClient();
-
-  await client.initInteraction({ interactionEvent: InteractionEvent.SignIn });
 
   const { verificationId, code } = await successfullySendVerificationCode(client, {
     identifier,
@@ -89,8 +85,6 @@ export const identifyUserWithUsernamePassword = async (
   username: string,
   password: string
 ) => {
-  await client.initInteraction({ interactionEvent: InteractionEvent.SignIn });
-
   const { verificationId } = await client.verifyPassword({
     identifier: {
       type: SignInIdentifier.Username,
@@ -108,9 +102,7 @@ export const registerNewUserWithVerificationCode = async (
   identifier: VerificationCodeIdentifier,
   options?: { fulfillPassword?: boolean }
 ) => {
-  const client = await initExperienceClient();
-
-  await client.initInteraction({ interactionEvent: InteractionEvent.Register });
+  const client = await initExperienceClient(InteractionEvent.Register);
 
   const { verificationId, code } = await successfullySendVerificationCode(client, {
     identifier,
@@ -166,7 +158,6 @@ export const signInWithSocial = async (
   const redirectUri = 'http://localhost:3000';
 
   const client = await initExperienceClient();
-  await client.initInteraction({ interactionEvent: InteractionEvent.SignIn });
 
   const { verificationId } = await successFullyCreateSocialVerification(client, connectorId, {
     redirectUri,
@@ -223,7 +214,6 @@ export const signInWithEnterpriseSso = async (
   const redirectUri = 'http://localhost:3000';
 
   const client = await initExperienceClient();
-  await client.initInteraction({ interactionEvent: InteractionEvent.SignIn });
 
   const { verificationId } = await client.getEnterpriseSsoAuthorizationUri(connectorId, {
     redirectUri,
@@ -257,8 +247,7 @@ export const signInWithEnterpriseSso = async (
 };
 
 export const registerNewUserUsernamePassword = async (username: string, password: string) => {
-  const client = await initExperienceClient();
-  await client.initInteraction({ interactionEvent: InteractionEvent.Register });
+  const client = await initExperienceClient(InteractionEvent.Register);
 
   const { verificationId } = await client.createNewPasswordIdentityVerification({
     identifier: {

--- a/packages/integration-tests/src/tests/api/experience-api/bind-mfa/happpy-path.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/bind-mfa/happpy-path.test.ts
@@ -43,8 +43,7 @@ devFeatureTest.describe('Bind MFA APIs happy path', () => {
 
     it('should bind TOTP on register', async () => {
       const { username, password } = generateNewUserProfile({ username: true, password: true });
-      const client = await initExperienceClient();
-      await client.initInteraction({ interactionEvent: InteractionEvent.Register });
+      const client = await initExperienceClient(InteractionEvent.Register);
 
       const { verificationId } = await client.createNewPasswordIdentityVerification({
         identifier: {
@@ -131,8 +130,7 @@ devFeatureTest.describe('Bind MFA APIs happy path', () => {
 
     it('should able to skip MFA binding on register', async () => {
       const { username, password } = generateNewUserProfile({ username: true, password: true });
-      const client = await initExperienceClient();
-      await client.initInteraction({ interactionEvent: InteractionEvent.Register });
+      const client = await initExperienceClient(InteractionEvent.Register);
 
       const { verificationId } = await client.createNewPasswordIdentityVerification({
         identifier: {
@@ -193,8 +191,7 @@ devFeatureTest.describe('Bind MFA APIs happy path', () => {
 
     it('should bind TOTP and backup codes on register', async () => {
       const { username, password } = generateNewUserProfile({ username: true, password: true });
-      const client = await initExperienceClient();
-      await client.initInteraction({ interactionEvent: InteractionEvent.Register });
+      const client = await initExperienceClient(InteractionEvent.Register);
 
       const { verificationId } = await client.createNewPasswordIdentityVerification({
         identifier: {

--- a/packages/integration-tests/src/tests/api/experience-api/bind-mfa/sad-path.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/bind-mfa/sad-path.test.ts
@@ -53,8 +53,7 @@ devFeatureTest.describe('Bind MFA APIs sad path', () => {
     it('should throw not supported error when binding TOTP on ForgotPassword interaction', async () => {
       const { username, password } = generateNewUserProfile({ username: true, password: true });
       await userApi.create({ username, password });
-      const client = await initExperienceClient();
-      await client.initInteraction({ interactionEvent: InteractionEvent.ForgotPassword });
+      const client = await initExperienceClient(InteractionEvent.ForgotPassword);
 
       await expectRejects(client.skipMfaBinding(), {
         code: 'session.not_supported_for_forgot_password',
@@ -69,7 +68,6 @@ devFeatureTest.describe('Bind MFA APIs sad path', () => {
 
     it('should throw identifier_not_found error, if user has not been identified', async () => {
       const client = await initExperienceClient();
-      await client.initInteraction({ interactionEvent: InteractionEvent.SignIn });
       await expectRejects(client.bindMfa(MfaFactor.TOTP, 'dummy_verification_id'), {
         code: 'session.identifier_not_found',
         status: 404,

--- a/packages/integration-tests/src/tests/api/experience-api/interaction.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/interaction.test.ts
@@ -12,35 +12,11 @@ devFeatureTest.describe('PUT /experience API', () => {
     await userApi.cleanUp();
   });
 
-  it('should throw 404 with interaction_not_found error if no interactionEvent is initiated', async () => {
-    const client = await initExperienceClient();
-
-    await expectRejects(
-      client.updateInteractionEvent({ interactionEvent: InteractionEvent.SignIn }),
-      {
-        code: 'session.interaction_not_found',
-        status: 404,
-      }
-    );
-
-    await expectRejects(
-      client.verifyPassword({
-        identifier: { type: SignInIdentifier.Username, value: 'test' },
-        password: 'test',
-      }),
-      {
-        code: 'session.interaction_not_found',
-        status: 404,
-      }
-    );
-  });
-
   it('PUT new experience API should reset all existing verification records', async () => {
     const { username, password } = generateNewUserProfile({ username: true, password: true });
     await userApi.create({ username, password });
 
     const client = await initExperienceClient();
-    await client.initInteraction({ interactionEvent: InteractionEvent.SignIn });
     const { verificationId } = await client.verifyPassword({
       identifier: { type: SignInIdentifier.Username, value: username },
       password,
@@ -56,8 +32,7 @@ devFeatureTest.describe('PUT /experience API', () => {
   });
 
   it('should throw if trying to update interaction event from ForgotPassword to others', async () => {
-    const client = await initExperienceClient();
-    await client.initInteraction({ interactionEvent: InteractionEvent.ForgotPassword });
+    const client = await initExperienceClient(InteractionEvent.ForgotPassword);
 
     await expectRejects(
       client.updateInteractionEvent({ interactionEvent: InteractionEvent.SignIn }),
@@ -70,7 +45,6 @@ devFeatureTest.describe('PUT /experience API', () => {
 
   it('should throw if trying to update interaction event from SignIn and Register to ForgotPassword', async () => {
     const client = await initExperienceClient();
-    await client.initInteraction({ interactionEvent: InteractionEvent.SignIn });
 
     await expectRejects(
       client.updateInteractionEvent({ interactionEvent: InteractionEvent.ForgotPassword }),
@@ -83,7 +57,6 @@ devFeatureTest.describe('PUT /experience API', () => {
 
   it('should update interaction event from SignIn to Register', async () => {
     const client = await initExperienceClient();
-    await client.initInteraction({ interactionEvent: InteractionEvent.SignIn });
 
     await expect(
       client.updateInteractionEvent({ interactionEvent: InteractionEvent.Register })

--- a/packages/integration-tests/src/tests/api/experience-api/profile/fulfill-user-profiles.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/profile/fulfill-user-profiles.test.ts
@@ -38,9 +38,7 @@ devFeatureTest.describe('Fulfill User Profiles', () => {
   });
 
   it('should throw 400 if the interaction event is ForgotPassword', async () => {
-    const client = await initExperienceClient();
-
-    await client.initInteraction({ interactionEvent: InteractionEvent.ForgotPassword });
+    const client = await initExperienceClient(InteractionEvent.ForgotPassword);
 
     await expectRejects(
       client.updateProfile({ type: SignInIdentifier.Username, value: 'username' }),
@@ -53,8 +51,6 @@ devFeatureTest.describe('Fulfill User Profiles', () => {
 
   it('should throw 404 if the interaction is not identified', async () => {
     const client = await initExperienceClient();
-
-    await client.initInteraction({ interactionEvent: InteractionEvent.SignIn });
 
     await expectRejects(
       client.updateProfile({ type: SignInIdentifier.Username, value: 'username' }),

--- a/packages/integration-tests/src/tests/api/experience-api/register-interaction/verification-code.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/register-interaction/verification-code.test.ts
@@ -59,8 +59,7 @@ devFeatureTest.describe('Register interaction with verification code happy path'
         value: userProfile[identifiersTypeToUserProfile[identifierType]]!,
       };
 
-      const client = await initExperienceClient();
-      await client.initInteraction({ interactionEvent: InteractionEvent.Register });
+      const client = await initExperienceClient(InteractionEvent.Register);
 
       const { verificationId, code } = await successfullySendVerificationCode(client, {
         identifier,

--- a/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/social.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/social.test.ts
@@ -137,8 +137,6 @@ devFeatureTest.describe('social sign-in and sign-up', () => {
       });
 
       const client = await initExperienceClient();
-      await client.initInteraction({ interactionEvent: InteractionEvent.SignIn });
-
       const { verificationId } = await successFullyCreateSocialVerification(client, connectorId, {
         redirectUri,
         state,

--- a/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/verification-code.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/verification-code.test.ts
@@ -61,7 +61,6 @@ devFeatureTest.describe('Sign-in with verification code', () => {
       };
 
       const client = await initExperienceClient();
-      await client.initInteraction({ interactionEvent: InteractionEvent.SignIn });
 
       const { verificationId, code } = await successfullySendVerificationCode(client, {
         identifier,


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
To better guard the experience interaction status, this PR makes the `interactionEvent` property mandatory. 

For new experience interaction initiation endpoint (`PUT /experience`):
- Skip the `koaExperienceInteraction` middleware.
- Create a new `ExperienceInteraction` instance by providing a new `interactionEvent`  value.

For existing experience interaction endpoints:
- User the `koaExperienceInteraction` middleware to retrieve the interaction data from the OIDC provider's interaction storage. 
- The `interactionEvent` property will be strictly guarded.  An `interaction_not_found` error will be thrown if the `interactionResult` data dose not satisfy the experience interaction data guard. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
integration test added

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
