### PR TITLE
fix(core): fix provision organization by ids query

### DIFF
--- a/packages/core/src/queries/organization/index.ts
+++ b/packages/core/src/queries/organization/index.ts
@@ -360,17 +360,19 @@ export default class OrganizationQueries extends SchemaQueries<
     if (organizationIds.length === 0) {
       return [];
     }
-    const { table, fields } = convertToIdentifiers(OrganizationJitRoles, true);
+    const organization = convertToIdentifiers(Organizations, true);
+    const organizationJitRoles = convertToIdentifiers(OrganizationJitRoles, true);
     return this.pool.any<JitOrganization>(sql`
       select
-        ${fields.organizationId},
+        ${organization.fields.id} as "organizationId",
         array_remove(
-          array_agg(${fields.organizationRoleId}),
+          array_agg(${organizationJitRoles.fields.organizationRoleId}),
           null
         ) as "organizationRoleIds"
-      from ${table}
-      where ${fields.organizationId} in (${sql.join(organizationIds, sql`, `)})
-      group by ${fields.organizationId}
+      from ${organization.table} left join ${organizationJitRoles.table}
+        on ${organization.fields.id} = ${organizationJitRoles.fields.organizationId}
+      where ${organization.fields.id} in (${sql.join(organizationIds, sql`, `)})
+      group by ${organization.fields.id}
     `);
   }
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the issue that when no default roles are set in organizations, new users cannot be provisioned to these organizations via one-time token, even though the organization IDs are already included in the token context.

This PR resolves the issue by left joining `Organization` table and `OrganizationJitRoles` table in the corresponding DB query.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
