### PR TITLE
fix(core): allow no password user to set password in console profile

### DIFF
--- a/packages/core/src/routes-me/user.ts
+++ b/packages/core/src/routes-me/user.ts
@@ -1,6 +1,6 @@
 import { emailRegEx, PasswordPolicyChecker, usernameRegEx } from '@logto/core-kit';
 import { userInfoSelectFields, jsonObjectGuard } from '@logto/schemas';
-import { conditional, pick } from '@silverhand/essentials';
+import { condArray, conditional, pick } from '@silverhand/essentials';
 import { literal, object, string } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
@@ -141,7 +141,7 @@ export default function userRoutes<T extends AuthedMeRouter>(
 
       const [signInExperience] = await Promise.all([
         findDefaultSignInExperience(),
-        checkVerificationStatus(userId, null),
+        ...condArray(user.passwordEncrypted && [checkVerificationStatus(userId, null)]),
       ]);
       const passwordPolicyChecker = new PasswordPolicyChecker(signInExperience.passwordPolicy);
       const issues = await checkPasswordPolicyForUser(passwordPolicyChecker, password, user);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Allow no password user to set password in Console profile. Should skip the verification status check in this scenario.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally and CI

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
