### PR TITLE
refactor(core): refactor get user social/sso identities API

### DIFF
--- a/packages/core/src/routes/admin-user/enterprise-sso.openapi.json
+++ b/packages/core/src/routes/admin-user/enterprise-sso.openapi.json
@@ -2,18 +2,38 @@
   "paths": {
     "/api/users/{userId}/sso-identities/{ssoConnectorId}": {
       "get": {
+        "summary": "Retrieve a user's enterprise SSO identity and associated token storage (if token storage is enabled).",
+        "description": "This API retrieves the user's enterprise SSO identity and associated token set record from the Logto Secret Vault. The token set will only be available if token storage is enabled for the corresponding SSO connector.",
         "tags": ["Dev feature"],
-        "parameters": [],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "includeTokenSecret",
+            "description": "Whether to include the token secret in the response. Defaults to false. Token storage must be supported and enabled by the connector to return the token secret."
+          }
+        ],
         "responses": {
           "200": {
-            "description": "The enterprise SSO identity is retrieved."
+            "description": "Returns the user's enterprise SSO identity and associated token storage.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "ssoIdentity": {
+                      "description": "The user's enterprise SSO identity."
+                    },
+                    "tokenSecret": {
+                      "description": "The desensitized token set secret associated with the user's SSO identity.\nThis field is included only if the `includeTokenSecret` query parameter is provided and the corresponding connector has token storage enabled."
+                    }
+                  }
+                }
+              }
+            }
           },
           "404": {
             "description": "User enterprise SSO identity not found."
           }
-        },
-        "summary": "Retrieve enterprise SSO identity of user by SSO connector ID",
-        "description": "Retrieves the user's enterprise SSO identity and associated token set record (if token storage is enabled for the SSO connector) by SSO connector ID."
+        }
       }
     }
   }

--- a/packages/core/src/routes/admin-user/enterprise-sso.test.ts
+++ b/packages/core/src/routes/admin-user/enterprise-sso.test.ts
@@ -92,7 +92,7 @@ describe('Enterprise SSO Routes', () => {
     expect(response.status).toBe(404);
   });
 
