### PR TITLE
fix(core): fix OIDC SSO token request failed issue

### DIFF
--- a/.changeset/dull-dolphins-return.md
+++ b/.changeset/dull-dolphins-return.md
@@ -1,0 +1,11 @@
+---
+"@logto/core": patch
+---
+
+remove client_id from OIDC SSO connector's token request body for better compatibility
+
+This updates addresses an issue with client authentication methods in the token request process. Previously, the `client_id` was included in the request body while also using the authentication header for client credentials authentication.
+This dual method of client authentication can lead to errors with certain OIDC providers, such as OKTA, which only support one authentication method at a time.
+
+Key Changes:
+Removal of `client_id` from request body: The `client_id` parameter has been removed from the token request body. According to the [OAuth 2.0 specification](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3), `client_id` in the body is required only for public clients.

--- a/.changeset/dull-dolphins-return.md
+++ b/.changeset/dull-dolphins-return.md
@@ -2,10 +2,12 @@
 "@logto/core": patch
 ---
 
-remove client_id from OIDC SSO connector's token request body for better compatibility
+remove `client_id` from OIDC SSO connector's token request body for better compatibility
 
 This updates addresses an issue with client authentication methods in the token request process. Previously, the `client_id` was included in the request body while also using the authentication header for client credentials authentication.
-This dual method of client authentication can lead to errors with certain OIDC providers, such as OKTA, which only support one authentication method at a time.
 
-Key Changes:
+This dual method of client authentication can lead to errors with certain OIDC providers, such as Okta, which only support one authentication method at a time.
+
+### Key changes
+
 Removal of `client_id` from request body: The `client_id` parameter has been removed from the token request body. According to the [OAuth 2.0 specification](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3), `client_id` in the body is required only for public clients.

--- a/packages/core/src/saml-application/SamlApplication/index.test.ts
+++ b/packages/core/src/saml-application/SamlApplication/index.test.ts
@@ -121,7 +121,7 @@ describe('SamlApplication', () => {
       nock(mockEndpoint)
         .post(
           '/token',
-          `grant_type=authorization_code&code=${mockCode}&client_id=${mockSamlApplicationId}&redirect_uri=${encodeURIComponent(
+          `grant_type=authorization_code&code=${mockCode}&redirect_uri=${encodeURIComponent(
             samlApp.config.redirectUri
           )}`
         )

--- a/packages/core/src/sso/OidcConnector/utils.test.ts
+++ b/packages/core/src/sso/OidcConnector/utils.test.ts
@@ -163,7 +163,6 @@ describe('fetchToken', () => {
       body: new URLSearchParams({
         grant_type: 'authorization_code',
         code: data.code,
-        client_id: oidcConfig.clientId,
         redirect_uri: redirectUri,
       }).toString(),
       headers: {

--- a/packages/core/src/sso/OidcConnector/utils.ts
+++ b/packages/core/src/sso/OidcConnector/utils.ts
@@ -71,6 +71,8 @@ export const handleTokenExchange = async (
     grant_type: 'authorization_code',
     code,
     ...(redirectUri ? { redirect_uri: redirectUri } : {}),
+    // No need to pass client_id and client_secret as it is already in the Authorization header
+    // For some providers like OKTA, pass client_id in the body while using client credentials authorization header will cause error
   });
 
   const headers = {

--- a/packages/core/src/sso/OidcConnector/utils.ts
+++ b/packages/core/src/sso/OidcConnector/utils.ts
@@ -71,8 +71,8 @@ export const handleTokenExchange = async (
     grant_type: 'authorization_code',
     code,
     ...(redirectUri ? { redirect_uri: redirectUri } : {}),
-    // No need to pass client_id and client_secret as it is already in the Authorization header
-    // For some providers like OKTA, pass client_id in the body while using client credentials authorization header will cause error
+    // No need to pass `client_id` and `client_secret` as it is already in the Authorization header
+    // For some providers like Okta, passing `client_id` in the body while using client credentials authorization header will cause an error
   });
 
   const headers = {

--- a/packages/core/src/sso/OidcConnector/utils.ts
+++ b/packages/core/src/sso/OidcConnector/utils.ts
@@ -56,24 +56,20 @@ export const fetchOidcConfig = async (
   }
 };
 
+type HandleTokenExchangePayload = {
+  code: string;
+  clientId: string;
+  clientSecret: string;
+  redirectUri?: string;
+};
+
 export const handleTokenExchange = async (
   tokenEndpoint: string,
-  {
-    code,
-    clientId,
-    clientSecret,
-    redirectUri,
-  }: {
-    code: string;
-    clientId: string;
-    clientSecret: string;
-    redirectUri?: string;
-  }
+  { code, clientId, clientSecret, redirectUri }: HandleTokenExchangePayload
 ) => {
   const tokenRequestParameters = new URLSearchParams({
     grant_type: 'authorization_code',
     code,
-    client_id: clientId,
     ...(redirectUri ? { redirect_uri: redirectUri } : {}),
   });
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Remove `client_id` from the OIDC SSO connector's token request body for better compatibility. 

This pull request addresses an issue with client authentication methods in the token request process. Previously, the `client_id` was included in the request body while also using the authentication header for client credentials authentication. 

This dual method of client authentication can lead to errors with certain OIDC providers, such as Okta, which only support one authentication method at a time.

### Key changes

Removal of `client_id` from Request Body: The `client_id` parameter has been removed from the token request body. According to the OAuth 2.0 specification, including the `client_id` in the body is optional when the authentication header is provided.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally with all the OIDC SSO connectors in Logto:
Google Workspace, EntraID, OKTA. 

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
