### PR TITLE
refactor(console): get and check `skuId` from checkout session

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@fontsource/roboto-mono": "^5.0.0",
     "@jest/types": "^29.5.0",
-    "@logto/cloud": "0.2.5-3b703da",
+    "@logto/cloud": "0.2.5-923c26f",
     "@logto/connector-kit": "workspace:^4.0.0",
     "@logto/core-kit": "workspace:^2.5.0",
     "@logto/elements": "workspace:^0.0.0",

--- a/packages/console/src/pages/CheckoutSuccessCallback/index.tsx
+++ b/packages/console/src/pages/CheckoutSuccessCallback/index.tsx
@@ -11,8 +11,10 @@ import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
 import AppLoading from '@/components/AppLoading';
 import { GtagConversionId, reportToGoogle } from '@/components/Conversion/utils';
 import PlanName from '@/components/PlanName';
+import { isDevFeaturesEnabled } from '@/consts/env';
 import { checkoutStateQueryKey } from '@/consts/subscriptions';
 import { TenantsContext } from '@/contexts/TenantsProvider';
+import useLogtoSkus from '@/hooks/use-logto-skus';
 import useSubscriptionPlans from '@/hooks/use-subscription-plans';
 import useTenantPathname from '@/hooks/use-tenant-pathname';
 import { clearLocalCheckoutSession, getLocalCheckoutSession } from '@/utils/checkout';
