### PR TITLE
refactor: add tests for content-type in oidc apis

### DIFF
--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -403,7 +403,7 @@ export default function initOidc(
         // eslint-disable-next-line no-restricted-syntax
         ctx.request.body = trySafe(() => JSON.parse(body) as unknown);
       } else if (ctx.is(formUrlEncodedContentType)) {
-        ctx.request.body = trySafe(() => querystring.parse(body));
+        ctx.request.body = querystring.parse(body);
       }
     }
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
update code to make it more reasonable as `querystring.parse` doesn't throw

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
added integration tests

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
