### PR TITLE
fix(console): fix webhook modal paywall for enterprise plan

### DIFF
--- a/packages/console/src/components/QuotaGuardFooter/index.module.scss
+++ b/packages/console/src/components/QuotaGuardFooter/index.module.scss
@@ -14,8 +14,4 @@
     flex-shrink: 0;
     font: var(--font-body-2);
   }
-
-  .button {
-    text-decoration: none;
-  }
 }

--- a/packages/console/src/components/QuotaGuardFooter/index.module.scss
+++ b/packages/console/src/components/QuotaGuardFooter/index.module.scss
@@ -14,4 +14,8 @@
     flex-shrink: 0;
     font: var(--font-body-2);
   }
+
+  .button {
+    text-decoration: none;
+  }
 }

--- a/packages/console/src/components/QuotaGuardFooter/index.tsx
+++ b/packages/console/src/components/QuotaGuardFooter/index.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from 'react';
 
 import { contactEmailLink } from '@/consts';
-import Button, { LinkButton } from '@/ds-components/Button';
+import { LinkButton } from '@/ds-components/Button';
 import useTenantPathname from '@/hooks/use-tenant-pathname';
 
 import styles from './index.module.scss';
@@ -19,30 +19,28 @@ function QuotaGuardFooter({ children, isLoading, onClickUpgrade, isContactUsPref
   return (
     <div className={styles.container}>
       <div className={styles.description}>{children}</div>
-      {isContactUsPreferred ? (
-        <LinkButton
-          title="general.contact_us_action"
-          size="large"
-          type="primary"
-          href={contactEmailLink}
-          targetBlank="noopener"
-        />
-      ) : (
-        <Button
-          size="large"
-          type="primary"
-          title="upsell.upgrade_plan"
-          isLoading={isLoading}
-          onClick={() => {
-            if (onClickUpgrade) {
-              onClickUpgrade();
-              return;
+      <LinkButton
+        size="large"
+        type="primary"
+        {...(isContactUsPreferred
+          ? {
+              title: 'general.contact_us_action',
+              href: contactEmailLink,
+              targetBlank: 'noopener',
             }
-            // Navigate to subscription page by default
-            navigate('/tenant-settings/subscription');
-          }}
-        />
-      )}
+          : {
+              title: 'upsell.upgrade_plan',
+              isLoading,
+              onClick: () => {
+                if (onClickUpgrade) {
+                  onClickUpgrade();
+                  return;
+                }
+                // Navigate to subscription page by default
+                navigate('/tenant-settings/subscription');
+              },
+            })}
+      />
     </div>
   );
 }

--- a/packages/console/src/components/QuotaGuardFooter/index.tsx
+++ b/packages/console/src/components/QuotaGuardFooter/index.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from 'react';
 
 import { contactEmailLink } from '@/consts';
-import Button from '@/ds-components/Button';
+import Button, { LinkButton } from '@/ds-components/Button';
 import useTenantPathname from '@/hooks/use-tenant-pathname';
 
 import styles from './index.module.scss';
@@ -20,9 +20,13 @@ function QuotaGuardFooter({ children, isLoading, onClickUpgrade, isContactUsPref
     <div className={styles.container}>
       <div className={styles.description}>{children}</div>
       {isContactUsPreferred ? (
-        <a href={contactEmailLink} className={styles.button} rel="noopener">
-          <Button size="large" type="primary" title="general.contact_us_action" />
-        </a>
+        <LinkButton
+          title="general.contact_us_action"
+          size="large"
+          type="primary"
+          href={contactEmailLink}
+          targetBlank="noopener"
+        />
       ) : (
         <Button
           size="large"

--- a/packages/console/src/components/QuotaGuardFooter/index.tsx
+++ b/packages/console/src/components/QuotaGuardFooter/index.tsx
@@ -20,8 +20,8 @@ function QuotaGuardFooter({ children, isLoading, onClickUpgrade, isContactUsPref
     <div className={styles.container}>
       <div className={styles.description}>{children}</div>
       {isContactUsPreferred ? (
-        <a href={contactEmailLink} className={styles.linkButton} rel="noopener">
-          <Button title="general.contact_us_action" />
+        <a href={contactEmailLink} className={styles.button} rel="noopener">
+          <Button size="large" type="primary" title="general.contact_us_action" />
         </a>
       ) : (
         <Button

--- a/packages/console/src/components/QuotaGuardFooter/index.tsx
+++ b/packages/console/src/components/QuotaGuardFooter/index.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode } from 'react';
 
+import { contactEmailLink } from '@/consts';
 import Button from '@/ds-components/Button';
 import useTenantPathname from '@/hooks/use-tenant-pathname';
 
@@ -9,28 +10,35 @@ type Props = {
   readonly children: ReactNode;
   readonly isLoading?: boolean;
   readonly onClickUpgrade?: () => void;
+  readonly isContactUsPreferred?: boolean;
 };
 
-function QuotaGuardFooter({ children, isLoading, onClickUpgrade }: Props) {
+function QuotaGuardFooter({ children, isLoading, onClickUpgrade, isContactUsPreferred }: Props) {
   const { navigate } = useTenantPathname();
 
   return (
     <div className={styles.container}>
       <div className={styles.description}>{children}</div>
-      <Button
-        size="large"
-        type="primary"
-        title="upsell.upgrade_plan"
-        isLoading={isLoading}
-        onClick={() => {
-          if (onClickUpgrade) {
-            onClickUpgrade();
-            return;
-          }
-          // Navigate to subscription page by default
-          navigate('/tenant-settings/subscription');
-        }}
-      />
+      {isContactUsPreferred ? (
+        <a href={contactEmailLink} className={styles.linkButton} rel="noopener">
+          <Button title="general.contact_us_action" />
+        </a>
+      ) : (
+        <Button
+          size="large"
+          type="primary"
+          title="upsell.upgrade_plan"
+          isLoading={isLoading}
+          onClick={() => {
+            if (onClickUpgrade) {
+              onClickUpgrade();
+              return;
+            }
+            // Navigate to subscription page by default
+            navigate('/tenant-settings/subscription');
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/packages/console/src/pages/Webhooks/CreateFormModal/CreateForm.tsx
+++ b/packages/console/src/pages/Webhooks/CreateFormModal/CreateForm.tsx
@@ -64,7 +64,7 @@ function CreateForm({ onClose }: Props) {
       subtitle="webhooks.create_form.subtitle"
       footer={
         shouldBlockCreation ? (
-          <QuotaGuardFooter>
+          <QuotaGuardFooter isContactUsPreferred={isEnterprisePlan}>
             <Trans
               components={{
                 a: <ContactUsPhraseLink />,


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix webhook modal paywall for enterprise plan.
When enterprise tenants hit webhook paywall, let user contact us instead of upgrade plan (upgrade plan is not feasible for enterprise plans).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
![image](https://github.com/user-attachments/assets/cb721b2f-addd-4151-9676-9f5f75aea93d)

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
