### PR TITLE
fix(experience): avoid carring identifer from reset password page to sign-in page

### DIFF
--- a/packages/experience/src/pages/ResetPassword/index.tsx
+++ b/packages/experience/src/pages/ResetPassword/index.tsx
@@ -21,13 +21,7 @@ const ResetPassword = () => {
   const { setToast } = useToast();
   const navigate = useNavigate();
   const { show } = usePromiseConfirmModal();
-  const {
-    identifierInputValue,
-    setIdentifierInputValue,
-    forgotPasswordIdentifierInputValue,
-    setForgotPasswordIdentifierInputValue,
-  } = useContext(UserInteractionContext);
-
+  const { setForgotPasswordIdentifierInputValue } = useContext(UserInteractionContext);
   const errorHandlers: ErrorHandlers = useMemo(
     () => ({
       'session.verification_session_not_found': async (error) => {
@@ -43,15 +37,6 @@ const ResetPassword = () => {
   const successHandler: SuccessHandler<typeof setUserPassword> = useCallback(
     (result) => {
       if (result) {
-        /**
-         * Improve user experience by caching the identifier input value for sign-in page
-         * when the user is first redirected to the reset password page.
-         * This allows user to continue the sign flow without having to re-enter the identifier.
-         */
-        if (!identifierInputValue) {
-          setIdentifierInputValue(forgotPasswordIdentifierInputValue);
-        }
-
         // Clear the forgot password identifier input value after the password is set
         setForgotPasswordIdentifierInputValue(undefined);
 
@@ -59,15 +44,7 @@ const ResetPassword = () => {
         navigate('/sign-in', { replace: true });
       }
     },
-    [
-      forgotPasswordIdentifierInputValue,
-      identifierInputValue,
-      navigate,
-      setForgotPasswordIdentifierInputValue,
-      setIdentifierInputValue,
-      setToast,
-      t,
-    ]
+    [navigate, setForgotPasswordIdentifierInputValue, setToast, t]
   );
 
   const [action] = usePasswordAction({


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Per offline discussion with @Rany0101 , we should not carry the identifier used in reset password flow to sign-in page.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
