### PR TITLE
refactor(core): has user with normalized phone number match

### DIFF
--- a/packages/core/src/libraries/user.ts
+++ b/packages/core/src/libraries/user.ts
@@ -29,7 +29,7 @@ export const createUserLibrary = (queries: Queries) => {
       hasUser,
       hasUserWithEmail,
       hasUserWithId,
-      hasUserWithPhone,
+      hasUserWithNormalizedPhone,
       hasUserWithIdentity,
       findUsersByIds,
       updateUserById,
@@ -103,7 +103,7 @@ export const createUserLibrary = (queries: Queries) => {
       throw new RequestError({ code: 'user.email_already_in_use', status: 422 });
     }
 
-    if (primaryPhone && (await hasUserWithPhone(primaryPhone, excludeUserId))) {
+    if (primaryPhone && (await hasUserWithNormalizedPhone(primaryPhone, excludeUserId))) {
       throw new RequestError({ code: 'user.phone_already_in_use', status: 422 });
     }
 

--- a/packages/core/src/queries/user.ts
+++ b/packages/core/src/queries/user.ts
@@ -244,8 +244,8 @@ export const createUserQueries = (pool: CommonQueryMethods) => {
     return pool.exists(sql`
       select ${fields.primaryPhone}
       from ${table}
-      where ${fields.primaryPhone}=${internationalNumber}
-      or ${fields.primaryPhone}=${internationalNumberWithLeadingZero}
+      where (${fields.primaryPhone}=${internationalNumber}
+      or ${fields.primaryPhone}=${internationalNumberWithLeadingZero})
       ${conditionalSql(excludeUserId, (id) => sql`and ${fields.id}<>${id}`)}
     `);
   };

--- a/packages/core/src/queries/user.ts
+++ b/packages/core/src/queries/user.ts
@@ -198,7 +198,7 @@ export const createUserQueries = (pool: CommonQueryMethods) => {
     `);
 
   /**
-   * Has user with phone number with exact match.
+   * Checks if a user exists in the database with an exact match on their phone number.
    */
   const hasUserWithPhone = async (phone: string, excludeUserId?: string) =>
     pool.exists(sql`
@@ -209,26 +209,29 @@ export const createUserQueries = (pool: CommonQueryMethods) => {
     `);
 
   /**
-   * Has user with phone number with normalized match.
+   * Checks if a user exists in the database with a phone number that matches the provided
+   * number in either normalized format or with a leading '0'.
    *
    * @remarks
-   * This function is used to check if a user exists that has the same phone number as the one provided.
-   * It will use the normalized phone number to check for the existence of phone numbers in the database in both formats:
-   * - standard international format: 61412345678
-   * - international format with leading '0' before the local number: 610412345678
+   * This function normalizes the input phone number to account for variations in formatting.
+   * It checks for the existence of a user with the same phone number in two formats:
+   * - Standard international format (e.g., 61412345678)
+   * - International format with a leading '0' before the local number (e.g., 610412345678)
    *
-   * We will treat the two formats as the same phone number.
-   * @see {findUserByNormalizedPhone} for more context
+   * If the provided phone number is not a valid international format, it falls back to checking
+   * for an exact match using the `hasUserWithPhone` function.
+   *
+   * @param phone - The phone number to check for user existence.
+   * @param excludeUserId - (Optional) If provided, excludes the user with this ID from the search,
+   * allowing for updates without false positives.
    *
    * @example
-   * - DB: 610412345678
-   * - hasUserWithNormalizedPhone(61412345678)
-   * - return : true
+   * // Database contains: 610412345678
+   * hasUserWithNormalizedPhone(61412345678); // returns: true
    *
-   * @example
-   * - DB: 61412345678
-   * - hasUserWithNormalizedPhone(610412345678)
-   * - return : true
+   *  @example
+   * // Database contains: 61412345678
+   * hasUserWithNormalizedPhone(610412345678); // returns: true
    */
   const hasUserWithNormalizedPhone = async (phone: string, excludeUserId?: string) => {
     const phoneNumberParser = new PhoneNumberParser(phone);

--- a/packages/core/src/routes/account/email-and-phone.ts
+++ b/packages/core/src/routes/account/email-and-phone.ts
@@ -31,7 +31,7 @@ export default function emailAndPhoneRoutes<T extends UserRouter>(...args: Route
         email: z.string().regex(emailRegEx),
         newIdentifierVerificationRecordId: z.string(),
       }),
-      status: [204, 400, 401],
+      status: [204, 400, 401, 422],
     }),
     async (ctx, next) => {
       const { id: userId, scopes, identityVerified } = ctx.auth;
@@ -123,7 +123,7 @@ export default function emailAndPhoneRoutes<T extends UserRouter>(...args: Route
         phone: z.string().regex(phoneRegEx),
         newIdentifierVerificationRecordId: z.string(),
       }),
-      status: [204, 400, 401],
+      status: [204, 400, 401, 422],
     }),
     async (ctx, next) => {
       const { id: userId, scopes, identityVerified } = ctx.auth;

--- a/packages/core/src/routes/admin-user/basics.test.ts
+++ b/packages/core/src/routes/admin-user/basics.test.ts
@@ -34,7 +34,7 @@ const mockedQueries = {
     findUserById: jest.fn(async (id: string) => mockUser),
     hasUser: jest.fn(async () => mockHasUser()),
     hasUserWithEmail: jest.fn(async () => mockHasUserWithEmail()),
-    hasUserWithPhone: jest.fn(async () => mockHasUserWithPhone()),
+    hasUserWithNormalizedPhone: jest.fn(async () => mockHasUserWithPhone()),
     updateUserById: jest.fn(
       async (_, data: Partial<CreateUser>): Promise<User> => ({
         ...mockUser,

--- a/packages/core/src/routes/admin-user/basics.ts
+++ b/packages/core/src/routes/admin-user/basics.ts
@@ -30,7 +30,7 @@ export default function adminUserBasicsRoutes<T extends ManagementApiRouter>(
       hasUser,
       updateUserById,
       hasUserWithEmail,
-      hasUserWithPhone,
+      hasUserWithNormalizedPhone,
     },
   } = queries;
   const {
@@ -191,7 +191,7 @@ export default function adminUserBasicsRoutes<T extends ManagementApiRouter>(
         })
       );
       assertThat(
-        !primaryPhone || !(await hasUserWithPhone(primaryPhone)),
+        !primaryPhone || !(await hasUserWithNormalizedPhone(primaryPhone)),
         new RequestError({ code: 'user.phone_already_in_use', status: 422 })
       );
 

--- a/packages/core/src/routes/admin-user/mfa-verifications.test.ts
+++ b/packages/core/src/routes/admin-user/mfa-verifications.test.ts
@@ -20,23 +20,14 @@ const { mockEsmWithActual } = createMockUtils(jest);
 const mockedQueries = {
   users: {
     findUserById: jest.fn(async (id: string) => mockUser),
-    hasUser: jest.fn(async () => mockHasUser()),
-    hasUserWithEmail: jest.fn(async () => mockHasUserWithEmail()),
-    hasUserWithPhone: jest.fn(async () => mockHasUserWithPhone()),
     updateUserById: jest.fn(
       async (_, data: Partial<CreateUser>): Promise<User> => ({
         ...mockUser,
         ...data,
       })
     ),
-    deleteUserById: jest.fn(),
-    deleteUserIdentity: jest.fn(),
   },
 } satisfies Partial2<Queries>;
-
-const mockHasUser = jest.fn(async () => false);
-const mockHasUserWithEmail = jest.fn(async () => false);
-const mockHasUserWithPhone = jest.fn(async () => false);
 
 const { findUserById, updateUserById } = mockedQueries.users;
 

--- a/packages/core/src/routes/experience/classes/experience-interaction.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.test.ts
@@ -33,7 +33,7 @@ const mockEmail = 'foo@bar.com';
 const userQueries = {
   hasActiveUsers: jest.fn().mockResolvedValue(false),
   hasUserWithEmail: jest.fn().mockResolvedValue(false),
-  hasUserWithPhone: jest.fn().mockResolvedValue(false),
+  hasUserWithNormalizedPhone: jest.fn().mockResolvedValue(false),
   hasUserWithIdentity: jest.fn().mockResolvedValue(false),
 };
 const userLibraries = {

--- a/packages/core/src/routes/experience/classes/libraries/profile-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/profile-validator.ts
@@ -10,7 +10,8 @@ export class ProfileValidator {
   constructor(private readonly queries: Queries) {}
 
   public async guardProfileUniquenessAcrossUsers(profile: InteractionProfile = {}) {
-    const { hasUser, hasUserWithEmail, hasUserWithPhone, hasUserWithIdentity } = this.queries.users;
+    const { hasUser, hasUserWithEmail, hasUserWithNormalizedPhone, hasUserWithIdentity } =
+      this.queries.users;
     const { userSsoIdentities } = this.queries;
 
     const { username, primaryEmail, primaryPhone, socialIdentity, enterpriseSsoIdentity } = profile;
@@ -37,7 +38,7 @@ export class ProfileValidator {
 
     if (primaryPhone) {
       assertThat(
-        !(await hasUserWithPhone(primaryPhone)),
+        !(await hasUserWithNormalizedPhone(primaryPhone)),
         new RequestError({
           code: 'user.phone_already_in_use',
           status: 422,

--- a/packages/core/src/routes/experience/classes/verifications/social-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/social-verification.ts
@@ -258,14 +258,16 @@ export class SocialVerification implements IdentifierVerificationRecord<Verifica
 
     if (isNewUser) {
       const {
-        users: { hasUserWithEmail, hasUserWithPhone },
+        users: { hasUserWithEmail, hasUserWithNormalizedPhone },
       } = this.queries;
 
       return {
         // Sync the email only if the email is not used by other users
         ...conditional(primaryEmail && !(await hasUserWithEmail(primaryEmail)) && { primaryEmail }),
         // Sync the phone only if the phone is not used by other users
-        ...conditional(primaryPhone && !(await hasUserWithPhone(primaryPhone)) && { primaryPhone }),
+        ...conditional(
+          primaryPhone && !(await hasUserWithNormalizedPhone(primaryPhone)) && { primaryPhone }
+        ),
         ...conditional(name && { name }),
         ...conditional(avatar && { avatar }),
       };

--- a/packages/core/src/routes/interaction/actions/helpers.ts
+++ b/packages/core/src/routes/interaction/actions/helpers.ts
@@ -53,7 +53,7 @@ const getSocialSyncProfile = async (
 
 /* Parse the user profile from the new linked Social identity */
 const parseNewSocialProfile = async (
-  { users: { hasUserWithEmail, hasUserWithPhone } }: Queries,
+  { users: { hasUserWithEmail, hasUserWithNormalizedPhone } }: Queries,
   { getLogtoConnectorById }: ConnectorLibrary,
   socialIdentifier: SocialIdentifier,
   user?: User
@@ -78,7 +78,9 @@ const parseNewSocialProfile = async (
       // Sync the email only if the email is not used by other users
       ...conditional(email && !(await hasUserWithEmail(email)) && { primaryEmail: email }),
       // Sync the phone only if the phone is not used by other users
-      ...conditional(phone && !(await hasUserWithPhone(phone)) && { primaryPhone: phone }),
+      ...conditional(
+        phone && !(await hasUserWithNormalizedPhone(phone)) && { primaryPhone: phone }
+      ),
     };
   }
 

--- a/packages/core/src/routes/interaction/actions/submit-interaction.mfa.test.ts
+++ b/packages/core/src/routes/interaction/actions/submit-interaction.mfa.test.ts
@@ -47,7 +47,7 @@ const userQueries = {
   updateUserById: jest.fn(),
   hasActiveUsers: jest.fn().mockResolvedValue(true),
   hasUserWithEmail: jest.fn().mockResolvedValue(false),
-  hasUserWithPhone: jest.fn().mockResolvedValue(false),
+  hasUserWithNormalizedPhone: jest.fn().mockResolvedValue(false),
 };
 
 const { hasActiveUsers, updateUserById } = userQueries;

--- a/packages/core/src/routes/interaction/actions/submit-interaction.test.ts
+++ b/packages/core/src/routes/interaction/actions/submit-interaction.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import {
   InteractionEvent,
   adminConsoleApplicationId,
@@ -55,10 +56,11 @@ const userQueries = {
   updateUserById: jest.fn(async (id: string, user: Partial<User>) => user as User),
   hasActiveUsers: jest.fn().mockResolvedValue(true),
   hasUserWithEmail: jest.fn().mockResolvedValue(false),
-  hasUserWithPhone: jest.fn().mockResolvedValue(false),
+  hasUserWithNormalizedPhone: jest.fn().mockResolvedValue(false),
 };
 
-const { hasActiveUsers, updateUserById, hasUserWithEmail, hasUserWithPhone } = userQueries;
+const { hasActiveUsers, updateUserById, hasUserWithEmail, hasUserWithNormalizedPhone } =
+  userQueries;
 
 const userLibraries = {
   generateUserId: jest.fn().mockResolvedValue('uid'),
@@ -251,7 +253,7 @@ describe('submit action', () => {
 
   it('register new social user should not sync email and phone if already exists', async () => {
     hasUserWithEmail.mockResolvedValueOnce(true);
-    hasUserWithPhone.mockResolvedValueOnce(true);
+    hasUserWithNormalizedPhone.mockResolvedValueOnce(true);
 
     const interaction: VerifiedRegisterInteractionResult = {
       event: InteractionEvent.Register,
@@ -462,3 +464,4 @@ describe('submit action', () => {
     });
   });
 });
+/* eslint-enable max-lines */

--- a/packages/core/src/routes/interaction/verifications/mandatory-user-profile-validation.test.ts
+++ b/packages/core/src/routes/interaction/verifications/mandatory-user-profile-validation.test.ts
@@ -17,9 +17,11 @@ const { mockEsm } = createMockUtils(jest);
 
 const findUserById = jest.fn();
 const hasUserWithEmail = jest.fn();
-const hasUserWithPhone = jest.fn();
+const hasUserWithNormalizedPhone = jest.fn();
 
-const { users } = new MockQueries({ users: { findUserById, hasUserWithEmail, hasUserWithPhone } });
+const { users } = new MockQueries({
+  users: { findUserById, hasUserWithEmail, hasUserWithNormalizedPhone },
+});
 
 const { isUserPasswordSet } = mockEsm('../utils/index.js', () => ({
   isUserPasswordSet: jest.fn(),
@@ -228,7 +230,7 @@ describe('validateMandatoryUserProfile', () => {
     });
 
     it('sign-in identifier includes social with verified phone but phone occupied should throw', async () => {
-      hasUserWithPhone.mockResolvedValueOnce(true);
+      hasUserWithNormalizedPhone.mockResolvedValueOnce(true);
 
       await expect(
         validateMandatoryUserProfile(users, phoneRequiredCtx, {
@@ -247,7 +249,7 @@ describe('validateMandatoryUserProfile', () => {
     });
 
     it('register identifier includes social with verified phone but phone occupied should throw', async () => {
-      hasUserWithPhone.mockResolvedValueOnce(true);
+      hasUserWithNormalizedPhone.mockResolvedValueOnce(true);
 
       await expect(
         validateMandatoryUserProfile(users, phoneRequiredCtx, {
@@ -267,7 +269,7 @@ describe('validateMandatoryUserProfile', () => {
     });
 
     it('identifier includes social with verified phone should not throw', async () => {
-      hasUserWithPhone.mockResolvedValueOnce(false);
+      hasUserWithNormalizedPhone.mockResolvedValueOnce(false);
 
       const updatedInteraction = await validateMandatoryUserProfile(users, phoneRequiredCtx, {
         ...interaction,

--- a/packages/core/src/routes/interaction/verifications/mandatory-user-profile-validation.ts
+++ b/packages/core/src/routes/interaction/verifications/mandatory-user-profile-validation.ts
@@ -177,7 +177,7 @@ const fillMissingProfileWithSocialIdentity = async (
   ) {
     // Check Phone not taken
     assertThat(
-      !(await userQueries.hasUserWithPhone(phone)),
+      !(await userQueries.hasUserWithNormalizedPhone(phone)),
       new RequestError(
         { code: 'user.missing_profile', status: 422 },
         {

--- a/packages/core/src/routes/interaction/verifications/profile-verification.profile-exist.test.ts
+++ b/packages/core/src/routes/interaction/verifications/profile-verification.profile-exist.test.ts
@@ -12,7 +12,7 @@ const { mockEsm } = createMockUtils(jest);
 const userQueries = {
   findUserById: jest.fn().mockResolvedValue({ id: 'foo' }),
   hasUserWithEmail: jest.fn().mockResolvedValue(false),
-  hasUserWithPhone: jest.fn().mockResolvedValue(false),
+  hasUserWithNormalizedPhone: jest.fn().mockResolvedValue(false),
   hasUserWithIdentity: jest.fn().mockResolvedValue(false),
 };
 const { findUserById } = userQueries;

--- a/packages/core/src/routes/interaction/verifications/profile-verification.profile-registered.test.ts
+++ b/packages/core/src/routes/interaction/verifications/profile-verification.profile-registered.test.ts
@@ -12,10 +12,10 @@ const userQueries = {
   hasUser: jest.fn().mockResolvedValue(false),
   findUserById: jest.fn().mockResolvedValue({ id: 'foo' }),
   hasUserWithEmail: jest.fn().mockResolvedValue(false),
-  hasUserWithPhone: jest.fn().mockResolvedValue(false),
+  hasUserWithNormalizedPhone: jest.fn().mockResolvedValue(false),
   hasUserWithIdentity: jest.fn().mockResolvedValue(false),
 };
-const { hasUser, hasUserWithEmail, hasUserWithPhone, hasUserWithIdentity } = userQueries;
+const { hasUser, hasUserWithEmail, hasUserWithNormalizedPhone, hasUserWithIdentity } = userQueries;
 
 const getLogtoConnectorById = jest.fn().mockResolvedValue({
   metadata: { target: 'logto' },
@@ -74,7 +74,7 @@ describe('profile registered validation', () => {
   });
 
   it('phone is registered', async () => {
-    hasUserWithPhone.mockResolvedValueOnce(true);
+    hasUserWithNormalizedPhone.mockResolvedValueOnce(true);
     const interaction = {
       ...baseInteraction,
       profile: {

--- a/packages/core/src/routes/interaction/verifications/profile-verification.protected-identifier.test.ts
+++ b/packages/core/src/routes/interaction/verifications/profile-verification.protected-identifier.test.ts
@@ -14,7 +14,7 @@ const tenantContext = new MockTenant(
     users: {
       findUserById: jest.fn().mockResolvedValue({ id: 'foo' }),
       hasUserWithEmail: jest.fn().mockResolvedValue(false),
-      hasUserWithPhone: jest.fn().mockResolvedValue(false),
+      hasUserWithNormalizedPhone: jest.fn().mockResolvedValue(false),
       hasUserWithIdentity: jest.fn().mockResolvedValue(false),
     },
   },

--- a/packages/core/src/routes/interaction/verifications/profile-verification.ts
+++ b/packages/core/src/routes/interaction/verifications/profile-verification.ts
@@ -62,7 +62,8 @@ const verifyProfileNotRegisteredByOtherUserAccount = async (
   { username, email, phone, connectorId }: Profile,
   identifiers: Identifier[] = []
 ) => {
-  const { hasUser, hasUserWithEmail, hasUserWithPhone, hasUserWithIdentity } = queries.users;
+  const { hasUser, hasUserWithEmail, hasUserWithNormalizedPhone, hasUserWithIdentity } =
+    queries.users;
 
   if (username) {
     assertThat(
@@ -86,7 +87,7 @@ const verifyProfileNotRegisteredByOtherUserAccount = async (
 
   if (phone) {
     assertThat(
-      !(await hasUserWithPhone(phone)),
+      !(await hasUserWithNormalizedPhone(phone)),
       new RequestError({
         code: 'user.phone_already_in_use',
         status: 422,

--- a/packages/integration-tests/src/tests/api/account/email-and-phone.test.ts
+++ b/packages/integration-tests/src/tests/api/account/email-and-phone.test.ts
@@ -374,7 +374,7 @@ describe('account (email and phone)', () => {
       ]);
     });
 
-    it('new phone with  with leading zero format format, existing phone use standard international format', async () => {
+    it('new phone with leading zero format, existing phone uses standard international format', async () => {
       // We use the country code 64 as New Zealand local phone number cloud have leading zero.
       const primaryPhone = `64${generateNationalPhoneNumber()}`;
       const { internationalNumber, internationalNumberWithLeadingZero } = new PhoneNumberParser(

--- a/packages/integration-tests/src/tests/api/account/email-and-phone.test.ts
+++ b/packages/integration-tests/src/tests/api/account/email-and-phone.test.ts
@@ -327,7 +327,7 @@ describe('account (email and phone)', () => {
     });
   });
 
-  describe('should fail if the new phone alreay exists', () => {
+  describe('should fail if the new phone already exists', () => {
     it('new phone with internationNumber format, existing phone with leading zero format', async () => {
       // We use the country code 64 as New Zealand local phone number cloud have leading zero.
       const primaryPhone = `64${generateNationalPhoneNumber()}`;

--- a/packages/integration-tests/src/tests/api/account/email-and-phone.test.ts
+++ b/packages/integration-tests/src/tests/api/account/email-and-phone.test.ts
@@ -1,5 +1,7 @@
+/* eslint-disable max-lines */
 import { UserScope } from '@logto/core-kit';
 import { SignInIdentifier } from '@logto/schemas';
+import { PhoneNumberParser } from '@logto/shared';
 
 import { enableAllAccountCenterFields } from '#src/api/account-center.js';
 import { authedAdminApi } from '#src/api/api.js';
@@ -23,7 +25,12 @@ import {
   signInAndGetUserApi,
 } from '#src/helpers/profile.js';
 import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
-import { devFeatureTest, generateEmail, generatePhone } from '#src/utils.js';
+import {
+  devFeatureTest,
+  generateEmail,
+  generatePhone,
+  generateNationalPhoneNumber,
+} from '#src/utils.js';
 
 describe('account (email and phone)', () => {
   beforeAll(async () => {
@@ -294,71 +301,118 @@ describe('account (email and phone)', () => {
       await deleteDefaultTenantUser(user.id);
     });
 
-    it('should fail if phone is the only sign-up identifier', async () => {
-      const { user, username, password } = await createDefaultTenantUserWithPassword();
+    it('should be able to update primary phone by verifying existing phone', async () => {
+      const primaryPhone = generatePhone();
+      const { user, username, password } = await createDefaultTenantUserWithPassword({
+        primaryPhone,
+      });
       const api = await signInAndGetUserApi(username, password, {
         scopes: [UserScope.Profile, UserScope.Phone],
       });
-      const verificationRecordId = await createVerificationRecordByPassword(api, password);
-      await enableAllPasswordSignInMethods({
-        identifiers: [SignInIdentifier.Phone],
-        password: true,
-        verify: true,
-      });
-
-      await expectRejects(deletePrimaryPhone(api, verificationRecordId), {
-        code: 'user.phone_required',
-        status: 400,
-      });
-
-      await enableAllPasswordSignInMethods();
-      await deleteDefaultTenantUser(user.id);
-    });
-
-    it('should fail if email or phone is the sign-up identifier', async () => {
-      const { user, username, password } = await createDefaultTenantUserWithPassword();
-      const api = await signInAndGetUserApi(username, password, {
-        scopes: [UserScope.Profile, UserScope.Phone],
-      });
-      const verificationRecordId = await createVerificationRecordByPassword(api, password);
-      await enableAllPasswordSignInMethods({
-        identifiers: [SignInIdentifier.Email, SignInIdentifier.Phone],
-        password: true,
-        verify: true,
-      });
-
-      await expectRejects(deletePrimaryPhone(api, verificationRecordId), {
-        code: 'user.email_or_phone_required',
-        status: 400,
-      });
-
-      await enableAllPasswordSignInMethods();
-      await deleteDefaultTenantUser(user.id);
-    });
-
-    it('should be able to delete primary phone', async () => {
-      const { user, username, password } = await createDefaultTenantUserWithPassword();
-      const api = await signInAndGetUserApi(username, password, {
-        scopes: [UserScope.Profile, UserScope.Phone],
-      });
-      const verificationRecordId = await createVerificationRecordByPassword(api, password);
       const newPhone = generatePhone();
+      const verificationRecordId = await createAndVerifyVerificationCode(api, {
+        type: SignInIdentifier.Phone,
+        value: primaryPhone,
+      });
       const newVerificationRecordId = await createAndVerifyVerificationCode(api, {
         type: SignInIdentifier.Phone,
         value: newPhone,
       });
 
       await updatePrimaryPhone(api, newPhone, verificationRecordId, newVerificationRecordId);
-
       const userInfo = await getUserInfo(api);
       expect(userInfo).toHaveProperty('primaryPhone', newPhone);
 
-      await deletePrimaryPhone(api, verificationRecordId);
-
-      const userInfoAfterDelete = await getUserInfo(api);
-      expect(userInfoAfterDelete).toHaveProperty('primaryPhone', null);
-
       await deleteDefaultTenantUser(user.id);
+    });
+  });
+
+  describe('should fail if the new phone alreay exists', () => {
+    it('new phone with internationNumber format, existing phone with leading zero format', async () => {
+      // We use the country code 64 as New Zealand local phone number cloud have leading zero.
+      const primaryPhone = `64${generateNationalPhoneNumber()}`;
+      const { internationalNumber, internationalNumberWithLeadingZero } = new PhoneNumberParser(
+        primaryPhone
+      );
+
+      if (!internationalNumber || !internationalNumberWithLeadingZero) {
+        throw new Error('Invalid phone number');
+      }
+
+      const { user: userWithExistingPhone } = await createDefaultTenantUserWithPassword({
+        primaryPhone: internationalNumber,
+      });
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
+
+      const api = await signInAndGetUserApi(username, password, {
+        scopes: [UserScope.Profile, UserScope.Phone],
+      });
+
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
+
+      const newVerificationRecordId = await createAndVerifyVerificationCode(api, {
+        type: SignInIdentifier.Phone,
+        value: internationalNumberWithLeadingZero,
+      });
+
+      await expectRejects(
+        updatePrimaryPhone(
+          api,
+          internationalNumberWithLeadingZero,
+          verificationRecordId,
+          newVerificationRecordId
+        ),
+        {
+          code: 'user.phone_already_in_use',
+          status: 422,
+        }
+      );
+
+      await Promise.all([
+        deleteDefaultTenantUser(user.id),
+        deleteDefaultTenantUser(userWithExistingPhone.id),
+      ]);
+    });
+
+    it('new phone with  with leading zero format format, existing phone use standard international format', async () => {
+      // We use the country code 64 as New Zealand local phone number cloud have leading zero.
+      const primaryPhone = `64${generateNationalPhoneNumber()}`;
+      const { internationalNumber, internationalNumberWithLeadingZero } = new PhoneNumberParser(
+        primaryPhone
+      );
+
+      if (!internationalNumber || !internationalNumberWithLeadingZero) {
+        throw new Error('Invalid phone number');
+      }
+
+      const { user: userWithExistingPhone } = await createDefaultTenantUserWithPassword({
+        primaryPhone: internationalNumberWithLeadingZero,
+      });
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
+
+      const api = await signInAndGetUserApi(username, password, {
+        scopes: [UserScope.Profile, UserScope.Phone],
+      });
+
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
+
+      const newVerificationRecordId = await createAndVerifyVerificationCode(api, {
+        type: SignInIdentifier.Phone,
+        value: internationalNumber,
+      });
+
+      await expectRejects(
+        updatePrimaryPhone(api, internationalNumber, verificationRecordId, newVerificationRecordId),
+        {
+          code: 'user.phone_already_in_use',
+          status: 422,
+        }
+      );
+
+      await Promise.all([
+        deleteDefaultTenantUser(user.id),
+        deleteDefaultTenantUser(userWithExistingPhone.id),
+      ]);
     });
   });
 
@@ -458,3 +512,4 @@ describe('account (email and phone)', () => {
     });
   });
 });
+/* eslint-enable max-lines */

--- a/packages/integration-tests/src/tests/api/admin-user.test.ts
+++ b/packages/integration-tests/src/tests/api/admin-user.test.ts
@@ -399,11 +399,11 @@ describe('admin console user management', () => {
         );
 
         // Should allow update existing user
-        await expect(async () => {
-          await updateUser(user.id, {
+        await expect(
+          updateUser(user.id, {
             primaryPhone: newCreated,
-          });
-        }).resolves.not.toThrow();
+          })
+        ).resolves.not.toThrow();
 
         await Promise.all([deleteUser(user.id), deleteUser(newUser.id)]);
       }

--- a/packages/integration-tests/src/tests/api/admin-user.test.ts
+++ b/packages/integration-tests/src/tests/api/admin-user.test.ts
@@ -376,5 +376,37 @@ describe('admin console user management', () => {
         await deleteUser(user.id);
       }
     );
+
+    it.each(testCases)(
+      'should failed to update user with phone number conflict',
+      async ({ existing, newCreated }) => {
+        const user = await createUserByAdmin({
+          primaryPhone: existing,
+        });
+
+        const newUser = await createUserByAdmin({
+          username: generateUsername(),
+        });
+
+        await expectRejects(
+          updateUser(newUser.id, {
+            primaryPhone: newCreated,
+          }),
+          {
+            code: 'user.phone_already_in_use',
+            status: 422,
+          }
+        );
+
+        // Should allow update existing user
+        await expect(async () => {
+          await updateUser(user.id, {
+            primaryPhone: newCreated,
+          });
+        }).resolves.not.toThrow();
+
+        await Promise.all([deleteUser(user.id), deleteUser(newUser.id)]);
+      }
+    );
   });
 });

--- a/packages/integration-tests/src/tests/api/admin-user.test.ts
+++ b/packages/integration-tests/src/tests/api/admin-user.test.ts
@@ -33,6 +33,7 @@ import {
   generatePhone,
   generatePassword,
   randomString,
+  generateNationalPhoneNumber,
 } from '#src/utils.js';
 
 describe('admin console user management', () => {
@@ -332,5 +333,48 @@ describe('admin console user management', () => {
       code: 'guard.invalid_input',
       status: 400,
     });
+  });
+
+  describe('create and update user phone number with normalization', () => {
+    const nationalNumber = generateNationalPhoneNumber();
+    const countryCode = '61';
+
+    const internationalFormatNumber = `${countryCode}${nationalNumber}`;
+    const leadingZeroFormatNumber = `${countryCode}0${nationalNumber}`;
+
+    const testCases: Array<{
+      existing: string;
+      newCreated: string;
+    }> = [
+      {
+        existing: internationalFormatNumber,
+        newCreated: leadingZeroFormatNumber,
+      },
+      {
+        existing: leadingZeroFormatNumber,
+        newCreated: internationalFormatNumber,
+      },
+    ];
+
+    it.each(testCases)(
+      'should failed to create user with phone number conflict',
+      async ({ existing, newCreated }) => {
+        const user = await createUserByAdmin({
+          primaryPhone: existing,
+        });
+
+        await expectRejects(
+          createUserByAdmin({
+            primaryPhone: newCreated,
+          }),
+          {
+            code: 'user.phone_already_in_use',
+            status: 422,
+          }
+        );
+
+        await deleteUser(user.id);
+      }
+    );
   });
 });

--- a/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/password.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/password.test.ts
@@ -208,35 +208,4 @@ describe('phone number sanitisation sign-in test +61 412 345 678', () => {
       });
     }
   );
-
-  it('should sign-in with extact phone number if multiple account is found', async () => {
-    const passwordA = generatePassword();
-    const passwordB = generatePassword();
-
-    await userApi.create({
-      primaryPhone: testPhoneNumber,
-      password: passwordA,
-    });
-
-    await userApi.create({
-      primaryPhone: testPhoneNumberWithLeadingZero,
-      password: passwordB,
-    });
-
-    await signInWithPassword({
-      identifier: {
-        type: SignInIdentifier.Phone,
-        value: testPhoneNumber,
-      },
-      password: passwordA,
-    });
-
-    await signInWithPassword({
-      identifier: {
-        type: SignInIdentifier.Phone,
-        value: testPhoneNumberWithLeadingZero,
-      },
-      password: passwordB,
-    });
-  });
 });

--- a/packages/integration-tests/src/utils.ts
+++ b/packages/integration-tests/src/utils.ts
@@ -43,6 +43,17 @@ export const generatePhone = (isE164?: boolean) => {
   return plus + countryAndAreaCode + centralOfficeCode + phoneNumber;
 };
 
+/**
+ * This method only generates a local phone number without a country code.
+ */
+export const generateNationalPhoneNumber = () => {
+  const areaCode = randomInt(100, 999).toString();
+  const centralOfficeCode = randomInt(100, 999).toString();
+  const phoneNumber = randomInt(0, 10_000).toString().padStart(4, '0');
+
+  return areaCode + centralOfficeCode + phoneNumber;
+};
+
 export const formatPhoneNumberToInternational = (phoneNumber: string) =>
   phoneNumber.slice(0, 2) +
   ' ' +


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

This PR is a follow-up to #7382.

It replaces hasUserWithPhone with the new hasUserWithNormalizedPhone. The updated logic checks for the existence of the phone number in both of the following formats:

Standard international format: 64 4 123 4567

National format with a leading zero: 64 04 123 4567

This ensures both formats are treated as the same phone number. If either format is found, a phone number conflict error will be thrown.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Integration tests added

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
