### PR TITLE
fix(console): fix disable sign-in password settings bug

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/use-sign-up-password-listeners.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/use-sign-up-password-listeners.ts
@@ -24,6 +24,15 @@ const useSignUpPasswordListeners = () => {
 
   const signUpPassword = useWatch({ control, name: 'signUp.password' });
 
+  // We create a ref to store the submit count
+  // to avoid the password update effect to be triggered by the submit count change.
+  const submitCountRef = useRef(submitCount);
+
+  useEffect(() => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    submitCountRef.current = submitCount;
+  }, [submitCount]);
+
   useEffect(() => {
     // Only sync the password settings on updates (skip the first mount)
     if (isFirstMount.current) {
@@ -31,7 +40,6 @@ const useSignUpPasswordListeners = () => {
       isFirstMount.current = false;
       return;
     }
-
     const signInMethods = getValues('signIn.methods');
 
     setValue(
@@ -57,13 +65,16 @@ const useSignUpPasswordListeners = () => {
       }
     );
 
-    if (submitCount) {
+    if (submitCountRef.current > 0) {
       // Wait for the form re-render before validating the new data.
       setTimeout(() => {
         void trigger('signIn.methods');
       }, 0);
     }
-  }, [getValues, setValue, signUpPassword, submitCount, trigger]);
+  }, [getValues, setValue, signUpPassword, trigger]);
 };
 
 export default useSignUpPasswordListeners;
+function trigger(arg0: string) {
+  throw new Error('Function not implemented.');
+}

--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/use-sign-up-password-listeners.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/use-sign-up-password-listeners.ts
@@ -75,6 +75,3 @@ const useSignUpPasswordListeners = () => {
 };
 
 export default useSignUpPasswordListeners;
-function trigger(arg0: string) {
-  throw new Error('Function not implemented.');
-}

--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/use-sign-up-password-listeners.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/use-sign-up-password-listeners.ts
@@ -65,6 +65,9 @@ const useSignUpPasswordListeners = () => {
       }
     );
 
+    // By default, the react-hook-form triggers validation only after the first submit.
+    // To keep the form validation behavior consistent, we trigger the validation manually
+    // if the form has been submitted at least once.
     if (submitCountRef.current > 0) {
       // Wait for the form re-render before validating the new data.
       setTimeout(() => {


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix disabled sign-in password settings that can not be saved bug.

Using a `useRef` to store the current `submitCount` form state. This will prevent the `submitCount` change triggers the sign-up and sign-in password syncing effect.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
