### PR TITLE
feat(console): add unknown session fallback URI field

### DIFF
--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/utils.ts
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/utils.ts
@@ -11,6 +11,7 @@ export type ApplicationForm = {
   oidcClientMetadata?: ApplicationResponse['oidcClientMetadata'];
   customClientMetadata?: ApplicationResponse['customClientMetadata'];
   isAdmin?: ApplicationResponse['isAdmin'];
+  unknownSessionFallbackUri?: ApplicationResponse['unknownSessionFallbackUri'];
   // eslint-disable-next-line @typescript-eslint/ban-types
   protectedAppMetadata?: Omit<Exclude<ProtectedAppMetadataType, null>, 'customDomains'>; // Custom domains are handled separately
   customData?: string;
@@ -33,6 +34,7 @@ export const applicationFormDataParser = {
       /** Specific metadata for protected apps */
       protectedAppMetadata,
       customData,
+      unknownSessionFallbackUri,
     } = data;
 
     return {
@@ -46,6 +48,7 @@ export const applicationFormDataParser = {
             ...customClientMetadata,
           },
           customData: JSON.stringify(customData, null, 2),
+          unknownSessionFallbackUri,
           isAdmin,
         }
       ),
@@ -68,6 +71,7 @@ export const applicationFormDataParser = {
       isAdmin,
       protectedAppMetadata,
       customData,
+      unknownSessionFallbackUri,
     } = data;
 
     return {
@@ -90,6 +94,7 @@ export const applicationFormDataParser = {
               customClientMetadata?.corsAllowedOrigins
             ),
           },
+          unknownSessionFallbackUri,
           ...conditional(
             // Invalid JSON string will be guarded by the form field validation
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/packages/phrases/src/locales/en/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/application-details.ts
@@ -100,6 +100,9 @@ const application_details = {
   field_custom_data_tip:
     'Additional custom application info not listed in the pre-defined application properties, such as business-specific settings and configurations.',
   custom_data_invalid: 'Custom data must be a valid JSON object',
+  field_unknown_session_fallback_uri: 'Unknown session sign-in fallback URI',
+  field_unknown_session_fallback_uri_tip:
+    'The fallback URI when the user accesses the sign-in page without a valid session. User will be redirected to this URI to initiate a new authentication flow.',
   branding: {
     name: 'Branding',
     description: 'Customize your app logo and branding color for the app-level experience.',


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add unknown session fallback URI field to the application details page,
 Only visible to: Traditional web app and SPA applications. 

<img width="827" alt="image" src="https://github.com/user-attachments/assets/af7ab92e-bc0d-41e4-8796-3b82cf62a52b">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
