### PR TITLE
feat(core): support google one tap

### DIFF
--- a/packages/core/src/routes/experience/classes/verifications/social-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/social-verification.ts
@@ -139,8 +139,6 @@ export class SocialVerification implements IdentifierVerificationRecord<Verifica
       new RequestError({ code: 'session.verification_failed', status: 400 })
     );
 
-    // TODO: sync userInfo and link social identity
-
     const user = await this.findUserBySocialIdentity();
 
     if (!user) {

--- a/packages/core/src/routes/experience/verification-routes/enterprise-sso-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/enterprise-sso-verification.ts
@@ -80,7 +80,11 @@ export default function enterpriseSsoVerificationRoutes<
       params: z.object({
         connectorId: z.string(),
       }),
-      body: socialVerificationCallbackPayloadGuard,
+      body: socialVerificationCallbackPayloadGuard.merge(
+        z.object({
+          verificationId: z.string(),
+        })
+      ),
       response: z.object({
         verificationId: z.string(),
       }),

--- a/packages/core/src/routes/interaction/utils/social-verification.ts
+++ b/packages/core/src/routes/interaction/utils/social-verification.ts
@@ -57,16 +57,18 @@ export const verifySocialIdentity = async (
   { provider, libraries }: TenantContext
 ): Promise<SocialUserInfo> => {
   const {
-    socials: { getUserInfo },
+    socials: { getUserInfo, getConnector },
   } = libraries;
 
   const log = ctx.createLog('Interaction.SignIn.Identifier.Social.Submit');
   log.append({ connectorId, connectorData });
 
+  const connector = await getConnector(connectorId);
+
   // Verify the CSRF token if it's a Google connector and has credential (a Google One Tap
   // verification)
   if (
-    connectorId === GoogleConnector.factoryId &&
+    connector.metadata.id === GoogleConnector.factoryId &&
     connectorData[GoogleConnector.oneTapParams.credential]
   ) {
     const csrfToken = connectorData[GoogleConnector.oneTapParams.csrfToken];

--- a/packages/integration-tests/src/tests/api/experience-api/verifications/social-verification.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/verifications/social-verification.test.ts
@@ -157,6 +157,7 @@ devFeatureTest.describe('social verification', () => {
     it('should throw if the connectorId is different', async () => {
       const client = await initExperienceClient();
       const connectorId = connectorIdMap.get(mockSocialConnectorId)!;
+      const emailConnectorId = connectorIdMap.get(mockEmailConnectorId)!;
 
       const { verificationId } = await client.getSocialAuthorizationUri(connectorId, {
         redirectUri,
@@ -164,7 +165,7 @@ devFeatureTest.describe('social verification', () => {
       });
 
       await expectRejects(
-        client.verifySocialAuthorization('invalid_connector_id', {
+        client.verifySocialAuthorization(emailConnectorId, {
           verificationId,
           connectorData: {
             authorizationCode,

--- a/packages/schemas/src/types/interactions.ts
+++ b/packages/schemas/src/types/interactions.ts
@@ -84,12 +84,12 @@ export const socialAuthorizationUrlPayloadGuard = z.object({
 export type SocialVerificationCallbackPayload = {
   /** The callback data from the social connector. */
   connectorData: Record<string, unknown>;
-  /**  The verification ID returned from the authorization URI. */
-  verificationId: string;
+  /**  The verification ID returned from the authorization URI. Optional for Google one tap callback */
+  verificationId?: string;
 };
 export const socialVerificationCallbackPayloadGuard = z.object({
   connectorData: jsonObjectGuard,
-  verificationId: z.string(),
+  verificationId: z.string().optional(),
 }) satisfies ToZodObject<SocialVerificationCallbackPayload>;
 
 /** Payload type for `POST /api/experience/verification/password`. */


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Update the social verification routes to support google one tap authentication. 

For a Google one-tap verification flow, the user can directly call the `/verifications/social/:connectorId/verify` endpoint to create and verify the verification record. 

- change the `verificationId` input parameter to optional
- if the `connectorId` is google connector Id,  and oneTapParams is present, auto-create a SocialVerificaiton record. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
need to test manually

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
