### PR TITLE
feat(experience,phrases): add fullname and address input fields in sie

### DIFF
--- a/packages/experience/src/components/InputFields/AddressField/index.module.scss
+++ b/packages/experience/src/components/InputFields/AddressField/index.module.scss
@@ -1,0 +1,22 @@
+@use '@/scss/underscore' as _;
+
+.addressGroup {
+  display: flex;
+  flex-wrap: wrap;
+  gap: _.unit(3);
+
+  .inputField {
+    flex: 1;
+    flex-basis: 100%;
+
+    &.halfSize {
+      flex: 1;
+      flex-basis: 50%;
+    }
+  }
+}
+
+.description {
+  margin-top: _.unit(-2);
+  @include _.text-hint;
+}

--- a/packages/experience/src/components/InputFields/AddressField/index.tsx
+++ b/packages/experience/src/components/InputFields/AddressField/index.tsx
@@ -1,0 +1,44 @@
+import type { AddressProfileField, UserProfile } from '@logto/schemas';
+import classNames from 'classnames';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import InputField from '../InputField';
+
+import styles from './index.module.scss';
+import { formatAddress } from './utils';
+
+type Props = {
+  readonly value?: UserProfile['address'];
+  readonly parts?: AddressProfileField['config']['parts'];
+  readonly description?: string;
+  readonly onChange: (value: UserProfile['address']) => void;
+};
+
+const AddressField = ({ value, parts, description, onChange }: Props) => {
+  const { t } = useTranslation();
+  const enabledParts = useMemo(() => parts?.filter(({ enabled }) => enabled), [parts]);
+
+  return (
+    <div className={styles.addressGroup}>
+      {enabledParts?.map(({ key }) => (
+        <InputField
+          key={key}
+          className={classNames(
+            styles.inputField,
+            (key === 'locality' || key === 'region') && styles.halfSize
+          )}
+          label={t(`profile.address.${key}`)}
+          value={value?.[key]}
+          onChange={(event) => {
+            const newValue = { ...value, [key]: event.currentTarget.value };
+            onChange(key === 'formatted' ? newValue : formatAddress(newValue));
+          }}
+        />
+      ))}
+      {description && <div className={styles.description}>{description}</div>}
+    </div>
+  );
+};
+
+export default AddressField;

--- a/packages/experience/src/components/InputFields/AddressField/utils.ts
+++ b/packages/experience/src/components/InputFields/AddressField/utils.ts
@@ -1,0 +1,11 @@
+import { type UserProfile } from '@logto/schemas';
+
+export const formatAddress = (
+  address: Exclude<UserProfile['address'], 'formatted' | undefined>
+): UserProfile['address'] => {
+  const { streetAddress, locality, region, postalCode, country } = address;
+  const formatted = [streetAddress, locality, region, postalCode, country]
+    .filter(Boolean)
+    .join(', ');
+  return { formatted, ...address };
+};

--- a/packages/experience/src/components/InputFields/FullnameField/index.module.scss
+++ b/packages/experience/src/components/InputFields/FullnameField/index.module.scss
@@ -1,0 +1,23 @@
+@use '@/scss/underscore' as _;
+
+.fullnameContainer {
+  display: flex;
+  gap: _.unit(3);
+
+  .inputField {
+    flex: 1;
+  }
+
+  &.vertical {
+    flex-direction: column;
+
+    .inputField {
+      flex: none;
+      width: 100%;
+    }
+  }
+}
+
+.description {
+  @include _.text-hint;
+}

