### PR TITLE
refactor(core): add email templates redis cache

### DIFF
--- a/packages/core/src/caches/base-cache.ts
+++ b/packages/core/src/caches/base-cache.ts
@@ -51,10 +51,7 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
   ): Promise<Optional<CacheMapT[Type]>> {
     return trySafe(async () => {
       const data = await this.cacheStore.get(this.cacheKey(type, key));
-      // Allow `null` value to be stored in the cache.
-      // If the value is `null`, we should return `null` instead of parsing it as JSON.
-      // Otherwise, treat the value as JSON and parse it.
-      return this.getValueGuard(type).parse(data === 'null' ? null : JSON.parse(data ?? ''));
+      return this.getValueGuard(type).parse(JSON.parse(data ?? ''));
     });
   }
 

--- a/packages/core/src/caches/well-known.ts
+++ b/packages/core/src/caches/well-known.ts
@@ -1,4 +1,10 @@
-import { type SignInExperience, SignInExperiences } from '@logto/schemas';
+import {
+  type EmailTemplate,
+  EmailTemplates,
+  type SignInExperience,
+  SignInExperiences,
+} from '@logto/schemas';
+import { type Nullable } from '@silverhand/essentials';
 import { type ZodType, z } from 'zod';
 
 import { type ConnectorWellKnown, connectorWellKnownGuard } from '#src/utils/connectors/types.js';
@@ -8,6 +14,7 @@ import { BaseCache } from './base-cache.js';
 type WellKnownMap = {
   sie: SignInExperience;
   'connectors-well-known': ConnectorWellKnown[];
+  'email-templates': Nullable<EmailTemplate>;
   'custom-phrases': Record<string, unknown>;
   'custom-phrases-tags': string[];
   'tenant-cache-expires-at': number;
@@ -41,6 +48,9 @@ function getValueGuard(type: WellKnownCacheType): ZodType<WellKnownMap[typeof ty
     }
     case 'is-development-tenant': {
       return z.boolean();
+    }
+    case 'email-templates': {
+      return EmailTemplates.guard.nullable();
     }
   }
 }


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add Redis cache for the email templates.
- Implement Redis caching for email templates using `languageTag` and `templateType` as cache keys to reduce DB queries
- Update WellKnownCache to support null values in Redis cache entries
- Add cache invalidation during template updates/deletions

### Changes
1. Added Redis caching layer for email template `findByLanguageTagAndTemplateType` query method
   - New Redis cache type `email-templates`
   - Cache lookup using composite key: `<languageTag>:<templateType>`
   - Cache null values to prevent DB lookups for non-existent templates

2. Enhanced WellKnownCache functionality to support nullable value
   - Modified JSON serialization to handle null values
   - Added null value detection in cache hydration logic
   - Added WellKnown supported cache type `email-templates` and data guard

3. Implemented cache invalidation:
   - Clear relevant cache entries on template `updateById` and `deleteById` query operations.
   - Added bulk cache invalidation for batch template`deleteMany` and `upsertMany` query operations.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Unit test added.
Test email template caching logic locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
