### PR TITLE
chore: update SAML auth request info guard and add more info to log

### DIFF
--- a/packages/core/src/routes/saml-application/anonymous.ts
+++ b/packages/core/src/routes/saml-application/anonymous.ts
@@ -271,6 +271,7 @@ export default function samlApplicationAnonymousRoutes<T extends AnonymousRouter
           octetString,
         });
 
+        log.append({ loginRequestResult });
         const extractResult = authRequestInfoGuard.safeParse(loginRequestResult.extract);
         log.append({ extractResult });
 
@@ -371,6 +372,7 @@ export default function samlApplicationAnonymousRoutes<T extends AnonymousRouter
           },
         });
 
+        log.append({ loginRequestResult });
         const extractResult = authRequestInfoGuard.safeParse(loginRequestResult.extract);
         log.append({ extractResult });
 

--- a/packages/schemas/src/foundations/jsonb-types/saml-application-sessions.ts
+++ b/packages/schemas/src/foundations/jsonb-types/saml-application-sessions.ts
@@ -5,7 +5,7 @@ export type AuthRequestInfo = {
   issuer: string;
   request: {
     id: string;
-    destination: string;
+    destination?: string;
     issueInstant: string;
     assertionConsumerServiceUrl: string;
   };
@@ -15,7 +15,7 @@ export const authRequestInfoGuard = z.object({
   issuer: z.string(),
   request: z.object({
     id: z.string(),
-    destination: z.string(),
+    destination: z.string().optional(),
     issueInstant: z.string(),
     assertionConsumerServiceUrl: z.string(),
   }),


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
update SAML auth request info guard and add more info to log.
![image](https://github.com/user-attachments/assets/7d139b4a-e8fa-4205-abc7-9f9f81cda2de)
When looking into use Logto SAML app as IdP and connector to Google Workspace issue, we encountered such issue. By investigating our code, `request.destination` field is not used and can be safely updated to be optional.
Since Google Workspace can not use localhost, we need to deploy this change to logto dev to unblock our checks.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
