### PR TITLE
feat(schemas): add idp-initiated SSO client side callback url columns

### DIFF
--- a/packages/core/src/libraries/sso-connector.test.ts
+++ b/packages/core/src/libraries/sso-connector.test.ts
@@ -180,6 +180,8 @@ describe('SsoConnectorLibrary', () => {
     const authConfig: SsoConnectorIdpInitiatedAuthConfig = {
       tenantId: 'tenantId',
       defaultApplicationId: 'appId',
+      autoSendAuthorizationRequest: true,
+      clientIdpInitiatedAuthCallbackUri: null,
       connectorId: 'connectorId',
       redirectUri: 'https://app.com',
       authParameters: {},

--- a/packages/core/src/routes/interaction/utils/single-sign-on.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on.ts
@@ -21,6 +21,9 @@ import type Queries from '#src/tenants/Queries.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 
+import { idpInitiatedSamlSsoSessionCookieName } from '../../../constants/index.js';
+import { EnvSet } from '../../../env-set/index.js';
+import SamlConnector from '../../../sso/SamlConnector/index.js';
 import { type WithInteractionHooksContext } from '../middleware/koa-interaction-hooks.js';
 
 import {

--- a/packages/core/src/routes/interaction/utils/single-sign-on.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on.ts
@@ -21,9 +21,6 @@ import type Queries from '#src/tenants/Queries.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 
-import { idpInitiatedSamlSsoSessionCookieName } from '../../../constants/index.js';
-import { EnvSet } from '../../../env-set/index.js';
-import SamlConnector from '../../../sso/SamlConnector/index.js';
 import { type WithInteractionHooksContext } from '../middleware/koa-interaction-hooks.js';
 
 import {

--- a/packages/schemas/alterations/next-1728887713-add-client-idp-initiated-auth-callback-uri-columns.ts
+++ b/packages/schemas/alterations/next-1728887713-add-client-idp-initiated-auth-callback-uri-columns.ts
@@ -1,0 +1,40 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      alter table sso_connector_idp_initiated_auth_configs
+        add column client_idp_initiated_auth_callback_uri text;
+      
+      alter table sso_connector_idp_initiated_auth_configs
+        add column auto_send_authorization_request boolean not null default false;
+
+      alter table sso_connector_idp_initiated_auth_configs
+        drop constraint application_type;
+
+      alter table sso_connector_idp_initiated_auth_configs
+        add constraint application_type
+          check (check_application_type(default_application_id, 'Traditional', 'SPA'));
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      alter table sso_connector_idp_initiated_auth_configs
+        drop constraint application_type;
+
+      alter table sso_connector_idp_initiated_auth_configs
+        drop column client_idp_initiated_auth_callback_uri;
+
+      alter table sso_connector_idp_initiated_auth_configs
+        drop column auto_send_authorization_request;
+
+      alter table sso_connector_idp_initiated_auth_configs
+        add constraint application_type
+          check (check_application_type(default_application_id, 'Traditional'));
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/sso_connector_idp_initiated_auth_configs.sql
+++ b/packages/schemas/tables/sso_connector_idp_initiated_auth_configs.sql
@@ -12,9 +12,13 @@ create table sso_connector_idp_initiated_auth_configs (
   redirect_uri text,
   /** Additional OIDC auth parameters. */
   auth_parameters jsonb /* @use IdpInitiatedAuthParams */ not null default '{}'::jsonb,
+  /** Whether to auto-trigger the auth flow on an IdP-initiated auth request. */
+  auto_send_authorization_request boolean not null default false,
+  /** The client side callback URI for handling IdP-initiated auth request. */
+  client_idp_initiated_auth_callback_uri text,
   created_at timestamptz not null default(now()),
   primary key (tenant_id, connector_id),
-  /** Insure the application type is Traditional. */
+  /** Insure the application type is Traditional or SPA. */
   constraint application_type
-    check (check_application_type(default_application_id, 'Traditional'))
+    check (check_application_type(default_application_id, 'Traditional', 'SPA'))
 );


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Alternate the `sso_connector_idp_initiated_auth_configs` to support directly redirecting the user to the client app to initiate a standard OIDC authorization request. 

### Context
For better security and to support SPA applications, instead of automatically sending the OIDC authorization requests from the server side, we provide a more recommended option, redirect the user to the client side to initiate an OIDC authentication flow. 

Since the IdP-initiated SAML SSO authentication request is unsolicited, thus sending an OIDC authorization request directly from the server side can not provide the necessary CRSF attack protection. 

 E.g. the `state` parameter and `PKCE` flow for SPA application. 
 
 As a better recommendation, by default, we redirect the user to a given client callback URL to initiate a standard OIDC auth flow, while keeping a live IdP-initiated SSO assertion session, so the user can be automatically authenticated via the same SSO connector. 
 
Option A (Default):
- `auto_send_authorization_request` set to false.
- Provide a ` field `client_idp_initiated_auth_callback_uri` in the config. 
- Logto will create an idp-initiated SAML SSO session, and redirect the user to the above URL to trigger a standard OIDC authentication request with sign-in param `direct-sign-in=sso:{connectorId}
 
Option B (Previously implemented):
- `auto_send_authorization_request` set to true.
- Set the `redirect_uri` and other `auth_parameters`
- Logto generate and send an OIDC authorization request on behave of the user. 

### Updates
- Add new field `auto_send_authorization_request`. Default false. When disabled, Logto will redirect the user to the client side to trigger an auth request. 
- Add new field `client_idp_initiated_auth_callback_uri`. Exclusively stores the client side idp-initiated auth callback URL. 
- Add `SPA` application type.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
