### PR TITLE
feat(core): add google identity support for OTT

### DIFF
--- a/packages/phrases/src/locales/en/errors/session.ts
+++ b/packages/phrases/src/locales/en/errors/session.ts
@@ -55,6 +55,7 @@ const session = {
   },
   google_one_tap: {
     invalid_id_token: 'Invalid Google ID Token.',
+    invalid_id_token_payload: 'Invalid Google ID Token payload.',
     unverified_email: 'Unverified email.',
   },
 };

--- a/packages/schemas/src/foundations/jsonb-types/one-time-tokens.ts
+++ b/packages/schemas/src/foundations/jsonb-types/one-time-tokens.ts
@@ -1,14 +1,17 @@
-import { type ToZodObject } from '@logto/connector-kit';
+import { type ToZodObject, GoogleConnector } from '@logto/connector-kit';
 import { z } from 'zod';
 
 export type OneTimeTokenContext = {
   // Used for organization JIT provisioning.
   jitOrganizationIds?: string[];
+  // Used for Google One Tap to carry the Google Identity Sub.
+  [GoogleConnector.oneTimeTokenContextKey]?: string;
 };
 
 export const oneTimeTokenContextGuard = z
   .object({
     jitOrganizationIds: z.string().array(),
+    [GoogleConnector.oneTimeTokenContextKey]: z.string(),
   })
   .partial() satisfies ToZodObject<OneTimeTokenContext>;
 

--- a/packages/toolkit/connector-kit/src/types/social.ts
+++ b/packages/toolkit/connector-kit/src/types/social.ts
@@ -116,6 +116,12 @@ export const tokenResponseGuard = z.object({
   token_type: z.string().optional(),
 }) satisfies ToZodObject<TokenResponse>;
 
+export const googleOneTapIdTokenPayloadGuard = z.object({
+  sub: z.string(),
+  email: z.string(),
+  email_verified: z.boolean(),
+});
+
 export type GetTokenResponseAndUserInfo = (
   data: unknown,
   getSession: GetSession
@@ -193,6 +199,8 @@ export const GoogleConnector = Object.freeze({
     prompts: oidcPromptsGuard,
     oneTap: googleOneTapConfigGuard.optional(),
   }) satisfies ToZodObject<GoogleConnectorConfig>,
+  // Use this key in One Time Token context to store the Google Identity Sub from Google One Tap.
+  oneTimeTokenContextKey: 'googleIdentitySub',
 });
 
 export type GoogleConnectorConfig = {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Extend one time token (OTT) context, support `googleIdentitySub` now, in this way, we can use one time token create user for Google one tap (with Google identity linked).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test this with Google One Tap flow.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
