### PR TITLE
fix(connector): filter out locale param in AliyunSMS

### DIFF
--- a/packages/connectors/connector-aliyun-sms/src/index.test.ts
+++ b/packages/connectors/connector-aliyun-sms/src/index.test.ts
@@ -25,7 +25,7 @@ describe('sendMessage()', () => {
     await connector.sendMessage({
       to: phoneTest,
       type: TemplateType.SignIn,
-      payload: { code: codeTest },
+      payload: { code: codeTest, locale: 'zh-CN' },
     });
     expect(sendSms).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/connectors/connector-aliyun-sms/src/index.ts
+++ b/packages/connectors/connector-aliyun-sms/src/index.ts
@@ -43,6 +43,7 @@ const sendMessage =
     validateConfig(config, aliyunSmsConfigGuard);
     const { accessKeyId, accessKeySecret, signName, templates, strictPhoneRegionNumberCheck } =
       config;
+
     const template = templates.find(({ usageType }) => usageType === type);
 
     assert(
@@ -53,6 +54,10 @@ const sendMessage =
       )
     );
 
+    // Aliyun SMS verification API only accepts [a-zA-Z0-9] values in the payload.
+    // We need to filter out the locale key from the payload as it may contain special characters e.g. zh-CN.
+    const { locale, ...filteredPayload } = payload;
+
     try {
       const httpResponse = await sendSms(
         {
@@ -60,7 +65,7 @@ const sendMessage =
           PhoneNumbers: to,
           SignName: signName,
           TemplateCode: getTemplateCode(template, to, strictPhoneRegionNumberCheck),
-          TemplateParam: JSON.stringify(payload),
+          TemplateParam: JSON.stringify(filteredPayload),
         },
         accessKeySecret
       );

--- a/packages/connectors/connector-tencent-sms/src/index.test.ts
+++ b/packages/connectors/connector-tencent-sms/src/index.test.ts
@@ -46,7 +46,7 @@ describe('sendMessage()', () => {
     await connector.sendMessage({
       to: phoneTest,
       type: TemplateType.SignIn,
-      payload: { code: codeTest },
+      payload: { code: codeTest, locale: 'zh-CN' },
     });
     expect(sendSmsRequest).toHaveBeenCalledWith(
       mockedTemplateCode,

--- a/packages/connectors/connector-tencent-sms/src/index.ts
+++ b/packages/connectors/connector-tencent-sms/src/index.ts
@@ -45,8 +45,11 @@ function sendMessage(getConfig: GetConnectorConfig): SendMessageFunction {
       )
     );
 
+    // Filter out locale from payload
+    const { locale, ...filteredPayload } = payload;
+
     // Tencent SMS API requires all parameters to be strings. Force parse all payload values to string.
-    const parametersSet = Object.values(payload).map(String);
+    const parametersSet = Object.values(filteredPayload).map(String);
 
     try {
       const httpResponse = await sendSmsRequest(template.templateCode, parametersSet, to, {


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Aliyun SMS only accepts `[a-z0-9A-Z]` value for verification template parameters.  

Need to filter out locale params in the Aliyun SMS connector.  E.g. `zh-CN` is not allowed. 


![image](https://github.com/user-attachments/assets/bb8857f1-4290-4907-8b4d-336a1f390915)


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
