### PR TITLE
chore(core): hide oidcClientMetadata of SAML apps when using GET app APIs

### DIFF
--- a/packages/core/src/routes/applications/application.ts
+++ b/packages/core/src/routes/applications/application.ts
@@ -1,8 +1,7 @@
 // TODO: @darcyYe refactor this file later to remove disable max line comment
 /* eslint-disable max-lines */
-import type { Role } from '@logto/schemas';
+import type { Role, Application } from '@logto/schemas';
 import {
-  type Application,
   Applications,
   ApplicationType,
   buildDemoAppDataForTenant,

--- a/packages/core/src/routes/saml-application/index.ts
+++ b/packages/core/src/routes/saml-application/index.ts
@@ -179,7 +179,6 @@ export default function samlApplicationRoutes<T extends ManagementApiRouter>(
 
   router.post(
     '/saml-applications/:id/secrets',
-    koaQuotaGuard({ key: 'samlApplicationsLimit', quota }),
     koaGuard({
       params: z.object({ id: z.string() }),
       // The life span of the SAML app secret is in years (at least 1 year), and for security concern, secrets which never expire are not recommended.

--- a/packages/integration-tests/src/tests/api/application/saml-application.test.ts
+++ b/packages/integration-tests/src/tests/api/application/saml-application.test.ts
@@ -50,16 +50,6 @@ describe('SAML application', () => {
       ({ id }) => id === createdSamlApplication.id
     );
     expect(pickedSamlApplication).toBeDefined();
-    expect(pickedSamlApplication!.oidcClientMetadata.redirectUris.length).toBe(1);
-    expect(
-      pickedSamlApplication!.oidcClientMetadata.redirectUris[0]!.endsWith(
-        `api/saml-applications/${createdSamlApplication.id}/callback`
-      )
-    ).toBe(true);
-
-    console.log('pickedSamlApplication', pickedSamlApplication);
-    console.log('samlApplications', samlApplications);
-
     expect(
       samlApplications.every(
         ({ oidcClientMetadata: { redirectUris, postLogoutRedirectUris } }) =>

--- a/packages/integration-tests/src/tests/api/application/saml-application.test.ts
+++ b/packages/integration-tests/src/tests/api/application/saml-application.test.ts
@@ -5,6 +5,7 @@ import {
   createApplication,
   deleteApplication,
   getApplications,
+  getApplication,
   updateApplication,
 } from '#src/api/application.js';
 import {
@@ -30,6 +31,15 @@ describe('SAML application', () => {
       description: 'test',
     });
 
+    await expect(getApplication(createdSamlApplication.id)).resolves.toMatchObject(
+      expect.objectContaining({
+        oidcClientMetadata: {
+          redirectUris: [],
+          postLogoutRedirectUris: [],
+        },
+      })
+    );
+
     expect(createdSamlApplication.nameIdFormat).toBe(NameIdFormat.Persistent);
 
     // Check if the SAML application's OIDC metadata redirect URI is properly set.
@@ -43,6 +53,13 @@ describe('SAML application', () => {
     expect(
       pickedSamlApplication!.oidcClientMetadata.redirectUris[0]!.endsWith(
         `api/saml-applications/${createdSamlApplication.id}/callback`
+      )
+    ).toBe(true);
+
+    expect(
+      samlApplications.every(
+        ({ oidcClientMetadata: { redirectUris, postLogoutRedirectUris } }) =>
+          redirectUris.length === 0 && postLogoutRedirectUris.length === 0
       )
     ).toBe(true);
 

--- a/packages/integration-tests/src/tests/api/application/saml-application.test.ts
+++ b/packages/integration-tests/src/tests/api/application/saml-application.test.ts
@@ -45,6 +45,7 @@ describe('SAML application', () => {
     // Check if the SAML application's OIDC metadata redirect URI is properly set.
     // We need to do this since we do not return OIDC related info when using SAML app APIs.
     const samlApplications = await getApplications([ApplicationType.SAML]);
+    expect(samlApplications.every(({ type }) => type === ApplicationType.SAML));
     const pickedSamlApplication = samlApplications.find(
       ({ id }) => id === createdSamlApplication.id
     );
@@ -55,6 +56,9 @@ describe('SAML application', () => {
         `api/saml-applications/${createdSamlApplication.id}/callback`
       )
     ).toBe(true);
+
+    console.log('pickedSamlApplication', pickedSamlApplication);
+    console.log('samlApplications', samlApplications);
 
     expect(
       samlApplications.every(


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
1. hide oidcClientMetadata of SAML apps when using GET app APIs (resolves LOG-10499), affect `GET /applications` and `GET /applications/:id` APIs.
2. also removed unnecessary guard for creating new secrets for SAML apps.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Covered by integration tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
