### PR TITLE
fix(console): fix PlanUsage not displayed for enterprise plan w/o subscription

### DIFF
--- a/packages/console/src/components/BillInfo/index.tsx
+++ b/packages/console/src/components/BillInfo/index.tsx
@@ -3,6 +3,7 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import Tip from '@/assets/icons/tip.svg?react';
 import { addOnPricingExplanationLink } from '@/consts';
+import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import Button from '@/ds-components/Button';
 import DynamicT from '@/ds-components/DynamicT';
@@ -22,6 +23,9 @@ function BillInfo({ cost, isManagePaymentVisible }: Props) {
   const { currentTenantId } = useContext(TenantsContext);
   const { visitManagePaymentPage } = useSubscribe();
   const [isLoading, setIsLoading] = useState(false);
+  const {
+    currentSubscription: { isEnterprisePlan },
+  } = useContext(SubscriptionDataContext);
 
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
@@ -38,21 +42,23 @@ function BillInfo({ cost, isManagePaymentVisible }: Props) {
             </ToggleTip>
           )}
         </div>
-        <div className={styles.description}>
-          <Trans
-            components={{
-              a: (
-                <TextLink
-                  className={styles.articleLink}
-                  href={addOnPricingExplanationLink}
-                  targetBlank="noopener"
-                />
-              ),
-            }}
-          >
-            {t('subscription.next_bill_hint')}
-          </Trans>
-        </div>
+        {!isEnterprisePlan && (
+          <div className={styles.description}>
+            <Trans
+              components={{
+                a: (
+                  <TextLink
+                    className={styles.articleLink}
+                    href={addOnPricingExplanationLink}
+                    targetBlank="noopener"
+                  />
+                ),
+              }}
+            >
+              {t('subscription.next_bill_hint')}
+            </Trans>
+          </div>
+        )}
       </div>
       {isManagePaymentVisible && (
         <Button

--- a/packages/console/src/components/PlanUsage/index.tsx
+++ b/packages/console/src/components/PlanUsage/index.tsx
@@ -83,7 +83,9 @@ function PlanUsage({ periodicUsage: rawPeriodicUsage }: Props) {
     .filter(
       (key) =>
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        isAddOnAvailable || (onlyShowPeriodicUsage && (key === 'mauLimit' || key === 'tokenLimit'))
+        isAddOnAvailable ||
+        isEnterprisePlan ||
+        (onlyShowPeriodicUsage && (key === 'mauLimit' || key === 'tokenLimit'))
     )
     .map((key) => ({
       usage: getUsageByKey(key, { periodicUsage, countBasedUsage: currentSubscriptionUsage }),

--- a/packages/console/src/components/PlanUsage/index.tsx
+++ b/packages/console/src/components/PlanUsage/index.tsx
@@ -84,6 +84,8 @@ function PlanUsage({ periodicUsage: rawPeriodicUsage }: Props) {
       (key) =>
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         isAddOnAvailable ||
+        // TODO: design a flow for enterprise tenants onboarding.
+        // Show all usages for Enterprise plan since some of the enterprise tenants does not have Stripe subscription, as a result, the `isAddOnAvailable` will be undefined in this case, even if we will deprecate `isAddOnAvailable` soon, the plan usage will not be automatically fixed for these enterprise tenants.
         isEnterprisePlan ||
         (onlyShowPeriodicUsage && (key === 'mauLimit' || key === 'tokenLimit'))
     )


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fixing 2 enterprise plan console issues:

1. fix PlanUsage not displayed for enterprise plan w/o subscription
2. hide next billing hint for enterprise plans

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
