### PR TITLE
fix(console): fix impersonation tag in audit log

### DIFF
--- a/packages/console/src/components/AuditLogTable/components/EventName/index.tsx
+++ b/packages/console/src/components/AuditLogTable/components/EventName/index.tsx
@@ -1,3 +1,4 @@
+import { type Log } from '@logto/schemas';
 import classNames from 'classnames';
 import { Link } from 'react-router-dom';
 
@@ -8,14 +9,16 @@ import Tag from '@/ds-components/Tag';
 import useTenantPathname from '@/hooks/use-tenant-pathname';
 
 import styles from './index.module.scss';
+import { isImpersonationLog } from './utils';
 
 type Props = {
   readonly eventKey: string;
   readonly isSuccess: boolean;
+  readonly payload: Log['payload'];
   readonly to?: string;
 };
 
-function EventName({ eventKey, isSuccess, to }: Props) {
+function EventName({ eventKey, payload, isSuccess, to }: Props) {
   const title = logEventTitle[eventKey] ?? eventKey;
   const { getTo } = useTenantPathname();
 
@@ -36,7 +39,10 @@ function EventName({ eventKey, isSuccess, to }: Props) {
         </Link>
       )}
       {!to && <div className={styles.title}>{title}</div>}
-      {eventKey === 'ExchangeTokenBy.TokenExchange' && <Tag status="alert">Impersonation</Tag>}
+      {isImpersonationLog({
+        key: eventKey,
+        payload,
+      }) && <Tag status="alert">Impersonation</Tag>}
     </div>
   );
 }

--- a/packages/console/src/components/AuditLogTable/components/EventName/utils.ts
+++ b/packages/console/src/components/AuditLogTable/components/EventName/utils.ts
@@ -1,0 +1,21 @@
+import { type Log } from '@logto/schemas';
+
+/**
+ * Check if the log (token exchange) is an impersonation log.
+ *
+ * @param log - The log object.
+ * @returns Whether the log is an impersonation log.
+ */
+export const isImpersonationLog = (
+  log: Pick<Log, 'key'> & { payload: Pick<Log['payload'], 'params'> }
+) => {
+  if (log.key !== 'ExchangeTokenBy.TokenExchange') {
+    return false;
+  }
+
+  if (log.payload.params?.subject_token_type === 'urn:ietf:params:oauth:token-type:access_token') {
+    return true;
+  }
+
+  return false;
+};

--- a/packages/console/src/components/AuditLogTable/index.tsx
+++ b/packages/console/src/components/AuditLogTable/index.tsx
@@ -70,8 +70,12 @@ function AuditLogTable({ applicationId, userId, className }: Props) {
     title: t('logs.event'),
     dataIndex: 'event',
     colSpan: isUserColumnVisible ? 5 : 6,
-    render: ({ key, payload: { result } }) => (
-      <EventName eventKey={key} isSuccess={result === LogResult.Success} />
+    render: ({ key, payload }) => (
+      <EventName
+        eventKey={key}
+        isSuccess={payload.result === LogResult.Success}
+        payload={payload}
+      />
     ),
   };
 

--- a/packages/console/src/pages/AuditLogDetails/index.tsx
+++ b/packages/console/src/pages/AuditLogDetails/index.tsx
@@ -7,6 +7,7 @@ import { useLocation, useParams } from 'react-router-dom';
 import useSWR from 'swr';
 
 import ApplicationName from '@/components/ApplicationName';
+import { isImpersonationLog } from '@/components/AuditLogTable/components/EventName/utils';
 import DetailsPage from '@/components/DetailsPage';
 import PageMeta from '@/components/PageMeta';
 import UserName from '@/components/UserName';
@@ -87,9 +88,7 @@ function AuditLogDetails() {
             <div className={styles.content}>
               <div className={styles.eventName}>
                 {logEventTitle[data.key]}
-                {data.key === 'ExchangeTokenBy.TokenExchange' && (
-                  <Tag status="alert">Impersonation</Tag>
-                )}
+                {isImpersonationLog(data) && <Tag status="alert">Impersonation</Tag>}
               </div>
               <div className={styles.basicInfo}>
                 <div className={styles.infoItem}>

--- a/packages/schemas/src/foundations/jsonb-types/logs.ts
+++ b/packages/schemas/src/foundations/jsonb-types/logs.ts
@@ -17,6 +17,7 @@ export const logContextPayloadGuard = z
     userId: z.string().optional(),
     applicationId: z.string().optional(),
     sessionId: z.string().optional(),
+    params: z.record(z.string(), z.unknown()).optional(),
   })
   .catchall(z.unknown());
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Fix the "impersonation" tag display condition:

1. the event key is token exchange
2. the subject token type is access token (new)

Because we are adding "PAT" feature that also uses the token exchange type, so the condition should be more specific.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
