### PR TITLE
refactor(core): add `hasRefreshToken` to token secret response

### DIFF
--- a/packages/core/src/routes/admin-user/enterprise-sso.test.ts
+++ b/packages/core/src/routes/admin-user/enterprise-sso.test.ts
@@ -58,6 +58,7 @@ describe('Enterprise SSO Routes', () => {
     encryptedDek: Buffer.from(''),
     metadata: {
       scope: 'foo bar',
+      hasRefreshToken: false,
     },
     ssoConnectorId: mockSsoConnectorId,
     issuer: mockSsoIdentity.issuer,

--- a/packages/core/src/utils/secret-encryption.ts
+++ b/packages/core/src/utils/secret-encryption.ts
@@ -8,8 +8,9 @@ import {
   type EncryptedTokenSet,
   type EnterpriseSsoTokenSetSecret,
   type SocialTokenSetSecret,
+  type DesensitizedTokenSetSecret,
 } from '@logto/schemas';
-import { conditional } from '@silverhand/essentials';
+import { conditional, trySafe } from '@silverhand/essentials';
 import { z } from 'zod';
 
 import { EnvSet } from '../env-set/index.js';
@@ -191,6 +192,11 @@ export const desensitizeTokenSetSecret = <
   authTag,
   ciphertext,
   ...rest
-}: T): Omit<T, 'encryptedDek' | 'iv' | 'authTag' | 'ciphertext'> => {
-  return rest;
+}: T): DesensitizedTokenSetSecret<T> => {
+  const tokenSet = trySafe(() => decryptTokens({ encryptedDek, iv, authTag, ciphertext }));
+
+  return {
+    ...rest,
+    hasRefreshToken: Boolean(tokenSet?.refresh_token),
+  };
 };

--- a/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/social.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/social.test.ts
@@ -76,6 +76,7 @@ describe('social sign-in and sign-up', () => {
     if (isDevFeaturesEnabled) {
       const { tokenSecret } = await getUserIdentity(userId, mockSocialConnectorTarget);
       expect(tokenSecret?.metadata.scope).toBe(mockTokenResponse.scope);
+      expect(tokenSecret?.metadata.hasRefreshToken).toBe(false);
     }
   });
 
@@ -123,7 +124,7 @@ describe('social sign-in and sign-up', () => {
     if (isDevFeaturesEnabled) {
       const { tokenSecret } = await getUserIdentity(userId, mockSocialConnectorTarget);
       expect(tokenSecret?.metadata.scope).toBe('openid profile email');
-      expect(tokenSecret?.hasRefreshToken).toBe(true);
+      expect(tokenSecret?.metadata.hasRefreshToken).toBe(true);
     }
     await deleteUser(userId);
   });

--- a/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/social.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/social.test.ts
@@ -111,6 +111,7 @@ describe('social sign-in and sign-up', () => {
       name: 'John Doe',
       tokenResponse: {
         ...mockTokenResponse,
+        refresh_token: 'refresh_token',
         scope: 'openid profile email',
       },
     });
@@ -122,6 +123,7 @@ describe('social sign-in and sign-up', () => {
     if (isDevFeaturesEnabled) {
       const { tokenSecret } = await getUserIdentity(userId, mockSocialConnectorTarget);
       expect(tokenSecret?.metadata.scope).toBe('openid profile email');
+      expect(tokenSecret?.hasRefreshToken).toBe(true);
     }
     await deleteUser(userId);
   });

--- a/packages/schemas/src/types/secrets.ts
+++ b/packages/schemas/src/types/secrets.ts
@@ -1,5 +1,5 @@
 import { tokenResponseGuard } from '@logto/connector-kit';
-import { boolean, z } from 'zod';
+import { z } from 'zod';
 
 import { SecretEnterpriseSsoConnectorRelations } from '../db-entries/secret-enterprise-sso-connector-relation.js';
 import { SecretSocialConnectorRelations } from '../db-entries/secret-social-connector-relation.js';
@@ -27,6 +27,7 @@ export const tokenSetMetadataGuard = z.object({
   scope: z.string().optional(),
   expiresAt: z.number().optional(),
   tokenType: z.string().optional(),
+  hasRefreshToken: z.boolean(),
 });
 
 export type TokenSetMetadata = z.infer<typeof tokenSetMetadataGuard>;
