### PR TITLE
feat(core,toolkit): pass locale ctx to sendMessage method

### DIFF
--- a/packages/cli/src/connector/utils.ts
+++ b/packages/cli/src/connector/utils.ts
@@ -8,6 +8,8 @@ import type {
   ConnectorMetadata,
   GetConnectorConfig,
   GetCloudServiceClient,
+  GetI18nEmailTemplate,
+  EmailConnector,
 } from '@logto/connector-kit';
 import { ConnectorError, ConnectorErrorCodes, ConnectorType } from '@logto/connector-kit';
 import type { BaseRoutes, Router } from '@withtyped/server';
@@ -98,12 +100,14 @@ export const buildRawConnector = async <
 >(
   connectorFactory: ConnectorFactory<T, U>,
   getConnectorConfig?: GetConnectorConfig,
-  getCloudServiceClient?: GetCloudServiceClient<T>
+  getCloudServiceClient?: GetCloudServiceClient<T>,
+  getI18nEmailTemplate?: U extends EmailConnector ? GetI18nEmailTemplate : undefined
 ): Promise<{ rawConnector: U; rawMetadata: ConnectorMetadata }> => {
   const { createConnector, path: packagePath } = connectorFactory;
   const rawConnector = await createConnector({
     getConfig: getConnectorConfig ?? notImplemented,
     getCloudServiceClient,
+    getI18nEmailTemplate,
   });
   validateConnectorModule(rawConnector);
   const rawMetadata = await parseMetadata(rawConnector.metadata, packagePath);

--- a/packages/core/src/libraries/connector.ts
+++ b/packages/core/src/libraries/connector.ts
@@ -3,6 +3,7 @@ import type {
   AllConnector,
   ConnectorPlatform,
   EmailConnector,
+  GetI18nEmailTemplate,
   SmsConnector,
 } from '@logto/connector-kit';
 import { validateConfig, ServiceConnector, ConnectorType } from '@logto/connector-kit';
@@ -13,6 +14,8 @@ import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 import { loadConnectorFactories } from '#src/utils/connectors/index.js';
 import type { LogtoConnector, LogtoConnectorWellKnown } from '#src/utils/connectors/types.js';
+
+import { EnvSet } from '../env-set/index.js';
 
 import { type CloudConnectionLibrary } from './cloud-connection.js';
 
@@ -83,7 +86,8 @@ export const createConnectorLibrary = (
           const { rawConnector, rawMetadata } = await buildRawConnector(
             connectorFactory,
             async () => getConnectorConfig(id),
-            conditional(connectorFactory.metadata.id === ServiceConnector.Email && getClient)
+            conditional(connectorFactory.metadata.id === ServiceConnector.Email && getClient),
+            conditional(connectorFactory.type === ConnectorType.Email && getI18nEmailTemplate)
           );
 
           const connector: AllConnector = {
@@ -164,6 +168,40 @@ export const createConnectorLibrary = (
     return connector;
   };
 
+  const getI18nEmailTemplate: GetI18nEmailTemplate = async (templateType, languageTag) => {
+    // TODO: Remove this check when the feature is enabled in production
+    if (!EnvSet.values.isDevFeaturesEnabled) {
+      return;
+    }
+
+    const { signInExperiences, emailTemplates } = queries;
+
+    // If the language tag is provided, try to get the template with the language tag.
+    if (languageTag) {
+      const template = await emailTemplates.findByLanguageTagAndTemplateType(
+        templateType,
+        languageTag
+      );
+
+      if (template) {
+        return template.details;
+      }
+    }
+
+    const {
+      languageInfo: { fallbackLanguage },
+    } = await signInExperiences.findDefaultSignInExperience();
+
+    // If the language tag is not provided or the template with the language tag is not available,
+    // fallback to the template with the fallback language.
+    const fallbackTemplate = await emailTemplates.findByLanguageTagAndTemplateType(
+      templateType,
+      fallbackLanguage
+    );
+
+    return fallbackTemplate?.details;
+  };
+
   return {
     getConnectorConfig,
     getLogtoConnectors,
@@ -178,5 +216,6 @@ export const createConnectorLibrary = (
      * @throws {RequestError} If no connector can send message of the given type (status 500).
      */
     getMessageConnector,
+    getI18nEmailTemplate,
   };
 };

--- a/packages/core/src/libraries/passcode.ts
+++ b/packages/core/src/libraries/passcode.ts
@@ -1,6 +1,7 @@
 import type { TemplateType } from '@logto/connector-kit';
 import { templateTypeGuard, ConnectorError, ConnectorErrorCodes } from '@logto/connector-kit';
 import type { Passcode } from '@logto/schemas';
+import { conditional } from '@silverhand/essentials';
 import { customAlphabet, nanoid } from 'nanoid';
 
 import RequestError from '#src/errors/RequestError/index.js';
@@ -54,7 +55,13 @@ export const createPasscodeLibrary = (queries: Queries, connectorLibrary: Connec
     });
   };
 
-  const sendPasscode = async (passcode: Passcode) => {
+  /**
+   *
+   * @param {Passcode} passcode The passcode object being sent.
+   * @param locale The language tag detected from the user's request.
+   * If provided, it will be used to localize the message.
+   */
+  const sendPasscode = async (passcode: Passcode, locale?: string) => {
     const emailOrPhone = passcode.email ?? passcode.phone;
 
     if (!emailOrPhone) {
@@ -76,6 +83,7 @@ export const createPasscodeLibrary = (queries: Queries, connectorLibrary: Connec
       type: messageTypeResult.data,
       payload: {
         code: passcode.code,
+        ...conditional(locale && { locale }),
       },
     });
 

--- a/packages/core/src/queries/email-templates.ts
+++ b/packages/core/src/queries/email-templates.ts
@@ -3,6 +3,7 @@ import {
   type EmailTemplateKeys,
   EmailTemplates,
   type CreateEmailTemplate,
+  type TemplateType,
 } from '@logto/schemas';
 import { sql, type CommonQueryMethods } from '@silverhand/slonik';
 
@@ -25,7 +26,6 @@ export default class EmailTemplatesQueries extends SchemaQueries<
 > {
   constructor(
     pool: CommonQueryMethods,
-    // TODO: Implement redis cache for email templates
     private readonly wellKnownCache: WellKnownCache
   ) {
     super(pool, EmailTemplates);
@@ -109,5 +109,19 @@ export default class EmailTemplatesQueries extends SchemaQueries<
         sql` and `
       )}
     `);
+  }
+
+  // TODO: Implement redis cache for email templates
+  async findByLanguageTagAndTemplateType(templateType: TemplateType, languageTag: string) {
+    const { fields, table } = convertToIdentifiers(EmailTemplates);
+
+    return this.pool.maybeOne<EmailTemplate>(
+      sql`
+        select ${expandFields(EmailTemplates)}
+        from ${table}
+        where ${fields.templateType} = ${templateType}
+        and ${fields.languageTag} = ${languageTag}
+      `
+    );
   }
 }

--- a/packages/core/src/routes-me/init.ts
+++ b/packages/core/src/routes-me/init.ts
@@ -7,6 +7,7 @@ import RequestError from '#src/errors/RequestError/index.js';
 import type { WithAuthContext } from '#src/middleware/koa-auth/index.js';
 import koaAuth from '#src/middleware/koa-auth/index.js';
 import koaCors from '#src/middleware/koa-cors.js';
+import { type WithI18nContext } from '#src/middleware/koa-i18next.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 
@@ -20,7 +21,7 @@ export default function initMeApis(tenant: TenantContext): Koa {
     throw new Error('`/me` routes should only be initialized in the admin tenant.');
   }
 
-  const meRouter = new Router<unknown, WithAuthContext>();
+  const meRouter = new Router<unknown, WithAuthContext & WithI18nContext>();
 
   meRouter.use(
     koaAuth(tenant.envSet, getManagementApiResourceIndicator(adminTenantId, 'me')),

--- a/packages/core/src/routes-me/types.ts
+++ b/packages/core/src/routes-me/types.ts
@@ -2,4 +2,6 @@ import type Router from 'koa-router';
 
 import type { WithAuthContext } from '#src/middleware/koa-auth/index.js';
 
-export type AuthedMeRouter = Router<unknown, WithAuthContext>;
+import type { WithI18nContext } from '../middleware/koa-i18next.js';
+
+export type AuthedMeRouter = Router<unknown, WithAuthContext & WithI18nContext>;

--- a/packages/core/src/routes-me/verification-code.ts
+++ b/packages/core/src/routes-me/verification-code.ts
@@ -31,7 +31,7 @@ export default function verificationCodeRoutes<T extends AuthedMeRouter>(
     }),
     async (ctx, next) => {
       const code = await createPasscode(undefined, codeType, ctx.guard.body);
-      await sendPasscode(code);
+      await sendPasscode(code, ctx.locale);
 
       ctx.status = 204;
 

--- a/packages/core/src/routes/connector/config-testing.openapi.json
+++ b/packages/core/src/routes/connector/config-testing.openapi.json
@@ -17,6 +17,9 @@
                   },
                   "config": {
                     "description": "Connector configuration object for testing."
+                  },
+                  "locale": {
+                    "description": "Preferred language for the message. If not set, the default language will be used. (Applicable only when custom i18n templates are configured.)"
                   }
                 }
               }

--- a/packages/core/src/routes/experience/classes/verifications/code-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/code-verification.ts
@@ -107,11 +107,13 @@ abstract class CodeVerification<T extends CodeVerificationType>
   /**
    * Send the verification code to the current `identifier`
    *
-   * @remark Instead of session jti,
+   * @param locale - The language tag detected from the user's request. If provided, it will be used to localize the message.
+   * @remarks
+   * Instead of session jti,
    * the verification id is used as `interaction_jti` to uniquely identify the passcode record in DB
    * for the current interaction.
    */
-  async sendVerificationCode() {
+  async sendVerificationCode(locale?: string) {
     const { createPasscode, sendPasscode } = this.libraries.passcodes;
 
     const verificationCode = await createPasscode(
@@ -120,7 +122,7 @@ abstract class CodeVerification<T extends CodeVerificationType>
       getPasscodeIdentifierPayload(this.identifier)
     );
 
-    await sendPasscode(verificationCode);
+    await sendPasscode(verificationCode, locale);
   }
 
   /**

--- a/packages/core/src/routes/experience/types.ts
+++ b/packages/core/src/routes/experience/types.ts
@@ -13,6 +13,8 @@ import { z } from 'zod';
 import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
 import { type WithInteractionDetailsContext } from '#src/middleware/koa-interaction-details.js';
 
+import { type WithI18nContext } from '../../middleware/koa-i18next.js';
+
 import { type VerificationRecordMap } from './classes/verifications/index.js';
 import { type WithExperienceInteractionHooksContext } from './middleware/koa-experience-interaction-hooks.js';
 import { type WithExperienceInteractionContext } from './middleware/koa-experience-interaction.js';
@@ -89,6 +91,7 @@ export type InteractionContext = {
 
 export type ExperienceInteractionRouterContext<ContextT extends WithLogContext = WithLogContext> =
   ContextT &
+    WithI18nContext &
     WithInteractionDetailsContext &
     WithExperienceInteractionHooksContext &
     WithExperienceInteractionContext;

--- a/packages/core/src/routes/experience/verification-routes/verification-code.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code.ts
@@ -74,7 +74,7 @@ export default function verificationCodeRoutes<T extends ExperienceInteractionRo
         getTemplateTypeByEvent(interactionEvent)
       );
 
-      await codeVerification.sendVerificationCode();
+      await codeVerification.sendVerificationCode(ctx.locale);
 
       ctx.experienceInteraction.setVerificationRecord(codeVerification);
 

--- a/packages/core/src/routes/interaction/additional.ts
+++ b/packages/core/src/routes/interaction/additional.ts
@@ -16,6 +16,7 @@ import type { WithInteractionDetailsContext } from '#src//middleware/koa-interac
 import RequestError from '#src/errors/RequestError/index.js';
 import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
 import koaGuard from '#src/middleware/koa-guard.js';
+import { type WithI18nContext } from '#src/middleware/koa-i18next.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 
@@ -39,7 +40,7 @@ import { verifyIdentifier } from './verifications/index.js';
 import verifyProfile from './verifications/profile-verification.js';
 
 export default function additionalRoutes<T extends IRouterParamContext>(
-  router: Router<unknown, WithInteractionDetailsContext<WithLogContext<T>>>,
+  router: Router<unknown, WithInteractionDetailsContext<WithI18nContext<WithLogContext<T>>>>,
   tenant: TenantContext
 ) {
   const {
@@ -99,7 +100,7 @@ export default function additionalRoutes<T extends IRouterParamContext>(
       const { event } = getInteractionStorage(interactionDetails.result);
 
       await sendVerificationCodeToIdentifier(
-        { event, ...guard.body },
+        { event, ...guard.body, locale: ctx.locale },
         interactionDetails.jti,
         createLog,
         passcodes

--- a/packages/core/src/routes/interaction/utils/verification-code-validation.ts
+++ b/packages/core/src/routes/interaction/utils/verification-code-validation.ts
@@ -22,19 +22,19 @@ const getTemplateTypeByEvent = (event: InteractionEvent): TemplateType =>
   eventToTemplateTypeMap[event];
 
 export const sendVerificationCodeToIdentifier = async (
-  payload: RequestVerificationCodePayload & { event: InteractionEvent },
+  payload: RequestVerificationCodePayload & { event: InteractionEvent; locale?: string },
   jti: string,
   createLog: LogContext['createLog'],
   { createPasscode, sendPasscode }: PasscodeLibrary
 ) => {
-  const { event, ...identifier } = payload;
+  const { event, locale, ...identifier } = payload;
   const messageType = getTemplateTypeByEvent(event);
 
   const log = createLog(`Interaction.${event}.Identifier.VerificationCode.Create`);
   log.append(identifier);
 
   const verificationCode = await createPasscode(jti, messageType, identifier);
-  const { dbEntry } = await sendPasscode(verificationCode);
+  const { dbEntry } = await sendPasscode(verificationCode, locale);
 
   log.append({ connectorId: dbEntry.id });
 };

--- a/packages/core/src/routes/verification-code.ts
+++ b/packages/core/src/routes/verification-code.ts
@@ -25,7 +25,7 @@ export default function verificationCodeRoutes<T extends ManagementApiRouter>(
     }),
     async (ctx, next) => {
       const code = await createPasscode(undefined, codeType, ctx.guard.body);
-      await sendPasscode(code);
+      await sendPasscode(code, ctx.locale);
 
       ctx.status = 204;
 

--- a/packages/core/src/routes/verification/index.ts
+++ b/packages/core/src/routes/verification/index.ts
@@ -97,7 +97,7 @@ export default function verificationRoutes<T extends UserRouter>(
         isNewIdentifier ? TemplateType.BindNewIdentifier : TemplateType.UserPermissionValidation
       );
 
-      await codeVerification.sendVerificationCode();
+      await codeVerification.sendVerificationCode(ctx.locale);
 
       const { expiresAt } = await insertVerificationRecord(
         codeVerification,

--- a/packages/integration-tests/src/__mocks__/email-templates.ts
+++ b/packages/integration-tests/src/__mocks__/email-templates.ts
@@ -1,6 +1,8 @@
 import { type CreateEmailTemplate, TemplateType } from '@logto/schemas';
 
-export const mockEmailTemplates: Array<Omit<CreateEmailTemplate, 'id'>> = [
+export type MockEmailTemplatePayload = Omit<CreateEmailTemplate, 'id'>;
+
+export const mockEmailTemplates: MockEmailTemplatePayload[] = [
   {
     languageTag: 'en',
     templateType: TemplateType.SignIn,

--- a/packages/integration-tests/src/api/connector.ts
+++ b/packages/integration-tests/src/api/connector.ts
@@ -63,17 +63,19 @@ export const sendSmsTestMessage = async (
 export const sendEmailTestMessage = async (
   connectorFactoryId: string,
   email: string,
-  config: Record<string, unknown>
-) => sendTestMessage(connectorFactoryId, 'email', email, config);
+  config: Record<string, unknown>,
+  locale?: string
+) => sendTestMessage(connectorFactoryId, 'email', email, config, locale);
 
 const sendTestMessage = async (
   connectorFactoryId: string,
   receiverType: 'phone' | 'email',
   receiver: string,
-  config: Record<string, unknown>
+  config: Record<string, unknown>,
+  locale?: string
 ) =>
   authedAdminApi.post(`connectors/${connectorFactoryId}/test`, {
-    json: { [receiverType]: receiver, config },
+    json: { [receiverType]: receiver, config, locale },
   });
 
 export const getConnectorAuthorizationUri = async (

--- a/packages/integration-tests/src/helpers/email-templates.ts
+++ b/packages/integration-tests/src/helpers/email-templates.ts
@@ -3,18 +3,41 @@ import { type CreateEmailTemplate, type EmailTemplate } from '@logto/schemas';
 import { EmailTemplatesApi } from '#src/api/email-templates.js';
 
 export class EmailTemplatesApiTest extends EmailTemplatesApi {
-  #emailTemplates: EmailTemplate[] = [];
+  readonly #emailTemplates = new Map<string, EmailTemplate>();
 
   override async create(
     templates: Array<Omit<CreateEmailTemplate, 'id'>>
   ): Promise<EmailTemplate[]> {
     const created = await super.create(templates);
-    this.#emailTemplates.concat(created);
+
+    for (const template of created) {
+      this.#emailTemplates.set(template.id, template);
+    }
+
     return created;
   }
 
+  override async delete(id: string): Promise<void> {
+    await super.delete(id);
+    this.#emailTemplates.delete(id);
+  }
+
+  override async deleteMany(
+    where: Partial<Pick<EmailTemplate, 'languageTag' | 'templateType'>>
+  ): Promise<{ rowCount: number }> {
+    // Find all templates that match the where clause
+    const templates = await this.findAll(where);
+    const result = await super.deleteMany(where);
+
+    // Remove the templates from the local cache
+    for (const template of templates) {
+      this.#emailTemplates.delete(template.id);
+    }
+
+    return result;
+  }
+
   async cleanUp(): Promise<void> {
-    await Promise.all(this.#emailTemplates.map(async (template) => this.delete(template.id)));
-    this.#emailTemplates = [];
+    await Promise.all(Array.from(this.#emailTemplates.keys()).map(async (id) => this.delete(id)));
   }
 }

--- a/packages/integration-tests/src/helpers/index.ts
+++ b/packages/integration-tests/src/helpers/index.ts
@@ -40,6 +40,11 @@ type ConnectorMessageRecord = {
   code: string;
   type: string;
   payload: SendMessagePayload;
+  /**
+   * Mock email connector will insert the template into the record.
+   * The template will be either the default template from connector config or the custom i18n template if it exists.
+   */
+  template?: Record<string, unknown>;
 };
 
 /**

--- a/packages/integration-tests/src/helpers/profile.ts
+++ b/packages/integration-tests/src/helpers/profile.ts
@@ -1,5 +1,6 @@
 import { type LogtoConfig } from '@logto/node';
 import { demoAppApplicationId, InteractionEvent, type User } from '@logto/schemas';
+import { conditional } from '@silverhand/essentials';
 
 import { type InteractionPayload } from '#src/api/interaction.js';
 import { demoAppRedirectUri, logtoUrl } from '#src/constants.js';
@@ -70,7 +71,11 @@ export const initClientAndSignInForDefaultTenant = async (
 export const signInAndGetUserApi = async (
   username: string,
   password: string,
-  config?: Partial<LogtoConfig>
+  config?: Partial<LogtoConfig>,
+  /**
+   * The Accept-Language header value.
+   */
+  locale?: string
 ) => {
   const client = await initClientAndSignInForDefaultTenant(username, password, config);
   const accessToken = await client.getAccessToken();
@@ -78,6 +83,7 @@ export const signInAndGetUserApi = async (
   return baseApi.extend({
     headers: {
       Authorization: `Bearer ${accessToken}`,
+      ...conditional(locale && { 'Accept-Language': locale }),
     },
   });
 };

--- a/packages/integration-tests/src/tests/api/email-templates/connector-test-api.test.ts
+++ b/packages/integration-tests/src/tests/api/email-templates/connector-test-api.test.ts
@@ -1,0 +1,69 @@
+import { TemplateType } from '@logto/connector-kit';
+
+import { mockEmailConnectorId, mockEmailConnectorConfig } from '#src/__mocks__/connectors-mock.js';
+import { type MockEmailTemplatePayload } from '#src/__mocks__/email-templates.js';
+import { sendEmailTestMessage } from '#src/api/connector.js';
+import { EmailTemplatesApiTest } from '#src/helpers/email-templates.js';
+import { readConnectorMessage } from '#src/helpers/index.js';
+import { devFeatureTest, generateEmail } from '#src/utils.js';
+
+devFeatureTest.describe('connector test message API with i18n email templates', () => {
+  const emailTemplatesApi = new EmailTemplatesApiTest();
+  const mockEmail = generateEmail();
+  const mockEnTemplate: MockEmailTemplatePayload = {
+    languageTag: 'en',
+    templateType: TemplateType.Generic,
+    details: {
+      subject: 'Test template',
+      content: 'Test value: {{code}}',
+      contentType: 'text/html',
+    },
+  };
+  const mockDeTemplate: MockEmailTemplatePayload = {
+    ...mockEnTemplate,
+    languageTag: 'de',
+  };
+
+  beforeAll(async () => {
+    await emailTemplatesApi.create([mockEnTemplate, mockDeTemplate]);
+  });
+
+  afterAll(async () => {
+    await emailTemplatesApi.cleanUp();
+  });
+
+  it('should read and use the i18n email template for test message', async () => {
+    await expect(
+      sendEmailTestMessage(mockEmailConnectorId, mockEmail, mockEmailConnectorConfig, 'de')
+    ).resolves.not.toThrow();
+
+    const { template } = await readConnectorMessage('Email');
+    expect(template).toEqual(mockDeTemplate.details);
+  });
+
+  it('should fallback to the default language template if the i18n template is not found for the given language', async () => {
+    await expect(
+      sendEmailTestMessage(mockEmailConnectorId, mockEmail, mockEmailConnectorConfig, 'fr')
+    ).resolves.not.toThrow();
+
+    const { template } = await readConnectorMessage('Email');
+    expect(template).toEqual(mockEnTemplate.details);
+  });
+
+  it('should fallback to the default template in connector configs if not i18n template is found', async () => {
+    // Delete default language templates
+    await emailTemplatesApi.deleteMany({
+      languageTag: 'en',
+      templateType: TemplateType.Generic,
+    });
+
+    await expect(
+      sendEmailTestMessage(mockEmailConnectorId, mockEmail, mockEmailConnectorConfig, 'br')
+    ).resolves.not.toThrow();
+
+    const { template } = await readConnectorMessage('Email');
+    expect(template).toEqual(
+      mockEmailConnectorConfig.templates.find(({ usageType }) => usageType === TemplateType.Generic)
+    );
+  });
+});

--- a/packages/integration-tests/src/tests/api/email-templates/index.test.ts
+++ b/packages/integration-tests/src/tests/api/email-templates/index.test.ts
@@ -6,7 +6,7 @@ import { EmailTemplatesApiTest } from '#src/helpers/email-templates.js';
 import { expectRejects } from '#src/helpers/index.js';
 import { devFeatureTest } from '#src/utils.js';
 
-devFeatureTest.describe('email templates', () => {
+devFeatureTest.describe('email templates management API', () => {
   const emailTemplatesApi = new EmailTemplatesApiTest();
 
   afterEach(async () => {

--- a/packages/integration-tests/src/tests/api/email-templates/organization-invitation.test.ts
+++ b/packages/integration-tests/src/tests/api/email-templates/organization-invitation.test.ts
@@ -1,0 +1,165 @@
+import { TemplateType } from '@logto/connector-kit';
+
+import { mockEmailConnectorConfig } from '#src/__mocks__/connectors-mock.js';
+import { type MockEmailTemplatePayload } from '#src/__mocks__/email-templates.js';
+import { setEmailConnector } from '#src/helpers/connector.js';
+import { EmailTemplatesApiTest } from '#src/helpers/email-templates.js';
+import { readConnectorMessage } from '#src/helpers/index.js';
+import { OrganizationApiTest, OrganizationInvitationApiTest } from '#src/helpers/organization.js';
+import { devFeatureTest, generateEmail } from '#src/utils.js';
+
+devFeatureTest.describe('organization invitation API with i18n email templates', () => {
+  const emailTemplatesApi = new EmailTemplatesApiTest();
+  const invitationApi = new OrganizationInvitationApiTest();
+  const organizationApi = new OrganizationApiTest();
+
+  const mockEmail = generateEmail();
+  const mockEnTemplate: MockEmailTemplatePayload = {
+    languageTag: 'en',
+    templateType: TemplateType.OrganizationInvitation,
+    details: {
+      subject: 'Test template',
+      content: 'Test value: {{code}}',
+      contentType: 'text/html',
+    },
+  };
+  const mockDeTemplate: MockEmailTemplatePayload = {
+    ...mockEnTemplate,
+    languageTag: 'de',
+  };
+  const mockFrSignInTemplate: MockEmailTemplatePayload = {
+    ...mockEnTemplate,
+    languageTag: 'fr',
+    templateType: TemplateType.SignIn,
+  };
+
+  beforeAll(async () => {
+    await Promise.all([
+      emailTemplatesApi.create([mockEnTemplate, mockDeTemplate, mockFrSignInTemplate]),
+      setEmailConnector(),
+    ]);
+  });
+
+  afterAll(async () => {
+    await emailTemplatesApi.cleanUp();
+  });
+
+  afterEach(async () => {
+    await Promise.all([organizationApi.cleanUp(), invitationApi.cleanUp()]);
+  });
+
+  it('should read and use the i18n email template for organization invitation', async () => {
+    await setEmailConnector();
+
+    const organization = await organizationApi.create({ name: 'test' });
+
+    await invitationApi.create({
+      organizationId: organization.id,
+      invitee: mockEmail,
+      expiresAt: Date.now() + 1_000_000,
+      messagePayload: {
+        locale: 'de',
+        link: 'https://example.com',
+      },
+    });
+
+    expect(await readConnectorMessage('Email')).toMatchObject({
+      type: 'OrganizationInvitation',
+      payload: {
+        locale: 'de',
+        link: 'https://example.com',
+      },
+      template: mockDeTemplate.details,
+    });
+  });
+
+  it('should fallback to the default language template if the i18n template is not found for the given language', async () => {
+    await setEmailConnector();
+
+    const organization = await organizationApi.create({ name: 'test' });
+
+    await invitationApi.create({
+      organizationId: organization.id,
+      invitee: mockEmail,
+      expiresAt: Date.now() + 1_000_000,
+      messagePayload: {
+        locale: 'fr',
+        link: 'https://example.com',
+      },
+    });
+
+    expect(await readConnectorMessage('Email')).toMatchObject({
+      type: 'OrganizationInvitation',
+      payload: {
+        locale: 'fr',
+        link: 'https://example.com',
+      },
+      template: mockEnTemplate.details,
+    });
+  });
+
+  it('should be able to resend the email after creating an invitation with a different language', async () => {
+    await setEmailConnector();
+    const organization = await organizationApi.create({ name: 'test' });
+
+    const invitation = await invitationApi.create({
+      organizationId: organization.id,
+      invitee: mockEmail,
+      expiresAt: Date.now() + 1_000_000,
+      messagePayload: {
+        locale: 'en',
+        link: 'https://example.com',
+      },
+    });
+    expect(await readConnectorMessage('Email')).toMatchObject({
+      type: 'OrganizationInvitation',
+      payload: {
+        locale: 'en',
+        link: 'https://example.com',
+      },
+      template: mockEnTemplate.details,
+    });
+
+    await invitationApi.resendMessage(invitation.id, {
+      locale: 'de',
+      link: 'https://example.com',
+    });
+
+    expect(await readConnectorMessage('Email')).toMatchObject({
+      type: 'OrganizationInvitation',
+      payload: {
+        locale: 'de',
+        link: 'https://example.com',
+      },
+      template: mockDeTemplate.details,
+    });
+  });
+
+  it('should be able to fallback to the default template in connector configs if no i18n template is found', async () => {
+    // Delete default language templates
+    await emailTemplatesApi.deleteMany({
+      languageTag: 'en',
+    });
+
+    const organization = await organizationApi.create({ name: 'test' });
+
+    const invitation = await invitationApi.create({
+      organizationId: organization.id,
+      invitee: mockEmail,
+      expiresAt: Date.now() + 1_000_000,
+      messagePayload: {
+        link: 'https://example.com',
+      },
+    });
+
+    expect(await readConnectorMessage('Email')).toMatchObject({
+      type: 'OrganizationInvitation',
+      payload: {
+        link: 'https://example.com',
+      },
+      template: mockEmailConnectorConfig.templates.find(
+        ({ usageType }) => usageType === TemplateType.OrganizationInvitation
+      ),
+    });
+  });
+});

--- a/packages/integration-tests/src/tests/api/email-templates/user-account-api.test.ts
+++ b/packages/integration-tests/src/tests/api/email-templates/user-account-api.test.ts
@@ -1,0 +1,141 @@
+import { TemplateType } from '@logto/connector-kit';
+import { UserScope } from '@logto/core-kit';
+import { SignInIdentifier } from '@logto/schemas';
+
+import { mockEmailConnectorConfig } from '#src/__mocks__/connectors-mock.js';
+import { type MockEmailTemplatePayload } from '#src/__mocks__/email-templates.js';
+import { enableAllAccountCenterFields } from '#src/api/account-center.js';
+import { createAndVerifyVerificationCode } from '#src/api/verification-record.js';
+import { setEmailConnector } from '#src/helpers/connector.js';
+import { EmailTemplatesApiTest } from '#src/helpers/email-templates.js';
+import { readConnectorMessage } from '#src/helpers/index.js';
+import {
+  createDefaultTenantUserWithPassword,
+  deleteDefaultTenantUser,
+  signInAndGetUserApi,
+} from '#src/helpers/profile.js';
+import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
+import { devFeatureTest, generateEmail } from '#src/utils.js';
+
+devFeatureTest.describe('user account email verification API with i18n email templates', () => {
+  const emailTemplatesApi = new EmailTemplatesApiTest();
+
+  const mockEnTemplate: MockEmailTemplatePayload = {
+    languageTag: 'en',
+    templateType: TemplateType.UserPermissionValidation,
+    details: {
+      subject: 'Test template',
+      content: 'Test value: {{code}}',
+      contentType: 'text/html',
+    },
+  };
+
+  const mockDeTemplate: MockEmailTemplatePayload = {
+    ...mockEnTemplate,
+    languageTag: 'de',
+    templateType: TemplateType.BindNewIdentifier,
+  };
+
+  beforeAll(async () => {
+    await Promise.all([
+      setEmailConnector(),
+      enableAllPasswordSignInMethods(),
+      enableAllAccountCenterFields(),
+      emailTemplatesApi.create([mockEnTemplate, mockDeTemplate]),
+    ]);
+  });
+
+  afterAll(async () => {
+    await emailTemplatesApi.cleanUp();
+  });
+
+  it('update primary email by verifying existing email with empty local', async () => {
+    const primaryEmail = generateEmail();
+    const { user, username, password } = await createDefaultTenantUserWithPassword({
+      primaryEmail,
+    });
+    const api = await signInAndGetUserApi(username, password, {
+      scopes: [UserScope.Profile, UserScope.Email],
+    });
+
+    await createAndVerifyVerificationCode(api, {
+      type: SignInIdentifier.Email,
+      value: primaryEmail,
+    });
+
+    // TemplateType.UserPermissionValidation
+    expect(await readConnectorMessage('Email')).toMatchObject({
+      type: TemplateType.UserPermissionValidation,
+      payload: {
+        locale: 'en',
+      },
+      template: mockEnTemplate.details,
+    });
+
+    const newEmail = generateEmail();
+    await createAndVerifyVerificationCode(api, {
+      type: SignInIdentifier.Email,
+      value: newEmail,
+    });
+
+    // TemplateType.BindNewIdentifier
+    expect(await readConnectorMessage('Email')).toMatchObject({
+      type: TemplateType.BindNewIdentifier,
+      payload: {
+        locale: 'en',
+      },
+      template: mockEmailConnectorConfig.templates.find(
+        ({ usageType }) => usageType === TemplateType.BindNewIdentifier
+      ),
+    });
+
+    await deleteDefaultTenantUser(user.id);
+  });
+
+  it('update primary email by verifying existing email with de local', async () => {
+    const primaryEmail = generateEmail();
+    const { user, username, password } = await createDefaultTenantUserWithPassword({
+      primaryEmail,
+    });
+    const api = await signInAndGetUserApi(
+      username,
+      password,
+      {
+        scopes: [UserScope.Profile, UserScope.Email],
+      },
+      'de'
+    );
+
+    await createAndVerifyVerificationCode(api, {
+      type: SignInIdentifier.Email,
+      value: primaryEmail,
+    });
+
+    // TemplateType.UserPermissionValidation
+    expect(await readConnectorMessage('Email')).toMatchObject({
+      type: TemplateType.UserPermissionValidation,
+      payload: {
+        locale: 'de',
+      },
+      // No de custom template found, fallback to en custom template
+      template: mockEnTemplate.details,
+    });
+
+    const newEmail = generateEmail();
+    await createAndVerifyVerificationCode(api, {
+      type: SignInIdentifier.Email,
+      value: newEmail,
+    });
+
+    // TemplateType.BindNewIdentifier
+    expect(await readConnectorMessage('Email')).toMatchObject({
+      type: TemplateType.BindNewIdentifier,
+      payload: {
+        locale: 'de',
+      },
+      template: mockDeTemplate.details,
+    });
+
+    await deleteDefaultTenantUser(user.id);
+  });
+});

--- a/packages/schemas/src/foundations/jsonb-types/email-templates.ts
+++ b/packages/schemas/src/foundations/jsonb-types/email-templates.ts
@@ -1,39 +1,6 @@
-import { z } from 'zod';
-
-export { TemplateType, templateTypeGuard } from '@logto/connector-kit';
-
-export type EmailTemplateDetails = {
-  subject: string;
-  content: string;
-  /**
-   * OPTIONAL: The content type of the email template.
-   *
-   * Some email clients may render email templates differently based on the content type. (e.g. Sendgrid, Mailgun)
-   * Use this field to specify the content type of the email template.
-   */
-  contentType?: 'text/html' | 'text/plain';
-  /**
-   * OPTIONAL: Custom replyTo template.
-   *
-   * Based on the email client, the replyTo field may be used to customize the reply-to field of the email.
-   * @remarks
-   * The original reply email value can be found in the template variables.
-   */
-  replyTo?: string;
-  /**
-   * OPTIONAL: Custom from template.
-   *
-   * Based on the email client, the sendFrom field may be used to customize the from field of the email.
-   * @remarks
-   * The sender email value can be found in the template variables.
-   */
-  sendFrom?: string;
-};
-
-export const emailTemplateDetailsGuard = z.object({
-  subject: z.string(),
-  content: z.string(),
-  contentType: z.union([z.literal('text/html'), z.literal('text/plain')]).optional(),
-  replyTo: z.string().optional(),
-  sendFrom: z.string().optional(),
-}) satisfies z.ZodType<EmailTemplateDetails>;
+export {
+  TemplateType,
+  templateTypeGuard,
+  type EmailTemplateDetails,
+  emailTemplateDetailsGuard,
+} from '@logto/connector-kit';

--- a/packages/toolkit/connector-kit/src/types/email-template.ts
+++ b/packages/toolkit/connector-kit/src/types/email-template.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+export type EmailTemplateDetails = {
+  subject: string;
+  content: string;
+  /**
+   * OPTIONAL: The content type of the email template.
+   *
+   * Some email clients may render email templates differently based on the content type. (e.g. Sendgrid, Mailgun)
+   * Use this field to specify the content type of the email template.
+   */
+  contentType?: 'text/html' | 'text/plain';
+  /**
+   * OPTIONAL: Custom replyTo template.
+   *
+   * Based on the email client, the replyTo field may be used to customize the reply-to field of the email.
+   * @remarks
+   * The original reply email value can be found in the template variables.
+   */
+  replyTo?: string;
+  /**
+   * OPTIONAL: Custom from template.
+   *
+   * Based on the email client, the sendFrom field may be used to customize the from field of the email.
+   * @remarks
+   * The sender email value can be found in the template variables.
+   */
+  sendFrom?: string;
+};
+
+export const emailTemplateDetailsGuard = z.object({
+  subject: z.string(),
+  content: z.string(),
+  contentType: z.union([z.literal('text/html'), z.literal('text/plain')]).optional(),
+  replyTo: z.string().optional(),
+  sendFrom: z.string().optional(),
+}) satisfies z.ZodType<EmailTemplateDetails>;

--- a/packages/toolkit/connector-kit/src/types/index.ts
+++ b/packages/toolkit/connector-kit/src/types/index.ts
@@ -1,7 +1,8 @@
 import type Client from '@withtyped/client';
 import type { BaseRoutes, Router } from '@withtyped/server';
 
-import { type SmsConnector, type EmailConnector } from './passwordless.js';
+import { type EmailTemplateDetails } from './email-template.js';
+import { type SmsConnector, type EmailConnector, type TemplateType } from './passwordless.js';
 import { type SocialConnector } from './social.js';
 
 export * from './config-form.js';
@@ -10,6 +11,7 @@ export * from './metadata.js';
 export * from './foundation.js';
 export * from './passwordless.js';
 export * from './social.js';
+export * from './email-template.js';
 
 export type GetConnectorConfig = (id: string) => Promise<unknown>;
 
@@ -18,6 +20,23 @@ export type GetCloudServiceClient<T extends Router<any, any, BaseRoutes, string>
   Client<T>
 >;
 
+/**
+ * Get the custom i18n template for the email connector.
+ *
+ * @param {TemplateType} templateType - The type of the template. e.g. 'SignIn'
+ * @param {string} [languageTag] - The preferred language tag of the template. e.g. 'en-US'
+ *
+ * @remarks
+ * Available for email connectors only.
+ * If not provided, or the language template returns undefined,
+ * the connector should fallback to the default template settings
+ * located in the email connector configuration.
+ */
+export type GetI18nEmailTemplate = (
+  templateType: TemplateType,
+  languageTag?: string
+) => Promise<EmailTemplateDetails | undefined>;
+
 export type CreateConnector<
   T extends AllConnector,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -25,6 +44,7 @@ export type CreateConnector<
 > = (options: {
   getConfig: GetConnectorConfig;
   getCloudServiceClient?: GetCloudServiceClient<U>;
+  getI18nEmailTemplate?: T extends EmailConnector ? GetI18nEmailTemplate : undefined;
 }) => Promise<T>;
 
 export type AllConnector = SmsConnector | EmailConnector | SocialConnector;

--- a/packages/toolkit/connector-kit/src/types/passwordless.ts
+++ b/packages/toolkit/connector-kit/src/types/passwordless.ts
@@ -51,6 +51,17 @@ export type SendMessagePayload = {
    * @example 'https://example.com'
    */
   link?: string;
+  /**
+   * The language tag detected from the user's request. It will be used to localize the message.
+   * If provided, Logto will use the corresponding language template to send the message.
+   * If not provided, or the language template is not available, will fallback to the default language and template.
+   *
+   * @remarks
+   * For email connectors that handle email templates at the provider side, use this field to indicate the user's preferred language.
+   *
+   * @example 'en-US'
+   */
+  locale?: string;
 } & Record<string, string>;
 
 /** The guard for {@link SendMessagePayload}. */
@@ -58,8 +69,9 @@ export const sendMessagePayloadGuard = z
   .object({
     code: z.string().optional(),
     link: z.string().optional(),
+    locale: z.string().optional(),
   })
-  .and(z.record(z.string())) satisfies z.ZodType<SendMessagePayload>;
+  .catchall(z.string()) satisfies z.ZodType<SendMessagePayload>;
 
 export const urlRegEx =
   /(https?:\/\/)?(?:www\.)?[\w#%+.:=@~-]{1,256}\.[\d()A-Za-z]{1,6}\b[\w#%&()+./:=?@~-]*/;
@@ -80,13 +92,13 @@ export type EmailServiceBranding = z.infer<typeof emailServiceBrandingGuard>;
 
 export type SendMessageData = {
   to: string;
-  type: TemplateType | VerificationCodeType;
+  type: TemplateType;
   payload: SendMessagePayload;
 };
 
 export const sendMessageDataGuard = z.object({
   to: z.string(),
-  type: templateTypeGuard.or(verificationCodeTypeGuard),
+  type: templateTypeGuard,
   payload: sendMessagePayloadGuard,
 }) satisfies z.ZodType<SendMessageData>;
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Adds end-to-end localization support for email connectors by introducing locale propagation and template customization capabilities.

### Updates:

- **Connector Schema Update**  
  - Extended `sendMessage` payload schema with optional `locale` property. If provided, this property will be used to find the preferred custom i18n email template. 
  - Relocate the `emailTemplateDetailsGuard` and `EmailTemplateDetails` definitions from `@logto/schemas` to `@logto/connector-kit` so they can be shared across email connector packages.
- **Locale Propagation**  
  - Client-facing API: `experience verification API`, `account verification API`, `me verification API`. Auto-inject `ctx.locale` into the `sendMessage` payload. 
  - Management APIs: `connector test API`, `organization invitation API`. Added optional `locale` body parameter to indicate the preferred email template language. 
- **Template Customization**
  -  Added the `getI18nTemplate` connector library method  to the `createConnector` factory method
    ✅ Fetch the custom i18n templates based on the given language and template type
    ✅ Fallback to the default language settings in SIE if no custom i18n template is found for the given language. 
    ✅ Fallback to the default template in connector config if no custom i18n template if found for the default language

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Integration tests added

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
