### PR TITLE
fix(console): should be able to edit password and email in profile

### DIFF
--- a/packages/console/src/cloud/AppRoutes.tsx
+++ b/packages/console/src/cloud/AppRoutes.tsx
@@ -1,5 +1,7 @@
+import { Suspense } from 'react';
 import { Route, Routes } from 'react-router-dom';
 
+import DelayedSuspenseFallback from '@/components/DelayedSuspenseFallback';
 import ProtectedRoutes from '@/containers/ProtectedRoutes';
 import { GlobalAnonymousRoute, GlobalRoute } from '@/contexts/TenantsProvider';
 import { OnboardingApp } from '@/onboarding';
@@ -17,21 +19,26 @@ import SocialDemoCallback from './pages/SocialDemoCallback';
 function AppRoutes() {
   return (
     <div className={styles.app}>
-      <Routes>
-        <Route path={GlobalAnonymousRoute.Callback} element={<Callback />} />
-        <Route path={GlobalAnonymousRoute.SocialDemoCallback} element={<SocialDemoCallback />} />
-        <Route element={<ProtectedRoutes />}>
-          <Route
-            path={`${GlobalRoute.AcceptInvitation}/:invitationId`}
-            element={<AcceptInvitation />}
-          />
-          <Route path={GlobalRoute.Profile + '/*'} element={<Profile />} />
-          <Route path={GlobalRoute.HandleSocial} element={<HandleSocialCallback />} />
-          <Route path={GlobalRoute.CheckoutSuccessCallback} element={<CheckoutSuccessCallback />} />
-          <Route path={GlobalRoute.Onboarding + '/*'} element={<OnboardingApp />} />
-          <Route index element={<Main />} />
-        </Route>
-      </Routes>
+      <Suspense fallback={<DelayedSuspenseFallback />}>
+        <Routes>
+          <Route path={GlobalAnonymousRoute.Callback} element={<Callback />} />
+          <Route path={GlobalAnonymousRoute.SocialDemoCallback} element={<SocialDemoCallback />} />
+          <Route element={<ProtectedRoutes />}>
+            <Route
+              path={`${GlobalRoute.AcceptInvitation}/:invitationId`}
+              element={<AcceptInvitation />}
+            />
+            <Route path={GlobalRoute.Profile + '/*'} element={<Profile />} />
+            <Route path={GlobalRoute.HandleSocial} element={<HandleSocialCallback />} />
+            <Route
+              path={GlobalRoute.CheckoutSuccessCallback}
+              element={<CheckoutSuccessCallback />}
+            />
+            <Route path={GlobalRoute.Onboarding + '/*'} element={<OnboardingApp />} />
+            <Route index element={<Main />} />
+          </Route>
+        </Routes>
+      </Suspense>
     </div>
   );
 }

--- a/packages/console/src/components/DelayedSuspenseFallback/index.module.scss
+++ b/packages/console/src/components/DelayedSuspenseFallback/index.module.scss
@@ -1,0 +1,6 @@
+.daisy {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+}

--- a/packages/console/src/components/DelayedSuspenseFallback/index.tsx
+++ b/packages/console/src/components/DelayedSuspenseFallback/index.tsx
@@ -1,0 +1,33 @@
+import { useState, useEffect } from 'react';
+
+import { Daisy } from '@/ds-components/Spinner';
+
+import styles from './index.module.scss';
+
+const suspenseDisplayTimeout = 500; // Milliseconds
+
+/**
+ * Displays a spinner after a short delay (500ms) to prevent flashing
+ * @returns {JSX.Element} The spinner
+ */
+function DelayedSuspenseFallback() {
+  const [showSpinner, setShowSpinner] = useState(false);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setShowSpinner(true);
+    }, suspenseDisplayTimeout);
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, []);
+
+  if (showSpinner) {
+    return <Daisy className={styles.daisy} />;
+  }
+
+  return null;
+}
+
+export default DelayedSuspenseFallback;

--- a/packages/console/src/containers/ConsoleContent/index.tsx
+++ b/packages/console/src/containers/ConsoleContent/index.tsx
@@ -1,10 +1,10 @@
-import { Suspense, useEffect, useState } from 'react';
+import { Suspense } from 'react';
 import { useOutletContext, useRoutes } from 'react-router-dom';
 import { safeLazy } from 'react-safe-lazy';
 
+import DelayedSuspenseFallback from '@/components/DelayedSuspenseFallback';
 import { isDevFeaturesEnabled } from '@/consts/env';
 import OverlayScrollbar from '@/ds-components/OverlayScrollbar';
-import { Daisy } from '@/ds-components/Spinner';
 import Tag from '@/ds-components/Tag';
 import { useConsoleRoutes } from '@/hooks/use-console-routes';
 import { usePlausiblePageview } from '@/hooks/use-plausible-pageview';
@@ -15,28 +15,7 @@ import { Skeleton } from './Sidebar';
 import useTenantScopeListener from './hooks';
 import styles from './index.module.scss';
 
-const suspenseDisplayTimeout = 500; // Milliseconds
 const Sidebar = safeLazy(async () => import('./Sidebar'));
-
-function SuspenseFallback() {
-  const [showSpinner, setShowSpinner] = useState(false);
-
-  useEffect(() => {
-    const timeout = window.setTimeout(() => {
-      setShowSpinner(true);
-    }, suspenseDisplayTimeout);
-
-    return () => {
-      clearTimeout(timeout);
-    };
-  }, []);
-
-  if (showSpinner) {
-    return <Daisy className={styles.daisy} />;
-  }
-
-  return null;
-}
 
 function ConsoleContent() {
   const { scrollableContent } = useOutletContext<AppContentOutletContext>();
@@ -54,7 +33,7 @@ function ConsoleContent() {
       </Suspense>
       <OverlayScrollbar className={styles.overlayScrollbarWrapper}>
         <div ref={scrollableContent} className={styles.main}>
-          <Suspense fallback={<SuspenseFallback />}>{routes}</Suspense>
+          <Suspense fallback={<DelayedSuspenseFallback />}>{routes}</Suspense>
         </div>
       </OverlayScrollbar>
       {isDevFeaturesEnabled && (


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Should be able to edit password and email in profile in Logto Cloud.

Currently all the user fields that requires a fullscreen popup modal in profile page are broken, due to a `lazyLoad` refactoring. Root cause is the Cloud routes lack of a `<Suspense></Suspense>` wrapper.

The OSS distributions are not affected.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
