### PR TITLE
fix(core): remove grant id of token exchange

### DIFF
--- a/packages/core/src/oidc/grants/token-exchange/account.ts
+++ b/packages/core/src/oidc/grants/token-exchange/account.ts
@@ -1,4 +1,3 @@
-import { generateStandardShortId } from '@logto/shared';
 import { trySafe } from '@silverhand/essentials';
 import { errors } from 'oidc-provider';
 
@@ -13,7 +12,7 @@ export const validateSubjectToken = async (
   queries: Queries,
   subjectToken: string,
   type: string
-): Promise<{ userId: string; grantId: string; subjectTokenId?: string }> => {
+): Promise<{ userId: string; subjectTokenId?: string }> => {
   const {
     subjectTokens: { findSubjectToken },
     personalAccessTokens: { findByValue },
@@ -27,7 +26,6 @@ export const validateSubjectToken = async (
 
     return {
       userId: token.userId,
-      grantId: token.id,
       subjectTokenId: token.id,
     };
   }
@@ -39,7 +37,7 @@ export const validateSubjectToken = async (
       new InvalidGrant('subject token is expired')
     );
 
-    return { userId: token.userId, grantId: generateStandardShortId() };
+    return { userId: token.userId };
   }
   throw new InvalidGrant('unsupported subject token type');
 };

--- a/packages/core/src/oidc/grants/token-exchange/index.test.ts
+++ b/packages/core/src/oidc/grants/token-exchange/index.test.ts
@@ -180,7 +180,6 @@ describe('token exchange', () => {
     expect(value).toMatchObject({
       accountId,
       clientId,
-      grantId: subjectTokenId,
       gty: 'urn:ietf:params:oauth:grant-type:token-exchange',
     });
   });
@@ -244,7 +243,6 @@ describe('token exchange', () => {
       expect(value).toMatchObject({
         accountId,
         clientId,
-        grantId: subjectTokenId,
         aud: 'urn:logto:organization:some_org_id',
       });
     });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Remove "grantId" value of the access token granted by "token exchange".

Token exchange is a special grant type that do not have a "grant" object, because it bypass the normal authentication flow. Normally, a "grant" object is genrated when the user passed the authentication check in sign in flow.

Previously, we assign a fake grantId to the access token, that is meaningless and cause introspection failure, see the code of `node-oidc-provider`, it'll check if the grant is valid if "grantId" is present:

```
if (token.grantId) {
  const grant = await ctx.oidc.provider.Grant.find(token.grantId, {
    ignoreExpiration: true,
  });

  if (!grant) return;
  if (grant.isExpired) return;
  if (grant.clientId !== token.clientId) return;
  if (grant.accountId !== token.accountId) return;

  ctx.oidc.entity('Grant', grant);
}
```

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested with token introspection, the result is `active: true`

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
