### PR TITLE
feat(schemas): add IdP initiated SAML SSO sessions table

### DIFF
--- a/packages/schemas/alterations/next-1728526649-add-idp-initiated-saml-sso-sessions-table.ts
+++ b/packages/schemas/alterations/next-1728526649-add-idp-initiated-saml-sso-sessions-table.ts
@@ -22,9 +22,6 @@ const alteration: AlterationScript = {
         expires_at timestamptz not null,
         primary key (tenant_id, id)
       );
-
-      create index idp_initiated_saml_sso_sessions__nameID
-        on idp_initiated_saml_sso_sessions (connector_id, (assertion_content->>'nameID'));
     `);
     await applyTableRls(pool, 'idp_initiated_saml_sso_sessions');
   },

--- a/packages/schemas/alterations/next-1728526649-add-idp-initiated-saml-sso-sessions-table.ts
+++ b/packages/schemas/alterations/next-1728526649-add-idp-initiated-saml-sso-sessions-table.ts
@@ -1,0 +1,39 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+import { applyTableRls, dropTableRls } from './utils/1704934999-tables.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      create table idp_initiated_saml_sso_sessions (
+        tenant_id varchar(21) not null
+          references tenants (id) on update cascade on delete cascade,
+        /** The globally unique identifier of the assertion record. */
+        id varchar(21) not null,
+        /** The identifier of the SAML SSO connector. */
+        connector_id varchar(128) not null
+          references sso_connectors (id) on update cascade on delete cascade,
+        /** The SAML assertion. */
+        assertion_content jsonb /* @use SsoSamlAssertionContent */ not null default '{}'::jsonb,
+        created_at timestamptz not null default(now()),
+        /** The expiration time of the assertion. */
+        expires_at timestamptz not null,
+        primary key (tenant_id, id)
+      );
+
+      create index idp_initiated_saml_sso_sessions__nameID
+        on idp_initiated_saml_sso_sessions (connector_id, (assertion_content->>'nameID'));
+    `);
+    await applyTableRls(pool, 'idp_initiated_saml_sso_sessions');
+  },
+  down: async (pool) => {
+    await dropTableRls(pool, 'idp_initiated_saml_sso_sessions');
+    await pool.query(sql`
+      drop table idp_initiated_saml_sso_sessions;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/foundations/jsonb-types/sso-connector.ts
+++ b/packages/schemas/src/foundations/jsonb-types/sso-connector.ts
@@ -10,6 +10,8 @@ export const ssoBrandingGuard = z.object({
   darkLogo: z.string().optional(),
 });
 
+export type SsoBranding = z.infer<typeof ssoBrandingGuard>;
+
 export const idpInitiatedAuthParamsGuard = z
   .object({
     resources: z.array(z.string()).optional(),
@@ -19,4 +21,17 @@ export const idpInitiatedAuthParamsGuard = z
 
 export type IdpInitiatedAuthParams = z.infer<typeof idpInitiatedAuthParamsGuard>;
 
-export type SsoBranding = z.infer<typeof ssoBrandingGuard>;
+export const ssoSamlAssertionContentGuard = z
+  .object({
+    nameID: z.string().optional(),
+    attributes: z.record(z.string().or(z.array(z.string()))).optional(),
+    conditions: z
+      .object({
+        notBefore: z.string(),
+        notOnOrAfter: z.string(),
+      })
+      .optional(),
+  })
+  .catchall(z.unknown());
+
+export type SsoSamlAssertionContent = z.infer<typeof ssoSamlAssertionContentGuard>;

--- a/packages/schemas/tables/idp_initiated_saml_sso_sessions.sql
+++ b/packages/schemas/tables/idp_initiated_saml_sso_sessions.sql
@@ -14,6 +14,3 @@ create table idp_initiated_saml_sso_sessions (
   expires_at timestamptz not null,
   primary key (tenant_id, id)
 );
-
-create index idp_initiated_saml_sso_sessions__nameID
-  on idp_initiated_saml_sso_sessions (connector_id, (assertion_content->>'nameID'));

--- a/packages/schemas/tables/idp_initiated_saml_sso_sessions.sql
+++ b/packages/schemas/tables/idp_initiated_saml_sso_sessions.sql
@@ -1,0 +1,19 @@
+/* init_order = 2 */
+create table idp_initiated_saml_sso_sessions (
+  tenant_id varchar(21) not null 
+    references tenants (id) on update cascade on delete cascade,
+  /** The globally unique identifier of the assertion record. */
+  id varchar(21) not null,
+  /** The identifier of the SAML SSO connector. */
+  connector_id varchar(128) not null
+    references sso_connectors (id) on update cascade on delete cascade,
+  /** The SAML assertion. */
+  assertion_content jsonb /* @use SsoSamlAssertionContent */ not null default '{}'::jsonb,
+  created_at timestamptz not null default(now()),
+  /** The expiration time of the assertion. */
+  expires_at timestamptz not null,
+  primary key (tenant_id, id)
+);
+
+create index idp_initiated_saml_sso_sessions__nameID
+  on idp_initiated_saml_sso_sessions (connector_id, (assertion_content->>'nameID'));


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add add IdP initiated SAML SSO sessions table

This table stores the session context of the IdP-initiated SAML SSO authentication request, including the SAML assertion content and expiration time. 

Previously, without the support of IdP-initiated SAML SSO, all the SAML assertions were processed immediately. SSO  identities will be extracted and stored in the Logto SSO connector sign-in session. 

To support the IdP-initiated SAML SSO flow, we need to temporarily store the received SAML assertion content in DB, so it can be retrieved later by a newly initiated Logto OIDC sign-in session.  

This table is for IdP-initiated SAML SSO flow only. 

- id: The unique identifier of the record. 
- connector_id: The ID of the SAML connector
- assertion_content: Successfully parsed and verified SAML assertion content
- expires_at: The expiration time of the assertion record. Should use the `NotOnOrAfter` value from the SAML assertion content if present, otherwise use a hard 10mins expiration period. 



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
