### PR TITLE
feat(core): delete email template by langaugeTag or templateType

### DIFF
--- a/packages/core/src/queries/email-templates.ts
+++ b/packages/core/src/queries/email-templates.ts
@@ -86,4 +86,28 @@ export default class EmailTemplatesQueries extends SchemaQueries<
     `)
     );
   }
+
+  /**
+   * Delete multiple email templates by language tag and template type
+   *
+   * @param where - Where clause to filter email templates by language tag and template type
+   * @param where.languageTag - The language tag of the email template
+   * @param where.templateType - The type of the email template
+   */
+  async deleteMany(
+    where: Partial<Pick<EmailTemplate, 'languageTag' | 'templateType'>>
+  ): Promise<{ rowCount: number }> {
+    const { fields, table } = convertToIdentifiers(EmailTemplates);
+
+    return this.pool.query(sql`
+      delete from ${table}
+      where ${sql.join(
+        Object.entries(where).map(
+          // eslint-disable-next-line no-restricted-syntax -- Object.entries can not infer the key type properly.
+          ([key, value]) => sql`${fields[key as keyof EmailTemplate]} = ${value}`
+        ),
+        sql` and `
+      )}
+    `);
+  }
 }

--- a/packages/core/src/routes/email-template/index.openapi.json
+++ b/packages/core/src/routes/email-template/index.openapi.json
@@ -148,6 +148,66 @@
           }
         }
       }
+    },
+    "/api/email-templates/language-tag/{languageTag}": {
+      "delete": {
+        "summary": "Delete email templates by language tag",
+        "description": "Delete all email templates by the language tag.",
+        "parameters": [
+          {
+            "name": "languageTag",
+            "description": "The language tag of the email template, e.g., `en` or `fr`."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The email templates were deleted successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "rowCount": {
+                      "type": "number",
+                      "description": "The number of email templates deleted."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/email-templates/template-type/{templateType}": {
+      "delete": {
+        "summary": "Delete email templates by template type",
+        "description": "Delete all email templates by the template type.",
+        "parameters": [
+          {
+            "name": "templateType",
+            "description": "The type of the email template, e.g. `SignIn` or `ForgotPassword`"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The email templates were deleted successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "rowCount": {
+                      "type": "number",
+                      "description": "The number of email templates deleted."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/packages/core/src/routes/email-template/index.openapi.json
+++ b/packages/core/src/routes/email-template/index.openapi.json
@@ -156,6 +156,7 @@
         "parameters": [
           {
             "name": "languageTag",
+            "in": "path",
             "description": "The language tag of the email template, e.g., `en` or `fr`."
           }
         ],
@@ -186,6 +187,7 @@
         "parameters": [
           {
             "name": "templateType",
+            "in": "path",
             "description": "The type of the email template, e.g. `SignIn` or `ForgotPassword`"
           }
         ],

--- a/packages/core/src/routes/email-template/index.ts
+++ b/packages/core/src/routes/email-template/index.ts
@@ -125,4 +125,45 @@ export default function emailTemplateRoutes<T extends ManagementApiRouter>(
       return next();
     }
   );
+
+  router.delete(
+    `${pathPrefix}/language-tag/:languageTag`,
+    koaGuard({
+      params: z.object({
+        languageTag: z.string(),
+      }),
+      status: [200],
+      response: z.object({
+        rowCount: z.number(),
+      }),
+    }),
+    async (ctx, next) => {
+      const {
+        params: { languageTag },
+      } = ctx.guard;
+      ctx.body = await emailTemplatesQueries.deleteMany({ languageTag });
+      return next();
+    }
+  );
+
+  router.delete(
+    `${pathPrefix}/template-type/:templateType`,
+    koaGuard({
+      params: EmailTemplates.guard.pick({
+        templateType: true,
+      }),
+      status: [200],
+      response: z.object({
+        rowCount: z.number(),
+      }),
+    }),
+    async (ctx, next) => {
+      const {
+        params: { templateType },
+      } = ctx.guard;
+
+      ctx.body = await emailTemplatesQueries.deleteMany({ templateType });
+      return next();
+    }
+  );
 }

--- a/packages/core/src/routes/swagger/utils/operation-id.ts
+++ b/packages/core/src/routes/swagger/utils/operation-id.ts
@@ -27,7 +27,11 @@ const methodToVerb = Object.freeze({
 
 type RouteDictionary = Record<`${OpenAPIV3.HttpMethods} ${string}`, string>;
 
-const devFeatureCustomRoutes: RouteDictionary = Object.freeze({});
+const devFeatureCustomRoutes: RouteDictionary = Object.freeze({
+  // TODO: move to the bellow list once the feature is published
+  'delete /email-templates/language-tag/:languageTag': 'DeleteAllEmailTemplatesByLanguageTag',
+  'delete /email-templates/template-type/:templateType': 'DeleteAllEmailTemplatesByTemplateType',
+});
 
 export const customRoutes: Readonly<RouteDictionary> = Object.freeze({
   // Authn

--- a/packages/integration-tests/src/api/email-templates.ts
+++ b/packages/integration-tests/src/api/email-templates.ts
@@ -2,6 +2,7 @@ import {
   type EmailTemplateDetails,
   type CreateEmailTemplate,
   type EmailTemplate,
+  type TemplateType,
 } from '@logto/schemas';
 
 import { authedAdminApi } from './index.js';
@@ -32,5 +33,17 @@ export class EmailTemplatesApi {
     details: Partial<EmailTemplateDetails>
   ): Promise<EmailTemplate> {
     return authedAdminApi.patch(`${path}/${id}/details`, { json: details }).json<EmailTemplate>();
+  }
+
+  async deleteAllByLanguageTag(languageTag: string): Promise<{ rowCount: number }> {
+    return authedAdminApi
+      .delete(`${path}/language-tag/${languageTag}`)
+      .json<{ rowCount: number }>();
+  }
+
+  async deleteAllByTemplateType(templateType: TemplateType): Promise<{ rowCount: number }> {
+    return authedAdminApi
+      .delete(`${path}/template-type/${templateType}`)
+      .json<{ rowCount: number }>();
   }
 }

--- a/packages/integration-tests/src/tests/api/email-templates.test.ts
+++ b/packages/integration-tests/src/tests/api/email-templates.test.ts
@@ -100,4 +100,30 @@ devFeatureTest.describe('email templates', () => {
       status: 404,
     });
   });
+
+  it('should delete email templates by language tag successfully', async () => {
+    const templates = await emailTemplatesApi.create(mockEmailTemplates);
+
+    const { rowCount } = await emailTemplatesApi.deleteAllByLanguageTag('en');
+    expect(rowCount).toBe(templates.filter(({ languageTag }) => languageTag === 'en').length);
+
+    const remaining = await emailTemplatesApi.findAll({
+      languageTag: 'en',
+    });
+    expect(remaining).toHaveLength(0);
+  });
+
+  it('should delete email templates by template type successfully', async () => {
+    const templates = await emailTemplatesApi.create(mockEmailTemplates);
+
+    const { rowCount } = await emailTemplatesApi.deleteAllByTemplateType(TemplateType.SignIn);
+    expect(rowCount).toBe(
+      templates.filter(({ templateType }) => templateType === TemplateType.SignIn).length
+    );
+
+    const remaining = await emailTemplatesApi.findAll({
+      templateType: TemplateType.SignIn,
+    });
+    expect(remaining).toHaveLength(0);
+  });
 });


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add APIs to delete multiple email templates by `languageTag` or `templateType`:

- `DELETE /api/email-templates/language-tag/:languageTag`
- `DELETE /api/email-templates/template-type/:templaetType`

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
integration tests added

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
