### PR TITLE
fix(core): allow all origins for profile and verification api

### DIFF
--- a/packages/core/src/middleware/koa-cors.ts
+++ b/packages/core/src/middleware/koa-cors.ts
@@ -5,11 +5,20 @@ import type { MiddlewareType } from 'koa';
 import { EnvSet } from '#src/env-set/index.js';
 
 export default function koaCors<StateT, ContextT, ResponseBodyT>(
-  ...urlSets: UrlSet[]
+  urlSets: UrlSet[],
+  allowedPrefixes: string[] = []
 ): MiddlewareType<StateT, ContextT, ResponseBodyT> {
   return cors({
     origin: (ctx) => {
-      const { origin } = ctx.request.headers;
+      const {
+        headers: { origin },
+        path,
+      } = ctx.request;
+
+      // Allow any origin if the path starts with an allowed prefix
+      if (allowedPrefixes.some((prefix) => path.startsWith(prefix))) {
+        return origin ?? '*';
+      }
 
       if (!EnvSet.values.isProduction) {
         return origin ?? '';

--- a/packages/core/src/routes-me/init.ts
+++ b/packages/core/src/routes-me/init.ts
@@ -40,7 +40,7 @@ export default function initMeApis(tenant: TenantContext): Koa {
   userAssetsRoutes(meRouter, tenant);
 
   const meApp = new Koa();
-  meApp.use(koaCors(EnvSet.values.cloudUrlSet));
+  meApp.use(koaCors([EnvSet.values.cloudUrlSet]));
   meApp.use(meRouter.routes()).use(meRouter.allowedMethods());
 
   return meApp;

--- a/packages/core/src/routes/init.ts
+++ b/packages/core/src/routes/init.ts
@@ -5,13 +5,13 @@ import Router from 'koa-router';
 import { EnvSet } from '#src/env-set/index.js';
 import koaAuditLog from '#src/middleware/koa-audit-log.js';
 import koaBodyEtag from '#src/middleware/koa-body-etag.js';
-import koaCors from '#src/middleware/koa-cors.js';
 import { koaManagementApiHooks } from '#src/middleware/koa-management-api-hooks.js';
 import koaTenantGuard from '#src/middleware/koa-tenant-guard.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 
 import koaAuth from '../middleware/koa-auth/index.js';
 import koaOidcAuth from '../middleware/koa-auth/koa-oidc-auth.js';
+import koaCors from '../middleware/koa-cors.js';
 
 import accountCentersRoutes from './account-center/index.js';
 import adminUserRoutes from './admin-user/index.js';
@@ -135,9 +135,8 @@ const createRouters = (tenant: TenantContext) => {
 
 export default function initApis(tenant: TenantContext): Koa {
   const apisApp = new Koa();
-
   const { adminUrlSet, cloudUrlSet } = EnvSet.values;
-  apisApp.use(koaCors(adminUrlSet, cloudUrlSet));
+  apisApp.use(koaCors([adminUrlSet, cloudUrlSet], ['/profile', '/verifications']));
   apisApp.use(koaBodyEtag());
 
   for (const router of createRouters(tenant)) {

--- a/packages/integration-tests/src/tests/api/profile/index.test.ts
+++ b/packages/integration-tests/src/tests/api/profile/index.test.ts
@@ -48,6 +48,16 @@ describe('profile', () => {
   });
 
   describe('GET /profile', () => {
+    it('should allow all origins', async () => {
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
+      const api = await signInAndGetUserApi(username, password);
+      const response = await api.get('api/profile');
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+
+      await deleteDefaultTenantUser(user.id);
+    });
+
     it('should be able to get profile with default scopes', async () => {
       const { user, username, password } = await createDefaultTenantUserWithPassword();
       const api = await signInAndGetUserApi(username, password);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Allow access from all origins for UserRoute, which includes `/profile` and `/verifications`.

Because thoese APIs are for end users directly.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested and integration tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
