### PR TITLE
refactor(console, core): refactor console to support new pro plan

### DIFF
--- a/packages/console/src/components/CreateTenantModal/SelectTenantPlanModal/SkuCardItem/FeaturedSkuContent/use-featured-sku-content.ts
+++ b/packages/console/src/components/CreateTenantModal/SelectTenantPlanModal/SkuCardItem/FeaturedSkuContent/use-featured-sku-content.ts
@@ -10,6 +10,8 @@ import {
   freePlanPermissionsLimit,
   freePlanRoleLimit,
   proPlanAuditLogsRetentionDays,
+  // eslint-disable-next-line unused-imports/no-unused-imports -- for jsdoc usage
+  featuredPlanIds,
 } from '@/consts/subscriptions';
 
 type ContentData = {
@@ -17,6 +19,15 @@ type ContentData = {
   readonly isAvailable: boolean;
 };
 
+/**
+ * This hook is used to build the plan content on the SelectTenantPlanModal.
+ * It is used to display the features of the selected plan.
+ * Currently, all the feature content is hardcoded.
+ * For the grandfathered Pro plan and new created Pro202411 plan, the content is the same.
+ * So we don't need to differentiate them. here.
+ *
+ * @param skuId The selected sku id. Can only be one of {@link featuredPlanIds}
+ */
 const useFeaturedSkuContent = (skuId: string) => {
   const { t } = useTranslation(undefined, {
     keyPrefix: 'admin_console.upsell.featured_plan_content',

--- a/packages/console/src/components/MauExceededModal/index.tsx
+++ b/packages/console/src/components/MauExceededModal/index.tsx
@@ -1,5 +1,5 @@
-import { cond } from '@silverhand/essentials';
-import { useContext, useState } from 'react';
+import { cond, conditional } from '@silverhand/essentials';
+import { useContext, useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import ReactModal from 'react-modal';
 
@@ -33,9 +33,16 @@ function MauExceededModal() {
     setHasClosed(true);
   };
 
-  if (hasClosed) {
-    return null;
-  }
+  const periodicUsage = useMemo(
+    () =>
+      conditional(
+        currentTenant && {
+          mauLimit: currentTenant.usage.activeUsers,
+          tokenLimit: currentTenant.usage.tokenUsage,
+        }
+      ),
+    [currentTenant]
+  );
 
   const isMauExceeded = cond(
     // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
@@ -44,7 +51,7 @@ function MauExceededModal() {
       currentTenant.usage.activeUsers >= currentTenant.quota.mauLimit
   );
 
-  if (!isMauExceeded) {
+  if (hasClosed || !isMauExceeded) {
     return null;
   }
 
@@ -85,7 +92,7 @@ function MauExceededModal() {
           </Trans>
         </InlineNotification>
         <FormField title="subscription.plan_usage">
-          <PlanUsage />
+          <PlanUsage periodicUsage={periodicUsage} />
         </FormField>
       </ModalLayout>
     </ReactModal>

--- a/packages/console/src/components/MauExceededModal/index.tsx
+++ b/packages/console/src/components/MauExceededModal/index.tsx
@@ -1,4 +1,4 @@
-import { cond, conditional } from '@silverhand/essentials';
+import { conditional } from '@silverhand/essentials';
 import { useContext, useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import ReactModal from 'react-modal';
@@ -44,7 +44,7 @@ function MauExceededModal() {
     [currentTenant]
   );
 
-  const isMauExceeded = cond(
+  const isMauExceeded = conditional(
     // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
     currentTenant &&
       currentTenant.quota.mauLimit !== null &&

--- a/packages/console/src/consts/subscriptions.ts
+++ b/packages/console/src/consts/subscriptions.ts
@@ -25,15 +25,25 @@ export const tokenAddOnUnitPrice = 80;
 export const hooksAddOnUnitPrice = 2;
 /* === Add-on unit price (in USD) === */
 
+// TODO: Remove this dev feature flag when we have the new Pro202411 plan released.
 /**
  * In console, only featured plans are shown in the plan selection component.
+ * we will this to filter out the public visible featured plans.
  */
-export const featuredPlanIds: string[] = [ReservedPlanId.Free, ReservedPlanId.Pro];
+export const featuredPlanIds: readonly string[] = isDevFeaturesEnabled
+  ? Object.freeze([ReservedPlanId.Free, ReservedPlanId.Pro202411])
+  : Object.freeze([ReservedPlanId.Free, ReservedPlanId.Pro]);
 
 /**
- * The order of featured plans in the plan selection content component.
+ * The order of plans in the plan selection content component.
+ * Unlike the `featuredPlanIds`, include both grandfathered plans and public visible featured plans.
+ * We need to properly identify the order of the grandfathered plans compared to the new public visible featured plans.
  */
-export const featuredPlanIdOrder: string[] = [ReservedPlanId.Free, ReservedPlanId.Pro];
+export const planIdOrder: Record<string, number> = Object.freeze({
+  [ReservedPlanId.Free]: 0,
+  [ReservedPlanId.Pro]: 1,
+  [ReservedPlanId.Pro202411]: 1,
+});
 
 export const checkoutStateQueryKey = 'checkout-state';
 

--- a/packages/console/src/pages/TenantSettings/Subscription/CurrentPlan/index.tsx
+++ b/packages/console/src/pages/TenantSettings/Subscription/CurrentPlan/index.tsx
@@ -1,4 +1,3 @@
-import { cond } from '@silverhand/essentials';
 import { useContext, useMemo } from 'react';
 
 import { type NewSubscriptionPeriodicUsage } from '@/cloud/types/router';
@@ -8,7 +7,6 @@ import PlanDescription from '@/components/PlanDescription';
 import PlanUsage from '@/components/PlanUsage';
 import SkuName from '@/components/SkuName';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
-import { TenantsContext } from '@/contexts/TenantsProvider';
 import FormField from '@/ds-components/FormField';
 import { isPaidPlan } from '@/utils/subscription';
 
@@ -21,24 +19,11 @@ type Props = {
   readonly periodicUsage?: NewSubscriptionPeriodicUsage;
 };
 
-function CurrentPlan({ periodicUsage: rawPeriodicUsage }: Props) {
+function CurrentPlan({ periodicUsage }: Props) {
   const {
     currentSku: { unitPrice },
     currentSubscription: { upcomingInvoice, isEnterprisePlan, planId },
   } = useContext(SubscriptionDataContext);
-  const { currentTenant } = useContext(TenantsContext);
-
-  const periodicUsage = useMemo(
-    () =>
-      rawPeriodicUsage ??
-      cond(
-        currentTenant && {
-          mauLimit: currentTenant.usage.activeUsers,
-          tokenLimit: currentTenant.usage.tokenUsage,
-        }
-      ),
-    [currentTenant, rawPeriodicUsage]
-  );
 
   /**
    * After the new pricing model goes live, `upcomingInvoice` will always exist. `upcomingInvoice` is updated more frequently than `currentSubscription.upcomingInvoice`.
@@ -64,7 +49,7 @@ function CurrentPlan({ periodicUsage: rawPeriodicUsage }: Props) {
         </div>
       </div>
       <FormField title="subscription.plan_usage">
-        <PlanUsage periodicUsage={rawPeriodicUsage} />
+        <PlanUsage periodicUsage={periodicUsage} />
       </FormField>
       <FormField title="subscription.next_bill">
         <BillInfo cost={upcomingCost} isManagePaymentVisible={Boolean(upcomingCost)} />
@@ -72,10 +57,7 @@ function CurrentPlan({ periodicUsage: rawPeriodicUsage }: Props) {
       {isPaidPlan(planId, isEnterprisePlan) && !isEnterprisePlan && (
         <AddOnUsageChangesNotification className={styles.notification} />
       )}
-      <MauLimitExceedNotification
-        periodicUsage={rawPeriodicUsage}
-        className={styles.notification}
-      />
+      <MauLimitExceedNotification periodicUsage={periodicUsage} className={styles.notification} />
       <PaymentOverdueNotification className={styles.notification} />
     </FormCard>
   );

--- a/packages/console/src/pages/TenantSettings/Subscription/PlanComparisonTable/index.tsx
+++ b/packages/console/src/pages/TenantSettings/Subscription/PlanComparisonTable/index.tsx
@@ -65,7 +65,7 @@ function PlanComparisonTable() {
     const includedTokens = t('quota.included_tokens');
     const includedTokensTip = t('tokens_tip');
     const proPlanIncludedTokens = isDevFeaturesEnabled ? '100,000' : t('million', { value: 1 });
-    const freePlanIncludedTokens = isDevFeaturesEnabled ? '100,000' : '50,000';
+    const freePlanIncludedTokens = isDevFeaturesEnabled ? '100,000' : '500,000';
     const proPlanTokenPrice = isDevFeaturesEnabled
       ? t('extra_token_price', { value: 0.08, amount: 100 })
       : t('extra_token_price', { value: 80, amount: 1_000_000 });

--- a/packages/console/src/pages/TenantSettings/Subscription/PlanComparisonTable/index.tsx
+++ b/packages/console/src/pages/TenantSettings/Subscription/PlanComparisonTable/index.tsx
@@ -3,6 +3,7 @@ import { type TFuncKey } from 'i18next';
 import { Fragment, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { isDevFeaturesEnabled } from '@/consts/env';
 import {
   freePlanAuditLogsRetentionDays,
   freePlanM2mLimit,
@@ -63,7 +64,11 @@ function PlanComparisonTable() {
     const mauLimitTip = t('mau_tip');
     const includedTokens = t('quota.included_tokens');
     const includedTokensTip = t('tokens_tip');
-    const proPlanIncludedTokens = t('million', { value: 1 });
+    const proPlanIncludedTokens = isDevFeaturesEnabled ? '100,000' : t('million', { value: 1 });
+    const freePlanIncludedTokens = isDevFeaturesEnabled ? '100,000' : '50,000';
+    const proPlanTokenPrice = isDevFeaturesEnabled
+      ? t('extra_token_price', { value: 0.08, amount: 100 })
+      : t('extra_token_price', { value: 80, amount: 1_000_000 });
 
     // Applications
     const totalApplications = t('application.total');
@@ -152,7 +157,11 @@ function PlanComparisonTable() {
           },
           {
             name: `${includedTokens}|${includedTokensTip}`,
-            data: ['500,000', `${proPlanIncludedTokens}`, contact],
+            data: [
+              `${freePlanIncludedTokens}`,
+              `${proPlanIncludedTokens}||${proPlanTokenPrice}`,
+              contact,
+            ],
           },
         ],
       },

--- a/packages/core/src/libraries/quota.ts
+++ b/packages/core/src/libraries/quota.ts
@@ -14,6 +14,7 @@ import { type CloudConnectionLibrary } from './cloud-connection.js';
 
 export type QuotaLibrary = ReturnType<typeof createQuotaLibrary>;
 
+const paidReservedPlans = new Set<string>([ReservedPlanId.Pro, ReservedPlanId.Pro202411]);
 /**
  * @remarks
  * Should report usage changes to the Cloud only when the following conditions are met:
@@ -25,7 +26,7 @@ const shouldReportSubscriptionUpdates = (
   isEnterprisePlan: boolean,
   key: keyof SubscriptionQuota
 ) =>
-  (planId === ReservedPlanId.Pro || isEnterprisePlan) && isReportSubscriptionUpdatesUsageKey(key);
+  (paidReservedPlans.has(planId) || isEnterprisePlan) && isReportSubscriptionUpdatesUsageKey(key);
 
 export const createQuotaLibrary = (cloudConnection: CloudConnectionLibrary) => {
   const guardTenantUsageByKey = async (key: keyof SubscriptionUsage) => {

--- a/packages/phrases/src/locales/ar/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/subscription/quota-table.ts
@@ -101,6 +101,7 @@ const quota_table = {
   included: '{{value, number}} مضمن',
   included_mao: '{{value, number}} MAO مضمنة',
   extra_quota_price: 'ثم ${{value, number}} شهريًا / لكل واحد بعد ذلك',
+  extra_token_price: 'ثم ${{value, number}} شهريًا / {{amount, number}} بعد ذلك',
   per_month_each: '${{value, number}} شهريًا / لكل واحد',
   extra_mao_price: 'ثم ${{value, number}} شهريًا لكل MAO',
   per_month: '${{value, number}} شهريًا',

--- a/packages/phrases/src/locales/de/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/subscription/quota-table.ts
@@ -102,6 +102,7 @@ const quota_table = {
   included: '{{value, number}} inklusive',
   included_mao: '{{value, number}} MAO enthalten',
   extra_quota_price: 'Dann ${{value, number}} pro Monat / je danach',
+  extra_token_price: 'Dann ${{value, number}} pro Monat / {{amount, number}} danach',
   per_month_each: '${{value, number}} pro Monat / je',
   extra_mao_price: 'Dann ${{value, number}} pro MAO',
   per_month: '${{value, number}} pro Monat',

--- a/packages/phrases/src/locales/en/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/subscription/quota-table.ts
@@ -104,6 +104,7 @@ const quota_table = {
   included: '{{value, number}} included',
   included_mao: '{{value, number}} MAO included',
   extra_quota_price: 'Then ${{value, number}} per mo / ea after',
+  extra_token_price: 'Then ${{value, number}} per mo / {{amount, number}} after',
   per_month_each: '${{value, number}} per mo / ea',
   extra_mao_price: 'Then ${{value, number}} per MAO',
   per_month: '${{value, number}} per mo',

--- a/packages/phrases/src/locales/es/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/subscription/quota-table.ts
@@ -102,6 +102,7 @@ const quota_table = {
   included: 'incluido{{value, number}}',
   included_mao: '{{value, number}} MAO incluido',
   extra_quota_price: 'Luego ${{value, number}} por mes / cada uno después',
+  extra_token_price: 'Luego ${{value, number}} por mes / {{amount, number}} después',
   per_month_each: '${{value, number}} por mes / cada uno',
   extra_mao_price: 'Luego ${{value, number}} por MAO',
   per_month: '${{value, number}} por mes',

--- a/packages/phrases/src/locales/fr/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/subscription/quota-table.ts
@@ -102,6 +102,7 @@ const quota_table = {
   included: '{{value, number}} inclus',
   included_mao: '{{value, number}} MAO inclus',
   extra_quota_price: 'Ensuite ${{value, number}} par mois / chacun après',
+  extra_token_price: 'Ensuite ${{value, number}} par mois / {{amount, number}} après',
   per_month_each: '${{value, number}} par mois / chacun',
   extra_mao_price: 'Ensuite ${{value, number}} par MAO',
   per_month: '${{value, number}} par mois',

--- a/packages/phrases/src/locales/it/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/subscription/quota-table.ts
@@ -102,6 +102,7 @@ const quota_table = {
   included: '{{value, number}} incluso',
   included_mao: '{{value, number}} MAO inclusi',
   extra_quota_price: 'Quindi ${{value, number}} al mese / ognuno dopo',
+  extra_token_price: 'Quindi ${{value, number}} al mese / {{amount, number}} dopo',
   per_month_each: '${{value, number}} al mese / ognuno',
   extra_mao_price: 'Quindi ${{value, number}} per MAO',
   per_month: '${{value, number}} al mese',

--- a/packages/phrases/src/locales/ja/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/subscription/quota-table.ts
@@ -102,6 +102,7 @@ const quota_table = {
   included: '{{value, number}} 込み',
   included_mao: '{{value, number}} MAO込み',
   extra_quota_price: 'その後、各${{value, number}} / 月ごと',
+  extra_token_price: 'その後、${{value, number}} / 月ごと {{amount, number}} ごと',
   per_month_each: '各${{value, number}} / 月ごと',
   extra_mao_price: 'その後、MAOごとに${{value, number}}',
   per_month: '${{value, number}} / 月ごと',

--- a/packages/phrases/src/locales/ko/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/subscription/quota-table.ts
@@ -100,6 +100,7 @@ const quota_table = {
   included: '{{value, number}} 포함',
   included_mao: '{{value, number}} MAO 포함',
   extra_quota_price: '이후 월당 ${{value, number}} / 각각',
+  extra_token_price: '이후 월당 ${{value, number}} / 각각 {{amount, number}} 당',
   per_month_each: '월당 ${{value, number}} / 각각',
   extra_mao_price: '이후 MAO 당 ${{value, number}}',
   per_month: '월당 ${{value, number}}',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/subscription/quota-table.ts
@@ -102,6 +102,7 @@ const quota_table = {
   included: '{{value, number}} zawarte',
   included_mao: '{{value, number}} MAO wliczone',
   extra_quota_price: 'Następnie ${{value, number}} za miesiąc / każdy po',
+  extra_token_price: 'Następnie ${{value, number}} za miesiąc / {{amount, number}} po',
   per_month_each: '${{value, number}} za miesiąc / każdy',
   extra_mao_price: 'Następnie ${{value, number}} za MAO',
   per_month: '${{value, number}} za miesiąc',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/subscription/quota-table.ts
@@ -102,6 +102,7 @@ const quota_table = {
   included: 'incluído{{value, number}}',
   included_mao: '{{value, number}} MAO incluído',
   extra_quota_price: 'Então ${{value, number}} por mês / cada depois',
+  extra_token_price: 'Então ${{value, number}} por mês / {{amount, number}} depois',
   per_month_each: '${{value, number}} por mês / cada',
   extra_mao_price: 'Então ${{value, number}} por MAO',
   per_month: '${{value, number}} por mês',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/subscription/quota-table.ts
@@ -102,6 +102,7 @@ const quota_table = {
   included: 'incluído{{value, number}}',
   included_mao: '{{value, number}} MAO incluída',
   extra_quota_price: 'Depois ${{value, number}} por mês / cada um depois',
+  extra_token_price: 'Depois ${{value, number}} por mês / {{amount, number}} depois',
   per_month_each: '${{value, number}} por mês / cada um',
   extra_mao_price: 'Depois ${{value, number}} por MAO',
   per_month: '${{value, number}} por mês',

--- a/packages/phrases/src/locales/ru/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/subscription/quota-table.ts
@@ -102,6 +102,7 @@ const quota_table = {
   included: 'включено {{value, number}}',
   included_mao: '{{value, number}} MAO включено',
   extra_quota_price: 'Затем $ {{value, number}} в месяц / за каждый после',
+  extra_token_price: 'Затем $ {{value, number}} в месяц / {{amount, number}} за каждый после',
   per_month_each: '$ {{value, number}} в месяц / за каждый',
   extra_mao_price: 'Затем $ {{value, number}} за MAO',
   per_month: '$ {{value, number}} в месяц',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/subscription/quota-table.ts
@@ -102,6 +102,7 @@ const quota_table = {
   included: '{{value, number}} dahil',
   included_mao: '{{value, number}} MAO dahil',
   extra_quota_price: 'Sonra aylık ${{value, number}} / sonrasında her biri',
+  extra_token_price: 'Sonra aylık ${{value, number}} / {{amount, number}} her biri',
   per_month_each: 'Aylık ${{value, number}} / her biri',
   extra_mao_price: 'Sonra MAO başına ${{value, number}}',
   per_month: 'Aylık ${{value, number}}',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/subscription/quota-table.ts
@@ -98,6 +98,7 @@ const quota_table = {
   included: '已包含{{value, number}}',
   included_mao: '已包含 {{value, number}} MAO',
   extra_quota_price: '然后每月 ${{value, number}} / 每个之后',
+  extra_token_price: '然后每月 ${{value, number}} / 每 {{amount, number}} 之后',
   per_month_each: '每月 ${{value, number}} / 每个',
   extra_mao_price: '然后每 MAO ${{value, number}}',
   per_month: '每月 ${{value, number}}',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/subscription/quota-table.ts
@@ -98,6 +98,7 @@ const quota_table = {
   included: '已包含 {{value, number}}',
   included_mao: '已包含 {{value, number}} MAO',
   extra_quota_price: '然後每月 ${{value, number}} / 每個之後',
+  extra_token_price: '然後每月 ${{value, number}} / 每 {{amount, number}} 之後',
   per_month_each: '每月 ${{value, number}} / 每個',
   extra_mao_price: '然後每 MAO ${{value, number}}',
   per_month: '每月 ${{value, number}}',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/subscription/quota-table.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/subscription/quota-table.ts
@@ -98,6 +98,7 @@ const quota_table = {
   included: '已包含 {{value, number}}',
   included_mao: '已包含 {{value, number}} MAO',
   extra_quota_price: '然後每月 ${{value, number}} / 每個之後',
+  extra_token_price: '然後每月 ${{value, number}} / 每 {{amount, number}} 之後',
   per_month_each: '每月 ${{value, number}} / 每個',
   extra_mao_price: '然後每 MAO ${{value, number}}',
   per_month: '每月 ${{value, number}}',


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR refactors the console and core code to support our new Pro plan migration. 

### Refactord
1. Add some missing comments to make the context clear
2. Refactor the `PlanUsage` component. Make the `periodicUsage` props required. 
   - For `MauExceededModel` we should use the usage data from the tenant context.
   - For `Subscription/CurrentPlan` we should always fetch the latest usage data.
3. Extract the SKU sorting logic from `formatLogtoSkusResponses` method to the  `pickupFeaturedLogtoSkus` method. We only need those SKUs to be ordered in the subscription plan table. No need to sort the data on every Logto SKU request. 
4. Extract a new `SkuButton` child component, to avoid complicated inline element display logic. 
   
 ### New Pro plan support
1. Update the `featuredPlanIds` list. Once the new plan is launched, the latest `Pro202411` ID should replace the current `Pro` ID.
2. Refactor the `featuredPlanIdOrder` to a map instead of a list. So we can support multiple plans that share the same order, e.g grandfathered `Pro` and `Pro202411`.
3. Update the `PlanComparisonTable` content to pick up the latest quota updates.
4. Introduce a new `isEquivalentPlan` util method. If the given planId is not equal to the target planId, but they both share the same plan order, we treat them as equivalent plans. New  `Pro202411` and grandfather `Pro`.  We display a Contact Us button for such a case. 
<img width="1369" alt="image" src="https://github.com/user-attachments/assets/8973686f-8dfe-4341-b5fc-ffc7add4a601">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
