### PR TITLE
fix(core): should not be able to skip mandatory MFA

### DIFF
--- a/packages/core/src/routes/experience/classes/mfa.ts
+++ b/packages/core/src/routes/experience/classes/mfa.ts
@@ -285,7 +285,7 @@ export class Mfa {
     }
 
     // If the policy is not mandatory and the user has skipped MFA, then there is nothing to check
-    if ((policy !== MfaPolicy.Mandatory && this.#mfaSkipped) ?? isMfaSkipped(logtoConfig)) {
+    if (policy !== MfaPolicy.Mandatory && (this.#mfaSkipped ?? isMfaSkipped(logtoConfig))) {
       return;
     }
 

--- a/packages/core/src/routes/interaction/verifications/mfa-verification.ts
+++ b/packages/core/src/routes/interaction/verifications/mfa-verification.ts
@@ -153,7 +153,7 @@ export const validateMandatoryBindMfa = async (
     return interaction;
   }
 
-  // If the policy is not mandatory and the user has skipped MFA, skip check
+  // If the policy is not mandatory and the user has skipped MFA (in the current interaction), skip check
   const { mfaSkipped } = interaction;
   if (policy !== MfaPolicy.Mandatory && mfaSkipped) {
     return interaction;
@@ -177,7 +177,8 @@ export const validateMandatoryBindMfa = async (
     const { accountId } = interaction;
     const { mfaVerifications, logtoConfig } = await tenant.queries.users.findUserById(accountId);
 
-    if (isMfaSkipped(logtoConfig)) {
+    // If the policy is not mandatory and the user has skipped MFA (not in the current interaction), skip check
+    if (policy !== MfaPolicy.Mandatory && isMfaSkipped(logtoConfig)) {
       return interaction;
     }
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

This PR address this bug: if user's config has "mfa skipped" mark, then he can bypass mandatory MFA policy.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Integration tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
