### PR TITLE
fix(experience): allow link social account on sign-in only mode

### DIFF
--- a/.changeset/proud-books-itch.md
+++ b/.changeset/proud-books-itch.md
@@ -3,15 +3,15 @@
 "@logto/experience": minor
 ---
 
-allow link new social identity to an existing user account when registra is disabled.
+allow link new social identity to an existing user account when registration is disabled.
 
 ### Previous behavior
 
-Sign-in with a social identity that does not have an existing user account will throw an `identity_not_exist` error. When the registration is disabled, error message will be shown, the user will not be able to create a new account or link the social identity to an existing account via verified email or phone number.
+Sign-in with a social identity that does not have an existing user account will throw an `identity_not_exist` error. When the registration is disabled, the error message will be shown, the user will not be able to create a new account or link the social identity to an existing account via verified email or phone number.
 
 ### Expected behavior
 
-When the registration is disabled, if a related user account is found, the user should be able to link the social identity to an existing account via verified email or phone number.
+When the registration is disabled, if a related user account is found, the user should be able to link the social identity to an existing account via a verified email or phone number.
 
 ### Updates
 
@@ -20,11 +20,11 @@ When the registration is disabled:
 - Show `identity_not_exist` error message if no related user account is found.
 - Automatically link the social identity to the existing account if a related user account is found and social automatic account linking is enabled.
 - Redirect the user to the social link account page if a related user account is found and social automatic account linking is disabled.
-- Hide the register button in the social link account page if the registration is disabled.
+- Hide the register button on the social link account page if the registration is disabled.
 
 When the registration is enabled:
 
 - Automatically register a new account with the social identity if no related user account is found.
 - Automatically link the social identity to the existing account if a related user account is found and social automatic account linking is enabled.
 - Redirect the user to the social link account page if a related user account is found and social automatic account linking is disabled.
-- Show the register new account button in the social link account page.
+- Show the register new account button on the social link account page.

--- a/.changeset/proud-books-itch.md
+++ b/.changeset/proud-books-itch.md
@@ -1,0 +1,30 @@
+---
+"@logto/experience-legacy": minor
+"@logto/experience": minor
+---
+
+allow link new social identity to an existing user account when registra is disabled.
+
+### Previous behavior
+
+Sign-in with a social identity that does not have an existing user account will throw an `identity_not_exist` error. When the registration is disabled, error message will be shown, the user will not be able to create a new account or link the social identity to an existing account via verified email or phone number.
+
+### Expected behavior
+
+When the registration is disabled, if a related user account is found, the user should be able to link the social identity to an existing account via verified email or phone number.
+
+### Updates
+
+When the registration is disabled:
+
+- Show `identity_not_exist` error message if no related user account is found.
+- Automatically link the social identity to the existing account if a related user account is found and social automatic account linking is enabled.
+- Redirect the user to the social link account page if a related user account is found and social automatic account linking is disabled.
+- Hide the register button in the social link account page if the registration is disabled.
+
+When the registration is enabled:
+
+- Automatically register a new account with the social identity if no related user account is found.
+- Automatically link the social identity to the existing account if a related user account is found and social automatic account linking is enabled.
+- Redirect the user to the social link account page if a related user account is found and social automatic account linking is disabled.
+- Show the register new account button in the social link account page.

--- a/packages/experience-legacy/src/containers/SocialLinkAccount/index.tsx
+++ b/packages/experience-legacy/src/containers/SocialLinkAccount/index.tsx
@@ -1,4 +1,4 @@
-import { SignInIdentifier } from '@logto/schemas';
+import { SignInIdentifier, SignInMode } from '@logto/schemas';
 import classNames from 'classnames';
 import type { TFuncKey } from 'i18next';
 import { useTranslation } from 'react-i18next';
@@ -41,7 +41,7 @@ const getCreateAccountActionText = (signUpMethods: string[]): TFuncKey => {
 
 const SocialLinkAccount = ({ connectorId, className, relatedUser }: Props) => {
   const { t } = useTranslation();
-  const { signUpMethods } = useSieMethods();
+  const { signUpMethods, signInMode } = useSieMethods();
 
   const bindSocialRelatedUser = useBindSocialRelatedUser();
   const registerWithSocial = useSocialRegister(connectorId);
@@ -65,17 +65,19 @@ const SocialLinkAccount = ({ connectorId, className, relatedUser }: Props) => {
         }}
       />
 
-      <div className={styles.hint}>
-        <div>
-          <DynamicT forKey="description.skip_social_linking" />
+      {signInMode !== SignInMode.SignIn && (
+        <div className={styles.hint}>
+          <div>
+            <DynamicT forKey="description.skip_social_linking" />
+          </div>
+          <TextLink
+            text={actionText}
+            onClick={() => {
+              void registerWithSocial(connectorId);
+            }}
+          />
         </div>
-        <TextLink
-          text={actionText}
-          onClick={() => {
-            void registerWithSocial(connectorId);
-          }}
-        />
-      </div>
+      )}
     </div>
   );
 };

