### PR TITLE
feat(core): consume IdP initiated session on SSO verification flow

### DIFF
--- a/packages/core/src/__mocks__/sso.ts
+++ b/packages/core/src/__mocks__/sso.ts
@@ -27,3 +27,17 @@ export const wellConfiguredSsoConnector = {
   syncProfile: true,
   createdAt: Date.now(),
 } satisfies SsoConnector;
+
+export const mockSamlSsoConnector = {
+  id: 'mock-saml-sso-connector',
+  tenantId: 'mock-tenant',
+  providerName: SsoProviderName.SAML,
+  connectorName: 'mock-connector-name',
+  config: {
+    metadata: 'mock-metadata',
+  },
+  domains: ['foo.com'],
+  branding: {},
+  syncProfile: true,
+  createdAt: Date.now(),
+} satisfies SsoConnector;

--- a/packages/core/src/libraries/sso-connector.test.ts
+++ b/packages/core/src/libraries/sso-connector.test.ts
@@ -1,4 +1,4 @@
-import { Prompt, QueryKey, withReservedScopes } from '@logto/js';
+import { Prompt, QueryKey, ReservedScope, UserScope } from '@logto/js';
 import { ApplicationType, type SsoConnectorIdpInitiatedAuthConfig } from '@logto/schemas';
 
 import { mockSsoConnector, wellConfiguredSsoConnector } from '#src/__mocks__/sso.js';
