### PR TITLE
feat(core,schemas): add webauthn related origins to account center

### DIFF
--- a/packages/core/src/routes/account-center/index.openapi.json
+++ b/packages/core/src/routes/account-center/index.openapi.json
@@ -31,6 +31,9 @@
                   },
                   "fields": {
                     "description": "The fields settings for the account API."
+                  },
+                  "webauthnRelatedOrigins": {
+                    "description": "The allowed domains for webauthn."
                   }
                 }
               }

--- a/packages/integration-tests/src/tests/api/account-center.test.ts
+++ b/packages/integration-tests/src/tests/api/account-center.test.ts
@@ -23,6 +23,7 @@ describe('account center', () => {
       fields: {
         username: AccountCenterControlValue.Edit,
       },
+      webauthnRelatedOrigins: ['https://example.com'],
     };
 
     const updatedAccountCenter = await updateAccountCenter(accountCenter);

--- a/packages/schemas/alterations/next-1748832174-add-webauthn-related-origins.ts
+++ b/packages/schemas/alterations/next-1748832174-add-webauthn-related-origins.ts
@@ -1,0 +1,20 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      alter table account_centers
+        add column webauthn_related_origins jsonb not null default '[]'::jsonb;
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      alter table account_centers
+        drop column webauthn_related_origins;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/foundations/jsonb-types/account-centers.ts
+++ b/packages/schemas/src/foundations/jsonb-types/account-centers.ts
@@ -27,3 +27,7 @@ export const accountCenterFieldControlGuard = z
   .partial();
 
 export type AccountCenterFieldControl = z.infer<typeof accountCenterFieldControlGuard>;
+
+export const webauthnRelatedOriginsGuard = z.array(z.string());
+
+export type WebauthnRelatedOrigins = z.infer<typeof webauthnRelatedOriginsGuard>;

--- a/packages/schemas/tables/account_centers.sql
+++ b/packages/schemas/tables/account_centers.sql
@@ -6,5 +6,6 @@ create table account_centers (
   enabled boolean not null default false,
   /** Control each fields */
   fields jsonb /* @use AccountCenterFieldControl */ not null default '{}'::jsonb,
+  webauthn_related_origins jsonb /* @use WebauthnRelatedOrigins */ not null default '[]'::jsonb,
   primary key (tenant_id, id)
 );


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Save WebAuthn related origins to account center, later this will be used to serve the well-known endpoint for the feature: https://passkeys.dev/docs/advanced/related-origins/

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Integration tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
