### PR TITLE
fix(core): prevent i18n context contamination by using request-scoped instance

### DIFF
--- a/.changeset/rare-readers-cry.md
+++ b/.changeset/rare-readers-cry.md
@@ -1,0 +1,22 @@
+---
+"@logto/core": patch
+---
+
+prevent i18n context contamination by using request-scoped instances
+
+This bug fix resolves a concurrency issue in i18n handling by moving from a global i18next instance to request-scoped instances.
+
+Problem:
+When handling concurrent requests:
+
+- The shared global `i18next` instance's language was being modified via `changeLanguage()` calls.
+- This could lead to race conditions where requests might receive translations in unexpected languages.
+- Particularly problematic in multi-tenant environments with different language requirements.
+
+Solution:
+
+- Updated `koaI18next` middleware to create a cloned i18next instance for each request.
+
+- Attach the request-scoped instance to Koa context (`ctx.i18n`) All subsequent middleware and handlers should now use `ctx.i18n` instead of the global `i18next` instance.
+
+- Maintains the global instance for initialization while preventing cross-request contamination

--- a/.changeset/rare-readers-cry.md
+++ b/.changeset/rare-readers-cry.md
@@ -6,17 +6,16 @@ prevent i18n context contamination by using request-scoped instances
 
 This bug fix resolves a concurrency issue in i18n handling by moving from a global i18next instance to request-scoped instances.
 
-Problem:
+### Problem
+
 When handling concurrent requests:
 
 - The shared global `i18next` instance's language was being modified via `changeLanguage()` calls.
 - This could lead to race conditions where requests might receive translations in unexpected languages.
 - Particularly problematic in multi-tenant environments with different language requirements.
 
-Solution:
+### Solution
 
 - Updated `koaI18next` middleware to create a cloned i18next instance for each request.
-
 - Attach the request-scoped instance to Koa context (`ctx.i18n`) All subsequent middleware and handlers should now use `ctx.i18n` instead of the global `i18next` instance.
-
 - Maintains the global instance for initialization while preventing cross-request contamination

