### PR TITLE
feat(core,schemas): implement sso token storage

### DIFF
--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -409,6 +409,7 @@ export default class ExperienceInteraction {
       queries: { users: userQueries, userSsoIdentities: userSsoIdentityQueries },
       libraries: {
         socials: { upsertSocialTokenSetSecret },
+        ssoConnectors: { upsertEnterpriseSsoTokenSetSecret },
       },
     } = this.tenant;
 
@@ -464,6 +465,7 @@ export default class ExperienceInteraction {
       syncedEnterpriseSsoIdentity,
       jitOrganizationIds,
       socialConnectorTokenSetSecret,
+      enterpriseSsoConnectorTokenSetSecret,
       ...rest
     } = this.profile.data;
     const { mfaSkipped, mfaVerifications } = this.mfa.toUserMfaVerifications();
@@ -514,6 +516,11 @@ export default class ExperienceInteraction {
     // Sync social token set secret
     if (socialConnectorTokenSetSecret) {
       await upsertSocialTokenSetSecret(user.id, socialConnectorTokenSetSecret);
+    }
+
+    // Sync enterprise sso token set secret
+    if (enterpriseSsoConnectorTokenSetSecret) {
+      await upsertEnterpriseSsoTokenSetSecret(user.id, enterpriseSsoConnectorTokenSetSecret);
     }
 
     // Provision organizations for one-time token that carries organization IDs in the context.

--- a/packages/core/src/routes/experience/classes/libraries/provision-library.ts
+++ b/packages/core/src/routes/experience/classes/libraries/provision-library.ts
@@ -59,6 +59,7 @@ export class ProvisionLibrary {
       libraries: {
         users: { generateUserId, insertUser },
         socials: { upsertSocialTokenSetSecret },
+        ssoConnectors: { upsertEnterpriseSsoTokenSetSecret },
       },
     } = this.tenantContext;
 
@@ -68,6 +69,7 @@ export class ProvisionLibrary {
       syncedEnterpriseSsoIdentity,
       jitOrganizationIds,
       socialConnectorTokenSetSecret,
+      enterpriseSsoConnectorTokenSetSecret,
       ...rest
     } = profile;
 
@@ -94,6 +96,10 @@ export class ProvisionLibrary {
 
     if (socialConnectorTokenSetSecret) {
       await upsertSocialTokenSetSecret(user.id, socialConnectorTokenSetSecret);
+    }
+
+    if (enterpriseSsoConnectorTokenSetSecret) {
+      await upsertEnterpriseSsoTokenSetSecret(user.id, enterpriseSsoConnectorTokenSetSecret);
     }
 
     await this.provisionNewUserJitOrganizations(user.id, profile);

--- a/packages/core/src/routes/experience/classes/verifications/enterprise-sso-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/enterprise-sso-verification.ts
@@ -7,10 +7,13 @@ import {
   type UserSsoIdentity,
   type EnterpriseSsoVerificationRecordData,
   enterpriseSsoVerificationRecordDataGuard,
+  type EncryptedTokenSet,
+  type SecretEnterpriseSsoConnectorRelationPayload,
 } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 import { conditional } from '@silverhand/essentials';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
 import {
@@ -33,6 +36,11 @@ export {
   enterpriseSsoVerificationRecordDataGuard,
 } from '@logto/schemas';
 
+export type EnterpriseSsoConnectorTokenSetSecret = {
+  encryptedTokenSet: EncryptedTokenSet;
+  enterpriseSsoConnectorRelationPayload: SecretEnterpriseSsoConnectorRelationPayload;
+};
+
 export class EnterpriseSsoVerification
   implements IdentifierVerificationRecord<VerificationType.EnterpriseSso>
 {
@@ -48,6 +56,7 @@ export class EnterpriseSsoVerification
   public readonly type = VerificationType.EnterpriseSso;
   public readonly connectorId: string;
   public enterpriseSsoUserInfo?: ExtendedSocialUserInfo;
+  public encryptedTokenSet?: EncryptedTokenSet;
   public issuer?: string;
 
   private connectorDataCache?: SupportedSsoConnector;
@@ -57,13 +66,14 @@ export class EnterpriseSsoVerification
     private readonly queries: Queries,
     data: EnterpriseSsoVerificationRecordData
   ) {
-    const { id, connectorId, enterpriseSsoUserInfo, issuer } =
+    const { id, connectorId, enterpriseSsoUserInfo, encryptedTokenSet, issuer } =
       enterpriseSsoVerificationRecordDataGuard.parse(data);
 
     this.id = id;
     this.connectorId = connectorId;
     this.enterpriseSsoUserInfo = enterpriseSsoUserInfo;
     this.issuer = issuer;
+    this.encryptedTokenSet = encryptedTokenSet;
   }
 
   /** Returns true if the enterprise SSO identity has been verified */
@@ -110,7 +120,7 @@ export class EnterpriseSsoVerification
    */
   async verify(ctx: WithLogContext, tenantContext: TenantContext, callbackData: JsonObject) {
     const connectorData = await this.getConnectorData();
-    const { issuer, userInfo } = await verifySsoIdentity(
+    const { issuer, userInfo, encryptedTokenSet } = await verifySsoIdentity(
       ctx,
       tenantContext,
       connectorData,
@@ -119,6 +129,7 @@ export class EnterpriseSsoVerification
 
     this.issuer = issuer;
     this.enterpriseSsoUserInfo = userInfo;
+    this.encryptedTokenSet = encryptedTokenSet;
   }
 
   /**
@@ -206,8 +217,28 @@ export class EnterpriseSsoVerification
       : {};
   }
 
+  getTokenSetSecret(): EnterpriseSsoConnectorTokenSetSecret | undefined {
+    if (!EnvSet.values.isDevFeaturesEnabled) {
+      return;
+    }
+
+    // Not verified or token set not found
+    if (!this.enterpriseSsoUserInfo || !this.issuer || !this.encryptedTokenSet) {
+      return;
+    }
+
+    return {
+      encryptedTokenSet: this.encryptedTokenSet,
+      enterpriseSsoConnectorRelationPayload: {
+        ssoConnectorId: this.connectorId,
+        issuer: this.issuer,
+        identityId: this.enterpriseSsoUserInfo.id,
+      },
+    };
+  }
+
   toJson(): EnterpriseSsoVerificationRecordData {
-    const { id, connectorId, type, enterpriseSsoUserInfo, issuer } = this;
+    const { id, connectorId, type, enterpriseSsoUserInfo, issuer, encryptedTokenSet } = this;
 
     return {
       id,
@@ -215,6 +246,7 @@ export class EnterpriseSsoVerification
       type,
       enterpriseSsoUserInfo,
       issuer,
+      encryptedTokenSet,
     };
   }
 

--- a/packages/core/src/routes/experience/types.ts
+++ b/packages/core/src/routes/experience/types.ts
@@ -3,6 +3,7 @@ import {
   type CreateUser,
   encryptedTokenSetGuard,
   InteractionEvent,
+  secretEnterpriseSsoConnectorRelationPayloadGuard,
   secretSocialConnectorRelationPayloadGuard,
   type User,
   Users,
@@ -18,6 +19,7 @@ import { type WithInteractionDetailsContext } from '#src/middleware/koa-interact
 import { type WithI18nContext } from '../../middleware/koa-i18next.js';
 
 import { mfaDataGuard, type MfaData } from './classes/mfa.js';
+import { type EnterpriseSsoConnectorTokenSetSecret } from './classes/verifications/enterprise-sso-verification.js';
 import {
   type VerificationRecordData,
   type VerificationRecord,
@@ -49,6 +51,10 @@ export type InteractionProfile = {
    * Store encrypted token set from a social verification record.  If present, Logto will save this token set in the Secret Vault for future use by the user.
    */
   socialConnectorTokenSetSecret?: SocialConnectorTokenSetSecret;
+  /**
+   * Store encrypted token set from a enterprise SSO verification record.  If present, Logto will save this token set in the Secret Vault for future use by the user.
+   */
+  enterpriseSsoConnectorTokenSetSecret?: EnterpriseSsoConnectorTokenSetSecret;
 } & Pick<
   CreateUser,
   | 'avatar'
@@ -97,6 +103,12 @@ const interactionProfileGuard = Users.createGuard
       .object({
         encryptedTokenSet: encryptedTokenSetGuard,
         socialConnectorRelationPayload: secretSocialConnectorRelationPayloadGuard,
+      })
+      .optional(),
+    enterpriseSsoConnectorTokenSetSecret: z
+      .object({
+        encryptedTokenSet: encryptedTokenSetGuard,
+        enterpriseSsoConnectorRelationPayload: secretEnterpriseSsoConnectorRelationPayloadGuard,
       })
       .optional(),
   }) satisfies ToZodObject<InteractionProfile>;

--- a/packages/core/src/routes/interaction/utils/single-sign-on.test.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on.test.ts
@@ -215,6 +215,7 @@ describe('Single sign on util methods tests', () => {
       expect(result).toStrictEqual({
         issuer: 'https://example.com',
         userInfo: { id: 'id', email: 'email' },
+        encryptedTokenSet: undefined,
       });
 
       expect(assignSingleSignOnAuthenticationResultMock).toBeCalledWith(mockContext, mockProvider, {

--- a/packages/core/src/routes/interaction/utils/single-sign-on.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on.ts
@@ -1,7 +1,9 @@
 /* eslint-disable max-lines -- will migrate this file to the latest experience APIs */
+import { appInsights } from '@logto/app-insights/node';
 import { ConnectorError } from '@logto/connector-kit';
 import { validateRedirectUrl } from '@logto/core-kit';
 import {
+  type EncryptedTokenSet,
   InteractionEvent,
   type SupportedSsoConnector,
   type User,
@@ -22,6 +24,8 @@ import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 import { safeParseUnknownJson } from '#src/utils/json.js';
 
+import OidcConnector from '../../../sso/OidcConnector/index.js';
+import { encryptTokenResponse } from '../../../utils/secret-encryption.js';
 import { type WithInteractionHooksContext } from '../middleware/koa-interaction-hooks.js';
 
 import {
@@ -130,6 +134,12 @@ type SsoAuthenticationResult = {
   /** The issuer of the SSO provider, we need to store this in the user SSO identity to identify the provider. */
   issuer: string;
   userInfo: ExtendedSocialUserInfo;
+  /**
+   * Only applied to the OIDC connectors.
+   * If the SSO connector has token storage enabled,
+   * this will contain the encrypted token set from the OIDC provider.
+   */
+  encryptedTokenSet?: EncryptedTokenSet;
 };
 
 /**
@@ -160,10 +170,38 @@ export const verifySsoIdentity = async (
       connectorData,
       envSet.endpoint
     );
-    const issuer = await connectorInstance.getIssuer();
-    const { userInfo } = await connectorInstance.getUserInfo(singleSignOnSession, data);
 
-    log.append({ issuer, userInfo });
+    const { enableTokenStorage } = connectorData;
+
+    const issuer = await connectorInstance.getIssuer();
+
+    // TODO: remove the dev feature guard when token storage is ready
+    if (EnvSet.values.isDevFeaturesEnabled && connectorInstance instanceof OidcConnector) {
+      const { userInfo, tokenResponse } = await connectorInstance.getUserInfo(
+        singleSignOnSession,
+        data
+      );
+
+      log.append({ issuer, userInfo });
+
+      return {
+        issuer,
+        userInfo,
+        encryptedTokenSet: conditional(
+          enableTokenStorage &&
+            tokenResponse &&
+            trySafe(
+              () => encryptTokenResponse(tokenResponse),
+              (error) => {
+                // If the token response cannot be encrypted, we log the error but continue to return user info.
+                void appInsights.trackException(error);
+              }
+            )
+        ),
+      };
+    }
+
+    const { userInfo } = await connectorInstance.getUserInfo(singleSignOnSession, data);
 
     return {
       issuer,

--- a/packages/core/src/test-utils/mock-libraries.ts
+++ b/packages/core/src/test-utils/mock-libraries.ts
@@ -25,4 +25,5 @@ export const mockSsoConnectorLibrary: jest.Mocked<SsoConnectorLibrary> = {
   createSsoConnectorIdpInitiatedAuthConfig: jest.fn(),
   createIdpInitiatedSamlSsoSession: jest.fn(),
   getIdpInitiatedSamlSsoSignInUrl: jest.fn(),
+  upsertEnterpriseSsoTokenSetSecret: jest.fn(),
 };

--- a/packages/core/src/utils/secret-encryption.ts
+++ b/packages/core/src/utils/secret-encryption.ts
@@ -1,6 +1,13 @@
 import crypto from 'node:crypto';
 
-import { type TokenSet, tokenSetGuard, type EncryptedSecret } from '@logto/schemas';
+import type { TokenResponse } from '@logto/connector-kit';
+import {
+  type TokenSet,
+  tokenSetGuard,
+  type EncryptedSecret,
+  type EncryptedTokenSet,
+} from '@logto/schemas';
+import { conditional } from '@silverhand/essentials';
 import { z } from 'zod';
 
 import { EnvSet } from '../env-set/index.js';
@@ -112,5 +119,44 @@ export const deserializeEncryptedSecret = (base64String: string): EncryptedSecre
     authTag: Buffer.from(serialized.authTag, 'base64'),
     ciphertext: Buffer.from(serialized.ciphertext, 'base64'),
     encryptedDek: Buffer.from(serialized.encryptedDek, 'base64'),
+  };
+};
+
+export const encryptTokenResponse = (
+  tokenResponse?: TokenResponse
+): EncryptedTokenSet | undefined => {
+  if (!tokenResponse?.access_token) {
+    return;
+  }
+
+  const {
+    access_token,
+    id_token,
+    refresh_token,
+    scope,
+    token_type: tokenType,
+    expires_in,
+  } = tokenResponse;
+
+  const requestedAt = Math.floor(Date.now() / 1000);
+
+  // Convert expires_in to a number if it's a string
+  // Some providers like Azure may return expires_in as a string.
+  const expiresIn = typeof expires_in === 'string' ? Number.parseInt(expires_in, 10) : expires_in;
+  const expiresAt = expiresIn && requestedAt + expiresIn;
+
+  const encryptedTokenSet = encryptTokens({
+    access_token,
+    ...conditional(id_token && { id_token }),
+    ...conditional(refresh_token && { refresh_token }),
+  });
+
+  return {
+    encryptedTokenSetBase64: serializeEncryptedSecret(encryptedTokenSet),
+    metadata: {
+      scope,
+      tokenType,
+      expiresAt,
+    },
   };
 };

--- a/packages/core/src/utils/secret-encryption.ts
+++ b/packages/core/src/utils/secret-encryption.ts
@@ -143,7 +143,7 @@ export const encryptTokenResponse = (
   // Convert expires_in to a number if it's a string
   // Some providers like Azure may return expires_in as a string.
   const expiresIn = typeof expires_in === 'string' ? Number.parseInt(expires_in, 10) : expires_in;
-  const expiresAt = expiresIn && requestedAt + expiresIn;
+  const expiresAt = conditional(expiresIn !== undefined && requestedAt + expiresIn);
 
   const encryptedTokenSet = encryptTokens({
     access_token,

--- a/packages/schemas/src/types/logto-config/jwt-customizer.ts
+++ b/packages/schemas/src/types/logto-config/jwt-customizer.ts
@@ -98,13 +98,17 @@ const jwtCustomizerUserInteractionVerificationRecordGuard = z.discriminatedUnion
     connectorSession: true,
     encryptedTokenSet: true,
   }),
-  enterpriseSsoVerificationRecordDataGuard.extend({
-    // The original `enterpriseSsoUserInfo` field type is extended with `socialUserInfo` with `catchall(unknown)`.
-    // However, the unknown type may cause error when using the `sql.jsonb` function in Slonik.
-    // See {@logto/cli/src/queries/logto-config.ts#updateValueByKey} for more reference.
-    // So we use `socialUserInfoGuard.catchall(jsonGuard)` to ensure the type is JSON serializable.
-    enterpriseSsoUserInfo: socialUserInfoGuard.catchall(jsonGuard).optional(),
-  }),
+  enterpriseSsoVerificationRecordDataGuard
+    .omit({
+      encryptedTokenSet: true,
+    })
+    .extend({
+      // The original `enterpriseSsoUserInfo` field type is extended with `socialUserInfo` with `catchall(unknown)`.
+      // However, the unknown type may cause error when using the `sql.jsonb` function in Slonik.
+      // See {@logto/cli/src/queries/logto-config.ts#updateValueByKey} for more reference.
+      // So we use `socialUserInfoGuard.catchall(jsonGuard)` to ensure the type is JSON serializable.
+      enterpriseSsoUserInfo: socialUserInfoGuard.catchall(jsonGuard).optional(),
+    }),
   totpVerificationRecordDataGuard.omit({
     secret: true,
   }),

--- a/packages/schemas/src/types/secrets.ts
+++ b/packages/schemas/src/types/secrets.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { SecretEnterpriseSsoConnectorRelations } from '../db-entries/secret-enterprise-sso-connector-relation.js';
 import { SecretSocialConnectorRelations } from '../db-entries/secret-social-connector-relation.js';
 import { type CreateSecret, Secrets } from '../db-entries/secret.js';
 import { SecretType } from '../foundations/index.js';
@@ -21,23 +22,23 @@ export const tokenSetGuard = z.object({
 
 export type TokenSet = z.infer<typeof tokenSetGuard>;
 
-export const socialConnectorTokenSetMetadataGuard = z.object({
+export const tokenSetMetadataGuard = z.object({
   scope: z.string().optional(),
   expiresAt: z.number().optional(),
   tokenType: z.string().optional(),
 });
 
-export type SocialConnectorTokenSetMetadata = z.infer<typeof socialConnectorTokenSetMetadataGuard>;
+export type TokenSetMetadata = z.infer<typeof tokenSetMetadataGuard>;
 
 export const encryptedTokenSetGuard = z.object({
   encryptedTokenSetBase64: z.string(),
-  metadata: socialConnectorTokenSetMetadataGuard,
+  metadata: tokenSetMetadataGuard,
 });
 
 export type EncryptedTokenSet = z.infer<typeof encryptedTokenSetGuard>;
 
 export type CreateSocialTokenSetSecret = CreateSecret & {
-  metadata: SocialConnectorTokenSetMetadata;
+  metadata: TokenSetMetadata;
 };
 
 export const secretSocialConnectorRelationPayloadGuard =
@@ -51,9 +52,20 @@ export type SecretSocialConnectorRelationPayload = z.infer<
   typeof secretSocialConnectorRelationPayloadGuard
 >;
 
+export const secretEnterpriseSsoConnectorRelationPayloadGuard =
+  SecretEnterpriseSsoConnectorRelations.createGuard.pick({
+    ssoConnectorId: true,
+    issuer: true,
+    identityId: true,
+  });
+
+export type SecretEnterpriseSsoConnectorRelationPayload = z.infer<
+  typeof secretEnterpriseSsoConnectorRelationPayloadGuard
+>;
+
 export const socialTokenSetSecretGuard = Secrets.guard.extend({
   type: z.literal(SecretType.FederatedTokenSet),
-  metadata: socialConnectorTokenSetMetadataGuard,
+  metadata: tokenSetMetadataGuard,
   connectorId: z.string(),
   identityId: z.string(),
   target: z.string(),
@@ -77,3 +89,19 @@ export const desensitizedSocialTokenSetSecretGuard = socialTokenSetSecretGuard.o
 export type DesensitizedSocialTokenSetSecret = z.infer<
   typeof desensitizedSocialTokenSetSecretGuard
 >;
+
+export const enterpriseSsoTokenSetSecretGuard = Secrets.guard.extend({
+  type: z.literal(SecretType.FederatedTokenSet),
+  metadata: tokenSetMetadataGuard,
+  ssoConnectorId: z.string(),
+  issuer: z.string(),
+  identityId: z.string(),
+});
+
+/**
+ * Enterprise SSO token set secret type
+ * - Secret type is `FederatedTokenSet`
+ * - Metadata is the Enterprise SSO connector token set metadata
+ * - Joined with the Enterprise SSO connector relation
+ */
+export type EnterpriseSsoTokenSetSecret = z.infer<typeof enterpriseSsoTokenSetSecretGuard>;

--- a/packages/schemas/src/types/verification-records/enterprise-sso-verification.ts
+++ b/packages/schemas/src/types/verification-records/enterprise-sso-verification.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { type ToZodObject } from '../../utils/zod.js';
+import { encryptedTokenSetGuard, type EncryptedTokenSet } from '../secrets.js';
 import { extendedSocialUserInfoGuard, type ExtendedSocialUserInfo } from '../sso-connector.js';
 
 import { VerificationType } from './verification-type.js';
@@ -14,6 +15,7 @@ export type EnterpriseSsoVerificationRecordData = {
    * The enterprise SSO identity returned by the connector.
    */
   enterpriseSsoUserInfo?: ExtendedSocialUserInfo;
+  encryptedTokenSet?: EncryptedTokenSet;
   issuer?: string;
 };
 
@@ -22,5 +24,6 @@ export const enterpriseSsoVerificationRecordDataGuard = z.object({
   connectorId: z.string(),
   type: z.literal(VerificationType.EnterpriseSso),
   enterpriseSsoUserInfo: extendedSocialUserInfoGuard.optional(),
+  encryptedTokenSet: encryptedTokenSetGuard.optional(),
   issuer: z.string().optional(),
 }) satisfies ToZodObject<EnterpriseSsoVerificationRecordData>;

--- a/packages/schemas/src/types/verification-records/social-verification.ts
+++ b/packages/schemas/src/types/verification-records/social-verification.ts
@@ -3,7 +3,6 @@ import {
   socialUserInfoGuard,
   type ConnectorSession,
   type SocialUserInfo,
-  tokenResponseGuard,
 } from '@logto/connector-kit';
 import { z } from 'zod';
 
@@ -34,6 +33,5 @@ export const socialVerificationRecordDataGuard = z.object({
   type: z.literal(VerificationType.Social),
   socialUserInfo: socialUserInfoGuard.optional(),
   encryptedTokenSet: encryptedTokenSetGuard.optional(),
-  tokenResponse: tokenResponseGuard.optional(),
   connectorSession: connectorSessionGuard.optional(),
 }) satisfies ToZodObject<SocialVerificationRecordData>;

--- a/packages/toolkit/connector-kit/src/types/social.ts
+++ b/packages/toolkit/connector-kit/src/types/social.ts
@@ -102,7 +102,8 @@ export type TokenResponse = {
   id_token?: string;
   access_token?: string;
   refresh_token?: string;
-  expires_in?: number;
+  /** Some providers like Azure may return expires_in as a string. */
+  expires_in?: number | string;
   scope?: string;
   token_type?: string;
 };
@@ -111,7 +112,7 @@ export const tokenResponseGuard = z.object({
   id_token: z.string().optional(),
   access_token: z.string().optional(),
   refresh_token: z.string().optional(),
-  expires_in: z.number().optional(),
+  expires_in: z.number().or(z.string()).optional(),
   scope: z.string().optional(),
   token_type: z.string().optional(),
 }) satisfies ToZodObject<TokenResponse>;


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR implements the token storage for the enterprise SSO authentication flow. 

### Key updates
- Extract the `encryptTokenResponse` util method from the social library to secret utils.  So the method can be shared by the enterprise SSO library. 

- Implement the query method and library method to store the token set secret from the enterprise SSO connector to the DB. 

- Update all OIDC SSO connectors to return the token response from the `getUserInfo` method.

- Update the `verifySsoIdentity` utility method used in experience interactions. If token storage is enabled for the connector, return the encrypted token set received from the SSO provider.

- Update the experience interaction SSO verification and profile classes to handle and store the encrypted enterprise SSO token set.

- During interaction submission, if `enterpriseSsoConnectorTokenSetSecret` exists in the current interaction profile data, store the token set in the Logto Secret Vault for the user.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally. 
interaction tests in the upcoming PR.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
