### PR TITLE
refactor(core): respond 404 for non-existing paths in `/assets`

### DIFF
--- a/.changeset/five-melons-kneel.md
+++ b/.changeset/five-melons-kneel.md
@@ -1,0 +1,10 @@
+---
+"@logto/core": patch
+---
+
+respond 404 for non-existing paths in `/assets`
+
+Our single-page application proxy now responds with a 404 for non-existing paths in `/assets` instead of falling back to the `index.html` file.
+
+This prevents the browser and CDN from caching the `index.html` file for non-existing paths in `/assets`, which can lead to confusion and unexpected behavior.
+Since the `/assets` path is used only for static assets, it is safe and improves the user experience. 

--- a/packages/core/src/middleware/koa-spa-proxy.ts
+++ b/packages/core/src/middleware/koa-spa-proxy.ts
@@ -67,7 +67,13 @@ export default function koaSpaProxy<StateT, ContextT extends IRouterParamContext
 
     const spaDistributionFiles = await fs.readdir(distributionPath);
 
-    if (!spaDistributionFiles.some((file) => requestPath.startsWith('/' + file))) {
+    // Fall back to root if the request is not for a SPA distribution file
+    // We should exclude the `/assets` folder here since it should return 404 if the file is not
+    // found
+    if (
+      !requestPath.startsWith('/assets/') &&
+      !spaDistributionFiles.some((file) => requestPath.startsWith('/' + file))
+    ) {
       ctx.request.path = '/';
     }
 

--- a/packages/integration-tests/src/tests/api/spa-proxy.test.ts
+++ b/packages/integration-tests/src/tests/api/spa-proxy.test.ts
@@ -1,0 +1,20 @@
+import ky, { HTTPError } from 'ky';
+
+import { logtoConsoleUrl, logtoUrl } from '#src/constants.js';
+
+const apps = [
+  { name: 'experience', app: ky.extend({ prefixUrl: new URL(logtoUrl) }) },
+  { name: 'console', app: ky.extend({ prefixUrl: new URL(logtoConsoleUrl) }) },
+];
+
+describe.each(apps)('single page app: %s', ({ app }) => {
+  it('should fall back to index.html when the path is not found', async () => {
+    const body = await app.get('non-existing-path').text();
+    expect(body).toContain('</html>');
+  });
+
+  it('should return 404 for non-existing path in the `/assets` folder', async () => {
+    const response = await app.get('assets/non-existing-path').catch((error: unknown) => error);
+    expect(response instanceof HTTPError && response.response.status === 404).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Our single-page application proxy now responds with a 404 for non-existing paths in `/assets` instead of falling back to the `index.html` file.

This prevents the browser and CDN from caching the `index.html` file for non-existing paths in `/assets`, which can lead to confusion and unexpected behavior.
Since the `/assets` path is used only for static assets, it is safe and improves the user experience. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
integration tests added.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
