### PR TITLE
fix(console): fix empty string update of connector config form

### DIFF
--- a/packages/console/src/hooks/use-connector-form-config-parser.tsx
+++ b/packages/console/src/hooks/use-connector-form-config-parser.tsx
@@ -31,13 +31,9 @@ const useJsonStringConfigParser = () => {
 export const useConnectorFormConfigParser = () => {
   const parseJsonConfig = useJsonStringConfigParser();
 
-  return (
-    data: ConnectorFormType,
-    formItems: ConnectorResponse['formItems'],
-    skipFalsyValuesRemoval = false
-  ) => {
+  return (data: ConnectorFormType, formItems: ConnectorResponse['formItems']) => {
     return formItems
-      ? parseFormConfig(data.formConfig, formItems, skipFalsyValuesRemoval)
+      ? parseFormConfig(data.formConfig, formItems)
       : parseJsonConfig(data.jsonConfig);
   };
 };

--- a/packages/console/src/pages/ConnectorDetails/ConnectorContent/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/ConnectorContent/index.tsx
@@ -68,11 +68,7 @@ function ConnectorContent({ isDeleted, connectorData, onConnectorUpdated }: Prop
       const { syncProfile, name, logo, logoDark, target, rawConfig } = data;
       // Apply the raw config first to avoid losing data updated from other forms that are not
       // included in the form items.
-      // Explicitly SKIP falsy values removal logic (the last argument of `configParser()` method) for social connectors.
-      const config = removeFalsyValues({
-        ...rawConfig,
-        ...configParser(data, formItems, isSocialConnector),
-      });
+      const config = removeFalsyValues({ ...rawConfig, ...configParser(data, formItems) });
 
       const payload = isSocialConnector
         ? {

--- a/packages/console/src/utils/connector-form.ts
+++ b/packages/console/src/utils/connector-form.ts
@@ -22,17 +22,11 @@ const initFormData = (formItems: ConnectorConfigFormItem[], config?: Record<stri
 
 export const parseFormConfig = (
   config: Record<string, unknown>,
-  formItems: ConnectorConfigFormItem[],
-  skipFalsyValuesRemoval = false
+  formItems: ConnectorConfigFormItem[]
 ) => {
   return Object.fromEntries(
     Object.entries(config)
       .map(([key, value]) => {
-        // Filter out empty input
-        if (!skipFalsyValuesRemoval && value === '') {
-          return null;
-        }
-
         const formItem = formItems.find((item) => item.key === key);
 
         if (!formItem) {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

This reverts commit [6963192ac5cf2285826799a34a20c9efaa1f343a.](https://github.com/logto-io/logto/pull/6268), which causes the bug that users can not update a field to empty string, bacause the field will be removed.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested, a field can now be updated to empty.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
