### PR TITLE
feat(toolkit,core): support nested properties in email template variables

### DIFF
--- a/.changeset/small-hairs-pretend.md
+++ b/.changeset/small-hairs-pretend.md
@@ -1,0 +1,55 @@
+---
+"@logto/connector-kit": minor
+---
+
+enhanced Handlebars template processing in the connector to support deep property access in email template variables.
+
+## Updates
+
+- Updated `replaceSendMessageHandlebars` logic to handle nested property paths in template variables
+- Latest template processing logic now supports:
+  - Direct replacement of primitive values (string/number/null/undefined)
+  - Deep property access using dot-notation (e.g., `organization.branding.logoUrl`)
+  - Graceful handling of missing properties (replaces with empty string)
+  - Preservation of original handlebars when variables aren't provided in payload
+
+## Examples
+
+1. Direct replacement
+
+```ts
+replaceSendMessageKeysWithPayload("Your verification code is {{code}}", {
+  code: "123456",
+});
+// 'Your verification code is 123456'
+```
+
+2. Deep property access
+
+```ts
+replaceSendMessageKeysWithPayload(
+  "Your logo is {{organization.branding.logoUrl}}",
+  { organization: { branding: { logoUrl: "https://example.com/logo.png" } } }
+);
+// 'Your logo is https://example.com/logo.png'
+```
+
+3. Missing properties
+
+```ts
+replaceSendMessageKeysWithPayload(
+  "Your logo is {{organization.branding.logoUrl}}",
+  { organization: { name: "foo" } }
+);
+// 'Your logo is '
+```
+
+4. Preservation of missing variables
+
+```ts
+replaceSendMessageKeysWithPayload(
+  "Your application is {{application.name}}",
+  {}
+);
+// 'Your application i {{application.name}}'
+```

--- a/.changeset/small-hairs-pretend.md
+++ b/.changeset/small-hairs-pretend.md
@@ -2,7 +2,7 @@
 "@logto/connector-kit": minor
 ---
 
-enhanced Handlebars template processing in the connector to support deep property access in email template variables.
+enhanced handlebars template processing in the connector to support nested property access in email template variables.
 
 ## Updates
 
@@ -51,5 +51,5 @@ replaceSendMessageKeysWithPayload(
   "Your application is {{application.name}}",
   {}
 );