--- a/packages/experience/src/components/InputFields/FullnameField/index.tsx
+++ b/packages/experience/src/components/InputFields/FullnameField/index.tsx
@@ -1,0 +1,44 @@
+import { type FullnameProfileField, type UserProfile } from '@logto/schemas';
+import classNames from 'classnames';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import InputField from '../InputField';
+
+import styles from './index.module.scss';
+
+type Fullname = Pick<UserProfile, 'givenName' | 'middleName' | 'familyName'>;
+
+type Props = {
+  readonly value?: Fullname;
+  readonly parts?: FullnameProfileField['config']['parts'];
+  readonly onChange: (value: Fullname) => void;
+};
+
+const FullnameField = ({ value, parts, onChange }: Props) => {
+  const { t } = useTranslation();
+  const enabledParts = useMemo(() => parts?.filter(({ enabled }) => enabled), [parts]);
+
+  return (
+    <div
+      className={classNames(
+        styles.fullnameContainer,
+        enabledParts?.length !== 2 && styles.vertical
+      )}
+    >
+      {enabledParts?.map(({ key }) => (
+        <InputField
+          key={key}
+          className={styles.inputField}
+          label={t(`profile.${key}`)}
+          value={value?.[key]}
+          onChange={(event) => {
+            onChange({ ...value, [key]: event.currentTarget.value });
+          }}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default FullnameField;

--- a/packages/experience/src/components/InputFields/InputField/index.tsx
+++ b/packages/experience/src/components/InputFields/InputField/index.tsx
@@ -27,7 +27,7 @@ export type Props = Omit<HTMLProps<HTMLInputElement>, 'prefix'> & {
   readonly suffix?: ReactElement;
   readonly isSuffixFocusVisible?: boolean;
   readonly label?: string;
-  readonly description?: string;
+  readonly description?: Nullable<string>;
 };
 
 const InputField = (

--- a/packages/experience/src/components/InputFields/SelectField/index.tsx
+++ b/packages/experience/src/components/InputFields/SelectField/index.tsx
@@ -1,3 +1,4 @@
+import { type Nullable } from '@silverhand/essentials';
 import { useRef, useState } from 'react';
 
 import Dropdown, { DropdownItem } from '@/components/Dropdown';
@@ -9,7 +10,7 @@ import styles from './index.module.scss';
 type Props = {
   readonly options: Array<{ value: string; label: string }>;
   readonly value?: string;
-  readonly description?: string;
+  readonly description?: Nullable<string>;
   readonly label?: string;
   readonly placeholder?: string;
   readonly errorMessage?: string;

--- a/packages/phrases-experience/src/locales/ar/index.ts
+++ b/packages/phrases-experience/src/locales/ar/index.ts
@@ -9,6 +9,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
 
@@ -23,6 +24,7 @@ const ar = {
     mfa,
     development_tenant,
     user_scopes,
+    profile,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/ar/profile.ts
+++ b/packages/phrases-experience/src/locales/ar/profile.ts
@@ -1,0 +1,26 @@
+const profile = {
+  name: 'الاسم',
+  avatar: 'الصورة الرمزية',
+  givenName: 'الاسم الأول',
+  familyName: 'اسم العائلة',
+  middleName: 'الاسم الأوسط',
+  fullName: 'الاسم الكامل',
+  nickname: 'الاسم المستعار',
+  preferredUsername: 'اسم المستخدم المفضل',
+  profile: 'الملف الشخصي',
+  website: 'الموقع الإلكتروني',
+  gender: 'الجنس',
+  birthdate: 'تاريخ الميلاد',
+  zoneinfo: 'معلومات المنطقة الزمنية',
+  locale: 'اللغة والمنطقة',
+  address: {
+    formatted: 'العنوان',
+    streetAddress: 'عنوان الشارع',
+    locality: 'المدينة',
+    region: 'الولاية/المقاطعة',
+    postalCode: 'الرمز البريدي',
+    country: 'الدولة',
+  },
+};
+
+export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/de/index.ts
+++ b/packages/phrases-experience/src/locales/de/index.ts
@@ -9,6 +9,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
 
@@ -23,6 +24,7 @@ const de = {
     mfa,
     development_tenant,
     user_scopes,
+    profile,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/de/profile.ts
+++ b/packages/phrases-experience/src/locales/de/profile.ts
@@ -1,0 +1,26 @@
+const profile = {
+  name: 'Name',
+  avatar: 'Avatar',
+  givenName: 'Vorname',
+  familyName: 'Nachname',
+  middleName: 'Zweitname',
+  fullName: 'Vollständiger Name',
+  nickname: 'Spitzname',
+  preferredUsername: 'Bevorzugter Benutzername',
+  profile: 'Profil',
+  website: 'Webseite',
+  gender: 'Geschlecht',
+  birthdate: 'Geburtsdatum',
+  zoneinfo: 'Zeitzone',
+  locale: 'Sprache',
+  address: {
+    formatted: 'Adresse',
+    streetAddress: 'Straßenadresse',
+    locality: 'Stadt',
+    region: 'Bundesland/Provinz',
+    postalCode: 'Postleitzahl',
+    country: 'Land',
+  },
+};
+
+export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/en/index.ts
+++ b/packages/phrases-experience/src/locales/en/index.ts
@@ -5,6 +5,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
 
@@ -19,6 +20,7 @@ const en = {
     mfa,
     development_tenant,
     user_scopes,
+    profile,
   },
 };
 

--- a/packages/phrases-experience/src/locales/en/profile.ts
+++ b/packages/phrases-experience/src/locales/en/profile.ts
@@ -1,0 +1,26 @@
+const profile = {
+  name: 'Name',
+  avatar: 'Avatar',
+  givenName: 'Given Name',
+  familyName: 'Family Name',
+  middleName: 'Middle Name',
+  fullName: 'Full Name',
+  nickname: 'Nickname',
+  preferredUsername: 'Preferred Username',
+  profile: 'Profile',
+  website: 'Website',
+  gender: 'Gender',
+  birthdate: 'Birthdate',
+  zoneinfo: 'Zoneinfo',
+  locale: 'Locale',
+  address: {
+    formatted: 'Address',
+    streetAddress: 'Street address',
+    locality: 'City',
+    region: 'State/Province',
+    postalCode: 'Zip code',
+    country: 'Country',
+  },
+};
+
+export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/es/index.ts
+++ b/packages/phrases-experience/src/locales/es/index.ts
@@ -9,6 +9,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
 
@@ -23,6 +24,7 @@ const es = {
     mfa,
     development_tenant,
     user_scopes,
+    profile,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/es/profile.ts
+++ b/packages/phrases-experience/src/locales/es/profile.ts
@@ -1,0 +1,26 @@
+const profile = {
+  name: 'Nombre',
+  avatar: 'Avatar',
+  givenName: 'Nombre de pila',
+  familyName: 'Apellido',
+  middleName: 'Segundo nombre',
+  fullName: 'Nombre completo',
+  nickname: 'Apodo',
+  preferredUsername: 'Nombre de usuario preferido',
+  profile: 'Perfil',
+  website: 'Sitio web',
+  gender: 'Género',
+  birthdate: 'Fecha de nacimiento',
+  zoneinfo: 'Zona horaria',
+  locale: 'Configuración regional',
+  address: {
+    formatted: 'Dirección',
+    streetAddress: 'Dirección',
+    locality: 'Ciudad',
+    region: 'Estado/Provincia',
+    postalCode: 'Código postal',
+    country: 'País',
+  },
+};
+
+export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/fr/index.ts
+++ b/packages/phrases-experience/src/locales/fr/index.ts
@@ -9,6 +9,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
 
@@ -23,6 +24,7 @@ const fr = {
     mfa,
     development_tenant,
     user_scopes,
+    profile,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/fr/profile.ts
+++ b/packages/phrases-experience/src/locales/fr/profile.ts
@@ -1,0 +1,26 @@
+const profile = {
+  name: 'Nom',
+  avatar: 'Avatar',
+  givenName: 'Prénom',
+  familyName: 'Nom de famille',
+  middleName: 'Deuxième prénom',
+  fullName: 'Nom complet',
+  nickname: 'Surnom',
+  preferredUsername: "Nom d'utilisateur préféré",
+  profile: 'Profil',
+  website: 'Site web',
+  gender: 'Genre',
+  birthdate: 'Date de naissance',
+  zoneinfo: 'Fuseau horaire',
+  locale: 'Langue',
+  address: {
+    formatted: 'Adresse',
+    streetAddress: 'Adresse',
+    locality: 'Ville',
+    region: 'État/Province',
+    postalCode: 'Code postal',
+    country: 'Pays',
+  },
+};
+
+export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/it/index.ts
+++ b/packages/phrases-experience/src/locales/it/index.ts
@@ -9,6 +9,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
 
@@ -23,6 +24,7 @@ const it = {
     mfa,
     development_tenant,
     user_scopes,
+    profile,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/it/profile.ts
+++ b/packages/phrases-experience/src/locales/it/profile.ts
@@ -1,0 +1,26 @@
+const profile = {
+  name: 'Nome',
+  avatar: 'Avatar',
+  givenName: 'Nome',
+  familyName: 'Cognome',
+  middleName: 'Secondo nome',
+  fullName: 'Nome completo',
+  nickname: 'Soprannome',
+  preferredUsername: 'Nome utente preferito',
+  profile: 'Profilo',
+  website: 'Sito web',
+  gender: 'Genere',
+  birthdate: 'Data di nascita',
+  zoneinfo: 'Fuso orario',
+  locale: 'Lingua',
+  address: {
+    formatted: 'Indirizzo',
+    streetAddress: 'Indirizzo',
+    locality: 'Città',
+    region: 'Stato/Provincia',
+    postalCode: 'CAP',
+    country: 'Paese',
+  },
+};
+
+export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/ja/index.ts
+++ b/packages/phrases-experience/src/locales/ja/index.ts
@@ -9,6 +9,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
 
@@ -23,6 +24,7 @@ const ja = {
     mfa,
     development_tenant,
     user_scopes,
+    profile,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/ja/profile.ts
+++ b/packages/phrases-experience/src/locales/ja/profile.ts
@@ -1,0 +1,26 @@
+const profile = {
+  name: '名前',
+  avatar: 'アバター',
+  givenName: '名',
+  familyName: '姓',
+  middleName: 'ミドルネーム',
+  fullName: 'フルネーム',
+  nickname: 'ニックネーム',
+  preferredUsername: '希望ユーザー名',
+  profile: 'プロフィール',
+  website: 'ウェブサイト',
+  gender: '性別',
+  birthdate: '生年月日',
+  zoneinfo: 'タイムゾーン',
+  locale: 'ロケール',
+  address: {
+    formatted: '住所',
+    streetAddress: '番地',
+    locality: '市区町村',
+    region: '都道府県',
+    postalCode: '郵便番号',
+    country: '国',
+  },
+};
+
+export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/ko/index.ts
+++ b/packages/phrases-experience/src/locales/ko/index.ts
@@ -9,6 +9,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
 
@@ -23,6 +24,7 @@ const ko = {
     mfa,
     development_tenant,
     user_scopes,
+    profile,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/ko/profile.ts
+++ b/packages/phrases-experience/src/locales/ko/profile.ts
@@ -1,0 +1,26 @@
+const profile = {
+  name: '이름',
+  avatar: '아바타',
+  givenName: '이름',
+  familyName: '성',
+  middleName: '중간 이름',
+  fullName: '전체 이름',
+  nickname: '별명',
+  preferredUsername: '선호하는 사용자명',
+  profile: '프로필',
+  website: '웹사이트',
+  gender: '성별',
+  birthdate: '생년월일',
+  zoneinfo: '시간대',
+  locale: '로케일',
+  address: {
+    formatted: '주소',
+    streetAddress: '도로명 주소',
+    locality: '도시',
+    region: '주/도',
+    postalCode: '우편번호',
+    country: '국가',
+  },
+};
+
+export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/pl-pl/index.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/index.ts
@@ -9,6 +9,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
 
@@ -23,6 +24,7 @@ const pl_pl = {
     mfa,
     development_tenant,
     user_scopes,
+    profile,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/pl-pl/profile.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/profile.ts
@@ -1,0 +1,26 @@
+const profile = {
+  name: 'Imię',
+  avatar: 'Avatar',
+  givenName: 'Imię własne',
+  familyName: 'Nazwisko',
+  middleName: 'Drugie imię',
+  fullName: 'Pełne imię i nazwisko',
+  nickname: 'Pseudonim',
+  preferredUsername: 'Preferowana nazwa użytkownika',
+  profile: 'Profil',
+  website: 'Strona internetowa',
+  gender: 'Płeć',
+  birthdate: 'Data urodzenia',
+  zoneinfo: 'Strefa czasowa',
+  locale: 'Język/locale',
+  address: {
+    formatted: 'Adres',
+    streetAddress: 'Ulica',
+    locality: 'Miasto',
+    region: 'Województwo/region',
+    postalCode: 'Kod pocztowy',
+    country: 'Kraj',
+  },
+};
+
+export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/pt-br/index.ts
+++ b/packages/phrases-experience/src/locales/pt-br/index.ts
@@ -9,6 +9,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
 
@@ -23,6 +24,7 @@ const pt_br = {
     mfa,
     development_tenant,
     user_scopes,
+    profile,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/pt-br/profile.ts
+++ b/packages/phrases-experience/src/locales/pt-br/profile.ts
@@ -1,0 +1,26 @@
+const profile = {
+  name: 'Nome',
+  avatar: 'Avatar',
+  givenName: 'Nome',
+  familyName: 'Sobrenome',
+  middleName: 'Nome do meio',
+  fullName: 'Nome completo',
+  nickname: 'Apelido',
+  preferredUsername: 'Nome de usuário preferido',
+  profile: 'Perfil',
+  website: 'Site',
+  gender: 'Gênero',
+  birthdate: 'Data de nascimento',
+  zoneinfo: 'Fuso horário',
+  locale: 'Localidade',
+  address: {
+    formatted: 'Endereço',
+    streetAddress: 'Endereço',
+    locality: 'Cidade',
+    region: 'Estado/Província',
+    postalCode: 'CEP',
+    country: 'País',
+  },
+};
+
+export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/pt-pt/index.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/index.ts
@@ -9,6 +9,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
 
@@ -23,6 +24,7 @@ const pt_pt = {
     mfa,
     development_tenant,
     user_scopes,
+    profile,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/pt-pt/profile.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/profile.ts
@@ -1,0 +1,26 @@
+const profile = {
+  name: 'Nome',
+  avatar: 'Avatar',
+  givenName: 'Nome próprio',
+  familyName: 'Apelido',
+  middleName: 'Nome do meio',
+  fullName: 'Nome completo',
+  nickname: 'Alcunha',
+  preferredUsername: 'Nome de utilizador preferido',
+  profile: 'Perfil',
+  website: 'Website',
+  gender: 'Género',
+  birthdate: 'Data de nascimento',
+  zoneinfo: 'Fuso horário',
+  locale: 'Localização',
+  address: {
+    formatted: 'Endereço',
+    streetAddress: 'Morada',
+    locality: 'Cidade',
+    region: 'Distrito/Província',
+    postalCode: 'Código postal',
+    country: 'País',
+  },
+};
+
+export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/ru/index.ts
+++ b/packages/phrases-experience/src/locales/ru/index.ts
@@ -9,6 +9,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
 
@@ -23,6 +24,7 @@ const ru = {
     mfa,
     development_tenant,
     user_scopes,
+    profile,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/ru/profile.ts
+++ b/packages/phrases-experience/src/locales/ru/profile.ts
@@ -1,0 +1,26 @@
+const profile = {
+  name: 'Имя',
+  avatar: 'Аватар',
+  givenName: 'Имя',
+  familyName: 'Фамилия',
+  middleName: 'Отчество',
+  fullName: 'Полное имя',
+  nickname: 'Никнейм',
+  preferredUsername: 'Предпочитаемое имя пользователя',
+  profile: 'Профиль',
+  website: 'Веб-сайт',
+  gender: 'Пол',
+  birthdate: 'Дата рождения',
+  zoneinfo: 'Часовой пояс',
+  locale: 'Язык',
+  address: {
+    formatted: 'Адрес',
+    streetAddress: 'Улица',
+    locality: 'Город',
+    region: 'Штат/Область',
+    postalCode: 'Почтовый индекс',
+    country: 'Страна',
+  },
+};
+
+export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/tr-tr/index.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/index.ts
@@ -9,6 +9,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
 
@@ -23,6 +24,7 @@ const tr_tr = {
     mfa,
     development_tenant,
     user_scopes,
+    profile,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/tr-tr/profile.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/profile.ts
@@ -1,0 +1,26 @@
+const profile = {
+  name: 'İsim',
+  avatar: 'Avatar',
+  givenName: 'Ad',
+  familyName: 'Soyad',
+  middleName: 'İkinci Ad',
+  fullName: 'Tam Ad',
+  nickname: 'Takma Ad',
+  preferredUsername: 'Tercih Edilen Kullanıcı Adı',
+  profile: 'Profil',
+  website: 'Web Sitesi',
+  gender: 'Cinsiyet',
+  birthdate: 'Doğum Tarihi',
+  zoneinfo: 'Zaman Dilimi',
+  locale: 'Dil',
+  address: {
+    formatted: 'Adres',
+    streetAddress: 'Sokak adresi',
+    locality: 'Şehir',
+    region: 'Eyalet/İl',
+    postalCode: 'Posta kodu',
+    country: 'Ülke',
+  },
+};
+
+export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/uk-ua/index.ts
+++ b/packages/phrases-experience/src/locales/uk-ua/index.ts
@@ -9,6 +9,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
 
@@ -23,6 +24,7 @@ const uk_ua = {
     mfa,
     development_tenant,
     user_scopes,
+    profile,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/uk-ua/profile.ts
+++ b/packages/phrases-experience/src/locales/uk-ua/profile.ts
@@ -1,0 +1,26 @@
+const profile = {
+  name: "Ім'я",
+  avatar: 'Аватар',
+  givenName: "Ім'я",
+  familyName: 'Прізвище',
+  middleName: 'По батькові',
+  fullName: "Повне ім'я",
+  nickname: 'Псевдонім',
+  preferredUsername: "Бажане ім'я користувача",
+  profile: 'Профіль',
+  website: 'Вебсайт',
+  gender: 'Стать',
+  birthdate: 'Дата народження',
+  zoneinfo: 'Часовий пояс',
+  locale: 'Локаль',
+  address: {
+    formatted: 'Адреса',
+    streetAddress: 'Вулиця',
+    locality: 'Місто',
+    region: 'Штат/Область',
+    postalCode: 'Поштовий індекс',
+    country: 'Країна',
+  },
+};
+
+export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/zh-cn/index.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/index.ts
@@ -9,6 +9,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
 
@@ -23,6 +24,7 @@ const zh_cn = {
     mfa,
     development_tenant,
     user_scopes,
+    profile,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/zh-cn/profile.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/profile.ts
@@ -1,0 +1,26 @@
+const profile = {
+  name: '姓名',
+  avatar: '头像',
+  givenName: '名',
+  familyName: '姓',
+  middleName: '中间名',
+  fullName: '全名',
+  nickname: '昵称',
+  preferredUsername: '首选用户名',
+  profile: '个人资料',
+  website: '网站',
+  gender: '性别',
+  birthdate: '出生日期',
+  zoneinfo: '时区信息',
+  locale: '语言环境',
+  address: {
+    formatted: '地址',
+    streetAddress: '街道地址',
+    locality: '城市',
+    region: '州 / 省份',
+    postalCode: '邮政编码',
+    country: '国家',
+  },
+};
+
+export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/zh-hk/index.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/index.ts
@@ -9,6 +9,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
 
@@ -23,6 +24,7 @@ const zh_hk = {
     mfa,
     development_tenant,
     user_scopes,
+    profile,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/zh-hk/profile.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/profile.ts
@@ -1,0 +1,26 @@
+const profile = {
+  name: '姓名',
+  avatar: '頭像',
+  givenName: '名字',
+  familyName: '姓氏',
+  middleName: '中間名',
+  fullName: '全名',
+  nickname: '暱稱',
+  preferredUsername: '偏好用戶名',
+  profile: '個人資料',
+  website: '網站',
+  gender: '性別',
+  birthdate: '出生日期',
+  zoneinfo: '時區資訊',
+  locale: '語言地區',
+  address: {
+    formatted: '地址',
+    streetAddress: '街道地址',
+    locality: '城市',
+    region: '州／省',
+    postalCode: '郵政編碼',
+    country: '國家',
+  },
+};
+
+export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/zh-tw/index.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/index.ts
@@ -9,6 +9,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
 
@@ -23,6 +24,7 @@ const zh_tw = {
     mfa,
     development_tenant,
     user_scopes,
+    profile,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/zh-tw/profile.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/profile.ts
@@ -1,0 +1,26 @@
+const profile = {
+  name: '名稱',
+  avatar: '頭像',
+  givenName: '名字',
+  familyName: '姓氏',
+  middleName: '中間名',
+  fullName: '全名',
+  nickname: '暱稱',
+  preferredUsername: '偏好用戶名',
+  profile: '個人資料',
+  website: '網站',
+  gender: '性別',
+  birthdate: '出生日期',
+  zoneinfo: '時區資訊',
+  locale: '語言地區',
+  address: {
+    formatted: '地址',
+    streetAddress: '街道地址',
+    locality: '城市',
+    region: '州／省份',
+    postalCode: '郵遞區號',
+    country: '國家',
+  },
+};
+
+export default Object.freeze(profile);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add `FullnameField` and `AddressField` components to Logto Experience, which can be later used in the extra profile fulfilling flow.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