@@ -80,16 +81,12 @@ export const socialTokenSetSecretGuard = Secrets.guard.extend({
  */
 export type SocialTokenSetSecret = z.infer<typeof socialTokenSetSecretGuard>;
 
-export const desensitizedSocialTokenSetSecretGuard = socialTokenSetSecretGuard
-  .omit({
-    encryptedDek: true,
-    iv: true,
-    authTag: true,
-    ciphertext: true,
-  })
-  .extend({
-    hasRefreshToken: boolean(),
-  });
+export const desensitizedSocialTokenSetSecretGuard = socialTokenSetSecretGuard.omit({
+  encryptedDek: true,
+  iv: true,
+  authTag: true,
+  ciphertext: true,
+});
 
 export type DesensitizedSocialTokenSetSecret = z.infer<
   typeof desensitizedSocialTokenSetSecretGuard
@@ -111,16 +108,12 @@ export const enterpriseSsoTokenSetSecretGuard = Secrets.guard.extend({
  */
 export type EnterpriseSsoTokenSetSecret = z.infer<typeof enterpriseSsoTokenSetSecretGuard>;
 
-export const desensitizedEnterpriseSsoTokenSetSecretGuard = enterpriseSsoTokenSetSecretGuard
-  .omit({
-    encryptedDek: true,
-    iv: true,
-    authTag: true,
-    ciphertext: true,
-  })
-  .extend({
-    hasRefreshToken: boolean(),
-  });
+export const desensitizedEnterpriseSsoTokenSetSecretGuard = enterpriseSsoTokenSetSecretGuard.omit({
+  encryptedDek: true,
+  iv: true,
+  authTag: true,
+  ciphertext: true,
+});
 
 export type DesensitizedEnterpriseSsoTokenSetSecret = z.infer<
   typeof desensitizedEnterpriseSsoTokenSetSecretGuard
@@ -128,9 +121,7 @@ export type DesensitizedEnterpriseSsoTokenSetSecret = z.infer<
 
 export type DesensitizedTokenSetSecret<
   T extends SocialTokenSetSecret | EnterpriseSsoTokenSetSecret,
-> = Omit<T, 'encryptedDek' | 'iv' | 'authTag' | 'ciphertext'> & {
-  hasRefreshToken: boolean;
-};
+> = Omit<T, 'encryptedDek' | 'iv' | 'authTag' | 'ciphertext'>;
 
 export const getThirdPartyAccessTokenResponseGuard = tokenResponseGuard
   .pick({

--- a/packages/schemas/src/types/secrets.ts
+++ b/packages/schemas/src/types/secrets.ts
@@ -1,5 +1,5 @@
 import { tokenResponseGuard } from '@logto/connector-kit';
-import { z } from 'zod';
+import { boolean, z } from 'zod';
 
 import { SecretEnterpriseSsoConnectorRelations } from '../db-entries/secret-enterprise-sso-connector-relation.js';
 import { SecretSocialConnectorRelations } from '../db-entries/secret-social-connector-relation.js';
@@ -80,12 +80,16 @@ export const socialTokenSetSecretGuard = Secrets.guard.extend({
  */
 export type SocialTokenSetSecret = z.infer<typeof socialTokenSetSecretGuard>;
 
-export const desensitizedSocialTokenSetSecretGuard = socialTokenSetSecretGuard.omit({
-  encryptedDek: true,
-  iv: true,
-  authTag: true,
-  ciphertext: true,
-});
+export const desensitizedSocialTokenSetSecretGuard = socialTokenSetSecretGuard
+  .omit({
+    encryptedDek: true,
+    iv: true,
+    authTag: true,
+    ciphertext: true,
+  })
+  .extend({
+    hasRefreshToken: boolean(),
+  });
 
 export type DesensitizedSocialTokenSetSecret = z.infer<
   typeof desensitizedSocialTokenSetSecretGuard
@@ -107,16 +111,26 @@ export const enterpriseSsoTokenSetSecretGuard = Secrets.guard.extend({
  */
 export type EnterpriseSsoTokenSetSecret = z.infer<typeof enterpriseSsoTokenSetSecretGuard>;
 
-export const desensitizedEnterpriseSsoTokenSetSecretGuard = enterpriseSsoTokenSetSecretGuard.omit({
-  encryptedDek: true,
-  iv: true,
-  authTag: true,
-  ciphertext: true,
-});
+export const desensitizedEnterpriseSsoTokenSetSecretGuard = enterpriseSsoTokenSetSecretGuard
+  .omit({
+    encryptedDek: true,
+    iv: true,
+    authTag: true,
+    ciphertext: true,
+  })
+  .extend({
+    hasRefreshToken: boolean(),
+  });
 
 export type DesensitizedEnterpriseSsoTokenSetSecret = z.infer<
   typeof desensitizedEnterpriseSsoTokenSetSecretGuard
 >;
+
+export type DesensitizedTokenSetSecret<
+  T extends SocialTokenSetSecret | EnterpriseSsoTokenSetSecret,
+> = Omit<T, 'encryptedDek' | 'iv' | 'authTag' | 'ciphertext'> & {
+  hasRefreshToken: boolean;
+};
 
 export const getThirdPartyAccessTokenResponseGuard = tokenResponseGuard
   .pick({


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Since the secret details are now desensitized in all token secret management API responses, developers can no longer determine whether a `refresh_token` is available. To address this, we introduce a new field, `hasRefreshToken`, in the token secret metadata. This boolean field explicitly indicates whether a `refresh_token` is present in the underlying token secret, improving clarity and enabling the console to display the offline access status appropriately.  

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Integration test updated

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
