### PR TITLE
chore: fix pnpm requirements in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -65,7 +65,7 @@ We use the monorepo approach for development. Since pnpm supports monorepo natur
 You'll need these installed to proceed:
 
 - [Node.js](https://nodejs.org/) `^18.12.0`
-- [pnpm](https://pnpm.io/) `^7.0`
+- [pnpm](https://pnpm.io/) `^9.0`
 - A [Postgres](https://postgresql.org/) `^14.0` instance
 
 ### Clone and install dependencies


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

use pnpm other than 9.x will report an error.

```
$ pnpm i
 ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)

Your pnpm version is incompatible with "/Users/hanyu/github/logto-io/logto".

Expected version: ^9.0.0
Got: 10.6.2

This is happening because the package's manifest has an engines.pnpm field specified.
To fix this issue, install the required pnpm version globally.

To install the latest version of pnpm, run "pnpm i -g pnpm".
To check your pnpm version, run "pnpm -v".
```

ref commit:
https://github.com/silverhand-io/essentials/commit/2171b962a9881a8abf44aa91160f816751e65bfe

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
