### PR TITLE
feat(schemas): add organizationRequiredMfa policy settings

### DIFF
--- a/packages/integration-tests/src/tests/api/sign-in-experience.test.ts
+++ b/packages/integration-tests/src/tests/api/sign-in-experience.test.ts
@@ -1,4 +1,4 @@
-import { MfaPolicy, SignInIdentifier } from '@logto/schemas';
+import { MfaPolicy, OrganizationRequiredMfaPolicy, SignInIdentifier } from '@logto/schemas';
 import { HTTPError, type ResponsePromise } from 'ky';
 
 import {
@@ -34,6 +34,7 @@ describe('admin console sign-in experience', () => {
       mfa: {
         policy: MfaPolicy.PromptAtSignInAndSignUp,
         factors: [],
+        organizationRequiredMfaPolicy: OrganizationRequiredMfaPolicy.Mandatory,
       },
       singleSignOnEnabled: true,
       supportEmail: 'contact@logto.io',

--- a/packages/schemas/src/foundations/jsonb-types/sign-in-experience.ts
+++ b/packages/schemas/src/foundations/jsonb-types/sign-in-experience.ts
@@ -117,12 +117,42 @@ export enum MfaPolicy {
   NoPrompt = 'NoPrompt',
 }
 
+export enum OrganizationRequiredMfaPolicy {
+  /** Do not ask users to set up MFA */
+  NoPrompt = 'NoPrompt',
+  /** MFA is required for all users */
+  Mandatory = 'Mandatory',
+}
+
+export type Mfa = {
+  /** Enabled MFA factors */
+  factors: MfaFactor[];
+  /** Global MFA prompt policy */
+  policy: MfaPolicy;
+  /**
+   * The MFA policy for organization level MFA settings.
+   *
+   * @remarks
+   * This policy is used to determine the MFA prompt behavior
+   * when the user is associated with one or more organizations that
+   * require MFA.
+   *
+   * @remarks
+   * For backward compatibility, if this policy is not set,
+   * the default behavior is {@link OrganizationRequiredMfaPolicy.NoPrompt}.
+   *
+   * @remarks
+   * Regardless of this policy setting, the user will always be rejected
+   * when request for an organization access_token if the user has not set up MFA.
+   */
+  organizationRequiredMfaPolicy?: OrganizationRequiredMfaPolicy;
+};
+
 export const mfaGuard = z.object({
   factors: mfaFactorsGuard,
   policy: z.nativeEnum(MfaPolicy),
-});
-
-export type Mfa = z.infer<typeof mfaGuard>;
+  organizationRequiredMfaPolicy: z.nativeEnum(OrganizationRequiredMfaPolicy).optional(),
+}) satisfies ToZodObject<Mfa>;
 
 export const customUiAssetsGuard = z.object({
   id: z.string(),


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add `organizationRequiredMfaPolicy` settings to the sign-in experience Mfa settings. 

This policy is used to determine the MFA prompt behavior when the user is associated with one to more organizations that require MFA. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
