### PR TITLE
fix(core): avoid duplicate operationId

### DIFF
--- a/packages/core/src/routes/experience/profile-routes.openapi.json
+++ b/packages/core/src/routes/experience/profile-routes.openapi.json
@@ -2,8 +2,8 @@
   "paths": {
     "/api/experience/profile": {
       "post": {
-        "operationId": "UpdateUserProfile",
-        "summary": "Update user profile data",
+        "operationId": "AddUserProfile",
+        "summary": "Add user profile",
         "description": "Adds user profile data to the current experience interaction. <br/>- For `Register`: The profile data provided before the identification request will be used to create a new user account. <br/>- For `SignIn` and `Register`: The profile data provided after the user is identified will be used to update the user's profile when the interaction is submitted. <br/>- `ForgotPassword`: Not supported.",
         "requestBody": {
           "content": {

--- a/packages/core/src/routes/experience/verification-routes/verification-code.openapi.json
+++ b/packages/core/src/routes/experience/verification-routes/verification-code.openapi.json
@@ -47,7 +47,7 @@
     },
     "/api/experience/verification/verification-code/verify": {
       "post": {
-        "operationId": "VerifyVerificationCode",
+        "operationId": "VerifyVerificationCodeVerification",
         "summary": "Verify verification code",
         "description": "Verify the provided verification code against the user's identifier. If successful, the verification record will be marked as verified.",
         "requestBody": {

--- a/packages/core/src/routes/swagger/utils/general.ts
+++ b/packages/core/src/routes/swagger/utils/general.ts
@@ -192,6 +192,8 @@ export const validateSupplement = (
  * @throws {TypeError} if the document is invalid.
  */
 export const validateSwaggerDocument = (document: OpenAPIV3.Document) => {
+  const operationIdSet = new Set<string>();
+
   for (const [path, operations] of Object.entries(document.paths)) {
     if (path.startsWith('/api/interaction')) {
       devConsole.warn(`Path \`${path}\` is not documented. Do something!`);
@@ -236,6 +238,11 @@ export const validateSwaggerDocument = (document: OpenAPIV3.Document) => {
         operation.operationId,
         `Path \`${path}\` and operation \`${method}\` must have an operationId.`
       );
+      assert(
+        !operationIdSet.has(operation.operationId),
+        `Operation ID \`${operation.operationId}\` is duplicated.`
+      );
+      operationIdSet.add(operation.operationId);
     }
 
     for (const tag of document.tags ?? []) {


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Avoid duplicate operationId between Management API and Experience API. 
Add the duplicate operationId guard. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
