### PR TITLE
feat(core): add denyAccess api context to customJwt script

### DIFF
--- a/packages/core/src/libraries/jwt-customizer.ts
+++ b/packages/core/src/libraries/jwt-customizer.ts
@@ -8,7 +8,7 @@ import {
   type JwtCustomizerType,
   type JwtCustomizerUserContext,
   type LogtoJwtTokenKey,
-  type JwtCustomizerApiContext,
+  type CustomJwtApiContext,
   type CustomJwtScriptPayload,
 } from '@logto/schemas';
 import { type ConsoleLog } from '@logto/shared';
@@ -32,7 +32,7 @@ import {
 
 import { type CloudConnectionLibrary } from './cloud-connection.js';
 
-const apiContext: JwtCustomizerApiContext = Object.freeze({
+const apiContext: CustomJwtApiContext = Object.freeze({
   denyAccess: (message = 'Access denied') => {
     const error: CustomJwtErrorBody = {
       code: CustomJwtErrorCode.AccessDenied,

--- a/packages/core/src/oidc/extra-token-claims.ts
+++ b/packages/core/src/oidc/extra-token-claims.ts
@@ -218,6 +218,11 @@ export const getExtraTokenClaimsForJwtCustomization = async (
       },
     });
 
+    // TODO: @simeng remove this once the feature is ready
+    if (!EnvSet.values.isDevFeaturesEnabled) {
+      return;
+    }
+
     // If the error is an instance of `ResponseError`, we need to parse the customJwtError body to get the error code.
     if (error instanceof ResponseError) {
       const customJwtError = await trySafe(async () => parseCustomJwtResponseError(error));

--- a/packages/core/src/oidc/extra-token-claims.ts
+++ b/packages/core/src/oidc/extra-token-claims.ts
@@ -6,10 +6,12 @@ import {
   jwtCustomizer as jwtCustomizerLog,
   type CustomJwtFetcher,
   GrantType,
+  CustomJwtErrorCode,
 } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 import { conditional, trySafe } from '@silverhand/essentials';
-import { type KoaContextWithOIDC, type UnknownObject } from 'oidc-provider';
+import { ResponseError } from '@withtyped/client';
+import { errors, type KoaContextWithOIDC, type UnknownObject } from 'oidc-provider';
 import { z } from 'zod';
 
 import { EnvSet } from '#src/env-set/index.js';
@@ -19,6 +21,8 @@ import { type LogtoConfigLibrary } from '#src/libraries/logto-config.js';
 import { LogEntry } from '#src/middleware/koa-audit-log.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
+
+import { parseCustomJwtResponseError } from '../utils/custom-jwt/index.js';
 
 import { tokenExchangeActGuard } from './grants/token-exchange/types.js';
 
@@ -196,11 +200,14 @@ export const getExtraTokenClaimsForJwtCustomization = async (
           : jwtCustomizerLog.Type.AccessToken
       }`
     );
+
     entry.append({
       result: LogResult.Error,
       error: { message: String(error) },
     });
+
     const { payload } = entry;
+
     await queries.logs.insertLog({
       id: generateStandardId(),
       key: payload.key,
@@ -210,6 +217,15 @@ export const getExtraTokenClaimsForJwtCustomization = async (
         token,
       },
     });
+
+    // If the error is an instance of `ResponseError`, we need to parse the customJwtError body to get the error code.
+    if (error instanceof ResponseError) {
+      const customJwtError = await trySafe(async () => parseCustomJwtResponseError(error));
+
+      if (customJwtError?.code === CustomJwtErrorCode.AccessDenied) {
+        throw new errors.AccessDenied(customJwtError.message);
+      }
+    }
   }
 };
 /* eslint-enable complexity */

--- a/packages/core/src/utils/custom-jwt/index.ts
+++ b/packages/core/src/utils/custom-jwt/index.ts
@@ -27,7 +27,7 @@ export const getJwtCustomizerScripts = (jwtCustomizers: Partial<JwtCustomizerTyp
  */
 const errorResponseGuard = z.object({
   message: z.string(),
-  error: z.unknown(),
+  error: z.unknown().optional(),
 });
 
 /**
@@ -54,7 +54,6 @@ export const parseCustomJwtResponseError = async (
   }
 
   const errorResponseData = errorResponse.data;
-
   const errorBody = customJwtErrorBodyGuard.safeParse(errorResponseData.error);
 
   // Not a standard CustomJwtError body.

--- a/packages/core/src/utils/custom-jwt/index.ts
+++ b/packages/core/src/utils/custom-jwt/index.ts
@@ -1,4 +1,13 @@
-import { LogtoJwtTokenKey, type JwtCustomizerType } from '@logto/schemas';
+import {
+  LogtoJwtTokenKey,
+  type JwtCustomizerType,
+  customJwtErrorBodyGuard,
+  type CustomJwtErrorBody,
+} from '@logto/schemas';
+import { type ResponseError } from '@withtyped/client';
+import { z } from 'zod';
+
+import RequestError from '../../errors/RequestError/index.js';
 
 import { type CustomJwtDeployRequestBody } from './types.js';
 
@@ -10,4 +19,54 @@ export const getJwtCustomizerScripts = (jwtCustomizers: Partial<JwtCustomizerTyp
   return Object.fromEntries(
     Object.values(LogtoJwtTokenKey).map((key) => [key, { production: jwtCustomizers[key]?.script }])
   ) as CustomJwtDeployRequestBody;
+};
+
+/**
+ * Parse the withtyped ResponseError body.
+ * @see {@link https://github.com/withtyped/withtyped/blob/master/packages/server/src/index.ts} handleError method
+ */
+const errorResponseGuard = z.object({
+  message: z.string(),
+  error: z.unknown(),
+});
+
+/**
+ * Parse the CustomJwtErrorBody from the response.
+ *
+ * @param {ResponseError} error The response error, should always be the cloud service ResponseError type.
+ * @returns {Promise<CustomJwtErrorBody>} The parsed CustomJwtErrorBody.
+ * @throws {RequestError} error if the response is not a standard CustomJwtError.
+ */
+export const parseCustomJwtResponseError = async (
+  error: ResponseError
+): Promise<CustomJwtErrorBody> => {
+  const errorResponse = errorResponseGuard.safeParse(await error.response.json());
+
+  // Can not parse the ResponseError body.
+  if (!errorResponse.success) {
+    throw new RequestError(
+      {
+        code: 'jwt_customizer.general',
+        status: 500,
+      },
+      { message: error.message }
+    );
+  }
+
+  const errorResponseData = errorResponse.data;
+
+  const errorBody = customJwtErrorBodyGuard.safeParse(errorResponseData.error);
+
+  // Not a standard CustomJwtError body.
+  if (!errorBody.success) {
+    throw new RequestError(
+      {
+        code: 'jwt_customizer.general',
+        status: 422,
+      },
+      { message: errorResponseData.message }
+    );
+  }
+
+  return errorBody.data;
 };

--- a/packages/integration-tests/src/__mocks__/jwt-customizer.ts
+++ b/packages/integration-tests/src/__mocks__/jwt-customizer.ts
@@ -54,10 +54,22 @@ export const accessTokenJwtCustomizerPayload = {
   },
 };
 
+export const accessDeniedMessage = 'You are not allowed to access this resource';
+
 export const accessTokenSampleScript = `const getCustomJwtClaims = async ({ token, context, environmentVariables }) => {
   return { user_id: context?.user?.id ?? 'unknown', hasPassword: context?.user?.hasPassword };
+};`;
+
+export const accessTokenAccessDeniedSampleScript = `const getCustomJwtClaims = async ({ token, context, environmentVariables, api }) => {
+  api.denyAccess(${accessDeniedMessage});
+  return { test: 'foo'};
 };`;
 
 export const clientCredentialsSampleScript = `const getCustomJwtClaims = async ({ token, context, environmentVariables }) => {
   return { ...environmentVariables };
 }`;
+
+export const clientCredentialsAccessDeniedSampleScript = `const getCustomJwtClaims = async ({ token, context, environmentVariables, api }) => {
+  api.denyAccess(${accessDeniedMessage});
+  return { test: 'foo'};
+};`;

--- a/packages/integration-tests/src/__mocks__/jwt-customizer.ts
+++ b/packages/integration-tests/src/__mocks__/jwt-customizer.ts
@@ -54,14 +54,12 @@ export const accessTokenJwtCustomizerPayload = {
   },
 };
 
-export const accessDeniedMessage = 'You are not allowed to access this resource';
-
 export const accessTokenSampleScript = `const getCustomJwtClaims = async ({ token, context, environmentVariables }) => {
   return { user_id: context?.user?.id ?? 'unknown', hasPassword: context?.user?.hasPassword };
 };`;
 
 export const accessTokenAccessDeniedSampleScript = `const getCustomJwtClaims = async ({ token, context, environmentVariables, api }) => {
-  api.denyAccess(${accessDeniedMessage});
+  api.denyAccess('You are not allowed to access this resource');
   return { test: 'foo'};
 };`;
 
@@ -70,6 +68,6 @@ export const clientCredentialsSampleScript = `const getCustomJwtClaims = async (
 }`;
 
 export const clientCredentialsAccessDeniedSampleScript = `const getCustomJwtClaims = async ({ token, context, environmentVariables, api }) => {
-  api.denyAccess(${accessDeniedMessage});
+  api.denyAccess('You are not allowed to access this resource');
   return { test: 'foo'};
 };`;

--- a/packages/integration-tests/src/tests/api/logto-config.test.ts
+++ b/packages/integration-tests/src/tests/api/logto-config.test.ts
@@ -11,6 +11,8 @@ import {
   clientCredentialsJwtCustomizerPayload,
   accessTokenSampleScript,
   clientCredentialsSampleScript,
+  accessTokenAccessDeniedSampleScript,
+  clientCredentialsAccessDeniedSampleScript,
 } from '#src/__mocks__/jwt-customizer.js';
 import {
   deleteOidcKey,
@@ -26,6 +28,7 @@ import {
   testJwtCustomizer,
 } from '#src/api/index.js';
 import { expectRejects } from '#src/helpers/index.js';
+import { devFeatureTest } from '#src/utils.js';
 
 const defaultAdminConsoleConfig: AdminConsoleData = {
   signInExperienceCustomized: false,
@@ -268,4 +271,41 @@ describe('admin console sign-in experience', () => {
     });
     expect(testResult).toMatchObject(clientCredentialsJwtCustomizerPayload.environmentVariables);
   });
+
+  devFeatureTest.it(
+    'should throw access denied error when calling the denyAccess api in the script',
+    async () => {
+      await expectRejects(
+        testJwtCustomizer({
+          tokenType: LogtoJwtTokenKeyType.AccessToken,
+          token: accessTokenJwtCustomizerPayload.tokenSample,
+          context: accessTokenJwtCustomizerPayload.contextSample,
+          script: accessTokenAccessDeniedSampleScript,
+          environmentVariables: accessTokenJwtCustomizerPayload.environmentVariables,
+        }),
+        {
+          code: 'jwt_customizer.general',
+          status: 403,
+        }
+      );
+    }
+  );
+
+  devFeatureTest.it(
+    'should throw access denied error when calling the denyAccess api in the script',
+    async () => {
+      await expectRejects(
+        testJwtCustomizer({
+          tokenType: LogtoJwtTokenKeyType.ClientCredentials,
+          token: clientCredentialsJwtCustomizerPayload.tokenSample,
+          script: clientCredentialsAccessDeniedSampleScript,
+          environmentVariables: clientCredentialsJwtCustomizerPayload.environmentVariables,
+        }),
+        {
+          code: 'jwt_customizer.general',
+          status: 403,
+        }
+      );
+    }
+  );
 });

--- a/packages/integration-tests/src/tests/api/logto-config.test.ts
+++ b/packages/integration-tests/src/tests/api/logto-config.test.ts
@@ -35,7 +35,7 @@ const defaultAdminConsoleConfig: AdminConsoleData = {
   organizationCreated: false,
 };
 
-describe('admin console sign-in experience', () => {
+describe('logto config', () => {
   it('should get admin console config successfully', async () => {
     const adminConsoleConfig = await getAdminConsoleConfig();
 

--- a/packages/schemas/src/types/logto-config/jwt-customizer.ts
+++ b/packages/schemas/src/types/logto-config/jwt-customizer.ts
@@ -166,7 +166,7 @@ export const customJwtErrorBodyGuard = z.object({
 
 export type CustomJwtErrorBody = z.infer<typeof customJwtErrorBodyGuard>;
 
-export type JwtCustomizerApiContext = {
+export type CustomJwtApiContext = {
   /**
    * Reject the the current token exchange request.
    *
@@ -190,5 +190,5 @@ export type CustomJwtScriptPayload = {
   token: Record<string, unknown>;
   context?: Record<string, unknown>;
   environmentVariables?: Record<string, string>;
-  api: JwtCustomizerApiContext;
+  api: CustomJwtApiContext;
 };

--- a/packages/schemas/src/types/logto-config/jwt-customizer.ts
+++ b/packages/schemas/src/types/logto-config/jwt-customizer.ts
@@ -145,3 +145,50 @@ export const customJwtFetcherGuard = z.discriminatedUnion('tokenType', [
 ]);
 
 export type CustomJwtFetcher = z.infer<typeof customJwtFetcherGuard>;
+
+export enum CustomJwtErrorCode {
+  /**
+   * The `AccessDenied` error explicitly thrown
+   * by calling the `api.denyAccess` function in the custom JWT script.
+   */
+  AccessDenied = 'AccessDenied',
+  /** General JWT customizer error,
+   * this is the fallback custom jwt error code
+   * for any internal error thrown by the JWT customizer (localVM, azure function, or CF worker).
+   */
+  General = 'General',
+}
+
+export const customJwtErrorBodyGuard = z.object({
+  code: z.nativeEnum(CustomJwtErrorCode),
+  message: z.string(),
+});
+
+export type CustomJwtErrorBody = z.infer<typeof customJwtErrorBodyGuard>;
+
+export type JwtCustomizerApiContext = {
+  /**
+   * Reject the the current token exchange request.
+   *
+   * @remarks
+   * By calling this function, the current token exchange request will be rejected,
+   * and a ODIC `AccessDenied` error will be thrown to the client with the given message.
+   *
+   * @param message The message to be shown to the user.
+   * @throws {ResponseError} with `CustomJwtErrorBody`
+   */
+  denyAccess: (message?: string) => never;
+};
+
+/**
+ * The payload type for the custom JWT script.
+ *
+ * @remarks
+ * We use this type to guard the input payload for the custom JWT script.
+ */
+export type CustomJwtScriptPayload = {
+  token: Record<string, unknown>;
+  context?: Record<string, unknown>;
+  environmentVariables?: Record<string, string>;
+  api: JwtCustomizerApiContext;
+};

--- a/packages/schemas/src/types/logto-config/jwt-customizer.ts
+++ b/packages/schemas/src/types/logto-config/jwt-customizer.ts
@@ -172,7 +172,7 @@ export type CustomJwtApiContext = {
    *
    * @remarks
    * By calling this function, the current token exchange request will be rejected,
-   * and a ODIC `AccessDenied` error will be thrown to the client with the given message.
+   * and a OIDC `AccessDenied` error will be thrown to the client with the given message.
    *
    * @param message The message to be shown to the user.
    * @throws {ResponseError} with `CustomJwtErrorBody`


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add API context to the customJwt script payload, including the new `denyAccess` API.

- Only localVM environment jwtCustomizer is updated in this PR. Cloud `azureFunction` updates will be made in the cloud repo.

example: 
```ts
const getCustomJwtClaims = async ({ token, context, environmentVariables, api }) => {
  api.denyAccess('You are not allowed to access this resource.');
};
```


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
<img width="1367" alt="image" src="https://github.com/user-attachments/assets/6ac4516d-90b8-46ab-98c1-7f3425419f9c">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
