### PR TITLE
feat(experience): add reset password first screen

### DIFF
--- a/packages/core/src/oidc/utils.test.ts
+++ b/packages/core/src/oidc/utils.test.ts
@@ -160,6 +160,7 @@ describe('buildLoginPromptUrl', () => {
       })
     ).toBe('identifier-register?identifier=username');
     expect(buildLoginPromptUrl({ first_screen: FirstScreen.SingleSignOn })).toBe('single-sign-on');
+    expect(buildLoginPromptUrl({ first_screen: FirstScreen.ResetPassword })).toBe('reset-password');
 
     // Legacy interactionMode support
     expect(buildLoginPromptUrl({ interaction_mode: InteractionMode.SignUp })).toBe('register');

--- a/packages/core/src/oidc/utils.ts
+++ b/packages/core/src/oidc/utils.ts
@@ -95,6 +95,7 @@ const firstScreenRouteMapping: Record<FirstScreen, keyof typeof experience.route
    * Todo @xiaoyijun remove isDevFeaturesEnabled check
    * Fallback to signIn when dev feature is not ready (these three screens are not supported yet)
    */
+  [FirstScreen.ResetPassword]: isDevFeaturesEnabled ? 'resetPassword' : 'signIn',
   [FirstScreen.IdentifierSignIn]: isDevFeaturesEnabled ? 'identifierSignIn' : 'signIn',
   [FirstScreen.IdentifierRegister]: isDevFeaturesEnabled ? 'identifierRegister' : 'signIn',
   [FirstScreen.SingleSignOn]: isDevFeaturesEnabled ? 'sso' : 'signIn',

--- a/packages/experience/src/App.tsx
+++ b/packages/experience/src/App.tsx
@@ -27,6 +27,7 @@ import WebAuthnVerification from './pages/MfaVerification/WebAuthnVerification';
 import Register from './pages/Register';
 import RegisterPassword from './pages/RegisterPassword';
 import ResetPassword from './pages/ResetPassword';
+import ResetPasswordLanding from './pages/ResetPasswordLanding';
 import SignIn from './pages/SignIn';
 import SignInPassword from './pages/SignInPassword';
 import SingleSignOnConnectors from './pages/SingleSignOnConnectors';
@@ -138,6 +139,12 @@ const App = () => {
                         <Route
                           path={experience.routes.identifierRegister}
                           element={<IdentifierRegister />}
+                        />
+
+                        {/* Reset password */}
+                        <Route
+                          path={experience.routes.resetPassword}
+                          element={<ResetPasswordLanding />}
                         />
                       </>
                     )}

--- a/packages/experience/src/Layout/FocusedAuthPageLayout/index.tsx
+++ b/packages/experience/src/Layout/FocusedAuthPageLayout/index.tsx
@@ -18,7 +18,7 @@ type Props = {
   readonly pageMeta: PageMetaProps;
   readonly title: TFuncKey;
   readonly description: string;
-  readonly footerTermsDisplayPolicies: AgreeToTermsPolicy[];
+  readonly footerTermsDisplayPolicies?: AgreeToTermsPolicy[];
   readonly authOptionsLink: TextLinkProps;
 };
 
@@ -33,7 +33,7 @@ const FocusedAuthPageLayout = ({
   pageMeta,
   title,
   description,
-  footerTermsDisplayPolicies,
+  footerTermsDisplayPolicies = [],
   authOptionsLink,
 }: Props) => {
   const { agreeToTermsPolicy } = useTerms();

--- a/packages/experience/src/hooks/use-send-verification-code.ts
+++ b/packages/experience/src/hooks/use-send-verification-code.ts
@@ -44,15 +44,9 @@ const useSendVerificationCode = (flow: UserFlow, replaceCurrentPage?: boolean) =
       }
 
       if (result) {
-        navigate(
-          {
-            pathname: `/${flow}/verification-code`,
-            search: window.location.search,
-          },
-          {
-            replace: replaceCurrentPage,
-          }
-        );
+        navigate(`/${flow}/verification-code`, {
+          replace: replaceCurrentPage,
+        });
       }
     },
     [asyncSendVerificationCode, flow, handleError, navigate, replaceCurrentPage]

