### PR TITLE
fix(console): manually trigger usage api updates on org member deletion

### DIFF
--- a/packages/console/src/pages/TenantSettings/TenantMembers/Members/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantMembers/Members/index.tsx
@@ -10,6 +10,7 @@ import ActionsButton from '@/components/ActionsButton';
 import EmptyDataPlaceholder from '@/components/EmptyDataPlaceholder';
 import UserPreview from '@/components/ItemPreview/UserPreview';
 import { RoleOption } from '@/components/OrganizationRolesSelect';
+import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import Table from '@/ds-components/Table';
 import Tag from '@/ds-components/Tag';
@@ -27,6 +28,7 @@ function Members() {
   const {
     access: { canRemoveMember, canUpdateMemberRole },
   } = useCurrentTenantScopes();
+  const { mutateSubscriptionQuotaAndUsages } = useContext(SubscriptionDataContext);
 
   const { data, error, isLoading, mutate } = useSWR<TenantMemberResponse[], RequestError>(
     `api/tenants/${currentTenantId}/members`,
@@ -100,6 +102,7 @@ function Members() {
                             params: { tenantId: currentTenantId, userId: user.id },
                           });
                           void mutate();
+                          mutateSubscriptionQuotaAndUsages();
                         })
                     )}
                   />


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
manually trigger usage api updates on org member deletion.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
