### PR TITLE
fix(console): add missing `/api` segment in SAML app SSO URL

### DIFF
--- a/.changeset/gentle-rabbits-chew.md
+++ b/.changeset/gentle-rabbits-chew.md
@@ -1,0 +1,5 @@
+---
+"@logto/console": patch
+---
+
+add missing `/api` segment in SAML application Single-sign-on service URL

--- a/packages/console/src/pages/ApplicationDetails/SamlApplicationDetailsContent/Settings.tsx
+++ b/packages/console/src/pages/ApplicationDetails/SamlApplicationDetailsContent/Settings.tsx
@@ -253,6 +253,7 @@ function Settings({ data, mutateApplication, isDeleted }: Props) {
                   value={applyCustomDomain(
                     appendPath(
                       tenantEndpoint,
+                      '/api',
                       samlApplicationEndpointPrefix,
                       data.id,
                       samlApplicationSingleSignOnEndpointSuffix


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
add missing `/api` segment in SAML app SSO URL.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally.
![image](https://github.com/user-attachments/assets/eaad1244-938a-4f7c-a7f8-2d12f84d3dd7)

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
