### PR TITLE
chore: rename SAML application secrets/configs constraints

### DIFF
--- a/packages/schemas/alterations/next-1732851150-rename-saml-application-constraints.ts
+++ b/packages/schemas/alterations/next-1732851150-rename-saml-application-constraints.ts
@@ -1,0 +1,34 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      alter table saml_application_configs 
+        rename constraint application_type 
+        to saml_application_configs__application_type;
+    `);
+
+    await pool.query(sql`
+      alter table saml_application_secrets
+        rename constraint application_type 
+        to saml_application_secrets__application_type;
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      alter table saml_application_configs 
+        rename constraint saml_application_configs__application_type 
+        to application_type;
+    `);
+
+    await pool.query(sql`
+      alter table saml_application_secrets
+        rename constraint saml_application_secrets__application_type 
+        to application_type;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/saml_application_configs.sql
+++ b/packages/schemas/tables/saml_application_configs.sql
@@ -10,6 +10,6 @@ create table saml_application_configs (
   entity_id varchar(128),
   acs_url jsonb /* @use SamlAcsUrl */,
   primary key (tenant_id, application_id),
-  constraint application_type
+  constraint saml_application_configs__application_type
     check (check_application_type(application_id, 'SAML'))
 );

--- a/packages/schemas/tables/saml_application_secrets.sql
+++ b/packages/schemas/tables/saml_application_secrets.sql
@@ -12,7 +12,7 @@ create table saml_application_secrets (
   expires_at timestamptz not null,
   active boolean not null,
   primary key (tenant_id, application_id, id),
-  constraint application_type
+  constraint saml_application_secrets__application_type
     check (check_application_type(application_id, 'SAML'))
 );
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
rename SAML application secrets/configs constraints, to unblock Cloud submodule update.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested with Cloud repo [CI](https://github.com/logto-io/cloud/pull/1040).

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
