### PR TITLE
chore: reuse subscription library cache in quota library to reduce cross region HTTP requests

### DIFF
--- a/packages/core/src/libraries/quota.ts
+++ b/packages/core/src/libraries/quota.ts
@@ -5,7 +5,7 @@ import RequestError from '#src/errors/RequestError/index.js';
 import { type SubscriptionLibrary } from '#src/libraries/subscription.js';
 import assertThat from '#src/utils/assert-that.js';
 import {
-  getRealtimeTenantSubscriptionData,
+  getTenantUsageData,
   reportSubscriptionUpdates,
   isReportSubscriptionUpdatesUsageKey,
 } from '#src/utils/subscription/index.js';
@@ -53,7 +53,7 @@ export const createQuotaLibrary = (
       return;
     }
 
-    const { usage: fullUsage } = await getRealtimeTenantSubscriptionData(cloudConnection);
+    const { usage: fullUsage } = await getTenantUsageData(cloudConnection);
 
     // Type `SubscriptionQuota` and type `SubscriptionUsage` are sharing keys, this design helps us to compare the usage with the quota limit in a easier way.
     const { [key]: limit } = fullQuota;
@@ -120,7 +120,7 @@ export const createQuotaLibrary = (
       quota: { scopesPerResourceLimit, scopesPerRoleLimit },
       resources,
       roles,
-    } = await getRealtimeTenantSubscriptionData(cloudConnection);
+    } = await getTenantUsageData(cloudConnection);
     const usage = (entityName === 'resources' ? resources[entityId] : roles[entityId]) ?? 0;
 
     if (entityName === 'resources') {

--- a/packages/core/src/libraries/quota.ts
+++ b/packages/core/src/libraries/quota.ts
@@ -5,7 +5,7 @@ import RequestError from '#src/errors/RequestError/index.js';
 import { type SubscriptionLibrary } from '#src/libraries/subscription.js';
 import assertThat from '#src/utils/assert-that.js';
 import {
-  getTenantSubscriptionData,
+  getRealtimeTenantSubscriptionData,
   reportSubscriptionUpdates,
   isReportSubscriptionUpdatesUsageKey,
 } from '#src/utils/subscription/index.js';
@@ -53,7 +53,7 @@ export const createQuotaLibrary = (
       return;
     }
 
-    const { usage: fullUsage } = await getTenantSubscriptionData(cloudConnection);
+    const { usage: fullUsage } = await getRealtimeTenantSubscriptionData(cloudConnection);
 
     // Type `SubscriptionQuota` and type `SubscriptionUsage` are sharing keys, this design helps us to compare the usage with the quota limit in a easier way.
     const { [key]: limit } = fullQuota;
@@ -120,7 +120,7 @@ export const createQuotaLibrary = (
       quota: { scopesPerResourceLimit, scopesPerRoleLimit },
       resources,
       roles,
-    } = await getTenantSubscriptionData(cloudConnection);
+    } = await getRealtimeTenantSubscriptionData(cloudConnection);
     const usage = (entityName === 'resources' ? resources[entityId] : roles[entityId]) ?? 0;
 
     if (entityName === 'resources') {

--- a/packages/core/src/libraries/quota.ts
+++ b/packages/core/src/libraries/quota.ts
@@ -2,6 +2,7 @@ import { ReservedPlanId } from '@logto/schemas';
 
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
+import { type SubscriptionLibrary } from '#src/libraries/subscription.js';
 import assertThat from '#src/utils/assert-that.js';
 import {
   getTenantSubscriptionData,
@@ -28,7 +29,10 @@ const shouldReportSubscriptionUpdates = (
 ) =>
   (paidReservedPlans.has(planId) || isEnterprisePlan) && isReportSubscriptionUpdatesUsageKey(key);
 
-export const createQuotaLibrary = (cloudConnection: CloudConnectionLibrary) => {
+export const createQuotaLibrary = (
+  cloudConnection: CloudConnectionLibrary,
+  subscription: SubscriptionLibrary
+) => {
   const guardTenantUsageByKey = async (key: keyof SubscriptionUsage) => {
     const { isCloud, isIntegrationTest } = EnvSet.values;
 
@@ -42,17 +46,14 @@ export const createQuotaLibrary = (cloudConnection: CloudConnectionLibrary) => {
       return;
     }
 
-    const {
-      planId,
-      quota: fullQuota,
-      usage: fullUsage,
-      isEnterprisePlan,
-    } = await getTenantSubscriptionData(cloudConnection);
+    const { planId, isEnterprisePlan, quota: fullQuota } = await subscription.getSubscriptionData();
 
     // Do not block Pro/Enterprise plan from adding add-on resources.
     if (shouldReportSubscriptionUpdates(planId, isEnterprisePlan, key)) {
       return;
     }
+
+    const { usage: fullUsage } = await getTenantSubscriptionData(cloudConnection);
 
     // Type `SubscriptionQuota` and type `SubscriptionUsage` are sharing keys, this design helps us to compare the usage with the quota limit in a easier way.
     const { [key]: limit } = fullQuota;
@@ -165,7 +166,7 @@ export const createQuotaLibrary = (cloudConnection: CloudConnectionLibrary) => {
       return;
     }
 
-    const { planId, isEnterprisePlan } = await getTenantSubscriptionData(cloudConnection);
+    const { planId, isEnterprisePlan } = await subscription.getSubscriptionData();
 
     if (shouldReportSubscriptionUpdates(planId, isEnterprisePlan, key)) {
       await reportSubscriptionUpdates(cloudConnection, key);

--- a/packages/core/src/libraries/subscription.test.ts
+++ b/packages/core/src/libraries/subscription.test.ts
@@ -9,11 +9,18 @@ const mockGetTenantSubscription = jest.fn();
 const mockCountTokenUsage = jest.fn();
 
 const now = new Date();
-// Set the current period end to 1 day from now
-const currentPeriodEnd = new Date(now.getTime() + 1000 * 60 * 60 * 24);
+// Set the current period end to 2 day from now
+const currentPeriodEnd = new Date(now.getTime() + 1000 * 60 * 60 * 24 * 2);
 const mockSubscription = {
   ...mockSubscriptionData,
   currentPeriodEnd: currentPeriodEnd.toISOString(),
+};
+
+// Set the current period end to a past date (1 day ago)
+const pastPeriodEnd = new Date(now.getTime() - 1000 * 60 * 60 * 24);
+const mockExpiredSubscription = {
+  ...mockSubscriptionData,
+  currentPeriodEnd: pastPeriodEnd.toISOString(),
 };
 
 await mockEsmWithActual('#src/utils/subscription/index.js', () => ({
@@ -40,17 +47,19 @@ describe('get subscription data', () => {
 });
 
 describe('get subscription data with cache expiration', () => {
-  const { subscription } = new MockTenant(undefined);
-
-  beforeAll(() => {
+  beforeEach(() => {
+    jest.setSystemTime(new Date());
     jest.useFakeTimers();
+    mockGetTenantSubscription.mockClear();
   });
 
-  afterAll(() => {
+  afterEach(() => {
     jest.useRealTimers();
   });
 
   it('should get new subscription data if cache is expired', async () => {
+    const { subscription } = new MockTenant(undefined);
+
     mockGetTenantSubscription.mockResolvedValueOnce(mockSubscription);
     const subscriptionData = await subscription.getSubscriptionData();
     expect(subscriptionData).toEqual(mockSubscription);
@@ -64,18 +73,89 @@ describe('get subscription data with cache expiration', () => {
     // Should hit the cache
     const subscriptionDataFromCache = await subscription.getSubscriptionData();
     expect(subscriptionDataFromCache).toEqual(mockSubscription);
+    expect(mockGetTenantSubscription).not.toHaveBeenCalled();
 
     // Move the time to 1 day later
     jest.advanceTimersByTime(60 * 60 * 24);
     mockGetTenantSubscription.mockResolvedValueOnce({
-      ...mockSubscriptionData,
+      ...mockSubscription,
       planId: ReservedPlanId.Pro202411,
     });
 
     // Should get new subscription data
     const refreshedSubscriptionData = await subscription.getSubscriptionData();
     expect(refreshedSubscriptionData).toEqual({
+      ...mockSubscription,
+      planId: ReservedPlanId.Pro202411,
+    });
+    expect(mockGetTenantSubscription).toHaveBeenCalled();
+  });
+
+  it('should respect the 24 hours max TTL limit', async () => {
+    const { subscription } = new MockTenant(undefined);
+
+    // Set the current period end to 30 days from now
+    const farFuturePeriodEnd = new Date(now.getTime() + 1000 * 60 * 60 * 24 * 30);
+    const mockFarFutureSubscription = {
       ...mockSubscriptionData,
+      currentPeriodEnd: farFuturePeriodEnd.toISOString(),
+    };
+
+    mockGetTenantSubscription.mockResolvedValueOnce(mockFarFutureSubscription);
+    const subscriptionData = await subscription.getSubscriptionData();
+    expect(subscriptionData).toEqual(mockFarFutureSubscription);
+
+    // Move the time to 23 hours later
+    jest.advanceTimersByTime(23 * 60 * 60);
+    mockGetTenantSubscription.mockClear();
+
+    // Should hit the cache
+    const subscriptionDataFromCache = await subscription.getSubscriptionData();
+    expect(subscriptionDataFromCache).toEqual(mockFarFutureSubscription);
+    expect(mockGetTenantSubscription).not.toHaveBeenCalled();
+
+    // Move the time to 25 hours later (past the 24h max TTL)
+    jest.advanceTimersByTime(2 * 60 * 60);
+    mockGetTenantSubscription.mockResolvedValueOnce({
+      ...mockFarFutureSubscription,
+      planId: ReservedPlanId.Pro202411,
+    });
+
+    // Should get new subscription data due to max TTL
+    const refreshedSubscriptionData = await subscription.getSubscriptionData();
+    expect(refreshedSubscriptionData).toEqual({
+      ...mockFarFutureSubscription,
+      planId: ReservedPlanId.Pro202411,
+    });
+    expect(mockGetTenantSubscription).toHaveBeenCalled();
+  });
+
+  it('should get new subscription data if current period end time is past', async () => {
+    // Create a new tenant to avoid interference with other tests
+    const { subscription } = new MockTenant(undefined);
+
+    mockGetTenantSubscription.mockResolvedValueOnce(mockExpiredSubscription);
+    const subscriptionData = await subscription.getSubscriptionData();
+    expect(subscriptionData).toEqual(mockExpiredSubscription);
+
+    // Even though the period has ended, the cache should still be valid for a short time
+    // (the implementation sets a minimum of 0 seconds, but the cache itself has a TTL)
+    mockGetTenantSubscription.mockClear();
+    const subscriptionDataFromCache = await subscription.getSubscriptionData();
+    expect(subscriptionDataFromCache).toEqual(mockExpiredSubscription);
+    expect(mockGetTenantSubscription).not.toHaveBeenCalled();
+
+    // Move the time forward by 1 hour
+    jest.advanceTimersByTime(60 * 60);
+    mockGetTenantSubscription.mockResolvedValueOnce({
+      ...mockExpiredSubscription,
+      planId: ReservedPlanId.Pro202411,
+    });
+
+    // Should get new subscription data since the cache should be invalidated
+    const refreshedSubscriptionData = await subscription.getSubscriptionData();
+    expect(refreshedSubscriptionData).toEqual({
+      ...mockExpiredSubscription,
       planId: ReservedPlanId.Pro202411,
     });
     expect(mockGetTenantSubscription).toHaveBeenCalled();

--- a/packages/core/src/libraries/subscription.ts
+++ b/packages/core/src/libraries/subscription.ts
@@ -10,6 +10,8 @@ import { type Subscription } from '#src/utils/subscription/types.js';
 
 import { type CloudConnectionLibrary } from './cloud-connection.js';
 
+const maxSubscriptionCacheTtl = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
+
 /**
  * Return the expiration time of the subscription cache in seconds.
  *
@@ -17,7 +19,8 @@ import { type CloudConnectionLibrary } from './cloud-connection.js';
  */
 const getSubscriptionCacheExpiration = (currentPeriodEnd: string) => {
   const expiration = Math.floor((new Date(currentPeriodEnd).getTime() - Date.now()) / 1000);
-  return Math.max(expiration, 0);
+  // Make sure the expiration is not less than 0 (in case the subscription period has already ended) and not greater than `maxSubscriptionCacheTtl`
+  return Math.min(Math.max(expiration, 0), maxSubscriptionCacheTtl);
 };
 
 const tokenUsageCacheTtl = 60 * 60 * 1000; // 1 hour

--- a/packages/core/src/libraries/subscription.ts
+++ b/packages/core/src/libraries/subscription.ts
@@ -10,7 +10,7 @@ import { type Subscription } from '#src/utils/subscription/types.js';
 
 import { type CloudConnectionLibrary } from './cloud-connection.js';
 
-const maxSubscriptionCacheTtl = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
+const maxSubscriptionCacheTtl = 24 * 60 * 60; // 24 hours in seconds
 
 /**
  * Return the expiration time of the subscription cache in seconds.
@@ -23,7 +23,7 @@ const getSubscriptionCacheExpiration = (currentPeriodEnd: string) => {
   return Math.min(Math.max(expiration, 0), maxSubscriptionCacheTtl);
 };
 
-const tokenUsageCacheTtl = 60 * 60 * 1000; // 1 hour
+const tokenUsageCacheTtl = 60 * 60 * 1000; // 1 hour in milliseconds
 /**
  *
  * @param to The end date of the token usage period.

--- a/packages/core/src/tenants/Libraries.ts
+++ b/packages/core/src/tenants/Libraries.ts
@@ -17,6 +17,7 @@ import { createScopeLibrary } from '#src/libraries/scope.js';
 import { createSignInExperienceLibrary } from '#src/libraries/sign-in-experience/index.js';
 import { createSocialLibrary } from '#src/libraries/social.js';
 import { createSsoConnectorLibrary } from '#src/libraries/sso-connector.js';
+import { type SubscriptionLibrary } from '#src/libraries/subscription.js';
 import { createUserLibrary } from '#src/libraries/user.js';
 import { createVerificationStatusLibrary } from '#src/libraries/verification-status.js';
 
@@ -43,7 +44,7 @@ export default class Libraries {
   roleScopes = createRoleScopeLibrary(this.queries);
   domains = createDomainLibrary(this.queries);
   protectedApps = createProtectedAppLibrary(this.queries);
-  quota = createQuotaLibrary(this.cloudConnection);
+  quota = createQuotaLibrary(this.cloudConnection, this.subscription);
   ssoConnectors = createSsoConnectorLibrary(this.queries);
   oneTimeTokens = createOneTimeTokenLibrary(this.queries);
   signInExperiences = createSignInExperienceLibrary(
@@ -66,6 +67,7 @@ export default class Libraries {
     // Explicitly passing connector library to eliminate dependency issue
     private readonly connectors: ConnectorLibrary,
     private readonly cloudConnection: CloudConnectionLibrary,
-    private readonly logtoConfigs: LogtoConfigLibrary
+    private readonly logtoConfigs: LogtoConfigLibrary,
+    private readonly subscription: SubscriptionLibrary
   ) {}
 }

--- a/packages/core/src/tenants/Tenant.ts
+++ b/packages/core/src/tenants/Tenant.ts
@@ -85,15 +85,21 @@ export default class Tenant implements TenantContext {
     public readonly logtoConfigs = createLogtoConfigLibrary(queries),
     public readonly cloudConnection = createCloudConnectionLibrary(logtoConfigs),
     public readonly connectors = createConnectorLibrary(queries, cloudConnection),
+    public readonly subscription = new SubscriptionLibrary(
+      id,
+      queries,
+      cloudConnection,
+      redisCache
+    ),
     public readonly libraries = new Libraries(
       id,
       queries,
       connectors,
       cloudConnection,
-      logtoConfigs
+      logtoConfigs,
+      subscription
     ),
-    public readonly sentinel = new BasicSentinel(envSet.pool),
-    public readonly subscription = new SubscriptionLibrary(id, queries, cloudConnection, redisCache)
+    public readonly sentinel = new BasicSentinel(envSet.pool)
   ) {
     const isAdminTenant = id === adminTenantId;
     const mountedApps = [

--- a/packages/core/src/test-utils/tenant.ts
+++ b/packages/core/src/test-utils/tenant.ts
@@ -87,14 +87,6 @@ export class MockTenant implements TenantContext {
       ...createConnectorLibrary(this.queries, this.cloudConnection),
       ...connectorsOverride,
     };
-    this.libraries = new Libraries(
-      this.id,
-      this.queries,
-      this.connectors,
-      this.cloudConnection,
-      this.logtoConfigs
-    );
-    this.setPartial('libraries', librariesOverride);
     this.sentinel = new MockSentinel();
     this.subscription = new SubscriptionLibrary(
       this.id,
@@ -102,6 +94,15 @@ export class MockTenant implements TenantContext {
       this.cloudConnection,
       new TtlCache<string, string>(60_000)
     );
+    this.libraries = new Libraries(
+      this.id,
+      this.queries,
+      this.connectors,
+      this.cloudConnection,
+      this.logtoConfigs,
+      this.subscription
+    );
+    this.setPartial('libraries', librariesOverride);
   }
 
   public async invalidateCache() {

--- a/packages/core/src/utils/subscription/index.ts
+++ b/packages/core/src/utils/subscription/index.ts
@@ -31,7 +31,7 @@ export const getTenantSubscription = async (
  * Get real-time subscription data from Logto Cloud service, including quota, usage, resources, and roles.
  * Since the core service computing resources may locate in another region other than the Cloud service, the response could take few seconds.
  */
-export const getRealtimeTenantSubscriptionData = async (
+export const getTenantUsageData = async (
   cloudConnection: CloudConnectionLibrary
 ): Promise<{
   quota: SubscriptionQuota;

--- a/packages/core/src/utils/subscription/index.ts
+++ b/packages/core/src/utils/subscription/index.ts
@@ -30,20 +30,15 @@ export const getTenantSubscription = async (
 export const getTenantSubscriptionData = async (
   cloudConnection: CloudConnectionLibrary
 ): Promise<{
-  planId: string;
-  isEnterprisePlan: boolean;
   quota: SubscriptionQuota;
   usage: SubscriptionUsage;
   resources: Record<string, number>;
   roles: Record<string, number>;
 }> => {
   const client = await cloudConnection.getClient();
-  const [{ planId, isEnterprisePlan }, { quota, usage, resources, roles }] = await Promise.all([
-    client.get('/api/tenants/my/subscription'),
-    client.get('/api/tenants/my/subscription-usage'),
-  ]);
+  const { quota, usage, resources, roles } = await client.get('/api/tenants/my/subscription-usage');
 
-  return { planId, isEnterprisePlan, quota, usage, resources, roles };
+  return { quota, usage, resources, roles };
 };
 
 export const reportSubscriptionUpdates = async (

--- a/packages/core/src/utils/subscription/index.ts
+++ b/packages/core/src/utils/subscription/index.ts
@@ -27,7 +27,11 @@ export const getTenantSubscription = async (
   };
 };
 
-export const getTenantSubscriptionData = async (
+/**
+ * Get real-time subscription data from Logto Cloud service, including quota, usage, resources, and roles.
+ * Since the core service computing resources may locate in another region other than the Cloud service, the response could take few seconds.
+ */
+export const getRealtimeTenantSubscriptionData = async (
   cloudConnection: CloudConnectionLibrary
 ): Promise<{
   quota: SubscriptionQuota;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Reuse subscription library cache in quota library to reduce cross region HTTP requests, resolves LOG-10881
Before this change, quota library relies on Logto Cloud service for checking whether some specific resources can be added. On our product environment, these kind of HTTP requests are in cross-region manner (e.g. request server locates in EU from AU/US regions, which are time-consuming). Since we now have subscription data cached in each region, the access to cached subscription data in the same region saves time and without affect existing logics.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested on local machine, subscriptions worked fine.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
