### PR TITLE
feat(core): support custom endpoint and addressing style for S3

### DIFF
--- a/.changeset/afraid-otters-crash.md
+++ b/.changeset/afraid-otters-crash.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": patch
+---
+
+support custom endpoint and addressing style for S3

--- a/packages/core/src/utils/storage/index.ts
+++ b/packages/core/src/utils/storage/index.ts
@@ -19,7 +19,7 @@ export const buildUploadFile = (config: StorageProviderData): UploadFile | Uploa
     return storage.uploadFile;
   }
 
-  const { endpoint, bucket, accessKeyId, accessSecretKey, region } = config;
+  const { endpoint, bucket, accessKeyId, forcePathStyle, accessSecretKey, region } = config;
 
   const storage = buildS3Storage({
     endpoint,
@@ -27,6 +27,7 @@ export const buildUploadFile = (config: StorageProviderData): UploadFile | Uploa
     accessKeyId,
     secretAccessKey: accessSecretKey,
     region,
+    forcePathStyle,
   });
 
   return storage.uploadFile;

--- a/packages/schemas/src/types/system.ts
+++ b/packages/schemas/src/types/system.ts
@@ -44,6 +44,7 @@ export const storageProviderDataGuard = z.discriminatedUnion('provider', [
     endpoint: z.string().optional(),
     region: z.string().optional(),
     bucket: z.string(),
+    forcePathStyle: z.boolean().optional(),
     accessKeyId: z.string(),
     accessSecretKey: z.string(),
     ...basicConfig,


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add support for configurable S3 endpoint and addressing style (path-style/virtual-hosted) to improve compatibility with S3-compatible storage services.

- Add forcePathStyle option to control URL addressing style
- Fix custom endpoint support implementation
- Improve URL generation logic for different configurations

Resolves: [#6920]


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
