### PR TITLE
feat: init `@logto/api`

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -17,12 +17,13 @@ So, we are using our own "grouping" release strategy in this monorepo:
 
 The release group that includes the Logto core service and its schemas and cli, which consists of the following packages:
 
-- @logto/core (main)
-- @logto/schemas
+- @logto/api
 - @logto/cli
+- @logto/core (main)
 - @logto/create
+- @logto/schemas
 
-Their versions will be always in sync, and forms our main release.
+Their versions will be always in sync, and forms our main release group.
 
 ### Others
 

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,13 +3,15 @@
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "//": "CAUTION: When updating the fields below, you should also update README accordingly.",
-  "fixed": [[
-    "@logto/api",
-    "@logto/core",
-    "@logto/schemas",
-    "@logto/cli",
-    "@logto/create"
-  ]],
+  "fixed": [
+    [
+      "@logto/api",
+      "@logto/cli",
+      "@logto/core",
+      "@logto/create",
+      "@logto/schemas"
+    ]
+  ],
   "linked": [],
   "//": "END OF CAUTION",
   "access": "restricted",

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,6 +4,7 @@
   "commit": false,
   "//": "CAUTION: When updating the fields below, you should also update README accordingly.",
   "fixed": [[
+    "@logto/api",
     "@logto/core",
     "@logto/schemas",
     "@logto/cli",

--- a/.changeset/shaggy-fans-remain.md
+++ b/.changeset/shaggy-fans-remain.md
@@ -1,0 +1,9 @@
+---
+"@logto/api": major
+---
+
+init Logto API SDK
+
+- Add `createManagementApi()` to create typed Management API clients
+- Handle OAuth token auth and renewal automatically
+- Support Logto Cloud and self-hosted instances

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,6 @@ services:
       POSTGRES_PASSWORD: p0stgr3s
     healthcheck:
       test: ["CMD-SHELL", "pg_isready"]
-      interval: 10s
+      interval: 5s
       timeout: 5s
       retries: 5

--- a/packages/api/.gitignore
+++ b/packages/api/.gitignore
@@ -1,0 +1,1 @@
+src/generated-types/

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -54,3 +54,15 @@ const { apiClient } = createManagementApi('default', {
 ### API documentation
 
 For detailed API documentation, refer to the [Logto Management API documentation](https://openapi.logto.io/).
+
+## Development
+
+To avoid unnecessary build time in CI, full type generation only happens before publishing. The `build` script will generate mock types if no types are found.
+
+To explicitly generate types, run:
+
+```bash
+pnpm generate-types
+```
+
+This will start a local Docker Compose environment, generate types by fetching the OpenAPI endpoints, and then shut down the environment.

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1,0 +1,56 @@
+# @logto/api
+
+A TypeScript SDK for interacting with Logto's Management API using client credentials authentication.
+
+## Installation
+
+```bash
+npm install @logto/api
+```
+
+## Quick start
+
+### Prerequisites
+
+Before using this SDK, you need to:
+
+1. Create a machine-to-machine application in your Logto Console
+2. Grant the application access to the Management API
+3. Note down the client ID and client secret
+
+For detailed setup instructions, visit: https://a.logto.io/m2m-mapi
+
+### Basic usage
+
+#### Logto Cloud
+
+```ts
+import { createManagementApi } from '@logto/api/management';
+
+// For Logto Cloud
+const { apiClient } = createManagementApi('your-tenant-id', {
+  clientId: 'your-client-id',
+  clientSecret: 'your-client-secret',
+});
+
+// Make API calls
+const response = await apiClient.GET('/api/users');
+console.log(response.data);
+```
+
+#### Self-hosted / OSS
+
+```ts
+import { createManagementApi } from '@logto/api/management';
+
+const { apiClient } = createManagementApi('default', {
+  clientId: 'your-client-id',
+  clientSecret: 'your-client-secret',
+  baseUrl: 'https://your-logto-instance.com',
+  apiIndicator: 'https://your-logto-instance.com/api',
+});
+```
+
+### API documentation
+
+For detailed API documentation, refer to the [Logto Management API documentation](https://openapi.logto.io/).

--- a/packages/api/check-types.sh
+++ b/packages/api/check-types.sh
@@ -1,0 +1,6 @@
+# Check if type files exist, if not, mock them to avoid build errors.
+if [ ! -f src/generated-types/management.ts ]; then
+  echo "WARNING: Type files not found. Mocking types to avoid build errors."
+  mkdir -p src/generated-types
+  echo "export interface paths {}" > src/generated-types/management.ts
+fi

--- a/packages/api/check-types.sh
+++ b/packages/api/check-types.sh
@@ -1,4 +1,3 @@
-# Check if type files exist, if not, mock them to avoid build errors.
 if [ ! -f src/generated-types/management.ts ]; then
   echo "WARNING: Type files not found. Mocking types to avoid build errors."
   mkdir -p src/generated-types

--- a/packages/api/docker-compose.local.yml
+++ b/packages/api/docker-compose.local.yml
@@ -1,0 +1,8 @@
+version: "3.9"
+services:
+  app:
+    container_name: app # Specify a container name for easier health check
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: svhd/logto:local

--- a/packages/api/generate-types.sh
+++ b/packages/api/generate-types.sh
@@ -16,5 +16,5 @@ while ! curl -sf http://localhost:3001/api/status > /dev/null; do
   elapsed=$((elapsed + interval))
 done
 
-pnpm exec openapi-typescript http://localhost:3001/api/swagger.json --output src/generated-types/management.ts
+pnpm exec openapi-typescript http://localhost:3001/api/.well-known/management.openapi.json --output src/generated-types/management.ts
 docker compose down

--- a/packages/api/generate-types.sh
+++ b/packages/api/generate-types.sh
@@ -1,0 +1,20 @@
+set -e
+
+docker compose -f ../../docker-compose.yml -f ./docker-compose.local.yml up -d
+
+timeout=60
+interval=5
+elapsed=0
+
+while ! curl -sf http://localhost:3001/api/status > /dev/null; do
+  if [ "$elapsed" -ge "$timeout" ]; then
+    echo "Timed out waiting for API to be healthy."
+    exit 1
+  fi
+  echo "Waiting for API to be healthy..."
+  sleep $interval
+  elapsed=$((elapsed + interval))
+done
+
+pnpm exec openapi-typescript http://localhost:3001/api/swagger.json --output src/types/management.d.ts
+docker compose down

--- a/packages/api/generate-types.sh
+++ b/packages/api/generate-types.sh
@@ -16,5 +16,5 @@ while ! curl -sf http://localhost:3001/api/status > /dev/null; do
   elapsed=$((elapsed + interval))
 done
 
-pnpm exec openapi-typescript http://localhost:3001/api/swagger.json --output src/types/management.d.ts
+pnpm exec openapi-typescript http://localhost:3001/api/swagger.json --output src/generated-types/management.ts
 docker compose down

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -9,7 +9,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "lib/index.js",
   "exports": {
     "./management": {
       "default": "./lib/management.js",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -11,7 +11,11 @@
   },
   "main": "lib/index.js",
   "exports": {
-    "./management": "./lib/management/index.js"
+    "./management": {
+      "default": "./lib/management.js",
+      "types": "./lib/management.d.ts",
+      "import": "./lib/management.js"
+    }
   },
   "files": [
     "lib"
@@ -24,9 +28,14 @@
     "url": "https://github.com/logto-io/logto/issues"
   },
   "scripts": {
+    "precommit": "lint-staged",
     "prepublishOnly": "pnpm generate-types && pnpm build",
     "generate-types": "./generate-types.sh",
-    "build": "tsc -p tsconfig.build.json"
+    "build": "tsc -p tsconfig.build.json",
+    "lint": "eslint --ext .ts src",
+    "lint:report": "pnpm lint --format json --output-file report.json",
+    "test": "vitest src",
+    "test:ci": "pnpm run test --silent --coverage"
   },
   "engines": {
     "node": "^22.14.0"
@@ -37,12 +46,17 @@
   "devDependencies": {
     "@silverhand/eslint-config": "6.0.1",
     "@silverhand/ts-config": "6.0.0",
+    "@vitest/coverage-v8": "^3.1.1",
     "eslint": "^8.57.0",
     "openapi-typescript": "^7.8.0",
     "prettier": "^3.5.3",
-    "typescript": "^5.5.3"
+    "typescript": "^5.5.3",
+    "vitest": "^3.1.1"
   },
   "eslintConfig": {
+    "ignorePatterns": [
+      "src/generated-types/*"
+    ],
     "extends": "@silverhand"
   },
   "prettier": "@silverhand/eslint-config/.prettierrc"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@logto/api",
+  "version": "0.0.0",
+  "description": "Logto API types and clients.",
+  "author": "Silverhand Inc. <contact@silverhand.io>",
+  "homepage": "https://github.com/logto-io/logto#readme",
+  "license": "MPL-2.0",
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "lib/index.js",
+  "exports": {
+    "./management": "./lib/management/index.js"
+  },
+  "files": [
+    "lib"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/logto-io/logto.git"
+  },
+  "bugs": {
+    "url": "https://github.com/logto-io/logto/issues"
+  },
+  "scripts": {
+    "prepublishOnly": "pnpm generate-types && pnpm build",
+    "generate-types": "./generate-types.sh",
+    "build": "tsc -p tsconfig.build.json"
+  },
+  "engines": {
+    "node": "^22.14.0"
+  },
+  "dependencies": {
+    "openapi-fetch": "^0.14.0"
+  },
+  "devDependencies": {
+    "@silverhand/eslint-config": "6.0.1",
+    "@silverhand/ts-config": "6.0.0",
+    "eslint": "^8.57.0",
+    "openapi-typescript": "^7.8.0",
+    "prettier": "^3.5.3",
+    "typescript": "^5.5.3"
+  },
+  "eslintConfig": {
+    "extends": "@silverhand"
+  },
+  "prettier": "@silverhand/eslint-config/.prettierrc"
+}

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -37,7 +37,7 @@
     "test:ci": "pnpm run test --silent --coverage"
   },
   "engines": {
-    "node": "^22.14.0"
+    "node": "^22.14.0 || ^24.0.0"
   },
   "dependencies": {
     "openapi-fetch": "^0.14.0"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -31,7 +31,7 @@
     "precommit": "lint-staged",
     "prepublishOnly": "pnpm generate-types && pnpm build",
     "generate-types": "./generate-types.sh",
-    "build": "tsc -p tsconfig.build.json",
+    "build": "./check-types.sh && rm -rf lib/ && tsc -p tsconfig.build.json",
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest src",

--- a/packages/api/src/client-credentials.test.ts
+++ b/packages/api/src/client-credentials.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import {
+  ClientCredentials,
+  ClientCredentialsError,
+  type ClientCredentialsOptions,
+} from './client-credentials.js';
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+// eslint-disable-next-line @silverhand/fp/no-mutation
+global.fetch = mockFetch;
+
+describe('ClientCredentialsError', () => {
+  it('should create error with correct name', () => {
+    const error = new ClientCredentialsError('test message');
+    expect(error.name).toBe('ClientCredentialsError');
+    expect(error.message).toBe('test message');
+    expect(error).toBeInstanceOf(Error);
+  });
+});
+
+describe('ClientCredentials', () => {
+  const defaultOptions: ClientCredentialsOptions = {
+    clientId: 'test-client-id',
+    clientSecret: 'test-client-secret',
+    tokenEndpoint: 'https://example.com/token',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('constructor', () => {
+    it('should create instance with options', () => {
+      const credentials = new ClientCredentials(defaultOptions);
+      expect(credentials).toBeInstanceOf(ClientCredentials);
+    });
+  });
+
+  describe('AccessTokenExpiryLeeway', () => {
+    it('should return default value of 60 when not specified', () => {
+      const credentials = new ClientCredentials(defaultOptions);
+      expect(credentials.accessTokenExpiryLeeway).toBe(60);
+    });
+
+    it('should return custom value when specified', () => {
+      const options = { ...defaultOptions, accessTokenExpiryLeeway: 120 };
+      const credentials = new ClientCredentials(options);
+      expect(credentials.accessTokenExpiryLeeway).toBe(120);
+    });
+  });
+
+  describe('getAccessToken', () => {
+    it('should fetch and return access token on first call', async () => {
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          access_token: 'test-token',
+          expires_in: 3600,
+        }),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const credentials = new ClientCredentials(defaultOptions);
+      const token = await credentials.getAccessToken();
+
+      expect(token.value).toBe('test-token');
+      expect(token.scope).toBeUndefined();
+      expect(mockFetch).toHaveBeenCalledWith('https://example.com/token', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: 'grant_type=client_credentials&client_id=test-client-id&client_secret=test-client-secret',
+      });
+    });
+
+    it('should include scope in token when provided in response', async () => {
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          access_token: 'test-token',
+          expires_in: 3600,
+          scope: 'read write admin',
+        }),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const credentials = new ClientCredentials(defaultOptions);
+      const token = await credentials.getAccessToken();
+
+      expect(token.value).toBe('test-token');
+      expect(token.scope).toBe('read write admin');
+    });
+
+    it('should include token params in request body', async () => {
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          access_token: 'test-token',
+          expires_in: 3600,
+          scope: 'read write',
+        }),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const options = {
+        ...defaultOptions,
+        tokenParams: { scope: 'read write', audience: 'api' },
+      };
+      const credentials = new ClientCredentials(options);
+      const token = await credentials.getAccessToken();
+
+      expect(token.scope).toBe('read write');
+      expect(mockFetch).toHaveBeenCalledWith('https://example.com/token', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: 'grant_type=client_credentials&client_id=test-client-id&client_secret=test-client-secret&scope=read+write&audience=api',
+      });
+    });
+
+    it('should return cached token if not expired', async () => {
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          access_token: 'test-token',
+          expires_in: 3600,
+          scope: 'cached-scope',
+        }),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const credentials = new ClientCredentials(defaultOptions);
+
+      // First call
+      await credentials.getAccessToken();
+
+      // Second call - should use cached token
+      const token = await credentials.getAccessToken();
+
+      expect(token.value).toBe('test-token');
+      expect(token.scope).toBe('cached-scope');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should refresh token when expired', async () => {
+      const mockResponse1 = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          access_token: 'test-token-1',
+          expires_in: 100,
+          scope: 'scope-1',
+        }),
+      };
+      const mockResponse2 = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          access_token: 'test-token-2',
+          expires_in: 3600,
+          scope: 'scope-2',
+        }),
+      };
+      mockFetch.mockResolvedValueOnce(mockResponse1).mockResolvedValueOnce(mockResponse2);
+
+      const credentials = new ClientCredentials(defaultOptions);
+
+      // First call
+      await credentials.getAccessToken();
+
+      // Advance time past expiry
+      vi.advanceTimersByTime(100 * 1000);
+
+      // Second call - should refresh token
+      const token = await credentials.getAccessToken();
+
+      expect(token.value).toBe('test-token-2');
+      expect(token.scope).toBe('scope-2');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should refresh token when close to expiry (within leeway)', async () => {
+      const mockResponse1 = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          access_token: 'test-token-1',
+          expires_in: 120,
+          scope: 'scope-1',
+        }),
+      };
+      const mockResponse2 = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          access_token: 'test-token-2',
+          expires_in: 3600,
+          scope: 'scope-2',
+        }),
+      };
+      mockFetch.mockResolvedValueOnce(mockResponse1).mockResolvedValueOnce(mockResponse2);
+
+      const credentials = new ClientCredentials(defaultOptions);
+
+      // First call
+      await credentials.getAccessToken();
+
+      // Advance time to within leeway period (120 - 60 = 60 seconds + 1)
+      vi.advanceTimersByTime(61 * 1000);
+
+      // Second call - should refresh token
+      const token = await credentials.getAccessToken();
+
+      expect(token.value).toBe('test-token-2');
+      expect(token.scope).toBe('scope-2');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should throw error when fetch fails', async () => {
+      const mockResponse = {
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const credentials = new ClientCredentials(defaultOptions);
+
+      await expect(credentials.getAccessToken()).rejects.toThrow(ClientCredentialsError);
+      await expect(credentials.getAccessToken()).rejects.toThrow(
+        'Failed to fetch access token: 401 Unauthorized'
+      );
+    });
+
+    it('should throw error when response is not an object', async () => {
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue('invalid response'),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const credentials = new ClientCredentials(defaultOptions);
+
+      await expect(credentials.getAccessToken()).rejects.toThrow(ClientCredentialsError);
+      await expect(credentials.getAccessToken()).rejects.toThrow(
+        'Invalid response from token endpoint'
+      );
+    });
+
+    it('should throw error when access_token is missing', async () => {
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          expires_in: 3600,
+        }),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const credentials = new ClientCredentials(defaultOptions);
+
+      await expect(credentials.getAccessToken()).rejects.toThrow(ClientCredentialsError);
+      await expect(credentials.getAccessToken()).rejects.toThrow(
+        'Invalid response from token endpoint'
+      );
+    });
+
+    it('should throw error when expires_in is missing', async () => {
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          access_token: 'test-token',
+        }),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const credentials = new ClientCredentials(defaultOptions);
+
+      await expect(credentials.getAccessToken()).rejects.toThrow(ClientCredentialsError);
+      await expect(credentials.getAccessToken()).rejects.toThrow(
+        'Invalid or missing expires_in in token response'
+      );
+    });
+
+    it('should throw error when expires_in is not a number', async () => {
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          access_token: 'test-token',
+          expires_in: 'invalid',
+        }),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const credentials = new ClientCredentials(defaultOptions);
+
+      await expect(credentials.getAccessToken()).rejects.toThrow(ClientCredentialsError);
+      await expect(credentials.getAccessToken()).rejects.toThrow(
+        'Invalid or missing expires_in in token response'
+      );
+    });
+  });
+});

