### PR TITLE
fix(console): catch timeout error when submitting form

### DIFF
--- a/packages/console/src/utils/form.ts
+++ b/packages/console/src/utils/form.ts
@@ -1,9 +1,13 @@
-import { HTTPError } from 'ky';
+import { HTTPError, TimeoutError } from 'ky';
 import { type FieldValues, type SubmitHandler } from 'react-hook-form';
+import { toast } from 'react-hot-toast';
 
 /**
  * After upgrading the react-hook-form to v7.42.0, the `isSubmitting` flag does not recover when the submit handler throws.
- * So we need to catch the error and do nothing if the error is an HTTPError and the status code is not 401 to prevent the `isSubmitting` flag from being stuck.
+ * So we need to catch the error and do nothing if the error is one of the following to prevent the `isSubmitting` flag from being stuck:
+ * - HTTPError with a status code that is not 401
+ * - TimeoutError
+ *
  * Reference: https://github.com/orgs/react-hook-form/discussions/10103#discussioncomment-5927542
  */
 export const trySubmitSafe =
@@ -13,6 +17,13 @@ export const trySubmitSafe =
       await handler(formData, event);
     } catch (error) {
       if (error instanceof HTTPError && error.response.status !== 401) {
+        // Returned directly, since the error has been handled by the `use-api` hook.
+        return;
+      }
+
+      if (error instanceof TimeoutError) {
+        // Display a toast message for the timeout error.
+        toast.error(error.message);
         return;
       }
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The `TimeoutError` from ky is not considered an `HTTPError`. However, the `beforeError` hook in ky only handles HTTP errors, which means we need to wrap every ky request in a `try...catch...` block (see: https://github.com/sindresorhus/ky/issues/508).

Fortunately, in our console, the `TimeoutError` only affects the user experience when submitting forms: the loading state of the submit button won't be reset:
![image](https://github.com/user-attachments/assets/62f0c9be-a838-430b-90a9-f19ff87dd88d)


Therefore, we added timeout error handling specifically for form submissions.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
![image](https://github.com/user-attachments/assets/68f9c9cc-c23a-41e7-a5f8-f029c3317b08)


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
