### PR TITLE
chore(experience): upgrade react-hook-form

### DIFF
--- a/packages/experience/package.json
+++ b/packages/experience/package.json
@@ -73,7 +73,7 @@
     "react-device-detect": "^2.2.3",
     "react-dom": "^18.3.1",
     "react-helmet": "^6.1.0",
-    "react-hook-form": "^7.34.0",
+    "react-hook-form": "^7.53.0",
     "react-i18next": "^12.3.1",
     "react-modal": "^3.15.1",
     "react-router-dom": "^6.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3345,8 +3345,8 @@ importers:
         specifier: ^6.1.0
         version: 6.1.0(react@18.3.1)
       react-hook-form:
-        specifier: ^7.34.0
-        version: 7.34.0(react@18.3.1)
+        specifier: ^7.53.0
+        version: 7.53.0(react@18.3.1)
       react-i18next:
         specifier: ^12.3.1
         version: 12.3.1(i18next@22.4.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -11270,17 +11270,17 @@ packages:
     peerDependencies:
       react: '>=16.3.0'
 
-  react-hook-form@7.34.0:
-    resolution: {integrity: sha512-s0/TJ09NVlEk2JPp3yit1WnMuPNBXFmUKEQPulgDi9pYBw/ZmmAFHe6AXWq73Y+kp8ye4OcMf0Jv+i/qLPektg==}
-    engines: {node: '>=12.22.0'}
-    peerDependencies:
-      react: ^16.8.0 || ^17 || ^18
-
   react-hook-form@7.43.9:
     resolution: {integrity: sha512-AUDN3Pz2NSeoxQ7Hs6OhQhDr6gtF9YRuutGDwPQqhSUAHJSgGl2VeY3qN19MG0SucpjgDiuMJ4iC5T5uB+eaNQ==}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18
+
+  react-hook-form@7.53.0:
+    resolution: {integrity: sha512-M1n3HhqCww6S2hxLxciEXy2oISPnAzxY7gvwVPrtlczTM/1dDadXgUxDpHMrMTblDOcm/AXtXxHwZ3jpg1mqKQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
 
   react-hot-toast@2.2.0:
     resolution: {integrity: sha512-248rXw13uhf/6TNDVzagX+y7R8J183rp7MwUMNkcrBRyHj/jWOggfXTGlM8zAOuh701WyVW+eUaWG2LeSufX9g==}
@@ -11404,7 +11404,7 @@ packages:
     resolution: {integrity: sha512-rQk2Nm+TOBrM1C4E3e6KwT65iXyRSgBHjCkr2FNja1S51WaPulRA5nKj/xazuQ3x89wDDdGsrqkqy0RBIfd0xg==}
     engines: {node: '>=10'}
     peerDependencies:
-      react: ^16 || ^17 || ^18 || ^18.0.0
+      react: ^16 || ^17 || ^18
 
   react-transition-group@2.9.0:
     resolution: {integrity: sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==}
@@ -22551,11 +22551,11 @@ snapshots:
       react-fast-compare: 3.2.1
       react-side-effect: 2.1.2(react@18.3.1)
 
-  react-hook-form@7.34.0(react@18.3.1):
+  react-hook-form@7.43.9(react@18.3.1):
     dependencies:
       react: 18.3.1
 
-  react-hook-form@7.43.9(react@18.3.1):
+  react-hook-form@7.53.0(react@18.3.1):
     dependencies:
       react: 18.3.1
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Upgrade react-hook-form to `v7.53.0` so that we can retrieve the form’s `defaultValues` from `formState`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
None.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
