### PR TITLE
feat(core,schemas): init auth flow for IdP initiated SAML SSO

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,6 +40,7 @@
     "@logto/demo-app": "workspace:*",
     "@logto/experience": "workspace:*",
     "@logto/experience-legacy": "workspace:*",
+    "@logto/js": "^4.1.4",
     "@logto/language-kit": "workspace:^1.1.0",
     "@logto/phrases": "workspace:^1.14.0",
     "@logto/phrases-experience": "workspace:^1.8.0",

--- a/packages/core/src/libraries/sign-in-experience/index.test.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.test.ts
@@ -15,11 +15,13 @@ import {
 import { WellKnownCache } from '#src/caches/well-known.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { ssoConnectorFactories } from '#src/sso/index.js';
-import { mockLogtoConfigsLibrary } from '#src/test-utils/mock-libraries.js';
+import {
+  mockLogtoConfigsLibrary,
+  mockSsoConnectorLibrary,
+} from '#src/test-utils/mock-libraries.js';
 
 import { createCloudConnectionLibrary } from '../cloud-connection.js';
 import { createConnectorLibrary } from '../connector.js';
-import { type SsoConnectorLibrary } from '../sso-connector.js';
 
 const { jest } = import.meta;
 
@@ -40,15 +42,6 @@ const signInExperiences = {
   ),
 };
 const { findDefaultSignInExperience, updateDefaultSignInExperience } = signInExperiences;
-
-const ssoConnectorLibrary: jest.Mocked<SsoConnectorLibrary> = {
-  getSsoConnectors: jest.fn(),
-  getSsoConnectorById: jest.fn(),
-  getAvailableSsoConnectors: jest.fn(),
-  createSsoConnectorIdpInitiatedAuthConfig: jest.fn(),
-  updateSsoConnectorIdpInitiatedAuthConfig: jest.fn(),
-  createIdpInitiatedSamlSsoSession: jest.fn(),
-};
 
 const { MockQueries } = await import('#src/test-utils/tenant.js');
 
