### PR TITLE
feat(core,console,schemas): add interaction context to custom claims

### DIFF
--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/GuideCard/index.tsx
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/GuideCard/index.tsx
@@ -10,6 +10,7 @@ import styles from './index.module.scss';
 export enum CardType {
   UserData = 'user_data',
   GrantData = 'grant_data',
+  InteractionData = 'interaction_data',
   TokenData = 'token_data',
   FetchExternalData = 'fetch_external_data',
   EnvironmentVariables = 'environment_variables',

--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/index.tsx
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/index.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
+import { isDevFeaturesEnabled } from '@/consts/env';
 import { type JwtCustomizerForm } from '@/pages/CustomizeJwtDetails/type';
 import {
   denyAccessCodeExample,
@@ -18,6 +19,7 @@ import {
   clientCredentialsPayloadTypeDefinition,
   jwtCustomizerUserContextTypeDefinition,
   jwtCustomizerGrantContextTypeDefinition,
+  jwtCustomizerUserInteractionContextTypeDefinition,
 } from '@/pages/CustomizeJwtDetails/utils/type-definitions';
 
 import tabContentStyles from '../index.module.scss';
@@ -92,6 +94,24 @@ function InstructionTab({ isActive }: Props) {
             className={styles.sampleCode}
             value={jwtCustomizerGrantContextTypeDefinition}
             height="180px"
+            theme="logto-dark"
+            options={typeDefinitionCodeEditorOptions}
+          />
+        </GuideCard>
+      )}
+      {tokenType === LogtoJwtTokenKeyType.AccessToken && isDevFeaturesEnabled && (
+        <GuideCard
+          name={CardType.InteractionData}
+          isExpanded={expendCard === CardType.InteractionData}
+          setExpanded={(expand) => {
+            setExpendCard(expand ? CardType.InteractionData : undefined);
+          }}
+        >
+          <Editor
+            language="typescript"
+            className={styles.sampleCode}
+            value={`declare ${jwtCustomizerUserInteractionContextTypeDefinition}`}
+            height="400px"
             theme="logto-dark"
             options={typeDefinitionCodeEditorOptions}
           />

--- a/packages/console/src/pages/CustomizeJwtDetails/utils/config.tsx
+++ b/packages/console/src/pages/CustomizeJwtDetails/utils/config.tsx
@@ -4,11 +4,15 @@ import {
   type ClientCredentialsPayload,
   type JwtCustomizerUserContext,
   type JwtCustomizerGrantContext,
+  type JwtCustomizerUserInteractionContext,
+  InteractionEvent,
 } from '@logto/schemas';
 import { type EditorProps } from '@monaco-editor/react';
+import { conditional } from '@silverhand/essentials';
 
 import TokenFileIcon from '@/assets/icons/token-file-icon.svg?react';
 import UserFileIcon from '@/assets/icons/user-file-icon.svg?react';
+import { isDevFeaturesEnabled } from '@/consts/env.js';
 
 import type { ModelSettings } from '../MainContent/MonacoCodeEditor/type.js';
 
@@ -29,6 +33,8 @@ declare interface CustomJwtClaims extends Record<string, any> {}
 /** Logto internal data that can be used to pass additional information
  * 
  * @param {${JwtCustomizerTypeDefinitionKey.JwtCustomizerUserContext}} user - The user info associated with the token.
+ * @param {${JwtCustomizerTypeDefinitionKey.JwtCustomizerGrantContext}} [grant] - The grant context associated with the token.
+ * @param {${JwtCustomizerTypeDefinitionKey.JwtCustomizerUserInteractionContext}} [interaction] - The user interaction context associated with the token.
  */
 declare type Context = {
   /**
@@ -39,6 +45,10 @@ declare type Context = {
    * The grant context associated with the token.
    */
   grant?: ${JwtCustomizerTypeDefinitionKey.JwtCustomizerGrantContext};
+  /**
+   * The user interaction context associated with the token.
+   */
+  interaction?: ${JwtCustomizerTypeDefinitionKey.JwtCustomizerUserInteractionContext};
 }
 
 declare type Payload = {
@@ -51,6 +61,7 @@ declare type Payload = {
    *
    * @params {${JwtCustomizerTypeDefinitionKey.JwtCustomizerUserContext}} user
    * @params {${JwtCustomizerTypeDefinitionKey.JwtCustomizerGrantContext}} [grant]
+   * @params {${JwtCustomizerTypeDefinitionKey.JwtCustomizerUserInteractionContext}} [interaction]
    */
   context: Context;
   /**
@@ -256,9 +267,15 @@ const defaultGrantContext: Partial<JwtCustomizerGrantContext> = {
   },
 };
 
+const defaultUserInteractionContext: Partial<JwtCustomizerUserInteractionContext> = {
+  interactionEvent: InteractionEvent.SignIn,
+  userId: '123',
+};
+
 export const defaultUserTokenContextData = {
   user: defaultUserContext,
   grant: defaultGrantContext,
+  ...conditional(isDevFeaturesEnabled && { interaction: defaultUserInteractionContext }),
 };
 
 export const accessTokenPayloadTestModel: ModelSettings = {

--- a/packages/console/src/pages/CustomizeJwtDetails/utils/type-definitions.ts
+++ b/packages/console/src/pages/CustomizeJwtDetails/utils/type-definitions.ts
@@ -4,6 +4,7 @@ import {
   clientCredentialsPayloadTypeDefinition,
   jwtCustomizerUserContextTypeDefinition,
   jwtCustomizerGrantContextTypeDefinition,
+  jwtCustomizerUserInteractionContextTypeDefinition,
   jwtCustomizerApiContextTypeDefinition,
 } from '@/consts/jwt-customizer-type-definition';
 
@@ -15,6 +16,7 @@ export {
   clientCredentialsPayloadTypeDefinition,
   jwtCustomizerUserContextTypeDefinition,
   jwtCustomizerGrantContextTypeDefinition,
+  jwtCustomizerUserInteractionContextTypeDefinition,
 } from '@/consts/jwt-customizer-type-definition';
 
 export const buildAccessTokenJwtCustomizerContextTsDefinition = () => {
@@ -24,7 +26,9 @@ export const buildAccessTokenJwtCustomizerContextTsDefinition = () => {
 
   declare ${jwtCustomizerApiContextTypeDefinition}
 
-  declare ${accessTokenPayloadTypeDefinition}`;
+  declare ${accessTokenPayloadTypeDefinition}
+  
+  declare ${jwtCustomizerUserInteractionContextTypeDefinition}`;
 };
 
 export const buildClientCredentialsJwtCustomizerContextTsDefinition = () =>

--- a/packages/core/src/queries/oidc-session-extensions.ts
+++ b/packages/core/src/queries/oidc-session-extensions.ts
@@ -1,4 +1,4 @@
-import { OidcSessionExtensions } from '@logto/schemas';
+import { OidcSessionExtensions, type OidcSessionExtension } from '@logto/schemas';
 import { sql, type CommonQueryMethods } from '@silverhand/slonik';
 
 import { buildInsertIntoWithPool } from '../database/insert-into.js';
@@ -28,6 +28,14 @@ export class OidcSessionExtensionsQueries {
     await this.pool.query(sql`
       delete from ${table}
         where ${fields.accountId} = ${accountId}
+    `);
+  }
+
+  async findBySessionUid(sessionUid: string) {
+    return this.pool.maybeOne<OidcSessionExtension>(sql`
+      select ${sql.join(Object.values(fields), sql`, `)}
+        from ${table}
+        where ${fields.sessionUid} = ${sessionUid}
     `);
   }
 }

--- a/packages/core/src/routes/experience/classes/verifications/enterprise-sso-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/enterprise-sso-verification.ts
@@ -6,7 +6,7 @@ import {
   type User,
   type UserSsoIdentity,
   type EnterpriseSsoVerificationRecordData,
-  enterPriseSsoVerificationRecordDataGuard,
+  enterpriseSsoVerificationRecordDataGuard,
 } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 import { conditional } from '@silverhand/essentials';
@@ -30,7 +30,7 @@ import { type IdentifierVerificationRecord } from './verification-record.js';
 
 export {
   type EnterpriseSsoVerificationRecordData,
-  enterPriseSsoVerificationRecordDataGuard,
+  enterpriseSsoVerificationRecordDataGuard,
 } from '@logto/schemas';
 
 export class EnterpriseSsoVerification
@@ -58,7 +58,7 @@ export class EnterpriseSsoVerification
     data: EnterpriseSsoVerificationRecordData
   ) {
     const { id, connectorId, enterpriseSsoUserInfo, issuer } =
-      enterPriseSsoVerificationRecordDataGuard.parse(data);
+      enterpriseSsoVerificationRecordDataGuard.parse(data);
 
     this.id = id;
     this.connectorId = connectorId;

--- a/packages/core/src/routes/experience/classes/verifications/index.ts
+++ b/packages/core/src/routes/experience/classes/verifications/index.ts
@@ -18,7 +18,7 @@ import {
 } from './code-verification.js';
 import {
   EnterpriseSsoVerification,
-  enterPriseSsoVerificationRecordDataGuard,
+  enterpriseSsoVerificationRecordDataGuard,
   type EnterpriseSsoVerificationRecordData,
 } from './enterprise-sso-verification.js';
 import {
@@ -100,7 +100,7 @@ export const verificationRecordDataGuard = z.discriminatedUnion('type', [
   emailCodeVerificationRecordDataGuard,
   phoneCodeVerificationRecordDataGuard,
   socialVerificationRecordDataGuard,
-  enterPriseSsoVerificationRecordDataGuard,
+  enterpriseSsoVerificationRecordDataGuard,
   totpVerificationRecordDataGuard,
   backupCodeVerificationRecordDataGuard,
   webAuthnVerificationRecordDataGuard,

--- a/packages/core/src/utils/zod.ts
+++ b/packages/core/src/utils/zod.ts
@@ -1,5 +1,5 @@
 import { languages, languageTagGuard } from '@logto/language-kit';
-import { jsonObjectGuard, translationGuard } from '@logto/schemas';
+import { jsonGuard, jsonObjectGuard, translationGuard } from '@logto/schemas';
 import type { ValuesOf } from '@silverhand/essentials';
 import { conditional } from '@silverhand/essentials';
 import type { OpenAPIV3 } from 'openapi-types';
@@ -152,6 +152,36 @@ export const zodTypeToSwagger = (
     return {
       type: 'object',
       description: 'arbitrary',
+    };
+  }
+
+  if (config === jsonGuard) {
+    return {
+      oneOf: [
+        {
+          type: 'object',
+          description: 'arbitrary JSON object',
+        },
+        {
+          type: 'array',
+          items: {
+            oneOf: [
+              { type: 'string' },
+              { type: 'number' },
+              { type: 'boolean' },
+              { nullable: true },
+              {
+                type: 'object',
+                description: 'arbitrary JSON object',
+              },
+            ],
+          },
+        },
+        { type: 'string' },
+        { type: 'number' },
+        { type: 'boolean' },
+      ],
+      nullable: true,
     };
   }
 

--- a/packages/integration-tests/src/__mocks__/jwt-customizer.ts
+++ b/packages/integration-tests/src/__mocks__/jwt-customizer.ts
@@ -1,4 +1,9 @@
-import { type AccessTokenPayload, type ClientCredentialsPayload } from '@logto/schemas';
+import {
+  InteractionEvent,
+  VerificationType,
+  type AccessTokenPayload,
+  type ClientCredentialsPayload,
+} from '@logto/schemas';
 
 const standardTokenPayloadData = {
   jti: 'f1d3d2d1-1f2d-3d4e-5d6f-7d8a9d0e1d2',
@@ -50,6 +55,17 @@ export const accessTokenJwtCustomizerPayload = {
       roles: [],
       organizations: [],
       organizationRoles: [],
+    },
+    interaction: {
+      interactionEvent: InteractionEvent.SignIn,
+      userId: '123',
+      VerificationRecords: [
+        {
+          id: 'verification_123',
+          type: VerificationType.Password,
+          verified: true,
+        },
+      ],
     },
   },
 };

--- a/packages/integration-tests/src/__mocks__/jwt-customizer.ts
+++ b/packages/integration-tests/src/__mocks__/jwt-customizer.ts
@@ -1,5 +1,7 @@
 import {
   InteractionEvent,
+  type JwtCustomizerUserInteractionContext,
+  SignInIdentifier,
   VerificationType,
   type AccessTokenPayload,
   type ClientCredentialsPayload,
@@ -59,19 +61,27 @@ export const accessTokenJwtCustomizerPayload = {
     interaction: {
       interactionEvent: InteractionEvent.SignIn,
       userId: '123',
-      VerificationRecords: [
+      verificationRecords: [
         {
           id: 'verification_123',
           type: VerificationType.Password,
+          identifier: {
+            type: SignInIdentifier.Email,
+            value: 'foo@example.com',
+          },
           verified: true,
         },
       ],
-    },
+    } satisfies JwtCustomizerUserInteractionContext,
   },
 };
 
 export const accessTokenSampleScript = `const getCustomJwtClaims = async ({ token, context, environmentVariables }) => {
-  return { user_id: context?.user?.id ?? 'unknown', hasPassword: context?.user?.hasPassword };
+  const { interaction } = context;
+
+  const verificationRecord = interaction?.verificationRecords?.[0];
+
+  return { user_id: context?.user?.id ?? 'unknown', hasPassword: context?.user?.hasPassword, interactionEvent: interaction?.interactionEvent, verificationType: verificationRecord?.type };
 };`;
 
 export const accessTokenAccessDeniedSampleScript = `const getCustomJwtClaims = async ({ token, context, environmentVariables, api }) => {

--- a/packages/integration-tests/src/tests/api/oidc/get-access-token.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/get-access-token.test.ts
@@ -26,7 +26,7 @@ import {
 import { assignUsersToRole, createRole, deleteRole } from '#src/api/role.js';
 import { createScope, deleteScope } from '#src/api/scope.js';
 import MockClient, { defaultConfig } from '#src/client/index.js';
-import { logtoUrl } from '#src/constants.js';
+import { isDevFeaturesEnabled, logtoUrl } from '#src/constants.js';
 import { initExperienceClient, processSession } from '#src/helpers/client.js';
 import { createUserByAdmin } from '#src/helpers/index.js';
 import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
@@ -142,14 +142,17 @@ describe('get access token', () => {
     expect(getAccessTokenPayload(accessToken)).toHaveProperty('user_id', guestUserId);
     // The guest user has password.
     expect(getAccessTokenPayload(accessToken)).toHaveProperty('hasPassword', true);
-    expect(getAccessTokenPayload(accessToken)).toHaveProperty(
-      'interactionEvent',
-      InteractionEvent.SignIn
-    );
-    expect(getAccessTokenPayload(accessToken)).toHaveProperty(
-      'verificationType',
-      VerificationType.Password
-    );
+
+    if (isDevFeaturesEnabled) {
+      expect(getAccessTokenPayload(accessToken)).toHaveProperty(
+        'interactionEvent',
+        InteractionEvent.SignIn
+      );
+      expect(getAccessTokenPayload(accessToken)).toHaveProperty(
+        'verificationType',
+        VerificationType.Password
+      );
+    }
 
     await deleteJwtCustomizer('access-token');
   });

--- a/packages/phrases/src/locales/en/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/jwt-claims.ts
@@ -35,6 +35,11 @@ const jwt_claims = {
     subtitle:
       'Use `context.grant` input parameter to provide vital grant info, only available for token exchange.',
   },
+  interaction_data: {
+    title: 'User interaction context',
+    subtitle:
+      "Use the context.interaction parameter to retrieve details about the user's sign-in interaction during the current session.",
+  },
   token_data: {
     title: 'Token payload',
     subtitle: 'Use `token` input parameter for current access token payload. ',

--- a/packages/schemas/src/types/logto-config/jwt-customizer.ts
+++ b/packages/schemas/src/types/logto-config/jwt-customizer.ts
@@ -123,9 +123,9 @@ const jwtCustomizerUserInteractionVerificationRecordGuard = z.discriminatedUnion
 ]);
 
 export const jwtCustomizerUserInteractionContextGuard = z.object({
-  interactionEvent: z.nativeEnum(InteractionEvent).optional(),
-  userId: z.string().optional(),
-  verificationRecords: jwtCustomizerUserInteractionVerificationRecordGuard.array().optional(),
+  interactionEvent: z.nativeEnum(InteractionEvent),
+  userId: z.string(),
+  verificationRecords: jwtCustomizerUserInteractionVerificationRecordGuard.array(),
 });
 
 export type JwtCustomizerUserInteractionContext = z.infer<

--- a/packages/schemas/src/types/verification-records/enterprise-sso-verification.ts
+++ b/packages/schemas/src/types/verification-records/enterprise-sso-verification.ts
@@ -17,7 +17,7 @@ export type EnterpriseSsoVerificationRecordData = {
   issuer?: string;
 };
 
-export const enterPriseSsoVerificationRecordDataGuard = z.object({
+export const enterpriseSsoVerificationRecordDataGuard = z.object({
   id: z.string(),
   connectorId: z.string(),
   type: z.literal(VerificationType.EnterpriseSso),


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Introduce user interaction context to the custom token claims script. Make the user's last submitted interaction verification records data accessible to the developers through a custom token claims script. 

This PR includes the following updates:

1. Schemas: 
  - Add a new interaction context guard and data type in the JWT customizer access token context. Including `interactionEvent`, `userId`, and `verificationRecords` with sensitive data filtered. 
2. Core:
  - Retrieve the user interaction last submission data from the `odic_session_extenstions` using token's `sesssion_uid` and pass the formated interaction data as user interaction context to the JWT customizer.
  - Update the Zod to openapi util method. Add a new `jsonGuard` type zod type parser.  By default, the `zodTypeToSwagger` parser can not handle `ZodLazy` type. We need to manually parse the `jsonGuard`.
3. Console
 - Add new interaction context type to the JWT customizer editor. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally:

<img width="1312" alt="image" src="https://github.com/user-attachments/assets/d81a8715-330d-4cc9-8205-313d634fde7f" />

<img width="342" alt="image" src="https://github.com/user-attachments/assets/dc96b472-9ec6-45db-993e-20c1a584215c" />

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
