### PR TITLE
feat(experience): show sign-in modal on register profile fulfillment flow

### DIFF
--- a/packages/experience/src/apis/experience/index.ts
+++ b/packages/experience/src/apis/experience/index.ts
@@ -30,11 +30,33 @@ export * from './mfa';
 export * from './social';
 export * from './one-time-token';
 
+/**
+ * For sign-in flow user identity not found error handling use.
+ *
+ * If the identity is not found, but the verification record is verified,
+ * allow the user registration with the verified identifier.
+ *
+ * Supported verification types:
+ * - email verification code
+ * - phone number verification code
+ * - social sign-in
+ * - SSO sign-in
+ */
 export const registerWithVerifiedIdentifier = async (verificationId: string) => {
   await updateInteractionEvent(InteractionEvent.Register);
   return identifyAndSubmitInteraction({ verificationId });
 };
 
+/**
+ * For sign-up flow user identifier already exists error handling user.
+ *
+ * If the identifier has been registered by an existing user,
+ * allow the user to sign-in with the verified identifier directly.
+ *
+ * Supported verification types:
+ * - email verification code
+ * - phone number verification code
+ */
 export const signInWithVerifiedIdentifier = async (verificationId: string) => {
   await updateInteractionEvent(InteractionEvent.SignIn);
   return identifyAndSubmitInteraction({ verificationId });

--- a/packages/experience/src/containers/VerificationCode/use-continue-flow-code-verification.ts
+++ b/packages/experience/src/containers/VerificationCode/use-continue-flow-code-verification.ts
@@ -6,16 +6,19 @@ import { useLocation, useSearchParams } from 'react-router-dom';
 import UserInteractionContext from '@/Providers/UserInteractionContextProvider/UserInteractionContext';
 import { updateProfileWithVerificationCode } from '@/apis/experience';
 import { getInteractionEventFromState } from '@/apis/utils';
+import { isDevFeaturesEnabled } from '@/constants/env';
 import useApi from '@/hooks/use-api';
 import type { ErrorHandlers } from '@/hooks/use-error-handler';
 import useErrorHandler from '@/hooks/use-error-handler';
 import useGlobalRedirectTo from '@/hooks/use-global-redirect-to';
+import { useSieMethods } from '@/hooks/use-sie';
 import useSubmitInteractionErrorHandler from '@/hooks/use-submit-interaction-error-handler';
 import { SearchParameters } from '@/types';
 
 import useGeneralVerificationCodeErrorHandler from './use-general-verification-code-error-handler';
 import useIdentifierErrorAlert, { IdentifierErrorType } from './use-identifier-error-alert';
 import useLinkSocialConfirmModal from './use-link-social-confirm-modal';
+import useSignInWithExistIdentifierConfirmModal from './use-sign-in-with-exist-identifier-confirm-modal';
 
 const useContinueFlowCodeVerification = (
   identifier: VerificationCodeIdentifier,
@@ -27,9 +30,15 @@ const useContinueFlowCodeVerification = (
 
   const { state } = useLocation();
   const { verificationIdsMap } = useContext(UserInteractionContext);
-  const interactionEvent = getInteractionEventFromState(state) ?? InteractionEvent.SignIn;
+  const { isVerificationCodeEnabledForSignIn } = useSieMethods();
+
+  const interactionEvent = useMemo(
+    () => getInteractionEventFromState(state) ?? InteractionEvent.SignIn,
+    [state]
+  );
 
   const handleError = useErrorHandler();
+
   const verifyVerificationCode = useApi(updateProfileWithVerificationCode);
 
   const { generalVerificationCodeErrorHandlers, errorMessage, clearErrorMessage } =
@@ -41,6 +50,7 @@ const useContinueFlowCodeVerification = (
 
   const showIdentifierErrorAlert = useIdentifierErrorAlert();
   const showLinkSocialConfirmModal = useLinkSocialConfirmModal();
+  const showSignInWithExistIdentifierConfirmModal = useSignInWithExistIdentifierConfirmModal();
 
   const identifierExistsErrorHandler = useCallback(async () => {
     const linkSocial = searchParameters.get(SearchParameters.LinkSocial);
@@ -49,16 +59,35 @@ const useContinueFlowCodeVerification = (
     // Show bind with social confirm modal
     if (linkSocial && socialVerificationId) {
       await showLinkSocialConfirmModal(identifier, verificationId, socialVerificationId);
-
       return;
     }
+
     const { type, value } = identifier;
+
+    // TODO: remove this dev feature check after the feature is fully implemented
+    // This is to ensure a consistent user experience during the registration process.
+    // If email or phone number has been enabled as additional sign-up identifiers,
+    // and user trying to provide an email/phone number that already exists in the system,
+    // prompt the user to sign in with the existing identifier.
+    // @see {user-register-flow-code-verification.ts} for more details.
+    if (
+      isDevFeaturesEnabled &&
+      interactionEvent === InteractionEvent.Register &&
+      isVerificationCodeEnabledForSignIn(type)
+    ) {
+      showSignInWithExistIdentifierConfirmModal({ identifier, verificationId });
+      return;
+    }
+
     await showIdentifierErrorAlert(IdentifierErrorType.IdentifierAlreadyExists, type, value);
   }, [
     identifier,
+    interactionEvent,
+    isVerificationCodeEnabledForSignIn,
     searchParameters,
     showIdentifierErrorAlert,
     showLinkSocialConfirmModal,
+    showSignInWithExistIdentifierConfirmModal,
     verificationId,
     verificationIdsMap,
   ]);

--- a/packages/experience/src/containers/VerificationCode/use-register-flow-code-verification.ts
+++ b/packages/experience/src/containers/VerificationCode/use-register-flow-code-verification.ts
@@ -58,6 +58,7 @@ const useRegisterFlowCodeVerification = (
       return;
     }
 
+    // TODO: replace with use-sign-in-with-exist-identifier-confirm-model.ts
     show({
       confirmText: 'action.sign_in',
       ModalContent: t('description.create_account_id_exists', {

--- a/packages/experience/src/containers/VerificationCode/use-sign-in-with-exist-identifier-confirm-modal.ts
+++ b/packages/experience/src/containers/VerificationCode/use-sign-in-with-exist-identifier-confirm-modal.ts
@@ -1,0 +1,82 @@
+import {
+  InteractionEvent,
+  SignInIdentifier,
+  type VerificationCodeIdentifier,
+} from '@logto/schemas';
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { signInWithVerifiedIdentifier } from '@/apis/experience';
+import useApi from '@/hooks/use-api';
+import { useConfirmModal } from '@/hooks/use-confirm-modal';
+import useErrorHandler from '@/hooks/use-error-handler';
+import useGlobalRedirectTo from '@/hooks/use-global-redirect-to';
+import useSubmitInteractionErrorHandler from '@/hooks/use-submit-interaction-error-handler';
+import { formatPhoneNumberWithCountryCallingCode } from '@/utils/country-code';
+
+type CallbackProps = {
+  /**
+   * Email or phone number identifier.
+   * The value will be used to display the detailed identifier info in the confirm modal.
+   **/
+  identifier: VerificationCodeIdentifier;
+  /**
+   * The verification ID for the given identifier.
+   */
+  verificationId: string;
+  onCanceled?: () => void;
+};
+
+/**
+ * For sign-up flow user identifier already exists error handling use.
+ *
+ * Returns a callback function that shows a confirm modal to allow the user to sign-in with the verified identifier directly.
+ */
+const useSignInWithExistIdentifierConfirmModal = () => {
+  const { t } = useTranslation();
+
+  const { show } = useConfirmModal();
+  const handleError = useErrorHandler();
+  const redirectTo = useGlobalRedirectTo();
+
+  const signInWithIdentifierAsync = useApi(signInWithVerifiedIdentifier);
+
+  const submitInteractionErrorHandler = useSubmitInteractionErrorHandler(
+    InteractionEvent.Register,
+    {
+      replace: true,
+    }
+  );
+
+  return useCallback(
+    ({ identifier: { type, value }, verificationId, onCanceled }: CallbackProps) => {
+      show({
+        confirmText: 'action.sign_in',
+        ModalContent: t('description.create_account_id_exists', {
+          type: t(`description.${type === SignInIdentifier.Email ? 'email' : 'phone_number'}`),
+          value:
+            type === SignInIdentifier.Phone
+              ? formatPhoneNumberWithCountryCallingCode(value)
+              : value,
+        }),
+        onConfirm: async () => {
+          const [error, result] = await signInWithIdentifierAsync(verificationId);
+
+          if (error) {
+            await handleError(error, submitInteractionErrorHandler);
+
+            return;
+          }
+
+          if (result?.redirectTo) {
+            await redirectTo(result.redirectTo);
+          }
+        },
+        onCancel: onCanceled,
+      });
+    },
+    [handleError, redirectTo, show, signInWithIdentifierAsync, submitInteractionErrorHandler, t]
+  );
+};
+
+export default useSignInWithExistIdentifierConfirmModal;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR updates the continue (profile fulfillment) flow in user registration. 

To ensure a consistent user experience during the registration process.
If the given email or phone number has been enabled as additional sign-up identifiers, and user trying to provide an email/phone number that already exists in the system, should prompt the user to sign-in directly using the existing verified email/phone. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
