### PR TITLE
fix(core): should not apply custom domain to SAML app SP entity ID

### DIFF
--- a/packages/core/src/routes/saml-application/anonymous.ts
+++ b/packages/core/src/routes/saml-application/anonymous.ts
@@ -285,7 +285,7 @@ export default function samlApplicationAnonymousRoutes<T extends AnonymousRouter
         log.append({ extractResultData: extractResult.data });
 
         assertThat(
-          extractResult.data.issuer === samlApplication.config.entityId,
+          extractResult.data.issuer === samlApplication.config.spEntityId,
           'application.saml.auth_request_issuer_not_match'
         );
 
@@ -385,7 +385,7 @@ export default function samlApplicationAnonymousRoutes<T extends AnonymousRouter
         log.append({ extractResultData: extractResult.data });
 
         assertThat(
-          extractResult.data.issuer === samlApplication.config.entityId,
+          extractResult.data.issuer === samlApplication.config.spEntityId,
           'application.saml.auth_request_issuer_not_match'
         );
 

--- a/packages/core/src/saml-application/SamlApplication/index.ts
+++ b/packages/core/src/saml-application/SamlApplication/index.ts
@@ -93,7 +93,7 @@ class SamlApplicationConfig {
 
   public get entityId() {
     assertThat(this._details.entityId, 'application.saml.entity_id_required');
-    return this.normalizeUrlHost(this._details.entityId);
+    return this._details.entityId;
   }
 
   public get acsUrl() {

--- a/packages/core/src/saml-application/SamlApplication/index.ts
+++ b/packages/core/src/saml-application/SamlApplication/index.ts
@@ -91,7 +91,7 @@ class SamlApplicationConfig {
     return this._details.secret;
   }
 
-  public get entityId() {
+  public get spEntityId() {
     assertThat(this._details.entityId, 'application.saml.entity_id_required');
     return this._details.entityId;
   }
@@ -519,7 +519,7 @@ export class SamlApplication {
 
   private buildSpConfig(): SamlServiceProviderConfig {
     return {
-      entityId: this.config.entityId,
+      entityId: this.config.spEntityId,
       acsUrl: this.config.acsUrl,
       certificate: this.config.encryption?.certificate,
     };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix: should not apply custom domain to SAML app SP entity ID
also rename SamlApplicationConfig.entityId to SamlApplicationConfig.spEntityId to avoid confusion.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
