### PR TITLE
fix(core): add `hasPassword` field to user API response

### DIFF
--- a/.changeset/polite-bats-learn.md
+++ b/.changeset/polite-bats-learn.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": patch
+---
+
+fix: add `hasPassword` field to user API response

--- a/packages/core/src/__mocks__/user.ts
+++ b/packages/core/src/__mocks__/user.ts
@@ -1,6 +1,7 @@
 import type { User } from '@logto/schemas';
-import { MfaFactor, userInfoSelectFields, UsersPasswordEncryptionMethod } from '@logto/schemas';
-import { pick } from '@silverhand/essentials';
+import { MfaFactor, UsersPasswordEncryptionMethod } from '@logto/schemas';
+
+import { transpileUserProfileResponse } from '../utils/user.js';
 
 export const mockUser: User = {
   tenantId: 'fake_tenant',
@@ -56,7 +57,7 @@ export const mockUserWithMfaVerifications: User = {
   mfaVerifications: [mockUserTotpMfaVerification],
 };
 
-export const mockUserResponse = pick(mockUser, ...userInfoSelectFields);
+export const mockUserResponse = transpileUserProfileResponse(mockUser);
 
 export const mockPasswordEncrypted = 'a1b2c3';
 export const mockUserWithPassword: User = {
@@ -191,4 +192,4 @@ export const mockUserList: User[] = [
   },
 ];
 
-export const mockUserListResponse = mockUserList.map((user) => pick(user, ...userInfoSelectFields));
+export const mockUserListResponse = mockUserList.map((user) => transpileUserProfileResponse(user));

--- a/packages/core/src/routes/admin-user/search.test.ts
+++ b/packages/core/src/routes/admin-user/search.test.ts
@@ -1,7 +1,7 @@
 import type { CreateUser, Role, User } from '@logto/schemas';
-import { userInfoSelectFields, RoleType } from '@logto/schemas';
+import { RoleType } from '@logto/schemas';
 import { pickDefault } from '@logto/shared/esm';
-import { pick, removeUndefinedKeys } from '@silverhand/essentials';
+import { removeUndefinedKeys } from '@silverhand/essentials';
 
 import { mockUser, mockUserList, mockUserListResponse } from '#src/__mocks__/index.js';
 import { type InsertUserResult } from '#src/libraries/user.js';
@@ -9,6 +9,8 @@ import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import { MockTenant, type Partial2 } from '#src/test-utils/tenant.js';
 import { createRequester } from '#src/utils/test-utils.js';
+
+import { transpileUserProfileResponse } from '../../utils/user.js';
 
 const { jest } = import.meta;
 
@@ -86,7 +88,7 @@ describe('adminUserRoutes', () => {
     const response = await userRequest.get('/users').send({ search });
     expect(response.status).toEqual(200);
     expect(response.body).toEqual(
-      filterUsersWithSearch(mockUserList, search).map((user) => pick(user, ...userInfoSelectFields))
+      filterUsersWithSearch(mockUserList, search).map((user) => transpileUserProfileResponse(user))
     );
     expect(response.header).toHaveProperty(
       'total-number',

--- a/packages/core/src/routes/admin-user/search.ts
+++ b/packages/core/src/routes/admin-user/search.ts
@@ -1,10 +1,5 @@
-import {
-  OrganizationUserRelations,
-  UsersRoles,
-  userInfoSelectFields,
-  userProfileResponseGuard,
-} from '@logto/schemas';
-import { type Nullable, pick, tryThat } from '@silverhand/essentials';
+import { OrganizationUserRelations, UsersRoles, userProfileResponseGuard } from '@logto/schemas';
+import { type Nullable, tryThat } from '@silverhand/essentials';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
@@ -12,6 +7,7 @@ import koaPagination from '#src/middleware/koa-pagination.js';
 import { type UserConditions } from '#src/queries/user.js';
 import { parseSearchParamsForSearch } from '#src/utils/search.js';
 
+import { transpileUserProfileResponse } from '../../utils/user.js';
 import type { ManagementApiRouter, RouterInitArgs } from '../types.js';
 
 const getQueryRelation = (
@@ -82,7 +78,7 @@ export default function adminUserSearchRoutes<T extends ManagementApiRouter>(
           ]);
 
           ctx.pagination.totalCount = count;
-          ctx.body = users.map((user) => pick(user, ...userInfoSelectFields));
+          ctx.body = users.map((user) => transpileUserProfileResponse(user));
 
           return next();
         },

--- a/packages/core/src/routes/admin-user/social.ts
+++ b/packages/core/src/routes/admin-user/social.ts
@@ -3,16 +3,16 @@ import {
   ConnectorType,
   identityGuard,
   identitiesGuard,
-  userInfoSelectFields,
   userProfileResponseGuard,
 } from '@logto/schemas';
-import { has, pick } from '@silverhand/essentials';
+import { has } from '@silverhand/essentials';
 import { object, record, string, unknown } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import assertThat from '#src/utils/assert-that.js';
 
+import { transpileUserProfileResponse } from '../../utils/user.js';
 import type { ManagementApiRouter, RouterInitArgs } from '../types.js';
 
 export default function adminUserSocialRoutes<T extends ManagementApiRouter>(
@@ -149,7 +149,7 @@ export default function adminUserSocialRoutes<T extends ManagementApiRouter>(
       }
 
       const updatedUser = await deleteUserIdentity(userId, target);
-      ctx.body = pick(updatedUser, ...userInfoSelectFields);
+      ctx.body = transpileUserProfileResponse(updatedUser);
 
       return next();
     }

--- a/packages/core/src/routes/role.user.ts
+++ b/packages/core/src/routes/role.user.ts
@@ -1,6 +1,6 @@
-import { UsersRoles, userInfoSelectFields, userProfileResponseGuard } from '@logto/schemas';
+import { UsersRoles, userProfileResponseGuard } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
-import { pick, tryThat } from '@silverhand/essentials';
+import { tryThat } from '@silverhand/essentials';
 import { object, string } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
@@ -8,6 +8,8 @@ import koaGuard from '#src/middleware/koa-guard.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
 import { type UserConditions } from '#src/queries/user.js';
 import { parseSearchParamsForSearch } from '#src/utils/search.js';
+
+import { transpileUserProfileResponse } from '../utils/user.js';
 
 import type { ManagementApiRouter, RouterInitArgs } from './types.js';
 
@@ -59,7 +61,7 @@ export default function roleUserRoutes<T extends ManagementApiRouter>(
           ]);
 
           ctx.pagination.totalCount = count;
-          ctx.body = users.map((user) => pick(user, ...userInfoSelectFields));
+          ctx.body = users.map((user) => transpileUserProfileResponse(user));
 
           return next();
         },

--- a/packages/core/src/utils/user.ts
+++ b/packages/core/src/utils/user.ts
@@ -1,4 +1,12 @@
-import { MfaFactor, type User, type UserMfaVerificationResponse } from '@logto/schemas';
+import {
+  MfaFactor,
+  userInfoSelectFields,
+  type UserProfileResponse,
+  type UserSsoIdentity,
+  type User,
+  type UserMfaVerificationResponse,
+} from '@logto/schemas';
+import { pick } from '@silverhand/essentials';
 
 export const transpileUserMfaVerifications = (
   mfaVerifications: User['mfaVerifications']
@@ -20,4 +28,37 @@ export const transpileUserMfaVerifications = (
 
     return { id, createdAt, type };
   });
+};
+
+type ExtraUserInfo = {
+  ssoIdentities?: UserSsoIdentity[];
+};
+
+/**
+ * Transforms user data into a user profile response format
+ *
+ * This function is used when API endpoints return user profile information,
+ * converting the internal user data model to an external user profile response format.
+ *
+ * Main purposes:
+ *
+ * 1. Selectively return user information fields
+ * 2. Add additional user-related information (e.g., SSO identities)
+ * 3. Handle password-related information
+ *
+ * @param user - Internal user data model
+ * @param extraInfo - Additional user-related information, such as SSO identities
+ * @returns Formatted user profile response object
+ */
+export const transpileUserProfileResponse = (
+  user: User,
+  extraInfo: ExtraUserInfo = {}
+): UserProfileResponse => {
+  const { ssoIdentities } = extraInfo;
+
+  return {
+    ...pick(user, ...userInfoSelectFields),
+    hasPassword: Boolean(user.passwordEncrypted),
+    ...(ssoIdentities && { ssoIdentities }),
+  };
 };

