### PR TITLE
feat(core): assign organization roles by name

### DIFF
--- a/.changeset/spicy-pets-approve.md
+++ b/.changeset/spicy-pets-approve.md
@@ -1,0 +1,20 @@
+---
+"@logto/core": minor
+---
+
+feat: support role names alongside role IDs in organization user role assignment/replacement with merge capability
+
+This update enhances organization user role management APIs to support role assignment by both names and IDs, improving integration flexibility.
+
+### Updates
+
+- Added `organizationRoleNames` parameter to:
+  - POST `/api/organizations/{id}/users/{userId}/roles` (assign roles)
+  - PUT `/api/organizations/{id}/users/{userId}/roles` (replace roles)
+- Make both `organizationRoleNames` and `organizationRoleIds` optional in the above APIs
+  - If both are not provided, or empty, an invalid data error will be thrown
+- Merge logic when both parameters are provided:
+  - Combines roles from `organizationRoleNames` and `organizationRoleIds`
+  - Automatically deduplicates entries
+  - Validates all names/IDs exist before applying changes
+- Maintains backward compatibility with existing integrations using role IDs

--- a/packages/core/src/queries/organization/index.ts
+++ b/packages/core/src/queries/organization/index.ts
@@ -62,6 +62,16 @@ class OrganizationRolesQueries extends SchemaQueries<
     ]);
   }
 
+  async findAllByNames(names: string[]): Promise<Readonly<OrganizationRole[]>> {
+    const { table, fields } = convertToIdentifiers(OrganizationRoles);
+
+    return this.pool.any<OrganizationRole>(sql`
+      select ${table}.*
+      from ${table}
+      where ${fields.name} = any(${sql.array(names, 'text')})  
+    `);
+  }
+
   #findWithScopesSql(
     roleId?: string,
     limit = 1,

--- a/packages/core/src/routes/organization/user/index.openapi.json
+++ b/packages/core/src/routes/organization/user/index.openapi.json
@@ -141,6 +141,9 @@
                 "properties": {
                   "organizationRoleIds": {
                     "description": "An array of organization role IDs to update for the user."
+                  },
+                  "organizationRoleNames": {
+                    "description": "An array of organization role names to update for the user."
                   }
                 }
               }
@@ -152,7 +155,7 @@
             "description": "Roles were updated for the user successfully."
           },
           "422": {
-            "description": "The user is not a member of the organization; or at least one of the IDs provided is not valid. For example, the organization ID or organization role ID does not exist."
+            "description": "The user is not a member of the organization; or at least one of the IDs provided is not valid. For example, the organization ID or organization role ID does not exist; or at least one of the role names provided is not valid. For example, the organization role name does not exist."
           }
         }
       },
@@ -166,6 +169,9 @@
                 "properties": {
                   "organizationRoleIds": {
                     "description": "An array of organization role IDs to assign to the user. User existed roles assignment will be ignored."
+                  },
+                  "organizationRoleNames": {
+                    "description": "An array of organization role names to assign to the user. User existed roles assignment will be ignored."
                   }
                 }
               }
@@ -177,7 +183,7 @@
             "description": "Roles were assigned to the user successfully."
           },
           "422": {
-            "description": "The user is not a member of the organization; or at least one of the IDs provided is not valid. For example, the organization ID or organization role ID does not exist."
+            "description": "The user is not a member of the organization; or at least one of the IDs provided is not valid. For example, the organization ID or organization role ID does not exist; or at least one of the role names provided is not valid. For example, the organization role name does not exist."
           }
         }
       }

--- a/packages/integration-tests/src/api/organization.ts
+++ b/packages/integration-tests/src/api/organization.ts
@@ -66,9 +66,25 @@ export class OrganizationApi extends ApiFactory<Organization, Omit<CreateOrganiz
     await authedAdminApi.delete(`${this.path}/${id}/users/${userId}`);
   }
 
-  async addUserRoles(id: string, userId: string, organizationRoleIds: string[]): Promise<void> {
+  async addUserRoles(
+    id: string,
+    userId: string,
+    organizationRoleIds: string[],
+    organizationRoleNames?: string[]
+  ): Promise<void> {
     await authedAdminApi.post(`${this.path}/${id}/users/${userId}/roles`, {
-      json: { organizationRoleIds },
+      json: { organizationRoleIds, organizationRoleNames },
+    });
+  }
+
+  async replaceUserRoles(
+    id: string,
+    userId: string,
+    organizationRoleIds: string[],
+    organizationRoleNames?: string[]
+  ): Promise<void> {
+    await authedAdminApi.put(`${this.path}/${id}/users/${userId}/roles`, {
+      json: { organizationRoleIds, organizationRoleNames },
     });
   }
 

--- a/packages/phrases/src/locales/en/errors/organization.ts
+++ b/packages/phrases/src/locales/en/errors/organization.ts
@@ -1,5 +1,7 @@
 const organizations = {
   require_membership: 'The user must be a member of the organization to proceed.',
+  role_names_not_found:
+    'Invalid role names detected: {{names,list(type:conjunction)}}. Please create these roles first before proceeding.',
 };
 
 export default Object.freeze(organizations);


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR address the feature request #7065.

### Description
This update enhances organization user role management APIs to support role assignment by both names and IDs, improving integration flexibility.

### Updates

- Added `organizationRoleNames` parameter to:
  - POST `/api/organizations/{id}/users/{userId}/roles` (assign roles)
  - PUT `/api/organizations/{id}/users/{userId}/roles` (replace roles)
- Make both `organizationRoleNames` and `organizationRoleIds` optional in the above APIs
  - If both are not provided, or empty, an invalid data error will be thrown
- Merge logic when both parameters are provided:
  - Combines roles from `organizationRoleNames` and `organizationRoleIds`
  - Automatically deduplicates entries
  - Validates all names/IDs exist before applying changes
- Maintains backward compatibility with existing integrations using role IDs



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
integration tests added

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
