### PR TITLE
feat(core): implement token refresh flow

### DIFF
--- a/packages/connectors/connector-github/src/index.ts
+++ b/packages/connectors/connector-github/src/index.ts
@@ -14,6 +14,7 @@ import type {
   CreateConnector,
   GetConnectorConfig,
   GetTokenResponseAndUserInfo,
+  GetAccessTokenByRefreshToken,
 } from '@logto/connector-kit';
 import ky, { HTTPError } from 'ky';
 
@@ -87,6 +88,37 @@ export const getAccessToken = async (config: GithubConfig, codeObject: { code: s
         client_id,
         client_secret,
         code,
+      }),
+      timeout: defaultTimeout,
+    })
+    .json();
+
+  const result = accessTokenResponseGuard.safeParse(httpResponse);
+
+  if (!result.success) {
+    throw new ConnectorError(ConnectorErrorCodes.InvalidResponse, result.error);
+  }
+
+  const { access_token } = result.data;
+
+  assert(access_token, new ConnectorError(ConnectorErrorCodes.SocialAuthCodeInvalid));
+
+  return result.data;
+};
+
+/**
+ * {@link https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/refreshing-user-access-tokens#refreshing-a-user-access-token-with-a-refresh-token}
+ */
+export const _getAccessTokenByRefreshToken = async (config: GithubConfig, refreshToken: string) => {
+  const { clientId: client_id, clientSecret: client_secret } = config;
+
+  const httpResponse = await ky
+    .post(accessTokenEndpoint, {
+      body: new URLSearchParams({
+        client_id,
+        client_secret,
+        refresh_token: refreshToken,
+        grant_type: 'refresh_token',
       }),
       timeout: defaultTimeout,
     })
@@ -197,6 +229,25 @@ const getUserInfo =
     return _getUserInfo(accessToken);
   };
 
