### PR TITLE
fix(connector): support string typed boolean ID token claims for OIDC connector

### DIFF
--- a/.changeset/selfish-zoos-worry.md
+++ b/.changeset/selfish-zoos-worry.md
@@ -1,0 +1,9 @@
+---
+"@logto/connector-oidc": patch
+---
+
+support string-typed boolean claims
+
+Add an optional `acceptStringTypedBooleanClaims` configuration to `OidcConnectorConfig`, with default value `false`.
+For standard OIDC protocol, some claims such as `email_verified` and `phone_verified` are boolean-typed, but some providers may return them as string-typed. Enabling this option will convert string-typed boolean claims to boolean-typed, which provides better compatibility.
+By enabling this configuration, the connector will accept string-typed boolean ID token claims, such as `email_verified` and `phone_verified`.

--- a/packages/connectors/connector-oidc/src/constant.ts
+++ b/packages/connectors/connector-oidc/src/constant.ts
@@ -36,6 +36,15 @@ export const defaultMetadata: ConnectorMetadata = {
       required: true,
     },
     {
+      key: 'acceptStringTypedBooleanClaims',
+      label: 'Accept String-typed Boolean Claims',
+      description:
+        'Whether to accept string-typed boolean claims. For standard OIDC protocol, some claims such as `email_verified` and `phone_verified` are boolean-typed, but some providers may return them as string-typed. Enabling this option will convert string-typed boolean claims to boolean-typed.',
+      type: ConnectorConfigFormItemType.Switch,
+      required: false,
+      defaultValue: false,
+    },
+    {
       key: 'idTokenVerificationConfig',
       label: 'ID Token Verification Config',
       type: ConnectorConfigFormItemType.Json,

--- a/packages/connectors/connector-oidc/src/index.ts
+++ b/packages/connectors/connector-oidc/src/index.ts
@@ -22,7 +22,7 @@ import { HTTPError } from 'ky';
 import { defaultMetadata } from './constant.js';
 import {
   idTokenProfileStandardClaimsGuard,
-  idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims,
+  idTokenClaimsGuardWithStringBooleans,
   oidcConnectorConfigGuard,
 } from './types.js';
 import { getIdToken } from './utils.js';
@@ -108,7 +108,7 @@ const getUserInfo =
       );
 
       const result = parsedConfig.acceptStringTypedBooleanClaims
-        ? idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims.safeParse(payload)
+        ? idTokenClaimsGuardWithStringBooleans.safeParse(payload)
         : idTokenProfileStandardClaimsGuard.safeParse(payload);
 
       if (!result.success) {

--- a/packages/connectors/connector-oidc/src/index.ts
+++ b/packages/connectors/connector-oidc/src/index.ts
@@ -20,7 +20,11 @@ import { createRemoteJWKSet, jwtVerify } from 'jose';
 import { HTTPError } from 'ky';
 
 import { defaultMetadata } from './constant.js';
-import { idTokenProfileStandardClaimsGuard, oidcConnectorConfigGuard } from './types.js';
+import {
+  idTokenProfileStandardClaimsGuard,
+  idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims,
+  oidcConnectorConfigGuard,
+} from './types.js';
 import { getIdToken } from './utils.js';
 
 const generateNonce = () => generateStandardId();
@@ -103,7 +107,9 @@ const getUserInfo =
         }
       );
 
