### PR TITLE
feat(core): redirect to redirect url from sie on session not found

### DIFF
--- a/packages/core/src/middleware/koa-spa-session-guard.test.ts
+++ b/packages/core/src/middleware/koa-spa-session-guard.test.ts
@@ -25,7 +25,11 @@ describe('koaSpaSessionGuard', () => {
   const provider = new Provider('https://logto.test');
   const interactionDetails = jest.spyOn(provider, 'interactionDetails');
   const getRowsByKeys = jest.fn().mockResolvedValue({ rows: [] });
-  const queries = new MockQueries({ logtoConfigs: { getRowsByKeys } });
+  const findDefaultSignInExperience = jest.fn().mockResolvedValue({});
+  const queries = new MockQueries({
+    logtoConfigs: { getRowsByKeys },
+    signInExperiences: { findDefaultSignInExperience },
+  });
 
   beforeEach(() => {
     process.env = { ...envBackup };
@@ -90,6 +94,28 @@ describe('koaSpaSessionGuard', () => {
       expect(ctx.redirect).toBeCalledWith('https://logto.test/unknown-session');
     });
   }
+
+  it('should redirect to configured unknown session redirect URL in SIE if session not found for a selected path', async () => {
+    const stub = Sinon.stub(EnvSet, 'values').value({
+      ...EnvSet.values,
+      isDevFeaturesEnabled: true,
+    });
+
+    const unknownSessionRedirectUrl = 'https://foo.bar/redirect';
+
+    interactionDetails.mockRejectedValue(new Error('session not found'));
+    findDefaultSignInExperience.mockResolvedValueOnce({
+      unknownSessionRedirectUrl,
+    });
+
+    const ctx = createContextWithRouteParameters({
+      url: `${guardedPath[0]!}/foo`,
+    });
+    await koaSpaSessionGuard(provider, queries)(ctx, next);
+    expect(ctx.redirect).toBeCalledWith(unknownSessionRedirectUrl);
+
+    stub.restore();
+  });
 
   it('should redirect to configured URL if session not found for a selected path', async () => {
     interactionDetails.mockRejectedValue(new Error('session not found'));


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Read and redirect users to the `unknownSessioniRedirectUrl`  from sie settings on session not found.



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
