### PR TITLE
refactor(core): make userinfo endpoint optional for OIDC SSO connectors

### DIFF
--- a/.changeset/dirty-mice-fail.md
+++ b/.changeset/dirty-mice-fail.md
@@ -1,0 +1,13 @@
+---
+"@logto/core": minor
+---
+
+refactor: make the `userinfo_endpoint` field optional in the OIDC connector configuration to support providers like Azure AD B2C that do not expose a userinfo endpoint
+
+Azure AD B2C SSO applications do not provide a userinfo_endpoint in their OIDC metadata. This has been a blocker for users attempting to integrate Azure AD B2C SSO with Logto, as our current implementation strictly follows the OIDC spec and relies on the userinfo endpoint to retrieve user claims after authentication.
+
+- Updated the OIDC config response schema to make the userinfo_endpoint optional for OIDC based SSO providers.
+- If the `userinfo_endpoint` is missing from the provider's OIDC metadata, the system will now extract user data directly from the `id_token` claims.
+- If the `userinfo_endpoint` is present, the system will continue to retrieve user claims by calling the endpoint (existing behavior).
+
+`userinfo_endpoint` is a standard OIDC field that specifies the endpoint for retrieving user information. For most of the OIDC providers, this update will not affect this existing implementation. However, for Azure AD B2C, this change allows users to successfully authenticate and retrieve user claims without the need for a userinfo endpoint.

--- a/packages/core/src/saml-application/SamlApplication/index.ts
+++ b/packages/core/src/saml-application/SamlApplication/index.ts
@@ -345,6 +345,12 @@ export class SamlApplication {
     accessToken: string;
   }): Promise<IdTokenProfileStandardClaims & Record<string, unknown>> => {
     const { userinfoEndpoint } = await this.fetchOidcConfig();
+
+    // We reuse the fetchOidcConfig function from SSO connector to fetch the OIDC config.
+    // userinfo endpoint is not required in the OIDC config.
+    // But it is mandatory in Logto OIDC flow. So we should always have a userinfo endpoint.
+    assertThat(userinfoEndpoint, new Error('Userinfo endpoint is not available'));
+
     const body = await getRawUserInfoResponse(accessToken, userinfoEndpoint);
     const result = idTokenProfileStandardClaimsGuard
       .catchall(z.unknown())

--- a/packages/core/src/sso/AzureOidcSsoConnector/index.ts
+++ b/packages/core/src/sso/AzureOidcSsoConnector/index.ts
@@ -97,7 +97,9 @@ export class AzureOidcSsoConnector extends OidcConnector implements SingleSignOn
     // Verify the id token and get the claims
     const idTokenClaims = await getIdTokenClaims(idToken, oidcConfig, nonce, jwtVerifyOptions);
     // Fetch user info from the userinfo endpoint
-    const userInfoClaims = await getUserInfo(accessToken, oidcConfig.userinfoEndpoint);
+    const userInfoClaims = oidcConfig.userinfoEndpoint
+      ? await getUserInfo(accessToken, oidcConfig.userinfoEndpoint)
+      : undefined;
 
     // Merge the claims from id token and userinfo endpoint as in Azure AD, some claims are only available in the userinfo endpoint
     const mergedClaims = {

--- a/packages/core/src/sso/OidcConnector/index.ts
+++ b/packages/core/src/sso/OidcConnector/index.ts
@@ -121,15 +121,18 @@ class OidcConnector {
       })
     );
 
-    // Verify the id token and get the user id
-    const { sub: id } = await getIdTokenClaims(idToken, oidcConfig, nonce);
+    // Verify the id token and get the user claims
+    const idTokenClaims = await getIdTokenClaims(idToken, oidcConfig, nonce);
 
-    // Fetch user info from the userinfo endpoint
+    // If userinfo endpoint is not provided, use the id token claims as user info,
+    // otherwise, fetch the user info from the userinfo endpoint
     const { sub, name, picture, email, email_verified, phone, phone_verified, ...rest } =
-      await getUserInfo(accessToken, oidcConfig.userinfoEndpoint);
+      oidcConfig.userinfoEndpoint
+        ? await getUserInfo(accessToken, oidcConfig.userinfoEndpoint)
+        : idTokenClaims;
 
     return {
-      id,
+      id: sub,
       ...conditional(name && { name }),
       ...conditional(picture && { avatar: picture }),
       ...conditional(email && email_verified && { email }),

--- a/packages/core/src/sso/types/oidc.ts
+++ b/packages/core/src/sso/types/oidc.ts
@@ -36,7 +36,7 @@ export type BasicOidcConnectorConfig = z.infer<typeof basicOidcConnectorConfigGu
 export const oidcConfigResponseGuard = z.object({
   authorization_endpoint: z.string(),
   token_endpoint: z.string(),
-  userinfo_endpoint: z.string(),
+  userinfo_endpoint: z.string().optional(),
   jwks_uri: z.string(),
   issuer: z.string(),
 });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Make the userinfo_endpoint field optional in the OIDC connector configuration to support providers like Azure AD B2C that do not expose a userinfo endpoint.

### Background
We've received reports that [Azure AD B2C SSO](https://learn.microsoft.com/en-us/azure/active-directory-b2c/userinfo-endpoint?pivots=b2c-custom-policy) applications do not provide a `userinfo_endpoint` in their OIDC metadata by default. This has been a blocker for users attempting to integrate Azure AD B2C SSO with Logto, as our current implementation strictly follows the OIDC spec and relies on the userinfo endpoint to retrieve user claims after authentication.

### Changes
- Updated the OIDC config response schema to make the userinfo_endpoint optional.
- If the `userinfo_endpoint` is missing, the system will now extract user data directly from the ID token claims.
- If the `userinfo_endpoint` is present, the system will continue to retrieve user claims by calling the endpoint (existing behavior).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
