### PR TITLE
feat(schemas): add `saml_application_configs` table

### DIFF
--- a/packages/schemas/alterations/next-1731904029-add-saml-application-configs-table.ts
+++ b/packages/schemas/alterations/next-1731904029-add-saml-application-configs-table.ts
@@ -1,0 +1,32 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+import { applyTableRls, dropTableRls } from './utils/1704934999-tables.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      create table saml_application_configs (
+        application_id varchar(21) not null
+          references applications (id) on update cascade on delete cascade,
+        tenant_id varchar(21) not null
+          references tenants (id) on update cascade on delete cascade,
+        attribute_mapping jsonb /* @use SamlAttributeMapping */ not null default '{}'::jsonb,
+        sp_metadata jsonb /* @use SamlSpMetadata */ not null,
+        primary key (tenant_id, application_id),
+        constraint application_type
+          check (check_application_type(application_id, 'SAML'))
+      );
+    `);
+    await applyTableRls(pool, 'saml_application_configs');
+  },
+  down: async (pool) => {
+    await dropTableRls(pool, 'saml_application_configs');
+    await pool.query(sql`
+      drop table saml_application_configs;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/alterations/next-1731904029-add-saml-application-configs-table.ts
+++ b/packages/schemas/alterations/next-1731904029-add-saml-application-configs-table.ts
@@ -13,7 +13,8 @@ const alteration: AlterationScript = {
         tenant_id varchar(21) not null
           references tenants (id) on update cascade on delete cascade,
         attribute_mapping jsonb /* @use SamlAttributeMapping */ not null default '{}'::jsonb,
-        sp_metadata jsonb /* @use SamlSpMetadata */ not null,
+        entity_id varchar(128),
+        acs_url jsonb /* @use SamlAcsUrl */,
         primary key (tenant_id, application_id),
         constraint application_type
           check (check_application_type(application_id, 'SAML'))

--- a/packages/schemas/src/foundations/jsonb-types/index.ts
+++ b/packages/schemas/src/foundations/jsonb-types/index.ts
@@ -10,6 +10,7 @@ export * from './sso-connector.js';
 export * from './applications.js';
 export * from './verification-records.js';
 export * from './account-centers.js';
+export * from './saml-application-configs.js';
 
 export {
   configurableConnectorMetadataGuard,

--- a/packages/schemas/src/foundations/jsonb-types/saml-application-configs.ts
+++ b/packages/schemas/src/foundations/jsonb-types/saml-application-configs.ts
@@ -13,16 +13,16 @@ export enum BindingType {
 }
 
 export type SamlSpMetadata = {
-  entityID: string;
-  acsURL: {
+  entityId: string;
+  acsUrl: {
     binding: BindingType;
     url: string;
   };
 };
 
 export const samlSpMetadataGuard = z.object({
-  entityID: z.string(),
-  acsURL: z.object({
+  entityId: z.string(),
+  acsUrl: z.object({
     binding: z.nativeEnum(BindingType),
     url: z.string(),
   }),

--- a/packages/schemas/src/foundations/jsonb-types/saml-application-configs.ts
+++ b/packages/schemas/src/foundations/jsonb-types/saml-application-configs.ts
@@ -7,23 +7,17 @@ export const samlAttributeMappingGuard = z.record(
   z.string()
 ) satisfies z.ZodType<SamlAttributeMapping>;
 
+// Only support SP HTTP-POST binding for now.
 export enum BindingType {
   POST = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
-  REDIRECT = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
 }
 
-export type SamlSpMetadata = {
-  entityId: string;
-  acsUrl: {
-    binding: BindingType;
-    url: string;
-  };
+export type SamlAcsUrl = {
+  binding?: BindingType;
+  url: string;
 };
 
-export const samlSpMetadataGuard = z.object({
-  entityId: z.string(),
-  acsUrl: z.object({
-    binding: z.nativeEnum(BindingType),
-    url: z.string(),
-  }),
-}) satisfies ToZodObject<SamlSpMetadata>;
+export const samlAcsUrlGuard = z.object({
+  binding: z.nativeEnum(BindingType).optional().default(BindingType.POST),
+  url: z.string(),
+}) satisfies ToZodObject<SamlAcsUrl>;

--- a/packages/schemas/src/foundations/jsonb-types/saml-application-configs.ts
+++ b/packages/schemas/src/foundations/jsonb-types/saml-application-configs.ts
@@ -1,0 +1,29 @@
+import { type ToZodObject } from '@logto/connector-kit';
+import { z } from 'zod';
+
+export type SamlAttributeMapping = Record<string, string>;
+
+export const samlAttributeMappingGuard = z.record(
+  z.string()
+) satisfies z.ZodType<SamlAttributeMapping>;
+
+export enum BindingType {
+  POST = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+  REDIRECT = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
+}
+
+export type SamlSpMetadata = {
+  entityID: string;
+  acsURL: {
+    binding: BindingType;
+    url: string;
+  };
+};
+
+export const samlSpMetadataGuard = z.object({
+  entityID: z.string(),
+  acsURL: z.object({
+    binding: z.nativeEnum(BindingType),
+    url: z.string(),
+  }),
+}) satisfies ToZodObject<SamlSpMetadata>;

--- a/packages/schemas/src/foundations/jsonb-types/saml-application-configs.ts
+++ b/packages/schemas/src/foundations/jsonb-types/saml-application-configs.ts
@@ -7,9 +7,9 @@ export const samlAttributeMappingGuard = z.record(
   z.string()
 ) satisfies z.ZodType<SamlAttributeMapping>;
 
-// Only support SP HTTP-POST binding for now.
 export enum BindingType {
   POST = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+  REDIRECT = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
 }
 
 export type SamlAcsUrl = {
@@ -18,6 +18,6 @@ export type SamlAcsUrl = {
 };
 
 export const samlAcsUrlGuard = z.object({
-  binding: z.nativeEnum(BindingType).optional().default(BindingType.POST),
+  binding: z.nativeEnum(BindingType),
   url: z.string(),
 }) satisfies ToZodObject<SamlAcsUrl>;

--- a/packages/schemas/tables/saml_application_configs.sql
+++ b/packages/schemas/tables/saml_application_configs.sql
@@ -1,0 +1,18 @@
+/* init_order = 2 */
+
+/**
+ * The SAML application config and SAML-type application have a one-to-one correspondence:
+ * - a SAML-type application can only have one SAML application config
+ * - a SAML application config can only configure one SAML-type application
+ */
+create table saml_application_configs (
+  application_id varchar(21) not null
+    references applications (id) on update cascade on delete cascade,
+  tenant_id varchar(21) not null
+    references tenants (id) on update cascade on delete cascade,
+  attribute_mapping jsonb /* @use SamlAttributeMapping */ not null default '{}'::jsonb,
+  sp_metadata jsonb /* @use SamlSpMetadata */ not null,
+  primary key (tenant_id, application_id),
+  constraint application_type
+    check (check_application_type(application_id, 'SAML'))
+);

--- a/packages/schemas/tables/saml_application_configs.sql
+++ b/packages/schemas/tables/saml_application_configs.sql
@@ -11,7 +11,8 @@ create table saml_application_configs (
   tenant_id varchar(21) not null
     references tenants (id) on update cascade on delete cascade,
   attribute_mapping jsonb /* @use SamlAttributeMapping */ not null default '{}'::jsonb,
-  sp_metadata jsonb /* @use SamlSpMetadata */ not null,
+  entity_id varchar(128),
+  acs_url jsonb /* @use SamlAcsUrl */,
   primary key (tenant_id, application_id),
   constraint application_type
     check (check_application_type(application_id, 'SAML'))


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
add `saml_application_configs` table

We made `entity_id` and `acs_url` nullable because:
1. There is a one-to-one correspondence between records in `saml_application_configs` and SAML apps.
2. If a SAML app is created via the API without simultaneously inserting a record into `saml_application_configs`, we would need to determine, based on the DB state at that time, when to insert a `saml_application_configs` record. If these fields are not nullable, for a particular SAML app, when the SAML config record does not exist, it would be impossible to use the patch API to modify one of these fields individually.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Covered by CI.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
