### PR TITLE
fix(ci): convert Windows absolute paths to valid file URLs for dynami…

### DIFF
--- a/packages/cli/src/commands/database/alteration/index.ts
+++ b/packages/cli/src/commands/database/alteration/index.ts
@@ -18,10 +18,11 @@ import {
   chooseRevertAlterationsByTimestamp,
 } from './utils.js';
 import { chooseAlterationsByVersion, chooseRevertAlterationsByVersion } from './version.js';
+import { pathToFileURL } from 'url';
 
 const importAlterationScript = async (filePath: string): Promise<AlterationScript> => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const module = await import(filePath);
+  const module = await import(pathToFileURL(filePath).href);
 
   // eslint-disable-next-line no-restricted-syntax
   return module.default as AlterationScript;


### PR DESCRIPTION
fix: convert Windows absolute paths to file URLs for dynamic imports

The dynamic import in `importAlterationScript` was failing on Windows because it used an absolute file path without converting it to a valid file URL. This commit updates the code to use `pathToFileURL` for converting file paths, resolving the ERR_UNSUPPORTED_ESM_URL_SCHEME error during database alteration deployment.

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

## Summary
This change fixes a bug where dynamic imports were failing on Windows due to the use of absolute file paths without the proper `file://` scheme. By converting these paths using Node's `pathToFileURL`, the error is resolved and the deployment process works consistently across platforms.

## Testing
Tested on Windows by running the `logto db alt deploy` command with a sample database URL. Verified that the alterations deploy successfully without triggering the ERR_UNSUPPORTED_ESM_URL_SCHEME error, and confirmed that existing unit tests pass.

## Checklist

- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments