### PR TITLE
feat(core): update application API to validate unknown session fallback URI

### DIFF
--- a/packages/core/src/routes/applications/types.ts
+++ b/packages/core/src/routes/applications/types.ts
@@ -1,12 +1,18 @@
 import {
+  ApplicationType,
   applicationCreateGuard as originalApplicationCreateGuard,
   applicationPatchGuard as originalApplicationPatchGuard,
 } from '@logto/schemas';
+import { conditional } from '@silverhand/essentials';
 import { z } from 'zod';
+
+import { EnvSet } from '#src/env-set/index.js';
 
 export const applicationCreateGuard = originalApplicationCreateGuard
   .omit({
     protectedAppMetadata: true,
+    // TODO: @simeng remove this conditional when the feature is enabled
+    ...conditional(!EnvSet.values.isDevFeaturesEnabled && { unknownSessionFallbackUri: true }),
   })
   .extend({
     protectedAppMetadata: z
@@ -20,6 +26,8 @@ export const applicationCreateGuard = originalApplicationCreateGuard
 export const applicationPatchGuard = originalApplicationPatchGuard
   .omit({
     protectedAppMetadata: true,
+    // TODO: @simeng remove this conditional when the feature is enabled
+    ...conditional(!EnvSet.values.isDevFeaturesEnabled && { unknownSessionFallbackUri: true }),
   })
   .extend({
     protectedAppMetadata: z
@@ -37,3 +45,5 @@ export const applicationPatchGuard = originalApplicationPatchGuard
       })
       .optional(),
   });
+
+export const applicationTypeGuard = z.nativeEnum(ApplicationType);

--- a/packages/integration-tests/src/tests/api/application/application.unknown-session-fallback-uri.test.ts
+++ b/packages/integration-tests/src/tests/api/application/application.unknown-session-fallback-uri.test.ts
@@ -1,0 +1,108 @@
+import { ApplicationType } from '@logto/schemas';
+
+import { createApplication, deleteApplication, updateApplication } from '#src/api/index.js';
+import { expectRejects } from '#src/helpers/index.js';
+import { devFeatureTest, generateUuid } from '#src/utils.js';
+
+devFeatureTest.describe('application unknown session fallback uri API tests', () => {
+  describe('create application', () => {
+    const unknownSessionFallbackUri = 'https://example.com';
+
+    it('should throw invalid_unknown_session_fallback_uri error when creating application with invalid unknown session fallback uri', async () => {
+      await expectRejects(
+        createApplication(generateUuid(), ApplicationType.SPA, {
+          unknownSessionFallbackUri: 'invalid-uri',
+        }),
+        { code: 'application.invalid_unknown_session_fallback_uri', status: 400 }
+      );
+    });
+
+    it('should throw unknown_session_fallback_uri_not_supported error when creating machine-to-machine application', async () => {
+      await expectRejects(
+        createApplication(generateUuid(), ApplicationType.MachineToMachine, {
+          unknownSessionFallbackUri,
+        }),
+        { code: 'application.unknown_session_fallback_uri_not_supported', status: 400 }
+      );
+    });
+
+    it('should throw unknown_session_fallback_uri_not_supported error when creating third-party application', async () => {
+      await expectRejects(
+        createApplication(generateUuid(), ApplicationType.Traditional, {
+          unknownSessionFallbackUri,
+          isThirdParty: true,
+        }),
+        { code: 'application.unknown_session_fallback_uri_not_supported', status: 400 }
+      );
+    });
+
+    it('should create application with unknown session fallback uri successfully', async () => {
+      const application = await createApplication(generateUuid(), ApplicationType.SPA, {
+        unknownSessionFallbackUri,
+      });
+
+      expect(application.unknownSessionFallbackUri).toBe(unknownSessionFallbackUri);
+
+      await deleteApplication(application.id);
+    });
+  });
+
+  describe('update application', () => {
+    it('should throw invalid_unknown_session_fallback_uri error when updating application with invalid unknown session fallback uri', async () => {
+      const application = await createApplication(generateUuid(), ApplicationType.SPA);
+      await expectRejects(
+        updateApplication(application.id, { unknownSessionFallbackUri: 'invalid-uri' }),
+        {
+          code: 'application.invalid_unknown_session_fallback_uri',
+          status: 400,
+        }
+      );
+      await deleteApplication(application.id);
+    });
+
+    it('should throw unknown_session_fallback_uri_not_supported error when updating machine-to-machine application', async () => {
+      const application = await createApplication(generateUuid(), ApplicationType.MachineToMachine);
+      await expectRejects(
+        updateApplication(application.id, { unknownSessionFallbackUri: 'https://example.com' }),
+        {
+          code: 'application.unknown_session_fallback_uri_not_supported',
+          status: 400,
+        }
+      );
+      await deleteApplication(application.id);
+    });
+
+    it('should throw unknown_session_fallback_uri_not_supported error when updating third-party application', async () => {
+      const application = await createApplication(generateUuid(), ApplicationType.Traditional, {
+        isThirdParty: true,
+      });
+      await expectRejects(
+        updateApplication(application.id, { unknownSessionFallbackUri: 'https://example.com' }),
+        {
+          code: 'application.unknown_session_fallback_uri_not_supported',
+          status: 400,
+        }
+      );
+      await deleteApplication(application.id);
+    });
+
+    it('should update application with unknown session fallback uri successfully', async () => {
+      const application = await createApplication(generateUuid(), ApplicationType.SPA);
+      const unknownSessionFallbackUri = 'https://example.com';
+
+      const updatedApplication = await updateApplication(application.id, {
+        unknownSessionFallbackUri,
+      });
+
+      expect(updatedApplication.unknownSessionFallbackUri).toBe(unknownSessionFallbackUri);
+
+      const removedUnknownSessionFallbackUriApplication = await updateApplication(application.id, {
+        unknownSessionFallbackUri: null,
+      });
+
+      expect(removedUnknownSessionFallbackUriApplication.unknownSessionFallbackUri).toBe(null);
+
+      await deleteApplication(application.id);
+    });
+  });
+});

--- a/packages/integration-tests/src/utils.ts
+++ b/packages/integration-tests/src/utils.ts
@@ -7,6 +7,7 @@ import { type Page } from 'puppeteer';
 
 import { isDevFeaturesEnabled } from './constants.js';
 
+export const generateUuid = () => crypto.randomUUID();
 export const generateName = () => crypto.randomUUID();
 export const generateUserId = () => crypto.randomUUID();
 export const generateUsername = () => `usr_${crypto.randomUUID().replaceAll('-', '_')}`;

--- a/packages/phrases/src/locales/en/errors/application.ts
+++ b/packages/phrases/src/locales/en/errors/application.ts
@@ -20,6 +20,10 @@ const application = {
   should_delete_custom_domains_first: 'Should delete custom domains first.',
   no_legacy_secret_found: 'The application does not have a legacy secret.',
   secret_name_exists: 'Secret name already exists.',
+  invalid_unknown_session_fallback_uri:
+    'The session fallback URI is invalid. It must be in a valid URI format.',
+  unknown_session_fallback_uri_not_supported:
+    'Unknown session fallback URI is not supported for this application type.',
 };
 
 export default Object.freeze(application);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Update application API to validate unknown session fallback URI.

- Add dev feature guard to the `applicationCreateGuard` and `applicationPatchGuard`.
- Add `unknownSessionFallbackUri` format validation
- Add supported application type validation, `third-party` app and `machine-to-machine` app can not have the unknownSessionFallbackUri`  set.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
