### PR TITLE
fix(core): trigger webhook in organization invitation flow

### DIFF
--- a/.changeset/afraid-turkeys-swim.md
+++ b/.changeset/afraid-turkeys-swim.md
@@ -1,0 +1,7 @@
+---
+"@logto/core": patch
+---
+
+bug fix. Trigger the `Organization.Membership.Updated` webhook when a user accepts an invitation and join an organization.
+
+Added a new `Organization.Membership.Accepted` webhook event in the `PUT /api/organization-invitations/{id}/status` endpoint. This event will be triggered when the organization-invitation status is updated to `accepted`, and user is added to the organization.

--- a/.changeset/afraid-turkeys-swim.md
+++ b/.changeset/afraid-turkeys-swim.md
@@ -2,6 +2,6 @@
 "@logto/core": patch
 ---
 
-bug fix. Trigger the `Organization.Membership.Updated` webhook when a user accepts an invitation and join an organization.
+fix(core): trigger the `Organization.Membership.Updated` webhook when a user accepts an invitation and join an organization.
 
 Added a new `Organization.Membership.Accepted` webhook event in the `PUT /api/organization-invitations/{id}/status` endpoint. This event will be triggered when the organization-invitation status is updated to `accepted`, and user is added to the organization.

--- a/packages/core/src/routes/organization-invitation/index.ts
+++ b/packages/core/src/routes/organization-invitation/index.ts
@@ -145,7 +145,15 @@ export default function organizationInvitationRoutes<T extends ManagementApiRout
         })
       );
 
-      ctx.body = await organizationInvitations.updateStatus(id, status, acceptedUserId);
+      const result = await organizationInvitations.updateStatus(id, status, acceptedUserId);
+
+      const { organizationId } = result;
+      ctx.appendDataHookContext('Organization.Membership.Updated', {
+        organizationId,
+      });
+
+      ctx.body = result;
+
       return next();
     }
   );


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
When an organization invitation is accepted, trigger the `Organization.Membership.Updated` webhook event.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
integration tests added

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
