### PR TITLE
feat(core): pass extra context to email template

### DIFF
--- a/packages/core/src/caches/base-cache.ts
+++ b/packages/core/src/caches/base-cache.ts
@@ -51,7 +51,10 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
   ): Promise<Optional<CacheMapT[Type]>> {
     return trySafe(async () => {
       const data = await this.cacheStore.get(this.cacheKey(type, key));
-      return this.getValueGuard(type).parse(JSON.parse(data ?? ''));
+      // Allow `null` value to be stored in the cache.
+      // If the value is `null`, we should return `null` instead of parsing it as JSON.
+      // Otherwise, treat the value as JSON and parse it.
+      return this.getValueGuard(type).parse(data === 'null' ? null : JSON.parse(data ?? ''));
     });
   }
 

--- a/packages/core/src/caches/base-cache.ts
+++ b/packages/core/src/caches/base-cache.ts
@@ -51,10 +51,7 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
   ): Promise<Optional<CacheMapT[Type]>> {
     return trySafe(async () => {
       const data = await this.cacheStore.get(this.cacheKey(type, key));
-      // Allow `null` value to be stored in the cache.
-      // If the value is `null`, we should return `null` instead of parsing it as JSON.
-      // Otherwise, treat the value as JSON and parse it.
-      return this.getValueGuard(type).parse(data === 'null' ? null : JSON.parse(data ?? ''));
+      return this.getValueGuard(type).parse(JSON.parse(data ?? ''));
     });
   }
 

--- a/packages/core/src/libraries/passcode.ts
+++ b/packages/core/src/libraries/passcode.ts
@@ -1,13 +1,24 @@
-import type { TemplateType } from '@logto/connector-kit';
+import { appInsights } from '@logto/app-insights/node';
+import type { SendMessagePayload, TemplateType } from '@logto/connector-kit';
 import { templateTypeGuard, ConnectorError, ConnectorErrorCodes } from '@logto/connector-kit';
-import type { Passcode } from '@logto/schemas';
+import {
+  buildDemoAppDataForTenant,
+  demoAppApplicationId,
+  type Passcode,
+  type User,
+} from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
 import { customAlphabet, nanoid } from 'nanoid';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import type { ConnectorLibrary } from '#src/libraries/connector.js';
 import type Queries from '#src/tenants/Queries.js';
-import { ConnectorType } from '#src/utils/connectors/types.js';
+import {
+  buildApplicationContextInfo,
+  buildOrganizationContextInfo,
+  buildUserContextInfo,
+} from '#src/utils/connectors/extra-information.js';
+import { ConnectorType, type VerificationCodeContextInfo } from '#src/utils/connectors/types.js';
 
 export const passcodeLength = 6;
 const randomCode = customAlphabet('1234567890', passcodeLength);
@@ -16,6 +27,9 @@ export const passcodeExpiration = 10 * 60 * 1000; // 10 minutes.
 export const passcodeMaxTryCount = 10;
 
 export type PasscodeLibrary = ReturnType<typeof createPasscodeLibrary>;
