### PR TITLE
feat(schemas): add oidc_session_extensions table

### DIFF
--- a/packages/schemas/alterations/next-1749026308-add-oidc-session-extension-table.ts
+++ b/packages/schemas/alterations/next-1749026308-add-oidc-session-extension-table.ts
@@ -1,0 +1,41 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+import { applyTableRls, dropTableRls } from './utils/1704934999-tables.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      create table oidc_session_extensions (
+        tenant_id varchar(21) not null
+          references tenants (id) on update cascade on delete cascade,
+        session_uid varchar(128) not null,
+        account_id varchar(12) not null
+          references users (id) on update cascade on delete cascade,
+        last_submission jsonb /* @use JsonObject */ not null default '{}'::jsonb,
+        created_at timestamptz not null default(now()),
+        updated_at timestamptz not null default(now()),
+        primary key (tenant_id, session_uid)
+      );
+    `);
+
+    await pool.query(sql`
+      create trigger set_updated_at
+        before update on oidc_session_extensions
+        for each row
+        execute procedure set_updated_at();
+    `);
+
+    await applyTableRls(pool, 'oidc_session_extensions');
+  },
+  down: async (pool) => {
+    await dropTableRls(pool, 'oidc_session_extensions');
+
+    await pool.query(sql`
+      drop table oidc_session_extensions;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/oidc_model_instances.sql
+++ b/packages/schemas/tables/oidc_model_instances.sql
@@ -1,3 +1,5 @@
+/* init_order = 1 */
+
 create table oidc_model_instances (
   tenant_id varchar(21) not null
     references tenants (id) on update cascade on delete cascade,

--- a/packages/schemas/tables/oidc_session_extensions.sql
+++ b/packages/schemas/tables/oidc_session_extensions.sql
@@ -1,0 +1,18 @@
+/* init_order = 2 */
+
+create table oidc_session_extensions (
+  tenant_id varchar(21) not null
+    references tenants (id) on update cascade on delete cascade,
+  session_uid varchar(128) not null,
+  account_id varchar(12) not null
+    references users (id) on update cascade on delete cascade,
+  last_submission jsonb /* @use JsonObject */ not null default '{}'::jsonb,
+  created_at timestamptz not null default(now()),
+  updated_at timestamptz not null default(now()),
+  primary key (tenant_id, session_uid)
+);
+
+create trigger set_updated_at
+  before update on oidc_session_extensions
+  for each row
+  execute procedure set_updated_at();


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The `oidc_model_instances` table—maintained by the OIDC provider—stores only the standard session payload and offers no flexibility for product-specific fields. Yet our application must capture extra, business-driven details about each session, such as the authentication verification method or other user-interaction metadata that fall outside the provider’s schema.

Compounding the problem, every `Interaction` instance is deleted as soon as the flow completes, leaving no persistent record of those details.

To bridge this gap, we introduce `oidc_session_extensions`: a companion table keyed to the rows in oidc_model_instances where model_name = 'Session'. This extension table holds any additional session metadata our product requires. By cleanly separating custom data from the provider’s core schema, the design preserves upstream compatibility while giving us a scalable path to add new fields as business needs evolve.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
