### PR TITLE
refactor(experience): improve go back logic handling in one-time token pages

### DIFF
--- a/packages/experience/src/pages/ErrorPage/index.tsx
+++ b/packages/experience/src/pages/ErrorPage/index.tsx
@@ -17,16 +17,22 @@ type Props = {
   readonly title?: TFuncKey;
   readonly message?: TFuncKey;
   readonly rawMessage?: string;
+  readonly isNavbarHidden?: boolean;
 };
 
-const ErrorPage = ({ title = 'description.not_found', message, rawMessage }: Props) => {
+const ErrorPage = ({
+  title = 'description.not_found',
+  message,
+  rawMessage,
+  isNavbarHidden,
+}: Props) => {
   const { theme } = useContext(PageContext);
   const errorMessage = Boolean(rawMessage ?? message);
 
   return (
     <StaticPageLayout>
       <PageMeta titleKey={title} />
-      {history.length > 1 && <NavBar />}
+      {history.length > 1 && <NavBar isHidden={isNavbarHidden} />}
       <div className={styles.container}>
         {theme === Theme.Light ? <EmptyState /> : <EmptyStateDark />}
         <div className={styles.title}>

--- a/packages/experience/src/pages/OneTimeToken/index.tsx
+++ b/packages/experience/src/pages/OneTimeToken/index.tsx
@@ -136,6 +136,7 @@ const OneTimeToken = () => {
   if (oneTimeTokenError) {
     return (
       <ErrorPage
+        isNavbarHidden
         title="error.invalid_link"
         message="error.invalid_link_description"
         rawMessage={condString(typeof oneTimeTokenError !== 'boolean' && oneTimeTokenError.message)}

--- a/packages/experience/src/pages/SwitchAccount/index.tsx
+++ b/packages/experience/src/pages/SwitchAccount/index.tsx
@@ -4,7 +4,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import StaticPageLayout from '@/Layout/StaticPageLayout';
 import PageContext from '@/Providers/PageContextProvider/PageContext';
-import { consent, getConsentInfo } from '@/apis/consent';
+import { getConsentInfo } from '@/apis/consent';
 import Button from '@/components/Button';
 import DynamicT from '@/components/DynamicT';
 import LoadingLayer from '@/components/LoadingLayer';
@@ -12,7 +12,6 @@ import PageMeta from '@/components/PageMeta';
 import TextLink from '@/components/TextLink';
 import useApi from '@/hooks/use-api';
 import useErrorHandler from '@/hooks/use-error-handler';
-import useGlobalRedirectTo from '@/hooks/use-global-redirect-to';
 import UserProfile from '@/pages/Consent/UserProfile';
 import ErrorPage from '@/pages/ErrorPage';
 import { getBrandingLogoUrl } from '@/utils/logo';
@@ -26,12 +25,10 @@ import styles from './index.module.scss';
 const SwitchAccount = () => {
   const { experienceSettings, theme } = useContext(PageContext);
   const navigate = useNavigate();
-  const redirectTo = useGlobalRedirectTo();
   const handleError = useErrorHandler();
 
   const [consentData, setConsentData] = useState<ConsentInfoResponse>();
   const asyncGetConsentInfo = useApi(getConsentInfo);
-  const asyncConsent = useApi(consent);
 
   const [params] = useSearchParams();
   const loginHint = params.get('login_hint');
@@ -94,14 +91,7 @@ const SwitchAccount = () => {
           <TextLink
             text="action.back_to_current_account"
             onClick={async () => {
-              const [error, result] = await asyncConsent();
-              if (error) {
-                await handleError(error);
-                return;
-              }
-              if (result?.redirectTo) {
-                await redirectTo(result.redirectTo);
-              }
+              history.back();
             }}
           />
         </div>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Improve go back logic handling in one-time token related intermediate pages (switch account page & error page)

- In the error page, remove "Go back to application" button from bottom. Also hide top navbar since it contains a "< Back" link.
- In the switch account page, make sure the "Back to current account" button doesn't use consent API, as that might introduce unexpected scopes to the authed user. Simply use "history.back()".

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Local dev testing

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