@@ -75,7 +68,7 @@ const { validateLanguageInfo, removeUnavailableSocialConnectorTargets, getFullSi
   createSignInExperienceLibrary(
     queries,
     connectorLibrary,
-    ssoConnectorLibrary,
+    mockSsoConnectorLibrary,
     cloudConnection,
     new WellKnownCache('foo', new TtlCache())
   );
@@ -157,7 +150,7 @@ describe('getFullSignInExperience()', () => {
   it('should return full sign-in experience', async () => {
     findDefaultSignInExperience.mockResolvedValueOnce(mockSignInExperience);
     getLogtoConnectors.mockResolvedValueOnce(mockSocialConnectors);
-    ssoConnectorLibrary.getAvailableSsoConnectors.mockResolvedValueOnce([
+    mockSsoConnectorLibrary.getAvailableSsoConnectors.mockResolvedValueOnce([
       wellConfiguredSsoConnector,
     ]);
 
@@ -191,7 +184,7 @@ describe('getFullSignInExperience()', () => {
       socialSignInConnectorTargets: ['github', 'facebook', 'google'],
     });
     getLogtoConnectors.mockResolvedValueOnce([mockGoogleConnector, mockGithubConnector]);
-    ssoConnectorLibrary.getAvailableSsoConnectors.mockResolvedValueOnce([
+    mockSsoConnectorLibrary.getAvailableSsoConnectors.mockResolvedValueOnce([
       wellConfiguredSsoConnector,
     ]);
 
@@ -238,7 +231,7 @@ describe('get sso connectors', () => {
 
     const { ssoConnectors } = await getFullSignInExperience({ locale: 'en' });
 
-    expect(ssoConnectorLibrary.getAvailableSsoConnectors).not.toBeCalled();
+    expect(mockSsoConnectorLibrary.getAvailableSsoConnectors).not.toBeCalled();
 
     expect(ssoConnectors).toEqual([]);
   });
@@ -247,7 +240,7 @@ describe('get sso connectors', () => {
     getLogtoConnectors.mockResolvedValueOnce(mockSocialConnectors);
     findDefaultSignInExperience.mockResolvedValueOnce(mockSignInExperience);
 
-    ssoConnectorLibrary.getAvailableSsoConnectors.mockResolvedValueOnce([
+    mockSsoConnectorLibrary.getAvailableSsoConnectors.mockResolvedValueOnce([
       wellConfiguredSsoConnector,
     ]);
 
@@ -271,7 +264,7 @@ describe('get sso connectors', () => {
 
     const displayName = 'Logto Connector';
 
-    ssoConnectorLibrary.getAvailableSsoConnectors.mockResolvedValueOnce([
+    mockSsoConnectorLibrary.getAvailableSsoConnectors.mockResolvedValueOnce([
       {
         ...wellConfiguredSsoConnector,
         branding: {

--- a/packages/core/src/libraries/sso-connector.test.ts
+++ b/packages/core/src/libraries/sso-connector.test.ts
@@ -1,3 +1,6 @@
+import { Prompt, QueryKey, withReservedScopes } from '@logto/js';
+import { ApplicationType, type SsoConnectorIdpInitiatedAuthConfig } from '@logto/schemas';
+
 import { mockSsoConnector, wellConfiguredSsoConnector } from '#src/__mocks__/sso.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { MockQueries } from '#src/test-utils/tenant.js';
@@ -7,14 +10,26 @@ import { createSsoConnectorLibrary } from './sso-connector.js';
 const { jest } = import.meta;
 
 const findAllSsoConnectors = jest.fn();
-const geConnectorById = jest.fn();
+const getConnectorById = jest.fn();
+const findApplicationById = jest.fn();
+const insertIdpInitiatedAuthConfig = jest.fn();
+const updateIdpInitiatedAuthConfig = jest.fn();
 
 const queries = new MockQueries({
-  ssoConnectors: { findAll: findAllSsoConnectors, findById: geConnectorById },
+  ssoConnectors: {
+    findAll: findAllSsoConnectors,
+    findById: getConnectorById,
+    insertIdpInitiatedAuthConfig,
+  },
+  applications: { findApplicationById },
 });
 
 describe('SsoConnectorLibrary', () => {
   const ssoConnectorLibrary = createSsoConnectorLibrary(queries);
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
   it('getSsoConnectors() should filter unsupported sso connectors', async () => {
     const { getSsoConnectors } = ssoConnectorLibrary;
@@ -76,7 +91,7 @@ describe('SsoConnectorLibrary', () => {
   it('getSsoConnectorById() should throw 404 if the connector is not supported', async () => {
     const { getSsoConnectorById } = ssoConnectorLibrary;
 
-    geConnectorById.mockResolvedValueOnce({
+    getConnectorById.mockResolvedValueOnce({
       ...mockSsoConnector,
       providerName: 'unsupported',
     });
@@ -92,10 +107,155 @@ describe('SsoConnectorLibrary', () => {
   it('getSsoConnectorById() should return the connector if it is supported', async () => {
     const { getSsoConnectorById } = ssoConnectorLibrary;
 
-    geConnectorById.mockResolvedValueOnce(mockSsoConnector);
+    getConnectorById.mockResolvedValueOnce(mockSsoConnector);
 
     const connector = await getSsoConnectorById('id');
 
     expect(connector).toEqual(mockSsoConnector);
+  });
+
+  it.each([
+    ApplicationType.MachineToMachine,
+    ApplicationType.Native,
+    ApplicationType.Protected,
+    ApplicationType.SPA,
+  ])(
+    'createSsoConnectorIdpInitiatedAuthConfig() should throw 400 if the application type is $s',
+    async (type) => {
+      findApplicationById.mockResolvedValueOnce({ type, isThirdParty: false });
+
+      await expect(
+        ssoConnectorLibrary.createSsoConnectorIdpInitiatedAuthConfig({
+          connectorId: 'connectorId',
+          defaultApplicationId: 'appId',
+        })
+      ).rejects.toMatchError(new RequestError('connector.invalid_application_type'));
+
+      expect(insertIdpInitiatedAuthConfig).not.toHaveBeenCalled();
+    }
+  );
+
+  it('createSsoConnectorIdpInitiatedAuthConfig() should throw 400 if the application is third-party app', async () => {
+    findApplicationById.mockResolvedValueOnce({
+      type: ApplicationType.Traditional,
+      isThirdParty: true,
+    });
+
+    await expect(
+      ssoConnectorLibrary.createSsoConnectorIdpInitiatedAuthConfig({
+        connectorId: 'connectorId',
+        defaultApplicationId: 'appId',
+      })
+    ).rejects.toMatchError(new RequestError('connector.invalid_application_type'));
+
+    expect(insertIdpInitiatedAuthConfig).not.toHaveBeenCalled();
+  });
+
+  it('should guard the application type if the defaultApplicationId is provided', async () => {
+    findApplicationById.mockResolvedValueOnce({
+      type: ApplicationType.MachineToMachine,
+      isThirdParty: false,
+    });
+
+    await expect(
+      ssoConnectorLibrary.updateSsoConnectorIdpInitiatedAuthConfig('connectorId', {
+        defaultApplicationId: 'appId',
+      })
+    ).rejects.toMatchError(new RequestError('connector.invalid_application_type'));
+
+    expect(updateIdpInitiatedAuthConfig).not.toHaveBeenCalled();
+  });
+
+  describe('getIdpInitiatedSamlSsoSignInUrl()', () => {
+    const { getIdpInitiatedSamlSsoSignInUrl } = ssoConnectorLibrary;
+
+    const issuer = 'https://example.com/oidc';
+
+    const authConfig: SsoConnectorIdpInitiatedAuthConfig = {
+      tenantId: 'tenantId',
+      defaultApplicationId: 'appId',
+      connectorId: 'connectorId',
+      redirectUri: 'https://app.com',
+      authParameters: {},
+      createdAt: Date.now(),
+    };
+
+    const defaultQueryParameters = {
+      [QueryKey.ClientId]: authConfig.defaultApplicationId,
+      [QueryKey.ResponseType]: 'code',
+      [QueryKey.Prompt]: Prompt.Login,
+      [QueryKey.DirectSignIn]: `sso:${authConfig.connectorId}`,
+    };
+
+    it('the returned sign-in url should be a auth endpoint', async () => {
+      const url = await getIdpInitiatedSamlSsoSignInUrl(issuer, authConfig);
+      expect(url.toString().indexOf(issuer)).toBe(0);
+    });
+
+    it('the returned sign-in url should contain the default query parameters', async () => {
+      const url = await getIdpInitiatedSamlSsoSignInUrl(issuer, authConfig);
+      const parameters = new URLSearchParams(url.search);
+      for (const [key, value] of Object.entries(defaultQueryParameters)) {
+        expect(parameters.get(key)).toBe(value);
+      }
+      expect(parameters.get(QueryKey.Scope)).toBe(withReservedScopes());
+    });
+
+    it('should use the provided redirectUri', async () => {
+      const url = await getIdpInitiatedSamlSsoSignInUrl(issuer, authConfig);
+
+      expect(findApplicationById).not.toHaveBeenCalled();
+      const parameters = new URLSearchParams(url.search);
+      expect(parameters.get(QueryKey.RedirectUri)).toBe(authConfig.redirectUri);
+    });
+
+    it('should use the first registered redirectUri of the default application if not provided', async () => {
+      findApplicationById.mockResolvedValueOnce({
+        oidcClientMetadata: {
+          redirectUris: ['https://fallback.com'],
+        },
+      });
+
+      const url = await getIdpInitiatedSamlSsoSignInUrl(issuer, {
+        ...authConfig,
+        redirectUri: null,
+      });
+
+      expect(findApplicationById).toHaveBeenCalledWith(authConfig.defaultApplicationId);
+      const parameters = new URLSearchParams(url.search);
+      expect(parameters.get(QueryKey.RedirectUri)).toBe('https://fallback.com');
+    });
+
+    it('should append extra scopes to the query parameters', async () => {
+      const scopes = ['scope1', 'scope2'];
+
+      const url = await getIdpInitiatedSamlSsoSignInUrl(issuer, {
+        ...authConfig,
+        authParameters: {
+          scope: scopes.join(' '),
+        },
+      });
+
+      const parameters = new URLSearchParams(url.search);
+      expect(parameters.get(QueryKey.Scope)).toBe(withReservedScopes(scopes));
+    });
+
+    it('should be able to append extra query parameters', async () => {
+      const extraParams = {
+        [QueryKey.State]: 'custom_state',
+        [QueryKey.Resource]: 'http://example.com/api',
+        [QueryKey.ResponseType]: 'token',
+      };
+
+      const url = await getIdpInitiatedSamlSsoSignInUrl(issuer, {
+        ...authConfig,
+        authParameters: extraParams,
+      });
+
+      const parameters = new URLSearchParams(url.search);
+      expect(parameters.get(QueryKey.State)).toBe(extraParams[QueryKey.State]);
+      expect(parameters.get(QueryKey.Resource)).toBe(extraParams[QueryKey.Resource]);
+      expect(parameters.get(QueryKey.ResponseType)).toBe(extraParams[QueryKey.ResponseType]);
+    });
   });
 });

--- a/packages/core/src/libraries/sso-connector.test.ts
+++ b/packages/core/src/libraries/sso-connector.test.ts
@@ -129,7 +129,9 @@ describe('SsoConnectorLibrary', () => {
           connectorId: 'connectorId',
           defaultApplicationId: 'appId',
         })
-      ).rejects.toMatchError(new RequestError('connector.invalid_application_type'));
+      ).rejects.toMatchError(
+        new RequestError('connector.saml_idp_initiated_auth_invalid_application_type')
+      );
 
       expect(insertIdpInitiatedAuthConfig).not.toHaveBeenCalled();
     }
@@ -146,7 +148,9 @@ describe('SsoConnectorLibrary', () => {
         connectorId: 'connectorId',
         defaultApplicationId: 'appId',
       })
-    ).rejects.toMatchError(new RequestError('connector.invalid_application_type'));
+    ).rejects.toMatchError(
+      new RequestError('connector.saml_idp_initiated_auth_invalid_application_type')
+    );
 
     expect(insertIdpInitiatedAuthConfig).not.toHaveBeenCalled();
   });
@@ -161,7 +165,9 @@ describe('SsoConnectorLibrary', () => {
       ssoConnectorLibrary.updateSsoConnectorIdpInitiatedAuthConfig('connectorId', {
         defaultApplicationId: 'appId',
       })
-    ).rejects.toMatchError(new RequestError('connector.invalid_application_type'));
+    ).rejects.toMatchError(
+      new RequestError('connector.saml_idp_initiated_auth_invalid_application_type')
+    );
 
     expect(updateIdpInitiatedAuthConfig).not.toHaveBeenCalled();
   });

--- a/packages/core/src/routes/authn.ts
+++ b/packages/core/src/routes/authn.ts
@@ -236,8 +236,14 @@ export default function authnRoutes<T extends AnonymousRouter>(
         });
 
         // TODO: redirect to SSO direct sign-in flow
+        const signInUrl = await ssoConnectorsLibrary.getIdpInitiatedSamlSsoSignInUrl(
+          envSet.oidc.issuer,
+          idpInitiatedAuthConfig
+        );
 
-        return next();
+        ctx.redirect(signInUrl.toString());
+
+        return;
       }
 
       // TODO: remove this assertion after the IdP initiated SSO flow is implemented

--- a/packages/core/src/routes/interaction/utils/single-sign-on-guard.test.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on-guard.test.ts
@@ -2,6 +2,7 @@ import { mockSignInExperience } from '#src/__mocks__/sign-in-experience.js';
 import { wellConfiguredSsoConnector } from '#src/__mocks__/sso.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { type SsoConnectorLibrary } from '#src/libraries/sso-connector.js';
+import { mockSsoConnectorLibrary } from '#src/test-utils/mock-libraries.js';
 
 import { verifySsoOnlyEmailIdentifier } from './single-sign-on-guard.js';
 
@@ -9,13 +10,9 @@ const { jest } = import.meta;
 
 const getAvailableSsoConnectorsMock = jest.fn();
 
-const mockSsoConnectorLibrary: jest.Mocked<SsoConnectorLibrary> = {
+const ssoConnectorLibrary: jest.Mocked<SsoConnectorLibrary> = {
+  ...mockSsoConnectorLibrary,
   getAvailableSsoConnectors: getAvailableSsoConnectorsMock,
-  getSsoConnectors: jest.fn(),
-  getSsoConnectorById: jest.fn(),
-  createSsoConnectorIdpInitiatedAuthConfig: jest.fn(),
-  updateSsoConnectorIdpInitiatedAuthConfig: jest.fn(),
-  createIdpInitiatedSamlSsoSession: jest.fn(),
 };
 
 describe('verifyEmailIdentifier tests', () => {
@@ -26,7 +23,7 @@ describe('verifyEmailIdentifier tests', () => {
   it('should return if the identifier is not an email', async () => {
     await expect(
       verifySsoOnlyEmailIdentifier(
-        mockSsoConnectorLibrary,
+        ssoConnectorLibrary,
         {
           username: 'foo',
           password: 'bar',
@@ -39,7 +36,7 @@ describe('verifyEmailIdentifier tests', () => {
   it('should return if the ssoConnector is not enabled', async () => {
     await expect(
       verifySsoOnlyEmailIdentifier(
-        mockSsoConnectorLibrary,
+        ssoConnectorLibrary,
         {
           email: 'foo@bar.com',
           password: 'bar',
@@ -64,7 +61,7 @@ describe('verifyEmailIdentifier tests', () => {
 
     await expect(
       verifySsoOnlyEmailIdentifier(
-        mockSsoConnectorLibrary,
+        ssoConnectorLibrary,
         {
           email: 'foo@bar.com',
           password: 'bar',
@@ -84,7 +81,7 @@ describe('verifyEmailIdentifier tests', () => {
 
     await expect(
       verifySsoOnlyEmailIdentifier(
-        mockSsoConnectorLibrary,
+        ssoConnectorLibrary,
         {
           email: 'foo@example.com',
           verificationCode: 'bar',

--- a/packages/core/src/test-utils/mock-libraries.ts
+++ b/packages/core/src/test-utils/mock-libraries.ts
@@ -3,6 +3,8 @@ import Client from '@withtyped/client';
 
 import { type LogtoConfigLibrary } from '#src/libraries/logto-config.js';
 
+import { type SsoConnectorLibrary } from '../libraries/sso-connector.js';
+
 const { jest } = import.meta;
 
 export const mockLogtoConfigsLibrary: jest.Mocked<LogtoConfigLibrary> = {
@@ -15,3 +17,13 @@ export const mockLogtoConfigsLibrary: jest.Mocked<LogtoConfigLibrary> = {
 };
 
 export const mockCloudClient = new Client<typeof router>({ baseUrl: 'http://localhost:3001' });
+
+export const mockSsoConnectorLibrary: jest.Mocked<SsoConnectorLibrary> = {
+  getAvailableSsoConnectors: jest.fn(),
+  getSsoConnectors: jest.fn(),
+  getSsoConnectorById: jest.fn(),
+  createSsoConnectorIdpInitiatedAuthConfig: jest.fn(),
+  updateSsoConnectorIdpInitiatedAuthConfig: jest.fn(),
+  createIdpInitiatedSamlSsoSession: jest.fn(),
+  getIdpInitiatedSamlSsoSignInUrl: jest.fn(),
+};

--- a/packages/integration-tests/src/tests/api/sso-connectors/sso-connector-idp-initiated-auth-config.test.ts
+++ b/packages/integration-tests/src/tests/api/sso-connectors/sso-connector-idp-initiated-auth-config.test.ts
@@ -108,8 +108,7 @@ devFeatureTest.describe('SAML IdP initiated authentication config', () => {
       const defaultApplicationId = applications.get('traditional')!.id;
       const redirectUri = 'https://example.com';
       const authParameters = {
-        resources: ['resource1', 'resource2'],
-        scopes: ['profile', 'email'],
+        scope: 'profile email',
       };
       const connectorId = ssoConnectors.get('saml')!.id;
 
@@ -202,8 +201,8 @@ devFeatureTest.describe('SAML IdP initiated authentication config', () => {
         {
           redirectUri: 'https://updated.com',
           authParameters: {
-            resources: ['resource1', 'resource2'],
-            scopes: ['profile', 'email'],
+            resource: 'test_api.com',
+            scopes: 'profile email',
           },
         }
       );
@@ -213,8 +212,8 @@ devFeatureTest.describe('SAML IdP initiated authentication config', () => {
         defaultApplicationId,
         redirectUri: 'https://updated.com',
         authParameters: {
-          resources: ['resource1', 'resource2'],
-          scopes: ['profile', 'email'],
+          resource: 'test_api.com',
+          scopes: 'profile email',
         },
       });
     });

--- a/packages/schemas/src/foundations/jsonb-types/sso-connector.ts
+++ b/packages/schemas/src/foundations/jsonb-types/sso-connector.ts
@@ -14,10 +14,9 @@ export type SsoBranding = z.infer<typeof ssoBrandingGuard>;
 
 export const idpInitiatedAuthParamsGuard = z
   .object({
-    resources: z.array(z.string()).optional(),
-    scopes: z.array(z.string()).optional(),
+    scope: z.string().optional(),
   })
-  .catchall(z.unknown());
+  .catchall(z.string());
 
 export type IdpInitiatedAuthParams = z.infer<typeof idpInitiatedAuthParamsGuard>;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,7 @@ importers:
         version: 8.8.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.12.7)(typescript@5.0.2))(typescript@5.0.2)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.12.7)(typescript@5.0.2))(typescript@5.0.2)
       typescript:
         specifier: ^5.0.0
         version: 5.0.2
@@ -263,7 +263,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -330,7 +330,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -388,7 +388,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -446,7 +446,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -510,7 +510,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -574,7 +574,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -635,7 +635,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -702,7 +702,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.12.7)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.12.7)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -760,7 +760,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -818,7 +818,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -876,7 +876,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -937,7 +937,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -1007,7 +1007,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.12.7)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.12.7)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -1068,7 +1068,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -1123,7 +1123,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.12.7)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.12.7)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -1181,7 +1181,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.12.7)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.12.7)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -1239,7 +1239,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -1297,7 +1297,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.12.7)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.12.7)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -1358,7 +1358,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -1416,7 +1416,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -1474,7 +1474,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -1532,7 +1532,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -1590,7 +1590,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -1648,7 +1648,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -1706,7 +1706,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -1764,7 +1764,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -1822,7 +1822,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -1889,7 +1889,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -1959,7 +1959,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -2017,7 +2017,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.12.7)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.12.7)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -2072,7 +2072,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.12.7)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.12.7)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -2136,7 +2136,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -2194,7 +2194,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -2252,7 +2252,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -2316,7 +2316,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -2374,7 +2374,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -2432,7 +2432,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -2490,7 +2490,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -2548,7 +2548,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -2606,7 +2606,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.10.4)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.10.4)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -2952,6 +2952,9 @@ importers:
       '@logto/experience-legacy':
         specifier: workspace:*
         version: link:../experience-legacy
+      '@logto/js':
+        specifier: ^4.1.4
+        version: 4.1.4
       '@logto/language-kit':
         specifier: workspace:^1.1.0
         version: link:../toolkit/language-kit
@@ -3192,7 +3195,7 @@ importers:
         version: 8.57.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.10.4)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.10.4)(typescript@5.5.3))
+        version: 29.7.0(@types/node@20.10.4)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.10.4)(typescript@5.5.3))
       jest-matcher-specific-error:
         specifier: ^1.0.0
         version: 1.0.0
@@ -3222,7 +3225,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.10.4)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.10.4)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -3373,7 +3376,7 @@ importers:
         version: 3.0.0
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.12.7)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.12.7)(typescript@5.5.3))(typescript@5.5.3)
 
   packages/experience:
     devDependencies:
@@ -3848,7 +3851,7 @@ importers:
         version: 10.0.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.10.4)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.10.4)(typescript@5.5.3))
+        version: 29.7.0(@types/node@20.10.4)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.10.4)(typescript@5.5.3))
       jest-matcher-specific-error:
         specifier: ^1.0.0
         version: 1.0.0
@@ -3875,7 +3878,7 @@ importers:
         version: 22.6.5(typescript@5.5.3)
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.10.4)(typescript@5.5.3))(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.10.4)(typescript@5.5.3))(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -7635,7 +7638,7 @@ packages:
     engines: {node: '>= 0.6'}
 
   concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
 
   confusing-browser-globals@1.0.11:
     resolution: {integrity: sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==}
@@ -8234,7 +8237,7 @@ packages:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ee-first@1.1.1:
-    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
 
   electron-to-chromium@1.5.0:
     resolution: {integrity: sha512-Vb3xHHYnLseK8vlMJQKJYXJ++t4u1/qJ3vykuVrVjvdiOEhYyT1AuP4x03G8EnPmYvYOhe9T+dADTmthjRQMkA==}
@@ -9255,7 +9258,7 @@ packages:
     engines: {node: '>=16.17.0'}
 
   humanize-number@0.0.2:
-    resolution: {integrity: sha512-un3ZAcNQGI7RzaWGZzQDH47HETM4Wrj6z6E4TId8Yeq9w5ZKUVB1nrT2jwFheTUjEmqcgTjXDc959jum+ai1kQ==}
+    resolution: {integrity: sha1-EcCvakcWQ2M1iFiASPF5lUFInBg=}
 
   husky@9.0.7:
     resolution: {integrity: sha512-vWdusw+y12DUEeoZqW1kplOFqk3tedGV8qlga8/SF6a3lOiWLqGZZQvfWvY0fQYdfiRi/u1DFNpudTSV9l1aCg==}
@@ -10475,7 +10478,7 @@ packages:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
 
   media-typer@0.3.0:
-    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    resolution: {integrity: sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=}
     engines: {node: '>= 0.6'}
 
   meow@10.1.5:
@@ -12471,7 +12474,7 @@ packages:
     resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}
 
   stubs@3.0.0:
-    resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
+    resolution: {integrity: sha1-6NK6H6nJBXAwPAMLaQD31fiavls=}
 
   style-search@0.1.0:
     resolution: {integrity: sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==}
@@ -13074,7 +13077,7 @@ packages:
         optional: true
 
   void-elements@3.1.0:
-    resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
+    resolution: {integrity: sha1-YU9/v42AHwu18GYfWy9XhXUOTwk=}
     engines: {node: '>=0.10.0'}
 
   w3c-xmlserializer@3.0.0:
@@ -14963,7 +14966,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.12.7)(typescript@5.5.3))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.10.4)(typescript@5.5.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -14977,7 +14980,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.12.7)(typescript@5.5.3))
+      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.10.4)(typescript@5.5.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -14998,7 +15001,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.10.4)(typescript@5.5.3))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.12.7)(typescript@5.5.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -15012,7 +15015,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.10.4)(typescript@5.5.3))
+      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.12.7)(typescript@5.5.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -17918,13 +17921,13 @@ snapshots:
     dependencies:
       lodash.get: 4.4.2
 
-  create-jest@29.7.0(@types/node@20.10.4)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.10.4)(typescript@5.5.3)):
+  create-jest@29.7.0(@types/node@20.10.4)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.10.4)(typescript@5.5.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.10.4)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.10.4)(typescript@5.5.3))
+      jest-config: 29.7.0(@types/node@20.10.4)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.10.4)(typescript@5.5.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -20258,16 +20261,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.10.4)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.10.4)(typescript@5.5.3)):
+  jest-cli@29.7.0(@types/node@20.10.4)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.10.4)(typescript@5.5.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.10.4)(typescript@5.5.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.10.4)(typescript@5.5.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.10.4)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.10.4)(typescript@5.5.3))
+      create-jest: 29.7.0(@types/node@20.10.4)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.10.4)(typescript@5.5.3))
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.10.4)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.10.4)(typescript@5.5.3))
+      jest-config: 29.7.0(@types/node@20.10.4)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.10.4)(typescript@5.5.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -20296,7 +20299,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.10.4)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.10.4)(typescript@5.5.3)):
+  jest-config@29.7.0(@types/node@20.10.4)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.10.4)(typescript@5.5.3)):
     dependencies:
       '@babel/core': 7.24.4
       '@jest/test-sequencer': 29.7.0
