### PR TITLE
feat: add saml app sessions table

### DIFF
--- a/packages/core/src/saml-applications/queries/sessions.ts
+++ b/packages/core/src/saml-applications/queries/sessions.ts
@@ -1,0 +1,66 @@
+import { type SamlApplicationSession, SamlApplicationSessions } from '@logto/schemas';
+import type { CommonQueryMethods } from '@silverhand/slonik';
+import { sql } from '@silverhand/slonik';
+
+import { buildInsertIntoWithPool } from '#src/database/insert-into.js';
+import { buildUpdateWhereWithPool } from '#src/database/update-where.js';
+import { convertToIdentifiers } from '#src/utils/sql.js';
+
+const { table, fields } = convertToIdentifiers(SamlApplicationSessions);
+
+export const createSamlApplicationSessionQueries = (pool: CommonQueryMethods) => {
+  const insertSession = buildInsertIntoWithPool(pool)(SamlApplicationSessions, {
+    returning: true,
+  });
+
+  const updateSession = buildUpdateWhereWithPool(pool)(SamlApplicationSessions, true);
+
+  const deleteExpiredOrFullyUsedSessions = async () => {
+    const { rowCount } = await pool.query(sql`
+      delete from ${table}
+      where ${fields.expiresAt} < now()
+      or (${fields.isSamlResponseSent} = true and ${fields.isOidcStateChecked} = true)
+    `);
+
+    return rowCount;
+  };
+
+  const findSessionsByApplicationId = async (applicationId: string) =>
+    pool.any<SamlApplicationSession>(sql`
+      select ${sql.join(Object.values(fields), sql`, `)}
+      from ${table}
+      where ${fields.applicationId}=${applicationId}
+    `);
+
+  const findAvailableSessionByAppIdAndState = async (applicationId: string, state: string) =>
+    pool.one<SamlApplicationSession>(sql`
+      select ${sql.join(Object.values(fields), sql`, `)}
+      from ${table}
+      where ${fields.applicationId}=${applicationId}
+      and ${fields.oidcState}=${state} and ${fields.isOidcStateChecked} = false and ${
+        fields.expiresAt
+      } > now()
+    `);
+
+  const findAvailableSessionByAppIdAndSamlRequestId = async (
+    applicationId: string,
+    samlRequestId: string
+  ) =>
+    pool.one<SamlApplicationSession>(sql`
+      select ${sql.join(Object.values(fields), sql`, `)}
+      from ${table}
+      where ${fields.applicationId}=${applicationId}
+      and ${fields.samlRequestId}=${samlRequestId} and ${fields.isSamlResponseSent} = false and ${
+        fields.expiresAt
+      } > now()
+    `);
+
+  return {
+    insertSession,
+    updateSession,
+    deleteExpiredOrFullyUsedSessions,
+    findSessionsByApplicationId,
+    findAvailableSessionByAppIdAndState,
+    findAvailableSessionByAppIdAndSamlRequestId,
+  };
+};

--- a/packages/core/src/tenants/Queries.ts
+++ b/packages/core/src/tenants/Queries.ts
@@ -30,6 +30,7 @@ import { createUsersRolesQueries } from '#src/queries/users-roles.js';
 import { createVerificationStatusQueries } from '#src/queries/verification-status.js';
 import { createSamlApplicationConfigQueries } from '#src/saml-applications/queries/configs.js';
 import { createSamlApplicationSecretsQueries } from '#src/saml-applications/queries/secrets.js';
+import { createSamlApplicationSessionQueries } from '#src/saml-applications/queries/sessions.js';
 
 import { AccountCenterQueries } from '../queries/account-center.js';
 import { PersonalAccessTokensQueries } from '../queries/personal-access-tokens.js';
