### PR TITLE
feat(schemas): add new email templates table

### DIFF
--- a/packages/schemas/alterations/next-1738828268-add-email-templates-table.ts
+++ b/packages/schemas/alterations/next-1738828268-add-email-templates-table.ts
@@ -32,7 +32,7 @@ const alteration: AlterationScript = {
   down: async (pool) => {
     await dropTableRls(pool, 'email_templates');
     await pool.query(sql`
-      drop table is exists email_templates;  
+      drop table if exists email_templates;
     `);
   },
 };

--- a/packages/schemas/alterations/next-1738828268-add-email-templates-table.ts
+++ b/packages/schemas/alterations/next-1738828268-add-email-templates-table.ts
@@ -1,0 +1,40 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+import { applyTableRls, dropTableRls } from './utils/1704934999-tables.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      create table email_templates (
+        tenant_id varchar(21) not null
+          references tenants (id) on update cascade on delete cascade,
+        id varchar(21) not null,
+        language_tag varchar(16) not null,
+        template_type varchar(64) not null,
+        details jsonb not null,
+        created_at timestamptz not null default now(),
+        primary key (tenant_id, id),
+        constraint email_templates__tenant_id__language_tag__template_type
+          unique (tenant_id, language_tag, template_type)
+      );
+
+      create index email_templates__tenant_id__language_tag
+        on email_templates (tenant_id, language_tag);
+
+      create index email_templates__tenant_id__template_type
+        on email_templates (tenant_id, template_type);
+    `);
+
+    await applyTableRls(pool, 'email_templates');
+  },
+  down: async (pool) => {
+    await dropTableRls(pool, 'email_templates');
+    await pool.query(sql`
+      drop table is exists email_templates;  
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/foundations/jsonb-types/email-templates.ts
+++ b/packages/schemas/src/foundations/jsonb-types/email-templates.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+
+export { TemplateType, templateTypeGuard } from '@logto/connector-kit';
+
+export type EmailTemplateDetails = {
+  subject: string;
+  content: string;
+  /**
+   * OPTIONAL: The content type of the email template.
+   *
+   * Some email clients may render email templates differently based on the content type. (e.g. Sendgrid, Mailgun)
+   * Use this field to specify the content type of the email template.
+   */
+  contentType?: 'text/html' | 'text/plain';
+  /**
+   * OPTIONAL: Custom replyTo template.
+   *
+   * Based on the email client, the replyTo field may be used to customize the reply-to field of the email.
+   * @remarks
+   * The original reply email value can be found in the template variables.
+   */
+  replyTo?: string;
+  /**
+   * OPTIONAL: Custom from template.
+   *
+   * Based on the email client, the sendFrom field may be used to customize the from field of the email.
+   * @remarks
+   * The sender email value can be found in the template variables.
+   */
+  sendFrom?: string;
+};
+
+export const emailTemplateDetailsGuard = z.object({
+  subject: z.string(),
+  content: z.string(),
+  contentType: z.union([z.literal('text/html'), z.literal('text/plain')]).optional(),
+  replyTo: z.string().optional(),
+  sendFrom: z.string().optional(),
+}) satisfies z.ZodType<EmailTemplateDetails>;

--- a/packages/schemas/src/foundations/jsonb-types/index.ts
+++ b/packages/schemas/src/foundations/jsonb-types/index.ts
@@ -12,6 +12,7 @@ export * from './verification-records.js';
 export * from './account-centers.js';
 export * from './saml-application-configs.js';
 export * from './saml-application-sessions.js';
+export * from './email-templates.js';
 
 export {
   configurableConnectorMetadataGuard,

--- a/packages/schemas/tables/email_templates.sql
+++ b/packages/schemas/tables/email_templates.sql
@@ -1,0 +1,18 @@
+create table email_templates (
+  tenant_id varchar(21) not null
+    references tenants (id) on update cascade on delete cascade,
+  id varchar(21) not null,
+  language_tag varchar(16) not null,
+  template_type varchar(64) /* @use TemplateType */ not null,
+  details jsonb /* @use EmailTemplateDetails */ not null,
+  created_at timestamptz not null default now(),
+  primary key (tenant_id, id),
+  constraint email_templates__tenant_id__language_tag__template_type
+    unique (tenant_id, language_tag, template_type)
+);
+
+create index email_templates__tenant_id__language_tag
+  on email_templates (tenant_id, language_tag);
+
+create index email_templates__tenant_id__template_type
+  on email_templates (tenant_id, template_type);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

In the previous implementation, we only supported one copy of the email templates configured under the email connector's settings. This becomes a limitation for some of our customers who require i18n support for their email templates. Users from different regions may receive emails in different languages, just like our SIE i18n phrases. We need to support i18n templates to meet the requirements

In addition to the current default email templates stored in connector configs, we need to add an extra global setting to allow users to configure multiple email templates for different languages. This PR introduces the new `email_templates` table.

This table will be used to globally maintain custom email templates with i18n support for developers. We will detect the user's language preference and locate the corresponding email template using the following priority:

 - p0: If the language auto-detection is enabled in SIE, we will use the user's browser language preference to locate the email template. (e.g. `Accept-Language: en-US`)
 - p1: If the language auto-detection is enabled in SIE, but the API request does not contain the `Accept-Language` header (e.g. Management API triggered email sending flow), use the `locale` value stored in the user's profile data.
 - p2: If the language auto-detection is enabled in SIE, but the user's profile does not have the `locale` value, use the default language in SIE.
 - p3: If the language auto-detection is disabled in SIE, use the default language in SIE.
 - fallback: If the email template for the detected language is not found, use the default email template from the connector settings. (Current behavior)

> [!NOTE]  
>  These new i18n email templates will be used globally regardless of the email connector.
> We use a shared schema type to define all the email template details. The connector-level template key mapping logic is needed based on different email connectors' interface definitions. 
> The following email connectors do not support custom email templates. i18n and template customization will be managed by the email provider:
> - Postmark
> - HTML Email
> - Logto cloud email service. (Read-only i18n email templates will be provided by Logto cloud service)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [x] necessary TSDoc comments
