### PR TITLE
fix(console): create tenant button should stretch to full width

### DIFF
--- a/packages/console/src/components/Topbar/TenantSelector/index.module.scss
+++ b/packages/console/src/components/Topbar/TenantSelector/index.module.scss
@@ -65,6 +65,8 @@ $dropdown-item-height: 40px;
 }
 
 .dropdown {
+  display: flex;
+  flex-direction: column;
   max-width: 500px;
   min-width: 320px;
 
@@ -75,11 +77,6 @@ $dropdown-item-height: 40px;
 
 .createTenantButton {
   all: unset;
-  /**
-   * `inline-size: stretch` is needed since button will have the used value `inline-size: fit-content` by default.
-   * @see {@link https://html.spec.whatwg.org/multipage/rendering.html#button-layout}
-   */
-  inline-size: stretch;
   display: flex;
   align-items: center;
   padding: _.unit(2.5) _.unit(3) _.unit(2.5) _.unit(4);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
I'm not sure since when this `inline-size: stretch` failed to work, but after investigation it seems this is never a valid CSS property. So I decide to remove it and make the parent div a flex-column container.

https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size
https://css-tricks.com/almanac/properties/i/inline-size/

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally

<img width="319" alt="image" src="https://github.com/user-attachments/assets/be7fb34b-9aaf-46e8-9336-7140d97199b5">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
