### PR TITLE
fix(schemas): fix alter script of init account center

### DIFF
--- a/packages/schemas/alterations/next-1731054001-init-account-center.ts
+++ b/packages/schemas/alterations/next-1731054001-init-account-center.ts
@@ -4,13 +4,6 @@ import type { AlterationScript } from '../lib/types/alteration.js';
 
 const alteration: AlterationScript = {
   up: async (pool) => {
-    // Delete the default account center if it exists
-    const { rowCount } = await pool.query(sql`
-      delete from account_centers where id = 'default';
-    `);
-
-    console.log(`Deleted ${rowCount} default account center`);
-
     // Process in chunks of 1000 tenants
     const batchSize = 1000;
     // eslint-disable-next-line @silverhand/fp/no-let
@@ -21,7 +14,7 @@ const alteration: AlterationScript = {
       // eslint-disable-next-line no-await-in-loop
       const tenants = await pool.any<{ id: string }>(sql`
         select id from tenants
-        order by created_at asc
+        order by created_at asc, id asc
         limit ${batchSize} offset ${offset};
       `);
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Fix alteration script of "init account center". Previously, the tenants selection is ordered by "created_at", but the DB has duplicated rows in the exact same datetime, so the splitting is unstable.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested with rows more then 1000.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
