### PR TITLE
feat(core,schemas,console): add email blocklist policy to sie

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/utils/parser.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/utils/parser.ts
@@ -122,6 +122,7 @@ export const sieFormDataParser = {
       mfa,
       captchaPolicy,
       sentinelPolicy,
+      emailBlocklistPolicy,
       // End: Remove the omitted fields from the data
       ...rest
     } = data;
@@ -161,10 +162,11 @@ export const sieFormDataParser = {
  * Affected fields:
  * - `signUp.secondaryIdentifiers`: This field is optional in the data schema,
  *  but through the form, we always fill it with an empty array.
- * - `mfa`: This field is omitted in the sign-in experience form.
- * - `passwordPolicy`: This field is omitted in the sign-in experience form.
- * - `captchaPolicy`: This field is omitted in the sign-in experience form.
- * - `sentinelPolicy`: This field is omitted in the sign-in experience form.
+ * - `mfa`
+ * - `passwordPolicy`
+ * - `captchaPolicy`
+ * - `sentinelPolicy`
+ * - `emailBlocklistPolicy`
  */
 export const signInExperienceToUpdatedDataParser = (
   data: SignInExperience
@@ -176,6 +178,7 @@ export const signInExperienceToUpdatedDataParser = (
     passwordPolicy,
     captchaPolicy,
     sentinelPolicy,
+    emailBlocklistPolicy,
     // End: Remove the omitted fields from the data
     ...rest
   } = data;

--- a/packages/console/src/pages/SignInExperience/types.ts
+++ b/packages/console/src/pages/SignInExperience/types.ts
@@ -6,12 +6,12 @@ import {
 } from '@logto/schemas';
 
 /**
- * Omit the `mfa`, `captchaPolicy`, 'passwordPolicy', and `sentinelPolicy` fields from the sign-in experience.
+ * Omit the `mfa`, `captchaPolicy`, 'passwordPolicy', `sentinelPolicy` and `emailBlocklistPolicy` fields from the sign-in experience.
  * Since those fields are not managed by the sign-in experience page.
  */
 type OmittedSignInExperienceKeys = keyof Pick<
   SignInExperience,
-  'mfa' | 'captchaPolicy' | 'sentinelPolicy' | 'passwordPolicy'
+  'mfa' | 'captchaPolicy' | 'sentinelPolicy' | 'passwordPolicy' | 'emailBlocklistPolicy'
 >;
 
 export enum SignInExperienceTab {
@@ -48,7 +48,7 @@ export type SignUpForm = Omit<SignUp, 'identifiers' | 'secondaryIdentifiers'> & 
 
 export type SignInExperienceForm = Omit<
   SignInExperience,
-  'signUp' | 'customCss' | 'passwordPolicy' | OmittedSignInExperienceKeys
+  'signUp' | 'customCss' | OmittedSignInExperienceKeys
 > & {
   customCss?: string; // Code editor components can not properly handle null value, manually transform null to undefined instead.
   signUp: SignUpForm;

--- a/packages/core/src/__mocks__/sign-in-experience.ts
+++ b/packages/core/src/__mocks__/sign-in-experience.ts
@@ -105,4 +105,5 @@ export const mockSignInExperience: SignInExperience = {
   unknownSessionRedirectUrl: null,
   captchaPolicy: {},
   sentinelPolicy: {},
+  emailBlocklistPolicy: {},
 };

--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
@@ -1,9 +1,9 @@
 import RequestError from '../../errors/RequestError/index.js';
 
-import { validateEmailBlocklistPolicy } from './email-blocklist-policy.js';
+import { parseEmailBlocklistPolicy } from './email-blocklist-policy.js';
 
 const invalidCustomBlockList = ['bar', 'bar@foo', '@foo', '@foo.', 'bar@foo.'];
-const validCustomBlockList = ['bar@foo.com', '@foo.com', 'abc.bar@foo.xyz'];
+const validCustomBlockList = ['bar@foo.com', '@foo.com', 'abc.bar@foo.xyz', 'bar@foo.com'];
 
 describe('validateEmailBlocklistPolicy', () => {
   it.each(invalidCustomBlockList)(
@@ -11,7 +11,7 @@ describe('validateEmailBlocklistPolicy', () => {
     (item) => {
       const emailBlocklistPolicy = { customBlocklist: [item] };
       expect(() => {
-        validateEmailBlocklistPolicy(emailBlocklistPolicy);
+        parseEmailBlocklistPolicy(emailBlocklistPolicy);
       }).toMatchError(
         new RequestError({
           code: 'sign_in_experiences.invalid_custom_email_blocklist_format',
@@ -24,13 +24,12 @@ describe('validateEmailBlocklistPolicy', () => {
 
   it('should throw if duplicate custom email blocklist items is detected', () => {
     expect(() => {
-      validateEmailBlocklistPolicy({ customBlocklist: ['bar@foo.com', 'bar@foo.com'] });
+      parseEmailBlocklistPolicy({ customBlocklist: ['bar@foo.com', 'bar@foo.com'] });
     }).toMatchError(new RequestError('sign_in_experiences.duplicate_custom_email_blocklist_items'));
   });
 
-  it('should pass the validation with valid format', () => {
-    expect(() => {
-      validateEmailBlocklistPolicy({ customBlocklist: validCustomBlockList });
-    }).not.toThrow();
+  it('should pass the validation with valid format and deduplicate items', () => {
+    const parsed = parseEmailBlocklistPolicy({ customBlocklist: ['bar@foo.com', 'bar@foo.com'] });
+    expect(parsed).toEqual(['bar@foo.com']);
   });
 });

--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
@@ -1,0 +1,36 @@
+import RequestError from '../../errors/RequestError/index.js';
+
+import { validateEmailBlocklistPolicy } from './email-blocklist-policy.js';
+
+const invalidCustomBlockList = ['bar', 'bar@foo', '@foo', '@foo.', 'bar@foo.'];
+const validCustomBlockList = ['bar@foo.com', '@foo.com', 'abc.bar@foo.xyz'];
+
+describe('validateEmailBlocklistPolicy', () => {
+  it.each(invalidCustomBlockList)(
+    'should throw error for invalid custom block list item: %s',
+    (item) => {
+      const emailBlocklistPolicy = { customBlocklist: [item] };
+      expect(() => {
+        validateEmailBlocklistPolicy(emailBlocklistPolicy);
+      }).toMatchError(
+        new RequestError({
+          code: 'sign_in_experiences.invalid_custom_email_blocklist_format',
+          items: Array.from([item]),
+          status: 400,
+        })
+      );
+    }
+  );
+
+  it('should throw if duplicate custom email blocklist items is detected', () => {
+    expect(() => {
+      validateEmailBlocklistPolicy({ customBlocklist: ['bar@foo.com', 'bar@foo.com'] });
+    }).toMatchError(new RequestError('sign_in_experiences.duplicate_custom_email_blocklist_items'));
+  });
+
+  it('should pass the validation with valid format', () => {
+    expect(() => {
+      validateEmailBlocklistPolicy({ customBlocklist: validCustomBlockList });
+    }).not.toThrow();
+  });
+});

--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
@@ -1,3 +1,5 @@
+import { deduplicate } from '@silverhand/essentials';
+
 import RequestError from '../../errors/RequestError/index.js';
 
 import { parseEmailBlocklistPolicy } from './email-blocklist-policy.js';
@@ -29,7 +31,7 @@ describe('validateEmailBlocklistPolicy', () => {
   });
 
   it('should pass the validation with valid format and deduplicate items', () => {
-    const parsed = parseEmailBlocklistPolicy({ customBlocklist: ['bar@foo.com', 'bar@foo.com'] });
-    expect(parsed).toEqual(['bar@foo.com']);
+    const parsed = parseEmailBlocklistPolicy({ customBlocklist: validCustomBlockList });
+    expect(parsed).toEqual({ customBlocklist: deduplicate(validCustomBlockList) });
   });
 });

--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
@@ -24,12 +24,6 @@ describe('validateEmailBlocklistPolicy', () => {
     }
   );
 
-  it('should throw if duplicate custom email blocklist items is detected', () => {
-    expect(() => {
-      parseEmailBlocklistPolicy({ customBlocklist: ['bar@foo.com', 'bar@foo.com'] });
-    }).toMatchError(new RequestError('sign_in_experiences.duplicate_custom_email_blocklist_items'));
-  });
-
   it('should pass the validation with valid format and deduplicate items', () => {
     const parsed = parseEmailBlocklistPolicy({ customBlocklist: validCustomBlockList });
     expect(parsed).toEqual({ customBlocklist: deduplicate(validCustomBlockList) });

--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
@@ -1,0 +1,37 @@
+import { type EmailBlocklistPolicy } from '@logto/schemas';
+import { deduplicate } from '@silverhand/essentials';
+
+import RequestError from '../../errors/RequestError/index.js';
+
+const emailOrEmailDomainRegex = /^\S+@\S+\.\S+|^@\S+\.\S+$/;
+
+const validateCustomBlockList = (list: string[]) => {
+  const invalidItems = new Set();
+
+  for (const item of list) {
+    if (!emailOrEmailDomainRegex.test(item)) {
+      invalidItems.add(item);
+    }
+  }
+
+  return invalidItems;
+};
+
+export const validateEmailBlocklistPolicy = (emailBlocklistPolicy: EmailBlocklistPolicy) => {
+  const { customBlocklist = [] } = emailBlocklistPolicy;
+  const invalidItems = validateCustomBlockList(customBlocklist);
+
+  if (invalidItems.size > 0) {
+    throw new RequestError({
+      code: 'sign_in_experiences.invalid_custom_email_blocklist_format',
+      items: Array.from(invalidItems),
+      status: 400,
+    });
+  }
+
+  const deduplicateList = deduplicate(customBlocklist);
+
+  if (deduplicateList.length !== customBlocklist.length) {
+    throw new RequestError('sign_in_experiences.duplicate_custom_email_blocklist_items');
+  }
+};

--- a/packages/core/src/libraries/sign-in-experience/index.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.ts
@@ -26,6 +26,7 @@ import { type CloudConnectionLibrary } from '../cloud-connection.js';
 
 export * from './sign-up.js';
 export * from './sign-in.js';
+export * from './email-blocklist-policy.js';
 
 export const developmentTenantPlanId = 'dev';
 

--- a/packages/core/src/queries/sign-in-experience.test.ts
+++ b/packages/core/src/queries/sign-in-experience.test.ts
@@ -38,12 +38,13 @@ describe('sign-in-experience query', () => {
     socialSignIn: JSON.stringify(mockSignInExperience.socialSignIn),
     captchaPolicy: JSON.stringify(mockSignInExperience.captchaPolicy),
     sentinelPolicy: JSON.stringify(mockSignInExperience.sentinelPolicy),
+    emailBlocklistPolicy: JSON.stringify(mockSignInExperience.emailBlocklistPolicy),
   };
 
   it('findDefaultSignInExperience', async () => {
     /* eslint-disable sql/no-unsafe-query */
     const expectSql = `
-      select "tenant_id", "id", "color", "branding", "language_info", "terms_of_use_url", "privacy_policy_url", "agree_to_terms_policy", "sign_in", "sign_up", "social_sign_in", "social_sign_in_connector_targets", "sign_in_mode", "custom_css", "custom_content", "custom_ui_assets", "password_policy", "mfa", "single_sign_on_enabled", "support_email", "support_website_url", "unknown_session_redirect_url", "captcha_policy", "sentinel_policy"
+      select "tenant_id", "id", "color", "branding", "language_info", "terms_of_use_url", "privacy_policy_url", "agree_to_terms_policy", "sign_in", "sign_up", "social_sign_in", "social_sign_in_connector_targets", "sign_in_mode", "custom_css", "custom_content", "custom_ui_assets", "password_policy", "mfa", "single_sign_on_enabled", "support_email", "support_website_url", "unknown_session_redirect_url", "captcha_policy", "sentinel_policy", "email_blocklist_policy"
       from "sign_in_experiences"
       where "id"=$1
     `;

--- a/packages/experience/src/__mocks__/logto.tsx
+++ b/packages/experience/src/__mocks__/logto.tsx
@@ -119,6 +119,7 @@ export const mockSignInExperience: SignInExperience = {
   unknownSessionRedirectUrl: null,
   captchaPolicy: {},
   sentinelPolicy: {},
+  emailBlocklistPolicy: {},
 };
 
 export const mockSignInExperienceSettings: SignInExperienceResponse = {
@@ -159,6 +160,7 @@ export const mockSignInExperienceSettings: SignInExperienceResponse = {
   unknownSessionRedirectUrl: null,
   captchaPolicy: {},
   sentinelPolicy: {},
+  emailBlocklistPolicy: {},
 };
 
 const usernameSettings = {

--- a/packages/phrases/src/locales/en/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/en/errors/sign-in-experiences.ts
@@ -21,7 +21,6 @@ const sign_in_experiences = {
   missing_sign_up_identifiers: 'Primary sign-up identifier cannot be empty.',
   invalid_custom_email_blocklist_format:
     'Invalid custom email blocklist items: {{items, list(type:conjunction)}}. Each item must be a valid email address or email domain, e.g., foo@example.com or @example.com.',
-  duplicate_custom_email_blocklist_items: 'Duplicate custom email blocklist items detected.',
 };
 
 export default Object.freeze(sign_in_experiences);

--- a/packages/phrases/src/locales/en/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/en/errors/sign-in-experiences.ts
@@ -19,6 +19,9 @@ const sign_in_experiences = {
   duplicated_mfa_factors: 'Duplicated MFA factors.',
   duplicated_sign_up_identifiers: 'Duplicate sign-up identifiers detected.',
   missing_sign_up_identifiers: 'Primary sign-up identifier cannot be empty.',
+  invalid_custom_email_blocklist_format:
+    'Invalid custom email blocklist items: {{items, list(type:conjunction)}}. Each item must be a valid email address or email domain, e.g., foo@example.com or @example.com.',
+  duplicate_custom_email_blocklist_items: 'Duplicate custom email blocklist items detected.',
 };
 
 export default Object.freeze(sign_in_experiences);

--- a/packages/schemas/alterations/next-1745735646-add-email-blocklist-policy-column-to-sie-table.ts
+++ b/packages/schemas/alterations/next-1745735646-add-email-blocklist-policy-column-to-sie-table.ts
@@ -1,0 +1,20 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      alter table sign_in_experiences
+        add column email_blocklist_policy jsonb not null default '{}'::jsonb;
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      alter table sign_in_experiences
+        drop column email_blocklist_policy;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/foundations/jsonb-types/sign-in-experience.ts
+++ b/packages/schemas/src/foundations/jsonb-types/sign-in-experience.ts
@@ -251,3 +251,30 @@ export const sentinelPolicyGuard = z.object({
   maxAttempts: z.number().optional(),
   lockoutDuration: z.number().optional(),
 }) satisfies ToZodObject<SentinelPolicy>;
+
+/**
+ * Email blocklist policy.
+ *
+ * @remarks
+ * This policy is used to block specific email addresses or domains from signing up.
+ */
+export type EmailBlocklistPolicy = {
+  blockDisposableAddresses?: boolean;
+  blockSubaddressing?: boolean;
+  /**
+   * Custom blocklist of email addresses or domains.
+   *
+   * @example
+   * Email address: abc@xyx.com
+   *
+   * @example
+   * Domain name: @xyz.com
+   */
+  customBlocklist?: string[];
+};
+
+export const emailBlocklistPolicyGuard = z.object({
+  blockDisposableAddresses: z.boolean().optional(),
+  blockSubaddressing: z.boolean().optional(),
+  customBlocklist: z.string().array().optional(),
+}) satisfies ToZodObject<EmailBlocklistPolicy>;

--- a/packages/schemas/tables/sign_in_experiences.sql
+++ b/packages/schemas/tables/sign_in_experiences.sql
@@ -28,5 +28,6 @@ create table sign_in_experiences (
   unknown_session_redirect_url text,
   captcha_policy jsonb /* @use CaptchaPolicy */ not null default '{}'::jsonb,
   sentinel_policy jsonb /* @use SentinelPolicy */ not null default '{}'::jsonb,
+  email_blocklist_policy jsonb /* @use EmailBlocklistPolicy */ not null default '{}'::jsonb,
   primary key (tenant_id, id)
 );


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add email blocklist policy field to the sign-in experience settings.

- `blockDisposableAddresses`: Boolean value, indicates whether to resrtrict the disposable email address from sign-up. 
- `blockSubaddressing`: Boolean value, indicates whether to restrict the email subaddressing from sign-up. 
- `customBlocklist`: String list, specifies custom email address or email domain blocklist. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
Unit test added

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
