### PR TITLE
fix(console): fix payment page cannot open in iOS Safari issue

### DIFF
--- a/packages/console/src/hooks/use-subscribe.ts
+++ b/packages/console/src/hooks/use-subscribe.ts
@@ -115,16 +115,18 @@ const useSubscribe = () => {
 
   const visitManagePaymentPage = async (tenantId: string) => {
     try {
+      const currentUrl = window.location.href;
       const { redirectUri } = await cloudApi.post('/api/tenants/:tenantId/stripe-customer-portal', {
         params: {
           tenantId,
         },
         body: {
-          callbackUrl: window.location.href,
+          callbackUrl: currentUrl,
         },
       });
 
-      window.open(redirectUri, '_blank', 'noopener,noreferrer');
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      window.location.href = redirectUri;
     } catch (error: unknown) {
       void toastResponseError(error);
     }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Problem Analysis:
1. Safari has strict popup blocking policies, especially on mobile Safari (iPhone)
2. When window.open() is called after an async operation (API call), Safari considers
   it as not being triggered directly by user action and blocks the popup
3. Previous attempts to work around this with pre-opened windows still involved hardcoded HTML

New Solution:
- Instead of opening a popup, navigate in the current window
- This completely bypasses popup blocking issues
- Provides better mobile experience

The payment portal will handle returning to the callback URL when done.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Tested on iPhone Safari (deployed this change to Logto Cloud dev).
https://github.com/user-attachments/assets/76c3ad26-5cda-4128-b45f-ca53a315744d

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
