### PR TITLE
feat(core): guard one-time token on consent request

### DIFF
--- a/packages/core/src/middleware/koa-consent-guard.test.ts
+++ b/packages/core/src/middleware/koa-consent-guard.test.ts
@@ -1,0 +1,88 @@
+import { Provider } from 'oidc-provider';
+
+import RequestError from '#src/errors/RequestError/index.js';
+import { MockQueries } from '#src/test-utils/tenant.js';
+import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
+
+import koaConsentGuard from './koa-consent-guard.js';
+
+const { jest } = import.meta;
+
+describe('koaConsentGuard middleware', () => {
+  const provider = new Provider('https://logto.test');
+  const interactionDetails = jest.spyOn(provider, 'interactionDetails');
+
+  const mockQueries = new MockQueries({
+    users: {
+      findUserById: jest.fn().mockResolvedValue({ primaryEmail: 'foo@example.com' }),
+    },
+  });
+
+  const next = jest.fn();
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should throw an error if session is not found', async () => {
+    // @ts-expect-error
+    interactionDetails.mockResolvedValue({
+      params: { one_time_token: 'token', login_hint: 'foo@example.com' },
+      session: undefined,
+    });
+    const ctx = createContextWithRouteParameters({
+      url: `/consent`,
+    });
+    const guard = koaConsentGuard(provider, mockQueries);
+
+    await expect(guard(ctx, next)).rejects.toThrow(new RequestError({ code: 'session.not_found' }));
+  });
+
+  it('should not block if token or login_hint are not provided', async () => {
+    interactionDetails.mockResolvedValue({
+      params: { one_time_token: '', login_hint: '' },
+      // @ts-expect-error
+      session: { accountId: 'foo' },
+    });
+    const ctx = createContextWithRouteParameters({
+      url: `/consent`,
+    });
+    const guard = koaConsentGuard(provider, mockQueries);
+
+    await guard(ctx, next);
+    expect(mockQueries.users.findUserById).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('should redirect to switch account page if email does not match', async () => {
+    interactionDetails.mockResolvedValue({
+      params: { one_time_token: 'abcdefg', login_hint: 'bar@example.com' },
+      // @ts-expect-error
+      session: { accountId: 'bar' },
+    });
+    const ctx = createContextWithRouteParameters({
+      url: `/consent`,
+    });
+    const guard = koaConsentGuard(provider, mockQueries);
+
+    await guard(ctx, jest.fn());
+    expect(ctx.redirect).toHaveBeenCalledWith(
+      expect.stringContaining('switch-account?login_hint=bar%40example.com&one_time_token=abcdefg')
+    );
+  });
+
+  it('should call next middleware if validations pass', async () => {
+    const ctx = createContextWithRouteParameters({
+      url: `/consent`,
+    });
+    interactionDetails.mockResolvedValue({
+      params: { one_time_token: 'token_value', login_hint: 'foo@example.com' },
+      // @ts-expect-error
+      session: { accountId: 'foo' },
+    });
+    const guard = koaConsentGuard(provider, mockQueries);
+
+    await guard(ctx, next);
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/middleware/koa-consent-guard.ts
+++ b/packages/core/src/middleware/koa-consent-guard.ts
@@ -1,0 +1,42 @@
+import { experience } from '@logto/schemas';
+import { type MiddlewareType } from 'koa';
+import { type IRouterParamContext } from 'koa-router';
+import { type Provider } from 'oidc-provider';
+
+import RequestError from '#src/errors/RequestError/index.js';
+import type Queries from '#src/tenants/Queries.js';
+import assertThat from '#src/utils/assert-that.js';
+
+/**
+ * Guard before allowing auto-consent.
+ * E.g. Check if the active session matches the upcoming one-time token auth request.
+ */
+export default function koaConsentGuard<
+  StateT,
+  ContextT extends IRouterParamContext,
+  ResponseBodyT,
+>(provider: Provider, query: Queries): MiddlewareType<StateT, ContextT, ResponseBodyT> {
+  return async (ctx, next) => {
+    const interactionDetails = await provider.interactionDetails(ctx.req, ctx.res);
+    const {
+      params: { one_time_token: token, login_hint: loginHint },
+      session,
+    } = interactionDetails;
+
+    assertThat(session, new RequestError({ code: 'session.not_found' }));
+
+    if (token && loginHint && typeof token === 'string' && typeof loginHint === 'string') {
+      const { primaryEmail } = await query.users.findUserById(session.accountId);
+
+      assertThat(primaryEmail, 'user.email_not_exist');
+
+      if (primaryEmail !== loginHint) {
+        const searchParams = new URLSearchParams({ login_hint: loginHint, one_time_token: token });
+        ctx.redirect(`${experience.routes.switchAccount}?${searchParams.toString()}`);
+        return;
+      }
+    }
+
+    return next();
+  };
+}

--- a/packages/core/src/tenants/Tenant.ts
+++ b/packages/core/src/tenants/Tenant.ts
@@ -32,6 +32,7 @@ import BasicSentinel from '#src/sentinel/basic-sentinel.js';
 
 import { redisCache } from '../caches/index.js';
 import { SubscriptionLibrary } from '../libraries/subscription.js';
+import koaConsentGuard from '../middleware/koa-consent-guard.js';
 
 import Libraries from './Libraries.js';
 import Queries from './Queries.js';
@@ -201,7 +202,10 @@ export default class Tenant implements TenantContext {
       compose([
         koaExperienceSsr(libraries, queries),
         koaSpaSessionGuard(provider, queries),
-        mount(`/${experience.routes.consent}`, koaAutoConsent(provider, queries)),
+        mount(
+          `/${experience.routes.consent}`,
+          compose([koaConsentGuard(provider, queries), koaAutoConsent(provider, queries)])
+        ),
         koaSpaProxy({ mountedApps, queries }),
       ])
     );

--- a/packages/experience/src/App.tsx
+++ b/packages/experience/src/App.tsx
@@ -39,6 +39,7 @@ import SocialLanding from './pages/SocialLanding';
 import SocialLinkAccount from './pages/SocialLinkAccount';
 import SocialSignInWebCallback from './pages/SocialSignInWebCallback';
 import Springboard from './pages/Springboard';
+import SwitchAccount from './pages/SwitchAccount';
 import VerificationCode from './pages/VerificationCode';
 import { UserMfaFlow } from './types';
 import { handleSearchParametersData } from './utils/search-parameters';
@@ -65,7 +66,10 @@ const App = () => {
                   <Route path="direct/:method/:target?" element={<DirectSignIn />} />
                   <Route element={<AppLayout />}>
                     {isDevFeaturesEnabled && (
-                      <Route path="one-time-token/:token" element={<OneTimeToken />} />
+                      <>
+                        <Route path="one-time-token" element={<OneTimeToken />} />
+                        <Route path={experience.routes.switchAccount} element={<SwitchAccount />} />
+                      </>
                     )}
                     <Route
                       path="unknown-session"

--- a/packages/experience/src/pages/OneTimeToken/index.tsx
+++ b/packages/experience/src/pages/OneTimeToken/index.tsx
@@ -1,12 +1,13 @@
 import {
   AgreeToTermsPolicy,
+  ExtraParamsKey,
   InteractionEvent,
   SignInIdentifier,
   type RequestErrorBody,
 } from '@logto/schemas';
 import { condString } from '@silverhand/essentials';
 import { useCallback, useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 
 import {
   identifyAndSubmitInteraction,
@@ -17,15 +18,13 @@ import LoadingLayer from '@/components/LoadingLayer';
 import useApi from '@/hooks/use-api';
 import useErrorHandler from '@/hooks/use-error-handler';
 import useGlobalRedirectTo from '@/hooks/use-global-redirect-to';
-import useLoginHint from '@/hooks/use-login-hint';
 import useSubmitInteractionErrorHandler from '@/hooks/use-submit-interaction-error-handler';
 import useTerms from '@/hooks/use-terms';
 
 import ErrorPage from '../ErrorPage';
 
 const OneTimeToken = () => {
-  const { token } = useParams();
-  const email = useLoginHint();
+  const [params] = useSearchParams();
   const [oneTimeTokenError, setOneTimeTokenError] = useState<RequestErrorBody | boolean>();
 
   const asyncIdentifyUserAndSubmit = useApi(identifyAndSubmitInteraction);
@@ -90,6 +89,8 @@ const OneTimeToken = () => {
 
   useEffect(() => {
     (async () => {
+      const token = params.get(ExtraParamsKey.OneTimeToken);
+      const email = params.get(ExtraParamsKey.LoginHint);
       if (!token || !email) {
         setOneTimeTokenError(true);
         return;
@@ -125,8 +126,7 @@ const OneTimeToken = () => {
     })();
   }, [
     agreeToTermsPolicy,
-    email,
-    token,
+    params,
     asyncRegisterWithOneTimeToken,
     handleError,
     termsValidation,

--- a/packages/experience/src/pages/Register/index.tsx
+++ b/packages/experience/src/pages/Register/index.tsx
@@ -1,7 +1,7 @@
-import { AgreeToTermsPolicy, SignInMode } from '@logto/schemas';
+import { AgreeToTermsPolicy, ExtraParamsKey, SignInMode } from '@logto/schemas';
 import { useCallback, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Navigate, useNavigate } from 'react-router-dom';
+import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 
 import LandingPageLayout from '@/Layout/LandingPageLayout';
 import SingleSignOnFormModeContextProvider from '@/Providers/SingleSignOnFormModeContextProvider';
@@ -26,6 +26,7 @@ const RegisterFooter = () => {
     useSieMethods();
   const { termsValidation, agreeToTermsPolicy } = useTerms();
   const navigate = useNavigate();
+  const [params] = useSearchParams();
 
   const { showSingleSignOnForm } = useContext(SingleSignOnFormModeContext);
 
@@ -40,6 +41,12 @@ const RegisterFooter = () => {
 
     navigate('/single-sign-on/email');
   }, [agreeToTermsPolicy, navigate, termsValidation]);
+
+  if (params.get(ExtraParamsKey.OneTimeToken)) {
+    return (
+      <Navigate replace to={{ pathname: '/one-time-token', search: `?${params.toString()}` }} />
+    );
+  }
 
   /* Hide footers when showing Single Sign On form */
   if (showSingleSignOnForm) {

--- a/packages/experience/src/pages/SignIn/index.tsx
+++ b/packages/experience/src/pages/SignIn/index.tsx
@@ -1,7 +1,7 @@
-import { AgreeToTermsPolicy, SignInMode } from '@logto/schemas';
+import { AgreeToTermsPolicy, ExtraParamsKey, SignInMode } from '@logto/schemas';
 import { useCallback, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Navigate, useNavigate } from 'react-router-dom';
+import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 
 import LandingPageLayout from '@/Layout/LandingPageLayout';
 import SingleSignOnFormModeContextProvider from '@/Providers/SingleSignOnFormModeContextProvider';
@@ -24,6 +24,7 @@ const SignInFooters = () => {
   const { t } = useTranslation();
   const { termsValidation, agreeToTermsPolicy } = useTerms();
   const navigate = useNavigate();
+  const [params] = useSearchParams();
 
   const { signInMethods, signUpMethods, socialConnectors, signInMode, singleSignOnEnabled } =
     useSieMethods();
@@ -94,6 +95,7 @@ const SignInFooters = () => {
 const SignIn = () => {
   const { signInMethods, socialConnectors, signInMode } = useSieMethods();
   const { agreeToTermsPolicy } = useTerms();
+  const [params] = useSearchParams();
 
   if (!signInMode) {
     return <ErrorPage />;
@@ -101,6 +103,12 @@ const SignIn = () => {
 
   if (signInMode === SignInMode.Register) {
     return <Navigate to="/register" />;
+  }
+
+  if (params.get(ExtraParamsKey.OneTimeToken)) {
+    return (
+      <Navigate replace to={{ pathname: '/one-time-token', search: `?${params.toString()}` }} />
+    );
   }
 
   return (

--- a/packages/experience/src/pages/SwitchAccount/index.module.scss
+++ b/packages/experience/src/pages/SwitchAccount/index.module.scss
@@ -9,11 +9,13 @@
 .title {
   margin-top: _.unit(8);
   font: var(--font-label-2);
+  align-self: flex-start;
 }
 
 .message {
   margin-top: _.unit(6);
   font: var(--font-body-2);
+  align-self: flex-start;
 }
 
 .logo {
@@ -36,14 +38,12 @@
 
 :global(body.mobile) {
   .title {
-    @include _.title;
     margin-bottom: _.unit(4);
   }
 }
 
 :global(body.desktop) {
   .title {
-    @include _.title-desktop;
     margin-bottom: _.unit(2);
   }
 }

--- a/packages/experience/src/utils/search-parameters.ts
+++ b/packages/experience/src/utils/search-parameters.ts
@@ -13,12 +13,6 @@ export const searchKeys = Object.freeze({
   appId: 'app_id',
 } satisfies Record<SearchKeysCamelCase, string>);
 
-/**
- * The one-time token used as verification method.
- * Example usage: Magic link
- */
-export const oneTimeTokenSearchKey = 'one_time_token';
-
 export const handleSearchParametersData = () => {
   const { search } = window.location;
 
@@ -41,13 +35,6 @@ export const handleSearchParametersData = () => {
   }
 
   const conditionalParamString = condString(parameters.size > 0 && `?${parameters.toString()}`);
-
-  // Check one-time token existence, and redirect to the `/one-time-token` route.
-  const oneTimeToken = parameters.get(oneTimeTokenSearchKey);
-  if (oneTimeToken) {
-    window.history.replaceState({}, '', '/one-time-token/' + oneTimeToken + conditionalParamString);
-    return;
-  }
 
   window.history.replaceState({}, '', window.location.pathname + conditionalParamString);
 };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- Guard one-time token on consent request. This makes sure even if the user has an active session, when they use magic sign-in link, the token is still checked before auto-consent.
- Change the client side navigation mechanism when `one_time_token` param is presented in the URL. The logic is now handled separately in both `/sign-in` and `/register` routes.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local dev test

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
