### PR TITLE
style(console): hide button title when loading

### DIFF
--- a/packages/console/src/ds-components/Button/index.tsx
+++ b/packages/console/src/ds-components/Button/index.tsx
@@ -95,14 +95,7 @@ function Button(
     >
       {showSpinner && <Spinner className={styles.spinner} />}
       {icon && <span className={styles.icon}>{icon}</span>}
-      {title &&
-        (typeof title === 'string' ? (
-          <span>
-            <DynamicT forKey={title} />
-          </span>
-        ) : (
-          title
-        ))}
+      {title && <span>{typeof title === 'string' ? <DynamicT forKey={title} /> : title}</span>}
       {trailingIcon && <span className={styles.trailingIcon}>{trailingIcon}</span>}
     </button>
   );


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
When the button is in a loading state, the CSS hides the internal span elements. However, since the custom title element is not wrapped in a span, the button’s title remains visible in certain cases. This PR fixes the issue by ensuring the title is properly hidden during loading.
<img width="986" alt="image" src="https://github.com/user-attachments/assets/190302bc-8b44-460a-b53b-87c7dc9e0817">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="821" alt="image" src="https://github.com/user-attachments/assets/993ac0bb-b014-493b-93fc-6100bba917fe">


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
