### PR TITLE
refactor: adjust TOTP secret length to 20 bytes

### DIFF
--- a/.changeset/four-houses-invite.md
+++ b/.changeset/four-houses-invite.md
@@ -1,0 +1,13 @@
+---
+"@logto/core": patch
+---
+
+refactor: adjust TOTP secret length to 20 bytes
+
+Update the TOTP secret generation to use 20 bytes (160 bits), following the recommendation in RFC 6238 (TOTP) and RFC 4226 (HOTP).
+
+This aligns with the standard secret length used by most 2FA applications and provides better security while maintaining compatibility with existing TOTP validators.
+
+Reference:
+- RFC 6238 (TOTP) Section 5.1: https://www.rfc-editor.org/rfc/rfc6238#section-5.1
+- RFC 4226 (HOTP) Section 4, Requirement 6: https://www.rfc-editor.org/rfc/rfc4226#section-4

--- a/packages/core/src/routes/interaction/utils/totp-validation.ts
+++ b/packages/core/src/routes/interaction/utils/totp-validation.ts
@@ -10,7 +10,11 @@ import { authenticator } from 'otplib';
 // eslint-disable-next-line @silverhand/fp/no-mutation
 authenticator.options = { window: 1 };
 
-export const generateTotpSecret = () => authenticator.generateSecret();
+/**
+ * Use 20 bytes (160 bits) as recommended by RFC 6238 (TOTP standard)
+ * This provides sufficient security and aligns with most 2FA implementations
+ */
+export const generateTotpSecret = () => authenticator.generateSecret(20);
 
 export const validateTotpSecret = (secret: string) => {
   const base32Regex =


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Update the TOTP secret generation to use 20 bytes (160 bits), following the recommendation in RFC 6238 (TOTP) and RFC 4226 (HOTP).

This aligns with the standard secret length used by most 2FA applications and provides better security while maintaining compatibility with existing TOTP validators.

Reference:
- RFC 6238 (TOTP) Section 5.1: https://www.rfc-editor.org/rfc/rfc6238#section-5.1
- RFC 4226 (HOTP) Section 4, Requirement 6: https://www.rfc-editor.org/rfc/rfc4226#section-4

Related issue: https://discord.com/channels/965845662535147551/965845662979719198/1342073498897485844

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Existing users' functionality remains unaffected
- [x] New users won't be prompted with security questions when binding authenticator app

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