--- a/packages/api/src/client-credentials.ts
+++ b/packages/api/src/client-credentials.ts
@@ -1,0 +1,84 @@
+type Second = number;
+
+export class ClientCredentialsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ClientCredentialsError';
+  }
+}
+
+export type ClientCredentialsOptions = {
+  clientId: string;
+  clientSecret: string;
+  tokenEndpoint: string;
+  tokenParams?: Record<string, string>;
+  /**
+   * The time in seconds before the access token expires to consider it valid.
+   * @default 60
+   */
+  accessTokenExpiryLeeway?: Second;
+};
+
+/**
+ * A class handles client credentials for API authentication. It caches the access token
+ * and provides methods to retrieve it, ensuring the token is valid and refreshing it when necessary.
+ */
+export class ClientCredentials {
+  protected accessToken?: string;
+  protected accessTokenExpiresAt?: Second;
+
+  get AccessTokenExpiryLeeway(): Second {
+    return this.options.accessTokenExpiryLeeway ?? 60;
+  }
+
+  constructor(protected options: ClientCredentialsOptions) { }
+
+  /**
+   * Retrieves the access token, refreshing it if necessary.
+   * @returns The access token as a string.
+   */
+  async getAccessToken(): Promise<string> {
+    const now = new Date();
+
+    // If the access token is not set or has expired, refresh it
+    if (
+      !this.accessToken ||
+      !this.accessTokenExpiresAt ||
+      this.accessTokenExpiresAt <= Math.floor(now.getTime() / 1000) + this.AccessTokenExpiryLeeway
+    ) {
+      const response = await fetch(this.options.tokenEndpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+          grant_type: 'client_credentials',
+          client_id: this.options.clientId,
+          client_secret: this.options.clientSecret,
+          ...this.options.tokenParams,
+        }).toString(),
+      });
+
+      if (!response.ok) {
+        throw new ClientCredentialsError(
+          `Failed to fetch access token: ${response.status} ${response.statusText}`
+        );
+      }
+
+      const data: unknown = await response.json();
+
+      if (typeof data !== 'object' || data === null || !('access_token' in data)) {
+        throw new ClientCredentialsError('Invalid response from token endpoint');
+      }
+
+      if (!('expires_in' in data) || typeof data.expires_in !== 'number') {
+        throw new ClientCredentialsError('Invalid or missing expires_in in token response');
+      }
+
+      this.accessToken = String(data.access_token);
+      this.accessTokenExpiresAt = Math.floor(now.getTime() / 1000) + data.expires_in;
+    }
+
+    return this.accessToken;
+  }
+}

