### PR TITLE
fix(cli): fix cli add official connectors command missing connectors bug

### DIFF
--- a/.changeset/rotten-bugs-pretend.md
+++ b/.changeset/rotten-bugs-pretend.md
@@ -1,0 +1,8 @@
+---
+"@logto/cli": patch
+---
+
+fix(cli): fix cli add offical connectors command missing connectors bug
+
+Fix the bug when running the cli commend `logto connectors add --official`, only 8 connectors are fetched from npm registry.
+This fix update logic to query additional pages of results when fetching connectors from the npm registry.

--- a/packages/cli/src/commands/connector/utils.ts
+++ b/packages/cli/src/commands/connector/utils.ts
@@ -144,6 +144,11 @@ const officialConnectorPrefix = '@logto/connector-';
 
 type PackageMeta = { name: string; scope: string; version: string };
 
+// NPM registry text search returns too many irrelevant results 1000+.
+// Making it impossible to filter out all official connectors in one go.
+// So we added an additional `maintainer` filter to reduce the number of irrelevant results.
+const maintainer = 'gaosun';
+
 export const fetchOfficialConnectorList = async (includingCloudConnectors = false) => {
   // See https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md#get-v1search
   type FetchResult = {
@@ -156,7 +161,7 @@ export const fetchOfficialConnectorList = async (includingCloudConnectors = fals
 
   const fetchList = async (from = 0, size = 20) => {
     const parameters = new URLSearchParams({
-      text: officialConnectorPrefix,
+      text: `${officialConnectorPrefix} maintainer:${maintainer}`,
       from: String(from),
       size: String(size),
     });
@@ -188,7 +193,7 @@ export const fetchOfficialConnectorList = async (includingCloudConnectors = fals
     // eslint-disable-next-line @silverhand/fp/no-mutating-methods
     packages.push(...objects.map(({ package: data }) => data));
 
-    if (objects.length < 20) {
+    if (rawObjects.length < 20) {
       break;
     }
   }


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix add official connectors cli command missing connectors bug.

1. Fix the loop-breaking logic bug. 
2. Add additional `maintainer` query logic to reduce the number of irrelevant results. Otherwise, there will be 1000+ results returned from the npm repository. 



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally
<img width="464" alt="image" src="https://github.com/user-attachments/assets/bac53758-7a26-48b7-b555-51fe1dccc3d3" />


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