@@ -20322,7 +20325,38 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.10.4
-      ts-node: 10.9.2(@swc/core@1.3.52)(@types/node@20.10.4)(typescript@5.5.3)
+      ts-node: 10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.10.4)(typescript@5.5.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.10.4)(typescript@5.5.3)):
+    dependencies:
+      '@babel/core': 7.24.4
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.24.4)
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.5
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.12.7
+      ts-node: 10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.10.4)(typescript@5.5.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -20354,37 +20388,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.12.7
       ts-node: 10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.12.7)(typescript@5.5.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.10.4)(typescript@5.5.3)):
-    dependencies:
-      '@babel/core': 7.24.4
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.24.4)
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.5
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 20.12.7
-      ts-node: 10.9.2(@swc/core@1.3.52)(@types/node@20.10.4)(typescript@5.5.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -20697,12 +20700,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.10.4)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.10.4)(typescript@5.5.3)):
+  jest@29.7.0(@types/node@20.10.4)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.10.4)(typescript@5.5.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.10.4)(typescript@5.5.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.10.4)(typescript@5.5.3))
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.10.4)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.10.4)(typescript@5.5.3))
+      jest-cli: 29.7.0(@types/node@20.10.4)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.10.4)(typescript@5.5.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -22636,31 +22639,31 @@ snapshots:
 
   possible-typed-array-names@1.0.0: {}
 
-  postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.10.4)(typescript@5.5.3)):
+  postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.10.4)(typescript@5.5.3)):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.4.5
     optionalDependencies:
       postcss: 8.4.39
