### PR TITLE
feat(core,schemas): add custom profile fields to sign-in experience well-known cache

### DIFF
--- a/packages/core/src/__mocks__/custom-profile-fields.ts
+++ b/packages/core/src/__mocks__/custom-profile-fields.ts
@@ -1,0 +1,58 @@
+import { CustomProfileFieldType, type CustomProfileField } from '@logto/schemas';
+
+export const mockCustomProfileFields: CustomProfileField[] = [
+  {
+    tenantId: 'fake_tenant',
+    id: 'fake-id-1',
+    name: 'fullname',
+    type: CustomProfileFieldType.Fullname,
+    label: 'Full name',
+    description: 'Your fullname (Given name, middle name, and family name)',
+    required: false,
+    config: {
+      parts: [
+        {
+          key: 'givenName',
+          enabled: true,
+        },
+        {
+          key: 'middleName',
+          enabled: true,
+        },
+        {
+          key: 'familyName',
+          enabled: true,
+        },
+      ],
+    },
+    createdAt: 1_751_275_036_222,
+    sieOrder: 1,
+  },
+  {
+    tenantId: 'fake_tenant',
+    id: 'fake-id-2',
+    name: 'gender',
+    type: CustomProfileFieldType.Select,
+    label: 'Gender',
+    description: null,
+    required: false,
+    config: {
+      options: [
+        {
+          label: 'Male',
+          value: 'male',
+        },
+        {
+          label: 'Female',
+          value: 'female',
+        },
+        {
+          label: 'Rather not tell',
+          value: 'doNotTell',
+        },
+      ],
+    },
+    createdAt: 1_751_275_162_369,
+    sieOrder: 2,
+  },
+];

--- a/packages/core/src/__mocks__/index.ts
+++ b/packages/core/src/__mocks__/index.ts
@@ -31,6 +31,7 @@ export * from './sign-in-experience.js';
 export * from './sso.js';
 export * from './user.js';
 export * from './captcha.js';
+export * from './custom-profile-fields.js';
 
 export const mockApplication: Application = {
   tenantId: 'fake_tenant',

--- a/packages/core/src/libraries/sign-in-experience/index.test.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.test.ts
@@ -5,6 +5,7 @@ import { TtlCache } from '@logto/shared';
 
 import {
   mockCaptchaProvider,
+  mockCustomProfileFields,
   mockGithubConnector,
   mockGoogleConnector,
   mockSignInExperience,
@@ -170,6 +171,7 @@ describe('getFullSignInExperience()', () => {
     mockSsoConnectorLibrary.getAvailableSsoConnectors.mockResolvedValueOnce([
       wellConfiguredSsoConnector,
     ]);
+    findAllCustomProfileFields.mockResolvedValueOnce(mockCustomProfileFields);
 
     const fullSignInExperience = await getFullSignInExperience({ locale: 'en' });
     const connectorFactory = ssoConnectorFactories[wellConfiguredSsoConnector.providerName];
@@ -193,6 +195,7 @@ describe('getFullSignInExperience()', () => {
       isDevelopmentTenant: false,
       googleOneTap: undefined,
       captchaConfig: undefined,
+      customProfileFields: mockCustomProfileFields,
     });
   });
 

--- a/packages/core/src/libraries/sign-in-experience/index.test.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.test.ts
@@ -49,12 +49,18 @@ const captchaProviders = {
 };
 const { findCaptchaProvider } = captchaProviders;
 
+const customProfileFields = {
+  findAllCustomProfileFields: jest.fn(),
+};
+const { findAllCustomProfileFields } = customProfileFields;
+
 const { MockQueries } = await import('#src/test-utils/tenant.js');
 
 const queries = new MockQueries({
   customPhrases,
   signInExperiences,
   captchaProviders,
+  customProfileFields,
 });
 const connectorLibrary = createConnectorLibrary(queries, {
   getClient: jest.fn(),

--- a/packages/core/src/libraries/sign-in-experience/index.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.ts
@@ -275,7 +275,7 @@ export const createSignInExperienceLibrary = (
       isDevelopmentTenant,
       googleOneTap: getGoogleOneTap(),
       captchaConfig: await getCaptchaConfig(),
-      ...cond(EnvSet.values.isDevFeaturesEnabled && { customProfileFields }),
+      ...cond(EnvSet.values.isDevFeaturesEnabled && customProfileFields && { customProfileFields }),
     };
   };
 

--- a/packages/core/src/libraries/sign-in-experience/index.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.ts
@@ -8,7 +8,7 @@ import type {
   SsoConnectorMetadata,
 } from '@logto/schemas';
 import { ConnectorType, ReservedPlanId } from '@logto/schemas';
-import { deduplicate, pick, trySafe } from '@silverhand/essentials';
+import { cond, conditional, deduplicate, pick, trySafe } from '@silverhand/essentials';
 import deepmerge from 'deepmerge';
 
 import { type WellKnownCache } from '#src/caches/well-known.js';
@@ -44,6 +44,7 @@ export const createSignInExperienceLibrary = (
     signInExperiences: { findDefaultSignInExperience, updateDefaultSignInExperience },
     applicationSignInExperiences: { safeFindSignInExperienceByApplicationId },
     captchaProviders: { findCaptchaProvider },
+    customProfileFields: { findAllCustomProfileFields },
     organizations,
   } = queries;
 
@@ -187,12 +188,14 @@ export const createSignInExperienceLibrary = (
       isDevelopmentTenant,
       organizationOverride,
       appSignInExperience,
+      customProfileFields,
     ] = await Promise.all([
       findDefaultSignInExperience(),
       getLogtoConnectors(),
       getIsDevelopmentTenant(),
       getOrganizationOverride(organizationId),
       findApplicationSignInExperience(appId),
+      conditional(EnvSet.values.isDevFeaturesEnabled && findAllCustomProfileFields()),
     ]);
 
     // Always return empty array if single-sign-on is disabled
@@ -272,6 +275,7 @@ export const createSignInExperienceLibrary = (
       isDevelopmentTenant,
       googleOneTap: getGoogleOneTap(),
       captchaConfig: await getCaptchaConfig(),
+      ...cond(EnvSet.values.isDevFeaturesEnabled && { customProfileFields }),
     };
   };
 

--- a/packages/schemas/src/types/sign-in-experience.ts
+++ b/packages/schemas/src/types/sign-in-experience.ts
@@ -6,7 +6,12 @@ import {
 } from '@logto/connector-kit';
 import { z } from 'zod';
 
-import { type SignInExperience, SignInExperiences } from '../db-entries/index.js';
+import {
+  type CustomProfileField,
+  CustomProfileFields,
+  type SignInExperience,
+  SignInExperiences,
+} from '../db-entries/index.js';
 import { CaptchaType } from '../foundations/jsonb-types/index.js';
 import { type ToZodObject } from '../utils/zod.js';
 
@@ -44,6 +49,7 @@ export type FullSignInExperience = SignInExperience & {
     type: CaptchaType;
     siteKey: string;
   };
+  customProfileFields?: Readonly<CustomProfileField[]>;
 };
 
 export const fullSignInExperienceGuard = SignInExperiences.guard.extend({
@@ -68,4 +74,6 @@ export const fullSignInExperienceGuard = SignInExperiences.guard.extend({
       siteKey: z.string(),
     })
     .optional(),
+  // @charles TODO: Remove `optional` before release
+  customProfileFields: CustomProfileFields.guard.array().optional(),
 }) satisfies ToZodObject<FullSignInExperience>;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Introduces support for custom profile fields in the sign-in experience. Updates tests and schema types to reflect the new `customProfileFields` property.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested.
API integration test case added.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
