### PR TITLE
refactor(schemas): change default sentinel settings

### DIFF
--- a/packages/core/src/sentinel/basic-sentinel.ts
+++ b/packages/core/src/sentinel/basic-sentinel.ts
@@ -20,6 +20,13 @@ import { convertToIdentifiers } from '#src/utils/sql.js';
 
 import { EnvSet } from '../env-set/index.js';
 
+// TODO: Remove this when the sentinel policy is fully integrated into the system.
+// This is a legacy sentinel policy that is used to sync with the current sentinel policy on production
+const legacyDefaultSentinelPolicy = {
+  maxAttempts: 5,
+  lockoutDuration: 10,
+};
+
 const { fields, table } = convertToIdentifiers(SentinelActivities);
 
 /**
@@ -123,7 +130,7 @@ export default class BasicSentinel extends Sentinel {
   protected async getSentinelPolicy() {
     // TODO: remove this check when the sentinel policy is fully integrated into the system.
     if (!EnvSet.values.isDevFeaturesEnabled) {
-      return defaultSentinelPolicy;
+      return legacyDefaultSentinelPolicy;
     }
 
     const {

--- a/packages/core/src/sentinel/basic-sentinel.ts
+++ b/packages/core/src/sentinel/basic-sentinel.ts
@@ -8,6 +8,7 @@ import {
   SentinelActionResult,
   SentinelActivityAction,
   defaultSentinelPolicy,
+  type SentinelPolicy,
 } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 import { type Nullable } from '@silverhand/essentials';
@@ -22,10 +23,10 @@ import { EnvSet } from '../env-set/index.js';
 
 // TODO: Remove this when the sentinel policy is fully integrated into the system.
 // This is a legacy sentinel policy that is used to sync with the current sentinel policy on production
-const legacyDefaultSentinelPolicy = {
+const legacyDefaultSentinelPolicy = Object.freeze({
   maxAttempts: 5,
   lockoutDuration: 10,
-};
+}) satisfies SentinelPolicy;
 
 const { fields, table } = convertToIdentifiers(SentinelActivities);
 

--- a/packages/integration-tests/src/tests/api/experience-api/basic-sentinel.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/basic-sentinel.test.ts
@@ -1,6 +1,7 @@
 import { SignInIdentifier } from '@logto/schemas';
 
 import { authedAdminApi } from '#src/api/api.js';
+import { updateSignInExperience } from '#src/api/sign-in-experience.js';
 import { initExperienceClient } from '#src/helpers/client.js';
 import { signInWithPassword } from '#src/helpers/experience/index.js';
 import { expectRejects } from '#src/helpers/index.js';
@@ -11,6 +12,20 @@ import { devFeatureTest, generateUsername } from '#src/utils.js';
 devFeatureTest.describe('basic sentinel', () => {
   beforeAll(async () => {
     await enableAllPasswordSignInMethods();
+    /**
+     * The default policy settings is way too big for the test.
+     * We need to override it to make the test.
+     * Update the sign-in experience to use the legacy policy settings:
+     *
+     * - maxAttempts: 5
+     * - lockoutDuration: 10 minutes
+     */
+    await updateSignInExperience({
+      sentinelPolicy: {
+        maxAttempts: 5,
+        lockoutDuration: 10,
+      },
+    });
   });
 
   describe('sign-in with non-existing username and password', () => {

--- a/packages/integration-tests/src/tests/experience/basic-sentinel.test.ts
+++ b/packages/integration-tests/src/tests/experience/basic-sentinel.test.ts
@@ -1,10 +1,26 @@
-import { demoAppUrl } from '#src/constants.js';
+import { demoAppUrl, isDevFeaturesEnabled } from '#src/constants.js';
 import ExpectExperience from '#src/ui-helpers/expect-experience.js';
 import { setupUsernameAndEmailExperience } from '#src/ui-helpers/index.js';
 
 describe('basic sentinel', () => {
   beforeAll(async () => {
-    await setupUsernameAndEmailExperience();
+    await setupUsernameAndEmailExperience(
+      undefined,
+      isDevFeaturesEnabled
+        ? /**
+           * The default policy settings is way too big for the test.
+           * We need to override it to make the test.
+           * Update the sign-in experience to use the legacy policy settings:
+           *
+           * - maxAttempts: 5
+           * - lockoutDuration: 10 minutes
+           */
+          {
+            maxAttempts: 5,
+            lockoutDuration: 10,
+          }
+        : undefined
+    );
   });
 
   it('should block a non-existing identifier after 5 failed attempts in 1 hour', async () => {

--- a/packages/integration-tests/src/ui-helpers/index.ts
+++ b/packages/integration-tests/src/ui-helpers/index.ts
@@ -1,5 +1,11 @@
 import { ConnectorType } from '@logto/connector-kit';
-import { SignInMode, SignInIdentifier, type PartialPasswordPolicy } from '@logto/schemas';
+import {
+  SignInMode,
+  SignInIdentifier,
+  type PartialPasswordPolicy,
+  type SentinelPolicy,
+} from '@logto/schemas';
+import { conditional } from '@silverhand/essentials';
 import { type ElementHandle, type Browser, type Page, type Frame } from 'puppeteer';
 
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
@@ -158,7 +164,10 @@ export const getInputValue = async (input: ElementHandle<HTMLInputElement>) => {
  *
  * @param passwordPolicy The password policy to partially update the existing one.
  */
-export const setupUsernameAndEmailExperience = async (passwordPolicy?: PartialPasswordPolicy) => {
+export const setupUsernameAndEmailExperience = async (
+  passwordPolicy?: PartialPasswordPolicy,
+  sentinelPolicy?: SentinelPolicy
+) => {
   await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);
   await setEmailConnector();
   await updateSignInExperience({
@@ -186,6 +195,7 @@ export const setupUsernameAndEmailExperience = async (passwordPolicy?: PartialPa
         },
       ],
     },
-    passwordPolicy,
+    ...conditional(passwordPolicy && { passwordPolicy }),
+    ...conditional(sentinelPolicy && { sentinelPolicy }),
   });
 };

--- a/packages/schemas/src/consts/sentinel.ts
+++ b/packages/schemas/src/consts/sentinel.ts
@@ -3,8 +3,8 @@ import type { SentinelPolicy } from '../foundations/index.js';
 /**
  * The default policy for this sentinel.
  *
- * - `maxAttempts`: 5
- * - `lockoutDuration`: 10 minutes
+ * - `maxAttempts`: 100
+ * - `lockoutDuration`: 60 minutes
  */
 export const defaultSentinelPolicy = Object.freeze({
   maxAttempts: 100,

--- a/packages/schemas/src/consts/sentinel.ts
+++ b/packages/schemas/src/consts/sentinel.ts
@@ -7,6 +7,6 @@ import type { SentinelPolicy } from '../foundations/index.js';
  * - `lockoutDuration`: 10 minutes
  */
 export const defaultSentinelPolicy = Object.freeze({
-  maxAttempts: 5,
-  lockoutDuration: 10,
+  maxAttempts: 100,
+  lockoutDuration: 60,
 } satisfies SentinelPolicy);


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Loosen the default sentinel policy settings:

- maxAttempts: 100
- lockoutDuration: 60

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
