### PR TITLE
feat(schemas): add new pro202411 reserved plan ID

### DIFF
--- a/packages/console/src/components/SkuName/index.tsx
+++ b/packages/console/src/components/SkuName/index.tsx
@@ -8,6 +8,7 @@ const registeredPlanNamePhraseMap: Record<
 > = {
   [ReservedPlanId.Free]: 'free_plan',
   [ReservedPlanId.Pro]: 'pro_plan',
+  [ReservedPlanId.Pro202411]: 'pro_plan',
   [ReservedPlanId.Development]: 'dev_plan',
   [ReservedPlanId.Admin]: 'admin_plan',
 } satisfies Record<ReservedPlanId, TFuncKey<'translation', 'admin_console.subscription'>>;

--- a/packages/schemas/src/consts/subscriptions.ts
+++ b/packages/schemas/src/consts/subscriptions.ts
@@ -8,7 +8,7 @@ export enum ReservedPlanId {
   Free = 'free',
   /**
    * @deprecated
-   * Grandfathered pro plan ID deprecated from 2024-11.
+   * Grandfathered Pro plan ID deprecated from 2024-11.
    * Use {@link Pro202411} instead.
    */
   Pro = 'pro',
@@ -19,9 +19,7 @@ export enum ReservedPlanId {
    */
   Admin = 'admin',
   /**
-   * New pro plan ID applied from 2024-11.
-   * This plan ID will used for new pro plan users.
-   * Deprecated {@link Pro} plan ID only for grandfathered users.
+   * The latest Pro plan ID applied from 2024-11.
    */
   Pro202411 = 'pro-202411',
 }


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add a new `Pro202411` reserved plan ID and mark old `Pro` plan as deprecated. 

`ReservedPlanId` will be used as the SSOT cross logto core and cloud service to maintain all Logto reserved plan (basic SKU). 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
