### PR TITLE
feat(connector,core,schemas): support custom scope in the social verification API

### DIFF
--- a/.changeset/calm-papayas-guess.md
+++ b/.changeset/calm-papayas-guess.md
@@ -1,0 +1,11 @@
+---
+"@logto/schemas": minor
+"@logto/core": minor
+---
+
+feat: support custom scope in the social verification API.
+
+This change allows developers to specify a custom `scope` parameter in the create social verification request. If a scope is provided, it will be used to generate the authorization URI; otherwise, the default scope configured in the connector will be used.
+
+- Affected endpoints:
+  - `POST /api/verifications/social`

--- a/.changeset/metal-pianos-heal.md
+++ b/.changeset/metal-pianos-heal.md
@@ -1,0 +1,20 @@
+---
+"@logto/connector-mock-social": minor
+"@logto/connector-facebook": minor
+"@logto/connector-discord": minor
+"@logto/connector-amazon": minor
+"@logto/connector-github": minor
+"@logto/connector-xiaomi": minor
+"@logto/connector-apple": minor
+"@logto/connector-slack": minor
+"@logto/connector-kook": minor
+"@logto/connector-line": minor
+"@logto/connector-x": minor
+"@logto/connector-kit": minor
+---
+
+feat: support custom scope in the `getAuthorizationUri` method
+
+This change allows the `getAuthorizationUri` method in the social connectors to accept an extra `scope` parameter, enabling more flexible authorization requests.
+
+If the scope is provided, it will be used in the authorization request; otherwise, the default scope configured in the connector settings will be used.

--- a/packages/connectors/connector-amazon/src/index.test.ts
+++ b/packages/connectors/connector-amazon/src/index.test.ts
@@ -35,6 +35,28 @@ describe('getAuthorizationUri', () => {
       `${authorizationEndpoint}?response_type=code&client_id=%3Cclient-id%3E&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&scope=profile&state=some_state`
     );
   });
