### PR TITLE
fix(core): fix SAML app redirect URIs sync custom domains logic

### DIFF
--- a/packages/core/src/routes/domain.test.ts
+++ b/packages/core/src/routes/domain.test.ts
@@ -36,7 +36,7 @@ const mockLibraries = {
   },
   quota: createMockQuotaLibrary(),
   samlApplications: {
-    syncCustomDomainToSamlApplicationRedirectUrls: jest.fn(),
+    syncCustomDomainsToSamlApplicationRedirectUrls: jest.fn(),
   },
 };
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix SAML app redirect URIs sync custom domains logic, with following updates:
1. update `syncCustomDomainsToSamlApplicationRedirectUrls()` method, takes `domains` as second parameter, handle all domains once instead of iterating through domain lists, which can hurt performance.
2. previously we use `startsWith(host)` to find default redirectURI, which is wrong.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally, can successfully sync custom domains to SAML app redirect URIs.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
