### PR TITLE
feat(core,schemas): add mandatory password guard on register

### DIFF
--- a/packages/core/src/routes/experience/classes/libraries/sign-in-experience-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/sign-in-experience-validator.ts
@@ -163,6 +163,25 @@ export class SignInExperienceValidator {
   }
 
   /**
+   * If password is enabled in the sign-up settings,
+   * guard the verification record contains password (NewPasswordIdentity).
+   *
+   * - Password is not required for social and SSO verification records.
+   */
+  public async guardMandatoryPasswordOnRegister({ type }: VerificationRecord) {
+    const { signUp } = await this.getSignInExperienceData();
+
+    if (
+      signUp.password &&
+      [VerificationType.EmailVerificationCode, VerificationType.PhoneVerificationCode].includes(
+        type
+      )
+    ) {
+      throw new RequestError({ code: 'user.password_required_in_profile', status: 422 });
+    }
+  }
+
+  /**
    * Guard the verification records contains email identifier with SSO enabled
    *
    * @remarks

--- a/packages/core/src/routes/experience/classes/verifications/new-password-identity-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/new-password-identity-verification.ts
@@ -45,8 +45,7 @@ export const newPasswordIdentityVerificationRecordDataGuard = z.object({
  *
  * @remarks This verification record can only be used for new user registration.
  * By default this verification record allows all types of identifiers, username, email, and phone.
- * But in our current product design, only username + password registration is supported. The identifier type
- * will be guarded at the API level.
+ * For email and phone identifiers, a `CodeVerification` record is required.
  */
 export class NewPasswordIdentityVerification
   implements VerificationRecord<VerificationType.NewPasswordIdentity>

--- a/packages/core/src/routes/experience/verification-routes/backup-code-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/backup-code-verification.ts
@@ -27,41 +27,6 @@ export default function backupCodeVerificationRoutes<T extends ExperienceInterac
         codes: z.array(z.string()),
       }),
     }),
