### PR TITLE
refactor(translate): improve prompts to better support i18n suffixes

### DIFF
--- a/.changeset/hungry-terms-smash.md
+++ b/.changeset/hungry-terms-smash.md
@@ -1,0 +1,5 @@
+---
+"@logto/translate": patch
+---
+
+improve openai prompt to better support i18n plural form suffixes

--- a/packages/translate/src/prompts.ts
+++ b/packages/translate/src/prompts.ts
@@ -22,9 +22,41 @@ export const getTranslationPromptMessages = ({
 }: GetTranslationPromptProperties) => [
   {
     role: 'assistant',
-    content: `You are a assistant translator and will receive a TypeScript object. Traverse and find object values with "${untranslatedMark}" annotation on the top, then translate these values to target locale "${targetLanguage}". Remove the "${untranslatedMark}" annotations from output. Escape the single quotes (if any) in translated results by prepending a backslash. Keep the interpolation double curly brackets and their inner values intact. Make sure there is a space between the CJK and non-CJK characters. Prefer using "你" instead of "您" in Chinese. Do not include sample code snippet below in the final output. ${conditionalString(
-      extraPrompt
-    )}
+    content: `
+You are a assistant translator and will receive a TypeScript object.
+Traverse and find object values with "${untranslatedMark}" annotation on the top,
+then translate these values to target locale "${targetLanguage}".
+Remove the "${untranslatedMark}" annotations from output.
+Escape the single quotes (if any) in translated results by prepending a backslash.
+Keep the interpolation double curly brackets and their inner values intact.
+Make sure there is a space between the CJK and non-CJK characters.
+Prefer using "你" instead of "您" in Chinese.
+Do not include sample code snippet below in the final output.
+When translating phrases whose keys have plural suffixes, pay attention to the plural rules of the target language.
+For example, the plural suffixes in English are "_one" and "_other". But other languages may have additional suffixes like "_two", "_few" and "_many".
+These suffixed phrases always have a "{{count}}" variable. When translating these phrases, you need to imagine the variable is replaced with the number indicated by the suffix, and use proper plural forms in the final translation.
+For example, you may meet these phrases in English:
+\`\`\`ts
+const password_requirement = {
+  length_one: 'requires a minimum of {{count}} character',
+  length_two: 'requires a minimum of {{count}} characters',
+  length_few: 'requires a minimum of {{count}} characters',
+  length_many: 'requires a minimum of {{count}} characters',
+  length_other: 'requires a minimum of {{count}} characters',
+};
+\`\`\`
+And the proper translation in Russian would be:
+\`\`\`ts
+const password_requirement = {
+  length_one: 'Требуется минимум {{count}} символ',
+  length_two: 'Требуется минимум {{count}} символа',
+  length_few: 'Требуется минимум {{count}} символа',
+  length_many: 'Требуется минимум {{count}} символов',
+  length_other: 'Требуется минимум {{count}} символов',
+};
+\`\`\`
+
+${conditionalString(extraPrompt)}
 
 Take translating to zh-CN as an example, if the input is:
 \`\`\`ts


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Improve AI prompt in the translate CLI tool, in order to better support i18n plural form suffixes.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Used in #7166. See differences in Arabic and Russian translations in `phrases-experience` package.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
