### PR TITLE
feat(core): add social identity

### DIFF
--- a/packages/core/src/libraries/user.ts
+++ b/packages/core/src/libraries/user.ts
@@ -29,6 +29,7 @@ export const createUserLibrary = (queries: Queries) => {
       hasUserWithEmail,
       hasUserWithId,
       hasUserWithPhone,
+      hasUserWithIdentity,
       findUsersByIds,
       updateUserById,
       findUserById,
@@ -91,10 +92,11 @@ export const createUserLibrary = (queries: Queries) => {
       username?: Nullable<string>;
       primaryEmail?: Nullable<string>;
       primaryPhone?: Nullable<string>;
+      identity?: Nullable<{ target: string; id: string }>;
     },
     excludeUserId?: string
   ) => {
-    const { primaryEmail, primaryPhone, username } = identifiers;
+    const { primaryEmail, primaryPhone, username, identity } = identifiers;
 
     if (primaryEmail && (await hasUserWithEmail(primaryEmail, excludeUserId))) {
       throw new RequestError({ code: 'user.email_already_in_use', status: 422 });
@@ -106,6 +108,10 @@ export const createUserLibrary = (queries: Queries) => {
 
     if (username && (await hasUser(username, excludeUserId))) {
       throw new RequestError({ code: 'user.username_already_in_use', status: 422 });
+    }
+
+    if (identity && (await hasUserWithIdentity(identity.target, identity.id, excludeUserId))) {
+      throw new RequestError({ code: 'user.identity_already_in_use', status: 422 });
     }
   };
 

--- a/packages/core/src/routes/experience/classes/verifications/social-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/social-verification.ts
@@ -102,7 +102,7 @@ export class SocialVerification implements IdentifierVerificationRecord<Verifica
   /**
    * Create the authorization URL for the social connector and generate a connector authorization session.
    *
-   * @param {SocialAuthorizationSessionStorageType} useInternalSession  - Whether to store the connector session result in the current verification record directly. Set to `true` for the profile API.
+   * @param {SocialAuthorizationSessionStorageType} connectorSessionType  - Whether to store the connector session result in the current verification record directly. Set to `true` for the profile API.
    *
    * @remarks
    * For the experience API:
@@ -126,10 +126,10 @@ export class SocialVerification implements IdentifierVerificationRecord<Verifica
     ctx: WithLogContext,
     tenantContext: TenantContext,
     { state, redirectUri }: SocialAuthorizationUrlPayload,
-    useInternalSession: SocialAuthorizationSessionStorageType = 'interactionSession'
+    connectorSessionType: SocialAuthorizationSessionStorageType = 'interactionSession'
   ) {
     // For the profile API, connector session result is stored in the current verification record directly.
-    if (useInternalSession === 'verificationRecord') {
+    if (connectorSessionType === 'verificationRecord') {
       return this.createSocialAuthorizationSession(ctx, { state, redirectUri });
     }
 
@@ -144,7 +144,7 @@ export class SocialVerification implements IdentifierVerificationRecord<Verifica
   /**
    * Verify the social identity and store the social identity in the verification record.
    *
-   * @param {SocialAuthorizationSessionStorageType} useInternalSession  - Whether to find the connector session result from the current verification record directly. Set to `true` for the profile API.
+   * @param {SocialAuthorizationSessionStorageType} connectorSessionType  - Whether to find the connector session result from the current verification record directly. Set to `true` for the profile API.
    *
    * @remarks
    * For the experience API:
@@ -162,10 +162,10 @@ export class SocialVerification implements IdentifierVerificationRecord<Verifica
     ctx: WithLogContext,
     tenantContext: TenantContext,
     connectorData: JsonObject,
-    useInternalSession: SocialAuthorizationSessionStorageType = 'interactionSession'
+    connectorSessionType: SocialAuthorizationSessionStorageType = 'interactionSession'
   ) {
     const socialUserInfo =
-      useInternalSession === 'verificationRecord'
+      connectorSessionType === 'verificationRecord'
         ? // For the profile API, find the connector session result from the current verification record directly.
           await this.verifySocialIdentityInternally(connectorData, ctx)
         : // For the experience API, fetch the connector session result from the provider's interactionDetails.

--- a/packages/core/src/routes/experience/classes/verifications/social-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/social-verification.ts
@@ -20,6 +20,10 @@ import { z } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
+import {
+  createSocialAuthorizationUrl,
+  verifySocialIdentity,
+} from '#src/routes/interaction/utils/social-verification.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
@@ -52,6 +56,8 @@ export const socialVerificationRecordDataGuard = z.object({
   socialUserInfo: socialUserInfoGuard.optional(),
   connectorSession: connectorSessionGuard.optional(),
 }) satisfies ToZodObject<SocialVerificationRecordData>;
+
+type SocialAuthorizationSessionStorageType = 'interactionSession' | 'verificationRecord';
 
 export class SocialVerification implements IdentifierVerificationRecord<VerificationType.Social> {
   /**
@@ -94,78 +100,80 @@ export class SocialVerification implements IdentifierVerificationRecord<Verifica
   }
 
   /**
-   * Create the authorization URL for the social connector.
-   * Store the connector session result in the provider's interaction storage.
+   * Create the authorization URL for the social connector and generate a connector authorization session.
+   *
+   * @param {SocialAuthorizationSessionStorageType} useInternalSession  - Whether to store the connector session result in the current verification record directly. Set to `true` for the profile API.
    *
    * @remarks
-   * Refers to the {@link createSocialAuthorizationUrl} method in the interaction/utils/social-verification.ts file.
-   * Currently, all the intermediate connector session results are stored in the provider's interactionDetails separately,
-   * apart from the new verification record.
+   * For the experience API:
+   * This method directly calls the {@link createSocialAuthorizationUrl} method in the interaction/utils/social-verification.ts file.
+   * All the intermediate connector session results are stored in the provider's interactionDetails separately, apart from the new verification record.
    * For compatibility reasons, we keep using the old {@link createSocialAuthorizationUrl} method here as a single source of truth.
    * Especially for the SAML connectors,
    * SAML ACS endpoint will find the connector session result by the jti and assign it to the interaction storage.
    * We will need to update the SAML ACS endpoint before move the logic to this new SocialVerification class.
    *
-   * TODO: Consider store the connector session result in the verification record directly.
+   * For the profile API:
+   * This method calls the internal {@link createSocialAuthorizationSession} method to create a social authorization session.
+   * The connector session result is stored in the current verification record directly.
+   * The social verification flow does not rely on the OIDC interaction context.
+   *
+   * TODO: Remove the old {@link createSocialAuthorizationUrl} once the old SAML connectors are updated.
+   * Align using the new {@link createSocialAuthorizationSession} method for both experience and profile APIs.
    * SAML ACS endpoint will find the verification record by the jti and assign the connector session result to the verification record.
    */
   async createAuthorizationUrl(
     ctx: WithLogContext,
     tenantContext: TenantContext,
-    { state, redirectUri }: SocialAuthorizationUrlPayload
+    { state, redirectUri }: SocialAuthorizationUrlPayload,
+    useInternalSession: SocialAuthorizationSessionStorageType = 'interactionSession'
   ) {
-    assertThat(state && redirectUri, 'session.insufficient_info');
+    // For the profile API, connector session result is stored in the current verification record directly.
+    if (useInternalSession === 'verificationRecord') {
+      return this.createSocialAuthorizationSession(ctx, { state, redirectUri });
+    }
 
-    const connector = await this.getConnectorData();
-
-    const {
-      headers: { 'user-agent': userAgent },
-    } = ctx.request;
-
-    return connector.getAuthorizationUri(
-      {
-        state,
-        redirectUri,
-        connectorId: this.connectorId,
-        connectorFactoryId: connector.metadata.id,
-        jti: await this.getJti(ctx, tenantContext),
-        headers: { userAgent },
-      },
-      async (connectorSession) => {
-        this.connectorSession = connectorSession;
-      }
-    );
+    // For the experience API, connector session result is stored in the provider's interactionDetails.
+    return createSocialAuthorizationUrl(ctx, tenantContext, {
+      connectorId: this.connectorId,
+      state,
+      redirectUri,
+    });
   }
 
   /**
    * Verify the social identity and store the social identity in the verification record.
    *
+   * @param {SocialAuthorizationSessionStorageType} useInternalSession  - Whether to find the connector session result from the current verification record directly. Set to `true` for the profile API.
+   *
    * @remarks
-   * Refer to the {@link verifySocialIdentity} method in the interaction/utils/social-verification.ts file.
+   * For the experience API:
+   * This method directly calls the {@link verifySocialIdentity} method in the interaction/utils/social-verification.ts file.
+   * Fetch the connector session result from the provider's interactionDetails and verify the social identity.
    * For compatibility reasons, we keep using the old {@link verifySocialIdentity} method here as a single source of truth.
    * See the above {@link createAuthorizationUrl} method for more details.
    *
-   * TODO: check the log event
+   * For the profile API:
+   * This method calls the internal {@link verifySocialIdentityInternally} method to verify the social identity.
+   * The connector session result is fetched from the current verification record directly.
+   *
    */
-  async verify(ctx: WithLogContext, tenantContext: TenantContext, connectorData: JsonObject) {
-    const connector = await this.getConnectorData();
-
-    // Verify the CSRF token if it's a Google connector and has credential (a Google One Tap
-    // verification)
-    if (
-      connector.metadata.id === GoogleConnector.factoryId &&
-      connectorData[GoogleConnector.oneTapParams.credential]
-    ) {
-      const csrfToken = connectorData[GoogleConnector.oneTapParams.csrfToken];
-      const value = ctx.cookies.get(GoogleConnector.oneTapParams.csrfToken);
-      assertThat(value === csrfToken, 'session.csrf_token_mismatch');
-    }
-
-    const socialUserInfo = await this.libraries.socials.getUserInfo(
-      this.connectorId,
-      connectorData,
-      async () => this.connectorSession ?? {}
-    );
+  async verify(
+    ctx: WithLogContext,
+    tenantContext: TenantContext,
+    connectorData: JsonObject,
+    useInternalSession: SocialAuthorizationSessionStorageType = 'interactionSession'
+  ) {
+    const socialUserInfo =
+      useInternalSession === 'verificationRecord'
+        ? // For the profile API, find the connector session result from the current verification record directly.
+          await this.verifySocialIdentityInternally(connectorData, ctx)
+        : // For the experience API, fetch the connector session result from the provider's interactionDetails.
+          await verifySocialIdentity(
+            { connectorId: this.connectorId, connectorData },
+            ctx,
+            tenantContext
+          );
 
     this.socialUserInfo = socialUserInfo;
   }
@@ -331,16 +339,74 @@ export class SocialVerification implements IdentifierVerificationRecord<Verifica
   }
 
   /**
-   * Get the `jti` from the interaction details.
-   * If the interaction details is not found, return an empty string.
+   * Internal method to create a social authorization session.
+   *
+   * @remarks
+   * This method is a alternative to the {@link createSocialAuthorizationUrl} method in the interaction/utils/social-verification.ts file.
+   * Generate the social authorization URL and store the connector session result in the current verification record directly.
+   * This social connector session result will be used to verify the social response later.
+   * This method can be used for both experience and profile APIs, w/o OIDC interaction context.
+   *
    */
-  private async getJti(ctx: WithLogContext, tenantContext: TenantContext) {
-    try {
-      const { jti } = await tenantContext.provider.interactionDetails(ctx.req, ctx.res);
+  private async createSocialAuthorizationSession(
+    ctx: WithLogContext,
+    { state, redirectUri }: SocialAuthorizationUrlPayload
+  ) {
+    assertThat(state && redirectUri, 'session.insufficient_info');
 
-      return jti;
-    } catch {
-      return '';
+    const connector = await this.getConnectorData();
+
+    const {
+      headers: { 'user-agent': userAgent },
+    } = ctx.request;
+
+    return connector.getAuthorizationUri(
+      {
+        state,
+        redirectUri,
+        connectorId: this.connectorId,
+        connectorFactoryId: connector.metadata.id,
+        // Instead of getting the jti from the interaction details, use the current verification record's id as the jti.
+        jti: this.id,
+        headers: { userAgent },
+      },
+      async (connectorSession) => {
+        // Store the connector session result in the current verification record directly.
+        this.connectorSession = connectorSession;
+      }
+    );
+  }
+
+  /**
+   * Internal method to verify the social identity.
+   *
+   * @remarks
+   * This method is a alternative to the {@link verifySocialIdentity} method in the interaction/utils/social-verification.ts file.
+   * Verify the social identity using the connector data received from the client and the connector session stored in the current verification record.
+   * This method can be used for both experience and profile APIs, w/o OIDC interaction context.
+   */
+  private async verifySocialIdentityInternally(connectorData: JsonObject, ctx: WithLogContext) {
+    const connector = await this.getConnectorData();
+
+    // Verify the CSRF token if it's a Google connector and has credential (a Google One Tap verification)
+    if (
+      connector.metadata.id === GoogleConnector.factoryId &&
+      connectorData[GoogleConnector.oneTapParams.credential]
+    ) {
+      const csrfToken = connectorData[GoogleConnector.oneTapParams.csrfToken];
+      const value = ctx.cookies.get(GoogleConnector.oneTapParams.csrfToken);
+      assertThat(value === csrfToken, 'session.csrf_token_mismatch');
     }
+
+    // Verify the social authorization session exists
+    assertThat(this.connectorSession, 'session.connector_validation_session_not_found');
+
+    const socialUserInfo = await this.libraries.socials.getUserInfo(
+      this.connectorId,
+      connectorData,
+      async () => this.connectorSession ?? {}
+    );
+
+    return socialUserInfo;
   }
 }

--- a/packages/core/src/routes/profile/index.openapi.json
+++ b/packages/core/src/routes/profile/index.openapi.json
@@ -218,6 +218,34 @@
           }
         }
       }
