### PR TITLE
fix(core,console): show custom jwt error logs

### DIFF
--- a/packages/console/src/consts/logs.ts
+++ b/packages/console/src/consts/logs.ts
@@ -106,6 +106,8 @@ export const auditLogEventTitle: Record<string, Optional<string>> & {
     'Verify forgot-password SMS verification code',
   'Interaction.SignIn.Verification.IdpInitiatedSso.Create':
     'Create IdP-initiated SAML SSO authentication session',
+  'JwtCustomizer.AccessToken': 'Get custom user access token claims',
+  'JwtCustomizer.ClientCredential': 'Get custom M2M access token claims',
 });
 
 export const logEventTitle: Record<string, Optional<string>> & {

--- a/packages/core/src/queries/log.ts
+++ b/packages/core/src/queries/log.ts
@@ -6,6 +6,7 @@ import {
   type Log,
   type interaction,
   type LogKeyUnknown,
+  type jwtCustomizer,
 } from '@logto/schemas';
 import { conditional, conditionalArray } from '@silverhand/essentials';
 import { sql } from '@silverhand/slonik';
@@ -18,7 +19,12 @@ import { conditionalSql, convertToIdentifiers } from '#src/utils/sql.js';
 
 const { table, fields } = convertToIdentifiers(Logs);
 
-export type AllowedKeyPrefix = hook.Type | token.Type | interaction.Prefix | typeof LogKeyUnknown;
+export type AllowedKeyPrefix =
+  | hook.Type
+  | token.Type
+  | interaction.Prefix
+  | jwtCustomizer.Prefix
+  | typeof LogKeyUnknown;
 
 type LogCondition = {
   logKey?: string;

--- a/packages/core/src/routes/log.test.ts
+++ b/packages/core/src/routes/log.test.ts
@@ -1,4 +1,4 @@
-import { LogResult, token, interaction, LogKeyUnknown } from '@logto/schemas';
+import { LogResult, token, interaction, LogKeyUnknown, jwtCustomizer } from '@logto/schemas';
 import type { Log } from '@logto/schemas';
 import { pickDefault } from '@logto/shared/esm';
 
@@ -49,6 +49,7 @@ describe('logRoutes', () => {
           token.Type.ExchangeTokenBy,
           token.Type.RevokeToken,
           interaction.prefix,
+          jwtCustomizer.prefix,
           LogKeyUnknown,
         ],
       });
@@ -59,6 +60,7 @@ describe('logRoutes', () => {
           token.Type.ExchangeTokenBy,
           token.Type.RevokeToken,
           interaction.prefix,
+          jwtCustomizer.prefix,
           LogKeyUnknown,
         ],
       });

--- a/packages/core/src/routes/log.ts
+++ b/packages/core/src/routes/log.ts
@@ -1,4 +1,4 @@
-import { Logs, interaction, token, LogKeyUnknown } from '@logto/schemas';
+import { Logs, interaction, token, LogKeyUnknown, jwtCustomizer } from '@logto/schemas';
 import { object, string } from 'zod';
 
 import koaGuard from '#src/middleware/koa-guard.js';
@@ -34,6 +34,7 @@ export default function logRoutes<T extends ManagementApiRouter>(
         token.Type.ExchangeTokenBy,
         token.Type.RevokeToken,
         interaction.prefix,
+        jwtCustomizer.prefix,
         LogKeyUnknown,
       ];
 


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Show custom JWT error logs on the console.

<img width="1334" alt="image" src="https://github.com/user-attachments/assets/69c91f0e-9cc3-41bc-b225-8b4eaa54b65b">

Should return the customJwt logs in the logs API. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
