### PR TITLE
feat: add advanced search params to all supported endpoints

### DIFF
--- a/packages/core/src/routes/swagger/index.ts
+++ b/packages/core/src/routes/swagger/index.ts
@@ -50,6 +50,18 @@ const anonymousPaths = new Set<string>([
   'status',
 ]);
 
+const advancedSearchPaths = new Set<string>([
+  '/applications',
+  '/applications/:applicationId/roles',
+  '/resources/:resourceId/scopes',
+  '/roles/:id/applications',
+  '/roles/:id/scopes',
+  '/roles',
+  '/roles/:id/users',
+  '/users',
+  '/users/:userId/roles',
+]);
+
 type RouteObject = {
   path: string;
   method: OpenAPIV3.HttpMethods;
@@ -73,7 +85,7 @@ const buildOperation = (
   const queryParameters = [
     ...buildParameters(query, 'query'),
     ...(hasPagination ? paginationParameters : []),
-    ...(path === '/users' && method === 'get' ? [searchParameters] : []),
+    ...(advancedSearchPaths.has(path) && method === 'get' ? [searchParameters] : []),
   ];
 
   const requestBody = body && {

--- a/packages/core/src/routes/swagger/index.ts
+++ b/packages/core/src/routes/swagger/index.ts
@@ -36,6 +36,7 @@ import { buildOperationId, customRoutes, throwByDifference } from './utils/opera
 import {
   buildParameters,
   paginationParameters,
+  searchParameters,
   buildPathIdParameters,
   mergeParameters,
   customParameters,
@@ -55,6 +56,7 @@ type RouteObject = {
   operation: OpenAPIV3.OperationObject;
 };
 
+// eslint-disable-next-line complexity
 const buildOperation = (
   method: OpenAPIV3.HttpMethods,
   stack: IMiddleware[],
@@ -71,6 +73,7 @@ const buildOperation = (
   const queryParameters = [
     ...buildParameters(query, 'query'),
     ...(hasPagination ? paginationParameters : []),
+    ...(path === '/users' && method === 'get' ? [searchParameters] : []),
   ];
 
   const requestBody = body && {

--- a/packages/core/src/routes/swagger/utils/parameters.ts
+++ b/packages/core/src/routes/swagger/utils/parameters.ts
@@ -41,6 +41,20 @@ export const paginationParameters: OpenAPIV3.ParameterObject[] = [
   },
 ];
 
+export const searchParameters: OpenAPIV3.ParameterObject = {
+  name: 'search_params',
+  in: 'query',
+  description: 'Search query parameters.',
+  required: false,
+  schema: {
+    type: 'object',
+    additionalProperties: {
+      type: 'string',
+    },
+  },
+  explode: true,
+};
+
 type BuildParameters = {
   /**
    * Build a parameter array for the given `ZodObject`.


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The `/api/users` (GET) endpoint (and [many others](https://github.com/logto-io/logto/pull/6358#discussion_r1698225283)) returns a list of users and supports [advanced search queries](https://docs.logto.io/docs/recipes/manage-users/advanced-user-search/). However, the OpenAPI spec documentation currently does not include any URL search (query) parameters for this functionality. This PR introduces a new dynamic parameter called `search_params`, defined as an `object` with `string` keys and values. This object will not appear in the generated OpenAPI client. Instead, users can pass a map of strings, which will append these keys and values to the URLSearchParams, thereby enabling advanced user search capabilities.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

### Query parameter
<img width="664" alt="api-search-params" src="https://github.com/user-attachments/assets/f3080abe-589e-426d-b98e-53995906baaf">

### Swagger UI
<img width="561" alt="swagger-ui" src="https://github.com/user-attachments/assets/70f0508c-b4d9-469c-9136-38e6f1aa7bc0">

### URL
![image](https://github.com/user-attachments/assets/65f220fa-f3dc-45d9-b9a7-9531b72d1f8f)

### Go API Client

```go
user, _, err := client.UsersAPI.ListUsers(ctx).SearchParams(map[string]string{
  "search.primaryEmail": "test@example.com",
  "mode": "exact"
}).Execute()
```

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
