### PR TITLE
fix(core): set default social session

### DIFF
--- a/packages/core/src/routes/experience/classes/verifications/social-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/social-verification.ts
@@ -75,7 +75,7 @@ export class SocialVerification implements IdentifierVerificationRecord<Verifica
   public readonly type = VerificationType.Social;
   public readonly connectorId: string;
   public socialUserInfo?: SocialUserInfo;
-  public connectorSession?: ConnectorSession;
+  public connectorSession: ConnectorSession;
   private connectorDataCache?: LogtoConnector;
 
   constructor(
@@ -89,7 +89,7 @@ export class SocialVerification implements IdentifierVerificationRecord<Verifica
     this.id = id;
     this.connectorId = connectorId;
     this.socialUserInfo = socialUserInfo;
-    this.connectorSession = connectorSession;
+    this.connectorSession = connectorSession ?? {};
   }
 
   /**
@@ -404,7 +404,7 @@ export class SocialVerification implements IdentifierVerificationRecord<Verifica
     const socialUserInfo = await this.libraries.socials.getUserInfo(
       this.connectorId,
       connectorData,
-      async () => this.connectorSession ?? {}
+      async () => this.connectorSession
     );
 
     return socialUserInfo;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

In social verification class, set default value `{}` of `connectorSession`, because some connectors do not use this, and this may cause `session.connector_validation_session_not_found` error.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
