### PR TITLE
fix(experience): smart input field should have correct initial type

### DIFF
--- a/packages/experience/src/components/InputFields/SmartInputField/utils.ts
+++ b/packages/experience/src/components/InputFields/SmartInputField/utils.ts
@@ -40,3 +40,53 @@ export const getInputHtmlProps = (
     label: enabledTypes.map((type) => i18next.t(identifierInputPlaceholderMap[type])).join(' / '),
   };
 };
+
+const digitsRegex = /^\d*$/;
+
+type DetectIdentifierTypeParams = {
+  value: string;
+  enabledTypeSet: Set<IdentifierInputType>;
+  defaultType?: IdentifierInputType;
+  currentType?: IdentifierInputType;
+};
+
+export const detectIdentifierType = ({
+  value,
+  enabledTypeSet,
+  defaultType,
+  currentType,
+}: DetectIdentifierTypeParams) => {
+  // Reset InputType
+  if (!value && enabledTypeSet.size > 1) {
+    return;
+  }
+
+  if (enabledTypeSet.size === 1) {
+    return defaultType;
+  }
+
+  const hasAtSymbol = value.includes('@');
+  const isAllDigits = digitsRegex.test(value);
+
+  if (enabledTypeSet.has(SignInIdentifier.Phone) && value.length >= 3 && isAllDigits) {
+    return SignInIdentifier.Phone;
+  }
+
+  if (enabledTypeSet.has(SignInIdentifier.Email) && hasAtSymbol) {
+    return SignInIdentifier.Email;
+  }
+
+  if (currentType === SignInIdentifier.Phone && isAllDigits) {
+    return SignInIdentifier.Phone;
+  }
+
+  if (enabledTypeSet.has(SignInIdentifier.Username)) {
+    return SignInIdentifier.Username;
+  }
+
+  if (enabledTypeSet.has(SignInIdentifier.Email)) {
+    return SignInIdentifier.Email;
+  }
+
+  return currentType;
+};


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The initial `SmartInputField` could only determine the correct type when user is inputting in the input field.
When the `SmartInputField` has a `defaultValue`, its initial type will be `undefined`, which causes an error during validation of the default value due to the incorrect type.

This PR fixes the issue by inferring the initial type of the `SmartInputField` from the `defaultValue`.

Key changes:
- Refactored the original `detectInputType` function into a function that determines the type of the identifier.
- Applied the new function to the original logic and used it to compute the default type for the smart input field.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally and all UT and IT passed.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
