### PR TITLE
feat(core):  migrate experience package for OSS

### DIFF
--- a/.changeset/hungry-olives-sell.md
+++ b/.changeset/hungry-olives-sell.md
@@ -1,0 +1,11 @@
+---
+"@logto/core": minor
+---
+
+refactor: switch to `@logto/experience` package with latest [Experience API](https://openapi.logto.io/group/endpoint-experience)
+
+In this release, we have transitioned the user sign-in experience from the legacy `@logto/experience-legacy` package to the latest `@logto/experience` package. This change fully adopts our new [Experience API](https://openapi.logto.io/group/endpoint-experience), enhancing the underlying architecture while maintaining the same user experience.
+
+- Package update: The user sign-in experience now utilizes the `@logto/experience` package by default.
+  API Transition: The new package leverages our latest [Experience API](https://openapi.logto.io/group/endpoint-experience).
+- No feature changes: Users will notice no changes in functionality or experience compared to the previous implementation.

--- a/packages/core/src/middleware/koa-spa-proxy.test.ts
+++ b/packages/core/src/middleware/koa-spa-proxy.test.ts
@@ -101,7 +101,7 @@ describe('koaSpaProxy middleware', () => {
 
       await koaSpaProxy({ mountedApps, queries })(ctx, next);
 
-      const packagePath = isDevFeaturesEnabled ? 'experience' : 'experience-legacy';
+      const packagePath = 'experience';
       const distributionPath = path.join('node_modules/@logto', packagePath, 'dist');
 
       expect(mockStaticMiddlewareFactory).toBeCalledWith(distributionPath);

--- a/packages/core/src/middleware/utils/experience-proxy.test.ts
+++ b/packages/core/src/middleware/utils/experience-proxy.test.ts
@@ -65,7 +65,7 @@ describe('experience proxy with feature flag detection test', () => {
     stub.restore();
   });
 
-  it('should return the legacy experience package if not in the cloud', async () => {
+  it('should return the new experience package if not in the cloud', async () => {
     const stub = Sinon.stub(EnvSet, 'values').value({
       ...EnvSet.values,
       isDevFeaturesEnabled: false,
@@ -74,7 +74,7 @@ describe('experience proxy with feature flag detection test', () => {
 
     const result = await getExperiencePackageWithFeatureFlagDetection(mockContext);
 
-    expect(result).toBe('experience-legacy');
+    expect(result).toBe('experience');
     expect(mockFindSystemByKey).not.toBeCalled();
     expect(mockIsRequestInTestGroup).not.toBeCalled();
 

--- a/packages/core/src/middleware/utils/experience-proxy.ts
+++ b/packages/core/src/middleware/utils/experience-proxy.ts
@@ -59,13 +59,9 @@ const getFeatureFlagSettings = async () => {
 export const getExperiencePackageWithFeatureFlagDetection = async <ContextT extends Context>(
   ctx: ContextT
 ) => {
-  if (EnvSet.values.isDevFeaturesEnabled) {
+  // Always use the new experience package if dev features are enabled or is OSS
+  if (EnvSet.values.isDevFeaturesEnabled || !EnvSet.values.isCloud) {
     return 'experience';
-  }
-
-  // Always use the legacy experience package if not in the cloud, until the new experience is fully rolled out
-  if (!EnvSet.values.isCloud) {
-    return 'experience-legacy';
   }
 
   const interactionSessionId = ctx.cookies.get(interactionCookieName);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Officially transitioned the user sign-in experience app from the legacy `@logto/experience-legacy` package to the latest `@logto/experience` package. This change fully adopts our new [Experience API](https://openapi.logto.io/group/endpoint-experience), enhancing the underlying architecture while maintaining the same user experience.

- Package update: The user sign-in experience now utilizes the `@logto/experience` package for OSS by default.
  API Transition: The new package leverages our latest [Experience API](https://openapi.logto.io/group/endpoint-experience).
- No feature changes: Users will notice no changes in functionality or experience compared to the previous implementation.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
