### PR TITLE
refactor(core): redesign email templates bulk delete API

### DIFF
--- a/packages/core/src/routes/email-template/index.openapi.json
+++ b/packages/core/src/routes/email-template/index.openapi.json
@@ -82,6 +82,43 @@
             "description": "The list of matched email templates. Returns empty list, if no email template is found."
           }
         }
+      },
+      "delete": {
+        "summary": "Delete email templates",
+        "description": "Bulk delete email templates by their language tag and template type.",
+        "parameters": [
+          {
+            "name": "languageTag",
+            "in": "query",
+            "description": "The language tag of the email template, e.g., `en` or `fr`."
+          },
+          {
+            "name": "templateType",
+            "in": "query",
+            "description": "The type of the email template, e.g. `SignIn` or `ForgotPassword`"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The email templates were deleted successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "rowCount": {
+                      "type": "number",
+                      "description": "The number of email templates deleted."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "No filter query parameters were provided. This bulk deletion API requires at least one filter query parameter."
+          }
+        }
       }
     },
     "/api/email-templates/{id}": {
@@ -145,68 +182,6 @@
           },
           "404": {
             "description": "The email template was not found."
-          }
-        }
-      }
-    },
-    "/api/email-templates/language-tag/{languageTag}": {
-      "delete": {
-        "summary": "Delete email templates by language tag",
-        "description": "Delete all email templates by the language tag.",
-        "parameters": [
-          {
-            "name": "languageTag",
-            "in": "path",
-            "description": "The language tag of the email template, e.g., `en` or `fr`."
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The email templates were deleted successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "rowCount": {
-                      "type": "number",
-                      "description": "The number of email templates deleted."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/email-templates/template-type/{templateType}": {
-      "delete": {
-        "summary": "Delete email templates by template type",
-        "description": "Delete all email templates by the template type.",
-        "parameters": [
-          {
-            "name": "templateType",
-            "in": "path",
-            "description": "The type of the email template, e.g. `SignIn` or `ForgotPassword`"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The email templates were deleted successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "rowCount": {
-                      "type": "number",
-                      "description": "The number of email templates deleted."
-                    }
-                  }
-                }
-              }
-            }
           }
         }
       }

--- a/packages/core/src/routes/email-template/index.ts
+++ b/packages/core/src/routes/email-template/index.ts
@@ -149,6 +149,7 @@ export default function emailTemplateRoutes<T extends ManagementApiRouter>(
         query.languageTag ?? query.templateType,
         new RequestError({
           code: 'connector.email_connector.bulk_deletion_no_filter',
+          properties: ['languageTag', 'templateType'],
           status: 422,
         })
       );

--- a/packages/core/src/routes/swagger/utils/operation-id.ts
+++ b/packages/core/src/routes/swagger/utils/operation-id.ts
@@ -27,11 +27,7 @@ const methodToVerb = Object.freeze({
 
 type RouteDictionary = Record<`${OpenAPIV3.HttpMethods} ${string}`, string>;
 
-const devFeatureCustomRoutes: RouteDictionary = Object.freeze({
-  // TODO: move to the bellow list once the feature is published
-  'delete /email-templates/language-tag/:languageTag': 'DeleteAllEmailTemplatesByLanguageTag',
-  'delete /email-templates/template-type/:templateType': 'DeleteAllEmailTemplatesByTemplateType',
-});
+const devFeatureCustomRoutes: RouteDictionary = Object.freeze({});
 
 export const customRoutes: Readonly<RouteDictionary> = Object.freeze({
   // Authn

--- a/packages/integration-tests/src/api/email-templates.ts
+++ b/packages/integration-tests/src/api/email-templates.ts
@@ -2,7 +2,6 @@ import {
   type EmailTemplateDetails,
   type CreateEmailTemplate,
   type EmailTemplate,
-  type TemplateType,
 } from '@logto/schemas';
 
 import { authedAdminApi } from './index.js';
@@ -35,15 +34,9 @@ export class EmailTemplatesApi {
     return authedAdminApi.patch(`${path}/${id}/details`, { json: details }).json<EmailTemplate>();
   }
 
-  async deleteAllByLanguageTag(languageTag: string): Promise<{ rowCount: number }> {
-    return authedAdminApi
-      .delete(`${path}/language-tag/${languageTag}`)
-      .json<{ rowCount: number }>();
-  }
-
-  async deleteAllByTemplateType(templateType: TemplateType): Promise<{ rowCount: number }> {
-    return authedAdminApi
-      .delete(`${path}/template-type/${templateType}`)
-      .json<{ rowCount: number }>();
+  async deleteMany(
+    where: Partial<Pick<EmailTemplate, 'languageTag' | 'templateType'>>
+  ): Promise<{ rowCount: number }> {
+    return authedAdminApi.delete(path, { searchParams: where }).json<{ rowCount: number }>();
   }
 }

--- a/packages/integration-tests/src/tests/api/email-templates.test.ts
+++ b/packages/integration-tests/src/tests/api/email-templates.test.ts
@@ -101,29 +101,51 @@ devFeatureTest.describe('email templates', () => {
     });
   });
 
-  it('should delete email templates by language tag successfully', async () => {
+  it('should delete email templates by languageTag successfully', async () => {
     const templates = await emailTemplatesApi.create(mockEmailTemplates);
-
-    const { rowCount } = await emailTemplatesApi.deleteAllByLanguageTag('en');
+    const { rowCount } = await emailTemplatesApi.deleteMany({
+      languageTag: 'en',
+    });
     expect(rowCount).toBe(templates.filter(({ languageTag }) => languageTag === 'en').length);
-
     const remaining = await emailTemplatesApi.findAll({
       languageTag: 'en',
     });
     expect(remaining).toHaveLength(0);
   });
 
-  it('should delete email templates by template type successfully', async () => {
+  it('should delete email templates by templateType successfully', async () => {
     const templates = await emailTemplatesApi.create(mockEmailTemplates);
-
-    const { rowCount } = await emailTemplatesApi.deleteAllByTemplateType(TemplateType.SignIn);
+    const { rowCount } = await emailTemplatesApi.deleteMany({
+      templateType: TemplateType.SignIn,
+    });
     expect(rowCount).toBe(
       templates.filter(({ templateType }) => templateType === TemplateType.SignIn).length
     );
-
     const remaining = await emailTemplatesApi.findAll({
       templateType: TemplateType.SignIn,
     });
     expect(remaining).toHaveLength(0);
+  });
+
+  it('should delete email template by languageTag and templateType', async () => {
+    const templates = await emailTemplatesApi.create(mockEmailTemplates);
+    const { rowCount } = await emailTemplatesApi.deleteMany({
+      languageTag: 'en',
+      templateType: TemplateType.SignIn,
+    });
+
+    expect(rowCount).toBe(
+      templates.filter(
+        ({ languageTag, templateType }) =>
+          languageTag === 'en' && templateType === TemplateType.SignIn
+      ).length
+    );
+  });
+
+  it('should throw 422 when trying to delete email templates without filter', async () => {
+    await expectRejects(emailTemplatesApi.deleteMany({}), {
+      code: 'connector.email_connector.bulk_deletion_no_filter',
+      status: 422,
+    });
   });
 });

--- a/packages/phrases/src/locales/en/errors/connector.ts
+++ b/packages/phrases/src/locales/en/errors/connector.ts
@@ -35,6 +35,10 @@ const connector = {
     'You can not have multiple social connectors that have same target and platform.',
   cannot_overwrite_metadata_for_non_standard_connector:
     "This connector's 'metadata' cannot be overwritten.",
+  email_connector: {
+    bulk_deletion_no_filter:
+      'At least one filter condition must be provided to perform bulk deletion by properties. Supported properties are: {{properties, list(type:conjunction)}}.',
+  },
 };
 
 export default Object.freeze(connector);


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Redesign email templates bulk delete API.

Remove the following API:
- `DELETE /api/email-templates/language-tag/:languageTag`
- `DELETE /api/email-templates/template-type/:templateType`

Replaced with:
- `DELETE /api/email-templates?languageTag=en`
- `DELETE /api/email-templates?templateType=SignIn`

Using query parameters instead of path parameters in the build deletion API, for the following reasons:

1. Query parameters are more flexible.
2. Reduce the number of API definitions.
3. Better align with our API design, as the path parameter with case-sensitive value does not follow our API path convention. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
integration test updated

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