-      ts-node: 10.9.2(@swc/core@1.3.52)(@types/node@20.10.4)(typescript@5.5.3)
+      ts-node: 10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.10.4)(typescript@5.5.3)
 
-  postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3)):
+  postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3)):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.4.5
     optionalDependencies:
       postcss: 8.4.39
-      ts-node: 10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3)
+      ts-node: 10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3)
 
-  postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.12.7)(typescript@5.0.2)):
+  postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.12.7)(typescript@5.0.2)):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.4.5
     optionalDependencies:
       postcss: 8.4.39
-      ts-node: 10.9.2(@swc/core@1.3.52)(@types/node@20.12.7)(typescript@5.0.2)
+      ts-node: 10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.12.7)(typescript@5.0.2)
 
-  postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.12.7)(typescript@5.5.3)):
+  postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.12.7)(typescript@5.5.3)):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.4.5
@@ -24227,28 +24230,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.12.7)(typescript@5.5.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.12.7
-      acorn: 8.12.1
-      acorn-walk: 8.3.3
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.5.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.3.52(@swc/helpers@0.5.1)
-    optional: true
-
-  ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.10.4)(typescript@5.5.3):
+  ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.10.4)(typescript@5.5.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -24269,7 +24251,7 @@ snapshots:
       '@swc/core': 1.3.52(@swc/helpers@0.5.1)
     optional: true
 
-  ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3):
+  ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -24290,7 +24272,7 @@ snapshots:
       '@swc/core': 1.3.52(@swc/helpers@0.5.1)
     optional: true
 
