### PR TITLE
refactor(cli): loose CLI version restriction on Node.js

### DIFF
--- a/.changeset/sweet-houses-lie.md
+++ b/.changeset/sweet-houses-lie.md
@@ -1,0 +1,7 @@
+---
+"@logto/cli": patch
+---
+
+loose CLI version restriction on Node.js
+
+Allows the CLI to run on a higher Node.js major version rather than exiting with an error. This is useful for users who are on a newer Node.js version but still want to use the CLI.

--- a/.github/workflows/alteration-compatibility-integration-test.yml
+++ b/.github/workflows/alteration-compatibility-integration-test.yml
@@ -80,6 +80,7 @@ jobs:
           test-target: ${{ matrix.target }}
           db-alteration-target: ${{ github.head_ref }}
           pnpm-version: 9
+          node-version: ^22.14.0
 
   # Automatically rerun the workflow since the integration tests are moody
   # From this genius: https://github.com/orgs/community/discussions/67654#discussioncomment-8038649

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -49,6 +49,7 @@ jobs:
           logto-artifact: integration-test-${{ github.sha }}-dev-features-${{ env.DEV_FEATURES_ENABLED }}
           test-target: ${{ matrix.target }}
           pnpm-version: 9
+          node-version: ^22.14.0
 
   # Automatically rerun the workflow since the integration tests are moody
   # From this genius: https://github.com/orgs/community/discussions/67654#discussioncomment-8038649


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
be more flexible with Node.js versions when installing Logto via CLI to enable more users.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

### Node.js 20

<img width="731" alt="image" src="https://github.com/user-attachments/assets/d12e3427-37bd-433f-ba66-47663455bb1e" />

### Node.js 22.14

<img width="503" alt="image" src="https://github.com/user-attachments/assets/3a42500c-906a-4192-8dfd-f9cb4240fadc" />

### Node.js 22.11

<img width="734" alt="image" src="https://github.com/user-attachments/assets/601e70d1-314a-49ab-93e0-4475fe3078b7" />

### Node.js 23

<img width="738" alt="image" src="https://github.com/user-attachments/assets/a171d462-6dc3-4cc5-af3b-8519ad72ab20" />


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
