### PR TITLE
fix(console): fix sign-in method can not removed bug

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/SignUpForm.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/SignUpForm.tsx
@@ -22,15 +22,8 @@ function SignUpForm() {
     setValue,
     getValues,
     trigger,
-    formState: { submitCount, dirtyFields },
+    formState: { submitCount },
   } = useFormContext<SignInExperienceForm>();
-
-  // Note: `useWatch` is a hook that returns the updated value on every render.
-  // Unlike `watch`, it doesn't require a re-render to get the updated value (alway return the current ref).
-  const signUp = useWatch({
-    control,
-    name: 'signUp',
-  });
 
   const signUpIdentifiers = useWatch({
     control,

--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/SignUpForm.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/SignUpForm.tsx
@@ -1,5 +1,5 @@
 import { AlternativeSignUpIdentifier, SignInIdentifier } from '@logto/schemas';
-import { useEffect, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -44,40 +44,11 @@ function SignUpForm() {
     };
   }, [signUpIdentifiers]);
 
-  // Should sync the sign-up identifier auth settings when the sign-up identifiers changed
-  // TODO: need to check with designer
-  useEffect(() => {
-    // Only trigger the effect when the identifiers field is dirty
-    const isIdentifiersDirty = dirtyFields.signUp?.identifiers;
-    if (!isIdentifiersDirty) {
-      return;
-    }
-
-    const identifiers = signUpIdentifiers.map(({ identifier }) => identifier);
-    if (identifiers.length === 0) {
-      setValue('signUp.password', false);
-      setValue('signUp.verify', false);
-      return;
-    }
-
-    if (identifiers.includes(SignInIdentifier.Username)) {
-      setValue('signUp.password', true);
-    }
-
-    // Disable verification when the primary identifier is username,
-    // otherwise enable it for the rest of the identifiers (email, phone, emailOrPhone)
-    setValue('signUp.verify', identifiers[0] !== SignInIdentifier.Username);
-  }, [dirtyFields.signUp?.identifiers, setValue, signUpIdentifiers]);
-
   // Sync sign-in methods when sign-up methods change
-  useEffect(() => {
-    // Only trigger the effect when the sign-up field is dirty
-    const isIdentifiersDirty = dirtyFields.signUp;
-    if (!isIdentifiersDirty) {
-      return;
-    }
-
+  const syncSignInMethods = useCallback(() => {
     const signInMethods = getValues('signIn.methods');
+    const signUp = getValues('signUp');
+
     const { password, identifiers } = signUp;
 
     const enabledSignUpIdentifiers = identifiers.reduce<SignInIdentifier[]>(
@@ -129,7 +100,7 @@ function SignUpForm() {
         void trigger('signIn.methods');
       }, 0);
     }
-  }, [dirtyFields.signUp, getValues, setValue, signUp, submitCount, trigger]);
+  }, [getValues, setValue, submitCount, trigger]);
 
   return (
     <Card>
@@ -138,7 +109,7 @@ function SignUpForm() {
         <FormFieldDescription>
           {t('sign_in_exp.sign_up_and_sign_in.sign_up.identifier_description')}
         </FormFieldDescription>
-        <SignUpIdentifiersEditBox />
+        <SignUpIdentifiersEditBox syncSignInMethods={syncSignInMethods} />
       </FormField>
       {shouldShowAuthenticationFields && (
         <FormField title="sign_in_exp.sign_up_and_sign_in.sign_up.sign_up_authentication">
@@ -153,7 +124,10 @@ function SignUpForm() {
                 <Checkbox
                   label={t('sign_in_exp.sign_up_and_sign_in.sign_up.set_a_password_option')}
                   checked={value}
-                  onChange={onChange}
+                  onChange={(value) => {
+                    onChange(value);
+                    syncSignInMethods();
+                  }}
                 />
               )}
             />


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR fixes two console bug:

1. Sign-in methods cannot be removed if the identifier is enabled as a sign-up identifier.
2. Setting `EmailOrPhon`e as a sign-up identifier incorrectly appends duplicate email and phone sign-in methods.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
New integration test cases added. 

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
