### PR TITLE
fix(console): should not apply dev guard

### DIFF
--- a/packages/console/src/pages/TenantSettings/Subscription/index.tsx
+++ b/packages/console/src/pages/TenantSettings/Subscription/index.tsx
@@ -5,7 +5,7 @@ import useSWR from 'swr';
 import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
 import { type TenantUsageAddOnSkus, type NewSubscriptionPeriodicUsage } from '@/cloud/types/router';
 import PageMeta from '@/components/PageMeta';
-import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
+import { isCloud } from '@/consts/env';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import { pickupFeaturedLogtoSkus } from '@/utils/subscription';
@@ -37,7 +37,7 @@ function Subscription() {
   const { data: usageAddOnSkus, error: usageAddOnSkusError } = useSWR<
     TenantUsageAddOnSkus,
     ResponseError
-  >(isCloud && isDevFeaturesEnabled && `/api/tenants/${currentTenantId}/add-on-skus`, async () =>
+  >(isCloud && `/api/tenants/${currentTenantId}/add-on-skus`, async () =>
     cloudApi.get(`/api/tenants/:tenantId/subscription/add-on-skus`, {
       params: { tenantId: currentTenantId },
     })


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Should not apply dev guard on the `/api/tenants/${currentTenantId}/add-on-skus` request. This request is applied to both grandfathered plans and new plans. We should not guard this request using the `isDevFeature` guard. Otherwise it will break the current token-usage tooltip content on prod. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
