### PR TITLE
fix(core): fix create org role API

### DIFF
--- a/.changeset/thick-baboons-sniff.md
+++ b/.changeset/thick-baboons-sniff.md
@@ -1,0 +1,7 @@
+---
+"@logto/core": patch
+---
+
+fix POST /api/organization-roles API
+
+When invalid organization scope IDs or resource scope IDs are provided, the API should return a 422 error without creating the organization role.

--- a/packages/core/src/routes/organization-role/index.openapi.json
+++ b/packages/core/src/routes/organization-role/index.openapi.json
@@ -46,7 +46,7 @@
             "description": "The organization role was created successfully."
           },
           "422": {
-            "description": "The organization role name is already in use."
+            "description": "The organization role name is already in use, or at least one of the IDs (organizationScopeIds or resourceScopeIds) provided is invalid. For example, the organization scope ID or resource scope ID does not exist."
           }
         }
       }

--- a/packages/phrases/src/locales/en/errors/organization.ts
+++ b/packages/phrases/src/locales/en/errors/organization.ts
@@ -1,5 +1,9 @@
 const organizations = {
   require_membership: 'The user must be a member of the organization to proceed.',
+  roles: {
+    invalid_scope_ids: 'The organization scope IDs are not valid.',
+    invalid_resource_scope_ids: 'The resource scope IDs are not valid.',
+  },
 };
 
 export default Object.freeze(organizations);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix create org role API:
Previously, if `organizationScopeIds` or `resourceScopeIds` contained an invalid ID (such as a non-existent scope ID), the API would return a 4xx error, but the role would still be created. In reality, the role should not have been created.

Repored by community users in [issue 6891](https://github.com/logto-io/logto/issues/6891).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Add integration tests to cover these scenarios.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
