### PR TITLE
refactor(core): move verification record id to header

### DIFF
--- a/packages/core/src/libraries/verification.ts
+++ b/packages/core/src/libraries/verification.ts
@@ -1,4 +1,3 @@
-import RequestError from '../errors/RequestError/index.js';
 import { expirationTime } from '../queries/verification-records.js';
 import {
   buildVerificationRecord,
@@ -41,34 +40,6 @@ const getVerificationRecordById = async ({
   assertThat(result.success, 'verification_record.not_found');
 
   return buildVerificationRecord(libraries, queries, result.data);
-};
-
-/**
- * Verifies the user sensitive permission by checking if the verification record is valid
- * and associated with the user.
- */
-export const verifyUserSensitivePermission = async ({
-  userId,
-  id,
-  queries,
-  libraries,
-}: {
-  userId: string;
-  id: string;
-  queries: Queries;
-  libraries: Libraries;
-}): Promise<void> => {
-  try {
-    const record = await getVerificationRecordById({ id, queries, libraries, userId });
-
-    assertThat(record.isVerified, 'verification_record.not_found');
-  } catch (error) {
-    if (error instanceof RequestError) {
-      throw new RequestError({ code: 'verification_record.permission_denied', status: 401 });
-    }
-
-    throw error;
-  }
 };
 
 /**

--- a/packages/core/src/middleware/koa-auth/constants.ts
+++ b/packages/core/src/middleware/koa-auth/constants.ts
@@ -1,0 +1,1 @@
+export const verificationRecordIdHeader = 'logto-verification-id';

--- a/packages/core/src/middleware/koa-auth/index.ts
+++ b/packages/core/src/middleware/koa-auth/index.ts
@@ -16,6 +16,7 @@ import { type WithAuthContext, type TokenInfo } from './types.js';
 import { extractBearerTokenFromHeaders, getAdminTenantTokenValidationSet } from './utils.js';
 
 export * from './types.js';
+export * from './constants.js';
 
 export const verifyBearerTokenFromRequest = async (
   envSet: EnvSet,

--- a/packages/core/src/middleware/koa-auth/koa-oidc-auth.ts
+++ b/packages/core/src/middleware/koa-auth/koa-oidc-auth.ts
@@ -1,18 +1,58 @@
 import type { MiddlewareType } from 'koa';
 import type { IRouterParamContext } from 'koa-router';
-import type Provider from 'oidc-provider';
 
 import RequestError from '#src/errors/RequestError/index.js';
+import {
+  verificationRecordDataGuard,
+  buildVerificationRecord,
+} from '#src/routes/experience/classes/verifications/index.js';
+import type Libraries from '#src/tenants/Libraries.js';
+import type Queries from '#src/tenants/Queries.js';
+import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 
+import { verificationRecordIdHeader } from './constants.js';
 import { type WithAuthContext } from './types.js';
 import { extractBearerTokenFromHeaders } from './utils.js';
+
+/**
+ * Builds a verification record by its id.
+ * The `userId` is optional and is only used for user sensitive permission verifications.
+ */
+const getVerificationRecordResultById = async ({
+  id,
+  queries,
+  libraries,
+  userId,
+}: {
+  id: string;
+  queries: Queries;
+  libraries: Libraries;
+  userId: string;
+}): Promise<boolean> => {
+  const record = await queries.verificationRecords.findActiveVerificationRecordById(id);
+  if (record?.userId !== userId) {
+    return false;
+  }
+
+  const result = verificationRecordDataGuard.safeParse({
+    ...record.data,
+    id: record.id,
+  });
+
+  if (!result.success) {
+    return false;
+  }
+
+  const instance = buildVerificationRecord(libraries, queries, result.data);
+  return instance.isVerified;
+};
 
 /**
  * Auth middleware for OIDC opaque token
  */
 export default function koaOidcAuth<StateT, ContextT extends IRouterParamContext, ResponseBodyT>(
-  provider: Provider
+  tenant: TenantContext
 ): MiddlewareType<StateT, WithAuthContext<ContextT>, ResponseBodyT> {
   const authMiddleware: MiddlewareType<StateT, WithAuthContext<ContextT>, ResponseBodyT> = async (
     ctx,
@@ -20,7 +60,7 @@ export default function koaOidcAuth<StateT, ContextT extends IRouterParamContext
   ) => {
     const { request } = ctx;
     const accessTokenValue = extractBearerTokenFromHeaders(request.headers);
-    const accessToken = await provider.AccessToken.find(accessTokenValue);
+    const accessToken = await tenant.provider.AccessToken.find(accessTokenValue);
 
     assertThat(accessToken, new RequestError({ code: 'auth.unauthorized', status: 401 }));
 
@@ -28,10 +68,22 @@ export default function koaOidcAuth<StateT, ContextT extends IRouterParamContext
     assertThat(accountId, new RequestError({ code: 'auth.unauthorized', status: 401 }));
     assertThat(scopes.has('openid'), new RequestError({ code: 'auth.forbidden', status: 403 }));
 
+    const verificationRecordId = request.headers[verificationRecordIdHeader];
+    const identityVerified =
+      typeof verificationRecordId === 'string'
+        ? await getVerificationRecordResultById({
+            id: verificationRecordId,
+            queries: tenant.queries,
+            libraries: tenant.libraries,
+            userId: accountId,
+          })
+        : false;
+
     ctx.auth = {
       type: 'user',
       id: accountId,
       scopes,
+      identityVerified,
     };
 
     return next();

--- a/packages/core/src/middleware/koa-auth/types.ts
+++ b/packages/core/src/middleware/koa-auth/types.ts
@@ -4,6 +4,8 @@ type Auth = {
   type: 'user' | 'app';
   id: string;
   scopes: Set<string>;
+  /** If the request is verified by a verification record, this will be set to `true`. */
+  identityVerified?: boolean;
 };
 
 export type WithAuthContext<ContextT extends IRouterParamContext = IRouterParamContext> =

--- a/packages/core/src/routes/init.ts
+++ b/packages/core/src/routes/init.ts
@@ -104,7 +104,7 @@ const createRouters = (tenant: TenantContext) => {
   const anonymousRouter: AnonymousRouter = new Router();
 
   const userRouter: UserRouter = new Router();
-  userRouter.use(koaOidcAuth(tenant.provider));
+  userRouter.use(koaOidcAuth(tenant));
   // TODO(LOG-10147): Rename to koaApiHooks, this middleware is used for both management API and user API
   userRouter.use(koaManagementApiHooks(tenant.libraries.hooks));
   profileRoutes(userRouter, tenant);

--- a/packages/core/src/routes/profile/index.openapi.json
+++ b/packages/core/src/routes/profile/index.openapi.json
@@ -118,7 +118,7 @@
       "post": {
         "operationId": "UpdatePassword",
         "summary": "Update password",
-        "description": "Update password for the user, a verification record is required for checking sensitive permissions.",
+        "description": "Update password for the user, a logto-verification-id in header is required for checking sensitive permissions.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -126,9 +126,6 @@
                 "properties": {
                   "password": {
                     "description": "The new password for the user."
-                  },
-                  "verificationRecordId": {
-                    "description": "The verification record ID for checking sensitive permissions."
                   }
                 }
               }
@@ -149,7 +146,7 @@
       "post": {
         "operationId": "UpdatePrimaryEmail",
         "summary": "Update primary email",
-        "description": "Update primary email for the user, a verification record is required for checking sensitive permissions, and a new identifier verification record is required for the new email ownership verification.",
+        "description": "Update primary email for the user, a logto-verification-id in header is required for checking sensitive permissions, and a new identifier verification record is required for the new email ownership verification.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -157,9 +154,6 @@
                 "properties": {
                   "email": {
                     "description": "The new email for the user."
-                  },
-                  "verificationRecordId": {
-                    "description": "The verification record ID for checking sensitive permissions."
                   },
                   "newIdentifierVerificationRecordId": {
                     "description": "The identifier verification record ID for the new email ownership verification."
@@ -186,7 +180,7 @@
       "post": {
         "operationId": "UpdatePrimaryPhone",
         "summary": "Update primary phone",
-        "description": "Update primary phone for the user, a verification record is required for checking sensitive permissions, and a new identifier verification record is required for the new phone ownership verification.",
+        "description": "Update primary phone for the user, a logto-verification-id in header is required for checking sensitive permissions, and a new identifier verification record is required for the new phone ownership verification.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -194,9 +188,6 @@
                 "properties": {
                   "phone": {
                     "description": "The new phone for the user."
-                  },
-                  "verificationRecordId": {
-                    "description": "The verification record ID for checking sensitive permissions."
                   },
                   "newIdentifierVerificationRecordId": {
                     "description": "The identifier verification record ID for the new phone ownership verification."
@@ -223,15 +214,12 @@
       "post": {
         "operationId": "AddUserIdentities",
         "summary": "Add a user identity",
-        "description": "Add an identity (social identity) to the user, a verification record is required for checking sensitive permissions, and a verification record for the social identity is required.",
+        "description": "Add an identity (social identity) to the user, a logto-verification-id in header is required for checking sensitive permissions, and a verification record for the social identity is required.",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
                 "properties": {
-                  "verificationRecordId": {
-                    "description": "The verification record ID for checking sensitive permissions."
-                  },
                   "newIdentifierVerificationRecordId": {
                     "description": "The identifier verification record ID for the new social identity ownership verification."
                   }
@@ -251,14 +239,7 @@
       "delete": {
         "operationId": "DeleteIdentity",
         "summary": "Delete a user identity",
-        "description": "Delete an identity (social identity) from the user, a verification record is required for checking sensitive permissions.",
-        "parameters": [
-          {
-            "name": "verificationRecordId",
-            "in": "query",
-            "description": "The verification record ID for checking sensitive permissions."
-          }
-        ],
+        "description": "Delete an identity (social identity) from the user, a logto-verification-id in header is required for checking sensitive permissions.",
         "responses": {
           "204": {
             "description": "The identity was deleted successfully."

--- a/packages/integration-tests/src/api/profile.ts
+++ b/packages/integration-tests/src/api/profile.ts
@@ -1,11 +1,17 @@
 import { type UserProfileResponse } from '@logto/schemas';
 import { type KyInstance } from 'ky';
 
+const verificationRecordIdHeader = 'logto-verification-id';
+
 export const updatePassword = async (
   api: KyInstance,
   verificationRecordId: string,
   password: string
-) => api.post('api/profile/password', { json: { password, verificationRecordId } });
+) =>
+  api.post('api/profile/password', {
+    json: { password },
+    headers: { [verificationRecordIdHeader]: verificationRecordId },
+  });
 
 export const updatePrimaryEmail = async (
   api: KyInstance,
@@ -14,7 +20,8 @@ export const updatePrimaryEmail = async (
   newIdentifierVerificationRecordId: string
 ) =>
   api.post('api/profile/primary-email', {
-    json: { email, verificationRecordId, newIdentifierVerificationRecordId },
+    json: { email, newIdentifierVerificationRecordId },
+    headers: { [verificationRecordIdHeader]: verificationRecordId },
   });
 
 export const updatePrimaryPhone = async (
@@ -24,7 +31,8 @@ export const updatePrimaryPhone = async (
   newIdentifierVerificationRecordId: string
 ) =>
   api.post('api/profile/primary-phone', {
-    json: { phone, verificationRecordId, newIdentifierVerificationRecordId },
+    json: { phone, newIdentifierVerificationRecordId },
+    headers: { [verificationRecordIdHeader]: verificationRecordId },
   });
 
 export const updateIdentities = async (
@@ -33,7 +41,8 @@ export const updateIdentities = async (
   newIdentifierVerificationRecordId: string
 ) =>
   api.post('api/profile/identities', {
-    json: { verificationRecordId, newIdentifierVerificationRecordId },
+    json: { newIdentifierVerificationRecordId },
+    headers: { [verificationRecordIdHeader]: verificationRecordId },
   });
 
 export const deleteIdentity = async (
@@ -42,7 +51,7 @@ export const deleteIdentity = async (
   verificationRecordId: string
 ) =>
   api.delete(`api/profile/identities/${target}`, {
-    searchParams: { verificationRecordId },
+    headers: { [verificationRecordIdHeader]: verificationRecordId },
   });
 
 export const updateUser = async (api: KyInstance, body: Record<string, unknown>) =>

--- a/packages/integration-tests/src/tests/api/profile/account-center-reject.test.ts
+++ b/packages/integration-tests/src/tests/api/profile/account-center-reject.test.ts
@@ -13,12 +13,14 @@ import {
   updatePrimaryPhone,
   updateUser,
 } from '#src/api/profile.js';
+import { createVerificationRecordByPassword } from '#src/api/verification-record.js';
 import { expectRejects } from '#src/helpers/index.js';
 import {
   createDefaultTenantUserWithPassword,
   deleteDefaultTenantUser,
   signInAndGetUserApi,
 } from '#src/helpers/profile.js';
+import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
 import { devFeatureTest, generateEmail, generatePhone } from '#src/utils.js';
 
 const { describe, it } = devFeatureTest;
@@ -30,6 +32,7 @@ const expectedError = {
 
 describe('profile, account center fields disabled', () => {
   beforeAll(async () => {
+    await enableAllPasswordSignInMethods();
     await updateAccountCenter({
       enabled: true,
       fields: {
@@ -79,38 +82,29 @@ describe('profile, account center fields disabled', () => {
       status: 400,
     });
 
-    await expectRejects(updatePassword(api, 'verification-record-id', 'new-password'), {
+    const verificationRecordId = await createVerificationRecordByPassword(api, password);
+    await expectRejects(updatePassword(api, verificationRecordId, 'new-password'), {
       code: 'account_center.filed_not_editable',
       status: 400,
     });
 
     await expectRejects(
-      updatePrimaryEmail(
-        api,
-        generateEmail(),
-        'verification-record-id',
-        'new-verification-record-id'
-      ),
+      updatePrimaryEmail(api, generateEmail(), verificationRecordId, 'new-verification-record-id'),
       expectedError
     );
 
     await expectRejects(
-      updatePrimaryPhone(
-        api,
-        generatePhone(),
-        'verification-record-id',
-        'new-verification-record-id'
-      ),
+      updatePrimaryPhone(api, generatePhone(), verificationRecordId, 'new-verification-record-id'),
       expectedError
     );
 
     await expectRejects(
-      updateIdentities(api, 'verification-record-id', 'new-verification-record-id'),
+      updateIdentities(api, verificationRecordId, 'new-verification-record-id'),
       expectedError
     );
 
     await expectRejects(
-      deleteIdentity(api, mockSocialConnectorTarget, 'verification-record-id'),
+      deleteIdentity(api, mockSocialConnectorTarget, verificationRecordId),
       expectedError
     );
 

--- a/packages/integration-tests/src/tests/api/profile/email-and-phone.test.ts
+++ b/packages/integration-tests/src/tests/api/profile/email-and-phone.test.ts
@@ -33,14 +33,10 @@ describe('profile (email and phone)', () => {
       const { user, username, password } = await createDefaultTenantUserWithPassword();
       const api = await signInAndGetUserApi(username, password);
       const newEmail = generateEmail();
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
 
       await expectRejects(
-        updatePrimaryEmail(
-          api,
-          newEmail,
-          'invalid-verification-record-id',
-          'new-verification-record-id'
-        ),
+        updatePrimaryEmail(api, newEmail, verificationRecordId, 'new-verification-record-id'),
         {
           code: 'auth.unauthorized',
           status: 400,
@@ -144,14 +140,10 @@ describe('profile (email and phone)', () => {
       const { user, username, password } = await createDefaultTenantUserWithPassword();
       const api = await signInAndGetUserApi(username, password);
       const newPhone = generatePhone();
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
 
       await expectRejects(
-        updatePrimaryPhone(
-          api,
-          newPhone,
-          'invalid-verification-record-id',
-          'new-verification-record-id'
-        ),
+        updatePrimaryPhone(api, newPhone, verificationRecordId, 'new-verification-record-id'),
         {
           code: 'auth.unauthorized',
           status: 400,

--- a/packages/integration-tests/src/tests/api/profile/index.test.ts
+++ b/packages/integration-tests/src/tests/api/profile/index.test.ts
@@ -244,8 +244,9 @@ describe('profile', () => {
       const { user, username, password } = await createDefaultTenantUserWithPassword();
       const api = await signInAndGetUserApi(username, password);
       const newPassword = '123456';
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
 
-      await expectRejects(updatePassword(api, 'invalid-varification-record-id', newPassword), {
+      await expectRejects(updatePassword(api, verificationRecordId, newPassword), {
         code: 'password.rejected',
         status: 422,
       });

--- a/packages/integration-tests/src/tests/api/profile/social.test.ts
+++ b/packages/integration-tests/src/tests/api/profile/social.test.ts
@@ -54,9 +54,10 @@ describe('profile (social)', () => {
     it('should fail if scope is missing', async () => {
       const { user, username, password } = await createDefaultTenantUserWithPassword();
       const api = await signInAndGetUserApi(username, password);
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
 
       await expectRejects(
-        updateIdentities(api, 'invalid-verification-record-id', 'new-verification-record-id'),
+        updateIdentities(api, verificationRecordId, 'new-verification-record-id'),
         {
           code: 'auth.unauthorized',
           status: 400,
@@ -107,7 +108,6 @@ describe('profile (social)', () => {
         const api = await signInAndGetUserApi(username, password, {
           scopes: [UserScope.Profile, UserScope.Identities],
         });
-
         await expectRejects(
           createSocialVerificationRecord(api, 'invalid-connector-id', state, redirectUri),
           {
@@ -173,14 +173,12 @@ describe('profile (social)', () => {
     it('should fail if scope is missing', async () => {
       const { user, username, password } = await createDefaultTenantUserWithPassword();
       const api = await signInAndGetUserApi(username, password);
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
 
-      await expectRejects(
-        deleteIdentity(api, mockSocialConnectorTarget, 'invalid-verification-record-id'),
-        {
-          code: 'auth.unauthorized',
-          status: 400,
-        }
-      );
+      await expectRejects(deleteIdentity(api, mockSocialConnectorTarget, verificationRecordId), {
+        code: 'auth.unauthorized',
+        status: 400,
+      });
 
       await deleteDefaultTenantUser(user.id);
     });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Move `verificationRecordId` param to header, this is more secury and convenient.

Please notice that `newVerificationRecordId` is still on request body, because this is not for general use and it is only for a specific new identifier only.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Integration tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
