### PR TITLE
fix(experience): should revalidate the profile form on blur

### DIFF
--- a/packages/experience/src/components/InputFields/AddressField/index.tsx
+++ b/packages/experience/src/components/InputFields/AddressField/index.tsx
@@ -14,10 +14,11 @@ type Props = {
   readonly parts?: AddressProfileField['config']['parts'];
   readonly description?: Nullable<string>;
   readonly errorMessage?: string;
+  readonly onBlur: () => void;
   readonly onChange: (value: UserProfile['address']) => void;
 };
 
-const AddressField = ({ value, parts, description, errorMessage, onChange }: Props) => {
+const AddressField = ({ value, parts, description, errorMessage, onBlur, onChange }: Props) => {
   const { t } = useTranslation();
   const enabledParts = useMemo(() => parts?.filter(({ enabled }) => enabled), [parts]);
 
@@ -33,6 +34,7 @@ const AddressField = ({ value, parts, description, errorMessage, onChange }: Pro
           label={t(`profile.address.${key}`)}
           value={value?.[key] ?? ''}
           isDanger={!!errorMessage}
+          onBlur={onBlur}
           onChange={(event) => {
             const newValue = { ...value, [key]: event.currentTarget.value };
             onChange(key === 'formatted' ? newValue : formatAddress(newValue));

--- a/packages/experience/src/components/InputFields/SelectField/index.tsx
+++ b/packages/experience/src/components/InputFields/SelectField/index.tsx
@@ -14,6 +14,7 @@ type Props = {
   readonly label?: string;
   readonly placeholder?: string;
   readonly errorMessage?: string;
+  readonly onBlur: () => void;
   readonly onChange: (value: string) => void;
 };
 
@@ -24,6 +25,7 @@ const SelectField = ({
   label,
   placeholder,
   errorMessage,
+  onBlur,
   onChange,
 }: Props) => {
   const ref = useRef<HTMLDivElement>(null);
@@ -45,6 +47,7 @@ const SelectField = ({
         onClick={() => {
           setIsOpen(true);
         }}
+        onBlur={onBlur}
       />
       <Dropdown
         isFullWidth

--- a/packages/experience/src/pages/Continue/ExtraProfileForm/FullnameSubForm/index.tsx
+++ b/packages/experience/src/pages/Continue/ExtraProfileForm/FullnameSubForm/index.tsx
@@ -45,12 +45,13 @@ const FullnameSubForm = ({ field }: Props) => {
             name={key}
             control={control}
             rules={{ required }}
-            render={({ field: { onChange, value } }) => (
+            render={({ field: { onBlur, onChange, value } }) => (
               <InputField
                 className={styles.inputField}
                 label={t(`profile.${key}`)}
                 value={value ?? ''}
                 isDanger={hasFullnameError}
+                onBlur={onBlur}
                 onChange={onChange}
               />
             )}

--- a/packages/experience/src/pages/Continue/ExtraProfileForm/index.tsx
+++ b/packages/experience/src/pages/Continue/ExtraProfileForm/index.tsx
@@ -54,7 +54,7 @@ const ExtraProfileForm = ({ customProfileFields, defaultValues, onSubmit }: Prop
               control={control}
               name={name}
               rules={{ validate: (value) => validateField(value, field) }}
-              render={({ field: { onChange, value } }) => {
+              render={({ field: { onBlur, onChange, value } }) => {
                 if (type === CustomProfileFieldType.Address) {
                   s.assert(value, addressFieldValueGuard);
                   s.assert(config, addressFieldConfigGuard);
@@ -64,6 +64,7 @@ const ExtraProfileForm = ({ customProfileFields, defaultValues, onSubmit }: Prop
                       value={value}
                       description={description}
                       errorMessage={errors[name]?.message}
+                      onBlur={onBlur}
                       onChange={onChange}
                     />
                   );
@@ -83,6 +84,7 @@ const ExtraProfileForm = ({ customProfileFields, defaultValues, onSubmit }: Prop
                       value={value}
                       description={description}
                       errorMessage={errors[name]?.message}
+                      onBlur={onBlur}
                       onChange={onChange}
                     />
                   );
@@ -96,6 +98,7 @@ const ExtraProfileForm = ({ customProfileFields, defaultValues, onSubmit }: Prop
                     errorMessage={errors[name]?.message}
                     placeholder={config.placeholder ?? config.format}
                     onChange={onChange}
+                    onBlur={onBlur}
                   />
                 );
               }}


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Revalidate the profile form status on field blur. Previously this did not work as the blur event was not passed into the customized `InputField` component, and broke the event bubble and handling.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested. Now the form field error state is revalidated on blur.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
