### PR TITLE
fix(core): fix the subscription api response type

### DIFF
--- a/packages/core/src/utils/subscription/index.ts
+++ b/packages/core/src/utils/subscription/index.ts
@@ -16,7 +16,15 @@ export const getTenantSubscription = async (
   const client = await cloudConnection.getClient();
   const subscription = await client.get('/api/tenants/my/subscription');
 
-  return subscription;
+  // All the dates will be converted to the ISO 8601 format after json serialization.
+  // Convert the dates to ISO 8601 format to match the exact type of the response.
+  const { currentPeriodStart, currentPeriodEnd, ...rest } = subscription;
+
+  return {
+    ...rest,
+    currentPeriodStart: new Date(currentPeriodStart).toISOString(),
+    currentPeriodEnd: new Date(currentPeriodEnd).toISOString(),
+  };
 };
 
 export const getTenantSubscriptionData = async (

--- a/packages/core/src/utils/subscription/types.ts
+++ b/packages/core/src/utils/subscription/types.ts
@@ -10,7 +10,17 @@ type RouteResponseType<T extends { search?: unknown; body?: unknown; response?: 
 type RouteRequestBodyType<T extends { search?: unknown; body?: ZodType; response?: unknown }> =
   z.infer<NonNullable<T['body']>>;
 
-export type Subscription = RouteResponseType<GetRoutes['/api/tenants/my/subscription']>;
+/**
+ * The subscription data is fetched from the Cloud API.
+ * All the dates are in ISO 8601 format, we need to manually fix the type to string here.
+ */
+export type Subscription = Omit<
+  RouteResponseType<GetRoutes['/api/tenants/my/subscription']>,
+  'currentPeriodStart' | 'currentPeriodEnd'
+> & {
+  currentPeriodStart: string;
+  currentPeriodEnd: string;
+};
 
 type CompleteSubscriptionUsage = RouteResponseType<GetRoutes['/api/tenants/my/subscription-usage']>;
 


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Fix the `Subscription` response type received from the Cloud subscription API. All date-typed properties are defined as `Date` in the Cloud model. However, after JSON serialization, the client side receives these values in ISO 8601 string format, leading to a type mismatch issue.

To resolve this, manually convert the `currentPeriodStart` and `currentPeriodEnd` values to strings to ensure consistent and accurate response types.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