-    async (ctx, next) => {
-      const { experienceInteraction } = ctx;
-
-      assertThat(experienceInteraction.identifiedUserId, 'session.identifier_not_found');
-
-      const backupCodeVerificationRecord = BackupCodeVerification.create(
-        libraries,
-        queries,
-        experienceInteraction.identifiedUserId
-      );
-
-      const codes = backupCodeVerificationRecord.generate();
-
-      ctx.experienceInteraction.setVerificationRecord(backupCodeVerificationRecord);
-
-      await ctx.experienceInteraction.save();
-
-      ctx.body = {
-        verificationId: backupCodeVerificationRecord.id,
-        codes,
-      };
-
-      return next();
-    }
-  );
-
-  router.post(
-    `${experienceRoutes.verification}/backup-code/generate`,
-    koaGuard({
-      status: [200, 400],
-      response: z.object({
-        verificationId: z.string(),
-        codes: z.array(z.string()),
-      }),
-    }),
     koaExperienceVerificationsAuditLog({
       type: VerificationType.BackupCode,
       action: Action.Create,

--- a/packages/core/src/routes/experience/verification-routes/backup-code-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/backup-code-verification.ts
@@ -18,6 +18,30 @@ export default function backupCodeVerificationRoutes<T extends ExperienceInterac
 ) {
   const { libraries, queries } = tenantContext;
 
+  router.post(`${experienceRoutes.verification}/backup-code/generate`, async (ctx, next) => {
+    const { experienceInteraction } = ctx;
+
+    assertThat(experienceInteraction.identifiedUserId, 'session.identifier_not_found');
+
+    const backupCodeVerificationRecord = BackupCodeVerification.create(
+      libraries,
+      queries,
+      experienceInteraction.identifiedUserId
+    );
+
+    backupCodeVerificationRecord.generate();
+
+    ctx.experienceInteraction.setVerificationRecord(backupCodeVerificationRecord);
+
+    await ctx.experienceInteraction.save();
+
+    ctx.body = {
+      verificationId: backupCodeVerificationRecord.id,
+    };
+
+    return next();
+  });
+
   router.post(
     `${experienceRoutes.verification}/backup-code/generate`,
     koaGuard({

--- a/packages/core/src/routes/experience/verification-routes/backup-code-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/backup-code-verification.ts
@@ -18,29 +18,40 @@ export default function backupCodeVerificationRoutes<T extends ExperienceInterac
 ) {
   const { libraries, queries } = tenantContext;
 
-  router.post(`${experienceRoutes.verification}/backup-code/generate`, async (ctx, next) => {
-    const { experienceInteraction } = ctx;
+  router.post(
+    `${experienceRoutes.verification}/backup-code/generate`,
+    koaGuard({
+      status: [200, 400],
+      response: z.object({
+        verificationId: z.string(),
+        codes: z.array(z.string()),
+      }),
+    }),
+    async (ctx, next) => {
+      const { experienceInteraction } = ctx;
 
-    assertThat(experienceInteraction.identifiedUserId, 'session.identifier_not_found');
+      assertThat(experienceInteraction.identifiedUserId, 'session.identifier_not_found');
 
-    const backupCodeVerificationRecord = BackupCodeVerification.create(
-      libraries,
-      queries,
-      experienceInteraction.identifiedUserId
-    );
+      const backupCodeVerificationRecord = BackupCodeVerification.create(
+        libraries,
+        queries,
+        experienceInteraction.identifiedUserId
+      );
 
-    backupCodeVerificationRecord.generate();
+      const codes = backupCodeVerificationRecord.generate();
 
-    ctx.experienceInteraction.setVerificationRecord(backupCodeVerificationRecord);
+      ctx.experienceInteraction.setVerificationRecord(backupCodeVerificationRecord);
 
-    await ctx.experienceInteraction.save();
+      await ctx.experienceInteraction.save();
 
-    ctx.body = {
-      verificationId: backupCodeVerificationRecord.id,
-    };
+      ctx.body = {
+        verificationId: backupCodeVerificationRecord.id,
+        codes,
+      };
 
-    return next();
-  });
+      return next();
+    }
+  );
 
   router.post(
     `${experienceRoutes.verification}/backup-code/generate`,

--- a/packages/core/src/routes/experience/verification-routes/new-password-identity-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/new-password-identity-verification.ts
@@ -1,4 +1,4 @@
-import { newPasswordIdentityVerificationPayloadGuard, VerificationType } from '@logto/schemas';
+import { passwordVerificationPayloadGuard, VerificationType } from '@logto/schemas';
 import { Action } from '@logto/schemas/lib/types/log/interaction.js';
 import type Router from 'koa-router';
 import { z } from 'zod';
@@ -17,7 +17,7 @@ export default function newPasswordIdentityVerificationRoutes<
   router.post(
     `${experienceRoutes.verification}/new-password-identity`,
     koaGuard({
-      body: newPasswordIdentityVerificationPayloadGuard,
+      body: passwordVerificationPayloadGuard,
       status: [200, 400, 422],
       response: z.object({
         verificationId: z.string(),

--- a/packages/integration-tests/src/client/experience/index.ts
+++ b/packages/integration-tests/src/client/experience/index.ts
@@ -3,7 +3,6 @@ import {
   type IdentificationApiPayload,
   type InteractionEvent,
   type MfaFactor,
-  type NewPasswordIdentityVerificationPayload,
   type PasswordVerificationPayload,
   type UpdateProfileApiPayload,
   type VerificationCodeIdentifier,
@@ -196,9 +195,7 @@ export class ExperienceClient extends MockClient {
       .json<{ verificationId: string }>();
   }
 
-  public async createNewPasswordIdentityVerification(
-    payload: NewPasswordIdentityVerificationPayload
-  ) {
+  public async createNewPasswordIdentityVerification(payload: PasswordVerificationPayload) {
     return api
       .post(`${experienceRoutes.verification}/new-password-identity`, {
         headers: { cookie: this.interactionCookie },

--- a/packages/phrases/src/locales/en/errors/session.ts
+++ b/packages/phrases/src/locales/en/errors/session.ts
@@ -27,6 +27,8 @@ const session = {
   not_supported_for_forgot_password: 'This operation is not supported for forgot password.',
   identity_conflict:
     'Identity mismatch detected. Please initiate a new session to proceed with a different identity.',
+  identifier_not_verified:
+    'The provided identifier {{identifier}} has not been verified. Please create a verification record for this identifier and complete the verification process.',
   mfa: {
     require_mfa_verification: 'Mfa verification is required to sign in.',
     mfa_sign_in_only: 'Mfa is only available for sign-in interaction.',

--- a/packages/schemas/src/types/interactions.ts
+++ b/packages/schemas/src/types/interactions.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 import { emailRegEx, phoneRegEx, usernameRegEx } from '@logto/core-kit';
 import { z } from 'zod';
 
@@ -120,26 +119,6 @@ export type BackupCodeVerificationVerifyPayload = {
 export const backupCodeVerificationVerifyPayloadGuard = z.object({
   code: z.string().min(1),
 }) satisfies ToZodObject<BackupCodeVerificationVerifyPayload>;
-
-/**
- * Payload type for `POST /api/experience/verification/new-password-identity`.
- * @remarks Currently we only support username identifier for new password identity registration.
- * For email and phone new identity registration, a `CodeVerification` record is required.
- */
-export type NewPasswordIdentityVerificationPayload = {
-  identifier: {
-    type: SignInIdentifier.Username;
-    value: string;
-  };
-  password: string;
-};
-export const newPasswordIdentityVerificationPayloadGuard = z.object({
-  identifier: z.object({
-    type: z.literal(SignInIdentifier.Username),
-    value: z.string(),
-  }),
-  password: z.string().min(1),
-}) satisfies ToZodObject<NewPasswordIdentityVerificationPayload>;
 
 /** Payload type for `POST /api/experience/identification`. */
 export type IdentificationApiPayload = {
@@ -432,4 +411,3 @@ export const verifyMfaResultGuard = z.object({
 });
 
 export type VerifyMfaResult = z.infer<typeof verifyMfaResultGuard>;
-/* eslint-enable max-lines */


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR implements a mandatory password guard and fulfillment flow on the user register using a verified email or phone. 

### Context
In the latest experience API design, we decoupled the new user creation (insert DB) and profile fulfillment (including bind MFA) into two separate steps.  A user account will be created as long as a valid unique identifier is provided:

- username + password
- verified email
- verified phone
- social
- enterprise sso

A new user account will be created and the user will be identified when sending the `POST /experience/identifier` request.
The user may, later on, provide additional profile and MFA registrations after the account is created. 
At the submit interaction step, we will guard the mandatory profile and MFA fulfillment status.  

In short, a missing profile won't block the creation of a new user account. 

### Issue
For password enabled user registration using email or phone as an identifier, the user may drop the registration process after the account has been successfully created in Logto, but password still not provided. 
In such a case, if the password is the only enabled sign-in method, that user can never access the new created account. 

### Solution
Treat the identifier with password regisrtaction as a special case. If the password is enabled, a `NewPasswordIdentity` verification record is required for new user registration using a verified email or phone. 

- Extend the existing `NewPasswordIdentity`  verification record to accept all types of `InteractionIdentifier`,  username, email and phone. 
- Add the`isIdentifierVerified` guard in the `createNewUser` method. If the `NewPasswordIdentity` record's identider type is email of phone, a related `CodeVerification` record must be created and provided.
- Add the `guardMandatoryPasswordOnRegister` guard in the `createNewUser` method. If the `CodeVerification` record is being used to create a new user account check against the sign-in experience settings. If password is required, throws a missing password error. A `NewPasswordIdentity` verification record must be created and provided for password enabled identifier registration. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT and integration test added

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
