### PR TITLE
feat(core): add recatpcha enterprise verification

### DIFF
--- a/packages/core/src/routes/experience/classes/libraries/captcha-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/captcha-validator.ts
@@ -1,34 +1,48 @@
-import { CaptchaType, type CaptchaProvider } from '@logto/schemas';
+import {
+  CaptchaType,
+  type CaptchaProvider,
+  type RecaptchaEnterpriseConfig,
+  type TurnstileConfig,
+} from '@logto/schemas';
 import ky from 'ky';
 import { z } from 'zod';
 
-import RequestError from '#src/errors/RequestError/index.js';
+function isRecaptchaEnterprise(
+  config: CaptchaProvider['config']
+): config is RecaptchaEnterpriseConfig {
+  return config.type === CaptchaType.RecaptchaEnterprise;
+}
+
+function isTurnstile(config: CaptchaProvider['config']): config is TurnstileConfig {
+  return config.type === CaptchaType.Turnstile;
+}
 
 export class CaptchaValidator {
   constructor(private readonly captchaProvider: CaptchaProvider) {}
 
   public async verifyCaptcha(captchaToken: string): Promise<boolean> {
-    const {
-      config: { type, secretKey },
-    } = this.captchaProvider;
+    const { config } = this.captchaProvider;
 
-    switch (type) {
-      case CaptchaType.Turnstile: {
-        return this.verifyTurnstile(secretKey, captchaToken);
-      }
-
-      default: {
-        throw new RequestError({ code: 'session.captcha_failed', status: 422 });
-      }
+    if (isRecaptchaEnterprise(config)) {
+      return this.verifyRecaptchaEnterprise(config, captchaToken);
     }
+
+    if (isTurnstile(config)) {
+      return this.verifyTurnstile(config, captchaToken);
+    }
+
+    throw new Error('Invalid captcha provider');
   }
 
-  private async verifyTurnstile(secretKey: string, captchaToken: string) {
+  private async verifyTurnstile(config: TurnstileConfig, captchaToken: string) {
     try {
       const result = await ky
         .post('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body: new URLSearchParams({ secret: secretKey, response: captchaToken }),
+          body: new URLSearchParams({
+            secret: config.secretKey,
+            response: captchaToken,
+          }),
         })
         .json();
 
@@ -40,6 +54,42 @@ export class CaptchaValidator {
       const response = responseGuard.parse(result);
 
       return response.success;
+    } catch {
+      return false;
+    }
+  }
+
+  private async verifyRecaptchaEnterprise(config: RecaptchaEnterpriseConfig, captchaToken: string) {
+    try {
+      const result = await ky.post(
+        `https://recaptchaenterprise.googleapis.com/v1/projects/${config.projectId}/assessments?key=${config.secretKey}`,
+        {
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            token: captchaToken,
+            siteKey: config.siteKey,
+            // We can't decide the action here, because the interaction event may change after the user interaction.
+            // So we use a fixed action here.
+            expectedAction: 'interaction',
+          }),
+        }
+      );
+
+      const responseGuard = z.object({
+        tokenProperties: z.object({
+          valid: z.boolean(),
+        }),
+        riskAnalysis: z.object({
+          score: z.number(),
+        }),
+      });
+
+      const {
+        tokenProperties: { valid },
+        riskAnalysis: { score },
+      } = responseGuard.parse(result);
+
+      return valid && score >= 0.5;
     } catch {
       return false;
     }

--- a/packages/schemas/src/foundations/jsonb-types/captcha.ts
+++ b/packages/schemas/src/foundations/jsonb-types/captcha.ts
@@ -11,12 +11,16 @@ export const turnstileConfigGuard = z.object({
   secretKey: z.string(),
 });
 
+export type TurnstileConfig = z.infer<typeof turnstileConfigGuard>;
+
 export const recaptchaEnterpriseConfigGuard = z.object({
   type: z.literal(CaptchaType.RecaptchaEnterprise),
   siteKey: z.string(),
   secretKey: z.string(),
   projectId: z.string(),
 });
+
+export type RecaptchaEnterpriseConfig = z.infer<typeof recaptchaEnterpriseConfigGuard>;
 
 export const captchaConfigGuard = z.discriminatedUnion('type', [
   turnstileConfigGuard,


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Add support for reCaptcha enterprise verification.

We may refactor the verification code to config based in the future.

Note: unlike Turnstile, reCaptcha enterprise does not provide test API keys with predicable results, so we don't do integration tests for it.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Tested locally with temp front-end.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
