### PR TITLE
fix(console): manually trigger usage api updates

### DIFF
--- a/packages/console/src/pages/TenantSettings/TenantMembers/Invitations/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantMembers/Invitations/index.tsx
@@ -17,6 +17,7 @@ import { useAuthedCloudApi } from '@/cloud/hooks/use-cloud-api';
 import type { InvitationResponse, TenantInvitationResponse } from '@/cloud/types/router';
 import Breakable from '@/components/Breakable';
 import { RoleOption } from '@/components/OrganizationRolesSelect';
+import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import ActionMenu, { ActionMenuItem } from '@/ds-components/ActionMenu';
 import Button from '@/ds-components/Button';
@@ -56,7 +57,7 @@ function Invitations() {
   const {
     access: { canInviteMember, canRemoveMember },
   } = useCurrentTenantScopes();
-
+  const { mutateSubscriptionQuotaAndUsages } = useContext(SubscriptionDataContext);
   const { data, error, isLoading, mutate } = useSWR<TenantInvitationResponse[], RequestError>(
     `api/tenants/${currentTenantId}/invitations`,
     async () =>
@@ -80,6 +81,7 @@ function Invitations() {
       params: { tenantId: currentTenantId, invitationId },
       body: { status: OrganizationInvitationStatus.Revoked },
     });
+    mutateSubscriptionQuotaAndUsages();
     void mutate();
     toast.success(t('messages.invitation_revoked'));
   };
@@ -97,6 +99,7 @@ function Invitations() {
     await cloudApi.delete(`/api/tenants/:tenantId/invitations/:invitationId`, {
       params: { tenantId: currentTenantId, invitationId },
     });
+    mutateSubscriptionQuotaAndUsages();
     void mutate();
     toast.success(t('messages.invitation_deleted'));
   };

--- a/packages/console/src/pages/TenantSettings/TenantMembers/InviteMemberModal/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantMembers/InviteMemberModal/index.tsx
@@ -45,6 +45,7 @@ function InviteMemberModal({ isOpen, onClose }: Props) {
     currentSubscription: { planId, isAddOnAvailable },
     currentSubscriptionQuota,
     currentSubscriptionUsage: { tenantMembersLimit },
+    mutateSubscriptionQuotaAndUsages,
   } = useContext(SubscriptionDataContext);
   const {
     data: { tenantMembersUpsellNoticeAcknowledged },
@@ -109,6 +110,7 @@ function InviteMemberModal({ isOpen, onClose }: Props) {
           params: { tenantId: currentTenantId },
           body: { invitee: emails.map(({ value }) => value), roleName: role },
         });
+        mutateSubscriptionQuotaAndUsages();
         toast.success(t('tenant_members.messages.invitation_sent'));
         onClose(true);
       } finally {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
manually trigger usage api updates when
1. new invitations sent
2. tenant members deleted
3. pending invitations revoked

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
