### PR TITLE
feat(core): add organizationRequiredMfaPolicy guard

### DIFF
--- a/packages/core/src/routes/experience/classes/mfa.ts
+++ b/packages/core/src/routes/experience/classes/mfa.ts
@@ -13,6 +13,8 @@ import {
   MfaPolicy,
   type User,
   VerificationType,
+  type Mfa as MfaSettings,
+  OrganizationRequiredMfaPolicy,
 } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 import { deduplicate } from '@silverhand/essentials';
@@ -24,6 +26,7 @@ import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
+import { EnvSet } from '../../../env-set/index.js';
 import { type InteractionContext } from '../types.js';
 
 import { SignInExperienceValidator } from './libraries/sign-in-experience-validator.js';
@@ -150,10 +153,13 @@ export class Mfa {
    * @throws {RequestError} with status 422 if the MFA policy is not user controlled
    */
   async skip() {
-    const { policy } = await this.signInExperienceValidator.getMfaSettings();
+    const mfaSettings = await this.signInExperienceValidator.getMfaSettings();
+    const { policy } = mfaSettings;
+    const user = await this.interactionContext.getIdentifiedUser();
 
     assertThat(
-      policy !== MfaPolicy.Mandatory,
+      policy !== MfaPolicy.Mandatory &&
+        !(await this.isMfaRequiredByUserOrganizations(mfaSettings, user.id)),
       new RequestError({
         code: 'session.mfa.mfa_policy_not_user_controlled',
         status: 422,
@@ -269,23 +275,39 @@ export class Mfa {
    * @throws {RequestError} with status 422 if the user has not bound the backup code but enabled in the sign-in experience
    * @throws {RequestError} with status 422 if the user existing backup codes is empty, new backup codes is required
    */
+  // eslint-disable-next-line complexity
   async assertUserMandatoryMfaFulfilled() {
-    const { factors, policy } = await this.signInExperienceValidator.getMfaSettings();
+    const mfaSettings = await this.signInExperienceValidator.getMfaSettings();
+    const { policy, factors } = mfaSettings;
 
     // If there are no factors, then there is nothing to check
     if (factors.length === 0) {
       return;
     }
 
-    const { mfaVerifications, logtoConfig } = await this.interactionContext.getIdentifiedUser();
+    const {
+      mfaVerifications,
+      logtoConfig,
+      id: userId,
+    } = await this.interactionContext.getIdentifiedUser();
 
-    // If the policy is no prompt, then there is nothing to check
-    if (policy === MfaPolicy.NoPrompt) {
+    const isMfaRequiredByUserOrganizations = await this.isMfaRequiredByUserOrganizations(
+      mfaSettings,
+      userId
+    );
+
+    // If the policy is no prompt, and mfa is not required by the user organizations, then there is nothing to check
+    if (policy === MfaPolicy.NoPrompt && !isMfaRequiredByUserOrganizations) {
       return;
     }
 
-    // If the policy is not mandatory and the user has skipped MFA, then there is nothing to check
-    if (policy !== MfaPolicy.Mandatory && (this.#mfaSkipped ?? isMfaSkipped(logtoConfig))) {
+    // If the policy is not mandatory and the user has skipped MFA,
+    // and MFA is not required by the user organizations, then there is nothing to check
+    if (
+      policy !== MfaPolicy.Mandatory &&
+      (this.#mfaSkipped ?? isMfaSkipped(logtoConfig)) &&
+      !isMfaRequiredByUserOrganizations
+    ) {
       return;
     }
 
@@ -308,7 +330,7 @@ export class Mfa {
       availableFactors.some((factor) => linkedFactors.includes(factor)),
       new RequestError(
         { code: 'user.missing_mfa', status: 422 },
-        policy === MfaPolicy.Mandatory
+        policy === MfaPolicy.Mandatory || isMfaRequiredByUserOrganizations
           ? { availableFactors }
           : { availableFactors, skippable: true }
       )
@@ -339,5 +361,22 @@ export class Mfa {
     const isFactorsEnabled = factors.every((factor) => enabledFactors.includes(factor));
 
     assertThat(isFactorsEnabled, new RequestError({ code: 'session.mfa.mfa_factor_not_enabled' }));
+  }
+
+  private async isMfaRequiredByUserOrganizations(mfaSettings: MfaSettings, userId: string) {
+    // TODO: Remove this check when the feature is enabled for production
+    if (!EnvSet.values.isDevFeaturesEnabled) {
+      return false;
+    }
+
+    if (mfaSettings.organizationRequiredMfaPolicy !== OrganizationRequiredMfaPolicy.Mandatory) {
+      return false;
+    }
+
+    const organizations = await this.queries.organizations.relations.users.getOrganizationsByUserId(
+      userId
+    );
+
+    return organizations.some(({ isMfaRequired }) => isMfaRequired);
   }
 }

--- a/packages/core/src/routes/experience/profile-routes.ts
+++ b/packages/core/src/routes/experience/profile-routes.ts
@@ -19,6 +19,8 @@ import { experienceRoutes } from './const.js';
 import { type ExperienceInteractionRouterContext } from './types.js';
 
 /**
+ * This middleware is guards the current interaction status is MFA verified (if MFA is enabled)
+ *
  * @throws {RequestError} with status 400 if current interaction is ForgotPassword
  * @throws {RequestError} with status 404 if current interaction is not identified
  * @throws {RequestError} with status 403 if MFA verification status is not verified
@@ -40,7 +42,6 @@ function verifiedInteractionGuard<
       })
     );
 
-    // Guard MFA verification status
     await experienceInteraction.guardMfaVerificationStatus();
 
     return next();
@@ -73,7 +74,7 @@ export default function interactionProfileRoutes<T extends ExperienceInteraction
         })
       );
 
-      // Guard MFA verification status for SignIn interaction only
+      //  User profile updates require MFA verification (if MFA is enabled) during the sign-in event.
       if (interactionEvent === InteractionEvent.SignIn) {
         await experienceInteraction.guardMfaVerificationStatus();
       }

--- a/packages/integration-tests/src/helpers/index.ts
+++ b/packages/integration-tests/src/helpers/index.ts
@@ -86,6 +86,7 @@ type ExpectedErrorInfo = {
   code: string;
   status: number;
   messageIncludes?: string;
+  unexpectedProperties?: string[];
 };
 
 export const expectRejects = async <T = void>(
@@ -102,7 +103,7 @@ export const expectRejects = async <T = void>(
 };
 
 const expectRequestError = async <T = void>(error: unknown, expected: ExpectedErrorInfo) => {
-  const { code, status, messageIncludes } = expected;
+  const { code, status, messageIncludes, unexpectedProperties = [] } = expected;
 
   if (!(error instanceof HTTPError)) {
     fail('Error should be an instance of RequestError');
@@ -122,6 +123,10 @@ const expectRequestError = async <T = void>(error: unknown, expected: ExpectedEr
 
   if (messageIncludes) {
     expect(body.message.includes(messageIncludes)).toBeTruthy();
+  }
+
+  for (const property of unexpectedProperties) {
+    expect(body.data).not.toHaveProperty(property);
   }
 
   return body.data;

--- a/packages/integration-tests/src/tests/api/experience-api/bind-mfa/organization-required-mfa.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/bind-mfa/organization-required-mfa.test.ts
@@ -1,0 +1,262 @@
+import {
+  InteractionEvent,
+  MfaFactor,
+  MfaPolicy,
+  OrganizationRequiredMfaPolicy,
+  SignInIdentifier,
+} from '@logto/schemas';
+
+import { updateSignInExperience } from '#src/api/sign-in-experience.js';
+import { initExperienceClient, logoutClient, processSession } from '#src/helpers/client.js';
+import {
+  identifyUserWithUsernamePassword,
+  signInWithPassword,
+} from '#src/helpers/experience/index.js';
+import { expectRejects } from '#src/helpers/index.js';
+import { OrganizationApiTest } from '#src/helpers/organization.js';
+import {
+  enableAllPasswordSignInMethods,
+  resetMfaSettings,
+} from '#src/helpers/sign-in-experience.js';
+import { generateNewUserProfile, UserApiTest } from '#src/helpers/user.js';
+import { devFeatureTest } from '#src/utils.js';
+
+devFeatureTest.describe('Organization required MFA policy', () => {
+  const userApi = new UserApiTest();
+  const organizationApi = new OrganizationApiTest();
+
+  beforeAll(async () => {
+    await enableAllPasswordSignInMethods({
+      identifiers: [SignInIdentifier.Username],
+      password: true,
+      verify: false,
+    });
+  });
+
+  afterEach(async () => {
+    await Promise.all([userApi.cleanUp(), organizationApi.cleanUp()]);
+  });
+
+  afterAll(async () => {
+    await resetMfaSettings();
+  });
+
+  it('should require MFA for NoPrompt settings, if user associated with organization that requires MFA and organizationRequiredMfaPolicy is Mandatory', async () => {
+    await updateSignInExperience({
+      mfa: {
+        factors: [MfaFactor.TOTP],
+        policy: MfaPolicy.NoPrompt,
+        organizationRequiredMfaPolicy: OrganizationRequiredMfaPolicy.Mandatory,
+      },
+    });
+
+    const { username, password } = generateNewUserProfile({ username: true, password: true });
+
+    const user = await userApi.create({
+      username,
+      password,
+    });
+
+    const organizations = await Promise.all([
+      organizationApi.create({ name: 'Foo', isMfaRequired: true }),
+      organizationApi.create({ name: 'Bar', isMfaRequired: false }),
+    ]);
+
+    await Promise.all(organizations.map(async ({ id }) => organizationApi.addUsers(id, [user.id])));
+
+    const client = await initExperienceClient();
+    await identifyUserWithUsernamePassword(client, username, password);
+
+    await expectRejects(client.submitInteraction(), {
+      code: 'user.missing_mfa',
+      status: 422,
+    });
+  });
+
+  it.each([
+    MfaPolicy.PromptAtSignInAndSignUp,
+    MfaPolicy.PromptOnlyAtSignIn,
+    MfaPolicy.UserControlled,
+  ])(
+    'should require MFA for %s settings, if user associated with organization that requires MFA and organizationRequiredMfaPolicy is Mandatory, even if user has MFA skipped',
+    async (policy) => {
+      await updateSignInExperience({
+        mfa: {
+          factors: [MfaFactor.TOTP],
+          policy,
+          organizationRequiredMfaPolicy: OrganizationRequiredMfaPolicy.Mandatory,
+        },
+      });
+
+      const { username, password } = generateNewUserProfile({ username: true, password: true });
+
+      // Register user and skip MFA
+      const client = await initExperienceClient(InteractionEvent.Register);
+      const { verificationId } = await client.createNewPasswordIdentityVerification({
+        identifier: {
+          type: SignInIdentifier.Username,
+          value: username,
+        },
+        password,
+      });
+      await client.identifyUser({ verificationId });
+      await client.skipMfaBinding();
+      const { redirectTo } = await client.submitInteraction();
+      const userId = await processSession(client, redirectTo);
+      await logoutClient(client);
+
+      const organizations = await Promise.all([
+        organizationApi.create({ name: 'Foo', isMfaRequired: true }),
+        organizationApi.create({ name: 'Bar', isMfaRequired: false }),
+      ]);
+
+      // Assign user to organizations
+      await Promise.all(
+        organizations.map(async ({ id }) => organizationApi.addUsers(id, [userId]))
+      );
+
+      // Should require MFA on next sign-in
+      const signInClient = await initExperienceClient();
+      await identifyUserWithUsernamePassword(signInClient, username, password);
+      await expectRejects(signInClient.submitInteraction(), {
+        code: 'user.missing_mfa',
+        status: 422,
+        unexpectedProperties: ['skippable'],
+      });
+    }
+  );
+
+  it.each([
+    MfaPolicy.PromptAtSignInAndSignUp,
+    MfaPolicy.PromptOnlyAtSignIn,
+    MfaPolicy.UserControlled,
+  ])(
+    'should not allow skipping MFA for %s settings, if user associated with organization that requires MFA and organizationRequiredMfaPolicy is Mandatory',
+    async (policy) => {
+      await updateSignInExperience({
+        mfa: {
+          factors: [MfaFactor.TOTP],
+          policy,
+          organizationRequiredMfaPolicy: OrganizationRequiredMfaPolicy.Mandatory,
+        },
+      });
+
+      const { username, password } = generateNewUserProfile({ username: true, password: true });
+      const user = await userApi.create({ username, password });
+
+      const organizations = await Promise.all([
+        organizationApi.create({ name: 'Foo', isMfaRequired: true }),
+        organizationApi.create({ name: 'Bar', isMfaRequired: false }),
+      ]);
+      await Promise.all(
+        organizations.map(async ({ id }) => organizationApi.addUsers(id, [user.id]))
+      );
+
+      const client = await initExperienceClient();
+      await identifyUserWithUsernamePassword(client, username, password);
+      await expectRejects(client.submitInteraction(), {
+        code: 'user.missing_mfa',
+        status: 422,
+        unexpectedProperties: ['skippable'],
+      });
+      await expectRejects(client.skipMfaBinding(), {
+        code: 'session.mfa.mfa_policy_not_user_controlled',
+        status: 422,
+      });
+    }
+  );
+
+  it('should not prompt MFA if user is not associated with any organization that requires MFA', async () => {
+    await updateSignInExperience({
+      mfa: {
+        factors: [MfaFactor.TOTP],
+        policy: MfaPolicy.NoPrompt,
+        organizationRequiredMfaPolicy: OrganizationRequiredMfaPolicy.Mandatory,
+      },
+    });
+    const { username, password } = generateNewUserProfile({ username: true, password: true });
+    const user = await userApi.create({
+      username,
+      password,
+    });
+    const organization = await organizationApi.create({ name: 'Foo' });
+    await organizationApi.addUsers(organization.id, [user.id]);
+    await expect(
+      signInWithPassword({
+        identifier: { type: SignInIdentifier.Username, value: username },
+        password,
+      })
+    ).resolves.not.toThrow();
+  });
+
+  it.each([
+    MfaPolicy.PromptAtSignInAndSignUp,
+    MfaPolicy.PromptOnlyAtSignIn,
+    MfaPolicy.UserControlled,
+  ])(
+    'should allow skip MFA for %s settings, if user associated with organization that requires MFA but organizationRequiredMfaPolicy is not set',
+    async (policy) => {
+      await updateSignInExperience({
+        mfa: {
+          factors: [MfaFactor.TOTP],
+          policy,
+        },
+      });
+
+      const { username, password } = generateNewUserProfile({ username: true, password: true });
+      const user = await userApi.create({
+        username,
+        password,
+      });
+
+      const organizations = await Promise.all([
+        organizationApi.create({ name: 'Foo', isMfaRequired: true }),
+        organizationApi.create({ name: 'Bar', isMfaRequired: false }),
+      ]);
+      await Promise.all(
+        organizations.map(async ({ id }) => organizationApi.addUsers(id, [user.id]))
+      );
+
+      const client = await initExperienceClient();
+      await identifyUserWithUsernamePassword(client, username, password);
+      await expectRejects(client.submitInteraction(), {
+        code: 'user.missing_mfa',
+        status: 422,
+      });
+      await client.skipMfaBinding();
+      await expect(client.submitInteraction()).resolves.not.toThrow();
+    }
+  );
+
+  it.each([
+    MfaPolicy.PromptAtSignInAndSignUp,
+    MfaPolicy.PromptOnlyAtSignIn,
+    MfaPolicy.UserControlled,
+  ])(
+    'should allow skip MFA for %s settings, is not associated with any organization that requires MFA',
+    async (policy) => {
+      await updateSignInExperience({
+        mfa: {
+          factors: [MfaFactor.TOTP],
+          policy,
+          organizationRequiredMfaPolicy: OrganizationRequiredMfaPolicy.Mandatory,
+        },
+      });
+      const { username, password } = generateNewUserProfile({ username: true, password: true });
+      const user = await userApi.create({
+        username,
+        password,
+      });
+      const organization = await organizationApi.create({ name: 'Foo' });
+      await organizationApi.addUsers(organization.id, [user.id]);
+      const client = await initExperienceClient();
+      await identifyUserWithUsernamePassword(client, username, password);
+      await expectRejects(client.submitInteraction(), {
+        code: 'user.missing_mfa',
+        status: 422,
+      });
+      await client.skipMfaBinding();
+      await expect(client.submitInteraction()).resolves.not.toThrow();
+    }
+  );
+});


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This pull request introduces the organization-level Multi-Factor Authentication (MFA) prompt policy to the end-user experience API.

When organizationRequiredMfaPolicy is set to `Mandatory`, users associated with one or more organizations that require MFA will be forced to bind MFA (Mandatory, not skippable).

```mermaid
flowchart TD
    A[User MFA settings prompt]
    B{has MFA factors enabled in SIE}
    C{MFA policy}
    
    subgraph OrganiztionChecks [Organization required MFA policy check]
      H{Organization required MFA policy}
      M{User has organization with MFA required}
    end

    K{MFA skipped by user}
    L{User has MFA enabled}
    N[Prompt to bind MFA]
    O[Continue without prompt]

    A --> B
    B -->|No| O
    B -->|Yes| C

    C -->|NoPrompt| H
    C -->|Mandatory| L
    C -->|PromptAtSignInAndSignUp| K
    C-->|PromptOnlyAtSignIn|K

    K -->|Yes|H
    K -->|No|L

    H --> |NoPrompt| O
    H --> |Mandatory|M

    M -->|Yes|L
    M -->|No|O

    L -->|Yes| O
    L -->|No| N
```

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