-// 'Your application i {{application.name}}'
+// 'Your application is {{application.name}}'
 ```

--- a/packages/connectors/connector-mock-email/src/index.ts
+++ b/packages/connectors/connector-mock-email/src/index.ts
@@ -14,6 +14,7 @@ import {
   validateConfig,
   ConnectorType,
   mockConnectorFilePaths,
+  replaceSendMessageHandlebars,
 } from '@logto/connector-kit';
 
 import { defaultMetadata } from './constant.js';
@@ -41,7 +42,15 @@ const sendMessage =
 
     await fs.writeFile(
       mockConnectorFilePaths.Email,
-      JSON.stringify({ address: to, code: payload.code, type, payload, template }) + '\n'
+      JSON.stringify({
+        address: to,
+        code: payload.code,
+        type,
+        payload,
+        template,
+        subject: replaceSendMessageHandlebars(template.subject, payload),
+        content: replaceSendMessageHandlebars(template.content, payload),
+      }) + '\n'
     );
 
     return { address: to, data: payload };

--- a/packages/connectors/connector-tencent-sms/src/index.ts
+++ b/packages/connectors/connector-tencent-sms/src/index.ts
@@ -45,8 +45,11 @@ function sendMessage(getConfig: GetConnectorConfig): SendMessageFunction {
       )
     );
 
+    // Tencent SMS API requires all parameters to be strings. Force parse all payload values to string.
+    const parametersSet = Object.values(payload).map(String);
+
     try {
-      const httpResponse = await sendSmsRequest(template.templateCode, Object.values(payload), to, {
+      const httpResponse = await sendSmsRequest(template.templateCode, parametersSet, to, {
         secretId: accessKeyId,
         secretKey: accessKeySecret,
         sdkAppId,

--- a/packages/core/src/caches/base-cache.ts
+++ b/packages/core/src/caches/base-cache.ts
@@ -51,7 +51,10 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
   ): Promise<Optional<CacheMapT[Type]>> {
     return trySafe(async () => {
       const data = await this.cacheStore.get(this.cacheKey(type, key));
-      return this.getValueGuard(type).parse(JSON.parse(data ?? ''));
+      // Allow `null` value to be stored in the cache.
+      // If the value is `null`, we should return `null` instead of parsing it as JSON.
+      // Otherwise, treat the value as JSON and parse it.
+      return this.getValueGuard(type).parse(data === 'null' ? null : JSON.parse(data ?? ''));
     });
   }
 

--- a/packages/core/src/caches/base-cache.ts
+++ b/packages/core/src/caches/base-cache.ts
@@ -51,10 +51,7 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
   ): Promise<Optional<CacheMapT[Type]>> {
     return trySafe(async () => {
       const data = await this.cacheStore.get(this.cacheKey(type, key));
-      // Allow `null` value to be stored in the cache.
-      // If the value is `null`, we should return `null` instead of parsing it as JSON.
-      // Otherwise, treat the value as JSON and parse it.
-      return this.getValueGuard(type).parse(data === 'null' ? null : JSON.parse(data ?? ''));
+      return this.getValueGuard(type).parse(JSON.parse(data ?? ''));
     });
   }
 

--- a/packages/core/src/utils/connectors/extra-information.ts
+++ b/packages/core/src/utils/connectors/extra-information.ts
@@ -18,7 +18,7 @@ export const buildExtraInfo = (metadata: ConnectorMetadata) => {
   return cleanDeep(extraInfo, { emptyObjects: false });
 };
 
-export type OrganizationExtraInfo = Pick<Organization, 'id' | 'name' | 'branding' | 'customData'>;
+export type OrganizationExtraInfo = Pick<Organization, 'id' | 'name' | 'branding'>;
 
 export const buildOrganizationExtraInfo = (organization: Organization): OrganizationExtraInfo =>
-  pick(organization, 'id', 'name', 'branding', 'customData');
+  pick(organization, 'id', 'name', 'branding');

--- a/packages/core/src/utils/connectors/extra-information.ts
+++ b/packages/core/src/utils/connectors/extra-information.ts
@@ -1,5 +1,6 @@
 import { type ConnectorMetadata, ServiceConnector } from '@logto/connector-kit';
-import { conditional } from '@silverhand/essentials';
+import { type Organization } from '@logto/schemas';
+import { conditional, pick } from '@silverhand/essentials';
 import cleanDeep from 'clean-deep';
 import { string, object } from 'zod';
 
@@ -16,3 +17,8 @@ export const buildExtraInfo = (metadata: ConnectorMetadata) => {
   };
   return cleanDeep(extraInfo, { emptyObjects: false });
 };
+
+export type OrganizationExtraInfo = Pick<Organization, 'id' | 'name' | 'branding' | 'customData'>;
+
+export const buildOrganizationExtraInfo = (organization: Organization): OrganizationExtraInfo =>
+  pick(organization, 'id', 'name', 'branding', 'customData');

--- a/packages/integration-tests/src/tests/api/email-templates/organization-invitation.test.ts
+++ b/packages/integration-tests/src/tests/api/email-templates/organization-invitation.test.ts
@@ -1,4 +1,4 @@
-import { TemplateType } from '@logto/connector-kit';
+import { type EmailTemplateDetails, TemplateType } from '@logto/connector-kit';
 
 import { mockEmailConnectorConfig } from '#src/__mocks__/connectors-mock.js';
 import { type MockEmailTemplatePayload } from '#src/__mocks__/email-templates.js';
@@ -8,30 +8,31 @@ import { readConnectorMessage } from '#src/helpers/index.js';
 import { OrganizationApiTest, OrganizationInvitationApiTest } from '#src/helpers/organization.js';
 import { devFeatureTest, generateEmail } from '#src/utils.js';
 
+const mockEnTemplate: MockEmailTemplatePayload = {
+  languageTag: 'en',
+  templateType: TemplateType.OrganizationInvitation,
+  details: {
+    subject: 'Organization invitation',
+    content: 'Click {{link}} to join the organization.',
+    contentType: 'text/html',
+  },
+};
+const mockDeTemplate: MockEmailTemplatePayload = {
+  ...mockEnTemplate,
+  languageTag: 'de',
+};
+const mockFrSignInTemplate: MockEmailTemplatePayload = {
+  ...mockEnTemplate,
+  languageTag: 'fr',
+  templateType: TemplateType.SignIn,
+};
+
 devFeatureTest.describe('organization invitation API with i18n email templates', () => {
   const emailTemplatesApi = new EmailTemplatesApiTest();
   const invitationApi = new OrganizationInvitationApiTest();
   const organizationApi = new OrganizationApiTest();
 
   const mockEmail = generateEmail();
-  const mockEnTemplate: MockEmailTemplatePayload = {
-    languageTag: 'en',
-    templateType: TemplateType.OrganizationInvitation,
-    details: {
-      subject: 'Test template',
-      content: 'Test value: {{code}}',
-      contentType: 'text/html',
-    },
-  };
-  const mockDeTemplate: MockEmailTemplatePayload = {
-    ...mockEnTemplate,
-    languageTag: 'de',
-  };
-  const mockFrSignInTemplate: MockEmailTemplatePayload = {
-    ...mockEnTemplate,
-    languageTag: 'fr',
-    templateType: TemplateType.SignIn,
-  };
 
   beforeAll(async () => {
     await Promise.all([
@@ -49,8 +50,6 @@ devFeatureTest.describe('organization invitation API with i18n email templates',
   });
 
   it('should read and use the i18n email template for organization invitation', async () => {
-    await setEmailConnector();
-
     const organization = await organizationApi.create({ name: 'test' });
 
     await invitationApi.create({
@@ -74,8 +73,6 @@ devFeatureTest.describe('organization invitation API with i18n email templates',
   });
 
   it('should fallback to the default language template if the i18n template is not found for the given language', async () => {
-    await setEmailConnector();
-
     const organization = await organizationApi.create({ name: 'test' });
 
     await invitationApi.create({
@@ -99,7 +96,6 @@ devFeatureTest.describe('organization invitation API with i18n email templates',
   });
 
   it('should be able to resend the email after creating an invitation with a different language', async () => {
-    await setEmailConnector();
     const organization = await organizationApi.create({ name: 'test' });
 
     const invitation = await invitationApi.create({
@@ -143,7 +139,7 @@ devFeatureTest.describe('organization invitation API with i18n email templates',
 
     const organization = await organizationApi.create({ name: 'test' });
 
-    const invitation = await invitationApi.create({
+    await invitationApi.create({
       organizationId: organization.id,
       invitee: mockEmail,
       expiresAt: Date.now() + 1_000_000,
@@ -160,6 +156,51 @@ devFeatureTest.describe('organization invitation API with i18n email templates',
       template: mockEmailConnectorConfig.templates.find(
         ({ usageType }) => usageType === TemplateType.OrganizationInvitation
       ),
+    });
+  });
+
+  it('should render the template with the extra organization information', async () => {
+    const organizationInvitationTemplate: EmailTemplateDetails = {
+      subject:
+        'You are invited by {{organization.customData.invitee}} to join {{organization.name}}',
+      content:
+        '<p>Click {{link}} to join the organization {{organization.name}}.<p><img src="{{organization.branding.logoUrl}}" />{{organization.invalid_field.foo}}',
+      contentType: 'text/html',
+    };
+
+    await emailTemplatesApi.create([
+      {
+        languageTag: 'en',
+        templateType: TemplateType.OrganizationInvitation,
+        details: organizationInvitationTemplate,
+      },
+    ]);
+
+    const organization = await organizationApi.create({
+      name: 'test',
+      branding: {
+        logoUrl: 'https://example.com/logo.png',
+      },
+      customData: { invitee: 'John Doe' },
+    });
+
+    await invitationApi.create({
+      organizationId: organization.id,
+      invitee: mockEmail,
+      expiresAt: Date.now() + 1_000_000,
+      messagePayload: {
+        link: 'https://example.com',
+      },
+    });
+
+    await expect(readConnectorMessage('Email')).resolves.toMatchObject({
+      type: 'OrganizationInvitation',
+      payload: {
+        link: 'https://example.com',
+      },
+      template: organizationInvitationTemplate,
+      subject: `You are invited by John Doe to join test`,
+      content: `<p>Click https://example.com to join the organization test.<p><img src="https://example.com/logo.png" />`,
     });
   });
 });