--- a/packages/experience/src/hooks/use-send-verification-code.ts
+++ b/packages/experience/src/hooks/use-send-verification-code.ts
@@ -44,9 +44,15 @@ const useSendVerificationCode = (flow: UserFlow, replaceCurrentPage?: boolean) =
       }
 
       if (result) {
-        navigate(`/${flow}/verification-code`, {
-          replace: replaceCurrentPage,
-        });
+        navigate(
+          {
+            pathname: `/${flow}/verification-code`,
+            search: window.location.search,
+          },
+          {
+            replace: replaceCurrentPage,
+          }
+        );
       }
     },
     [asyncSendVerificationCode, flow, handleError, navigate, replaceCurrentPage]

--- a/packages/experience/src/pages/ForgotPassword/ForgotPasswordForm/index.tsx
+++ b/packages/experience/src/pages/ForgotPassword/ForgotPasswordForm/index.tsx
@@ -19,7 +19,7 @@ type Props = {
   // eslint-disable-next-line react/boolean-prop-naming
   readonly autoFocus?: boolean;
   readonly defaultValue?: string;
-  readonly defaultType: VerificationCodeIdentifier;
+  readonly defaultType?: VerificationCodeIdentifier;
   readonly enabledTypes: VerificationCodeIdentifier[];
 };
 

--- a/packages/experience/src/pages/ResetPasswordLanding/index.tsx
+++ b/packages/experience/src/pages/ResetPasswordLanding/index.tsx
@@ -1,0 +1,62 @@
+import { experience, ExtraParamsKey } from '@logto/schemas';
+import { useTranslation } from 'react-i18next';
+import { Navigate, useSearchParams } from 'react-router-dom';
+
+import FocusedAuthPageLayout from '@/Layout/FocusedAuthPageLayout';
+import { identifierInputDescriptionMap } from '@/utils/form';
+
+import ForgotPasswordForm from '../ForgotPassword/ForgotPasswordForm';
+
+import { useResetPasswordMethods } from './use-reset-password-methods';
+
+/**
+ * ResetPasswordLanding Component
+ *
+ * This is a specialized "first screen" page dedicated to the password reset process,
+ * distinct from the password reset step in the regular login flow.
+ * As the entry point for the password reset flow, it allows users to initiate
+ * the password reset process directly.
+ *
+ * Developers can specify this page as the initial screen of the user's login flow
+ * by setting the `first_screen=reset_password` parameter in the authentication flow.
+ *
+ * Typical use cases include:
+ * 1. When system administrators create accounts for new users and require them
+ *    to update their password upon first login.
+ * 2. When users initiate an authentication flow with reset password as the first screen
+ *    by clicking a link in a password reset email.
+ *
+ * This approach ensures that users can seamlessly enter the password reset flow
+ * in specific scenarios, enhancing both user experience and account security.
+ */
+const ResetPasswordLanding = () => {
+  const { t } = useTranslation();
+  const enabledMethods = useResetPasswordMethods();
+  const [searchParams] = useSearchParams();
+  const loginHint = searchParams.get(ExtraParamsKey.LoginHint) ?? undefined;
+
+  // Fallback to sign-in page
+  if (enabledMethods.length === 0) {
+    return <Navigate to={`/${experience.routes.signIn}`} />;
+  }
+
+  return (
+    <FocusedAuthPageLayout
+      pageMeta={{
+        titleKey: 'description.reset_password',
+      }}
+      title="description.reset_password"
+      description={t('description.reset_password_description', {
+        types: enabledMethods.map((method) => t(identifierInputDescriptionMap[method])),
+      })}
+      authOptionsLink={{
+        to: `/${experience.routes.signIn}`,
+        text: 'description.back_to_sign_in',
+      }}
+    >
+      <ForgotPasswordForm autoFocus defaultValue={loginHint} enabledTypes={enabledMethods} />
+    </FocusedAuthPageLayout>
+  );
+};
+
+export default ResetPasswordLanding;

