### PR TITLE
style(console): fix custom jwt guide card style

### DIFF
--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/GuideCard/index.module.scss
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/GuideCard/index.module.scss
@@ -53,7 +53,7 @@
     }
 
     .cardContent {
-      max-height: 1000;
+      max-height: 1000px;
       overflow: visible;
     }
   }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add missing unit for `max-height` CSS prop of custom JWT guide card content.

It doesn’t work after using Vite, possibly due to Vite.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
### Before
![image](https://github.com/user-attachments/assets/f568ae38-bf18-4387-98f3-d54a2dcc0ec2)

### After
<img width="621" alt="image" src="https://github.com/user-attachments/assets/07d3200b-57f6-49c4-ad67-50b0943b27ca">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