-  ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.12.7)(typescript@5.0.2):
+  ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.12.7)(typescript@5.0.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -24305,6 +24287,27 @@ snapshots:
       diff: 4.0.2
       make-error: 1.3.6
       typescript: 5.0.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.3.52(@swc/helpers@0.5.1)
+    optional: true
+
+  ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.12.7)(typescript@5.5.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.12.7
+      acorn: 8.12.1
+      acorn-walk: 8.3.3
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.5.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
@@ -24331,7 +24334,7 @@ snapshots:
 
   tsscmp@1.0.6: {}
 
-  tsup@8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.10.4)(typescript@5.5.3))(typescript@5.5.3):
+  tsup@8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.10.4)(typescript@5.5.3))(typescript@5.5.3):
     dependencies:
       bundle-require: 4.2.1(esbuild@0.21.5)
       cac: 6.7.14
@@ -24341,7 +24344,7 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.10.4)(typescript@5.5.3))
+      postcss-load-config: 4.0.2(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.10.4)(typescript@5.5.3))
       resolve-from: 5.0.0
       rollup: 4.14.3
       source-map: 0.8.0-beta.0
@@ -24355,7 +24358,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  tsup@8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3):
+  tsup@8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))(typescript@5.5.3):
     dependencies:
       bundle-require: 4.2.1(esbuild@0.21.5)
       cac: 6.7.14
