### PR TITLE
feat(schemas): add secret vault related tables

### DIFF
--- a/packages/schemas/alterations/next-1750317488-add-secrets-table.ts
+++ b/packages/schemas/alterations/next-1750317488-add-secrets-table.ts
@@ -1,0 +1,50 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+import { applyTableRls, dropTableRls } from './utils/1704934999-tables.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      create table secrets (
+        tenant_id varchar(21) not null
+          references tenants (id) on update cascade on delete cascade,
+        id varchar(36) not null primary key,
+        user_id varchar(21) not null 
+          references users (id) on update cascade on delete cascade,
+        type text /* @user SecretType */ not null,
+        /** Encrypted data encryption key (DEK) for the secret. */
+        encrypted_dek bytea not null,
+        /** Initialization vector for the secret encryption. */
+        iv bytea not null,
+        /** Authentication tag for the secret encryption. */
+        auth_tag bytea not null,
+        /** The encrypted secret data. e.g. { access_token, refresh_token }*/
+        ciphertext bytea not null,
+        /** The medadata associated with the secret. */
+        metadata jsonb not null default '{}'::jsonb,
+        created_at timestamptz not null default(now()),
+        updated_at timestamptz not null default(now())
+      );
+    `);
+
+    await pool.query(sql`
+      create trigger set_updated_at
+        before update on secrets
+        for each row
+        execute procedure set_updated_at();
+    `);
+
+    await applyTableRls(pool, 'secrets');
+  },
+  down: async (pool) => {
+    await dropTableRls(pool, 'secrets');
+
+    await pool.query(sql`
+      drop table secrets;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/alterations/next-1750317737-add-secret-connector-relations-table.ts
+++ b/packages/schemas/alterations/next-1750317737-add-secret-connector-relations-table.ts
@@ -1,0 +1,109 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+import { applyTableRls, dropTableRls } from './utils/1704934999-tables.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      create table secret_connector_relations (
+        tenant_id varchar(21) not null
+          references tenants (id) on update cascade on delete cascade,
+        secret_id varchar(21) not null
+          references secrets (id) on update cascade on delete cascade,
+        /** Social connector ID foreign reference. Only present for secrets that store social connector tokens. Note: avoid directly cascading deletes here, need to delete the secrets first.*/
+        connector_id varchar(128)
+          references connectors (id) on update cascade,
+        /** SSO connector ID foreign reference. Only present for secrets that store SSO connector tokens. Note: avoid directly cascading deletes here, need to delete the secrets first.*/
+        sso_connector_id varchar(128)
+          references sso_connectors (id) on update cascade,
+        /** The target of the social connector. e.g. 'github', 'google', etc. */
+        social_connector_target text,
+        /** User social identity ID foreign reference. Only present for secrets that store social identity tokens. */
+        social_identity_id varchar(128),
+        /** User sso connector issuer. Only present for secrets that store SSO connector tokens. */
+        sso_connector_issuer varchar(256),
+        /** User SSO identity ID. Only present for secrets that store SSO identity tokens. */
+        sso_identity_id varchar(128),
+        primary key (tenant_id, secret_id),
+        /** Ensures that each social identity is associated with only one secret. */
+        constraint secret_connector_relations__target__social_identity_id
+          unique (tenant_id, social_connector_target, social_identity_id),
+        /** Ensures that each SSO identity is associated with only one secret. */
+        foreign key (tenant_id, sso_connector_issuer, sso_identity_id)
+          references user_sso_identities (tenant_id, issuer, identity_id) on update cascade,
+        /** Ensure that each secret is associated with a social connector or SSO connector, but not both at the same time. */
+        constraint secret_connector_relations__connector_id__sso_connector_id__check
+          check (
+            (
+              connector_id is not null and social_connector_target is not null and social_identity_id is not null and
+              sso_connector_id is null and sso_identity_id is null
+            ) or (
+              connector_id is null and social_connector_target is null and social_identity_id is null and
+              sso_connector_id is not null and sso_identity_id is not null
+            )
+          )
+      );
+    `);
+
+    /** Trigger function to delete secrets when the social connector is deleted. */
+    await pool.query(sql`
+      create function delete_secrets_on_social_connector_delete()
+      returns trigger as $$
+      begin
+        delete from secrets
+        where id in (
+          select secret_id from secret_connector_relations
+          where tenant_id = old.tenant_id and connector_id = old.id
+        );
+        return old;
+      end;
+      $$ language plpgsql;
+
+      create trigger delete_secrets_before_social_connector_delete
+        before delete on connectors
+        for each row
+        execute procedure delete_secrets_on_social_connector_delete();
+    `);
+
+    /** Trigger function to delete secrets when the SSO connector is deleted. */
+    await pool.query(sql`
+      create function delete_secrets_on_sso_connector_delete()
+      returns trigger as $$
+      begin
+        delete from secrets
+        where id in (
+          select secret_id from secret_connector_relations
+          where tenant_id = old.tenant_id and sso_connector_id = old.id
+        );
+        return old;
+      end;
+      $$ language plpgsql;
+
+      create trigger delete_secrets_before_sso_connector_delete
+        before delete on sso_connectors
+        for each row
+        execute procedure delete_secrets_on_sso_connector_delete();
+    `);
+
+    await applyTableRls(pool, 'secret_connector_relations');
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      drop trigger if exists delete_secrets_before_social_connector_delete on connectors;
+      drop function if exists delete_secrets_on_social_connector_delete;
+
+      drop trigger if exists delete_secrets_before_sso_connector_delete on sso_connectors;
+      drop function if exists delete_secrets_on_sso_connector_delete;
+    `);
+
+    await dropTableRls(pool, 'secret_connector_relations');
+
+    await pool.query(sql`
+      drop table secret_connector_relations;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/foundations/jsonb-types/index.ts
+++ b/packages/schemas/src/foundations/jsonb-types/index.ts
@@ -15,6 +15,7 @@ export * from './email-templates.js';
 export * from './one-time-tokens.js';
 export * from './captcha.js';
 export * from './custom-profile-fields.js';
+export * from './secrets.js';
 
 export {
   configurableConnectorMetadataGuard,

--- a/packages/schemas/src/foundations/jsonb-types/secrets.ts
+++ b/packages/schemas/src/foundations/jsonb-types/secrets.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export enum SecretType {
+  /**
+   * A federated token set is a collection of OAuth tokens from the third-party providers.
+   * Use these tokens to get access to the third-party APIs.
+   */
+  FederatedTokenSet = 'federated_token_set',
+}
+
+export const secretTypeGuard = z.nativeEnum(SecretType);

--- a/packages/schemas/tables/secret_connector_relations.sql
+++ b/packages/schemas/tables/secret_connector_relations.sql
@@ -1,0 +1,78 @@
+/* init_order = 3 */
+
+create table secret_connector_relations (
+  tenant_id varchar(21) not null
+    references tenants (id) on update cascade on delete cascade,
+  secret_id varchar(21) not null
+    references secrets (id) on update cascade on delete cascade,
+  /** Social connector ID foreign reference. Only present for secrets that store social connector tokens. Note: avoid directly cascading deletes here, need to delete the secrets first.*/
+  connector_id varchar(128)
+    references connectors (id) on update cascade,
+  /** SSO connector ID foreign reference. Only present for secrets that store SSO connector tokens. Note: avoid directly cascading deletes here, need to delete the secrets first.*/
+  sso_connector_id varchar(128)
+    references sso_connectors (id) on update cascade,
+  /** The target of the social connector. e.g. 'github', 'google', etc. */
+  social_connector_target text,
+  /** User social identity ID foreign reference. Only present for secrets that store social identity tokens. */
+  social_identity_id varchar(128),
+  /** User sso connector issuer. Only present for secrets that store SSO connector tokens. */
+  sso_connector_issuer varchar(256),
+  /** User SSO identity ID. Only present for secrets that store SSO identity tokens. */
+  sso_identity_id varchar(128),
+  primary key (tenant_id, secret_id),
+  /** Ensures that each social identity is associated with only one secret. */
+  constraint secret_connector_relations__target__social_identity_id
+    unique (tenant_id, social_connector_target, social_identity_id),
+  /** Ensures that each SSO identity is associated with only one secret. */
+  foreign key (tenant_id, sso_connector_issuer, sso_identity_id)
+    references user_sso_identities (tenant_id, issuer, identity_id) on update cascade,
+  /** Ensure that each secret is associated with a social connector or SSO connector, but not both at the same time. */
+  constraint secret_connector_relations__connector_id__sso_connector_id
+    check (
+      (
+        connector_id is not null and social_connector_target is not null and social_identity_id is not null and
+        sso_connector_id is null and sso_identity_id is null
+      ) or (
+        connector_id is null and social_connector_target is null and social_identity_id is null and
+        sso_connector_id is not null and sso_identity_id is not null
+      )
+    )
+);
+
+
+/** Trigger function to delete secrets when the social connector is deleted. */
+create function delete_secrets_on_social_connector_delete()
+returns trigger as $$
+begin
+  delete from secrets
+  where id in (
+    select secret_id from secret_connector_relations
+    where tenant_id = old.tenant_id and connector_id = old.id
+  );
+  return old;
+end;
+$$ language plpgsql;
+
+create trigger delete_secrets_before_social_connector_delete
+  before delete on connectors
+  for each row
+  execute procedure delete_secrets_on_social_connector_delete();
+
+
+/** Trigger function to delete secrets when the SSO connector is deleted. */
+create function delete_secrets_on_sso_connector_delete()
+returns trigger as $$
+begin
+  delete from secrets
+  where id in (
+    select secret_id from secret_connector_relations
+    where tenant_id = old.tenant_id and sso_connector_id = old.id
+  );
+  return old;
+end;
+$$ language plpgsql;
+
+create trigger delete_secrets_before_sso_connector_delete
+  before delete on sso_connectors
+  for each row
+  execute procedure delete_secrets_on_sso_connector_delete();

--- a/packages/schemas/tables/secrets.sql
+++ b/packages/schemas/tables/secrets.sql
@@ -1,0 +1,26 @@
+/* init_order = 2 */
+create table secrets (
+  tenant_id varchar(21) not null 
+    references tenants (id) on update cascade on delete cascade,
+  id varchar(21) not null primary key,
+  user_id varchar(21) not null 
+    references users (id) on update cascade on delete cascade,
+  type text /* @use SecretType */ not null,
+  /** Encrypted data encryption key (DEK) for the secret. */
+  encrypted_dek bytea not null,
+  /** Initialization vector for the secret encryption. */
+  iv bytea not null,
+  /** Authentication tag for the secret encryption. */
+  auth_tag bytea not null,
+  /** The encrypted secret data. e.g. { access_token, refresh_token } */
+  ciphertext bytea not null,
+  /** The medadata associated with the secret. */
+  metadata jsonb /* @use JsonObject */ not null default '{}'::jsonb,
+  created_at timestamptz not null default(now()),
+  updated_at timestamptz not null default(now())
+);
+
+create trigger set_updated_at
+  before update on secrets
+  for each row
+  execute procedure set_updated_at();


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR introduces two new tables to the database schema: secrets and secret_connector_relations. These tables are designed to securely store sensitive user secrets (such as tokens) and manage their associations with social and SSO connectors.

### `secrets` table: 
Stores encrypted secrets (e.g., access tokens, refresh tokens) for users.

Key Columns:
- `id`: Primary key for the secret.
- `user_id`: References the user the secret belongs to.
- `type`: The type/category of the secret.
- `encrypted_dek`, `iv`, `auth_tag`, `ciphertext`: Fields for storing the encrypted data encryption key, initialization vector, authentication tag, and the encrypted secret itself.
- `metadata`: JSONB field for additional metadata.
- `created_at`, `updated_at`: Timestamps for auditing.

### `secret_connector_relations` Table
Manages the relationship between secrets and their associated connectors (either social or SSO). Ensures that each third-party provider token set secret is linked to the correct connector and identity, and enforces data integrity.

Key Columns:
- `secret_id`: Foreign key referencing `secrets(id)`
- `connector_id`, `social_connector_target`, `social_identity_id`: Represent the association with a social connector and its corresponding user identity.
- `sso_connector_id`, `sso_connector_issuer`, `sso_identity_id`: Represent the association with an SSO connector and its corresponding user identity.

Constraints & Triggers:
- Ensures a token set secret is associated with either a social connector or an SSO connector, but not both.
- Enforces uniqueness for social and SSO identity associations.
- Triggers automatically delete secrets when their associated connector is deleted, maintaining referential integrity.

TODO: Add triggers to automatically delete secrets when their associated third-party identities are deleted.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A
will implement the tests later

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
