### PR TITLE
feat(core): add third-party token account API

### DIFF
--- a/packages/core/src/routes/account/index.openapi.json
+++ b/packages/core/src/routes/account/index.openapi.json
@@ -478,6 +478,44 @@
           }
         }
       }
+    },
+    "/api/my-account/identities/{target}/access-token": {
+      "get": {
+        "operationId": "GetSocialIdentityAccessToken",
+        "tags": ["Dev feature"],
+        "summary": "Retrieve the access token issued by a third-party social provider",
+        "description": "This API retrieves the access token issued by a third-party social provider for a given social target. \nAccess is only available if token storage is enabled for the corresponding social connector.\nWhen a user authenticates through a social provider, Logto automatically stores the provider’s tokens in an encrypted form.\nYou can use this API to securely retrieve the stored access token and use it to access third-party APIs on behalf of the user.",
+        "responses": {
+          "200": {
+            "description": "The access token was retrieved successfully."
+          },
+          "404": {
+            "description": "The social identity does not exist or the access token is not available."
+          },
+          "401": {
+            "description": "Permission denied, the access_token is expired and the offline_access scope is not granted or expired."
+          }
+        }
+      }
+    },
+    "/api/my-account/sso-identities/{connectorId}/access-token": {
+      "get": {
+        "operationId": "GetEnterpriseSsoIdentityAccessToken",
+        "tags": ["Dev feature"],
+        "summary": "Retrieve the access token issued by a third-party enterprise SSO provider",
+        "description": "This API retrieves the access token issued by a third-party  enterprise SSO provider for a given SSO connector ID. \nAccess is only available if token storage is enabled for the corresponding connector.\nWhen a user authenticates through a SSO provider, Logto automatically stores the provider’s tokens in an encrypted form.\nYou can use this API to securely retrieve the stored access token and use it to access third-party APIs on behalf of the user.",
+        "responses": {
+          "200": {
+            "description": "The access token was retrieved successfully."
+          },
+          "404": {
+            "description": "The SSO connector does not exist or the access token is not available."
+          },
+          "401": {
+            "description": "Permission denied, the access_token is expired and the offline_access scope is not granted or expired."
+          }
+        }
+      }
     }
   }
 }

--- a/packages/core/src/routes/account/index.openapi.json
+++ b/packages/core/src/routes/account/index.openapi.json
@@ -503,7 +503,7 @@
         "operationId": "GetEnterpriseSsoIdentityAccessToken",
         "tags": ["Dev feature"],
         "summary": "Retrieve the access token issued by a third-party enterprise SSO provider",
