### PR TITLE
feat(experience): add switch account page

### DIFF
--- a/packages/experience/src/pages/SwitchAccount/index.module.scss
+++ b/packages/experience/src/pages/SwitchAccount/index.module.scss
@@ -1,0 +1,55 @@
+@use '@/scss/underscore' as _;
+
+.container {
+  flex: 1;
+  @include _.flex-column;
+  @include _.full-width;
+}
+
+.title {
+  margin-top: _.unit(8);
+  text-align: center;
+}
+
+.message {
+  @include _.text-hint;
+  text-align: center;
+}
+
+.support {
+  margin-top: _.unit(4);
+}
+
+.logo {
+  height: 40px;
+  width: auto;
+  @include _.image-align-center;
+}
+
+.button {
+  margin-top: _.unit(6);
+}
+
+:global(body.mobile) {
+  .title {
+    @include _.title;
+    margin-bottom: _.unit(4);
+  }
+
+  .backButton {
+    @include _.full-width;
+    margin-bottom: _.unit(4);
+  }
+}
+
+:global(body.desktop) {
+  .title {
+    @include _.title-desktop;
+    margin-bottom: _.unit(2);
+  }
+
+  .backButton {
+    @include _.full-width;
+    margin-bottom: _.unit(12);
+  }
+}

--- a/packages/experience/src/pages/SwitchAccount/index.module.scss
+++ b/packages/experience/src/pages/SwitchAccount/index.module.scss
@@ -8,16 +8,12 @@
 
 .title {
   margin-top: _.unit(8);
-  text-align: center;
+  font: var(--font-label-2);
 }
 
 .message {
-  @include _.text-hint;
-  text-align: center;
-}
-
-.support {
-  margin-top: _.unit(4);
+  margin-top: _.unit(6);
+  font: var(--font-body-2);
 }
 
 .logo {
@@ -26,7 +22,15 @@
   @include _.image-align-center;
 }
 
+.userProfile {
+  width: 100%;
+}
+
 .button {
+  margin-top: _.unit(2);
+}
+
+.linkButton {
   margin-top: _.unit(6);
 }
 
@@ -35,21 +39,11 @@
     @include _.title;
     margin-bottom: _.unit(4);
   }
-
-  .backButton {
-    @include _.full-width;
-    margin-bottom: _.unit(4);
-  }
 }
 
 :global(body.desktop) {
   .title {
     @include _.title-desktop;
     margin-bottom: _.unit(2);
-  }
-
-  .backButton {
-    @include _.full-width;
-    margin-bottom: _.unit(12);
   }
 }

