### PR TITLE
feat(core): add default redirect URI for SAML apps on creation

### DIFF
--- a/packages/core/src/saml-applications/SamlApplication/utils.ts
+++ b/packages/core/src/saml-applications/SamlApplication/utils.ts
@@ -1,5 +1,6 @@
 import { NameIdFormat } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
+import { appendPath } from '@silverhand/essentials';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import { type IdTokenProfileStandardClaims } from '#src/sso/types/oidc.js';
@@ -68,3 +69,6 @@ export const generateAutoSubmitForm = (actionUrl: string, samlResponse: string):
     </html>
   `;
 };
+
+export const getSamlAppCallbackUrl = (baseUrl: URL, samlAppId: string) =>
+  appendPath(baseUrl, `api/saml-applications/${samlAppId}/callback`);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
1. add default redirect URI for SAML apps on creation (resolves LOG-10694)
2. refactor the `getScopesFromAttributeMapping()` class method as well.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Added both unit test and integration test cases to cover the changes.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
