### PR TITLE
refactor: align cloud API response type definition

### DIFF
--- a/packages/console/src/cloud/types/router.ts
+++ b/packages/console/src/cloud/types/router.ts
@@ -15,13 +15,13 @@ export type Subscription = GuardedResponse<GetRoutes['/api/tenants/:tenantId/sub
 export type NewSubscriptionUsageResponse = GuardedResponse<
   GetRoutes['/api/tenants/:tenantId/subscription-usage']
 >;
-/** The response of `GET /api/tenants/my/subscription/quota` has the same response type. */
+
 export type NewSubscriptionQuota = Omit<
   NewSubscriptionUsageResponse['quota'],
   // Since we are deprecation the `organizationsEnabled` key soon (use `organizationsLimit` instead), we exclude it from the quota keys for now to avoid confusion.
   'organizationsEnabled'
 >;
-/** The response of `GET /api/tenants/my/subscription/usage` has the same response type. */
+
 export type NewSubscriptionCountBasedUsage = Omit<
   NewSubscriptionUsageResponse['usage'],
   // Since we are deprecation the `organizationsEnabled` key soon (use `organizationsLimit` instead), we exclude it from the usage keys for now to avoid confusion.

--- a/packages/core/src/utils/subscription/types.ts
+++ b/packages/core/src/utils/subscription/types.ts
@@ -10,27 +10,20 @@ type RouteResponseType<T extends { search?: unknown; body?: unknown; response?: 
 type RouteRequestBodyType<T extends { search?: unknown; body?: ZodType; response?: unknown }> =
   z.infer<NonNullable<T['body']>>;
 
-export type Subscription = RouteResponseType<GetRoutes['/api/tenants/:tenantId/subscription']>;
+export type Subscription = RouteResponseType<GetRoutes['/api/tenants/my/subscription']>;
 
 /**
- * The type of the response of the `GET /api/tenants/:tenantId/subscription/quota` endpoint.
- * It is the same as the response type of `GET /api/tenants/my/subscription/quota` endpoint.
- *
  * @remarks
  * The `auditLogsRetentionDays` will be handled by cron job in Azure Functions, outdated audit logs will be removed automatically.
  */
 export type SubscriptionQuota = Omit<
-  RouteResponseType<GetRoutes['/api/tenants/:tenantId/subscription/quota']>,
+  RouteResponseType<GetRoutes['/api/tenants/my/subscription/quota']>,
   // Since we are deprecation the `organizationsEnabled` key soon (use `organizationsLimit` instead), we exclude it from the usage keys for now to avoid confusion.
   'auditLogsRetentionDays' | 'organizationsEnabled'
 >;
 
-/**
- * The type of the response of the `GET /api/tenants/:tenantId/subscription/usage` endpoint.
- * It is the same as the response type of `GET /api/tenants/my/subscription/usage` endpoint.
- */
 export type SubscriptionUsage = Omit<
-  RouteResponseType<GetRoutes['/api/tenants/:tenantId/subscription/usage']>,
+  RouteResponseType<GetRoutes['/api/tenants/my/subscription/usage']>,
   // Since we are deprecation the `organizationsEnabled` key soon (use `organizationsLimit` instead), we exclude it from the usage keys for now to avoid confusion.
   'organizationsEnabled'
 >;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Align cloud API response type definition.

Console and core depends rely on the subscription-related cloud APIs' response, we have type definitions with these types. Previously, we have two sets of subscription-related cloud APIs (one set for user access and one set for m2m access). Since not all of these APIs are being used, we are removing used ones. Before we remove these APIs, we need to align the type definitions and the actual Cloud API calls.

This change unblocks Linear issue LOG-10111.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
