### PR TITLE
refactor(core,experience): adjust missing profiles prompt order

### DIFF
--- a/packages/core/src/routes/experience/classes/libraries/profile-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/profile-validator.ts
@@ -137,21 +137,6 @@ export class ProfileValidator {
   ): Set<MissingProfile> {
     const missingProfile = new Set<MissingProfile>();
 
-    if (mandatoryUserProfile.has(MissingProfile.password)) {
-      const isUserPasswordSet = user
-        ? // Social and enterprise SSO identities can take place the role of password
-          Boolean(user.passwordEncrypted) || Object.keys(user.identities).length > 0
-        : false;
-
-      const isProfilePasswordSet = Boolean(
-        profile.passwordEncrypted ?? profile.socialIdentity ?? profile.enterpriseSsoIdentity
-      );
-
-      if (!isUserPasswordSet && !isProfilePasswordSet) {
-        missingProfile.add(MissingProfile.password);
-      }
-    }
-
     if (mandatoryUserProfile.has(MissingProfile.username) && !user?.username && !profile.username) {
       missingProfile.add(MissingProfile.username);
     }
@@ -180,6 +165,21 @@ export class ProfileValidator {
       !profile.primaryPhone
     ) {
       missingProfile.add(MissingProfile.phone);
+    }
+
+    if (mandatoryUserProfile.has(MissingProfile.password)) {
+      const isUserPasswordSet = user
+        ? // Social and enterprise SSO identities can take place the role of password
+          Boolean(user.passwordEncrypted) || Object.keys(user.identities).length > 0
+        : false;
+
+      const isProfilePasswordSet = Boolean(
+        profile.passwordEncrypted ?? profile.socialIdentity ?? profile.enterpriseSsoIdentity
+      );
+
+      if (!isUserPasswordSet && !isProfilePasswordSet) {
+        missingProfile.add(MissingProfile.password);
+      }
     }
 
     return missingProfile;

--- a/packages/experience/src/components/IdentifierRegisterForm/use-register-with-username.ts
+++ b/packages/experience/src/components/IdentifierRegisterForm/use-register-with-username.ts
@@ -16,7 +16,7 @@ const useRegisterWithUsername = () => {
 
   const [errorMessage, setErrorMessage] = useState<string>();
 
-  const { passwordRequiredForSignUp } = useSieMethods();
+  const { passwordRequiredForSignUp, secondaryIdentifiers } = useSieMethods();
 
   const clearErrorMessage = useCallback(() => {
     setErrorMessage('');
@@ -39,7 +39,6 @@ const useRegisterWithUsername = () => {
   const asyncRegister = useApi(registerWithUsername);
 
   const asyncSubmitInteraction = useApi(identifyAndSubmitInteraction);
-
   const onSubmitInteraction = useCallback(async () => {
     const [error, result] = await asyncSubmitInteraction();
 
@@ -62,18 +61,20 @@ const useRegisterWithUsername = () => {
         return;
       }
 
-      // If password is required for sign up, navigate to the password page
-      if (passwordRequiredForSignUp) {
+      // If password is required and no secondary identifiers are present, (current behavior without multi-sign-up identifiers support)
+      // navigate to password screen directly
+      if (passwordRequiredForSignUp && secondaryIdentifiers.length === 0) {
         navigate('password');
         return;
       }
 
-      // Otherwise, identify and submit interaction
+      // Otherwise, identify and submit interaction let the backend decide the next step
       await onSubmitInteraction();
     },
     [
       asyncRegister,
       passwordRequiredForSignUp,
+      secondaryIdentifiers.length,
       onSubmitInteraction,
       handleError,
       usernameErrorHandlers,

--- a/packages/experience/src/hooks/use-sie.ts
+++ b/packages/experience/src/hooks/use-sie.ts
@@ -3,6 +3,7 @@ import {
   AlternativeSignUpIdentifier,
   SignInIdentifier,
   SignInMode,
+  type SignUpIdentifier,
   type VerificationCodeSignInIdentifier,
 } from '@logto/schemas';
 import { condArray } from '@silverhand/essentials';
@@ -25,6 +26,7 @@ type UseSieMethodsReturnType = {
    * @see {useRequiredProfileErrorHandler} for more information.
    */
   signUpMethods: SignInIdentifier[];
+  secondaryIdentifiers: SignUpIdentifier[];
   passwordRequiredForSignUp: boolean;
   signInMethods: SignInExperienceResponse['signIn']['methods'];
   socialSignInSettings: SignInExperienceResponse['socialSignIn'];
@@ -112,6 +114,7 @@ export const useSieMethods = (): UseSieMethodsReturnType => {
     () => ({
       signUpMethods,
       signInMethods,
+      secondaryIdentifiers,
       socialSignInSettings: experienceSettings?.socialSignIn ?? {},
       socialConnectors: experienceSettings?.socialConnectors ?? [],
       ssoConnectors: experienceSettings?.ssoConnectors ?? [],


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR includes the following updates:
1. Adjust the missing profiles'r prompt order
  - username -> emailOrPhon -> email -> phone -> password
2. Update the experience user registration flow
  - Directly navigate to the new password page only if the password is enabled for sign-up and no additional `secondaryIdentifiers` are required.
  - otherwise let the backend to decide the next step. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
