### PR TITLE
feat(core,console): add trust unverified email settings to Azure SSO

### DIFF
--- a/packages/console/src/pages/EnterpriseSsoDetails/Connection/OidcMetadataForm/index.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Connection/OidcMetadataForm/index.tsx
@@ -2,9 +2,11 @@ import { SsoProviderName } from '@logto/schemas';
 import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
+import { isDevFeaturesEnabled } from '@/consts/env';
 import CopyToClipboard from '@/ds-components/CopyToClipboard';
 import FormField from '@/ds-components/FormField';
 import InlineNotification from '@/ds-components/InlineNotification';
+import Switch from '@/ds-components/Switch';
 import TextInput from '@/ds-components/TextInput';
 import { uriValidator } from '@/utils/validator';
 
@@ -83,6 +85,17 @@ function OidcMetadataForm({ providerConfig, config, providerName }: Props) {
       <FormField title="enterprise_sso.metadata.oidc.scope_field_name">
         <TextInput {...register('scope')} error={Boolean(errors.scope)} />
       </FormField>
+      {isDevFeaturesEnabled && providerName === SsoProviderName.AZURE_AD_OIDC && (
+        <FormField
+          title="enterprise_sso_details.trust_unverified_email"
+          tip={t('enterprise_sso_details.trust_unverified_email_tip')}
+        >
+          <Switch
+            label={t('enterprise_sso_details.trust_unverified_email_label')}
+            {...register('trustUnverifiedEmail')}
+          />
+        </FormField>
+      )}
     </>
   );
 }

--- a/packages/console/src/pages/EnterpriseSsoDetails/types/oidc.ts
+++ b/packages/console/src/pages/EnterpriseSsoDetails/types/oidc.ts
@@ -20,6 +20,8 @@ export const oidcConnectorConfigGuard = z
     clientSecret: z.string(),
     issuer: z.string(),
     scope: z.string().optional(),
+    // The following fields are only available for EntraID (OIDC) connector
+    trustUnverifiedEmail: z.boolean().optional(),
   })
   .partial();
 

--- a/packages/core/src/sso/types/index.ts
+++ b/packages/core/src/sso/types/index.ts
@@ -2,7 +2,10 @@ import { type I18nPhrases } from '@logto/connector-kit';
 import { type SsoProviderType, type SsoProviderName } from '@logto/schemas';
 
 import { type AzureAdSsoConnector } from '../AzureAdSsoConnector/index.js';
-import { type AzureOidcSsoConnector } from '../AzureOidcSsoConnector/index.js';
+import {
+  type azureOidcConnectorConfigGuard,
+  type AzureOidcSsoConnector,
+} from '../AzureOidcSsoConnector/index.js';
 import {
   type googleWorkspaceSsoConnectorConfigGuard,
   type GoogleWorkspaceSsoConnector,
@@ -29,7 +32,7 @@ export type SingleSignOnConnectorConfig = {
   [SsoProviderName.AZURE_AD]: typeof samlConnectorConfigGuard;
   [SsoProviderName.GOOGLE_WORKSPACE]: typeof googleWorkspaceSsoConnectorConfigGuard;
   [SsoProviderName.OKTA]: typeof basicOidcConnectorConfigGuard;
-  [SsoProviderName.AZURE_AD_OIDC]: typeof basicOidcConnectorConfigGuard;
+  [SsoProviderName.AZURE_AD_OIDC]: typeof azureOidcConnectorConfigGuard;
 };
 
 export type SingleSignOnFactory<T extends SsoProviderName> = {

--- a/packages/phrases/src/locales/en/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/enterprise-sso-details.ts
@@ -109,6 +109,11 @@ const enterprise_sso_details = {
     auth_params_tooltip:
       'Additional parameters to be passed in the authorization request. By default only (openid profile) scopes will be requested, you can specify additional scopes or a exclusive state value here. (e.g., { "scope": "organizations email", "state": "secret_state" }).',
   },
+  trust_unverified_email: 'Trust unverified email',
+  trust_unverified_email_label:
+    'Always trust the unverified email addresses returned from the identity provider',
+  trust_unverified_email_tip:
+    'The Entra ID (OIDC) connector does not return the `email_verified` claim, meaning that email addresses from Azure are not guaranteed to be verified. By default, Logto will not sync unverified email addresses to the user profile. Enable this option only if you trust all the email addresses from the Entra ID directory.',
 };
 
 export default Object.freeze(enterprise_sso_details);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add trust unverified email settings to Azure OIDC SSO connector.

### Context

Since we launched the EntraID OIDC SSO connector we have received several feedbacks that their customer's email address can not be populated to Logto's user profile when signing up through the EntraID OIDC SSO connector.
The root cause is that Logto only syncs trusted email addresses with `email_verified` claim present in the OIDC userinfo response. 
However, for EntraID, the user email address is manually management by admin users. Those emails are not verified-guaranteed.  So as a result when connecting EntraID through an OIDC-based SSO connector, the `email_verified`  claim will not be returned. 
As a work around,  we add this extra `trustUnverifiedEmail` config field for the EntraID OIDC connector. Developers may choose to always trust those emails returned from the Azure Directory at their own risk. 

<img width="789" alt="image" src="https://github.com/user-attachments/assets/a9a118e8-27ef-446a-b61c-42f10f047eac">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<img width="860" alt="image" src="https://github.com/user-attachments/assets/06b58f1c-09b7-4791-97f3-1ee193925e79">

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
