### PR TITLE
feat(core): add expiresAt in response of verification record creation

### DIFF
--- a/packages/core/src/routes/verification/index.openapi.json
+++ b/packages/core/src/routes/verification/index.openapi.json
@@ -29,7 +29,21 @@
         },
         "responses": {
           "201": {
-            "description": "The verification record was created successfully."
+            "description": "The verification record was created successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "verificationRecordId": {
+                      "type": "string"
+                    },
+                    "expiresAt": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           },
           "422": {
             "description": "The password is invalid."
@@ -57,7 +71,21 @@
         },
         "responses": {
           "201": {
-            "description": "The verification code has been successfully sent."
+            "description": "The verification code has been successfully sent.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "verificationRecordId": {
+                      "type": "string"
+                    },
+                    "expiresAt": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           },
           "501": {
             "description": "The connector for sending the verification code is not configured."

--- a/packages/integration-tests/src/api/verification-record.ts
+++ b/packages/integration-tests/src/api/verification-record.ts
@@ -4,13 +4,14 @@ import { type KyInstance } from 'ky';
 import { readConnectorMessage } from '#src/helpers/index.js';
 
 export const createVerificationRecordByPassword = async (api: KyInstance, password: string) => {
-  const { verificationRecordId } = await api
+  const { verificationRecordId, expiresAt } = await api
     .post('api/verifications/password', {
       json: {
         password,
       },
     })
-    .json<{ verificationRecordId: string }>();
+    .json<{ verificationRecordId: string; expiresAt: string }>();
+  expect(expiresAt).toBeTruthy();
 
   return verificationRecordId;
 };
@@ -19,7 +20,7 @@ const createVerificationCode = async (
   api: KyInstance,
   identifier: { type: SignInIdentifier; value: string }
 ) => {
-  const { verificationRecordId } = await api
+  const { verificationRecordId, expiresAt } = await api
     .post('api/verifications/verification-code', {
       json: {
         identifier: {
@@ -28,7 +29,8 @@ const createVerificationCode = async (
         },
       },
     })
-    .json<{ verificationRecordId: string }>();
+    .json<{ verificationRecordId: string; expiresAt: string }>();
+  expect(expiresAt).toBeTruthy();
 
   return verificationRecordId;
 };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Add `expiresAt` in the response body of verification record creations endpoints:

1. `POST /api/verifications/password`
2. `POST /api/verifications/verification-code`

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Integration tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
