### PR TITLE
release: @logto/core-kit:2.5.1 and @logto/tunnel:0.2.1

### DIFF
--- a/.changeset/tricky-mice-pay.md
+++ b/.changeset/tricky-mice-pay.md
@@ -1,5 +1,0 @@
----
-"@logto/core-kit": patch
----
-
-add range request handling to url utilities

--- a/.changeset/violet-ligers-carry.md
+++ b/.changeset/violet-ligers-carry.md
@@ -1,7 +1,0 @@
----
-"@logto/tunnel": patch
----
-
-support range request for mp4 video source hosting
-
-Safari browser uses range request to fetch video data, but it was not supported by the `@logto/tunnel` CLI tool. This prevents our users who want to build custom sign-in pages with video background. In order to fix this, we need to partially read the video file stream based on the `range` request header, and set proper response headers and status code (206).

--- a/packages/toolkit/core-kit/CHANGELOG.md
+++ b/packages/toolkit/core-kit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 2.5.1
+
+### Patch Changes
+
+- 3c993d59c: add range request handling to url utilities
+
 ## 2.5.0
 
 ### Minor Changes

--- a/packages/toolkit/core-kit/package.json
+++ b/packages/toolkit/core-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logto/core-kit",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "author": "Silverhand Inc. <contact@silverhand.io>",
   "homepage": "https://github.com/logto-io/toolkit#readme",
   "repository": {

--- a/packages/tunnel/CHANGELOG.md
+++ b/packages/tunnel/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @logto/tunnel
 
+## @logto/tunnel@0.2.1
+
+### Patch Changes
+
+- 349a6a405: support range request for mp4 video source hosting
+
+  Safari browser uses range request to fetch video data, but it was not supported by the `@logto/tunnel` CLI tool. This prevents our users who want to build custom sign-in pages with video background. In order to fix this, we need to partially read the video file stream based on the `range` request header, and set proper response headers and status code (206).
+
+- Updated dependencies [3c993d59c]
+  - @logto/core-kit@2.5.1
+
 ## @logto/tunnel@0.2.0
 
 ### Minor Changes

--- a/packages/tunnel/package.json
+++ b/packages/tunnel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logto/tunnel",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A CLI tool that creates tunnel service to Logto Cloud for local development.",
   "author": "Silverhand Inc. <contact@silverhand.io>",
   "homepage": "https://github.com/logto-io/logto#readme",


### PR DESCRIPTION
# Releases

## @logto/core-kit@2.5.1

### Patch Changes

-   3c993d59c: add range request handling to url utilities

## @logto/tunnel@0.2.1

### Patch Changes

-   349a6a405: support range request for mp4 video source hosting

    Safari browser uses range request to fetch video data, but it was not supported by the `@logto/tunnel` CLI tool. This prevents our users who want to build custom sign-in pages with video background. In order to fix this, we need to partially read the video file stream based on the `range` request header, and set proper response headers and status code (206).

-   Updated dependencies [3c993d59c]
    -   @logto/core-kit@2.5.1
