### PR TITLE
feat(demo-app,core): support one-time token in demo-app

### DIFF
--- a/packages/core/src/middleware/koa-auto-consent.ts
+++ b/packages/core/src/middleware/koa-auto-consent.ts
@@ -1,4 +1,4 @@
-import { demoAppApplicationId } from '@logto/schemas';
+import { buildDemoAppDataForTenant, demoAppApplicationId } from '@logto/schemas';
 import { type MiddlewareType } from 'koa';
 import { type IRouterParamContext } from 'koa-router';
 import type { Provider } from 'oidc-provider';
@@ -32,11 +32,12 @@ export default function koaAutoConsent<StateT, ContextT extends IRouterParamCont
       new errors.InvalidClient('client must be available')
     );
 
-    // Demo app not in the database
     const application =
-      clientId === demoAppApplicationId ? undefined : await findApplicationById(clientId);
+      clientId === demoAppApplicationId
+        ? buildDemoAppDataForTenant('')
+        : await findApplicationById(clientId);
 
-    const shouldAutoConsent = !application?.isThirdParty;
+    const shouldAutoConsent = !application.isThirdParty;
 
     if (shouldAutoConsent) {
       const { missingOIDCScope: missingOIDCScopes, missingResourceScopes: resourceScopesToGrant } =

--- a/packages/core/src/routes/interaction/consent/index.ts
+++ b/packages/core/src/routes/interaction/consent/index.ts
@@ -1,8 +1,10 @@
 import { UserScope } from '@logto/core-kit';
 import {
   applicationSignInExperienceGuard,
+  buildDemoAppDataForTenant,
   type ConsentInfoResponse,
   consentInfoResponseGuard,
+  demoAppApplicationId,
   Organizations,
   publicApplicationGuard,
   publicUserInfoGuard,
@@ -222,7 +224,10 @@ export default function consentRoutes<T extends IRouterParamContext>(
 
       const { accountId } = session;
 
-      const application = await queries.applications.findApplicationById(clientId);
+      const application =
+        clientId === demoAppApplicationId
+          ? buildDemoAppDataForTenant('')
+          : await queries.applications.findApplicationById(clientId);
 
       const applicationSignInExperience =
         await queries.applicationSignInExperiences.safeFindSignInExperienceByApplicationId(

--- a/packages/demo-app/src/App.tsx
+++ b/packages/demo-app/src/App.tsx
@@ -90,6 +90,24 @@ const Main = () => {
     };
   }, []);
 
+  // Handle one-time token authentication
+  useEffect(() => {
+    const oneTimeToken = params.get('one_time_token');
+    const loginHint = params.get('login_hint');
+
+    if (oneTimeToken && loginHint) {
+      void signIn({
+        redirectUri: window.location.origin + window.location.pathname,
+        extraParams: Object.fromEntries(
+          new URLSearchParams([
+            ...new URLSearchParams(config.signInExtraParams).entries(),
+            ...new URLSearchParams(window.location.search).entries(),
+          ]).entries()
+        ),
+      });
+    }
+  }, [config.signInExtraParams, params, signIn]);
+
   if (isInCallback) {
     return <Callback />;
   }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add better support for one-time token authentication in demo-app. So that even when the user is already authenticated in demo-app, the one-time token auth will still be triggered.

The PR also includes core API changes that allow using `/interaction/consent` APIs in demo-app.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local dev testing

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