+const getAccessTokenByRefreshToken =
+  (getConfig: GetConnectorConfig): GetAccessTokenByRefreshToken =>
+  async (refreshToken: string) => {
+    const config = await getConfig(defaultMetadata.id);
+    validateConfig(config, githubConfigGuard);
+
+    try {
+      return await _getAccessTokenByRefreshToken(config, refreshToken);
+    } catch (error: unknown) {
+      if (error instanceof HTTPError) {
+        const { body: rawBody } = error.response;
+
+        throw new ConnectorError(ConnectorErrorCodes.General, JSON.stringify(rawBody));
+      }
+
+      throw error;
+    }
+  };
+
 const createGithubConnector: CreateConnector<SocialConnector> = async ({ getConfig }) => {
   return {
     metadata: defaultMetadata,
@@ -205,6 +256,7 @@ const createGithubConnector: CreateConnector<SocialConnector> = async ({ getConf
     getAuthorizationUri: getAuthorizationUri(getConfig),
     getUserInfo: getUserInfo(getConfig),
     getTokenResponseAndUserInfo: getTokenResponseAndUserInfo(getConfig),
+    getAccessTokenByRefreshToken: getAccessTokenByRefreshToken(getConfig),
   };
 };
 

--- a/packages/connectors/connector-github/src/index.ts
+++ b/packages/connectors/connector-github/src/index.ts
@@ -109,7 +109,7 @@ export const getAccessToken = async (config: GithubConfig, codeObject: { code: s
 /**
  * {@link https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/refreshing-user-access-tokens#refreshing-a-user-access-token-with-a-refresh-token}
  */
-export const _getAccessTokenByRefreshToken = async (config: GithubConfig, refreshToken: string) => {
+const _getAccessTokenByRefreshToken = async (config: GithubConfig, refreshToken: string) => {
   const { clientId: client_id, clientSecret: client_secret } = config;
 
   const httpResponse = await ky

--- a/packages/core/src/libraries/social.ts
+++ b/packages/core/src/libraries/social.ts
@@ -199,6 +199,13 @@ export const createSocialLibrary = (queries: Queries, connectorLibrary: Connecto
     }
   };
 
+  /**
+   * Refreshes the token set secret by using the provided refresh token.
+   *
+   * - Fetches the latest token response using the refresh token.
+   * - Updates the secret using the latest encrypted token response.
+   * - Returns the access token and metadata from the updated secret.
+   */
   const refreshTokenSetSecret = async (
     connectorId: string,
     secretId: string,

--- a/packages/core/src/libraries/social.ts
+++ b/packages/core/src/libraries/social.ts
@@ -14,7 +14,12 @@ import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 import type { LogtoConnector } from '#src/utils/connectors/types.js';
 
-import { deserializeEncryptedSecret, encryptTokenResponse } from '../utils/secret-encryption.js';
+import {
+  deserializeEncryptedSecret,
+  encryptAndSerializeTokenResponse,
+  encryptTokenResponse,
+  isValidAccessTokenResponse,
+} from '../utils/secret-encryption.js';
 
 const getUserInfoFromInteractionResult = async (
   connectorId: string,
@@ -119,7 +124,7 @@ export const createSocialLibrary = (queries: Queries, connectorLibrary: Connecto
       );
 
       const encryptedTokenSet = trySafe(
-        () => encryptTokenResponse(tokenResponse),
+        () => encryptAndSerializeTokenResponse(tokenResponse),
         (error) => {
           // If the token response cannot be encrypted, we log the error but continue to return user info.
           void appInsights.trackException(error);
@@ -194,6 +199,57 @@ export const createSocialLibrary = (queries: Queries, connectorLibrary: Connecto
     }
   };
 
+  const refreshTokenSetSecret = async (
+    connectorId: string,
+    secretId: string,
+    refreshToken: string
+  ) => {
+    const connector = await getConnector(connectorId);
+
+    assertThat(
+      connector.type === ConnectorType.Social,
+      new RequestError({
+        code: 'session.invalid_connector_id',
+        status: 422,
+        connectorId,
+      })
+    );
+
+    const {
+      metadata: { isTokenStorageSupported },
+      dbEntry: { enableTokenStorage },
+      getAccessTokenByRefreshToken,
+    } = connector;
+
+    assertThat(
+      isTokenStorageSupported && enableTokenStorage && getAccessTokenByRefreshToken,
+      new RequestError({
+        code: 'connector.token_storage_not_supported',
+        status: 422,
+      })
+    );
+
+    const tokenResponse = await getAccessTokenByRefreshToken(refreshToken);
+
+    assertThat(
+      isValidAccessTokenResponse(tokenResponse),
+      new RequestError('connector.invalid_response')
+    );
+
+    const { tokenSecret, metadata } = encryptTokenResponse(tokenResponse);
+    const { access_token } = tokenResponse;
+
+    await queries.secrets.updateById(secretId, {
+      ...tokenSecret,
+      metadata,
+    });
+
+    return {
+      access_token,
+      metadata,
+    };
+  };
+
   return {
     getConnector,
     getUserInfo,
@@ -201,5 +257,6 @@ export const createSocialLibrary = (queries: Queries, connectorLibrary: Connecto
     getUserInfoFromInteractionResult,
     findSocialRelatedUser,
     upsertSocialTokenSetSecret,
+    refreshTokenSetSecret,
   };
 };

--- a/packages/core/src/libraries/sso-connector.ts
+++ b/packages/core/src/libraries/sso-connector.ts
@@ -251,6 +251,13 @@ export const createSsoConnectorLibrary = (queries: Queries) => {
     }
   };
 
+  /**
+   * Refreshes the token set secret by using the provided refresh token.
+   *
+   * - Fetches the latest token response using the refresh token.
+   * - Updates the secret using the latest encrypted token response.
+   * - Returns the access token and metadata from the updated secret.
+   */
   const refreshTokenSetSecret = async (
     ssoConnectorId: string,
     secretId: string,

--- a/packages/core/src/libraries/sso-connector.ts
+++ b/packages/core/src/libraries/sso-connector.ts
@@ -20,7 +20,12 @@ import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 import { type OmitAutoSetFields } from '#src/utils/sql.js';
 
-import { deserializeEncryptedSecret } from '../utils/secret-encryption.js';
+import OidcConnector from '../sso/OidcConnector/index.js';
+import {
+  deserializeEncryptedSecret,
+  encryptTokenResponse,
+  isValidAccessTokenResponse,
+} from '../utils/secret-encryption.js';
 
 export type SsoConnectorLibrary = ReturnType<typeof createSsoConnectorLibrary>;
 
@@ -246,6 +251,48 @@ export const createSsoConnectorLibrary = (queries: Queries) => {
     }
   };
 
+  const refreshTokenSetSecret = async (
+    ssoConnectorId: string,
+    secretId: string,
+    refreshToken: string
+  ) => {
+    const connector = await getSsoConnectorById(ssoConnectorId);
+    const connectorInstance = new ssoConnectorFactories[connector.providerName].constructor(
+      connector,
+      // Placeholder, not used in OIDC SSO connectors
+      // Avoid importing unnecessary envSet to this method
+      new URL('http://auth.logto.io')
+    );
+
+    assertThat(
+      connectorInstance instanceof OidcConnector && connector.enableTokenStorage,
+      new RequestError({
+        code: 'connector.token_storage_not_supported',
+        status: 422,
+      })
+    );
+
+    const tokenResponse = await connectorInstance.getTokenByRefreshToken(refreshToken);
+
+    assertThat(
+      isValidAccessTokenResponse(tokenResponse),
+      new RequestError('connector.invalid_response')
+    );
+
+    const { tokenSecret, metadata } = encryptTokenResponse(tokenResponse);
+    const { access_token } = tokenResponse;
+
+    await queries.secrets.updateById(secretId, {
+      ...tokenSecret,
+      metadata,
+    });
+
+    return {
+      access_token,
+      metadata,
+    };
+  };
+
   return {
     getSsoConnectors,
     getAvailableSsoConnectors,
@@ -254,5 +301,6 @@ export const createSsoConnectorLibrary = (queries: Queries) => {
     createIdpInitiatedSamlSsoSession,
     getIdpInitiatedSamlSsoSignInUrl,
     upsertEnterpriseSsoTokenSetSecret,
+    refreshTokenSetSecret,
   };
 };

--- a/packages/core/src/routes/account/third-party-tokens.ts
+++ b/packages/core/src/routes/account/third-party-tokens.ts
@@ -3,12 +3,14 @@ import {
   getThirdPartyAccessTokenResponseGuard,
   type GetThirdPartyAccessTokenResponse,
   type SocialTokenSetSecret,
+  type TokenSetMetadata,
 } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
 import { z } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
+import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import { decryptTokens } from '#src/utils/secret-encryption.js';
 
@@ -16,18 +18,34 @@ import { type UserRouter, type RouterInitArgs } from '../types.js';
 
 import { accountApiPrefix } from './constants.js';
 
+const isSocialTokenSetSecret = (
+  tokenSetSecret: SocialTokenSetSecret | EnterpriseSsoTokenSetSecret
+): tokenSetSecret is SocialTokenSetSecret =>
+  'connectorId' in tokenSetSecret && 'target' in tokenSetSecret;
+
+const formatTokenResponse = (
+  access_token: string,
+  metadata: TokenSetMetadata,
+  now = Math.floor(Date.now() / 1000)
+) => {
+  const { expiresAt, scope, tokenType } = metadata;
+
+  const expires_in = expiresAt ? expiresAt - now : undefined;
+
+  return {
+    access_token,
+    ...conditional(scope && { scope }),
+    ...conditional(tokenType && { token_type: tokenType }),
+    ...conditional(expires_in && { expires_in }),
+  };
+};
+
 const getAccessToken = async (
+  { socials, ssoConnectors }: Libraries,
   { secrets }: Queries,
   tokenSetSecret: SocialTokenSetSecret | EnterpriseSsoTokenSetSecret
 ): Promise<GetThirdPartyAccessTokenResponse> => {
-  const {
-    id,
-    metadata: { expiresAt, scope, tokenType },
-    iv,
-    encryptedDek,
-    ciphertext,
-    authTag,
-  } = tokenSetSecret;
+  const { id, metadata, iv, encryptedDek, ciphertext, authTag } = tokenSetSecret;
 
   const { access_token, refresh_token } = decryptTokens({
     iv,
@@ -43,21 +61,22 @@ const getAccessToken = async (
     });
   }
 
+  const { expiresAt } = metadata;
   const now = Math.floor(Date.now() / 1000);
 
   if (!expiresAt || now < expiresAt) {
-    const expires_in = expiresAt ? expiresAt - now : undefined;
-    return {
-      access_token,
-      ...conditional(scope && { scope }),
-      ...conditional(tokenType && { token_type: tokenType }),
-      ...conditional(expires_in && { expires_in }),
-    };
+    return formatTokenResponse(access_token, metadata, now);
   }
 
-  // TODO: if refresh_token is available, we should refresh the token and update the secret.
+  if (refresh_token) {
+    const refreshedResponse = isSocialTokenSetSecret(tokenSetSecret)
+      ? await socials.refreshTokenSetSecret(tokenSetSecret.connectorId, id, refresh_token)
+      : await ssoConnectors.refreshTokenSetSecret(tokenSetSecret.ssoConnectorId, id, refresh_token);
 
-  await secrets.deleteById(id);
+    return formatTokenResponse(refreshedResponse.access_token, metadata);
+  }
+
+  // Await secrets.deleteById(id);
   throw new RequestError({
     code: 'secrets.third_party_token_set.access_token_expired',
     status: 401,
@@ -65,7 +84,7 @@ const getAccessToken = async (
 };
 
 export default function thirdPartyTokensRoutes<T extends UserRouter>(
-  ...[router, { queries }]: RouterInitArgs<T>
+  ...[router, { queries, libraries }]: RouterInitArgs<T>
 ) {
   const { secrets: secretsQueries } = queries;
 
@@ -75,7 +94,7 @@ export default function thirdPartyTokensRoutes<T extends UserRouter>(
       params: z.object({
         target: z.string().min(1),
       }),
-      status: [200, 404, 401],
+      status: [200, 404, 401, 422],
       response: getThirdPartyAccessTokenResponseGuard,
     }),
     async (ctx, next) => {
@@ -94,7 +113,7 @@ export default function thirdPartyTokensRoutes<T extends UserRouter>(
         });
       }
 
-      ctx.body = await getAccessToken(queries, tokenSetSecret);
+      ctx.body = await getAccessToken(libraries, queries, tokenSetSecret);
 
       return next();
     }
@@ -126,7 +145,7 @@ export default function thirdPartyTokensRoutes<T extends UserRouter>(
         });
       }
 
-      ctx.body = await getAccessToken(queries, tokenSetSecret);
+      ctx.body = await getAccessToken(libraries, queries, tokenSetSecret);
 
       return next();
     }

--- a/packages/core/src/routes/interaction/utils/single-sign-on.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on.ts
@@ -17,15 +17,15 @@ import { idpInitiatedSamlSsoSessionCookieName } from '#src/constants/index.js';
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
+import OidcConnector from '#src/sso/OidcConnector/index.js';
 import SamlConnector from '#src/sso/SamlConnector/index.js';
 import { ssoConnectorFactories, type SingleSignOnConnectorSession } from '#src/sso/index.js';
 import { type ExtendedSocialUserInfo } from '#src/sso/types/saml.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 import { safeParseUnknownJson } from '#src/utils/json.js';
+import { encryptAndSerializeTokenResponse } from '#src/utils/secret-encryption.js';
 
-import OidcConnector from '../../../sso/OidcConnector/index.js';
-import { encryptTokenResponse } from '../../../utils/secret-encryption.js';
 import { type WithInteractionHooksContext } from '../middleware/koa-interaction-hooks.js';
 
 import {
@@ -191,7 +191,7 @@ export const verifySsoIdentity = async (
           enableTokenStorage &&
             tokenResponse &&
             trySafe(
-              () => encryptTokenResponse(tokenResponse),
+              () => encryptAndSerializeTokenResponse(tokenResponse),
               (error) => {
                 // If the token response cannot be encrypted, we log the error but continue to return user info.
                 void appInsights.trackException(error);

--- a/packages/core/src/sso/GoogleWorkspaceSsoConnector/index.ts
+++ b/packages/core/src/sso/GoogleWorkspaceSsoConnector/index.ts
@@ -1,5 +1,7 @@
 import { ConnectorError, ConnectorErrorCodes } from '@logto/connector-kit';
 import { SsoProviderName, SsoProviderType } from '@logto/schemas';
+import { generateStandardId } from '@logto/shared/universal';
+import snakecaseKeys from 'snakecase-keys';
 
 import OidcConnector from '../OidcConnector/index.js';
 import { type SingleSignOnFactory } from '../index.js';
@@ -26,12 +28,46 @@ export class GoogleWorkspaceSsoConnector extends OidcConnector implements Single
     });
   }
 
-  // Always use select_account prompt for Google Workspace SSO.
+  /**
+   * Override the standard getOidcConfig method for Google Workspace SSO.
+   * - Set the `prompt` to `select_account` to ensure the user can choose an account.
+   * - Remove `offline_access` from the scope as Google Workspace SSO does not support it.
+   * - Add `access_type=offline` if `offline_access` is in the scope.
+   * {@link https://developers.google.com/identity/protocols/oauth2/web-server#offline}
+   */
   override async getAuthorizationUrl(
-    payload: { state: string; redirectUri: string; connectorId: string },
+    {
+      state,
+      redirectUri,
+      connectorId,
+    }: { state: string; redirectUri: string; connectorId: string },
     setSession: CreateSingleSignOnSession
   ) {
-    return super.getAuthorizationUrl(payload, setSession, 'select_account');
+    const oidcConfig = await this.getOidcConfig();
+    const nonce = generateStandardId();
+    const isOfflineAccess = oidcConfig.scope.includes('offline_access');
+
+    await setSession({ nonce, redirectUri, connectorId, state });
+
+    const queryParameters = new URLSearchParams({
+      state,
+      nonce,
+      ...snakecaseKeys({
+        clientId: oidcConfig.clientId,
+        responseType: 'code',
+        redirectUri,
+      }),
+      // Always use select_account prompt for Google Workspace SSO.
+      prompt: 'select_account consent',
+      // Remove offline_access from scope if it exists, as Google Workspace SSO does not support it.
+      scope: oidcConfig.scope.replace('offline_access', '').trim(),
+      ...(isOfflineAccess && { access_type: 'offline' }),
+      // Include granted scopes to ensure the user can see the scopes they are consenting to.
+      // Recommended by Google for better user experience.
+      include_granted_scopes: 'true',
+    });
+
+    return `${oidcConfig.authorizationEndpoint}?${queryParameters.toString()}`;
   }
 
   async getConfig() {

--- a/packages/core/src/sso/GoogleWorkspaceSsoConnector/index.ts
+++ b/packages/core/src/sso/GoogleWorkspaceSsoConnector/index.ts
@@ -61,6 +61,7 @@ export class GoogleWorkspaceSsoConnector extends OidcConnector implements Single
       prompt: 'select_account consent',
       // Remove offline_access from scope if it exists, as Google Workspace SSO does not support it.
       scope: oidcConfig.scope.replace('offline_access', '').trim(),
+      // Add `access_type=offline` if `offline_access` is in the scope.
       ...(isOfflineAccess && { access_type: 'offline' }),
       // Include granted scopes to ensure the user can see the scopes they are consenting to.
       // Recommended by Google for better user experience.

--- a/packages/core/src/sso/OidcConnector/index.ts
+++ b/packages/core/src/sso/OidcConnector/index.ts
@@ -1,3 +1,4 @@
+import { type TokenResponse } from '@logto/connector-kit';
 import { type ExtendedSocialUserInfo } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared/universal';
 import { conditional } from '@silverhand/essentials';
@@ -20,7 +21,13 @@ import {
 } from '../types/session.js';
 
 import { mockGetTokenResponse, mockGetUserInfo } from './test-utils.js';
-import { fetchOidcConfig, fetchToken, getIdTokenClaims, getUserInfo } from './utils.js';
+import {
+  fetchOidcConfig,
+  fetchToken,
+  getIdTokenClaims,
+  getTokenByRefreshToken,
+  getUserInfo,
+} from './utils.js';
 
 /**
  * OIDC connector
@@ -147,6 +154,11 @@ class OidcConnector {
       },
       tokenResponse,
     };
+  }
+
+  async getTokenByRefreshToken(refreshToken: string): Promise<TokenResponse> {
+    const oidcConfig = await this.getOidcConfig();
+    return getTokenByRefreshToken(oidcConfig, refreshToken);
   }
 }
 

--- a/packages/core/src/sso/OidcConnector/utils.ts
+++ b/packages/core/src/sso/OidcConnector/utils.ts
@@ -1,4 +1,4 @@
-import { parseJson } from '@logto/connector-kit';
+import { parseJson, tokenResponseGuard, type TokenResponse } from '@logto/connector-kit';
 import { assert } from '@silverhand/essentials';
 import camelcaseKeys, { type CamelCaseKeys } from 'camelcase-keys';
 import { got, HTTPError } from 'got';
@@ -234,6 +234,49 @@ export const getUserInfo = async (accessToken: string, userinfoEndpoint: string)
 
     throw new SsoConnectorError(SsoConnectorErrorCodes.AuthorizationFailed, {
       message: 'Fail to fetch user info',
+      error: error instanceof HTTPError ? error.response.body : error,
+    });
+  }
+};
+
+export const getTokenByRefreshToken = async (
+  { tokenEndpoint, clientId, clientSecret }: BaseOidcConfig,
+  refreshToken: string
+): Promise<TokenResponse> => {
+  const tokenRequestParameters = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+  });
+
+  const headers = {
+    Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`, 'utf8').toString('base64')}`,
+    'Content-Type': 'application/x-www-form-urlencoded',
+  };
+
+  try {
+    const httpResponse = await got.post(tokenEndpoint, {
+      body: tokenRequestParameters.toString(),
+      headers,
+    });
+
+    const result = tokenResponseGuard.safeParse(parseJson(httpResponse.body));
+
+    if (!result.success) {
+      throw new SsoConnectorError(SsoConnectorErrorCodes.AuthorizationFailed, {
+        message: 'Invalid token response',
+        response: result.data,
+        error: result.error.flatten(),
+      });
+    }
+
+    return result.data;
+  } catch (error: unknown) {
+    if (error instanceof SsoConnectorError) {
+      throw error;
+    }
+
+    throw new SsoConnectorError(SsoConnectorErrorCodes.AuthorizationFailed, {
+      message: 'Fail to fetch token',
       error: error instanceof HTTPError ? error.response.body : error,
     });
   }

--- a/packages/core/src/test-utils/mock-libraries.ts
+++ b/packages/core/src/test-utils/mock-libraries.ts
@@ -26,4 +26,5 @@ export const mockSsoConnectorLibrary: jest.Mocked<SsoConnectorLibrary> = {
   createIdpInitiatedSamlSsoSession: jest.fn(),
   getIdpInitiatedSamlSsoSignInUrl: jest.fn(),
   upsertEnterpriseSsoTokenSetSecret: jest.fn(),
+  refreshTokenSetSecret: jest.fn(),
 };

--- a/packages/toolkit/connector-kit/src/types/social.ts
+++ b/packages/toolkit/connector-kit/src/types/social.ts
@@ -125,6 +125,8 @@ export type GetTokenResponseAndUserInfo = (
   userInfo: SocialUserInfo;
 }>;
 
+export type GetAccessTokenByRefreshToken = (refreshToken: string) => Promise<TokenResponse>;
+
 export type SocialConnector = BaseConnector<ConnectorType.Social> & {
   getAuthorizationUri: GetAuthorizationUri;
   getUserInfo: GetUserInfo;
@@ -136,6 +138,12 @@ export type SocialConnector = BaseConnector<ConnectorType.Social> & {
    * otherwise, use `getUserInfo` to retrieve the user info directly.
    */
   getTokenResponseAndUserInfo?: GetTokenResponseAndUserInfo;
+  /**
+   * @remarks
+   * If the social connector has token storage enabled,
+   * this function can be used to retrieve the access token by the refresh token.
+   */
+  getAccessTokenByRefreshToken?: GetAccessTokenByRefreshToken;
   validateSamlAssertion?: ValidateSamlAssertion;
 };
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR implements the token refresh flow for federated third-party access token exchange.
If the access token issued by a third-party social or enterprise SSO connector has expired and a refresh token is available, Logto will automatically refresh the access token and return the updated response.

### Updates:
1. connector-kit: Adds a new callback method type definition: `getAccessTokenByRefreshToken` for social connectors.
This method allows the connector to exchange a new access token using a refresh token.
It is required for all social connectors that have token storage enabled.
2. connector-github: Update the github connector with new `getAccessTokenByRefreshToken` method to support token refresh.
3. Social library and SSO library:  Adds a new `refreshTokenSetSecret` method to handle token refresh requests.
If the request is successful, Logto will update the existing token secret with the latest response and return the refreshed access token.
4. Account API:  Updates the user account third-party token API to support token refresh.
If the access token stored in the Secret Vault has expired and a refresh token is available, the API will call the refreshTokenSetSecret method to obtain a new access token. 
5. OIDC SSO connector:  Adds a new getTokenByRefreshToken method to support token refresh for all OIDC SSO connectors.
6. Google SSO connector: Overwrite the default OIDC `getAuthorizationUrl` method. As Google does not support the `offline_access` scope. We need to replace it with an `access_type=offline` parameter. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.
Need to mock the connector for integration tests. Will add integration tests in a separate PR later. 


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
