### PR TITLE
fix(experience): browser password manager should pick up one-time token email from hidden input

### DIFF
--- a/packages/experience/src/pages/OneTimeToken/index.tsx
+++ b/packages/experience/src/pages/OneTimeToken/index.tsx
@@ -6,9 +6,10 @@ import {
   type RequestErrorBody,
 } from '@logto/schemas';
 import { condString } from '@silverhand/essentials';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
+import UserInteractionContext from '@/Providers/UserInteractionContextProvider/UserInteractionContext';
 import {
   identifyAndSubmitInteraction,
   signInWithVerifiedIdentifier,
@@ -31,6 +32,7 @@ const OneTimeToken = () => {
   const asyncSignInWithVerifiedIdentifier = useApi(signInWithVerifiedIdentifier);
   const asyncRegisterWithOneTimeToken = useApi(registerWithOneTimeToken);
 
+  const { setIdentifierInputValue } = useContext(UserInteractionContext);
   const { termsValidation, agreeToTermsPolicy } = useTerms();
   const handleError = useErrorHandler();
   const redirectTo = useGlobalRedirectTo();
@@ -129,6 +131,10 @@ const OneTimeToken = () => {
         return;
       }
 
+      // Set email identifier to the <HiddenIdentifierInput />, so that when being asked for fulfilling
+      // the password later, the browser password manager can pick up both the email and the password.
+      setIdentifierInputValue({ type: SignInIdentifier.Email, value: email });
+
       await submit(result.verificationId);
     })();
   }, [
@@ -136,8 +142,9 @@ const OneTimeToken = () => {
     params,
     asyncRegisterWithOneTimeToken,
     handleError,
-    termsValidation,
+    setIdentifierInputValue,
     submit,
+    termsValidation,
   ]);
 
   if (oneTimeTokenError) {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Set one-time token associated email identifier to the hidden identifier input when submitting the authentication requests, which guarantees the browser password manager can always pick up a sign-in identifier when trying to saving the password.

![image](https://github.com/user-attachments/assets/a4b35ebe-4891-4523-b95c-40e41bbb4811)


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested locally. See screenshot above.

- SIE enable email as sign-up identifier, and check "Create password" checkbox
- Create a one-time token with a new user email, and use it as a magic link to register
- User registered successfully, and then asked for password before proceeding.
- User sets password, and then Chrome password manager pops-up the dialog to confirm saving password
- In the confirm dialog above, both the email and password are pre-populated.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
