### PR TITLE
feat(experience): display support info in error page

### DIFF
--- a/packages/experience-legacy/src/pages/ErrorPage/SupportInfo.tsx
+++ b/packages/experience-legacy/src/pages/ErrorPage/SupportInfo.tsx
@@ -1,0 +1,51 @@
+import { useContext } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+
+import PageContext from '@/Providers/PageContextProvider/PageContext';
+import TextLink from '@/components/TextLink';
+
+import styles from './index.module.scss';
+
+const TextLinkComponent = ({ href, text }: { readonly href: string; readonly text: string }) => (
+  <TextLink href={href}>{text}</TextLink>
+);
+
+const SupportInfo = () => {
+  const { experienceSettings } = useContext(PageContext);
+  const { t } = useTranslation();
+
+  if (!experienceSettings?.supportEmail && !experienceSettings?.supportWebsiteUrl) {
+    return null;
+  }
+
+  const { supportEmail, supportWebsiteUrl } = experienceSettings;
+
+  return (
+    <div className={styles.support}>
+      {supportEmail && (
+        <div className={styles.message}>
+          <Trans
+            components={{
+              link: <TextLinkComponent href={`mailto:${supportEmail}`} text={supportEmail} />,
+            }}
+          >
+            {t('description.support_email')}
+          </Trans>
+        </div>
+      )}
+      {supportWebsiteUrl && (
+        <div className={styles.message}>
+          <Trans
+            components={{
+              link: <TextLinkComponent href={supportWebsiteUrl} text={supportWebsiteUrl} />,
+            }}
+          >
+            {t('description.support_website')}
+          </Trans>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SupportInfo;

--- a/packages/experience-legacy/src/pages/ErrorPage/index.module.scss
+++ b/packages/experience-legacy/src/pages/ErrorPage/index.module.scss
@@ -16,6 +16,10 @@
   text-align: center;
 }
 
+.support {
+  margin-top: _.unit(4);
+}
+
 
 :global(body.mobile) {
   .title {

--- a/packages/experience-legacy/src/pages/ErrorPage/index.tsx
+++ b/packages/experience-legacy/src/pages/ErrorPage/index.tsx
@@ -10,6 +10,7 @@ import DynamicT from '@/components/DynamicT';
 import NavBar from '@/components/NavBar';
 import PageMeta from '@/components/PageMeta';
 
+import SupportInfo from './SupportInfo';
 import styles from './index.module.scss';
 
 type Props = {
@@ -34,6 +35,7 @@ const ErrorPage = ({ title = 'description.not_found', message, rawMessage }: Pro
         {errorMessage && (
           <div className={styles.message}>{rawMessage ?? <DynamicT forKey={message} />}</div>
         )}
+        <SupportInfo />
       </div>
     </StaticPageLayout>
   );

--- a/packages/experience/src/pages/ErrorPage/SupportInfo.tsx
+++ b/packages/experience/src/pages/ErrorPage/SupportInfo.tsx
@@ -1,0 +1,51 @@
+import { useContext } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+
+import PageContext from '@/Providers/PageContextProvider/PageContext';
+import TextLink from '@/components/TextLink';
+
+import styles from './index.module.scss';
+
+const TextLinkComponent = ({ href, text }: { readonly href: string; readonly text: string }) => (
+  <TextLink href={href}>{text}</TextLink>
+);
+
+const SupportInfo = () => {
+  const { experienceSettings } = useContext(PageContext);
+  const { t } = useTranslation();
+
+  if (!experienceSettings?.supportEmail && !experienceSettings?.supportWebsiteUrl) {
+    return null;
+  }
+
+  const { supportEmail, supportWebsiteUrl } = experienceSettings;
+
+  return (
+    <div className={styles.support}>
+      {supportEmail && (
+        <div className={styles.message}>
+          <Trans
+            components={{
+              link: <TextLinkComponent href={`mailto:${supportEmail}`} text={supportEmail} />,
+            }}
+          >
+            {t('description.support_email')}
+          </Trans>
+        </div>
+      )}
+      {supportWebsiteUrl && (
+        <div className={styles.message}>
+          <Trans
+            components={{
+              link: <TextLinkComponent href={supportWebsiteUrl} text={supportWebsiteUrl} />,
+            }}
+          >
+            {t('description.support_website')}
+          </Trans>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SupportInfo;

--- a/packages/experience/src/pages/ErrorPage/index.module.scss
+++ b/packages/experience/src/pages/ErrorPage/index.module.scss
@@ -16,6 +16,10 @@
   text-align: center;
 }
 
+.support {
+  margin-top: _.unit(4);
+}
+
 
 :global(body.mobile) {
   .title {

--- a/packages/experience/src/pages/ErrorPage/index.tsx
+++ b/packages/experience/src/pages/ErrorPage/index.tsx
@@ -10,6 +10,7 @@ import DynamicT from '@/components/DynamicT';
 import NavBar from '@/components/NavBar';
 import PageMeta from '@/components/PageMeta';
 
+import SupportInfo from './SupportInfo';
 import styles from './index.module.scss';
 
 type Props = {
@@ -34,6 +35,7 @@ const ErrorPage = ({ title = 'description.not_found', message, rawMessage }: Pro
         {errorMessage && (
           <div className={styles.message}>{rawMessage ?? <DynamicT forKey={message} />}</div>
         )}
+        <SupportInfo />
       </div>
     </StaticPageLayout>
   );

--- a/packages/phrases-experience/src/locales/ar/description.ts
+++ b/packages/phrases-experience/src/locales/ar/description.ts
@@ -95,6 +95,10 @@ const description = {
   all_account_creation_options: 'All account creation options',
   /** UNTRANSLATED */
   back_to_sign_in: 'Back to sign in',
+  /** UNTRANSLATED */
+  support_email: 'Support email: <link></link>',
+  /** UNTRANSLATED */
+  support_website: 'Support website: <link></link>',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/de/description.ts
+++ b/packages/phrases-experience/src/locales/de/description.ts
@@ -109,6 +109,8 @@ const description = {
     'Geben Sie Ihre {{types, list(type: disjunction;)}} ein, um ein neues Konto zu erstellen.',
   all_account_creation_options: 'Alle Kontoerstellungsoptionen',
   back_to_sign_in: 'Zurück zur Anmeldung',
+  support_email: 'Support-E-Mail: <link></link>',
+  support_website: 'Support-Website: <link></link>',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/en/description.ts
+++ b/packages/phrases-experience/src/locales/en/description.ts
@@ -94,6 +94,8 @@ const description = {
     'Enter you {{types, list(type: disjunction;)}} to create a new account.',
   all_account_creation_options: 'All account creation options',
   back_to_sign_in: 'Back to sign in',
+  support_email: 'Support email: <link></link>',
+  support_website: 'Support website: <link></link>',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/es/description.ts
+++ b/packages/phrases-experience/src/locales/es/description.ts
@@ -109,6 +109,8 @@ const description = {
     'Ingrese su {{types, list(type: disjunction;)}} para crear una nueva cuenta.',
   all_account_creation_options: 'Todas las opciones de creación de cuenta',
   back_to_sign_in: 'Volver a iniciar sesión',
+  support_email: 'Correo electrónico de soporte: <link></link>',
+  support_website: 'Sitio web de soporte: <link></link>',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/fr/description.ts
+++ b/packages/phrases-experience/src/locales/fr/description.ts
@@ -34,7 +34,7 @@ const description = {
     'Vous pouvez lier une autre adresse e-mail ou un autre numéro de téléphone',
   social_bind_with_existing:
     'Nous avons trouvé un compte associé qui a été enregistré, et vous pouvez le lier directement.',
-  skip_social_linking: 'Ignorer le lien avec le compte existant ?',
+  skip_social_linking: 'Ignorer le lien avec le compte existant ?',
   reset_password: 'Mot de passe oublié',
   reset_password_description:
     'Entrez le {{types, list(type: disjunction;)}} associé à votre compte et nous vous enverrons le code de vérification pour réinitialiser votre mot de passe.',
@@ -109,6 +109,8 @@ const description = {
     'Entrez votre {{types, list(type: disjunction;)}} pour créer un nouveau compte.',
   all_account_creation_options: 'Toutes les options de création de compte',
   back_to_sign_in: 'Retour à la connexion',
+  support_email: 'Email de support: <link></link>',
+  support_website: 'Site web de support: <link></link>',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/it/description.ts
+++ b/packages/phrases-experience/src/locales/it/description.ts
@@ -106,6 +106,8 @@ const description = {
     'Inserisci il tuo {{types, list(type: disjunction;)}} per creare un nuovo account.',
   all_account_creation_options: 'Tutte le opzioni di creazione account',
   back_to_sign_in: 'Torna al login',
+  support_email: 'Email di supporto: <link></link>',
+  support_website: 'Sito web di supporto: <link></link>',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/ja/description.ts
+++ b/packages/phrases-experience/src/locales/ja/description.ts
@@ -105,6 +105,8 @@ const description = {
     '{{types, list(type: disjunction;)}}を入力して新しいアカウントを作成します。',
   all_account_creation_options: 'すべてのアカウント作成オプション',
   back_to_sign_in: 'サインインに戻る',
+  support_email: 'サポートメール: <link></link>',
+  support_website: 'サポートウェブサイト: <link></link>',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/ko/description.ts
+++ b/packages/phrases-experience/src/locales/ko/description.ts
@@ -100,6 +100,8 @@ const description = {
     '새 계정을 만들려면 {{types, list(type: disjunction;)}}을(를) 입력하세요.',
   all_account_creation_options: '모든 계정 생성 옵션',
   back_to_sign_in: '로그인으로 돌아가기',
+  support_email: '지원 이메일: <link></link>',
+  support_website: '지원 웹사이트: <link></link>',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/pl-pl/description.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/description.ts
@@ -107,6 +107,8 @@ const description = {
     'Wprowadź swoje {{types, list(type: disjunction;)}} aby utworzyć nowe konto.',
   all_account_creation_options: 'Wszystkie opcje tworzenia konta',
   back_to_sign_in: 'Wróć do logowania',
+  support_email: 'Email wsparcia: <link></link>',
+  support_website: 'Strona wsparcia: <link></link>',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/pt-br/description.ts
+++ b/packages/phrases-experience/src/locales/pt-br/description.ts
@@ -103,6 +103,8 @@ const description = {
     'Digite seu {{types, list(type: disjunction;)}} para criar uma nova conta.',
   all_account_creation_options: 'Todas as opções de criação de conta',
   back_to_sign_in: 'Voltar para o login',
+  support_email: 'E-mail de suporte: <link></link>',
+  support_website: 'Site de suporte: <link></link>',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/pt-pt/description.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/description.ts
@@ -104,6 +104,8 @@ const description = {
     'Introduza o seu {{types, list(type: disjunction;)}} para criar uma nova conta.',
   all_account_creation_options: 'Todas as opções de criação de conta',
   back_to_sign_in: 'Voltar para o login',
+  support_email: 'Email de suporte: <link></link>',
+  support_website: 'Site de suporte: <link></link>',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/ru/description.ts
+++ b/packages/phrases-experience/src/locales/ru/description.ts
@@ -107,6 +107,8 @@ const description = {
     'Введите свои {{types, list(type: disjunction;)}} чтобы создать новую учётную запись.',
   all_account_creation_options: 'Все варианты создания учётной записи',
   back_to_sign_in: 'Вернуться ко входу',
+  support_email: 'Поддержка по электронной почте: <link></link>',
+  support_website: 'Сайт поддержки: <link></link>',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/tr-tr/description.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/description.ts
@@ -103,6 +103,8 @@ const description = {
     'Yeni bir hesap oluşturmak için {{types, list(type: disjunction;)}} girin.',
   all_account_creation_options: 'Tüm hesap oluşturma seçenekleri',
   back_to_sign_in: 'Girişe dön',
+  support_email: 'Destek e-postası: <link></link>',
+  support_website: 'Destek web sitesi: <link></link>',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/zh-cn/description.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/description.ts
@@ -82,6 +82,8 @@ const description = {
   identifier_register_description: '输入您的{{types, list(type: disjunction;)}}以创建新账户。',
   all_account_creation_options: '所有账户创建选项',
   back_to_sign_in: '返回登录',
+  support_email: '支持邮箱：<link></link>',
+  support_website: '支持网站：<link></link>',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/zh-hk/description.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/description.ts
@@ -94,6 +94,8 @@ const description = {
   identifier_register_description: '輸入您的{{types, list(type: disjunction;)}}以建立新帳戶。',
   all_account_creation_options: '所有帳戶創建選項',
   back_to_sign_in: '返回登入',
+  support_email: '支持郵件：<link></link>',
+  support_website: '支持網站：<link></link>',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/zh-tw/description.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/description.ts
@@ -94,6 +94,8 @@ const description = {
   identifier_register_description: '輸入您的{{types, list(type: disjunction;)}}以建立新帳戶。',
   all_account_creation_options: '所有帳戶創建選項',
   back_to_sign_in: '返回登入',
+  support_email: '支援郵箱: <link></link>',
+  support_website: '支援網站: <link></link>',
 };
 
 export default Object.freeze(description);


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Display support email and website on the error page.

<img width="615" alt="image" src="https://github.com/user-attachments/assets/71d9efb5-caef-4506-8a5f-1f4f6b0ad1a6">



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
