### PR TITLE
fix: translate cli workspace dependency reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@logto/cli": "workspace:^1.1.0",
-    "@logto/translate": "workspace:^0.0.0"
+    "@logto/cli": "workspace:^",
+    "@logto/translate": "workspace:^"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,10 +12,10 @@ importers:
   .:
     dependencies:
       '@logto/cli':
-        specifier: workspace:^1.1.0
+        specifier: workspace:^
         version: link:packages/cli
       '@logto/translate':
-        specifier: workspace:^0.0.0
+        specifier: workspace:^
         version: link:packages/translate
     devDependencies:
       '@changesets/cli':


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The monorepo root package.json contains a dependency referece to the newly added "@logto/translate" package. However, when referecing the dependency, a semver number `0.0.0` was used, and has caused a build error in CI of the master branch.
This PR removes the unnecessary trailing semver, and directly use `workspace:^` instead.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Master CI should be successful. Pending for further verification.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
