### PR TITLE
fix(core,tunnel,phrases): support range requests when hosting custom ui assets

### DIFF
--- a/.changeset/tasty-kings-fetch.md
+++ b/.changeset/tasty-kings-fetch.md
@@ -1,0 +1,9 @@
+---
+"@logto/phrases": patch
+"@logto/tunnel": patch
+"@logto/core": patch
+---
+
+fix an issue that prevent mp4 video from playing on Safari
+
+Safari browser uses range request to fetch video data, but it was not supported by the `@logto/tunnel` CLI tool and `koa-serve-custom-ui-assets` middleware in core. This prevents our users who want to build custom sign-in pages with video background. In order to fix this, we need to partially read the video file stream based on the `range` request header, and set proper response headers and status code (206).

--- a/.changeset/tricky-mice-pay.md
+++ b/.changeset/tricky-mice-pay.md
@@ -1,0 +1,5 @@
+---
+"@logto/core-kit": patch
+---
+
+add range request handling to url utilities

--- a/packages/core/src/middleware/koa-serve-custom-ui-assets.ts
+++ b/packages/core/src/middleware/koa-serve-custom-ui-assets.ts
@@ -1,9 +1,16 @@
+import { isFileAssetPath, parseRange } from '@logto/core-kit';
+import { tryThat } from '@silverhand/essentials';
 import type { MiddlewareType } from 'koa';
 
 import SystemContext from '#src/tenants/SystemContext.js';
 import assertThat from '#src/utils/assert-that.js';
 import { buildAzureStorage } from '#src/utils/storage/azure-storage.js';
 import { getTenantId } from '#src/utils/tenant.js';
