### PR TITLE
feat(core): allow origin list for webauthn register and verify

### DIFF
--- a/packages/core/src/routes/experience/verification-routes/web-authn-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/web-authn-verification.ts
@@ -55,8 +55,9 @@ export default function webAuthnVerificationRoute<T extends ExperienceInteractio
         experienceInteraction.identifiedUserId
       );
 
-      const registrationOptions =
-        await webAuthnVerification.generateWebAuthnRegistrationOptions(ctx);
+      const registrationOptions = await webAuthnVerification.generateWebAuthnRegistrationOptions(
+        ctx.URL.hostname
+      );
 
       experienceInteraction.setVerificationRecord(webAuthnVerification);
 

--- a/packages/core/src/routes/interaction/utils/webauthn.test.ts
+++ b/packages/core/src/routes/interaction/utils/webauthn.test.ts
@@ -54,7 +54,7 @@ describe('generateWebAuthnRegistrationOptions', () => {
 describe('verifyWebAuthnRegistration', () => {
   it('should verify registration response', async () => {
     await expect(
-      verifyWebAuthnRegistration(mockBindWebAuthnPayload, 'challenge', rpId, origin)
+      verifyWebAuthnRegistration(mockBindWebAuthnPayload, 'challenge', [origin])
     ).resolves.toHaveProperty('verified', true);
     expect(verifyRegistrationResponse).toHaveBeenCalled();
   });

--- a/packages/core/src/routes/interaction/utils/webauthn.ts
+++ b/packages/core/src/routes/interaction/utils/webauthn.ts
@@ -64,8 +64,7 @@ export const generateWebAuthnRegistrationOptions = async ({
 export const verifyWebAuthnRegistration = async (
   payload: Omit<BindWebAuthnPayload, 'type'>,
   challenge: string,
-  rpId: string,
-  origin: string
+  origins: string[]
 ) => {
   const options: VerifyRegistrationResponseOpts = {
     response: {
@@ -73,8 +72,7 @@ export const verifyWebAuthnRegistration = async (
       type: 'public-key',
     },
     expectedChallenge: challenge,
-    expectedOrigin: origin,
-    expectedRPID: rpId,
+    expectedOrigin: origins,
     requireUserVerification: false,
   };
   return verifyRegistrationResponse(options);

--- a/packages/core/src/routes/interaction/verifications/mfa-payload-verification.ts
+++ b/packages/core/src/routes/interaction/verifications/mfa-payload-verification.ts
@@ -92,12 +92,9 @@ const verifyBindWebAuthn = async (
 
   const { type, ...rest } = payload;
   const { challenge } = pendingMfa;
-  const { verified, registrationInfo } = await verifyWebAuthnRegistration(
-    rest,
-    challenge,
-    rpId,
-    origin
-  );
+  const { verified, registrationInfo } = await verifyWebAuthnRegistration(rest, challenge, [
+    origin,
+  ]);
 
   assertThat(verified, 'session.mfa.webauthn_verification_failed');
   assertThat(registrationInfo, 'session.mfa.webauthn_verification_failed');


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Set allow origin list for webauthn util functions:

1. Allow current URL and the origin list in `account_center` table.
2. Remove the expected `rpId` in verification, since this is already specific in registration options.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested, successfully registered a new passkey in different domain.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
