### PR TITLE
refactor(console): avoid getSubscription call before authentication

### DIFF
--- a/packages/console/src/containers/AppContent/index.tsx
+++ b/packages/console/src/containers/AppContent/index.tsx
@@ -24,16 +24,11 @@ export default function AppContent() {
   const { isLoading: isLoadingPreference } = useUserPreferences();
   const { currentTenant } = useContext(TenantsContext);
   const isTenantSuspended = isCloud && currentTenant?.isSuspended;
+  // TODO: @darcyYe remove this
   const { isLoading: isLoadingSubscriptionData, ...subscriptionDta } = useSubscriptionData();
-  const {
-    isLoading: isLoadingNewSubscriptionData,
-    logtoSkus,
-    currentSku,
-    currentSubscriptionQuota,
-    currentSubscriptionUsage,
-    currentSubscriptionScopeResourceUsage,
-    currentSubscriptionScopeRoleUsage,
-  } = useNewSubscriptionData();
+
+  const { isLoading: isLoadingNewSubscriptionData, ...newSubscriptionData } =
+    useNewSubscriptionData();
 
   const scrollableContent = useRef<HTMLDivElement>(null);
   const { scrollTop } = useScroll(scrollableContent.current);
@@ -49,12 +44,7 @@ export default function AppContent() {
     <SubscriptionDataProvider
       subscriptionData={{
         ...subscriptionDta,
-        logtoSkus,
-        currentSku,
-        currentSubscriptionQuota,
-        currentSubscriptionUsage,
-        currentSubscriptionScopeResourceUsage,
-        currentSubscriptionScopeRoleUsage,
+        ...newSubscriptionData,
       }}
     >
       <div className={styles.app}>

--- a/packages/console/src/contexts/SubscriptionDataProvider/index.tsx
+++ b/packages/console/src/contexts/SubscriptionDataProvider/index.tsx
@@ -32,6 +32,7 @@ export const SubscriptionDataContext = createContext<FullContext>({
   currentSubscriptionUsage: defaultSubscriptionUsage,
   currentSubscriptionScopeResourceUsage: {},
   currentSubscriptionScopeRoleUsage: {},
+  mutateSubscriptionQuotaAndUsages: noop,
   /* ==== For new pricing model ==== */
 });
 

--- a/packages/console/src/contexts/SubscriptionDataProvider/types.ts
+++ b/packages/console/src/contexts/SubscriptionDataProvider/types.ts
@@ -23,6 +23,7 @@ type NewSubscriptionSupplementContext = {
   currentSubscriptionUsage: NewSubscriptionUsage;
   currentSubscriptionScopeResourceUsage: NewSubscriptionScopeUsage;
   currentSubscriptionScopeRoleUsage: NewSubscriptionScopeUsage;
+  mutateSubscriptionQuotaAndUsages: () => void;
 };
 
 export type NewSubscriptionContext = Omit<Context, 'subscriptionPlans' | 'currentPlan'> &

--- a/packages/console/src/hooks/use-api.ts
+++ b/packages/console/src/hooks/use-api.ts
@@ -22,11 +22,10 @@ import { useTranslation } from 'react-i18next';
 import { requestTimeout } from '@/consts';
 import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
 import { AppDataContext } from '@/contexts/AppDataProvider';
+import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import { useConfirmModal } from '@/hooks/use-confirm-modal';
 import useRedirectUri from '@/hooks/use-redirect-uri';
-
-import useSubscribe from './use-subscribe';
 
 export class RequestError extends Error {
   constructor(
@@ -118,6 +117,7 @@ export const useStaticApi = ({
 }: StaticApiProps): KyInstance => {
   const { isAuthenticated, getAccessToken, getOrganizationToken } = useLogto();
   const { i18n } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const { mutateSubscriptionQuotaAndUsages } = useContext(SubscriptionDataContext);
 
   // Disable global error handling if `hideErrorToast` is true.
   const disableGlobalErrorHandling = hideErrorToast === true;
@@ -125,7 +125,6 @@ export const useStaticApi = ({
   const toastDisabledErrorCodes = Array.isArray(hideErrorToast) ? hideErrorToast : undefined;
 
   const { handleError } = useGlobalRequestErrorHandler(toastDisabledErrorCodes);
-  const { syncSubscriptionData } = useSubscribe();
 
   const api = useMemo(
     () =>
@@ -162,7 +161,7 @@ export const useStaticApi = ({
                 response.status >= 200 &&
                 response.status < 300
               ) {
-                syncSubscriptionData();
+                mutateSubscriptionQuotaAndUsages();
               }
             },
           ],
@@ -179,7 +178,7 @@ export const useStaticApi = ({
       getOrganizationToken,
       getAccessToken,
       i18n.language,
-      syncSubscriptionData,
+      mutateSubscriptionQuotaAndUsages,
     ]
   );
 


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->


Remove the `useSubscription` dependency from from the `useApi` hook. 

This fixes two issues:
- remove this missing security header error on console page reload 
- avoid unnecessary subscription calls on each page load.



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
