### PR TITLE
refactor: use `gpt-4.1` as the default translate model

### DIFF
--- a/.changeset/funny-eels-wonder.md
+++ b/.changeset/funny-eels-wonder.md
@@ -1,0 +1,9 @@
+---
+"@logto/translate": patch
+---
+
+allow empty file when syncing keys
+
+The previous behavior was to throw an error if any of the `import` files was empty. This caused issues when we needed to remove files and resync keys, as it would lead to manual intervention to delete the `import` clauses.
+
+With this change, missing or empty `import` files are treated as empty by default, allowing the sync process to continue without errors.

--- a/.changeset/moody-turtles-bake.md
+++ b/.changeset/moody-turtles-bake.md
@@ -1,0 +1,7 @@
+---
+"@logto/translate": patch
+---
+
+use `gpt-4.1` as the default model
+
+As it's newer and cheaper than `gpt-4o-2024-08-06`.

--- a/packages/translate/src/openai.ts
+++ b/packages/translate/src/openai.ts
@@ -19,7 +19,7 @@ import {
 } from './utils.js';
 
 // The full list of OPENAI model can be found at https://platform.openai.com/docs/models.
-export const getModel = () => process.env.OPENAI_MODEL_NAME ?? 'gpt-4o-2024-08-06';
+export const getModel = () => process.env.OPENAI_MODEL_NAME ?? 'gpt-4.1';
 
 export const createOpenaiApi = () => {
   const proxy = getProxy();
@@ -130,12 +130,12 @@ export const createFullTranslation = async ({
   if (verbose) {
     consoleLog.info(
       'Found ' +
-        String(localeFiles.length) +
-        ' file' +
-        conditionalString(localeFiles.length !== 1 && 's') +
-        ' in ' +
-        packageName +
-        ' to create'
+      String(localeFiles.length) +
+      ' file' +
+      conditionalString(localeFiles.length !== 1 && 's') +
+      ' in ' +
+      packageName +
+      ' to create'
     );
   }
 
@@ -174,12 +174,12 @@ export const syncTranslation = async ({
   if (verbose) {
     consoleLog.info(
       'Found ' +
-        String(localeFiles.length) +
-        ' file' +
-        conditionalString(localeFiles.length !== 1 && 's') +
-        ' in ' +
-        packageName +
-        ' to translate'
+      String(localeFiles.length) +
+      ' file' +
+      conditionalString(localeFiles.length !== 1 && 's') +
+      ' in ' +
+      packageName +
+      ' to translate'
     );
   }
 

--- a/packages/translate/src/openai.ts
+++ b/packages/translate/src/openai.ts
@@ -130,12 +130,12 @@ export const createFullTranslation = async ({
   if (verbose) {
     consoleLog.info(
       'Found ' +
-      String(localeFiles.length) +
-      ' file' +
-      conditionalString(localeFiles.length !== 1 && 's') +
-      ' in ' +
-      packageName +
-      ' to create'
+        String(localeFiles.length) +
+        ' file' +
+        conditionalString(localeFiles.length !== 1 && 's') +
+        ' in ' +
+        packageName +
+        ' to create'
     );
   }
 
@@ -174,12 +174,12 @@ export const syncTranslation = async ({
   if (verbose) {
     consoleLog.info(
       'Found ' +
-      String(localeFiles.length) +
-      ' file' +
-      conditionalString(localeFiles.length !== 1 && 's') +
-      ' in ' +
-      packageName +
-      ' to translate'
+        String(localeFiles.length) +
+        ' file' +
+        conditionalString(localeFiles.length !== 1 && 's') +
+        ' in ' +
+        packageName +
+        ' to translate'
     );
   }
 

--- a/packages/translate/src/sync-keys/utils.ts
+++ b/packages/translate/src/sync-keys/utils.ts
@@ -1,8 +1,8 @@
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, statSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-import { tryThat } from '@silverhand/essentials';
+import { trySafe, tryThat } from '@silverhand/essentials';
 import ts from 'typescript';
 
 import { consoleLog } from '../utils.js';
@@ -94,6 +94,12 @@ type ParsedTuple = readonly [NestedPhraseObject, FileStructure];
  *
  */
 export const parseLocaleFiles = (filePath: string): ParsedTuple => {
+  const fileStat = trySafe(() => statSync(filePath));
+
+  if (!fileStat?.isFile()) {
+    return [{}, {}];
+  }
+
   const content = readFileSync(filePath, 'utf8');
   const ast = ts.createSourceFile(filePath, content, ts.ScriptTarget.Latest, true);
   const importIdentifierPath = new Map<string, string>();


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

### new model, less price

<img width="786" alt="image" src="https://github.com/user-attachments/assets/31d281e8-529b-4944-a54c-33b683e65d3d" />

### allow non-existing `import` targets when syncing keys

instead of throwing an error, treat non-existing `import` targets as empty files

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="578" alt="image" src="https://github.com/user-attachments/assets/738b0621-579a-497c-9d86-a6103dd1d49b" />


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
