### PR TITLE
fix(schemas): change password encrypted length to 256

### DIFF
--- a/.changeset/olive-falcons-invite.md
+++ b/.changeset/olive-falcons-invite.md
@@ -1,0 +1,7 @@
+---
+"@logto/schemas": minor
+---
+
+change user password_encrypted length to 256
+
+For some hash algorithms, the hash length is longer than 128 characters.

--- a/packages/core/src/routes/admin-user/basics.ts
+++ b/packages/core/src/routes/admin-user/basics.ts
@@ -149,7 +149,7 @@ export default function adminUserBasicsRoutes<T extends ManagementApiRouter>(
         primaryEmail: string().regex(emailRegEx),
         username: string().regex(usernameRegEx),
         password: string().min(1),
-        passwordDigest: string(),
+        passwordDigest: string().max(256),
         passwordAlgorithm: nativeEnum(UsersPasswordEncryptionMethod),
         name: string(),
         avatar: string().url().or(literal('')).nullable(),

--- a/packages/schemas/alterations/next-1750663091-change-user-password-encrypted-length.ts
+++ b/packages/schemas/alterations/next-1750663091-change-user-password-encrypted-length.ts
@@ -1,0 +1,18 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      alter table users alter column password_encrypted set data type varchar(256);
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      alter table users alter column password_encrypted set data type varchar(128);
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/users.sql
+++ b/packages/schemas/tables/users.sql
@@ -9,7 +9,7 @@ create table users (
   username varchar(128),
   primary_email varchar(128),
   primary_phone varchar(128),
-  password_encrypted varchar(128),
+  password_encrypted varchar(256),
   password_encryption_method users_password_encryption_method,
   name varchar(128),
   /** The URL that points to the user's profile picture. Mapped to OpenID Connect's `picture` claim. */ 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

change password encrypted length to 256, to support hash algorithm like `sha512`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested with sha512

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
