### PR TITLE
refactor(console): move password policy to security page

### DIFF
--- a/packages/console/src/hooks/use-console-routes/routes/security.tsx
+++ b/packages/console/src/hooks/use-console-routes/routes/security.tsx
@@ -19,5 +19,9 @@ export const security: RouteObject = {
       path: `${SecurityTabs.Captcha}/details`,
       element: <CaptchaDetails />,
     },
+    {
+      path: SecurityTabs.PasswordPolicy,
+      element: <Security tab={SecurityTabs.PasswordPolicy} />,
+    },
   ],
 };

--- a/packages/console/src/pages/Security/PasswordPolicy/PasswordOption/index.module.scss
+++ b/packages/console/src/pages/Security/PasswordPolicy/PasswordOption/index.module.scss
@@ -1,0 +1,26 @@
+@use '@/scss/underscore' as _;
+
+
+.passwordOption {
+  // Every password option should be put in a `<FormField>` component, a margin
+  // is added to the component to separate it from the previous one or the title.
+  margin-top: _.unit(3);
+  font: var(--font-body-2);
+
+  > div[role='checkbox'] {
+    align-items: flex-start;
+  }
+
+  .label {
+    white-space: normal;
+
+    .title {
+      color: var(--color-text);
+    }
+
+    .description {
+      color: var(--color-text-secondary);
+      margin-top: _.unit(0.5);
+    }
+  }
+}

--- a/packages/console/src/pages/Security/PasswordPolicy/PasswordOption/index.tsx
+++ b/packages/console/src/pages/Security/PasswordPolicy/PasswordOption/index.tsx
@@ -1,0 +1,43 @@
+import { type ReactNode } from 'react';
+import { Controller, type FieldPath, useFormContext } from 'react-hook-form';
+
+import Checkbox from '@/ds-components/Checkbox';
+
+import { type PasswordPolicyFormData } from '../use-password-policy';
+
+import styles from './index.module.scss';
+
+type PasswordOptionProps = {
+  readonly name: FieldPath<PasswordPolicyFormData>;
+  readonly title: string;
+  readonly description: string;
+  readonly children?: ReactNode;
+};
+
+/** A display component for password policy options with a title and description. */
+function PasswordOption({ name, title, description, children }: PasswordOptionProps) {
+  const { control } = useFormContext<PasswordPolicyFormData>();
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      render={({ field: { onChange, value } }) => (
+        <Checkbox
+          className={styles.passwordOption}
+          label={
+            <div className={styles.label}>
+              <div className={styles.title}>{title}</div>
+              <div className={styles.description}>{description}</div>
+              {children}
+            </div>
+          }
+          checked={Boolean(value)}
+          onChange={onChange}
+        />
+      )}
+    />
+  );
+}
+
+export default PasswordOption;

--- a/packages/console/src/pages/Security/PasswordPolicy/PasswordPolicyForm/index.module.scss
+++ b/packages/console/src/pages/Security/PasswordPolicy/PasswordPolicyForm/index.module.scss
@@ -1,0 +1,29 @@
+@use '@/scss/underscore' as _;
+
+
+.title {
+  @include _.section-head-1;
+  color: var(--color-neutral-variant-60);
+}
+
+.formFieldDescription {
+  font: var(--font-body-2);
+  color: var(--color-text-secondary);
+  margin: _.unit(1) 0 _.unit(2);
+}
+
+
+.minLength > div[class*='container'] {
+  // From Figma design
+  max-width: 156px;
+}
+
+.characterTypes {
+  display: flex;
+  gap: _.unit(6);
+}
+
+.textarea {
+  margin-inline-start: _.unit(7);
+  margin-top: _.unit(2);
+}