@@ -24365,7 +24368,7 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.11.20)(typescript@5.5.3))
+      postcss-load-config: 4.0.2(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.11.20)(typescript@5.5.3))
       resolve-from: 5.0.0
       rollup: 4.14.3
       source-map: 0.8.0-beta.0
@@ -24379,7 +24382,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  tsup@8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.12.7)(typescript@5.0.2))(typescript@5.0.2):
+  tsup@8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.12.7)(typescript@5.0.2))(typescript@5.0.2):
     dependencies:
       bundle-require: 4.2.1(esbuild@0.21.5)
       cac: 6.7.14
@@ -24389,7 +24392,7 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.12.7)(typescript@5.0.2))
+      postcss-load-config: 4.0.2(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.12.7)(typescript@5.0.2))
       resolve-from: 5.0.0
       rollup: 4.14.3
       source-map: 0.8.0-beta.0
@@ -24403,7 +24406,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  tsup@8.1.0(@swc/core@1.3.52)(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.12.7)(typescript@5.5.3))(typescript@5.5.3):
+  tsup@8.1.0(@swc/core@1.3.52(@swc/helpers@0.5.1))(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.12.7)(typescript@5.5.3))(typescript@5.5.3):
     dependencies:
       bundle-require: 4.2.1(esbuild@0.21.5)
       cac: 6.7.14
