### PR TITLE
refactor(core): handle webauthn regsitration verify error

### DIFF
--- a/packages/core/src/routes/interaction/utils/webauthn.ts
+++ b/packages/core/src/routes/interaction/utils/webauthn.ts
@@ -80,7 +80,15 @@ export const verifyWebAuthnRegistration = async (
     expectedOrigin: origins,
     requireUserVerification: false,
   };
-  return verifyRegistrationResponse(options);
+
+  try {
+    return await verifyRegistrationResponse(options);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    throw new RequestError('session.mfa.webauthn_verification_failed', {
+      message,
+    });
+  }
 };
 
 export const generateWebAuthnAuthenticationOptions = async ({

--- a/packages/integration-tests/src/tests/api/account/mfa.test.ts
+++ b/packages/integration-tests/src/tests/api/account/mfa.test.ts
@@ -66,7 +66,7 @@ describe('my-account (mfa)', () => {
         .replaceAll('/', '_')
         .replace(/=+$/, '');
 
-      // This 500 error is expected because the mock registration response
+      // This error is expected because the mock registration response
       // can not pass the server side validation.
       await expectRejects(
         verifyWebAuthnRegistration(api, verificationRecordId, {
@@ -87,8 +87,8 @@ describe('my-account (mfa)', () => {
           clientExtensionResults: {},
         }),
         {
-          code: undefined,
-          status: 500,
+          code: 'session.mfa.webauthn_verification_failed',
+          status: 400,
         }
       );
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Refactor `verifyWebAuthnAuthentication`:

1. The error code is now 400.
2. Show detailed message.

<img width="502" alt="截屏2025-06-12 上午11 04 44" src="https://github.com/user-attachments/assets/4978ad70-9dce-4209-b62d-73a9e7a297d6" />

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Integration tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
