### PR TITLE
refactor(core): update SIE order endpoint path for custom profile fields

### DIFF
--- a/packages/core/src/routes/custom-profile-fields.openapi.json
+++ b/packages/core/src/routes/custom-profile-fields.openapi.json
@@ -53,7 +53,7 @@
         }
       }
     },
-    "/api/custom-profile-fields/sie-order": {
+    "/api/custom-profile-fields/properties/sie-order": {
       "post": {
         "summary": "Update the display order of the custom profile fields in Sign-in Experience.",
         "description": "Update the display order of the custom profile fields in Sign-in Experience.",

--- a/packages/core/src/routes/custom-profile-fields.ts
+++ b/packages/core/src/routes/custom-profile-fields.ts
@@ -109,7 +109,7 @@ export default function customProfileFieldsRoutes<T extends ManagementApiRouter>
   );
 
   router.post(
-    '/custom-profile-fields/sie-order',
+    '/custom-profile-fields/properties/sie-order',
     koaGuard({
       body: z.object({
         order: z.array(updateCustomProfileFieldSieOrderGuard),

--- a/packages/core/src/routes/swagger/utils/operation-id.ts
+++ b/packages/core/src/routes/swagger/utils/operation-id.ts
@@ -33,7 +33,7 @@ const devFeatureCustomRoutes: RouteDictionary = Object.freeze({
   'get /custom-profile-fields/:name': 'GetCustomProfileFieldByName',
   'put /custom-profile-fields/:name': 'UpdateCustomProfileFieldByName',
   'delete /custom-profile-fields/:name': 'DeleteCustomProfileFieldByName',
-  'post /custom-profile-fields/sie-order': 'UpdateCustomProfileFieldsSieOrder',
+  'post /custom-profile-fields/properties/sie-order': 'UpdateCustomProfileFieldsSieOrder',
 });
 
 export const customRoutes: Readonly<RouteDictionary> = Object.freeze({

--- a/packages/integration-tests/src/api/custom-profile-fields.ts
+++ b/packages/integration-tests/src/api/custom-profile-fields.ts
@@ -31,7 +31,7 @@ export const updateCustomProfileFieldsSieOrder = async (
   order: UpdateCustomProfileFieldSieOrder[]
 ) =>
   authedAdminApi
-    .post('custom-profile-fields/sie-order', {
+    .post('custom-profile-fields/properties/sie-order', {
       json: { order },
     })
     .json<CustomProfileField[]>();


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Update `POST /custom-profile-fields/sie-order` to `POST /custom-profile-fields/properties/sie-order` to avoid a potential API path naming conflict with `POST /custom-profile-fields/:name`

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
CI

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
