### PR TITLE
feat(schemas,core): add unknown session redirect url to sie

### DIFF
--- a/packages/core/src/__mocks__/sign-in-experience.ts
+++ b/packages/core/src/__mocks__/sign-in-experience.ts
@@ -102,4 +102,5 @@ export const mockSignInExperience: SignInExperience = {
   socialSignIn: {},
   supportEmail: null,
   supportWebsiteUrl: null,
+  unknownSessionRedirectUrl: null,
 };

--- a/packages/core/src/queries/sign-in-experience.test.ts
+++ b/packages/core/src/queries/sign-in-experience.test.ts
@@ -41,7 +41,7 @@ describe('sign-in-experience query', () => {
   it('findDefaultSignInExperience', async () => {
     /* eslint-disable sql/no-unsafe-query */
     const expectSql = `
-      select "tenant_id", "id", "color", "branding", "language_info", "terms_of_use_url", "privacy_policy_url", "agree_to_terms_policy", "sign_in", "sign_up", "social_sign_in", "social_sign_in_connector_targets", "sign_in_mode", "custom_css", "custom_content", "custom_ui_assets", "password_policy", "mfa", "single_sign_on_enabled", "support_email", "support_website_url"
+      select "tenant_id", "id", "color", "branding", "language_info", "terms_of_use_url", "privacy_policy_url", "agree_to_terms_policy", "sign_in", "sign_up", "social_sign_in", "social_sign_in_connector_targets", "sign_in_mode", "custom_css", "custom_content", "custom_ui_assets", "password_policy", "mfa", "single_sign_on_enabled", "support_email", "support_website_url, "unknown_session_redirect_url"
       from "sign_in_experiences"
       where "id"=$1
     `;

--- a/packages/core/src/queries/sign-in-experience.test.ts
+++ b/packages/core/src/queries/sign-in-experience.test.ts
@@ -41,7 +41,7 @@ describe('sign-in-experience query', () => {
   it('findDefaultSignInExperience', async () => {
     /* eslint-disable sql/no-unsafe-query */
     const expectSql = `
-      select "tenant_id", "id", "color", "branding", "language_info", "terms_of_use_url", "privacy_policy_url", "agree_to_terms_policy", "sign_in", "sign_up", "social_sign_in", "social_sign_in_connector_targets", "sign_in_mode", "custom_css", "custom_content", "custom_ui_assets", "password_policy", "mfa", "single_sign_on_enabled", "support_email", "support_website_url, "unknown_session_redirect_url"
+      select "tenant_id", "id", "color", "branding", "language_info", "terms_of_use_url", "privacy_policy_url", "agree_to_terms_policy", "sign_in", "sign_up", "social_sign_in", "social_sign_in_connector_targets", "sign_in_mode", "custom_css", "custom_content", "custom_ui_assets", "password_policy", "mfa", "single_sign_on_enabled", "support_email", "support_website_url", "unknown_session_redirect_url"
       from "sign_in_experiences"
       where "id"=$1
     `;

--- a/packages/core/src/routes/sign-in-experience/index.openapi.json
+++ b/packages/core/src/routes/sign-in-experience/index.openapi.json
@@ -51,6 +51,15 @@
                     },
                     "mfa": {
                       "description": "MFA settings"
+                    },
+                    "supportEmail": {
+                      "description": "The support email address to display on the error pages."
+                    },
+                    "supportWebsiteUrl": {
+                      "description": "The support website URL to display on the error pages."
+                    },
+                    "unknownSessionRedirectUrl": {
+                      "description": "The fallback URL to redirect users when the sign-in session does not exist or unknown. Client should initiates a new authentication flow after the redirection."
                     }
                   }
                 }
@@ -111,6 +120,15 @@
                   },
                   "mfa": {
                     "description": "MFA settings"
+                  },
+                  "supportEmail": {
+                    "description": "The support email address to display on the error pages."
+                  },
+                  "supportWebsiteUrl": {
+                    "description": "The support website URL to display on the error pages."
+                  },
+                  "unknownSessionRedirectUrl": {
+                    "description": "The fallback URL to redirect users when the sign-in session does not exist or unknown. Client should initiates a new authentication flow after the redirection."
                   }
                 }
               }

--- a/packages/core/src/routes/sign-in-experience/index.openapi.json
+++ b/packages/core/src/routes/sign-in-experience/index.openapi.json
@@ -128,7 +128,7 @@
                     "description": "The support website URL to display on the error pages."
                   },
                   "unknownSessionRedirectUrl": {
-                    "description": "The fallback URL to redirect users when the sign-in session does not exist or unknown. Client should initiates a new authentication flow after the redirection."
+                    "description": "The fallback URL to redirect users when the sign-in session does not exist or unknown. Client should initiate a new authentication flow after the redirection."
                   }
                 }
               }