-  it('should return the enterprise SSO identity properly', async () => {
+  it('should return the enterprise SSO identity only', async () => {
     mockFindUserSsoIdentities.mockResolvedValueOnce([mockSsoIdentity]);
     mockFindEnterpriseSsoTokenSetSecret.mockResolvedValueOnce(null);
 
@@ -102,13 +102,31 @@ describe('Enterprise SSO Routes', () => {
 
     expect(mockFindUserById).toHaveBeenCalledWith(mockUser.id);
     expect(mockFindUserSsoIdentities).toHaveBeenCalledWith(mockUser.id);
+    expect(mockFindEnterpriseSsoTokenSetSecret).not.toBeCalled();
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      ssoIdentity: mockSsoIdentity,
+    });
+  });
+
+  it('should return the enterprise SSO identity properly only if token secret is not found', async () => {
+    mockFindUserSsoIdentities.mockResolvedValueOnce([mockSsoIdentity]);
+    mockFindEnterpriseSsoTokenSetSecret.mockResolvedValueOnce(null);
+
+    const response = await userRequest.get(
+      `/users/${mockUser.id}/sso-identities/${mockSsoConnectorId}?includeTokenSet=true`
+    );
+
+    expect(mockFindUserById).toHaveBeenCalledWith(mockUser.id);
+    expect(mockFindUserSsoIdentities).toHaveBeenCalledWith(mockUser.id);
     expect(mockFindEnterpriseSsoTokenSetSecret).toHaveBeenCalledWith(
       mockUser.id,
       mockSsoConnectorId
     );
     expect(response.status).toBe(200);
     expect(response.body).toEqual({
-      enterpriseSsoIdentity: mockSsoIdentity,
+      ssoIdentity: mockSsoIdentity,
     });
   });
 
@@ -117,7 +135,7 @@ describe('Enterprise SSO Routes', () => {
     mockFindUserSsoIdentities.mockResolvedValueOnce([mockSsoIdentity]);
 
     const response = await userRequest.get(
-      `/users/${mockUser.id}/sso-identities/${mockSsoConnectorId}`
+      `/users/${mockUser.id}/sso-identities/${mockSsoConnectorId}?includeTokenSet=true`
     );
     expect(mockFindUserById).toHaveBeenCalledWith(mockUser.id);
     expect(mockFindUserSsoIdentities).toHaveBeenCalledWith(mockUser.id);
@@ -127,8 +145,8 @@ describe('Enterprise SSO Routes', () => {
     );
     expect(response.status).toBe(200);
     expect(response.body).toEqual({
-      enterpriseSsoIdentity: mockSsoIdentity,
-      tokenSet: desensitizeTokenSetSecret(mockTokenSetSecret),
+      ssoIdentity: mockSsoIdentity,
+      tokenSecret: desensitizeTokenSetSecret(mockTokenSetSecret),
     });
   });
 });

--- a/packages/core/src/routes/admin-user/enterprise-sso.test.ts
+++ b/packages/core/src/routes/admin-user/enterprise-sso.test.ts
@@ -115,7 +115,7 @@ describe('Enterprise SSO Routes', () => {
     mockFindEnterpriseSsoTokenSetSecret.mockResolvedValueOnce(null);
 
     const response = await userRequest.get(
-      `/users/${mockUser.id}/sso-identities/${mockSsoConnectorId}?includeTokenSet=true`
+      `/users/${mockUser.id}/sso-identities/${mockSsoConnectorId}?includeTokenSecret=true`
     );
 
     expect(mockFindUserById).toHaveBeenCalledWith(mockUser.id);
@@ -135,7 +135,7 @@ describe('Enterprise SSO Routes', () => {
     mockFindUserSsoIdentities.mockResolvedValueOnce([mockSsoIdentity]);
 
     const response = await userRequest.get(
-      `/users/${mockUser.id}/sso-identities/${mockSsoConnectorId}?includeTokenSet=true`
+      `/users/${mockUser.id}/sso-identities/${mockSsoConnectorId}?includeTokenSecret=true`
     );
     expect(mockFindUserById).toHaveBeenCalledWith(mockUser.id);
     expect(mockFindUserSsoIdentities).toHaveBeenCalledWith(mockUser.id);

--- a/packages/core/src/routes/admin-user/enterprise-sso.ts
+++ b/packages/core/src/routes/admin-user/enterprise-sso.ts
@@ -20,7 +20,7 @@ export default function adminUserEnterpriseSsoRoutes<T extends ManagementApiRout
         ssoConnectorId: string(),
       }),
       query: object({
-        includeTokenSet: string().optional(),
+        includeTokenSecret: string().optional(),
       }),
       response: object({
         ssoIdentity: UserSsoIdentities.guard,
@@ -31,7 +31,7 @@ export default function adminUserEnterpriseSsoRoutes<T extends ManagementApiRout
     async (ctx, next) => {
       const {
         params: { userId, ssoConnectorId },
-        query: { includeTokenSet },
+        query: { includeTokenSecret },
       } = ctx.guard;
 
       const {
@@ -60,7 +60,7 @@ export default function adminUserEnterpriseSsoRoutes<T extends ManagementApiRout
         })
       );
 
-      if (!yes(includeTokenSet)) {
+      if (!yes(includeTokenSecret)) {
         ctx.body = {
           ssoIdentity,
         };

--- a/packages/core/src/routes/admin-user/social.openapi.json
+++ b/packages/core/src/routes/admin-user/social.openapi.json
@@ -67,22 +67,40 @@
             }
           }
         }
-      }
-    },
-    "/api/users/{userId}/identities/{target}/secret": {
+      },
       "get": {
+        "summary": "Retrieve a user's social identity and associated token storage .",
+        "description": "This API retrieves the social identity and its associated token set for the specified user from the Logto Secret Vault. The token set will only be available if token storage is enabled for the corresponding social connector.",
         "tags": ["Dev feature"],
-        "parameters": [],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "includeTokenSecret",
+            "description": "Whether to include the token secret in the response. Defaults to false. Token storage must be supported and enabled by the connector to return the token secret."
+          }
+        ],
         "responses": {
           "200": {
-            "description": "Token set record of the social identity. (For security reasons, encrypted token details will be omitted from the response.)"
+            "description": "Returns the user's social identity and associated token storage.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "identity": {
+                      "description": "The user's social identity."
+                    },
+                    "tokenSecret": {
+                      "description": "The desensitized token set secret associated with the user's social identity.\nThis field is included only if the `includeTokenSecret` query parameter is provided and the corresponding connector has token storage enabled."
+                    }
+                  }
+                }
+              }
+            }
           },
           "404": {
-            "description": "User social identity not found, or no token set record exists for the user's social identity."
+            "description": "User social identity not found."
           }
