### PR TITLE
fix(console): fix crash issue caused by mis-used inkeep code editor theme

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -89,6 +89,7 @@
     "postcss": "^8.4.39",
     "postcss-modules": "^6.0.0",
     "prettier": "^3.5.3",
+    "prism-react-renderer": "^2.4.1",
     "prop-types": "^15.8.1",
     "property-information": "^6.2.0",
     "react": "^18.3.1",

--- a/packages/console/src/hooks/use-inkeep-configs.ts
+++ b/packages/console/src/hooks/use-inkeep-configs.ts
@@ -1,4 +1,5 @@
 import { type InkeepSettings } from '@inkeep/cxkit-react';
+import { themes } from 'prism-react-renderer';
 import { useMemo } from 'react';
 
 import logtoAiBotDark from '@/assets/icons/logto-ai-bot-dark.svg?url';
@@ -33,7 +34,26 @@ const customStyles = `
     height: 20px;
     background: var(--inkeep-logto-icon) center/60px 20px no-repeat;
   }
-}`;
+}
+.ikp-codeblock-header {
+  background-color: var(--ikp-color-gray-dark-800);
+
+  .ikp-codeblock-header-language {
+    color: var(--ikp-color-gray-400);
+  }
+
+  .ikp-codeblock-copy-button {
+    color: var(--ikp-color-white-alpha-700);
+    
+    &:hover {
+      color: var(--ikp-color-white-alpha-950);
+    }
+  }
+}
+.ikp-codeblock-highlighter {
+  background-color: var(--ikp-color-gray-dark-900);
+}
+`;
 
 const useInkeepConfigs = () => {
   const theme = useTheme();
@@ -53,6 +73,10 @@ const useInkeepConfigs = () => {
             },
           },
           theme: {
+            syntaxHighlighter: {
+              lightTheme: themes.dracula,
+              darkTheme: themes.dracula,
+            },
             styles: [
               {
                 key: 'custom-styles',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3358,6 +3358,9 @@ importers:
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
+      prism-react-renderer:
+        specifier: ^2.4.1
+        version: 2.4.1(react@18.3.1)
       prop-types:
         specifier: ^15.8.1
         version: 15.8.1


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Completely fix the crash issue caused by a mis-used code editor theme in the inkeep AI bot.

Previously I was using the theme from `react-syntax-highlighter` package for the prism code editors in the AI bot, since we also use it in the Console app. However, after further investigation, inkeep uses theme from `prism-react-renderer`, and themes from these two packages are not 100% compatible.

Therefore, the inkeep config is updated to use the correct prism theme, and the crash issue is fixed completely.

Also the code editor theme is now fixed to "Dracula" (dark only).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested with built js files. No more app crash.

![image](https://github.com/user-attachments/assets/cb4fb138-77f8-4e90-9103-58078c177b1b)

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
