### PR TITLE
feat(core): add get user social and sso identities API

### DIFF
--- a/packages/core/src/queries/secret.ts
+++ b/packages/core/src/queries/secret.ts
@@ -141,6 +141,34 @@ class SecretQueries extends SchemaQueries<SecretKeys, CreateSecret, Secret> {
           and ${secretEnterpriseSsoConnectorRelations.fields.ssoConnectorId} = ${ssoConnectorId}
     `);
   }
+
+  public async findSocialTokenSetSecretsByUserId(userId: string) {
+    return this.pool.many<SocialTokenSetSecret>(sql`
+      select ${sql.join(Object.values(secrets.fields), sql`, `)},
+          ${secretSocialConnectorRelations.fields.connectorId},
+          ${secretSocialConnectorRelations.fields.identityId},
+          ${secretSocialConnectorRelations.fields.target}
+        from ${secrets.table}
+        join ${secretSocialConnectorRelations.table}
+          on ${secrets.fields.id} = ${secretSocialConnectorRelations.fields.secretId}
+        where ${secrets.fields.userId} = ${userId}
+          and ${secrets.fields.type} = ${SecretType.FederatedTokenSet}
+    `);
+  }
+
+  public async findEnterpriseSsoTokenSetSecretsByUserId(userId: string) {
+    return this.pool.many<EnterpriseSsoTokenSetSecret>(sql`
+      select ${sql.join(Object.values(secrets.fields), sql`, `)},
+          ${secretEnterpriseSsoConnectorRelations.fields.ssoConnectorId},
+          ${secretEnterpriseSsoConnectorRelations.fields.identityId},
+          ${secretEnterpriseSsoConnectorRelations.fields.issuer}
+        from ${secrets.table}
+        join ${secretEnterpriseSsoConnectorRelations.table}
+          on ${secrets.fields.id} = ${secretEnterpriseSsoConnectorRelations.fields.secretId}
+        where ${secrets.fields.userId} = ${userId}
+          and ${secrets.fields.type} = ${SecretType.FederatedTokenSet}
+    `);
+  }
 }
 
 export default SecretQueries;

--- a/packages/core/src/routes/admin-user/enterprise-sso.openapi.json
+++ b/packages/core/src/routes/admin-user/enterprise-sso.openapi.json
@@ -2,7 +2,7 @@
   "paths": {
     "/api/users/{userId}/sso-identities/{ssoConnectorId}": {
       "get": {
-        "summary": "Retrieve a user's enterprise SSO identity and associated token storage (if token storage is enabled).",
+        "summary": "Retrieve a user's enterprise SSO identity and associated token secret (if token storage is enabled).",
         "description": "This API retrieves the user's enterprise SSO identity and associated token set record from the Logto Secret Vault. The token set will only be available if token storage is enabled for the corresponding SSO connector.",
         "tags": ["Dev feature"],
         "parameters": [
@@ -14,7 +14,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the user's enterprise SSO identity and associated token storage.",
+            "description": "Returns the user's enterprise SSO identity and associated token secret.",
             "content": {
               "application/json": {
                 "schema": {
@@ -32,6 +32,42 @@
           },
           "404": {
             "description": "User enterprise SSO identity not found."
+          }
+        }
+      }
+    },
+    "/api/users/{userId}/all-identities": {
+      "get": {
+        "summary": "Retrieve social identities, enterprise SSO identities and associated token secret (if token storage is enabled) for a user.",
+        "description": "This API retrieves all identities (social and enterprise SSO) for a user, along with their associated token set records from the Logto Secret Vault. The token sets will only be available if token storage is enabled for the corresponding identity connector.",
+        "tags": ["Dev feature"],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "includeTokenSecret",
+            "description": "Whether to include the token secret in the response. Defaults to false. Token storage must be supported and enabled by the connector to return the token secret."
+          }
+        ],
+        "response": {
+          "200": {
+            "description": "Returns the user's social identities, enterprise SSO identities and associated token secret.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "socialIdentities": {
+                      "description": "The user's social identities."
+                    },
+                    "ssoIdentities": {
+                      "description": "The user's enterprise SSO identities."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "User not found."
           }
         }
       }

--- a/packages/core/src/routes/admin-user/enterprise-sso.openapi.json
+++ b/packages/core/src/routes/admin-user/enterprise-sso.openapi.json
@@ -48,7 +48,7 @@
             "description": "Whether to include the token secret in the response. Defaults to false. Token storage must be supported and enabled by the connector to return the token secret."
           }
         ],
-        "response": {
+        "responses": {
           "200": {
             "description": "Returns the user's social identities, enterprise SSO identities and associated token secret.",
             "content": {

--- a/packages/core/src/routes/admin-user/social.ts
+++ b/packages/core/src/routes/admin-user/social.ts
@@ -4,7 +4,7 @@ import {
   identityGuard,
   identitiesGuard,
   userProfileResponseGuard,
-  desensitizedSocialTokenSetSecretGuard,
+  getUserSocialIdentityResponseGuard,
 } from '@logto/schemas';
 import { conditional, has, yes } from '@silverhand/essentials';
 import { object, record, string, unknown } from 'zod';
@@ -167,10 +167,7 @@ export default function adminUserSocialRoutes<T extends ManagementApiRouter>(
         query: object({
           includeTokenSecret: string().optional(),
         }),
-        response: object({
-          identity: identityGuard,
-          tokenSecret: desensitizedSocialTokenSetSecretGuard.optional(),
-        }),
+        response: getUserSocialIdentityResponseGuard,
         status: [200, 404],
       }),
       async (ctx, next) => {

--- a/packages/schemas/src/types/user.ts
+++ b/packages/schemas/src/types/user.ts
@@ -1,7 +1,12 @@
 import { z } from 'zod';
 
 import { type User, Users, UserSsoIdentities } from '../db-entries/index.js';
-import { MfaFactor } from '../foundations/index.js';
+import { identityGuard, MfaFactor } from '../foundations/index.js';
+
+import {
+  desensitizedEnterpriseSsoTokenSetSecretGuard,
+  desensitizedSocialTokenSetSecretGuard,
+} from './secrets.js';
 
 export const userInfoSelectFields = Object.freeze([
   'id',
@@ -90,3 +95,24 @@ export const featuredUserGuard = Users.guard.pick({
 
 export const consoleUserPreferenceKey = 'adminConsolePreferences';
 export const guideRequestsKey = 'guideRequests';
+
+export const getUserSocialIdentityResponseGuard = z.object({
+  identity: identityGuard,
+  tokenSecret: desensitizedSocialTokenSetSecretGuard.optional(),
+});
+
+export type GetUserSocialIdentityResponse = z.infer<typeof getUserSocialIdentityResponseGuard>;
+
+export const getUserSsoIdentityResponseGuard = z.object({
+  ssoIdentity: UserSsoIdentities.guard,
+  tokenSecret: desensitizedEnterpriseSsoTokenSetSecretGuard.optional(),
+});
+
+export type GetUserSsoIdentityResponse = z.infer<typeof getUserSsoIdentityResponseGuard>;
+
+export const getUserAllIdentitiesResponseGuard = z.object({
+  socialIdentities: getUserSocialIdentityResponseGuard.extend({ target: z.string() }).array(),
+  ssoIdentities: getUserSsoIdentityResponseGuard.extend({ ssoConnectorId: z.string() }).array(),
+});
+
+export type GetUserAllIdentitiesResponse = z.infer<typeof getUserAllIdentitiesResponseGuard>;


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add new `GET /users/:userId/all-identities` API to retrieve the user's social identities and enterprise SSO identities. 
If the `includeTokenSecret` parameter is set, this API also returns the token secret associated with each identity. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
<img width="1184" height="1038" alt="image" src="https://github.com/user-attachments/assets/b8c3cc7c-fe7c-4ce7-88b6-71b6cb4b7066" />

Will add integration tests later. 

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
