### PR TITLE
feat(core): add sanitized interaction data API and tests

### DIFF
--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -13,6 +13,7 @@ import {
   type Interaction,
   type InteractionContext,
   type WithHooksAndLogsContext,
+  type SanitizedInteractionStorageData,
 } from '../types.js';
 
 import {
@@ -566,6 +567,19 @@ export default class ExperienceInteraction {
       profile: this.profile.data,
       mfa: this.mfa.data,
       verificationRecords: this.verificationRecordsArray.map((record) => record.toJson()),
+      captcha,
+    };
+  }
+
+  public toSanitizedJson(): SanitizedInteractionStorageData {
+    const { interactionEvent, userId, captcha } = this;
+
+    return {
+      interactionEvent,
+      userId,
+      profile: this.profile.sanitizedData,
+      mfa: this.mfa.sanitizedData,
+      verificationRecords: this.verificationRecordsArray.map((record) => record.toSanitizedJson()),
       captcha,
     };
   }

--- a/packages/core/src/routes/experience/classes/profile.ts
+++ b/packages/core/src/routes/experience/classes/profile.ts
@@ -5,7 +5,7 @@ import {
   type UpdateProfileApiPayload,
   VerificationType,
 } from '@logto/schemas';
-import { trySafe } from '@silverhand/essentials';
+import { pick, trySafe } from '@silverhand/essentials';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import { type LogEntry } from '#src/middleware/koa-audit-log.js';
@@ -13,7 +13,11 @@ import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
-import { type InteractionContext, type InteractionProfile } from '../types.js';
+import type {
+  SanitizedInteractionProfile,
+  InteractionContext,
+  InteractionProfile,
+} from '../types.js';
 
 import { PasswordValidator } from './libraries/password-validator.js';
 import { ProfileValidator } from './libraries/profile-validator.js';
