### PR TITLE
chore: add google connector default prompt

### DIFF
--- a/.changeset/light-clocks-retire.md
+++ b/.changeset/light-clocks-retire.md
@@ -1,0 +1,5 @@
+---
+"@logto/connector-google": minor
+---
+
+update the default `prompts` to be `select_account`

--- a/.changeset/tricky-walls-add.md
+++ b/.changeset/tricky-walls-add.md
@@ -2,4 +2,4 @@
 "@logto/console": patch
 ---
 
-connector config default values should only show up on when creating new connectors
+Connector config default values should only show up when creating new connectors

--- a/.changeset/tricky-walls-add.md
+++ b/.changeset/tricky-walls-add.md
@@ -1,0 +1,5 @@
+---
+"@logto/console": patch
+---
+
+connector config default values should only show up on when creating new connectors

--- a/packages/connectors/connector-google/src/constant.ts
+++ b/packages/connectors/connector-google/src/constant.ts
@@ -69,6 +69,7 @@ export const defaultMetadata: ConnectorMetadata = {
         .map((prompt) => ({
           value: prompt,
         })),
+      defaultValue: [OidcPrompt.SelectAccount],
     },
   ],
 };

--- a/packages/console/src/utils/connector-form.ts
+++ b/packages/console/src/utils/connector-form.ts
@@ -13,7 +13,10 @@ import { safeParseJson } from '@/utils/json';
  */
 const initFormData = (formItems: ConnectorConfigFormItem[], config?: Record<string, unknown>) => {
   const data: Array<[string, unknown]> = formItems.map((item) => {
-    const configValue = config?.[item.key];
+    const configValue =
+      config?.[item.key] ??
+      conditional(item.type === ConnectorConfigFormItemType.Json && {}) ??
+      conditional(item.type === ConnectorConfigFormItemType.MultiSelect && []);
     const { defaultValue } = item;
     const value = config ? configValue : defaultValue;
 

--- a/packages/console/src/utils/connector-form.ts
+++ b/packages/console/src/utils/connector-form.ts
@@ -8,8 +8,8 @@ import { safeParseJson } from '@/utils/json';
 
 /**
  * @remarks
- * - When creating a new connector, it's called in the `convertFactoryResponseToForm()` method. At this time, there is no `config` data, so the default values in `formItems` are used.
- * - When editing an existing connector, it's called in the `convertResponseToForm()` method. `config` data will always exist, and the `config` data is used, never using the default values.
+ * - When creating a new connector, this function will be called in the `convertFactoryResponseToForm()` method. At this time, there is no `config` data, so the default values in `formItems` are used.
+ * - When editing an existing connector, this function will be called in the `convertResponseToForm()` method. `config` data will always exist, and the `config` data is used, never using the default values.
  */
 const initFormData = (formItems: ConnectorConfigFormItem[], config?: Record<string, unknown>) => {
   const data: Array<[string, unknown]> = formItems.map((item) => {

--- a/packages/console/src/utils/connector-form.ts
+++ b/packages/console/src/utils/connector-form.ts
@@ -6,9 +6,16 @@ import { conditional } from '@silverhand/essentials';
 import { SyncProfileMode, type ConnectorFormType } from '@/types/connector';
 import { safeParseJson } from '@/utils/json';
 
+/**
+ * @remarks
+ * - When creating a new connector, it's called in the `convertFactoryResponseToForm()` method. At this time, there is no `config` data, so the default values in `formItems` are used.
+ * - When editing an existing connector, it's called in the `convertResponseToForm()` method. `config` data will always exist, and the `config` data is used, never using the default values.
+ */
 const initFormData = (formItems: ConnectorConfigFormItem[], config?: Record<string, unknown>) => {
   const data: Array<[string, unknown]> = formItems.map((item) => {
-    const value = config?.[item.key] ?? item.defaultValue;
+    const configValue = config?.[item.key];
+    const { defaultValue } = item;
+    const value = config ? configValue : defaultValue;
 
     if (item.type === ConnectorConfigFormItemType.Json) {
       return [item.key, JSON.stringify(value, null, 2)];


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
1. add google connector default prompt (`select_account`), this does not effect existing users. When creating a new google connector, the `select_account` checkbox will be checked automatically. (users with existing Google connector will not be affected)
2. fix the connector `initFormData()` method logic, only apply `formItem.defaultValue` on connector creation. (If not fixed, after making change descripted in 1, if the user unchecks `select_account` and creates the connector, then when entering the Google Connector's edit page, the prompt field's value will be overwritten by the defaultValue. This is a bug.)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
![image](https://github.com/user-attachments/assets/95b48183-0ea8-429b-aefb-bb2dcddb62f2)

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
