### PR TITLE
feat(schemas, core): add secret encryption util method

### DIFF
--- a/packages/core/src/utils/secret-encryption.test.ts
+++ b/packages/core/src/utils/secret-encryption.test.ts
@@ -7,7 +7,7 @@ import { EnvSet } from '#src/env-set/index.js';
 
 import { encryptTokens, decryptTokens } from './secret-encryption.js';
 
-describe('secrety encryption', () => {
+describe('secret encryption', () => {
   const mockKek = crypto.randomBytes(32).toString('base64');
 
   it('should successfully encrypt and decrypt token', () => {

--- a/packages/core/src/utils/secret-encryption.test.ts
+++ b/packages/core/src/utils/secret-encryption.test.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 
-import { type TokenRecord } from '@logto/schemas';
+import { type TokenSet } from '@logto/schemas';
 import Sinon from 'sinon';
 
 import { EnvSet } from '#src/env-set/index.js';
@@ -16,9 +16,9 @@ describe('secret encryption', () => {
       secretVaultKek: mockKek,
     });
 
-    const mockToken: TokenRecord = {
-      accessToken: crypto.randomBytes(32).toString('hex'),
-      refreshToken: crypto.randomBytes(32).toString('hex'),
+    const mockToken: TokenSet = {
+      access_token: crypto.randomBytes(32).toString('hex'),
+      refresh_token: crypto.randomBytes(32).toString('hex'),
     };
 
     const encryptedSecret = encryptTokens(mockToken);

--- a/packages/core/src/utils/secret-encryption.test.ts
+++ b/packages/core/src/utils/secret-encryption.test.ts
@@ -1,0 +1,31 @@
+import crypto from 'node:crypto';
+
+import { type TokenRecord } from '@logto/schemas';
+import Sinon from 'sinon';
+
+import { EnvSet } from '#src/env-set/index.js';
+
+import { encryptTokens, decryptTokens } from './secret-encryption.js';
+
+describe('secrety encryption', () => {
+  const mockKek = crypto.randomBytes(32).toString('base64');
+
+  it('should successfully encrypt and decrypt token', () => {
+    const stub = Sinon.stub(EnvSet, 'values').value({
+      ...EnvSet.values,
+      secretVaultKek: mockKek,
+    });
+
+    const mockToken: TokenRecord = {
+      accessToken: crypto.randomBytes(32).toString('hex'),
+      refreshToken: crypto.randomBytes(32).toString('hex'),
+    };
+
+    const encryptedSecret = encryptTokens(mockToken);
+    const decryptedSecret = decryptTokens(encryptedSecret);
+
+    expect(decryptedSecret).toEqual(mockToken);
+
+    stub.restore();
+  });
+});

--- a/packages/core/src/utils/secret-encryption.ts
+++ b/packages/core/src/utils/secret-encryption.ts
@@ -1,0 +1,80 @@
+import crypto from 'node:crypto';
+
+import { type TokenRecord, tokenRecrodGuard, type EncryptedSecret } from '@logto/schemas';
+
+import { EnvSet } from '../env-set/index.js';
+
+import assertThat from './assert-that.js';
+
+const ecryptionMethod = 'aes-256-gcm';
+
+const encryprSecret = (plainTextSecret: string): EncryptedSecret => {
+  assertThat(
+    EnvSet.values.secretVaultKek,
+    new Error(
+      'The key encryption key (KEK) for the secret vault is not set. Please set the `SECRET_VAULT_KEK` environment variable.'
+    )
+  );
+
+  const kek = Buffer.from(EnvSet.values.secretVaultKek, 'base64');
+
+  // 1. genretate a Data Encryption Key (DEK)
+  const dek = crypto.randomBytes(32);
+
+  // 2. Encrypt the secret with the DEK (AES-256-GCM)
+
+  // Generate a random IV (initialization vector) for AES-GCM
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv(ecryptionMethod, dek, iv);
+  const ciphertext = Buffer.concat([cipher.update(plainTextSecret, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  // 3. Encrypt the DEK with the KEK (AES-256-GCM)
+  const ivDek = crypto.randomBytes(12);
+  const dekCipher = crypto.createCipheriv(ecryptionMethod, kek, ivDek);
+  const encryptedDek = Buffer.concat([dekCipher.update(dek), dekCipher.final()]);
+  const dekAuthTag = dekCipher.getAuthTag();
+
+  return {
+    iv,
+    authTag,
+    ciphertext,
+    encryptedDek: Buffer.concat([ivDek, encryptedDek, dekAuthTag]),
+  };
+};
+
+const decriptSecret = ({ iv, authTag, ciphertext, encryptedDek }: EncryptedSecret): string => {
+  assertThat(
+    EnvSet.values.secretVaultKek,
+    new Error('The key encryption key (KEK) for the secret vault is found.')
+  );
+
+  const kek = Buffer.from(EnvSet.values.secretVaultKek, 'base64');
+
+  // 1. Extract IV and authTag for DEK
+  // The first 12 bytes of `encryptedDek` is the IV
+  const ivDek = encryptedDek.subarray(0, 12);
+  // The last 16 bytes of `encryptedDek` is the authTag
+  const dekAuthTag = encryptedDek.subarray(-16, encryptedDek.length);
+  // The rest is the encrypted DEK
+  const _encryptedDek = encryptedDek.subarray(12, -16);
+
+  const dekDecipher = crypto.createDecipheriv(ecryptionMethod, kek, ivDek);
+  dekDecipher.setAuthTag(dekAuthTag);
+  const dek = Buffer.concat([dekDecipher.update(_encryptedDek), dekDecipher.final()]);
+
+  // 2. Decrypt the secret with the DEK
+  const decipher = crypto.createDecipheriv(ecryptionMethod, dek, iv);
+  decipher.setAuthTag(authTag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+};
+
+export const encryptTokens = (tokens: TokenRecord): EncryptedSecret => {
+  const tokensString = JSON.stringify(tokens);
+  return encryprSecret(tokensString);
+};
+
+export const decryptTokens = (encryptedSecret: EncryptedSecret): TokenRecord => {
+  const decryptedString = decriptSecret(encryptedSecret);
+  return tokenRecrodGuard.parse(JSON.parse(decryptedString));
+};

--- a/packages/core/src/utils/secret-encryption.ts
+++ b/packages/core/src/utils/secret-encryption.ts
@@ -46,7 +46,7 @@ const encryprSecret = (plainTextSecret: string): EncryptedSecret => {
 const decriptSecret = ({ iv, authTag, ciphertext, encryptedDek }: EncryptedSecret): string => {
   assertThat(
     EnvSet.values.secretVaultKek,
-    new Error('The key encryption key (KEK) for the secret vault is found.')
+    new Error('The key encryption key (KEK) for the secret vault is not found.')
   );
 
   const kek = Buffer.from(EnvSet.values.secretVaultKek, 'base64');

--- a/packages/core/src/utils/secret-encryption.ts
+++ b/packages/core/src/utils/secret-encryption.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 
-import { type TokenRecord, tokenRecrodGuard, type EncryptedSecret } from '@logto/schemas';
+import { type TokenSet, tokenSetGuard, type EncryptedSecret } from '@logto/schemas';
 
 import { EnvSet } from '../env-set/index.js';
 
@@ -69,12 +69,12 @@ const decriptSecret = ({ iv, authTag, ciphertext, encryptedDek }: EncryptedSecre
   return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
 };
 
-export const encryptTokens = (tokens: TokenRecord): EncryptedSecret => {
+export const encryptTokens = (tokens: TokenSet): EncryptedSecret => {
   const tokensString = JSON.stringify(tokens);
   return encryprSecret(tokensString);
 };
 
-export const decryptTokens = (encryptedSecret: EncryptedSecret): TokenRecord => {
+export const decryptTokens = (encryptedSecret: EncryptedSecret): TokenSet => {
   const decryptedString = decriptSecret(encryptedSecret);
-  return tokenRecrodGuard.parse(JSON.parse(decryptedString));
+  return tokenSetGuard.parse(JSON.parse(decryptedString));
 };

--- a/packages/schemas/src/foundations/jsonb-types/secrets.ts
+++ b/packages/schemas/src/foundations/jsonb-types/secrets.ts
@@ -9,3 +9,14 @@ export enum SecretType {
 }
 
 export const secretTypeGuard = z.nativeEnum(SecretType);
+
+export type BufferLike = Buffer;
+
+export const bufferLikeGuard = z.custom<BufferLike>(
+  (value) => {
+    return Buffer.isBuffer(value);
+  },
+  {
+    message: 'Invalid Buffer instance',
+  }
+);

--- a/packages/schemas/src/types/index.ts
+++ b/packages/schemas/src/types/index.ts
@@ -33,3 +33,4 @@ export * from './ssr.js';
 export * from './saml-application.js';
 export * from './verification-records/index.js';
 export * from './custom-profile-fields.js';
+export * from './secrets.js';

--- a/packages/schemas/src/types/secrets.ts
+++ b/packages/schemas/src/types/secrets.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+import { type Secret } from '../db-entries/secret.js';
+
+export type EncryptedSecret = Pick<Secret, 'encryptedDek' | 'iv' | 'authTag' | 'ciphertext'>;
+
+export const tokenRecrodGuard = z.object({
+  accessToken: z.string(),
+  refreshToken: z.string(),
+});
+
+export type TokenRecord = z.infer<typeof tokenRecrodGuard>;

--- a/packages/schemas/src/types/secrets.ts
+++ b/packages/schemas/src/types/secrets.ts
@@ -4,9 +4,10 @@ import { type Secret } from '../db-entries/secret.js';
 
 export type EncryptedSecret = Pick<Secret, 'encryptedDek' | 'iv' | 'authTag' | 'ciphertext'>;
 
-export const tokenRecrodGuard = z.object({
-  accessToken: z.string(),
-  refreshToken: z.string(),
+export const tokenSetGuard = z.object({
+  id_token: z.string().optional(),
+  access_token: z.string(),
+  refresh_token: z.string().optional(),
 });
 
-export type TokenRecord = z.infer<typeof tokenRecrodGuard>;
+export type TokenSet = z.infer<typeof tokenSetGuard>;

--- a/packages/schemas/tables/secrets.sql
+++ b/packages/schemas/tables/secrets.sql
@@ -7,13 +7,13 @@ create table secrets (
     references users (id) on update cascade on delete cascade,
   type varchar(256) /* @use SecretType */ not null,
   /** Encrypted data encryption key (DEK) for the secret. */
-  encrypted_dek bytea not null,
+  encrypted_dek bytea /* @use BufferLike */ not null,
   /** Initialization vector for the secret encryption. */
-  iv bytea not null,
+  iv bytea /* @use BufferLike */ not null,
   /** Authentication tag for the secret encryption. */
-  auth_tag bytea not null,
+  auth_tag bytea /* @use BufferLike */ not null,
   /** The encrypted secret data. e.g. { access_token, refresh_token } */
-  ciphertext bytea not null,
+  ciphertext bytea /* @use BufferLike */ not null,
   /** The metadata associated with the secret. */
   metadata jsonb /* @use JsonObject */ not null default '{}'::jsonb,
   created_at timestamptz not null default(now()),

--- a/packages/shared/src/database/types.ts
+++ b/packages/shared/src/database/types.ts
@@ -1,5 +1,10 @@
 export type SchemaValuePrimitive = string | number | boolean | undefined;
-export type SchemaValue = SchemaValuePrimitive | Record<string, unknown> | unknown[] | null;
+export type SchemaValue =
+  | SchemaValuePrimitive
+  | Record<string, unknown>
+  | unknown[]
+  | null
+  | Buffer;
 export type SchemaLike<Key extends string> = {
   [key in Key]: SchemaValue;
 };

--- a/packages/shared/src/node/env/GlobalValues.ts
+++ b/packages/shared/src/node/env/GlobalValues.ts
@@ -137,6 +137,14 @@ export default class GlobalValues {
     return getEnv('AZURE_FUNCTION_APP_KEY');
   }
 
+  /**
+   * The key encryption key (KEK) for the secret vault.
+   * It is used to encrypt and decrypt secret DEKs (data encryption keys) in the secret vault.
+   */
+  public get secretVaultKek() {
+    return getEnv('SECRET_VAULT_KEK');
+  }
+
   constructor() {
     if (this.isPathBasedMultiTenancy) {
       console.warn(


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add secret encryption utility methods to encrypt and decrypt given secrets.

### Updates
- Add the `SecretBuffer` type annotation and the corresponding Zod custom buffer type guard to the `iv`, `authTag`, `ciphertext`, and `encryptedDek` fields. This ensures consistent data types across all secret encryption fields, which must be of type Buffer.
- Add `encryptSecret` and `decryptSecret`. 
- Add global KEK (Key encryption key) as a required environment variable.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