+
+  it('should get a valid uri with custom scope', async () => {
+    const connector = await createConnector({ getConfig });
+    const authorizationUri = await connector.getAuthorizationUri(
+      {
+        state: 'some_state',
+        redirectUri: 'http://localhost:3000/callback',
+        scope: 'custom_scope',
+        connectorId: 'some_connector_id',
+        connectorFactoryId: 'some_connector_factory_id',
+        jti: 'some_jti',
+        headers: {},
+      },
+      setSession
+    );
+    expect(setSession).toHaveBeenCalledWith({
+      redirectUri: 'http://localhost:3000/callback',
+    });
+    expect(authorizationUri).toEqual(
+      `${authorizationEndpoint}?response_type=code&client_id=%3Cclient-id%3E&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&scope=custom_scope&state=some_state`
+    );
+  });
 });
 
 describe('getAccessToken', () => {

--- a/packages/connectors/connector-amazon/src/index.ts
+++ b/packages/connectors/connector-amazon/src/index.ts
@@ -34,7 +34,7 @@ import {
 
 const getAuthorizationUri =
   (getConfig: GetConnectorConfig): GetAuthorizationUri =>
-  async ({ state, redirectUri }, setSession) => {
+  async ({ state, redirectUri, scope }, setSession) => {
     const config = await getConfig(defaultMetadata.id);
     validateConfig(config, amazonConfigGuard);
 
@@ -44,7 +44,7 @@ const getAuthorizationUri =
       response_type: 'code',
       client_id: config.clientId,
       redirect_uri: redirectUri,
-      scope: config.scope ?? defaultScope,
+      scope: scope ?? config.scope ?? defaultScope,
       state,
     });
 

--- a/packages/connectors/connector-apple/src/index.test.ts
+++ b/packages/connectors/connector-apple/src/index.test.ts
@@ -44,6 +44,33 @@ describe('getAuthorizationUri', () => {
     expect(searchParams.get('scope')).toEqual('scope');
     expect(searchParams.has('nonce')).toBeTruthy();
   });
+
+  it('should get a valid uri with custom scope', async () => {
+    const connector = await createConnector({ getConfig });
+    const setSession = vi.fn();
+    const authorizationUri = await connector.getAuthorizationUri(
+      {
+        state: 'some_state',
+        redirectUri: 'http://localhost:3000/callback',
+        scope: 'custom_scope',
+        connectorId: 'some_connector_id',
+        connectorFactoryId: 'some_connector_factory_id',
+        jti: 'some_jti',
+        headers: {},
+      },
+      setSession
+    );
+
+    const { origin, pathname, searchParams } = new URL(authorizationUri);
+    expect(origin + pathname).toEqual(authorizationEndpoint);
+    expect(searchParams.get('client_id')).toEqual('<client-id>');
+    expect(searchParams.get('redirect_uri')).toEqual('http://localhost:3000/callback');
+    expect(searchParams.get('state')).toEqual('some_state');
+    expect(searchParams.get('response_type')).toEqual('code id_token');
+    expect(searchParams.get('response_mode')).toEqual('form_post');
+    expect(searchParams.get('scope')).toEqual('custom_scope');
+    expect(searchParams.has('nonce')).toBeTruthy();
+  });
 });
 
 describe('getUserInfo', () => {

--- a/packages/connectors/connector-apple/src/index.ts
+++ b/packages/connectors/connector-apple/src/index.ts
@@ -24,7 +24,7 @@ const generateNonce = () => generateStandardId();
 
 const getAuthorizationUri =
   (getConfig: GetConnectorConfig): GetAuthorizationUri =>
-  async ({ state, redirectUri }, setSession) => {
+  async ({ state, redirectUri, scope }, setSession) => {
     const config = await getConfig(defaultMetadata.id);
 
     validateConfig(config, appleConfigGuard);
@@ -34,7 +34,7 @@ const getAuthorizationUri =
     const queryParameters = new URLSearchParams({
       client_id: config.clientId,
       redirect_uri: redirectUri,
-      scope: config.scope ?? '',
+      scope: scope ?? config.scope ?? '',
       state,
       nonce,
       // https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_js/incorporating_sign_in_with_apple_into_other_platforms#3332113

--- a/packages/connectors/connector-discord/src/index.test.ts
+++ b/packages/connectors/connector-discord/src/index.test.ts
@@ -31,6 +31,25 @@ describe('Discord connector', () => {
         `${authorizationEndpoint}?client_id=%3Cclient-id%3E&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&response_type=code&scope=identify+email&state=some_state`
       );
     });
+
+    it('should get a valid authorizationUri with scope', async () => {
+      const connector = await createConnector({ getConfig });
+      const authorizationUri = await connector.getAuthorizationUri(
+        {
+          state: 'some_state',
+          redirectUri: 'http://localhost:3000/callback',
+          scope: 'custom_scope',
+          connectorId: 'some_connector_id',
+          connectorFactoryId: 'some_connector_factory_id',
+          jti: 'some_jti',
+          headers: {},
+        },
+        vi.fn()
+      );
+      expect(authorizationUri).toEqual(
+        `${authorizationEndpoint}?client_id=%3Cclient-id%3E&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&response_type=code&scope=custom_scope&state=some_state`
+      );
+    });
   });
 
   describe('getAccessToken', () => {

--- a/packages/connectors/connector-discord/src/index.ts
+++ b/packages/connectors/connector-discord/src/index.ts
@@ -40,7 +40,7 @@ import {
 
 const getAuthorizationUri =
   (getConfig: GetConnectorConfig): GetAuthorizationUri =>
-  async ({ state, redirectUri }) => {
+  async ({ state, redirectUri, scope }) => {
     const config = await getConfig(defaultMetadata.id);
     validateConfig(config, discordConfigGuard);
 
@@ -48,7 +48,7 @@ const getAuthorizationUri =
       client_id: config.clientId,
       redirect_uri: redirectUri,
       response_type: 'code',
-      scope: config.scope ?? defaultScope,
+      scope: scope ?? config.scope ?? defaultScope,
       state,
     });
 

--- a/packages/connectors/connector-facebook/src/index.ts
+++ b/packages/connectors/connector-facebook/src/index.ts
@@ -40,7 +40,7 @@ import {
 
 const getAuthorizationUri =
   (getConfig: GetConnectorConfig): GetAuthorizationUri =>
-  async ({ state, redirectUri }) => {
+  async ({ state, redirectUri, scope }) => {
     const config = await getConfig(defaultMetadata.id);
     validateConfig(config, facebookConfigGuard);
 
@@ -49,7 +49,7 @@ const getAuthorizationUri =
       redirect_uri: redirectUri,
       response_type: 'code',
       state,
-      scope: config.scope ?? defaultScope,
+      scope: scope ?? config.scope ?? defaultScope,
     });
 
     return `${authorizationEndpoint}?${queryParameters.toString()}`;

--- a/packages/connectors/connector-github/src/index.test.ts
+++ b/packages/connectors/connector-github/src/index.test.ts
@@ -35,6 +35,25 @@ describe('getAuthorizationUri', () => {
       `${authorizationEndpoint}?client_id=%3Cclient-id%3E&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&state=some_state&scope=read%3Auser+user%3Aemail`
     );
   });
+
+  it('should get a valid uri with custom scope', async () => {
+    const connector = await createConnector({ getConfig });
+    const authorizationUri = await connector.getAuthorizationUri(
+      {
+        state: 'some_state',
+        redirectUri: 'http://localhost:3000/callback',
+        scope: 'custom_scope',
+        connectorId: 'some_connector_id',
+        connectorFactoryId: 'some_connector_factory_id',
+        jti: 'some_jti',
+        headers: {},
+      },
+      vi.fn()
+    );
+    expect(authorizationUri).toEqual(
+      `${authorizationEndpoint}?client_id=%3Cclient-id%3E&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&state=some_state&scope=custom_scope`
+    );
+  });
 });
 
 describe('getAccessToken', () => {

--- a/packages/connectors/connector-github/src/index.ts
+++ b/packages/connectors/connector-github/src/index.ts
@@ -39,14 +39,14 @@ import {
 
 const getAuthorizationUri =
   (getConfig: GetConnectorConfig): GetAuthorizationUri =>
-  async ({ state, redirectUri }) => {
+  async ({ state, redirectUri, scope }) => {
     const config = await getConfig(defaultMetadata.id);
     validateConfig(config, githubConfigGuard);
     const queryParameters = new URLSearchParams({
       client_id: config.clientId,
       redirect_uri: redirectUri,
       state,
-      scope: config.scope ?? defaultScope,
+      scope: scope ?? config.scope ?? defaultScope,
     });
 
     return `${authorizationEndpoint}?${queryParameters.toString()}`;

--- a/packages/connectors/connector-kook/src/index.test.ts
+++ b/packages/connectors/connector-kook/src/index.test.ts
@@ -31,6 +31,25 @@ describe('Kook connector', () => {
         `${authorizationEndpoint}?client_id=%3Cclient-id%3E&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&response_type=code&scope=get_user_info&state=some_state`
       );
     });
+
+    it('should get a valid authorizationUri with custom scope', async () => {
+      const connector = await createConnector({ getConfig });
+      const authorizationUri = await connector.getAuthorizationUri(
+        {
+          state: 'some_state',
+          redirectUri: 'http://localhost:3000/callback',
+          scope: 'custom_scope',
+          connectorId: 'some_connector_id',
+          connectorFactoryId: 'some_connector_factory_id',
+          jti: 'some_jti',
+          headers: {},
+        },
+        vi.fn()
+      );
+      expect(authorizationUri).toEqual(
+        `${authorizationEndpoint}?client_id=%3Cclient-id%3E&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&response_type=code&scope=custom_scope&state=some_state`
+      );
+    });
   });
 
   describe('getAccessToken', () => {

--- a/packages/connectors/connector-kook/src/index.ts
+++ b/packages/connectors/connector-kook/src/index.ts
@@ -34,7 +34,7 @@ import {
 
 const getAuthorizationUri =
   (getConfig: GetConnectorConfig): GetAuthorizationUri =>
-  async ({ state, redirectUri }) => {
+  async ({ state, redirectUri, scope }) => {
     const config = await getConfig(defaultMetadata.id);
     validateConfig(config, kookConfigGuard);
 
@@ -42,7 +42,7 @@ const getAuthorizationUri =
       client_id: config.clientId,
       redirect_uri: redirectUri,
       response_type: 'code',
-      scope: config.scope ?? defaultScope,
+      scope: scope ?? config.scope ?? defaultScope,
       state,
     });
 

--- a/packages/connectors/connector-line/src/index.test.ts
+++ b/packages/connectors/connector-line/src/index.test.ts
@@ -35,6 +35,25 @@ describe('getAuthorizationUri', () => {
       `${authorizationEndpoint}?response_type=code&client_id=%3Cclient-id%3E&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&scope=openid+profile&state=some_state`
     );
   });
+
+  it('should get a valid uri with custom scope', async () => {
+    const connector = await createConnector({ getConfig });
+    const authorizationUri = await connector.getAuthorizationUri(
+      {
+        state: 'some_state',
+        redirectUri: 'http://localhost:3000/callback',
+        scope: 'custom_scope',
+        connectorId: 'some_connector_id',
+        connectorFactoryId: 'some_connector_factory_id',
+        jti: 'some_jti',
+        headers: {},
+      },
+      setSession
+    );
+    expect(authorizationUri).toEqual(
+      `${authorizationEndpoint}?response_type=code&client_id=%3Cclient-id%3E&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&scope=custom_scope&state=some_state`
+    );
+  });
 });
 
 describe('getAccessToken', () => {

--- a/packages/connectors/connector-line/src/index.ts
+++ b/packages/connectors/connector-line/src/index.ts
@@ -34,7 +34,7 @@ import {
 
 const getAuthorizationUri =
   (getConfig: GetConnectorConfig): GetAuthorizationUri =>
-  async ({ state, redirectUri }, setSession) => {
+  async ({ state, redirectUri, scope }, setSession) => {
     const config = await getConfig(defaultMetadata.id);
     validateConfig(config, lineConfigGuard);
 
@@ -44,7 +44,7 @@ const getAuthorizationUri =
       response_type: 'code',
       client_id: config.clientId,
       redirect_uri: redirectUri,
-      scope: config.scope ?? defaultScope,
+      scope: scope ?? config.scope ?? defaultScope,
       state,
     });
 

--- a/packages/connectors/connector-mock-social/src/index.ts
+++ b/packages/connectors/connector-mock-social/src/index.ts
@@ -20,8 +20,11 @@ import {
 import { defaultMetadata } from './constant.js';
 import { mockSocialConfigGuard } from './types.js';
 
+const mockSocialAuthDomain = 'http://mock-social/';
+const defaultScope = 'email profile';
+
 const getAuthorizationUri: GetAuthorizationUri = async (
-  { state, redirectUri, connectorId },
+  { state, redirectUri, connectorId, scope },
   setSession
 ) => {
   try {
@@ -33,7 +36,13 @@ const getAuthorizationUri: GetAuthorizationUri = async (
     }
   }
 
-  return `http://mock-social/?state=${state}&redirect_uri=${redirectUri}`;
+  const queryParams = new URLSearchParams({
+    state,
+    redirect_uri: redirectUri,
+    scope: scope ?? defaultScope,
+  });
+
+  return `${mockSocialAuthDomain}?${queryParams.toString()}`;
 };
 
 const validateConnectorSession = async (getSession: GetSession) => {

--- a/packages/connectors/connector-slack/src/index.test.ts
+++ b/packages/connectors/connector-slack/src/index.test.ts
@@ -36,6 +36,26 @@ describe('getAuthorizationUri', () => {
       `${authorizationEndpoint}?response_type=code&client_id=%3Cclient-id%3E&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&scope=openid+profile+email&state=some_state`
     );
   });
+
+  it('should get a valid uri with custom scope', async () => {
+    const connector = await createConnector({ getConfig });
+    const authorizationUri = await connector.getAuthorizationUri(
+      {
+        state: 'some_state',
+        redirectUri,
+        connectorId: 'some_connector_id',
+        connectorFactoryId: 'some_connector_factory_id',
+        jti: 'some_jti',
+        scope: 'custom_scope',
+        headers: {},
+      },
+      setSession
+    );
+
+    expect(authorizationUri).toEqual(
+      `${authorizationEndpoint}?response_type=code&client_id=%3Cclient-id%3E&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&scope=custom_scope&state=some_state`
+    );
+  });
 });
 
 describe('getAccessToken', () => {

--- a/packages/connectors/connector-slack/src/index.ts
+++ b/packages/connectors/connector-slack/src/index.ts
@@ -33,7 +33,7 @@ import {
 
 const getAuthorizationUri =
   (getConfig: GetConnectorConfig): GetAuthorizationUri =>
-  async ({ state, redirectUri }, setSession) => {
+  async ({ state, redirectUri, scope }, setSession) => {
     const config = await getConfig(defaultMetadata.id);
     validateConfig(config, slackConfigGuard);
 
@@ -45,7 +45,7 @@ const getAuthorizationUri =
       response_type: 'code',
       client_id: config.clientId,
       redirect_uri: redirectUri,
-      scope: config.scope ?? defaultScope,
+      scope: scope ?? config.scope ?? defaultScope,
       state,
     });
 

--- a/packages/connectors/connector-x/src/index.test.ts
+++ b/packages/connectors/connector-x/src/index.test.ts
@@ -40,6 +40,28 @@ describe('getAuthorizationUri', () => {
       `${authorizationEndpoint}?response_type=code&client_id=%3Cclient-id%3E&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&scope=tweet.read+users.read&state=some_state&code_challenge=codeChallenge&code_challenge_method=S256`
     );
   });
+
+  it('should get a valid uri with custom scope', async () => {
+    const connector = await createConnector({ getConfig });
+    const authorizationUri = await connector.getAuthorizationUri(
+      {
+        state: 'some_state',
+        redirectUri: 'http://localhost:3000/callback',
+        scope: 'custom_scope',
+        connectorId: 'some_connector_id',
+        connectorFactoryId: 'some_connector_factory_id',
+        jti: 'some_jti',
+        headers: {},
+      },
+      setSession
+    );
+    expect(setSession).toHaveBeenCalledWith({
+      codeVerifier: 'codeVerifier',
+    });
+    expect(authorizationUri).toEqual(
+      `${authorizationEndpoint}?response_type=code&client_id=%3Cclient-id%3E&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&scope=custom_scope&state=some_state&code_challenge=codeChallenge&code_challenge_method=S256`
+    );
+  });
 });
 
 describe('getAccessToken', () => {

--- a/packages/connectors/connector-x/src/index.ts
+++ b/packages/connectors/connector-x/src/index.ts
@@ -35,7 +35,7 @@ import { generateCodeVerifier, generateCodeChallenge } from './utils.js';
 
 const getAuthorizationUri =
   (getConfig: GetConnectorConfig): GetAuthorizationUri =>
-  async ({ state, redirectUri }, setSession) => {
+  async ({ state, redirectUri, scope }, setSession) => {
     const config = await getConfig(defaultMetadata.id);
     validateConfig(config, xConfigGuard);
 
@@ -48,7 +48,7 @@ const getAuthorizationUri =
       response_type: 'code',
       client_id: config.clientId,
       redirect_uri: redirectUri,
-      scope: config.scope ?? defaultScope,
+      scope: scope ?? config.scope ?? defaultScope,
       state,
       code_challenge: codeChallenge,
       code_challenge_method: 'S256',

--- a/packages/connectors/connector-xiaomi/src/index.test.ts
+++ b/packages/connectors/connector-xiaomi/src/index.test.ts
@@ -30,6 +30,25 @@ describe('getAuthorizationUri', () => {
       `${authorizationEndpoint}?client_id=%3Cclient-id%3E&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&response_type=code&state=some_state&scope=1&skip_confirm=true`
     );
   });
+
+  it('should get a valid uri with custom scope', async () => {
+    const connector = await createConnector({ getConfig });
+    const authorizationUri = await connector.getAuthorizationUri(
+      {
+        state: 'some_state',
+        redirectUri: 'http://localhost:3000/callback',
+        scope: 'custom_scope profile',
+        connectorId: 'some_connector_id',
+        connectorFactoryId: 'some_connector_factory_id',
+        jti: 'some_jti',
+        headers: {},
+      },
+      vi.fn()
+    );
+    expect(authorizationUri).toEqual(
+      `${authorizationEndpoint}?client_id=%3Cclient-id%3E&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&response_type=code&state=some_state&scope=custom_scope+profile&skip_confirm=true`
+    );
+  });
 });
 
 describe('getAccessToken', () => {

--- a/packages/connectors/connector-xiaomi/src/index.ts
+++ b/packages/connectors/connector-xiaomi/src/index.ts
@@ -55,7 +55,7 @@ const authorizationCallbackHandler = async (parameterObject: unknown) => {
 
 const getAuthorizationUri =
   (getConfig: GetConnectorConfig): GetAuthorizationUri =>
-  async ({ state, redirectUri }) => {
+  async ({ state, redirectUri, scope }) => {
     const config = await getConfig(defaultMetadata.id);
     validateConfig(config, xiaomiConfigGuard);
 
@@ -64,7 +64,7 @@ const getAuthorizationUri =
       redirect_uri: redirectUri,
       response_type: 'code',
       state,
-      scope: config.scope ?? defaultScope,
+      scope: scope ?? config.scope ?? defaultScope,
       skip_confirm: String(config.skipConfirm ?? false),
     });
 

--- a/packages/core/src/routes/experience/classes/verifications/social-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/social-verification.ts
@@ -121,12 +121,12 @@ export class SocialVerification implements IdentifierVerificationRecord<Verifica
   async createAuthorizationUrl(
     ctx: WithLogContext,
     tenantContext: TenantContext,
-    { state, redirectUri }: SocialAuthorizationUrlPayload,
+    { state, redirectUri, scope }: SocialAuthorizationUrlPayload,
     connectorSessionType: SocialAuthorizationSessionStorageType = 'interactionSession'
   ) {
     // For the profile API, connector session result is stored in the current verification record directly.
     if (connectorSessionType === 'verificationRecord') {
-      return this.createSocialAuthorizationSession(ctx, { state, redirectUri });
+      return this.createSocialAuthorizationSession(ctx, { state, redirectUri, scope });
     }
 
     // For the experience API, connector session result is stored in the provider's interactionDetails.
@@ -134,6 +134,7 @@ export class SocialVerification implements IdentifierVerificationRecord<Verifica
       connectorId: this.connectorId,
       state,
       redirectUri,
+      scope,
     });
   }
 
@@ -395,7 +396,7 @@ export class SocialVerification implements IdentifierVerificationRecord<Verifica
    */
   private async createSocialAuthorizationSession(
     ctx: WithLogContext,
-    { state, redirectUri }: SocialAuthorizationUrlPayload
+    { state, redirectUri, scope }: SocialAuthorizationUrlPayload
   ) {
     assertThat(state && redirectUri, 'session.insufficient_info');
 
@@ -414,6 +415,7 @@ export class SocialVerification implements IdentifierVerificationRecord<Verifica
         // Instead of getting the jti from the interaction details, use the current verification record's id as the jti.
         jti: this.id,
         headers: { userAgent },
+        scope,
       },
       async (connectorSession) => {
         // Store the connector session result in the current verification record directly.

--- a/packages/core/src/routes/experience/verification-routes/enterprise-sso-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/enterprise-sso-verification.ts
@@ -28,7 +28,10 @@ export default function enterpriseSsoVerificationRoutes<
       params: z.object({
         connectorId: z.string(),
       }),
-      body: socialAuthorizationUrlPayloadGuard,
+      body: socialAuthorizationUrlPayloadGuard.omit({
+        // Custom scope parameter is currently only available for the my-account social verification API
+        scope: true,
+      }),
       response: z.object({
         authorizationUri: z.string(),
         verificationId: z.string(),

--- a/packages/core/src/routes/experience/verification-routes/social-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/social-verification.ts
@@ -30,7 +30,10 @@ export default function socialVerificationRoutes<T extends ExperienceInteraction
       params: z.object({
         connectorId: z.string(),
       }),
-      body: socialAuthorizationUrlPayloadGuard,
+      body: socialAuthorizationUrlPayloadGuard.omit({
+        // Custom scope parameter is currently only available for the my-account social verification API
+        scope: true,
+      }),
       response: z.object({
         authorizationUri: z.string(),
         verificationId: z.string(),

--- a/packages/core/src/routes/interaction/types/guard.ts
+++ b/packages/core/src/routes/interaction/types/guard.ts
@@ -14,6 +14,7 @@ export const socialAuthorizationUrlPayloadGuard = z.object({
   connectorId: z.string(),
   state: z.string(),
   redirectUri: z.string().refine((url) => validateRedirectUrl(url, 'web')),
+  scope: z.string().optional(),
 });
 
 // Identifier Guard

--- a/packages/core/src/routes/interaction/utils/social-verification.ts
+++ b/packages/core/src/routes/interaction/utils/social-verification.ts
@@ -19,7 +19,7 @@ export const createSocialAuthorizationUrl = async (
 ) => {
   const { getLogtoConnectorById } = connectors;
 
-  const { connectorId, state, redirectUri } = payload;
+  const { connectorId, state, redirectUri, scope } = payload;
   assertThat(state && redirectUri, 'session.insufficient_info');
 
   const connector = await getLogtoConnectorById(connectorId);
@@ -36,6 +36,7 @@ export const createSocialAuthorizationUrl = async (
     {
       state,
       redirectUri,
+      scope,
       /**
        * For POST /authn/saml/:connectorId API, we need to block requests
        * for non-SAML connector (relies on connectorFactoryId) and use `connectorId`

--- a/packages/core/src/routes/verification/index.openapi.json
+++ b/packages/core/src/routes/verification/index.openapi.json
@@ -145,6 +145,9 @@
                   },
                   "state": {
                     "description": "A random string generated on the client side to prevent CSRF (Cross-Site Request Forgery) attacks."
+                  },
+                  "scope": {
+                    "description": "The custom scopes of the social verification. It can be used to request specific permissions from the social identity provider. If provided, it will override the scope configured in the connector settings."
                   }
                 }
               }

--- a/packages/core/src/routes/verification/index.ts
+++ b/packages/core/src/routes/verification/index.ts
@@ -180,6 +180,7 @@ export default function verificationRoutes<T extends UserRouter>(
     koaGuard({
       body: socialAuthorizationUrlPayloadGuard.extend({
         connectorId: z.string(),
+        scope: z.string().optional(),
       }),
       response: z.object({
         verificationRecordId: z.string(),

--- a/packages/integration-tests/src/api/verification-record.ts
+++ b/packages/integration-tests/src/api/verification-record.ts
@@ -79,11 +79,12 @@ export const createSocialVerificationRecord = async (
   api: KyInstance,
   connectorId: string,
   state: string,
-  redirectUri: string
+  redirectUri: string,
+  scope?: string
 ) => {
   const { verificationRecordId, authorizationUri, expiresAt } = await api
     .post('api/verifications/social', {
-      json: { connectorId, state, redirectUri },
+      json: { connectorId, state, redirectUri, scope },
     })
     .json<{ verificationRecordId: string; authorizationUri: string; expiresAt: string }>();
 

--- a/packages/integration-tests/src/tests/api/account/social.test.ts
+++ b/packages/integration-tests/src/tests/api/account/social.test.ts
@@ -164,13 +164,21 @@ describe('my-account (social)', () => {
           scope: 'profile',
         };
 
-        const { verificationRecordId: newVerificationRecordId } =
+        const mockSocialScope = 'profile custom_scope';
+
+        const { verificationRecordId: newVerificationRecordId, authorizationUri } =
           await createSocialVerificationRecord(
             api,
             connectorIdMap.get(mockSocialConnectorId)!,
             state,
-            redirectUri
+            redirectUri,
+            mockSocialScope
           );
+
+        const authorizationUriParams = new URLSearchParams(authorizationUri.split('?')[1]);
+        expect(authorizationUriParams.get('state')).toBe(state);
+        expect(authorizationUriParams.get('redirect_uri')).toBe(redirectUri);
+        expect(authorizationUriParams.get('scope')).toBe(mockSocialScope);
 
         await verifySocialAuthorization(api, newVerificationRecordId, {
           code: authorizationCode,

--- a/packages/schemas/src/types/interactions.ts
+++ b/packages/schemas/src/types/interactions.ts
@@ -73,10 +73,12 @@ export const verificationCodeIdentifierGuard = z.object({
 export type SocialAuthorizationUrlPayload = {
   state: string;
   redirectUri: string;
+  scope?: string;
 };
 export const socialAuthorizationUrlPayloadGuard = z.object({
   state: z.string(),
   redirectUri: z.string(),
+  scope: z.string().optional(),
 }) satisfies ToZodObject<SocialAuthorizationUrlPayload>;
 
 /** Payload type for `POST /api/experience/verification/{social|sso}/:connectorId/verify`. */

--- a/packages/toolkit/connector-kit/src/types/social.ts
+++ b/packages/toolkit/connector-kit/src/types/social.ts
@@ -35,6 +35,7 @@ export type GetAuthorizationUri = (
     connectorFactoryId: string;
     jti: string;
     headers: { userAgent?: string };
+    scope?: string;
   },
   setSession: SetSession
 ) => Promise<string>;


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Support custom scope in the social verification API.

This change allows developers to specify a custom `scope` parameter in the user account social verification API. If a scope is provided, it will be used to generate the authorization URI; otherwise, the default scope configured in the connector settings will be used.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Integration tests added.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
