### PR TITLE
feat(core): add passkey via account api

### DIFF
--- a/packages/core/src/routes/account/index.openapi.json
+++ b/packages/core/src/routes/account/index.openapi.json
@@ -269,6 +269,30 @@
           }
         }
       }
+    },
+    "/api/my-account/mfa-verifications": {
+      "post": {
+        "tags": ["Dev feature"],
+        "operationId": "AddMfaVerification",
+        "summary": "Add a MFA verification",
+        "description": "Add a MFA verification to the user, a logto-verification-id in header is required for checking sensitive permissions. Only WebAuthn is supported for now, a new identifier verification record is required for the webauthn registration verification.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "newIdentifierVerificationRecordId": {
+                    "description": "The identifier verification record ID for the new WebAuthn registration verification."
+                  },
+                  "type": {
+                    "description": "The type of the MFA verification."
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/packages/core/src/routes/account/index.ts
+++ b/packages/core/src/routes/account/index.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 
 import koaGuard from '#src/middleware/koa-guard.js';
 
+import { EnvSet } from '../../env-set/index.js';
 import RequestError from '../../errors/RequestError/index.js';
 import { encryptUserPassword } from '../../libraries/user.utils.js';
 import assertThat from '../../utils/assert-that.js';
@@ -18,6 +19,7 @@ import type { UserRouter, RouterInitArgs } from '../types.js';
 import { accountApiPrefix } from './constants.js';
 import emailAndPhoneRoutes from './email-and-phone.js';
 import identitiesRoutes from './identities.js';
+import mfaVerificationsRoutes from './mfa-verifications.js';
 import koaAccountCenter from './middlewares/koa-account-center.js';
 import { getAccountCenterFilteredProfile, getScopedProfile } from './utils/get-scoped-profile.js';
 
@@ -181,4 +183,8 @@ export default function accountRoutes<T extends UserRouter>(...args: RouterInitA
 
   emailAndPhoneRoutes(...args);
   identitiesRoutes(...args);
+
+  if (EnvSet.values.isDevFeaturesEnabled) {
+    mfaVerificationsRoutes(...args);
+  }
 }

--- a/packages/core/src/routes/account/mfa-verifications.ts
+++ b/packages/core/src/routes/account/mfa-verifications.ts
@@ -1,0 +1,85 @@
+import { UserScope } from '@logto/core-kit';
+import { VerificationType, MfaFactor, AccountCenterControlValue } from '@logto/schemas';
+import { generateStandardId } from '@logto/shared';
+import { z } from 'zod';
+
+import koaGuard from '#src/middleware/koa-guard.js';
+
+import RequestError from '../../errors/RequestError/index.js';
+import { buildVerificationRecordByIdAndType } from '../../libraries/verification.js';
+import assertThat from '../../utils/assert-that.js';
+import type { UserRouter, RouterInitArgs } from '../types.js';
+
+import { accountApiPrefix } from './constants.js';
+
+export default function mfaVerificationsRoutes<T extends UserRouter>(
+  ...[router, { queries, libraries }]: RouterInitArgs<T>
+) {
+  const {
+    users: { updateUserById, findUserById },
+    signInExperiences: { findDefaultSignInExperience },
+  } = queries;
+
+  router.post(
+    `${accountApiPrefix}/mfa-verifications`,
+    koaGuard({
+      body: z.object({
+        type: z.literal(MfaFactor.WebAuthn),
+        newIdentifierVerificationRecordId: z.string(),
+      }),
+      status: [204, 400, 401],
+    }),
+    async (ctx, next) => {
+      const { id: userId, scopes, identityVerified } = ctx.auth;
+      assertThat(
+        identityVerified,
+        new RequestError({ code: 'verification_record.permission_denied', status: 401 })
+      );
+      const { newIdentifierVerificationRecordId } = ctx.guard.body;
+      const { fields } = ctx.accountCenter;
+      assertThat(
+        fields.mfa === AccountCenterControlValue.Edit,
+        'account_center.filed_not_editable'
+      );
+
+      assertThat(scopes.has(UserScope.Identities), 'auth.unauthorized');
+
+      // Check new identifier
+      const newVerificationRecord = await buildVerificationRecordByIdAndType({
+        type: VerificationType.WebAuthn,
+        id: newIdentifierVerificationRecordId,
+        queries,
+        libraries,
+      });
+      assertThat(newVerificationRecord.isVerified, 'verification_record.not_found');
+
+      const bindMfa = newVerificationRecord.toBindMfa();
+
+      const user = await findUserById(userId);
+
+      // Check sign in experience, if webauthn is enabled
+      const { mfa } = await findDefaultSignInExperience();
+      assertThat(
+        mfa.factors.includes(MfaFactor.WebAuthn),
+        new RequestError({ code: 'session.mfa.mfa_factor_not_enabled', status: 400 })
+      );
+
+      const updatedUser = await updateUserById(userId, {
+        mfaVerifications: [
+          ...user.mfaVerifications,
+          {
+            ...bindMfa,
+            id: generateStandardId(),
+            createdAt: new Date().toISOString(),
+          },
+        ],
+      });
+
+      ctx.appendDataHookContext('User.Data.Updated', { user: updatedUser });
+
+      ctx.status = 204;
+
+      return next();
+    }
+  );
+}

--- a/packages/core/src/routes/verification/index.openapi.json
+++ b/packages/core/src/routes/verification/index.openapi.json
@@ -208,6 +208,62 @@
           }
         }
       }
