### PR TITLE
feat: add SAML app anonymous metadata and certificate APIs

### DIFF
--- a/packages/core/src/routes/init.ts
+++ b/packages/core/src/routes/init.ts
@@ -7,6 +7,7 @@ import koaAuditLog from '#src/middleware/koa-audit-log.js';
 import koaBodyEtag from '#src/middleware/koa-body-etag.js';
 import { koaManagementApiHooks } from '#src/middleware/koa-management-api-hooks.js';
 import koaTenantGuard from '#src/middleware/koa-tenant-guard.js';
+import samlApplicationAnonymousRoutes from '#src/saml-applications/routes/anonymous.js';
 import samlApplicationRoutes from '#src/saml-applications/routes/index.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 
@@ -120,6 +121,13 @@ const createRouters = (tenant: TenantContext) => {
   wellKnownRoutes(anonymousRouter, tenant);
   statusRoutes(anonymousRouter, tenant);
   authnRoutes(anonymousRouter, tenant);
+  // TODO: @darcy per our design, we will move related routes to Cloud repo and the routes will be loaded from remote.
+  if (
+    (EnvSet.values.isDevFeaturesEnabled && EnvSet.values.isCloud) ||
+    EnvSet.values.isIntegrationTest
+  ) {
+    samlApplicationAnonymousRoutes(anonymousRouter, tenant);
+  }
 
   wellKnownOpenApiRoutes(anonymousRouter, {
     experienceRouters: [experienceRouter, interactionRouter],

--- a/packages/core/src/saml-applications/libraries/saml-applications.ts
+++ b/packages/core/src/saml-applications/libraries/saml-applications.ts
@@ -101,8 +101,10 @@ export const createSamlApplicationsLibrary = (queries: Queries) => {
     });
   };
 
-  const getSamlApplicationMetadataByApplicationId = async (id: string): Promise<string> => {
-    const [{ tenantId, entityId }, { certificate }] = await Promise.all([
+  const getSamlApplicationMetadataByApplicationId = async (
+    id: string
+  ): Promise<{ metadata: string; secretId: string }> => {
+    const [{ tenantId, entityId }, { id: secretId, certificate }] = await Promise.all([
       findSamlApplicationConfigByApplicationId(id),
       findActiveSamlApplicationSecretByApplicationId(id),
     ]);
@@ -123,7 +125,10 @@ export const createSamlApplicationsLibrary = (queries: Queries) => {
       ],
     });
 
-    return idp.getMetadata();
+    return {
+      metadata: idp.getMetadata(),
+      secretId,
+    };
   };
 
   return {

--- a/packages/core/src/saml-applications/libraries/saml-applications.ts
+++ b/packages/core/src/saml-applications/libraries/saml-applications.ts
@@ -35,8 +35,8 @@ export const createSamlApplicationsLibrary = (queries: Queries) => {
 
   const createSamlApplicationSecret = async (
     applicationId: string,
-    // Set certificate life span to 1 year by default.
-    lifeSpanInDays = 365
+    // Set certificate life span to 3 years by default.
+    lifeSpanInDays = 365 * 3
   ): Promise<SamlApplicationSecret> => {
     const { privateKey, certificate, notAfter } = await generateKeyPairAndCertificate(
       lifeSpanInDays

--- a/packages/core/src/saml-applications/libraries/saml-applications.ts
+++ b/packages/core/src/saml-applications/libraries/saml-applications.ts
@@ -47,7 +47,7 @@ export const createSamlApplicationsLibrary = (queries: Queries) => {
       applicationId,
       privateKey,
       certificate,
-      expiresAt: Math.floor(notAfter.getTime() / 1000),
+      expiresAt: notAfter.getTime(),
       active: false,
     });
   };
@@ -101,10 +101,8 @@ export const createSamlApplicationsLibrary = (queries: Queries) => {
     });
   };
 
-  const getSamlApplicationMetadataByApplicationId = async (
-    id: string
-  ): Promise<{ metadata: string; secretId: string }> => {
-    const [{ tenantId, entityId }, { id: secretId, certificate }] = await Promise.all([
+  const getSamlIdPMetadataByApplicationId = async (id: string): Promise<{ metadata: string }> => {
+    const [{ tenantId, entityId }, { certificate }] = await Promise.all([
       findSamlApplicationConfigByApplicationId(id),
       findActiveSamlApplicationSecretByApplicationId(id),
     ]);
@@ -127,7 +125,6 @@ export const createSamlApplicationsLibrary = (queries: Queries) => {
 
     return {
       metadata: idp.getMetadata(),
-      secretId,
     };
   };
 
@@ -135,6 +132,6 @@ export const createSamlApplicationsLibrary = (queries: Queries) => {
     createSamlApplicationSecret,
     findSamlApplicationById,
     updateSamlApplicationById,
-    getSamlApplicationMetadataByApplicationId,
+    getSamlIdPMetadataByApplicationId,
   };
 };

--- a/packages/core/src/saml-applications/libraries/utils.test.ts
+++ b/packages/core/src/saml-applications/libraries/utils.test.ts
@@ -1,7 +1,9 @@
 import { addDays } from 'date-fns';
 import forge from 'node-forge';
 
-import { generateKeyPairAndCertificate } from './utils.js';
+import RequestError from '#src/errors/RequestError/index.js';
+
+import { generateKeyPairAndCertificate, calculateCertificateFingerprints } from './utils.js';
 
 describe('generateKeyPairAndCertificate', () => {
   it('should generate valid key pair and certificate', async () => {
@@ -55,5 +57,74 @@ describe('generateKeyPairAndCertificate', () => {
 
     // RSA key should be 4096 bits
     expect(forge.pki.privateKeyToPem(privateKey).length).toBeGreaterThan(3000); // A 4096-bit RSA private key in PEM format is typically longer than 3000 characters
+  });
+});
+
+describe('calculateCertificateFingerprints', () => {
+  // eslint-disable-next-line @silverhand/fp/no-let
+  let validCertificate: string;
+
+  beforeAll(async () => {
+    // Generate a valid certificate for testing
+    const { certificate } = await generateKeyPairAndCertificate();
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    validCertificate = certificate;
+  });
+
+  it('should calculate correct fingerprints for valid certificate', () => {
+    const fingerprints = calculateCertificateFingerprints(validCertificate);
+
+    // Verify fingerprint format
+    expect(fingerprints.sha1.formatted).toMatch(/^([\dA-F]{2}:){19}[\dA-F]{2}$/);
+    expect(fingerprints.sha1.unformatted).toMatch(/^[\dA-F]{40}$/);
+    expect(fingerprints.sha256.formatted).toMatch(/^([\dA-F]{2}:){31}[\dA-F]{2}$/);
+    expect(fingerprints.sha256.unformatted).toMatch(/^[\dA-F]{64}$/);
+
+    // Verify formatted and unformatted consistency
+    expect(fingerprints.sha1.unformatted).toBe(fingerprints.sha1.formatted.replaceAll(':', ''));
+    expect(fingerprints.sha256.unformatted).toBe(fingerprints.sha256.formatted.replaceAll(':', ''));
+  });
+
+  it('should throw error for invalid PEM format', () => {
+    const invalidCertificates = [
+      'not a certificate',
+      '-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n',
+      // Missing begin/end markers
+      'MIIFWjCCA0KgAwIBAgIUMDAwMDAwMDAwMDAwMDAwMDAwMDAwDQYJKoZIhvcNAQEL',
+    ];
+
+    for (const cert of invalidCertificates) {
+      expect(() => calculateCertificateFingerprints(cert)).toThrow(
+        new RequestError('application.saml.invalid_certificate_pem_format')
+      );
+    }
+  });
+
+  it('should throw error for invalid base64 content', () => {
+    const invalidBase64Certificate =
+      '-----BEGIN CERTIFICATE-----\n' +
+      'This is not base64!@#$%^&*()\n' +
+      '-----END CERTIFICATE-----\n';
+
+    expect(() => calculateCertificateFingerprints(invalidBase64Certificate)).toThrow(
+      new RequestError('application.saml.invalid_certificate_pem_format')
+    );
+  });
+
+  it('should handle certificates with different line endings', () => {
+    // Replace \n with \r\n in valid certificate
+    const crlfCertificate = validCertificate.replaceAll('\n', '\r\n');
+
+    const originalFingerprints = calculateCertificateFingerprints(validCertificate);
+    const crlfFingerprints = calculateCertificateFingerprints(crlfCertificate);
+
+    expect(crlfFingerprints).toEqual(originalFingerprints);
+  });
+
+  it('should calculate consistent fingerprints for the same certificate', () => {
+    const firstResult = calculateCertificateFingerprints(validCertificate);
+    const secondResult = calculateCertificateFingerprints(validCertificate);
+
+    expect(firstResult).toEqual(secondResult);
   });
 });

--- a/packages/core/src/saml-applications/libraries/utils.test.ts
+++ b/packages/core/src/saml-applications/libraries/utils.test.ts
@@ -75,13 +75,10 @@ describe('calculateCertificateFingerprints', () => {
     const fingerprints = calculateCertificateFingerprints(validCertificate);
 
     // Verify fingerprint format
-    expect(fingerprints.sha1.formatted).toMatch(/^([\dA-F]{2}:){19}[\dA-F]{2}$/);
-    expect(fingerprints.sha1.unformatted).toMatch(/^[\dA-F]{40}$/);
     expect(fingerprints.sha256.formatted).toMatch(/^([\dA-F]{2}:){31}[\dA-F]{2}$/);
     expect(fingerprints.sha256.unformatted).toMatch(/^[\dA-F]{64}$/);
 
     // Verify formatted and unformatted consistency
-    expect(fingerprints.sha1.unformatted).toBe(fingerprints.sha1.formatted.replaceAll(':', ''));
     expect(fingerprints.sha256.unformatted).toBe(fingerprints.sha256.formatted.replaceAll(':', ''));
   });
 

--- a/packages/core/src/saml-applications/libraries/utils.ts
+++ b/packages/core/src/saml-applications/libraries/utils.ts
@@ -98,10 +98,6 @@ export const calculateCertificateFingerprints = (
     // Convert base64 to binary
     const certDer = Buffer.from(cleanedPem, 'base64');
 
-    // Calculate SHA-1 fingerprint
-    const sha1Unformatted = crypto.createHash('sha1').update(certDer).digest('hex').toUpperCase();
-    const sha1Formatted = sha1Unformatted.match(/.{2}/g)?.join(':') ?? '';
-
     // Calculate SHA-256 fingerprint
     const sha256Unformatted = crypto
       .createHash('sha256')
@@ -111,10 +107,6 @@ export const calculateCertificateFingerprints = (
     const sha256Formatted = sha256Unformatted.match(/.{2}/g)?.join(':') ?? '';
 
     return {
-      sha1: {
-        formatted: sha1Formatted,
-        unformatted: sha1Unformatted,
-      },
       sha256: {
         formatted: sha256Formatted,
         unformatted: sha256Unformatted,

--- a/packages/core/src/saml-applications/queries/configs.ts
+++ b/packages/core/src/saml-applications/queries/configs.ts
@@ -18,11 +18,6 @@ export const createSamlApplicationConfigQueries = (pool: CommonQueryMethods) => 
   const findSamlApplicationConfigByApplicationId = async (applicationId: string) =>
     /**
      * @remarks
-     * 这里我们使用了 `.one()` 方法 instead of `.maybeOne()` 方法，是因为我们在创建 SAML app 时，直接会创建一条对应的 SAML config 记录。这样在后续我们通过 API 操作 SAML app 的 config 时，不需要额外判断：
-     * 1. 是否需要插入 SAML config（一个 alternative 是，在创建 SAML app 时，不插入一条 SAML config 记录，在 PATCH 时，使用 insert into ... on conflict 的 query 来达到同样的目的）
-     * 2. 在 SAML app 对应的 config 不存在时，GET 方法需要对 null 的 SAML config 进行额外的处理
-     * 根据我们的设计，如果在创建 SAML app 时，就同时创建一条 SAML config 记录，在之后的所有场景中，我们只涉及对这条 DB 记录的 update 操作。在我们的业务场景中，没有手动对 SAML config 记录的 delete 操作。
-     *
      * Here we use the `.one()` method instead of the `.maybeOne()` method because when creating a SAML app, we directly create a corresponding SAML config record. This means that in subsequent API operations on the SAML app's config, we don't need additional checks:
      * 1. Whether to insert a SAML config (an alternative approach is not to insert a SAML config record when creating the SAML app, and use an `insert into ... on conflict` query during PATCH to achieve the same result).
      * 2. When the corresponding config for the SAML app does not exist, the GET method needs to handle the null SAML config additionally.

--- a/packages/core/src/saml-applications/routes/anonymous.ts
+++ b/packages/core/src/saml-applications/routes/anonymous.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+import koaGuard from '#src/middleware/koa-guard.js';
+import type { AnonymousRouter, RouterInitArgs } from '#src/routes/types.js';
+
+export default function samlApplicationAnonymousRoutes<T extends AnonymousRouter>(
+  ...[router, { libraries }]: RouterInitArgs<T>
+) {
+  const {
+    samlApplications: { getSamlApplicationMetadataByApplicationId },
+  } = libraries;
+
+  router.get(
+    '/saml-applications/:id/metadata',
+    koaGuard({
+      params: z.object({ id: z.string() }),
+      status: [200, 400, 404],
+      response: z.string(),
+    }),
+    async (ctx, next) => {
+      const { id } = ctx.guard.params;
+
+      const metadata = await getSamlApplicationMetadataByApplicationId(id);
+
+      ctx.status = 200;
+      ctx.body = metadata;
+      ctx.type = 'text/xml;charset=utf-8';
+
+      return next();
+    }
+  );
+}

--- a/packages/core/src/saml-applications/routes/anonymous.ts
+++ b/packages/core/src/saml-applications/routes/anonymous.ts
@@ -7,7 +7,7 @@ export default function samlApplicationAnonymousRoutes<T extends AnonymousRouter
   ...[router, { libraries }]: RouterInitArgs<T>
 ) {
   const {
-    samlApplications: { getSamlApplicationMetadataByApplicationId },
+    samlApplications: { getSamlIdPMetadataByApplicationId },
   } = libraries;
 
   router.get(
@@ -20,7 +20,7 @@ export default function samlApplicationAnonymousRoutes<T extends AnonymousRouter
     async (ctx, next) => {
       const { id } = ctx.guard.params;
 
-      const metadata = await getSamlApplicationMetadataByApplicationId(id);
+      const { metadata } = await getSamlIdPMetadataByApplicationId(id);
 
       ctx.status = 200;
       ctx.body = metadata;

--- a/packages/core/src/saml-applications/routes/index.ts
+++ b/packages/core/src/saml-applications/routes/index.ts
@@ -44,7 +44,7 @@ export default function samlApplicationRoutes<T extends ManagementApiRouter>(
       createSamlApplicationSecret,
       findSamlApplicationById,
       updateSamlApplicationById,
-      getSamlApplicationMetadataByApplicationId,
+      getSamlIdPMetadataByApplicationId,
     },
   } = libraries;
 
@@ -286,7 +286,7 @@ export default function samlApplicationRoutes<T extends ManagementApiRouter>(
   );
 
   router.get(
-    '/saml-applications/:id/certificate/download',
+    '/saml-applications/:id/certificate.pem',
     koaGuard({
       params: z.object({ id: z.string() }),
       status: [200, 400, 404],
@@ -295,24 +295,19 @@ export default function samlApplicationRoutes<T extends ManagementApiRouter>(
     async (ctx, next) => {
       const { id } = ctx.guard.params;
 
-      const { id: secretId, certificate } = await findActiveSamlApplicationSecretByApplicationId(
-        id
-      );
+      const { certificate } = await findActiveSamlApplicationSecretByApplicationId(id);
 
       ctx.status = 200;
       ctx.body = certificate;
       ctx.type = 'application/x-pem-file';
-      ctx.set(
-        'Content-Disposition',
-        createContentDisposition(`saml-certificate-app-${id}-secret-${secretId}.pem`)
-      );
+      ctx.set('Content-Disposition', createContentDisposition(`certificate.pem`));
 
       return next();
     }
   );
 
   router.get(
-    '/saml-applications/:id/metadata/download',
+    '/saml-applications/:id/metadata.xml',
     koaGuard({
       params: z.object({ id: z.string() }),
       status: [200, 400, 404],
@@ -321,15 +316,12 @@ export default function samlApplicationRoutes<T extends ManagementApiRouter>(
     async (ctx, next) => {
       const { id } = ctx.guard.params;
 
-      const { metadata, secretId } = await getSamlApplicationMetadataByApplicationId(id);
+      const { metadata } = await getSamlIdPMetadataByApplicationId(id);
 
       ctx.status = 200;
       ctx.body = metadata;
       ctx.type = 'text/xml;charset=utf-8';
-      ctx.set(
-        'Content-Disposition',
-        createContentDisposition(`saml-metadata-app-${id}-secret-${secretId}.xml`)
-      );
+      ctx.set('Content-Disposition', createContentDisposition(`metadata.xml`));
 
       return next();
     }

--- a/packages/core/src/utils/content-disposition.ts
+++ b/packages/core/src/utils/content-disposition.ts
@@ -1,0 +1,10 @@
+/**
+ * Generate Content-Disposition header value for file download
+ * @param filename The name of the file to be downloaded
+ * @returns Content-Disposition header value
+ */
+export const createContentDisposition = (filename: string) => {
+  // RFC 6266 requires the filename to be quoted and UTF-8 encoded
+  const encodedFilename = encodeURIComponent(filename);
+  return `attachment; filename="${encodedFilename}"; filename*=UTF-8''${encodedFilename}`;
+};

--- a/packages/integration-tests/src/api/saml-application.ts
+++ b/packages/integration-tests/src/api/saml-application.ts
@@ -5,7 +5,7 @@ import {
   type SamlApplicationSecretResponse,
 } from '@logto/schemas';
 
-import { authedAdminApi } from './api.js';
+import api, { authedAdminApi } from './api.js';
 
 export const createSamlApplication = async (createSamlApplication: CreateSamlApplication) =>
   authedAdminApi
@@ -43,3 +43,10 @@ export const updateSamlApplicationSecret = async (id: string, secretId: string, 
   authedAdminApi
     .patch(`saml-applications/${id}/secrets/${secretId}`, { json: { active } })
     .json<SamlApplicationSecretResponse>();
+
+export const getSamlApplicationCertificate = async (id: string) =>
+  authedAdminApi.get(`saml-applications/${id}/certificate`).json<{ certificate: string }>();
+
+// Anonymous endpoints
+export const getSamlApplicationMetadata = async (id: string) =>
+  api.get(`saml-applications/${id}/metadata`).text();

--- a/packages/integration-tests/src/api/saml-application.ts
+++ b/packages/integration-tests/src/api/saml-application.ts
@@ -49,4 +49,10 @@ export const getSamlApplicationCertificate = async (id: string) =>
 
 // Anonymous endpoints
 export const getSamlApplicationMetadata = async (id: string) =>
-  api.get(`saml-applications/${id}/metadata`).text();
+  api
+    .get(`saml-applications/${id}/metadata`, {
+      headers: {
+        Accept: 'text/xml',
+      },
+    })
+    .text();

--- a/packages/integration-tests/src/tests/api/application/saml-application.test.ts
+++ b/packages/integration-tests/src/tests/api/application/saml-application.test.ts
@@ -10,6 +10,8 @@ import {
   createSamlApplicationSecret,
   updateSamlApplicationSecret,
   getSamlApplicationSecrets,
+  getSamlApplicationMetadata,
+  getSamlApplicationCertificate,
 } from '#src/api/saml-application.js';
 import { expectRejects } from '#src/helpers/index.js';
 import { devFeatureTest } from '#src/utils.js';
@@ -33,7 +35,7 @@ describe('SAML application', () => {
         description: 'test',
         config: {
           acsUrl: {
-            binding: BindingType.REDIRECT,
+            binding: BindingType.Redirect,
             url: 'https://example.com',
           },
         },
@@ -49,7 +51,7 @@ describe('SAML application', () => {
     const config = {
       entityId: 'https://example.logto.io',
       acsUrl: {
-        binding: BindingType.POST,
+        binding: BindingType.Post,
         url: 'https://example.logto.io/sso/saml',
       },
     };
@@ -71,7 +73,7 @@ describe('SAML application', () => {
 
     const newConfig = {
       acsUrl: {
-        binding: BindingType.POST,
+        binding: BindingType.Post,
         url: 'https://example.logto.io/sso/saml',
       },
     };
@@ -156,6 +158,11 @@ describe('SAML application', () => {
     expect(updatedSecret.active).toBe(true);
     // @ts-expect-error - Make sure the `privateKey` is not exposed in the response.
     expect(updatedSecret.privateKey).toBeUndefined();
+
+    const { certificate } = await getSamlApplicationCertificate(id);
+    expect(typeof certificate).toBe('string');
+
+    await expect(getSamlApplicationMetadata(id)).resolves.not.toThrow();
 
     await expectRejects(deleteSamlApplicationSecret(id, createdSecret.id), {
       code: 'application.saml.can_not_delete_active_secret',

--- a/packages/phrases/src/locales/en/errors/application.ts
+++ b/packages/phrases/src/locales/en/errors/application.ts
@@ -26,6 +26,9 @@ const application = {
     acs_url_binding_not_supported:
       'Only HTTP-POST binding is supported for receiving SAML assertions.',
     can_not_delete_active_secret: 'Can not delete the active secret.',
+    no_active_secret: 'No active secret found.',
+    entity_id_required: 'Entity ID is required to generate metadata.',
+    invalid_certificate_pem_format: 'Invalid PEM certificate format',
   },
 };
 

--- a/packages/schemas/src/foundations/jsonb-types/saml-application-configs.ts
+++ b/packages/schemas/src/foundations/jsonb-types/saml-application-configs.ts
@@ -8,8 +8,8 @@ export const samlAttributeMappingGuard = z.record(
 ) satisfies z.ZodType<SamlAttributeMapping>;
 
 export enum BindingType {
-  POST = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
-  REDIRECT = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
+  Post = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+  Redirect = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
 }
 
 export type SamlAcsUrl = {

--- a/packages/schemas/src/types/saml-application.ts
+++ b/packages/schemas/src/types/saml-application.ts
@@ -1,4 +1,5 @@
-import { type z } from 'zod';
+import { type ToZodObject } from '@logto/connector-kit';
+import { z } from 'zod';
 
 import { Applications } from '../db-entries/application.js';
 import { SamlApplicationConfigs } from '../db-entries/saml-application-config.js';
@@ -54,3 +55,23 @@ export const samlApplicationResponseGuard = Applications.guard.merge(
 );
 
 export type SamlApplicationResponse = z.infer<typeof samlApplicationResponseGuard>;
+
+type FingerprintFormat = {
+  formatted: string;
+  unformatted: string;
+};
+
+const fingerprintFormatGuard = z.object({
+  formatted: z.string(),
+  unformatted: z.string(),
+}) satisfies ToZodObject<FingerprintFormat>;
+
+export type CertificateFingerprints = {
+  sha1: FingerprintFormat;
+  sha256: FingerprintFormat;
+};
+
+export const certificateFingerprintsGuard = z.object({
+  sha1: fingerprintFormatGuard,
+  sha256: fingerprintFormatGuard,
+}) satisfies ToZodObject<CertificateFingerprints>;

--- a/packages/schemas/src/types/saml-application.ts
+++ b/packages/schemas/src/types/saml-application.ts
@@ -67,11 +67,9 @@ const fingerprintFormatGuard = z.object({
 }) satisfies ToZodObject<FingerprintFormat>;
 
 export type CertificateFingerprints = {
-  sha1: FingerprintFormat;
   sha256: FingerprintFormat;
 };
 
 export const certificateFingerprintsGuard = z.object({
-  sha1: fingerprintFormatGuard,
   sha256: fingerprintFormatGuard,
 }) satisfies ToZodObject<CertificateFingerprints>;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add GET SAML app certificate and anonymous metadata APIs
1. GET /saml-applications/:id/metadata (resolves LOG-10118)
2. GET /saml-applications/:id/certificate (resolves LOG-10119, LOG-10525)

Also provide corresponding APIs for downloading metadata and certificate in file format.
1. GET /saml-applications/:id/metadata/download
2. GET /saml-applications/:id/certificate/download

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Covered by CI.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
