### PR TITLE
refactor(core): refactor sso getUserInfo endpoint

### DIFF
--- a/packages/core/src/routes/interaction/utils/single-sign-on.test.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on.test.ts
@@ -197,8 +197,9 @@ describe('Single sign on util methods tests', () => {
       };
 
       getSingleSignOnSessionResultMock.mockResolvedValueOnce(session);
-
-      getUserInfoMock.mockResolvedValueOnce({ id: 'id', email: 'email' });
+      getUserInfoMock.mockResolvedValueOnce({
+        userInfo: { id: 'id', email: 'email' },
+      });
       getIssuerMock.mockReturnValueOnce('https://example.com');
 
       const result = await getSsoAuthentication(

--- a/packages/core/src/routes/interaction/utils/single-sign-on.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on.ts
@@ -161,7 +161,7 @@ export const verifySsoIdentity = async (
       envSet.endpoint
     );
     const issuer = await connectorInstance.getIssuer();
-    const userInfo = await connectorInstance.getUserInfo(singleSignOnSession, data);
+    const { userInfo } = await connectorInstance.getUserInfo(singleSignOnSession, data);
 
     log.append({ issuer, userInfo });
 

--- a/packages/core/src/sso/OidcConnector/utils.test.ts
+++ b/packages/core/src/sso/OidcConnector/utils.test.ts
@@ -219,6 +219,6 @@ describe('fetchToken', () => {
         data,
         redirectUri
       )
-    ).resolves.toEqual(camelcaseKeys(tokenResponse));
+    ).resolves.toEqual(tokenResponse);
   });
 });

--- a/packages/core/src/sso/OidcConnector/utils.ts
+++ b/packages/core/src/sso/OidcConnector/utils.ts
@@ -98,7 +98,7 @@ export const fetchToken = async (
   { tokenEndpoint, clientId, clientSecret }: BaseOidcConfig,
   data: unknown,
   redirectUri: string
-): Promise<CamelCaseKeys<OidcTokenResponse>> => {
+): Promise<OidcTokenResponse> => {
   const result = oidcAuthorizationResponseGuard.safeParse(data);
 
   if (!result.success) {
@@ -127,7 +127,7 @@ export const fetchToken = async (
       });
     }
 
-    return camelcaseKeys(exchangeResult.data);
+    return exchangeResult.data;
   } catch (error: unknown) {
     if (error instanceof SsoConnectorError) {
       throw error;

--- a/packages/core/src/sso/SamlSsoConnector/index.ts
+++ b/packages/core/src/sso/SamlSsoConnector/index.ts
@@ -99,7 +99,7 @@ export class SamlSsoConnector extends SamlConnector implements SingleSignOn {
   async getUserInfo({ userInfo }: SingleSignOnConnectorSession) {
     assertThat(userInfo, new RequestError('session.connector_session_not_found'));
 
-    return userInfo;
+    return { userInfo };
   }
 }
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR refactors the return type of the SSO connector’s `getUserInfo` method.

Previously, the `getUserInfo` method returned only a userInfo object. However, as we prepare to support token storage for OIDC SSO connectors, we need to return both the fetched user information and the token response to the upper scope. Therefore, the method's return type has been updated as follows:

- OIDC connectors: `{ userInfo, tokenResponse }`
- SAML connectors: `{ userInfo }`

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
