### PR TITLE
fix(console): should not show diff modal for default values update

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/index.tsx
@@ -33,7 +33,7 @@ import {
   getContentErrorCount,
   hasSignUpAndSignInConfigChanged,
 } from './utils/form';
-import { sieFormDataParser } from './utils/parser';
+import { sieFormDataParser, signInExperienceDataDefaultValueParser } from './utils/parser';
 
 const PageTab = TabNavItem<`../${SignInExperienceTab}`>;
 
@@ -96,9 +96,10 @@ function PageContent({ data, onSignInExperienceUpdated }: Props) {
       }
 
       const formatted = sieFormDataParser.toSignInExperience(formData);
+      const original = signInExperienceDataDefaultValueParser(data);
 
       // Sign-in methods changed, need to show confirm modal first.
-      if (!hasSignUpAndSignInConfigChanged(data, formatted)) {
+      if (!hasSignUpAndSignInConfigChanged(original, formatted)) {
         setDataToCompare(formatted);
 
         return;

--- a/packages/console/src/pages/SignInExperience/PageContent/utils/parser.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/utils/parser.ts
@@ -163,3 +163,27 @@ export const sieFormDataParser = {
     mfa: undefined,
   }),
 };
+
+/**
+ * The data parser takes the raw data from the API,
+ * and fulfills the default values for the missing fields.
+ * This is to ensure the data consistency between the form and the remote model.
+ * So it won't trigger the form diff modal when the user hasn't changed anything.
+ *
+ * Affected fields:
+ * - `signUp.secondaryIdentifiers`: This field is optional in the data schema,
+ *  but through the form, we always fill it with an empty array.
+ */
+export const signInExperienceDataDefaultValueParser = (
+  data: SignInExperience
+): SignInExperience => {
+  const { signUp } = data;
+
+  return {
+    ...data,
+    signUp: {
+      ...signUp,
+      secondaryIdentifiers: signUp.secondaryIdentifiers ?? [],
+    },
+  };
+};


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR addresses a bug where the diff modal incorrectly appears when the `signUp.secondaryIdentifiers` value is undefined but is filled with a default empty array by the SIE form parser.

**Background:**
The `secondaryIdentifiers` field is optional in the sign-in experience schema. However, the console form parser automatically populates this field with an empty array for data processing convenience. This behavior can lead to data inconsistencies when comparing the submitted data (parsed from form values) with the original data.

**Changes made:**
- Implemented a default value parser to ensure consistent comparison between the submitted data and the original data.
- Prevented the diff modal from displaying when the `secondaryIdentifiers` field is auto-filled with an empty array.



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
