### PR TITLE
fix(console): fix enterprise tenant current sku always return dev

### DIFF
--- a/packages/console/src/components/CreateTenantModal/SelectTenantPlanModal/index.tsx
+++ b/packages/console/src/components/CreateTenantModal/SelectTenantPlanModal/index.tsx
@@ -35,7 +35,7 @@ function SelectTenantPlanModal({ tenantData, onClose }: Props) {
   const { subscribe } = useSubscribe();
   const cloudApi = useCloudApi({ hideErrorToast: true });
 
-  const reservedBasicLogtoSkus = conditional(logtoSkus && pickupFeaturedLogtoSkus(logtoSkus));
+  const reservedBasicLogtoSkus = conditional(pickupFeaturedLogtoSkus(logtoSkus));
 
   if (!reservedBasicLogtoSkus || !tenantData) {
     return null;

--- a/packages/console/src/hooks/use-logto-skus.ts
+++ b/packages/console/src/hooks/use-logto-skus.ts
@@ -5,17 +5,22 @@ import useSWRImmutable from 'swr/immutable';
 import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
 import { type LogtoSkuResponse } from '@/cloud/types/router';
 import { isCloud } from '@/consts/env';
-import { featuredPlanIdOrder } from '@/consts/subscriptions';
 // Used in the docs
 // eslint-disable-next-line unused-imports/no-unused-imports
 import TenantAccess from '@/containers/TenantAccess';
+// eslint-disable-next-line unused-imports/no-unused-imports -- for jsDoc use
+import type { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import { LogtoSkuType } from '@/types/skus';
-import { sortBy } from '@/utils/sort';
-import { addSupportQuota } from '@/utils/subscription';
+import { formatLogtoSkusResponses } from '@/utils/subscription';
 
 /**
- * Fetch Logto SKUs from the cloud API.
- * Note: If you want to retrieve Logto SKUs under the {@link TenantAccess} component, use `SubscriptionDataContext` instead.
+ * Fetch public Logto SKUs from the cloud API.
+ *
+ * @remarks
+ * Note: This hook is used for retrieving public available Logto SKUs for all the users.
+ * If you want to retrieve tenant specific available Logto SKUs under the {@link TenantAccess} component,
+ * e.g. For enterprise tenant who have their own private SKUs, and all grandfathered plan tenants,
+ * use the logtoSkus from the {@link SubscriptionDataContext} instead.
  */
 const useLogtoSkus = () => {
   const cloudApi = useCloudApi();
@@ -30,18 +35,10 @@ const useLogtoSkus = () => {
 
   const { data: logtoSkuResponse } = useSwrResponse;
 
-  const logtoSkus: Optional<LogtoSkuResponse[]> = useMemo(() => {
-    if (!logtoSkuResponse) {
-      return;
-    }
-
-    return logtoSkuResponse
-      .map((logtoSku) => addSupportQuota(logtoSku))
-      .slice()
-      .sort(({ id: previousId }, { id: nextId }) =>
-        sortBy(featuredPlanIdOrder)(previousId, nextId)
-      );
-  }, [logtoSkuResponse]);
+  const logtoSkus: Optional<LogtoSkuResponse[]> = useMemo(
+    () => formatLogtoSkusResponses(logtoSkuResponse),
+    [logtoSkuResponse]
+  );
 
   return {
     ...useSwrResponse,

--- a/packages/console/src/utils/subscription.ts
+++ b/packages/console/src/utils/subscription.ts
@@ -9,7 +9,7 @@ import { ticketSupportResponseTimeMap } from '@/consts/plan-quotas';
 import { featuredPlanIdOrder, featuredPlanIds } from '@/consts/subscriptions';
 import { type LogtoSkuQuota } from '@/types/skus';
 
-export const addSupportQuota = (logtoSkuResponse: LogtoSkuResponse) => {
+const addSupportQuota = (logtoSkuResponse: LogtoSkuResponse) => {
   const { id, quota } = logtoSkuResponse;
 
   return {
@@ -22,6 +22,26 @@ export const addSupportQuota = (logtoSkuResponse: LogtoSkuResponse) => {
       ticketSupportResponseTime: ticketSupportResponseTimeMap[id] ?? 0, // Fallback to not supported
     },
   };
+};
+
+/**
+ * Format Logto SKUs responses.
+ *
+ * - add support quota to the SKUs.
+ * - Sort the SKUs by the order of `featuredPlanIdOrder`.
+ */
+export const formatLogtoSkusResponses = (logtoSkus: LogtoSkuResponse[] | undefined) => {
+  if (!logtoSkus) {
+    return [];
+  }
+
+  return logtoSkus
+    .map((logtoSku) => addSupportQuota(logtoSku))
+    .slice()
+    .sort(
+      ({ id: previousId }, { id: nextId }) =>
+        featuredPlanIdOrder.indexOf(previousId) - featuredPlanIdOrder.indexOf(nextId)
+    );
 };
 
 const getSubscriptionPlanOrderById = (id: string) => {


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fixing the enterprise tenant's current SKU always returns `dev` bug.

In the previous implementation, we used the `GET api/skus` API to fetch available Logto SKUs for a given tenant. However, this endpoint is intended exclusively for public Logto SKU access and does not include any private Logto SKUs, such as enterprise SKUs or grandfathered SKUs. 
As a result, this caused a bug where the `currentSku` value in the `SubscriptionContext` for an enterprise tenant always defaulted to dev, the fallback value. Enterprise users can not invite additional tenant members due the the limitation of the dev tenant quota. 

To fix this, we switch the `GET /api/skus`  API to the `GET /api/tenants/:tenantId/available-sku` API instead. It will return all the publicly accessible Logto SKUs plus any private SKUs that are available to the current tenant.


This PR also refactors the `CheckoutSessionSuccessCallback` component. Remove the dependency of the `useLogtoSkus`. The validation is useless. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
