### PR TITLE
fix(core): add redis ping interval

### DIFF
--- a/packages/core/src/caches/index.ts
+++ b/packages/core/src/caches/index.ts
@@ -92,7 +92,7 @@ export class RedisCache extends RedisCacheBase {
         socket: this.getSocketOptions(trySafe(() => new URL(redisUrl))),
         // Azure redis has a 10 minutes idle timeout
         // @see https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-best-practices-connection#idle-timeout
-        pingInterval: 8 * 60 * 1000,
+        pingInterval: 8 * 60 * 1000, // 8 minutes
       });
 
       this.client.on('error', (error) => {

--- a/packages/core/src/caches/index.ts
+++ b/packages/core/src/caches/index.ts
@@ -90,6 +90,9 @@ export class RedisCache extends RedisCacheBase {
       this.client = createClient({
         url: conditional(!yes(redisUrl) && redisUrl),
         socket: this.getSocketOptions(trySafe(() => new URL(redisUrl))),
+        // Azure redis has a 10 minutes idle timeout
+        // @see https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-best-practices-connection#idle-timeout
+        pingInterval: 8 * 60 * 1000,
       });
 
       this.client.on('error', (error) => {

--- a/packages/core/src/caches/well-known.ts
+++ b/packages/core/src/caches/well-known.ts
@@ -89,15 +89,16 @@ export class WellKnownCache {
 
   /**
    * Get value from the inner cache store for the given type and key.
-   * Note: Format errors will be silently caught and result an `undefined` return.
+   * Note: Redis connection and format errors will be silently caught and result an `undefined` return.
    */
   async get<Type extends WellKnownCacheType>(
     type: Type,
     key: string
   ): Promise<Optional<WellKnownMap[Type]>> {
-    const data = await this.cacheStore.get(this.cacheKey(type, key));
-
-    return trySafe(() => getValueGuard(type).parse(JSON.parse(data ?? '')));
+    return trySafe(async () => {
+      const data = await this.cacheStore.get(this.cacheKey(type, key));
+      return getValueGuard(type).parse(JSON.parse(data ?? ''));
+    });
   }
 
   /**


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

1. Add a Redis ping interval to prevent idle connections from being disconnected by Azure. For more details, refer to the [Azure documentation on idle timeout](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-best-practices-connection#idle-timeout).
2. Add `trySafe` wrapper to the `WellKnown`  cache getter method. Incase of any Redis connection failure,  it should not affect the Logto core functionality. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
