### PR TITLE
feat(core): enhanced user lookup by phone number

### DIFF
--- a/.changeset/nice-houses-sneeze.md
+++ b/.changeset/nice-houses-sneeze.md
@@ -2,7 +2,7 @@
 "@logto/core": minor
 ---
 
-feat: enhanced user lookup by phone with phone number normalization.
+refactor: enhanced user lookup by phone with phone number normalization
 
 In some countries, local phone numbers are often entered with a leading '0'. However, in the context of the international format this leading '0' should be stripped. E.g., +61 (0)2 1234 5678 should be normalized to +61 2 1234 5678.
 

--- a/.changeset/nice-houses-sneeze.md
+++ b/.changeset/nice-houses-sneeze.md
@@ -2,9 +2,9 @@
 "@logto/core": minor
 ---
 
-enhenced user lookup by phone with phone number normalization.
+feat: enhanced user lookup by phone with phone number normalization.
 
-In some countries, local phone numbers are often entered with a leading '0'. However, in the context of international format this leading '0' should be stripped. E.g. +61 (0)2 1234 5678 should be normalized to +61 2 1234 5678.
+In some countries, local phone numbers are often entered with a leading '0'. However, in the context of the international format this leading '0' should be stripped. E.g., +61 (0)2 1234 5678 should be normalized to +61 2 1234 5678.
 
 In the previous implementation, Logto did not normalize the user's phone number during the user sign-up process. Both 61021345678 and 61212345678 were considered as valid phone numbers, and we do not normalize them before storing them in the database. This could lead to confusion when users try to sign-in with their phone numbers, as they may not remember the exact format they used during sign-up. Users may also end up with different accounts for the same phone number, depending on how they entered it during sign-up.
 
@@ -15,10 +15,10 @@ For example:
 - If a user signs up with the phone number +61 2 1234 5678, they can now sign-in with either +61 2 1234 5678 or +61 02 1234 5678.
 - The same applies to the phone number +61 02 1234 5678, which can be used to sign-in with either +61 2 1234 5678 or +61 02 1234 5678.
 
-For users who might have created two different counts with the same phone number but different formats. The look up process will alway return the one with exact match. This means that if a user has two accounts with the same phone number but different formats, they will still be able to sign-in with either format, but they will only be able to access the account that matches the format they used during sign-up.
+For users who might have created two different counts with the same phone number but different formats. The lookup process will always return the one with an exact match. This means that if a user has two accounts with the same phone number but different formats, they will still be able to sign-in with either format, but they will only be able to access the account that matches the format they used during sign-up.
 
 For example:
 