@@ -24413,7 +24416,7 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52)(@types/node@20.12.7)(typescript@5.5.3))
+      postcss-load-config: 4.0.2(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.3.52(@swc/helpers@0.5.1))(@types/node@20.12.7)(typescript@5.5.3))
       resolve-from: 5.0.0
       rollup: 4.14.3
       source-map: 0.8.0-beta.0


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Initiated the OIDC auth flow on the user's behavior once an IdP-initiated SAML SSO authentication request was received.

### Refactors
Redefine the `IdpInitiatedAuthParams` type in the `SsoConnecorIdpInitiatedAuthConfig` schema.
- Remove the `resources` param. Keep it hidden. It is risky to use `RBAC` in an IdP-initiated SSO flow, as the authentication request itself is unsolicited. Developers may still specify the `resource` query parameter, but doing so is at their own risk.
- Replace the array typed `scopes` param with string typed `scope`, as this is more consistent with the actual format we are using in the authentication request query parameters. 

### Implementations

1. Add the `@logto/js` dependency to Logto core, as we need to use it as an SSOT for those sign-in authorization parameters. 
2. Implement the `getIdpInitiatedSamlSsoSignInUrl` method. Based on the SAML SSO connector's `SsoConnecorIdpInitiatedAuthConfig` setting, we will generate an OIDC auth sign-in URL for the user when an IdP-initiated auth request is received. 
- Use the `defaultApplicationId` from auth config as the request `clientId`
- Use the `redirectUri` from the auth config as the request `redirectUri`.  If not specified, fallback to the first registered `redirectUri` in the application record.
- Always prompt the user to log in, in an IdP-initiated auth flow.
- Append the SSO direct sign-in parameter using the `connectorId`, so we can trigger the SSO validation instantly after the redirection.
- Use the same `preservedScopes` method in our `@logto/js` SDK to build the scope parameter. 
- Redirect the user to this OIDC authentication URL to kick off the SP(Logto) side sign-in flow. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT case added
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
