### PR TITLE
fix(console): reset MFA forms on all factors disabled

### DIFF
--- a/packages/console/src/pages/Mfa/MfaForm/index.tsx
+++ b/packages/console/src/pages/Mfa/MfaForm/index.tsx
@@ -78,10 +78,25 @@ function MfaForm({ data, onMfaUpdated }: Props) {
   }, [formValues, isMfaDisabled]);
 
   useEffect(() => {
-    // Reset the `isMandatory` to false when there is no MFA factor
     const { factors } = convertMfaFormToConfig(formValues);
-    if (factors.length === 0 && formValues.isMandatory) {
+
+    if (factors.length > 0) {
+      return;
+    }
+
+    // Reset the `isMandatory` to false when there is no MFA factor
+    if (formValues.isMandatory) {
       setValue('isMandatory', false);
+    }
+
+    // Reset the `setUpPrompt` to `NoPrompt` when there is no MFA factor
+    if (formValues.setUpPrompt !== MfaPolicy.NoPrompt) {
+      setValue('setUpPrompt', MfaPolicy.NoPrompt);
+    }
+
+    // Reset the `organizationRequiredMfaPolicy` to `NoPrompt` when there is no MFA factor
+    if (formValues.organizationRequiredMfaPolicy === OrganizationRequiredMfaPolicy.Mandatory) {
+      setValue('organizationRequiredMfaPolicy', OrganizationRequiredMfaPolicy.NoPrompt);
     }
   }, [formValues, setValue]);
 

--- a/packages/core/src/routes/experience/classes/mfa.ts
+++ b/packages/core/src/routes/experience/classes/mfa.ts
@@ -26,7 +26,6 @@ import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
-import { EnvSet } from '../../../env-set/index.js';
 import { type InteractionContext } from '../types.js';
 
 import { SignInExperienceValidator } from './libraries/sign-in-experience-validator.js';
@@ -364,11 +363,6 @@ export class Mfa {
   }
 
   private async isMfaRequiredByUserOrganizations(mfaSettings: MfaSettings, userId: string) {
-    // TODO: Remove this check when the feature is enabled for production
-    if (!EnvSet.values.isDevFeaturesEnabled) {
-      return false;
-    }
-
     if (mfaSettings.organizationRequiredMfaPolicy !== OrganizationRequiredMfaPolicy.Mandatory) {
       return false;
     }

--- a/packages/integration-tests/src/tests/api/experience-api/bind-mfa/organization-required-mfa.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/bind-mfa/organization-required-mfa.test.ts
@@ -19,9 +19,8 @@ import {
   resetMfaSettings,
 } from '#src/helpers/sign-in-experience.js';
 import { generateNewUserProfile, UserApiTest } from '#src/helpers/user.js';
-import { devFeatureTest } from '#src/utils.js';
 
-devFeatureTest.describe('Organization required MFA policy', () => {
+describe('Organization required MFA policy', () => {
   const userApi = new UserApiTest();
   const organizationApi = new OrganizationApiTest();
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Reset MFA forms on disabling all factors.

Should reset the MFA prompt policy to `NoPrompt` when disabling all the MFA factors. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