--- a/packages/console/src/pages/Security/PasswordPolicy/PasswordPolicyForm/index.tsx
+++ b/packages/console/src/pages/Security/PasswordPolicy/PasswordPolicyForm/index.tsx
@@ -1,0 +1,210 @@
+import { PasswordPolicyChecker } from '@logto/core-kit';
+import { type SignInExperience } from '@logto/schemas';
+import { cond } from '@silverhand/essentials';
+import { type ChangeEvent } from 'react';
+import { Controller, FormProvider, useForm } from 'react-hook-form';
+import { toast } from 'react-hot-toast';
+import { Trans, useTranslation } from 'react-i18next';
+import { useSWRConfig } from 'swr';
+
+import DetailsForm from '@/components/DetailsForm';
+import FormCard from '@/components/FormCard';
+import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
+import FormField from '@/ds-components/FormField';
+import RadioGroup, { Radio } from '@/ds-components/RadioGroup';
+import NumericInput from '@/ds-components/TextInput/NumericInput';
+import TextLink from '@/ds-components/TextLink';
+import Textarea from '@/ds-components/Textarea';
+import useApi from '@/hooks/use-api';
+import { trySubmitSafe } from '@/utils/form';
+
+import PasswordOption from '../PasswordOption';
+import { passwordPolicyFormParser, type PasswordPolicyFormData } from '../use-password-policy';
+
+import styles from './index.module.scss';
+
+type Props = {
+  readonly data: PasswordPolicyFormData;
+};
+
+function PasswordPolicyForm({ data }: Props) {
+  const api = useApi();
+
+  const { mutate: mutateGlobal } = useSWRConfig();
+
+  const { t } = useTranslation(undefined, {
+    keyPrefix: 'admin_console.security.password_policy',
+  });
+
+  const { t: globalT } = useTranslation(undefined, {
+    keyPrefix: 'admin_console',
+  });
+
+  const formMethods = useForm<PasswordPolicyFormData>({
+    defaultValues: data,
+  });
+
+  const {
+    control,
+    register,
+    reset,
+    handleSubmit,
+    getValues,
+    formState: { isDirty, isSubmitting, errors },
+  } = formMethods;
+
+  const max = getValues('length.max');
+
+  const onSubmit = handleSubmit(
+    trySubmitSafe(async (formData: PasswordPolicyFormData) => {
+      if (isSubmitting) {
+        return;
+      }
+
+      const updatedData = await api
+        .patch('api/sign-in-exp', {
+          json: passwordPolicyFormParser.toSignInExperience(formData),
+        })
+        .json<SignInExperience>();
+
+      // Reset the form with the updated data
+      reset(passwordPolicyFormParser.fromSignInExperience(updatedData));
+
+      // Global mutate the SIE data
+      await mutateGlobal('api/sign-in-exp');
+
+      toast.success(globalT('general.saved'));
+    })
+  );
+
+  return (
+    <>
+      <FormProvider {...formMethods}>
+        <DetailsForm
+          isDirty={isDirty}
+          isSubmitting={isSubmitting}
+          onSubmit={onSubmit}
+          onDiscard={reset}
+        >
+          <FormCard title="security.password_policy.password_requirements">
+            <FormField title="security.password_policy.minimum_length">
+              <div className={styles.formFieldDescription}>
+                <Trans
+                  components={{
+                    a: (
+                      <TextLink
+                        targetBlank
+                        href="https://pages.nist.gov/800-63-3/sp800-63b.html#sec5"
+                      />
+                    ),
+                  }}
+                >
+                  {t('minimum_length_description')}
+                </Trans>
+              </div>
+              <Controller
+                name="length.min"
+                control={control}
+                rules={{
+                  min: 1,
+                  max,
+                }}
+                render={({ field: { onChange, value, name } }) => (
+                  <NumericInput
+                    className={styles.minLength}
+                    name={name}
+                    value={String(value)}
+                    min={1}
+                    max={max}
+                    error={errors.length?.min && t('minimum_length_error', { min: 1, max })}
+                    onChange={({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
+                      onChange(value && Number(value));
+                    }}
+                    onValueUp={() => {
+                      onChange(value + 1);
+                    }}
+                    onValueDown={() => {
+                      onChange(value - 1);
+                    }}
+                    onBlur={() => {
+                      if (value < 1) {
+                        onChange(1);
+                      } else if (value > max) {
+                        onChange(max);
+                      }
+                    }}
+                  />
+                )}
+              />
+            </FormField>
+            <FormField title="security.password_policy.minimum_required_char_types">
+              <div className={styles.formFieldDescription}>
+                {t('minimum_required_char_types_description', {
+                  symbols: PasswordPolicyChecker.symbols,
+                })}
+              </div>
+              <Controller
+                name="characterTypes.min"
+                control={control}
+                render={({ field: { onChange, value, name } }) => (
+                  <RadioGroup
+                    name={name}
+                    className={styles.characterTypes}
+                    value={cond(value && String(value))}
+                    onChange={(value) => {
+                      onChange(Number(value));
+                    }}
+                  >
+                    {[1, 2, 3, 4].map((i) => (
+                      <Radio key={i} title={<span>{i}</span>} value={String(i)} />
+                    ))}
+                  </RadioGroup>
+                )}
+              />
+            </FormField>
+          </FormCard>
+          <FormCard title="security.password_policy.password_rejection">
+            <FormField title="security.password_policy.compromised_passwords">
+              <PasswordOption
+                name="rejects.pwned"
+                title={t('breached_passwords')}
+                description={t('breached_passwords_description')}
+              />
+            </FormField>
+            <FormField
+              title="security.password_policy.restricted_phrases"
+              tip={t('restricted_phrases_tooltip')}
+            >
+              <PasswordOption
+                name="rejects.repetitionAndSequence"
+                title={t('repetitive_or_sequential_characters')}
+                description={t('repetitive_or_sequential_characters_description')}
+              />
+              <PasswordOption
+                name="rejects.userInfo"
+                title={t('user_information')}
+                description={t('user_information_description')}
+              />
+              <PasswordOption
+                name="isCustomWordsEnabled"
+                title={t('custom_words')}
+                description={t('custom_words_description')}
+              />
+              {getValues('isCustomWordsEnabled') && (
+                <Textarea
+                  className={styles.textarea}
+                  rows={5}
+                  placeholder={t('custom_words_placeholder')}
+                  {...register('customWords')}
+                />
+              )}
+            </FormField>
+          </FormCard>
+        </DetailsForm>
+      </FormProvider>
+      <UnsavedChangesAlertModal hasUnsavedChanges={isDirty} />
+    </>
+  );
+}
+
+export default PasswordPolicyForm;

--- a/packages/console/src/pages/Security/PasswordPolicy/index.module.scss
+++ b/packages/console/src/pages/Security/PasswordPolicy/index.module.scss
@@ -1,0 +1,34 @@
+@use '@/scss/underscore' as _;
+
+.content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.title {
+  @include _.section-head-1;
+  color: var(--color-neutral-variant-60);
+}
+
+.formFieldDescription {
+  font: var(--font-body-2);
+  color: var(--color-text-secondary);
+  margin: _.unit(1) 0 _.unit(2);
+}
+
+
+.minLength > div[class*='container'] {
+  // From Figma design
+  max-width: 156px;
+}
+
+.characterTypes {
+  display: flex;
+  gap: _.unit(6);
+}
+
+.textarea {
+  margin-inline-start: _.unit(7);
+  margin-top: _.unit(2);
+}

--- a/packages/console/src/pages/Security/PasswordPolicy/index.tsx
+++ b/packages/console/src/pages/Security/PasswordPolicy/index.tsx
@@ -1,0 +1,28 @@
+import { useTranslation } from 'react-i18next';
+
+import { FormCardSkeleton } from '@/components/FormCard';
+import PageMeta from '@/components/PageMeta';
+import RequestDataError from '@/components/RequestDataError';
+
+import PasswordPolicyForm from './PasswordPolicyForm';
+import styles from './index.module.scss';
+import usePasswordPolicy from './use-password-policy';
+
+function PasswordPolicy() {
+  const { isLoading, data, error, mutate } = usePasswordPolicy();
+
+  const { t } = useTranslation(undefined, {
+    keyPrefix: 'admin_console.security.password_policy',
+  });
+
+  return (
+    <div className={styles.content}>
+      <PageMeta titleKey={['security.tabs.password_policy', 'security.page_title']} />
+      {isLoading ? <FormCardSkeleton formFieldCount={2} /> : null}
+      {error && <RequestDataError error={error} onRetry={mutate} />}
+      {data && <PasswordPolicyForm data={data} />}
+    </div>
+  );
+}
+
+export default PasswordPolicy;

--- a/packages/console/src/pages/Security/PasswordPolicy/use-password-policy.ts
+++ b/packages/console/src/pages/Security/PasswordPolicy/use-password-policy.ts
@@ -1,0 +1,68 @@
+import { passwordPolicyGuard, type PasswordPolicy } from '@logto/core-kit';
+import { type SignInExperience } from '@logto/schemas';
+import { useMemo } from 'react';
+import useSWR from 'swr';
+
+import { type RequestError } from '@/hooks/use-api';
+
+/** The parsed password policy object. All properties are required. */
+export type PasswordPolicyFormData = PasswordPolicy & {
+  /**
+   * The custom words separated by line breaks.
+   *
+   * This property is only used for UI display.
+   */
+  customWords: string;
+  /**
+   * Whether the custom words feature is enabled. Default value will be true if `rejects.words` is not empty.
+   *
+   * This property is only used for UI display.
+   */
+  isCustomWordsEnabled: boolean;
+};
+
+export const passwordPolicyFormParser = {
+  fromSignInExperience: ({ passwordPolicy }: SignInExperience): PasswordPolicyFormData => ({
+    ...passwordPolicyGuard.parse(passwordPolicy),
+    customWords: passwordPolicy.rejects?.words?.join('\n') ?? '',
+    isCustomWordsEnabled: Boolean(passwordPolicy.rejects?.words?.length),
+  }),
+  toSignInExperience: (
+    formData: PasswordPolicyFormData
+  ): Pick<SignInExperience, 'passwordPolicy'> => {
+    const { isCustomWordsEnabled, customWords, ...passwordPolicy } = formData;
+
+    return {
+      passwordPolicy: {
+        ...passwordPolicy,
+        rejects: {
+          ...passwordPolicy.rejects,
+          words: isCustomWordsEnabled ? customWords.split('\n').filter(Boolean) : [],
+        },
+      },
+    };
+  },
+};
+
+const usePasswordPolicy = () => {
+  const { data, error, isLoading, mutate } = useSWR<SignInExperience, RequestError>(
+    'api/sign-in-exp'
+  );
+
+  const formData = useMemo<PasswordPolicyFormData | undefined>(() => {
+    if (!data) {
+      return;
+    }
+
+    return passwordPolicyFormParser.fromSignInExperience(data);
+  }, [data]);
+
+  return {
+    isLoading: isLoading && !error,
+    mutate,
+    error,
+    data: formData,
+  };
+};
+
+export default usePasswordPolicy;

--- a/packages/console/src/pages/Security/index.module.scss
+++ b/packages/console/src/pages/Security/index.module.scss
@@ -3,3 +3,7 @@
 .tabs {
   margin: _.unit(4) 0;
 }
+
+.noPaddingBottom {
+  padding-bottom: 0;
+}

--- a/packages/console/src/pages/Security/index.tsx
+++ b/packages/console/src/pages/Security/index.tsx
@@ -1,12 +1,15 @@
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 
 import PageMeta from '@/components/PageMeta';
+import { isDevFeaturesEnabled } from '@/consts/env';
 import { security } from '@/consts/external-links';
 import CardTitle from '@/ds-components/CardTitle';
 import TabNav, { TabNavItem } from '@/ds-components/TabNav';
 import pageLayout from '@/scss/page-layout.module.scss';
 
 import Captcha from './Captcha';
+import PasswordPolicy from './PasswordPolicy';
 import styles from './index.module.scss';
 import { SecurityTabs } from './types';
 
@@ -18,7 +21,7 @@ function Security({ tab }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
   return (
-    <div className={pageLayout.container}>
+    <div className={classNames(pageLayout.container, styles.noPaddingBottom)}>
       <PageMeta titleKey="security.page_title" />
       <div className={pageLayout.headline}>
         <CardTitle
@@ -34,8 +37,18 @@ function Security({ tab }: Props) {
         >
           {t('security.tabs.captcha')}
         </TabNavItem>
+        {isDevFeaturesEnabled && (
+          <TabNavItem
+            href={`/security/${SecurityTabs.PasswordPolicy}`}
+            isActive={tab === SecurityTabs.PasswordPolicy}
+          >
+            {t('security.tabs.password_policy')}
+          </TabNavItem>
+        )}
       </TabNav>
       {tab === SecurityTabs.Captcha && <Captcha />}
+      {/** TODO: Remove the dev feature guard */}
+      {tab === SecurityTabs.PasswordPolicy && isDevFeaturesEnabled && <PasswordPolicy />}
     </div>
   );
 }

--- a/packages/console/src/pages/SignInExperience/PageContent/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/index.tsx
@@ -8,6 +8,7 @@ import { useParams } from 'react-router-dom';
 
 import SubmitFormChangesActionBar from '@/components/SubmitFormChangesActionBar';
 import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
+import { isDevFeaturesEnabled } from '@/consts/env';
 import ConfirmModal from '@/ds-components/ConfirmModal';
 import TabNav, { TabNavItem } from '@/ds-components/TabNav';
 import useApi from '@/hooks/use-api';
@@ -131,7 +132,9 @@ function PageContent({ data, onSignInExperienceUpdated }: Props) {
         <PageTab href="../content" errorCount={getContentErrorCount(errors)}>
           {t('sign_in_exp.tabs.content')}
         </PageTab>
-        <PageTab href="../password-policy">{t('sign_in_exp.tabs.password_policy')}</PageTab>
+        {!isDevFeaturesEnabled && (
+          <PageTab href="../password-policy">{t('sign_in_exp.tabs.password_policy')}</PageTab>
+        )}
       </TabNav>
       <div className={styles.content}>
         <div className={classNames(styles.contentTop, isDirty && styles.withSubmitActionBar)}>
@@ -140,7 +143,9 @@ function PageContent({ data, onSignInExperienceUpdated }: Props) {
               <Branding isActive={tab === SignInExperienceTab.Branding} />
               <SignUpAndSignIn isActive={tab === SignInExperienceTab.SignUpAndSignIn} />
               <Content isActive={tab === SignInExperienceTab.Content} />
-              <PasswordPolicy isActive={tab === SignInExperienceTab.PasswordPolicy} />
+              {!isDevFeaturesEnabled && (
+                <PasswordPolicy isActive={tab === SignInExperienceTab.PasswordPolicy} />
+              )}
             </form>
           </FormProvider>
           {formData.id && (

--- a/packages/integration-tests/src/tests/console/security/password-policy.test.ts
+++ b/packages/integration-tests/src/tests/console/security/password-policy.test.ts
@@ -1,15 +1,23 @@
 import ExpectConsole from '#src/ui-helpers/expect-console.js';
 import { getInputValue } from '#src/ui-helpers/index.js';
-import { devFeatureDisabledTest } from '#src/utils.js';
+import { dcls, devFeatureTest } from '#src/utils.js';
 
 const expectConsole = new ExpectConsole(await browser.newPage());
 
-devFeatureDisabledTest.describe('sign-in experience: password policy', () => {
-  it('navigates to sign-in experience page', async () => {
+devFeatureTest.describe('security: password policy', () => {
+  it('navigates to security page', async () => {
     await expectConsole.start();
-    await expectConsole.gotoPage('/sign-in-experience', 'Sign-in experience');
+    await expectConsole.gotoPage('/security', 'Security');
     await expectConsole.toClickTab('Password policy');
-    await expectConsole.toExpectCards('PASSWORD REQUIREMENTS', 'PASSWORD REJECTION');
+
+    await Promise.all(
+      ['PASSWORD REQUIREMENTS', 'PASSWORD REJECTION'].map(async (title) => {
+        return expect(expectConsole.page).toMatchElement([dcls('card'), dcls('title')].join(' '), {
+          text: new RegExp(title, 'i'),
+          visible: true,
+        });
+      })
+    );
   });
 
   it('should be able to set minimum length', async () => {
@@ -38,7 +46,7 @@ devFeatureDisabledTest.describe('sign-in experience: password policy', () => {
   });
 
   it('should be able to see character types selections', async () => {
-    const inputs = await expectConsole.getFieldInputs('Character types');
+    const inputs = await expectConsole.getFieldInputs('required character types');
 
     for (const input of inputs) {
       // eslint-disable-next-line no-await-in-loop

--- a/packages/integration-tests/src/ui-helpers/expect-console.ts
+++ b/packages/integration-tests/src/ui-helpers/expect-console.ts
@@ -23,7 +23,8 @@ export type ConsoleTitle =
   | 'Sign-in experience'
   | 'Organizations'
   | 'API resources'
-  | 'Organization template';
+  | 'Organization template'
+  | 'Security';
 
 export default class ExpectConsole extends ExpectPage {
   readonly options: Required<ExpectConsoleOptions>;
@@ -179,7 +180,8 @@ export default class ExpectConsole extends ExpectPage {
     const fieldTitle = await expect(this.page).toMatchElement(
       // Use `:has()` for a quick and dirty way to match the field title.
       // Not harmful in most cases.
-      `${dcls('field')}:has(${dcls('title')})`,
+      // Exclude the `fields` class to avoid matching the `.fields` wrapper in `DetailsForm`
+      `${dcls('field')}:not([class*="fields"]):has(${dcls('title')})`,
       {
         text: new RegExp(title, 'i'),
         visible: true,

--- a/packages/phrases/src/locales/en/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/security.ts
@@ -1,9 +1,35 @@
+const password_policy = {
+  password_requirements: 'Password requirements',
+  minimum_length: 'Minimum length',
+  minimum_length_description: 'NIST suggests using <a>at least 8 characters</a> for web products.',
+  minimum_length_error: 'Minimum length must be between {{min}} and {{max}} (inclusive).',
+  minimum_required_char_types: 'Minimum required character types',
+  minimum_required_char_types_description:
+    'Character types: uppercase (A-Z), lowercase (a-z), numbers (0-9), and special symbols ({{symbols}}).',
+  password_rejection: 'Password rejection',
+  compromised_passwords: 'Reject compromised password',
+  breached_passwords: 'Breached passwords',
+  breached_passwords_description: 'Reject passwords previously found in breach databases.',
+  restricted_phrases: 'Restrict low-security phrases',
+  restricted_phrases_tooltip:
+    'Your password should avoid these phrases unless you combine with 3 or more extra characters.',
+  repetitive_or_sequential_characters: 'Repetitive or sequential characters',
+  repetitive_or_sequential_characters_description: 'E.g., "AAAA", "1234", and "abcd".',
+  user_information: 'User information',
+  user_information_description: 'E.g., email address, phone number, username, etc.',
+  custom_words: 'Custom words',
+  custom_words_description:
+    'Personalize context-specific words, case-insensitive, and one per line.',
+  custom_words_placeholder: 'Your service name, company name, etc.',
+};
+
 const security = {
   page_title: 'Security',
   title: 'Security',
   subtitle: 'Configure advanced protection against sophisticated attacks.',
   tabs: {
     captcha: 'CAPTCHA',
+    password_policy: 'Password policy',
   },
   bot_protection: {
     title: 'Bot protection',
@@ -50,6 +76,7 @@ const security = {
     captcha_deleted: 'CAPTCHA provider deleted successfully',
     setup_captcha: 'Setup CAPTCHA',
   },
+  password_policy,
 };
 
 export default Object.freeze(security);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Migrate the password policy settings page under the security section.



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally
<img width="1378" alt="image" src="https://github.com/user-attachments/assets/77cc58b3-95eb-4b88-aef7-6025f43acae3" />

<img width="1386" alt="image" src="https://github.com/user-attachments/assets/1b39ad38-b6be-4585-b8db-6772325097aa" />


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
