### PR TITLE
fix(core): provision user who has valid sign-in session to organizations when using one-time token

### DIFF
--- a/packages/core/src/libraries/one-time-token.ts
+++ b/packages/core/src/libraries/one-time-token.ts
@@ -14,7 +14,7 @@ export const createOneTimeTokenLibrary = (queries: Queries) => {
     return updateOneTimeTokenStatusQuery(token, status);
   };
 
-  const verifyOneTimeToken = async (token: string, email: string) => {
+  const checkOneTimeToken = async (token: string, email: string) => {
     const oneTimeToken = await getOneTimeTokenByToken(token);
 
     assertThat(
@@ -39,8 +39,14 @@ export const createOneTimeTokenLibrary = (queries: Queries) => {
     );
     assertThat(oneTimeToken.status !== OneTimeTokenStatus.Revoked, 'one_time_token.token_revoked');
 
+    return oneTimeToken;
+  };
+
+  const verifyOneTimeToken = async (token: string, email: string) => {
+    await checkOneTimeToken(token, email);
+
     return updateOneTimeTokenStatus(token, OneTimeTokenStatus.Consumed);
   };
 
-  return { updateOneTimeTokenStatus, verifyOneTimeToken };
+  return { checkOneTimeToken, updateOneTimeTokenStatus, verifyOneTimeToken };
 };

--- a/packages/core/src/middleware/koa-consent-guard.ts
+++ b/packages/core/src/middleware/koa-consent-guard.ts
@@ -1,9 +1,10 @@
-import { experience } from '@logto/schemas';
+import { experience, OneTimeTokenStatus } from '@logto/schemas';
 import { type MiddlewareType } from 'koa';
 import { type IRouterParamContext } from 'koa-router';
 import { type Provider } from 'oidc-provider';
 
 import RequestError from '#src/errors/RequestError/index.js';
+import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
@@ -15,7 +16,11 @@ export default function koaConsentGuard<
   StateT,
   ContextT extends IRouterParamContext,
   ResponseBodyT,
->(provider: Provider, query: Queries): MiddlewareType<StateT, ContextT, ResponseBodyT> {
+>(
+  provider: Provider,
+  libraries: Libraries,
+  queries: Queries
+): MiddlewareType<StateT, ContextT, ResponseBodyT> {
   return async (ctx, next) => {
     const interactionDetails = await provider.interactionDetails(ctx.req, ctx.res);
     const {
@@ -25,8 +30,9 @@ export default function koaConsentGuard<
 
     assertThat(session, new RequestError({ code: 'session.not_found' }));
 
+    // Handle one-time token before auto-consent
     if (token && loginHint && typeof token === 'string' && typeof loginHint === 'string') {
-      const { primaryEmail } = await query.users.findUserById(session.accountId);
+      const { primaryEmail } = await queries.users.findUserById(session.accountId);
 
       assertThat(primaryEmail, 'user.email_not_exist');
 
@@ -34,6 +40,33 @@ export default function koaConsentGuard<
         const searchParams = new URLSearchParams({ login_hint: loginHint, one_time_token: token });
         ctx.redirect(`${experience.routes.switchAccount}?${searchParams.toString()}`);
         return;
+      }
+
+      try {
+        await libraries.oneTimeTokens.checkOneTimeToken(token, loginHint);
+        const {
+          context: { jitOrganizationIds },
+        } = await libraries.oneTimeTokens.updateOneTimeTokenStatus(
+          token,
+          OneTimeTokenStatus.Consumed
+        );
+
+        if (jitOrganizationIds) {
+          await libraries.users.provisionOrganizations({
+            userId: session.accountId,
+            organizationIds: jitOrganizationIds,
+          });
+        }
+      } catch (error: unknown) {
+        if (error instanceof RequestError) {
+          // Green light for token in consumed state
+          if (error.code === 'one_time_token.token_consumed') {
+            return next();
+          }
+          ctx.redirect(`${experience.routes.oneTimeToken}?errorMessage=${error.message}`);
+          return;
+        }
+        throw error;
       }
     }
 

--- a/packages/core/src/tenants/Tenant.ts
+++ b/packages/core/src/tenants/Tenant.ts
@@ -204,7 +204,10 @@ export default class Tenant implements TenantContext {
         koaSpaSessionGuard(provider, queries),
         mount(
           `/${experience.routes.consent}`,
-          compose([koaConsentGuard(provider, queries), koaAutoConsent(provider, queries)])
+          compose([
+            koaConsentGuard(provider, libraries, queries),
+            koaAutoConsent(provider, queries),
+          ])
         ),
         koaSpaProxy({ mountedApps, queries }),
       ])

--- a/packages/experience/src/App.tsx
+++ b/packages/experience/src/App.tsx
@@ -69,7 +69,7 @@ const App = () => {
                     <Route element={<AppLayout />}>
                       {isDevFeaturesEnabled && (
                         <>
-                          <Route path="one-time-token" element={<OneTimeToken />} />
+                          <Route path={experience.routes.oneTimeToken} element={<OneTimeToken />} />
                           <Route
                             path={experience.routes.switchAccount}
                             element={<SwitchAccount />}

--- a/packages/experience/src/pages/OneTimeToken/index.tsx
+++ b/packages/experience/src/pages/OneTimeToken/index.tsx
@@ -25,7 +25,7 @@ import ErrorPage from '../ErrorPage';
 
 const OneTimeToken = () => {
   const [params] = useSearchParams();
-  const [oneTimeTokenError, setOneTimeTokenError] = useState<RequestErrorBody | boolean>();
+  const [oneTimeTokenError, setOneTimeTokenError] = useState<string | boolean>();
 
   const asyncIdentifyUserAndSubmit = useApi(identifyAndSubmitInteraction);
   const asyncSignInWithVerifiedIdentifier = useApi(signInWithVerifiedIdentifier);
@@ -91,6 +91,13 @@ const OneTimeToken = () => {
     (async () => {
       const token = params.get(ExtraParamsKey.OneTimeToken);
       const email = params.get(ExtraParamsKey.LoginHint);
+      const errorMessage = params.get('errorMessage');
+
+      if (errorMessage) {
+        setOneTimeTokenError(errorMessage);
+        return;
+      }
+
       if (!token || !email) {
         setOneTimeTokenError(true);
         return;
@@ -112,7 +119,7 @@ const OneTimeToken = () => {
       if (error) {
         await handleError(error, {
           global: (error: RequestErrorBody) => {
-            setOneTimeTokenError(error);
+            setOneTimeTokenError(error.message);
           },
         });
         return;
@@ -139,7 +146,7 @@ const OneTimeToken = () => {
         isNavbarHidden
         title="error.invalid_link"
         message="error.invalid_link_description"
-        rawMessage={condString(typeof oneTimeTokenError !== 'boolean' && oneTimeTokenError.message)}
+        rawMessage={condString(typeof oneTimeTokenError !== 'boolean' && oneTimeTokenError)}
       />
     );
   }

--- a/packages/experience/src/pages/Register/index.tsx
+++ b/packages/experience/src/pages/Register/index.tsx
@@ -1,4 +1,4 @@
-import { AgreeToTermsPolicy, ExtraParamsKey, SignInMode } from '@logto/schemas';
+import { AgreeToTermsPolicy, experience, ExtraParamsKey, SignInMode } from '@logto/schemas';
 import { useCallback, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
@@ -44,7 +44,10 @@ const RegisterFooter = () => {
 
   if (params.get(ExtraParamsKey.OneTimeToken)) {
     return (
-      <Navigate replace to={{ pathname: '/one-time-token', search: `?${params.toString()}` }} />
+      <Navigate
+        replace
+        to={{ pathname: `/${experience.routes.oneTimeToken}`, search: `?${params.toString()}` }}
+      />
     );
   }
 

--- a/packages/experience/src/pages/SignIn/index.tsx
+++ b/packages/experience/src/pages/SignIn/index.tsx
@@ -1,4 +1,4 @@
-import { AgreeToTermsPolicy, ExtraParamsKey, SignInMode } from '@logto/schemas';
+import { AgreeToTermsPolicy, experience, ExtraParamsKey, SignInMode } from '@logto/schemas';
 import { useCallback, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
@@ -107,7 +107,10 @@ const SignIn = () => {
 
   if (params.get(ExtraParamsKey.OneTimeToken)) {
     return (
-      <Navigate replace to={{ pathname: '/one-time-token', search: `?${params.toString()}` }} />
+      <Navigate
+        replace
+        to={{ pathname: `/${experience.routes.oneTimeToken}`, search: `?${params.toString()}` }}
+      />
     );
   }
 

--- a/packages/experience/src/pages/SwitchAccount/index.tsx
+++ b/packages/experience/src/pages/SwitchAccount/index.tsx
@@ -1,4 +1,4 @@
-import { type ConsentInfoResponse } from '@logto/schemas';
+import { experience, type ConsentInfoResponse } from '@logto/schemas';
 import { useContext, useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
@@ -82,7 +82,7 @@ const SwitchAccount = () => {
           i18nProps={{ name: loginHint }}
           onClick={() => {
             navigate(
-              { pathname: '/one-time-token', search: `?${params.toString()}` },
+              { pathname: `/${experience.routes.oneTimeToken}`, search: `?${params.toString()}` },
               { replace: true }
             );
           }}

--- a/packages/schemas/src/consts/experience.ts
+++ b/packages/schemas/src/consts/experience.ts
@@ -7,7 +7,7 @@ const routes = Object.freeze({
   identifierSignIn: 'identifier-sign-in',
   identifierRegister: 'identifier-register',
   switchAccount: 'switch-account',
-  error: 'error',
+  oneTimeToken: 'one-time-token',
 } as const);
 
 export const experience = Object.freeze({


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Provision user who has a valid sign-in session to organizations when using one-time token that contains `jitOrganizationIds` in its context.

This enables the already signed-in users to accept organization invitations via a magic link.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally dev testing + UT

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
