### PR TITLE
feat(core): add email blocklist guard

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+public-hoist-pattern[]=*eslint*

--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
@@ -1,8 +1,12 @@
+import { type EmailBlocklistPolicy } from '@logto/schemas';
 import { deduplicate } from '@silverhand/essentials';
 
-import RequestError from '../../errors/RequestError/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
 
-import { parseEmailBlocklistPolicy } from './email-blocklist-policy.js';
+import {
+  parseEmailBlocklistPolicy,
+  validateEmailAgainstBlocklistPolicy,
+} from './email-blocklist-policy.js';
 
 const invalidCustomBlockList = ['bar', 'bar@foo', '@foo', '@foo.', 'bar@foo.'];
 const validCustomBlockList = ['bar@foo.com', '@foo.com', 'abc.bar@foo.xyz', 'bar@foo.com'];
@@ -27,5 +31,60 @@ describe('validateEmailBlocklistPolicy', () => {
   it('should pass the validation with valid format and deduplicate items', () => {
     const parsed = parseEmailBlocklistPolicy({ customBlocklist: validCustomBlockList });
     expect(parsed).toEqual({ customBlocklist: deduplicate(validCustomBlockList) });
+  });
+});
+
+describe('validateEmailAgainstBlocklistPolicy', () => {
+  const emailBlocklistPolicy: EmailBlocklistPolicy = {
+    blockDisposableAddresses: true,
+    blockSubaddressing: true,
+    customBlocklist: ['foo@bar.com', '@foo.com'],
+  };
+
+  it('should throw if the email uses subaddressing', async () => {
+    await expect(
+      validateEmailAgainstBlocklistPolicy(emailBlocklistPolicy, 'foo+1@bar.com')
+    ).rejects.toMatchError(
+      new RequestError({
+        code: 'session.email_blocklist.email_subaddressing_not_allowed',
+        status: 422,
+      })
+    );
+  });
+
+  it('should throw if the email domain is in the custom blocklist', async () => {
+    const emails = ['test@foo.com', 'bar@foo.com'];
+
+    for (const email of emails) {
+      // eslint-disable-next-line no-await-in-loop
+      await expect(
+        validateEmailAgainstBlocklistPolicy(emailBlocklistPolicy, email)
+      ).rejects.toMatchError(
+        new RequestError({
+          code: 'session.email_blocklist.email_not_allowed',
+          status: 422,
+          email,
+        })
+      );
+    }
+  });
+
+  it('should throw if the email address is in the custom blocklist', async () => {
+    const email = 'foo@bar.com';
+    await expect(
+      validateEmailAgainstBlocklistPolicy(emailBlocklistPolicy, email)
+    ).rejects.toMatchError(
+      new RequestError({
+        code: 'session.email_blocklist.email_not_allowed',
+        status: 422,
+        email,
+      })
+    );
+  });
+
+  it('should pass the blocklist policy validation', async () => {
+    await expect(
+      validateEmailAgainstBlocklistPolicy(emailBlocklistPolicy, 'test@bar.com')
+    ).resolves.not.toThrow();
   });
 });

--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
@@ -2,9 +2,9 @@ import { emailOrEmailDomainRegex } from '@logto/core-kit';
 import { type EmailBlocklistPolicy } from '@logto/schemas';
 import { conditional, deduplicate } from '@silverhand/essentials';
 
