### PR TITLE
fix(core): fix applications APIs status guard

### DIFF
--- a/packages/core/src/routes/applications/application.ts
+++ b/packages/core/src/routes/applications/application.ts
@@ -256,7 +256,7 @@ export default function applicationRoutes<T extends ManagementApiRouter>(
         })
       ),
       response: Applications.guard,
-      status: [200, 404, 422, 500],
+      status: [200, 400, 404, 422, 500],
     }),
     async (ctx, next) => {
       const {
@@ -341,7 +341,7 @@ export default function applicationRoutes<T extends ManagementApiRouter>(
     koaGuard({
       params: object({ id: string().min(1) }),
       response: z.undefined(),
-      status: [204, 404, 422],
+      status: [204, 400, 404, 422],
     }),
     async (ctx, next) => {
       const { id } = ctx.guard.params;

--- a/packages/integration-tests/src/tests/api/application/saml-application.test.ts
+++ b/packages/integration-tests/src/tests/api/application/saml-application.test.ts
@@ -1,6 +1,6 @@
 import { ApplicationType, BindingType } from '@logto/schemas';
 
-import { createApplication, deleteApplication } from '#src/api/application.js';
+import { createApplication, deleteApplication, updateApplication } from '#src/api/application.js';
 import {
   createSamlApplication,
   deleteSamlApplication,
@@ -123,6 +123,14 @@ describe('SAML application secrets/certificate/metadata', () => {
     // @ts-expect-error - Make sure the `privateKey` is not exposed
     expect(createdSecret.privateKey).toBeUndefined();
 
+    await expectRejects(updateApplication(id, { name: 'updated' }), {
+      code: 'application.saml.use_saml_app_api',
+      status: 400,
+    });
+    await expectRejects(deleteApplication(id), {
+      code: 'application.saml.use_saml_app_api',
+      status: 400,
+    });
     await deleteSamlApplication(id);
   });
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix applications APIs status guard, we throws 400 when trying to PATCH/DELETE SAML apps, we should include 400 in status response guard to avoid throwing 500.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Should be covered by new integration tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
