### PR TITLE
chore(console): remove new pro plan dev feature guard

### DIFF
--- a/packages/console/src/consts/subscriptions.ts
+++ b/packages/console/src/consts/subscriptions.ts
@@ -1,7 +1,5 @@
 import { ReservedPlanId } from '@logto/schemas';
 
-import { isDevFeaturesEnabled } from './env';
-
 /**
  * Shared quota limits between the featured plan content in the `CreateTenantModal` and the `PlanComparisonTable`.
  */
@@ -25,14 +23,14 @@ export const tokenAddOnUnitPrice = 80;
 export const hooksAddOnUnitPrice = 2;
 /* === Add-on unit price (in USD) === */
 
-// TODO: Remove this dev feature flag when we have the new Pro202411 plan released.
 /**
  * In console, only featured plans are shown in the plan selection component.
  * we will this to filter out the public visible featured plans.
  */
-export const featuredPlanIds: readonly string[] = isDevFeaturesEnabled
-  ? Object.freeze([ReservedPlanId.Free, ReservedPlanId.Pro202411])
-  : Object.freeze([ReservedPlanId.Free, ReservedPlanId.Pro]);
+export const featuredPlanIds: readonly string[] = Object.freeze([
+  ReservedPlanId.Free,
+  ReservedPlanId.Pro202411,
+]);
 
 /**
  * The order of plans in the plan selection content component.
@@ -47,5 +45,5 @@ export const planIdOrder: Record<string, number> = Object.freeze({
 
 export const checkoutStateQueryKey = 'checkout-state';
 
-/** The latest pro plan id we are using. TODO: Remove this when we have the new Pro202411 plan released. */
-export const latestProPlanId = isDevFeaturesEnabled ? ReservedPlanId.Pro202411 : ReservedPlanId.Pro;
+/** The latest pro plan id we are using. */
+export const latestProPlanId = ReservedPlanId.Pro202411;

--- a/packages/console/src/pages/TenantSettings/Subscription/PlanComparisonTable/index.tsx
+++ b/packages/console/src/pages/TenantSettings/Subscription/PlanComparisonTable/index.tsx
@@ -3,7 +3,6 @@ import { type TFuncKey } from 'i18next';
 import { Fragment, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { isDevFeaturesEnabled } from '@/consts/env';
 import {
   freePlanAuditLogsRetentionDays,
   freePlanM2mLimit,
@@ -64,11 +63,9 @@ function PlanComparisonTable() {
     const mauLimitTip = t('mau_tip');
     const includedTokens = t('quota.included_tokens');
     const includedTokensTip = t('tokens_tip');
-    const proPlanIncludedTokens = isDevFeaturesEnabled ? '100,000' : t('million', { value: 1 });
-    const freePlanIncludedTokens = isDevFeaturesEnabled ? '100,000' : '500,000';
-    const proPlanTokenPrice = isDevFeaturesEnabled
-      ? t('extra_token_price', { value: 0.08, amount: 100 })
-      : t('extra_token_price', { value: 80, amount: 1_000_000 });
+    const proPlanIncludedTokens = '100,000';
+    const freePlanIncludedTokens = '100,000';
+    const proPlanTokenPrice = t('extra_token_price', { value: 0.08, amount: 100 });
 
     // Applications
     const totalApplications = t('application.total');

--- a/packages/console/src/pages/TenantSettings/Subscription/index.tsx
+++ b/packages/console/src/pages/TenantSettings/Subscription/index.tsx
@@ -5,7 +5,7 @@ import useSWR from 'swr';
 import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
 import { type TenantUsageAddOnSkus, type NewSubscriptionPeriodicUsage } from '@/cloud/types/router';
 import PageMeta from '@/components/PageMeta';
-import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
+import { isCloud } from '@/consts/env';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import { pickupFeaturedLogtoSkus } from '@/utils/subscription';
@@ -37,7 +37,7 @@ function Subscription() {
   const { data: usageAddOnSkus, error: usageAddOnSkusError } = useSWR<
     TenantUsageAddOnSkus,
     ResponseError
-  >(isCloud && isDevFeaturesEnabled && `/api/tenants/${currentTenantId}/add-on-skus`, async () =>
+  >(isCloud && `/api/tenants/${currentTenantId}/add-on-skus`, async () =>
     cloudApi.get(`/api/tenants/:tenantId/subscription/add-on-skus`, {
       params: { tenantId: currentTenantId },
     })


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Remove the new pro plan dev feature guard.

Notice: merging this PR to the cloud will enable the Pro202411 plan on prod and block the public visibility of the grandfathered  Pro plan. 

cloud [PR](https://github.com/logto-io/cloud/pull/1058).


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