@@ -29,8 +31,11 @@ function CheckoutSuccessCallback() {
   const { search } = useLocation();
   const checkoutState = new URLSearchParams(search).get(checkoutStateQueryKey);
   const { state, sessionId, callbackPage, isDowngrade } = getLocalCheckoutSession() ?? {};
+
   const { data: subscriptionPlans, error: fetchPlansError } = useSubscriptionPlans();
   const isLoadingPlans = !subscriptionPlans && !fetchPlansError;
+  const { data: logtoSkus, error: fetchLogtoSkusError } = useLogtoSkus();
+  const isLoadingLogtoSkus = !logtoSkus && !fetchLogtoSkusError;
 
   // Note: if we can't get the subscription results in 10 seconds, we will redirect to the console home page
   useTimer({
@@ -61,6 +66,7 @@ function CheckoutSuccessCallback() {
 
   const checkoutTenantId = stripeCheckoutSession?.tenantId;
   const checkoutPlanId = stripeCheckoutSession?.planId;
+  const checkoutSkuId = stripeCheckoutSession?.skuId;
 
   const { data: tenantSubscription } = useSWR(
     checkoutTenantId && `/api/tenants/${checkoutTenantId}/subscription`,
@@ -74,22 +80,45 @@ function CheckoutSuccessCallback() {
   );
 
   const isCheckoutSuccessful =
-    !isLoadingPlans &&
     checkoutTenantId &&
     stripeCheckoutSession.status === 'complete' &&
-    checkoutPlanId === tenantSubscription?.planId;
+    (isDevFeaturesEnabled
+      ? !isLoadingLogtoSkus && checkoutSkuId === tenantSubscription?.planId
+      : !isLoadingPlans && checkoutPlanId === tenantSubscription?.planId);
 
   useEffect(() => {
     if (isCheckoutSuccessful) {
       clearLocalCheckoutSession();
 
-      const checkoutPlan = subscriptionPlans?.find((plan) => plan.id === checkoutPlanId);
-      if (checkoutPlan) {
-        toast.success(
-          <Trans components={{ name: <PlanName name={checkoutPlan.name} /> }}>
-            {t(isDowngrade ? 'downgrade_success' : 'upgrade_success')}
-          </Trans>
-        );
+      if (isDevFeaturesEnabled) {
+        const checkoutSku = logtoSkus?.find((sku) => sku.id === checkoutPlanId);
+        if (checkoutSku) {
+          toast.success(
+            <Trans
+              components={{
+                name: (
+                  <PlanName
+                    skuId={checkoutSku.id}
+                    // Generally `checkoutPlanId` and a properly setup of SKU `name` should not be null, we still need to handle the edge case to make the type inference happy.
+                    // Also `name` will be deprecated in the future once the new pricing model is ready.
+                    name={checkoutPlanId ?? checkoutSku.name ?? checkoutSku.id}
+                  />
+                ),
+              }}
+            >
+              {t(isDowngrade ? 'downgrade_success' : 'upgrade_success')}
+            </Trans>
+          );
+        }
+      } else {
+        const checkoutPlan = subscriptionPlans?.find((plan) => plan.id === checkoutPlanId);
+        if (checkoutPlan) {
+          toast.success(
+            <Trans components={{ name: <PlanName name={checkoutPlan.name} /> }}>
+              {t(isDowngrade ? 'downgrade_success' : 'upgrade_success')}
+            </Trans>
+          );
+        }
       }
 
       // No need to check `isDowngrade` here, since a downgrade must occur in a tenant with a Pro
@@ -115,6 +144,7 @@ function CheckoutSuccessCallback() {
     currentTenantId,
     isCheckoutSuccessful,
     isDowngrade,
+    logtoSkus,
     navigate,
     navigateTenant,
     subscriptionPlans,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2394,8 +2394,8 @@ importers:
         specifier: ^29.5.0
         version: 29.5.0
       '@logto/cloud':
-        specifier: 0.2.5-3b703da
-        version: 0.2.5-3b703da(zod@3.23.8)
+        specifier: 0.2.5-923c26f
+        version: 0.2.5-923c26f(zod@3.23.8)
       '@logto/connector-kit':
         specifier: workspace:^4.0.0
         version: link:../toolkit/connector-kit
@@ -5008,6 +5008,10 @@ packages:
 
   '@logto/cloud@0.2.5-3b703da':
     resolution: {integrity: sha512-VCevQnxP5910s/cDYAxoJRim9iH1yN/La0HAlOP6FhVGtZofYwTTfT9AQXC+dZScgydpcFWo4k/6MYOFRtZCLg==}
+    engines: {node: ^20.9.0}
+
+  '@logto/cloud@0.2.5-923c26f':
+    resolution: {integrity: sha512-NAK9/T7HxEfE2djO6VTekMziOXH6NtbAzwumZcZo0bqIUDGiKlUvted/KY6iqpCdfFOF4aIyKp+pvlQIjj1T6Q==}
     engines: {node: ^20.9.0}
 
   '@logto/js@4.1.4':
@@ -14606,6 +14610,13 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  '@logto/cloud@0.2.5-923c26f(zod@3.23.8)':
+    dependencies:
+      '@silverhand/essentials': 2.9.1
+      '@withtyped/server': 0.13.6(zod@3.23.8)
+    transitivePeerDependencies:
+      - zod
+
   '@logto/js@4.1.4':
     dependencies:
       '@silverhand/essentials': 2.9.1
@@ -15025,10 +15036,10 @@ snapshots:
       eslint-config-prettier: 9.1.0(eslint@8.57.0)
       eslint-config-xo: 0.44.0(eslint@8.57.0)
       eslint-config-xo-typescript: 4.0.0(@typescript-eslint/eslint-plugin@7.7.0(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3))(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3)
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
       eslint-plugin-consistent-default-export-name: 0.0.15
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-n: 17.2.1(eslint@8.57.0)
       eslint-plugin-no-use-extend-native: 0.5.0
       eslint-plugin-prettier: 5.1.3(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.0.0)
@@ -17962,13 +17973,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.16.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.3
       is-core-module: 2.13.1
@@ -17979,14 +17990,14 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7(supports-color@5.5.0)
     optionalDependencies:
       '@typescript-eslint/parser': 7.7.0(eslint@8.57.0)(typescript@5.5.3)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18008,7 +18019,7 @@ snapshots:
       eslint: 8.57.0
       ignore: 5.3.1
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -18018,7 +18029,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Get and check `skuId` from checkout session. Since we are migrating to new pricing model and we use `skuId` instead of `planId`. The CIs are expected to fail before we merge and publish [this cloud PR](https://github.com/logto-io/cloud/pull/847).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