-        "description": "This API retrieves the access token issued by a third-party  enterprise SSO provider for a given SSO connector ID. \nAccess is only available if token storage is enabled for the corresponding connector.\nWhen a user authenticates through a SSO provider, Logto automatically stores the provider’s tokens in an encrypted form.\nYou can use this API to securely retrieve the stored access token and use it to access third-party APIs on behalf of the user.",
+        "description": "This API retrieves the access token issued by a third-party enterprise SSO provider for a given SSO connector ID. \nAccess is only available if token storage is enabled for the corresponding connector.\nWhen a user authenticates through a SSO provider, Logto automatically stores the provider’s tokens in an encrypted form.\nYou can use this API to securely retrieve the stored access token and use it to access third-party APIs on behalf of the user.",
         "responses": {
           "200": {
             "description": "The access token was retrieved successfully."

--- a/packages/core/src/routes/account/index.ts
+++ b/packages/core/src/routes/account/index.ts
@@ -25,6 +25,7 @@ import emailAndPhoneRoutes from './email-and-phone.js';
 import identitiesRoutes from './identities.js';
 import mfaVerificationsRoutes from './mfa-verifications.js';
 import koaAccountCenter from './middlewares/koa-account-center.js';
+import thirdPartyTokensRoutes from './third-party-tokens.js';
 import { getAccountCenterFilteredProfile, getScopedProfile } from './utils/get-scoped-profile.js';
 
 export default function accountRoutes<T extends UserRouter>(...args: RouterInitArgs<T>) {
@@ -277,6 +278,11 @@ export default function accountRoutes<T extends UserRouter>(...args: RouterInitA
         return next();
       }
     );
+  }
+
+  // TODO: remove this when the third-party tokens feature is no longer experimental.
+  if (EnvSet.values.isDevFeaturesEnabled) {
+    thirdPartyTokensRoutes(...args);
   }
 
   emailAndPhoneRoutes(...args);

--- a/packages/core/src/routes/account/middlewares/koa-account-center.ts
+++ b/packages/core/src/routes/account/middlewares/koa-account-center.ts
@@ -13,14 +13,14 @@ import { accountApiPrefix } from '../constants.js';
 export type WithAccountCenterContext<ContextT extends IRouterParamContext = IRouterParamContext> =
   ContextT & { accountCenter: AccountCenter };
 
-const getSocialTokenRequestPathRegex = new RegExp(
-  `^/${accountApiPrefix}/identities/[^/]+/access-token$`
+const getThirdPartyTokenRequestPathRegex = new RegExp(
+  `^${accountApiPrefix}/(identities|sso-identities)/[^/]+/access-token$`
 );
 
 const isGetThirdPartyTokenRequest = <ContextT extends Context>({
   request: { method, path },
 }: ContextT) => {
-  return method === 'GET' && getSocialTokenRequestPathRegex.test(path);
+  return method === 'GET' && getThirdPartyTokenRequestPathRegex.test(path);
 };
 
 /**

--- a/packages/core/src/routes/account/middlewares/koa-account-center.ts
+++ b/packages/core/src/routes/account/middlewares/koa-account-center.ts
@@ -1,15 +1,27 @@
 import type { AccountCenter } from '@logto/schemas';
-import type { MiddlewareType } from 'koa';
+import type { Context, MiddlewareType } from 'koa';
 import { type IRouterParamContext } from 'koa-router';
 
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
+
+import { accountApiPrefix } from '../constants.js';
 
 /**
  * Extend the context with the account center configs.
  */
 export type WithAccountCenterContext<ContextT extends IRouterParamContext = IRouterParamContext> =
   ContextT & { accountCenter: AccountCenter };
+
+const getSocialTokenRequestPathRegex = new RegExp(
+  `^/${accountApiPrefix}/identities/[^/]+/access-token$`
+);
+
+const isGetThirdPartyTokenRequest = <ContextT extends Context>({
+  request: { method, path },
+}: ContextT) => {
+  return method === 'GET' && getSocialTokenRequestPathRegex.test(path);
+};
 
 /**
  * Create a middleware that injects the account center configs and ensures
@@ -20,7 +32,12 @@ export default function koaAccountCenter<StateT, ContextT extends IRouterParamCo
 }: Queries): MiddlewareType<StateT, WithAccountCenterContext<ContextT>, ResponseT> {
   return async (ctx, next) => {
     const accountCenter = await findDefaultAccountCenter();
-    assertThat(accountCenter.enabled, 'account_center.not_enabled');
+
+    // Whitelist the request to get third-party token,
+    // as it does not require the account center to be enabled.
+    if (!isGetThirdPartyTokenRequest(ctx)) {
+      assertThat(accountCenter.enabled, 'account_center.not_enabled');
+    }
 
     ctx.accountCenter = accountCenter;
 

--- a/packages/core/src/routes/account/third-party-tokens.ts
+++ b/packages/core/src/routes/account/third-party-tokens.ts
@@ -1,0 +1,134 @@
+import {
+  type EnterpriseSsoTokenSetSecret,
+  getThirdPartyAccessTokenResponseGuard,
+  type GetThirdPartyAccessTokenResponse,
+  type SocialTokenSetSecret,
+} from '@logto/schemas';
+import { conditional } from '@silverhand/essentials';
+import { z } from 'zod';
+
+import RequestError from '#src/errors/RequestError/index.js';
+import koaGuard from '#src/middleware/koa-guard.js';
+import type Queries from '#src/tenants/Queries.js';
+import { decryptTokens } from '#src/utils/secret-encryption.js';
+
+import { type UserRouter, type RouterInitArgs } from '../types.js';
+
+import { accountApiPrefix } from './constants.js';
+
+const getAccessToken = async (
+  { secrets }: Queries,
+  tokenSetSecret: SocialTokenSetSecret | EnterpriseSsoTokenSetSecret
+): Promise<GetThirdPartyAccessTokenResponse> => {
+  const {
+    id,
+    metadata: { expiresAt, scope, tokenType },
+    iv,
+    encryptedDek,
+    ciphertext,
+    authTag,
+  } = tokenSetSecret;
+
+  const { access_token, refresh_token } = decryptTokens({
+    iv,
+    encryptedDek,
+    ciphertext,
+    authTag,
+  });
+
+  if (!access_token) {
+    throw new RequestError({
+      code: 'secrets.third_party_token_set.token_not_found',
+      status: 404,
+    });
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+
+  if (!expiresAt || now < expiresAt) {
+    const expires_in = expiresAt ? expiresAt - now : undefined;
+    return {
+      access_token,
+      ...conditional(scope && { scope }),
+      ...conditional(tokenType && { token_type: tokenType }),
+      ...conditional(expires_in && { expires_in }),
+    };
+  }
+
+  // TODO: if refresh_token is available, we should refresh the token and update the secret.
+
+  await secrets.deleteById(id);
+  throw new RequestError({
+    code: 'secrets.third_party_token_set.access_token_expired',
+    status: 401,
+  });
+};
+
+export default function thirdPartyTokensRoutes<T extends UserRouter>(
+  ...[router, { queries }]: RouterInitArgs<T>
+) {
+  const { secrets: secretsQueries } = queries;
+
+  router.get(
+    `${accountApiPrefix}/identities/:target/access-token`,
+    koaGuard({
+      params: z.object({
+        target: z.string().min(1),
+      }),
+      status: [200, 404, 401],
+      response: getThirdPartyAccessTokenResponseGuard,
+    }),
+    async (ctx, next) => {
+      const { id: userId } = ctx.auth;
+      const { target } = ctx.guard.params;
+
+      const tokenSetSecret = await secretsQueries.findSocialTokenSetSecretByUserIdAndTarget(
+        userId,
+        target
+      );
+
+      if (!tokenSetSecret) {
+        throw new RequestError({
+          code: 'secrets.third_party_token_set.token_not_found',
+          status: 404,
+        });
+      }
+
+      ctx.body = await getAccessToken(queries, tokenSetSecret);
+
+      return next();
+    }
+  );
+
+  router.get(
+    `${accountApiPrefix}/sso-identities/:connectorId/access-token`,
+    koaGuard({
+      params: z.object({
+        connectorId: z.string().min(1),
+      }),
+      status: [200, 404, 401],
+      response: getThirdPartyAccessTokenResponseGuard,
+    }),
+    async (ctx, next) => {
+      const { id: userId } = ctx.auth;
+      const { connectorId } = ctx.guard.params;
+
+      const tokenSetSecret =
+        await secretsQueries.findEnterpriseSsoTokenSetSecretByUserIdAndConnectorId(
+          userId,
+          connectorId
+        );
+
+      if (!tokenSetSecret) {
+        throw new RequestError({
+          code: 'secrets.third_party_token_set.token_not_found',
+          status: 404,
+        });
+      }
+
+      ctx.body = await getAccessToken(queries, tokenSetSecret);
+
+      return next();
+    }
+  );
+}

--- a/packages/core/src/routes/swagger/utils/documents.ts
+++ b/packages/core/src/routes/swagger/utils/documents.ts
@@ -170,7 +170,7 @@ export const buildExperienceApiBaseDocument = (
   tags: [...tags].map((tag) => ({ name: tag })),
 });
 
-const userApiIdentifiableEntityNames = Object.freeze(['profile', 'verification']);
+const userApiIdentifiableEntityNames = Object.freeze(['profile', 'verification', 'connector']);
 
 export const buildUserApiBaseDocument = (
   pathMap: Map<string, OpenAPIV3.PathItemObject>,

--- a/packages/core/src/utils/sql.ts
+++ b/packages/core/src/utils/sql.ts
@@ -44,8 +44,8 @@ export const convertToPrimitiveOrSql = (
   }
 
   // For Buffer values, we convert them to binary SQL tokens,
-  // Slonik will handle the binary data correctly in to `bytea` typed column.
-  // Secret vault table use only
+  // Slonik will handle the binary data correctly into `bytea` typed column.
+  // Only used for the secret vault table.
   if (Buffer.isBuffer(value)) {
     return sql.binary(value);
   }

--- a/packages/core/src/utils/sql.ts
+++ b/packages/core/src/utils/sql.ts
@@ -43,6 +43,13 @@ export const convertToPrimitiveOrSql = (
     return null;
   }
 
+  // For Buffer values, we convert them to binary SQL tokens,
+  // Slonik will handle the binary data correctly in to `bytea` typed column.
+  // Secret vault table use only
+  if (Buffer.isBuffer(value)) {
+    return sql.binary(value);
+  }
+
   if (typeof value === 'object') {
     return JSON.stringify(value);
   }

--- a/packages/phrases/src/locales/en/errors/index.ts
+++ b/packages/phrases/src/locales/en/errors/index.ts
@@ -18,6 +18,7 @@ import request from './request.js';
 import resource from './resource.js';
 import role from './role.js';
 import scope from './scope.js';
+import secrets from './secrets.js';
 import session from './session.js';
 import sign_in_experiences from './sign-in-experiences.js';
 import single_sign_on from './single-sign-on.js';
@@ -58,6 +59,7 @@ const errors = {
   account_center,
   one_time_token,
   custom_profile_fields,
+  secrets,
 };
 
 export default Object.freeze(errors);

--- a/packages/phrases/src/locales/en/errors/secrets.ts
+++ b/packages/phrases/src/locales/en/errors/secrets.ts
@@ -1,0 +1,8 @@
+const secrets = {
+  third_party_token_set: {
+    token_not_found: 'Token record not found.',
+    access_token_expired: 'The access token has expired. Please reconnect your account.',
+  },
+};
+
+export default Object.freeze(secrets);

--- a/packages/schemas/src/types/secrets.ts
+++ b/packages/schemas/src/types/secrets.ts
@@ -1,3 +1,4 @@
+import { tokenResponseGuard } from '@logto/connector-kit';
 import { z } from 'zod';
 
 import { SecretEnterpriseSsoConnectorRelations } from '../db-entries/secret-enterprise-sso-connector-relation.js';
@@ -115,4 +116,19 @@ export const desensitizedEnterpriseSsoTokenSetSecretGuard = enterpriseSsoTokenSe
 
 export type DesensitizedEnterpriseSsoTokenSetSecret = z.infer<
   typeof desensitizedEnterpriseSsoTokenSetSecretGuard
+>;
+
+export const getThirdPartyAccessTokenResponseGuard = tokenResponseGuard
+  .pick({
+    access_token: true,
+    scope: true,
+    token_type: true,
+    expires_in: true,
+  })
+  .extend({
+    access_token: z.string(),
+  });
+
+export type GetThirdPartyAccessTokenResponse = z.infer<
+  typeof getThirdPartyAccessTokenResponseGuard
 >;

--- a/packages/shared/src/database/types.ts
+++ b/packages/shared/src/database/types.ts
@@ -1,4 +1,4 @@
-export type SchemaValuePrimitive = string | number | boolean | undefined;
+export type SchemaValuePrimitive = string | number | boolean | undefined | Buffer;
 export type SchemaValue =
   | SchemaValuePrimitive
   | Record<string, unknown>


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add third-party token account APIs for users to retrieve access tokens issued by social or enterprise SSO providers. 

This PR includes the following updates:
1. Add a new `GET /my-account/identities/:target/access-token` endpoint to retrieve social access token.
2. Add a new `GET /my-account/sso-identities/:connectorId/access-token` endpoint to retrieve the enterprise SSO access token.
3. Refactor the `koaAccountCenter` middleware. Whitelist the two newly added endpoints. By design, retrieving a third-party access token does not require the account center to be enabled. 
4. Bug fix. Update the `convertToPrimitiveOrSql`  SQL util method to handle the Buffer typed value properly. Previously, all `Buffer` typed values were handled as an object, converted using `JSON.stringify`, and stored in the BYTEA column. The binary data is broken. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally
<img width="1086" height="643" alt="image" src="https://github.com/user-attachments/assets/8d6ff938-0c78-4b2e-95b0-e245ad3e6310" />

Integration test will be included in the upcoming PR. 


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
