### PR TITLE
fix(console): add dev guard on new pricing model subscription hooks

### DIFF
--- a/packages/console/src/hooks/use-new-subscription-quota.ts
+++ b/packages/console/src/hooks/use-new-subscription-quota.ts
@@ -2,13 +2,13 @@ import useSWR from 'swr';
 
 import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
 import { type NewSubscriptionQuota } from '@/cloud/types/router';
-import { isCloud } from '@/consts/env';
+import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
 
 const useNewSubscriptionQuota = (tenantId: string) => {
   const cloudApi = useCloudApi();
 
   return useSWR<NewSubscriptionQuota, Error>(
-    isCloud && `/api/tenants/${tenantId}/subscription/quota`,
+    isCloud && isDevFeaturesEnabled && `/api/tenants/${tenantId}/subscription/quota`,
     async () =>
       cloudApi.get('/api/tenants/:tenantId/subscription/quota', {
         params: { tenantId },

--- a/packages/console/src/hooks/use-new-subscription-scopes-usage.ts
+++ b/packages/console/src/hooks/use-new-subscription-scopes-usage.ts
@@ -2,7 +2,7 @@ import useSWR from 'swr';
 
 import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
 import { type NewSubscriptionScopeUsage } from '@/cloud/types/router';
-import { isCloud } from '@/consts/env';
+import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
 
 const useNewSubscriptionScopeUsage = (tenantId: string) => {
   const cloudApi = useCloudApi();
@@ -12,7 +12,9 @@ const useNewSubscriptionScopeUsage = (tenantId: string) => {
 
   return {
     scopeResourceUsage: useSWR<NewSubscriptionScopeUsage, Error>(
-      isCloud && `/api/tenants/${tenantId}/subscription/usage/${resourceEntityName}/scopes`,
+      isCloud &&
+        isDevFeaturesEnabled &&
+        `/api/tenants/${tenantId}/subscription/usage/${resourceEntityName}/scopes`,
       async () =>
         cloudApi.get('/api/tenants/:tenantId/subscription/usage/:entityName/scopes', {
           params: { tenantId, entityName: resourceEntityName },
@@ -20,7 +22,9 @@ const useNewSubscriptionScopeUsage = (tenantId: string) => {
         })
     ),
     scopeRoleUsage: useSWR<NewSubscriptionScopeUsage, Error>(
-      isCloud && `/api/tenants/${tenantId}/subscription/usage/${roleEntityName}/scopes`,
+      isCloud &&
+        isDevFeaturesEnabled &&
+        `/api/tenants/${tenantId}/subscription/usage/${roleEntityName}/scopes`,
       async () =>
         cloudApi.get('/api/tenants/:tenantId/subscription/usage/:entityName/scopes', {
           params: { tenantId, entityName: roleEntityName },

--- a/packages/console/src/hooks/use-new-subscription-usage.ts
+++ b/packages/console/src/hooks/use-new-subscription-usage.ts
@@ -2,13 +2,13 @@ import useSWR from 'swr';
 
 import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
 import { type NewSubscriptionUsage } from '@/cloud/types/router';
-import { isCloud } from '@/consts/env';
+import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
 
 const useNewSubscriptionUsage = (tenantId: string) => {
   const cloudApi = useCloudApi();
 
   return useSWR<NewSubscriptionUsage, Error>(
-    isCloud && `/api/tenants/${tenantId}/subscription/usage`,
+    isCloud && isDevFeaturesEnabled && `/api/tenants/${tenantId}/subscription/usage`,
     async () =>
       cloudApi.get('/api/tenants/:tenantId/subscription/usage', {
         params: { tenantId },


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add dev guard on new pricing model subscription hooks.

Since Cloud APIs `GET /subscription/{usage,quota}` and `GET /subscription/usage/:entityName/scopes` are also guarded by dev feature switch, we should not call these APIs in prod env, even though we have fallbacks.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
