### PR TITLE
refactor(console): refactor sign-in experience page data

### DIFF
--- a/packages/console/src/components/SignInExperiencePreview/index.tsx
+++ b/packages/console/src/components/SignInExperiencePreview/index.tsx
@@ -1,18 +1,10 @@
 import type { LanguageTag } from '@logto/language-kit';
 import { Theme, ConnectorType } from '@logto/schemas';
-import type { ConnectorMetadata, SignInExperience, ConnectorResponse } from '@logto/schemas';
+import type { ConnectorMetadata, ConnectorResponse } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
 import classNames from 'classnames';
 import { format } from 'date-fns';
-import {
-  useContext,
-  useRef,
-  useMemo,
-  useCallback,
-  useEffect,
-  useState,
-  type ReactNode,
-} from 'react';
+import { useContext, useRef, useMemo, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 
@@ -20,6 +12,7 @@ import PhoneInfo from '@/assets/images/phone-info.svg?react';
 import { AppDataContext } from '@/contexts/AppDataProvider';
 import type { RequestError } from '@/hooks/use-api';
 import useUiLanguages from '@/hooks/use-ui-languages';
+import { type SignInExperiencePageManagedData } from '@/pages/SignInExperience/types';
 
 import styles from './index.module.scss';
 import { PreviewPlatform } from './types';
@@ -30,7 +23,7 @@ type Props = {
   readonly platform: PreviewPlatform;
   readonly mode: Theme;
   readonly language?: LanguageTag;
-  readonly signInExperience?: SignInExperience;
+  readonly signInExperience?: SignInExperiencePageManagedData;
   /**
    * The Logto endpoint to use for the preview. If not provided, the current tenant endpoint from
    * the `AppDataContext` will be used.
@@ -42,10 +35,6 @@ type Props = {
    */
   // eslint-disable-next-line react/boolean-prop-naming
   readonly disabled?: boolean;
-  /**
-   * The placeholder to show when the preview is disabled.
-   */
-  readonly disabledPlaceholder?: ReactNode;
 };
 
 function SignInExperiencePreview({
@@ -55,7 +44,6 @@ function SignInExperiencePreview({
   signInExperience,
   endpoint: endpointInput,
   disabled = false,
-  disabledPlaceholder,
 }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 

--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignInChangePreview/PasswordDisabledNotification.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignInChangePreview/PasswordDisabledNotification.tsx
@@ -1,13 +1,14 @@
-import { SignInIdentifier, type SignInExperience } from '@logto/schemas';
+import { SignInIdentifier } from '@logto/schemas';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import InlineNotification from '@/ds-components/InlineNotification';
 
+import { type SignInExperiencePageManagedData } from '../../types';
 import { signUpFormDataParser } from '../utils/parser';
 
 type Props = {
-  readonly after: SignInExperience;
+  readonly after: SignInExperiencePageManagedData;
   readonly className?: string;
 };
 

--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignInChangePreview/SignUpAndSignInDiffSection/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignInChangePreview/SignUpAndSignInDiffSection/index.tsx
@@ -1,12 +1,12 @@
-import type { SignInExperience } from '@logto/schemas';
+import { type SignInExperiencePageManagedData } from '@/pages/SignInExperience/types';
 
 import SignInDiffSection from './SignInDiffSection';
 import SignUpDiffSection from './SignUpDiffSection';
 import SocialTargetsDiffSection from './SocialTargetsDiffSection';
 
 type Props = {
-  readonly before: SignInExperience;
-  readonly after: SignInExperience;
+  readonly before: SignInExperiencePageManagedData;
+  readonly after: SignInExperiencePageManagedData;
   readonly isAfter?: boolean;
 };
 

--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignInChangePreview/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignInChangePreview/index.tsx
@@ -1,13 +1,14 @@
-import type { SignInExperience } from '@logto/schemas';
 import { useTranslation } from 'react-i18next';
+
+import { type SignInExperiencePageManagedData } from '../../types';
 
 import PasswordDisabledNotification from './PasswordDisabledNotification';
 import SignUpAndSignInDiffSection from './SignUpAndSignInDiffSection';
 import styles from './index.module.scss';
 
 type Props = {
-  readonly before: SignInExperience;
-  readonly after: SignInExperience;
+  readonly before: SignInExperiencePageManagedData;
+  readonly after: SignInExperiencePageManagedData;
 };
 
 function SignUpAndSignInChangePreview({ before, after }: Props) {

--- a/packages/console/src/pages/SignInExperience/PageContent/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/index.tsx
@@ -19,8 +19,11 @@ import { trySubmitSafe } from '@/utils/form';
 import Preview from '../components/Preview';
 import { SignInExperienceContext } from '../contexts/SignInExperienceContextProvider';
 import usePreviewConfigs from '../hooks/use-preview-configs';
-import { SignInExperienceTab } from '../types';
-import { type SignInExperienceForm } from '../types';
+import {
+  SignInExperienceTab,
+  type SignInExperiencePageManagedData,
+  type SignInExperienceForm,
+} from '../types';
 
 import Branding from './Branding';
 import Content from './Content';
@@ -34,7 +37,7 @@ import {
   getContentErrorCount,
   hasSignUpAndSignInConfigChanged,
 } from './utils/form';
-import { sieFormDataParser, signInExperienceDataDefaultValueParser } from './utils/parser';
+import { sieFormDataParser, signInExperienceToUpdatedDataParser } from './utils/parser';
 
 const PageTab = TabNavItem<`../${SignInExperienceTab}`>;
 
@@ -52,7 +55,7 @@ function PageContent({ data, onSignInExperienceUpdated }: Props) {
   const { getPathname } = useTenantPathname();
   const { isUploading, cancelUpload } = useContext(SignInExperienceContext);
 
-  const [dataToCompare, setDataToCompare] = useState<SignInExperience>();
+  const [dataToCompare, setDataToCompare] = useState<SignInExperiencePageManagedData>();
 
   const methods = useForm<SignInExperienceForm>({
     defaultValues: sieFormDataParser.fromSignInExperience(data),
@@ -76,7 +79,7 @@ function PageContent({ data, onSignInExperienceUpdated }: Props) {
     try {
       const updatedData = await api
         .patch('api/sign-in-exp', {
-          json: sieFormDataParser.toUpdateSignInExperienceData(getValues()),
+          json: sieFormDataParser.toSignInExperience(getValues()),
         })
         .json<SignInExperience>();
 
@@ -97,7 +100,7 @@ function PageContent({ data, onSignInExperienceUpdated }: Props) {
       }
 
       const formatted = sieFormDataParser.toSignInExperience(formData);
-      const original = signInExperienceDataDefaultValueParser(data);
+      const original = signInExperienceToUpdatedDataParser(data);
 
       // Sign-in methods changed, need to show confirm modal first.
       if (!hasSignUpAndSignInConfigChanged(original, formatted)) {

--- a/packages/console/src/pages/SignInExperience/PageContent/utils/form.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/utils/form.ts
@@ -1,8 +1,13 @@
-import type { SignInExperience, SignUp } from '@logto/schemas';
+import type { SignUp } from '@logto/schemas';
 import { diff } from 'deep-object-diff';
 import type { DeepRequired, FieldErrorsImpl } from 'react-hook-form';
 
-import type { SignInExperienceForm, SignInMethod, SignInMethodsObject } from '../../types';
+import type {
+  SignInExperienceForm,
+  SignInExperiencePageManagedData,
+  SignInMethod,
+  SignInMethodsObject,
+} from '../../types';
 
 export const convertToSignInMethodsObject = (signInMethods: SignInMethod[]): SignInMethodsObject =>
   signInMethods.reduce<SignInMethodsObject>(
@@ -25,8 +30,8 @@ const hasSocialTargetsChanged = (before: string[], after: string[]) =>
   Object.keys(diff(before.slice().sort(), after.slice().sort())).length > 0;
 
 export const hasSignUpAndSignInConfigChanged = (
-  before: SignInExperience,
-  after: SignInExperience
+  before: SignInExperiencePageManagedData,
+  after: SignInExperiencePageManagedData
 ): boolean => {
   return (
     !hasSignUpSettingsChanged(before.signUp, after.signUp) &&

--- a/packages/console/src/pages/SignInExperience/PageContent/utils/parser.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/utils/parser.ts
@@ -12,7 +12,7 @@ import { emptyBranding } from '@/types/sign-in-experience';
 import { removeFalsyValues } from '@/utils/object';
 
 import {
-  type UpdateSignInExperienceData,
+  type SignInExperiencePageManagedData,
   type SignInExperienceForm,
   type SignUpForm,
 } from '../../types';
@@ -114,12 +114,23 @@ export const signUpFormDataParser = {
 
 export const sieFormDataParser = {
   fromSignInExperience: (data: SignInExperience): SignInExperienceForm => {
-    const { signUp, signInMode, customCss, branding, passwordPolicy } = data;
+    const {
+      signUp,
+      customCss,
+      branding,
+      passwordPolicy,
+      // Start: Remove the omitted fields from the data
+      mfa,
+      captchaPolicy,
+      sentinelPolicy,
+      // End: Remove the omitted fields from the data
+      ...rest
+    } = data;
 
     return {
-      ...data,
+      ...rest,
       signUp: signUpFormDataParser.fromSignUp(signUp),
-      createAccountEnabled: signInMode !== SignInMode.SignIn,
+      createAccountEnabled: rest.signInMode !== SignInMode.SignIn,
       customCss: customCss ?? undefined,
       branding: {
         ...emptyBranding,
@@ -133,7 +144,7 @@ export const sieFormDataParser = {
       },
     };
   },
-  toSignInExperience: (formData: SignInExperienceForm): SignInExperience => {
+  toSignInExperience: (formData: SignInExperienceForm): SignInExperiencePageManagedData => {
     const {
       branding,
       createAccountEnabled,
@@ -158,29 +169,38 @@ export const sieFormDataParser = {
       },
     };
   },
-  toUpdateSignInExperienceData: (formData: SignInExperienceForm): UpdateSignInExperienceData => ({
-    ...sieFormDataParser.toSignInExperience(formData),
-    mfa: undefined,
-  }),
 };
 
 /**
  * The data parser takes the raw data from the API,
- * and fulfills the default values for the missing fields.
+ * - fulfills the default values for the missing fields.
+ * - removes the omitted fields from the data, convert the @see {SignInExperience} to the @see {SignInExperiencePageManagedData}
+ *
  * This is to ensure the data consistency between the form and the remote model.
  * So it won't trigger the form diff modal when the user hasn't changed anything.
  *
  * Affected fields:
  * - `signUp.secondaryIdentifiers`: This field is optional in the data schema,
  *  but through the form, we always fill it with an empty array.
+ * - `mfa`: This field is omitted in the data schema,
+ * - `captchaPolicy`: This field is omitted in the data schema,
+ * - `sentinelPolicy`: This field is omitted in the data schema,
  */
-export const signInExperienceDataDefaultValueParser = (
+export const signInExperienceToUpdatedDataParser = (
   data: SignInExperience
-): SignInExperience => {
-  const { signUp } = data;
+): SignInExperiencePageManagedData => {
+  const {
+    signUp,
+    // Start: Remove the omitted fields from the data
+    mfa,
+    captchaPolicy,
+    sentinelPolicy,
+    // End: Remove the omitted fields from the data
+    ...rest
+  } = data;
 
   return {
-    ...data,
+    ...rest,
     signUp: {
       ...signUp,
       secondaryIdentifiers: signUp.secondaryIdentifiers ?? [],

--- a/packages/console/src/pages/SignInExperience/components/Preview/index.tsx
+++ b/packages/console/src/pages/SignInExperience/components/Preview/index.tsx
@@ -1,6 +1,6 @@
 import type { LanguageTag } from '@logto/language-kit';
 import { languages as uiLanguageNameMapping } from '@logto/language-kit';
-import { type SignInExperience, Theme } from '@logto/schemas';
+import { Theme } from '@logto/schemas';
 import classNames from 'classnames';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -13,13 +13,15 @@ import TabNav, { TabNavItem } from '@/ds-components/TabNav';
 import useConnectorGroups from '@/hooks/use-connector-groups';
 import useUiLanguages from '@/hooks/use-ui-languages';
 
+import { type SignInExperiencePageManagedData } from '../../types';
+
 import styles from './index.module.scss';
 
 type Props = {
   readonly isLivePreviewDisabled?: boolean;
   readonly isLivePreviewEntryInvisible?: boolean;
   readonly isPreviewIframeDisabled?: boolean;
-  readonly signInExperience?: SignInExperience;
+  readonly signInExperience?: SignInExperiencePageManagedData;
   readonly className?: string;
 };
 

--- a/packages/console/src/pages/SignInExperience/types.ts
+++ b/packages/console/src/pages/SignInExperience/types.ts
@@ -86,7 +86,7 @@ export type SignInMethodsObject = Record<
  * as they are not managed by the sign-in experience page.
  *
  * - Those keys should be omitted from the form data.
- * - Those keys should be ommited from the submitted data.
+ * - Those keys should be omitted from the submitted data.
  * - Those keys should not be used in any data comparison logic.
  */
 export type SignInExperiencePageManagedData = Omit<SignInExperience, OmittedSignInExperienceKeys>;

--- a/packages/console/src/pages/SignInExperience/types.ts
+++ b/packages/console/src/pages/SignInExperience/types.ts
@@ -6,6 +6,16 @@ import {
   type SignUpIdentifier as SignUpIdentifierMethod,
 } from '@logto/schemas';
 
+// TODO: Should also remove password policy from the sign-in experience once the security is ready
+/**
+ * Omit the `mfa`, `captchaPolicy`, and `sentinelPolicy` fields from the sign-in experience.
+ * Since those fields are not managed by the sign-in experience page.
+ */
+type OmittedSignInExperienceKeys = keyof Pick<
+  SignInExperience,
+  'mfa' | 'captchaPolicy' | 'sentinelPolicy'
+>;
+
 export enum SignInExperienceTab {
   Branding = 'branding',
   SignUpAndSignIn = 'sign-up-and-sign-in',
@@ -41,7 +51,7 @@ export type SignUpForm = Omit<SignUp, 'identifiers' | 'secondaryIdentifiers'> & 
 
 export type SignInExperienceForm = Omit<
   SignInExperience,
-  'signUp' | 'customCss' | 'passwordPolicy'
+  'signUp' | 'customCss' | 'passwordPolicy' | OmittedSignInExperienceKeys
 > & {
   customCss?: string; // Code editor components can not properly handle null value, manually transform null to undefined instead.
   signUp: SignUpForm;
@@ -70,10 +80,13 @@ export type SignInMethodsObject = Record<
   { password: boolean; verificationCode: boolean }
 >;
 
-export type UpdateSignInExperienceData = Omit<SignInExperience, 'mfa'> & {
-  /**
-   * `mfa` data will not be updated in the sign-in experience page.
-   * Hard code it to `undefined` to have a better type checking when constructing the update data.
-   */
-  mfa: undefined;
-};
+/**
+ * The managed data of the sign-in experience page.
+ * This type omits the properties defined in @see {OmittedSignInExperienceKeys},
+ * as they are not managed by the sign-in experience page.
+ *
+ * - Those keys should be omitted from the form data.
+ * - Those keys should be ommited from the submitted data.
+ * - Those keys should not be used in any data comparison logic.
+ */
+export type SignInExperiencePageManagedData = Omit<SignInExperience, OmittedSignInExperienceKeys>;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR refactors the sign-in experience page data parsing logic and type definitions on the console. 

We need to omit the `mfa`, `captchaPolicy`, and `sentinelPolicy` fields from the raw sign-in experience data, as they are not editable on the sign-in experience page. 

- Those keys should be omitted from the form data.
- Those keys should be omitted from the submitted data.
- Those keys should not be used in any data comparison logic.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