--- a/packages/core/src/errors/RequestError/index.ts
+++ b/packages/core/src/errors/RequestError/index.ts
@@ -22,8 +22,7 @@ export default class RequestError extends Error {
    *
    * @remarks
    * This message is intended for server-side logging only.
-   * For client-facing messages, use the @see toBody method which provides proper language translation.
-   * @override
+   * For client-facing messages, use the {@link toBody} method which provides proper language translation.
    */
   declare message: string;
 
@@ -70,6 +69,10 @@ export default class RequestError extends Error {
 
   /**
    * Parse the error message with i18n context
+   *
+   * @remarks
+   * This method is intended for client-facing error responses.
+   * For server-side log entries use the {@link RequestError.message} property instead.
    */
   toBody(i18next: i18n): RequestErrorBody {
     const message = i18next.t<string, LogtoErrorI18nKey>(`errors:${this.code}`, {

--- a/packages/core/src/errors/RequestError/index.ts
+++ b/packages/core/src/errors/RequestError/index.ts
@@ -17,6 +17,16 @@ export const formatZodError = ({ issues }: ZodError): string[] =>
   });
 
 export default class RequestError extends Error {
+  /**
+   * Error message generated using i18n with default language (en).
+   *
+   * @remarks
+   * This message is intended for server-side logging only.
+   * For client-facing messages, use the @see toBody method which provides proper language translation.
+   * @override
+   */
+  declare message: string;
+
   code: LogtoErrorCode;
   status: number;
   expose: boolean;
@@ -32,14 +42,6 @@ export default class RequestError extends Error {
       ...interpolation
     } = typeof input === 'string' ? { code: input } : input;
 
-    /**
-     * For the error log use only.
-     *
-     * @remarks
-     * This error message in constructor uses the global i18n instance to get the user-friendly message in the error log.
-     * It will always use the default language (en) to get the message.
-     * For client-facing error response, use the  @see toBody  method to get the error message translated to the user's language.
-     */
     const message = i18next.t<string, LogtoErrorI18nKey>(`errors:${code}`, {
       ...interpolation,
       interpolation: {
@@ -70,18 +72,16 @@ export default class RequestError extends Error {
    * Parse the error message with i18n context
    */
   toBody(i18next: i18n): RequestErrorBody {
-    return {
-      ...pick(this, 'code', 'data', 'details'),
-      message: this.#getI18nErrorMessage(i18next),
-    };
-  }
-
-  #getI18nErrorMessage(i18next: i18n): string {
-    return i18next.t<string, LogtoErrorI18nKey>(`errors:${this.code}`, {
+    const message = i18next.t<string, LogtoErrorI18nKey>(`errors:${this.code}`, {
       ...this.#i18nInterpolation,
       interpolation: {
         escapeValue: false,
       },
     });
+
+    return {
+      ...pick(this, 'code', 'data', 'details'),
+      message,
+    };
   }
 }

--- a/packages/core/src/errors/RequestError/index.ts
+++ b/packages/core/src/errors/RequestError/index.ts
@@ -32,6 +32,14 @@ export default class RequestError extends Error {
       ...interpolation
     } = typeof input === 'string' ? { code: input } : input;
 
+    /**
+     * For the error log use only.
+     *
+     * @remarks
+     * This error message in constructor uses the global i18n instance to get the user-friendly message in the error log.
+     * It will always use the default language (en) to get the message.
+     * For client-facing error response, use the  @see toBody  method to get the error message translated to the user's language.
+     */
     const message = i18next.t<string, LogtoErrorI18nKey>(`errors:${code}`, {
       ...interpolation,
       interpolation: {
@@ -59,7 +67,7 @@ export default class RequestError extends Error {
   }
 
   /**
-   * Parse the error body with i18n context
+   * Parse the error message with i18n context
    */
   toBody(i18next: i18n): RequestErrorBody {
     return {

--- a/packages/core/src/errors/RequestError/index.ts
+++ b/packages/core/src/errors/RequestError/index.ts
@@ -68,7 +68,7 @@ export default class RequestError extends Error {
   }
 
   /**
-   * Parse the error message with i18n context
+   * Parse the error into response body. An i18n context is required.
    *
    * @remarks
    * This method is intended for client-facing error responses.

--- a/packages/core/src/errors/RequestError/request-error.test.ts
+++ b/packages/core/src/errors/RequestError/request-error.test.ts
@@ -1,7 +1,7 @@
 import type { LogtoErrorI18nKey } from '@logto/phrases';
-import i18next, { type i18n } from 'i18next';
 
 import initI18n from '#src/i18n/init.js';
+import { i18next } from '#src/utils/i18n.js';
 
 import RequestError from './index.js';
 
@@ -21,7 +21,7 @@ describe('RequestError', () => {
     expect(newRequestError.code).toEqual(errorCode);
     expect(newRequestError.expose).toEqual(true);
     expect(newRequestError.message).toEqual(expectMessage);
-    expect(newRequestError.toBody(i18next as unknown as i18n)).toEqual({
+    expect(newRequestError.toBody(i18next)).toEqual({
       code: errorCode,
       data,
       message: expectMessage,
@@ -46,7 +46,7 @@ describe('RequestError', () => {
     expect(newRequestError.code).toEqual(errorCode);
     expect(newRequestError.expose).toEqual(false);
     expect(newRequestError.message).toEqual(expectMessage);
-    expect(newRequestError.toBody(i18next as unknown as i18n)).toEqual({
+    expect(newRequestError.toBody(i18next)).toEqual({
       code: errorCode,
       data,
       message: expectMessage,

--- a/packages/core/src/errors/RequestError/request-error.test.ts
+++ b/packages/core/src/errors/RequestError/request-error.test.ts
@@ -1,5 +1,5 @@
 import type { LogtoErrorI18nKey } from '@logto/phrases';
-import i18next from 'i18next';
+import i18next, { type i18n } from 'i18next';
 
 import initI18n from '#src/i18n/init.js';
 
@@ -21,7 +21,7 @@ describe('RequestError', () => {
     expect(newRequestError.code).toEqual(errorCode);
     expect(newRequestError.expose).toEqual(true);
     expect(newRequestError.message).toEqual(expectMessage);
-    expect(newRequestError.body).toEqual({
+    expect(newRequestError.toBody(i18next as unknown as i18n)).toEqual({
       code: errorCode,
       data,
       message: expectMessage,
@@ -46,7 +46,7 @@ describe('RequestError', () => {
     expect(newRequestError.code).toEqual(errorCode);
     expect(newRequestError.expose).toEqual(false);
     expect(newRequestError.message).toEqual(expectMessage);
-    expect(newRequestError.body).toEqual({
+    expect(newRequestError.toBody(i18next as unknown as i18n)).toEqual({
       code: errorCode,
       data,
       message: expectMessage,

--- a/packages/core/src/middleware/koa-error-handler.test.ts
+++ b/packages/core/src/middleware/koa-error-handler.test.ts
@@ -1,7 +1,9 @@
 import createError from 'http-errors';
 
 import RequestError from '#src/errors/RequestError/index.js';
-import createMockContext from '#src/test-utils/jest-koa-mocks/create-mock-context.js';
+import { i18next } from '#src/utils/i18n.js';
+
+import { createContextWithRouteParameters } from '../utils/test-utils.js';
 
 import koaErrorHandler from './koa-error-handler.js';
 
@@ -12,11 +14,15 @@ const httpError = createError(404, 'Not Found');
 describe('koaErrorHandler middleware', () => {
   const mockBody = { data: 'foo' };
 
-  const ctx = createMockContext({
-    customProperties: {
-      body: mockBody,
-    },
-  });
+  const ctx = {
+    ...createContextWithRouteParameters({
+      customProperties: {
+        body: mockBody,
+      },
+    }),
+    i18n: i18next,
+    locale: 'en',
+  };
 
   const next = jest.fn().mockReturnValue(Promise.resolve());
 
@@ -34,7 +40,7 @@ describe('koaErrorHandler middleware', () => {
     next.mockRejectedValueOnce(error);
     await koaErrorHandler()(ctx, next);
     expect(ctx.status).toEqual(error.status);
-    expect(ctx.body).toEqual(error.body);
+    expect(ctx.body).toEqual(error.toBody(ctx));
   });
 
   // Koa will handle `HttpError` with a built-in manner. Hence it needs to return 200 here.

--- a/packages/core/src/middleware/koa-error-handler.test.ts
+++ b/packages/core/src/middleware/koa-error-handler.test.ts
@@ -1,7 +1,6 @@
 import createError from 'http-errors';
 
 import RequestError from '#src/errors/RequestError/index.js';
-import { i18next } from '#src/utils/i18n.js';
 
 import { createContextWithRouteParameters } from '../utils/test-utils.js';
 
@@ -14,28 +13,17 @@ const httpError = createError(404, 'Not Found');
 describe('koaErrorHandler middleware', () => {
   const mockBody = { data: 'foo' };
 
-  const ctx = {
-    ...createContextWithRouteParameters({
-      customProperties: {
-        body: mockBody,
-      },
-    }),
-    i18n: i18next,
-    locale: 'en',
-  };
-
   const next = jest.fn().mockReturnValue(Promise.resolve());
-
-  beforeEach(() => {
-    ctx.body = mockBody;
-    ctx.status = 200;
-  });
-
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   it('expect to return error response if error type is RequestError', async () => {
+    const ctx = createContextWithRouteParameters({
+      customProperties: {
+        body: mockBody,
+      },
+    });
     const error = new RequestError('auth.unauthorized');
     next.mockRejectedValueOnce(error);
     await koaErrorHandler()(ctx, next);
@@ -45,18 +33,34 @@ describe('koaErrorHandler middleware', () => {
 
   // Koa will handle `HttpError` with a built-in manner. Hence it needs to return 200 here.
   it('expect to return 200 if error type is HttpError', async () => {
+    const ctx = createContextWithRouteParameters({
+      customProperties: {
+        body: mockBody,
+        status: 404,
+      },
+    });
     next.mockRejectedValueOnce(httpError);
     await koaErrorHandler()(ctx, next);
-    expect(ctx.status).toEqual(200);
+    expect(ctx.status).toEqual(404);
   });
 
-  it('expect to return orginal body if not error found', async () => {
+  it('expect to return original body if no error found', async () => {
+    const ctx = createContextWithRouteParameters({
+      customProperties: {
+        body: mockBody,
+      },
+    });
     await koaErrorHandler()(ctx, next);
     expect(ctx.status).toEqual(200);
     expect(ctx.body).toEqual(mockBody);
   });
 
   it('expect status 500 if error type is not RequestError', async () => {
+    const ctx = createContextWithRouteParameters({
+      customProperties: {
+        body: mockBody,
+      },
+    });
     next.mockRejectedValueOnce(new Error('err'));
     await koaErrorHandler()(ctx, next);
     expect(ctx.status).toEqual(500);

--- a/packages/core/src/middleware/koa-error-handler.test.ts
+++ b/packages/core/src/middleware/koa-error-handler.test.ts
@@ -40,7 +40,7 @@ describe('koaErrorHandler middleware', () => {
     next.mockRejectedValueOnce(error);
     await koaErrorHandler()(ctx, next);
     expect(ctx.status).toEqual(error.status);
-    expect(ctx.body).toEqual(error.toBody(ctx));
+    expect(ctx.body).toEqual(error.toBody(ctx.i18n));
   });
 
   // Koa will handle `HttpError` with a built-in manner. Hence it needs to return 200 here.

--- a/packages/core/src/middleware/koa-error-handler.ts
+++ b/packages/core/src/middleware/koa-error-handler.ts
@@ -36,7 +36,7 @@ export default function koaErrorHandler<
 
       if (error instanceof RequestError) {
         ctx.status = error.status;
-        ctx.body = error.toBody(ctx);
+        ctx.body = error.toBody(ctx.i18n);
 
         return;
       }

--- a/packages/core/src/middleware/koa-error-handler.ts
+++ b/packages/core/src/middleware/koa-error-handler.ts
@@ -9,16 +9,18 @@ import RequestError from '#src/errors/RequestError/index.js';
 import { getConsoleLogFromContext } from '#src/utils/console.js';
 import { buildAppInsightsTelemetry } from '#src/utils/request.js';
 
+import { type WithI18nContext } from './koa-i18next.js';
+
 /**
  * The middleware to handle errors.
  *
  * Note: A context-aware console log is required to be present in the context (i.e. `ctx.console`).
  */
-export default function koaErrorHandler<StateT, ContextT, BodyT>(): Middleware<
+export default function koaErrorHandler<
   StateT,
-  ContextT,
-  BodyT | RequestErrorBody | { message: string }
-> {
+  ContextT extends WithI18nContext,
+  BodyT,
+>(): Middleware<StateT, ContextT, BodyT | RequestErrorBody | { message: string }> {
   return async (ctx, next) => {
     const consoleLog = getConsoleLogFromContext(ctx);
 
@@ -34,7 +36,7 @@ export default function koaErrorHandler<StateT, ContextT, BodyT>(): Middleware<
 
       if (error instanceof RequestError) {
         ctx.status = error.status;
-        ctx.body = error.body;
+        ctx.body = error.toBody(ctx);
 
         return;
       }

--- a/packages/core/src/middleware/koa-experience-ssr.test.ts
+++ b/packages/core/src/middleware/koa-experience-ssr.test.ts
@@ -2,6 +2,7 @@ import { ssrPlaceholder } from '@logto/schemas';
 
 import { mockSignInExperience } from '#src/__mocks__/sign-in-experience.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
+import { i18next } from '#src/utils/i18n.js';
 import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
 
 import koaExperienceSsr from './koa-experience-ssr.js';
@@ -12,6 +13,7 @@ describe('koaExperienceSsr()', () => {
   const phrases = { foo: 'bar' };
   const baseCtx = Object.freeze({
     ...createContextWithRouteParameters({}),
+    i18n: i18next,
     locale: 'en',
     query: {},
     set: jest.fn(),

--- a/packages/core/src/middleware/koa-experience-ssr.test.ts
+++ b/packages/core/src/middleware/koa-experience-ssr.test.ts
@@ -2,7 +2,6 @@ import { ssrPlaceholder } from '@logto/schemas';
 
 import { mockSignInExperience } from '#src/__mocks__/sign-in-experience.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
-import { i18next } from '#src/utils/i18n.js';
 import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
 
 import koaExperienceSsr from './koa-experience-ssr.js';
@@ -13,8 +12,6 @@ describe('koaExperienceSsr()', () => {
   const phrases = { foo: 'bar' };
   const baseCtx = Object.freeze({
     ...createContextWithRouteParameters({}),
-    i18n: i18next,
-    locale: 'en',
     query: {},
     set: jest.fn(),
   });

--- a/packages/core/src/middleware/koa-i18next.test.ts
+++ b/packages/core/src/middleware/koa-i18next.test.ts
@@ -1,6 +1,6 @@
 import { pickDefault, createMockUtils } from '@logto/shared/esm';
-import i18next from 'i18next';
 
+import { i18next } from '#src/utils/i18n.js';
 import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
 
 const { jest } = import.meta;
@@ -11,7 +11,7 @@ mockEsmDefault('#src/i18n/detect-language.js', () => mockLanguage);
 
 const initI18n = await pickDefault(import('#src/i18n/init.js'));
 const koaI18next = await pickDefault(import('./koa-i18next.js'));
-const changLanguageSpy = jest.spyOn(i18next, 'changeLanguage');
+const cloneInstanceSpy = jest.spyOn(i18next, 'cloneInstance');
 
 describe('koaI18next', () => {
   const next = jest.fn();
@@ -20,11 +20,12 @@ describe('koaI18next', () => {
     const ctx = {
       ...createContextWithRouteParameters(),
       query: {},
-      locale: 'en',
+      i18n: i18next,
+      locale: '',
     };
     await initI18n();
     await koaI18next()(ctx, next);
     expect(ctx.locale).toEqual('zh-CN');
-    expect(changLanguageSpy).toBeCalled();
+    expect(cloneInstanceSpy).toBeCalled();
   });
 });

--- a/packages/core/src/middleware/koa-oidc-error-handler.test.ts
+++ b/packages/core/src/middleware/koa-oidc-error-handler.test.ts
@@ -1,9 +1,10 @@
-import i18next from 'i18next';
-import { type Context } from 'koa';
+import { type IRouterContext } from 'koa-router';
 import { errors } from 'oidc-provider';
 
+import { i18next } from '#src/utils/i18n.js';
 import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
 
+import { type WithI18nContext } from './koa-i18next.js';
 import koaOidcErrorHandler, { errorOut } from './koa-oidc-error-handler.js';
 
 const { jest } = import.meta;
@@ -12,7 +13,7 @@ describe('koaOidcErrorHandler middleware', () => {
   const next = jest.fn();
 
   const expectErrorResponse = async (
-    ctx: Context,
+    ctx: WithI18nContext<IRouterContext>,
     error: errors.OIDCProviderError,
     extraMatch?: Record<string, unknown>
   ) => {
@@ -32,13 +33,17 @@ describe('koaOidcErrorHandler middleware', () => {
     });
   };
 
+  const ctx = {
+    ...createContextWithRouteParameters(),
+    i18n: i18next,
+    locale: 'en',
+  };
+
   it('should throw no errors if no errors are caught', async () => {
-    const ctx = createContextWithRouteParameters();
     await expect(koaOidcErrorHandler()(ctx, next)).resolves.not.toThrow();
   });
 
   it('should throw original error if error type is not OIDCProviderError', async () => {
-    const ctx = createContextWithRouteParameters();
     const error = new Error('err');
 
     next.mockImplementationOnce(() => {
@@ -49,15 +54,12 @@ describe('koaOidcErrorHandler middleware', () => {
   });
 
   it('should recognize invalid scope error', async () => {
-    const ctx = createContextWithRouteParameters();
     const error_description = 'Mock scope is invalid';
     const mockScope = 'read:foo';
     await expectErrorResponse(ctx, new errors.InvalidScope(error_description, mockScope));
   });
 
   it('should transform session not found error code', async () => {
-    const ctx = createContextWithRouteParameters();
-
     await expectErrorResponse(ctx, new errors.SessionNotFound('session not found'), {
       code: 'session.not_found',
       message: i18next.t('errors:session.not_found'),
@@ -65,7 +67,6 @@ describe('koaOidcErrorHandler middleware', () => {
   });
 
   it('should add scope in response when needed', async () => {
-    const ctx = createContextWithRouteParameters();
     const error_description = 'Insufficient scope for access_token';
     const scope = 'read:foo';
 
@@ -75,7 +76,6 @@ describe('koaOidcErrorHandler middleware', () => {
   });
 
   it('should add error uri when available', async () => {
-    const ctx = createContextWithRouteParameters();
     const error = new errors.InvalidGrant('invalid grant');
 
     await expectErrorResponse(ctx, error, {
@@ -84,7 +84,6 @@ describe('koaOidcErrorHandler middleware', () => {
   });
 
   it('should handle unrecognized oidc error', async () => {
-    const ctx = createContextWithRouteParameters();
     const unrecognizedError = { error: 'some_error', error_description: 'some error description' };
 
     ctx.status = 500;

--- a/packages/core/src/middleware/koa-oidc-error-handler.test.ts
+++ b/packages/core/src/middleware/koa-oidc-error-handler.test.ts
@@ -33,18 +33,14 @@ describe('koaOidcErrorHandler middleware', () => {
     });
   };
 
-  const ctx = {
-    ...createContextWithRouteParameters(),
-    i18n: i18next,
-    locale: 'en',
-  };
-
   it('should throw no errors if no errors are caught', async () => {
+    const ctx = createContextWithRouteParameters();
     await expect(koaOidcErrorHandler()(ctx, next)).resolves.not.toThrow();
   });
 
   it('should throw original error if error type is not OIDCProviderError', async () => {
     const error = new Error('err');
+    const ctx = createContextWithRouteParameters();
 
     next.mockImplementationOnce(() => {
       throw error;
@@ -54,12 +50,14 @@ describe('koaOidcErrorHandler middleware', () => {
   });
 
   it('should recognize invalid scope error', async () => {
+    const ctx = createContextWithRouteParameters();
     const error_description = 'Mock scope is invalid';
     const mockScope = 'read:foo';
     await expectErrorResponse(ctx, new errors.InvalidScope(error_description, mockScope));
   });
 
   it('should transform session not found error code', async () => {
+    const ctx = createContextWithRouteParameters();
     await expectErrorResponse(ctx, new errors.SessionNotFound('session not found'), {
       code: 'session.not_found',
       message: i18next.t('errors:session.not_found'),
@@ -69,6 +67,7 @@ describe('koaOidcErrorHandler middleware', () => {
   it('should add scope in response when needed', async () => {
     const error_description = 'Insufficient scope for access_token';
     const scope = 'read:foo';
+    const ctx = createContextWithRouteParameters();
 
     await expectErrorResponse(ctx, new errors.InsufficientScope(error_description, scope), {
       scope,
@@ -77,6 +76,7 @@ describe('koaOidcErrorHandler middleware', () => {
 
   it('should add error uri when available', async () => {
     const error = new errors.InvalidGrant('invalid grant');
+    const ctx = createContextWithRouteParameters();
 
     await expectErrorResponse(ctx, error, {
       error_uri: 'https://openid.sh/debug/invalid_grant',
@@ -85,6 +85,7 @@ describe('koaOidcErrorHandler middleware', () => {
 
   it('should handle unrecognized oidc error', async () => {
     const unrecognizedError = { error: 'some_error', error_description: 'some error description' };
+    const ctx = createContextWithRouteParameters();
 
     ctx.status = 500;
     ctx.body = unrecognizedError;

--- a/packages/core/src/middleware/koa-oidc-error-handler.ts
+++ b/packages/core/src/middleware/koa-oidc-error-handler.ts
@@ -1,6 +1,5 @@
 import { appInsights } from '@logto/app-insights/node';
 import { condObject, isObject } from '@silverhand/essentials';
-import i18next from 'i18next';
 import type { Middleware } from 'koa';
 import { errors } from 'oidc-provider';
 import { z } from 'zod';
@@ -8,6 +7,8 @@ import { z } from 'zod';
 import { EnvSet } from '#src/env-set/index.js';
 import { getConsoleLogFromContext } from '#src/utils/console.js';
 import { buildAppInsightsTelemetry } from '#src/utils/request.js';
+
+import { type WithI18nContext } from './koa-i18next.js';
 
 /**
  * Supplementary URIs for oidc-provider errors.
@@ -81,7 +82,10 @@ const isSessionNotFound = (description?: string) =>
  *
  * @see {@link errorUris} for the list of error URIs.
  */
-export default function koaOidcErrorHandler<StateT, ContextT>(): Middleware<StateT, ContextT> {
+export default function koaOidcErrorHandler<StateT, ContextT extends WithI18nContext>(): Middleware<
+  StateT,
+  ContextT
+> {
   // eslint-disable-next-line complexity
   return async (ctx, next) => {
     try {
@@ -134,7 +138,7 @@ export default function koaOidcErrorHandler<StateT, ContextT>(): Middleware<Stat
 
         ctx.body = {
           code,
-          message: i18next.t(['errors:' + code, 'errors:oidc.provider_error_fallback'], {
+          message: ctx.i18n.t(['errors:' + code, 'errors:oidc.provider_error_fallback'], {
             code,
           }),
           error_uri: uri,

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -17,7 +17,7 @@ import {
   ExtraParamsKey,
 } from '@logto/schemas';
 import { removeUndefinedKeys, trySafe, tryThat } from '@silverhand/essentials';
-import i18next from 'i18next';
+import { type i18n } from 'i18next';
 import { Provider, errors } from 'oidc-provider';
 import getRawBody from 'raw-body';
 import snakecaseKeys from 'snakecase-keys';
@@ -38,6 +38,7 @@ import {
 } from '#src/oidc/utils.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
+import { i18next } from '#src/utils/i18n.js';
 
 import { type SubscriptionLibrary } from '../libraries/subscription.js';
 import koaTokenUsageGuard from '../middleware/koa-token-usage-guard.js';
@@ -126,10 +127,13 @@ export default function initOidc(
           ctx.body = logoutSource.replace('${form}', form);
         },
         postLogoutSuccessSource(ctx) {
+          // eslint-disable-next-line no-restricted-syntax -- detect if i18n is available in the context @see {koaI18next middleware}
+          const i18n = 'i18n' in ctx ? (ctx.i18n as i18n) : i18next;
+
           ctx.body = logoutSuccessSource.replace(
             // eslint-disable-next-line no-template-curly-in-string
             '${message}',
-            i18next.t<string, I18nKey>('oidc.logout_success')
+            i18n.t<string, I18nKey>('oidc.logout_success')
           );
         },
       },

--- a/packages/core/src/tenants/Tenant.ts
+++ b/packages/core/src/tenants/Tenant.ts
@@ -106,11 +106,11 @@ export default class Tenant implements TenantContext {
     // Init app
     const app = new Koa();
 
+    app.use(koaI18next());
     app.use(koaErrorHandler());
     app.use(koaOidcErrorHandler());
     app.use(koaSlonikErrorHandler());
     app.use(koaConnectorErrorHandler());
-    app.use(koaI18next());
     app.use(koaCompress());
     app.use(koaSecurityHeaders(mountedApps, id));
 

--- a/packages/core/src/utils/i18n.ts
+++ b/packages/core/src/utils/i18n.ts
@@ -8,6 +8,14 @@ import { type IRouterParamContext } from 'koa-router';
 
 import detectLanguage from '#src/i18n/detect-language.js';
 
+/**
+ * The global scoped i18next instance.
+ * We use this instance to maintain the global configuration and resources for i18next.
+ *
+ * @remarks
+ * This instance should not be used directly in the request lifecycle as it is shared across all requests.
+ * For different language settings in the request lifecycle, use `ctx.i18next` instead.
+ */
 // This may be fixed by a cjs require wrapper. TBD.
 // See https://github.com/microsoft/TypeScript/issues/49189
 // eslint-disable-next-line no-restricted-syntax

--- a/packages/core/src/utils/test-utils.ts
+++ b/packages/core/src/utils/test-utils.ts
@@ -17,6 +17,9 @@ import type TenantContext from '#src/tenants/TenantContext.js';
 import type { Options } from '#src/test-utils/jest-koa-mocks/create-mock-context.js';
 import createMockContext from '#src/test-utils/jest-koa-mocks/create-mock-context.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
+import { i18next } from '#src/utils/i18n.js';
+
+import { type WithI18nContext } from '../middleware/koa-i18next.js';
 
 /**
  *  Slonik Query Mock Utils
@@ -91,11 +94,13 @@ export const emptyMiddleware =
 
 export const createContextWithRouteParameters = (
   mockContextOptions?: Options<Record<string, unknown>>
-): Context & IRouterParamContext => {
+): WithI18nContext<Context & IRouterParamContext> => {
   const ctx = createMockContext(mockContextOptions);
 
   return {
     ...ctx,
+    body: ctx.body,
+    status: ctx.status,
     set: ctx.set,
     path: ctx.path,
     URL: ctx.URL,
@@ -105,6 +110,8 @@ export const createContextWithRouteParameters = (
     router: new Router(),
     _matchedRoute: undefined,
     _matchedRouteName: undefined,
+    i18n: i18next,
+    locale: 'en',
   };
 };
 


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR resolves a concurrency issue in i18n handling by moving from a global i18next instance to request-scoped instances.

### Problem

When handling concurrent requests:

- The shared global i18next instance's language was being modified via `changeLanguage()` calls
- This could lead to race conditions where requests might receive translations in unexpected languages
- Particularly problematic in our cloud multi-tenant environments. Error messages in random languages may occur.

### Solution

- Updated `koaI18next` middleware to create a cloned i18next instance for each request
- Attach the request-scoped instance to Koa context (`ctx.i18n`)
- All subsequent middleware and handlers should now use `ctx.i18n` instead of the global instance
- Maintains the global instance for initialization while preventing cross-request contamination

### Affected content
- OIDC error messages
- Logto `RequestError` messages

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
