### PR TITLE
feat(core): add update email template details api

### DIFF
--- a/packages/core/src/routes/email-template/index.openapi.json
+++ b/packages/core/src/routes/email-template/index.openapi.json
@@ -109,6 +109,45 @@
           }
         }
       }
+    },
+    "/api/email-templates/{id}/details": {
+      "patch": {
+        "summary": "Update email template details",
+        "description": "Update the details of an email template by its ID.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "subject": {
+                    "description": "The template of the email subject."
+                  },
+                  "content": {
+                    "description": "The template of the email body."
+                  },
+                  "contentType": {
+                    "description": "The content type of the email body. (Only required by some specific email providers.)"
+                  },
+                  "replyTo": {
+                    "description": "The reply name template of the email. If not provided, the target email address will be used. (The render logic may differ based on the email provider.)"
+                  },
+                  "sendFrom": {
+                    "description": "The send from name template of the email. If not provided, the default Logto email address will be used. (The render logic may differ based on the email provider.)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The updated email template."
+          },
+          "404": {
+            "description": "The email template was not found."
+          }
+        }
+      }
     }
   }
 }

--- a/packages/core/src/routes/email-template/index.ts
+++ b/packages/core/src/routes/email-template/index.ts
@@ -1,4 +1,4 @@
-import { EmailTemplates } from '@logto/schemas';
+import { emailTemplateDetailsGuard, EmailTemplates } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 import { z } from 'zod';
 
@@ -74,6 +74,35 @@ export default function emailTemplateRoutes<T extends ManagementApiRouter>(
         params: { id },
       } = ctx.guard;
       ctx.body = await emailTemplatesQueries.findById(id);
+      return next();
+    }
+  );
+
+  router.patch(
+    `${pathPrefix}/:id/details`,
+    koaGuard({
+      params: z.object({
+        id: z.string(),
+      }),
+      body: emailTemplateDetailsGuard.partial(),
+      response: EmailTemplates.guard,
+      status: [200, 404],
+    }),
+    async (ctx, next) => {
+      const {
+        params: { id },
+        body,
+      } = ctx.guard;
+
+      const { details } = await emailTemplatesQueries.findById(id);
+
+      ctx.body = await emailTemplatesQueries.updateById(id, {
+        details: {
+          ...details,
+          ...body,
+        },
+      });
+
       return next();
     }
   );

--- a/packages/integration-tests/src/api/email-templates.ts
+++ b/packages/integration-tests/src/api/email-templates.ts
@@ -1,4 +1,8 @@
-import { type CreateEmailTemplate, type EmailTemplate } from '@logto/schemas';
+import {
+  type EmailTemplateDetails,
+  type CreateEmailTemplate,
+  type EmailTemplate,
+} from '@logto/schemas';
 
 import { authedAdminApi } from './index.js';
 
@@ -21,5 +25,12 @@ export class EmailTemplatesApi {
     where?: Partial<Pick<EmailTemplate, 'languageTag' | 'templateType'>>
   ): Promise<EmailTemplate[]> {
     return authedAdminApi.get(path, { searchParams: where }).json<EmailTemplate[]>();
+  }
+
+  async updateTemplateDetailsById(
+    id: string,
+    details: Partial<EmailTemplateDetails>
+  ): Promise<EmailTemplate> {
+    return authedAdminApi.patch(`${path}/${id}/details`, { json: details }).json<EmailTemplate>();
   }
 }

--- a/packages/integration-tests/src/tests/api/email-templates.test.ts
+++ b/packages/integration-tests/src/tests/api/email-templates.test.ts
@@ -1,4 +1,5 @@
 import { TemplateType } from '@logto/connector-kit';
+import { type EmailTemplateDetails } from '@logto/schemas';
 
 import { mockEmailTemplates } from '#src/__mocks__/email-templates.js';
 import { EmailTemplatesApiTest } from '#src/helpers/email-templates.js';
@@ -76,6 +77,25 @@ devFeatureTest.describe('email templates', () => {
 
   it('should throw 404 error when email template not found by ID', async () => {
     await expectRejects(emailTemplatesApi.findById('invalid-id'), {
+      code: 'entity.not_exists_with_id',
+      status: 404,
+    });
+  });
+
+  it('should partially update email template details by ID successfully', async () => {
+    const [template] = await emailTemplatesApi.create(mockEmailTemplates);
+
+    const updatedDetails: Partial<EmailTemplateDetails> = {
+      subject: `${template!.details.subject} updated`,
+      replyTo: 'logto test',
+    };
+
+    const updated = await emailTemplatesApi.updateTemplateDetailsById(template!.id, updatedDetails);
+    expect(updated.details).toEqual({ ...template!.details, ...updatedDetails });
+  });
+
+  it('should throw 404 when trying to partially update email template details by invalid ID', async () => {
+    await expectRejects(emailTemplatesApi.updateTemplateDetailsById('invalid-id', {}), {
       code: 'entity.not_exists_with_id',
       status: 404,
     });


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add update email template details API. `PATCH /api/email-templates/:id/details`.

This API allows for the partial update of an email template's details using its template ID for convenience.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
integration test added. 

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