--- a/packages/experience/src/pages/ResetPasswordLanding/use-reset-password-methods.ts
+++ b/packages/experience/src/pages/ResetPasswordLanding/use-reset-password-methods.ts
@@ -1,0 +1,41 @@
+import { useMemo } from 'react';
+
+import useIdentifierParams from '@/hooks/use-identifier-params';
+import { useForgotPasswordSettings } from '@/hooks/use-sie';
+
+/**
+ * Retrieves reset password methods from sign-in experience settings and URL identifier parameters.
+ * Note: this is only used for the reset password first screen.
+ *
+ * Reset password methods fallback logic:
+ * 1. If forgot password is not enabled, return an empty array
+ * 2. If no identifiers are provided in the URL, return all reset password methods from sign-in experience settings.
+ * 3. If identifiers are provided in the URL but none are supported by sign-in experience settings, return all reset password methods from sign-in experience settings.
+ * 4. If identifiers are provided in the URL and supported by sign-in experience settings, return the intersection of both.
+ */
+export const useResetPasswordMethods = () => {
+  const { identifiers } = useIdentifierParams();
+  const { isForgotPasswordEnabled, enabledMethodSet } = useForgotPasswordSettings();
+
+  return useMemo(() => {
+    // If forgot password is not enabled, return an empty array
+    if (!isForgotPasswordEnabled) {
+      return [];
+    }
+
+    const enabledMethods = [...enabledMethodSet];
+
+    if (identifiers.length === 0) {
+      return enabledMethods;
+    }
+
+    const methods = enabledMethods.filter((identifier) => identifiers.includes(identifier));
+
+    // Fallback to enabled methods if no identifiers are supported
+    if (methods.length === 0) {
+      return enabledMethods;
+    }
+
+    return methods;
+  }, [isForgotPasswordEnabled, enabledMethodSet, identifiers]);
+};

--- a/packages/integration-tests/src/ui-helpers/expect-experience.ts
+++ b/packages/integration-tests/src/ui-helpers/expect-experience.ts
@@ -26,7 +26,8 @@ export type ExperiencePath =
   | `mfa-verification/${MfaFactor}`
   | 'identifier-sign-in'
   | 'identifier-register'
