### PR TITLE
fix(translate): translate cli tool should read model name from env

### DIFF
--- a/.changeset/six-rivers-lick.md
+++ b/.changeset/six-rivers-lick.md
@@ -1,0 +1,5 @@
+---
+"@logto/translate": patch
+---
+
+should correctly read modal name from env

--- a/packages/translate/src/openai.ts
+++ b/packages/translate/src/openai.ts
@@ -19,7 +19,7 @@ import {
 } from './utils.js';
 
 // The full list of OPENAI model can be found at https://platform.openai.com/docs/models.
-export const model = process.env.OPENAI_MODEL_NAME ?? 'gpt-4o-2024-08-06';
+export const getModel = () => process.env.OPENAI_MODEL_NAME ?? 'gpt-4o-2024-08-06';
 
 export const createOpenaiApi = () => {
   const proxy = getProxy();
@@ -61,7 +61,7 @@ export const translate = async ({
     api
       .post('chat/completions', {
         json: {
-          model,
+          model: getModel(),
           messages: getTranslationPromptMessages({
             sourceFileContent,
             targetLanguage,

--- a/packages/translate/src/sync.ts
+++ b/packages/translate/src/sync.ts
@@ -5,7 +5,7 @@ import { isLanguageTag } from '@logto/language-kit';
 import PQueue from 'p-queue';
 import type { CommandModule } from 'yargs';
 
-import { model, syncTranslation } from './openai.js';
+import { getModel, syncTranslation } from './openai.js';
 import {
   inquireInstancePath,
   lintLocaleFiles,
@@ -34,7 +34,7 @@ const sync: CommandModule<
     const phrasesPath = path.join(instancePath, 'packages', packageName);
     const localesPath = path.join(phrasesPath, 'src/locales');
     const targetLocales = fs.readdirSync(localesPath);
-    consoleLog.info(`Translating files using model ${model}`);
+    consoleLog.info(`Translating files using model ${getModel()}`);
 
     for (const languageTag of targetLocales) {
       if (languageTag === baseLanguage || !isLanguageTag(languageTag)) {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Translate CLI tool should correctly read LLM model name from `.env` or other environment variable configurations.

Previously, the `const model` is defined before loading dotenv configs, and thus the model name in env is always ignored.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
