### PR TITLE
refactor(experience): remove the image CORS attributes

### DIFF
--- a/.changeset/soft-kings-grin.md
+++ b/.changeset/soft-kings-grin.md
@@ -1,0 +1,9 @@
+---
+"@logto/experience": patch
+---
+
+remove the image element's cross-origin="anouymous" attribute.
+
+Some public image resources may not have the proper cross-origin headers configured, those images may fail to load when the cross-origin="anouymous" attribute is present.
+Since those image elements are only used for display purposes, Logto does not need to access the image data, so the cross-origin="anouymous" attribute is not necessary.
+To make the image elements more compatible with public image resources, remove the cross-origin="anouymous" attribute from the image elements.

--- a/.changeset/soft-kings-grin.md
+++ b/.changeset/soft-kings-grin.md
@@ -2,8 +2,8 @@
 "@logto/experience": patch
 ---
 
-remove the image element's cross-origin="anouymous" attribute.
+remove the image element's cross-origin="anonymous" attribute.
 
-Some public image resources may not have the proper cross-origin headers configured, those images may fail to load when the cross-origin="anouymous" attribute is present.
-Since those image elements are only used for display purposes, Logto does not need to access the image data, so the cross-origin="anouymous" attribute is not necessary.
-To make the image elements more compatible with public image resources, remove the cross-origin="anouymous" attribute from the image elements.
+Some public image resources may not have the proper cross-origin headers configured, those images may fail to load when the cross-origin="anonymous" attribute is present.
+Since those image elements are only used for display purposes, Logto does not need to access the image data, so the cross-origin="anonymous" attribute is not necessary.
+To make the image elements more compatible with public image resources, remove the cross-origin="anonymous" attribute from the image elements.

--- a/.changeset/soft-kings-grin.md
+++ b/.changeset/soft-kings-grin.md
@@ -2,8 +2,8 @@
 "@logto/experience": patch
 ---
 
-remove the image element's cross-origin="anonymous" attribute.
+remove the image element's `cross-origin="anonymous"` attribute.
 
-Some public image resources may not have the proper cross-origin headers configured, those images may fail to load when the cross-origin="anonymous" attribute is present.
-Since those image elements are only used for display purposes, Logto does not need to access the image data, so the cross-origin="anonymous" attribute is not necessary.
-To make the image elements more compatible with public image resources, remove the cross-origin="anonymous" attribute from the image elements.
+Some public image resources may not have the proper cross-origin headers configured, those images may fail to load when the `cross-origin="anonymous"` attribute is present.
+Since those image elements are only used for display purposes, Logto does not need to access the image data, so the `cross-origin="anonymous"` attribute is not necessary.
+To make the image elements more compatible with public image resources, remove the `cross-origin="anonymous"` attribute from the image elements.

--- a/packages/experience-legacy/src/components/BrandingHeader/index.tsx
+++ b/packages/experience-legacy/src/components/BrandingHeader/index.tsx
@@ -31,17 +31,10 @@ const BrandingHeader = ({
       {shouldShowLogo && (
         <div className={styles.logoWrapper}>
           {thirdPartyLogo && (
-            <img
-              className={styles.logo}
-              alt="third party logo"
-              src={thirdPartyLogo}
-              crossOrigin="anonymous"
-            />
+            <img className={styles.logo} alt="third party logo" src={thirdPartyLogo} />
           )}
           {shouldConnectSvg && <ConnectIcon className={styles.connectIcon} />}
-          {logo && (
-            <img className={styles.logo} alt="app logo" src={logo} crossOrigin="anonymous" />
-          )}
+          {logo && <img className={styles.logo} alt="app logo" src={logo} />}
         </div>
       )}
 

--- a/packages/experience-legacy/src/components/Button/SocialLinkButton.tsx
+++ b/packages/experience-legacy/src/components/Button/SocialLinkButton.tsx
@@ -49,12 +49,7 @@ const SocialLinkButton = ({
       onClick={onClick}
     >
       {logo && !isLoadingActive && (
-        <img
-          src={logo}
-          alt={target}
-          className={socialLinkButtonStyles.icon}
-          crossOrigin="anonymous"
-        />
+        <img src={logo} alt={target} className={socialLinkButtonStyles.icon} />
       )}
       {isLoadingActive && (
         <span className={socialLinkButtonStyles.loadingIcon}>

--- a/packages/experience-legacy/src/containers/SocialLanding/index.tsx
+++ b/packages/experience-legacy/src/containers/SocialLanding/index.tsx
@@ -18,11 +18,7 @@ const SocialLanding = ({ className, connectorId, isLoading = false }: Props) => 
   return (
     <div className={classNames(styles.container, className)}>
       <div className={styles.connector}>
-        {result ? (
-          <img src={getConnectorLogo(result)} alt="logo" crossOrigin="anonymous" />
-        ) : (
-          connectorId
-        )}
+        {result ? <img src={getConnectorLogo(result)} alt="logo" /> : connectorId}
       </div>
       {isLoading && <LoadingIcon />}
     </div>

--- a/packages/experience/src/components/BrandingHeader/index.tsx
+++ b/packages/experience/src/components/BrandingHeader/index.tsx
@@ -31,17 +31,10 @@ const BrandingHeader = ({
       {shouldShowLogo && (
         <div className={styles.logoWrapper}>
           {thirdPartyLogo && (
-            <img
-              className={styles.logo}
-              alt="third party logo"
-              src={thirdPartyLogo}
-              crossOrigin="anonymous"
-            />
+            <img className={styles.logo} alt="third party logo" src={thirdPartyLogo} />
           )}
           {shouldConnectSvg && <ConnectIcon className={styles.connectIcon} />}
-          {logo && (
-            <img className={styles.logo} alt="app logo" src={logo} crossOrigin="anonymous" />
-          )}
+          {logo && <img className={styles.logo} alt="app logo" src={logo} />}
         </div>
       )}
 

--- a/packages/experience/src/components/Button/SocialLinkButton.tsx
+++ b/packages/experience/src/components/Button/SocialLinkButton.tsx
@@ -49,12 +49,7 @@ const SocialLinkButton = ({
       onClick={onClick}
     >
       {logo && !isLoadingActive && (
-        <img
-          src={logo}
-          alt={target}
-          className={socialLinkButtonStyles.icon}
-          crossOrigin="anonymous"
-        />
+        <img src={logo} alt={target} className={socialLinkButtonStyles.icon} />
       )}
       {isLoadingActive && (
         <span className={socialLinkButtonStyles.loadingIcon}>

--- a/packages/experience/src/containers/SocialLanding/index.tsx
+++ b/packages/experience/src/containers/SocialLanding/index.tsx
@@ -18,11 +18,7 @@ const SocialLanding = ({ className, connectorId, isLoading = false }: Props) => 
   return (
     <div className={classNames(styles.container, className)}>
       <div className={styles.connector}>
-        {result ? (
-          <img src={getConnectorLogo(result)} alt="logo" crossOrigin="anonymous" />
-        ) : (
-          connectorId
-        )}
+        {result ? <img src={getConnectorLogo(result)} alt="logo" /> : connectorId}
       </div>
       {isLoading && <LoadingIcon />}
     </div>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Remove the [cross-origin](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#crossorigin) attribute on experience image elements.  

Some public image resources may not have the proper cross-origin headers configured, those images may fail to load when the cross-origin="anonymous" attribute is present.
Since those image elements are only used for display purposes, Logto does not need to access the image data, so the cross-origin="anonymous" attribute is not necessary.
To make the image elements more compatible with public image resources, remove the cross-origin="anonymous" attribute from the image elements.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally. 

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
