### PR TITLE
Introducing Logto Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 [![cloud](https://img.shields.io/badge/cloud-available-7958ff)](https://cloud.logto.io/?sign_up=true&utm_source=github&utm_medium=repo_logto)
 [![gitpod](https://img.shields.io/badge/gitpod-available-f09439)](https://gitpod.io/#https://github.com/logto-io/demo)
 [![render](https://img.shields.io/badge/render-deploy-5364e9)](https://render.com/deploy?repo=https://github.com/logto-io/logto)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Logto%20Guru-006BFF)](https://gurubase.io/g/logto)
 
 # Logto
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Logto Guru](https://gurubase.io/g/logto) to Gurubase. Logto Guru uses the data from this repo and data from the [docs](https://docs.logto.io/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Logto Guru", which highlights that Logto now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Logto Guru in Gurubase, just let me know that's totally fine.
