### PR TITLE
feat(core,experience): add disposable email validation

### DIFF
--- a/packages/console/src/pages/Security/Blocklist/BlocklistForm/index.tsx
+++ b/packages/console/src/pages/Security/Blocklist/BlocklistForm/index.tsx
@@ -11,6 +11,7 @@ import FormCard from '@/components/FormCard';
 import MultiOptionInput from '@/components/MultiOptionInput';
 import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
 import { emailBlocklist } from '@/consts';
+import { isCloud } from '@/consts/env';
 import { latestProPlanId } from '@/consts/subscriptions';
 import FormField from '@/ds-components/FormField';
 import Switch from '@/ds-components/Switch';
@@ -94,13 +95,15 @@ function BlocklistForm({ formData }: Props) {
           }
           learnMoreLink={{ href: emailBlocklist }}
         >
-          <FormField title="security.blocklist.disposable_email.title">
-            <Switch
-              disabled={isFreeTenant}
-              label={t('blocklist.disposable_email.description')}
-              {...register('blockDisposableAddresses')}
-            />
-          </FormField>
+          {isCloud && (
+            <FormField title="security.blocklist.disposable_email.title">
+              <Switch
+                disabled={isFreeTenant}
+                label={t('blocklist.disposable_email.description')}
+                {...register('blockDisposableAddresses')}
+              />
+            </FormField>
+          )}
           <FormField title="security.blocklist.email_subaddressing.title">
             <Switch
               disabled={isFreeTenant}

