### PR TITLE
fix(console): fix console z index issue on modals and banners

### DIFF
--- a/packages/console/src/containers/AppContent/TenantNotificationContainer/CreateProductionTenantBanner/index.module.scss
+++ b/packages/console/src/containers/AppContent/TenantNotificationContainer/CreateProductionTenantBanner/index.module.scss
@@ -1,17 +1,20 @@
 @use '@/scss/underscore' as _;
 
-.banner {
-  @include _.z-index(front);
+.container {
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
   top: _.unit(4);
-  font: var(--font-label-2);
-  color: var(--color-text);
-  display: flex;
-  align-items: center;
-  gap: _.unit(2.5);
-  padding: _.unit(1.5) _.unit(4);
-  background: var(--color-neutral-variant-90);
-  border-radius: _.unit(4);
+
+  .banner {
+    font: var(--font-label-2);
+    color: var(--color-text);
+    display: flex;
+    align-items: center;
+    gap: _.unit(2.5);
+    padding: _.unit(1.5) _.unit(4);
+    background: var(--color-neutral-variant-90);
+    border-radius: _.unit(4);
+    @include _.z-index(front);
+  }
 }

--- a/packages/console/src/containers/AppContent/TenantNotificationContainer/CreateProductionTenantBanner/index.tsx
+++ b/packages/console/src/containers/AppContent/TenantNotificationContainer/CreateProductionTenantBanner/index.tsx
@@ -22,25 +22,27 @@ function CreateProductionTenantBanner() {
   }
 
   return createPortal(
-    <div className={styles.banner}>
-      <CreateTenantModal
-        isOpen={isCreateModalOpen}
-        onClose={async (tenant?: TenantResponse) => {
-          setIsCreateModalOpen(false);
-          if (tenant) {
-            prependTenant(tenant);
-            navigateTenant(tenant.id);
-          }
-        }}
-      />
-      <span>{t('text')}</span>
-      <TextLink
-        onClick={() => {
-          setIsCreateModalOpen(true);
-        }}
-      >
-        {t('action')}
-      </TextLink>
+    <div className={styles.container}>
+      <div className={styles.banner}>
+        <CreateTenantModal
+          isOpen={isCreateModalOpen}
+          onClose={async (tenant?: TenantResponse) => {
+            setIsCreateModalOpen(false);
+            if (tenant) {
+              prependTenant(tenant);
+              navigateTenant(tenant.id);
+            }
+          }}
+        />
+        <span>{t('text')}</span>
+        <TextLink
+          onClick={() => {
+            setIsCreateModalOpen(true);
+          }}
+        >
+          {t('action')}
+        </TextLink>
+      </div>
     </div>,
     document.body
   );

--- a/packages/console/src/scss/modal.module.scss
+++ b/packages/console/src/scss/modal.module.scss
@@ -6,7 +6,7 @@
   inset: 0;
   overflow-y: auto;
   padding: _.unit(3) 0;
-  z-index: 101;
+  @include _.z-index(modal);
 }
 
 .content {
@@ -25,6 +25,7 @@
 .fullScreen {
   position: fixed;
   inset: 0;
+  @include _.z-index(modal);
 
   &:focus-visible {
     outline: none;

--- a/packages/console/src/scss/normalized.scss
+++ b/packages/console/src/scss/normalized.scss
@@ -46,10 +46,3 @@ input {
   height: 100%;
   flex: 1;
 }
-
-.ReactModalPortal {
-  position: relative;
-  // Set `z-index` for the portal to ensure it can be placed on the right layer among other
-  // top-level doms.
-  @include _.z-index(modal);
-}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fixed a bug that cannot invite admin user, which is a regression bug caused by incorrect z-index config.
Currently all react-modal portals have been set at the same z-index value (#5948), as a result, the children elements z-index does not function.

This PR removes the global CSS class that sets the z-index value to all react-modal portals, and fix the #5948 by providing an absolute position parent. This way, the z-index will be applied to children element and won't affect other modal portals.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested.
- The production banner does not show on top of modal dialogs
<img width="1336" alt="image" src="https://github.com/user-attachments/assets/c7da9dfa-fb1a-4d17-94c6-c0e698e0f208">

- The invite admin confirm modal can be displayed on top of the invite modal
<img width="869" alt="image" src="https://github.com/user-attachments/assets/e1d0756d-59e4-489e-ac5f-6ed53367426f">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