--- a/packages/integration-tests/src/tests/api/email-templates/organization-invitation.test.ts
+++ b/packages/integration-tests/src/tests/api/email-templates/organization-invitation.test.ts
@@ -161,8 +161,7 @@ devFeatureTest.describe('organization invitation API with i18n email templates',
 
   it('should render the template with the extra organization information', async () => {
     const organizationInvitationTemplate: EmailTemplateDetails = {
-      subject:
-        'You are invited by {{organization.customData.invitee}} to join {{organization.name}}',
+      subject: 'You are invited to join {{organization.name}}',
       content:
         '<p>Click {{link}} to join the organization {{organization.name}}.<p><img src="{{organization.branding.logoUrl}}" />{{organization.invalid_field.foo}}',
       contentType: 'text/html',
@@ -181,7 +180,6 @@ devFeatureTest.describe('organization invitation API with i18n email templates',
       branding: {
         logoUrl: 'https://example.com/logo.png',
       },
-      customData: { invitee: 'John Doe' },
     });
 
     await invitationApi.create({
@@ -199,7 +197,7 @@ devFeatureTest.describe('organization invitation API with i18n email templates',
         link: 'https://example.com',
       },
       template: organizationInvitationTemplate,
-      subject: `You are invited by John Doe to join test`,
+      subject: `You are invited to join test`,
       content: `<p>Click https://example.com to join the organization test.<p><img src="https://example.com/logo.png" />`,
     });
   });

--- a/packages/toolkit/connector-kit/src/index.ts
+++ b/packages/toolkit/connector-kit/src/index.ts
@@ -61,8 +61,11 @@ export const mockConnectorFilePaths = Object.freeze({
 
 /**
  * Replace all handlebars that match the keys in {@link SendMessagePayload} with the payload
- * values. If the payload does not contain the key, the handlebar will be replaced with an empty
- * string.
+ * values.
+ *
+ * - If the payload does not contain the root property, the handlebars will not be replaced.
+ * - If the payload contains the root property but does not contain the nested property,
+ *  the handlebars will be replaced with an empty string.
  *
  * @param template The template to replace the handlebars with.
  * @param payload The payload to replace the handlebars with.
@@ -72,21 +75,50 @@ export const mockConnectorFilePaths = Object.freeze({
  * ```ts
  * replaceSendMessageKeysWithPayload('Your verification code is {{code}}', { code: '123456' });
  * // 'Your verification code is 123456'
+ *
+ * replaceSendMessageKeysWithPayload('Your application name is {{application.name}}', { application: { name: 'Logto' } });
+ * // 'Your application name is Logto'
  * ```
+ * replaceSendMessageKeysWithPayload('Your application name is {{application.name}}', { application: {}});
+ * // 'Your application name is '
  *
  * @example
  * ```ts
  * replaceSendMessageKeysWithPayload('Your verification code is {{code}}', {});
- * // 'Your verification code is '
+ * // 'Your verification code is {{code}}'
+ *
+ * replaceSendMessageKeysWithPayload('Your application name is {{application.name}}', {});
+ * // 'Your application name is {{application.name}}'
  * ```
+ *
  */
 export const replaceSendMessageHandlebars = (
   template: string,
   payload: SendMessagePayload
 ): string => {
-  return Object.keys(payload).reduce(
-    (accumulator, key) =>
-      accumulator.replaceAll(new RegExp(`{{\\s*${key}\\s*}}`, 'g'), payload[key] ?? ''),
-    template
-  );
+  const regex = /{{\s*([\w.]+)\s*}}/g;
+
+  return template.replaceAll(regex, (handleBar, key: string) => {
+    const baseKey = key.split('.')[0];
+    // If the root variable does not exist in the payload, return the original key
+    if (!(baseKey && baseKey in payload)) {
+      return handleBar;
+    }
+
+    const value = getValue(payload, key);
+
+    return String(value ?? '');
+  });
+};
+
+export const getValue = (object: Record<string, unknown>, path: string): unknown | undefined => {
+  return path.split('.').reduce<unknown | undefined>((current, part) => {
+    // Return undefined if the current value is not an object
+    if (!current || typeof current !== 'object') {
+      return;
+    }
+
+    // eslint-disable-next-line no-restricted-syntax
+    return (current as Record<string, unknown>)[part];
+  }, object);
 };

--- a/packages/toolkit/connector-kit/src/index.ts
+++ b/packages/toolkit/connector-kit/src/index.ts
@@ -78,9 +78,10 @@ export const mockConnectorFilePaths = Object.freeze({
  *
  * replaceSendMessageKeysWithPayload('Your application name is {{application.name}}', { application: { name: 'Logto' } });
  * // 'Your application name is Logto'
- * ```
+ *
  * replaceSendMessageKeysWithPayload('Your application name is {{application.name}}', { application: {}});
  * // 'Your application name is '
+ * ```
  *
  * @example
  * ```ts
@@ -90,7 +91,6 @@ export const mockConnectorFilePaths = Object.freeze({
  * replaceSendMessageKeysWithPayload('Your application name is {{application.name}}', {});
  * // 'Your application name is {{application.name}}'
  * ```
- *
  */
 export const replaceSendMessageHandlebars = (
   template: string,

--- a/packages/toolkit/connector-kit/src/types/passwordless.ts
+++ b/packages/toolkit/connector-kit/src/types/passwordless.ts
@@ -62,7 +62,7 @@ export type SendMessagePayload = {
    * @example 'en-US'
    */
   locale?: string;
-} & Record<string, string>;
+} & Record<string, unknown>;
 
 /** The guard for {@link SendMessagePayload}. */
 export const sendMessagePayloadGuard = z
@@ -71,7 +71,7 @@ export const sendMessagePayloadGuard = z
     link: z.string().optional(),
     locale: z.string().optional(),
   })
-  .catchall(z.string()) satisfies z.ZodType<SendMessagePayload>;
+  .catchall(z.unknown()) satisfies z.ZodType<SendMessagePayload>;
 
 export const urlRegEx =
   /(https?:\/\/)?(?:www\.)?[\w#%+.:=@~-]{1,256}\.[\d()A-Za-z]{1,6}\b[\w#%&()+./:=?@~-]*/;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Enhanced handlebars template processing in the connector to support deep property access in email template variables. 

This enables more flexible template authoring, allowing nested object traversal in payload data.

### Updates

- Updated `replaceSendMessageHandlebars` logic to handle nested property paths in template variables
- Latest template processing logic now supports:
  - Direct replacement of primitive values (string/number/null/undefined)
  - Deep property access using dot-notation (e.g., `organization.branding.logoUrl`)
  - Graceful handling of missing properties (replaces with empty string)
  - Preservation of original handlebars when variables aren't provided in payload
- Append extra organization context to the organization invitation sendMessage payload
  
### Examples

1. Direct replacement

```ts
replaceSendMessageKeysWithPayload("Your verification code is {{code}}", {
  code: "123456",
});
// 'Your verification code is 123456'
```

2. Deep property access

```ts
replaceSendMessageKeysWithPayload(
  "Your logo is {{organization.branding.logoUrl}}",
  { organization: { branding: { logoUrl: "https://example.com/logo.png" } } }
);
// 'Your logo is https://example.com/logo.png'
```

3. Missing properties

```ts
replaceSendMessageKeysWithPayload(
  "Your logo is {{organization.branding.logoUrl}}",
  { organization: { name: "foo" } }
);
// 'Your logo is '
```

4. Preservation of missing variables

```ts
replaceSendMessageKeysWithPayload(
  "Your application is {{application.name}}",
  {}
);
// 'Your application i {{application.name}}'
```


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
