### PR TITLE
feat: implement verify one-time token experience api

### DIFF
--- a/packages/core/src/routes/experience/classes/helpers.ts
+++ b/packages/core/src/routes/experience/classes/helpers.ts
@@ -30,7 +30,8 @@ export const getNewUserProfileFromVerificationRecord = async (
   switch (verificationRecord.type) {
     case VerificationType.NewPasswordIdentity:
     case VerificationType.EmailVerificationCode:
-    case VerificationType.PhoneVerificationCode: {
+    case VerificationType.PhoneVerificationCode:
+    case VerificationType.OneTimeToken: {
       return verificationRecord.toUserProfile();
     }
     case VerificationType.EnterpriseSso:
@@ -56,6 +57,7 @@ export const getNewUserProfileFromVerificationRecord = async (
  * @throws {RequestError} -400 if the verification record is not verified.
  * @throws {RequestError} -404 if the user is not found.
  */
+// eslint-disable-next-line complexity
 export const identifyUserByVerificationRecord = async (
   verificationRecord: VerificationRecord,
   linkSocialIdentity?: boolean
@@ -81,7 +83,8 @@ export const identifyUserByVerificationRecord = async (
   switch (verificationRecord.type) {
     case VerificationType.Password:
     case VerificationType.EmailVerificationCode:
-    case VerificationType.PhoneVerificationCode: {
+    case VerificationType.PhoneVerificationCode:
+    case VerificationType.OneTimeToken: {
       return { user: await verificationRecord.identifyUser() };
     }
     case VerificationType.Social: {

--- a/packages/core/src/routes/experience/classes/libraries/sign-in-experience-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/sign-in-experience-validator.ts
@@ -234,6 +234,16 @@ export class SignInExperienceValidator {
         );
         break;
       }
+      case VerificationType.OneTimeToken: {
+        const {
+          identifier: { type },
+        } = verificationRecord;
+        assertThat(
+          signInMethods.some(({ identifier }) => type === identifier),
+          new RequestError({ code: 'user.sign_in_method_not_enabled', status: 422 })
+        );
+        break;
+      }
       default: {
         throw new RequestError({ code: 'user.sign_in_method_not_enabled', status: 422 });
       }

--- a/packages/core/src/routes/experience/classes/verifications/index.ts
+++ b/packages/core/src/routes/experience/classes/verifications/index.ts
@@ -27,6 +27,11 @@ import {
   type NewPasswordIdentityVerificationRecordData,
 } from './new-password-identity-verification.js';
 import {
+  OneTimeTokenVerification,
+  oneTimeTokenVerificationRecordDataGuard,
+  type OneTimeTokenVerificationRecordData,
+} from './one-time-token-verification.js';
+import {
   PasswordVerification,
   passwordVerificationRecordDataGuard,
   type PasswordVerificationRecordData,
@@ -57,7 +62,8 @@ export type VerificationRecordData =
   | TotpVerificationRecordData
   | BackupCodeVerificationRecordData
   | WebAuthnVerificationRecordData
-  | NewPasswordIdentityVerificationRecordData;
+  | NewPasswordIdentityVerificationRecordData
+  | OneTimeTokenVerificationRecordData;
 
 // This is to ensure the keys of the map are the same as the type of the verification record
 type VerificationRecordInterfaceMap = {
@@ -75,6 +81,7 @@ export type VerificationRecordMap = AssertVerificationMap<{
   [VerificationType.BackupCode]: BackupCodeVerification;
   [VerificationType.WebAuthn]: WebAuthnVerification;
   [VerificationType.NewPasswordIdentity]: NewPasswordIdentityVerification;
+  [VerificationType.OneTimeToken]: OneTimeTokenVerification;
 }>;
 
 type ValueOf<T> = T[keyof T];
@@ -98,6 +105,7 @@ export const verificationRecordDataGuard = z.discriminatedUnion('type', [
   backupCodeVerificationRecordDataGuard,
   webAuthnVerificationRecordDataGuard,
   newPasswordIdentityVerificationRecordDataGuard,
+  oneTimeTokenVerificationRecordDataGuard,
 ]);
 
 /**
@@ -135,6 +143,9 @@ export const buildVerificationRecord = (
     }
     case VerificationType.NewPasswordIdentity: {
       return new NewPasswordIdentityVerification(libraries, queries, data);
+    }
+    case VerificationType.OneTimeToken: {
+      return new OneTimeTokenVerification(libraries, queries, data);
     }
   }
 };

--- a/packages/core/src/routes/experience/classes/verifications/one-time-token-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/one-time-token-verification.ts
@@ -1,0 +1,128 @@
+import { type ToZodObject } from '@logto/connector-kit';
+import {
+  type InteractionIdentifier,
+  SignInIdentifier,
+  type User,
+  VerificationType,
+} from '@logto/schemas';
+import { generateStandardId } from '@logto/shared';
+import { z } from 'zod';
+
+import RequestError from '#src/errors/RequestError/index.js';
+import type Libraries from '#src/tenants/Libraries.js';
+import type Queries from '#src/tenants/Queries.js';
+import assertThat from '#src/utils/assert-that.js';
+
+import { type InteractionProfile } from '../../types.js';
+import { findUserByIdentifier } from '../utils.js';
+
+import { type IdentifierVerificationRecord } from './verification-record.js';
+
+export type OneTimeTokenVerificationRecordData = {
+  id: string;
+  type: VerificationType.OneTimeToken;
+  identifier: InteractionIdentifier<SignInIdentifier.Email>;
+  verified: boolean;
+};
+
+export const oneTimeTokenVerificationRecordDataGuard = z.object({
+  id: z.string(),
+  type: z.literal(VerificationType.OneTimeToken),
+  verified: z.boolean(),
+  identifier: z.object({
+    type: z.literal(SignInIdentifier.Email),
+    value: z.string(),
+  }),
+}) satisfies ToZodObject<OneTimeTokenVerificationRecordData>;
+
+export class OneTimeTokenVerification
+  implements IdentifierVerificationRecord<VerificationType.OneTimeToken>
+{
+  /** Factory method to create a new `OneTimeTokenVerification` record using an identifier */
+  static create(
+    libraries: Libraries,
+    queries: Queries,
+    identifier: InteractionIdentifier<SignInIdentifier.Email>
+  ) {
+    return new OneTimeTokenVerification(libraries, queries, {
+      id: generateStandardId(),
+      type: VerificationType.OneTimeToken,
+      identifier,
+      verified: false,
+    });
+  }
+
+  readonly type = VerificationType.OneTimeToken;
+  readonly id: string;
+  readonly identifier: InteractionIdentifier<SignInIdentifier.Email>;
+  private verified: boolean;
+
+  /**
+   * The constructor method is intended to be used internally by the interaction class
+   * to instantiate a `VerificationRecord` object from existing `OneTimeTokenVerificationRecordData`.
+   * It directly sets the instance properties based on the provided data.
+   * For creating a new verification record from context, use the static `create` method instead.
+   */
+  constructor(
+    private readonly libraries: Libraries,
+    private readonly queries: Queries,
+    data: OneTimeTokenVerificationRecordData
+  ) {
+    const { id, identifier, verified } = data;
+
+    this.id = id;
+    this.identifier = identifier;
+    this.verified = verified;
+  }
+
+  get isVerified() {
+    return this.verified;
+  }
+
+  /**
+   * Verifies if the one-time token matches the record in database with the provided email.
+   */
+  async verify(token: string) {
+    await this.libraries.oneTimeTokens.verifyOneTimeToken(token, this.identifier.value);
+    this.verified = true;
+  }
+
+  async identifyUser(): Promise<User> {
+    assertThat(
+      this.verified,
+      new RequestError({ code: 'session.verification_failed', status: 400 })
+    );
+
+    const user = await findUserByIdentifier(this.queries.users, this.identifier);
+
+    assertThat(
+      user,
+      new RequestError(
+        { code: 'user.user_not_exist', status: 404 },
+        { identifier: this.identifier }
+      )
+    );
+
+    return user;
+  }
+
+  toUserProfile(): InteractionProfile {
+    assertThat(
+      this.verified,
+      new RequestError({
+        code: 'session.verification_failed',
+        state: 400,
+      })
+    );
+
+    const { value } = this.identifier;
+
+    return { primaryEmail: value };
+  }
+
+  toJson(): OneTimeTokenVerificationRecordData {
+    const { id, type, identifier, verified } = this;
+
+    return { id, type, identifier, verified };
+  }
+}

--- a/packages/core/src/routes/experience/classes/verifications/verification-record.ts
+++ b/packages/core/src/routes/experience/classes/verifications/verification-record.ts
@@ -23,7 +23,8 @@ type IdentifierVerificationType =
   | VerificationType.PhoneVerificationCode
   | VerificationType.Password
   | VerificationType.Social
-  | VerificationType.EnterpriseSso;
+  | VerificationType.EnterpriseSso
+  | VerificationType.OneTimeToken;
 
 /**
  * The abstract class for all identifier verification records.

--- a/packages/core/src/routes/experience/index.ts
+++ b/packages/core/src/routes/experience/index.ts
@@ -19,6 +19,7 @@ import koaGuard from '#src/middleware/koa-guard.js';
 import koaInteractionDetails from '#src/middleware/koa-interaction-details.js';
 import assertThat from '#src/utils/assert-that.js';
 
+import { EnvSet } from '../../env-set/index.js';
 import { type AnonymousRouter, type RouterInitArgs } from '../types.js';
 
 import experienceAnonymousRoutes from './anonymous-routes/index.js';
@@ -188,7 +189,9 @@ export default function experienceApiRoutes<T extends AnonymousRouter>(
   webAuthnVerificationRoute(experienceRouter, tenant);
   backupCodeVerificationRoutes(experienceRouter, tenant);
   newPasswordIdentityVerificationRoutes(experienceRouter, tenant);
-  oneTimeTokenRoutes(experienceRouter, tenant);
+  if (EnvSet.values.isDevFeaturesEnabled) {
+    oneTimeTokenRoutes(experienceRouter, tenant);
+  }
 
   profileRoutes(experienceRouter, tenant);
   experienceAnonymousRoutes(experienceRouter, tenant);

--- a/packages/core/src/routes/experience/index.ts
+++ b/packages/core/src/routes/experience/index.ts
@@ -31,6 +31,7 @@ import { type ExperienceInteractionRouterContext } from './types.js';
 import backupCodeVerificationRoutes from './verification-routes/backup-code-verification.js';
 import enterpriseSsoVerificationRoutes from './verification-routes/enterprise-sso-verification.js';
 import newPasswordIdentityVerificationRoutes from './verification-routes/new-password-identity-verification.js';
+import oneTimeTokenRoutes from './verification-routes/one-time-token.js';
 import passwordVerificationRoutes from './verification-routes/password-verification.js';
 import socialVerificationRoutes from './verification-routes/social-verification.js';
 import totpVerificationRoutes from './verification-routes/totp-verification.js';
@@ -187,6 +188,7 @@ export default function experienceApiRoutes<T extends AnonymousRouter>(
   webAuthnVerificationRoute(experienceRouter, tenant);
   backupCodeVerificationRoutes(experienceRouter, tenant);
   newPasswordIdentityVerificationRoutes(experienceRouter, tenant);
+  oneTimeTokenRoutes(experienceRouter, tenant);
 
   profileRoutes(experienceRouter, tenant);
   experienceAnonymousRoutes(experienceRouter, tenant);

--- a/packages/core/src/routes/experience/verification-routes/one-time-token.openapi.json
+++ b/packages/core/src/routes/experience/verification-routes/one-time-token.openapi.json
@@ -1,0 +1,49 @@
+{
+  "paths": {
+    "/api/experience/verification/one-time-token/verify": {
+      "post": {
+        "operationId": "VerifyOneTimeTokenVerification",
+        "summary": "Verify one-time token",
+        "description": "Verify the provided one-time token against the user's email. If successful, the verification record will be marked as verified.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "token": {
+                    "description": "The one-time token to be verified."
+                  },
+                  "identifier": {
+                    "description": "The unique user identifier.  <br/> Currently, only `email` is accepted."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The one-time token was successfully verified.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "verificationId": {
+                      "description": "The unique ID of the verification record. Required for user identification via the `Identification` API or to bind the identifier to the user's account via the `Profile` API."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The one-time token is invalid or the maximum number of attempts has been exceeded. Check the error message for details."
+          },
+          "404": {
+            "description": "Verification record not found."
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/core/src/routes/experience/verification-routes/one-time-token.openapi.json
+++ b/packages/core/src/routes/experience/verification-routes/one-time-token.openapi.json
@@ -1,4 +1,9 @@
 {
+  "tags": [
+    {
+      "name": "Dev feature"
+    }
+  ],
   "paths": {
     "/api/experience/verification/one-time-token/verify": {
       "post": {

--- a/packages/core/src/routes/experience/verification-routes/one-time-token.ts
+++ b/packages/core/src/routes/experience/verification-routes/one-time-token.ts
@@ -1,0 +1,73 @@
+import {
+  oneTimeTokenVerificationVerifyPayloadGuard,
+  SentinelActivityAction,
+  VerificationType,
+} from '@logto/schemas';
+import { Action } from '@logto/schemas/lib/types/log/interaction.js';
+import type Router from 'koa-router';
+import { z } from 'zod';
+
+import koaGuard from '#src/middleware/koa-guard.js';
+import type TenantContext from '#src/tenants/TenantContext.js';
+
+import { withSentinel } from '../classes/libraries/sentinel-guard.js';
+import { OneTimeTokenVerification } from '../classes/verifications/one-time-token-verification.js';
+import { experienceRoutes } from '../const.js';
+import koaExperienceVerificationsAuditLog from '../middleware/koa-experience-verifications-audit-log.js';
+import { type ExperienceInteractionRouterContext } from '../types.js';
+
+export default function oneTimeTokenVerificationRoutes<
+  T extends ExperienceInteractionRouterContext,
+>(router: Router<unknown, T>, tenantContext: TenantContext) {
+  const { libraries, queries, sentinel } = tenantContext;
+
+  router.post(
+    `${experienceRoutes.verification}/one-time-token/verify`,
+    koaGuard({
+      body: oneTimeTokenVerificationVerifyPayloadGuard,
+      response: z.object({
+        verificationId: z.string(),
+      }),
+      status: [200, 400, 404],
+    }),
+    koaExperienceVerificationsAuditLog({
+      type: VerificationType.OneTimeToken,
+      action: Action.Submit,
+    }),
+    async (ctx, next) => {
+      const { experienceInteraction, verificationAuditLog } = ctx;
+      const { identifier, token } = ctx.guard.body;
+
+      verificationAuditLog.append({ payload: { identifier, token } });
+
+      const oneTimeTokenVerificationRecord = OneTimeTokenVerification.create(
+        libraries,
+        queries,
+        identifier
+      );
+
+      ctx.experienceInteraction.setVerificationRecord(oneTimeTokenVerificationRecord);
+
+      await withSentinel(
+        {
+          sentinel,
+          action: SentinelActivityAction.OneTimeToken,
+          identifier,
+          payload: {
+            event: experienceInteraction.interactionEvent,
+            verificationId: oneTimeTokenVerificationRecord.id,
+          },
+        },
+        oneTimeTokenVerificationRecord.verify(token)
+      );
+
+      await ctx.experienceInteraction.save();
+
+      ctx.body = {
+        verificationId: oneTimeTokenVerificationRecord.id,
+      };
+
+      return next();
+    }
+  );
+}

--- a/packages/core/src/sentinel/basic-sentinel.ts
+++ b/packages/core/src/sentinel/basic-sentinel.ts
@@ -28,6 +28,7 @@ export default class BasicSentinel extends Sentinel {
   static supportedActions = Object.freeze([
     SentinelActivityAction.Password,
     SentinelActivityAction.VerificationCode,
+    SentinelActivityAction.OneTimeToken,
   ] as const);
 
   /** The array of all supported actions in SQL format. */

--- a/packages/integration-tests/src/client/experience/index.ts
+++ b/packages/integration-tests/src/client/experience/index.ts
@@ -1,4 +1,6 @@
 import {
+  type InteractionIdentifier,
+  type SignInIdentifier,
   type CreateExperienceApiPayload,
   type IdentificationApiPayload,
   type InteractionEvent,
@@ -221,5 +223,17 @@ export class ExperienceClient extends MockClient {
       headers: { cookie: this.interactionCookie },
       json: { type, verificationId },
     });
+  }
+
+  public async verifyOneTimeToken(payload: {
+    token: string;
+    identifier: InteractionIdentifier<SignInIdentifier.Email>;
+  }) {
+    return this.api
+      .post(`${experienceRoutes.verification}/one-time-token/verify`, {
+        headers: { cookie: this.interactionCookie },
+        json: payload,
+      })
+      .json<{ verificationId: string }>();
   }
 }

--- a/packages/integration-tests/src/tests/api/experience-api/register-interaction/one-time-token.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/register-interaction/one-time-token.test.ts
@@ -1,0 +1,144 @@
+import { InteractionEvent, SignInIdentifier, SignInMode } from '@logto/schemas';
+
+import { deleteUser, updateSignInExperience } from '#src/api/index.js';
+import { createOneTimeToken } from '#src/api/one-time-token.js';
+import { initExperienceClient, logoutClient, processSession } from '#src/helpers/client.js';
+import { setEmailConnector } from '#src/helpers/connector.js';
+import { expectRejects } from '#src/helpers/index.js';
+import { generateNewUser } from '#src/helpers/user.js';
+import { generatePassword, devFeatureTest } from '#src/utils.js';
+
+const { it, describe } = devFeatureTest;
+
+describe('Register interaction with one-time token happy path', () => {
+  beforeAll(async () => {
+    await setEmailConnector();
+    await updateSignInExperience({
+      signInMode: SignInMode.SignInAndRegister,
+      signUp: {
+        identifiers: [SignInIdentifier.Email],
+        password: false,
+        verify: true,
+      },
+      signIn: {
+        methods: [
+          {
+            identifier: SignInIdentifier.Username,
+            password: true,
+            verificationCode: false,
+            isPasswordPrimary: true,
+          },
+          {
+            identifier: SignInIdentifier.Email,
+            password: true,
+            verificationCode: true,
+            isPasswordPrimary: false,
+          },
+        ],
+      },
+    });
+  });
+
+  it('should successfully register a new user with a magic link containing a one-time token', async () => {
+    const client = await initExperienceClient(InteractionEvent.Register);
+
+    const oneTimeToken = await createOneTimeToken({
+      email: 'foo@logto.io',
+    });
+
+    const { verificationId } = await client.verifyOneTimeToken({
+      token: oneTimeToken.token,
+      identifier: {
+        type: SignInIdentifier.Email,
+        value: 'foo@logto.io',
+      },
+    });
+
+    await client.identifyUser({ verificationId });
+
+    const { redirectTo } = await client.submitInteraction();
+    const userId = await processSession(client, redirectTo);
+    await logoutClient(client);
+    await deleteUser(userId);
+  });
+
+  it('should fail to sign-up with existing email and be able to sign-in instead', async () => {
+    const { userProfile, user } = await generateNewUser({
+      primaryEmail: true,
+      password: true,
+    });
+
+    const oneTimeToken = await createOneTimeToken({
+      email: userProfile.primaryEmail,
+    });
+
+    const client = await initExperienceClient(InteractionEvent.Register);
+
+    const { verificationId } = await client.verifyOneTimeToken({
+      token: oneTimeToken.token,
+      identifier: {
+        type: SignInIdentifier.Email,
+        value: userProfile.primaryEmail,
+      },
+    });
+
+    await expectRejects(
+      client.identifyUser({
+        verificationId,
+      }),
+      {
+        code: 'user.email_already_in_use',
+        status: 422,
+      }
+    );
+
+    await client.updateInteractionEvent({ interactionEvent: InteractionEvent.SignIn });
+    await client.identifyUser({ verificationId });
+
+    const { redirectTo } = await client.submitInteraction();
+    await processSession(client, redirectTo);
+    await logoutClient(client);
+
+    await deleteUser(user.id);
+  });
+
+  it('should prompt user to fulfill password if required upon registration', async () => {
+    await updateSignInExperience({
+      signUp: {
+        identifiers: [SignInIdentifier.Email],
+        password: true,
+        verify: true,
+      },
+    });
+
+    const client = await initExperienceClient(InteractionEvent.Register);
+
+    const oneTimeToken = await createOneTimeToken({
+      email: 'bar@logto.io',
+    });
+
+    const { verificationId } = await client.verifyOneTimeToken({
+      token: oneTimeToken.token,
+      identifier: {
+        type: SignInIdentifier.Email,
+        value: 'bar@logto.io',
+      },
+    });
+
+    await expectRejects(client.identifyUser({ verificationId }), {
+      code: 'user.missing_profile',
+      status: 422,
+    });
+
+    const password = generatePassword();
+
+    await client.updateProfile({ type: 'password', value: password });
+
+    await client.identifyUser({ verificationId });
+
+    const { redirectTo } = await client.submitInteraction();
+    const userId = await processSession(client, redirectTo);
+    await logoutClient(client);
+    await deleteUser(userId);
+  });
+});

--- a/packages/integration-tests/src/tests/api/experience-api/verifications/one-time-token.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/verifications/one-time-token.test.ts
@@ -1,0 +1,123 @@
+import { SignInIdentifier } from '@logto/schemas';
+
+import { createOneTimeToken } from '#src/api/one-time-token.js';
+import { initExperienceClient } from '#src/helpers/client.js';
+import { expectRejects } from '#src/helpers/index.js';
+import { devFeatureTest, waitFor } from '#src/utils.js';
+
+const { it, describe } = devFeatureTest;
+
+describe('One-time token verification APIs', () => {
+  it('should successfully verify one-time token', async () => {
+    const client = await initExperienceClient();
+
+    const oneTimeToken = await createOneTimeToken({
+      email: 'foo@logto.io',
+    });
+
+    const { verificationId } = await client.verifyOneTimeToken({
+      token: oneTimeToken.token,
+      identifier: {
+        type: SignInIdentifier.Email,
+        value: 'foo@logto.io',
+      },
+    });
+
+    expect(verificationId).toBeTruthy();
+  });
+
+  it('should throw token_consumed error when token is already consumed', async () => {
+    const client = await initExperienceClient();
+
+    const oneTimeToken = await createOneTimeToken({
+      email: 'foo@logto.io',
+    });
+
+    await client.verifyOneTimeToken({
+      token: oneTimeToken.token,
+      identifier: {
+        type: SignInIdentifier.Email,
+        value: 'foo@logto.io',
+      },
+    });
+
+    await expectRejects(
+      client.verifyOneTimeToken({
+        token: oneTimeToken.token,
+        identifier: {
+          type: SignInIdentifier.Email,
+          value: 'foo@logto.io',
+        },
+      }),
+      {
+        code: 'one_time_token.token_consumed',
+        status: 400,
+      }
+    );
+  });
+
+  it('should throw token_expired error when token is expired', async () => {
+    const client = await initExperienceClient();
+
+    const oneTimeToken = await createOneTimeToken({
+      email: 'foo@logto.io',
+      expiresIn: 1,
+    });
+
+    await waitFor(2000);
+
+    await expectRejects(
+      client.verifyOneTimeToken({
+        token: oneTimeToken.token,
+        identifier: {
+          type: SignInIdentifier.Email,
+          value: 'foo@logto.io',
+        },
+      }),
+      {
+        code: 'one_time_token.token_expired',
+        status: 400,
+      }
+    );
+  });
+
+  it('should throw token_not_found error when token is not found', async () => {
+    const client = await initExperienceClient();
+
+    await expectRejects(
+      client.verifyOneTimeToken({
+        token: 'invalid_token',
+        identifier: {
+          type: SignInIdentifier.Email,
+          value: 'foo@logto.io',
+        },
+      }),
+      {
+        code: 'one_time_token.token_not_found',
+        status: 404,
+      }
+    );
+  });
+
+  it('should throw email_mismatch error when email is mismatched', async () => {
+    const client = await initExperienceClient();
+
+    const oneTimeToken = await createOneTimeToken({
+      email: 'foo@logto.io',
+    });
+
+    await expectRejects(
+      client.verifyOneTimeToken({
+        token: oneTimeToken.token,
+        identifier: {
+          type: SignInIdentifier.Email,
+          value: 'bar@logto.io',
+        },
+      }),
+      {
+        code: 'one_time_token.email_mismatch',
+        status: 400,
+      }
+    );
+  });
+});

--- a/packages/schemas/src/foundations/jsonb-types/sentinel.ts
+++ b/packages/schemas/src/foundations/jsonb-types/sentinel.ts
@@ -23,6 +23,13 @@ export enum SentinelActivityAction {
    * themselves (target).
    */
   VerificationCode = 'VerificationCode',
+  /**
+   * The subject tries to pass a verification by inputting a one-time token.
+   *
+   * For example, a user (subject) who inputted a one-time token (action) to authenticate
+   * themselves (target), e.g. Magic Link.
+   */
+  OneTimeToken = 'OneTimeToken',
 }
 export const sentinelActivityActionGuard = z.nativeEnum(SentinelActivityAction);
 

--- a/packages/schemas/src/foundations/jsonb-types/verification-records.ts
+++ b/packages/schemas/src/foundations/jsonb-types/verification-records.ts
@@ -10,6 +10,7 @@ export enum VerificationType {
   WebAuthn = 'WebAuthn',
   BackupCode = 'BackupCode',
   NewPasswordIdentity = 'NewPasswordIdentity',
+  OneTimeToken = 'OneTimeToken',
 }
 
 export const verificationTypeGuard = z.nativeEnum(VerificationType);

--- a/packages/schemas/src/types/interactions.ts
+++ b/packages/schemas/src/types/interactions.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { emailRegEx, phoneRegEx, usernameRegEx } from '@logto/core-kit';
 import { z } from 'zod';
 
@@ -129,6 +130,22 @@ export type BackupCodeVerificationVerifyPayload = {
 export const backupCodeVerificationVerifyPayloadGuard = z.object({
   code: z.string().min(1),
 }) satisfies ToZodObject<BackupCodeVerificationVerifyPayload>;
+
+/** Payload type for `POST /api/experience/verification/one-time-token/verify` */
+export type OneTimeTokenVerificationVerifyPayload = {
+  /**
+   * The email address that the one-time token was sent to. Currently only email identifier is supported.
+   */
+  identifier: InteractionIdentifier<SignInIdentifier.Email>;
+  token: string;
+};
+export const oneTimeTokenVerificationVerifyPayloadGuard = z.object({
+  identifier: z.object({
+    type: z.literal(SignInIdentifier.Email),
+    value: z.string().regex(emailRegEx),
+  }),
+  token: z.string().min(1),
+}) satisfies ToZodObject<OneTimeTokenVerificationVerifyPayload>;
 
 /** Payload type for `POST /api/experience/identification`. */
 export type IdentificationApiPayload = {
@@ -432,3 +449,4 @@ export const verifyMfaResultGuard = z.object({
 });
 
 export type VerifyMfaResult = z.infer<typeof verifyMfaResultGuard>;
+/* eslint-enable max-lines */


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Implement new experience API `POST /experience/one-time-token/verify`.

This API provides the ability to verify a one-time token in Logto Sign-in Experience. Thus, a new verification type `VerificationType.OneTimeToken` is introduced, as well as the new `OneTimeTokenVerification` class.

After successfully verifying the one-time token, a verification ID is returned, which can be used in the `/api/experience/identification` request later to help identify the user.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
API integration tests. See test results in CI.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
