### PR TITLE
feat(core,schemas): federated third-party access token exchange

### DIFF
--- a/packages/core/src/event-listeners/grant.ts
+++ b/packages/core/src/event-listeners/grant.ts
@@ -71,6 +71,8 @@ const grantTypeToExchangeByType: Record<GrantType, token.ExchangeByType> = {
   [GrantType.RefreshToken]: token.ExchangeByType.RefreshToken,
   [GrantType.ClientCredentials]: token.ExchangeByType.ClientCredentials,
   [GrantType.TokenExchange]: token.ExchangeByType.TokenExchange,
+  [GrantType.FederatedThirdPartyTokenExchange]:
+    token.ExchangeByType.FederatedThirdPartyTokenExchange,
 };
 
 const getExchangeByType = (grantType: unknown): token.ExchangeByType => {

--- a/packages/core/src/oidc/grants/federated-third-party-token-exchange.ts
+++ b/packages/core/src/oidc/grants/federated-third-party-token-exchange.ts
@@ -10,7 +10,7 @@ import { errors } from 'oidc-provider';
 import revoke from 'oidc-provider/lib/helpers/revoke.js';
 import validatePresence from 'oidc-provider/lib/helpers/validate_presence.js';
 
-import { type EnvSet } from '#src/env-set/index.js';
+import { EnvSet } from '#src/env-set/index.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
@@ -166,6 +166,9 @@ export const buildHandler: (
 ) => Parameters<Provider['registerGrantType']>[1] = (envSet, queries) => async (ctx, next) => {
   const { client, params, provider } = ctx.oidc;
   const { RefreshToken, Account, Grant } = provider;
+
+  // TODO: remove this dev feature guard
+  assertThat(EnvSet.values.isDevFeaturesEnabled, new InvalidRequest('Invalid grant type'));
 
   /* === Start standard OIDC refresh token  validation  === */
   assertThat(params, new InvalidGrant('parameters must be available'));

--- a/packages/core/src/oidc/grants/federated-third-party-token-exchange.ts
+++ b/packages/core/src/oidc/grants/federated-third-party-token-exchange.ts
@@ -1,0 +1,252 @@
+/**
+ * @overview
+ * This file implements the `federated_third_party_token_exchange` grant type.
+ * It allows Logto authenticated users to exchange for tokens from third-party identity providers
+ * (e.g., Google, GitHub) using their Logto refresh token.
+ */
+import { conditional, isKeyInObject } from '@silverhand/essentials';
+import type { Provider, UnknownObject } from 'oidc-provider';
+import { errors } from 'oidc-provider';
+import revoke from 'oidc-provider/lib/helpers/revoke.js';
+import validatePresence from 'oidc-provider/lib/helpers/validate_presence.js';
+
+import { type EnvSet } from '#src/env-set/index.js';
+import type Queries from '#src/tenants/Queries.js';
+import assertThat from '#src/utils/assert-that.js';
+
+import RequestError from '../../errors/RequestError/index.js';
+import { decryptTokens } from '../../utils/secret-encryption.js';
+
+const { InvalidClient, InvalidGrant, InvalidTarget } = errors;
+
+enum FederatedThirdPartyTokenExchangeTokenType {
+  ThirdPartyAccessToken = 'urn:logto:token-type:federated_third_party_access_token',
+}
+
+enum SubjectTokenType {
+  RefreshToken = 'urn:ietf:params:oauth:token-type:refresh_token',
+}
+
+enum ThirdPartyProviderType {
+  Social = 'social',
+  SSO = 'sso',
+}
+
+type ConnectorTarget = {
+  type: ThirdPartyProviderType;
+  target: string;
+};
+
+export const parameters = Object.freeze([
+  'subject_token',
+  'subject_token_type',
+  'requested_token_type',
+  'connector',
+] as const);
+
+const requiredParameters = Object.freeze([
+  'subject_token',
+  'subject_token_type',
+  'requested_token_type',
+  'connector',
+] as const) satisfies ReadonlyArray<(typeof parameters)[number]>;
+
+const validateTokenTypes = (params: UnknownObject): void => {
+  const subjectTokenType = String(params.subject_token_type);
+  const requestedTokenType = String(params.requested_token_type);
+
+  assertThat(
+    subjectTokenType === SubjectTokenType.RefreshToken,
+    new InvalidGrant('Invalid subject token type')
+  );
+
+  assertThat(
+    requestedTokenType === FederatedThirdPartyTokenExchangeTokenType.ThirdPartyAccessToken,
+    new InvalidGrant('Invalid requested token type')
+  );
+};
+
+/**
+ * Validate the connector parameter.
+ * @remarks
+ * We use `connector` to identify the third-party identity provider,
+ * in the format of `social:<target>` or `sso:<connector-id>`.
+ *
+ * This function checks if the `connector` parameter is provided and is in a valid format.
+ */
+const parseConnectorParameter = (params: UnknownObject): ConnectorTarget => {
+  const connector = String(params.connector);
+  assertThat(connector, new InvalidTarget('connector must be provided'));
+
+  const [targetType, targetValue] = connector.split(':');
+  assertThat(
+    (targetType === ThirdPartyProviderType.Social || targetType === ThirdPartyProviderType.SSO) &&
+      targetValue,
+    new InvalidTarget(
+      'Invalid connector format, expected "social:<target>" or "sso:<connector-id>"'
+    )
+  );
+
+  return {
+    type: targetType,
+    target: targetValue,
+  };
+};
+
+const getThirdPartyTokenSetSecret = async (
+  queries: Queries,
+  userId: string,
+  { type, target }: ConnectorTarget
+) => {
+  const tokenSetSecret =
+    type === ThirdPartyProviderType.Social
+      ? await queries.secrets.findSocialTokenSetSecretByUserIdAndTarget(userId, target)
+      : await queries.secrets.findEnterpriseSsoTokenSetSecretByUserIdAndConnectorId(userId, target);
+
+  if (!tokenSetSecret) {
+    throw new RequestError({
+      code: 'third_party_token_exchange.token_not_found',
+      status: 401,
+    });
+  }
+
+  const {
+    id,
+    metadata: { expiresAt, scope, tokenType },
+    iv,
+    encryptedDek,
+    ciphertext,
+    authTag,
+  } = tokenSetSecret;
+
+  const { access_token, refresh_token } = decryptTokens({
+    iv,
+    encryptedDek,
+    ciphertext,
+    authTag,
+  });
+
+  if (!access_token) {
+    throw new RequestError({
+      code: 'third_party_token_exchange.token_not_found',
+      status: 401,
+    });
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+
+  if (expiresAt && now >= expiresAt && !refresh_token) {
+    await queries.secrets.deleteById(id);
+    throw new RequestError({
+      code: 'third_party_token_exchange.token_expires',
+      status: 401,
+    });
+  }
+
+  // TODO: refresh expired token if refresh_token is available
+  // If the token is expired and a refresh token is available, we should refresh it.
+
+  // Recalculate expires_in based on the current time and expiresAt
+  // If expiresAt is not set, expires_in will be undefined
+  const expires_in = expiresAt ? expiresAt - now : undefined;
+
+  return {
+    access_token,
+    ...conditional(scope && { scope }),
+    ...conditional(tokenType && { token_type: tokenType }),
+    ...conditional(expires_in && { expires_in }),
+  };
+};
+
+/* eslint-disable unicorn/no-array-method-this-argument */
+export const buildHandler: (
+  envSet: EnvSet,
+  queries: Queries
+  // eslint-disable-next-line complexity
+) => Parameters<Provider['registerGrantType']>[1] = (envSet, queries) => async (ctx, next) => {
+  const { client, params, provider } = ctx.oidc;
+  const { RefreshToken, Account, Grant } = provider;
+
+  /* === Start standard OIDC refresh token  validation  === */
+  assertThat(params, new InvalidGrant('parameters must be available'));
+  assertThat(client, new InvalidClient('client must be available'));
+
+  validatePresence(ctx, ...requiredParameters);
+
+  validateTokenTypes(params);
+
+  const refreshTokenValue = String(params.subject_token);
+
+  const refreshToken = await RefreshToken.find(refreshTokenValue, { ignoreExpiration: true });
+
+  if (!refreshToken) {
+    throw new InvalidGrant('refresh token not found');
+  }
+
+  if (refreshToken.clientId !== client.clientId) {
+    throw new InvalidGrant('client mismatch');
+  }
+
+  if (refreshToken.isExpired) {
+    throw new InvalidGrant('refresh token is expired');
+  }
+
+  if (!refreshToken.grantId) {
+    throw new InvalidGrant('grantId not found');
+  }
+
+  const grant = await Grant.find(refreshToken.grantId, {
+    ignoreExpiration: true,
+  });
+
+  if (!grant) {
+    throw new InvalidGrant('grant not found');
+  }
+
+  /**
+   * It's actually available on the `BaseModel` class - but missing from the typings.
+   *
+   * @see {@link https://github.com/panva/node-oidc-provider/blob/cf2069cbb31a6a855876e95157372d25dde2511c/lib/models/base_model.js#L128 | oidc-provider/lib/models/base_model.js#L128}
+   */
+  if (isKeyInObject(grant, 'isExpired') && grant.isExpired) {
+    throw new InvalidGrant('grant is expired');
+  }
+
+  if (grant.clientId !== client.clientId) {
+    throw new InvalidGrant('client mismatch');
+  }
+
+  ctx.oidc.entity('RefreshToken', refreshToken);
+  ctx.oidc.entity('Grant', grant);
+
+  // @ts-expect-error -- code from oidc-provider. the original type definition does not include
+  // `RefreshToken` but it's actually available.
+  const account = await Account.findAccount(ctx, refreshToken.accountId, refreshToken);
+
+  if (!account) {
+    throw new InvalidGrant('refresh token invalid (referenced account not found)');
+  }
+
+  if (refreshToken.accountId !== grant.accountId) {
+    throw new InvalidGrant('accountId mismatch');
+  }
+
+  ctx.oidc.entity('Account', account);
+
+  if (refreshToken.consumed) {
+    await Promise.all([refreshToken.destroy(), revoke(ctx, refreshToken.grantId)]);
+    throw new InvalidGrant('refresh token already used');
+  }
+  /* === End standard OIDC refresh token grant type validation === */
+
+  const connector = String(params.connector);
+  assertThat(connector, new InvalidGrant('connector must be provided'));
+
+  const connectorTarget = parseConnectorParameter(params);
+  const result = await getThirdPartyTokenSetSecret(queries, account.accountId, connectorTarget);
+
+  ctx.body = result;
+
+  await next();
+};
+/* eslint-enable unicorn/no-array-method-this-argument */

--- a/packages/core/src/oidc/grants/federated-third-party-token-exchange.ts
+++ b/packages/core/src/oidc/grants/federated-third-party-token-exchange.ts
@@ -17,7 +17,7 @@ import assertThat from '#src/utils/assert-that.js';
 import RequestError from '../../errors/RequestError/index.js';
 import { decryptTokens } from '../../utils/secret-encryption.js';
 
-const { InvalidClient, InvalidGrant, InvalidTarget } = errors;
+const { InvalidClient, InvalidGrant, InvalidRequest } = errors;
 
 enum FederatedThirdPartyTokenExchangeTokenType {
   ThirdPartyAccessToken = 'urn:logto:token-type:federated_third_party_access_token',
@@ -57,12 +57,12 @@ const validateTokenTypes = (params: UnknownObject): void => {
 
   assertThat(
     subjectTokenType === SubjectTokenType.RefreshToken,
-    new InvalidGrant('Invalid subject token type')
+    new InvalidRequest('Invalid subject token type')
   );
 
   assertThat(
     requestedTokenType === FederatedThirdPartyTokenExchangeTokenType.ThirdPartyAccessToken,
-    new InvalidGrant('Invalid requested token type')
+    new InvalidRequest('Invalid requested token type')
   );
 };
 
@@ -76,13 +76,13 @@ const validateTokenTypes = (params: UnknownObject): void => {
  */
 const parseConnectorParameter = (params: UnknownObject): ConnectorTarget => {
   const connector = String(params.connector);
-  assertThat(connector, new InvalidTarget('connector must be provided'));
+  assertThat(connector, new InvalidRequest('connector must be provided'));
 
   const [targetType, targetValue] = connector.split(':');
   assertThat(
     (targetType === ThirdPartyProviderType.Social || targetType === ThirdPartyProviderType.SSO) &&
       targetValue,
-    new InvalidTarget(
+    new InvalidRequest(
       'Invalid connector format, expected "social:<target>" or "sso:<connector-id>"'
     )
   );

--- a/packages/core/src/oidc/grants/index.ts
+++ b/packages/core/src/oidc/grants/index.ts
@@ -2,7 +2,7 @@ import { GrantType } from '@logto/schemas';
 import type { Provider } from 'oidc-provider';
 import instance from 'oidc-provider/lib/helpers/weak_cache.js';
 
-import { EnvSet } from '#src/env-set/index.js';
+import { type EnvSet } from '#src/env-set/index.js';
 import type Queries from '#src/tenants/Queries.js';
 
 import * as clientCredentials from './client-credentials.js';
@@ -41,11 +41,9 @@ export const registerGrants = (oidc: Provider, envSet: EnvSet, queries: Queries)
     ...getParameterConfig(tokenExchange.parameters)
   );
 
-  if (EnvSet.values.isDevFeaturesEnabled) {
-    oidc.registerGrantType(
-      GrantType.FederatedThirdPartyTokenExchange,
-      federatedThirdPartyTokenExchange.buildHandler(envSet, queries),
-      ...getParameterConfig(federatedThirdPartyTokenExchange.parameters)
-    );
-  }
+  oidc.registerGrantType(
+    GrantType.FederatedThirdPartyTokenExchange,
+    federatedThirdPartyTokenExchange.buildHandler(envSet, queries),
+    ...getParameterConfig(federatedThirdPartyTokenExchange.parameters)
+  );
 };

--- a/packages/core/src/oidc/grants/index.ts
+++ b/packages/core/src/oidc/grants/index.ts
@@ -2,10 +2,11 @@ import { GrantType } from '@logto/schemas';
 import type { Provider } from 'oidc-provider';
 import instance from 'oidc-provider/lib/helpers/weak_cache.js';
 
-import { type EnvSet } from '#src/env-set/index.js';
+import { EnvSet } from '#src/env-set/index.js';
 import type Queries from '#src/tenants/Queries.js';
 
 import * as clientCredentials from './client-credentials.js';
+import * as federatedThirdPartyTokenExchange from './federated-third-party-token-exchange.js';
 import * as refreshToken from './refresh-token.js';
 import * as tokenExchange from './token-exchange/index.js';
 
@@ -39,4 +40,12 @@ export const registerGrants = (oidc: Provider, envSet: EnvSet, queries: Queries)
     tokenExchange.buildHandler(envSet, queries),
     ...getParameterConfig(tokenExchange.parameters)
   );
+
+  if (EnvSet.values.isDevFeaturesEnabled) {
+    oidc.registerGrantType(
+      GrantType.FederatedThirdPartyTokenExchange,
+      federatedThirdPartyTokenExchange.buildHandler(envSet, queries),
+      ...getParameterConfig(federatedThirdPartyTokenExchange.parameters)
+    );
+  }
 };

--- a/packages/core/src/oidc/utils.test.ts
+++ b/packages/core/src/oidc/utils.test.ts
@@ -17,20 +17,27 @@ import {
   buildLoginPromptUrl,
 } from './utils.js';
 
+const clientApplicationGrantTypes = Object.freeze([
+  GrantType.AuthorizationCode,
+  GrantType.RefreshToken,
+  GrantType.TokenExchange,
+  GrantType.FederatedThirdPartyTokenExchange,
+] as const);
+
 describe('getConstantClientMetadata()', () => {
   expect(getConstantClientMetadata(mockEnvSet, ApplicationType.SPA)).toEqual({
     application_type: 'web',
-    grant_types: [GrantType.AuthorizationCode, GrantType.RefreshToken, GrantType.TokenExchange],
+    grant_types: clientApplicationGrantTypes,
     token_endpoint_auth_method: 'none',
   });
   expect(getConstantClientMetadata(mockEnvSet, ApplicationType.Native)).toEqual({
     application_type: 'native',
-    grant_types: [GrantType.AuthorizationCode, GrantType.RefreshToken, GrantType.TokenExchange],
+    grant_types: clientApplicationGrantTypes,
     token_endpoint_auth_method: 'none',
   });
   expect(getConstantClientMetadata(mockEnvSet, ApplicationType.Traditional)).toEqual({
     application_type: 'web',
-    grant_types: [GrantType.AuthorizationCode, GrantType.RefreshToken, GrantType.TokenExchange],
+    grant_types: clientApplicationGrantTypes,
     token_endpoint_auth_method: 'client_secret_basic',
   });
   expect(getConstantClientMetadata(mockEnvSet, ApplicationType.MachineToMachine)).toEqual({

--- a/packages/core/src/oidc/utils.ts
+++ b/packages/core/src/oidc/utils.ts
@@ -38,7 +38,12 @@ export const getConstantClientMetadata = (
     grant_types:
       type === ApplicationType.MachineToMachine
         ? [GrantType.ClientCredentials]
-        : [GrantType.AuthorizationCode, GrantType.RefreshToken, GrantType.TokenExchange],
+        : [
+            GrantType.AuthorizationCode,
+            GrantType.RefreshToken,
+            GrantType.TokenExchange,
+            GrantType.FederatedThirdPartyTokenExchange,
+          ],
     token_endpoint_auth_method: getTokenEndpointAuthMethod(),
     response_types: conditional(type === ApplicationType.MachineToMachine && []),
     // https://www.scottbrady91.com/jose/jwts-which-signing-algorithm-should-i-use

--- a/packages/core/src/utils/sql.ts
+++ b/packages/core/src/utils/sql.ts
@@ -43,11 +43,10 @@ export const convertToPrimitiveOrSql = (
     return null;
   }
 
-  // If the value is a buffer or a binary data, return it directly.
-  // secret vault table use only
+  // For Buffer values, we convert them to binary SQL tokens,
+  // Slonik will handle the binary data correctly in to `bytea` typed column.
+  // Secret vault table use only
   if (Buffer.isBuffer(value)) {
-    // For bytea columns, we need to pass the buffer as a raw value
-    // slonik should handle Buffer objects correctly for bytea columns
     return sql.binary(value);
   }
 

--- a/packages/core/src/utils/sql.ts
+++ b/packages/core/src/utils/sql.ts
@@ -43,6 +43,14 @@ export const convertToPrimitiveOrSql = (
     return null;
   }
 
+  // If the value is a buffer or a binary data, return it directly.
+  // secret vault table use only
+  if (Buffer.isBuffer(value)) {
+    // For bytea columns, we need to pass the buffer as a raw value
+    // slonik should handle Buffer objects correctly for bytea columns
+    return sql.binary(value);
+  }
+
   if (typeof value === 'object') {
     return JSON.stringify(value);
   }

--- a/packages/phrases/src/locales/en/errors/index.ts
+++ b/packages/phrases/src/locales/en/errors/index.ts
@@ -24,6 +24,7 @@ import single_sign_on from './single-sign-on.js';
 import storage from './storage.js';
 import subscription from './subscription.js';
 import swagger from './swagger.js';
+import third_party_token_exchange from './third-party-token-exchange.js';
 import user from './user.js';
 import verification_code from './verification-code.js';
 import verification_record from './verification-record.js';
@@ -58,6 +59,7 @@ const errors = {
   account_center,
   one_time_token,
   custom_profile_fields,
+  third_party_token_exchange,
 };
 
 export default Object.freeze(errors);

--- a/packages/phrases/src/locales/en/errors/third-party-token-exchange.ts
+++ b/packages/phrases/src/locales/en/errors/third-party-token-exchange.ts
@@ -1,0 +1,6 @@
+const third_party_token_exchange = {
+  token_not_found: 'Token record not found.',
+  token_expires: 'The token has expired. Please reauthenticate with the auth provider.',
+};
+
+export default Object.freeze(third_party_token_exchange);

--- a/packages/schemas/src/types/log/token.ts
+++ b/packages/schemas/src/types/log/token.ts
@@ -21,6 +21,7 @@ export enum ExchangeByType {
   RefreshToken = 'RefreshToken',
   ClientCredentials = 'ClientCredentials',
   TokenExchange = 'TokenExchange',
+  FederatedThirdPartyTokenExchange = 'FederatedThirdPartyTokenExchange',
 }
 
 export type LogKey = `${Type.ExchangeTokenBy}.${ExchangeByType}` | `${Type.RevokeToken}`;

--- a/packages/schemas/src/types/oidc-config.ts
+++ b/packages/schemas/src/types/oidc-config.ts
@@ -13,4 +13,5 @@ export enum GrantType {
   RefreshToken = 'refresh_token',
   ClientCredentials = 'client_credentials',
   TokenExchange = 'urn:ietf:params:oauth:grant-type:token-exchange',
+  FederatedThirdPartyTokenExchange = 'urn:logto:params:oauth:grant-type:federated-third-party-access-token',
 }

--- a/packages/shared/src/database/types.ts
+++ b/packages/shared/src/database/types.ts
@@ -1,4 +1,4 @@
-export type SchemaValuePrimitive = string | number | boolean | undefined;
+export type SchemaValuePrimitive = string | number | boolean | undefined | Buffer;
 export type SchemaValue =
   | SchemaValuePrimitive
   | Record<string, unknown>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Implement `FederatedThirdPartyTokenExchange` grant type.

Added a new `FederatedThirdPartyTokenExchange` grant type, allowing users to exchange a Logto refresh token for a third-party access token (from social or enterprise SSO providers). 

We introduced a secret vault feature to securely store token responses from third-party providers when token storage is enabled for social and enterprise SSO connectors.

After authenticating via a social or enterprise SSO sign-in, users can use this grant type to retrieve their securely stored third-party access token from Logto.

The grant flow validates the user’s refresh token and Logto auth status, then looks up the token record for the specified provider:
- If a valid, unexpired access token is found, it is returned.
- If the token has expired, the record is deleted, and a token expiration error is thrown.
- Note: Automatic access token refresh on expiration will be implemented in a future PR.


### Bug fixes
Update the `convertToPrimitiveOrSql` util method to handle the `Buffer` typed data properly. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test lcoally
<img width="1136" alt="image" src="https://github.com/user-attachments/assets/946ead61-094e-4c72-aef1-61e44d0b84fe" />

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
