### PR TITLE
refactor(core): skip sign-in mode check for one-time token verification

### DIFF
--- a/packages/core/src/routes/experience/classes/helpers.ts
+++ b/packages/core/src/routes/experience/classes/helpers.ts
@@ -70,7 +70,12 @@ export const identifyUserByVerificationRecord = async (
    */
   syncedProfile?: Pick<
     InteractionProfile,
-    'enterpriseSsoIdentity' | 'syncedEnterpriseSsoIdentity' | 'socialIdentity' | 'avatar' | 'name'
+    | 'enterpriseSsoIdentity'
+    | 'syncedEnterpriseSsoIdentity'
+    | 'jitOrganizationIds'
+    | 'socialIdentity'
+    | 'avatar'
+    | 'name'
   >;
 }> => {
   // Check verification record can be used to identify a user using the `identifyUser` method.
@@ -83,9 +88,18 @@ export const identifyUserByVerificationRecord = async (
   switch (verificationRecord.type) {
     case VerificationType.Password:
     case VerificationType.EmailVerificationCode:
-    case VerificationType.PhoneVerificationCode:
+    case VerificationType.PhoneVerificationCode: {
+      return {
+        user: await verificationRecord.identifyUser(),
+      };
+    }
     case VerificationType.OneTimeToken: {
-      return { user: await verificationRecord.identifyUser() };
+      return {
+        user: await verificationRecord.identifyUser(),
+        syncedProfile: {
+          jitOrganizationIds: verificationRecord.oneTimeTokenContext?.jitOrganizationIds,
+        },
+      };
     }
     case VerificationType.Social: {
       const user = linkSocialIdentity

--- a/packages/core/src/routes/experience/classes/verifications/one-time-token-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/one-time-token-verification.ts
@@ -18,7 +18,6 @@ import assertThat from '#src/utils/assert-that.js';
 import { type InteractionProfile } from '../../types.js';
 import { findUserByIdentifier } from '../utils.js';
 
-import { type VerificationRecordData } from './index.js';
 import { type IdentifierVerificationRecord } from './verification-record.js';
 
 export type OneTimeTokenVerificationRecordData = {
@@ -131,8 +130,9 @@ export class OneTimeTokenVerification
     );
 
     const { value } = this.identifier;
+    const { jitOrganizationIds } = this.context ?? {};
 
-    return { primaryEmail: value };
+    return { primaryEmail: value, jitOrganizationIds };
   }
 
   toJson(): OneTimeTokenVerificationRecordData {
@@ -141,9 +141,3 @@ export class OneTimeTokenVerification
     return { id, type, identifier, verified, oneTimeTokenContext: context };
   }
 }
-
-export const isOneTimeTokenVerificationRecordData = (
-  data?: VerificationRecordData
-): data is OneTimeTokenVerificationRecordData => {
-  return oneTimeTokenVerificationRecordDataGuard.safeParse(data).success;
-};

--- a/packages/core/src/routes/experience/types.ts
+++ b/packages/core/src/routes/experience/types.ts
@@ -33,6 +33,10 @@ export type InteractionProfile = {
     UserSsoIdentity,
     'identityId' | 'ssoConnectorId' | 'issuer' | 'detail'
   >;
+  /**
+   * This is from one-time token verification. User will be automatically added to the specified organizations.
+   */
+  jitOrganizationIds?: string[];
   // Syncing the existing enterprise SSO identity detail
   syncedEnterpriseSsoIdentity?: Pick<UserSsoIdentity, 'identityId' | 'issuer' | 'detail'>;
 } & Pick<
@@ -78,6 +82,7 @@ export const interactionProfileGuard = Users.createGuard
         detail: true,
       })
       .optional(),
+    jitOrganizationIds: z.array(z.string()).optional(),
   }) satisfies ToZodObject<InteractionProfile>;
 
 /**


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR skips sign-in mode check for verified one-time token verifications. So that adding users via the one-time token always work even if the registration is turned off.

It also includes code refactoring that provision user organizations on submitting interaction. This makes sure the user will always be provisioned to the organizations that linked with the one-time token, on both new registration and upcoming sign-in actions.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally. Will add test case later.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
