### PR TITLE
refactor(core): should return token object upon successful verification in experience api

### DIFF
--- a/packages/core/src/routes/experience/classes/verifications/one-time-token-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/one-time-token-verification.ts
@@ -83,8 +83,13 @@ export class OneTimeTokenVerification
    * Verifies if the one-time token matches the record in database with the provided email.
    */
   async verify(token: string) {
-    await this.libraries.oneTimeTokens.verifyOneTimeToken(token, this.identifier.value);
+    const oneTimeToken = await this.libraries.oneTimeTokens.verifyOneTimeToken(
+      token,
+      this.identifier.value
+    );
     this.verified = true;
+
+    return oneTimeToken;
   }
 
   async identifyUser(): Promise<User> {

--- a/packages/core/src/routes/experience/verification-routes/one-time-token.ts
+++ b/packages/core/src/routes/experience/verification-routes/one-time-token.ts
@@ -1,4 +1,5 @@
 import {
+  OneTimeTokens,
   oneTimeTokenVerificationVerifyPayloadGuard,
   SentinelActivityAction,
   VerificationType,
@@ -27,6 +28,7 @@ export default function oneTimeTokenVerificationRoutes<
       body: oneTimeTokenVerificationVerifyPayloadGuard,
       response: z.object({
         verificationId: z.string(),
+        token: OneTimeTokens.guard,
       }),
       status: [200, 400, 404],
     }),
@@ -48,7 +50,7 @@ export default function oneTimeTokenVerificationRoutes<
 
       ctx.experienceInteraction.setVerificationRecord(oneTimeTokenVerificationRecord);
 
-      await withSentinel(
+      const tokenRecord = await withSentinel(
         {
           sentinel,
           action: SentinelActivityAction.OneTimeToken,
@@ -65,6 +67,7 @@ export default function oneTimeTokenVerificationRoutes<
 
       ctx.body = {
         verificationId: oneTimeTokenVerificationRecord.id,
+        token: tokenRecord,
       };
 
       return next();


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Should return the one-time token object in response data, upon successful token verification. This behavior should be consistent between Experience API and Management API.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
local dev testing

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