-import { EnvSet } from '../../env-set/index.js';
-import RequestError from '../../errors/RequestError/index.js';
-import assertThat from '../../utils/assert-that.js';
+import { EnvSet } from '#src/env-set/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
+import assertThat from '#src/utils/assert-that.js';
 
 const validateCustomBlockListFormat = (list: string[]) => {
   const invalidItems = new Set();
@@ -54,4 +54,65 @@ export const parseEmailBlocklistPolicy = (
     ...rest,
     ...conditional(customBlocklist && { customBlocklist: parseCustomBlocklist(customBlocklist) }),
   };
+};
+
+/**
+ * Guard the email address is not in the sign-in experience blocklist. *
+ *
+ * @remarks
+ * - guard disposable email domain if enabled
+ * - guard email subaddessing if enabled
+ * - guard custom email address/domain if provided
+ *
+ * @remarks
+ * This validation should be applied to all the client email profile fullment flow.
+ * - experience API
+ * - account API
+ */
+export const validateEmailAgainstBlocklistPolicy = async (
+  emailBlocklistPolicy: EmailBlocklistPolicy,
+  email: string
+) => {
+  const { customBlocklist, blockDisposableAddresses, blockSubaddressing } = emailBlocklistPolicy;
+  const domain = email.split('@')[1];
+
+  assertThat(domain, new RequestError('session.email_blocklist.invalid_email'));
+
+  // Guard disposable email domain if enabled
+  if (EnvSet.values.isCloud && blockDisposableAddresses) {
+    // TODO: call Azure function
+  }
+
+  // Guard email subaddressing if enabled
+  if (blockSubaddressing) {
+    const subaddressingRegex = new RegExp(`^.*\\+.*@${domain}$`);
+    assertThat(
+      !subaddressingRegex.test(email),
+      new RequestError({
+        code: 'session.email_blocklist.email_subaddressing_not_allowed',
+        status: 422,
+      })
+    );
+  }
+
+  // Guard custom email address/domain if provided
+  if (customBlocklist) {
+    const isCustomBlocklisted = customBlocklist.some((item) => {
+      // Guard email domain
+      if (item.startsWith('@')) {
+        return domain === item.slice(1);
+      }
+
+      return email === item;
+    });
+
+    assertThat(
+      !isCustomBlocklisted,
+      new RequestError({
+        code: 'session.email_blocklist.email_not_allowed',
+        status: 422,
+        email,
+      })
+    );
+  }
 };

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -291,11 +291,14 @@ export default class ExperienceInteraction {
         verification: verificationData,
       });
 
-      await this.signInExperienceValidator.guardSsoOnlyEmailIdentifier(verificationRecord);
+      if (verificationRecord.type !== VerificationType.EnterpriseSso) {
+        await this.signInExperienceValidator.guardSsoOnlyEmailIdentifier(verificationRecord);
+      }
+      await this.signInExperienceValidator.guardEmailBlocklist(verificationRecord);
+
       const identifierProfile = await getNewUserProfileFromVerificationRecord(verificationRecord);
 
       await this.profile.setProfileWithValidation(identifierProfile);
-
       // Save the updated profile data to the interaction storage
       await this.save();
     }

