### PR TITLE
refactor(core): make password optional in NewPasswordIdentity

### DIFF
--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -483,8 +483,6 @@ export default class ExperienceInteraction {
     const newProfile = await getNewUserProfileFromVerificationRecord(verificationRecord);
     await this.profile.profileValidator.guardProfileUniquenessAcrossUsers(newProfile);
 
-    await this.signInExperienceValidator.guardMandatoryPasswordOnRegister(verificationRecord);
-
     const user = await this.provisionLibrary.createUser(newProfile);
 
     this.userId = user.id;

--- a/packages/core/src/routes/experience/classes/libraries/sign-in-experience-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/sign-in-experience-validator.ts
@@ -163,25 +163,6 @@ export class SignInExperienceValidator {
   }
 
   /**
-   * If password is enabled in the sign-up settings,
-   * guard the verification record contains password (NewPasswordIdentity).
-   *
-   * - Password is not required for social and SSO verification records.
-   */
-  public async guardMandatoryPasswordOnRegister({ type }: VerificationRecord) {
-    const { signUp } = await this.getSignInExperienceData();
-
-    if (
-      signUp.password &&
-      [VerificationType.EmailVerificationCode, VerificationType.PhoneVerificationCode].includes(
-        type
-      )
-    ) {
-      throw new RequestError({ code: 'user.password_required_in_profile', status: 422 });
-    }
-  }
-
-  /**
    * Guard the verification records contains email identifier with SSO enabled
    *
    * @remarks
@@ -282,6 +263,11 @@ export class SignInExperienceValidator {
         assertThat(
           signUp.identifiers.includes(type) && signUp.verify,
           new RequestError({ code: 'user.sign_up_method_not_enabled', status: 422 })
+        );
+
+        assertThat(
+          !signUp.password,
+          new RequestError({ code: 'user.password_required_in_profile', status: 422 })
         );
         break;
       }

--- a/packages/core/src/routes/experience/classes/verifications/new-password-identity-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/new-password-identity-verification.ts
@@ -93,11 +93,20 @@ export class NewPasswordIdentityVerification
    *
    * - Check if the identifier is unique across users
    * - Validate the password against the password policy
+   *
+   * @throws {RequestError} with status 422 if the identifier is in use by another user
+   * @throws {RequestError} with status 422 if the password is not provided
+   * @throws {RequestError} with status 422 if the password does not meet the password policy
    */
-  async verify(password: string) {
+  async verify(password?: string) {
     const { identifier } = this;
     const identifierProfile = interactionIdentifierToUserProfile(identifier);
     await this.profileValidator.guardProfileUniquenessAcrossUsers(identifierProfile);
+
+    assertThat(
+      password,
+      new RequestError({ code: 'user.password_required_in_profile', status: 422 })
+    );
 
     const passwordPolicy = await this.signInExperienceValidator.getPasswordPolicy();
     const passwordValidator = new PasswordValidator(passwordPolicy);

--- a/packages/core/src/routes/experience/verification-routes/new-password-identity-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/new-password-identity-verification.ts
@@ -1,4 +1,4 @@
-import { passwordVerificationPayloadGuard, VerificationType } from '@logto/schemas';
+import { interactionIdentifierGuard, VerificationType } from '@logto/schemas';
 import { Action } from '@logto/schemas/lib/types/log/interaction.js';
 import type Router from 'koa-router';
 import { z } from 'zod';
@@ -17,7 +17,10 @@ export default function newPasswordIdentityVerificationRoutes<
   router.post(
     `${experienceRoutes.verification}/new-password-identity`,
     koaGuard({
-      body: passwordVerificationPayloadGuard,
+      body: z.object({
+        identifier: interactionIdentifierGuard,
+        password: z.string().optional(),
+      }),
       status: [200, 400, 422],
       response: z.object({
         verificationId: z.string(),

--- a/packages/integration-tests/src/client/experience/index.ts
+++ b/packages/integration-tests/src/client/experience/index.ts
@@ -195,7 +195,9 @@ export class ExperienceClient extends MockClient {
       .json<{ verificationId: string }>();
   }
 
-  public async createNewPasswordIdentityVerification(payload: PasswordVerificationPayload) {
+  public async createNewPasswordIdentityVerification(
+    payload: Pick<PasswordVerificationPayload, 'identifier'> & { password?: string }
+  ) {
     return api
       .post(`${experienceRoutes.verification}/new-password-identity`, {
         headers: { cookie: this.interactionCookie },

--- a/packages/integration-tests/src/tests/api/experience-api/verifications/new-password-identity-verification.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/verifications/new-password-identity-verification.test.ts
@@ -119,6 +119,27 @@ devFeatureTest.describe('password verifications', () => {
       [username, 'userInfo'],
     ];
 
+    it('should throw error if password is not provided', async () => {
+      const { primaryEmail } = generateNewUserProfile({
+        primaryEmail: true,
+      });
+
+      const client = await initExperienceClient();
+
+      await expectRejects(
+        client.createNewPasswordIdentityVerification({
+          identifier: {
+            type: SignInIdentifier.Email,
+            value: primaryEmail,
+          },
+        }),
+        {
+          code: 'user.password_required_in_profile',
+          status: 422,
+        }
+      );
+    });
+
     it.each(invalidPasswords)('should reject invalid password %p', async (password) => {
       const client = await initExperienceClient();
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Make password optional in `NewPasswordIdentity` verification endpoints. So users may pre-validate their `identifier` ahead without providing the password.

Issue:
In our SIE design, the username + password registration flow is split into two forms. User will be asked to provide their username ahead. If the username is valid then jump to the password form. 
If the username is taken throws an error in the current page. 

Updates:
To better support that, we refactor the current `NewPasswordIdentity` verification endpoint, making the `password` field optional. So users may pre-validate their identifiers before specifying the password.  



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
integration tests updated

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
