### PR TITLE
fix(toolkit): language tag check should be case insensitive

### DIFF
--- a/.changeset/tame-snails-fold.md
+++ b/.changeset/tame-snails-fold.md
@@ -1,0 +1,10 @@
+---
+"@logto/language-kit": patch
+"@logto/translate": patch
+---
+
+utility method `isLanguageTag` should be case insensitive.
+
+The language tags should be case insensitive. In `phrases` and `phrases-experience` packages, the language tags are all in lowercase. However, in the language kit, the language tags are in mixed cases, such as `pt-BR` and `zh-CN`.
+
+Therefore, some of the i18n phrases were not translated by the translate CLI tool. The fix is to update the language kit to ignore cases in `isLanguageTag` function, so that the previously mismatched language tags can be detected and translated.

--- a/.changeset/tame-snails-fold.md
+++ b/.changeset/tame-snails-fold.md
@@ -3,7 +3,7 @@
 "@logto/translate": patch
 ---
 
-utility method `isLanguageTag` should be case insensitive.
+make method `isLanguageTag` case-insensitive
 
 The language tags should be case insensitive. In `phrases` and `phrases-experience` packages, the language tags are all in lowercase. However, in the language kit, the language tags are in mixed cases, such as `pt-BR` and `zh-CN`.
 

--- a/packages/toolkit/language-kit/src/utility.ts
+++ b/packages/toolkit/language-kit/src/utility.ts
@@ -4,7 +4,10 @@ import { languages } from './const.js';
 import type { LanguageTag } from './type.js';
 
 export const isLanguageTag = (value: unknown): value is LanguageTag =>
-  typeof value === 'string' && value in languages;
+  typeof value === 'string' &&
+  Object.keys(languages)
+    .map((key) => key.toLowerCase())
+    .includes(value.toLowerCase());
 
 export const languageTagGuard: z.ZodType<LanguageTag> = z
   .any()

--- a/packages/translate/src/prompts.ts
+++ b/packages/translate/src/prompts.ts
@@ -1,4 +1,4 @@
-import { languages, type LanguageTag } from '@logto/language-kit';
+import { type LanguageTag } from '@logto/language-kit';
 import { conditionalString } from '@silverhand/essentials';
 
 type GetTranslationPromptProperties = {
@@ -22,9 +22,7 @@ export const getTranslationPromptMessages = ({
 }: GetTranslationPromptProperties) => [
   {
     role: 'assistant',
-    content: `You are a assistant translator and will receive a TypeScript object. Traverse and find object values with "${untranslatedMark}" annotation on the top, then translate these values to target locale "${
-      languages[targetLanguage]
-    }". Remove the "${untranslatedMark}" annotations from output. Escape the single quotes (if any) in translated results by prepending a backslash. Keep the interpolation double curly brackets and their inner values intact. Make sure there is a space between the CJK and non-CJK characters. Prefer using "你" instead of "您" in Chinese. Do not include sample code snippet below in the final output. ${conditionalString(
+    content: `You are a assistant translator and will receive a TypeScript object. Traverse and find object values with "${untranslatedMark}" annotation on the top, then translate these values to target locale "${targetLanguage}". Remove the "${untranslatedMark}" annotations from output. Escape the single quotes (if any) in translated results by prepending a backslash. Keep the interpolation double curly brackets and their inner values intact. Make sure there is a space between the CJK and non-CJK characters. Prefer using "你" instead of "您" in Chinese. Do not include sample code snippet below in the final output. ${conditionalString(
       extraPrompt
     )}
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Language tag check should be case insensitive. Our language tags in `phrases` and `phrases-experience` are in lowercase, such as `pt-br` and `zh-cn`. However, the language tag is case sensitive in toolkit, e.g., `pt-BR` and `zh-CN`.

This causes a bug that some language tags that contain regional variation suffixes will not be picked up by the translate CLI, and thus lots of phrases end up untranslated.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