--- a/packages/api/src/management.test.ts
+++ b/packages/api/src/management.test.ts
@@ -1,0 +1,206 @@
+import createClient, { type Middleware } from 'openapi-fetch';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { ClientCredentials } from './client-credentials.js';
+import {
+  createManagementApi,
+  getBaseUrl,
+  getManagementApiIndicator,
+  allScope,
+  type CreateManagementApiOptions,
+} from './management.js';
+
+vi.mock('openapi-fetch');
+vi.mock('./client-credentials.js');
+
+const mockCreateClient = vi.mocked(createClient);
+const MockClientCredentials = vi.mocked(ClientCredentials);
+
+describe('Management API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('getBaseUrl', () => {
+    it('should return correct base URL for given tenant ID', () => {
+      expect(getBaseUrl('test-tenant')).toBe('https://test-tenant.logto.app');
+    });
+  });
+
+  describe('getManagementApiIndicator', () => {
+    it('should return correct management API indicator for given tenant ID', () => {
+      expect(getManagementApiIndicator('test-tenant')).toBe('https://test-tenant.logto.app/api');
+    });
+  });
+
+  describe('createManagementApi', () => {
+    const mockApiClient = {
+      use: vi.fn(),
+    };
+    const mockClientCredentials = {
+      getAccessToken: vi.fn(),
+    };
+
+    beforeEach(() => {
+      // @ts-expect-error
+      mockCreateClient.mockReturnValue(mockApiClient);
+      // @ts-expect-error
+      MockClientCredentials.mockImplementation(() => mockClientCredentials);
+    });
+
+    it('should create management API with default options', () => {
+      const options: CreateManagementApiOptions = {
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+      };
+
+      const result = createManagementApi('test-tenant', options);
+
+      expect(MockClientCredentials).toHaveBeenCalledWith({
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+        tokenEndpoint: 'https://test-tenant.logto.app/oidc/token',
+        tokenParams: {
+          resource: 'https://test-tenant.logto.app/api',
+          scope: allScope,
+        },
+      });
+
+      expect(mockCreateClient).toHaveBeenCalledWith({
+        baseUrl: 'https://test-tenant.logto.app',
+      });
+
+      expect(result.apiClient).toBe(mockApiClient);
+      expect(result.clientCredentials).toBe(mockClientCredentials);
+    });
+
+    it('should create management API with custom base URL and API indicator', () => {
+      const options: CreateManagementApiOptions = {
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+        baseUrl: 'https://custom.example.com',
+        apiIndicator: 'https://custom.example.com/custom-api',
+      };
+
+      createManagementApi('test-tenant', options);
+
+      expect(MockClientCredentials).toHaveBeenCalledWith({
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+        tokenEndpoint: 'https://custom.example.com/oidc/token',
+        tokenParams: {
+          resource: 'https://custom.example.com/custom-api',
+          scope: allScope,
+        },
+      });
+
+      expect(mockCreateClient).toHaveBeenCalledWith({
+        baseUrl: 'https://custom.example.com',
+      });
+    });
+
+    it('should configure API client middleware correctly', async () => {
+      const options: CreateManagementApiOptions = {
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+      };
+
+      mockClientCredentials.getAccessToken.mockResolvedValue({
+        value: 'test-token',
+        scope: allScope,
+      });
+
+      createManagementApi('test-tenant', options);
+
+      expect(mockApiClient.use).toHaveBeenCalledWith({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        onRequest: expect.any(Function),
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const middleware: Middleware = mockApiClient.use.mock.calls[0]?.[0];
+      const mockRequest = {
+        headers: {
+          set: vi.fn(),
+        },
+      };
+
+      const result = await middleware.onRequest?.({
+        schemaPath: '/api/test',
+        // @ts-expect-error: Mock request object
+        request: mockRequest,
+      });
+
+      expect(mockClientCredentials.getAccessToken).toHaveBeenCalled();
+      expect(mockRequest.headers.set).toHaveBeenCalledWith('Authorization', 'Bearer test-token');
+      expect(result).toBe(mockRequest);
+    });
+
+    it('should skip auth for well-known endpoints', async () => {
+      const options: CreateManagementApiOptions = {
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+      };
+
+      createManagementApi('test-tenant', options);
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const middleware: Middleware = mockApiClient.use.mock.calls[0]?.[0];
+      const mockRequest = {
+        headers: {
+          set: vi.fn(),
+        },
+      };
+
+      const result = await middleware.onRequest?.({
+        schemaPath: '/.well-known/openid-configuration',
+        // @ts-expect-error: Mock request object
+        request: mockRequest,
+      });
+
+      expect(mockClientCredentials.getAccessToken).not.toHaveBeenCalled();
+      expect(mockRequest.headers.set).not.toHaveBeenCalled();
+      expect(result).toBeUndefined();
+    });
+
+    it('should warn when scope does not match expected value', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const options: CreateManagementApiOptions = {
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+      };
+
+      mockClientCredentials.getAccessToken.mockResolvedValue({
+        value: 'test-token',
+        scope: 'limited-scope',
+      });
+
+      createManagementApi('test-tenant', options);
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const middleware: Middleware = mockApiClient.use.mock.calls[0]?.[0];
+      const mockRequest = {
+        headers: {
+          set: vi.fn(),
+        },
+      };
+
+      await middleware.onRequest?.({
+        schemaPath: '/api/test',
+        // @ts-expect-error: Mock request object
+        request: mockRequest,
+      });
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        `The scope "limited-scope" is not equal to the expected value "${allScope}". This may cause issues with API access. See https://a.logto.io/m2m-mapi to learn more about configuring machine-to-machine access to the Management API.`
+      );
+
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/packages/api/src/management.ts
+++ b/packages/api/src/management.ts
@@ -1,10 +1,22 @@
-import createClient from 'openapi-fetch';
+import createClient, { type Client } from 'openapi-fetch';
 
 import { ClientCredentials } from './client-credentials.js';
 import { type paths } from './generated-types/management.js';
 
-type CreateManagementApiOptions = {
+/**
+ * Options for creating a Management API client.
+ */
+export type CreateManagementApiOptions = {
+  /**
+   * The client ID for the machine-to-machine application in Logto. This application must be
+   * granted access to the Management API.
+   * @see https://a.logto.io/m2m-mapi for more details on configuring machine-to-machine access.
+   */
   clientId: string;
+  /**
+   * The client secret for the machine-to-machine application in Logto.
+   * This should be kept secure and not exposed in client-side code.
+   */
   clientSecret: string;
   /**
    * Override the base URL generated from the tenant ID.
@@ -18,10 +30,86 @@ type CreateManagementApiOptions = {
   apiIndicator?: string;
 };
 
-const getBaseUrl = (tenantId: string) => `https://${tenantId}.logto.app`;
-const getManagementApiIndicator = (tenantId: string) => `${getBaseUrl(tenantId)}/api`;
+/**
+ * Returns the base URL for the Management API based on the tenant ID.
+ * @param tenantId The tenant ID to construct the base URL.
+ * @returns The base URL for the Management API.
+ */
+export const getBaseUrl = (tenantId: string) => `https://${tenantId}.logto.app`;
 
-export function createManagementApi(tenantId: string, options: CreateManagementApiOptions) {
+/**
+ * Returns the API indicator for the Management API based on the tenant ID.
+ * This will be used as the `resource` parameter when requesting an access token.
+ * @param tenantId The tenant ID to construct the API indicator.
+ * @returns The API indicator for the Management API.
+ */
+export const getManagementApiIndicator = (tenantId: string) => `${getBaseUrl(tenantId)}/api`;
+
+/**
+ * The scope used for accessing all endpoints of the Management API.
+ * This is used when requesting an access token for the Management API.
+ */
+export const allScope = 'all';
+
+type ManagementApiReturnType = {
+  /**
+   * The API client for the Management API.
+   *
+   * This client is configured to use the provided client credentials
+   * and will automatically include the access token in requests.
+   */
+  apiClient: Client<paths>;
+  /**
+   * The client credentials instance used for authentication.
+   */
+  clientCredentials: ClientCredentials;
+};
+
+/**
+ * Creates a Management API client with the specified tenant ID and options.
+ *
+ * Before using this function, ensure that you have created a machine-to-machine application in
+ * Logto and granted it access to the Management API. See the documentation for more details:
+ *
+ * https://a.logto.io/m2m-mapi
+ *
+ * This function sets up the API client with the necessary authentication using client credentials.
+ * It will automatically handle token retrieval and renewal as needed.
+ *
+ * @param tenantId The tenant ID for which to create the Management API client. For OSS deployments,
+ * you can pass any string as the tenant ID, for example, 'default'.
+ * @param options The options for creating the Management API client, including client ID and secret.
+ * @returns An object containing the API client and client credentials instance.
+ * @example
+ * ```ts
+ * import { createManagementApi } from '@logto/api/management';
+ *
+ * // Logto Cloud example
+ * const { apiClient, clientCredentials } = createManagementApi('my-tenant-id', {
+ *   clientId: 'my-client-id',
+ *   clientSecret: 'my-client-secret',
+ * });
+ *
+ * // Use apiClient to make requests to the Management API
+ * const response = await apiClient.GET('/api/users');
+ * console.log(response.data);
+ * ```
+ *
+ * @example
+ * ```ts
+ * // OSS example
+ * const { apiClient, clientCredentials } = createManagementApi('default', {
+ *   clientId: 'my-client-id',
+ *   clientSecret: 'my-client-secret',
+ *   baseUrl: 'https://my-oss-logto-instance.com',
+ *   apiIndicator: 'https://default.logto.app/api',
+ * });
+ * ```
+ */
+export function createManagementApi(
+  tenantId: string,
+  options: CreateManagementApiOptions
+): ManagementApiReturnType {
   const { clientId, clientSecret } = options;
   const baseUrl = options.baseUrl ?? getBaseUrl(tenantId);
   const apiIndicator = options.apiIndicator ?? getManagementApiIndicator(tenantId);
@@ -31,7 +119,7 @@ export function createManagementApi(tenantId: string, options: CreateManagementA
     tokenEndpoint: `${baseUrl}/oidc/token`,
     tokenParams: {
       resource: apiIndicator,
-      scope: 'all',
+      scope: allScope,
     },
   });
   const apiClient = createClient<paths>({
@@ -41,11 +129,18 @@ export function createManagementApi(tenantId: string, options: CreateManagementA
   apiClient.use({
     async onRequest({ schemaPath, request }) {
       if (schemaPath.includes('/.well-known/')) {
-        // Skip authentication for well-known endpoints
+        // Skip auth for well-known endpoints
         return;
       }
-      const accessToken = await clientCredentials.getAccessToken();
-      request.headers.set('Authorization', `Bearer ${accessToken}`);
+      const { value, scope } = await clientCredentials.getAccessToken();
+
+      if (scope !== allScope) {
+        console.warn(
+          `The scope "${scope}" is not equal to the expected value "${allScope}". This may cause issues with API access. See https://a.logto.io/m2m-mapi to learn more about configuring machine-to-machine access to the Management API.`
+        );
+      }
+
+      request.headers.set('Authorization', `Bearer ${value}`);
       return request;
     },
   });

--- a/packages/api/src/management.ts
+++ b/packages/api/src/management.ts
@@ -1,0 +1,57 @@
+import createClient from 'openapi-fetch';
+
+import { ClientCredentials } from './client-credentials.js';
+import { type paths } from './generated-types/management.js';
+
+type CreateManagementApiOptions = {
+  clientId: string;
+  clientSecret: string;
+  /**
+   * Override the base URL generated from the tenant ID.
+   * Useful for testing or custom deployments.
+   */
+  baseUrl?: string;
+  /**
+   * Override the API indicator for the management API.
+   * Useful for testing or custom deployments.
+   */
+  apiIndicator?: string;
+};
+
+const getBaseUrl = (tenantId: string) => `https://${tenantId}.logto.app`;
+const getManagementApiIndicator = (tenantId: string) => `${getBaseUrl(tenantId)}/api`;
+
+export function createManagementApi(tenantId: string, options: CreateManagementApiOptions) {
+  const { clientId, clientSecret } = options;
+  const baseUrl = options.baseUrl ?? getBaseUrl(tenantId);
+  const apiIndicator = options.apiIndicator ?? getManagementApiIndicator(tenantId);
+  const clientCredentials = new ClientCredentials({
+    clientId,
+    clientSecret,
+    tokenEndpoint: `${baseUrl}/oidc/token`,
+    tokenParams: {
+      resource: apiIndicator,
+      scope: 'all',
+    },
+  });
+  const apiClient = createClient<paths>({
+    baseUrl,
+  });
+
+  apiClient.use({
+    async onRequest({ schemaPath, request }) {
+      if (schemaPath.includes('/.well-known/')) {
+        // Skip authentication for well-known endpoints
+        return;
+      }
+      const accessToken = await clientCredentials.getAccessToken();
+      request.headers.set('Authorization', `Bearer ${accessToken}`);
+      return request;
+    },
+  });
+
+  return {
+    apiClient,
+    clientCredentials,
+  };
+}

--- a/packages/api/tsconfig.build.json
+++ b/packages/api/tsconfig.build.json
@@ -2,5 +2,8 @@
   "extends": "./tsconfig",
   "include": [
     "src/"
+  ],
+  "exclude": [
+    "src/**/*.test.ts",
   ]
 }

--- a/packages/api/tsconfig.build.json
+++ b/packages/api/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig",
+  "include": [
+    "src/"
+  ]
+}

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@silverhand/ts-config/tsconfig.base",
+  "compilerOptions": {
+    "outDir": "lib",
+    "baseUrl": ".",
+  },
+  "include": [
+    "src",
+    "*.config.ts",
+    "*.setup.ts"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,31 @@ importers:
         specifier: ^6.2.7
         version: 6.2.7(@types/node@22.14.1)(jiti@1.21.0)(lightningcss@1.25.1)(sass@1.77.8)(yaml@2.4.5)
 
+  packages/api:
+    dependencies:
+      openapi-fetch:
+        specifier: ^0.14.0
+        version: 0.14.0
+    devDependencies:
+      '@silverhand/eslint-config':
+        specifier: 6.0.1
+        version: 6.0.1(eslint@8.57.0)(prettier@3.5.3)(typescript@5.5.3)
+      '@silverhand/ts-config':
+        specifier: 6.0.0
+        version: 6.0.0(typescript@5.5.3)
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.0
+      openapi-typescript:
+        specifier: ^7.8.0
+        version: 7.8.0(typescript@5.5.3)
+      prettier:
+        specifier: ^3.5.3
+        version: 3.5.3
+      typescript:
+        specifier: ^5.5.3
+        version: 5.5.3
+
   packages/app-insights:
     dependencies:
       '@silverhand/essentials':
@@ -7081,6 +7106,16 @@ packages:
     peerDependencies:
       '@redis/client': ^1.0.0
 
+  '@redocly/ajv@8.11.2':
+    resolution: {integrity: sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==}
+
+  '@redocly/config@0.22.2':
+    resolution: {integrity: sha512-roRDai8/zr2S9YfmzUfNhKjOF0NdcOIqF7bhf4MVC5UxpjIysDjyudvlAiVbpPHp3eDRWbdzUgtkK1a7YiDNyQ==}
+
+  '@redocly/openapi-core@1.34.3':
+    resolution: {integrity: sha512-3arRdUp1fNx55itnjKiUhO6t4Mf91TsrTIYINDNLAZPS0TPd5YpiXRctwjel0qqWoOOhjA34cZ3m4dksLDFUYg==}
+    engines: {node: '>=18.17.0', npm: '>=9.5.0'}
+
   '@remix-run/router@1.18.0':
     resolution: {integrity: sha512-L3jkqmqoSVBVKHfpGZmLrex0lxR5SucGA0sUfFzGctehw+S/ggL9L/0NnC5mw6P8HUWpFZ3nQw3cRApjjWx9Sw==}
     engines: {node: '>=14.0.0'}
@@ -8892,6 +8927,9 @@ packages:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  change-case@5.4.4:
+    resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
@@ -9073,6 +9111,9 @@ packages:
 
   colord@2.9.3:
     resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
+
+  colorette@1.4.0:
+    resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
@@ -10363,16 +10404,9 @@ packages:
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
-  flat-cache@3.0.4:
-    resolution: {integrity: sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-
   flat-cache@3.2.0:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
     engines: {node: ^10.12.0 || >=12.0.0}
-
-  flatted@3.2.7:
-    resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
 
   flatted@3.3.1:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
@@ -10953,6 +10987,10 @@ packages:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
     engines: {node: '>=12'}
 
+  index-to-position@1.1.0:
+    resolution: {integrity: sha512-XPdx9Dq4t9Qk1mTMbWONJqU7boCoumEH7fRET37HX5+khDUl3J2W6PdALxhILYlIYx2amlwYcRPp28p0tSiojg==}
+    engines: {node: '>=18'}
+
   inflation@2.0.0:
     resolution: {integrity: sha512-m3xv4hJYR2oXw4o4Y5l6P5P16WYmazYof+el6Al3f+YlggGj6qT9kImBAnzDelRALnP5d3h4jGBPKzYCizjZZw==}
     engines: {node: '>= 0.8.0'}
@@ -11513,6 +11551,10 @@ packages:
 
   js-base64@3.7.5:
     resolution: {integrity: sha512-3MEt5DTINKqfScXKfJFrRbxkrnk2AxPWGBL/ycjz4dK8iqiSJ06UxD8jh8xuh6p10TX4t2+7FsBYVxxQbMg+qA==}
+
+  js-levenshtein@1.1.6:
+    resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
+    engines: {node: '>=0.10.0'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -12379,6 +12421,10 @@ packages:
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
+  minimatch@5.1.6:
+    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
+    engines: {node: '>=10'}
+
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -12669,11 +12715,23 @@ packages:
       zod:
         optional: true
 
+  openapi-fetch@0.14.0:
+    resolution: {integrity: sha512-PshIdm1NgdLvb05zp8LqRQMNSKzIlPkyMxYFxwyHR+UlKD4t2nUjkDhNxeRbhRSEd3x5EUNh2w5sJYwkhOH4fg==}
+
   openapi-schema-validator@12.1.3:
     resolution: {integrity: sha512-xTHOmxU/VQGUgo7Cm0jhwbklOKobXby+/237EG967+3TQEYJztMgX9Q5UE2taZKwyKPUq0j11dngpGjUuxz1hQ==}
 
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
+
+  openapi-typescript-helpers@0.0.15:
+    resolution: {integrity: sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==}
+
+  openapi-typescript@7.8.0:
+    resolution: {integrity: sha512-1EeVWmDzi16A+siQlo/SwSGIT7HwaFAVjvMA7/jG5HMLSnrUOzPL7uSTRZZa4v/LCRxHTApHKtNY6glApEoiUQ==}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.x
 
   optionator@0.9.3:
     resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
@@ -12823,6 +12881,10 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
+
+  parse-json@8.3.0:
+    resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
+    engines: {node: '>=18'}
 
   parse-passwd@1.0.0:
     resolution: {integrity: sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==}
@@ -14237,6 +14299,10 @@ packages:
     resolution: {integrity: sha512-qlsr7fIC0lSddmA3tzojvzubYxvlGtzumcdHgPwbFWMISQwL22MhM2Y3LNt+6w9Yyx7559VW5ab70dgphm8qQA==}
     engines: {node: '>=14.18.0'}
 
+  supports-color@10.0.0:
+    resolution: {integrity: sha512-HRVVSbCCMbj7/kdWF9Q+bbckjBHLtHMEoJWlkmYzzdwhYMkjkOwubLM6t7NbWKjgKamGDrWL1++KrjUO1t9oAQ==}
+    engines: {node: '>=18'}
+
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -14561,6 +14627,10 @@ packages:
     resolution: {integrity: sha512-tB9lu0pQpX5KJq54g+oHOLumOx+pMep4RaM6liXh2PKmVRFF+/vAtUP0ZaJ0kOySfVNjF6doBWPHhBhISKdlIA==}
     engines: {node: '>=16'}
 
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
@@ -14677,6 +14747,9 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  uri-js-replace@1.0.1:
+    resolution: {integrity: sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -15108,6 +15181,9 @@ packages:
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
+
+  yaml-ast-parser@0.0.43:
+    resolution: {integrity: sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==}
 
   yaml@2.3.3:
     resolution: {integrity: sha512-zw0VAJxgeZ6+++/su5AFoqBbZbrEakwu+X0M5HmcwUiBL7AzcuPKjj5we4xfQLp78LkEMpD0cOnUhmgOVy3KdQ==}
@@ -15917,7 +15993,7 @@ snapshots:
   '@babel/core@7.24.4':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.27.1
       '@babel/generator': 7.24.4
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.24.4)
@@ -16032,7 +16108,7 @@ snapshots:
       '@babel/helper-module-imports': 7.24.3
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/helper-validator-identifier': 7.27.1
 
   '@babel/helper-module-transforms@7.24.9(@babel/core@7.24.9)':
     dependencies:
@@ -16095,7 +16171,7 @@ snapshots:
 
   '@babel/highlight@7.22.5':
     dependencies:
-      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/helper-validator-identifier': 7.27.1
       chalk: 2.4.2
       js-tokens: 4.0.0
 
@@ -16108,7 +16184,7 @@ snapshots:
 
   '@babel/highlight@7.24.7':
     dependencies:
-      '@babel/helper-validator-identifier': 7.25.7
+      '@babel/helper-validator-identifier': 7.27.1
       chalk: 2.4.2
       js-tokens: 4.0.0
       picocolors: 1.1.1
@@ -16217,13 +16293,13 @@ snapshots:
 
   '@babel/template@7.18.10':
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.27.1
       '@babel/parser': 7.26.3
       '@babel/types': 7.26.3
 
   '@babel/template@7.24.0':
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.27.1
       '@babel/parser': 7.26.3
       '@babel/types': 7.26.3
 
@@ -16235,13 +16311,13 @@ snapshots:
 
   '@babel/template@7.27.0':
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.27.1
       '@babel/parser': 7.27.0
       '@babel/types': 7.27.0
 
   '@babel/traverse@7.24.1':
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.27.1
       '@babel/generator': 7.24.4
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
@@ -16284,7 +16360,7 @@ snapshots:
   '@babel/types@7.26.3':
     dependencies:
       '@babel/helper-string-parser': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/helper-validator-identifier': 7.27.1
 
   '@babel/types@7.27.0':
     dependencies:
@@ -18197,6 +18273,29 @@ snapshots:
     dependencies:
       '@redis/client': 1.5.16
 
+  '@redocly/ajv@8.11.2':
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js-replace: 1.0.1
+
+  '@redocly/config@0.22.2': {}
+
+  '@redocly/openapi-core@1.34.3(supports-color@10.0.0)':
+    dependencies:
+      '@redocly/ajv': 8.11.2
+      '@redocly/config': 0.22.2
+      colorette: 1.4.0
+      https-proxy-agent: 7.0.6(supports-color@10.0.0)
+      js-levenshtein: 1.1.6
+      js-yaml: 4.1.0
+      minimatch: 5.1.6
+      pluralize: 8.0.0
+      yaml-ast-parser: 0.0.43
+    transitivePeerDependencies:
+      - supports-color
+
   '@remix-run/router@1.18.0': {}
 
   '@rollup/plugin-node-resolve@15.2.3(rollup@4.40.1)':
@@ -20003,12 +20102,12 @@ snapshots:
 
   acorn-globals@7.0.1:
     dependencies:
-      acorn: 8.11.3
+      acorn: 8.14.1
       acorn-walk: 8.3.2
 
-  acorn-import-assertions@1.9.0(acorn@8.11.3):
+  acorn-import-assertions@1.9.0(acorn@8.14.1):
     dependencies:
-      acorn: 8.11.3
+      acorn: 8.14.1
 
   acorn-jsx@5.3.2(acorn@8.10.0):
     dependencies:
@@ -20017,6 +20116,10 @@ snapshots:
   acorn-jsx@5.3.2(acorn@8.11.3):
     dependencies:
       acorn: 8.11.3
+
+  acorn-jsx@5.3.2(acorn@8.14.1):
+    dependencies:
+      acorn: 8.14.1
 
   acorn-walk@8.3.2: {}
 
@@ -20566,6 +20669,8 @@ snapshots:
 
   chalk@5.3.0: {}
 
+  change-case@5.4.4: {}
+
   char-regex@1.0.2: {}
 
   character-entities-html4@2.1.0: {}
@@ -20747,6 +20852,8 @@ snapshots:
       color-string: 1.9.1
 
   colord@2.9.3: {}
+
+  colorette@1.4.0: {}
 
   colorette@2.0.20: {}
 
@@ -21212,6 +21319,12 @@ snapshots:
   debug@4.3.7:
     dependencies:
       ms: 2.1.3
+
+  debug@4.4.0(supports-color@10.0.0):
+    dependencies:
+      ms: 2.1.3
+    optionalDependencies:
+      supports-color: 10.0.0
 
   debug@4.4.0(supports-color@5.5.0):
     dependencies:
@@ -21882,7 +21995,7 @@ snapshots:
 
   eslint-plugin-unicorn@52.0.0(eslint@8.57.0):
     dependencies:
-      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/helper-validator-identifier': 7.27.1
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@eslint/eslintrc': 2.1.4
       ci-info: 4.0.0
@@ -21933,7 +22046,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.3.4
+      debug: 4.4.0(supports-color@5.5.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -21967,12 +22080,12 @@ snapshots:
     dependencies:
       acorn: 8.10.0
       acorn-jsx: 5.3.2(acorn@8.10.0)
-      eslint-visitor-keys: 3.4.1
+      eslint-visitor-keys: 3.4.3
 
   espree@9.6.1:
     dependencies:
-      acorn: 8.11.3
-      acorn-jsx: 5.3.2(acorn@8.11.3)
+      acorn: 8.14.1
+      acorn-jsx: 5.3.2(acorn@8.14.1)
       eslint-visitor-keys: 3.4.3
 
   esprima@4.0.1: {}
@@ -22164,7 +22277,7 @@ snapshots:
 
   file-entry-cache@6.0.1:
     dependencies:
-      flat-cache: 3.0.4
+      flat-cache: 3.2.0
 
   file-entry-cache@7.0.2:
     dependencies:
@@ -22230,18 +22343,11 @@ snapshots:
       mlly: 1.7.4
       rollup: 4.40.1
 
-  flat-cache@3.0.4:
-    dependencies:
-      flatted: 3.2.7
-      rimraf: 3.0.2
-
   flat-cache@3.2.0:
     dependencies:
       flatted: 3.3.1
       keyv: 4.5.4
       rimraf: 3.0.2
-
-  flatted@3.2.7: {}
 
   flatted@3.3.1: {}
 
@@ -22337,8 +22443,8 @@ snapshots:
   function.prototype.name@1.1.5:
     dependencies:
       call-bind: 1.0.7
-      define-properties: 1.1.4
-      es-abstract: 1.20.4
+      define-properties: 1.2.1
+      es-abstract: 1.23.3
       functions-have-names: 1.2.3
 
   function.prototype.name@1.1.6:
@@ -22880,6 +22986,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  https-proxy-agent@7.0.6(supports-color@10.0.0):
+    dependencies:
+      agent-base: 7.1.3
+      debug: 4.4.0(supports-color@10.0.0)
+    transitivePeerDependencies:
+      - supports-color
+
   human-id@1.0.2: {}
 
   human-signals@2.1.0: {}
@@ -22936,8 +23049,8 @@ snapshots:
 
   import-in-the-middle@1.4.2:
     dependencies:
-      acorn: 8.11.3
-      acorn-import-assertions: 1.9.0(acorn@8.11.3)
+      acorn: 8.14.1
+      acorn-import-assertions: 1.9.0(acorn@8.14.1)
       cjs-module-lexer: 1.2.2
       module-details-from-path: 1.0.3
 
@@ -22957,6 +23070,8 @@ snapshots:
   indent-string@4.0.0: {}
 
   indent-string@5.0.0: {}
+
+  index-to-position@1.1.0: {}
 
   inflation@2.0.0: {}
 
@@ -23712,6 +23827,8 @@ snapshots:
   joycon@3.1.1: {}
 
   js-base64@3.7.5: {}
+
+  js-levenshtein@1.1.6: {}
 
   js-tokens@4.0.0: {}
 
@@ -25016,6 +25133,10 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
+  minimatch@5.1.6:
+    dependencies:
+      brace-expansion: 2.0.2
+
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.2
@@ -25213,7 +25334,7 @@ snapshots:
   object.assign@4.1.4:
     dependencies:
       call-bind: 1.0.7
-      define-properties: 1.1.4
+      define-properties: 1.2.1
       has-symbols: 1.1.0
       object-keys: 1.1.1
 
@@ -25315,6 +25436,10 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  openapi-fetch@0.14.0:
+    dependencies:
+      openapi-typescript-helpers: 0.0.15
+
   openapi-schema-validator@12.1.3:
     dependencies:
       ajv: 8.12.0
@@ -25323,6 +25448,18 @@ snapshots:
       openapi-types: 12.1.3
 
   openapi-types@12.1.3: {}
+
+  openapi-typescript-helpers@0.0.15: {}
+
+  openapi-typescript@7.8.0(typescript@5.5.3):
+    dependencies:
+      '@redocly/openapi-core': 1.34.3(supports-color@10.0.0)
+      ansi-colors: 4.1.3
+      change-case: 5.4.4
+      parse-json: 8.3.0
+      supports-color: 10.0.0
+      typescript: 5.5.3
+      yargs-parser: 21.1.1
 
   optionator@0.9.3:
     dependencies:
@@ -25342,7 +25479,7 @@ snapshots:
       is-interactive: 2.0.0
       is-unicode-supported: 1.3.0
       log-symbols: 5.1.0
-      strip-ansi: 7.0.1
+      strip-ansi: 7.1.0
       wcwidth: 1.0.1
 
   ora@8.0.1:
@@ -25494,10 +25631,16 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.22.5
+      '@babel/code-frame': 7.27.1
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+
+  parse-json@8.3.0:
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      index-to-position: 1.1.0
+      type-fest: 4.41.0
 
   parse-passwd@1.0.0: {}
 
@@ -26334,7 +26477,7 @@ snapshots:
   regexp.prototype.flags@1.4.3:
     dependencies:
       call-bind: 1.0.7
-      define-properties: 1.1.4
+      define-properties: 1.2.1
       functions-have-names: 1.2.3
 
   regexp.prototype.flags@1.5.2:
@@ -26889,8 +27032,8 @@ snapshots:
   string.prototype.trimend@1.0.5:
     dependencies:
       call-bind: 1.0.7
-      define-properties: 1.1.4
-      es-abstract: 1.20.4
+      define-properties: 1.2.1
+      es-abstract: 1.23.3
 
   string.prototype.trimend@1.0.8:
     dependencies:
@@ -26901,8 +27044,8 @@ snapshots:
   string.prototype.trimstart@1.0.5:
     dependencies:
       call-bind: 1.0.7
-      define-properties: 1.1.4
-      es-abstract: 1.20.4
+      define-properties: 1.2.1
+      es-abstract: 1.23.3
 
   string.prototype.trimstart@1.0.8:
     dependencies:
@@ -27073,6 +27216,8 @@ snapshots:
       superagent: 9.0.1
     transitivePeerDependencies:
       - supports-color
+
+  supports-color@10.0.0: {}
 
   supports-color@5.5.0:
     dependencies:
@@ -27392,6 +27537,8 @@ snapshots:
 
   type-fest@4.15.0: {}
 
+  type-fest@4.41.0: {}
+
   type-is@1.6.18:
     dependencies:
       media-typer: 0.3.0
@@ -27532,6 +27679,8 @@ snapshots:
       browserslist: 4.23.2
       escalade: 3.1.2
       picocolors: 1.1.1
+
+  uri-js-replace@1.0.1: {}
 
   uri-js@4.4.1:
     dependencies:
@@ -27882,7 +28031,7 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.1
       string-width: 5.1.2
-      strip-ansi: 7.0.1
+      strip-ansi: 7.1.0
 
   wrap-ansi@8.1.0:
     dependencies:
@@ -27946,6 +28095,8 @@ snapshots:
   yallist@4.0.0: {}
 
   yallist@5.0.0: {}
+
+  yaml-ast-parser@0.0.43: {}
 
   yaml@2.3.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@silverhand/ts-config':
         specifier: 6.0.0
         version: 6.0.0(typescript@5.5.3)
+      '@vitest/coverage-v8':
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1(@types/debug@4.1.12)(@types/node@22.14.1)(jiti@1.21.0)(jsdom@26.0.0)(lightningcss@1.25.1)(sass@1.77.8)(yaml@2.4.5))
       eslint:
         specifier: ^8.57.0
         version: 8.57.0
@@ -89,6 +92,9 @@ importers:
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
+      vitest:
+        specifier: ^3.1.1
+        version: 3.1.1(@types/debug@4.1.12)(@types/node@22.14.1)(jiti@1.21.0)(jsdom@26.0.0)(lightningcss@1.25.1)(sass@1.77.8)(yaml@2.4.5)
 
   packages/app-insights:
     dependencies:
@@ -5299,11 +5305,6 @@ packages:
 
   '@babel/parser@7.24.8':
     resolution: {integrity: sha512-WzfbgXOkGzZiXXCqk43kKwZjzwx4oulxZi3nq2TYL9mOjQv6kYwul9mz6ID36njuL7Xkp6nJEfok848Zj10j/w==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@7.26.3':
-    resolution: {integrity: sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -15998,10 +15999,10 @@ snapshots:
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.24.4)
       '@babel/helpers': 7.27.0
-      '@babel/parser': 7.26.3
+      '@babel/parser': 7.27.0
       '@babel/template': 7.24.0
       '@babel/traverse': 7.24.1
-      '@babel/types': 7.26.3
+      '@babel/types': 7.27.0
       convert-source-map: 2.0.0
       debug: 4.4.0(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
@@ -16032,21 +16033,21 @@ snapshots:
 
   '@babel/generator@7.20.4':
     dependencies:
-      '@babel/types': 7.26.3
-      '@jridgewell/gen-mapping': 0.3.5
+      '@babel/types': 7.27.0
+      '@jridgewell/gen-mapping': 0.3.8
       jsesc: 2.5.2
 
   '@babel/generator@7.24.10':
     dependencies:
-      '@babel/types': 7.26.3
-      '@jridgewell/gen-mapping': 0.3.5
+      '@babel/types': 7.27.0
+      '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
 
   '@babel/generator@7.24.4':
     dependencies:
-      '@babel/types': 7.26.3
-      '@jridgewell/gen-mapping': 0.3.5
+      '@babel/types': 7.27.0
+      '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
 
@@ -16070,34 +16071,34 @@ snapshots:
 
   '@babel/helper-environment-visitor@7.24.7':
     dependencies:
-      '@babel/types': 7.26.3
+      '@babel/types': 7.27.0
 
   '@babel/helper-function-name@7.23.0':
     dependencies:
       '@babel/template': 7.24.0
-      '@babel/types': 7.26.3
+      '@babel/types': 7.27.0
 
   '@babel/helper-function-name@7.24.7':
     dependencies:
       '@babel/template': 7.24.7
-      '@babel/types': 7.26.3
+      '@babel/types': 7.27.0
 
   '@babel/helper-hoist-variables@7.22.5':
     dependencies:
-      '@babel/types': 7.26.3
+      '@babel/types': 7.27.0
 
   '@babel/helper-hoist-variables@7.24.7':
     dependencies:
-      '@babel/types': 7.26.3
+      '@babel/types': 7.27.0
 
   '@babel/helper-module-imports@7.24.3':
     dependencies:
-      '@babel/types': 7.26.3
+      '@babel/types': 7.27.0
 
   '@babel/helper-module-imports@7.24.7':
     dependencies:
       '@babel/traverse': 7.24.8
-      '@babel/types': 7.26.3
+      '@babel/types': 7.27.0
     transitivePeerDependencies:
       - supports-color
 
@@ -16127,22 +16128,22 @@ snapshots:
 
   '@babel/helper-simple-access@7.22.5':
     dependencies:
-      '@babel/types': 7.26.3
+      '@babel/types': 7.27.0
 
   '@babel/helper-simple-access@7.24.7':
     dependencies:
       '@babel/traverse': 7.24.8
-      '@babel/types': 7.26.3
+      '@babel/types': 7.27.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-split-export-declaration@7.22.6':
     dependencies:
-      '@babel/types': 7.26.3
+      '@babel/types': 7.27.0
 
   '@babel/helper-split-export-declaration@7.24.7':
     dependencies:
-      '@babel/types': 7.26.3
+      '@babel/types': 7.27.0
 
   '@babel/helper-string-parser@7.23.4': {}
 
@@ -16191,15 +16192,11 @@ snapshots:
 
   '@babel/parser@7.24.4':
     dependencies:
-      '@babel/types': 7.26.3
+      '@babel/types': 7.27.0
 
   '@babel/parser@7.24.8':
     dependencies:
-      '@babel/types': 7.26.3
-
-  '@babel/parser@7.26.3':
-    dependencies:
-      '@babel/types': 7.26.3
+      '@babel/types': 7.27.0
 
   '@babel/parser@7.27.0':
     dependencies:
@@ -16294,20 +16291,20 @@ snapshots:
   '@babel/template@7.18.10':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.26.3
-      '@babel/types': 7.26.3
+      '@babel/parser': 7.27.0
+      '@babel/types': 7.27.0
 
   '@babel/template@7.24.0':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.26.3
-      '@babel/types': 7.26.3
+      '@babel/parser': 7.27.0
+      '@babel/types': 7.27.0
 
   '@babel/template@7.24.7':
     dependencies:
       '@babel/code-frame': 7.24.7
-      '@babel/parser': 7.26.3
-      '@babel/types': 7.26.3
+      '@babel/parser': 7.27.0
+      '@babel/types': 7.27.0
 
   '@babel/template@7.27.0':
     dependencies:
@@ -16323,8 +16320,8 @@ snapshots:
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/parser': 7.26.3
-      '@babel/types': 7.26.3
+      '@babel/parser': 7.27.0
+      '@babel/types': 7.27.0
       debug: 4.4.0(supports-color@5.5.0)
       globals: 11.12.0
     transitivePeerDependencies:
@@ -16338,8 +16335,8 @@ snapshots:
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-hoist-variables': 7.24.7
       '@babel/helper-split-export-declaration': 7.24.7
-      '@babel/parser': 7.26.3
-      '@babel/types': 7.26.3
+      '@babel/parser': 7.27.0
+      '@babel/types': 7.27.0
       debug: 4.4.0(supports-color@5.5.0)
       globals: 11.12.0
     transitivePeerDependencies:
@@ -16365,7 +16362,7 @@ snapshots:
   '@babel/types@7.27.0':
     dependencies:
       '@babel/helper-string-parser': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/helper-validator-identifier': 7.27.1
 
   '@bcoe/v8-coverage@0.2.3': {}
 
@@ -18430,10 +18427,10 @@ snapshots:
       eslint-config-prettier: 9.1.0(eslint@8.57.0)
       eslint-config-xo: 0.44.0(eslint@8.57.0)
       eslint-config-xo-typescript: 4.0.0(@typescript-eslint/eslint-plugin@7.7.0(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3))(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3)
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
       eslint-plugin-consistent-default-export-name: 0.0.15
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-n: 17.2.1(eslint@8.57.0)
       eslint-plugin-no-use-extend-native: 0.5.0
       eslint-plugin-prettier: 5.1.3(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.5.3)
@@ -18905,7 +18902,7 @@ snapshots:
 
   '@svgr/hast-util-to-babel-ast@8.0.0':
     dependencies:
-      '@babel/types': 7.26.3
+      '@babel/types': 7.27.0
       entities: 4.5.0
 
   '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.5.3))':
@@ -19047,8 +19044,8 @@ snapshots:
 
   '@types/babel__core@7.1.19':
     dependencies:
-      '@babel/parser': 7.26.3
-      '@babel/types': 7.26.3
+      '@babel/parser': 7.27.0
+      '@babel/types': 7.27.0
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
       '@types/babel__traverse': 7.18.2
@@ -19063,16 +19060,16 @@ snapshots:
 
   '@types/babel__generator@7.6.4':
     dependencies:
-      '@babel/types': 7.26.3
+      '@babel/types': 7.27.0
 
   '@types/babel__template@7.4.1':
     dependencies:
-      '@babel/parser': 7.26.3
-      '@babel/types': 7.26.3
+      '@babel/parser': 7.27.0
+      '@babel/types': 7.27.0
 
   '@types/babel__traverse@7.18.2':
     dependencies:
-      '@babel/types': 7.26.3
+      '@babel/types': 7.27.0
 
   '@types/body-parser@1.19.2':
     dependencies:
@@ -20426,7 +20423,7 @@ snapshots:
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
       '@babel/template': 7.18.10
-      '@babel/types': 7.26.3
+      '@babel/types': 7.27.0
       '@types/babel__core': 7.1.19
       '@types/babel__traverse': 7.18.2
 
@@ -21831,13 +21828,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0):
     dependencies:
       debug: 4.4.0(supports-color@5.5.0)
       enhanced-resolve: 5.16.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.3
       is-core-module: 2.13.1
@@ -21848,14 +21845,14 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.7.0(eslint@8.57.0)(typescript@5.5.3)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -21877,7 +21874,7 @@ snapshots:
       eslint: 8.57.0
       ignore: 5.3.1
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -21887,7 +21884,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -22132,7 +22129,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
 
   esutils@2.0.3: {}
 
@@ -23386,7 +23383,7 @@ snapshots:
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.24.9
-      '@babel/parser': 7.26.3
+      '@babel/parser': 7.27.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -23396,7 +23393,7 @@ snapshots:
   istanbul-lib-instrument@6.0.1:
     dependencies:
       '@babel/core': 7.24.9
-      '@babel/parser': 7.26.3
+      '@babel/parser': 7.27.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 7.7.1


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->


<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

This PR introduces `@logto/api`, a TypeScript SDK for Logto's APIs using client credentials flow. The initial version includes Management API.

### Features
- OAuth 2.0 M2M authentication with automatic token management
- Full TypeScript support with OpenAPI-generated types
- Supports both Logto Cloud and self-hosted deployments
- Middleware automatically includes access tokens in requests

### Usage
```ts
import { createManagementApi } from '@logto/api/management';

// Logto Cloud
const { apiClient } = createManagementApi('tenant-id', {
  clientId: 'client-id',
  clientSecret: 'client-secret',
});

// Self-hosted
const { apiClient } = createManagementApi('default', {
  clientId: 'client-id',
  clientSecret: 'client-secret',
  baseUrl: 'https://your-instance.com',
});

const response = await apiClient.GET('/api/users');
console.log(response.data);
```

The SDK handles token caching, renewal, and proper error handling automatically.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

- added unit tests
- manually tested with Logto Cloud

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments

