### PR TITLE
fix(console): mutate sie data on captcha settings update

### DIFF
--- a/packages/console/src/pages/Security/Captcha/CaptchaForm.tsx
+++ b/packages/console/src/pages/Security/Captcha/CaptchaForm.tsx
@@ -3,6 +3,7 @@ import { useContext, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
+import { useSWRConfig } from 'swr';
 
 import Plus from '@/assets/icons/plus.svg?react';
 import DetailsForm from '@/components/DetailsForm';
@@ -45,6 +46,8 @@ function CaptchaForm({ captchaProvider, formData }: Props) {
   } = formMethods;
   const api = useApi();
 
+  const { mutate: mutateGlobal } = useSWRConfig();
+
   const onSubmit = trySubmitSafe(async (data: CaptchaPolicy) => {
     const { captchaPolicy } = await api
       .patch('api/sign-in-exp', {
@@ -53,6 +56,9 @@ function CaptchaForm({ captchaProvider, formData }: Props) {
       .json<SignInExperience>();
     reset(captchaPolicy);
     mutateSubscriptionQuotaAndUsages();
+
+    // Global mutate the SIE data
+    await mutateGlobal('api/sign-in-exp');
     toast.success(t('general.saved'));
   });
 


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

This PR addresses a bug related to the Captcha form submission process. After toggling the enable captcha status switch and submitting the form, the updated form data was not retained when the user navigated away from the form page and returned. 
This issue arose because the form was using the cached data from the sign-in experience (SIE) as its default values, which did not reflect the latest updates due to SWR's caching logic.

### Updates
Implemented a mutation of the SWR data upon successful form submission in the Captcha form. This ensures that any updates made to the form data are reflected in the SWR cache, allowing the form to display the most current state when the user navigates back to it.



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
