### PR TITLE
feat(core): database connection timeout env overwrite support (#6187)

### DIFF
--- a/.changeset/fifty-apes-arrive.md
+++ b/.changeset/fifty-apes-arrive.md
@@ -1,0 +1,8 @@
+---
+"@logto/shared": patch
+"@logto/core": patch
+---
+
+add environment variable to override default database connection timeout
+
+By default, out database connection timeout is set to 5 seconds, which might not be enough for some network conditions. This change allows users to override the default value by setting the `DATABASE_CONNECTION_TIMEOUT` environment variable.

--- a/packages/core/src/env-set/create-pool.ts
+++ b/packages/core/src/env-set/create-pool.ts
@@ -10,7 +10,8 @@ import {
 const createPoolByEnv = async (
   databaseDsn: string,
   mockDatabaseConnection: boolean,
-  poolSize?: number
+  poolSize?: number,
+  connectionTimeout?: number
 ) => {
   // Database connection is disabled in unit test environment
   if (mockDatabaseConnection) {
@@ -22,6 +23,7 @@ const createPoolByEnv = async (
   return createPool(databaseDsn, {
     interceptors: createInterceptorsPreset(),
     maximumPoolSize: poolSize,
+    connectionTimeout,
   });
 };
 

--- a/packages/core/src/env-set/index.ts
+++ b/packages/core/src/env-set/index.ts
@@ -37,7 +37,8 @@ export class EnvSet {
   static sharedPool = createPoolByEnv(
     this.dbUrl,
     EnvSet.values.isUnitTest,
-    this.values.databasePoolSize
+    this.values.databasePoolSize,
+    EnvSet.values.databaseConnectionTimeout
   );
 
   #pool: Optional<DatabasePool>;
@@ -68,7 +69,8 @@ export class EnvSet {
     const pool = await createPoolByEnv(
       this.databaseUrl,
       EnvSet.values.isUnitTest,
-      EnvSet.values.databasePoolSize
+      EnvSet.values.databasePoolSize,
+      EnvSet.values.databaseConnectionTimeout
     );
 
     this.#pool = pool;

--- a/packages/shared/src/node/env/GlobalValues.ts
+++ b/packages/shared/src/node/env/GlobalValues.ts
@@ -104,6 +104,8 @@ export default class GlobalValues {
   /** Maximum number of clients to keep in a single database pool (i.e. per `Tenant` class). */
   public readonly databasePoolSize = Number(getEnv('DATABASE_POOL_SIZE', '20'));
 
+  public readonly databaseConnectionTimeout = Number(getEnv('DATABASE_CONNECTION_TIMEOUT', '5000'));
+
   /** Case insensitive username */
   public readonly isCaseSensitiveUsername = yes(getEnv('CASE_SENSITIVE_USERNAME', 'true'));
 


### PR DESCRIPTION
## Summary
Adding environmental variable to overwrite default database connection timeout, as the default value is causing some instances fail to start.

Default value for createPool is documented [here](https://github.com/silverhand-io/slonik-fork?tab=readme-ov-file#default-timeouts)

## Testing
Locally by verifying value is passed to `@silverhand/slonik createPool` and application starts

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