-- If a user has two accounts with the phone numbers +61 2 1234 5678 and +61 02 1234 5678. They will need to sign-in each account using the exact format they used during sign-up.
+- If a user has two accounts with the phone numbers +61 2 1234 5678 and +61 02 1234 5678. They will need to sign-in to each account using the exact format they used during sign-up.
 
 related github issue [#7371](https://github.com/logto-io/logto/issues/7371).

--- a/.changeset/nice-houses-sneeze.md
+++ b/.changeset/nice-houses-sneeze.md
@@ -15,7 +15,7 @@ For example:
 - If a user signs up with the phone number +61 2 1234 5678, they can now sign-in with either +61 2 1234 5678 or +61 02 1234 5678.
 - The same applies to the phone number +61 02 1234 5678, which can be used to sign-in with either +61 2 1234 5678 or +61 02 1234 5678.
 
-For users who might have created two different counts with the same phone number but different formats. The lookup process will always return the one with an exact match. This means that if a user has two accounts with the same phone number but different formats, they will still be able to sign-in with either format, but they will only be able to access the account that matches the format they used during sign-up.
+For users who might have created two different accounts with the same phone number but different formats. The lookup process will always return the one with an exact match. This means that if a user has two accounts with the same phone number but different formats, they will still be able to sign-in with either format, but they will only be able to access the account that matches the format they used during sign-up.
 
 For example:
 

--- a/.changeset/nice-houses-sneeze.md
+++ b/.changeset/nice-houses-sneeze.md
@@ -1,0 +1,24 @@
+---
+"@logto/core": minor
+---
+
+enhenced user lookup by phone with phone number normalization.
+
+In some countries, local phone numbers are often entered with a leading '0'. However, in the context of international format this leading '0' should be stripped. E.g. +61 (0)2 1234 5678 should be normalized to +61 2 1234 5678.
+
+In the previous implementation, Logto did not normalize the user's phone number during the user sign-up process. Both 61021345678 and 61212345678 were considered as valid phone numbers, and we do not normalize them before storing them in the database. This could lead to confusion when users try to sign-in with their phone numbers, as they may not remember the exact format they used during sign-up. Users may also end up with different accounts for the same phone number, depending on how they entered it during sign-up.
+
+To address this issue, especially for legacy users, we have added a new enhenced user lookup by phone with either format (with or without leading '0') to the user sign-in process. This means that users can now sign-in with either format of their phone number, and Logto will try to match it with the one stored in the database, even if they might have different formats. This will help to reduce confusion and improve the user experience when logging in with phone numbers.
+
+For example:
+
+- If a user signs up with the phone number +61 2 1234 5678, they can now sign-in with either +61 2 1234 5678 or +61 02 1234 5678.
+- The same applies to the phone number +61 02 1234 5678, which can be used to sign-in with either +61 2 1234 5678 or +61 02 1234 5678.
+
+For users who might have created two different counts with the same phone number but different formats. The look up process will alway return the one with exact match. This means that if a user has two accounts with the same phone number but different formats, they will still be able to sign-in with either format, but they will only be able to access the account that matches the format they used during sign-up.
+
+For example:
+
+- If a user has two accounts with the phone numbers +61 2 1234 5678 and +61 02 1234 5678. They will need to sign-in each account using the exact format they used during sign-up.
+
+related github issue [#7371](https://github.com/logto-io/logto/issues/7371).

--- a/packages/core/src/libraries/social.ts
+++ b/packages/core/src/libraries/social.ts
@@ -36,7 +36,7 @@ const getUserInfoFromInteractionResult = async (
 };
 
 export const createSocialLibrary = (queries: Queries, connectorLibrary: ConnectorLibrary) => {
-  const { findUserByEmail, findUserByPhone } = queries.users;
+  const { findUserByEmail, findUserByNormalizedPhone } = queries.users;
   const { getLogtoConnectorById } = connectorLibrary;
 
   const getConnector = async (connectorId: string): Promise<LogtoConnector> => {
@@ -85,7 +85,7 @@ export const createSocialLibrary = (queries: Queries, connectorLibrary: Connecto
     info: SocialUserInfo
   ): Promise<Nullable<[{ type: 'email' | 'phone'; value: string }, User]>> => {
     if (info.phone) {
-      const user = await findUserByPhone(info.phone);
+      const user = await findUserByNormalizedPhone(info.phone);
 
       if (user) {
         return [{ type: 'phone', value: info.phone }, user];

--- a/packages/core/src/routes/experience/classes/utils.ts
+++ b/packages/core/src/routes/experience/classes/utils.ts
@@ -24,7 +24,7 @@ export const findUserByIdentifier = async (
       return userQuery.findUserByEmail(value);
     }
     case SignInIdentifier.Phone: {
-      return userQuery.findUserByPhone(value);
+      return userQuery.findUserByNormalizedPhone(value);
     }
     case AdditionalIdentifier.UserId: {
       return userQuery.findUserById(value);

--- a/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/password.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/password.test.ts
@@ -27,7 +27,7 @@ const identifiersTypeToUserProfile = Object.freeze({
   userId: '',
 });
 
-describe.skip('sign-in with password verification happy path', () => {
+describe('sign-in with password verification happy path', () => {
   beforeAll(async () => {
     await enableAllPasswordSignInMethods();
     await Promise.all([setEmailConnector(), setSmsConnector()]);

--- a/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/password.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/password.test.ts
@@ -17,8 +17,8 @@ import {
   enableAllPasswordSignInMethods,
   enableAllVerificationCodeSignInMethods,
 } from '#src/helpers/sign-in-experience.js';
-import { generateNewUser } from '#src/helpers/user.js';
-import { devFeatureTest, generateEmail } from '#src/utils.js';
+import { generateNewUser, UserApiTest } from '#src/helpers/user.js';
+import { devFeatureTest, generateEmail, generatePassword } from '#src/utils.js';
 
 const identifiersTypeToUserProfile = Object.freeze({
   username: 'username',
@@ -27,7 +27,7 @@ const identifiersTypeToUserProfile = Object.freeze({
   userId: '',
 });
 
-describe('sign-in with password verification happy path', () => {
+describe.skip('sign-in with password verification happy path', () => {
   beforeAll(async () => {
     await enableAllPasswordSignInMethods();
     await Promise.all([setEmailConnector(), setSmsConnector()]);
@@ -146,5 +146,99 @@ describe('sign-in with password verification happy path', () => {
     });
 
     await deleteUser(user.id);
+  });
+});
+
+describe('phone number sanitisation sign-in test +61 412 345 678', () => {
+  const testPhoneNumber = '61412345678';
+  const testPhoneNumberWithLeadingZero = '610412345678';
+  const password = generatePassword();
+  const userApi = new UserApiTest();
+
+  beforeAll(async () => {
+    await enableAllPasswordSignInMethods();
+    await updateSignInExperience({
+      sentinelPolicy: {
+        maxAttempts: 100,
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await userApi.cleanUp();
+  });
+
+  type TestCase = {
+    registerPhone: string;
+    signInPhone: string;
+  };
+  const testCases: TestCase[] = [
+    {
+      registerPhone: testPhoneNumber,
+      signInPhone: testPhoneNumber,
+    },
+    {
+      registerPhone: testPhoneNumberWithLeadingZero,
+      signInPhone: testPhoneNumberWithLeadingZero,
+    },
+    {
+      registerPhone: testPhoneNumber,
+      signInPhone: testPhoneNumberWithLeadingZero,
+    },
+    {
+      registerPhone: testPhoneNumberWithLeadingZero,
+      signInPhone: testPhoneNumber,
+    },
+  ];
+
+  it.each(testCases)(
+    'should register with $registerPhone and sign-in with $signInPhone successfully',
+    async ({ registerPhone, signInPhone }) => {
+      const user = await userApi.create({
+        primaryPhone: registerPhone,
+        password,
+      });
+
+      console.log(user.primaryPhone);
+
+      await signInWithPassword({
+        identifier: {
+          type: SignInIdentifier.Phone,
+          value: signInPhone,
+        },
+        password,
+      });
+    }
+  );
+
+  it('should sign-in with extact phone number if multiple account is found', async () => {
+    const passwordA = generatePassword();
+    const passwordB = generatePassword();
+
+    await userApi.create({
+      primaryPhone: testPhoneNumber,
+      password: passwordA,
+    });
+
+    await userApi.create({
+      primaryPhone: testPhoneNumberWithLeadingZero,
+      password: passwordB,
+    });
+
+    await signInWithPassword({
+      identifier: {
+        type: SignInIdentifier.Phone,
+        value: testPhoneNumber,
+      },
+      password: passwordA,
+    });
+
+    await signInWithPassword({
+      identifier: {
+        type: SignInIdentifier.Phone,
+        value: testPhoneNumberWithLeadingZero,
+      },
+      password: passwordB,
+    });
   });
 });

--- a/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/password.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/password.test.ts
@@ -199,8 +199,6 @@ describe('phone number sanitisation sign-in test +61 412 345 678', () => {
         password,
       });
 
-      console.log(user.primaryPhone);
-
       await signInWithPassword({
         identifier: {
           type: SignInIdentifier.Phone,

--- a/packages/shared/src/utils/phone.test.ts
+++ b/packages/shared/src/utils/phone.test.ts
@@ -13,7 +13,7 @@ describe('parsePhoneNumber', () => {
     expect(parsePhoneNumber(phoneNumber)).toEqual('12025550123');
   });
 
-  it('parsePhoneNumber should srtip the leading 0', () => {
+  it('parsePhoneNumber should strip the leading 0', () => {
     const phoneNumber = '610412345678';
     expect(parsePhoneNumber(phoneNumber)).toEqual('61412345678');
   });

--- a/packages/shared/src/utils/phone.test.ts
+++ b/packages/shared/src/utils/phone.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+
+import { parsePhoneNumber, PhoneNumberParser } from './phone.js';
+
+describe('parsePhoneNumber', () => {
+  it('parsePhoneNumber should return if the phone number is valid', () => {
+    const phoneNumber = '12025550123';
+    expect(parsePhoneNumber(phoneNumber, true)).toEqual('12025550123');
+  });
+
+  it('parsePhoneNumber should strip the leading +', () => {
+    const phoneNumber = '+12025550123';
+    expect(parsePhoneNumber(phoneNumber)).toEqual('12025550123');
+  });
+
+  it('parsePhoneNumber should srtip the leading 0', () => {
+    const phoneNumber = '610412345678';
+    expect(parsePhoneNumber(phoneNumber)).toEqual('61412345678');
+  });
+
+  it('parsePhoneNumber should strip non-digit characters', () => {
+    const phoneNumber = '+61 (0) 412 345 678';
+    expect(parsePhoneNumber(phoneNumber)).toEqual('61412345678');
+  });
+
+  it('should return the original phone number if it is invalid', () => {
+    const phoneNumber = '0123';
+    expect(parsePhoneNumber(phoneNumber)).toEqual(phoneNumber);
+  });
+
+  it('should throw an error if the phone number is invalid and throwError is true', () => {
+    const phoneNumber = '0123';
+    expect(() => parsePhoneNumber(phoneNumber, true)).toThrowError();
+  });
+});
+
+describe('PhoneNumberParser', () => {
+  type TestCase = {
+    phone: string;
+    isValid: boolean;
+    countryCode?: string;
+    nationalNumber?: string;
+    internationalNumber?: string;
+    internationalNumberWithLeadingZero?: string;
+  };
+  const testCases: TestCase[] = [
+    {
+      phone: '12025550123',
+      isValid: true,
+      countryCode: '1',
+      nationalNumber: '2025550123',
+      internationalNumber: '12025550123',
+      internationalNumberWithLeadingZero: '102025550123',
+    },
+    {
+      phone: '+61 (0) 412 345 678',
+      isValid: true,
+      countryCode: '61',
+      nationalNumber: '412345678',
+      internationalNumber: '61412345678',
+      internationalNumberWithLeadingZero: '610412345678',
+    },
+    {
+      phone: '61 412 345 678',
+      isValid: true,
+      countryCode: '61',
+      nationalNumber: '412345678',
+      internationalNumber: '61412345678',
+      internationalNumberWithLeadingZero: '610412345678',
+    },
+    {
+      phone: '456',
+      isValid: false,
+      countryCode: undefined,
+      nationalNumber: undefined,
+      internationalNumber: undefined,
+      internationalNumberWithLeadingZero: undefined,
+    },
+  ];
+
+  it.each(testCases)(
+    'parsePhoneNumber should return $phone if the phone number is valid',
+    ({
+      phone,
+      isValid,
+      countryCode,
+      nationalNumber,
+      internationalNumber,
+      internationalNumberWithLeadingZero,
+    }) => {
+      const parser = new PhoneNumberParser(phone);
+      expect(parser.raw).toEqual(phone);
+      expect(parser.isValid).toEqual(isValid);
+      expect(parser.countryCode).toEqual(countryCode);
+      expect(parser.nationalNumber).toEqual(nationalNumber);
+      expect(parser.internationalNumber).toEqual(internationalNumber);
+      expect(parser.internationalNumberWithLeadingZero).toEqual(internationalNumberWithLeadingZero);
+    }
+  );
+});

--- a/packages/shared/src/utils/phone.ts
+++ b/packages/shared/src/utils/phone.ts
@@ -1,14 +1,43 @@
-import { parsePhoneNumberWithError } from 'libphonenumber-js';
+import { parsePhoneNumberWithError, type PhoneNumber } from 'libphonenumber-js';
+
+/**
+ * Parse phone number to E.164 format.
+ * This method will add a leading `+` sign if the phone number does not start with it.
+ */
+export const parseE164Number = (phone: string) => {
+  if (!phone || phone.startsWith('+')) {
+    return phone;
+  }
+
+  return `+${phone}`;
+};
 
 /**
  * Parse phone number to number string.
- * E.g. +1 (650) 253-0000 -> 16502530000
+ * This method will strip the:
+ *  - leading `+` sign of the country code if any,
+ *  - the leading `0` of the phone number if any,
+ *  - non-digit characters if any.
+ *
+ * @params phone - The phone number to parse.
+ * @params throwError - If true, throw an error if the phone number is invalid. Otherwise, return the original phone number.
+ *
+ * @example
+ * +1 (650) 253-0000 -> 16502530000
+ *
+ * @example
+ * +61 0412 345 678 -> 61412345678
  */
-export const parsePhoneNumber = (phone: string) => {
+export const parsePhoneNumber = (phone: string, throwError?: true) => {
   try {
-    return parsePhoneNumberWithError(phone).number.slice(1);
-  } catch {
+    return parsePhoneNumberWithError(parseE164Number(phone)).number.slice(1);
+  } catch (error: unknown) {
+    if (throwError) {
+      throw error;
+    }
+
     console.error(`Invalid phone number: ${phone}`);
+
     return phone;
   }
 };
@@ -26,3 +55,88 @@ export const formatToInternationalPhoneNumber = (phone: string) => {
     return phone;
   }
 };
+
+export class PhoneNumberParser {
+  static parse(phone: string) {
+    return parsePhoneNumberWithError(parseE164Number(phone));
+  }
+
+  readonly #parsedPhoneNumber?: PhoneNumber;
+
+  readonly #isValid: boolean;
+
+  constructor(private readonly phone: string) {
+    try {
+      this.#parsedPhoneNumber = PhoneNumberParser.parse(phone);
+      this.#isValid = true;
+    } catch {
+      this.#isValid = false;
+    }
+  }
+
+  get raw() {
+    return this.phone;
+  }
+
+  get isValid() {
+    return this.#isValid;
+  }
+
+  get countryCode() {
+    return this.#parsedPhoneNumber?.countryCallingCode;
+  }
+
+  /**
+   * Local number without country code.
+   */
+  get nationalNumber() {
+    return this.#parsedPhoneNumber?.nationalNumber;
+  }
+
+  /**
+   * Formatted international number. With
+   * - leading `+` sign stripped,
+   * - leading `0` of the phone number stripped,
+   * - non-digit characters stripped.
+   *
+   * @remarks
+   * Logto use this format to store phone number in the database.
+   *
+   * @example
+   * +1 (650) 253-0000 -> 16502530000
+   */
+  get internationalNumber() {
+    if (!this.#isValid || !this.nationalNumber || !this.countryCode) {
+      // eslint-disable-next-line getter-return
+      return;
+    }
+
+    return `${this.countryCode}${this.nationalNumber}`;
+  }
+
+  /**
+   * Formatted international number with leading `0` of the phone number.
+   *
+   * @example
+   * 61 412 345 678 -> 610412345678
+   *
+   * @remarks
+   * In some countries, local phone numbers are often entered with a leading '0'.
+   * However, in the international format that includes the country code, this leading '0' should be removed.
+   *
+   * The previous implementation did not handle this correctly, causing the combination of country code + 0 + local number
+   *  to be treated as different from country code + local number in the Logto system.
+   *
+   * Both formats should be considered the same phone number.
+   *
+   * We use this format to find the legacy phone number in the database incase the user registered the phone number with leading `0`.
+   */
+  get internationalNumberWithLeadingZero() {
+    if (!this.#isValid || !this.nationalNumber || !this.countryCode) {
+      // eslint-disable-next-line getter-return
+      return;
+    }
+
+    return `${this.countryCode}0${this.nationalNumber}`;
+  }
+}


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Enhanced user lookup by phone with phone number normalization.

In some countries, local phone numbers are often entered with a leading '0'. However, in the context of the international format this leading '0' should be stripped. E.g., +61 (0)2 1234 5678 should be normalized to +61 2 1234 5678.

In the previous implementation, Logto did not normalize the user's phone number during the user sign-up process. Both 61021345678 and 61212345678 were considered as valid phone numbers, and we do not normalize them before storing them in the database. This could lead to confusion when users try to sign-in with their phone numbers, as they may not remember the exact format they used during sign-up. Users may also end up with different accounts for the same phone number, depending on how they entered it during sign-up.

To address this issue, especially for legacy users, we have added a new enhanced user lookup by phone with either format (with or without leading '0') to the user sign-in process. This means that users can now sign-in with either format of their phone number, and Logto will try to match it with the one stored in the database, even if they might have different formats. This will help to reduce confusion and improve the user experience when logging in with phone numbers.

For example:

- If a user signs up with the phone number +61 2 1234 5678, they can now sign-in with either +61 2 1234 5678 or +61 02 1234 5678.
- The same applies to the phone number +61 02 1234 5678, which can be used to sign-in with either +61 2 1234 5678 or +61 02 1234 5678.

For users who might have created two different counts with the same phone number but different formats. The lookup process will always return the one with an exact match. This means that if a user has two accounts with the same phone number but different formats, they will still be able to sign-in with either format, but they will only be able to access the account that matches the format they used during sign-up.

For example:

- If a user has two accounts with the phone numbers +61 2 1234 5678 and +61 02 1234 5678. They will need to sign-in to each account using the exact format they used during sign-up.

related github issue [#7371](https://github.com/logto-io/logto/issues/7371).


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Integration tests and unit tests added

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