+    },
+    "/api/verifications/web-authn/registration": {
+      "post": {
+        "tags": ["Dev feature"],
+        "operationId": "GenerateWebAuthnRegistrationOptions",
+        "summary": "Generate WebAuthn registration options",
+        "description": "Generate WebAuthn registration options for the user to register a new WebAuthn device.",
+        "responses": {
+          "200": {
+            "description": "Successfully generated the WebAuthn registration options.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "registrationOptions": {
+                      "type": "object"
+                    },
+                    "verificationRecordId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/verifications/web-authn/registration/verify": {
+      "post": {
+        "tags": ["Dev feature"],
+        "operationId": "VerifyWebAuthnRegistration",
+        "summary": "Verify WebAuthn registration",
+        "description": "Verify the WebAuthn registration by the user's response.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "verificationId": {
+                    "description": "The ID of the verification record."
+                  },
+                  "payload": {
+                    "description": "The payload of the WebAuthn device."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The WebAuthn registration has been successfully verified."
+          }
+        }
+      }
     }
   }
 }

--- a/packages/integration-tests/src/api/verification-record.ts
+++ b/packages/integration-tests/src/api/verification-record.ts
@@ -1,4 +1,8 @@
-import { type SignInIdentifier } from '@logto/schemas';
+import {
+  type WebAuthnRegistrationOptions,
+  type SignInIdentifier,
+  type BindWebAuthnPayload,
+} from '@logto/schemas';
 import { type KyInstance } from 'ky';
 
 import { readConnectorMessage } from '#src/helpers/index.js';
@@ -96,5 +100,23 @@ export const verifySocialAuthorization = async (
 ) => {
   await api.post('api/verifications/social/verify', {
     json: { verificationRecordId, connectorData },
+  });
+};
+
+export const createWebAuthnRegistrationOptions = async (api: KyInstance) => {
+  const { verificationRecordId, registrationOptions } = await api
+    .post('api/verifications/web-authn/registration', {})
+    .json<{ verificationRecordId: string; registrationOptions: WebAuthnRegistrationOptions }>();
+
+  return { verificationRecordId, registrationOptions };
+};
+
+export const verifyWebAuthnRegistration = async (
+  api: KyInstance,
+  verificationRecordId: string,
+  payload: BindWebAuthnPayload
+) => {
+  await api.post('api/verifications/web-authn/registration/verify', {
+    json: { verificationRecordId, payload },
   });
 };

--- a/packages/integration-tests/src/helpers/index.ts
+++ b/packages/integration-tests/src/helpers/index.ts
@@ -83,7 +83,7 @@ export const removeConnectorMessage = async (
 };
 
 type ExpectedErrorInfo = {
-  code: string;
+  code?: string;
   status: number;
   messageIncludes?: string;
   unexpectedProperties?: string[];

--- a/packages/integration-tests/src/helpers/sign-in-experience.ts
+++ b/packages/integration-tests/src/helpers/sign-in-experience.ts
@@ -113,6 +113,14 @@ export const enableUserControlledMfaWithTotp = async () =>
     },
   });
 
