### PR TITLE
fix(console): should not call cloud API when tenant ID is not valid

### DIFF
--- a/packages/console/src/hooks/use-new-subscription-quota.ts
+++ b/packages/console/src/hooks/use-new-subscription-quota.ts
@@ -8,7 +8,7 @@ const useNewSubscriptionQuota = (tenantId: string) => {
   const cloudApi = useCloudApi();
 
   return useSWR<NewSubscriptionQuota, Error>(
-    isCloud && isDevFeaturesEnabled && `/api/tenants/${tenantId}/subscription/quota`,
+    isCloud && isDevFeaturesEnabled && tenantId && `/api/tenants/${tenantId}/subscription/quota`,
     async () =>
       cloudApi.get('/api/tenants/:tenantId/subscription/quota', {
         params: { tenantId },

--- a/packages/console/src/hooks/use-new-subscription-scopes-usage.ts
+++ b/packages/console/src/hooks/use-new-subscription-scopes-usage.ts
@@ -14,6 +14,7 @@ const useNewSubscriptionScopeUsage = (tenantId: string) => {
     scopeResourceUsage: useSWR<NewSubscriptionScopeUsage, Error>(
       isCloud &&
         isDevFeaturesEnabled &&
+        tenantId &&
         `/api/tenants/${tenantId}/subscription/usage/${resourceEntityName}/scopes`,
       async () =>
         cloudApi.get('/api/tenants/:tenantId/subscription/usage/:entityName/scopes', {
@@ -24,6 +25,7 @@ const useNewSubscriptionScopeUsage = (tenantId: string) => {
     scopeRoleUsage: useSWR<NewSubscriptionScopeUsage, Error>(
       isCloud &&
         isDevFeaturesEnabled &&
+        tenantId &&
         `/api/tenants/${tenantId}/subscription/usage/${roleEntityName}/scopes`,
       async () =>
         cloudApi.get('/api/tenants/:tenantId/subscription/usage/:entityName/scopes', {

--- a/packages/console/src/hooks/use-new-subscription-usage.ts
+++ b/packages/console/src/hooks/use-new-subscription-usage.ts
@@ -8,7 +8,7 @@ const useNewSubscriptionUsage = (tenantId: string) => {
   const cloudApi = useCloudApi();
 
   return useSWR<NewSubscriptionUsage, Error>(
-    isCloud && isDevFeaturesEnabled && `/api/tenants/${tenantId}/subscription/usage`,
+    isCloud && isDevFeaturesEnabled && tenantId && `/api/tenants/${tenantId}/subscription/usage`,
     async () =>
       cloudApi.get('/api/tenants/:tenantId/subscription/usage', {
         params: { tenantId },


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
should not call cloud API when tenant ID is not valid

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration testsshould not call cloud API when tenant ID is not valid
- [ ] necessary TSDoc comments
