### PR TITLE
feat(core): apply requireMfaOnSignIn

### DIFF
--- a/packages/core/src/routes/experience/classes/libraries/mfa-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/mfa-validator.ts
@@ -1,5 +1,6 @@
 import {
   MfaFactor,
+  MfaPolicy,
   VerificationType,
   type Mfa,
   type MfaVerification,
@@ -105,6 +106,12 @@ export class MfaValidator {
    * Check if the user has enabled MFA verifications, if true, MFA verification records are required.
    */
   get isMfaEnabled() {
+    // Users can manually disable MFA verification requirement for sign-in,
+    // but if the MFA policy is set to mandatory, this setting will be ignored.
+    if (!this.user.requireMfaOnSignIn && this.mfaSettings.policy !== MfaPolicy.Mandatory) {
+      return false;
+    }
+
     return this.userEnabledMfaVerifications.length > 0;
   }
 

--- a/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/require-mfa-on-sign-in.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/require-mfa-on-sign-in.test.ts
@@ -1,0 +1,96 @@
+import { UserScope } from '@logto/core-kit';
+import { MfaFactor, MfaPolicy } from '@logto/schemas';
+
+import { enableAllAccountCenterFields } from '#src/api/account-center.js';
+import { createUserMfaVerification } from '#src/api/admin-user.js';
+import { updateSignInExperience } from '#src/api/index.js';
+import { updateMfaSettings } from '#src/api/my-account.js';
+import { createVerificationRecordByPassword } from '#src/api/verification-record.js';
+import { initExperienceClient } from '#src/helpers/client.js';
+import { identifyUserWithUsernamePassword } from '#src/helpers/experience/index.js';
+import {
+  signInAndGetUserApi,
+  createDefaultTenantUserWithPassword,
+  deleteDefaultTenantUser,
+} from '#src/helpers/profile.js';
+import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
+import { UserApiTest } from '#src/helpers/user.js';
+import { devFeatureTest } from '#src/utils.js';
+
+devFeatureTest.describe('requireMfaOnSignIn user setting', () => {
+  const userApi = new UserApiTest();
+
+  beforeAll(async () => {
+    await enableAllPasswordSignInMethods();
+    await enableAllAccountCenterFields();
+  });
+
+  beforeEach(async () => {
+    // Reset MFA policy for test isolation
+    await updateSignInExperience({
+      mfa: {
+        factors: [MfaFactor.TOTP],
+        policy: MfaPolicy.NoPrompt, // Non-mandatory policy
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await userApi.cleanUp();
+  });
+
+  devFeatureTest.describe('MFA bypass functionality', () => {
+    devFeatureTest.it('should bypass MFA when requireMfaOnSignIn is false', async () => {
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
+      const api = await signInAndGetUserApi(username, password, {
+        scopes: [UserScope.Profile, UserScope.Identities],
+      });
+
+      // Disable MFA requirement for this user
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
+      await updateMfaSettings(api, verificationRecordId, false);
+
+      // Set up MFA factor (should be bypassed)
+      await createUserMfaVerification(user.id, MfaFactor.TOTP);
+
+      const client = await initExperienceClient();
+      await identifyUserWithUsernamePassword(client, username, password);
+
+      // Should complete sign-in without MFA verification
+      await expect(client.submitInteraction()).resolves.not.toThrow();
+
+      await deleteDefaultTenantUser(user.id);
+    });
+  });
+
+  devFeatureTest.describe('Mandatory MFA policy override', () => {
+    devFeatureTest.it('should ignore user setting when MFA policy is Mandatory', async () => {
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
+
+      // First, set up MFA factor and disable MFA requirement using the user API
+      // (before setting Mandatory policy which would prevent sign-in)
+      const api = await signInAndGetUserApi(username, password, {
+        scopes: [UserScope.Profile, UserScope.Identities],
+      });
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
+      await updateMfaSettings(api, verificationRecordId, false);
+      await createUserMfaVerification(user.id, MfaFactor.TOTP);
+
+      // Now set MFA policy to Mandatory (this should override the user setting)
+      await updateSignInExperience({
+        mfa: {
+          factors: [MfaFactor.TOTP],
+          policy: MfaPolicy.Mandatory,
+        },
+      });
+
+      const client = await initExperienceClient();
+      await identifyUserWithUsernamePassword(client, username, password);
+
+      // Should still require MFA due to Mandatory policy (ignoring user's requireMfaOnSignIn = false)
+      await expect(client.submitInteraction()).rejects.toThrow();
+
+      await deleteDefaultTenantUser(user.id);
+    });
+  });
+});


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

This PR implements the `requireMfaOnSignIn` user setting functionality that allows users to bypass MFA verification during sign-in, with proper policy override support. When `requireMfaOnSignIn` is set to false, users can skip MFA verification even if they have MFA factors configured, unless the MFA policy is set to `Mandatory`.

Because administrators can enforce MFA through policy regardless of user preference, there is no need to restrict this option.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Unit & Integration tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