--- a/packages/core/src/routes/experience/classes/libraries/sign-in-experience-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/sign-in-experience-validator.ts
@@ -281,10 +281,13 @@ export class SignInExperienceValidator {
    * - guard custom email address/domain if provided
    */
   public async guardEmailBlocklist(verificationRecord: VerificationRecord) {
-    const email = getEmailIdentifierFromVerificationRecord(verificationRecord);
-
     // TODO: Remove this once the dev feature is ready
-    if (!EnvSet.values.isDevFeaturesEnabled || !email) {
+    if (!EnvSet.values.isDevFeaturesEnabled) {
+      return;
+    }
+
+    const email = getEmailIdentifierFromVerificationRecord(verificationRecord);
+    if (!email) {
       return;
     }
 

--- a/packages/core/src/routes/experience/classes/profile.ts
+++ b/packages/core/src/routes/experience/classes/profile.ts
@@ -87,6 +87,8 @@ export class Profile {
     // Guard SSO only email identifier in verification record  (EmailVerificationCode, Social)
     await this.signInExperienceValidator.guardSsoOnlyEmailIdentifier(verificationRecord);
 
+    await this.signInExperienceValidator.guardEmailBlocklist(verificationRecord);
+
     log?.append({
       verification: verificationRecord.toJson(),
     });
@@ -99,7 +101,6 @@ export class Profile {
     if (verificationRecord.type === VerificationType.Social) {
       const user = await this.safeGetIdentifiedUser();
       const isNewUserIdentity = !user;
-
       // Sync the email and phone to the user profile only for new user identity
       const syncedProfile = await verificationRecord.toSyncedProfile(isNewUserIdentity);
       this.unsafePrepend(syncedProfile);
@@ -120,6 +121,7 @@ export class Profile {
     }
 
     await this.profileValidator.guardProfileUniquenessAcrossUsers(profile);
+
     this.unsafeSet(profile);
   }
 

--- a/packages/integration-tests/src/tests/api/experience-api/register-interaction/email-blocklist.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/register-interaction/email-blocklist.test.ts
@@ -1,3 +1,6 @@
+import { ConnectorType, InteractionEvent, SignInIdentifier } from '@logto/schemas';
+import { generateStandardId } from '@logto/shared';
+
 import { mockSocialConnectorId } from '#src/__mocks__/connectors-mock.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
 import { SsoConnectorApi } from '#src/api/sso-connector.js';
@@ -17,8 +20,6 @@ import {
 } from '#src/helpers/experience/verification-code.js';
 import { expectRejects } from '#src/helpers/index.js';
 import { devFeatureTest, generateEmail } from '#src/utils.js';
-import { ConnectorType, InteractionEvent, SignInIdentifier } from '@logto/schemas';
-import { generateStandardId } from '@logto/shared';
 
 devFeatureTest.describe(
   'should reject the email registration if the email is in the blocklist',

--- a/packages/integration-tests/src/tests/api/experience-api/register-interaction/email-blocklist.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/register-interaction/email-blocklist.test.ts
@@ -1,0 +1,186 @@
+import { mockSocialConnectorId } from '#src/__mocks__/connectors-mock.js';
+import { updateSignInExperience } from '#src/api/sign-in-experience.js';
+import { SsoConnectorApi } from '#src/api/sso-connector.js';
+import { initExperienceClient } from '#src/helpers/client.js';
+import {
+  clearConnectorsByTypes,
+  setEmailConnector,
+  setSocialConnector,
+} from '#src/helpers/connector.js';
+import {
+  successFullyCreateSocialVerification,
+  successFullyVerifySocialAuthorization,
+} from '#src/helpers/experience/social-verification.js';
+import {
+  successfullySendVerificationCode,
+  successfullyVerifyVerificationCode,
+} from '#src/helpers/experience/verification-code.js';
+import { expectRejects } from '#src/helpers/index.js';
+import { devFeatureTest, generateEmail } from '#src/utils.js';
+import { ConnectorType, InteractionEvent, SignInIdentifier } from '@logto/schemas';
+import { generateStandardId } from '@logto/shared';
+
+devFeatureTest.describe(
+  'should reject the email registration if the email is in the blocklist',
+  () => {
+    const ssoConnectorApi = new SsoConnectorApi();
+    const ssoDomain = 'sso.com';
+    const blockDomain = 'block.com';
+    const ssoEmail = generateEmail(ssoDomain);
+    const blockEmail = generateEmail(blockDomain);
+
+    afterAll(async () => {
+      await ssoConnectorApi.cleanUp();
+    });
+
+    beforeAll(async () => {
+      await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Social]);
+      await setEmailConnector();
+      await updateSignInExperience({
+        singleSignOnEnabled: true,
+        signUp: { identifiers: [SignInIdentifier.Email], password: false, verify: true },
+        emailBlocklistPolicy: {
+          blockSubaddressing: true,
+          customBlocklist: [`@${blockDomain}`, ssoEmail],
+        },
+      });
+    });
+
+    it('should reject subaddressing email', async () => {
+      const identifier = Object.freeze({
+        type: SignInIdentifier.Email,
+        value: 'foo+test@bar.com',
+      });
+
+      const client = await initExperienceClient({
+        interactionEvent: InteractionEvent.Register,
+      });
+
+      const { verificationId, code } = await successfullySendVerificationCode(client, {
+        identifier,
+        interactionEvent: InteractionEvent.Register,
+      });
+
+      await successfullyVerifyVerificationCode(client, {
+        identifier,
+        verificationId,
+        code,
+      });
+
+      // Should reject the registration directly
+      await expectRejects(
+        client.identifyUser({
+          verificationId,
+        }),
+        {
+          code: 'session.email_blocklist.email_subaddressing_not_allowed',
+          status: 422,
+        }
+      );
+
+      // Should reject the profile creation
+      await expectRejects(
+        client.updateProfile({
+          type: SignInIdentifier.Email,
+          verificationId,
+        }),
+        {
+          code: 'session.email_blocklist.email_subaddressing_not_allowed',
+          status: 422,
+        }
+      );
+    });
+
+    it('should reject email with domain in the custom blocklist', async () => {
+      const identifier = Object.freeze({
+        type: SignInIdentifier.Email,
+        value: blockEmail,
+      });
+
+      const errorCode = 'session.email_blocklist.email_not_allowed';
+
+      const client = await initExperienceClient({
+        interactionEvent: InteractionEvent.Register,
+      });
+
+      const { verificationId, code } = await successfullySendVerificationCode(client, {
+        identifier,
+        interactionEvent: InteractionEvent.Register,
+      });
+
+      await successfullyVerifyVerificationCode(client, {
+        identifier,
+        verificationId,
+        code,
+      });
+
+      // Should reject the registration directly
+      await expectRejects(
+        client.identifyUser({
+          verificationId,
+        }),
+        {
+          code: errorCode,
+          status: 422,
+        }
+      );
+
+      // Should reject the profile creation
+      await expectRejects(
+        client.updateProfile({
+          type: SignInIdentifier.Email,
+          verificationId,
+        }),
+        {
+          code: errorCode,
+          status: 422,
+        }
+      );
+    });
+
+    describe('should reject the social registraction if the email is in the blocklist', () => {
+      const connectorIdMap = new Map<string, string>();
+      const state = 'state';
+      const redirectUri = 'http://localhost:3000';
+      const socialUserId = generateStandardId();
+
+      beforeAll(async () => {
+        const { id: socialConnectorId } = await setSocialConnector();
+        connectorIdMap.set(mockSocialConnectorId, socialConnectorId);
+      });
+
+      it('should reject social register if the provided email is in the blocklist', async () => {
+        const connectorId = connectorIdMap.get(mockSocialConnectorId)!;
+        const client = await initExperienceClient({
+          interactionEvent: InteractionEvent.Register,
+        });
+
+        const { verificationId } = await successFullyCreateSocialVerification(client, connectorId, {
+          redirectUri,
+          state,
+        });
+
+        await successFullyVerifySocialAuthorization(client, connectorId, {
+          verificationId,
+          connectorData: {
+            state,
+            redirectUri,
+            code: 'fake_code',
+            userId: socialUserId,
+            email: blockEmail,
+          },
+        });
+
+        await expectRejects(
+          client.identifyUser({
+            verificationId,
+          }),
+          {
+            code: 'session.email_blocklist.email_not_allowed',
+            status: 422,
+          }
+        );
+      });
+    });
+  }
+);

--- a/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/password.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/password.test.ts
@@ -1,6 +1,7 @@
 import { InteractionEvent, SignInIdentifier } from '@logto/schemas';
 
 import { deleteUser, getUser } from '#src/api/admin-user.js';
+import { updateSignInExperience } from '#src/api/sign-in-experience.js';
 import { initExperienceClient, logoutClient, processSession } from '#src/helpers/client.js';
 import { setEmailConnector, setSmsConnector } from '#src/helpers/connector.js';
 import {
@@ -18,7 +19,6 @@ import {
 } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
 import { devFeatureTest, generateEmail } from '#src/utils.js';
-import { updateSignInExperience } from '#src/api/sign-in-experience.js';
 
 const identifiersTypeToUserProfile = Object.freeze({
   username: 'username',

--- a/packages/phrases/src/locales/ar/errors/session.ts
+++ b/packages/phrases/src/locales/ar/errors/session.ts
@@ -41,6 +41,15 @@ const session = {
     'تم تمكين تسجيل الدخول الموحد لهذا البريد الإلكتروني المحدد. يرجى تسجيل الدخول باستخدام SSO.',
   captcha_required: 'مطلوب التحقق من Captcha.',
   captcha_failed: 'فشل التحقق من Captcha.',
+  email_blocklist: {
+    /** UNTRANSLATED */
+    invalid_email: 'Invalid email address.',
+    /** UNTRANSLATED */
+    email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',
+    /** UNTRANSLATED */
+    email_not_allowed:
+      'The email address "{{email}}" is restricted. Please choose a different one.',
+  },
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/de/errors/session.ts
+++ b/packages/phrases/src/locales/de/errors/session.ts
@@ -51,6 +51,15 @@ const session = {
     'Einmaliges Anmelden ist für diese gegebene E-Mail aktiviert. Bitte melden Sie sich mit SSO an.',
   captcha_required: 'Captcha ist erforderlich.',
   captcha_failed: 'Captcha-Verifizierung fehlgeschlagen.',
+  email_blocklist: {
+    /** UNTRANSLATED */
+    invalid_email: 'Invalid email address.',
+    /** UNTRANSLATED */
+    email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',
+    /** UNTRANSLATED */
+    email_not_allowed:
+      'The email address "{{email}}" is restricted. Please choose a different one.',
+  },
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/en/errors/session.ts
+++ b/packages/phrases/src/locales/en/errors/session.ts
@@ -46,6 +46,12 @@ const session = {
   sso_enabled: 'Single sign on is enabled for this given email. Please sign in with SSO.',
   captcha_required: 'Captcha is required.',
   captcha_failed: 'Captcha verification failed.',
+  email_blocklist: {
+    invalid_email: 'Invalid email address.',
+    email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',
+    email_not_allowed:
+      'The email address "{{email}}" is restricted. Please choose a different one.',
+  },
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/es/errors/session.ts
+++ b/packages/phrases/src/locales/es/errors/session.ts
@@ -52,6 +52,15 @@ const session = {
     'El inicio de sesión único está habilitado para este correo electrónico dado. Inicie sesión con SSO, por favor.',
   captcha_required: 'Se requiere captcha.',
   captcha_failed: 'La verificación del captcha falló.',
+  email_blocklist: {
+    /** UNTRANSLATED */
+    invalid_email: 'Invalid email address.',
+    /** UNTRANSLATED */
+    email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',
+    /** UNTRANSLATED */
+    email_not_allowed:
+      'The email address "{{email}}" is restricted. Please choose a different one.',
+  },
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/fr/errors/session.ts
+++ b/packages/phrases/src/locales/fr/errors/session.ts
@@ -53,6 +53,15 @@ const session = {
     'La connexion unique est activée pour cet e-mail donné. Veuillez vous connecter avec SSO.',
   captcha_required: 'Le captcha est requis.',
   captcha_failed: 'La vérification du captcha a échoué.',
+  email_blocklist: {
+    /** UNTRANSLATED */
+    invalid_email: 'Invalid email address.',
+    /** UNTRANSLATED */
+    email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',
+    /** UNTRANSLATED */
+    email_not_allowed:
+      'The email address "{{email}}" is restricted. Please choose a different one.',
+  },
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/it/errors/session.ts
+++ b/packages/phrases/src/locales/it/errors/session.ts
@@ -49,6 +49,15 @@ const session = {
   sso_enabled: "L'accesso singolo è abilitato per questa email. Accedi con SSO.",
   captcha_required: 'È richiesto il Captcha.',
   captcha_failed: 'La verifica del Captcha non è riuscita.',
+  email_blocklist: {
+    /** UNTRANSLATED */
+    invalid_email: 'Invalid email address.',
+    /** UNTRANSLATED */
+    email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',
+    /** UNTRANSLATED */
+    email_not_allowed:
+      'The email address "{{email}}" is restricted. Please choose a different one.',
+  },
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/ja/errors/session.ts
+++ b/packages/phrases/src/locales/ja/errors/session.ts
@@ -48,6 +48,15 @@ const session = {
     'このメールアドレスではシングルサインオンが有効になっています。SSO でサインインしてください。',
   captcha_required: 'Captcha が必要です。',
   captcha_failed: 'Captcha 検証に失敗しました。',
+  email_blocklist: {
+    /** UNTRANSLATED */
+    invalid_email: 'Invalid email address.',
+    /** UNTRANSLATED */
+    email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',
+    /** UNTRANSLATED */
+    email_not_allowed:
+      'The email address "{{email}}" is restricted. Please choose a different one.',
+  },
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/ko/errors/session.ts
+++ b/packages/phrases/src/locales/ko/errors/session.ts
@@ -44,6 +44,15 @@ const session = {
   sso_enabled: '이 이메일로는 SSO가 활성화되어 있어요. SSO로 로그인해 주세요.',
   captcha_required: 'Captcha 가 필요해요.',
   captcha_failed: 'Captcha 인증에 실패했어요.',
+  email_blocklist: {
+    /** UNTRANSLATED */
+    invalid_email: 'Invalid email address.',
+    /** UNTRANSLATED */
+    email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',
+    /** UNTRANSLATED */
+    email_not_allowed:
+      'The email address "{{email}}" is restricted. Please choose a different one.',
+  },
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/pl-pl/errors/session.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/session.ts
@@ -48,6 +48,15 @@ const session = {
   sso_enabled: 'Single sign on jest włączony dla tego adresu e-mail. Zaloguj się za pomocą SSO.',
   captcha_required: 'Wymagana jest captcha.',
   captcha_failed: 'Weryfikacja captchy nie powiodła się.',
+  email_blocklist: {
+    /** UNTRANSLATED */
+    invalid_email: 'Invalid email address.',
+    /** UNTRANSLATED */
+    email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',
+    /** UNTRANSLATED */
+    email_not_allowed:
+      'The email address "{{email}}" is restricted. Please choose a different one.',
+  },
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/pt-br/errors/session.ts
+++ b/packages/phrases/src/locales/pt-br/errors/session.ts
@@ -50,6 +50,15 @@ const session = {
     'O login único está habilitado para este e-mail fornecido. Faça login com SSO, por favor.',
   captcha_required: 'Captcha é necessário.',
   captcha_failed: 'Falha na verificação do captcha.',
+  email_blocklist: {
+    /** UNTRANSLATED */
+    invalid_email: 'Invalid email address.',
+    /** UNTRANSLATED */
+    email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',
+    /** UNTRANSLATED */
+    email_not_allowed:
+      'The email address "{{email}}" is restricted. Please choose a different one.',
+  },
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/pt-pt/errors/session.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/session.ts
@@ -52,6 +52,15 @@ const session = {
     'O login único está habilitado para este e-mail fornecido. Faça login com SSO, por favor.',
   captcha_required: 'O Captcha é necessário.',
   captcha_failed: 'Falha na verificação do Captcha.',
+  email_blocklist: {
+    /** UNTRANSLATED */
+    invalid_email: 'Invalid email address.',
+    /** UNTRANSLATED */
+    email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',
+    /** UNTRANSLATED */
+    email_not_allowed:
+      'The email address "{{email}}" is restricted. Please choose a different one.',
+  },
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/ru/errors/session.ts
+++ b/packages/phrases/src/locales/ru/errors/session.ts
@@ -49,6 +49,15 @@ const session = {
     'Единый вход в систему включен для этого указанного адреса электронной почты. Войдите в систему с помощью SSO.',
   captcha_required: 'Требуется Capctha.',
   captcha_failed: 'Проверка Captcha не удалась.',
+  email_blocklist: {
+    /** UNTRANSLATED */
+    invalid_email: 'Invalid email address.',
+    /** UNTRANSLATED */
+    email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',
+    /** UNTRANSLATED */
+    email_not_allowed:
+      'The email address "{{email}}" is restricted. Please choose a different one.',
+  },
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/tr-tr/errors/session.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/session.ts
@@ -47,6 +47,15 @@ const session = {
   sso_enabled: 'Bu e-posta için tek oturum açma etkin. Lütfen SSO ile oturum açın.',
   captcha_required: 'Captcha gereklidir.',
   captcha_failed: 'Captcha doğrulaması başarısız oldu.',
+  email_blocklist: {
+    /** UNTRANSLATED */
+    invalid_email: 'Invalid email address.',
+    /** UNTRANSLATED */
+    email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',
+    /** UNTRANSLATED */
+    email_not_allowed:
+      'The email address "{{email}}" is restricted. Please choose a different one.',
+  },
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/zh-cn/errors/session.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/session.ts
@@ -39,6 +39,15 @@ const session = {
   sso_enabled: '该邮箱已开启单点登录，请使用 SSO 登录。',
   captcha_required: '需要验证码。',
   captcha_failed: '验证码验证失败。',
+  email_blocklist: {
+    /** UNTRANSLATED */
+    invalid_email: 'Invalid email address.',
+    /** UNTRANSLATED */
+    email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',
+    /** UNTRANSLATED */
+    email_not_allowed:
+      'The email address "{{email}}" is restricted. Please choose a different one.',
+  },
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/zh-hk/errors/session.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/session.ts
@@ -39,6 +39,15 @@ const session = {
   sso_enabled: '該郵箱已開啟單點登錄，請使用 SSO 登錄。',
   captcha_required: '需要 Captcha。',
   captcha_failed: 'Captcha 驗證失敗。',
+  email_blocklist: {
+    /** UNTRANSLATED */
+    invalid_email: 'Invalid email address.',
+    /** UNTRANSLATED */
+    email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',
+    /** UNTRANSLATED */
+    email_not_allowed:
+      'The email address "{{email}}" is restricted. Please choose a different one.',
+  },
 };
 
 export default Object.freeze(session);

--- a/packages/phrases/src/locales/zh-tw/errors/session.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/session.ts
@@ -39,6 +39,15 @@ const session = {
   sso_enabled: '該郵箱已開啟單點登錄，請使用 SSO 登錄。',
   captcha_required: '需要驗證碼。',
   captcha_failed: '驗證碼驗證失敗。',
+  email_blocklist: {
+    /** UNTRANSLATED */
+    invalid_email: 'Invalid email address.',
+    /** UNTRANSLATED */
+    email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',
+    /** UNTRANSLATED */
+    email_not_allowed:
+      'The email address "{{email}}" is restricted. Please choose a different one.',
+  },
 };
 
 export default Object.freeze(session);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add email blocllist validation to all the experience API email profile fulfillment flow.

- link profile
- account creation

Extract the email profile from the verification record and validate the value against the email blocklist policy settings in SIE. Reject the use to create account or link new profile if the email is restricted by the policy. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Unit test added
Integration tests added

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