+export const enableUserControlledMfaWithTotpAndWebAuthn = async () =>
+  updateSignInExperience({
+    mfa: {
+      factors: [MfaFactor.TOTP, MfaFactor.WebAuthn],
+      policy: MfaPolicy.NoPrompt,
+    },
+  });
+
 export const enableUserControlledMfaWithTotpOnlyAtSignIn = async () =>
   updateSignInExperience({
     mfa: {

--- a/packages/integration-tests/src/tests/api/account/mfa.test.ts
+++ b/packages/integration-tests/src/tests/api/account/mfa.test.ts
@@ -1,0 +1,100 @@
+import { UserScope } from '@logto/core-kit';
+import { MfaFactor } from '@logto/schemas';
+
+import { enableAllAccountCenterFields } from '#src/api/account-center.js';
+import {
+  createWebAuthnRegistrationOptions,
+  verifyWebAuthnRegistration,
+} from '#src/api/verification-record.js';
+import { expectRejects } from '#src/helpers/index.js';
+import {
+  createDefaultTenantUserWithPassword,
+  deleteDefaultTenantUser,
+  signInAndGetUserApi,
+} from '#src/helpers/profile.js';
+import {
+  enableAllPasswordSignInMethods,
+  enableUserControlledMfaWithTotpAndWebAuthn,
+  resetMfaSettings,
+} from '#src/helpers/sign-in-experience.js';
+import { devFeatureTest } from '#src/utils.js';
+
+const { describe, it } = devFeatureTest;
+
+describe('my-account (mfa)', () => {
+  beforeAll(async () => {
+    await enableAllPasswordSignInMethods();
+    await enableAllAccountCenterFields();
+    await enableUserControlledMfaWithTotpAndWebAuthn();
+  });
+
+  afterAll(async () => {
+    await resetMfaSettings();
+  });
+
+  describe('POST /my-account/mfa-verifications/web-authn/registration', () => {
+    it('should be able to get webauthn registration options', async () => {
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
+      const api = await signInAndGetUserApi(username, password, {
+        scopes: [UserScope.Profile],
+      });
+
+      const { verificationRecordId, registrationOptions } =
+        await createWebAuthnRegistrationOptions(api);
+
+      expect(verificationRecordId).toBeTruthy();
+      expect(registrationOptions.rp.name).toBe('localhost');
+
+      await deleteDefaultTenantUser(user.id);
+    });
+
+    it('should be able to verify webauthn registration', async () => {
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
+      const api = await signInAndGetUserApi(username, password, {
+        scopes: [UserScope.Profile],
+      });
+
+      const {
+        verificationRecordId,
+        registrationOptions: {
+          rp: { id: rpId },
+          challenge,
+        },
+      } = await createWebAuthnRegistrationOptions(api);
+
+      const rawId = Buffer.from(rpId ?? 'localhost')
+        .toString('base64')
+        .replaceAll('+', '-')
+        .replaceAll('/', '_')
+        .replace(/=+$/, '');
+
+      // This 500 error is expected because the mock registration response
+      // can not pass the server side validation.
+      await expectRejects(
+        verifyWebAuthnRegistration(api, verificationRecordId, {
+          type: MfaFactor.WebAuthn,
+          id: rawId,
+          rawId,
+          response: {
+            clientDataJSON: Buffer.from(
+              JSON.stringify({
+                type: 'webauthn.create',
+                challenge,
+                origin: 'http://localhost:3001',
+                crossOrigin: false,
+              })
+            ).toString('base64url'),
+            attestationObject: rawId,
+          },
+          clientExtensionResults: {},
+        }),
+        {
+          code: undefined,
+          status: 500,
+        }
+      );
+
+      await deleteDefaultTenantUser(user.id);
+    });
+  });
+});

--- a/packages/schemas/src/foundations/jsonb-types/account-centers.ts
+++ b/packages/schemas/src/foundations/jsonb-types/account-centers.ts
@@ -22,6 +22,7 @@ export const accountCenterFieldControlGuard = z
     username: z.nativeEnum(AccountCenterControlValue),
     social: z.nativeEnum(AccountCenterControlValue),
     customData: z.nativeEnum(AccountCenterControlValue),
+    mfa: z.nativeEnum(AccountCenterControlValue),
   })
   .partial();
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

New feature: add WebAuthn (Passkey) via account API.

1. Get registraction info from `POST /verifications/web-authn/registration`
2. Get webauthn response from local device
3. Verify response by `POST /verifications/web-authn/registration/verify` and get "verification record id".
4. Use this id to complete binding `POST /my-account/mfa-verifications`

Please notice that some APIs are not covered by integration tests, because we dont' have an easy way to generate mock webauthn response to pass the verification.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Integration tests & local test.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
