### PR TITLE
fix(core): allow non-json body type when parsing

### DIFF
--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -400,10 +400,10 @@ export default function initOidc(
       // 'application/json' for body parsing. Update relatively when we enable that feature.
       if (ctx.is(jsonContentType)) {
         ctx.headers['content-type'] = formUrlEncodedContentType;
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        ctx.request.body = JSON.parse(body);
+        // eslint-disable-next-line no-restricted-syntax
+        ctx.request.body = trySafe(() => JSON.parse(body) as unknown);
       } else if (ctx.is(formUrlEncodedContentType)) {
-        ctx.request.body = querystring.parse(body);
+        ctx.request.body = trySafe(() => querystring.parse(body));
       }
     }
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
the content body may be empty when `content-type` has value. we should allow a failed parsing as a temp fix.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
locally tested ok

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
