### PR TITLE
fix(experience): filter wechat connectors by platform

### DIFF
--- a/.changeset/pink-roses-confess.md
+++ b/.changeset/pink-roses-confess.md
@@ -3,7 +3,7 @@
 "@logto/experience": patch
 ---
 
-fix(experience): properly filter WeChat connectors by platform (Web | Native) in SSR sign-in experience settings
+properly filter WeChat connectors by platform (Web | Native) in SSR sign-in experience settings
 
 Previously, platform-based social connector filtering was applied during the sign-in experience settings fetch process but not in the SSR sign-in experience data. As a result, platform-specific connectors were not correctly filtered when rendering the page using SSR data.
 

--- a/.changeset/pink-roses-confess.md
+++ b/.changeset/pink-roses-confess.md
@@ -1,0 +1,12 @@
+---
+"@logto/experience-legacy": patch
+"@logto/experience": patch
+---
+
+fix(experience): properly filter WeChat connectors by platform (Web | Native) in SSR sign-in experience settings
+
+Previously, platform-based social connector filtering was applied during the sign-in experience settings fetch process but not in the SSR sign-in experience data. As a result, platform-specific connectors were not correctly filtered when rendering the page using SSR data.
+
+This update ensures that the same filtering logic is applied to SSR sign-in experience data, resolving the issue.
+
+Affected connectors: WeChat Web and WeChat Native.

--- a/.changeset/rotten-bugs-pretend.md
+++ b/.changeset/rotten-bugs-pretend.md
@@ -2,7 +2,7 @@
 "@logto/cli": patch
 ---
 
-fix(cli): fix cli add offical connectors command missing connectors bug
+fix cli add offical connectors command missing connectors bug
 
 Fix the bug when running the cli commend `logto connectors add --official`, only 8 connectors are fetched from npm registry.
 This fix update logic to query additional pages of results when fetching connectors from the npm registry.

--- a/packages/experience-legacy/src/utils/sign-in-experience.ts
+++ b/packages/experience-legacy/src/utils/sign-in-experience.ts
@@ -35,7 +35,7 @@ export const getSignInExperienceSettings = async (): Promise<SignInExperienceRes
         return (!ssrValue && !storageValue) || ssrValue === storageValue;
       })
     ) {
-      return data;
+      return parseSignInExperienceResponse(data);
     }
   }
   const response = await getSignInExperience<SignInExperienceResponse>();

--- a/packages/experience/src/utils/sign-in-experience.ts
+++ b/packages/experience/src/utils/sign-in-experience.ts
@@ -35,9 +35,10 @@ export const getSignInExperienceSettings = async (): Promise<SignInExperienceRes
         return (!ssrValue && !storageValue) || ssrValue === storageValue;
       })
     ) {
-      return data;
+      return parseSignInExperienceResponse(data);
     }
   }
+
   const response = await getSignInExperience<SignInExperienceResponse>();
   return parseSignInExperienceResponse(response);
 };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Previously, platform-based social connector filtering was applied during the sign-in experience settings fetch process but not in the SSR sign-in experience data. As a result, platform-specific connectors were not correctly filtered when rendering the page using SSR data.

This update ensures that the same filtering logic is applied to SSR sign-in experience data, resolving the issue.

Affected connectors: WeChat Web and WeChat Native.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
