### PR TITLE
fix(core): fix incorrect condition check

### DIFF
--- a/.changeset/seven-cows-look.md
+++ b/.changeset/seven-cows-look.md
@@ -1,0 +1,18 @@
+---
+"@logto/core": patch
+---
+
+fixes an incorrect condition check in the verification code flow where `isNewIdentifier` was using inverted logic for email and phone comparisons.
+
+### Changes
+
+- Corrected `isNewIdentifier` boolean logic to use `identifier.value !== user.primaryEmail` for email checks
+- Fixed phone number comparison to properly use `identifier.value !== user.primaryPhone`
+
+### Impact
+
+This fixes a regression where:
+
+- Verification codes for existing emails/phones were incorrectly using the`BindNewIdentifier` template
+- New identifiers were mistakenly getting the `UserPermissionValidation` template
+- Affected both email and phone verification flows

--- a/packages/core/src/routes/verification/index.ts
+++ b/packages/core/src/routes/verification/index.ts
@@ -87,8 +87,8 @@ export default function verificationRoutes<T extends UserRouter>(
 
       const user = await queries.users.findUserById(userId);
       const isNewIdentifier =
-        (identifier.type === SignInIdentifier.Email && identifier.value === user.primaryEmail) ||
-        (identifier.type === SignInIdentifier.Phone && identifier.value === user.primaryPhone);
+        (identifier.type === SignInIdentifier.Email && identifier.value !== user.primaryEmail) ||
+        (identifier.type === SignInIdentifier.Phone && identifier.value !== user.primaryPhone);
 
       const codeVerification = createNewCodeVerificationRecord(
         libraries,
@@ -102,7 +102,7 @@ export default function verificationRoutes<T extends UserRouter>(
       const { expiresAt } = await insertVerificationRecord(
         codeVerification,
         queries,
-        isNewIdentifier ? userId : undefined
+        isNewIdentifier ? undefined : userId
       );
 
       ctx.body = {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fixes an incorrect condition check in the verification code flow where `isNewIdentifier` was using inverted logic for email and phone comparisons.

### Changes
- Corrected `isNewIdentifier` boolean logic to use `identifier.value !== user.primaryEmail` for email checks
- Fixed phone number comparison to properly use `identifier.value !== user.primaryPhone`

### Impact
This fixes a regression where:
- Verification codes for existing emails/phones were incorrectly using the `BindNewIdentifier` template
- New identifiers were mistakenly getting the `UserPermissionValidation` template
- Affected both email and phone verification flows

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
integration test covered

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