--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
@@ -75,7 +75,7 @@ const disposableEmailDomainValidationResponseGuard = z.object({
 const validateDisposableEmailDomain = async (email: string) => {
   // TODO: Skip the validation for integration test for now
   if (EnvSet.values.isIntegrationTest) {
-    return false;
+    return;
   }
   assertThat(
     EnvSet.values.azureFunctionAppEndpoint,

--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
@@ -1,6 +1,8 @@
 import { emailOrEmailDomainRegex } from '@logto/core-kit';
 import { type EmailBlocklistPolicy } from '@logto/schemas';
 import { conditional, deduplicate } from '@silverhand/essentials';
+import { got } from 'got';
+import { z } from 'zod';
 
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
@@ -50,10 +52,60 @@ export const parseEmailBlocklistPolicy = (
 
   const { customBlocklist, ...rest } = emailBlocklistPolicy;
 
+  // BlockDisposableAddresses is not supported for OSS.
+  if (rest.blockDisposableAddresses) {
+    assertThat(
+      EnvSet.values.isCloud,
+      new RequestError('request.invalid_input', {
+        details: 'blockDisposableAddresses is not supported in this environment',
+      })
+    );
+  }
+
   return {
     ...rest,
     ...conditional(customBlocklist && { customBlocklist: parseCustomBlocklist(customBlocklist) }),
   };
+};
+
+const disposableEmailDomainValidationResponseGuard = z.object({
+  isDisposable: z.boolean(),
+});
+
+const validateDisposableEmailDomain = async (email: string) => {
+  // TODO: Skip the validation for integration test for now
+  if (EnvSet.values.isIntegrationTest) {
+    return false;
+  }
+  assertThat(
+    EnvSet.values.azureFunctionAppEndpoint,
+    new Error('Environment variable AZURE_FUNCTION_APP_ENDPOINT is not set')
+  );
+
+  const result = await got
+    .post(
+      new URL('/api/disposable-email-domain-validation', EnvSet.values.azureFunctionAppEndpoint),
+      {
+        json: {
+          email,
+        },
+        headers: {
+          'x-functions-key': EnvSet.values.azureFunctionAppKey,
+        },
+      }
+    )
+    .json<unknown>();
+
+  const { isDisposable } = disposableEmailDomainValidationResponseGuard.parse(result);
+
+  assertThat(
+    !isDisposable,
+    new RequestError({
+      code: 'session.email_blocklist.email_not_allowed',
+      status: 422,
+      email,
+    })
+  );
 };
 
 /**
@@ -80,7 +132,7 @@ export const validateEmailAgainstBlocklistPolicy = async (
 
   // Guard disposable email domain if enabled
   if (EnvSet.values.isCloud && blockDisposableAddresses) {
-    // TODO: call Azure function
+    await validateDisposableEmailDomain(email);
   }
 
   // Guard email subaddressing if enabled

--- a/packages/experience/src/hooks/use-email-blocked-error-handler.ts
+++ b/packages/experience/src/hooks/use-email-blocked-error-handler.ts
@@ -1,0 +1,33 @@
+import { type RequestErrorBody } from '@logto/schemas';
+import { useCallback, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { usePromiseConfirmModal } from './use-confirm-modal';
+import { type ErrorHandlers } from './use-error-handler';
+
+const useEmailBlockedErrorHandler = (): ErrorHandlers => {
+  const navigate = useNavigate();
+  const { show } = usePromiseConfirmModal();
+
+  const errorCallback = useCallback(
+    async (error: RequestErrorBody) => {
+      await show({
+        type: 'alert',
+        ModalContent: error.message,
+        cancelText: 'action.got_it',
+      });
+      navigate(-1);
+    },
+    [navigate, show]
+  );
+
+  return useMemo<ErrorHandlers>(
+    () => ({
+      'session.email_blocklist.email_not_allowed': errorCallback,
+      'session.email_blocklist.email_subaddressing_not_allowed': errorCallback,
+    }),
+    [errorCallback]
+  );
+};
+
+export default useEmailBlockedErrorHandler;

--- a/packages/experience/src/hooks/use-submit-interaction-error-handler.ts
+++ b/packages/experience/src/hooks/use-submit-interaction-error-handler.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import { type ContinueFlowInteractionEvent } from '@/types';
 
+import useEmailBlockedErrorHandler from './use-email-blocked-error-handler';
 import { type ErrorHandlers } from './use-error-handler';
 import useMfaErrorHandler, {
   type Options as UseMfaVerificationErrorHandlerOptions,
@@ -36,13 +37,15 @@ const useSubmitInteractionErrorHandler = (
     ...rest,
   });
   const mfaErrorHandler = useMfaErrorHandler({ replace });
+  const emailBlockedErrorHandler = useEmailBlockedErrorHandler();
 
   return useMemo(
     () => ({
+      ...emailBlockedErrorHandler,
       ...requiredProfileErrorHandler,
       ...mfaErrorHandler,
     }),
-    [mfaErrorHandler, requiredProfileErrorHandler]
+    [emailBlockedErrorHandler, mfaErrorHandler, requiredProfileErrorHandler]
   );
 };
 

--- a/packages/phrases/src/locales/ar/errors/session.ts
+++ b/packages/phrases/src/locales/ar/errors/session.ts
@@ -43,6 +43,8 @@ const session = {
   captcha_failed: 'فشل التحقق من Captcha.',
   email_blocklist: {
     /** UNTRANSLATED */
+    disposable_email_validation_failed: 'Email address validation failed.',
+    /** UNTRANSLATED */
     invalid_email: 'Invalid email address.',
     /** UNTRANSLATED */
     email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',

--- a/packages/phrases/src/locales/de/errors/session.ts
+++ b/packages/phrases/src/locales/de/errors/session.ts
@@ -53,6 +53,8 @@ const session = {
   captcha_failed: 'Captcha-Verifizierung fehlgeschlagen.',
   email_blocklist: {
     /** UNTRANSLATED */
+    disposable_email_validation_failed: 'Email address validation failed.',
+    /** UNTRANSLATED */
     invalid_email: 'Invalid email address.',
     /** UNTRANSLATED */
     email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',

--- a/packages/phrases/src/locales/en/errors/session.ts
+++ b/packages/phrases/src/locales/en/errors/session.ts
@@ -47,6 +47,7 @@ const session = {
   captcha_required: 'Captcha is required.',
   captcha_failed: 'Captcha verification failed.',
   email_blocklist: {
+    disposable_email_validation_failed: 'Email address validation failed.',
     invalid_email: 'Invalid email address.',
     email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',
     email_not_allowed:

--- a/packages/phrases/src/locales/es/errors/session.ts
+++ b/packages/phrases/src/locales/es/errors/session.ts
@@ -54,6 +54,8 @@ const session = {
   captcha_failed: 'La verificación del captcha falló.',
   email_blocklist: {
     /** UNTRANSLATED */
+    disposable_email_validation_failed: 'Email address validation failed.',
+    /** UNTRANSLATED */
     invalid_email: 'Invalid email address.',
     /** UNTRANSLATED */
     email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',

--- a/packages/phrases/src/locales/fr/errors/session.ts
+++ b/packages/phrases/src/locales/fr/errors/session.ts
@@ -55,6 +55,8 @@ const session = {
   captcha_failed: 'La vérification du captcha a échoué.',
   email_blocklist: {
     /** UNTRANSLATED */
+    disposable_email_validation_failed: 'Email address validation failed.',
+    /** UNTRANSLATED */
     invalid_email: 'Invalid email address.',
     /** UNTRANSLATED */
     email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',

--- a/packages/phrases/src/locales/it/errors/session.ts
+++ b/packages/phrases/src/locales/it/errors/session.ts
@@ -51,6 +51,8 @@ const session = {
   captcha_failed: 'La verifica del Captcha non è riuscita.',
   email_blocklist: {
     /** UNTRANSLATED */
+    disposable_email_validation_failed: 'Email address validation failed.',
+    /** UNTRANSLATED */
     invalid_email: 'Invalid email address.',
     /** UNTRANSLATED */
     email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',

--- a/packages/phrases/src/locales/ja/errors/session.ts
+++ b/packages/phrases/src/locales/ja/errors/session.ts
@@ -50,6 +50,8 @@ const session = {
   captcha_failed: 'Captcha 検証に失敗しました。',
   email_blocklist: {
     /** UNTRANSLATED */
+    disposable_email_validation_failed: 'Email address validation failed.',
+    /** UNTRANSLATED */
     invalid_email: 'Invalid email address.',
     /** UNTRANSLATED */
     email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',

--- a/packages/phrases/src/locales/ko/errors/session.ts
+++ b/packages/phrases/src/locales/ko/errors/session.ts
@@ -46,6 +46,8 @@ const session = {
   captcha_failed: 'Captcha 인증에 실패했어요.',
   email_blocklist: {
     /** UNTRANSLATED */
+    disposable_email_validation_failed: 'Email address validation failed.',
+    /** UNTRANSLATED */
     invalid_email: 'Invalid email address.',
     /** UNTRANSLATED */
     email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',

--- a/packages/phrases/src/locales/pl-pl/errors/session.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/session.ts
@@ -50,6 +50,8 @@ const session = {
   captcha_failed: 'Weryfikacja captchy nie powiodła się.',
   email_blocklist: {
     /** UNTRANSLATED */
+    disposable_email_validation_failed: 'Email address validation failed.',
+    /** UNTRANSLATED */
     invalid_email: 'Invalid email address.',
     /** UNTRANSLATED */
     email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',

--- a/packages/phrases/src/locales/pt-br/errors/session.ts
+++ b/packages/phrases/src/locales/pt-br/errors/session.ts
@@ -52,6 +52,8 @@ const session = {
   captcha_failed: 'Falha na verificação do captcha.',
   email_blocklist: {
     /** UNTRANSLATED */
+    disposable_email_validation_failed: 'Email address validation failed.',
+    /** UNTRANSLATED */
     invalid_email: 'Invalid email address.',
     /** UNTRANSLATED */
     email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',

--- a/packages/phrases/src/locales/pt-pt/errors/session.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/session.ts
@@ -54,6 +54,8 @@ const session = {
   captcha_failed: 'Falha na verificação do Captcha.',
   email_blocklist: {
     /** UNTRANSLATED */
+    disposable_email_validation_failed: 'Email address validation failed.',
+    /** UNTRANSLATED */
     invalid_email: 'Invalid email address.',
     /** UNTRANSLATED */
     email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',

--- a/packages/phrases/src/locales/ru/errors/session.ts
+++ b/packages/phrases/src/locales/ru/errors/session.ts
@@ -51,6 +51,8 @@ const session = {
   captcha_failed: 'Проверка Captcha не удалась.',
   email_blocklist: {
     /** UNTRANSLATED */
+    disposable_email_validation_failed: 'Email address validation failed.',
+    /** UNTRANSLATED */
     invalid_email: 'Invalid email address.',
     /** UNTRANSLATED */
     email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',

--- a/packages/phrases/src/locales/tr-tr/errors/session.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/session.ts
@@ -49,6 +49,8 @@ const session = {
   captcha_failed: 'Captcha doğrulaması başarısız oldu.',
   email_blocklist: {
     /** UNTRANSLATED */
+    disposable_email_validation_failed: 'Email address validation failed.',
+    /** UNTRANSLATED */
     invalid_email: 'Invalid email address.',
     /** UNTRANSLATED */
     email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',

--- a/packages/phrases/src/locales/zh-cn/errors/session.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/session.ts
@@ -41,6 +41,8 @@ const session = {
   captcha_failed: '验证码验证失败。',
   email_blocklist: {
     /** UNTRANSLATED */
+    disposable_email_validation_failed: 'Email address validation failed.',
+    /** UNTRANSLATED */
     invalid_email: 'Invalid email address.',
     /** UNTRANSLATED */
     email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',

--- a/packages/phrases/src/locales/zh-hk/errors/session.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/session.ts
@@ -41,6 +41,8 @@ const session = {
   captcha_failed: 'Captcha 驗證失敗。',
   email_blocklist: {
     /** UNTRANSLATED */
+    disposable_email_validation_failed: 'Email address validation failed.',
+    /** UNTRANSLATED */
     invalid_email: 'Invalid email address.',
     /** UNTRANSLATED */
     email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',

--- a/packages/phrases/src/locales/zh-tw/errors/session.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/session.ts
@@ -41,6 +41,8 @@ const session = {
   captcha_failed: '驗證碼驗證失敗。',
   email_blocklist: {
     /** UNTRANSLATED */
+    disposable_email_validation_failed: 'Email address validation failed.',
+    /** UNTRANSLATED */
     invalid_email: 'Invalid email address.',
     /** UNTRANSLATED */
     email_subaddressing_not_allowed: 'Email subaddressing is not allowed.',

--- a/packages/shared/src/node/env/GlobalValues.ts
+++ b/packages/shared/src/node/env/GlobalValues.ts
@@ -124,6 +124,19 @@ export default class GlobalValues {
     return this.urlSet.endpoint;
   }
 
+  /**
+   * For cloud use only.
+   * Define regional Azure function app endpoint and key to enable the Logto Azure Functions integration.
+   * This is the prerequisite of the calling on `@logto/azure-functions`.
+   */
+  public get azureFunctionAppEndpoint() {
+    return getEnv('AZURE_FUNCTION_APP_ENDPOINT');
+  }
+
+  public get azureFunctionAppKey() {
+    return getEnv('AZURE_FUNCTION_APP_KEY');
+  }
+
   constructor() {
     if (this.isPathBasedMultiTenancy) {
       console.warn(


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add disposable email validation in the experience API.

- Call Azure function `disposable-email-domain-validation` to validate a given email against disposable email domain list
- Add Azure function endpoint and API key environment.
- Block the blockDisposableEmail form field for OSS on the console. This is a cloud-only feature. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
