### PR TITLE
feat(core): merge idToken claims with userinfo response

### DIFF
--- a/packages/core/src/sso/OidcConnector/utils.ts
+++ b/packages/core/src/sso/OidcConnector/utils.ts
@@ -163,7 +163,7 @@ export const getIdTokenClaims = async (
       });
     }
 
-    const result = idTokenProfileStandardClaimsGuard.safeParse(payload);
+    const result = idTokenProfileStandardClaimsGuard.catchall(z.unknown()).safeParse(payload);
 
     if (!result.success) {
       throw new SsoConnectorError(SsoConnectorErrorCodes.AuthorizationFailed, {


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Merge `idToken` claims with the `userinfo` response in the Azure OIDC SSO connector, as Entra ID returns different claim sets in each request.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
<img width="628" alt="image" src="https://github.com/user-attachments/assets/74682458-d78c-45d0-8dff-bfbbf8e562de" />

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