-  | 'single-sign-on';
+  | 'single-sign-on'
+  | 'reset-password';
 
 export type ExpectExperienceOptions = {
   /** The URL of the experience endpoint. */

--- a/packages/phrases-experience/src/locales/de/description.ts
+++ b/packages/phrases-experience/src/locales/de/description.ts
@@ -108,6 +108,7 @@ const description = {
   identifier_register_description:
     'Geben Sie Ihre {{types, list(type: disjunction;)}} ein, um ein neues Konto zu erstellen.',
   all_account_creation_options: 'Alle Kontoerstellungsoptionen',
+  back_to_sign_in: 'Zurück zur Anmeldung',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/en/description.ts
+++ b/packages/phrases-experience/src/locales/en/description.ts
@@ -93,6 +93,7 @@ const description = {
   identifier_register_description:
     'Enter you {{types, list(type: disjunction;)}} to create a new account.',
   all_account_creation_options: 'All account creation options',
+  back_to_sign_in: 'Back to sign in',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/es/description.ts
+++ b/packages/phrases-experience/src/locales/es/description.ts
@@ -108,6 +108,7 @@ const description = {
   identifier_register_description:
     'Ingrese su {{types, list(type: disjunction;)}} para crear una nueva cuenta.',
   all_account_creation_options: 'Todas las opciones de creación de cuenta',
+  back_to_sign_in: 'Volver a iniciar sesión',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/fr/description.ts
+++ b/packages/phrases-experience/src/locales/fr/description.ts
@@ -108,6 +108,7 @@ const description = {
   identifier_register_description:
     'Entrez votre {{types, list(type: disjunction;)}} pour créer un nouveau compte.',
   all_account_creation_options: 'Toutes les options de création de compte',
+  back_to_sign_in: 'Retour à la connexion',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/it/description.ts
+++ b/packages/phrases-experience/src/locales/it/description.ts
@@ -105,6 +105,7 @@ const description = {
   identifier_register_description:
     'Inserisci il tuo {{types, list(type: disjunction;)}} per creare un nuovo account.',
   all_account_creation_options: 'Tutte le opzioni di creazione account',
+  back_to_sign_in: 'Torna al login',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/ja/description.ts
+++ b/packages/phrases-experience/src/locales/ja/description.ts
@@ -104,6 +104,7 @@ const description = {
   identifier_register_description:
     '{{types, list(type: disjunction;)}}を入力して新しいアカウントを作成します。',
   all_account_creation_options: 'すべてのアカウント作成オプション',
+  back_to_sign_in: 'サインインに戻る',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/ko/description.ts
+++ b/packages/phrases-experience/src/locales/ko/description.ts
@@ -99,6 +99,7 @@ const description = {
   identifier_register_description:
     '새 계정을 만들려면 {{types, list(type: disjunction;)}}을(를) 입력하세요.',
   all_account_creation_options: '모든 계정 생성 옵션',
+  back_to_sign_in: '로그인으로 돌아가기',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/pl-pl/description.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/description.ts
@@ -106,6 +106,7 @@ const description = {
   identifier_register_description:
     'Wprowadź swoje {{types, list(type: disjunction;)}} aby utworzyć nowe konto.',
   all_account_creation_options: 'Wszystkie opcje tworzenia konta',
+  back_to_sign_in: 'Wróć do logowania',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/pt-br/description.ts
+++ b/packages/phrases-experience/src/locales/pt-br/description.ts
@@ -102,6 +102,7 @@ const description = {
   identifier_register_description:
     'Digite seu {{types, list(type: disjunction;)}} para criar uma nova conta.',
   all_account_creation_options: 'Todas as opções de criação de conta',
+  back_to_sign_in: 'Voltar para o login',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/pt-pt/description.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/description.ts
@@ -103,6 +103,7 @@ const description = {
   identifier_register_description:
     'Introduza o seu {{types, list(type: disjunction;)}} para criar uma nova conta.',
   all_account_creation_options: 'Todas as opções de criação de conta',
+  back_to_sign_in: 'Voltar para o login',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/ru/description.ts
+++ b/packages/phrases-experience/src/locales/ru/description.ts
@@ -106,6 +106,7 @@ const description = {
   identifier_register_description:
     'Введите свои {{types, list(type: disjunction;)}} чтобы создать новую учётную запись.',
   all_account_creation_options: 'Все варианты создания учётной записи',
+  back_to_sign_in: 'Вернуться ко входу',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/tr-tr/description.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/description.ts
@@ -102,6 +102,7 @@ const description = {
   identifier_register_description:
     'Yeni bir hesap oluşturmak için {{types, list(type: disjunction;)}} girin.',
   all_account_creation_options: 'Tüm hesap oluşturma seçenekleri',
+  back_to_sign_in: 'Girişe dön',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/zh-cn/description.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/description.ts
@@ -81,6 +81,7 @@ const description = {
   all_sign_in_options: '所有登录选项',
   identifier_register_description: '输入您的{{types, list(type: disjunction;)}}以创建新账户。',
   all_account_creation_options: '所有账户创建选项',
+  back_to_sign_in: '返回登录',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/zh-hk/description.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/description.ts
@@ -93,6 +93,7 @@ const description = {
   all_sign_in_options: '所有登入選項',
   identifier_register_description: '輸入您的{{types, list(type: disjunction;)}}以建立新帳戶。',
   all_account_creation_options: '所有帳戶創建選項',
+  back_to_sign_in: '返回登入',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/zh-tw/description.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/description.ts
@@ -93,6 +93,7 @@ const description = {
   all_sign_in_options: '所有登入選項',
   identifier_register_description: '輸入您的{{types, list(type: disjunction;)}}以建立新帳戶。',
   all_account_creation_options: '所有帳戶創建選項',
+  back_to_sign_in: '返回登入',
 };
 
 export default Object.freeze(description);

--- a/packages/schemas/src/consts/experience.ts
+++ b/packages/schemas/src/consts/experience.ts
@@ -3,6 +3,7 @@ const routes = Object.freeze({
   register: 'register',
   sso: 'single-sign-on',
   consent: 'consent',
+  resetPassword: 'reset-password',
   identifierSignIn: 'identifier-sign-in',
   identifierRegister: 'identifier-register',
 } as const);

--- a/packages/schemas/src/consts/oidc.ts
+++ b/packages/schemas/src/consts/oidc.ts
@@ -69,6 +69,7 @@ export enum InteractionMode {
 export enum FirstScreen {
   SignIn = 'sign_in',
   Register = 'register',
+  ResetPassword = 'reset_password',
   IdentifierSignIn = 'identifier:sign_in',
   IdentifierRegister = 'identifier:register',
   SingleSignOn = 'single_sign_on',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add a reset password first screen page for the dedicated password reset process, distinct from the password reset step in the regular login flow.

As the entry point for the password reset flow, it allows users to initiate the password reset process directly.

Developers can specify this page as the initial screen of the user's login flow by setting the `first_screen=reset_password` parameter in the authentication flow.

Typical use cases include:
- When system administrators create accounts for new users and require them to update their password upon first login.
- When users initiate an authentication flow with reset password as the first screen by clicking a link in a password reset email.

This approach ensures that users can seamlessly enter the password reset flow in specific scenarios, enhancing both user experience and account security.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="538" alt="image" src="https://github.com/user-attachments/assets/aae324d2-b3ac-4cbc-ad9e-9288dc1a1fd7">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
