### PR TITLE
fix: reCaptcha cannot be loaded in China

### DIFF
--- a/packages/core/src/middleware/koa-security-headers.ts
+++ b/packages/core/src/middleware/koa-security-headers.ts
@@ -111,7 +111,7 @@ export default function koaSecurityHeaders<StateT, ContextT, ResponseBodyT>(
           // Cloudflare Turnstile
           'https://challenges.cloudflare.com/turnstile/v0/api.js',
           // Google Recaptcha Enterprise
-          'https://www.google.com/recaptcha/enterprise.js',
+          'https://recaptcha.net/recaptcha/enterprise.js',
           // Google Recaptcha static resources
           'https://www.gstatic.com/recaptcha/',
           // Allow "unsafe-eval" for debugging purpose in non-production environment
@@ -123,7 +123,7 @@ export default function koaSecurityHeaders<StateT, ContextT, ResponseBodyT>(
           gsiOrigin,
           tenantEndpointOrigin,
           // Allow reCAPTCHA API calls
-          'https://www.google.com/recaptcha/',
+          'https://recaptcha.net/recaptcha/',
           'https://www.gstatic.com/recaptcha/',
           ...developmentOrigins,
         ],

--- a/packages/core/src/middleware/koa-security-headers.ts
+++ b/packages/core/src/middleware/koa-security-headers.ts
@@ -111,7 +111,7 @@ export default function koaSecurityHeaders<StateT, ContextT, ResponseBodyT>(
           // Cloudflare Turnstile
           'https://challenges.cloudflare.com/turnstile/v0/api.js',
           // Google Recaptcha Enterprise
-          'https://recaptcha.net/recaptcha/enterprise.js',
+          'https://www.recaptcha.net/recaptcha/enterprise.js',
           // Google Recaptcha static resources
           'https://www.gstatic.com/recaptcha/',
           // Allow "unsafe-eval" for debugging purpose in non-production environment
@@ -123,7 +123,7 @@ export default function koaSecurityHeaders<StateT, ContextT, ResponseBodyT>(
           gsiOrigin,
           tenantEndpointOrigin,
           // Allow reCAPTCHA API calls
-          'https://recaptcha.net/recaptcha/',
+          'https://www.recaptcha.net/recaptcha/',
           'https://www.gstatic.com/recaptcha/',
           ...developmentOrigins,
         ],

--- a/packages/experience/src/Providers/CaptchaContextProvider/utiles.ts
+++ b/packages/experience/src/Providers/CaptchaContextProvider/utiles.ts
@@ -11,5 +11,5 @@ export const getScript = (config: SignInExperienceResponse['captchaConfig']) => 
     return `https://challenges.cloudflare.com/turnstile/v0/api.js`;
   }
 
-  return `https://recaptcha.net/recaptcha/enterprise.js?render=${config.siteKey}`;
+  return `https://www.recaptcha.net/recaptcha/enterprise.js?render=${config.siteKey}`;
 };

--- a/packages/experience/src/Providers/CaptchaContextProvider/utiles.ts
+++ b/packages/experience/src/Providers/CaptchaContextProvider/utiles.ts
@@ -11,5 +11,5 @@ export const getScript = (config: SignInExperienceResponse['captchaConfig']) => 
     return `https://challenges.cloudflare.com/turnstile/v0/api.js`;
   }
 
-  return `https://www.google.com/recaptcha/enterprise.js?render=${config.siteKey}`;
+  return `https://recaptcha.net/recaptcha/enterprise.js?render=${config.siteKey}`;
 };

--- a/packages/experience/src/Providers/CaptchaContextProvider/utils.ts
+++ b/packages/experience/src/Providers/CaptchaContextProvider/utils.ts
@@ -12,5 +12,5 @@ export const getScript = (config: SignInExperienceResponse['captchaConfig']) => 
     return `https://challenges.cloudflare.com/turnstile/v0/api.js`;
   }
 
-  return `https://recaptcha.net/recaptcha/enterprise.js?render=${config.siteKey}`;
+  return `https://www.recaptcha.net/recaptcha/enterprise.js?render=${config.siteKey}`;
 };

--- a/packages/experience/src/Providers/CaptchaContextProvider/utils.ts
+++ b/packages/experience/src/Providers/CaptchaContextProvider/utils.ts
@@ -12,5 +12,5 @@ export const getScript = (config: SignInExperienceResponse['captchaConfig']) => 
     return `https://challenges.cloudflare.com/turnstile/v0/api.js`;
   }
 
-  return `https://www.google.com/recaptcha/enterprise.js?render=${config.siteKey}`;
+  return `https://recaptcha.net/recaptcha/enterprise.js?render=${config.siteKey}`;
 };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Since China's firewall blocks google.com, use recaptcha.net to avoid Chinese visitors not being able to load recaptcha

fix: https://github.com/logto-io/logto/issues/7351

Source: https://developers.google.com/recaptcha/docs/faq#can-i-use-recaptcha-globally



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