-        },
-        "summary": "Retrieve the social provider token set for the current user.",
-        "description": "This API retrieves the token set record associated with the current user's social identity from the Logto Secret Vault. The operation is only available if the corresponding social connector has token set storage enabled. If a token set record exists for the user's social identity, it will be returned.  "
+        }
       }
     }
   }

--- a/packages/core/src/routes/admin-user/social.ts
+++ b/packages/core/src/routes/admin-user/social.ts
@@ -201,7 +201,7 @@ export default function adminUserSocialRoutes<T extends ManagementApiRouter>(
           identity: identities[target],
           ...conditional(
             secret && {
-              secret: desensitizeTokenSetSecret(secret),
+              tokenSecret: desensitizeTokenSetSecret(secret),
             }
           ),
         };

--- a/packages/integration-tests/src/api/admin-user.ts
+++ b/packages/integration-tests/src/api/admin-user.ts
@@ -118,11 +118,6 @@ export const putUserIdentity = async (userId: string, target: string, identity: 
 export const verifyUserPassword = async (userId: string, password: string) =>
   authedAdminApi.post(`users/${userId}/password/verify`, { json: { password } });
 
-export const getUserIdentityTokenSetRecord = async (userId: string, target: string) =>
-  authedAdminApi
-    .get(`users/${userId}/identities/${target}/secret`)
-    .json<DesensitizedSocialTokenSetSecret>();
-
 export const getUserMfaVerifications = async (userId: string) =>
   authedAdminApi.get(`users/${userId}/mfa-verifications`).json<MfaVerification[]>();
 
@@ -165,8 +160,38 @@ export const updatePersonalAccessToken = async (
     })
     .json<PersonalAccessToken>();
 
-export const getUserSsoIdentity = async (userId: string, connectorId: string) =>
-  authedAdminApi.get(`users/${userId}/sso-identities/${connectorId}`).json<{
-    enterpriseSsoIdentity: UserSsoIdentity;
-    tokenSet?: DesensitizedEnterpriseSsoTokenSetSecret;
-  }>();
+export const getUserIdentity = async (
+  userId: string,
+  target: string,
+  includeTokenSecret = true
+) => {
+  const searchParams = new URLSearchParams({
+    ...conditional(includeTokenSecret && { includeTokenSecret: 'true' }),
+  });
+
+  return authedAdminApi
+    .get(`users/${userId}/identities/${target}`, {
+      searchParams,
+    })
+    .json<{
+      identity: Identity;
+      tokenSecret?: DesensitizedSocialTokenSetSecret;
+    }>();
+};
+
+export const getUserSsoIdentity = async (
+  userId: string,
+  connectorId: string,
+  includeTokenSecret = true
+) => {
+  const searchParams = new URLSearchParams({
+    ...conditional(includeTokenSecret && { includeTokenSet: 'true' }),
+  });
+
+  return authedAdminApi
+    .get(`users/${userId}/sso-identities/${connectorId}`, { searchParams })
+    .json<{
+      ssoIdentity: UserSsoIdentity;
+      tokenSecret?: DesensitizedEnterpriseSsoTokenSetSecret;
+    }>();
+};