+
+import RequestError from '../errors/RequestError/index.js';
+
+const noCache = 'no-cache, no-store, must-revalidate';
+const maxAgeSevenDays = 'max-age=604_800_000';
 
 /**
  * Middleware that serves custom UI assets user uploaded previously through sign-in experience settings.
@@ -19,19 +26,46 @@ export default function koaServeCustomUiAssets(customUiAssetId: string) {
     assertThat(tenantId, 'session.not_found', 404);
 
     const { container, connectionString } = experienceBlobsProviderConfig;
-    const { downloadFile, isFileExisted } = buildAzureStorage(connectionString, container);
+    const { downloadFile, isFileExisted, getFileProperties } = buildAzureStorage(
+      connectionString,
+      container
+    );
 
     const contextPath = `${tenantId}/${customUiAssetId}`;
     const requestPath = ctx.request.path;
-    const isFileRequest = requestPath.includes('.');
+    const isFileAssetRequest = isFileAssetPath(requestPath);
 
-    const fileObjectKey = `${contextPath}${isFileRequest ? requestPath : '/index.html'}`;
+    const fileObjectKey = `${contextPath}${isFileAssetRequest ? requestPath : '/index.html'}`;
     const isExisted = await isFileExisted(fileObjectKey);
     assertThat(isExisted, 'entity.not_found', 404);
 
-    const downloadResponse = await downloadFile(fileObjectKey);
-    ctx.type = downloadResponse.contentType ?? 'application/octet-stream';
-    ctx.body = downloadResponse.readableStreamBody;
+    const range = ctx.get('range');
+    const { start, end, count } = tryThat(
+      () => parseRange(range),
+      new RequestError({ code: 'request.range_not_satisfiable', status: 416 })
+    );
+
+    const [
+      { contentLength = 0, readableStreamBody, contentType },
+      { contentLength: totalFileSize = 0 },
+    ] = await Promise.all([
+      downloadFile(fileObjectKey, start, count),
+      getFileProperties(fileObjectKey),
+    ]);
+
+    ctx.body = readableStreamBody;
+    ctx.type = contentType ?? 'application/octet-stream';
+    ctx.status = range ? 206 : 200;
+
+    ctx.set('Cache-Control', isFileAssetRequest ? maxAgeSevenDays : noCache);
+    ctx.set('Content-Length', contentLength.toString());
+    if (range) {
+      ctx.set('Accept-Ranges', 'bytes');
+      ctx.set(
+        'Content-Range',
+        `bytes ${start ?? 0}-${end ?? Math.max(totalFileSize - 1, 0)}/${totalFileSize}`
+      );
+    }
 
     return next();
   };

--- a/packages/core/src/utils/storage/azure-storage.ts
+++ b/packages/core/src/utils/storage/azure-storage.ts
@@ -1,4 +1,9 @@
-import { type BlobDownloadResponseParsed, BlobServiceClient } from '@azure/storage-blob';
+import {
+  type BlobDownloadOptions,
+  type BlobDownloadResponseParsed,
+  type BlobGetPropertiesResponse,
+  BlobServiceClient,
+} from '@azure/storage-blob';
 
 import type { UploadFile } from './types.js';
 
@@ -9,8 +14,14 @@ export const buildAzureStorage = (
   container: string
 ): {
   uploadFile: UploadFile;
-  downloadFile: (objectKey: string) => Promise<BlobDownloadResponseParsed>;
+  downloadFile: (
+    objectKey: string,
+    offset?: number,
+    count?: number,
+    options?: BlobDownloadOptions
+  ) => Promise<BlobDownloadResponseParsed>;
   isFileExisted: (objectKey: string) => Promise<boolean>;
+  getFileProperties: (objectKey: string) => Promise<BlobGetPropertiesResponse>;
 } => {
   const blobServiceClient = BlobServiceClient.fromConnectionString(connectionString);
   const containerClient = blobServiceClient.getContainerClient(container);
@@ -31,9 +42,14 @@ export const buildAzureStorage = (
     };
   };
 
-  const downloadFile = async (objectKey: string) => {
+  const downloadFile = async (
+    objectKey: string,
+    offset?: number,
+    count?: number,
+    options?: BlobDownloadOptions
+  ) => {
     const blockBlobClient = containerClient.getBlockBlobClient(objectKey);
-    return blockBlobClient.download();
+    return blockBlobClient.download(offset, count, options);
   };
 
   const isFileExisted = async (objectKey: string) => {
@@ -41,5 +57,10 @@ export const buildAzureStorage = (
     return blockBlobClient.exists();
   };
 
-  return { uploadFile, downloadFile, isFileExisted };
+  const getFileProperties = async (objectKey: string) => {
+    const blockBlobClient = containerClient.getBlockBlobClient(objectKey);
+    return blockBlobClient.getProperties();
+  };
+
+  return { uploadFile, downloadFile, isFileExisted, getFileProperties };
 };

--- a/packages/phrases/src/locales/en/errors/request.ts
+++ b/packages/phrases/src/locales/en/errors/request.ts
@@ -1,6 +1,7 @@
 const request = {
   invalid_input: 'Input is invalid. {{details}}',
   general: 'Request error occurred.',
+  range_not_satisfiable: 'Range not satisfiable.',
 };
 
 export default Object.freeze(request);

--- a/packages/toolkit/core-kit/src/utils/url.test.ts
+++ b/packages/toolkit/core-kit/src/utils/url.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { isLocalhost, isValidUrl, validateRedirectUrl } from './url.js';
+import {
+  isFileAssetPath,
+  isLocalhost,
+  isValidUrl,
+  parseRange,
+  validateRedirectUrl,
+} from './url.js';
 
 describe('url utilities', () => {
   it('should allow valid redirect URIs', () => {
@@ -41,6 +47,27 @@ describe('url utilities', () => {
     expect(isValidUrl('abc.com/callback')).toBeFalsy();
     expect(isValidUrl('abc.com/callback?test=123')).toBeFalsy();
     expect(isValidUrl('abc.com/callback#test=123')).toBeFalsy();
+  });
+
+  it('should be able to parse value from request URL with range header', () => {
+    expect(parseRange('bytes=0-499')).toEqual({ start: 0, end: 499, count: 500 });
+    expect(parseRange('bytes=0-')).toEqual({ start: 0, end: undefined, count: undefined });
+    expect(() => parseRange('invalid')).toThrowError('Range not satisfiable.');
+  });
+
+  it('should be able to check if a request path is file asset', () => {
+    expect(isFileAssetPath('/file.js')).toBe(true);
+    expect(isFileAssetPath('/file.css')).toBe(true);
+    expect(isFileAssetPath('/file.png')).toBe(true);
+    expect(isFileAssetPath('/oidc/.well-known/openid-configuration')).toBe(false);
+    expect(isFileAssetPath('/oidc/auth')).toBe(false);
+    expect(isFileAssetPath('/api/interaction/submit')).toBe(false);
+    expect(isFileAssetPath('/consent')).toBe(false);
+    expect(
+      isFileAssetPath(
+        '/callback/45doq0d004awrjyvdbp92?state=PxsR_Iqtkxw&code=4/0AcvDMrCOMTFXWlKzTcUO24xDify5tQbIMYvaYDS0sj82NzzYlrG4BWXJB4-OxjBI1RPL8g&scope=email%20profile%20openid%20https:/www.googleapis.com/auth/userinfo.profile%20https:/www.googleapis.com/auth/userinfo.email&authuser=0&hd=silverhand.io&prompt=consent'
+      )
+    ).toBe(false);
   });
 });
 

--- a/packages/toolkit/core-kit/src/utils/url.ts
+++ b/packages/toolkit/core-kit/src/utils/url.ts
@@ -36,3 +36,46 @@ export const isLocalhost = (url: string) => {
 
   return ['localhost', '127.0.0.1', '::1'].includes(parsedUrl.hostname);
 };
+
+/**
+ * Check if the request URL is a file asset path.
+ * The check is based on the last segment of the URL path containing a dot, ignoring query params.
+ * Example:
+ * - `path/scripts.js` -> true
+ * - `path/index.html?query=param` -> true
+ * - `path` -> false
+ * - `path?email=abc@test.com` -> false
+ * @param url Request URL
+ * @returns Boolean value indicating if the request URL is a file asset path
+ */
+export const isFileAssetPath = (url: string): boolean => {
+  const pathWithoutQuery = url.split('?')[0];
+  return Boolean(pathWithoutQuery?.split('/').at(-1)?.includes('.'));
+};
+
+/**
+ * Parse the "range" request header value to get the start, end, and count values.
+ * Example:
+ * - `range: bytes=0-499` -> { start: 0, end: 499, count: 500 }
+ * - `range: bytes=0-` -> { start: 0, end: undefined, count: undefined }
+ * - `range: invalid` -> Error: Range not satisfiable
+ * - Without range header -> { start: undefined, end: undefined, count: undefined }
+ * @param range Range request header value
+ * @returns Object containing start, end, and count values
+ */
+export const parseRange = (range: string) => {
+  const rangeMatch = /bytes=(\d+)-(\d+)?/.exec(range);
+  if (range && !rangeMatch) {
+    throw new Error('Range not satisfiable.');
+  }
+
+  const start = rangeMatch?.[1] === undefined ? undefined : Number.parseInt(rangeMatch[1], 10);
+  const end = rangeMatch?.[2] === undefined ? undefined : Number.parseInt(rangeMatch[2], 10);
+  const count = end === undefined ? undefined : end - (start ?? 0) + 1;
+
+  return {
+    start,
+    end,
+    count,
+  };
+};