+    },
+    "/api/profile/identities": {
+      "post": {
+        "operationId": "AddUserIdentities",
+        "summary": "Add a user identity",
+        "description": "Add an identity (social identity) to the user, a verification record is required for checking sensitive permissions, and a verification record for the social identity is required.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "verificationRecordId": {
+                    "description": "The verification record ID for checking sensitive permissions."
+                  },
+                  "newIdentifierVerificationRecordId": {
+                    "description": "The identifier verification record ID for the new social identity ownership verification."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "The identity was added successfully."
+          }
+        }
+      }
     }
   }
 }

--- a/packages/core/src/routes/verification/index.openapi.json
+++ b/packages/core/src/routes/verification/index.openapi.json
@@ -129,6 +129,88 @@
           }
         }
       }
+    },
+    "/api/verifications/social": {
+      "post": {
+        "operationId": "CreateVerificationBySocial",
+        "summary": "Create a social verification record",
+        "description": "Create a social verification record and return the authorization URI.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "connectorId": {
+                    "description": "The Logto connector ID."
+                  },
+                  "redirectUri": {
+                    "description": "The URI to navigate back to after the user is authenticated by the connected social identity provider and has granted access to the connector."
+                  },
+                  "state": {
+                    "description": "A random string generated on the client side to prevent CSRF (Cross-Site Request Forgery) attacks."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successfully created the social verification record and returned the authorization URI.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "verificationRecordId": {
+                      "description": "The ID of the verification record."
+                    },
+                    "authorizationUri": {
+                      "description": "The authorization URI to navigate to for authentication and authorization in the connected social identity provider."
+                    },
+                    "expiresAt": {
+                      "description": "The expiration date and time of the verification record."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The connector specified by connectorId is not found."
+          },
+          "422": {
+            "description": "The connector specified by connectorId is not a valid social connector."
+          }
+        }
+      }
+    },
+    "/api/verifications/social/verify": {
+      "post": {
+        "operationId": "VerifyVerificationBySocial",
+        "summary": "Verify a social verification record",
+        "description": "Verify a social verification record by callback connector data, and save the user information to the record.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "connectorData": {
+                    "description": "A json object constructed from the url query params returned by the social platform. Typically it contains `code`, `state` and `redirectUri` fields."
+                  },
+                  "verificationId": {
+                    "description": "The verification ID of the SocialVerification record."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The social verification record has been successfully verified and the user information has been saved."
+          }
+        }
+      }
     }
   }
 }

