### PR TITLE
fix(experience): fix dropdown arrow position in select field

### DIFF
--- a/packages/experience/src/components/InputFields/SelectField/index.module.scss
+++ b/packages/experience/src/components/InputFields/SelectField/index.module.scss
@@ -28,7 +28,7 @@
       transition: transform 0.2s ease-in-out;
 
       &.up {
-        transform: translateY(50%) rotate(180deg);
+        transform: translateY(-50%) rotate(180deg);
       }
     }
   }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Adjusts the transform property for the 'up' state of the dropdown arrow to use translateY(-50%) instead of translateY(50%).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="848" height="132" alt="image" src="https://github.com/user-attachments/assets/a5b12273-5f7e-475b-ab13-84912c0aceeb" />
<img width="832" height="350" alt="image" src="https://github.com/user-attachments/assets/379e1e1e-ee22-4c82-a8a1-e08adab06abf" />

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