--- a/packages/experience-legacy/src/hooks/use-social-register.ts
+++ b/packages/experience-legacy/src/hooks/use-social-register.ts
@@ -1,4 +1,6 @@
+import { AgreeToTermsPolicy, experience } from '@logto/schemas';
 import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { registerWithVerifiedSocial } from '@/apis/interaction';
 
@@ -6,16 +8,29 @@ import useApi from './use-api';
 import useErrorHandler from './use-error-handler';
 import useGlobalRedirectTo from './use-global-redirect-to';
 import usePreSignInErrorHandler from './use-pre-sign-in-error-handler';
+import useTerms from './use-terms';
 
 const useSocialRegister = (connectorId?: string, replace?: boolean) => {
   const handleError = useErrorHandler();
   const asyncRegisterWithSocial = useApi(registerWithVerifiedSocial);
   const redirectTo = useGlobalRedirectTo();
+  const { termsValidation, agreeToTermsPolicy } = useTerms();
+  const navigate = useNavigate();
 
   const preSignInErrorHandler = usePreSignInErrorHandler({ linkSocial: connectorId, replace });
 
   return useCallback(
     async (connectorId: string) => {
+      /**
+       * Agree to terms and conditions first before proceeding
+       * If the agreement policy is `Manual`, the user must agree to the terms to reach this step.
+       * Therefore, skip the check for `Manual` policy.
+       */
+      if (agreeToTermsPolicy !== AgreeToTermsPolicy.Manual && !(await termsValidation())) {
+        navigate('/' + experience.routes.signIn);
+        return;
+      }
+
       const [error, result] = await asyncRegisterWithSocial(connectorId);
 
       if (error) {
@@ -28,7 +43,15 @@ const useSocialRegister = (connectorId?: string, replace?: boolean) => {
         await redirectTo(result.redirectTo);
       }
     },
-    [asyncRegisterWithSocial, handleError, preSignInErrorHandler, redirectTo]
+    [
+      agreeToTermsPolicy,
+      asyncRegisterWithSocial,
+      handleError,
+      navigate,
+      preSignInErrorHandler,
+      redirectTo,
+      termsValidation,
+    ]
   );
 };
 

--- a/packages/experience/src/containers/SocialLinkAccount/index.tsx
+++ b/packages/experience/src/containers/SocialLinkAccount/index.tsx
@@ -1,4 +1,4 @@
-import { SignInIdentifier } from '@logto/schemas';
+import { SignInIdentifier, SignInMode } from '@logto/schemas';
 import classNames from 'classnames';
 import type { TFuncKey } from 'i18next';
 import { useTranslation } from 'react-i18next';
@@ -42,7 +42,7 @@ const getCreateAccountActionText = (signUpMethods: string[]): TFuncKey => {
 
 const SocialLinkAccount = ({ connectorId, verificationId, className, relatedUser }: Props) => {
   const { t } = useTranslation();
-  const { signUpMethods } = useSieMethods();
+  const { signUpMethods, signInMode } = useSieMethods();
 
   const bindSocialRelatedUser = useBindSocialRelatedUser();
   const registerWithSocial = useSocialRegister(connectorId);
@@ -63,17 +63,19 @@ const SocialLinkAccount = ({ connectorId, verificationId, className, relatedUser
         }}
       />
 
-      <div className={styles.hint}>
-        <div>
-          <DynamicT forKey="description.skip_social_linking" />
+      {signInMode !== SignInMode.SignIn && (
+        <div className={styles.hint}>
+          <div>
+            <DynamicT forKey="description.skip_social_linking" />
+          </div>
+          <TextLink
+            text={actionText}
+            onClick={() => {
+              void registerWithSocial(verificationId);
+            }}
+          />
         </div>
-        <TextLink
-          text={actionText}
-          onClick={() => {
-            void registerWithSocial(verificationId);
-          }}
-        />
-      </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Allow link new social identity to an existing user account when registration is disabled.

### Previous behavior

Sign-in with a social identity that does not have an existing user account will throw an `identity_not_exist` error. When the registration is disabled, the error message will be shown, the user will not be able to create a new account or link the social identity to an existing account via verified email or phone number.

### Expected behavior

When the registration is disabled, if a related user account is found, the user should be able to link the social identity to an existing account via a verified email or phone number.

### Updates

When the registration is disabled:

- Show `identity_not_exist` error message if no related user account is found.
- Automatically link the social identity to the existing account if a related user account is found and social automatic account linking is enabled.
- Redirect the user to the social link account page if a related user account is found and social automatic account linking is disabled.
- Hide the register button on the social link account page if the registration is disabled.

When the registration is enabled:

- Automatically register a new account with the social identity if no related user account is found.
- Automatically link the social identity to the existing account if a related user account is found and social automatic account linking is enabled.
- Redirect the user to the social link account page if a related user account is found and social automatic account linking is disabled.
- Show the register new account button on the social link account page.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