@@ -64,6 +65,7 @@ export default class Queries {
   subjectTokens = createSubjectTokenQueries(this.pool);
   samlApplicationSecrets = createSamlApplicationSecretsQueries(this.pool);
   samlApplicationConfigs = createSamlApplicationConfigQueries(this.pool);
+  samlApplicationSessions = createSamlApplicationSessionQueries(this.pool);
   personalAccessTokens = new PersonalAccessTokensQueries(this.pool);
   verificationRecords = new VerificationRecordQueries(this.pool);
   accountCenters = new AccountCenterQueries(this.pool);

--- a/packages/schemas/alterations/next-1735012422-add-saml-application-sessions-table.ts
+++ b/packages/schemas/alterations/next-1735012422-add-saml-application-sessions-table.ts
@@ -13,23 +13,16 @@ const alteration: AlterationScript = {
         id varchar(32) not null,
         application_id varchar(21) not null 
           references applications (id) on update cascade on delete cascade,
-        saml_request_id varchar(128),
+        saml_request_id varchar(128) not null,
         oidc_state varchar(32),
-        is_oidc_state_checked boolean not null default false,
-        is_saml_response_sent boolean not null default false,
         relay_state varchar(256),
-        auth_request_info jsonb not null,
+        raw_auth_request text not null,
         created_at timestamptz not null default(now()),
         expires_at timestamptz not null,
         primary key (tenant_id, id),
         constraint saml_application_sessions__application_type 
           check (check_application_type(application_id, 'SAML'))
       );
-
-      create unique index saml_application_sessions__oidc_state 
-        on saml_application_sessions (tenant_id, oidc_state);
-      create unique index saml_application_sessions__saml_request_id
-        on saml_application_sessions (tenant_id, saml_request_id);
     `);
     await applyTableRls(pool, 'saml_application_sessions');
   },

--- a/packages/schemas/alterations/next-1735012422-add-saml-application-sessions-table.ts
+++ b/packages/schemas/alterations/next-1735012422-add-saml-application-sessions-table.ts
@@ -1,0 +1,44 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+import { applyTableRls, dropTableRls } from './utils/1704934999-tables.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      create table saml_application_sessions (
+        tenant_id varchar(21) not null 
+          references tenants (id) on update cascade on delete cascade,
+        id varchar(32) not null,
+        application_id varchar(21) not null 
+          references applications (id) on update cascade on delete cascade,
+        saml_request_id varchar(128),
+        oidc_state varchar(32),
+        is_oidc_state_checked boolean not null default false,
+        is_saml_response_sent boolean not null default false,
+        relay_state varchar(256),
+        auth_request_info jsonb not null,
+        created_at timestamptz not null default(now()),
+        expires_at timestamptz not null,
+        primary key (tenant_id, id),
+        constraint saml_application_sessions__application_type 
+          check (check_application_type(application_id, 'SAML'))
+      );
+
+      create unique index saml_application_sessions__oidc_state 
+        on saml_application_sessions (tenant_id, oidc_state);
+      create unique index saml_application_sessions__saml_request_id
+        on saml_application_sessions (tenant_id, saml_request_id);
+    `);
+    await applyTableRls(pool, 'saml_application_sessions');
+  },
+  down: async (pool) => {
+    await dropTableRls(pool, 'saml_application_sessions');
+    await pool.query(sql`
+      drop table if exists saml_application_sessions;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/foundations/jsonb-types/index.ts
+++ b/packages/schemas/src/foundations/jsonb-types/index.ts
@@ -11,6 +11,7 @@ export * from './applications.js';
 export * from './verification-records.js';
 export * from './account-centers.js';
 export * from './saml-application-configs.js';
+export * from './saml-application-sessions.js';
 
 export {
   configurableConnectorMetadataGuard,

--- a/packages/schemas/src/foundations/jsonb-types/saml-application-sessions.ts
+++ b/packages/schemas/src/foundations/jsonb-types/saml-application-sessions.ts
@@ -1,0 +1,22 @@
+import { type ToZodObject } from '@logto/connector-kit';
+import { z } from 'zod';
+
+export type AuthRequestInfo = {
+  issuer: string;
+  request: {
+    id: string;
+    destination: string;
+    issueInstant: string;
+    assertionConsumerServiceUrl: string;
+  };
+};
+
+export const authRequestInfoGuard = z.object({
+  issuer: z.string(),
+  request: z.object({
+    id: z.string(),
+    destination: z.string(),
+    issueInstant: z.string(),
+    assertionConsumerServiceUrl: z.string(),
+  }),
+}) satisfies ToZodObject<AuthRequestInfo>;

--- a/packages/schemas/tables/saml_application_sessions.sql
+++ b/packages/schemas/tables/saml_application_sessions.sql
@@ -8,25 +8,16 @@ create table saml_application_sessions (
   application_id varchar(21) not null
     references applications (id) on update cascade on delete cascade,
   /** The identifier of the SAML SSO auth request ID, SAML request ID is pretty long. */
-  saml_request_id varchar(128),
+  saml_request_id varchar(128) not null,
   /** The identifier of the OIDC auth request state. */
   oidc_state varchar(32),
-  /** When checking the OIDC auth state, we should have this flag to prevent replay attack. */
-  is_oidc_state_checked boolean not null default false,
-  /** When sending the SAML authn response, we should have this flag to prevent replay attack. */
-  is_saml_response_sent boolean not null default false,
   /** The relay state of the SAML auth request. */
   relay_state varchar(256),
-  /** The request info of the SAML auth request. */
-  auth_request_info jsonb /* @use AuthRequestInfo */ not null,
+  /** The raw request of the SAML auth request. */
+  raw_auth_request text not null,
   created_at timestamptz not null default(now()),
   expires_at timestamptz not null,
   primary key (tenant_id, id),
   constraint saml_application_sessions__application_type 
     check (check_application_type(application_id, 'SAML'))
 );
-
-create unique index saml_application_sessions__oidc_state 
-  on saml_application_sessions (tenant_id, oidc_state);
-create unique index saml_application_sessions__saml_request_id
-  on saml_application_sessions (tenant_id, saml_request_id);

--- a/packages/schemas/tables/saml_application_sessions.sql
+++ b/packages/schemas/tables/saml_application_sessions.sql
@@ -1,0 +1,32 @@
+/* init_order = 2 */
+
+create table saml_application_sessions (
+  tenant_id varchar(21) not null 
+    references tenants (id) on update cascade on delete cascade,
+  /** The globally unique identifier of the session. */
+  id varchar(32) not null,
+  application_id varchar(21) not null
+    references applications (id) on update cascade on delete cascade,
+  /** The identifier of the SAML SSO auth request ID, SAML request ID is pretty long. */
+  saml_request_id varchar(128),
+  /** The identifier of the OIDC auth request state. */
+  oidc_state varchar(32),
+  /** When checking the OIDC auth state, we should have this flag to prevent replay attack. */
+  is_oidc_state_checked boolean not null default false,
+  /** When sending the SAML authn response, we should have this flag to prevent replay attack. */
+  is_saml_response_sent boolean not null default false,
+  /** The relay state of the SAML auth request. */
+  relay_state varchar(256),
+  /** The request info of the SAML auth request. */
+  auth_request_info jsonb /* @use AuthRequestInfo */ not null,
+  created_at timestamptz not null default(now()),
+  expires_at timestamptz not null,
+  primary key (tenant_id, id),
+  constraint saml_application_sessions__application_type 
+    check (check_application_type(application_id, 'SAML'))
+);
+
+create unique index saml_application_sessions__oidc_state 
+  on saml_application_sessions (tenant_id, oidc_state);
+create unique index saml_application_sessions__saml_request_id
+  on saml_application_sessions (tenant_id, saml_request_id);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add `saml_application_sessions` table to help improve the security of OIDC and SAML proxy. (resolves LOG-10581)
1. when we receice SAML auth request, we create create a record (using `applicationId`, and `samlRequestId`) in this table
2. and then we start a OIDC auth request on backend, which should update the record and attach `oidcState`
3. on SAML proxy callback page, we check whether we have unexpired and unused OIDC state in record, if not, throw an error otherwise mark the OIDC state as used (this prevents replay attack)
4. after getting the OIDC token with the OIDC auth code, we get the unused `samlRequestId` and sent SAML response to the ACS URL in record and hence marked the `samlRequestId` as parsed

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
