### PR TITLE
feat(core): store interaction last submission details

### DIFF
--- a/packages/core/src/event-listeners/session.test.ts
+++ b/packages/core/src/event-listeners/session.test.ts
@@ -1,0 +1,23 @@
+import { type Session } from 'oidc-provider';
+
+import { MockQueries } from '#src/test-utils/tenant.js';
+
+import { deleteSessionExtensions } from './session.js';
+
+const { jest } = import.meta;
+const deleteBySessionUid = jest.fn();
+const queries = new MockQueries({
+  oidcSessionExtensions: { deleteBySessionUid },
+});
+
+describe('deleteSessionExtensions()', () => {
+  afterEach(() => {
+    deleteBySessionUid.mockClear();
+  });
+
+  it('should call deleteBySessionUid with session uid', async () => {
+    const session = { uid: 'sessionUid' } as unknown as Session;
+    await deleteSessionExtensions(queries, session);
+    expect(deleteBySessionUid).toHaveBeenCalledWith('sessionUid');
+  });
+});

--- a/packages/core/src/event-listeners/session.ts
+++ b/packages/core/src/event-listeners/session.ts
@@ -1,0 +1,12 @@
+import { type Session } from 'oidc-provider';
+
+import type Queries from '#src/tenants/Queries.js';
+
+export const deleteSessionExtensions = async (
+  { oidcSessionExtensions }: Queries,
+  session: Session
+) => {
+  const { uid } = session;
+
+  await oidcSessionExtensions.deleteBySessionUid(uid);
+};

--- a/packages/core/src/libraries/user.ts
+++ b/packages/core/src/libraries/user.ts
@@ -42,6 +42,7 @@ export const createUserLibrary = (queries: Queries) => {
     organizations,
     oidcModelInstances: { revokeInstanceByUserId },
     userSsoIdentities,
+    oidcSessionExtensions: { deleteByAccountId: deleteSessionExtensionsByAccountId },
   } = queries;
 
   const generateUserId = async (retries = 500) =>
@@ -244,6 +245,7 @@ export const createUserLibrary = (queries: Queries) => {
       revokeInstanceByUserId('AccessToken', userId),
       revokeInstanceByUserId('RefreshToken', userId),
       revokeInstanceByUserId('Session', userId),
+      deleteSessionExtensionsByAccountId(userId),
     ]);
   };
 

--- a/packages/core/src/queries/oidc-session-extensions.ts
+++ b/packages/core/src/queries/oidc-session-extensions.ts
@@ -1,0 +1,33 @@
+import { OidcSessionExtensions } from '@logto/schemas';
+import { sql, type CommonQueryMethods } from '@silverhand/slonik';
+
+import { buildInsertIntoWithPool } from '../database/insert-into.js';
+import { convertToIdentifiers } from '../utils/sql.js';
+
+const { table, fields } = convertToIdentifiers(OidcSessionExtensions);
+
+export class OidcSessionExtensionsQueries {
+  public readonly insert = buildInsertIntoWithPool(this.pool)(OidcSessionExtensions, {
+    onConflict: {
+      fields: [fields.tenantId, fields.sessionUid],
+      setExcludedFields: [fields.lastSubmission, fields.updatedAt, fields.accountId],
+    },
+    returning: true,
+  });
+
+  constructor(public readonly pool: CommonQueryMethods) {}
+
+  async deleteBySessionUid(sessionUid: string) {
+    await this.pool.query(sql`
+      delete from ${table}
+        where ${fields.sessionUid} = ${sessionUid}
+    `);
+  }
+
+  async deleteByAccountId(accountId: string) {
+    await this.pool.query(sql`
+      delete from ${table}
+        where ${fields.accountId} = ${accountId}
+    `);
+  }
+}

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -549,6 +549,8 @@ export default class ExperienceInteraction {
 
     const redirectTo = await provider.interactionResult(this.ctx.req, this.ctx.res, {
       login: { accountId: user.id },
+      // Persist the interaction status to the OIDC session after interaction submission
+      ...this.toJson(),
     });
 
     this.ctx.body = { redirectTo };

--- a/packages/core/src/tenants/Queries.ts
+++ b/packages/core/src/tenants/Queries.ts
@@ -37,6 +37,7 @@ import { createVerificationStatusQueries } from '#src/queries/verification-statu
 import { AccountCenterQueries } from '../queries/account-center.js';
 import { CaptchaProviderQueries } from '../queries/captcha-providers.js';
 import EmailTemplatesQueries from '../queries/email-templates.js';
+import { OidcSessionExtensionsQueries } from '../queries/oidc-session-extensions.js';
 import { PersonalAccessTokensQueries } from '../queries/personal-access-tokens.js';
 import { createSentinelActivitiesQueries } from '../queries/sentinel-activities.js';
 import TenantUsageQuery from '../queries/tenant-usage/index.js';
@@ -82,6 +83,7 @@ export default class Queries {
   emailTemplates = new EmailTemplatesQueries(this.pool, this.wellKnownCache);
   captchaProviders = new CaptchaProviderQueries(this.pool);
   sentinelActivities = createSentinelActivitiesQueries(this.pool);
+  oidcSessionExtensions = new OidcSessionExtensionsQueries(this.pool);
 
   constructor(
     public readonly pool: CommonQueryMethods,


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Store the interaction's last submission details in the session extension to retain the user's initial interaction context. This allows the system to access relevant interaction information for any associated active session.

This PR includes the following updates:

1. Store the Logto experience interaction data in the interactionResult when the user submits the interaction.

2. At the consent step, after the user authentication session is created,  retrieve the `lastSubmission` data from the interaction and persist it in the new `oidc_session_extensions` table for future reference.

3. Use the session UID as the stable identifier to associate user interactions with the corresponding OIDC session, as the session ID may change.

4. Manually delete the associated `oidc_session_extensions` record when the corresponding OIDC session is destroyed.

5. Manually remove `oidc_session_extensions` records when a user is deleted or forced sign-out.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
