### PR TITLE
fix(connector): fix misuse of replyTo field

### DIFF
--- a/packages/connectors/connector-mailgun/src/index.test.ts
+++ b/packages/connectors/connector-mailgun/src/index.test.ts
@@ -258,13 +258,13 @@ describe('Maligun connector', () => {
       to: 'bar@example.com',
       subject: 'Passcode 123456',
       html: '<p>Your passcode is 123456</p>',
-      'h:Reply-To': 'Reply to bar@example.com',
+      'h:Reply-To': 'Reply to foo@email.com',
     });
 
     getI18nEmailTemplate.mockResolvedValue({
       subject: 'Passcode {{code}}',
       content: '<p>Your passcode is {{code}}</p>',
-      replyTo: 'Reply to {{to}}',
+      replyTo: 'Reply to {{user.primaryEmail}}',
     } satisfies EmailTemplateDetails);
 
     getConfig.mockResolvedValue({
@@ -281,7 +281,7 @@ describe('Maligun connector', () => {
     await connector.sendMessage({
       to: 'bar@example.com',
       type: TemplateType.Generic,
-      payload: { code: '123456' },
+      payload: { code: '123456', user: { primaryEmail: 'foo@email.com' } },
     });
   });
 
@@ -292,15 +292,15 @@ describe('Maligun connector', () => {
       subject: 'Passcode 123456',
       html: 'Your passcode is 123456',
       text: 'Your passcode is 123456',
-      'h:Reply-To': 'Reply to bar@example.com',
+      'h:Reply-To': 'Reply to {{user.primaryEmail}}',
     });
 
     getI18nEmailTemplate.mockResolvedValue({
       subject: 'Passcode {{code}}',
       content: 'Your passcode is {{code}}',
-      replyTo: 'Reply to {{to}}',
+      replyTo: 'Reply to {{user.primaryEmail}}',
       contentType: 'text/plain',
-      sendFrom: `{{applicationName}} <${baseConfig.from}>`,
+      sendFrom: `{{application.name}} <${baseConfig.from}>`,
     } satisfies EmailTemplateDetails);
 
     getConfig.mockResolvedValue({
@@ -309,7 +309,7 @@ describe('Maligun connector', () => {
         [TemplateType.Generic]: {
           subject: 'Verification code is {{code}}',
           html: '<p>Your verification code is {{code}}</p>',
-          replyTo: 'baz@example.com',
+          replyTo: 'no-reply@mail.com',
         },
       },
     });
@@ -317,7 +317,7 @@ describe('Maligun connector', () => {
     await connector.sendMessage({
       to: 'bar@example.com',
       type: TemplateType.Generic,
-      payload: { code: '123456', applicationName: 'Foo' },
+      payload: { code: '123456', application: { name: 'Foo' } },
     });
   });
 });

--- a/packages/connectors/connector-mailgun/src/index.ts
+++ b/packages/connectors/connector-mailgun/src/index.ts
@@ -81,10 +81,7 @@ const sendMessage = (
     const template = deliveries[type] ?? deliveries[TemplateType.Generic];
 
     const data = customTemplate
-      ? getDataFromCustomTemplate(customTemplate, {
-          ...payload,
-          to,
-        })
+      ? getDataFromCustomTemplate(customTemplate, payload)
       : // Fallback to the default template if the custom i18n template is not found.
         template && getDataFromDeliveryConfig(template, payload);
 

--- a/packages/connectors/connector-sendgrid-email/src/index.test.ts
+++ b/packages/connectors/connector-sendgrid-email/src/index.test.ts
@@ -89,12 +89,11 @@ describe('SendGrid connector', () => {
       subject: 'Passcode {{code}}',
       content: '<p>Your passcode is {{code}}</p>',
       contentType: 'text/html',
-      sendFrom: '{{applicationName}}',
-      replyTo: '{{userName}}',
+      sendFrom: '{{application.name}}',
     });
 
     nockMessages({
-      personalizations: [{ to: [{ email: toEmail, name: 'John Doe' }] }],
+      personalizations: [{ to: [{ email: toEmail }] }],
       from: { email: fromEmail, name: 'Test app' },
       subject: 'Passcode 123456',
       content: [
@@ -112,8 +111,7 @@ describe('SendGrid connector', () => {
       type: TemplateType.Generic,
       payload: {
         code: '123456',
-        applicationName: 'Test app',
-        userName: 'John Doe',
+        application: { name: 'Test app' },
       },
     });
   });

--- a/packages/connectors/connector-sendgrid-email/src/index.ts
+++ b/packages/connectors/connector-sendgrid-email/src/index.ts
@@ -47,7 +47,7 @@ const buildParametersFromDefaultTemplate = (
 const buildParametersFromCustomTemplate = (
   to: string,
   config: SendGridMailConfig,
-  { subject, content, replyTo, sendFrom, contentType = 'text/html' }: EmailTemplateDetails,
+  { subject, content, sendFrom, contentType = 'text/html' }: EmailTemplateDetails,
   payload: SendMessagePayload
 ): PublicParameters => {
   return {
@@ -56,8 +56,7 @@ const buildParametersFromCustomTemplate = (
         to: [
           {
             email: to,
-            // If replyTo is provided, we will replace the handlebars with the payload
-            ...conditional(replyTo && { name: replaceSendMessageHandlebars(replyTo, payload) }),
+            ...conditional(config.fromName && { name: config.fromName }),
           },
         ],
       },

--- a/packages/connectors/connector-smtp/src/index.test.ts
+++ b/packages/connectors/connector-smtp/src/index.test.ts
@@ -167,8 +167,8 @@ describe('Test SMTP connector with custom i18n templates', () => {
       subject: 'Custom subject {{code}}',
       content: 'Your verification code is {{code}}',
       contentType: 'text/plain',
-      replyTo: `{{userName}}`,
-      sendFrom: `{{applicationName}} <notice@test.smtp>`,
+      replyTo: `{{user.primaryEmail}}`,
+      sendFrom: `{{application.name}} <notice@test.smtp>`,
     } satisfies EmailTemplateDetails);
 
     const connector = await createConnector({ getConfig, getI18nEmailTemplate });
@@ -176,7 +176,11 @@ describe('Test SMTP connector with custom i18n templates', () => {
     await connector.sendMessage({
       to: 'bar',
       type: TemplateType.SignIn,
-      payload: { code: '234567', userName: 'John Doe', applicationName: 'Test app' },
+      payload: {
+        code: '234567',
+        user: { primaryEmail: 'test@email.com' },
+        application: { name: 'Test app' },
+      },
     });
 
     expect(sendMail).toHaveBeenCalledWith({
@@ -184,7 +188,7 @@ describe('Test SMTP connector with custom i18n templates', () => {
       subject: 'Custom subject 234567',
       text: 'Your verification code is 234567',
       to: 'bar',
-      replyTo: 'John Doe',
+      replyTo: 'test@email.com',
     });
   });
 });

--- a/packages/toolkit/connector-kit/src/types/email-template.ts
+++ b/packages/toolkit/connector-kit/src/types/email-template.ts
@@ -14,16 +14,12 @@ export type EmailTemplateDetails = {
    * OPTIONAL: Custom replyTo template.
    *
    * Based on the email client, the replyTo field may be used to customize the reply-to field of the email.
-   * @remarks
-   * The original reply email value can be found in the template variables.
    */
   replyTo?: string;
   /**
    * OPTIONAL: Custom from template.
    *
    * Based on the email client, the sendFrom field may be used to customize the from field of the email.
-   * @remarks
-   * The sender email value can be found in the template variables.
    */
   sendFrom?: string;
 };


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix the misuse of the `replyTo` field. 

For some email providers, this field can indicate the reply email address.  Previously, it was confused with the alias of send to email address. 



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Unit test updated

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
