### PR TITLE
refactor(core,phrases): disallow sign-in identifiers in custom profile fields

### DIFF
--- a/packages/core/src/libraries/custom-profile-fields/utils.ts
+++ b/packages/core/src/libraries/custom-profile-fields/utils.ts
@@ -27,6 +27,14 @@ const reservedCustomDataKeys = Object.freeze([
   defaultTenantIdKey,
 ]);
 
+const reservedSignInIdentifierKeys = Object.freeze([
+  'username',
+  'primaryEmail',
+  'primaryPhone',
+  'email',
+  'phone',
+]);
+
 type ValidateCustomProfileField = (
   data: { name: string; type: CustomProfileFieldType } & Record<string, unknown>
 ) => void;
@@ -98,15 +106,19 @@ const validateDateProfileField: ValidateCustomProfileField = (data) => {
   }
 };
 
-const validateFieldKey = (key: string) => {
-  assertThat(/^[\dA-Za-z]+$/.test(key), 'custom_profile_fields.invalid_name');
-  assertThat(!reservedCustomDataKeys.includes(key), 'custom_profile_fields.name_exists');
+const validateFieldName = (name: string) => {
+  assertThat(/^[\dA-Za-z]+$/.test(name), 'custom_profile_fields.invalid_name');
+  assertThat(!reservedCustomDataKeys.includes(name), 'custom_profile_fields.name_exists');
+  assertThat(
+    !reservedSignInIdentifierKeys.includes(name),
+    new RequestError({ code: 'custom_profile_fields.name_conflict_sign_in_identifier', name })
+  );
 };
 
 export const validateCustomProfileFieldData: ValidateCustomProfileField = (data) => {
   const { name, type } = data;
 
-  validateFieldKey(name);
+  validateFieldName(name);
 
   switch (type) {
     case CustomProfileFieldType.Text: {

--- a/packages/integration-tests/src/__mocks__/profile-fields-mock.ts
+++ b/packages/integration-tests/src/__mocks__/profile-fields-mock.ts
@@ -9,13 +9,13 @@ import {
   type CheckboxProfileField,
 } from '@logto/schemas';
 
-export const primaryEmailData = {
-  name: `primaryEmail`,
+export const nameData = {
+  name: `name`,
   type: CustomProfileFieldType.Text,
-  label: 'Email address',
+  label: 'Name',
   required: true,
   config: {
-    placeholder: 'foo@bar.com',
+    placeholder: 'John Doe',
     minLength: 5,
     maxLength: 50,
   },

--- a/packages/integration-tests/src/tests/api/custom-profile-fields.test.ts
+++ b/packages/integration-tests/src/tests/api/custom-profile-fields.test.ts
@@ -1,7 +1,7 @@
 import { CustomProfileFieldType, type FullnameProfileField } from '@logto/schemas';
 
 import {
-  primaryEmailData,
+  nameData,
   fullnameData,
   birthDateData,
   genderData,
@@ -23,10 +23,10 @@ const { describe, it } = devFeatureTest;
 
 describe('custom profile fields API', () => {
   it('should create custom profile field and find it by name', async () => {
-    const customProfileField = await createCustomProfileField(primaryEmailData);
+    const customProfileField = await createCustomProfileField(nameData);
 
     expect(customProfileField).toMatchObject({
-      ...primaryEmailData,
+      ...nameData,
       sieOrder: 1,
     });
 
@@ -66,13 +66,13 @@ describe('custom profile fields API', () => {
   });
 
   it('should fail to create if field name is conflicted', async () => {
-    const emailField = await createCustomProfileField(primaryEmailData);
-    await expectRejects(createCustomProfileField(primaryEmailData), {
+    const nameField = await createCustomProfileField(nameData);
+    await expectRejects(createCustomProfileField(nameData), {
       code: 'custom_profile_fields.name_exists',
       status: 422,
     });
 
-    void deleteCustomProfileFieldByName(emailField.name);
+    void deleteCustomProfileFieldByName(nameField.name);
   });
 
   it('should fail to create if field name is invalid format', async () => {
@@ -111,8 +111,22 @@ describe('custom profile fields API', () => {
     );
   });
 
+  it('should fail to create if field name is conflict with sign-in identifier', async () => {
+    await expectRejects(
+      createCustomProfileField({
+        name: 'primaryEmail',
+        type: CustomProfileFieldType.Text,
+        label: 'Email address',
+      }),
+      {
+        code: 'custom_profile_fields.name_conflict_sign_in_identifier',
+        status: 400,
+      }
+    );
+  });
+
   it('should update custom profile field', async () => {
-    const emailField = await createCustomProfileField(primaryEmailData);
+    const nameField = await createCustomProfileField(nameData);
     const fullnameField = await createCustomProfileField(fullnameData);
 
     expect(fullnameField).toMatchObject({
@@ -143,15 +157,15 @@ describe('custom profile fields API', () => {
       ...dataToUpdate,
     });
 
-    void deleteCustomProfileFieldByName(emailField.name);
+    void deleteCustomProfileFieldByName(nameField.name);
     void deleteCustomProfileFieldByName(fullnameField.name);
   });
 
   it('should not be able to update the name, and sieOrder', async () => {
-    const emailField = await createCustomProfileField(primaryEmailData);
+    const nameField = await createCustomProfileField(nameData);
 
-    const updatedField = await updateCustomProfileFieldByName(primaryEmailData.name, {
-      ...primaryEmailData,
+    const updatedField = await updateCustomProfileFieldByName(nameField.name, {
+      ...nameData,
       // @ts-expect-error Invalid update name and type
       name: 'newName',
       sieOrder: 5,
@@ -160,15 +174,15 @@ describe('custom profile fields API', () => {
 
     // Only label is updated, name and sieOrder are not changed
     expect(updatedField).toMatchObject({
-      ...emailField,
+      ...nameField,
       label: 'New label',
     });
 
-    void deleteCustomProfileFieldByName(emailField.name);
+    void deleteCustomProfileFieldByName(nameField.name);
   });
 
   it('should fail to update custom profile field by non-existent name', async () => {
-    await expectRejects(updateCustomProfileFieldByName('nonExistName', primaryEmailData), {
+    await expectRejects(updateCustomProfileFieldByName('nonExistName', nameData), {
       code: 'entity.not_exists',
       status: 404,
     });

--- a/packages/phrases/src/locales/ar/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/ar/errors/custom-profile-fields.ts
@@ -8,6 +8,7 @@ const custom_profile_fields = {
   name_exists: 'هناك حقل بالفعل بهذا الاسم.',
   conflicted_sie_order: 'هناك تعارض في ترتيب الحقول لتجربة تسجيل الدخول.',
   invalid_name: 'اسم الحقل غير صالح ، يُسمح فقط بالأحرف أو الأرقام ، مع مراعاة حالة الأحرف.',
+  name_conflict_sign_in_identifier: 'اسم الحقل غير صالح. {{name}} هو معرف تسجيل دخول محجوز.',
 };
 
 export default Object.freeze(custom_profile_fields);

--- a/packages/phrases/src/locales/de/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/de/errors/custom-profile-fields.ts
@@ -10,6 +10,8 @@ const custom_profile_fields = {
   conflicted_sie_order: 'Konflikt im Feldreihenfolgewert für die Sign-in Experience.',
   invalid_name:
     'Ungültiger Feldname, nur Buchstaben oder Zahlen sind erlaubt, Groß- und Kleinschreibung beachten.',
+  name_conflict_sign_in_identifier:
+    'Ungültiger Feldname. {{name}} ist eine reservierte Anmeldekennung.',
 };
 
 export default Object.freeze(custom_profile_fields);

--- a/packages/phrases/src/locales/en/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/en/errors/custom-profile-fields.ts
@@ -8,6 +8,8 @@ const custom_profile_fields = {
   name_exists: 'Field already exists with the given name.',
   conflicted_sie_order: 'Conflicted field order value for Sign-in Experience.',
   invalid_name: 'Invalid field name, only letters or numbers are allowed, case sensitive.',
+  name_conflict_sign_in_identifier:
+    'Invalid field name. {{name}} is a reserved sign-in identifier.',
 };
 
 export default Object.freeze(custom_profile_fields);

--- a/packages/phrases/src/locales/es/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/es/errors/custom-profile-fields.ts
@@ -10,6 +10,8 @@ const custom_profile_fields = {
     'Valor de orden de campo en conflicto para la experiencia de inicio de sesión.',
   invalid_name:
     'Nombre de campo no válido, solo se permiten letras o números, distingue entre mayúsculas y minúsculas.',
+  name_conflict_sign_in_identifier:
+    'Nombre de campo no válido. {{name}} es un identificador reservado para iniciar sesión.',
 };
 
 export default Object.freeze(custom_profile_fields);

--- a/packages/phrases/src/locales/fr/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/fr/errors/custom-profile-fields.ts
@@ -10,6 +10,8 @@ const custom_profile_fields = {
   conflicted_sie_order: "Valeur d'ordre de champ en conflit pour l'expérience de connexion.",
   invalid_name:
     'Nom de champ invalide, seules les lettres ou les chiffres sont autorisés, sensible à la casse.',
+  name_conflict_sign_in_identifier:
+    'Nom de champ invalide. {{name}} est un identifiant de connexion réservé.',
 };
 
 export default Object.freeze(custom_profile_fields);

--- a/packages/phrases/src/locales/it/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/it/errors/custom-profile-fields.ts
@@ -9,6 +9,8 @@ const custom_profile_fields = {
   conflicted_sie_order: "Valore dell'ordine del campo in conflitto per Sign-in Experience.",
   invalid_name:
     'Nome del campo non valido, sono consentite solo lettere o numeri, sensibili alle maiuscole.',
+  name_conflict_sign_in_identifier:
+    "Nome del campo non valido. {{name}} è un identificatore riservato per l'accesso.",
 };
 
 export default Object.freeze(custom_profile_fields);

--- a/packages/phrases/src/locales/ja/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/ja/errors/custom-profile-fields.ts
@@ -9,6 +9,8 @@ const custom_profile_fields = {
   conflicted_sie_order: 'サインイン体験のフィールド順序の値が重複しています。',
   invalid_name:
     'フィールド名が無効です。文字または数字のみが許可され、大文字小文字が区別されます。',
+  name_conflict_sign_in_identifier:
+    '無効なフィールド名です。{{name}} は予約されたサインイン識別子です。',
 };
 
 export default Object.freeze(custom_profile_fields);

--- a/packages/phrases/src/locales/ko/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/ko/errors/custom-profile-fields.ts
@@ -8,6 +8,8 @@ const custom_profile_fields = {
   name_exists: '해당 이름의 필드가 이미 존재합니다.',
   conflicted_sie_order: 'Sign-in Experience 용 필드 순서 값이 충돌합니다.',
   invalid_name: '필드 이름이 올바르지 않습니다. 대소문자를 구분하며, 문자 또는 숫자만 허용됩니다.',
+  name_conflict_sign_in_identifier:
+    '필드 이름이 올바르지 않습니다. {{name}} 은(는) 예약된 로그인 식별자입니다.',
 };
 
 export default Object.freeze(custom_profile_fields);

--- a/packages/phrases/src/locales/pl-pl/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/custom-profile-fields.ts
@@ -9,6 +9,8 @@ const custom_profile_fields = {
   conflicted_sie_order: 'Konfliktowa wartość kolejności pola dla Sign-in Experience.',
   invalid_name:
     'Nieprawidłowa nazwa pola, dozwolone są tylko litery lub cyfry, rozróżniana wielkość liter.',
+  name_conflict_sign_in_identifier:
+    'Nieprawidłowa nazwa pola. {{name}} jest zarezerwowanym identyfikatorem logowania.',
 };
 
 export default Object.freeze(custom_profile_fields);

--- a/packages/phrases/src/locales/pt-br/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/pt-br/errors/custom-profile-fields.ts
@@ -10,6 +10,8 @@ const custom_profile_fields = {
   conflicted_sie_order: 'Valor de ordem de campo em conflito para a Experiência de Login.',
   invalid_name:
     'Nome de campo inválido, apenas letras ou números são permitidos, diferenciação por maiúsculas e minúsculas.',
+  name_conflict_sign_in_identifier:
+    'Nome de campo inválido. {{name}} é um identificador de login reservado.',
 };
 
 export default Object.freeze(custom_profile_fields);

--- a/packages/phrases/src/locales/pt-pt/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/custom-profile-fields.ts
@@ -11,6 +11,8 @@ const custom_profile_fields = {
     'Valor de ordem do campo em conflito para a experiência de início de sessão.',
   invalid_name:
     'Nome de campo inválido, apenas letras ou números são permitidos, diferencia maiúsculas de minúsculas.',
+  name_conflict_sign_in_identifier:
+    'Nome de campo inválido. {{name}} é um identificador reservado para início de sessão.',
 };
 
 export default Object.freeze(custom_profile_fields);

--- a/packages/phrases/src/locales/ru/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/ru/errors/custom-profile-fields.ts
@@ -8,6 +8,8 @@ const custom_profile_fields = {
   name_exists: 'Поле с таким именем уже существует.',
   conflicted_sie_order: 'Конфликт значения порядка поля для опыта входа.',
   invalid_name: 'Неверное имя поля, допускаются только буквы или цифры, чувствительно к регистру.',
+  name_conflict_sign_in_identifier:
+    'Недопустимое имя поля. {{name}} является зарезервированным идентификатором входа.',
 };
 
 export default Object.freeze(custom_profile_fields);

--- a/packages/phrases/src/locales/tr-tr/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/custom-profile-fields.ts
@@ -9,6 +9,8 @@ const custom_profile_fields = {
   conflicted_sie_order: 'Oturum Açma Deneyimi için çakışan alan sırası değeri.',
   invalid_name:
     'Geçersiz alan adı, sadece harfler veya sayılar kullanılabilir, büyük/küçük harf duyarlıdır.',
+  name_conflict_sign_in_identifier:
+    'Geçersiz alan adı. {{name}} rezerve edilmiş bir oturum açma tanımlayıcısıdır.',
 };
 
 export default Object.freeze(custom_profile_fields);

--- a/packages/phrases/src/locales/zh-cn/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/custom-profile-fields.ts
@@ -8,6 +8,7 @@ const custom_profile_fields = {
   name_exists: '已存在具有该名称的字段。',
   conflicted_sie_order: '登录体验的字段顺序值冲突。',
   invalid_name: '无效的字段名称，只允许字母或数字，区分大小写。',
+  name_conflict_sign_in_identifier: '无效的字段名称。{{name}} 是保留的登录标识符。',
 };
 
 export default Object.freeze(custom_profile_fields);

--- a/packages/phrases/src/locales/zh-hk/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/custom-profile-fields.ts
@@ -8,6 +8,7 @@ const custom_profile_fields = {
   name_exists: '已有具有該名稱的欄位存在。',
   conflicted_sie_order: '登入體驗欄位順序值有衝突。',
   invalid_name: '欄位名稱無效，只允許字母或數字，區分大小寫。',
+  name_conflict_sign_in_identifier: '欄位名稱無效。{{name}} 是登入識別用的保留字。',
 };
 
 export default Object.freeze(custom_profile_fields);

--- a/packages/phrases/src/locales/zh-tw/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/custom-profile-fields.ts
@@ -8,6 +8,7 @@ const custom_profile_fields = {
   name_exists: '已存在具有該名稱的欄位。',
   conflicted_sie_order: '登入體驗的欄位順序值衝突。',
   invalid_name: '欄位名稱無效，只允許字母或數字，區分大小寫。',
+  name_conflict_sign_in_identifier: '欄位名稱無效。{{name}} 是保留的登入識別碼。',
 };
 
 export default Object.freeze(custom_profile_fields);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Do NOT allow configuring sign-in identifier fields in the "custom profile fields" feature, including:
- primaryEmail
- email
- primaryPhone
- phone
- username

These fields are sign-in identifiers related and can only be update through management API or account API.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested & UT + CI

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
