### PR TITLE
fix(experience): adding flexible size property in turnstile widget

### DIFF
--- a/packages/experience/src/Providers/CaptchaContextProvider/index.tsx
+++ b/packages/experience/src/Providers/CaptchaContextProvider/index.tsx
@@ -70,6 +70,7 @@ const CaptchaContextProvider = ({ children }: Props) => {
             setToast(t('error.captcha_verification_failed'));
             reject(new Error(`Turnstile error: ${errorCode}`));
           },
+          size: 'flexible',
         });
       });
     }

--- a/packages/experience/src/include.d/global.d.ts
+++ b/packages/experience/src/include.d/global.d.ts
@@ -35,6 +35,7 @@ declare global {
           callback: (token: string) => void;
           theme: 'light' | 'dark';
           'error-callback': (errorCode: string) => void;
+          size: string;
         }
       ) => void;
     };


### PR DESCRIPTION
## Summary
Added support for the new size property in the Cloudflare Turnstile widget component.
This allows the widget to scale responsively and fill the available space, making it easier to control its size via custom CSS, especially on the login screen.

By default, the Turnstile widget comes with size="normal" and a maximum width of 300px, which limits its responsiveness.
With this change, we now set the widget to use size="flexible", allowing it to stretch and fill the full container width.

Before:
The Turnstile widget was fixed at a maximum of 300px width, regardless of container size.
<img src="https://github.com/user-attachments/assets/eda843a7-7fdc-4e6a-8350-039295b9e15e" alt="Captura de tela de 2025-06-20 22-55-46" width="500" />

After:
By setting a flexible size, the widget can now scale to fill the full container, adapting to larger layouts such as the login screen.
<img src="https://github.com/user-attachments/assets/33c5b6e8-6597-465c-88ef-91b870074ee0" alt="Captura de tela de 2025-06-20 22-38-30" width="500" />

## Testing
Tested locally on the login page verifying that the widget now stretches responsively.
Validated across multiple screen sizes (desktop, tablet, mobile).
Confirmed that the Turnstile verification still works after resizing.
Compared rendering between the default size and the new flexible size.

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
