### PR TITLE
feat(schemas): add secrets deletion triggers

### DIFF
--- a/packages/schemas/alterations/next-1750402536-add-triggers-to-delete-secrets-on-social-identities-deletion.ts
+++ b/packages/schemas/alterations/next-1750402536-add-triggers-to-delete-secrets-on-social-identities-deletion.ts
@@ -1,0 +1,81 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    /** Trigger function to delete secret when the SSO identity is deleted. */
+    await pool.query(sql`
+      create function delete_secret_on_sso_identity_delete()
+      returns trigger as $$
+      begin
+        delete from secrets
+        where id in (
+          select secret_id from secret_connector_relations
+          where tenant_id = old.tenant_id
+          and sso_connector_issuer = old.issuer
+          and sso_identity_id = old.identity_id
+        )
+        -- we also need to ensure that the secret is associated with the correct user
+        and user_id = old.user_id;
+        return old;
+      end;
+      $$ language plpgsql;
+
+      create trigger delete_secret_before_sso_identity_delete
+        before delete on user_sso_identities
+        for each row
+        execute procedure delete_secret_on_sso_identity_delete();
+    `);
+
+    /** Trigger function to delete associalted secrets when social identities is deleted. */
+    await pool.query(sql`
+      create function delete_secrets_on_social_identity_delete()
+      returns trigger as $$
+      declare
+        target text;
+        old_identity jsonb;
+        new_identity jsonb;
+      begin
+        -- Loop over eold identies to detect deletions or modificaitons
+        for target in select jsonb_object_keys(old.identities)
+        loop
+          old_identity := old.identities -> target;
+          new_identity := new.identities -> target;
+
+          -- If the identity was deleted or modified, delete the associated secret
+          if new_identity is null or (new_identity->>'userId') is distinct from (old_identity->>'userId') then
+            -- Identity was removed or changed, delete the corresponding secrets
+            delete from secrets
+            using secret_connector_relations
+            where secrets.id = secret_connector_relations.secret_id
+            -- Ensure we are deleting the correct social identity
+            and secret_connector_relations.social_connector_target = target
+            and secret_connector_relations.social_identity_id = old_identity->>'userId'
+            -- Ensure we delete the correct user's secret
+            and secrets.user_id = old.id;
+          end if;
+        end loop;
+
+        return new;
+      end;
+      $$ language plpgsql;
+
+      create trigger delete_secrets_before_social_identity_delete
+        before update of identities on users
+        for each row
+        execute procedure delete_secrets_on_social_identity_delete();
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      drop trigger if exists delete_secret_before_sso_identity_delete on user_sso_identities;
+      drop function if exists delete_secret_on_sso_identity_delete();
+
+      drop trigger if exists delete_secrets_before_social_identity_delete on users;
+      drop function if exists delete_secrets_on_social_identity_delete();
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/secret_connector_relations.sql
+++ b/packages/schemas/tables/secret_connector_relations.sql
@@ -76,3 +76,63 @@ create trigger delete_secrets_before_sso_connector_delete
   before delete on sso_connectors
   for each row
   execute procedure delete_secrets_on_sso_connector_delete();
+
+/** Trigger function to delete secret when the SSO identity is deleted. */
+create function delete_secret_on_sso_identity_delete()
+returns trigger as $$
+begin
+  delete from secrets
+  where id in (
+    select secret_id from secret_connector_relations
+    where tenant_id = old.tenant_id
+    and sso_connector_issuer = old.issuer
+    and sso_identity_id = old.identity_id
+  )
+  -- we also need to ensure that the secret is associated with the correct user
+  and user_id = old.user_id;
+  return old;
+end;
+$$ language plpgsql;
+
+create trigger delete_secret_before_sso_identity_delete
+  before delete on user_sso_identities
+  for each row
+  execute procedure delete_secret_on_sso_identity_delete();
+
+
+/** Trigger function to delete associalted secrets when social identities is deleted. */
+create function delete_secrets_on_social_identity_delete()
+returns trigger as $$
+declare
+  target text;
+  old_identity jsonb;
+  new_identity jsonb;
+begin
+  -- Loop over eold identies to detect deletions or modificaitons
+  for target in select jsonb_object_keys(old.identities)
+  loop
+    old_identity := old.identities -> target;
+    new_identity := new.identities -> target;
+
+    -- If the identity was deleted or modified, delete the associated secret
+    if new_identity is null or (new_identity->>'userId') is distinct from (old_identity->>'userId') then
+      -- Identity was removed or changed, delete the corresponding secrets
+      delete from secrets
+      using secret_connector_relations
+      where secrets.id = secret_connector_relations.secret_id
+      -- Ensure we are deleting the correct social identity
+      and secret_connector_relations.social_connector_target = target
+      and secret_connector_relations.social_identity_id = old_identity->>'userId'
+      -- Ensure we delete the correct user's secret
+      and secrets.user_id = old.id;
+    end if;
+  end loop;
+
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger delete_secrets_before_social_identity_delete
+  before update of identities on users
+  for each row
+  execute procedure delete_secrets_on_social_identity_delete();


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add secrets deletion triggers on social and SSO identity deletion.

### SSO identities
Add a trigger to the `user_sso_identities` table. On user SSO identity deletion, we trigger the function to delete all secrets that are associated with that user's SSO identity.  Using `issuer` + `identityId` to uniquely identify the relation.


### Social identities
Unlike `user_sso_identities` we do not have a dedicated table for user social identity storage. Add a trigger to the `users` table instead.
Listens on the `update` operation on the `identities` column. 
Loop through the identities that have been deleted/modified (exist in old data but removed from the new updated identities field), if the social target no longer exists or the social identityId is updated, remove all the secrets that are associated with old social identities that about to be deleted. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally using DB query
Integration test will be added once the API implementations are ready.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