--- a/packages/core/src/routes/sign-in-experience/index.test.ts
+++ b/packages/core/src/routes/sign-in-experience/index.test.ts
@@ -232,4 +232,28 @@ describe('PATCH /sign-in-exp', () => {
       },
     });
   });
+
+  it('should guard unknown session redirect URL field format', async () => {
+    const exception = await signInExperienceRequester
+      .patch('/sign-in-exp')
+      .send({ unknownSessionRedirectUrl: 'invalid' });
+
+    expect(exception).toMatchObject({
+      status: 400,
+    });
+
+    const unknownSessionRedirectUrl = 'https://logto.io';
+
+    const response = await signInExperienceRequester.patch('/sign-in-exp').send({
+      unknownSessionRedirectUrl,
+    });
+
+    expect(response).toMatchObject({
+      status: 200,
+      body: {
+        ...mockSignInExperience,
+        unknownSessionRedirectUrl,
+      },
+    });
+  });
 });

--- a/packages/core/src/routes/sign-in-experience/index.ts
+++ b/packages/core/src/routes/sign-in-experience/index.ts
@@ -55,6 +55,7 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
           privacyPolicyUrl: true,
           supportEmail: true,
           supportWebsiteUrl: true,
+          unknownSessionRedirectUrl: true,
         })
         .merge(
           object({
@@ -62,6 +63,7 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
             privacyPolicyUrl: string().url().optional().nullable().or(literal('')),
             supportEmail: string().email().optional().nullable().or(literal('')),
             supportWebsiteUrl: string().url().optional().nullable().or(literal('')),
+            unknownSessionRedirectUrl: string().url().optional().nullable().or(literal('')),
           })
         )
         .partial(),

--- a/packages/experience-legacy/src/__mocks__/logto.tsx
+++ b/packages/experience-legacy/src/__mocks__/logto.tsx
@@ -116,6 +116,7 @@ export const mockSignInExperience: SignInExperience = {
   socialSignIn: {},
   supportEmail: null,
   supportWebsiteUrl: null,
+  unknownSessionRedirectUrl: null,
 };
 
 export const mockSignInExperienceSettings: SignInExperienceResponse = {
@@ -153,6 +154,7 @@ export const mockSignInExperienceSettings: SignInExperienceResponse = {
   socialSignIn: {},
   supportEmail: null,
   supportWebsiteUrl: null,
+  unknownSessionRedirectUrl: null,
 };
 
 const usernameSettings = {

--- a/packages/experience/src/__mocks__/logto.tsx
+++ b/packages/experience/src/__mocks__/logto.tsx
@@ -116,6 +116,7 @@ export const mockSignInExperience: SignInExperience = {
   socialSignIn: {},
   supportEmail: null,
   supportWebsiteUrl: null,
+  unknownSessionRedirectUrl: null,
 };
 
 export const mockSignInExperienceSettings: SignInExperienceResponse = {
@@ -153,6 +154,7 @@ export const mockSignInExperienceSettings: SignInExperienceResponse = {
   socialSignIn: {},
   supportEmail: null,
   supportWebsiteUrl: null,
+  unknownSessionRedirectUrl: null,
 };
 
 const usernameSettings = {

--- a/packages/schemas/alterations/next-1731377260-add-unknown-session-redirect-url-to-sie.ts
+++ b/packages/schemas/alterations/next-1731377260-add-unknown-session-redirect-url-to-sie.ts
@@ -1,0 +1,20 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      alter table sign_in_experiences
+        add column unknown_session_redirect_url text;
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      alter table sign_in_experiences
+        drop column unknown_session_redirect_url;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/sign_in_experiences.sql
+++ b/packages/schemas/tables/sign_in_experiences.sql
@@ -25,5 +25,6 @@ create table sign_in_experiences (
   single_sign_on_enabled boolean not null default false,
   support_email text,
   support_website_url text,
+  unknown_session_redirect_url text,
   primary key (tenant_id, id)
 );


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add unknown session redirect URL config to sie settings.

Once set, user will be redirect to this fallback URL when access Logto sign-in page without a valid session.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
