### PR TITLE
feat: add `GET /saml-app/:id/secrets/:secretId/certificate.crt` API

### DIFF
--- a/packages/integration-tests/src/api/saml-application.ts
+++ b/packages/integration-tests/src/api/saml-application.ts
@@ -44,8 +44,10 @@ export const updateSamlApplicationSecret = async (id: string, secretId: string, 
     .patch(`saml-applications/${id}/secrets/${secretId}`, { json: { active } })
     .json<SamlApplicationSecretResponse>();
 
-export const getSamlApplicationCertificate = async (id: string) =>
-  authedAdminApi.get(`saml-applications/${id}/certificate`).json<{ certificate: string }>();
+export const getSamlApplicationCertificateByAppIdAndSecretId = async (
+  id: string,
+  secretId: string
+) => authedAdminApi.get(`saml-applications/${id}/secrets/${secretId}/certificate.crt`);
 
 // Anonymous endpoints
 export const getSamlApplicationMetadata = async (id: string) =>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
1. add `GET /saml-applications/:id/secrets/:secretId/certificate.crt` API (resolves LOG-10564)
2. also remove `GET /saml-applications/:id/certificate` API, we will get certificates from `GET /saml-applications/:id/secrets` API instead

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Add integration tests

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
