### PR TITLE
fix: fix fetch official connector CLI error

### DIFF
--- a/.changeset/chilled-radios-cover.md
+++ b/.changeset/chilled-radios-cover.md
@@ -1,0 +1,5 @@
+---
+"@logto/cli": patch
+---
+
+fix fetch official connector list CLI 429 error

--- a/.changeset/chilled-radios-cover.md
+++ b/.changeset/chilled-radios-cover.md
@@ -2,4 +2,8 @@
 "@logto/cli": patch
 ---
 
-fix fetch official connector list CLI 429 error
+fix fetch official connector list CLI command error
+
+Due to changes in the npm registry API (`https://registry.npmjs.org/-/v1/search`) that our CLI add official connector depends on, the new API behavior returns irrelevant search results.
+
+We need to manually filter out these irrelevant results to avoid potential infinite loops, where each loop triggers an API call, eventually hitting a rate limit and resulting in a status code 429.


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix fetch official connector CLI error
Error reported by [community members](https://discord.com/channels/965845662535147551/1314281175686185032), the npm registry API has now changed to `text` fuzzy search, which will yield an infinite number of results. We need to filter the results again before processing them to avoid hitting npm registry API rate limit, which throws 429 response code.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally, without this fix, the CLI command seems will load forever.
![image](https://github.com/user-attachments/assets/4bc7450e-b825-440a-94ac-ee951d63b306)

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
