### PR TITLE
test: add ui integration test for lang and dir html attributes in experience

### DIFF
--- a/packages/integration-tests/src/helpers/sign-in-experience.ts
+++ b/packages/integration-tests/src/helpers/sign-in-experience.ts
@@ -152,3 +152,14 @@ export const setUsernamePasswordOnly = async () => {
     passwordPolicy: {},
   });
 };
+
+export const setLanguage = async (
+  language: SignInExperience['languageInfo']['fallbackLanguage'],
+  autoDetect = false
+) =>
+  updateSignInExperience({
+    languageInfo: {
+      fallbackLanguage: language,
+      autoDetect,
+    },
+  });

--- a/packages/integration-tests/src/tests/experience/bootstrap.test.ts
+++ b/packages/integration-tests/src/tests/experience/bootstrap.test.ts
@@ -1,5 +1,5 @@
 import { demoAppUrl } from '#src/constants.js';
-import { setUsernamePasswordOnly } from '#src/helpers/sign-in-experience.js';
+import { setLanguage, setUsernamePasswordOnly } from '#src/helpers/sign-in-experience.js';
 import ExpectExperience from '#src/ui-helpers/expect-experience.js';
 
 const credentials = {
@@ -17,6 +17,28 @@ const credentials = {
 describe('smoke testing on the demo app', () => {
   beforeAll(async () => {
     await setUsernamePasswordOnly();
+  });
+
+  it('should have html attribute "lang=en" and "dir=ltr" by default', async () => {
+    const experience = new ExpectExperience(await browser.newPage());
+    await experience.startWith(demoAppUrl);
+
+    await experience.toMatchElement('html[lang=en][dir=ltr]');
+
+    void experience.page.close();
+  });
+
+  it('should have html attribute "lang=ar" and "dir=rtl" for Arabic language', async () => {
+    await setLanguage('ar');
+
+    const experience = new ExpectExperience(await browser.newPage());
+    await experience.startWith(demoAppUrl);
+
+    await experience.toMatchElement('html[lang=ar][dir=rtl]');
+
+    // Clean up
+    await setLanguage('en', true);
+    void experience.page.close();
   });
 
   it('should be able to create a new account with a credential preset', async () => {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add UI integration tests for "lang" and "dir" html attributes in experience.

For example:
- English: lang="en" dir="ltr"
- Arbic: lang="ar" dir="rtl"

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
CI

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
