### PR TITLE
fix(schemas): add user tenantId foreign key constraint

### DIFF
--- a/packages/schemas/alterations/next-1727597588-add-organization-user-relations-foreign-key.ts
+++ b/packages/schemas/alterations/next-1727597588-add-organization-user-relations-foreign-key.ts
@@ -1,0 +1,39 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      alter table users
+        add constraint users__tenant_id__id unique (tenant_id, id);
+    `);
+
+    await pool.query(sql`
+      alter table organization_user_relations
+        add constraint organization_user_relations__user_id__fk
+          foreign key (tenant_id, user_id) references users (tenant_id, id) on update cascade on delete cascade;
+    `);
+
+    await pool.query(sql`
+      drop index users__id;
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      create index users__id on users (id);
+    `);
+
+    await pool.query(sql`
+      alter table organization_user_relations
+        drop constraint organization_user_relations__user_id__fk;
+    `);
+
+    await pool.query(sql`
+      alter table users
+        drop constraint users__tenant_id__id;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/organization_user_relations.sql
+++ b/packages/schemas/tables/organization_user_relations.sql
@@ -8,5 +8,7 @@ create table organization_user_relations (
     references organizations (id) on update cascade on delete cascade,
   user_id varchar(21) not null
     references users (id) on update cascade on delete cascade,
-  primary key (tenant_id, organization_id, user_id)
+  primary key (tenant_id, organization_id, user_id),
+  /** Ensures that the user is a member of the organization. */
+  foreign key (tenant_id, user_id) references users (tenant_id, id) on update cascade on delete cascade
 );

--- a/packages/schemas/tables/users.sql
+++ b/packages/schemas/tables/users.sql
@@ -31,7 +31,9 @@ create table users (
   constraint users__primary_email
     unique (tenant_id, primary_email),
   constraint users__primary_phone
-    unique (tenant_id, primary_phone)
+    unique (tenant_id, primary_phone),
+  constraint users__tenant_id__id
+    unique (tenant_id, id)
 );
 
 create index users__id


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->


We have identified a bug where developers can insert cross-tenant users into an organization using the `POST /organizations/:id?users` API. Previously, there was no constraint to ensure that a user's `tenant_id` matches the current organization's `tenant_id`.

To address this issue, we will add a foreign key constraint for the (tenant_id, user_id) in the `organization_user_relations` table.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<img width="1042" alt="image" src="https://github.com/user-attachments/assets/42fdf5da-55f2-4e81-b5ba-b25e5c2d64e0">




<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