--- a/packages/tunnel/src/commands/tunnel/utils.test.ts
+++ b/packages/tunnel/src/commands/tunnel/utils.test.ts
@@ -1,20 +1,13 @@
 import { expect, describe, it } from 'vitest';
 
-import { isFileAssetPath } from './utils.js';
+import { getMimeType } from './utils.js';
 
 describe('Tunnel utils', () => {
-  it('should be able to check if a request path is file asset', () => {
-    expect(isFileAssetPath('/file.js')).toBe(true);
-    expect(isFileAssetPath('/file.css')).toBe(true);
-    expect(isFileAssetPath('/file.png')).toBe(true);
-    expect(isFileAssetPath('/oidc/.well-known/openid-configuration')).toBe(false);
-    expect(isFileAssetPath('/oidc/auth')).toBe(false);
-    expect(isFileAssetPath('/api/interaction/submit')).toBe(false);
-    expect(isFileAssetPath('/consent')).toBe(false);
-    expect(
-      isFileAssetPath(
-        '/callback/45doq0d004awrjyvdbp92?state=PxsR_Iqtkxw&code=4/0AcvDMrCOMTFXWlKzTcUO24xDify5tQbIMYvaYDS0sj82NzzYlrG4BWXJB4-OxjBI1RPL8g&scope=email%20profile%20openid%20https:/www.googleapis.com/auth/userinfo.profile%20https:/www.googleapis.com/auth/userinfo.email&authuser=0&hd=silverhand.io&prompt=consent'
-      )
-    ).toBe(false);
+  it('should be able to get mime type according to request path', () => {
+    expect(getMimeType('/scripts.js')).toEqual('text/javascript');
+    expect(getMimeType('/image.png')).toEqual('image/png');
+    expect(getMimeType('/style.css')).toEqual('text/css');
+    expect(getMimeType('/index.html')).toEqual('text/html');
+    expect(getMimeType('/')).toEqual('text/html; charset=utf-8');
   });
 });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix an issue that prevent MP4 video from playing in custom sign-in pages on Safari. (fixes #6623)

Safari uses "range requests" to load video data from server, and the response is partially read from the destination file, with a status code 206 instead of 200.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested on both Chrome and Safari, both worked.
Also tested the tunnel CLI hosting local html assets, worked.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
