### PR TITLE
refactor(core): update Cloud API response type definition

### DIFF
--- a/packages/core/src/utils/subscription/types.ts
+++ b/packages/core/src/utils/subscription/types.ts
@@ -12,18 +12,20 @@ type RouteRequestBodyType<T extends { search?: unknown; body?: ZodType; response
 
 export type Subscription = RouteResponseType<GetRoutes['/api/tenants/my/subscription']>;
 
+type CompleteSubscriptionUsage = RouteResponseType<GetRoutes['/api/tenants/my/subscription-usage']>;
+
 /**
  * @remarks
  * The `auditLogsRetentionDays` will be handled by cron job in Azure Functions, outdated audit logs will be removed automatically.
  */
 export type SubscriptionQuota = Omit<
-  RouteResponseType<GetRoutes['/api/tenants/my/subscription/quota']>,
+  CompleteSubscriptionUsage['quota'],
   // Since we are deprecation the `organizationsEnabled` key soon (use `organizationsLimit` instead), we exclude it from the usage keys for now to avoid confusion.
   'auditLogsRetentionDays' | 'organizationsEnabled'
 >;
 
 export type SubscriptionUsage = Omit<
-  RouteResponseType<GetRoutes['/api/tenants/my/subscription/usage']>,
+  CompleteSubscriptionUsage['usage'],
   // Since we are deprecation the `organizationsEnabled` key soon (use `organizationsLimit` instead), we exclude it from the usage keys for now to avoid confusion.
   'organizationsEnabled'
 >;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
update Cloud API response type definition.

Since we are deprecating
1. `GET /tenants/my/subscription/quota`
2. `GET /tenants/my/subscription/usage`
Cloud APIs, we use `GET /tenants/my/subscription-usage` to get the type definition.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
CI

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
