### PR TITLE
fix(experience): replace global loading layer

### DIFF
--- a/packages/experience/src/components/LoadingLayer/index.tsx
+++ b/packages/experience/src/components/LoadingLayer/index.tsx
@@ -5,11 +5,15 @@ import styles from './index.module.scss';
 
 export { default as LoadingIcon } from './LoadingIcon';
 
+export const LoadingIconWithContainer = () => (
+  <div className={styles.container}>
+    <LoadingIcon />
+  </div>
+);
+
 const LoadingLayer = () => (
   <LoadingMask>
-    <div className={styles.container}>
-      <LoadingIcon />
-    </div>
+    <LoadingIconWithContainer />
   </LoadingMask>
 );
 

--- a/packages/experience/src/pages/DirectSignIn/index.module.scss
+++ b/packages/experience/src/pages/DirectSignIn/index.module.scss
@@ -1,0 +1,7 @@
+@use '@/scss/underscore' as _;
+
+.container {
+  position: fixed;
+  inset: 0;
+  @include _.flex-column;
+}

--- a/packages/experience/src/pages/DirectSignIn/index.tsx
+++ b/packages/experience/src/pages/DirectSignIn/index.tsx
@@ -1,11 +1,13 @@
 import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 
-import LoadingLayer from '@/components/LoadingLayer';
+import { LoadingIconWithContainer } from '@/components/LoadingLayer';
 import useSocial from '@/containers/SocialSignInList/use-social';
 import useFallbackRoute from '@/hooks/use-fallback-route';
 import { useSieMethods } from '@/hooks/use-sie';
 import useSingleSignOn from '@/hooks/use-single-sign-on';
+
+import styles from './index.module.scss';
 
 const DirectSignIn = () => {
   const { method, target } = useParams();
@@ -35,6 +37,10 @@ const DirectSignIn = () => {
     window.location.replace('/' + fallback);
   }, [fallback, invokeSocialSignIn, invokeSso, method, socialConnectors, ssoConnectors, target]);
 
-  return <LoadingLayer />;
+  return (
+    <div className={styles.container}>
+      <LoadingIconWithContainer />
+    </div>
+  );
 };
 export default DirectSignIn;


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

###  Description
This PR fixes issue #7347. Replace the global loading layer in the direct sign-in landing page. 

### Steps to reproduce
- Enable terms of use, and set the policy to "Require checkbox agreement on both registration and sign-in".
- Use any social direct sign-in method

<img width="894" alt="image" src="https://github.com/user-attachments/assets/818eddfd-c072-4210-b49c-b57f929a7438" />

### Root cause
The loading layer displayed in the direct sign-in landing page should not block any user interaction.  As we do not have any form in this page so it is safe to keep it as a  in place loading icon. 



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
