### PR TITLE
fix(core): forgot password on the first access of migrated users

### DIFF
--- a/packages/core/src/routes/interaction/verifications/profile-verification.forgot-password.test.ts
+++ b/packages/core/src/routes/interaction/verifications/profile-verification.forgot-password.test.ts
@@ -1,4 +1,4 @@
-import { InteractionEvent } from '@logto/schemas';
+import { InteractionEvent, UsersPasswordEncryptionMethod } from '@logto/schemas';
 import { createMockUtils, pickDefault } from '@logto/shared/esm';
 
 import RequestError from '#src/errors/RequestError/index.js';
@@ -9,7 +9,11 @@ import type { Identifier } from '../types/index.js';
 const { jest } = import.meta;
 const { mockEsm } = createMockUtils(jest);
 
-const findUserById = jest.fn().mockResolvedValue({ id: 'foo', passwordEncrypted: 'passwordHash' });
+const findUserById = jest.fn().mockResolvedValue({
+  id: 'foo',
+  passwordEncrypted: 'passwordHash',
+  passwordEncryptionMethod: UsersPasswordEncryptionMethod.Argon2i,
+});
 
 const tenantContext = new MockTenant(undefined, { users: { findUserById } });
 


### PR DESCRIPTION
## Summary
This pull request fixes a bug that occurred when users were migrated from the old system to Logto ([migration guide](https://docs.logto.io/docs/recipes/migrations/)) using a different password encryption method than Argon2i. The issue caused a 500 error when users attempted to reset their password for the first time using the "Forgot my password" option. The error was due to a missing validation step where the system was incorrectly comparing the new password with the old one, despite the previous password being encrypted with a different method (not Argon2i).

## Testing
Manual testing was conducted by creating user accounts with various encryption methods, resetting passwords, and verifying system behavior.

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
