### PR TITLE
fix(core): make access_token optional for Azure SSO

### DIFF
--- a/.changeset/lemon-walls-fry.md
+++ b/.changeset/lemon-walls-fry.md
@@ -1,0 +1,15 @@
+---
+"@logto/core": patch
+---
+
+fix: make `access_token` optional for Azure OIDC SSO connector
+
+Previously, the Azure OIDC connector strictly required an access token in the token response, which caused issues with Azure B2C applications that only return ID tokens.
+
+This change makes the connector more flexible by:
+
+- Making access token optional in token response
+- Conditionally fetching user claims from userinfo endpoint only when:
+  - Access token is present in the response
+  - Userinfo endpoint is supported by the provider
+- Falling back to ID token claims when access token is not available


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Make `access_token` optional in Azure OIDC SSO connector token response.

Previously, the Azure OIDC connector strictly required an `access-token` in the token response, which caused issues with Azure B2C applications that only return ID tokens.

This change makes the connector more flexible by:

- Making access token optional in token response
- Conditionally fetching user claims from userinfo endpoint only when:
  - Access token is present in the response
  - Userinfo endpoint is supported by the provider
- Falling back to ID token claims when access token is not available


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Guarded by integration test

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