@@ -43,6 +47,23 @@ export class Profile {
 
   get data() {
     return this.#data;
+  }
+
+  get sanitizedData(): SanitizedInteractionProfile {
+    return pick(
+      this.#data,
+      'avatar',
+      'name',
+      'username',
+      'primaryEmail',
+      'primaryPhone',
+      'profile',
+      'customData',
+      'socialIdentity',
+      'enterpriseSsoIdentity',
+      'jitOrganizationIds',
+      'syncedEnterpriseSsoIdentity'
+    );
   }
 
   /**

--- a/packages/core/src/routes/experience/classes/utils.ts
+++ b/packages/core/src/routes/experience/classes/utils.ts
@@ -7,13 +7,10 @@ import {
   type VerificationCodeSignInIdentifier,
   AdditionalIdentifier,
 } from '@logto/schemas';
-import { cond, pick } from '@silverhand/essentials';
 
 import type Queries from '#src/tenants/Queries.js';
 
-import type { InteractionProfile, PublicInteractionStorageData } from '../types.js';
-
-import type ExperienceInteraction from './experience-interaction.js';
+import type { InteractionProfile } from '../types.js';
 
 export const findUserByIdentifier = async (
   userQuery: Queries['users'],
@@ -72,56 +69,3 @@ export const codeVerificationIdentifierRecordTypeMap = Object.freeze({
   [SignInIdentifier.Email]: VerificationType.EmailVerificationCode,
   [SignInIdentifier.Phone]: VerificationType.PhoneVerificationCode,
 }) satisfies Record<VerificationCodeSignInIdentifier, VerificationType>;
-
-export const sanitizeInteractionData = (
-  experienceInteraction: ExperienceInteraction
-): PublicInteractionStorageData => {
-  const { interactionEvent, userId, profile, verificationRecords, captcha } =
-    experienceInteraction.toJson();
-
-  return {
-    interactionEvent,
-    userId,
-    // Only include sanitized profile fields, excluding sensitive data like passwords and tokens
-    profile: cond(
-      profile &&
-        pick(
-          profile,
-          'avatar',
-          'name',
-          'username',
-          'primaryEmail',
-          'primaryPhone',
-          'profile',
-          'customData',
-          'socialIdentity',
-          'enterpriseSsoIdentity',
-          'jitOrganizationIds',
-          'syncedEnterpriseSsoIdentity'
-        )
-    ),
-    verificationRecords: verificationRecords?.map((record) => {
-      return {
-        id: record.id,
-        type: record.type,
-        ...cond('verified' in record && { verified: record.verified }),
-        ...cond('identifier' in record && { identifier: record.identifier }),
-        ...cond('userId' in record && { userId: record.userId }),
-        ...cond('connectorId' in record && { connectorId: record.connectorId }),
-        ...cond('templateType' in record && { templateType: record.templateType }),
-        ...cond('socialUserInfo' in record && { socialUserInfo: record.socialUserInfo }),
-        ...cond(
-          'enterpriseSsoUserInfo' in record && {
-            enterpriseSsoUserInfo: record.enterpriseSsoUserInfo,
-          }
-        ),
-        ...cond(
-          'oneTimeTokenContext' in record && {
-            oneTimeTokenContext: record.oneTimeTokenContext,
-          }
-        ),
-      };
-    }),
-    captcha,
-  };
-};

--- a/packages/core/src/routes/experience/classes/verifications/backup-code-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/backup-code-verification.ts
@@ -4,6 +4,7 @@ import {
   type BindBackupCode,
   type MfaVerificationBackupCode,
   type BackupCodeVerificationRecordData,
+  type SanitizedBackupCodeVerificationRecordData,
 } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 
@@ -16,7 +17,9 @@ import { type MfaVerificationRecord } from './verification-record.js';
 
 export {
   type BackupCodeVerificationRecordData,
+  type SanitizedBackupCodeVerificationRecordData,
   backupCodeVerificationRecordDataGuard,
+  sanitizedBackupCodeVerificationRecordDataGuard,
 } from '@logto/schemas';
 
 export class BackupCodeVerification implements MfaVerificationRecord<VerificationType.BackupCode> {
@@ -135,5 +138,11 @@ export class BackupCodeVerification implements MfaVerificationRecord<Verificatio
       code,
       backupCodes,
     };
+  }
+
+  toSanitizedJson(): SanitizedBackupCodeVerificationRecordData {
+    const { id, type, userId, code } = this;
+
+    return { id, type, userId, code };
   }
 }

--- a/packages/core/src/routes/experience/classes/verifications/code-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/code-verification.ts
@@ -168,6 +168,10 @@ abstract class CodeVerification<T extends CodeVerificationType>
     };
   }
 
+  toSanitizedJson(): CodeVerificationRecordData<T> {
+    return this.toJson();
+  }
+
   abstract toUserProfile(): CodeVerificationIdentifierMap[T];
 }
 

--- a/packages/core/src/routes/experience/classes/verifications/enterprise-sso-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/enterprise-sso-verification.ts
@@ -7,6 +7,7 @@ import {
   type UserSsoIdentity,
   type EnterpriseSsoVerificationRecordData,
   enterpriseSsoVerificationRecordDataGuard,
+  type SanitizedEnterpriseSsoVerificationRecordData,
   type EncryptedTokenSet,
   type SecretEnterpriseSsoConnectorRelationPayload,
 } from '@logto/schemas';
@@ -33,7 +34,9 @@ import { type IdentifierVerificationRecord } from './verification-record.js';
 
 export {
   type EnterpriseSsoVerificationRecordData,
+  type SanitizedEnterpriseSsoVerificationRecordData,
   enterpriseSsoVerificationRecordDataGuard,
+  sanitizedEnterpriseSsoVerificationRecordDataGuard,
 } from '@logto/schemas';
 
 export type EnterpriseSsoConnectorTokenSetSecret = {
@@ -238,16 +241,22 @@ export class EnterpriseSsoVerification
   }
 
   toJson(): EnterpriseSsoVerificationRecordData {
-    const { id, connectorId, type, enterpriseSsoUserInfo, issuer, encryptedTokenSet } = this;
+    const { id, type, connectorId, enterpriseSsoUserInfo, encryptedTokenSet, issuer } = this;
 
     return {
       id,
-      connectorId,
       type,
+      connectorId,
       enterpriseSsoUserInfo,
-      issuer,
       encryptedTokenSet,
+      issuer,
     };
+  }
+
+  toSanitizedJson(): SanitizedEnterpriseSsoVerificationRecordData {
+    const { id, type, connectorId, enterpriseSsoUserInfo, issuer } = this;
+
+    return { id, type, connectorId, enterpriseSsoUserInfo, issuer };
   }
 
   private async findUserSsoIdentityByEnterpriseSsoUserInfo(): Promise<

--- a/packages/core/src/routes/experience/classes/verifications/index.ts
+++ b/packages/core/src/routes/experience/classes/verifications/index.ts
@@ -108,6 +108,36 @@ export const verificationRecordDataGuard = z.discriminatedUnion('type', [
   oneTimeTokenVerificationRecordDataGuard,
 ]);
 
+export const publicVerificationRecordDataGuard = z.discriminatedUnion('type', [
+  passwordVerificationRecordDataGuard,
+  emailCodeVerificationRecordDataGuard,
+  phoneCodeVerificationRecordDataGuard,
+  socialVerificationRecordDataGuard.omit({
+    encryptedTokenSet: true,
+    connectorSession: true,
+  }),
+  enterpriseSsoVerificationRecordDataGuard.omit({
+    encryptedTokenSet: true,
+  }),
+  totpVerificationRecordDataGuard.omit({
+    secret: true,
+  }),
+  backupCodeVerificationRecordDataGuard.omit({
+    code: true,
+    backupCodes: true,
+  }),
+  webAuthnVerificationRecordDataGuard.omit({
+    registrationInfo: true,
+    registrationChallenge: true,
+    authenticationChallenge: true,
+  }),
+  newPasswordIdentityVerificationRecordDataGuard.omit({
+    passwordEncrypted: true,
+    passwordEncryptionMethod: true,
+  }),
+  oneTimeTokenVerificationRecordDataGuard,
+]);
+
 /**
  * The factory method to build a new `VerificationRecord` instance based on the provided `VerificationRecordData`.
  */

--- a/packages/core/src/routes/experience/classes/verifications/index.ts
+++ b/packages/core/src/routes/experience/classes/verifications/index.ts
@@ -7,7 +7,9 @@ import type Queries from '#src/tenants/Queries.js';
 import {
   BackupCodeVerification,
   backupCodeVerificationRecordDataGuard,
+  sanitizedBackupCodeVerificationRecordDataGuard,
   type BackupCodeVerificationRecordData,
+  type SanitizedBackupCodeVerificationRecordData,
 } from './backup-code-verification.js';
 import {
   EmailCodeVerification,
@@ -19,12 +21,16 @@ import {
 import {
   EnterpriseSsoVerification,
   enterpriseSsoVerificationRecordDataGuard,
+  sanitizedEnterpriseSsoVerificationRecordDataGuard,
+  type SanitizedEnterpriseSsoVerificationRecordData,
   type EnterpriseSsoVerificationRecordData,
 } from './enterprise-sso-verification.js';
 import {
   NewPasswordIdentityVerification,
   newPasswordIdentityVerificationRecordDataGuard,
+  sanitizedNewPasswordIdentityVerificationRecordDataGuard,
   type NewPasswordIdentityVerificationRecordData,
+  type SanitizedNewPasswordIdentityVerificationRecordData,
 } from './new-password-identity-verification.js';
 import {
   OneTimeTokenVerification,
@@ -39,18 +45,24 @@ import {
 import {
   SocialVerification,
   socialVerificationRecordDataGuard,
+  sanitizedSocialVerificationRecordDataGuard,
   type SocialVerificationRecordData,
+  type SanitizedSocialVerificationRecordData,
 } from './social-verification.js';
 import {
   TotpVerification,
   totpVerificationRecordDataGuard,
+  sanitizedTotpVerificationRecordDataGuard,
   type TotpVerificationRecordData,
+  type SanitizedTotpVerificationRecordData,
 } from './totp-verification.js';
 import { type VerificationRecord as GenericVerificationRecord } from './verification-record.js';
 import {
   WebAuthnVerification,
   webAuthnVerificationRecordDataGuard,
+  sanitizedWebAuthnVerificationRecordDataGuard,
   type WebAuthnVerificationRecordData,
+  type SanitizedWebAuthnVerificationRecordData,
 } from './web-authn-verification.js';
 
 export type VerificationRecordData =
@@ -63,6 +75,18 @@ export type VerificationRecordData =
   | BackupCodeVerificationRecordData
   | WebAuthnVerificationRecordData
   | NewPasswordIdentityVerificationRecordData
+  | OneTimeTokenVerificationRecordData;
+
+export type SanitizedVerificationRecordData =
+  | PasswordVerificationRecordData
+  | CodeVerificationRecordData<VerificationType.EmailVerificationCode>
+  | CodeVerificationRecordData<VerificationType.PhoneVerificationCode>
+  | SanitizedSocialVerificationRecordData
+  | SanitizedEnterpriseSsoVerificationRecordData
+  | SanitizedTotpVerificationRecordData
+  | SanitizedBackupCodeVerificationRecordData
+  | SanitizedWebAuthnVerificationRecordData
+  | SanitizedNewPasswordIdentityVerificationRecordData
   | OneTimeTokenVerificationRecordData;
 
 // This is to ensure the keys of the map are the same as the type of the verification record
@@ -112,29 +136,12 @@ export const publicVerificationRecordDataGuard = z.discriminatedUnion('type', [
   passwordVerificationRecordDataGuard,
   emailCodeVerificationRecordDataGuard,
   phoneCodeVerificationRecordDataGuard,
-  socialVerificationRecordDataGuard.omit({
-    encryptedTokenSet: true,
-    connectorSession: true,
-  }),
-  enterpriseSsoVerificationRecordDataGuard.omit({
-    encryptedTokenSet: true,
-  }),
-  totpVerificationRecordDataGuard.omit({
-    secret: true,
-  }),
-  backupCodeVerificationRecordDataGuard.omit({
-    code: true,
-    backupCodes: true,
-  }),
-  webAuthnVerificationRecordDataGuard.omit({
-    registrationInfo: true,
-    registrationChallenge: true,
-    authenticationChallenge: true,
-  }),
-  newPasswordIdentityVerificationRecordDataGuard.omit({
-    passwordEncrypted: true,
-    passwordEncryptionMethod: true,
-  }),
+  sanitizedSocialVerificationRecordDataGuard,
+  sanitizedEnterpriseSsoVerificationRecordDataGuard,
+  sanitizedTotpVerificationRecordDataGuard,
+  sanitizedBackupCodeVerificationRecordDataGuard,
+  sanitizedWebAuthnVerificationRecordDataGuard,
+  sanitizedNewPasswordIdentityVerificationRecordDataGuard,
   oneTimeTokenVerificationRecordDataGuard,
 ]);
 

--- a/packages/core/src/routes/experience/classes/verifications/new-password-identity-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/new-password-identity-verification.ts
@@ -3,6 +3,7 @@ import {
   type UsersPasswordEncryptionMethod,
   VerificationType,
   type NewPasswordIdentityVerificationRecordData,
+  type SanitizedNewPasswordIdentityVerificationRecordData,
 } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 
@@ -20,7 +21,9 @@ import { type VerificationRecord } from './verification-record.js';
 
 export {
   type NewPasswordIdentityVerificationRecordData,
+  type SanitizedNewPasswordIdentityVerificationRecordData,
   newPasswordIdentityVerificationRecordDataGuard,
+  sanitizedNewPasswordIdentityVerificationRecordDataGuard,
 } from '@logto/schemas';
 
 /**
@@ -123,5 +126,10 @@ export class NewPasswordIdentityVerification
       passwordEncrypted,
       passwordEncryptionMethod,
     };
+  }
+
+  toSanitizedJson(): SanitizedNewPasswordIdentityVerificationRecordData {
+    const { id, type, identifier } = this;
+    return { id, type, identifier };
   }
 }

--- a/packages/core/src/routes/experience/classes/verifications/one-time-token-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/one-time-token-verification.ts
@@ -124,4 +124,8 @@ export class OneTimeTokenVerification
 
     return { id, type, identifier, verified, oneTimeTokenContext: context };
   }
+
+  toSanitizedJson(): OneTimeTokenVerificationRecordData {
+    return this.toJson();
+  }
 }

--- a/packages/core/src/routes/experience/classes/verifications/password-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/password-verification.ts
@@ -111,4 +111,8 @@ export class PasswordVerification
       verified,
     };
   }
+
+  toSanitizedJson(): PasswordVerificationRecordData {
+    return this.toJson();
+  }
 }

--- a/packages/core/src/routes/experience/classes/verifications/social-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/social-verification.ts
@@ -13,6 +13,7 @@ import {
   type User,
   type SocialVerificationRecordData,
   socialVerificationRecordDataGuard,
+  type SanitizedSocialVerificationRecordData,
   type SocialConnectorPayload,
   type EncryptedTokenSet,
   type SecretSocialConnectorRelationPayload,
@@ -40,7 +41,9 @@ import { type IdentifierVerificationRecord } from './verification-record.js';
 
 export {
   type SocialVerificationRecordData,
+  type SanitizedSocialVerificationRecordData,
   socialVerificationRecordDataGuard,
+  sanitizedSocialVerificationRecordDataGuard,
 } from '@logto/schemas';
 
 type SocialAuthorizationSessionStorageType = 'interactionSession' | 'verificationRecord';
@@ -319,16 +322,22 @@ export class SocialVerification implements IdentifierVerificationRecord<Verifica
   }
 
   toJson(): SocialVerificationRecordData {
-    const { id, connectorId, type, socialUserInfo, encryptedTokenSet, connectorSession } = this;
+    const { id, type, connectorId, socialUserInfo, encryptedTokenSet, connectorSession } = this;
 
     return {
       id,
-      connectorId,
       type,
+      connectorId,
       socialUserInfo,
       encryptedTokenSet,
       connectorSession,
     };
+  }
+
+  toSanitizedJson(): SanitizedSocialVerificationRecordData {
+    const { id, type, connectorId, socialUserInfo } = this;
+
+    return { id, type, connectorId, socialUserInfo };
   }
 
   private async findUserBySocialIdentity(): Promise<User | undefined> {

--- a/packages/core/src/routes/experience/classes/verifications/totp-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/totp-verification.ts
@@ -6,6 +6,7 @@ import {
   type User,
   type TotpVerificationRecordData,
   totpVerificationRecordDataGuard,
+  type SanitizedTotpVerificationRecordData,
 } from '@logto/schemas';
 import { generateStandardId, getUserDisplayName } from '@logto/shared';
 import { authenticator } from 'otplib';
@@ -22,7 +23,12 @@ import assertThat from '#src/utils/assert-that.js';
 
 import { type MfaVerificationRecord } from './verification-record.js';
 
-export { type TotpVerificationRecordData, totpVerificationRecordDataGuard } from '@logto/schemas';
+export {
+  type TotpVerificationRecordData,
+  type SanitizedTotpVerificationRecordData,
+  totpVerificationRecordDataGuard,
+  sanitizedTotpVerificationRecordDataGuard,
+} from '@logto/schemas';
 
 const defaultDisplayName = 'Unnamed User';
 
@@ -167,6 +173,12 @@ export class TotpVerification implements MfaVerificationRecord<VerificationType.
       secret,
       verified,
     };
+  }
+
+  toSanitizedJson(): SanitizedTotpVerificationRecordData {
+    const { id, type, userId, verified } = this;
+
+    return { id, type, userId, verified };
   }
 
   /**

--- a/packages/core/src/routes/experience/classes/verifications/verification-record.ts
+++ b/packages/core/src/routes/experience/classes/verifications/verification-record.ts
@@ -16,6 +16,7 @@ export abstract class VerificationRecord<
   abstract get isVerified(): boolean;
 
   abstract toJson(): Json;
+  abstract toSanitizedJson(): Json;
 }
 
 type IdentifierVerificationType =

--- a/packages/core/src/routes/experience/classes/verifications/web-authn-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/web-authn-verification.ts
@@ -7,6 +7,7 @@ import {
   type WebAuthnVerificationPayload,
   type WebAuthnVerificationRecordData,
   webAuthnVerificationRecordDataGuard,
+  type SanitizedWebAuthnVerificationRecordData,
 } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 import { conditional } from '@silverhand/essentials';
@@ -28,7 +29,9 @@ import { type MfaVerificationRecord } from './verification-record.js';
 
 export {
   type WebAuthnVerificationRecordData,
+  type SanitizedWebAuthnVerificationRecordData,
   webAuthnVerificationRecordDataGuard,
+  sanitizedWebAuthnVerificationRecordDataGuard,
 } from '@logto/schemas';
 
 export class WebAuthnVerification implements MfaVerificationRecord<VerificationType.WebAuthn> {
@@ -260,6 +263,11 @@ export class WebAuthnVerification implements MfaVerificationRecord<VerificationT
       authenticationChallenge,
       registrationInfo,
     };
+  }
+
+  toSanitizedJson(): SanitizedWebAuthnVerificationRecordData {
+    const { id, type, userId, verified } = this;
+    return { id, type, userId, verified };
   }
 
   private async findUser() {

--- a/packages/core/src/routes/experience/const.ts
+++ b/packages/core/src/routes/experience/const.ts
@@ -2,6 +2,7 @@ const prefix = '/experience';
 
 export const experienceRoutes = Object.freeze({
   prefix,
+  interaction: `${prefix}/interaction`,
   identification: `${prefix}/identification`,
   verification: `${prefix}/verification`,
   profile: `${prefix}/profile`,

--- a/packages/core/src/routes/experience/experience.openapi.json
+++ b/packages/core/src/routes/experience/experience.openapi.json
@@ -118,6 +118,19 @@
           }
         }
       }
+    },
+    "/api/experience/interaction": {
+      "get": {
+        "tags": ["Dev feature"],
+        "operationId": "GetInteraction",
+        "summary": "Get public interaction data",
+        "description": "Get the public interaction data.",
+        "responses": {
+          "200": {
+            "description": "The public interaction data has been successfully retrieved."
+          }
+        }
+      }
     }
   }
 }

--- a/packages/core/src/routes/experience/index.ts
+++ b/packages/core/src/routes/experience/index.ts
@@ -24,12 +24,14 @@ import { type AnonymousRouter, type RouterInitArgs } from '../types.js';
 
 import experienceAnonymousRoutes from './anonymous-routes/index.js';
 import ExperienceInteraction from './classes/experience-interaction.js';
-import { sanitizeInteractionData } from './classes/utils.js';
 import { experienceRoutes } from './const.js';
 import { koaExperienceInteractionHooks } from './middleware/koa-experience-interaction-hooks.js';
 import koaExperienceInteraction from './middleware/koa-experience-interaction.js';
 import profileRoutes from './profile-routes.js';
-import { publicInteractionStorageGuard, type ExperienceInteractionRouterContext } from './types.js';
+import {
+  sanitizedInteractionStorageGuard,
+  type ExperienceInteractionRouterContext,
+} from './types.js';
 import backupCodeVerificationRoutes from './verification-routes/backup-code-verification.js';
 import enterpriseSsoVerificationRoutes from './verification-routes/enterprise-sso-verification.js';
 import newPasswordIdentityVerificationRoutes from './verification-routes/new-password-identity-verification.js';
@@ -196,12 +198,12 @@ export default function experienceApiRoutes<T extends AnonymousRouter>(
       `${experienceRoutes.interaction}`,
       koaGuard({
         status: [200],
-        response: publicInteractionStorageGuard,
+        response: sanitizedInteractionStorageGuard,
       }),
       async (ctx, next) => {
         const { experienceInteraction } = ctx;
 
-        ctx.body = sanitizeInteractionData(experienceInteraction);
+        ctx.body = experienceInteraction.toSanitizedJson();
         ctx.status = 200;
         return next();
       }

--- a/packages/integration-tests/src/client/experience/const.ts
+++ b/packages/integration-tests/src/client/experience/const.ts
@@ -5,5 +5,6 @@ export const experienceRoutes = {
   identification: `${prefix}/identification`,
   profile: `${prefix}/profile`,
   mfa: `${prefix}/profile/mfa`,
+  interaction: `${prefix}/interaction`,
   prefix,
 };

--- a/packages/integration-tests/src/client/experience/index.ts
+++ b/packages/integration-tests/src/client/experience/index.ts
@@ -13,7 +13,7 @@ import {
 import MockClient from '#src/client/index.js';
 
 import { experienceRoutes } from './const.js';
-import type { PublicInteractionStorageData, RedirectResponse } from './types.js';
+import type { SanitizedInteractionStorageData, RedirectResponse } from './types.js';
 
 export class ExperienceClient extends MockClient {
   public async identifyUser(payload: IdentificationApiPayload = {}) {
@@ -239,6 +239,6 @@ export class ExperienceClient extends MockClient {
       .get(experienceRoutes.interaction, {
         headers: { cookie: this.interactionCookie },
       })
-      .json<PublicInteractionStorageData>();
+      .json<SanitizedInteractionStorageData>();
   }
 }

--- a/packages/integration-tests/src/client/experience/index.ts
+++ b/packages/integration-tests/src/client/experience/index.ts
@@ -13,10 +13,7 @@ import {
 import MockClient from '#src/client/index.js';
 
 import { experienceRoutes } from './const.js';
-
-type RedirectResponse = {
-  redirectTo: string;
-};
+import type { PublicInteractionStorageData, RedirectResponse } from './types.js';
 
 export class ExperienceClient extends MockClient {
   public async identifyUser(payload: IdentificationApiPayload = {}) {
@@ -235,5 +232,13 @@ export class ExperienceClient extends MockClient {
         json: payload,
       })
       .json<{ verificationId: string }>();
+  }
+
+  public async getInteractionData() {
+    return this.api
+      .get(experienceRoutes.interaction, {
+        headers: { cookie: this.interactionCookie },
+      })
+      .json<PublicInteractionStorageData>();
   }
 }

--- a/packages/integration-tests/src/client/experience/types.ts
+++ b/packages/integration-tests/src/client/experience/types.ts
@@ -11,9 +11,9 @@ export type RedirectResponse = {
 };
 
 /**
- * @see {@linkcode @logto/core/src/routes/experience/types.ts}
+ * @see {@link file://./../../../../../core/src/routes/experience/types.ts}
  */
-export type PublicInteractionStorageData = {
+export type SanitizedInteractionStorageData = {
   interactionEvent: InteractionEvent;
   userId?: string;
   profile?: Partial<

--- a/packages/integration-tests/src/client/experience/types.ts
+++ b/packages/integration-tests/src/client/experience/types.ts
@@ -1,0 +1,58 @@
+import { type TemplateType, type SocialUserInfo } from '@logto/connector-kit';
+import {
+  type VerificationType,
+  type InteractionEvent,
+  type User,
+  type VerificationIdentifier,
+} from '@logto/schemas';
+
+export type RedirectResponse = {
+  redirectTo: string;
+};
+
+/**
+ * @see {@linkcode @logto/core/src/routes/experience/types.ts}
+ */
+export type PublicInteractionStorageData = {
+  interactionEvent: InteractionEvent;
+  userId?: string;
+  profile?: Partial<
+    Pick<
+      User,
+      'avatar' | 'name' | 'username' | 'primaryEmail' | 'primaryPhone' | 'profile' | 'customData'
+    >
+  > & {
+    socialIdentity?: {
+      target: string;
+      userInfo: SocialUserInfo;
+    };
+    enterpriseSsoIdentity?: {
+      identityId: string;
+      ssoConnectorId: string;
+      issuer: string;
+      detail: Record<string, unknown>;
+    };
+    syncedEnterpriseSsoIdentity?: {
+      identityId: string;
+      issuer: string;
+      detail: Record<string, unknown>;
+    };
+    jitOrganizationIds?: string[];
+  };
+  verificationRecords?: Array<{
+    id: string;
+    type: VerificationType;
+    verified?: boolean;
+    identifier?: VerificationIdentifier;
+    userId?: string;
+    connectorId?: string;
+    templateType?: TemplateType;
+    socialUserInfo?: SocialUserInfo;
+    enterpriseSsoUserInfo?: Record<string, unknown>;
+    oneTimeTokenContext?: Record<string, unknown>;
+  }>;
+  captcha?: {
+    verified: boolean;
+    skipped: boolean;
+  };
+};

--- a/packages/integration-tests/src/tests/api/experience-api/interaction.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/interaction.test.ts
@@ -1,8 +1,35 @@
-import { InteractionEvent, SignInIdentifier } from '@logto/schemas';
+import {
+  ConnectorType,
+  InteractionEvent,
+  SignInIdentifier,
+  VerificationType,
+} from '@logto/schemas';
 
+import { mockEmailConnectorId, mockSocialConnectorId } from '#src/__mocks__/connectors-mock.js';
+import { updateSignInExperience } from '#src/api/sign-in-experience.js';
+import { SsoConnectorApi } from '#src/api/sso-connector.js';
 import { initExperienceClient } from '#src/helpers/client.js';
+import {
+  clearConnectorsByTypes,
+  setEmailConnector,
+  setSocialConnector,
+} from '#src/helpers/connector.js';
+import {
+  successFullyCreateEnterpriseSsoVerification,
+  successFullyVerifyEnterpriseSsoAuthorization,
+} from '#src/helpers/experience/enterprise-sso-verification.js';
+import { identifyUserWithUsernamePassword } from '#src/helpers/experience/index.js';
+import {
+  successFullyCreateSocialVerification,
+  successFullyVerifySocialAuthorization,
+} from '#src/helpers/experience/social-verification.js';
+import {
+  successfullySendVerificationCode,
+  successfullyVerifyVerificationCode,
+} from '#src/helpers/experience/verification-code.js';
 import { expectRejects } from '#src/helpers/index.js';
 import { generateNewUserProfile, UserApiTest } from '#src/helpers/user.js';
+import { devFeatureTest, generateEmail, generateUserId, randomString } from '#src/utils.js';
 
 describe('PUT /experience API', () => {
   const userApi = new UserApiTest();
@@ -62,5 +89,341 @@ describe('PUT /experience API', () => {
     await expect(
       client.updateInteractionEvent({ interactionEvent: InteractionEvent.Register })
     ).resolves.not.toThrow();
+  });
+});
+
+devFeatureTest.describe('GET /experience/interaction', () => {
+  const userApi = new UserApiTest();
+  const connectorIdMap = new Map<string, string>();
+  const ssoConnectorApi = new SsoConnectorApi();
+
+  beforeAll(async () => {
+    await clearConnectorsByTypes([ConnectorType.Social, ConnectorType.Email]);
+
+    const [emailConnector, socialConnector] = await Promise.all([
+      setEmailConnector(),
+      setSocialConnector(),
+    ]);
+    connectorIdMap.set(mockEmailConnectorId, emailConnector.id);
+    connectorIdMap.set(mockSocialConnectorId, socialConnector.id);
+  });
+
+  afterAll(async () => {
+    await clearConnectorsByTypes([ConnectorType.Social]);
+    await userApi.cleanUp();
+    await ssoConnectorApi.cleanUp();
+  });
+
+  devFeatureTest.it('should return public interaction data for fresh interaction', async () => {
+    const client = await initExperienceClient();
+    const data = await client.getInteractionData();
+
+    expect(data).toMatchObject({
+      interactionEvent: InteractionEvent.SignIn,
+      profile: {},
+      verificationRecords: [],
+      captcha: {
+        verified: false,
+        skipped: false,
+      },
+    });
+  });
+
+  devFeatureTest.it(
+    'should return correct interaction event type in interaction data',
+    async () => {
+      // Test SignIn event
+      const signInClient = await initExperienceClient({
+        interactionEvent: InteractionEvent.SignIn,
+      });
+      const signInData = await signInClient.getInteractionData();
+      expect(signInData.interactionEvent).toBe(InteractionEvent.SignIn);
+
+      // Test Register event
+      const registerClient = await initExperienceClient({
+        interactionEvent: InteractionEvent.Register,
+      });
+      const registerData = await registerClient.getInteractionData();
+      expect(registerData.interactionEvent).toBe(InteractionEvent.Register);
+
+      // Test ForgotPassword event
+      const forgotPasswordClient = await initExperienceClient({
+        interactionEvent: InteractionEvent.ForgotPassword,
+      });
+      const forgotPasswordData = await forgotPasswordClient.getInteractionData();
+      expect(forgotPasswordData.interactionEvent).toBe(InteractionEvent.ForgotPassword);
+    }
+  );
+
+  devFeatureTest.it(
+    'should return interaction data with password verification record',
+    async () => {
+      const { username, password } = generateNewUserProfile({ username: true, password: true });
+      await userApi.create({ username, password });
+
+      const client = await initExperienceClient();
+
+      // Create a password verification record
+      const { verificationId } = await client.verifyPassword({
+        identifier: { type: SignInIdentifier.Username, value: username },
+        password,
+      });
+
+      const data = await client.getInteractionData();
+
+      expect(data.verificationRecords).toHaveLength(1);
+      expect(data.verificationRecords![0]).toMatchObject({
+        id: verificationId,
+        type: VerificationType.Password,
+        verified: true,
+        identifier: { type: SignInIdentifier.Username, value: username },
+      });
+    }
+  );
+
+  devFeatureTest.it('should return interaction data with email verification record', async () => {
+    const { primaryEmail } = generateNewUserProfile({ primaryEmail: true });
+    await userApi.create({ primaryEmail });
+
+    const client = await initExperienceClient();
+
+    // Create an email verification record
+    const { verificationId, code } = await successfullySendVerificationCode(client, {
+      identifier: { type: SignInIdentifier.Email, value: primaryEmail },
+      interactionEvent: InteractionEvent.SignIn,
+    });
+
+    const dataBeforeVerification = await client.getInteractionData();
+
+    expect(dataBeforeVerification.verificationRecords).toHaveLength(1);
+    expect(dataBeforeVerification.verificationRecords![0]).toMatchObject({
+      id: verificationId,
+      type: VerificationType.EmailVerificationCode,
+      verified: false,
+      identifier: { type: SignInIdentifier.Email, value: primaryEmail },
+    });
+
+    await successfullyVerifyVerificationCode(client, {
+      identifier: { type: SignInIdentifier.Email, value: primaryEmail },
+      verificationId,
+      code,
+    });
+
+    const dataAfterVerification = await client.getInteractionData();
+
+    expect(dataAfterVerification.verificationRecords![0]).toMatchObject({
+      id: verificationId,
+      type: VerificationType.EmailVerificationCode,
+      verified: true,
+      identifier: { type: SignInIdentifier.Email, value: primaryEmail },
+    });
+  });
+
+  devFeatureTest.it('should return interaction data with phone verification record', async () => {
+    const { primaryPhone } = generateNewUserProfile({ primaryPhone: true });
+    await userApi.create({ primaryPhone });
+
+    const client = await initExperienceClient();
+
+    // Create a phone verification record
+    const { verificationId, code } = await successfullySendVerificationCode(client, {
+      identifier: { type: SignInIdentifier.Phone, value: primaryPhone },
+      interactionEvent: InteractionEvent.SignIn,
+    });
+
+    const dataBeforeVerification = await client.getInteractionData();
+
+    expect(dataBeforeVerification.verificationRecords).toHaveLength(1);
+    expect(dataBeforeVerification.verificationRecords![0]).toMatchObject({
+      id: verificationId,
+      type: VerificationType.PhoneVerificationCode,
+      verified: false,
+      identifier: { type: SignInIdentifier.Phone, value: primaryPhone },
+    });
+
+    await successfullyVerifyVerificationCode(client, {
+      identifier: { type: SignInIdentifier.Phone, value: primaryPhone },
+      verificationId,
+      code,
+    });
+
+    const dataAfterVerification = await client.getInteractionData();
+
+    expect(dataAfterVerification.verificationRecords![0]).toMatchObject({
+      id: verificationId,
+      type: VerificationType.PhoneVerificationCode,
+      verified: true,
+      identifier: { type: SignInIdentifier.Phone, value: primaryPhone },
+    });
+  });
+
+  devFeatureTest.it(
+    'should return interaction data with profile info after fulfilling profile',
+    async () => {
+      const { username, password } = generateNewUserProfile({ username: true, password: true });
+      const { id: userId } = await userApi.create({ username, password });
+
+      const client = await initExperienceClient();
+      const { verificationId: passwordVerificationId } = await identifyUserWithUsernamePassword(
+        client,
+        username,
+        password
+      );
+
+      const primaryEmail = generateEmail();
+
+      const { verificationId: emailVerificationId, code: verificationCode } =
+        await successfullySendVerificationCode(client, {
+          identifier: { type: SignInIdentifier.Email, value: primaryEmail },
+          interactionEvent: InteractionEvent.SignIn,
+        });
+      await successfullyVerifyVerificationCode(client, {
+        identifier: { type: SignInIdentifier.Email, value: primaryEmail },
+        verificationId: emailVerificationId,
+        code: verificationCode,
+      });
+
+      await client.updateProfile({
+        type: SignInIdentifier.Email,
+        verificationId: emailVerificationId,
+      });
+
+      const data = await client.getInteractionData();
+
+      expect(data).toMatchObject({
+        interactionEvent: InteractionEvent.SignIn,
+        userId,
+        profile: { primaryEmail },
+        verificationRecords: [
+          {
+            id: passwordVerificationId,
+            type: VerificationType.Password,
+            verified: true,
+            identifier: { type: SignInIdentifier.Username, value: username },
+          },
+          {
+            id: emailVerificationId,
+            type: VerificationType.EmailVerificationCode,
+            verified: true,
+            identifier: { type: SignInIdentifier.Email, value: primaryEmail },
+          },
+        ],
+      });
+    }
+  );
+
+  devFeatureTest.it('should not include sensitive data in verification records', async () => {
+    const { username, password } = generateNewUserProfile({ username: true, password: true });
+    await userApi.create({ username, password });
+
+    const client = await initExperienceClient();
+
+    await client.verifyPassword({
+      identifier: { type: SignInIdentifier.Username, value: username },
+      password,
+    });
+
+    const data = await client.getInteractionData();
+
+    const passwordRecord = data.verificationRecords![0];
+
+    // Should not include password or other sensitive data
+    expect(passwordRecord).not.toHaveProperty('password');
+    expect(passwordRecord).not.toHaveProperty('passwordEncrypted');
+  });
+
+  devFeatureTest.it('should return interaction data for social verification', async () => {
+    const state = 'fake_state';
+    const redirectUri = 'http://localhost:3000/redirect';
+    const authorizationCode = 'fake_code';
+    const socialConnectorId = connectorIdMap.get(mockSocialConnectorId)!;
+    const email = generateEmail();
+
+    const client = await initExperienceClient({ interactionEvent: InteractionEvent.Register });
+
+    const { verificationId } = await successFullyCreateSocialVerification(
+      client,
+      socialConnectorId,
+      { redirectUri, state }
+    );
+
+    await successFullyVerifySocialAuthorization(client, socialConnectorId, {
+      verificationId,
+      connectorData: { code: authorizationCode, userId: '12345', email, name: 'John Doe' },
+    });
+
+    const data = await client.getInteractionData();
+
+    expect(data).toMatchObject({
+      verificationRecords: [
+        {
+          id: verificationId,
+          type: VerificationType.Social,
+          connectorId: socialConnectorId,
+          socialUserInfo: {
+            id: '12345',
+            email,
+            name: 'John Doe',
+          },
+        },
+      ],
+    });
+  });
+
+  devFeatureTest.it('should return interaction data for enterprise SSO verification', async () => {
+    const state = 'fake_state';
+    const redirectUri = 'http://localhost:3000/redirect';
+    const code = 'fake_code';
+    const domain = `foo${randomString()}.com`;
+    await ssoConnectorApi.createMockOidcConnector([domain]);
+
+    // Enable single sign-on
+    await updateSignInExperience({ singleSignOnEnabled: true });
+
+    const connectorId = ssoConnectorApi.firstConnectorId!;
+    const client = await initExperienceClient({ interactionEvent: InteractionEvent.Register });
+
+    // Create enterprise SSO verification
+    const { verificationId } = await successFullyCreateEnterpriseSsoVerification(
+      client,
+      connectorId,
+      { redirectUri, state }
+    );
+
+    const fakeSsoIdentitySub = generateUserId();
+    // Verify enterprise SSO authorization with basic format (similar to verification test)
+    await successFullyVerifyEnterpriseSsoAuthorization(client, connectorId, {
+      verificationId,
+      connectorData: {
+        code,
+        sub: fakeSsoIdentitySub,
+        name: 'John Doe',
+        email: `john.doe@${domain}`,
+        email_verified: true,
+        picture: 'https://example.com/picture.jpg',
+        phone: '1234567890',
+        phone_verified: true,
+      },
+    });
+
+    // Get interaction data
+    const data = await client.getInteractionData();
+
+    expect(data).toMatchObject({
+      verificationRecords: [
+        {
+          id: verificationId,
+          type: VerificationType.EnterpriseSso,
+          connectorId,
+          enterpriseSsoUserInfo: {
+            id: fakeSsoIdentitySub,
+            name: 'John Doe',
+            email: `john.doe@${domain}`,
+            avatar: 'https://example.com/picture.jpg',
+            phone: '1234567890',
+          },
+        },
+      ],
+    });
   });
 });

--- a/packages/schemas/src/types/verification-records/backup-code-verification.ts
+++ b/packages/schemas/src/types/verification-records/backup-code-verification.ts
@@ -19,3 +19,13 @@ export const backupCodeVerificationRecordDataGuard = z.object({
   code: z.string().optional(),
   backupCodes: z.string().array().optional(),
 }) satisfies ToZodObject<BackupCodeVerificationRecordData>;
+
+export type SanitizedBackupCodeVerificationRecordData = Omit<
+  BackupCodeVerificationRecordData,
+  'backupCodes'
+>;
+
+export const sanitizedBackupCodeVerificationRecordDataGuard =
+  backupCodeVerificationRecordDataGuard.omit({
+    backupCodes: true,
+  }) satisfies ToZodObject<SanitizedBackupCodeVerificationRecordData>;

--- a/packages/schemas/src/types/verification-records/enterprise-sso-verification.ts
+++ b/packages/schemas/src/types/verification-records/enterprise-sso-verification.ts
@@ -27,3 +27,13 @@ export const enterpriseSsoVerificationRecordDataGuard = z.object({
   encryptedTokenSet: encryptedTokenSetGuard.optional(),
   issuer: z.string().optional(),
 }) satisfies ToZodObject<EnterpriseSsoVerificationRecordData>;
+
+export type SanitizedEnterpriseSsoVerificationRecordData = Omit<
+  EnterpriseSsoVerificationRecordData,
+  'encryptedTokenSet'
+>;
+
+export const sanitizedEnterpriseSsoVerificationRecordDataGuard =
+  enterpriseSsoVerificationRecordDataGuard.omit({
+    encryptedTokenSet: true,
+  }) satisfies ToZodObject<SanitizedEnterpriseSsoVerificationRecordData>;

--- a/packages/schemas/src/types/verification-records/new-password-identity-verification.ts
+++ b/packages/schemas/src/types/verification-records/new-password-identity-verification.ts
@@ -31,3 +31,14 @@ export const newPasswordIdentityVerificationRecordDataGuard = z.object({
   passwordEncrypted: z.string().optional(),
   passwordEncryptionMethod: z.literal(UsersPasswordEncryptionMethod.Argon2i).optional(),
 }) satisfies ToZodObject<NewPasswordIdentityVerificationRecordData>;
+
+export type SanitizedNewPasswordIdentityVerificationRecordData = Omit<
+  NewPasswordIdentityVerificationRecordData,
+  'passwordEncrypted' | 'passwordEncryptionMethod'
+>;
+
+export const sanitizedNewPasswordIdentityVerificationRecordDataGuard =
+  newPasswordIdentityVerificationRecordDataGuard.omit({
+    passwordEncrypted: true,
+    passwordEncryptionMethod: true,
+  }) satisfies ToZodObject<SanitizedNewPasswordIdentityVerificationRecordData>;

--- a/packages/schemas/src/types/verification-records/social-verification.ts
+++ b/packages/schemas/src/types/verification-records/social-verification.ts
@@ -35,3 +35,13 @@ export const socialVerificationRecordDataGuard = z.object({
   encryptedTokenSet: encryptedTokenSetGuard.optional(),
   connectorSession: connectorSessionGuard.optional(),
 }) satisfies ToZodObject<SocialVerificationRecordData>;
+
+export type SanitizedSocialVerificationRecordData = Omit<
+  SocialVerificationRecordData,
+  'encryptedTokenSet' | 'connectorSession'
+>;
+
+export const sanitizedSocialVerificationRecordDataGuard = socialVerificationRecordDataGuard.omit({
+  encryptedTokenSet: true,
+  connectorSession: true,
+}) satisfies ToZodObject<SanitizedSocialVerificationRecordData>;

--- a/packages/schemas/src/types/verification-records/totp-verification.ts
+++ b/packages/schemas/src/types/verification-records/totp-verification.ts
@@ -20,3 +20,9 @@ export const totpVerificationRecordDataGuard = z.object({
   secret: z.string().optional(),
   verified: z.boolean(),
 }) satisfies ToZodObject<TotpVerificationRecordData>;
+
+export type SanitizedTotpVerificationRecordData = Omit<TotpVerificationRecordData, 'secret'>;
+
+export const sanitizedTotpVerificationRecordDataGuard = totpVerificationRecordDataGuard.omit({
+  secret: true,
+}) satisfies ToZodObject<SanitizedTotpVerificationRecordData>;

--- a/packages/schemas/src/types/verification-records/web-authn-verification.ts
+++ b/packages/schemas/src/types/verification-records/web-authn-verification.ts
@@ -27,3 +27,15 @@ export const webAuthnVerificationRecordDataGuard = z.object({
   authenticationChallenge: z.string().optional(),
   registrationInfo: bindWebAuthnGuard.optional(),
 }) satisfies ToZodObject<WebAuthnVerificationRecordData>;
+
+export type SanitizedWebAuthnVerificationRecordData = Omit<
+  WebAuthnVerificationRecordData,
+  'registrationInfo' | 'registrationChallenge' | 'authenticationChallenge'
+>;
+
+export const sanitizedWebAuthnVerificationRecordDataGuard =
+  webAuthnVerificationRecordDataGuard.omit({
+    registrationInfo: true,
+    registrationChallenge: true,
+    authenticationChallenge: true,
+  }) satisfies ToZodObject<SanitizedWebAuthnVerificationRecordData>;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Introduces a new `GET /experience/interaction` endpoint for returning sanitized interaction data, including profile and verification records, excluding sensitive fields.

Also adds corresponding Zod guards, types, and integration tests to verify correct public data exposure for various verification flows.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
