### PR TITLE
feat(core): add `error_code_key` query string param

### DIFF
--- a/.changeset/tiny-fishes-bake.md
+++ b/.changeset/tiny-fishes-bake.md
@@ -1,0 +1,26 @@
+---
+"@logto/core": patch
+---
+
+introduce new `error_code_key` query parameter in the `koaErrorHandler`.
+
+By default, Logto uses `code` as the error code key in the error response body.
+For some third-party connectors, like Google, `code` is considered as a reserved OIDC key,
+can't be used as the error code key in the error response body. Any oidc error response body containing `code` will be rejected by Google.
+
+To workaround this, we introduce a new `error_code_key` query parameter to customize the error code key in the error response body.
+In the oidc requests, if the `error_code_key` is present in the query string, we will use the value of `error_code_key` as the error code key in the error response body.
+
+example:
+
+```curl
+curl -X POST "http://localhost:3001/oidc/token?error_code_key=error_code"
+```
+
+```json
+{
+  "error_code": "oidc.invalid_grant",
+  "error": "invalid_grant",
+  "error_description": "Invalid value for parameter 'code': 'invalid_code'."
+}
+```

--- a/packages/core/src/middleware/koa-oidc-error-handler.ts
+++ b/packages/core/src/middleware/koa-oidc-error-handler.ts
@@ -115,18 +115,18 @@ export default function koaOidcErrorHandler<StateT, ContextT>(): Middleware<Stat
           : `oidc.${data.error}`;
         const uri = errorUris[data.error];
 
-        // Parse the `error_key` from the query string.
+        // Parse the `error_code_key` from the query string.
         // This is used to customize the error key in the response body.
         // For some third-party connectors, like Google, `code` is considered as a reserved OIDC key,
         // can't be used as the error code key in the error response body.
-        // We add `error_key` to the query string to customize the error key in the response body.
+        // We add `error_code_key` to the query string to customize the error key in the response body.
         const errorKeyQuery = z
           .object({
-            error_key: z.string().optional(),
+            error_code_key: z.string().optional(),
           })
           .parse(ctx.query);
 
-        const errorKey = errorKeyQuery.error_key ?? 'code';
+        const errorKey = errorKeyQuery.error_code_key ?? 'code';
 
         ctx.body = {
           [errorKey]: code,

--- a/packages/core/src/middleware/koa-oidc-error-handler.ts
+++ b/packages/core/src/middleware/koa-oidc-error-handler.ts
@@ -82,6 +82,7 @@ const isSessionNotFound = (description?: string) =>
  * @see {@link errorUris} for the list of error URIs.
  */
 export default function koaOidcErrorHandler<StateT, ContextT>(): Middleware<StateT, ContextT> {
+  // eslint-disable-next-line complexity
   return async (ctx, next) => {
     try {
       await next();
@@ -114,8 +115,21 @@ export default function koaOidcErrorHandler<StateT, ContextT>(): Middleware<Stat
           : `oidc.${data.error}`;
         const uri = errorUris[data.error];
 
+        // Parse the `error_key` from the query string.
+        // This is used to customize the error key in the response body.
+        // For some third-party connectors, like Google, `code` is considered as a reserved OIDC key,
+        // can't be used as the error code key in the error response body.
+        // We add `error_key` to the query string to customize the error key in the response body.
+        const errorKeyQuery = z
+          .object({
+            error_key: z.string().optional(),
+          })
+          .parse(ctx.query);
+
+        const errorKey = errorKeyQuery.error_key ?? 'code';
+
         ctx.body = {
-          code,
+          [errorKey]: code,
           message: i18next.t(['errors:' + code, 'errors:oidc.provider_error_fallback'], { code }),
           error_uri: uri,
           ...ctx.body,

--- a/packages/core/src/middleware/koa-oidc-error-handler.ts
+++ b/packages/core/src/middleware/koa-oidc-error-handler.ts
@@ -120,13 +120,15 @@ export default function koaOidcErrorHandler<StateT, ContextT>(): Middleware<Stat
         // For some third-party connectors, like Google, `code` is considered as a reserved OIDC key,
         // can't be used as the error code key in the error response body.
         // We add `error_code_key` to the query string to customize the error key in the response body.
-        const errorKeyQuery = z
+        const errorKeyQueryResult = z
           .object({
             error_code_key: z.string().optional(),
           })
-          .parse(ctx.query);
+          .safeParse(ctx.query);
 
-        const errorKey = errorKeyQuery.error_code_key ?? 'code';
+        const errorKey = errorKeyQueryResult.success
+          ? errorKeyQueryResult.data.error_code_key ?? 'code'
+          : 'code';
 
         ctx.body = {
           [errorKey]: code,


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add `error_code_key` query string param check in the `koaOidcErrorHandler`.

By default, we use the `code` key to represent the error code in the Logto API requests' error response body. However, it has been reported that in Google, `code` is considered a reserved OIDC key and is not allowed in any error response body. Therefore, we need to offer a way to override the default `code` key.

To address this, we are introducing a new query parameter, `error_code_key`, which allows developers to customize the error code key.

Defaul:
```
http://localhost:3001/oidc/token
```
```json
{
    "code": "oidc.invalid_client",
    "message": "An OIDC error occurred: oidc.invalid_client.",
    "error": "invalid_client",
    "error_description": "invalid client test"
}
```

With query param:
```
http://localhost:3001/oidc/token?error_code_key=error_code
```
{
    "error_code": "oidc.invalid_client",
    "message": "An OIDC error occurred: oidc.invalid_client.",
    "error": "invalid_client",
    "error_description": "invalid client test"
}




<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
