### PR TITLE
refactor(core): refactor GET saml app metadata endpoint

### DIFF
--- a/packages/core/src/saml-applications/routes/anonymous.ts
+++ b/packages/core/src/saml-applications/routes/anonymous.ts
@@ -46,7 +46,7 @@ export default function samlApplicationAnonymousRoutes<T extends AnonymousRouter
     '/saml-applications/:id/metadata',
     koaGuard({
       params: z.object({ id: z.string() }),
-      status: [200, 404],
+      status: [200, 400, 404],
       response: z.string(),
     }),
     async (ctx, next) => {
@@ -97,7 +97,7 @@ export default function samlApplicationAnonymousRoutes<T extends AnonymousRouter
       const samlApplication = new SamlApplication(details, id, envSet.oidc.issuer, tenantId);
 
       assertThat(
-        samlApplication.details.redirectUri === samlApplication.samlAppCallbackUrl,
+        samlApplication.config.redirectUri === samlApplication.samlAppCallbackUrl,
         'oidc.invalid_redirect_uri'
       );
 
@@ -244,7 +244,7 @@ export default function samlApplicationAnonymousRoutes<T extends AnonymousRouter
         log.append({ extractResultData: extractResult.data });
 
         assertThat(
-          extractResult.data.issuer === samlApplication.details.entityId,
+          extractResult.data.issuer === samlApplication.config.entityId,
           'application.saml.auth_request_issuer_not_match'
         );
 
@@ -343,7 +343,7 @@ export default function samlApplicationAnonymousRoutes<T extends AnonymousRouter
         log.append({ extractResultData: extractResult.data });
 
         assertThat(
-          extractResult.data.issuer === samlApplication.details.entityId,
+          extractResult.data.issuer === samlApplication.config.entityId,
           'application.saml.auth_request_issuer_not_match'
         );
 

--- a/packages/core/src/saml-applications/routes/anonymous.ts
+++ b/packages/core/src/saml-applications/routes/anonymous.ts
@@ -33,9 +33,6 @@ export default function samlApplicationAnonymousRoutes<T extends AnonymousRouter
   ...[router, { id: tenantId, libraries, queries, envSet }]: RouterInitArgs<T>
 ) {
   const {
-    samlApplications: { getSamlIdPMetadataByApplicationId },
-  } = libraries;
-  const {
     samlApplications: { getSamlApplicationDetailsById },
     samlApplicationSessions: {
       insertSession,
@@ -55,10 +52,11 @@ export default function samlApplicationAnonymousRoutes<T extends AnonymousRouter
     async (ctx, next) => {
       const { id } = ctx.guard.params;
 
-      const { metadata } = await getSamlIdPMetadataByApplicationId(id);
+      const details = await getSamlApplicationDetailsById(id);
+      const samlApplication = new SamlApplication(details, id, envSet.oidc.issuer, tenantId);
 
       ctx.status = 200;
-      ctx.body = metadata;
+      ctx.body = samlApplication.idPMetadata;
       ctx.type = 'text/xml;charset=utf-8';
 
       return next();


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
refactor GET saml app metadata endpoint, reuse SamlApplication class instead of using seprated methods to keep accordance. (resolves LOG-10699)
Previously we check all config attributes when construct the SamlApplication class, but in fact, we should only check those attributes when needed. E.g. when constructing IdP, we do not need to check the config of `acsUrl`, we hence update the implementation as well to fix this.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Should be covered by existing integration tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
