### PR TITLE
fix(core): should sync the sso identity detail on sign-in

### DIFF
--- a/packages/core/src/queries/user-sso-identities.ts
+++ b/packages/core/src/queries/user-sso-identities.ts
@@ -10,6 +10,8 @@ import { sql, type CommonQueryMethods } from '@silverhand/slonik';
 import SchemaQueries from '#src/utils/SchemaQueries.js';
 import { manyRows } from '#src/utils/sql.js';
 
+import { buildUpdateWhereWithPool } from '../database/update-where.js';
+
 export default class UserSsoIdentityQueries extends SchemaQueries<
   UserSsoIdentityKeys,
   CreateUserSsoIdentity,
@@ -39,5 +41,17 @@ export default class UserSsoIdentityQueries extends SchemaQueries<
         where ${sql.identifier([UserSsoIdentities.fields.userId])} = ${userId}
       `)
     );
+  }
+
+  async updateUserSsoIdentityDetailByIdentityId(
+    issuer: string,
+    identityId: string,
+    detail: UserSsoIdentity['detail']
+  ) {
+    return buildUpdateWhereWithPool(this.pool)(this.schema, true)({
+      set: { detail },
+      where: { issuer, identityId },
+      jsonbMode: 'replace',
+    });
   }
 }

--- a/packages/core/src/routes/experience/classes/helpers.ts
+++ b/packages/core/src/routes/experience/classes/helpers.ts
@@ -68,7 +68,7 @@ export const identifyUserByVerificationRecord = async (
    */
   syncedProfile?: Pick<
     InteractionProfile,
-    'enterpriseSsoIdentity' | 'socialIdentity' | 'avatar' | 'name'
+    'enterpriseSsoIdentity' | 'syncedEnterpriseSsoIdentity' | 'socialIdentity' | 'avatar' | 'name'
   >;
 }> => {
   // Check verification record can be used to identify a user using the `identifyUser` method.
@@ -99,7 +99,12 @@ export const identifyUserByVerificationRecord = async (
     case VerificationType.EnterpriseSso: {
       try {
         const user = await verificationRecord.identifyUser();
-        const syncedProfile = await verificationRecord.toSyncedProfile();
+        const { enterpriseSsoIdentity } = verificationRecord.toUserProfile();
+        // Sync the enterprise SSO identity details
+        const syncedProfile = {
+          syncedEnterpriseSsoIdentity: enterpriseSsoIdentity,
+          ...(await verificationRecord.toSyncedProfile()),
+        };
         return { user, syncedProfile };
       } catch (error: unknown) {
         // Auto fallback to identify the related user if the user does not exist for enterprise SSO.

--- a/packages/core/src/routes/experience/classes/libraries/provision-library.ts
+++ b/packages/core/src/routes/experience/classes/libraries/provision-library.ts
@@ -58,7 +58,7 @@ export class ProvisionLibrary {
       queries: { userSsoIdentities: userSsoIdentitiesQueries },
     } = this.tenantContext;
 
-    const { socialIdentity, enterpriseSsoIdentity, ...rest } = profile;
+    const { socialIdentity, enterpriseSsoIdentity, syncedEnterpriseSsoIdentity, ...rest } = profile;
 
     const { isCreatingFirstAdminUser, initialUserRoles, customData } =
       await this.getUserProvisionContext(profile);

--- a/packages/core/src/routes/experience/classes/verifications/enterprise-sso-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/enterprise-sso-verification.ts
@@ -137,8 +137,7 @@ export class EnterpriseSsoVerification
   }
 
   /**
-   * Identify the user by the enterprise SSO identity.
-   * If the user is not found, find the related user by the enterprise SSO identity and return the related user.
+   * Identify the user by the enterprise SSO identity and sync the user SSO identity.
    */
   async identifyUser(): Promise<User> {
     assertThat(
@@ -171,7 +170,7 @@ export class EnterpriseSsoVerification
   }
 
   /**
-   * Returns the use SSO identity as a new user profile.
+   * Returns the user SSO identity as a new user profile.
    */
   toUserProfile(): Required<Pick<InteractionProfile, 'enterpriseSsoIdentity'>> {
     assertThat(

--- a/packages/core/src/routes/experience/types.ts
+++ b/packages/core/src/routes/experience/types.ts
@@ -28,6 +28,8 @@ export type InteractionProfile = {
     UserSsoIdentity,
     'identityId' | 'ssoConnectorId' | 'issuer' | 'detail'
   >;
+  // Syncing the existing enterprise SSO identity detail
+  syncedEnterpriseSsoIdentity?: Pick<UserSsoIdentity, 'identityId' | 'issuer' | 'detail'>;
 } & Pick<
   CreateUser,
   | 'avatar'
@@ -60,6 +62,13 @@ export const interactionProfileGuard = Users.createGuard
       .pick({
         identityId: true,
         ssoConnectorId: true,
+        issuer: true,
+        detail: true,
+      })
+      .optional(),
+    syncedEnterpriseSsoIdentity: UserSsoIdentities.guard
+      .pick({
+        identityId: true,
         issuer: true,
         detail: true,
       })


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Should sync the enterprise SSO identity detail on sign-in.

Previously, user enterprise SSO identity only synced once when a new SSO identity was created. All the SSO identity details should be synced every time on user sign-in. 

Create the logic to sync the SSO identity on existing SSO user's sign-in flow. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
