### PR TITLE
refactor(console,core,schemas): allow SAML application to use  IdP-initiated SSO

### DIFF
--- a/packages/console/src/pages/EnterpriseSsoDetails/IdpInitiatedAuth/ConfigForm.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/IdpInitiatedAuth/ConfigForm.tsx
@@ -42,28 +42,13 @@ type FormProps = {
 
 function ConfigForm({
   ssoConnector,
-  applications: allApplications,
+  applications,
   idpInitiatedAuthConfig,
   mutateIdpInitiatedConfig,
 }: FormProps) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { getTo } = useTenantPathname();
   const api = useApi();
-
-  /**
-   * See definition of `applicationsSearchUrl`, there is only non-third party SPA/Traditional applications here, and SAML applications are always third party secured by DB schema, we need to manually exclude other application types here to make TypeScript happy.
-   */
-  const applications = useMemo(
-    () =>
-      allApplications.filter(
-        (
-          application
-        ): application is Omit<Application, 'type'> & {
-          type: Exclude<ApplicationType, ApplicationType.SAML>;
-        } => application.type !== ApplicationType.SAML
-      ),
-    [allApplications]
-  );
 
   const {
     control,

--- a/packages/console/src/pages/EnterpriseSsoDetails/IdpInitiatedAuth/index.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/IdpInitiatedAuth/index.tsx
@@ -1,4 +1,8 @@
-import { type Application, type SsoConnectorWithProviderConfig } from '@logto/schemas';
+import {
+  ApplicationType,
+  type Application,
+  type SsoConnectorWithProviderConfig,
+} from '@logto/schemas';
 import { useMemo } from 'react';
 import useSWR from 'swr';
 
@@ -31,6 +35,15 @@ function IdpInitiatedAuth({ ssoConnector }: Props) {
     [applicationError, applications, idpInitiatedAuthConfig, idpInitiatedAuthConfigError]
   );
 
+  // Filter out non-SAML third-party applications
+  const filteredApplications = useMemo(
+    () =>
+      applications?.filter(
+        ({ type, isThirdParty }) => !isThirdParty || type === ApplicationType.SAML
+      ),
+    [applications]
+  );
+
   if (isLoading) {
     return (
       <FormCard
@@ -45,7 +58,7 @@ function IdpInitiatedAuth({ ssoConnector }: Props) {
   return (
     <ConfigForm
       ssoConnector={ssoConnector}
-      applications={applications ?? []}
+      applications={filteredApplications ?? []}
       idpInitiatedAuthConfig={idpInitiatedAuthConfig}
       mutateIdpInitiatedConfig={mutate}
     />

--- a/packages/console/src/pages/EnterpriseSsoDetails/IdpInitiatedAuth/utils.ts
+++ b/packages/console/src/pages/EnterpriseSsoDetails/IdpInitiatedAuth/utils.ts
@@ -12,7 +12,8 @@ import { toast } from 'react-hot-toast';
 const applicationsSearchParams = new URLSearchParams([
   ['types', ApplicationType.Traditional],
   ['types', ApplicationType.SPA],
-  ['isThirdParty', 'false'],
+  ['types', ApplicationType.SAML],
+  // TODO: for now we allow all third-party applications here, including SAML and OIDC
 ]);
 
 export const applicationsSearchUrl = `api/applications?${applicationsSearchParams.toString()}`;

--- a/packages/core/src/libraries/sso-connector.test.ts
+++ b/packages/core/src/libraries/sso-connector.test.ts
@@ -13,7 +13,6 @@ const findAllSsoConnectors = jest.fn();
 const getConnectorById = jest.fn();
 const findApplicationById = jest.fn();
 const insertIdpInitiatedAuthConfig = jest.fn();
-const updateIdpInitiatedAuthConfig = jest.fn();
 
 const queries = new MockQueries({
   ssoConnectors: {
@@ -132,8 +131,10 @@ describe('SsoConnectorLibrary', () => {
             autoSendAuthorizationRequest: true,
           })
         ).rejects.toMatchError(
-          new RequestError('single_sign_on.idp_initiated_authentication_invalid_application_type', {
-            type: ApplicationType.Traditional,
+          new RequestError({
+            code: 'single_sign_on.idp_initiated_authentication_invalid_application_type',
+            type: `${ApplicationType.Traditional}, ${ApplicationType.SAML}`,
+            statue: 400,
           })
         );
 
@@ -154,8 +155,10 @@ describe('SsoConnectorLibrary', () => {
             clientIdpInitiatedAuthCallbackUri: 'https://callback.com',
           })
         ).rejects.toMatchError(
-          new RequestError('single_sign_on.idp_initiated_authentication_invalid_application_type', {
-            type: `${ApplicationType.Traditional}, ${ApplicationType.SPA}`,
+          new RequestError({
+            code: 'single_sign_on.idp_initiated_authentication_invalid_application_type',
+            type: `${ApplicationType.Traditional}, ${ApplicationType.SPA}, ${ApplicationType.SAML}`,
+            status: 400,
           })
         );
 
@@ -176,8 +179,10 @@ describe('SsoConnectorLibrary', () => {
           autoSendAuthorizationRequest: true,
         })
       ).rejects.toMatchError(
-        new RequestError('single_sign_on.idp_initiated_authentication_invalid_application_type', {
-          type: ApplicationType.Traditional,
+        new RequestError({
+          code: 'single_sign_on.idp_initiated_authentication_invalid_application_type',
+          type: `${ApplicationType.Traditional}, ${ApplicationType.SAML}`,
+          status: 400,
         })
       );
 

--- a/packages/core/src/libraries/sso-connector.ts
+++ b/packages/core/src/libraries/sso-connector.ts
@@ -85,11 +85,14 @@ export const createSsoConnectorLibrary = (queries: Queries) => {
 
     // Authorization request initiated by Logto server
     if (autoSendAuthorizationRequest) {
-      // Only first-party traditional web applications are allowed
+      // Only first-party traditional web applications or SAML applications are allowed
       assertThat(
-        application.type === ApplicationType.Traditional && !application.isThirdParty,
-        new RequestError('single_sign_on.idp_initiated_authentication_invalid_application_type', {
+        (application.type === ApplicationType.Traditional && !application.isThirdParty) ||
+          application.type === ApplicationType.SAML,
+        new RequestError({
+          code: 'single_sign_on.idp_initiated_authentication_invalid_application_type',
           type: ApplicationType.Traditional,
+          status: 400,
         })
       );
 
@@ -100,11 +103,16 @@ export const createSsoConnectorLibrary = (queries: Queries) => {
       );
     } else {
       // Authorization request initiated by the client
+
+      // Only first-party traditional web applications, SPAs, or SAML applications are allowed
       assertThat(
         (application.type === ApplicationType.Traditional && !application.isThirdParty) ||
-          application.type === ApplicationType.SPA,
-        new RequestError('single_sign_on.idp_initiated_authentication_invalid_application_type', {
-          type: `${ApplicationType.Traditional}, ${ApplicationType.SPA}`,
+          application.type === ApplicationType.SPA ||
+          application.type === ApplicationType.SAML,
+        new RequestError({
+          code: 'single_sign_on.idp_initiated_authentication_invalid_application_type',
+          type: `${ApplicationType.Traditional}, ${ApplicationType.SPA}, ${ApplicationType.SAML}`,
+          status: 400,
         })
       );
 

--- a/packages/core/src/libraries/sso-connector.ts
+++ b/packages/core/src/libraries/sso-connector.ts
@@ -91,7 +91,7 @@ export const createSsoConnectorLibrary = (queries: Queries) => {
           application.type === ApplicationType.SAML,
         new RequestError({
           code: 'single_sign_on.idp_initiated_authentication_invalid_application_type',
-          type: ApplicationType.Traditional,
+          type: `${ApplicationType.Traditional}, ${ApplicationType.SAML}`,
           status: 400,
         })
       );

--- a/packages/phrases/src/locales/en/translation/admin-console/guide.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/guide.ts
@@ -9,6 +9,7 @@ const guide = {
     MachineToMachine: 'Machine-to-machine',
     Protected: 'Non-SDK Integration',
     ThirdParty: 'Third-party app',
+    SAML: 'SAML',
   },
   filter: {
     title: 'Filter framework',

--- a/packages/schemas/alterations/next-1733212543-add-saml-application-type-to-idp-initiated-sso-application-allow-list.ts
+++ b/packages/schemas/alterations/next-1733212543-add-saml-application-type-to-idp-initiated-sso-application-allow-list.ts
@@ -1,0 +1,30 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      alter table sso_connector_idp_initiated_auth_configs
+        drop constraint application_type;`);
+
+    await pool.query(sql`
+      alter table sso_connector_idp_initiated_auth_configs
+        add constraint application_type
+        check (check_application_type(default_application_id, 'Traditional', 'SPA', 'SAML'));
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      alter table sso_connector_idp_initiated_auth_configs
+        drop constraint application_type;`);
+
+    await pool.query(sql`
+      alter table sso_connector_idp_initiated_auth_configs
+        add constraint application_type
+        check (check_application_type(default_application_id, 'Traditional', 'SPA'));
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/sso_connector_idp_initiated_auth_configs.sql
+++ b/packages/schemas/tables/sso_connector_idp_initiated_auth_configs.sql
@@ -20,5 +20,5 @@ create table sso_connector_idp_initiated_auth_configs (
   primary key (tenant_id, connector_id),
   /** Insure the application type is Traditional or SPA. */
   constraint application_type
-    check (check_application_type(default_application_id, 'Traditional', 'SPA'))
+    check (check_application_type(default_application_id, 'Traditional', 'SPA', 'SAML'))
 );


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Allow SAML application to use IdP-initiated SSO.

- Allow all `ApplicationType.SAML` typed applications to be used as the IdP-initiated SSO default application.
- Return the SAML IdP applications to the IdP-initiated SSO applications config page. So the user can pick the SAML IdP application in the dropdown list. 

*This whole feature is guarded by the `devFeature` and `isCloud` flags. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