--- a/packages/core/src/routes/verification/index.ts
+++ b/packages/core/src/routes/verification/index.ts
@@ -184,7 +184,8 @@ export default function verificationRoutes<T extends UserRouter>(
       const authorizationUri = await socialVerification.createAuthorizationUrl(
         ctx,
         tenantContext,
-        rest
+        rest,
+        'verificationRecord'
       );
 
       const { expiresAt } = await insertVerificationRecord(socialVerification, queries);
@@ -225,7 +226,7 @@ export default function verificationRoutes<T extends UserRouter>(
         libraries,
       });
 
-      await socialVerification.verify(ctx, tenantContext, connectorData);
+      await socialVerification.verify(ctx, tenantContext, connectorData, 'verificationRecord');
 
       await updateVerificationRecord(socialVerification, queries);
 

--- a/packages/core/src/routes/verification/index.ts
+++ b/packages/core/src/routes/verification/index.ts
@@ -3,6 +3,8 @@ import {
   AdditionalIdentifier,
   SentinelActivityAction,
   SignInIdentifier,
+  socialAuthorizationUrlPayloadGuard,
+  socialVerificationCallbackPayloadGuard,
   verificationCodeIdentifierGuard,
   VerificationType,
 } from '@logto/schemas';
@@ -19,11 +21,14 @@ import {
 import { withSentinel } from '../experience/classes/libraries/sentinel-guard.js';
 import { createNewCodeVerificationRecord } from '../experience/classes/verifications/code-verification.js';
 import { PasswordVerification } from '../experience/classes/verifications/password-verification.js';
+import { SocialVerification } from '../experience/classes/verifications/social-verification.js';
 import type { UserRouter, RouterInitArgs } from '../types.js';
 
 export default function verificationRoutes<T extends UserRouter>(
-  ...[router, { queries, libraries, sentinel }]: RouterInitArgs<T>
+  ...[router, tenantContext]: RouterInitArgs<T>
 ) {
+  const { queries, libraries, sentinel } = tenantContext;
+
   if (!EnvSet.values.isDevFeaturesEnabled) {
     return;
   }
@@ -153,6 +158,80 @@ export default function verificationRoutes<T extends UserRouter>(
       await updateVerificationRecord(codeVerification, queries);
 
       ctx.body = { verificationRecordId: codeVerification.id };
+
+      return next();
+    }
+  );
+
+  router.post(
+    '/verifications/social',
+    koaGuard({
+      body: socialAuthorizationUrlPayloadGuard.extend({
+        connectorId: z.string(),
+      }),
+      response: z.object({
+        verificationRecordId: z.string(),
+        authorizationUri: z.string(),
+        expiresAt: z.string(),
+      }),
+      status: [201, 400, 404, 422],
+    }),
+    async (ctx, next) => {
+      const { connectorId, ...rest } = ctx.guard.body;
+
+      const socialVerification = SocialVerification.create(libraries, queries, connectorId);
+
+      const authorizationUri = await socialVerification.createAuthorizationUrl(
+        ctx,
+        tenantContext,
+        rest
+      );
+
+      const { expiresAt } = await insertVerificationRecord(socialVerification, queries);
+
+      ctx.body = {
+        verificationRecordId: socialVerification.id,
+        authorizationUri,
+        expiresAt: new Date(expiresAt).toISOString(),
+      };
+      ctx.status = 201;
+
+      return next();
+    }
+  );
+
+  router.post(
+    '/verifications/social/verify',
+    koaGuard({
+      body: socialVerificationCallbackPayloadGuard
+        .pick({
+          connectorData: true,
+        })
+        .extend({
+          verificationRecordId: z.string(),
+        }),
+      response: z.object({
+        verificationRecordId: z.string(),
+      }),
+      status: [200, 400, 404, 422],
+    }),
+    async (ctx, next) => {
+      const { connectorData, verificationRecordId } = ctx.guard.body;
+
+      const socialVerification = await buildVerificationRecordByIdAndType({
+        type: VerificationType.Social,
+        id: verificationRecordId,
+        queries,
+        libraries,
+      });
+
+      await socialVerification.verify(ctx, tenantContext, connectorData);
+
+      await updateVerificationRecord(socialVerification, queries);
+
+      ctx.body = {
+        verificationRecordId,
+      };
 
       return next();
     }

--- a/packages/integration-tests/src/api/profile.ts
+++ b/packages/integration-tests/src/api/profile.ts
@@ -27,6 +27,15 @@ export const updatePrimaryPhone = async (
     json: { phone, verificationRecordId, newIdentifierVerificationRecordId },
   });
 
+export const updateIdentities = async (
+  api: KyInstance,
+  verificationRecordId: string,
+  newIdentifierVerificationRecordId: string
+) =>
+  api.post('api/profile/identities', {
+    json: { verificationRecordId, newIdentifierVerificationRecordId },
+  });
+
 export const updateUser = async (api: KyInstance, body: Record<string, unknown>) =>
   api.patch('api/profile', { json: body }).json<Partial<UserProfileResponse>>();
 

--- a/packages/integration-tests/src/api/verification-record.ts
+++ b/packages/integration-tests/src/api/verification-record.ts
@@ -70,3 +70,31 @@ export const createAndVerifyVerificationCode = async (
 
   return verificationRecordId;
 };
+
+export const createSocialVerificationRecord = async (
+  api: KyInstance,
+  connectorId: string,
+  state: string,
+  redirectUri: string
+) => {
+  const { verificationRecordId, authorizationUri, expiresAt } = await api
+    .post('api/verifications/social', {
+      json: { connectorId, state, redirectUri },
+    })
+    .json<{ verificationRecordId: string; authorizationUri: string; expiresAt: string }>();
+
+  expect(expiresAt).toBeTruthy();
+  expect(authorizationUri).toBeTruthy();
+
+  return { verificationRecordId, authorizationUri };
+};
+
+export const verifySocialAuthorization = async (
+  api: KyInstance,
+  verificationRecordId: string,
+  connectorData: Record<string, unknown>
+) => {
+  await api.post('api/verifications/social/verify', {
+    json: { verificationRecordId, connectorData },
+  });
+};

--- a/packages/integration-tests/src/tests/api/profile/social.test.ts
+++ b/packages/integration-tests/src/tests/api/profile/social.test.ts
@@ -45,7 +45,7 @@ describe('profile (social)', () => {
   });
 
   afterAll(async () => {
-    await clearConnectorsByTypes([ConnectorType.Social]);
+    await clearConnectorsByTypes([ConnectorType.Social, ConnectorType.Email]);
   });
 
   describe('POST /profile/identities', () => {

--- a/packages/integration-tests/src/tests/api/profile/social.test.ts
+++ b/packages/integration-tests/src/tests/api/profile/social.test.ts
@@ -1,0 +1,169 @@
+import { UserScope } from '@logto/core-kit';
+import { ConnectorType } from '@logto/schemas';
+
+import {
+  mockEmailConnectorId,
+  mockSocialConnectorId,
+  mockSocialConnectorTarget,
+} from '#src/__mocks__/connectors-mock.js';
+import { getUserInfo, updateIdentities } from '#src/api/profile.js';
+import {
+  createSocialVerificationRecord,
+  createVerificationRecordByPassword,
+  verifySocialAuthorization,
+} from '#src/api/verification-record.js';
+import {
+  clearConnectorsByTypes,
+  setEmailConnector,
+  setSocialConnector,
+} from '#src/helpers/connector.js';
+import { expectRejects } from '#src/helpers/index.js';
+import {
+  createDefaultTenantUserWithPassword,
+  deleteDefaultTenantUser,
+  signInAndGetUserApi,
+} from '#src/helpers/profile.js';
+import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
+import { devFeatureTest } from '#src/utils.js';
+
+const { describe, it } = devFeatureTest;
+
+describe('profile (social)', () => {
+  const state = 'fake_state';
+  const redirectUri = 'http://localhost:3000/redirect';
+  const authorizationCode = 'fake_code';
+  const connectorIdMap = new Map<string, string>();
+
+  beforeAll(async () => {
+    await enableAllPasswordSignInMethods();
+
+    await clearConnectorsByTypes([ConnectorType.Social]);
+    const { id: socialConnectorId } = await setSocialConnector();
+    const { id: emailConnectorId } = await setEmailConnector();
+    connectorIdMap.set(mockSocialConnectorId, socialConnectorId);
+    connectorIdMap.set(mockEmailConnectorId, emailConnectorId);
+  });
+
+  afterAll(async () => {
+    await clearConnectorsByTypes([ConnectorType.Social]);
+  });
+
+  describe('POST /profile/identities', () => {
+    it('should fail if scope is missing', async () => {
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
+      const api = await signInAndGetUserApi(username, password);
+
+      await expectRejects(
+        updateIdentities(api, 'invalid-verification-record-id', 'new-verification-record-id'),
+        {
+          code: 'auth.unauthorized',
+          status: 400,
+        }
+      );
+
+      await deleteDefaultTenantUser(user.id);
+    });
+
+    it('should fail if verification record is invalid', async () => {
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
+      const api = await signInAndGetUserApi(username, password, {
+        scopes: [UserScope.Profile, UserScope.Identities],
+      });
+
+      await expectRejects(
+        updateIdentities(api, 'invalid-verification-record-id', 'new-verification-record-id'),
+        {
+          code: 'verification_record.permission_denied',
+          status: 401,
+        }
+      );
+
+      await deleteDefaultTenantUser(user.id);
+    });
+
+    it('should fail if new identifier verification record is invalid', async () => {
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
+      const api = await signInAndGetUserApi(username, password, {
+        scopes: [UserScope.Profile, UserScope.Identities],
+      });
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
+
+      await expectRejects(
+        updateIdentities(api, verificationRecordId, 'new-verification-record-id'),
+        {
+          code: 'verification_record.not_found',
+          status: 400,
+        }
+      );
+
+      await deleteDefaultTenantUser(user.id);
+    });
+
+    describe('create social verification record', () => {
+      it('should throw if the connector is not found', async () => {
+        const { user, username, password } = await createDefaultTenantUserWithPassword();
+        const api = await signInAndGetUserApi(username, password, {
+          scopes: [UserScope.Profile, UserScope.Identities],
+        });
+
+        await expectRejects(
+          createSocialVerificationRecord(api, 'invalid-connector-id', state, redirectUri),
+          {
+            code: 'session.invalid_connector_id',
+            status: 422,
+          }
+        );
+
+        await deleteDefaultTenantUser(user.id);
+      });
+
+      it('should throw if the connector is not a social connector', async () => {
+        const { user, username, password } = await createDefaultTenantUserWithPassword();
+        const api = await signInAndGetUserApi(username, password, {
+          scopes: [UserScope.Profile, UserScope.Identities],
+        });
+
+        await expectRejects(
+          createSocialVerificationRecord(
+            api,
+            connectorIdMap.get(mockEmailConnectorId)!,
+            state,
+            redirectUri
+          ),
+          {
+            code: 'connector.unexpected_type',
+            status: 400,
+          }
+        );
+
+        await deleteDefaultTenantUser(user.id);
+      });
+
+      it('should be able to verify social authorization and update user identities', async () => {
+        const { user, username, password } = await createDefaultTenantUserWithPassword();
+        const api = await signInAndGetUserApi(username, password, {
+          scopes: [UserScope.Profile, UserScope.Identities],
+        });
+
+        const { verificationRecordId: newVerificationRecordId } =
+          await createSocialVerificationRecord(
+            api,
+            connectorIdMap.get(mockSocialConnectorId)!,
+            state,
+            redirectUri
+          );
+
+        await verifySocialAuthorization(api, newVerificationRecordId, {
+          code: authorizationCode,
+        });
+
+        const verificationRecordId = await createVerificationRecordByPassword(api, password);
+        await updateIdentities(api, verificationRecordId, newVerificationRecordId);
+        const userInfo = await getUserInfo(api);
+        expect(userInfo.identities).toHaveProperty(mockSocialConnectorTarget);
+
+        await deleteDefaultTenantUser(user.id);
+      });
+    });
+  });
+});

--- a/packages/phrases/src/locales/en/errors/verification-record.ts
+++ b/packages/phrases/src/locales/en/errors/verification-record.ts
@@ -1,6 +1,7 @@
 const verification_record = {
   not_found: 'Verification record not found.',
   permission_denied: 'Permission denied, please re-authenticate.',
+  not_supported_for_google_one_tap: 'This API does not support Google One Tap.',
 };
 
 export default Object.freeze(verification_record);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Implement linking new social identities in profile API.

Steps to link a new social identity:

1. Verify permission, by password or existing phone/email
2. Call `POST /verificiations/social` to create a record and get `authorizationUri`
3. Redirect to it and perform social provider auth.
4. Redirect back to the front end (a callback page is required) and get callback data
5. Call `POST /verifications/social/verify` with the connector data to verify
6. Use the 2 verification record ids to link.

This PR also add some changes to `SocialVerification`, it no longer relys on "interaction session".

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Integration tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
