### PR TITLE
feat(core): add get email-templates api

### DIFF
--- a/packages/core/src/routes/email-template/index.openapi.json
+++ b/packages/core/src/routes/email-template/index.openapi.json
@@ -23,7 +23,7 @@
                     "items": {
                       "properties": {
                         "languageTag": {
-                          "description": "The language tag of the email template, e.g., `en` or `zh-CN`."
+                          "description": "The language tag of the email template, e.g., `en` or `fr`."
                         },
                         "templateType": {
                           "description": "The type of the email template, e.g. `SignIn` or `ForgotPassword`"
@@ -61,6 +61,27 @@
             "description": "The list of newly created or replaced email templates."
           }
         }
+      },
+      "get": {
+        "summary": "Get email templates",
+        "description": "Get the list of email templates.",
+        "parameters": [
+          {
+            "name": "languageTag",
+            "in": "query",
+            "description": "The language tag of the email template, e.g., `en` or `fr`."
+          },
+          {
+            "name": "templateType",
+            "in": "query",
+            "description": "The type of the email template, e.g. `SignIn` or `ForgotPassword`"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The list of matched email templates. Returns empty list, if no email template is found."
+          }
+        }
       }
     },
     "/api/email-templates/{id}": {
@@ -70,6 +91,18 @@
         "responses": {
           "204": {
             "description": "The email template was deleted successfully."
+          },
+          "404": {
+            "description": "The email template was not found."
+          }
+        }
+      },
+      "get": {
+        "summary": "Get email template by ID",
+        "description": "Get the email template by its ID.",
+        "responses": {
+          "200": {
+            "description": "The email template."
           },
           "404": {
             "description": "The email template was not found."

--- a/packages/core/src/routes/email-template/index.ts
+++ b/packages/core/src/routes/email-template/index.ts
@@ -31,14 +31,49 @@ export default function emailTemplateRoutes<T extends ManagementApiRouter>(
     }),
     async (ctx, next) => {
       const { body } = ctx.guard;
-
       ctx.body = await emailTemplatesQueries.upsertMany(
         body.templates.map((template) => ({
           id: generateStandardId(),
           ...template,
         }))
       );
+      return next();
+    }
+  );
 
+  router.get(
+    pathPrefix,
+    koaGuard({
+      query: EmailTemplates.guard
+        .pick({
+          languageTag: true,
+          templateType: true,
+        })
+        .partial(),
+      response: EmailTemplates.guard.array(),
+      status: [200],
+    }),
+    async (ctx, next) => {
+      const { query } = ctx.guard;
+      ctx.body = await emailTemplatesQueries.findAllWhere(query);
+      return next();
+    }
+  );
+
+  router.get(
+    `${pathPrefix}/:id`,
+    koaGuard({
+      params: z.object({
+        id: z.string(),
+      }),
+      response: EmailTemplates.guard,
+      status: [200, 404],
+    }),
+    async (ctx, next) => {
+      const {
+        params: { id },
+      } = ctx.guard;
+      ctx.body = await emailTemplatesQueries.findById(id);
       return next();
     }
   );

--- a/packages/integration-tests/src/api/email-templates.ts
+++ b/packages/integration-tests/src/api/email-templates.ts
@@ -12,4 +12,14 @@ export class EmailTemplatesApi {
   async delete(id: string): Promise<void> {
     await authedAdminApi.delete(`${path}/${id}`);
   }
+
+  async findById(id: string): Promise<EmailTemplate> {
+    return authedAdminApi.get(`${path}/${id}`).json<EmailTemplate>();
+  }
+
+  async findAll(
+    where?: Partial<Pick<EmailTemplate, 'languageTag' | 'templateType'>>
+  ): Promise<EmailTemplate[]> {
+    return authedAdminApi.get(path, { searchParams: where }).json<EmailTemplate[]>();
+  }
 }

--- a/packages/integration-tests/src/tests/api/email-templates.test.ts
+++ b/packages/integration-tests/src/tests/api/email-templates.test.ts
@@ -1,5 +1,8 @@
+import { TemplateType } from '@logto/connector-kit';
+
 import { mockEmailTemplates } from '#src/__mocks__/email-templates.js';
 import { EmailTemplatesApiTest } from '#src/helpers/email-templates.js';
+import { expectRejects } from '#src/helpers/index.js';
 import { devFeatureTest } from '#src/utils.js';
 
 devFeatureTest.describe('email templates', () => {
@@ -34,5 +37,47 @@ devFeatureTest.describe('email templates', () => {
       expect(template.details.subject).toBe(updatedTemplates[index]!.details.subject);
       expect(template.details.content).toBe(updatedTemplates[index]!.details.content);
     }
+  });
+
+  it('should get email templates with query search successfully', async () => {
+    await emailTemplatesApi.create(mockEmailTemplates);
+
+    const templates = await emailTemplatesApi.findAll();
+    expect(templates).toHaveLength(3);
+
+    for (const mockTemplate of mockEmailTemplates) {
+      const template = templates.find(
+        ({ languageTag, templateType }) =>
+          languageTag === mockTemplate.languageTag && templateType === mockTemplate.templateType
+      );
+
+      expect(template).toBeDefined();
+      expect(template!.details).toEqual(mockTemplate.details);
+    }
+
+    // Search by language tag
+    const enTemplates = await emailTemplatesApi.findAll({ languageTag: 'en' });
+    expect(enTemplates).toHaveLength(
+      mockEmailTemplates.filter(({ languageTag }) => languageTag === 'en').length
+    );
+
+    // Search by template type
+    const signInTemplates = await emailTemplatesApi.findAll({ templateType: TemplateType.SignIn });
+    expect(signInTemplates).toHaveLength(
+      mockEmailTemplates.filter(({ templateType }) => templateType === TemplateType.SignIn).length
+    );
+  });
+
+  it('should get email template by ID successfully', async () => {
+    const [template] = await emailTemplatesApi.create(mockEmailTemplates);
+    const found = await emailTemplatesApi.findById(template!.id);
+    expect(found).toEqual(template);
+  });
+
+  it('should throw 404 error when email template not found by ID', async () => {
+    await expectRejects(emailTemplatesApi.findById('invalid-id'), {
+      code: 'entity.not_exists_with_id',
+      status: 404,
+    });
   });
 });


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Implement the email templates GET endpoints:

- `GET /api/email-templates`: Get all email templates.  `languageTag` and `templateType` filters are supported. 
- `GET /api/email-tempaltes/:id`: Get the email template by ID.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Integration test added

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
