### PR TITLE
feat(schemas): add application unknown session fallback uri field

### DIFF
--- a/packages/core/src/__mocks__/index.ts
+++ b/packages/core/src/__mocks__/index.ts
@@ -49,6 +49,7 @@ export const mockApplication: Application = {
   },
   protectedAppMetadata: null,
   isThirdParty: false,
+  unknownSessionFallbackUri: null,
   createdAt: 1_645_334_775_356,
   customData: {},
 };
@@ -77,6 +78,7 @@ export const mockProtectedApplication: Omit<Application, 'protectedAppMetadata'>
     sessionDuration: 1_209_600,
     pageRules: [],
   },
+  unknownSessionFallbackUri: null,
   isThirdParty: false,
   createdAt: 1_645_334_775_356,
   customData: {},

--- a/packages/schemas/alterations/next-1731037123-add-unknown-session-fallback-uri-column-to-application-table.ts
+++ b/packages/schemas/alterations/next-1731037123-add-unknown-session-fallback-uri-column-to-application-table.ts
@@ -1,0 +1,20 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      alter table applications
+        add column unknown_session_fallback_uri text;
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      alter table applications
+        drop column unknown_session_fallback_uri;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/seeds/application.ts
+++ b/packages/schemas/src/seeds/application.ts
@@ -29,6 +29,7 @@ export const buildDemoAppDataForTenant = (tenantId: string): Application => ({
   customClientMetadata: {},
   protectedAppMetadata: null,
   isThirdParty: false,
+  unknownSessionFallbackUri: null,
   createdAt: 0,
   customData: {},
 });

--- a/packages/schemas/tables/applications.sql
+++ b/packages/schemas/tables/applications.sql
@@ -15,6 +15,7 @@ create table applications (
   custom_client_metadata jsonb /* @use CustomClientMetadata */ not null default '{}'::jsonb,
   protected_app_metadata jsonb /* @use ProtectedAppMetadata */,
   custom_data jsonb /* @use JsonObject */ not null default '{}'::jsonb,
+  unknown_session_fallback_uri text,
   is_third_party boolean not null default false,
   created_at timestamptz not null default(now()),
   primary key (id)


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add a new `unknown_session_fallback_uri` field to the applications.

This new field will be used to store a fallback URL for the application when the user accesses the sign-in page without a valid auth session. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
