### PR TITLE
feat(core): initial implementation of user set mfa secrets / codes

### DIFF
--- a/packages/core/src/routes/admin-user/mfa-verification.openapi.json
+++ b/packages/core/src/routes/admin-user/mfa-verification.openapi.json
@@ -25,11 +25,10 @@
                       },
                       "secret": {
                         "type": "string",
-                        "description": "The secret for the MFA verification."
+                        "description": "The secret for the MFA verification, if not provided, a new secret will be generated."
                       }
                     },
-                    "required": ["type", "secret"],
-                    "additionalProperties": false
+                    "required": ["type"]
                   },
                   {
                     "type": "object",
@@ -43,11 +42,10 @@
                         "items": {
                           "type": "string"
                         },
-                        "description": "The backup codes for the MFA verification."
+                        "description": "The backup codes for the MFA verification, if not provided, a new group of backup codes will be generated."
                       }
                     },
-                    "required": ["type", "codes"],
-                    "additionalProperties": false
+                    "required": ["type"]
                   }
                 ]
               }

--- a/packages/core/src/routes/admin-user/mfa-verification.openapi.json
+++ b/packages/core/src/routes/admin-user/mfa-verification.openapi.json
@@ -15,11 +15,41 @@
           "content": {
             "application/json": {
               "schema": {
-                "properties": {
-                  "type": {
-                    "description": "The type of MFA verification to create."
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "description": "The type of MFA verification to create."
+                      },
+                      "secret": {
+                        "type": "string",
+                        "description": "The secret for the MFA verification."
+                      }
+                    },
+                    "required": ["type", "secret"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "description": "The type of MFA verification to create."
+                      },
+                      "codes": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "The backup codes for the MFA verification."
+                      }
+                    },
+                    "required": ["type", "codes"],
+                    "additionalProperties": false
                   }
-                }
+                ]
               }
             }
           }

--- a/packages/core/src/routes/admin-user/mfa-verifications.test.ts
+++ b/packages/core/src/routes/admin-user/mfa-verifications.test.ts
@@ -59,6 +59,19 @@ const usersLibraries = {
   ),
 } satisfies Partial<Libraries['users']>;
 
