### PR TITLE
chore: make report subscription usage to be non-blocking

### DIFF
--- a/packages/core/src/routes/applications/application.ts
+++ b/packages/core/src/routes/applications/application.ts
@@ -223,7 +223,7 @@ export default function applicationRoutes<T extends ManagementApiRouter>(
       ctx.body = application;
 
       if (rest.type === ApplicationType.MachineToMachine) {
-        await quota.reportSubscriptionUpdatesUsage('machineToMachineLimit');
+        void quota.reportSubscriptionUpdatesUsage('machineToMachineLimit');
       }
 
       return next();
@@ -380,7 +380,7 @@ export default function applicationRoutes<T extends ManagementApiRouter>(
       ctx.status = 204;
 
       if (type === ApplicationType.MachineToMachine) {
-        await quota.reportSubscriptionUpdatesUsage('machineToMachineLimit');
+        void quota.reportSubscriptionUpdatesUsage('machineToMachineLimit');
       }
 
       return next();

--- a/packages/core/src/routes/sign-in-experience/index.ts
+++ b/packages/core/src/routes/sign-in-experience/index.ts
@@ -134,7 +134,7 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
           : rest
       );
 
-      await reportSubscriptionUpdatesUsage('mfaEnabled');
+      void reportSubscriptionUpdatesUsage('mfaEnabled');
 
       return next();
     }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
make report subscription usage to be non-blocking, resolves LOG-10880
we only need to trigger this function, and there is no need to wait for the result.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
