### PR TITLE
fix(console): hide name label if agent is empty

### DIFF
--- a/packages/console/src/components/MfaFactorName/index.tsx
+++ b/packages/console/src/components/MfaFactorName/index.tsx
@@ -29,6 +29,10 @@ function MfaFactorName({ type, agent, name }: Props) {
       return name;
     }
 
+    if (!agent) {
+      return null;
+    }
+
     const { browser, os } = parseUa(agent);
 
     return `${browser.name} on ${os.name}`;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Hide passkey name when `name` and `agent` are both empty.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
