### PR TITLE
fix(phrases): improve wording of "existing account?" question

### DIFF
--- a/packages/phrases-experience/src/locales/en/description.ts
+++ b/packages/phrases-experience/src/locales/en/description.ts
@@ -42,7 +42,7 @@ const description = {
   set_password: 'Set password',
   password_changed: 'Password changed',
   no_account: 'No account yet? ',
-  have_account: 'Already had an account?',
+  have_account: 'Already have an account?',
   enter_password: 'Enter password',
   enter_password_for: 'Sign in with the password to {{method}} {{value}}',
   enter_username: 'Set username',

--- a/packages/phrases-experience/src/locales/en/secondary.ts
+++ b/packages/phrases-experience/src/locales/en/secondary.ts
@@ -1,6 +1,6 @@
 const secondary = {
   social_bind_with:
-    'Already had an account? Sign in to link {{methods, list(type: disjunction;)}} with your social identity.',
+    'Already have an account? Sign in to link {{methods, list(type: disjunction;)}} with your social identity.',
 };
 
 export default Object.freeze(secondary);


### PR DESCRIPTION
## Summary

A small improvement to the wording of the "existing account" question on login prompts. Changes "Already had an account?" to "Already have an account?".

This is my first contribution to Logto so let me know if I did anything wrong!

## Testing

Text-only change so didn't set up a local env

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