--- a/packages/integration-tests/src/helpers/user.ts
+++ b/packages/integration-tests/src/helpers/user.ts
@@ -1,4 +1,4 @@
-import { type User } from '@logto/schemas';
+import { type UserProfileResponse } from '@logto/schemas';
 import { trySafe } from '@silverhand/essentials';
 
 import { type CreateUserPayload, createUser, deleteUser } from '#src/api/index.js';
@@ -51,13 +51,13 @@ export const generateNewUser = async <T extends NewUserProfileOptions>(options: 
 };
 
 export class UserApiTest {
-  #users: User[] = [];
+  #users: UserProfileResponse[] = [];
 
-  get users(): User[] {
+  get users(): UserProfileResponse[] {
     return this.#users;
   }
 
-  async create(data: CreateUserPayload): Promise<User> {
+  async create(data: CreateUserPayload): Promise<UserProfileResponse> {
     const user = await createUser(data);
     // eslint-disable-next-line @silverhand/fp/no-mutating-methods
     this.users.push(user);

--- a/packages/integration-tests/src/tests/api/admin-user.test.ts
+++ b/packages/integration-tests/src/tests/api/admin-user.test.ts
@@ -201,7 +201,11 @@ describe('admin console user management', () => {
   it('should update user password successfully', async () => {
     const { updatedAt, ...rest } = await createUserByAdmin();
     const userEntity = await updateUserPassword(rest.id, 'new_password');
-    expect(userEntity).toMatchObject(rest);
+    expect(userEntity).toMatchObject({
+      ...rest,
+      // Since the password is updated, the hasPassword field will be true.
+      hasPassword: true,
+    });
     expect(userEntity.updatedAt).toBeGreaterThan(updatedAt);
   });
 

--- a/packages/integration-tests/src/tests/api/organization/organization-user.test.ts
+++ b/packages/integration-tests/src/tests/api/organization/organization-user.test.ts
@@ -47,7 +47,11 @@ describe('organization user APIs', () => {
     it('should be able to get organization users with search', async () => {
       const organizationId = organizationApi.organizations[0]!.id;
       const username = generateTestName();
-      const createdUser = await userApi.create({ username });
+      /**
+       * Exclude `hasPassword` field since the user type returned by the organization user API is not `userProfileResponse`.
+       * So the `hasPassword` field will not be included in the user object.
+       */
+      const { hasPassword, ...createdUser } = await userApi.create({ username });
 
       await organizationApi.addUsers(organizationId, [createdUser.id]);
       const [users] = await organizationApi.getUsers(organizationId, {
@@ -59,7 +63,11 @@ describe('organization user APIs', () => {
 
     it('should be able to get organization users with their roles', async () => {
       const organizationId = organizationApi.organizations[0]!.id;
-      const user = userApi.users[0]!;
+      /**
+       * Exclude `hasPassword` field since the user type returned by the organization user API is not `userProfileResponse`.
+       * So the `hasPassword` field will not be included in the user object.
+       */
+      const { hasPassword, ...user } = userApi.users[0]!;
 
       const roles = await Promise.all([
         organizationApi.roleApi.create({ name: generateTestName() }),


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
In the original implementation, `hasPassword` field is mentioned in the API doc, but missing in API response.
This PR fix this issue.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally and all UT & IT passed.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
