### PR TITLE
fix(core,experience): relax validation for optional custom profile field

### DIFF
--- a/packages/core/src/libraries/custom-profile-fields/utils.ts
+++ b/packages/core/src/libraries/custom-profile-fields/utils.ts
@@ -27,7 +27,7 @@ const validateTextProfileField: ValidateCustomProfileField = (data) => {
   const { minLength, maxLength } = config ?? {};
 
   assertThat(
-    minLength !== undefined && maxLength !== undefined && minLength <= maxLength,
+    minLength === undefined || maxLength === undefined || minLength <= maxLength,
     'custom_profile_fields.invalid_min_max_input'
   );
 };
@@ -37,7 +37,7 @@ const validateNumberProfileField: ValidateCustomProfileField = (data) => {
   const { minValue, maxValue } = config ?? {};
 
   assertThat(
-    minValue !== undefined && maxValue !== undefined && minValue <= maxValue,
+    minValue === undefined || maxValue === undefined || minValue <= maxValue,
     'custom_profile_fields.invalid_min_max_input'
   );
 };

--- a/packages/experience/src/pages/Continue/ExtraProfileForm/index.tsx
+++ b/packages/experience/src/pages/Continue/ExtraProfileForm/index.tsx
@@ -1,7 +1,5 @@
 import { CustomProfileFieldType, type CustomProfileField } from '@logto/schemas';
-import { cond } from '@silverhand/essentials';
 import { Controller, FormProvider, useForm } from 'react-hook-form';
-import { useTranslation } from 'react-i18next';
 import * as s from 'superstruct';
 
 import Button from '@/components/Button';
@@ -22,7 +20,6 @@ type Props = {
 };
 
 const ExtraProfileForm = ({ customProfileFields, defaultValues, onSubmit }: Props) => {
-  const { t } = useTranslation();
   const getFieldLabel = useFieldLabel();
   const validateField = useValidateField();
   const methods = useForm<Record<string, unknown>>({
@@ -50,18 +47,13 @@ const ExtraProfileForm = ({ customProfileFields, defaultValues, onSubmit }: Prop
           if (field.type === CustomProfileFieldType.Fullname) {
             return <FullnameSubForm key={field.name} field={field} />;
           }
-          const { name, type, required, label, description, config } = field;
+          const { name, type, label, description, config } = field;
           return (
             <Controller
               key={name}
               control={control}
               name={name}
-              rules={{
-                required: cond(
-                  required && t('error.general_required', { types: [getFieldLabel(name, label)] })
-                ),
-                validate: (value) => validateField(value, field),
-              }}
+              rules={{ validate: (value) => validateField(value, field) }}
               render={({ field: { onChange, value } }) => {
                 if (type === CustomProfileFieldType.Address) {
                   s.assert(value, addressFieldValueGuard);

--- a/packages/experience/src/pages/Continue/ExtraProfileForm/use-validate-field.ts
+++ b/packages/experience/src/pages/Continue/ExtraProfileForm/use-validate-field.ts
@@ -23,7 +23,6 @@ const isValidAddressField = (value: unknown, config: CustomProfileFieldConfig): 
 const isValidDateField = (value: unknown, config: CustomProfileFieldConfig): boolean => {
   s.assert(value, s.string());
   s.assert(config.format, s.string());
-
   const parsedDate = parse(value, config.format, new Date(), {
     useAdditionalDayOfYearTokens: true,
     useAdditionalWeekYearTokens: true,
@@ -34,8 +33,8 @@ const isValidDateField = (value: unknown, config: CustomProfileFieldConfig): boo
 
 const isValidRegexField = (value: unknown, config: CustomProfileFieldConfig): boolean => {
   s.assert(value, s.string());
-
-  const regex = new RegExp(config.format ?? '');
+  s.assert(config.format, s.string());
+  const regex = new RegExp(config.format);
   return regex.test(value);
 };
 
@@ -47,7 +46,6 @@ const isValidUrlField = (value: unknown): boolean => {
 
 const isValidNumberRange = (value: unknown, config: CustomProfileFieldConfig): boolean => {
   s.assert(value, s.string());
-
   const parsedNumber = Number(value);
   return (
     !Number.isNaN(parsedNumber) &&
@@ -72,10 +70,12 @@ const useValidateField = () => {
   const validate = useCallback(
     (value: unknown, field: CustomProfileField) => {
       const { type, name, label, required, config } = field;
-      const generalInvalidMessage = t('error.general_invalid', {
-        types: [getFieldLabel(name, label)],
-      });
+      const labelWithI18nFallback = getFieldLabel(name, label);
+      const generalInvalidMessage = t('error.general_invalid', { types: [labelWithI18nFallback] });
 
+      if (!value) {
+        return !required || t('error.general_required', { types: [labelWithI18nFallback] });
+      }
       if (type === CustomProfileFieldType.Address) {
         return !required || isValidAddressField(value, config) || generalInvalidMessage;
       }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Updated validation logic in custom profile field utilities and form validation to allow undefined values for optional fields. This change ensures that fields are only validated when values are present, preventing errors when optional fields are left empty. (fixes log-11822 log-11821 log-11819)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
