### PR TITLE
fix(core,console): make SAML related log visible in audit log listing page

### DIFF
--- a/packages/core/src/queries/log.ts
+++ b/packages/core/src/queries/log.ts
@@ -7,6 +7,7 @@ import {
   type interaction,
   type LogKeyUnknown,
   type jwtCustomizer,
+  type saml,
 } from '@logto/schemas';
 import { conditional, conditionalArray } from '@silverhand/essentials';
 import { sql } from '@silverhand/slonik';
@@ -24,6 +25,7 @@ export type AllowedKeyPrefix =
   | token.Type
   | interaction.Prefix
   | jwtCustomizer.Prefix
+  | saml.Prefix
   | typeof LogKeyUnknown;
 
 type LogCondition = {

--- a/packages/core/src/routes/log.test.ts
+++ b/packages/core/src/routes/log.test.ts
@@ -1,4 +1,4 @@
-import { LogResult, token, interaction, LogKeyUnknown, jwtCustomizer } from '@logto/schemas';
+import { LogResult, token, interaction, LogKeyUnknown, jwtCustomizer, saml } from '@logto/schemas';
 import type { Log } from '@logto/schemas';
 import { pickDefault } from '@logto/shared/esm';
 
@@ -50,6 +50,7 @@ describe('logRoutes', () => {
           token.Type.RevokeToken,
           interaction.prefix,
           jwtCustomizer.prefix,
+          saml.prefix,
           LogKeyUnknown,
         ],
       });
@@ -61,6 +62,7 @@ describe('logRoutes', () => {
           token.Type.RevokeToken,
           interaction.prefix,
           jwtCustomizer.prefix,
+          saml.prefix,
           LogKeyUnknown,
         ],
       });

--- a/packages/core/src/routes/log.ts
+++ b/packages/core/src/routes/log.ts
@@ -1,4 +1,4 @@
-import { Logs, interaction, token, LogKeyUnknown, jwtCustomizer } from '@logto/schemas';
+import { Logs, interaction, token, LogKeyUnknown, jwtCustomizer, saml } from '@logto/schemas';
 import { object, string } from 'zod';
 
 import koaGuard from '#src/middleware/koa-guard.js';
@@ -35,6 +35,7 @@ export default function logRoutes<T extends ManagementApiRouter>(
         token.Type.RevokeToken,
         interaction.prefix,
         jwtCustomizer.prefix,
+        saml.prefix,
         LogKeyUnknown,
       ];
 

--- a/packages/core/src/saml-applications/routes/anonymous.ts
+++ b/packages/core/src/saml-applications/routes/anonymous.ts
@@ -82,7 +82,7 @@ export default function samlApplicationAnonymousRoutes<T extends AnonymousRouter
 
       log.append({
         query,
-        samlApplicationId: id,
+        applicationId: id,
       });
 
       // Handle error in query parameters
@@ -208,7 +208,7 @@ export default function samlApplicationAnonymousRoutes<T extends AnonymousRouter
       const log = ctx.createLog('SamlApplication.AuthnRequest');
       log.append({
         query: ctx.guard.query,
-        samlApplicationId: id,
+        applicationId: id,
       });
 
       const details = await getSamlApplicationDetailsById(id);
@@ -317,7 +317,7 @@ export default function samlApplicationAnonymousRoutes<T extends AnonymousRouter
       const log = ctx.createLog('SamlApplication.AuthnRequest');
       log.append({
         body: ctx.guard.body,
-        samlApplicationId: id,
+        applicationId: id,
       });
 
       const details = await getSamlApplicationDetailsById(id);


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
1. Make SAML related logs visible in audit listing page by updating log queries methods.
2. Use `applicationId` instead of `samlApplicationId` in log to improve the query UX.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