@@ -204,7 +204,7 @@ describe('SsoConnectorLibrary', () => {
       for (const [key, value] of Object.entries(defaultQueryParameters)) {
         expect(parameters.get(key)).toBe(value);
       }
-      expect(parameters.get(QueryKey.Scope)).toBe(withReservedScopes());
+      expect(parameters.get(QueryKey.Scope)).toBe(`${ReservedScope.OpenId} ${UserScope.Profile}`);
     });
 
     it('should use the provided redirectUri', async () => {
@@ -233,7 +233,7 @@ describe('SsoConnectorLibrary', () => {
     });
 
     it('should append extra scopes to the query parameters', async () => {
-      const scopes = ['scope1', 'scope2'];
+      const scopes = ['organization', 'email', 'profile'];
 
       const url = await getIdpInitiatedSamlSsoSignInUrl(issuer, {
         ...authConfig,
@@ -243,7 +243,9 @@ describe('SsoConnectorLibrary', () => {
       });
 
       const parameters = new URLSearchParams(url.search);
-      expect(parameters.get(QueryKey.Scope)).toBe(withReservedScopes(scopes));
+      expect(parameters.get(QueryKey.Scope)).toBe(
+        `${ReservedScope.OpenId} ${UserScope.Profile} organization email`
+      );
     });
 
     it('should be able to append extra query parameters', async () => {

--- a/packages/core/src/queries/sso-connectors.ts
+++ b/packages/core/src/queries/sso-connectors.ts
@@ -6,6 +6,7 @@ import {
   type SsoConnectorKeys,
   SsoConnectors,
   IdpInitiatedSamlSsoSessions,
+  type IdpInitiatedSamlSsoSession,
 } from '@logto/schemas';
 import { sql, type CommonQueryMethods } from '@silverhand/slonik';
 
@@ -91,5 +92,13 @@ export default class SsoConnectorQueries extends SchemaQueries<
     if (rowCount < 1) {
       throw new DeletionError(SsoConnectorIdpInitiatedAuthConfigs.table);
     }
+  }
+
+  async findIdpInitiatedSamlSsoSessionById(id: string) {
+    const { table, fields } = convertToIdentifiers(IdpInitiatedSamlSsoSessions);
+    return this.pool.maybeOne<IdpInitiatedSamlSsoSession>(sql`
+      SELECT * FROM ${table}
+      WHERE ${fields.id}=${id}
+    `);
   }
 }

--- a/packages/core/src/routes/interaction/utils/single-sign-on.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on.ts
@@ -11,16 +11,16 @@ import { generateStandardId } from '@logto/shared';
 import { conditional, trySafe } from '@silverhand/essentials';
 import { z } from 'zod';
 
+import { idpInitiatedSamlSsoSessionCookieName } from '#src/constants/index.js';
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
+import SamlConnector from '#src/sso/SamlConnector/index.js';
 import { ssoConnectorFactories, type SingleSignOnConnectorSession } from '#src/sso/index.js';
 import type Queries from '#src/tenants/Queries.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 
-import { idpInitiatedSamlSsoSessionCookieName } from '../../../constants/index.js';
-import { EnvSet } from '../../../env-set/index.js';
-import SamlConnector from '../../../sso/SamlConnector/index.js';
 import { type WithInteractionHooksContext } from '../middleware/koa-interaction-hooks.js';
 
 import {

--- a/packages/core/src/routes/interaction/utils/single-sign-on.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on.ts
@@ -8,7 +8,7 @@ import {
   type UserSsoIdentity,
 } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
-import { conditional } from '@silverhand/essentials';
+import { conditional, trySafe } from '@silverhand/essentials';
 import { z } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
@@ -18,6 +18,9 @@ import type Queries from '#src/tenants/Queries.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 
+import { idpInitiatedSamlSsoSessionCookieName } from '../../../constants/index.js';
+import { EnvSet } from '../../../env-set/index.js';
+import SamlConnector from '../../../sso/SamlConnector/index.js';
 import { type WithInteractionHooksContext } from '../middleware/koa-interaction-hooks.js';
 
 import {
@@ -34,7 +37,7 @@ type AuthorizationUrlPayload = z.infer<typeof authorizationUrlPayloadGuard>;
 
 export const getSsoAuthorizationUrl = async (
   ctx: WithLogContext,
-  { provider, id: tenantId }: TenantContext,
+  { provider, id: tenantId, queries }: TenantContext,
   connectorData: SupportedSsoConnector,
   payload: AuthorizationUrlPayload
 ): Promise<string> => {
@@ -43,6 +46,7 @@ export const getSsoAuthorizationUrl = async (
   const { createLog } = ctx;
 
   const log = createLog(`Interaction.SignIn.Identifier.SingleSignOn.Create`);
+
   log.append({
     connectorId,
     payload,
@@ -58,6 +62,53 @@ export const getSsoAuthorizationUrl = async (
     assertThat(payload, 'session.insufficient_info');
 
     const { jti } = await provider.interactionDetails(ctx.req, ctx.res);
+
+    if (
+      // TODO: Remove this check when IdP-initiated SSO is fully supported
+      EnvSet.values.isDevFeaturesEnabled &&
+      connectorInstance instanceof SamlConnector
+    ) {
+      // Check if a IdP-initiated SSO session exists
+      const sessionId = ctx.cookies.get(idpInitiatedSamlSsoSessionCookieName);
+
+      const idpInitiatedSamlSsoSession =
+        sessionId && (await queries.ssoConnectors.findIdpInitiatedSamlSsoSessionById(sessionId));
+
+      // Consume the session if it exists and the connector matches
+      if (idpInitiatedSamlSsoSession && idpInitiatedSamlSsoSession.connectorId === connectorId) {
+        log.append({ idpInitiatedSamlSsoSession });
+
+        // Clear the session cookie
+        ctx.cookies.set(idpInitiatedSamlSsoSessionCookieName, '', {
+          httpOnly: true,
+          expires: new Date(0),
+        });
+
+        // Safely clear the session record
+        void trySafe(async () => {
+          await queries.ssoConnectors.deleteIdpInitiatedSamlSsoSessionById(sessionId);
+        });
+
+        const { expiresAt, assertionContent } = idpInitiatedSamlSsoSession;
+
+        // Validate the session expiry
+        // Directly assign the SAML assertion result to the interaction and redirect to the SSO callback URL
+        if (expiresAt > Date.now()) {
+          const userInfo = connectorInstance.getUserInfoFromSamlAssertion(assertionContent);
+          const { redirectUri, state } = payload;
+          await assignSingleSignOnSessionResult(ctx, provider, {
+            redirectUri,
+            state,
+            userInfo,
+            connectorId,
+          });
+          // Redirect to the callback URL directly if the session is valid
+          const url = new URL(redirectUri);
+          url.searchParams.append('state', state);
+          return url.toString();
+        }
+      }
+    }
 
     return await connectorInstance.getAuthorizationUrl(
       { jti, ...payload, connectorId },

--- a/packages/core/src/utils/test-utils.ts
+++ b/packages/core/src/utils/test-utils.ts
@@ -99,6 +99,7 @@ export const createContextWithRouteParameters = (
     set: ctx.set,
     path: ctx.path,
     URL: ctx.URL,
+    cookies: ctx.cookies,
     params: {},
     headers: {},
     router: new Router(),


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Auto consume the IdP-initiated SAML SSO session on the SSO sign-in verification flow.

1. Check the current SSO connector type is SAML
2. Check if an IdP-initiated SAML SSO session ID exists in the cookie
3. Check if the  IdP-initiated SAML SSO session exists in DB and if connectorId matches the current SSO verification request connectorId.
4. Clear the session record in DB and cookie
5. If the IdP-initiated SAML SSO session is valid (not expired), consume the assertion content and assign the verification result directly to the SSO verification session.
6. Return the SSO verification callback URL instead of the IdP authorization URL. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally 
unit test case added

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
