### PR TITLE
fix: hide error toast for subscription hooks for prod env

### DIFF
--- a/packages/console/src/hooks/use-new-subscription-quota.ts
+++ b/packages/console/src/hooks/use-new-subscription-quota.ts
@@ -5,7 +5,8 @@ import { type NewSubscriptionQuota } from '@/cloud/types/router';
 import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
 
 const useNewSubscriptionQuota = (tenantId: string) => {
-  const cloudApi = useCloudApi();
+  // TODO: Console sometimes toast 401 unauthorized error, but can not be reproduced in local environment easily, we temporarily hide the error toast for prod env.
+  const cloudApi = useCloudApi({ hideErrorToast: !isDevFeaturesEnabled });
 
   return useSWR<NewSubscriptionQuota, Error>(
     isCloud && isDevFeaturesEnabled && tenantId && `/api/tenants/${tenantId}/subscription/quota`,

--- a/packages/console/src/hooks/use-new-subscription-scopes-usage.ts
+++ b/packages/console/src/hooks/use-new-subscription-scopes-usage.ts
@@ -5,7 +5,8 @@ import { type NewSubscriptionScopeUsage } from '@/cloud/types/router';
 import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
 
 const useNewSubscriptionScopeUsage = (tenantId: string) => {
-  const cloudApi = useCloudApi();
+  // TODO: Console sometimes toast 401 unauthorized error, but can not be reproduced in local environment easily, we temporarily hide the error toast for prod env.
+  const cloudApi = useCloudApi({ hideErrorToast: !isDevFeaturesEnabled });
 
   const resourceEntityName = 'resources';
   const roleEntityName = 'roles';

--- a/packages/console/src/hooks/use-new-subscription-usage.ts
+++ b/packages/console/src/hooks/use-new-subscription-usage.ts
@@ -5,7 +5,8 @@ import { type NewSubscriptionUsage } from '@/cloud/types/router';
 import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
 
 const useNewSubscriptionUsage = (tenantId: string) => {
-  const cloudApi = useCloudApi();
+  // TODO: Console sometimes toast 401 unauthorized error, but can not be reproduced in local environment easily, we temporarily hide the error toast for prod env.
+  const cloudApi = useCloudApi({ hideErrorToast: !isDevFeaturesEnabled });
 
   return useSWR<NewSubscriptionUsage, Error>(
     isCloud && isDevFeaturesEnabled && tenantId && `/api/tenants/${tenantId}/subscription/usage`,

--- a/packages/console/src/hooks/use-subscription.ts
+++ b/packages/console/src/hooks/use-subscription.ts
@@ -2,10 +2,11 @@ import useSWR from 'swr';
 
 import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
 import { type Subscription } from '@/cloud/types/router';
-import { isCloud } from '@/consts/env';
+import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
 
 const useSubscription = (tenantId: string) => {
-  const cloudApi = useCloudApi();
+  // TODO: Console sometimes toast 401 unauthorized error, but can not be reproduced in local environment easily, we temporarily hide the error toast for prod env.
+  const cloudApi = useCloudApi({ hideErrorToast: !isDevFeaturesEnabled });
   return useSWR<Subscription, Error>(
     // `tenantId` could be an empty string which may cause the request to fail
     isCloud && tenantId && `/api/tenants/${tenantId}/subscription`,


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
hide error toast for subscription hooks for prod env.

This issue can not reproduced easily on local machine, temporarily hide the error toast for prod end.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
