### PR TITLE
fix(core): should not throw when not adding any new roles to a user

### DIFF
--- a/packages/core/src/queries/users-roles.ts
+++ b/packages/core/src/queries/users-roles.ts
@@ -42,16 +42,19 @@ export const createUsersRolesQueries = (pool: CommonQueryMethods) => {
       ${conditionalSql(limit, (value) => sql`limit ${value}`)}
     `);
 
-  const insertUsersRoles = async (usersRoles: CreateUsersRole[]) =>
-    usersRoles.length > 0
-      ? pool.query(sql`
+  const insertUsersRoles = async (usersRoles: CreateUsersRole[]) => {
+    if (usersRoles.length === 0) {
+      return;
+    }
+
+    return pool.query(sql`
       insert into ${table} (${fields.id}, ${fields.userId}, ${fields.roleId}) values
       ${sql.join(
         usersRoles.map(({ id, userId, roleId }) => sql`(${id}, ${userId}, ${roleId})`),
         sql`, `
       )}
-    `)
-      : null;
+    `);
+  };
 
   const deleteUsersRolesByUserIdAndRoleId = async (userId: string, roleId: string) => {
     const { rowCount } = await pool.query(sql`

--- a/packages/core/src/queries/users-roles.ts
+++ b/packages/core/src/queries/users-roles.ts
@@ -43,13 +43,15 @@ export const createUsersRolesQueries = (pool: CommonQueryMethods) => {
     `);
 
   const insertUsersRoles = async (usersRoles: CreateUsersRole[]) =>
-    pool.query(sql`
+    usersRoles.length > 0
+      ? pool.query(sql`
       insert into ${table} (${fields.id}, ${fields.userId}, ${fields.roleId}) values
       ${sql.join(
         usersRoles.map(({ id, userId, roleId }) => sql`(${id}, ${userId}, ${roleId})`),
         sql`, `
       )}
-    `);
+    `)
+      : null;
 
   const deleteUsersRolesByUserIdAndRoleId = async (userId: string, roleId: string) => {
     const { rowCount } = await pool.query(sql`

--- a/packages/integration-tests/src/api/admin-user.ts
+++ b/packages/integration-tests/src/api/admin-user.ts
@@ -76,6 +76,9 @@ export const deleteUserIdentity = async (userId: string, connectorTarget: string
 export const assignRolesToUser = async (userId: string, roleIds: string[]) =>
   authedAdminApi.post(`users/${userId}/roles`, { json: { roleIds } });
 
+export const putRolesToUser = async (userId: string, roleIds: string[]) =>
+  authedAdminApi.put(`users/${userId}/roles`, { json: { roleIds } });
+
 /**
  * Get roles assigned to the user.
  *

--- a/packages/integration-tests/src/tests/api/oidc/id-token.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/id-token.test.ts
@@ -1,7 +1,7 @@
 import { Prompt } from '@logto/node';
 import { InteractionEvent, demoAppApplicationId } from '@logto/schemas';
 
-import { assignRolesToUser, putInteraction } from '#src/api/index.js';
+import { assignRolesToUser, putRolesToUser, putInteraction } from '#src/api/index.js';
 import { createRole } from '#src/api/role.js';
 import MockClient from '#src/client/index.js';
 import { demoAppRedirectUri } from '#src/constants.js';
@@ -56,6 +56,8 @@ describe('OpenID Connect ID token', () => {
   it('should be issued with correct `username` and `roles` claims', async () => {
     const role = await createRole({});
     await assignRolesToUser(userId, [role.id]);
+    // Should not throw when not adding any new role(s) to a user.
+    await expect(putRolesToUser(userId, [role.id])).resolves.not.toThrow();
     await fetchIdToken(['username', 'roles'], {
       username,
       roles: [role.name],


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Should not throw when not adding any new roles to a user when calling `PUT /users/{:userId}/roles` API.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Secured by adding integration test cases.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