+
+export type SendPasscodeContextPayload = Pick<SendMessagePayload, 'locale'> &
+  VerificationCodeContextInfo;
 
 export const createPasscodeLibrary = (queries: Queries, connectorLibrary: ConnectorLibrary) => {
   const {
@@ -58,10 +72,9 @@ export const createPasscodeLibrary = (queries: Queries, connectorLibrary: Connec
   /**
    *
    * @param {Passcode} passcode The passcode object being sent.
-   * @param locale The language tag detected from the user's request.
-   * If provided, it will be used to localize the message.
+   * @param {SendPasscodeContextPayload} contextPayload The extra context information for the verification code email template.
    */
-  const sendPasscode = async (passcode: Passcode, locale?: string) => {
+  const sendPasscode = async (passcode: Passcode, contextPayload?: SendPasscodeContextPayload) => {
     const emailOrPhone = passcode.email ?? passcode.phone;
 
     if (!emailOrPhone) {
@@ -83,7 +96,7 @@ export const createPasscodeLibrary = (queries: Queries, connectorLibrary: Connec
       type: messageTypeResult.data,
       payload: {
         code: passcode.code,
-        ...conditional(locale && { locale }),
+        ...contextPayload,
       },
     });
 
@@ -130,5 +143,59 @@ export const createPasscodeLibrary = (queries: Queries, connectorLibrary: Connec
     await consumePasscode(passcode.id);
   };
 
-  return { createPasscode, sendPasscode, verifyPasscode };
+  /**
+   * Build the context information for the verification code email template.
+   * The context data may vary depending on the context of the verification code request.
+   */
+  const buildVerificationCodeContext = async ({
+    applicationId,
+    organizationId,
+    userId,
+    user,
+  }: {
+    applicationId?: string;
+    organizationId?: string;
+    userId?: string;
+    /*
+     * If available in the request context, directly providing the user object
+     * is more efficient than providing the userId.
+     */
+    user?: User;
+  }): Promise<VerificationCodeContextInfo> => {
+    try {
+      const [application, applicationSignInExperience, organization, userData] = await Promise.all([
+        applicationId
+          ? applicationId === demoAppApplicationId
+            ? buildDemoAppDataForTenant('') // Use empty string as the tenantId will be ignored here.
+            : queries.applications.findApplicationById(applicationId)
+          : undefined,
+        applicationId
+          ? queries.applicationSignInExperiences.safeFindSignInExperienceByApplicationId(
+              applicationId
+            )
+          : undefined,
+        organizationId ? queries.organizations.findById(organizationId) : undefined,
+        user ?? (userId ? queries.users.findUserById(userId) : undefined),
+      ]);
+
+      return {
+        ...conditional(
+          application && {
+            application: buildApplicationContextInfo(application, applicationSignInExperience),
+          }
+        ),
+        ...conditional(
+          organization && { organization: buildOrganizationContextInfo(organization) }
+        ),
+        ...conditional(userData && { user: buildUserContextInfo(userData) }),
+      };
+    } catch (error: unknown) {
+      void appInsights.trackException(error);
+
+      // Should not block the verification code sending if the context information is not available.
+      return {};
+    }
+  };
+
+  return { createPasscode, sendPasscode, verifyPasscode, buildVerificationCodeContext };
 };

--- a/packages/core/src/middleware/koa-auth/koa-oidc-auth.test.ts
+++ b/packages/core/src/middleware/koa-auth/koa-oidc-auth.test.ts
@@ -80,6 +80,7 @@ describe('koaOidcAuth middleware', () => {
       id: 'fooUser',
       scopes: new Set(['openid']),
       identityVerified: false,
+      clientId: mockAccessToken.clientId,
     });
   });
 

--- a/packages/core/src/middleware/koa-auth/koa-oidc-auth.ts
+++ b/packages/core/src/middleware/koa-auth/koa-oidc-auth.ts
@@ -64,7 +64,7 @@ export default function koaOidcAuth<StateT, ContextT extends IRouterParamContext
 
     assertThat(accessToken, new RequestError({ code: 'auth.unauthorized', status: 401 }));
 
-    const { accountId, scopes } = accessToken;
+    const { accountId, scopes, clientId } = accessToken;
     assertThat(accountId, new RequestError({ code: 'auth.unauthorized', status: 401 }));
     assertThat(scopes.has('openid'), new RequestError({ code: 'auth.forbidden', status: 403 }));
 
@@ -83,6 +83,7 @@ export default function koaOidcAuth<StateT, ContextT extends IRouterParamContext
       type: 'user',
       id: accountId,
       scopes,
+      clientId,
       identityVerified,
     };
 

--- a/packages/core/src/middleware/koa-auth/types.ts
+++ b/packages/core/src/middleware/koa-auth/types.ts
@@ -6,6 +6,8 @@ type Auth = {
   scopes: Set<string>;
   /** If the request is verified by a verification record, this will be set to `true`. */
   identityVerified?: boolean;
+  /** Client ID of the OIDC access token */
+  clientId?: string;
 };
 
 export type WithAuthContext<ContextT extends IRouterParamContext = IRouterParamContext> =

--- a/packages/core/src/routes-me/verification-code.ts
+++ b/packages/core/src/routes-me/verification-code.ts
@@ -31,7 +31,7 @@ export default function verificationCodeRoutes<T extends AuthedMeRouter>(
     }),
     async (ctx, next) => {
       const code = await createPasscode(undefined, codeType, ctx.guard.body);
-      await sendPasscode(code, ctx.locale);
+      await sendPasscode(code, { locale: ctx.locale });
 
       ctx.status = 204;
 

--- a/packages/core/src/routes/experience/classes/verifications/code-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/code-verification.ts
@@ -11,7 +11,10 @@ import { generateStandardId } from '@logto/shared';
 import { z } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
-import { type createPasscodeLibrary } from '#src/libraries/passcode.js';
+import {
+  type SendPasscodeContextPayload,
+  type createPasscodeLibrary,
+} from '#src/libraries/passcode.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
@@ -107,13 +110,13 @@ abstract class CodeVerification<T extends CodeVerificationType>
   /**
    * Send the verification code to the current `identifier`
    *
-   * @param locale - The language tag detected from the user's request. If provided, it will be used to localize the message.
+   * @param {SendPasscodeContextPayload} payload - The extra context information for the verification code template.
    * @remarks
    * Instead of session jti,
    * the verification id is used as `interaction_jti` to uniquely identify the passcode record in DB
    * for the current interaction.
    */
-  async sendVerificationCode(locale?: string) {
+  async sendVerificationCode(payload?: SendPasscodeContextPayload) {
     const { createPasscode, sendPasscode } = this.libraries.passcodes;
 
     const verificationCode = await createPasscode(
@@ -122,7 +125,7 @@ abstract class CodeVerification<T extends CodeVerificationType>
       getPasscodeIdentifierPayload(this.identifier)
     );
 
-    await sendPasscode(verificationCode, locale);
+    await sendPasscode(verificationCode, payload);
   }
 
   /**

--- a/packages/core/src/routes/interaction/additional.test.ts
+++ b/packages/core/src/routes/interaction/additional.test.ts
@@ -154,10 +154,10 @@ describe('interaction routes', () => {
       const response = await sessionRequest.post(path).send(body);
       expect(getInteractionStorage).toBeCalled();
       expect(sendVerificationCodeToIdentifier).toBeCalledWith(
-        {
+        expect.objectContaining({
           event: InteractionEvent.SignIn,
           ...body,
-        },
+        }),
         'jti',
         createLog,
         tenantContext.libraries.passcodes

--- a/packages/core/src/routes/interaction/additional.ts
+++ b/packages/core/src/routes/interaction/additional.ts
@@ -1,11 +1,16 @@
 import {
   InteractionEvent,
+  logtoCookieKey,
+  logtoUiCookieGuard,
   MfaFactor,
+  type RequestVerificationCodePayload,
   requestVerificationCodePayloadGuard,
   webAuthnAuthenticationOptionsGuard,
   webAuthnRegistrationOptionsGuard,
 } from '@logto/schemas';
 import { getUserDisplayName } from '@logto/shared';
+import { trySafe } from '@silverhand/essentials';
+import { type Context } from 'koa';
 import type Router from 'koa-router';
 import { type IRouterParamContext } from 'koa-router';
 import { authenticator } from 'otplib';
@@ -13,7 +18,9 @@ import qrcode from 'qrcode';
 import { z } from 'zod';
 
 import type { WithInteractionDetailsContext } from '#src//middleware/koa-interaction-details.js';
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
+import { type PasscodeLibrary } from '#src/libraries/passcode.js';
 import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import { type WithI18nContext } from '#src/middleware/koa-i18next.js';
@@ -38,6 +45,27 @@ import {
 } from './utils/webauthn.js';
 import { verifyIdentifier } from './verifications/index.js';
 import verifyProfile from './verifications/profile-verification.js';
+
+const buildVerificationCodeTemplateContext = async (
+  passcodeLibrary: PasscodeLibrary,
+  ctx: Context,
+  body: RequestVerificationCodePayload
+) => {
+  // TODO: @simeng remove dev guard when the feature is ready
+  if (!EnvSet.values.isDevFeaturesEnabled || !('email' in body)) {
+    return {};
+  }
+
+  // Safely get the orgId and appId context from cookie
+  const { appId: applicationId, organizationId } =
+    trySafe(() => logtoUiCookieGuard.parse(JSON.parse(ctx.cookies.get(logtoCookieKey) ?? '{}'))) ??
+    {};
+
+  return passcodeLibrary.buildVerificationCodeContext({
+    applicationId,
+    organizationId,
+  });
+};
 
 export default function additionalRoutes<T extends IRouterParamContext>(
   router: Router<unknown, WithInteractionDetailsContext<WithI18nContext<WithLogContext<T>>>>,
@@ -99,8 +127,10 @@ export default function additionalRoutes<T extends IRouterParamContext>(
       // Check interaction exists
       const { event } = getInteractionStorage(interactionDetails.result);
 
+      const messageContext = await buildVerificationCodeTemplateContext(passcodes, ctx, guard.body);
+
       await sendVerificationCodeToIdentifier(
-        { event, ...guard.body, locale: ctx.locale },
+        { event, ...guard.body, locale: ctx.locale, messageContext },
         interactionDetails.jti,
         createLog,
         passcodes

--- a/packages/core/src/routes/interaction/utils/verification-code-validation.ts
+++ b/packages/core/src/routes/interaction/utils/verification-code-validation.ts
@@ -7,6 +7,7 @@ import type {
 
 import type { PasscodeLibrary } from '#src/libraries/passcode.js';
 import type { LogContext } from '#src/middleware/koa-audit-log.js';
+import { type VerificationCodeContextInfo } from '#src/utils/connectors/types.js';
 
 /**
  * Refactor Needed:
@@ -22,19 +23,23 @@ const getTemplateTypeByEvent = (event: InteractionEvent): TemplateType =>
   eventToTemplateTypeMap[event];
 
 export const sendVerificationCodeToIdentifier = async (
-  payload: RequestVerificationCodePayload & { event: InteractionEvent; locale?: string },
+  payload: RequestVerificationCodePayload & {
+    event: InteractionEvent;
+    locale?: string;
+    messageContext?: VerificationCodeContextInfo;
+  },
   jti: string,
   createLog: LogContext['createLog'],
   { createPasscode, sendPasscode }: PasscodeLibrary
 ) => {
-  const { event, locale, ...identifier } = payload;
+  const { event, locale, messageContext, ...identifier } = payload;
   const messageType = getTemplateTypeByEvent(event);
 
   const log = createLog(`Interaction.${event}.Identifier.VerificationCode.Create`);
   log.append(identifier);
 
   const verificationCode = await createPasscode(jti, messageType, identifier);
-  const { dbEntry } = await sendPasscode(verificationCode, locale);
+  const { dbEntry } = await sendPasscode(verificationCode, { locale, ...messageContext });
 
   log.append({ connectorId: dbEntry.id });
 };

--- a/packages/core/src/routes/organization-invitation/index.ts
+++ b/packages/core/src/routes/organization-invitation/index.ts
@@ -11,6 +11,7 @@ import koaGuard from '#src/middleware/koa-guard.js';
 import SchemaRouter from '#src/utils/SchemaRouter.js';
 import assertThat from '#src/utils/assert-that.js';
 
+import { EnvSet } from '../../env-set/index.js';
 import { errorHandler } from '../organization/utils.js';
 import { type ManagementApiRouter, type RouterInitArgs } from '../types.js';
 
@@ -101,11 +102,12 @@ export default function organizationInvitationRoutes<T extends ManagementApiRout
       } = ctx.guard;
       const { invitee, organizationId, inviterId } = await invitations.findById(id);
 
-      const templateContext =
-        await organizationInvitations.getOrganizationInvitationTemplateContext(
-          organizationId,
-          inviterId
-        );
+      const templateContext = EnvSet.values.isDevFeaturesEnabled
+        ? await organizationInvitations.getOrganizationInvitationTemplateContext(
+            organizationId,
+            inviterId
+          )
+        : undefined;
 
       await organizationInvitations.sendEmail(invitee, {
         ...templateContext,

--- a/packages/core/src/routes/organization-invitation/index.ts
+++ b/packages/core/src/routes/organization-invitation/index.ts
@@ -10,7 +10,6 @@ import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import SchemaRouter from '#src/utils/SchemaRouter.js';
 import assertThat from '#src/utils/assert-that.js';
-import { buildOrganizationExtraInfo } from '#src/utils/connectors/extra-information.js';
 
 import { errorHandler } from '../organization/utils.js';
 import { type ManagementApiRouter, type RouterInitArgs } from '../types.js';
@@ -100,11 +99,16 @@ export default function organizationInvitationRoutes<T extends ManagementApiRout
         params: { id },
         body,
       } = ctx.guard;
-      const { invitee, organizationId } = await invitations.findById(id);
-      const organization = await organizations.findById(organizationId);
+      const { invitee, organizationId, inviterId } = await invitations.findById(id);
+
+      const templateContext =
+        await organizationInvitations.getOrganizationInvitationTemplateContext(
+          organizationId,
+          inviterId
+        );
 
       await organizationInvitations.sendEmail(invitee, {
-        organization: buildOrganizationExtraInfo(organization),
+        ...templateContext,
         ...body,
       });
       ctx.status = 204;

--- a/packages/core/src/routes/verification-code.ts
+++ b/packages/core/src/routes/verification-code.ts
@@ -25,7 +25,7 @@ export default function verificationCodeRoutes<T extends ManagementApiRouter>(
     }),
     async (ctx, next) => {
       const code = await createPasscode(undefined, codeType, ctx.guard.body);
-      await sendPasscode(code, ctx.locale);
+      await sendPasscode(code);
 
       ctx.status = 204;
 

--- a/packages/core/src/utils/connectors/extra-information.ts
+++ b/packages/core/src/utils/connectors/extra-information.ts
@@ -1,5 +1,5 @@
 import { type ConnectorMetadata, ServiceConnector } from '@logto/connector-kit';
-import { type Organization } from '@logto/schemas';
+import { type User, type Organization } from '@logto/schemas';
 import { conditional, pick } from '@silverhand/essentials';
 import cleanDeep from 'clean-deep';
 import { string, object } from 'zod';
@@ -18,7 +18,8 @@ export const buildExtraInfo = (metadata: ConnectorMetadata) => {
   return cleanDeep(extraInfo, { emptyObjects: false });
 };
 
-export type OrganizationExtraInfo = Pick<Organization, 'id' | 'name' | 'branding'>;
-
-export const buildOrganizationExtraInfo = (organization: Organization): OrganizationExtraInfo =>
+export const buildOrganizationContextInfo = (organization: Organization) =>
   pick(organization, 'id', 'name', 'branding');
+
+export const buildUserContextInfo = (user: User) =>
+  pick(user, 'id', 'avatar', 'name', 'primaryEmail', 'primaryPhone', 'username', 'profile');

--- a/packages/core/src/utils/connectors/extra-information.ts
+++ b/packages/core/src/utils/connectors/extra-information.ts
@@ -1,8 +1,19 @@
 import { type ConnectorMetadata, ServiceConnector } from '@logto/connector-kit';
-import { type User, type Organization } from '@logto/schemas';
-import { conditional, pick } from '@silverhand/essentials';
+import {
+  type User,
+  type Organization,
+  type ApplicationSignInExperience,
+  type Application,
+} from '@logto/schemas';
+import { conditional, type Nullable, pick } from '@silverhand/essentials';
 import cleanDeep from 'clean-deep';
 import { string, object } from 'zod';
+
+import {
+  type ApplicationContextInfo,
+  type OrganizationContextInfo,
+  type UserContextInfo,
+} from './types.js';
 
 const getFromEmailFromMetadata = (metadata: ConnectorMetadata) => {
   const result = object({ fromEmail: string() }).safeParse(metadata);
@@ -18,8 +29,23 @@ export const buildExtraInfo = (metadata: ConnectorMetadata) => {
   return cleanDeep(extraInfo, { emptyObjects: false });
 };
 
-export const buildOrganizationContextInfo = (organization: Organization) =>
+export const buildOrganizationContextInfo = (organization: Organization): OrganizationContextInfo =>
   pick(organization, 'id', 'name', 'branding');
 
-export const buildUserContextInfo = (user: User) =>
+export const buildUserContextInfo = (user: User): UserContextInfo =>
   pick(user, 'id', 'avatar', 'name', 'primaryEmail', 'primaryPhone', 'username', 'profile');
+
+export const buildApplicationContextInfo = (
+  application: Application,
+  applicationSignInExperience?: Nullable<ApplicationSignInExperience>
+): ApplicationContextInfo => {
+  const { id, name } = application;
+  const { branding, displayName } = applicationSignInExperience ?? {};
+
+  return {
+    id,
+    name,
+    ...conditional(branding && { branding }),
+    ...conditional(displayName && { displayName }),
+  };
+};

--- a/packages/core/src/utils/connectors/types.ts
+++ b/packages/core/src/utils/connectors/types.ts
@@ -1,5 +1,5 @@
 import type { AllConnector } from '@logto/connector-kit';
-import { type Connector, Connectors } from '@logto/schemas';
+import { type Connector, Connectors, type Organization, type User } from '@logto/schemas';
 import { type z } from 'zod';
 
 export { ConnectorType } from '@logto/schemas';
@@ -26,4 +26,24 @@ export type LogtoConnectorWellKnown<T extends AllConnector = AllConnector> = Pic
   'type' | 'metadata'
 > & {
   dbEntry: ConnectorWellKnown;
+};
+
+/**
+ * Public organization context info for message template payload.
+ */
+type OrganizationContextInfo = Pick<Organization, 'id' | 'name' | 'branding'>;
+/**
+ * Public user context info for message template payload.
+ */
+type UserContextInfo = Pick<
+  User,
+  'id' | 'avatar' | 'name' | 'primaryEmail' | 'primaryPhone' | 'username' | 'profile'
+>;
+
+/**
+ * The context info for organization invitation message template payload.
+ */
+export type OrganizationInvitationContextInfo = {
+  organization: OrganizationContextInfo;
+  inviter?: UserContextInfo;
 };

--- a/packages/core/src/utils/connectors/types.ts
+++ b/packages/core/src/utils/connectors/types.ts
@@ -1,5 +1,12 @@
 import type { AllConnector } from '@logto/connector-kit';
-import { type Connector, Connectors, type Organization, type User } from '@logto/schemas';
+import {
+  type Application,
+  type ApplicationSignInExperience,
+  type Connector,
+  Connectors,
+  type Organization,
+  type User,
+} from '@logto/schemas';
 import { type z } from 'zod';
 
 export { ConnectorType } from '@logto/schemas';
@@ -31,19 +38,32 @@ export type LogtoConnectorWellKnown<T extends AllConnector = AllConnector> = Pic
 /**
  * Public organization context info for message template payload.
  */
-type OrganizationContextInfo = Pick<Organization, 'id' | 'name' | 'branding'>;
+export type OrganizationContextInfo = Pick<Organization, 'id' | 'name' | 'branding'>;
 /**
  * Public user context info for message template payload.
  */
-type UserContextInfo = Pick<
+export type UserContextInfo = Pick<
   User,
   'id' | 'avatar' | 'name' | 'primaryEmail' | 'primaryPhone' | 'username' | 'profile'
 >;
+/**
+ * Public application context info for message template payload.
+ */
+export type ApplicationContextInfo = Pick<Application, 'id' | 'name'> &
+  Partial<Pick<ApplicationSignInExperience, 'branding' | 'displayName'>>;
 
 /**
  * The context info for organization invitation message template payload.
  */
 export type OrganizationInvitationContextInfo = {
-  organization: OrganizationContextInfo;
+  organization?: OrganizationContextInfo;
   inviter?: UserContextInfo;
+};
+/**
+ * The context info for verification code message template payload.
+ */
+export type VerificationCodeContextInfo = {
+  user?: UserContextInfo;
+  organization?: OrganizationContextInfo;
+  application?: ApplicationContextInfo;
 };

--- a/packages/integration-tests/src/helpers/index.ts
+++ b/packages/integration-tests/src/helpers/index.ts
@@ -45,6 +45,8 @@ type ConnectorMessageRecord = {
    * The template will be either the default template from connector config or the custom i18n template if it exists.
    */
   template?: Record<string, unknown>;
+  subject?: string;
+  content?: string;
 };
 
 /**

--- a/packages/integration-tests/src/tests/api/email-templates/experience-api.test.ts
+++ b/packages/integration-tests/src/tests/api/email-templates/experience-api.test.ts
@@ -1,0 +1,103 @@
+import { TemplateType } from '@logto/connector-kit';
+import { demoAppApplicationId, InteractionEvent, SignInIdentifier } from '@logto/schemas';
+
+import { mockEmailConnectorConfig } from '#src/__mocks__/connectors-mock.js';
+import { type MockEmailTemplatePayload } from '#src/__mocks__/email-templates.js';
+import { initExperienceClient } from '#src/helpers/client.js';
+import { setEmailConnector } from '#src/helpers/connector.js';
+import { EmailTemplatesApiTest } from '#src/helpers/email-templates.js';
+import { successfullySendVerificationCode } from '#src/helpers/experience/verification-code.js';
+import { readConnectorMessage } from '#src/helpers/index.js';
+import { OrganizationApiTest } from '#src/helpers/organization.js';
+import { devFeatureTest, generateEmail } from '#src/utils.js';
+
+const mockSignInTemplate: MockEmailTemplatePayload = {
+  languageTag: 'en',
+  templateType: TemplateType.SignIn,
+  details: {
+    subject: 'Sign in to {{ application.name }}, {{ organization.name }}',
+    content: 'Your verification code is: {{code}}',
+    contentType: 'text/html',
+  },
+};
+
+devFeatureTest.describe('experience API with i18n email templates', () => {
+  const emailTemplatesApi = new EmailTemplatesApiTest();
+  const organizationApi = new OrganizationApiTest();
+  const mockEmail = generateEmail();
+
+  beforeAll(async () => {
+    await Promise.all([setEmailConnector(), emailTemplatesApi.create([mockSignInTemplate])]);
+  });
+
+  afterAll(async () => {
+    await Promise.all([emailTemplatesApi.cleanUp(), organizationApi.cleanUp()]);
+  });
+
+  it('should send verification code using custom i18n template', async () => {
+    const organization = await organizationApi.create({
+      name: 'test org',
+    });
+
+    const client = await initExperienceClient(undefined, undefined, undefined, {
+      extraParams: {
+        organization_id: organization.id,
+      },
+    });
+
+    const { code } = await successfullySendVerificationCode(client, {
+      interactionEvent: InteractionEvent.SignIn,
+      identifier: {
+        type: SignInIdentifier.Email,
+        value: mockEmail,
+      },
+    });
+
+    expect(await readConnectorMessage('Email')).toMatchObject({
+      type: TemplateType.SignIn,
+      payload: {
+        code,
+        application: {
+          id: demoAppApplicationId,
+          name: 'Live Preview',
+        },
+        organization: {
+          id: organization.id,
+          name: 'test org',
+        },
+      },
+      template: mockSignInTemplate.details,
+      subject: `Sign in to Live Preview, test org`,
+      content: `Your verification code is: ${code}`,
+    });
+  });
+
+  it('should send verification code using callback email template if custom i18n template is not found', async () => {
+    const defaultForgotPasswordTemplate = mockEmailConnectorConfig.templates.find(
+      ({ usageType }) => usageType === 'ForgotPassword'
+    )!;
+
+    const client = await initExperienceClient();
+    const { code } = await successfullySendVerificationCode(client, {
+      interactionEvent: InteractionEvent.ForgotPassword,
+      identifier: {
+        type: SignInIdentifier.Email,
+        value: mockEmail,
+      },
+    });
+
+    expect(await readConnectorMessage('Email')).toMatchObject({
+      type: TemplateType.ForgotPassword,
+      payload: {
+        code,
+        application: {
+          id: demoAppApplicationId,
+          name: 'Live Preview',
+        },
+      },
+      template: defaultForgotPasswordTemplate,
+      content: defaultForgotPasswordTemplate.content.replace('{{code}}', code),
+      subject: defaultForgotPasswordTemplate.subject,
+    });
+  });
+});

--- a/packages/integration-tests/src/tests/api/email-templates/interaction-api.test.ts
+++ b/packages/integration-tests/src/tests/api/email-templates/interaction-api.test.ts
@@ -1,0 +1,104 @@
+import { TemplateType } from '@logto/connector-kit';
+import { demoAppApplicationId, InteractionEvent } from '@logto/schemas';
+
+import { mockEmailConnectorConfig } from '#src/__mocks__/connectors-mock.js';
+import { type MockEmailTemplatePayload } from '#src/__mocks__/email-templates.js';
+import { putInteraction, sendVerificationCode } from '#src/api/interaction.js';
+import { initClient } from '#src/helpers/client.js';
+import { setEmailConnector } from '#src/helpers/connector.js';
+import { EmailTemplatesApiTest } from '#src/helpers/email-templates.js';
+import { readConnectorMessage } from '#src/helpers/index.js';
+import { OrganizationApiTest } from '#src/helpers/organization.js';
+import { enableAllVerificationCodeSignInMethods } from '#src/helpers/sign-in-experience.js';
+import { devFeatureTest, generateEmail } from '#src/utils.js';
+
+const mockSignInTemplate: MockEmailTemplatePayload = {
+  languageTag: 'en',
+  templateType: TemplateType.SignIn,
+  details: {
+    subject: 'Sign in to {{ application.name }}, {{ organization.name }}',
+    content: 'Your verification code is: {{code}}',
+    contentType: 'text/html',
+  },
+};
+
+devFeatureTest.describe('interaction API with i18n email templates', () => {
+  const emailTemplatesApi = new EmailTemplatesApiTest();
+  const organizationApi = new OrganizationApiTest();
+  const mockEmail = generateEmail();
+
+  beforeAll(async () => {
+    await Promise.all([
+      setEmailConnector(),
+      emailTemplatesApi.create([mockSignInTemplate]),
+      enableAllVerificationCodeSignInMethods(),
+    ]);
+  });
+
+  afterAll(async () => {
+    await Promise.all([emailTemplatesApi.cleanUp(), organizationApi.cleanUp()]);
+  });
+
+  it('should send verification code using custom i18n template', async () => {
+    const organization = await organizationApi.create({
+      name: 'test org',
+    });
+
+    const client = await initClient(undefined, undefined, {
+      extraParams: {
+        organization_id: organization.id,
+      },
+    });
+
+    await client.successSend(putInteraction, {
+      event: InteractionEvent.SignIn,
+    });
+
+    await client.successSend(sendVerificationCode, {
+      email: mockEmail,
+    });
+
+    expect(await readConnectorMessage('Email')).toMatchObject({
+      type: TemplateType.SignIn,
+      payload: {
+        application: {
+          id: demoAppApplicationId,
+          name: 'Live Preview',
+        },
+        organization: {
+          id: organization.id,
+          name: 'test org',
+        },
+      },
+      template: mockSignInTemplate.details,
+      subject: `Sign in to Live Preview, test org`,
+    });
+  });
+
+  it('should send verification code using callback email template if custom i18n template is not found', async () => {
+    const defaultForgotPasswordTemplate = mockEmailConnectorConfig.templates.find(
+      ({ usageType }) => usageType === 'Register'
+    )!;
+
+    const client = await initClient();
+
+    await client.successSend(putInteraction, {
+      event: InteractionEvent.Register,
+    });
+
+    await client.successSend(sendVerificationCode, {
+      email: mockEmail,
+    });
+
+    expect(await readConnectorMessage('Email')).toMatchObject({
+      type: TemplateType.Register,
+      payload: {
+        application: {
+          id: demoAppApplicationId,
+          name: 'Live Preview',
+        },
+      },
+      template: defaultForgotPasswordTemplate,
+    });
+  });
+});

--- a/packages/integration-tests/src/tests/api/email-templates/interaction-api.test.ts
+++ b/packages/integration-tests/src/tests/api/email-templates/interaction-api.test.ts
@@ -5,7 +5,7 @@ import { mockEmailConnectorConfig } from '#src/__mocks__/connectors-mock.js';
 import { type MockEmailTemplatePayload } from '#src/__mocks__/email-templates.js';
 import { putInteraction, sendVerificationCode } from '#src/api/interaction.js';
 import { initClient } from '#src/helpers/client.js';
-import { setEmailConnector } from '#src/helpers/connector.js';
+import { setEmailConnector, setSmsConnector } from '#src/helpers/connector.js';
 import { EmailTemplatesApiTest } from '#src/helpers/email-templates.js';
 import { readConnectorMessage } from '#src/helpers/index.js';
 import { OrganizationApiTest } from '#src/helpers/organization.js';
@@ -28,8 +28,8 @@ devFeatureTest.describe('interaction API with i18n email templates', () => {
   const mockEmail = generateEmail();
 
   beforeAll(async () => {
+    await Promise.all([setEmailConnector(), setSmsConnector()]);
     await Promise.all([
-      setEmailConnector(),
       emailTemplatesApi.create([mockSignInTemplate]),
       enableAllVerificationCodeSignInMethods(),
     ]);

--- a/packages/integration-tests/src/tests/api/email-templates/user-account-api.test.ts
+++ b/packages/integration-tests/src/tests/api/email-templates/user-account-api.test.ts
@@ -24,8 +24,9 @@ devFeatureTest.describe('user account email verification API with i18n email tem
     languageTag: 'en',
     templateType: TemplateType.UserPermissionValidation,
     details: {
-      subject: 'Test template',
-      content: 'Test value: {{code}}',
+      subject:
+        '{{user.username}} verify your account {{ user.primaryEmail }} in {{ application.name }}',
+      content: 'Your verification code is: {{code}}',
       contentType: 'text/html',
     },
   };
@@ -70,6 +71,7 @@ devFeatureTest.describe('user account email verification API with i18n email tem
         locale: 'en',
       },
       template: mockEnTemplate.details,
+      subject: `${username} verify your account ${primaryEmail} in Live Preview`,
     });
 
     const newEmail = generateEmail();


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Passing extra context variables to the email templates in different conditions:

| API                                           | Template type                               | User context  | Application context | Organization context | Memo                                                                |
| --------------------------------------------- | ------------------------------------------- | ------------- | ------------------- | -------------------- | ------------------------------------------------------------------- |
| `/experience/verification/verification-code`  | SignIn, Register, ForgotPassword            | x             | ✅                  | ✅ (optional)        | read the applicationId and organizationId from cookie               |
| `/interaction/verification/verification-code` | SignIn, Register, ForgotPassword            | x             | ✅                  | ✅ (optional)        | read the applicationId and organizationId from cookie               |
| `/verification/verification-code`             | UserPermissionValidation, BindNewIdentifier | ✅            | x                   | x                    | read the userId from the auth context                               |
| `/verification-code`                          | Generic                                     | x             | x                   | x                    | generic email template has no context variables                     |
| `/organization-invitation`                    | OrganizationInvitation                      | ✅ (optional) | x                   | ✅                   | inviter user context will be provided if inviter userId is provided |
| `/organization-invitation/{id}/message`       | OrganizationInvitation                      | ✅ (optional) | x                   | ✅                   | inviter user context will be provided if inviter userId is provided |



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
