### PR TITLE
fix(experience): avoid asking user to register when sign-up method is not supported

### DIFF
--- a/packages/experience/src/containers/VerificationCode/use-sign-in-flow-code-verification.ts
+++ b/packages/experience/src/containers/VerificationCode/use-sign-in-flow-code-verification.ts
@@ -30,7 +30,7 @@ const useSignInFlowCodeVerification = (
   const { show } = useConfirmModal();
   const navigate = useNavigate();
   const redirectTo = useGlobalRedirectTo();
-  const { signInMode } = useSieMethods();
+  const { signInMode, signUpMethods } = useSieMethods();
 
   const handleError = useErrorHandler();
   const registerWithIdentifierAsync = useApi(registerWithVerifiedIdentifier);
@@ -44,8 +44,12 @@ const useSignInFlowCodeVerification = (
   const showIdentifierErrorAlert = useIdentifierErrorAlert();
 
   const identifierNotExistErrorHandler = useCallback(async () => {
-    // Should not redirect user to register if is sign-in only mode or bind social flow
-    if (signInMode === SignInMode.SignIn) {
+    /**
+     * Should not redirect user to register in the following cases:
+     * 1. in the sign-in only mode
+     * 2. the method is not supported for sign-up
+     */
+    if (signInMode === SignInMode.SignIn || !signUpMethods.includes(method)) {
       void showIdentifierErrorAlert(IdentifierErrorType.IdentifierNotExist, method, target);
 
       return;
@@ -81,16 +85,17 @@ const useSignInFlowCodeVerification = (
     });
   }, [
     signInMode,
+    signUpMethods,
+    method,
     show,
     t,
-    method,
     target,
-    registerWithIdentifierAsync,
     showIdentifierErrorAlert,
-    navigate,
+    registerWithIdentifierAsync,
     handleError,
     preSignInErrorHandler,
     redirectTo,
+    navigate,
   ]);
 
   const errorHandlers = useMemo<ErrorHandlers>(


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

We encountered a bug as follows:

The sign-in method has email login enabled, but in the sign-up configuration, email is set to “not applicable.” When a user attempts to log in with a new email, they are prompted with a message asking if they want to create a new account. After selecting “create,” an error message appears stating “method not enabled.”

![image](https://github.com/user-attachments/assets/bafa150f-e4fb-476b-9983-4dd6b1c67ce3)

![image](https://github.com/user-attachments/assets/c7c3ab7c-f048-4c0f-a1ac-64eb73450590)

Expected behavior: After attempting to log in, the user should be informed that the email does not exist, rather than being asked if they want to create a new account (the same issue occurs with phone numbers).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

<img width="821" alt="image" src="https://github.com/user-attachments/assets/ffe40b54-de6b-4fd0-83db-b211d8caaac7">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
