### PR TITLE
feat: adding pbkdf2 support

### DIFF
--- a/packages/core/src/utils/password.ts
+++ b/packages/core/src/utils/password.ts
@@ -99,7 +99,7 @@ export const executeLegacyHash = async (
   const inputString = resolvedArgs.join('');
 
   if (isPbkdf2Algorithm(algorithm)) {
-    const [salt, iterations = '10_000', keylen = '64', digest = 'sha512'] = resolvedArgs;
+    const [salt, iterations, keylen, digest] = resolvedArgs;
     if (!salt || !iterations || !keylen || !digest) {
       throw new RequestError({ code: 'password.invalid_legacy_password_format' });
     }

--- a/packages/core/src/utils/password.ts
+++ b/packages/core/src/utils/password.ts
@@ -19,7 +19,15 @@ type LegacyPassword = {
   encryptedPassword: string;
 };
 
+function isPbkdf2Algorithm(algorithm: string): boolean {
+  return algorithm === 'pbkdf2Sync' || algorithm === 'pbkdf2';
+}
+
 function isLegacyHashAlgorithm(algorithm: string): boolean {
+  if (isPbkdf2Algorithm(algorithm)) {
+    return true;
+  }
+
   try {
     crypto.createHash(algorithm);
     return true;
@@ -89,6 +97,23 @@ export const executeLegacyHash = async (
   // Replace @ with input password
   const resolvedArgs = args.map((arg) => (arg === '@' ? inputPassword : arg));
   const inputString = resolvedArgs.join('');
+
+  if (isPbkdf2Algorithm(algorithm)) {
+    const [salt, iterations = '10_000', keylen = '64', digest = 'sha512'] = resolvedArgs;
+    if (!salt || !iterations || !keylen || !digest) {
+      throw new RequestError({ code: 'password.invalid_legacy_password_format' });
+    }
+
+    return crypto
+      .pbkdf2Sync(
+        inputPassword,
+        salt,
+        Number.parseInt(`${iterations}`, 10),
+        Number.parseInt(`${keylen}`, 10),
+        digest
+      )
+      .toString('hex');
+  }
 
   // Use `node:crypto` for hash calculation
   const hash = crypto.createHash(algorithm);


### PR DESCRIPTION
## Summary
Adding support PBKDF2-hashed passwords on user import

## Testing
1. Migration user payload:
```javascript
{
  username: 'john_doe',
  primaryEmail: 'john.doe@example.com',
  passwordAlgorithm: 'Legacy',
  passwordDigest: JSON.stringify(['pbkdf2Sync', [SALT, "1000", "20", 'sha512', "@"], expected_hashed_value]),
}
```

2. Args(can be changed according to pbkdf2Sync function arguments):
- salt: user defined
- iterations: 1000
- keylen: 20
- digest: sha512
- password: `@` placeholder and expected_hashed_value