+const codes = [
+  'd94c2f29ae',
+  '74fa801bb7',
+  '2cbcc9323c',
+  '87299f89aa',
+  '0d95df8598',
+  '78eedbf35d',
+  '0fa4c1fd19',
+  '7384b69eb5',
+  '7bf2481db7',
+  'f00febc9ae',
+];
+
 const adminUserRoutes = await pickDefault(import('./mfa-verifications.js'));
 
 describe('adminUserRoutes', () => {
@@ -169,7 +182,7 @@ describe('adminUserRoutes', () => {
     it('should fail for wrong length', async () => {
       findUserById.mockResolvedValueOnce({
         ...mockUser,
-        mfaVerifications: [],
+        mfaVerifications: [mockUserTotpMfaVerification],
       });
       const response = await userRequest.post(`/users/${mockUser.id}/mfa-verifications`).send({
         type: MfaFactor.BackupCode,
@@ -181,22 +194,11 @@ describe('adminUserRoutes', () => {
     it('should fail for wrong characters', async () => {
       findUserById.mockResolvedValueOnce({
         ...mockUser,
-        mfaVerifications: [],
+        mfaVerifications: [mockUserTotpMfaVerification],
       });
       const response = await userRequest.post(`/users/${mockUser.id}/mfa-verifications`).send({
         type: MfaFactor.BackupCode,
-        codes: [
-          'd94c2f29ae',
-          '74fa801bb7',
-          '2cbcc9323c',
-          '87299f89aa',
-          '0d95df8598',
-          '78eedbf35d',
-          '0fa4c1xd19',
-          '7384b69eb5',
-          '7bf2481db7',
-          'f00febc9ae',
-        ],
+        codes: [...codes, '0fa4c1xd19'],
       });
       expect(response.status).toEqual(422);
     });
@@ -204,37 +206,15 @@ describe('adminUserRoutes', () => {
     it('should return the supplied codes', async () => {
       findUserById.mockResolvedValueOnce({
         ...mockUser,
-        mfaVerifications: [],
+        mfaVerifications: [mockUserTotpMfaVerification],
       });
       const response = await userRequest.post(`/users/${mockUser.id}/mfa-verifications`).send({
         type: MfaFactor.BackupCode,
-        codes: [
-          'd94c2f29ae',
-          '74fa801bb7',
-          '2cbcc9323c',
-          '87299f89aa',
-          '0d95df8598',
-          '78eedbf35d',
-          '0fa4c1fd19',
-          '7384b69eb5',
-          '7bf2481db7',
-          'f00febc9ae',
-        ],
+        codes,
       });
       expect(response.body).toMatchObject({
         type: MfaFactor.BackupCode,
-        codes: [
-          'd94c2f29ae',
-          '74fa801bb7',
-          '2cbcc9323c',
-          '87299f89aa',
-          '0d95df8598',
-          '78eedbf35d',
-          '0fa4c1fd19',
-          '7384b69eb5',
-          '7bf2481db7',
-          'f00febc9ae',
-        ],
+        codes,
       });
     });
   });

--- a/packages/core/src/routes/admin-user/mfa-verifications.ts
+++ b/packages/core/src/routes/admin-user/mfa-verifications.ts
@@ -13,7 +13,7 @@ import {
   generateBackupCodes,
   validateBackupCodes,
 } from '../interaction/utils/backup-code-validation.js';
-import { generateTotpSecret } from '../interaction/utils/totp-validation.js';
+import { generateTotpSecret, validateTotpSecret } from '../interaction/utils/totp-validation.js';
 import type { ManagementApiRouter, RouterInitArgs } from '../types.js';
 
 export default function adminUserMfaVerificationsRoutes<T extends ManagementApiRouter>(
@@ -90,14 +90,8 @@ export default function adminUserMfaVerificationsRoutes<T extends ManagementApiR
         );
 
         if (ctx.guard.body.secret) {
-          const base32Regex =
-            /^(?:[2-7A-Z]{8})*(?:[2-7A-Z]{2}={6}|[2-7A-Z]{4}={4}|[2-7A-Z]{5}={3}|[2-7A-Z]{7}=)?$/;
-          base32Regex.test(ctx.guard.body.secret);
-
           assertThat(
-            ctx.guard.body.secret.length >= 16 &&
-              ctx.guard.body.secret.length <= 32 &&
-              base32Regex.test(ctx.guard.body.secret),
+            validateTotpSecret(ctx.guard.body.secret),
             new RequestError({
               code: 'user.totp_secret_invalid',
               status: 422,

--- a/packages/core/src/routes/admin-user/mfa-verifications.ts
+++ b/packages/core/src/routes/admin-user/mfa-verifications.ts
@@ -9,7 +9,10 @@ import koaGuard from '#src/middleware/koa-guard.js';
 import assertThat from '#src/utils/assert-that.js';
 import { transpileUserMfaVerifications } from '#src/utils/user.js';
 
-import { generateBackupCodes } from '../interaction/utils/backup-code-validation.js';
+import {
+  generateBackupCodes,
+  validateBackupCodes,
+} from '../interaction/utils/backup-code-validation.js';
 import { generateTotpSecret } from '../interaction/utils/totp-validation.js';
 import type { ManagementApiRouter, RouterInitArgs } from '../types.js';
 
@@ -47,9 +50,16 @@ export default function adminUserMfaVerificationsRoutes<T extends ManagementApiR
     '/users/:userId/mfa-verifications',
     koaGuard({
       params: object({ userId: string() }),
-      body: z.object({
-        type: z.literal(MfaFactor.TOTP).or(z.literal(MfaFactor.BackupCode)),
-      }),
+      body: z.discriminatedUnion('type', [
+        z.object({
+          type: z.literal(MfaFactor.TOTP),
+          secret: z.string().optional(),
+        }),
+        z.object({
+          type: z.literal(MfaFactor.BackupCode),
+          codes: z.string().array().optional(),
+        }),
+      ]),
       response: z.discriminatedUnion('type', [
         z.object({
           type: z.literal(MfaFactor.TOTP),
@@ -79,7 +89,23 @@ export default function adminUserMfaVerificationsRoutes<T extends ManagementApiR
           })
         );
 
-        const secret = generateTotpSecret();
+        if (ctx.guard.body.secret) {
+          const base32Regex =
+            /^(?:[2-7A-Z]{8})*(?:[2-7A-Z]{2}={6}|[2-7A-Z]{4}={4}|[2-7A-Z]{5}={3}|[2-7A-Z]{7}=)?$/;
+          base32Regex.test(ctx.guard.body.secret);
+
+          assertThat(
+            ctx.guard.body.secret.length >= 16 &&
+              ctx.guard.body.secret.length <= 32 &&
+              base32Regex.test(ctx.guard.body.secret),
+            new RequestError({
+              code: 'user.totp_secret_invalid',
+              status: 422,
+            })
+          );
+        }
+
+        const secret = ctx.guard.body.secret ?? generateTotpSecret();
         const service = ctx.URL.hostname;
         const user = getUserDisplayName({ username, primaryEmail, primaryPhone, name });
         const keyUri = authenticator.keyuri(user ?? 'Unnamed User', service, secret);
@@ -111,7 +137,16 @@ export default function adminUserMfaVerificationsRoutes<T extends ManagementApiR
           status: 422,
         })
       );
-      const codes = generateBackupCodes();
+      if (ctx.guard.body.codes) {
+        assertThat(
+          validateBackupCodes(ctx.guard.body.codes),
+          new RequestError({
+            code: 'user.wrong_backup_code_format',
+            status: 422,
+          })
+        );
+      }
+      const codes = ctx.guard.body.codes ?? generateBackupCodes();
       await addUserMfaVerification(id, { type: MfaFactor.BackupCode, codes });
       ctx.body = { codes, type: MfaFactor.BackupCode };
       return next();

--- a/packages/core/src/routes/interaction/utils/backup-code-validation.ts
+++ b/packages/core/src/routes/interaction/utils/backup-code-validation.ts
@@ -8,6 +8,13 @@ const alphabet = '0123456789abcdef';
  * The code is a 10-digit string of letters from 1 to f.
  */
 export const generateBackupCodes = () => {
-  const codes = Array.from({ length: backupCodeCount }, () => customAlphabet(alphabet, 10)());
-  return codes;
+  return Array.from({ length: backupCodeCount }, () => customAlphabet(alphabet, 10)());
+};
+
+/**
+ * Validates a group of backup codes.
+ * @param codes
+ */
+export const validateBackupCodes = (codes: string[]) => {
+  return codes.length === backupCodeCount && codes.every((code) => /^[\da-f]{10}$/i.test(code));
 };

--- a/packages/core/src/routes/interaction/utils/totp-validation.test.ts
+++ b/packages/core/src/routes/interaction/utils/totp-validation.test.ts
@@ -1,10 +1,22 @@
 const { jest } = import.meta;
 
-const { generateTotpSecret, validateTotpToken } = await import('./totp-validation.js');
+const { generateTotpSecret, validateTotpToken, validateTotpSecret } = await import(
+  './totp-validation.js'
+);
 
 describe('generateTotpSecret', () => {
   it('should generate a secret', () => {
     expect(typeof generateTotpSecret()).toBe('string');
+  });
+});
+
+describe('validateTotpSecret', () => {
+  it('should return true on valid secret', () => {
+    expect(validateTotpSecret(generateTotpSecret())).toBe(true);
+  });
+
+  it('should return false on invalid secret', () => {
+    expect(validateTotpSecret('invalid')).toBe(false);
   });
 });
 

--- a/packages/core/src/routes/interaction/utils/totp-validation.ts
+++ b/packages/core/src/routes/interaction/utils/totp-validation.ts
@@ -12,6 +12,13 @@ authenticator.options = { window: 1 };
 
 export const generateTotpSecret = () => authenticator.generateSecret();
 
+export const validateTotpSecret = (secret: string) => {
+  const base32Regex =
+    /^(?:[2-7A-Z]{8})*(?:[2-7A-Z]{2}={6}|[2-7A-Z]{4}={4}|[2-7A-Z]{5}={3}|[2-7A-Z]{7}=)?$/;
+
+  return secret.length >= 16 && secret.length <= 32 && base32Regex.test(secret);
+};
+
 export const validateTotpToken = (secret: string, token: string) => {
   return authenticator.check(token, secret);
 };

--- a/packages/phrases/src/locales/en/errors/user.ts
+++ b/packages/phrases/src/locales/en/errors/user.ts
@@ -35,6 +35,8 @@ const user = {
   password_algorithm_required: 'Password algorithm is required.',
   password_and_digest: 'You cannot set both plain text password and password digest.',
   personal_access_token_name_exists: 'Personal access token name already exists.',
+  totp_secret_invalid: 'Invalid TOTP secret supplied.',
+  wrong_backup_code_format: 'Backup code format is invalid.',
 };
 
 export default Object.freeze(user);


### PR DESCRIPTION
## Summary

This adds the possibility to add user set mfa secrets (TOTP / backup codes). This is necessary for the creation of such secrets directly in the application, because the user has first to confirm the answer or that he printed the backup codes before really creating them in Logto.

## Testing

Manually by creating a TOTP secret.

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
