### PR TITLE
fix(core): skip catpcha for otp

### DIFF
--- a/packages/core/src/routes/experience/verification-routes/one-time-token.ts
+++ b/packages/core/src/routes/experience/verification-routes/one-time-token.ts
@@ -61,6 +61,8 @@ export default function oneTimeTokenVerificationRoutes<
         oneTimeTokenVerificationRecord.verify(token)
       );
 
+      // Skip CAPTCHA for one-time token flow
+      ctx.experienceInteraction.skipCaptcha();
       await ctx.experienceInteraction.save();
 
       ctx.body = {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Similar to https://github.com/logto-io/logto/pull/7196, one-time token flow should skip CAPTCHA verification.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Integration tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
