### PR TITLE
fix: otp double signin bug

### DIFF
--- a/packages/experience-legacy/src/containers/TotpCodeVerification/index.tsx
+++ b/packages/experience-legacy/src/containers/TotpCodeVerification/index.tsx
@@ -40,12 +40,16 @@ const TotpCodeVerification = ({ flow }: Props) => {
 
   const handleSubmit = useCallback(
     async (code: string[]) => {
+      if (isSubmitting) {
+        return;
+      }
+
       setInputErrorMessage(undefined);
       setIsSubmitting(true);
       await onSubmit(code.join(''));
       setIsSubmitting(false);
     },
-    [onSubmit]
+    [onSubmit, isSubmitting]
   );
 
   return (

--- a/packages/experience/src/containers/TotpCodeVerification/index.tsx
+++ b/packages/experience/src/containers/TotpCodeVerification/index.tsx
@@ -42,13 +42,17 @@ const TotpCodeVerification = <T extends UserMfaFlow>(props: Props<T>) => {
 
   const handleSubmit = useCallback(
     async (code: string[]) => {
+      if (isSubmitting) {
+        return;
+      }
+
       setInputErrorMessage(undefined);
       setIsSubmitting(true);
 
       await onSubmit(code.join(''), props);
       setIsSubmitting(false);
     },
-    [onSubmit, props]
+    [onSubmit, isSubmitting, props]
   );
 
   return (


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
Fixes a bug with double submission on the OTP screen.

Issue:
https://github.com/logto-io/logto/issues/6991


<!-- MANDATORY -->
## Testing
Discovered by adding this line:

```ts
      if (isSubmitting) {
        alert('already submitting')
      }
```

Every few otp attempts I got the alert, so replaced it with:

```ts
      if (isSubmitting) {
        return;
      }
```

So far I haven't experienced the bug since.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
