### PR TITLE
fix: make alteration script compatible for core DB in all regions

### DIFF
--- a/packages/schemas/alterations/next-1724229102-add-report-sub-updates-cloud-scope.ts
+++ b/packages/schemas/alterations/next-1724229102-add-report-sub-updates-cloud-scope.ts
@@ -40,11 +40,15 @@ const reportSubscriptionUpdatesScopeDescription =
 const alteration: AlterationScript = {
   up: async (pool) => {
     // Get the Cloud API resource
-    const cloudApiResource = await pool.one<Resource>(sql`
+    const cloudApiResource = await pool.maybeOne<Resource>(sql`
       select * from resources
       where tenant_id = ${adminTenantId}
       and indicator = ${cloudApiIndicator}
     `);
+
+    if (!cloudApiResource) {
+      return;
+    }
 
     // Get cloud connection application role
     const tenantApplicationRole = await pool.one<Role>(sql`
@@ -59,6 +63,7 @@ const alteration: AlterationScript = {
       values (${generateStandardId()}, ${adminTenantId}, ${
         cloudApiResource.id
       }, ${reportSubscriptionUpdatesScopeName}, ${reportSubscriptionUpdatesScopeDescription})
+      on conflict (tenant_id, name, resource_id) do nothing
       returning *;
     `);
 
@@ -67,16 +72,20 @@ const alteration: AlterationScript = {
       insert into roles_scopes (id, tenant_id, role_id, scope_id)
       values (${generateStandardId()}, ${adminTenantId}, ${tenantApplicationRole.id}, ${
         reportSubscriptionUpdatesCloudScope.id
-      });
+      }) on conflict (tenant_id, role_id, scope_id) do nothing;
     `);
   },
   down: async (pool) => {
     // Get the Cloud API resource
-    const cloudApiResource = await pool.one<Resource>(sql`
+    const cloudApiResource = await pool.maybeOne<Resource>(sql`
       select * from resources
       where tenant_id = ${adminTenantId}
       and indicator = ${cloudApiIndicator}
     `);
+
+    if (!cloudApiResource) {
+      return;
+    }
 
     // Remove the `report:subscription:updates` scope
     await pool.query(sql`


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
update alteration script

Context:
This alteration script is to add scope to the cloud API resource of admin tenant and assign this scope to a specific role, so that all the m2m apps which are assigned with this role can get this scope.
But the admin tenant only exists in the core DB corresponding to the region where the cloud DB is located (EU region), so in other regions, the corresponding cloud API resource cannot be found, and the alteration should be completed directly at this time.
In the original alteration script, the existence of cloud API resources in all regions of core DB is mandatory, which is incorrect. In this PR, we fix this problem and judge whether it is EU region by whether the cloud API resource exists. For the core DB without cloud API resource in non EU region, the alteration is completed directly.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
