### PR TITLE
refactor(console): replace get sku api

### DIFF
--- a/packages/console/src/hooks/use-logto-skus.ts
+++ b/packages/console/src/hooks/use-logto-skus.ts
@@ -1,5 +1,5 @@
 import { type Optional } from '@silverhand/essentials';
-import { useMemo } from 'react';
+import { useContext, useMemo } from 'react';
 import useSWRImmutable from 'swr/immutable';
 
 import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
@@ -9,6 +9,7 @@ import { featuredPlanIdOrder } from '@/consts/subscriptions';
 // Used in the docs
 // eslint-disable-next-line unused-imports/no-unused-imports
 import TenantAccess from '@/containers/TenantAccess';
+import { TenantsContext } from '@/contexts/TenantsProvider';
 import { LogtoSkuType } from '@/types/skus';
 import { sortBy } from '@/utils/sort';
 import { addSupportQuota } from '@/utils/subscription';
@@ -19,11 +20,13 @@ import { addSupportQuota } from '@/utils/subscription';
  */
 const useLogtoSkus = () => {
   const cloudApi = useCloudApi();
+  const { currentTenantId } = useContext(TenantsContext);
 
   const useSwrResponse = useSWRImmutable<LogtoSkuResponse[], Error>(
-    isCloud && '/api/skus',
+    isCloud && currentTenantId && `/api/tenants/${currentTenantId}/available-skus`,
     async () =>
-      cloudApi.get('/api/skus', {
+      cloudApi.get('/api/tenants/:tenantId/available-skus', {
+        params: { tenantId: currentTenantId },
         search: { type: LogtoSkuType.Basic },
       })
   );


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Replace the `api/sku` API using the `api/tenants/:tenantId/available-sku`.

This will address the bug that all enterprise tenant can not retrieve their SKU details properly. 

- `api/sku`: Only returns the public available SKUs
- `api/tenants/:tenantId/available-sku`: Returns all the public available SKUs plus the current tenant's basic SKU. This is essential for all enterprise plan users and grandfathered plan users. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