--- a/packages/integration-tests/src/api/admin-user.ts
+++ b/packages/integration-tests/src/api/admin-user.ts
@@ -185,7 +185,7 @@ export const getUserSsoIdentity = async (
   includeTokenSecret = true
 ) => {
   const searchParams = new URLSearchParams({
-    ...conditional(includeTokenSecret && { includeTokenSet: 'true' }),
+    ...conditional(includeTokenSecret && { includeTokenSecret: 'true' }),
   });
 
   return authedAdminApi

--- a/packages/integration-tests/src/tests/api/account/social.test.ts
+++ b/packages/integration-tests/src/tests/api/account/social.test.ts
@@ -7,7 +7,7 @@ import {
   mockSocialConnectorTarget,
 } from '#src/__mocks__/connectors-mock.js';
 import { enableAllAccountCenterFields } from '#src/api/account-center.js';
-import { getUserIdentityTokenSetRecord } from '#src/api/admin-user.js';
+import { getUserIdentity } from '#src/api/admin-user.js';
 import { updateConnectorConfig } from '#src/api/connector.js';
 import { deleteIdentity, getUserInfo, updateIdentities } from '#src/api/my-account.js';
 import {
@@ -184,12 +184,8 @@ describe('my-account (social)', () => {
 
         // TODO: Remove this once we have token storage enabled
         if (isDevFeaturesEnabled) {
-          const tokenSetRecord = await getUserIdentityTokenSetRecord(
-            user.id,
-            mockSocialConnectorTarget
-          );
-          expect(tokenSetRecord).not.toBeNull();
-          expect(tokenSetRecord.metadata.scope).toBe(mockTokenResponse.scope);
+          const { tokenSecret } = await getUserIdentity(user.id, mockSocialConnectorTarget);
+          expect(tokenSecret?.metadata.scope).toBe(mockTokenResponse.scope);
         }
 
         await deleteDefaultTenantUser(user.id);

--- a/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/enterprise-sso.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/enterprise-sso.test.ts
@@ -67,15 +67,15 @@ describe('enterprise sso sign-in and sign-up', () => {
     expect(primaryEmail).toBe(email);
 
     if (isDevFeaturesEnabled) {
-      const { enterpriseSsoIdentity, tokenSet } = await getUserSsoIdentity(
+      const { ssoIdentity, tokenSecret } = await getUserSsoIdentity(
         userId,
         ssoConnectorApi.firstConnectorId!
       );
 
-      expect(enterpriseSsoIdentity.identityId).toBe(enterpriseSsoIdentityId);
-      expect(tokenSet?.identityId).toBe(enterpriseSsoIdentityId);
-      expect(tokenSet?.ssoConnectorId).toBe(ssoConnectorApi.firstConnectorId);
-      expect(tokenSet?.metadata.scope).toBe(mockTokenResponse.scope);
+      expect(ssoIdentity.identityId).toBe(enterpriseSsoIdentityId);
+      expect(tokenSecret?.identityId).toBe(enterpriseSsoIdentityId);
+      expect(tokenSecret?.ssoConnectorId).toBe(ssoConnectorApi.firstConnectorId);
+      expect(tokenSecret?.metadata.scope).toBe(mockTokenResponse.scope);
     }
 
     await signInWithEnterpriseSso(ssoConnectorApi.firstConnectorId!, {
@@ -94,8 +94,8 @@ describe('enterprise sso sign-in and sign-up', () => {
 
     // Should update the token set
     if (isDevFeaturesEnabled) {
-      const { tokenSet } = await getUserSsoIdentity(userId, ssoConnectorApi.firstConnectorId!);
-      expect(tokenSet?.metadata.scope).toBe('openid profile email');
+      const { tokenSecret } = await getUserSsoIdentity(userId, ssoConnectorApi.firstConnectorId!);
+      expect(tokenSecret?.metadata.scope).toBe('openid profile email');
     }
 
     await deleteUser(userId);

--- a/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/social.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/social.test.ts
@@ -5,7 +5,7 @@ import {
   mockSocialConnectorId,
   mockSocialConnectorTarget,
 } from '#src/__mocks__/connectors-mock.js';
-import { deleteUser, getUser, getUserIdentityTokenSetRecord } from '#src/api/admin-user.js';
+import { deleteUser, getUser, getUserIdentity } from '#src/api/admin-user.js';
 import { updateConnectorConfig } from '#src/api/connector.js';
 import { isDevFeaturesEnabled } from '#src/constants.js';
 import {
@@ -74,9 +74,8 @@ describe('social sign-in and sign-up', () => {
 
     // TODO: Remove this once we have token storage enabled
     if (isDevFeaturesEnabled) {
-      const tokenSetRecord = await getUserIdentityTokenSetRecord(userId, mockSocialConnectorTarget);
-      expect(tokenSetRecord).not.toBeNull();
-      expect(tokenSetRecord.metadata.scope).toBe(mockTokenResponse.scope);
+      const { tokenSecret } = await getUserIdentity(userId, mockSocialConnectorTarget);
+      expect(tokenSecret?.metadata.scope).toBe(mockTokenResponse.scope);
     }
   });
 
@@ -121,11 +120,9 @@ describe('social sign-in and sign-up', () => {
     expect(name).toBe('John Doe');
 
     if (isDevFeaturesEnabled) {
-      const tokenSetRecord = await getUserIdentityTokenSetRecord(userId, mockSocialConnectorTarget);
-      expect(tokenSetRecord).not.toBeNull();
-      expect(tokenSetRecord.metadata.scope).toBe('openid profile email');
+      const { tokenSecret } = await getUserIdentity(userId, mockSocialConnectorTarget);
+      expect(tokenSecret?.metadata.scope).toBe('openid profile email');
     }
-
     await deleteUser(userId);
   });
 
@@ -154,9 +151,8 @@ describe('social sign-in and sign-up', () => {
     expect(name).toBe('Foo Bar');
 
     if (isDevFeaturesEnabled) {
-      const tokenSetRecord = await getUserIdentityTokenSetRecord(userId, mockSocialConnectorTarget);
-      expect(tokenSetRecord).not.toBeNull();
-      expect(tokenSetRecord.metadata.scope).toBe('openid profile phone');
+      const { tokenSecret } = await getUserIdentity(userId, mockSocialConnectorTarget);
+      expect(tokenSecret?.metadata.scope).toBe('openid profile phone');
     }
 
     await deleteUser(userId);


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR refactors the design of the GET user social identity and enterprise SSO identity API. 

1.  Replace the `GET /users/:userId/identities/:target/secret` with `GET /users/:userId/identities/:target`.
   - Align API design with the GET sso-identity API
   - This API is better suited for our console UI form, where we need to retrieve both the user identity details and associated secrets on the same page.
   - Added a new includeTokenSecret query parameter to control whether the associated token secret should be included in the response.
   
 2. Update the `GET /users/:userId/sso-identities/:target` API
   - Renamed `enterpriseSsoIdentity` to `ssoIdentity` for consistency with other user SSO identity response bodies (e.g., GET /users/:userId).
  - Renamed `tokenSet` to `tokenSecret` to match the social API and clarify that the value represents a secret-type field.
  - Added a new includeTokenSecret query parameter to control whether the associated token secret should be included in the response.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Integration tests and unit test updated. 

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
