### PR TITLE
refactor: sync SAML app redirectUris upon custom domain status updates

### DIFF
--- a/packages/core/src/libraries/domain.test.ts
+++ b/packages/core/src/libraries/domain.test.ts
@@ -31,13 +31,18 @@ const { clearCustomDomainCache } = await mockEsmWithActual('#src/utils/tenant.js
 
 const { MockQueries } = await import('#src/test-utils/tenant.js');
 const { createDomainLibrary } = await import('./domain.js');
+const { createSamlApplicationsLibrary } = await import('./saml-application/saml-applications.js');
 
 const updateDomainById = jest.fn(async (_, data) => data);
 const insertDomain = jest.fn(async (data) => data);
 const findDomainById = jest.fn(async () => mockDomain);
 const deleteDomainById = jest.fn();
 const { syncDomainStatus, addDomain, deleteDomain } = createDomainLibrary(
-  new MockQueries({ domains: { updateDomainById, insertDomain, findDomainById, deleteDomainById } })
+  'mock-tenant-id',
+  new MockQueries({
+    domains: { updateDomainById, insertDomain, findDomainById, deleteDomainById },
+  }),
+  createSamlApplicationsLibrary(new MockQueries({}))
 );
 
 beforeAll(() => {

--- a/packages/core/src/libraries/domain.test.ts
+++ b/packages/core/src/libraries/domain.test.ts
@@ -31,18 +31,15 @@ const { clearCustomDomainCache } = await mockEsmWithActual('#src/utils/tenant.js
 
 const { MockQueries } = await import('#src/test-utils/tenant.js');
 const { createDomainLibrary } = await import('./domain.js');
-const { createSamlApplicationsLibrary } = await import('./saml-application/saml-applications.js');
 
 const updateDomainById = jest.fn(async (_, data) => data);
 const insertDomain = jest.fn(async (data) => data);
 const findDomainById = jest.fn(async () => mockDomain);
 const deleteDomainById = jest.fn();
 const { syncDomainStatus, addDomain, deleteDomain } = createDomainLibrary(
-  'mock-tenant-id',
   new MockQueries({
     domains: { updateDomainById, insertDomain, findDomainById, deleteDomainById },
-  }),
-  createSamlApplicationsLibrary(new MockQueries({}))
+  })
 );
 
 beforeAll(() => {

--- a/packages/core/src/libraries/domain.ts
+++ b/packages/core/src/libraries/domain.ts
@@ -15,15 +15,9 @@ import {
 import { isSubdomainOf } from '#src/utils/domain.js';
 import { clearCustomDomainCache } from '#src/utils/tenant.js';
 
-import { type SamlApplicationLibrary } from './saml-application/saml-applications.js';
-
 export type DomainLibrary = ReturnType<typeof createDomainLibrary>;
 
-export const createDomainLibrary = (
-  tenantId: string,
-  queries: Queries,
-  samlApplicationsLibrary: SamlApplicationLibrary
-) => {
+export const createDomainLibrary = (queries: Queries) => {
   const {
     domains: { updateDomainById, insertDomain, findDomainById, deleteDomainById },
   } = queries;
@@ -60,11 +54,6 @@ export const createDomainLibrary = (
     );
 
     const updatedDomain = await syncDomainStatusFromCloudflareData(domain, cloudflareData);
-
-    await samlApplicationsLibrary.applyCustomDomainToSamlApplicationRedirectUrls(
-      tenantId,
-      updatedDomain
-    );
 
     await clearCustomDomainCache(domain.domain);
     return updatedDomain;
@@ -123,7 +112,6 @@ export const createDomainLibrary = (
 
     await deleteDomainById(id);
     await clearCustomDomainCache(domain.domain);
-    await samlApplicationsLibrary.applyCustomDomainToSamlApplicationRedirectUrls(tenantId);
   };
 
   return {

--- a/packages/core/src/routes/domain.test.ts
+++ b/packages/core/src/routes/domain.test.ts
@@ -35,6 +35,9 @@ const mockLibraries = {
     deleteDomain,
   },
   quota: createMockQuotaLibrary(),
+  samlApplications: {
+    syncCustomDomainToSamlApplicationRedirectUrls: jest.fn(),
+  },
 };
 
 const tenantContext = new MockTenant(undefined, { domains }, undefined, mockLibraries);

--- a/packages/core/src/routes/domain.ts
+++ b/packages/core/src/routes/domain.ts
@@ -1,5 +1,5 @@
 import { Domains, domainResponseGuard, domainSelectFields } from '@logto/schemas';
-import { pick } from '@silverhand/essentials';
+import { pick, trySafe } from '@silverhand/essentials';
 import { z } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
@@ -9,14 +9,14 @@ import assertThat from '#src/utils/assert-that.js';
 import type { ManagementApiRouter, RouterInitArgs } from './types.js';
 
 export default function domainRoutes<T extends ManagementApiRouter>(
-  ...[router, { queries, libraries }]: RouterInitArgs<T>
+  ...[router, { id: tenantId, queries, libraries }]: RouterInitArgs<T>
 ) {
   const {
     domains: { findAllDomains, findDomainById },
   } = queries;
   const {
-    quota,
     domains: { syncDomainStatus, addDomain, deleteDomain },
+    samlApplications: { syncCustomDomainToSamlApplicationRedirectUrls },
   } = libraries;
 
   router.get(
@@ -27,6 +27,15 @@ export default function domainRoutes<T extends ManagementApiRouter>(
       const syncedDomains = await Promise.all(
         domains.map(async (domain) => syncDomainStatus(domain))
       );
+
+      await trySafe(async () =>
+        Promise.all(
+          syncedDomains.map(async (syncedDomain) =>
+            syncCustomDomainToSamlApplicationRedirectUrls(tenantId, syncedDomain)
+          )
+        )
+      );
+
       ctx.body = syncedDomains.map((domain) => pick(domain, ...domainSelectFields));
 
       return next();
@@ -45,7 +54,10 @@ export default function domainRoutes<T extends ManagementApiRouter>(
         params: { id },
       } = ctx.guard;
 
-      const syncedDomain = await syncDomainStatus(await findDomainById(id));
+      const domain = await findDomainById(id);
+      const syncedDomain = await syncDomainStatus(domain);
+
+      await syncCustomDomainToSamlApplicationRedirectUrls(tenantId, syncedDomain);
 
       ctx.body = pick(syncedDomain, ...domainSelectFields);
 
@@ -86,6 +98,9 @@ export default function domainRoutes<T extends ManagementApiRouter>(
     async (ctx, next) => {
       const { id } = ctx.guard.params;
       await deleteDomain(id);
+
+      await trySafe(async () => syncCustomDomainToSamlApplicationRedirectUrls(tenantId));
+
       ctx.status = 204;
 
       return next();

--- a/packages/core/src/saml-application/SamlApplication/index.test.ts
+++ b/packages/core/src/saml-application/SamlApplication/index.test.ts
@@ -27,7 +27,7 @@ describe('SamlApplication', () => {
       url: 'https://sp.example.com/acs',
     },
     oidcClientMetadata: {
-      redirectUris: ['https://app.example.com/callback'],
+      redirectUris: ['https://logto.test/callback'],
     },
     privateKey: 'mock-private-key',
     certificate: 'mock-certificate',
@@ -116,13 +116,11 @@ describe('SamlApplication', () => {
         'utf8'
       ).toString('base64')}`;
 
-      const redirectUri = mockDetails.oidcClientMetadata.redirectUris[0]!;
-
       nock(mockEndpoint)
         .post(
           '/token',
           `grant_type=authorization_code&code=${mockCode}&client_id=${mockSamlApplicationId}&redirect_uri=${encodeURIComponent(
-            redirectUri
+            samlApp.config.redirectUri
           )}`
         )
         .matchHeader('Authorization', expectedAuthHeader)

--- a/packages/core/src/tenants/Libraries.ts
+++ b/packages/core/src/tenants/Libraries.ts
@@ -40,7 +40,7 @@ export default class Libraries {
   verificationStatuses = createVerificationStatusLibrary(this.queries);
   samlApplications = createSamlApplicationsLibrary(this.queries);
   roleScopes = createRoleScopeLibrary(this.queries);
-  domains = createDomainLibrary(this.tenantId, this.queries, this.samlApplications);
+  domains = createDomainLibrary(this.queries);
   protectedApps = createProtectedAppLibrary(this.queries);
   quota = createQuotaLibrary(this.cloudConnection);
   ssoConnectors = createSsoConnectorLibrary(this.queries);

--- a/packages/core/src/tenants/Libraries.ts
+++ b/packages/core/src/tenants/Libraries.ts
@@ -40,7 +40,7 @@ export default class Libraries {
   verificationStatuses = createVerificationStatusLibrary(this.queries);
   samlApplications = createSamlApplicationsLibrary(this.queries);
   roleScopes = createRoleScopeLibrary(this.queries);
-  domains = createDomainLibrary(this.queries);
+  domains = createDomainLibrary(this.tenantId, this.queries, this.samlApplications);
   protectedApps = createProtectedAppLibrary(this.queries);
   quota = createQuotaLibrary(this.cloudConnection);
   ssoConnectors = createSsoConnectorLibrary(this.queries);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
update SAML app custom domain logics.
1. use original domain for default redirect URI of SAML app upon creation.
2. apply custom domain when parsing SAML app configs.
3. update redirect URIs to SAML app when syncing custom domain status
 - if custom domain removed or domain status is not health, remove redirect URIs with custom domain in SAML apps
 - if custom domain is activated, add redirect URIs with custom domain applied to SAML apps'

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
