### PR TITLE
fix(core): show all organization permissions

### DIFF
--- a/.changeset/strange-oranges-sort.md
+++ b/.changeset/strange-oranges-sort.md
@@ -2,4 +2,9 @@
 "@logto/core": patch
 ---
 
-fix: show all organization scopes instead of only the first page
+fix: incorrect pagination behavior in organization role scopes APIs
+
+- Fix `/api/organization-roles/{id}/scopes` and `/api/organization-roles/{id}/resource-scopes` endpoints to:
+  - Return all scopes when no pagination parameters are provided
+  - Support optional pagination when query parameters are present
+- Fix Console to properly display all organization role scopes on the organization template page

--- a/.changeset/strange-oranges-sort.md
+++ b/.changeset/strange-oranges-sort.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": patch
+---
+
+fix: show all organization scopes instead of only the first page

--- a/packages/core/src/routes/organization-role/index.openapi.json
+++ b/packages/core/src/routes/organization-role/index.openapi.json
@@ -102,7 +102,7 @@
     "/api/organization-roles/{id}/scopes": {
       "get": {
         "summary": "Get organization role scopes",
-        "description": "Get all organization scopes that are assigned to the specified organization role.",
+        "description": "Get organization scopes that are assigned to the specified organization role with optional pagination.",
         "responses": {
           "200": {
             "description": "A list of organization scopes."
@@ -174,7 +174,7 @@
     "/api/organization-roles/{id}/resource-scopes": {
       "get": {
         "summary": "Get organization role resource scopes",
-        "description": "Get all resource scopes that are assigned to the specified organization role.",
+        "description": "Get resource scopes that are assigned to the specified organization role with optional pagination.",
         "responses": {
           "200": {
             "description": "A list of resource scopes."

--- a/packages/core/src/routes/organization-role/index.ts
+++ b/packages/core/src/routes/organization-role/index.ts
@@ -127,8 +127,8 @@ export default function organizationRoleRoutes<T extends ManagementApiRouter>(
     }
   );
 
-  router.addRelationRoutes(rolesScopes, 'scopes');
-  router.addRelationRoutes(rolesResourceScopes, 'resource-scopes');
+  router.addRelationRoutes(rolesScopes, 'scopes', { isPaginationOptional: true });
+  router.addRelationRoutes(rolesResourceScopes, 'resource-scopes', { isPaginationOptional: true });
 
   originalRouter.use(router.routes());
 }

--- a/packages/core/src/routes/organization-scope/index.openapi.json
+++ b/packages/core/src/routes/organization-scope/index.openapi.json
@@ -9,7 +9,7 @@
     "/api/organization-scopes": {
       "get": {
         "summary": "Get organization scopes",
-        "description": "Get organization scopes that match with pagination.",
+        "description": "Get organization scopes that match with optional pagination.",
         "responses": {
           "200": {
             "description": "A list of organization scopes."

--- a/packages/core/src/routes/organization-scope/index.ts
+++ b/packages/core/src/routes/organization-scope/index.ts
@@ -19,6 +19,7 @@ export default function organizationScopeRoutes<T extends ManagementApiRouter>(
     middlewares: [],
     errorHandler,
     searchFields: ['name'],
+    isPaginationOptional: true,
   });
 
   originalRouter.use(router.routes());

--- a/packages/core/src/utils/SchemaRouter.ts
+++ b/packages/core/src/utils/SchemaRouter.ts
@@ -86,6 +86,11 @@ type SchemaRouterConfig<Key extends string> = {
    * If not provided, the `schema.guard` will be used.
    */
   entityGuard?: z.ZodTypeAny;
+  /**
+   * If the GET route's pagination is optional.
+   * @default false
+   */
+  isPaginationOptional?: boolean;
 };
 
 type RelationRoutesConfig = {
@@ -313,12 +318,12 @@ export default class SchemaRouter<
 
   #addRoutes() {
     const { queries, schema, config } = this;
-    const { disabled, searchFields, idLength, entityGuard } = config;
+    const { disabled, searchFields, idLength, entityGuard, isPaginationOptional } = config;
 
     if (!disabled.get) {
       this.get(
         '/',
-        koaPagination(),
+        koaPagination({ isOptional: isPaginationOptional }),
         koaGuard({
           query: z.object({ q: z.string().optional() }),
           response: (entityGuard ?? schema.guard).array(),

--- a/packages/integration-tests/src/tests/api/hook/hook.trigger.data.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.trigger.data.test.ts
@@ -299,6 +299,10 @@ describe('organization scope data hook events', () => {
     expect(organizationScopeCreateHook?.payload.event).toBe('OrganizationScope.Created');
   });
 
+  afterAll(async () => {
+    await organizationScopeApi.cleanUp();
+  });
+
   it.each(organizationScopeDataHookTestCases)(
     'test case %#: %p',
     async ({ route, event, method, endpoint, payload }) => {

--- a/packages/integration-tests/src/tests/api/organization/organization-scope.test.ts
+++ b/packages/integration-tests/src/tests/api/organization/organization-scope.test.ts
@@ -39,15 +39,21 @@ describe('organization scope APIs', () => {
     expect(scopes).toContainEqual(expect.objectContaining({ name: name2, description: null }));
   });
 
-  it('should get organization scopes with pagination', async () => {
-    // Add 20 scopes to exceed the default page size
+  it('should get organization scopes with optional pagination', async () => {
+    const pageSize = 20;
+    // Create scopes to exceed the default page size
+    const createCount = pageSize + 10;
     await Promise.all(
-      Array.from({ length: 30 }).map(async () => scopeApi.create({ name: 'test' + randomId() }))
+      Array.from({ length: createCount }).map(async () =>
+        scopeApi.create({ name: 'test' + randomId() })
+      )
     );
 
+    // Should return all scopes if no pagination is provided
     const scopes = await scopeApi.getList();
-    expect(scopes).toHaveLength(20);
+    expect(scopes).toHaveLength(createCount);
 
+    // Should return paginated scopes based on specified page number and page size
     const scopes2 = await scopeApi.getList(
       new URLSearchParams({
         page: '2',

--- a/packages/integration-tests/src/tests/api/organization/organization-user.test.ts
+++ b/packages/integration-tests/src/tests/api/organization/organization-user.test.ts
@@ -390,6 +390,9 @@ describe('organization user APIs', () => {
       await organizationApi.addUserRoles(organization.id, user.id, [role2.id]);
       const newScopes = await organizationApi.getUserOrganizationScopes(organization.id, user.id);
       expect(newScopes.map(({ name }) => name)).toEqual([scope1.name]);
+
+      // Clean up
+      await organizationApi.cleanUp();
     });
   });
 });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Issue: #7064 

During the initial introduction of the organization feature, a limitation was introduced where the frontend only displayed the first 20 organization scopes (first page) due to default pagination settings. Despite several iterations and improvements to the organization features, this issue remained unnoticed.

This PR fixes the long-standing bug by making pagination optional for organization scopes GET API endpoints. The change ensures all available scopes are returned when needed, particularly in organization permissions management and scopes assignment scenarios.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally and all scopes are returned.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