--- a/packages/experience/src/pages/SwitchAccount/index.tsx
+++ b/packages/experience/src/pages/SwitchAccount/index.tsx
@@ -1,0 +1,66 @@
+import { useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import StaticPageLayout from '@/Layout/StaticPageLayout';
+import PageContext from '@/Providers/PageContextProvider/PageContext';
+import Button from '@/components/Button';
+import DynamicT from '@/components/DynamicT';
+import NavBar from '@/components/NavBar';
+import PageMeta from '@/components/PageMeta';
+import { getBrandingLogoUrl } from '@/utils/logo';
+
+import SupportInfo from '../ErrorPage/SupportInfo';
+
+import styles from './index.module.scss';
+
+type Props = {
+  readonly account?: string;
+};
+
+const SwitchAccount = ({ account }: Props) => {
+  const navigate = useNavigate();
+  const { experienceSettings, theme } = useContext(PageContext);
+  const searchParams = new URLSearchParams(window.location.search);
+  const currentAccountName = searchParams.get('account') ?? account;
+
+  if (!experienceSettings) {
+    return null;
+  }
+
+  const {
+    color: { isDarkModeEnabled },
+    branding,
+  } = experienceSettings;
+  const logoUrl = getBrandingLogoUrl({ theme, branding, isDarkModeEnabled });
+
+  return (
+    <StaticPageLayout>
+      <PageMeta titleKey="description.switch_account" />
+      {history.length > 1 && <NavBar />}
+      <div className={styles.container}>
+        {logoUrl && <img className={styles.logo} src={logoUrl} alt="app logo" />}
+        <div className={styles.title}>
+          <DynamicT
+            forKey="description.account_mismatch_title"
+            interpolation={{ account: currentAccountName }}
+          />
+        </div>
+        <div className={styles.message}>
+          <DynamicT forKey="description.account_mismatch_description" />
+        </div>
+        <SupportInfo />
+        <Button
+          className={styles.button}
+          type="primary"
+          size="large"
+          title="description.switch_account"
+          onClick={() => {
+            navigate('/sign-in');
+          }}
+        />
+      </div>
+    </StaticPageLayout>
+  );
+};
+
+export default SwitchAccount;

--- a/packages/experience/src/pages/SwitchAccount/index.tsx
+++ b/packages/experience/src/pages/SwitchAccount/index.tsx
@@ -1,30 +1,67 @@
-import { useContext } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { type ConsentInfoResponse } from '@logto/schemas';
+import { useContext, useEffect, useState } from 'react';
 
 import StaticPageLayout from '@/Layout/StaticPageLayout';
 import PageContext from '@/Providers/PageContextProvider/PageContext';
+import { getConsentInfo } from '@/apis/consent';
 import Button from '@/components/Button';
 import DynamicT from '@/components/DynamicT';
-import NavBar from '@/components/NavBar';
+import LoadingLayer from '@/components/LoadingLayer';
 import PageMeta from '@/components/PageMeta';
+import TextLink from '@/components/TextLink';
+import useApi from '@/hooks/use-api';
+import useErrorHandler from '@/hooks/use-error-handler';
+import UserProfile from '@/pages/Consent/UserProfile';
+import ErrorPage from '@/pages/ErrorPage';
 import { getBrandingLogoUrl } from '@/utils/logo';
-
-import SupportInfo from '../ErrorPage/SupportInfo';
 
 import styles from './index.module.scss';
 
+/**
+ * This component is only used when there's an active session, and then the user
+ * is trying to sign-in with another account (e.g., using a magic link).
+ */
+
 type Props = {
-  readonly account?: string;
+  /**
+   * The account name of the current active session
+   */
+  readonly account: string;
+  /**
+   * The callback function to be called after clicking the "Go back" link
+   */
+  readonly onCancel: () => Promise<void>;
+  /**
+   * The callback function to be called after clicking the "Switch" button
+   */
+  readonly onSwitch: () => Promise<void>;
 };
 
-const SwitchAccount = ({ account }: Props) => {
-  const navigate = useNavigate();
+const SwitchAccount = ({ account, onCancel, onSwitch }: Props) => {
   const { experienceSettings, theme } = useContext(PageContext);
-  const searchParams = new URLSearchParams(window.location.search);
-  const currentAccountName = searchParams.get('account') ?? account;
+  const handleError = useErrorHandler();
 
-  if (!experienceSettings) {
-    return null;
+  const [consentData, setConsentData] = useState<ConsentInfoResponse>();
+  const asyncGetConsentInfo = useApi(getConsentInfo);
+
+  useEffect(() => {
+    (async () => {
+      const [error, result] = await asyncGetConsentInfo();
+
+      if (error) {
+        await handleError(error);
+        return;
+      }
+      setConsentData(result);
+    })();
+  }, [asyncGetConsentInfo, handleError]);
+
+  if (!account) {
+    return <ErrorPage title="error.unknown" message="error.unknown" />;
+  }
+
+  if (!experienceSettings || !consentData) {
+    return <LoadingLayer />;
   }
 
   const {
@@ -36,28 +73,26 @@ const SwitchAccount = ({ account }: Props) => {
   return (
     <StaticPageLayout>
       <PageMeta titleKey="description.switch_account" />
-      {history.length > 1 && <NavBar />}
       <div className={styles.container}>
         {logoUrl && <img className={styles.logo} src={logoUrl} alt="app logo" />}
         <div className={styles.title}>
-          <DynamicT
-            forKey="description.account_mismatch_title"
-            interpolation={{ account: currentAccountName }}
-          />
+          <DynamicT forKey="description.switch_account_title" interpolation={{ account }} />
         </div>
+        <UserProfile user={consentData.user} className={styles.userProfile} />
         <div className={styles.message}>
-          <DynamicT forKey="description.account_mismatch_description" />
+          <DynamicT forKey="description.switch_account_description" />
         </div>
-        <SupportInfo />
         <Button
           className={styles.button}
           type="primary"
           size="large"
-          title="description.switch_account"
-          onClick={() => {
-            navigate('/sign-in');
-          }}
+          title="action.switch_to"
+          i18nProps={{ method: account }}
+          onClick={onSwitch}
         />
+        <div className={styles.linkButton}>
+          <TextLink text="action.back_to_current_account" onClick={onCancel} />
+        </div>
       </div>
     </StaticPageLayout>
   );

--- a/packages/phrases-experience/src/locales/ar/action.ts
+++ b/packages/phrases-experience/src/locales/ar/action.ts
@@ -31,6 +31,7 @@ const action = {
   single_sign_on: 'تسجيل الدخول الموحد',
   authorize: 'التفويض',
   use_another_account: 'استخدام حساب آخر',
+  back_to_current_account: 'الرجوع إلى الحساب الحالي',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/ar/description.ts
+++ b/packages/phrases-experience/src/locales/ar/description.ts
@@ -10,8 +10,7 @@ const description = {
   sign_in: 'تسجيل الدخول',
   privacy_policy: 'سياسة الخصوصية',
   create_account: 'إنشاء حساب',
-  /** UNTRANSLATED */
-  switch_account: 'Switch account',
+  switch_account: 'تبديل الحساب',
   or: 'أو',
   and: 'و',
   enter_passcode: 'تم إرسال رمز التحقق إلى {{address}} {{target}} الخاص بك',
@@ -104,11 +103,9 @@ const description = {
   back_to_sign_in: 'العودة إلى تسجيل الدخول',
   support_email: 'البريد الإلكتروني للدعم: <link></link>',
   support_website: 'موقع الدعم: <link></link>',
-  /** UNTRANSLATED */
-  account_mismatch_title: 'You are currently signed in as {{account}}',
-  /** UNTRANSLATED */
-  account_mismatch_description:
-    'Please switch to the account that associated with this magic link, and try again.',
+  switch_account_title: 'أنت حاليًا مسجل الدخول كـ {{account}}',
+  switch_account_description:
+    'للمتابعة، سيتم تسجيل الخروج من الحساب الحالي، والتبديل تلقائيًا إلى الحساب الجديد.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/ar/description.ts
+++ b/packages/phrases-experience/src/locales/ar/description.ts
@@ -10,6 +10,8 @@ const description = {
   sign_in: 'تسجيل الدخول',
   privacy_policy: 'سياسة الخصوصية',
   create_account: 'إنشاء حساب',
+  /** UNTRANSLATED */
+  switch_account: 'Switch account',
   or: 'أو',
   and: 'و',
   enter_passcode: 'تم إرسال رمز التحقق إلى {{address}} {{target}} الخاص بك',
@@ -102,6 +104,11 @@ const description = {
   back_to_sign_in: 'العودة إلى تسجيل الدخول',
   support_email: 'البريد الإلكتروني للدعم: <link></link>',
   support_website: 'موقع الدعم: <link></link>',
+  /** UNTRANSLATED */
+  account_mismatch_title: 'You are currently signed in as {{account}}',
+  /** UNTRANSLATED */
+  account_mismatch_description:
+    'Please switch to the account that associated with this magic link, and try again.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/de/action.ts
+++ b/packages/phrases-experience/src/locales/de/action.ts
@@ -31,6 +31,7 @@ const action = {
   single_sign_on: 'Single Sign-On',
   authorize: 'Autorisieren',
   use_another_account: 'Anderes Konto verwenden',
+  back_to_current_account: 'Zurück zum aktuellen Konto',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/de/description.ts
+++ b/packages/phrases-experience/src/locales/de/description.ts
@@ -10,6 +10,8 @@ const description = {
   sign_in: 'Anmelden',
   privacy_policy: 'Datenschutzrichtlinien',
   create_account: 'Konto erstellen',
+  /** UNTRANSLATED */
+  switch_account: 'Switch account',
   or: 'oder',
   and: 'und',
   enter_passcode: 'Der Bestätigungscode wurde an deine {{address}} gesendet',
@@ -108,6 +110,11 @@ const description = {
   back_to_sign_in: 'Zurück zur Anmeldung',
   support_email: 'Support-E-Mail: <link></link>',
   support_website: 'Support-Website: <link></link>',
+  /** UNTRANSLATED */
+  account_mismatch_title: 'You are currently signed in as {{account}}',
+  /** UNTRANSLATED */
+  account_mismatch_description:
+    'Please switch to the account that associated with this magic link, and try again.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/de/description.ts
+++ b/packages/phrases-experience/src/locales/de/description.ts
@@ -10,8 +10,7 @@ const description = {
   sign_in: 'Anmelden',
   privacy_policy: 'Datenschutzrichtlinien',
   create_account: 'Konto erstellen',
-  /** UNTRANSLATED */
-  switch_account: 'Switch account',
+  switch_account: 'Konto wechseln',
   or: 'oder',
   and: 'und',
   enter_passcode: 'Der Bestätigungscode wurde an deine {{address}} gesendet',
@@ -110,11 +109,9 @@ const description = {
   back_to_sign_in: 'Zurück zur Anmeldung',
   support_email: 'Support-E-Mail: <link></link>',
   support_website: 'Support-Website: <link></link>',
-  /** UNTRANSLATED */
-  account_mismatch_title: 'You are currently signed in as {{account}}',
-  /** UNTRANSLATED */
-  account_mismatch_description:
-    'Please switch to the account that associated with this magic link, and try again.',
+  switch_account_title: 'Du bist derzeit als {{account}} angemeldet',
+  switch_account_description:
+    'Um fortzufahren, wirst du vom aktuellen Konto abgemeldet und automatisch zum neuen Konto gewechselt.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/en/action.ts
+++ b/packages/phrases-experience/src/locales/en/action.ts
@@ -31,6 +31,7 @@ const action = {
   single_sign_on: 'Single Sign-On',
   authorize: 'Authorize',
   use_another_account: 'Use another account',
+  back_to_current_account: 'Back to current account',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/en/description.ts
+++ b/packages/phrases-experience/src/locales/en/description.ts
@@ -106,9 +106,9 @@ const description = {
   back_to_sign_in: 'Back to sign in',
   support_email: 'Support email: <link></link>',
   support_website: 'Support website: <link></link>',
-  account_mismatch_title: 'You are currently signed in as {{account}}',
-  account_mismatch_description:
-    'Please switch to the account that associated with this magic link, and try again.',
+  switch_account_title: 'You are currently signed in as {{account}}',
+  switch_account_description:
+    'To continue, you will be signed out of the current account, and switch to the new account automatically.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/en/description.ts
+++ b/packages/phrases-experience/src/locales/en/description.ts
@@ -10,6 +10,7 @@ const description = {
   sign_in: 'Sign in',
   privacy_policy: 'Privacy Policy',
   create_account: 'Create account',
+  switch_account: 'Switch account',
   or: 'or',
   and: 'and',
   enter_passcode: 'The verification code has been sent to your {{address}} {{target}}',
@@ -105,6 +106,9 @@ const description = {
   back_to_sign_in: 'Back to sign in',
   support_email: 'Support email: <link></link>',
   support_website: 'Support website: <link></link>',
+  account_mismatch_title: 'You are currently signed in as {{account}}',
+  account_mismatch_description:
+    'Please switch to the account that associated with this magic link, and try again.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/es/action.ts
+++ b/packages/phrases-experience/src/locales/es/action.ts
@@ -31,6 +31,7 @@ const action = {
   single_sign_on: 'Inicio de sesión único',
   authorize: 'Autorizar',
   use_another_account: 'Usar otra cuenta',
+  back_to_current_account: 'Regresar a la cuenta actual',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/es/description.ts
+++ b/packages/phrases-experience/src/locales/es/description.ts
@@ -10,6 +10,8 @@ const description = {
   sign_in: 'Iniciar sesión',
   privacy_policy: 'Política de privacidad',
   create_account: 'Crear cuenta',
+  /** UNTRANSLATED */
+  switch_account: 'Switch account',
   or: 'o',
   and: 'y',
   enter_passcode: 'El código de verificación ha sido enviado a su {{address}} {{target}}',
@@ -108,6 +110,11 @@ const description = {
   back_to_sign_in: 'Volver a iniciar sesión',
   support_email: 'Correo electrónico de soporte: <link></link>',
   support_website: 'Sitio web de soporte: <link></link>',
+  /** UNTRANSLATED */
+  account_mismatch_title: 'You are currently signed in as {{account}}',
+  /** UNTRANSLATED */
+  account_mismatch_description:
+    'Please switch to the account that associated with this magic link, and try again.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/es/description.ts
+++ b/packages/phrases-experience/src/locales/es/description.ts
@@ -10,8 +10,7 @@ const description = {
   sign_in: 'Iniciar sesión',
   privacy_policy: 'Política de privacidad',
   create_account: 'Crear cuenta',
-  /** UNTRANSLATED */
-  switch_account: 'Switch account',
+  switch_account: 'Cambiar cuenta',
   or: 'o',
   and: 'y',
   enter_passcode: 'El código de verificación ha sido enviado a su {{address}} {{target}}',
@@ -110,11 +109,9 @@ const description = {
   back_to_sign_in: 'Volver a iniciar sesión',
   support_email: 'Correo electrónico de soporte: <link></link>',
   support_website: 'Sitio web de soporte: <link></link>',
-  /** UNTRANSLATED */
-  account_mismatch_title: 'You are currently signed in as {{account}}',
-  /** UNTRANSLATED */
-  account_mismatch_description:
-    'Please switch to the account that associated with this magic link, and try again.',
+  switch_account_title: 'Actualmente has iniciado sesión como {{account}}',
+  switch_account_description:
+    'Para continuar, se cerrará la sesión de la cuenta actual, y se cambiará automáticamente a la nueva cuenta.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/fr/action.ts
+++ b/packages/phrases-experience/src/locales/fr/action.ts
@@ -31,6 +31,7 @@ const action = {
   single_sign_on: 'Connexion unique',
   authorize: 'Autoriser',
   use_another_account: 'Utiliser un autre compte',
+  back_to_current_account: 'Retour au compte actuel',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/fr/description.ts
+++ b/packages/phrases-experience/src/locales/fr/description.ts
@@ -10,6 +10,8 @@ const description = {
   sign_in: 'Connexion',
   privacy_policy: 'Politique de confidentialité',
   create_account: 'Créer un compte',
+  /** UNTRANSLATED */
+  switch_account: 'Switch account',
   or: 'ou',
   and: 'et',
   enter_passcode: 'Le code a été envoyé à {{address}} {{target}}',
@@ -108,6 +110,11 @@ const description = {
   back_to_sign_in: 'Retour à la connexion',
   support_email: 'Email de support: <link></link>',
   support_website: 'Site web de support: <link></link>',
+  /** UNTRANSLATED */
+  account_mismatch_title: 'You are currently signed in as {{account}}',
+  /** UNTRANSLATED */
+  account_mismatch_description:
+    'Please switch to the account that associated with this magic link, and try again.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/fr/description.ts
+++ b/packages/phrases-experience/src/locales/fr/description.ts
@@ -10,8 +10,7 @@ const description = {
   sign_in: 'Connexion',
   privacy_policy: 'Politique de confidentialité',
   create_account: 'Créer un compte',
-  /** UNTRANSLATED */
-  switch_account: 'Switch account',
+  switch_account: 'Changer de compte',
   or: 'ou',
   and: 'et',
   enter_passcode: 'Le code a été envoyé à {{address}} {{target}}',
@@ -110,11 +109,9 @@ const description = {
   back_to_sign_in: 'Retour à la connexion',
   support_email: 'Email de support: <link></link>',
   support_website: 'Site web de support: <link></link>',
-  /** UNTRANSLATED */
-  account_mismatch_title: 'You are currently signed in as {{account}}',
-  /** UNTRANSLATED */
-  account_mismatch_description:
-    'Please switch to the account that associated with this magic link, and try again.',
+  switch_account_title: 'Vous êtes actuellement connecté en tant que {{account}}',
+  switch_account_description:
+    'Pour continuer, vous serez déconnecté du compte actuel, et le passage au nouveau compte se fera automatiquement.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/it/action.ts
+++ b/packages/phrases-experience/src/locales/it/action.ts
@@ -31,6 +31,7 @@ const action = {
   single_sign_on: 'Single Sign-On',
   authorize: 'Autorizza',
   use_another_account: 'Usa un altro account',
+  back_to_current_account: "Torna all'account attuale",
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/it/description.ts
+++ b/packages/phrases-experience/src/locales/it/description.ts
@@ -10,8 +10,7 @@ const description = {
   sign_in: 'Accedi',
   privacy_policy: 'Informativa sulla privacy',
   create_account: 'Crea account',
-  /** UNTRANSLATED */
-  switch_account: 'Switch account',
+  switch_account: 'Cambia account',
   or: 'o',
   and: 'e',
   enter_passcode: 'Il codice di verifica è stato inviato alla tua {{address}} {{target}}',
@@ -108,11 +107,9 @@ const description = {
   back_to_sign_in: 'Torna al login',
   support_email: 'Email di supporto: <link></link>',
   support_website: 'Sito web di supporto: <link></link>',
-  /** UNTRANSLATED */
-  account_mismatch_title: 'You are currently signed in as {{account}}',
-  /** UNTRANSLATED */
-  account_mismatch_description:
-    'Please switch to the account that associated with this magic link, and try again.',
+  switch_account_title: 'Attualmente sei connesso come {{account}}',
+  switch_account_description:
+    "Per continuare, verrai disconnesso dall'account attuale e passerai automaticamente al nuovo account.",
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/it/description.ts
+++ b/packages/phrases-experience/src/locales/it/description.ts
@@ -10,6 +10,8 @@ const description = {
   sign_in: 'Accedi',
   privacy_policy: 'Informativa sulla privacy',
   create_account: 'Crea account',
+  /** UNTRANSLATED */
+  switch_account: 'Switch account',
   or: 'o',
   and: 'e',
   enter_passcode: 'Il codice di verifica è stato inviato alla tua {{address}} {{target}}',
@@ -106,6 +108,11 @@ const description = {
   back_to_sign_in: 'Torna al login',
   support_email: 'Email di supporto: <link></link>',
   support_website: 'Sito web di supporto: <link></link>',
+  /** UNTRANSLATED */
+  account_mismatch_title: 'You are currently signed in as {{account}}',
+  /** UNTRANSLATED */
+  account_mismatch_description:
+    'Please switch to the account that associated with this magic link, and try again.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/ja/action.ts
+++ b/packages/phrases-experience/src/locales/ja/action.ts
@@ -31,6 +31,7 @@ const action = {
   single_sign_on: 'シングルサインオン',
   authorize: '認証する',
   use_another_account: '別のアカウントを使用する',
+  back_to_current_account: '現在のアカウントに戻る',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/ja/description.ts
+++ b/packages/phrases-experience/src/locales/ja/description.ts
@@ -10,8 +10,7 @@ const description = {
   sign_in: 'サインイン',
   privacy_policy: 'プライバシーポリシー',
   create_account: 'アカウントを作成する',
-  /** UNTRANSLATED */
-  switch_account: 'Switch account',
+  switch_account: 'アカウントを切り替える',
   or: 'または',
   and: '及び',
   enter_passcode: '確認コードが{{address}} {{target}}に送信されました',
@@ -103,11 +102,9 @@ const description = {
   back_to_sign_in: 'サインインに戻る',
   support_email: 'サポートメール: <link></link>',
   support_website: 'サポートウェブサイト: <link></link>',
-  /** UNTRANSLATED */
-  account_mismatch_title: 'You are currently signed in as {{account}}',
-  /** UNTRANSLATED */
-  account_mismatch_description:
-    'Please switch to the account that associated with this magic link, and try again.',
+  switch_account_title: '現在 {{account}} としてサインインしています',
+  switch_account_description:
+    '続行するには、現在のアカウントからサインアウトし、新しいアカウントに自動的に切り替わります。',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/ja/description.ts
+++ b/packages/phrases-experience/src/locales/ja/description.ts
@@ -10,6 +10,8 @@ const description = {
   sign_in: 'サインイン',
   privacy_policy: 'プライバシーポリシー',
   create_account: 'アカウントを作成する',
+  /** UNTRANSLATED */
+  switch_account: 'Switch account',
   or: 'または',
   and: '及び',
   enter_passcode: '確認コードが{{address}} {{target}}に送信されました',
@@ -101,6 +103,11 @@ const description = {
   back_to_sign_in: 'サインインに戻る',
   support_email: 'サポートメール: <link></link>',
   support_website: 'サポートウェブサイト: <link></link>',
+  /** UNTRANSLATED */
+  account_mismatch_title: 'You are currently signed in as {{account}}',
+  /** UNTRANSLATED */
+  account_mismatch_description:
+    'Please switch to the account that associated with this magic link, and try again.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/ko/action.ts
+++ b/packages/phrases-experience/src/locales/ko/action.ts
@@ -31,6 +31,7 @@ const action = {
   single_sign_on: '단일 로그인',
   authorize: '권한 부여',
   use_another_account: '다른 계정 사용',
+  back_to_current_account: '현재 계정으로 돌아가기',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/ko/description.ts
+++ b/packages/phrases-experience/src/locales/ko/description.ts
@@ -10,8 +10,7 @@ const description = {
   sign_in: '로그인',
   privacy_policy: '개인정보처리방침',
   create_account: '계정 생성',
-  /** UNTRANSLATED */
-  switch_account: 'Switch account',
+  switch_account: '계정 전환',
   or: '또는',
   and: '그리고',
   enter_passcode: '{{address}} {{target}} 으로 비밀번호가 전송되었어요.',
@@ -98,11 +97,9 @@ const description = {
   back_to_sign_in: '로그인으로 돌아가기',
   support_email: '지원 이메일: <link></link>',
   support_website: '지원 웹사이트: <link></link>',
-  /** UNTRANSLATED */
-  account_mismatch_title: 'You are currently signed in as {{account}}',
-  /** UNTRANSLATED */
-  account_mismatch_description:
-    'Please switch to the account that associated with this magic link, and try again.',
+  switch_account_title: '현재 {{account}}으로 로그인 중입니다',
+  switch_account_description:
+    '계속 진행하려면 현재 계정에서 로그아웃되고 새 계정으로 자동 전환됩니다.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/ko/description.ts
+++ b/packages/phrases-experience/src/locales/ko/description.ts
@@ -10,6 +10,8 @@ const description = {
   sign_in: '로그인',
   privacy_policy: '개인정보처리방침',
   create_account: '계정 생성',
+  /** UNTRANSLATED */
+  switch_account: 'Switch account',
   or: '또는',
   and: '그리고',
   enter_passcode: '{{address}} {{target}} 으로 비밀번호가 전송되었어요.',
@@ -96,6 +98,11 @@ const description = {
   back_to_sign_in: '로그인으로 돌아가기',
   support_email: '지원 이메일: <link></link>',
   support_website: '지원 웹사이트: <link></link>',
+  /** UNTRANSLATED */
+  account_mismatch_title: 'You are currently signed in as {{account}}',
+  /** UNTRANSLATED */
+  account_mismatch_description:
+    'Please switch to the account that associated with this magic link, and try again.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/pl-pl/action.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/action.ts
@@ -31,6 +31,8 @@ const action = {
   single_sign_on: 'Pojedyncze logowanie',
   authorize: 'Autoryzować',
   use_another_account: 'Użyj innego konta',
+  /** UNTRANSLATED */
+  back_to_current_account: 'Back to current account',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/pl-pl/action.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/action.ts
@@ -31,8 +31,7 @@ const action = {
   single_sign_on: 'Pojedyncze logowanie',
   authorize: 'Autoryzować',
   use_another_account: 'Użyj innego konta',
-  /** UNTRANSLATED */
-  back_to_current_account: 'Back to current account',
+  back_to_current_account: 'Powróć do bieżącego konta',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/pl-pl/description.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/description.ts
@@ -10,8 +10,7 @@ const description = {
   sign_in: 'Zaloguj się',
   privacy_policy: 'Polityka prywatności',
   create_account: 'Utwórz konto',
-  /** UNTRANSLATED */
-  switch_account: 'Switch account',
+  switch_account: 'Przełącz konto',
   or: 'lub',
   and: 'i',
   enter_passcode: 'Kod weryfikacyjny został wysłany na twoje {{address}} {{target}}',
@@ -108,11 +107,9 @@ const description = {
   back_to_sign_in: 'Wróć do logowania',
   support_email: 'Email wsparcia: <link></link>',
   support_website: 'Strona wsparcia: <link></link>',
-  /** UNTRANSLATED */
-  switch_account_title: 'You are currently signed in as {{account}}',
-  /** UNTRANSLATED */
+  switch_account_title: 'Jesteś obecnie zalogowany jako {{account}}',
   switch_account_description:
-    'To continue, you will be signed out of the current account, and switch to the new account automatically.',
+    'Aby kontynuować, zostaniesz wylogowany z obecnego konta i automatycznie przełączony na nowe konto.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/pl-pl/description.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/description.ts
@@ -10,6 +10,8 @@ const description = {
   sign_in: 'Zaloguj się',
   privacy_policy: 'Polityka prywatności',
   create_account: 'Utwórz konto',
+  /** UNTRANSLATED */
+  switch_account: 'Switch account',
   or: 'lub',
   and: 'i',
   enter_passcode: 'Kod weryfikacyjny został wysłany na twoje {{address}} {{target}}',
@@ -106,6 +108,11 @@ const description = {
   back_to_sign_in: 'Wróć do logowania',
   support_email: 'Email wsparcia: <link></link>',
   support_website: 'Strona wsparcia: <link></link>',
+  /** UNTRANSLATED */
+  account_mismatch_title: 'You are currently signed in as {{account}}',
+  /** UNTRANSLATED */
+  account_mismatch_description:
+    'Please switch to the account that associated with this magic link, and try again.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/pl-pl/description.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/description.ts
@@ -109,10 +109,10 @@ const description = {
   support_email: 'Email wsparcia: <link></link>',
   support_website: 'Strona wsparcia: <link></link>',
   /** UNTRANSLATED */
-  account_mismatch_title: 'You are currently signed in as {{account}}',
+  switch_account_title: 'You are currently signed in as {{account}}',
   /** UNTRANSLATED */
-  account_mismatch_description:
-    'Please switch to the account that associated with this magic link, and try again.',
+  switch_account_description:
+    'To continue, you will be signed out of the current account, and switch to the new account automatically.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/pt-br/action.ts
+++ b/packages/phrases-experience/src/locales/pt-br/action.ts
@@ -31,6 +31,8 @@ const action = {
   single_sign_on: 'Single Sign-On',
   authorize: '授权',
   use_another_account: '使用其他帐户',
+  /** UNTRANSLATED */
+  back_to_current_account: 'Back to current account',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/pt-br/action.ts
+++ b/packages/phrases-experience/src/locales/pt-br/action.ts
@@ -31,8 +31,7 @@ const action = {
   single_sign_on: 'Single Sign-On',
   authorize: '授权',
   use_another_account: '使用其他帐户',
-  /** UNTRANSLATED */
-  back_to_current_account: 'Back to current account',
+  back_to_current_account: 'Voltar para a conta atual',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/pt-br/description.ts
+++ b/packages/phrases-experience/src/locales/pt-br/description.ts
@@ -105,10 +105,10 @@ const description = {
   support_email: 'E-mail de suporte: <link></link>',
   support_website: 'Site de suporte: <link></link>',
   /** UNTRANSLATED */
-  account_mismatch_title: 'You are currently signed in as {{account}}',
+  switch_account_title: 'You are currently signed in as {{account}}',
   /** UNTRANSLATED */
-  account_mismatch_description:
-    'Please switch to the account that associated with this magic link, and try again.',
+  switch_account_description:
+    'To continue, you will be signed out of the current account, and switch to the new account automatically.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/pt-br/description.ts
+++ b/packages/phrases-experience/src/locales/pt-br/description.ts
@@ -10,8 +10,7 @@ const description = {
   sign_in: 'Entrar',
   privacy_policy: 'Política de privacidade',
   create_account: 'Criar conta',
-  /** UNTRANSLATED */
-  switch_account: 'Switch account',
+  switch_account: 'Trocar conta',
   or: 'ou',
   and: 'e',
   enter_passcode: 'O código de verificação foi enviado para o seu {{address}} {{target}}',
@@ -104,11 +103,9 @@ const description = {
   back_to_sign_in: 'Voltar para o login',
   support_email: 'E-mail de suporte: <link></link>',
   support_website: 'Site de suporte: <link></link>',
-  /** UNTRANSLATED */
-  switch_account_title: 'You are currently signed in as {{account}}',
-  /** UNTRANSLATED */
+  switch_account_title: 'Você está atualmente conectado como {{account}}',
   switch_account_description:
-    'To continue, you will be signed out of the current account, and switch to the new account automatically.',
+    'Para continuar, você será desconectado da conta atual e automaticamente trocado para a nova conta.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/pt-br/description.ts
+++ b/packages/phrases-experience/src/locales/pt-br/description.ts
@@ -10,6 +10,8 @@ const description = {
   sign_in: 'Entrar',
   privacy_policy: 'Política de privacidade',
   create_account: 'Criar conta',
+  /** UNTRANSLATED */
+  switch_account: 'Switch account',
   or: 'ou',
   and: 'e',
   enter_passcode: 'O código de verificação foi enviado para o seu {{address}} {{target}}',
@@ -102,6 +104,11 @@ const description = {
   back_to_sign_in: 'Voltar para o login',
   support_email: 'E-mail de suporte: <link></link>',
   support_website: 'Site de suporte: <link></link>',
+  /** UNTRANSLATED */
+  account_mismatch_title: 'You are currently signed in as {{account}}',
+  /** UNTRANSLATED */
+  account_mismatch_description:
+    'Please switch to the account that associated with this magic link, and try again.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/pt-pt/action.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/action.ts
@@ -31,8 +31,7 @@ const action = {
   single_sign_on: 'Logon Único',
   authorize: '授权',
   use_another_account: '使用其他账户',
-  /** UNTRANSLATED */
-  back_to_current_account: 'Back to current account',
+  back_to_current_account: 'Voltar à conta atual',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/pt-pt/action.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/action.ts
@@ -31,6 +31,8 @@ const action = {
   single_sign_on: 'Logon Único',
   authorize: '授权',
   use_another_account: '使用其他账户',
+  /** UNTRANSLATED */
+  back_to_current_account: 'Back to current account',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/pt-pt/description.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/description.ts
@@ -10,8 +10,7 @@ const description = {
   sign_in: 'Entrar',
   privacy_policy: 'Política de privacidade',
   create_account: 'Criar uma conta',
-  /** UNTRANSLATED */
-  switch_account: 'Switch account',
+  switch_account: 'Mudar de conta',
   or: 'ou',
   and: 'e',
   enter_passcode: 'O código de verificação foi enviado para o seu {{address}} {{target}}',
@@ -105,11 +104,9 @@ const description = {
   back_to_sign_in: 'Voltar para o login',
   support_email: 'Email de suporte: <link></link>',
   support_website: 'Site de suporte: <link></link>',
-  /** UNTRANSLATED */
-  switch_account_title: 'You are currently signed in as {{account}}',
-  /** UNTRANSLATED */
+  switch_account_title: 'Atualmente, você está conectado como {{account}}',
   switch_account_description:
-    'To continue, you will be signed out of the current account, and switch to the new account automatically.',
+    'Para continuar, você sairá da conta atual e mudará automaticamente para a nova conta.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/pt-pt/description.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/description.ts
@@ -106,10 +106,10 @@ const description = {
   support_email: 'Email de suporte: <link></link>',
   support_website: 'Site de suporte: <link></link>',
   /** UNTRANSLATED */
-  account_mismatch_title: 'You are currently signed in as {{account}}',
+  switch_account_title: 'You are currently signed in as {{account}}',
   /** UNTRANSLATED */
-  account_mismatch_description:
-    'Please switch to the account that associated with this magic link, and try again.',
+  switch_account_description:
+    'To continue, you will be signed out of the current account, and switch to the new account automatically.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/pt-pt/description.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/description.ts
@@ -10,6 +10,8 @@ const description = {
   sign_in: 'Entrar',
   privacy_policy: 'Política de privacidade',
   create_account: 'Criar uma conta',
+  /** UNTRANSLATED */
+  switch_account: 'Switch account',
   or: 'ou',
   and: 'e',
   enter_passcode: 'O código de verificação foi enviado para o seu {{address}} {{target}}',
@@ -103,6 +105,11 @@ const description = {
   back_to_sign_in: 'Voltar para o login',
   support_email: 'Email de suporte: <link></link>',
   support_website: 'Site de suporte: <link></link>',
+  /** UNTRANSLATED */
+  account_mismatch_title: 'You are currently signed in as {{account}}',
+  /** UNTRANSLATED */
+  account_mismatch_description:
+    'Please switch to the account that associated with this magic link, and try again.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/ru/action.ts
+++ b/packages/phrases-experience/src/locales/ru/action.ts
@@ -31,6 +31,7 @@ const action = {
   single_sign_on: 'Единый вход',
   authorize: 'Авторизовать',
   use_another_account: 'Использовать другой аккаунт',
+  back_to_current_account: 'Назад к текущему аккаунту',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/ru/description.ts
+++ b/packages/phrases-experience/src/locales/ru/description.ts
@@ -10,8 +10,7 @@ const description = {
   sign_in: 'Войти',
   privacy_policy: 'Политикой конфиденциальности',
   create_account: 'Создать аккаунт',
-  /** UNTRANSLATED */
-  switch_account: 'Switch account',
+  switch_account: 'Сменить аккаунт',
   or: 'или',
   and: 'и',
   enter_passcode: 'Код подтверждения был отправлен на {{address}}',
@@ -108,11 +107,9 @@ const description = {
   back_to_sign_in: 'Вернуться ко входу',
   support_email: 'Поддержка по электронной почте: <link></link>',
   support_website: 'Сайт поддержки: <link></link>',
-  /** UNTRANSLATED */
-  account_mismatch_title: 'You are currently signed in as {{account}}',
-  /** UNTRANSLATED */
-  account_mismatch_description:
-    'Please switch to the account that associated with this magic link, and try again.',
+  switch_account_title: 'В настоящее время вы вошли как {{account}}',
+  switch_account_description:
+    'Чтобы продолжить, вы будете выйти из текущей учетной записи и автоматически переключены на новую учетную запись.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/ru/description.ts
+++ b/packages/phrases-experience/src/locales/ru/description.ts
@@ -10,6 +10,8 @@ const description = {
   sign_in: 'Войти',
   privacy_policy: 'Политикой конфиденциальности',
   create_account: 'Создать аккаунт',
+  /** UNTRANSLATED */
+  switch_account: 'Switch account',
   or: 'или',
   and: 'и',
   enter_passcode: 'Код подтверждения был отправлен на {{address}}',
@@ -106,6 +108,11 @@ const description = {
   back_to_sign_in: 'Вернуться ко входу',
   support_email: 'Поддержка по электронной почте: <link></link>',
   support_website: 'Сайт поддержки: <link></link>',
+  /** UNTRANSLATED */
+  account_mismatch_title: 'You are currently signed in as {{account}}',
+  /** UNTRANSLATED */
+  account_mismatch_description:
+    'Please switch to the account that associated with this magic link, and try again.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/tr-tr/action.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/action.ts
@@ -31,6 +31,8 @@ const action = {
   single_sign_on: 'Tek oturum açma',
   authorize: 'Yetkilendir',
   use_another_account: 'Başka bir hesap kullan',
+  /** UNTRANSLATED */
+  back_to_current_account: 'Back to current account',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/tr-tr/action.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/action.ts
@@ -31,8 +31,7 @@ const action = {
   single_sign_on: 'Tek oturum açma',
   authorize: 'Yetkilendir',
   use_another_account: 'Başka bir hesap kullan',
-  /** UNTRANSLATED */
-  back_to_current_account: 'Back to current account',
+  back_to_current_account: 'Mevcut hesaba geri dön',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/tr-tr/description.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/description.ts
@@ -10,8 +10,7 @@ const description = {
   sign_in: 'Giriş Yap',
   privacy_policy: 'Gizlilik Politikası',
   create_account: 'Hesap Oluştur',
-  /** UNTRANSLATED */
-  switch_account: 'Switch account',
+  switch_account: 'Hesabı değiştir',
   or: 'veya',
   and: 've',
   enter_passcode: 'Doğrulama kodu {{address}} {{target}} adresinize gönderildi',
@@ -101,11 +100,9 @@ const description = {
   back_to_sign_in: 'Girişe dön',
   support_email: 'Destek e-postası: <link></link>',
   support_website: 'Destek web sitesi: <link></link>',
-  /** UNTRANSLATED */
-  switch_account_title: 'You are currently signed in as {{account}}',
-  /** UNTRANSLATED */
+  switch_account_title: 'Şu anda {{account}} olarak oturum açtınız',
   switch_account_description:
-    'To continue, you will be signed out of the current account, and switch to the new account automatically.',
+    'Devam etmek için, mevcut hesaptan çıkış yapacak ve otomatik olarak yeni hesaba geçeceksiniz.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/tr-tr/description.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/description.ts
@@ -10,6 +10,8 @@ const description = {
   sign_in: 'Giriş Yap',
   privacy_policy: 'Gizlilik Politikası',
   create_account: 'Hesap Oluştur',
+  /** UNTRANSLATED */
+  switch_account: 'Switch account',
   or: 'veya',
   and: 've',
   enter_passcode: 'Doğrulama kodu {{address}} {{target}} adresinize gönderildi',
@@ -99,6 +101,11 @@ const description = {
   back_to_sign_in: 'Girişe dön',
   support_email: 'Destek e-postası: <link></link>',
   support_website: 'Destek web sitesi: <link></link>',
+  /** UNTRANSLATED */
+  account_mismatch_title: 'You are currently signed in as {{account}}',
+  /** UNTRANSLATED */
+  account_mismatch_description:
+    'Please switch to the account that associated with this magic link, and try again.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/tr-tr/description.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/description.ts
@@ -102,10 +102,10 @@ const description = {
   support_email: 'Destek e-postası: <link></link>',
   support_website: 'Destek web sitesi: <link></link>',
   /** UNTRANSLATED */
-  account_mismatch_title: 'You are currently signed in as {{account}}',
+  switch_account_title: 'You are currently signed in as {{account}}',
   /** UNTRANSLATED */
-  account_mismatch_description:
-    'Please switch to the account that associated with this magic link, and try again.',
+  switch_account_description:
+    'To continue, you will be signed out of the current account, and switch to the new account automatically.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/zh-cn/action.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/action.ts
@@ -31,8 +31,7 @@ const action = {
   single_sign_on: '单点登录',
   authorize: '授权',
   use_another_account: '使用另一个账号',
-  /** UNTRANSLATED */
-  back_to_current_account: 'Back to current account',
+  back_to_current_account: '返回到当前账号',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/zh-cn/action.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/action.ts
@@ -31,6 +31,8 @@ const action = {
   single_sign_on: '单点登录',
   authorize: '授权',
   use_another_account: '使用另一个账号',
+  /** UNTRANSLATED */
+  back_to_current_account: 'Back to current account',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/zh-cn/description.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/description.ts
@@ -93,10 +93,10 @@ const description = {
   support_email: '支持邮箱：<link></link>',
   support_website: '支持网站：<link></link>',
   /** UNTRANSLATED */
-  account_mismatch_title: 'You are currently signed in as {{account}}',
+  switch_account_title: 'You are currently signed in as {{account}}',
   /** UNTRANSLATED */
-  account_mismatch_description:
-    'Please switch to the account that associated with this magic link, and try again.',
+  switch_account_description:
+    'To continue, you will be signed out of the current account, and switch to the new account automatically.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/zh-cn/description.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/description.ts
@@ -10,6 +10,8 @@ const description = {
   sign_in: '登录',
   privacy_policy: '隐私政策',
   create_account: '创建帐号',
+  /** UNTRANSLATED */
+  switch_account: 'Switch account',
   or: '或',
   and: '和',
   enter_passcode: '验证码已经发送至你的{{ address }} {{target}}',
@@ -90,6 +92,11 @@ const description = {
   back_to_sign_in: '返回登录',
   support_email: '支持邮箱：<link></link>',
   support_website: '支持网站：<link></link>',
+  /** UNTRANSLATED */
+  account_mismatch_title: 'You are currently signed in as {{account}}',
+  /** UNTRANSLATED */
+  account_mismatch_description:
+    'Please switch to the account that associated with this magic link, and try again.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/zh-cn/description.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/description.ts
@@ -10,8 +10,7 @@ const description = {
   sign_in: '登录',
   privacy_policy: '隐私政策',
   create_account: '创建帐号',
-  /** UNTRANSLATED */
-  switch_account: 'Switch account',
+  switch_account: '切换账户',
   or: '或',
   and: '和',
   enter_passcode: '验证码已经发送至你的{{ address }} {{target}}',
@@ -70,7 +69,7 @@ const description = {
   use: '使用',
   single_sign_on_email_form: '输入你的企业电子邮件地址',
   single_sign_on_connectors_list:
-    '你的企业已为电子邮件账户 {{email}} 启用了单点登录。你可以继续使用以下SSO提供商进行登录。',
+    '你的企业已为电子邮件账户 {{email}} 启用了单点登录。你可以继续使用以下 SSO 提供商进行登录。',
   single_sign_on_enabled: '该帐户已启用单点登录',
   authorize_title: '授权给 {{name}}',
   request_permission: '{{name}} 需要权限：',
@@ -92,11 +91,8 @@ const description = {
   back_to_sign_in: '返回登录',
   support_email: '支持邮箱：<link></link>',
   support_website: '支持网站：<link></link>',
-  /** UNTRANSLATED */
-  switch_account_title: 'You are currently signed in as {{account}}',
-  /** UNTRANSLATED */
-  switch_account_description:
-    'To continue, you will be signed out of the current account, and switch to the new account automatically.',
+  switch_account_title: '你当前登录的账号是 {{account}}',
+  switch_account_description: '要继续，你将退出当前账户，并自动切换到新账户。',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/zh-hk/action.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/action.ts
@@ -31,8 +31,7 @@ const action = {
   single_sign_on: '單點登錄',
   authorize: '授权',
   use_another_account: '使用其他帐户',
-  /** UNTRANSLATED */
-  back_to_current_account: 'Back to current account',
+  back_to_current_account: '返回當前帳戶',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/zh-hk/action.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/action.ts
@@ -31,6 +31,8 @@ const action = {
   single_sign_on: '單點登錄',
   authorize: '授权',
   use_another_account: '使用其他帐户',
+  /** UNTRANSLATED */
+  back_to_current_account: 'Back to current account',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/zh-hk/description.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/description.ts
@@ -10,8 +10,7 @@ const description = {
   sign_in: '登錄',
   privacy_policy: '隱私政策',
   create_account: '創建帳號',
-  /** UNTRANSLATED */
-  switch_account: 'Switch account',
+  switch_account: '切換帳號',
   or: '或',
   and: '和',
   enter_passcode: '驗證碼已經發送至你的{{ address }} {{target}}',
@@ -92,11 +91,8 @@ const description = {
   back_to_sign_in: '返回登入',
   support_email: '支持郵件：<link></link>',
   support_website: '支持網站：<link></link>',
-  /** UNTRANSLATED */
-  switch_account_title: 'You are currently signed in as {{account}}',
-  /** UNTRANSLATED */
-  switch_account_description:
-    'To continue, you will be signed out of the current account, and switch to the new account automatically.',
+  switch_account_title: '你當前以 {{account}} 登錄',
+  switch_account_description: '要繼續，你將退出當前帳號，並自動切換到新帳號。',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/zh-hk/description.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/description.ts
@@ -93,10 +93,10 @@ const description = {
   support_email: '支持郵件：<link></link>',
   support_website: '支持網站：<link></link>',
   /** UNTRANSLATED */
-  account_mismatch_title: 'You are currently signed in as {{account}}',
+  switch_account_title: 'You are currently signed in as {{account}}',
   /** UNTRANSLATED */
-  account_mismatch_description:
-    'Please switch to the account that associated with this magic link, and try again.',
+  switch_account_description:
+    'To continue, you will be signed out of the current account, and switch to the new account automatically.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/zh-hk/description.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/description.ts
@@ -10,6 +10,8 @@ const description = {
   sign_in: '登錄',
   privacy_policy: '隱私政策',
   create_account: '創建帳號',
+  /** UNTRANSLATED */
+  switch_account: 'Switch account',
   or: '或',
   and: '和',
   enter_passcode: '驗證碼已經發送至你的{{ address }} {{target}}',
@@ -90,6 +92,11 @@ const description = {
   back_to_sign_in: '返回登入',
   support_email: '支持郵件：<link></link>',
   support_website: '支持網站：<link></link>',
+  /** UNTRANSLATED */
+  account_mismatch_title: 'You are currently signed in as {{account}}',
+  /** UNTRANSLATED */
+  account_mismatch_description:
+    'Please switch to the account that associated with this magic link, and try again.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/zh-tw/action.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/action.ts
@@ -31,8 +31,7 @@ const action = {
   single_sign_on: '單點登錄',
   authorize: '授权',
   use_another_account: '使用其他帐户',
-  /** UNTRANSLATED */
-  back_to_current_account: 'Back to current account',
+  back_to_current_account: '返回當前帳戶',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/zh-tw/action.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/action.ts
@@ -31,6 +31,8 @@ const action = {
   single_sign_on: '單點登錄',
   authorize: '授权',
   use_another_account: '使用其他帐户',
+  /** UNTRANSLATED */
+  back_to_current_account: 'Back to current account',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/zh-tw/description.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/description.ts
@@ -10,6 +10,8 @@ const description = {
   sign_in: '登錄',
   privacy_policy: '隱私政策',
   create_account: '創建帳號',
+  /** UNTRANSLATED */
+  switch_account: 'Switch account',
   or: '或',
   and: '和',
   enter_passcode: '驗證碼已經發送至你的{{address}} {{target}}',
@@ -90,6 +92,11 @@ const description = {
   back_to_sign_in: '返回登入',
   support_email: '支援郵箱: <link></link>',
   support_website: '支援網站: <link></link>',
+  /** UNTRANSLATED */
+  account_mismatch_title: 'You are currently signed in as {{account}}',
+  /** UNTRANSLATED */
+  account_mismatch_description:
+    'Please switch to the account that associated with this magic link, and try again.',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/zh-tw/description.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/description.ts
@@ -10,8 +10,7 @@ const description = {
   sign_in: '登錄',
   privacy_policy: '隱私政策',
   create_account: '創建帳號',
-  /** UNTRANSLATED */
-  switch_account: 'Switch account',
+  switch_account: '切換帳號',
   or: '或',
   and: '和',
   enter_passcode: '驗證碼已經發送至你的{{address}} {{target}}',
@@ -92,11 +91,8 @@ const description = {
   back_to_sign_in: '返回登入',
   support_email: '支援郵箱: <link></link>',
   support_website: '支援網站: <link></link>',
-  /** UNTRANSLATED */
-  switch_account_title: 'You are currently signed in as {{account}}',
-  /** UNTRANSLATED */
-  switch_account_description:
-    'To continue, you will be signed out of the current account, and switch to the new account automatically.',
+  switch_account_title: '目前以 {{account}} 登錄',
+  switch_account_description: '若要繼續，你將退出當前帳號，並自動切換到新帳號。',
 };
 
 export default Object.freeze(description);

--- a/packages/phrases-experience/src/locales/zh-tw/description.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/description.ts
@@ -93,10 +93,10 @@ const description = {
   support_email: '支援郵箱: <link></link>',
   support_website: '支援網站: <link></link>',
   /** UNTRANSLATED */
-  account_mismatch_title: 'You are currently signed in as {{account}}',
+  switch_account_title: 'You are currently signed in as {{account}}',
   /** UNTRANSLATED */
-  account_mismatch_description:
-    'Please switch to the account that associated with this magic link, and try again.',
+  switch_account_description:
+    'To continue, you will be signed out of the current account, and switch to the new account automatically.',
 };
 
 export default Object.freeze(description);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add a new "Switch account" page in Logto Experience. The page is used when the user is trying to sign-in with another account than the one in the active session.

![image](https://github.com/user-attachments/assets/6fb654be-78c4-472e-bfcd-bec6fd4d9114)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
