### PR TITLE
fix(core): do not check sign-in method on one-time token verification

### DIFF
--- a/packages/core/src/routes/experience/classes/libraries/sign-in-experience-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/sign-in-experience-validator.ts
@@ -119,7 +119,12 @@ export class SignInExperienceValidator {
   ) {
     const hasVerifiedOneTimeToken =
       verificationRecord.type === VerificationType.OneTimeToken && verificationRecord.isVerified;
-    await this.guardInteractionEvent(event, hasVerifiedOneTimeToken);
+
+    if (hasVerifiedOneTimeToken) {
+      return;
+    }
+
+    await this.guardInteractionEvent(event);
 
     switch (event) {
       case InteractionEvent.SignIn: {
@@ -286,23 +291,14 @@ export class SignInExperienceValidator {
         break;
       }
 
+      case VerificationType.OneTimeToken:
       case VerificationType.Social: {
-        // No need to verify social verification method
+        // No need to verify one-time token and social verification methods
         break;
       }
       case VerificationType.EnterpriseSso: {
         assertThat(
           singleSignOnEnabled,
-          new RequestError({ code: 'user.sign_in_method_not_enabled', status: 422 })
-        );
-        break;
-      }
-      case VerificationType.OneTimeToken: {
-        const {
-          identifier: { type },
-        } = verificationRecord;
-        assertThat(
-          signInMethods.some(({ identifier }) => type === identifier),
           new RequestError({ code: 'user.sign_in_method_not_enabled', status: 422 })
         );
         break;

--- a/packages/integration-tests/src/tests/api/experience-api/register-interaction/one-time-token.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/register-interaction/one-time-token.test.ts
@@ -6,7 +6,7 @@ import { initExperienceClient, logoutClient, processSession } from '#src/helpers
 import { setEmailConnector } from '#src/helpers/connector.js';
 import { expectRejects } from '#src/helpers/index.js';
 import { generateNewUser } from '#src/helpers/user.js';
-import { generatePassword, devFeatureTest } from '#src/utils.js';
+import { generateUsername, generatePassword, devFeatureTest } from '#src/utils.js';
 
 const { it, describe } = devFeatureTest;
 
@@ -219,6 +219,8 @@ describe('Register interaction with one-time token', () => {
       },
     });
 
+    await client.updateProfile({ type: SignInIdentifier.Username, value: generateUsername() });
+    await client.updateProfile({ type: 'password', value: generatePassword() });
     await client.identifyUser({ verificationId });
 
     const { redirectTo } = await client.submitInteraction();

--- a/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/one-time-token.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/one-time-token.test.ts
@@ -1,0 +1,184 @@
+import { InteractionEvent, OneTimeTokenStatus, SignInIdentifier, SignInMode } from '@logto/schemas';
+
+import { deleteUser } from '#src/api/admin-user.js';
+import { updateSignInExperience } from '#src/api/index.js';
+import {
+  createOneTimeToken,
+  updateOneTimeTokenStatus,
+  deleteOneTimeTokenById,
+} from '#src/api/one-time-token.js';
+import { initExperienceClient, logoutClient, processSession } from '#src/helpers/client.js';
+import { expectRejects } from '#src/helpers/index.js';
+import { generateNewUser } from '#src/helpers/user.js';
+import { devFeatureTest, waitFor } from '#src/utils.js';
+
+const { it, describe } = devFeatureTest;
+
+describe('Sign-in interaction with one-time token', async () => {
+  const { user, userProfile } = await generateNewUser({ primaryEmail: true, password: true });
+
+  it('should successfully sign-in with a one-time token', async () => {
+    const client = await initExperienceClient({
+      interactionEvent: InteractionEvent.SignIn,
+    });
+
+    const oneTimeToken = await createOneTimeToken({
+      email: userProfile.primaryEmail,
+    });
+
+    const { verificationId } = await client.verifyOneTimeToken({
+      token: oneTimeToken.token,
+      identifier: { type: SignInIdentifier.Email, value: userProfile.primaryEmail },
+    });
+
+    await client.identifyUser({ verificationId });
+    const { redirectTo } = await client.submitInteraction();
+    const userId = await processSession(client, redirectTo);
+
+    expect(userId).toBe(user.id);
+
+    await logoutClient(client);
+    void deleteOneTimeTokenById(oneTimeToken.id);
+  });
+
+  it('should fail to sign-in with an invalid one-time token', async () => {
+    const client = await initExperienceClient({
+      interactionEvent: InteractionEvent.SignIn,
+    });
+
+    await expectRejects(
+      client.verifyOneTimeToken({
+        token: 'invalid_token',
+        identifier: { type: SignInIdentifier.Email, value: userProfile.primaryEmail },
+      }),
+      {
+        code: 'one_time_token.token_not_found',
+        status: 404,
+      }
+    );
+  });
+
+  it('should fail to sign-in with an expired one-time token', async () => {
+    const client = await initExperienceClient({
+      interactionEvent: InteractionEvent.SignIn,
+    });
+
+    const oneTimeToken = await createOneTimeToken({
+      email: userProfile.primaryEmail,
+      expiresIn: 1,
+    });
+
+    await waitFor(1001);
+
+    await expectRejects(
+      client.verifyOneTimeToken({
+        token: oneTimeToken.token,
+        identifier: { type: SignInIdentifier.Email, value: userProfile.primaryEmail },
+      }),
+      {
+        code: 'one_time_token.token_expired',
+        status: 400,
+      }
+    );
+
+    void deleteOneTimeTokenById(oneTimeToken.id);
+  });
+
+  it('should fail to sign-in with a consumed one-time token', async () => {
+    const client = await initExperienceClient({
+      interactionEvent: InteractionEvent.SignIn,
+    });
+
+    const oneTimeToken = await createOneTimeToken({
+      email: userProfile.primaryEmail,
+    });
+
+    await client.verifyOneTimeToken({
+      token: oneTimeToken.token,
+      identifier: { type: SignInIdentifier.Email, value: userProfile.primaryEmail },
+    });
+
+    await expectRejects(
+      client.verifyOneTimeToken({
+        token: oneTimeToken.token,
+        identifier: { type: SignInIdentifier.Email, value: userProfile.primaryEmail },
+      }),
+      {
+        code: 'one_time_token.token_consumed',
+        status: 400,
+      }
+    );
+
+    void deleteOneTimeTokenById(oneTimeToken.id);
+  });
+
+  it('should fail to sign-in with a revoked one-time token', async () => {
+    const client = await initExperienceClient({
+      interactionEvent: InteractionEvent.SignIn,
+    });
+
+    const oneTimeToken = await createOneTimeToken({
+      email: userProfile.primaryEmail,
+    });
+
+    await updateOneTimeTokenStatus(oneTimeToken.token, OneTimeTokenStatus.Revoked);
+
+    await expectRejects(
+      client.verifyOneTimeToken({
+        token: oneTimeToken.token,
+        identifier: { type: SignInIdentifier.Email, value: userProfile.primaryEmail },
+      }),
+      {
+        code: 'one_time_token.token_revoked',
+        status: 400,
+      }
+    );
+
+    void deleteOneTimeTokenById(oneTimeToken.id);
+  });
+
+  it('should sign-in the user even if the sign-in method does not support email', async () => {
+    await updateSignInExperience({
+      signInMode: SignInMode.SignIn,
+      signUp: {
+        identifiers: [SignInIdentifier.Username],
+        password: true,
+        verify: false,
+      },
+      signIn: {
+        methods: [
+          {
+            identifier: SignInIdentifier.Username,
+            password: true,
+            verificationCode: false,
+            isPasswordPrimary: true,
+          },
+        ],
+      },
+    });
+
+    const client = await initExperienceClient({
+      interactionEvent: InteractionEvent.SignIn,
+    });
+
+    const oneTimeToken = await createOneTimeToken({
+      email: userProfile.primaryEmail,
+    });
+
+    const { verificationId } = await client.verifyOneTimeToken({
+      token: oneTimeToken.token,
+      identifier: { type: SignInIdentifier.Email, value: userProfile.primaryEmail },
+    });
+
+    await client.identifyUser({ verificationId });
+
+    const { redirectTo } = await client.submitInteraction();
+    const userId = await processSession(client, redirectTo);
+
+    expect(userId).toBe(user.id);
+
+    await logoutClient(client);
+    void deleteUser(userId);
+    void deleteOneTimeTokenById(oneTimeToken.id);
+  });
+});


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Do NOT check sign-in method when sign-in user with magic link (one-time token).

Previously if the email sign-in method is not enabled, we'll see the error below when sign-in via magic link.
```
This sign-in method is not enabled.
```

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
More API integration tests added

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