-      const result = idTokenProfileStandardClaimsGuard.safeParse(payload);
+      const result = parsedConfig.acceptStringTypedBooleanClaims
+        ? idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims.safeParse(payload)
+        : idTokenProfileStandardClaimsGuard.safeParse(payload);
 
       if (!result.success) {
         throw new ConnectorError(ConnectorErrorCodes.SocialIdTokenInvalid, result.error);

--- a/packages/connectors/connector-oidc/src/types.test.ts
+++ b/packages/connectors/connector-oidc/src/types.test.ts
@@ -1,4 +1,7 @@
-import { scopePostProcessor } from './types.js';
+import {
+  scopePostProcessor,
+  idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims,
+} from './types.js';
 
 describe('scopePostProcessor', () => {
   it('`openid` will be added if not exists (with empty string)', () => {
@@ -11,5 +14,113 @@ describe('scopePostProcessor', () => {
 
   it('return original input if openid exists', () => {
     expect(scopePostProcessor('profile openid')).toEqual('profile openid');
+  });
+});
+
+describe('idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims', () => {
+  it('should accept boolean values for email_verified and phone_verified', () => {
+    const result = idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims.parse({
+      sub: 'subject',
+      email_verified: true,
+      phone_verified: false,
+    });
+
+    expect(result).toEqual({
+      sub: 'subject',
+      email_verified: true,
+      phone_verified: false,
+    });
+  });
+
+  it('should accept null values for email_verified and phone_verified', () => {
+    const result = idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims.parse({
+      sub: 'subject',
+      email_verified: null,
+      phone_verified: null,
+    });
+
+    expect(result).toEqual({
+      sub: 'subject',
+      email_verified: null,
+      phone_verified: null,
+    });
+  });
+
+  it('should transform string "true" to boolean true for email_verified and phone_verified', () => {
+    const result = idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims.parse({
+      sub: 'subject',
+      email_verified: 'true',
+      phone_verified: 'TRUE',
+    });
+
+    expect(result).toEqual({
+      sub: 'subject',
+      email_verified: true,
+      phone_verified: true,
+    });
+  });
+
+  it('should transform string "false" to boolean false for email_verified and phone_verified', () => {
+    const result = idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims.parse({
+      sub: 'subject',
+      email_verified: 'false',
+      phone_verified: 'FALSE',
+    });
+
+    expect(result).toEqual({
+      sub: 'subject',
+      email_verified: false,
+      phone_verified: false,
+    });
+  });
+
+  it('should transform string "0" to boolean false for email_verified and phone_verified', () => {
+    const result = idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims.parse({
+      sub: 'subject',
+      email_verified: '0',
+      phone_verified: '0',
+    });
+
+    expect(result).toEqual({
+      sub: 'subject',
+      email_verified: false,
+      phone_verified: false,
+    });
+  });
+
+  it('should transform string "1" to boolean true for email_verified and phone_verified', () => {
+    const result = idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims.parse({
+      sub: 'subject',
+      email_verified: '1',
+      phone_verified: '1',
+    });
+
+    expect(result).toEqual({
+      sub: 'subject',
+      email_verified: true,
+      phone_verified: true,
+    });
+  });
+
+  it('should accept other standard claims', () => {
+    const result = idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims.parse({
+      sub: 'subject',
+      name: 'John Doe',
+      email: 'john@example.com',
+      phone: '+1234567890',
+      picture: 'https://example.com/avatar.jpg',
+      profile: 'https://example.com/profile',
+      nonce: 'random-nonce',
+    });
+
+    expect(result).toEqual({
+      sub: 'subject',
+      name: 'John Doe',
+      email: 'john@example.com',
+      phone: '+1234567890',
+      picture: 'https://example.com/avatar.jpg',
+      profile: 'https://example.com/profile',
+      nonce: 'random-nonce',
+    });
   });
 });

--- a/packages/connectors/connector-oidc/src/types.test.ts
+++ b/packages/connectors/connector-oidc/src/types.test.ts
@@ -1,7 +1,4 @@
-import {
-  scopePostProcessor,
-  idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims,
-} from './types.js';
+import { scopePostProcessor, idTokenClaimsGuardWithStringBooleans } from './types.js';
 
 describe('scopePostProcessor', () => {
   it('`openid` will be added if not exists (with empty string)', () => {
@@ -17,9 +14,9 @@ describe('scopePostProcessor', () => {
   });
 });
 
-describe('idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims', () => {
+describe('idTokenClaimsGuardWithStringBooleans', () => {
   it('should accept boolean values for email_verified and phone_verified', () => {
-    const result = idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims.parse({
+    const result = idTokenClaimsGuardWithStringBooleans.parse({
       sub: 'subject',
       email_verified: true,
       phone_verified: false,
@@ -33,7 +30,7 @@ describe('idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims', (
   });
 
   it('should accept null values for email_verified and phone_verified', () => {
-    const result = idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims.parse({
+    const result = idTokenClaimsGuardWithStringBooleans.parse({
       sub: 'subject',
       email_verified: null,
       phone_verified: null,
@@ -47,7 +44,7 @@ describe('idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims', (
   });
 
   it('should transform string "true" to boolean true for email_verified and phone_verified', () => {
-    const result = idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims.parse({
+    const result = idTokenClaimsGuardWithStringBooleans.parse({
       sub: 'subject',
       email_verified: 'true',
       phone_verified: 'TRUE',
@@ -61,7 +58,7 @@ describe('idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims', (
   });
 
   it('should transform string "false" to boolean false for email_verified and phone_verified', () => {
-    const result = idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims.parse({
+    const result = idTokenClaimsGuardWithStringBooleans.parse({
       sub: 'subject',
       email_verified: 'false',
       phone_verified: 'FALSE',
@@ -75,7 +72,7 @@ describe('idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims', (
   });
 
   it('should transform string "0" to boolean false for email_verified and phone_verified', () => {
-    const result = idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims.parse({
+    const result = idTokenClaimsGuardWithStringBooleans.parse({
       sub: 'subject',
       email_verified: '0',
       phone_verified: '0',
@@ -89,7 +86,7 @@ describe('idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims', (
   });
 
   it('should transform string "1" to boolean true for email_verified and phone_verified', () => {
-    const result = idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims.parse({
+    const result = idTokenClaimsGuardWithStringBooleans.parse({
       sub: 'subject',
       email_verified: '1',
       phone_verified: '1',
@@ -103,7 +100,7 @@ describe('idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims', (
   });
 
   it('should accept other standard claims', () => {
-    const result = idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims.parse({
+    const result = idTokenClaimsGuardWithStringBooleans.parse({
       sub: 'subject',
       name: 'John Doe',
       email: 'john@example.com',

--- a/packages/connectors/connector-oidc/src/types.ts
+++ b/packages/connectors/connector-oidc/src/types.ts
@@ -6,7 +6,9 @@ import { oauth2ConfigGuard } from '@logto/connector-oauth';
 const scopeOpenid = 'openid';
 export const delimiter = /[ +]/;
 
-// Space-delimited 'scope' MUST contain 'openid', see https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth
+/**
+ * Space-delimited 'scope' MUST contain 'openid', see https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth
+ */
 export const scopePostProcessor = (scope: string) => {
   const splitScopes = scope.split(delimiter).filter(Boolean);
 
@@ -17,8 +19,10 @@ export const scopePostProcessor = (scope: string) => {
   return scope;
 };
 
-// See https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims.
-// We only concern a subset of them, and social identity provider usually does not provide a complete set of them.
+/**
+ * See https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims.
+ * We only concern a subset of them, and social identity provider usually does not provide a complete set of them.
+ */
 export const idTokenProfileStandardClaimsGuard = z.object({
   sub: z.string(),
   name: z.string().nullish(),
@@ -31,7 +35,9 @@ export const idTokenProfileStandardClaimsGuard = z.object({
   nonce: z.string().nullish(),
 });
 
-// Extend `idTokenProfileStandardClaimsGuard` by accepting string-typed boolean claims.
+/**
+ * Extend `idTokenProfileStandardClaimsGuard` by accepting string-typed boolean claims.
+ */
 export const idTokenClaimsGuardWithStringBooleans = idTokenProfileStandardClaimsGuard
   .omit({ email_verified: true, phone_verified: true })
   .extend({
@@ -72,7 +78,9 @@ export const authRequestOptionalConfigGuard = z
   })
   .partial();
 
-// See https://github.com/panva/jose/blob/main/docs/interfaces/jwt_verify.JWTVerifyOptions.md for details.
+/**
+ * See https://github.com/panva/jose/blob/main/docs/interfaces/jwt_verify.JWTVerifyOptions.md for details.
+ */
 export const idTokenVerificationConfigGuard = z.object({ jwksUri: z.string() }).merge(
   z
     .object({

--- a/packages/connectors/connector-oidc/src/types.ts
+++ b/packages/connectors/connector-oidc/src/types.ts
@@ -32,16 +32,17 @@ export const idTokenProfileStandardClaimsGuard = z.object({
 });
 
 // Extend `idTokenProfileStandardClaimsGuard` by accepting string-typed boolean claims.
-export const idTokenProfileStandardClaimsGuardAcceptingStringTypedBooleanClaims =
-  idTokenProfileStandardClaimsGuard.omit({ email_verified: true, phone_verified: true }).extend({
+export const idTokenClaimsGuardWithStringBooleans = idTokenProfileStandardClaimsGuard
+  .omit({ email_verified: true, phone_verified: true })
+  .extend({
     email_verified: z
       .boolean()
-      .nullish()
-      .or(z.string().transform((value: string) => yes(value))),
+      .or(z.string().transform((value: string) => yes(value)))
+      .nullish(),
     phone_verified: z
       .boolean()
-      .nullish()
-      .or(z.string().transform((value: string) => yes(value))),
+      .or(z.string().transform((value: string) => yes(value)))
+      .nullish(),
   });
 
 export const userProfileGuard = z.object({


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add an optional `acceptStringTypedBooleanClaims` configuration to `OidcConnectorConfig`, with default value `false`.
For standard OIDC protocol, some claims such as `email_verified` and `phone_verified` are boolean-typed, but some providers may return them as string-typed. Enabling this option will convert string-typed boolean claims to boolean-typed, which provides better compatibility.
By enabling this configuration, the connector will accept string-typed boolean ID token claims, such as `email_verified` and `phone_verified`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Covered by unit tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
