### PR TITLE
fix(console): fix the subscription plan display in tenant dropdown

### DIFF
--- a/packages/console/src/components/Topbar/TenantSelector/TenantDropdownItem/index.tsx
+++ b/packages/console/src/components/Topbar/TenantSelector/TenantDropdownItem/index.tsx
@@ -1,4 +1,5 @@
 import { TenantTag } from '@logto/schemas';
+import { conditional } from '@silverhand/essentials';
 import classNames from 'classnames';
 import { useContext, useMemo } from 'react';
 
@@ -6,6 +7,7 @@ import Tick from '@/assets/icons/tick.svg?react';
 import { type TenantResponse } from '@/cloud/types/router';
 import PlanName from '@/components/PlanName';
 import TenantEnvTag from '@/components/TenantEnvTag';
+import { isDevFeaturesEnabled } from '@/consts/env';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import { DropdownItem } from '@/ds-components/Dropdown';
 import DynamicT from '@/ds-components/DynamicT';
@@ -27,8 +29,8 @@ function TenantDropdownItem({ tenantData, isSelected, onClick }: Props) {
   } = tenantData;
 
   const {
+    currentPlan,
     subscriptionPlans,
-    currentSku,
     currentSubscriptionUsage: usage,
     currentSubscriptionQuota: quota,
   } = useContext(SubscriptionDataContext);
@@ -58,7 +60,7 @@ function TenantDropdownItem({ tenantData, isSelected, onClick }: Props) {
           {tag === TenantTag.Development ? (
             <DynamicT forKey="subscription.no_subscription" />
           ) : (
-            <PlanName skuId={currentSku.id} name={tenantSubscriptionPlan.name} />
+            <PlanName skuId={conditional(isDevFeaturesEnabled && planId)} name={currentPlan.name} />
           )}
         </div>
       </div>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the subscription plan display in tenant dropdown.

Before this change, all non-dev tenant are using the plan of the current selected tenant, which is wrong. Should use the plan ID of the corresponding tenant as SKU ID in for new pricing model. (We use SKU ID to represent the plan ID in new pricing model)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
