### PR TITLE
refactor(demo-app): better showcase the magic link usage in demo app

### DIFF
--- a/packages/demo-app/src/Callback.tsx
+++ b/packages/demo-app/src/Callback.tsx
@@ -1,6 +1,13 @@
-import { useHandleSignInCallback } from '@logto/react';
+import { useHandleSignInCallback, useLogto } from '@logto/react';
+import { useEffect } from 'react';
 
 const Callback = () => {
+  const { clearAllTokens } = useLogto();
+
+  useEffect(() => {
+    void clearAllTokens();
+  }, [clearAllTokens]);
+
   const { error } = useHandleSignInCallback(() => {
     window.location.assign('/demo-app');
   });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Improve demo app to better show case the best practices consolidated for implementing magic link feature.

- Do not clear tokens if user is already authenticated and use a new magic link (e.g. org invitation link), and this may end up losing authenticated status on the client side.
- Properly set browser history state when calling `signIn()` function to validate the magic link.
- Clear tokens first on the "Callback" page when sign-in is redirected back. In case the tokens are not cleared when calling `signIn()`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
1. User not authenticated, use magic link to sign-in and register, both worked. ✅
2. User is authenticated, use new magic link to join organization. Worked. ✅
3. User is authenticated, use a magic link intended for another account. The switch account page showed up. ✅
   - Choose to "Continue as" the new account, new account signed in successfully ✅
   - Choose to "Go back to current account", go back to demo-app with current user. And the one-time token is not consumed. ✅
4. User sign-in with username and password still works ✅

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
