### PR TITLE
feat: add support for nested attribute profile mapping

### DIFF
--- a/.changeset/violet-beds-yawn.md
+++ b/.changeset/violet-beds-yawn.md
@@ -1,0 +1,5 @@
+---
+"@logto/connector-oauth": minor
+---
+
+adding support for nested attributes

--- a/packages/connectors/connector-oauth2/README.md
+++ b/packages/connectors/connector-oauth2/README.md
@@ -38,21 +38,43 @@ You are expected to find `authorizationEndpoint`, `tokenEndpoint` and `userInfoE
 
 *userInfoEndpoint*: This endpoint is used by the client application to obtain additional information about the user, such as their fullname, email address or profile picture. The user info endpoint is typically accessed after the client application has obtained an access token from the token endpoint.
 
-Logto also provide a `profileMap` field that users can customize the mapping from the social vendors' profiles which are usually not standard. The keys are Logto's standard user profile field names and corresponding values should be social profiles' field names. In current stage, Logto only concern 'id', 'name', 'avatar', 'email' and 'phone' from social profile, only 'id' is required and others are optional fields.
+Logto also provides a `profileMap` field that users can customize the mapping from the social vendors' profiles which are usually not standard. The keys are Logto's standard user profile field names and corresponding values should be social profiles' field names. In the current stage, Logto only concerns 'id', 'name', 'avatar', 'email', and 'phone' from social profiles, only 'id' is required and others are optional fields.
 
-`responseType` and `grantType` can ONLY be FIXED values with authorization code grant type, so we make them optional and default values will be automatically filled.
+### Nested Attributes
 
-For example, you can find [Google user profile response](https://developers.google.com/identity/openid-connect/openid-connect#an-id-tokens-payload) and hence its `profileMap` should be like:
+The `profileMap` also supports nested attributes. You can map nested properties from the social vendor's profile to Logto's standard user profile fields.
 
+For example, if the social vendor's profile has nested attributes like the following:
 ```json
 {
-  "id": "sub",
-  "avatar": "picture"
+  "id": "123456",
+  "contact": {
+    "email": "octcat@github.com",
+    "phone": "123-456-7890"
+  },
+  "details": {
+    "name": "Oct Cat",
+    "avatar": {
+      "url": "avatar.png"
+    },
+    "groups": ["group1", "group2", "group3"]
+  }
 }
 ```
+You can configure the `profileMap` like this:
+```json
+{
+  "id": "id",
+  "name": "details.name",
+  "avatar": "details.avatar.url",
+  "email": "contact.email",
+  "phone": "contact.phone"
+}
+```
+In this example, `details.name`, `details.avatar.url`, `contact.email`, and `contact.phone` are nested attributes in the social vendor's profile.
 
 > ℹ️ **Note**
-> 
+>
 > We provided an OPTIONAL `customConfig` key to put your customize parameters.
 > Each social identity provider could have their own variant on OAuth standard protocol. If your desired social identity provider strictly stick to OAuth standard protocol, the you do not need to care about `customConfig`.
 

--- a/packages/connectors/connector-oauth2/package.json
+++ b/packages/connectors/connector-oauth2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logto/connector-oauth",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "OAuth standard connector implementation.",
   "author": "Silverhand Inc. <contact@silverhand.io>",
   "dependencies": {

--- a/packages/connectors/connector-oauth2/package.json
+++ b/packages/connectors/connector-oauth2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logto/connector-oauth",
-  "version": "1.5.0",
+  "version": "1.4.0",
   "description": "OAuth standard connector implementation.",
   "author": "Silverhand Inc. <contact@silverhand.io>",
   "dependencies": {

--- a/packages/connectors/connector-oauth2/src/utils.test.ts
+++ b/packages/connectors/connector-oauth2/src/utils.test.ts
@@ -80,7 +80,7 @@ describe('userProfileMapping', () => {
     });
   });
 
-  it('should throw an exception for non-existent nested attributes', () => {
+  it('should safely return undefined for non-existent nested attributes', () => {
     const keyMapping: ProfileMap = {
       id: 'id',
       email: 'contact.email',
@@ -98,8 +98,11 @@ describe('userProfileMapping', () => {
       },
     };
 
-    expect(() => {
-      userProfileMapping(originUserProfile, keyMapping);
-    }).toThrowError();
+    const profile: UserProfile = userProfileMapping(originUserProfile, keyMapping);
+    expect(profile).toMatchObject({
+      id: '123456',
+      email: 'octcat@github.com',
+      name: 'Oct Cat',
+    });
   });
 });

--- a/packages/connectors/connector-oauth2/src/utils.test.ts
+++ b/packages/connectors/connector-oauth2/src/utils.test.ts
@@ -80,7 +80,7 @@ describe('userProfileMapping', () => {
     });
   });
 
-  it('should return undefined for non-existent nested attributes', () => {
+  it('should throw an exception for non-existent nested attributes', () => {
     const keyMapping: ProfileMap = {
       id: 'id',
       email: 'contact.email',
@@ -97,13 +97,9 @@ describe('userProfileMapping', () => {
         name: 'Oct Cat',
       },
     };
-    const profile: UserProfile = userProfileMapping(originUserProfile, keyMapping);
-    expect(profile).toMatchObject({
-      id: '123456',
-      email: 'octcat@github.com',
-      name: 'Oct Cat',
-    });
-    expect(profile.phone).toBeUndefined();
-    expect(profile.avatar).toBeUndefined();
+
+    expect(() => {
+      userProfileMapping(originUserProfile, keyMapping);
+    }).toThrowError();
   });
 });

--- a/packages/connectors/connector-oauth2/src/utils.test.ts
+++ b/packages/connectors/connector-oauth2/src/utils.test.ts
@@ -48,4 +48,62 @@ describe('userProfileMapping', () => {
       avatar: 'avatar.png',
     });
   });
+
+  it('should handle nested attributes correctly', () => {
+    const keyMapping: ProfileMap = {
+      id: 'id',
+      email: 'contact.email',
+      phone: 'contact.phone',
+      name: 'details.name',
+      avatar: 'details.avatar.url',
+    };
+    const originUserProfile = {
+      id: '123456',
+      contact: {
+        email: 'octcat@github.com',
+        phone: '123-456-7890',
+      },
+      details: {
+        name: 'Oct Cat',
+        avatar: {
+          url: 'avatar.png',
+        },
+      },
+    };
+    const profile: UserProfile = userProfileMapping(originUserProfile, keyMapping);
+    expect(profile).toMatchObject({
+      id: '123456',
+      email: 'octcat@github.com',
+      phone: '123-456-7890',
+      name: 'Oct Cat',
+      avatar: 'avatar.png',
+    });
+  });
+
+  it('should return undefined for non-existent nested attributes', () => {
+    const keyMapping: ProfileMap = {
+      id: 'id',
+      email: 'contact.email',
+      phone: 'contact.phone',
+      name: 'details.name',
+      avatar: 'details.avatar.url',
+    };
+    const originUserProfile = {
+      id: '123456',
+      contact: {
+        email: 'octcat@github.com',
+      },
+      details: {
+        name: 'Oct Cat',
+      },
+    };
+    const profile: UserProfile = userProfileMapping(originUserProfile, keyMapping);
+    expect(profile).toMatchObject({
+      id: '123456',
+      email: 'octcat@github.com',
+      name: 'Oct Cat',
+    });
+    expect(profile.phone).toBeUndefined();
+    expect(profile.avatar).toBeUndefined();
+  });
 });

--- a/packages/connectors/connector-oauth2/src/utils.ts
+++ b/packages/connectors/connector-oauth2/src/utils.ts
@@ -1,4 +1,4 @@
-import { assert, get } from '@silverhand/essentials';
+import { assert, getSafe } from '@silverhand/essentials';
 
 import { ConnectorError, ConnectorErrorCodes, parseJson } from '@logto/connector-kit';
 import { type KyResponse } from 'ky';
@@ -44,7 +44,7 @@ export const userProfileMapping = (
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const mappedUserProfile = Object.fromEntries(
     Object.entries(keyMapping)
-      .map(([destination, source]) => [destination, get(originUserProfile, source)])
+      .map(([destination, source]) => [destination, getSafe(originUserProfile, source)])
       .filter(([_, value]) => value)
   );
 

--- a/packages/connectors/connector-oauth2/src/utils.ts
+++ b/packages/connectors/connector-oauth2/src/utils.ts
@@ -1,4 +1,4 @@
-import { assert } from '@silverhand/essentials';
+import { assert, get } from '@silverhand/essentials';
 
 import { ConnectorError, ConnectorErrorCodes, parseJson } from '@logto/connector-kit';
 import { type KyResponse } from 'ky';
@@ -36,32 +36,15 @@ const accessTokenResponseHandler = async (
   return result.data;
 };
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-const getValue = (object: Record<string, unknown> | object, path: string) => {
-  return path.split('.').reduce<unknown>((accumulator, part: string) => {
-    // Check if the accumulator is an object and has the property
-    if (accumulator && typeof accumulator === 'object' && part in accumulator) {
-      // eslint-disable-next-line no-restricted-syntax
-      return (accumulator as Record<string, unknown>)[part];
-    }
-
-    return null;
-  }, object);
-};
-
 export const userProfileMapping = (
   // eslint-disable-next-line @typescript-eslint/ban-types
   originUserProfile: object,
   keyMapping: ProfileMap
 ) => {
-  const keyMap = new Map(
-    Object.entries(keyMapping).map(([destination, source]) => [source, destination])
-  );
-
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const mappedUserProfile = Object.fromEntries(
     Object.entries(keyMapping)
-      .map(([destination, source]) => [destination, getValue(originUserProfile, source)])
+      .map(([destination, source]) => [destination, get(originUserProfile, source)])
       .filter(([_, value]) => value)
   );
 

--- a/packages/connectors/connector-oauth2/src/utils.ts
+++ b/packages/connectors/connector-oauth2/src/utils.ts
@@ -36,6 +36,19 @@ const accessTokenResponseHandler = async (
   return result.data;
 };
 
+// eslint-disable-next-line @typescript-eslint/ban-types
+const getValue = (object: Record<string, unknown> | object, path: string) => {
+  return path.split('.').reduce<unknown>((accumulator, part: string) => {
+    // Check if the accumulator is an object and has the property
+    if (accumulator && typeof accumulator === 'object' && part in accumulator) {
+      // eslint-disable-next-line no-restricted-syntax
+      return (accumulator as Record<string, unknown>)[part];
+    }
+
+    return null;
+  }, object);
+};
+
 export const userProfileMapping = (
   // eslint-disable-next-line @typescript-eslint/ban-types
   originUserProfile: object,
@@ -47,9 +60,9 @@ export const userProfileMapping = (
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const mappedUserProfile = Object.fromEntries(
-    Object.entries(originUserProfile)
-      .filter(([key, value]) => keyMap.get(key) && value)
-      .map(([key, value]) => [keyMap.get(key), value])
+    Object.entries(keyMapping)
+      .map(([destination, source]) => [destination, getValue(originUserProfile, source)])
+      .filter(([_, value]) => value)
   );
 
   const result = userProfileGuard.safeParse(mappedUserProfile);


### PR DESCRIPTION
## Summary

This MR introduces support for nested properties in the OAuth connector for Logto, allowing users to map and retrieve nested attributes from social vendor profiles. This enhancement builds upon the existing functionality, enabling more flexible and comprehensive user profile mappings.

### Key Changes:
- Updated the `userProfileMapping` function to handle nested properties.
- Modified the `ProfileMap` type to support nested attribute paths.
- Added unit tests to verify the correct mapping of nested properties.
- Updated the README to include documentation and examples for nested attribute mappings.

## Why? 
Imagine the social vendor user info returns something like 
```json
{
  "id": "123456",
  "contact": {
    "email": "octcat@github.com",
    "phone": "123-456-7890"
  },
  "details": {
    "name": "Oct Cat",
    "avatar": {
      "url": "avatar.png"
    }
  }
}
```

now we can map it without the need of creating a new connector like this 
```json
{
  "id": "id",
  "name": "details.name",
  "avatar": "details.avatar.url",
  "email": "contact.email",
  "phone": "contact.phone"
}
```

for the final result of 
```json
{
  "id": "123456",
  "name": "Oct Cat",
  "avatar": "avatar.png",
  "email": "octcat@github.com",
  "phone": "123-456-7890"
}
```

## Testing

- Created unit tests to ensure the connector correctly handles nested attributes from social vendor profiles.
- Ran existing unit tests to validate that the existing behavior remains as expected.
- Manually tested the connector by authenticating with a real social vendor account, verifying that nested user
 details are retrieved correctly.

### For my testing I connected with Patreon with the following config

- Authorization Endpoint: `https://www.patreon.com/oauth2/authorize`
- Token Endpoint: `https://www.patreon.com/api/oauth2/token`
- User Info Endpoint: `https://www.patreon.com/api/oauth2/api/current_user`
- Token Endpoint Auth Method: `client_secret_basic`
- Token Endpoint Response Type: `json`
- Scope: `identity identity[email]`
And finally, the Profile Map: 
```json
{
  "id": "data.id",
  "name": "data.attributes.full_name",
  "email": "data.attributes.email",
  "avatar": "data.attributes.image_url"
}
```

<img width="1021" alt="image" src="https://github.com/user-attachments/assets/fe58006b-4f38-40ba-875b-f2ce22c92c28">


## Checklist

- [x] `.changeset` - Added a changeset file to record the new feature introduction.
- [x] unit tests - Developed unit tests for nested property mapping.
- [ ] necessary TSDoc comments - Added TSDoc comments to the new methods and classes introduced for documentation.
- [ ] integration tests - Ran integration tests to ensure proper interaction with nested attributes.


### Footnote
This resolves https://github.com/logto-io/logto/issues/5580