### PR TITLE
feat(console,core): handle mfa and sign in method conflict

### DIFF
--- a/packages/console/src/ds-components/Switch/index.tsx
+++ b/packages/console/src/ds-components/Switch/index.tsx
@@ -5,23 +5,36 @@ import { forwardRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import DynamicT from '../DynamicT';
+import Tooltip from '../Tip/Tooltip';
 
 import styles from './index.module.scss';
 
+type BaseProps = {
+  readonly hasError?: boolean;
+  readonly tooltip?: ReactNode;
+};
+
 type Props =
-  | (Omit<HTMLProps<HTMLInputElement>, 'label'> & {
-      /** @deprecated Use `description` instead */
-      readonly label?: ReactNode;
-      readonly hasError?: boolean;
-    })
-  | (HTMLProps<HTMLInputElement> & {
-      readonly description: AdminConsoleKey | ReactElement;
-      readonly hasError?: boolean;
-    });
+  | (Omit<HTMLProps<HTMLInputElement>, 'label'> &
+      BaseProps & {
+        /** @deprecated Use `description` instead */
+        readonly label?: ReactNode;
+      })
+  | (HTMLProps<HTMLInputElement> &
+      BaseProps & {
+        readonly description: AdminConsoleKey | ReactElement;
+      });
 
 function Switch(props: Props, ref?: Ref<HTMLInputElement>) {
-  const { label, hasError, ...rest } = props;
+  const { label, hasError, tooltip, ...rest } = props;
   const { i18n } = useTranslation();
+
+  const switchElement = (
+    <label className={classNames(styles.switch, styles[i18n.dir()])}>
+      <input type="checkbox" {...rest} ref={ref} />
+      <span className={styles.slider} />
+    </label>
+  );
 
   return (
     <div className={classNames(styles.wrapper, hasError && styles.error)}>
@@ -35,10 +48,7 @@ function Switch(props: Props, ref?: Ref<HTMLInputElement>) {
         </div>
       )}
       {label && <div className={styles.label}>{label}</div>}
-      <label className={classNames(styles.switch, styles[i18n.dir()])}>
-        <input type="checkbox" {...rest} ref={ref} />
-        <span className={styles.slider} />
-      </label>
+      {tooltip ? <Tooltip content={tooltip}>{switchElement}</Tooltip> : switchElement}
     </div>
   );
 }

--- a/packages/console/src/pages/Mfa/index.tsx
+++ b/packages/console/src/pages/Mfa/index.tsx
@@ -34,6 +34,7 @@ function Mfa() {
       {data && (
         <MfaForm
           data={data.mfa}
+          signInMethods={data.signIn.methods}
           onMfaUpdated={(mfa) => {
             void mutate({ ...data, mfa });
           }}

--- a/packages/core/src/libraries/sign-in-experience/mfa.ts
+++ b/packages/core/src/libraries/sign-in-experience/mfa.ts
@@ -1,8 +1,10 @@
-import { MfaFactor, type Mfa } from '@logto/schemas';
+import { MfaFactor, SignInIdentifier, type Mfa, type SignIn } from '@logto/schemas';
 
 import assertThat from '#src/utils/assert-that.js';
 
-export const validateMfa = (mfa: Mfa) => {
+import { EnvSet } from '../../env-set/index.js';
+
+export const validateMfa = (mfa: Mfa, signIn?: SignIn) => {
   assertThat(
     new Set(mfa.factors).size === mfa.factors.length,
     'sign_in_experiences.duplicated_mfa_factors'
@@ -12,5 +14,35 @@ export const validateMfa = (mfa: Mfa) => {
 
   if (backupCodeEnabled) {
     assertThat(mfa.factors.length > 1, 'sign_in_experiences.backup_code_cannot_be_enabled_alone');
+  }
+
+  // TODO @wangsijie: Remove this guard when features are ready
+  if (
+    !EnvSet.values.isDevFeaturesEnabled &&
+    (mfa.factors.includes(MfaFactor.EmailVerificationCode) ||
+      mfa.factors.includes(MfaFactor.PhoneVerificationCode))
+  ) {
+    throw new Error('Not implemented');
+  }
+
+  // Validate that email/phone verification codes are not used as both sign-in method and MFA
+  if (signIn && mfa.factors.includes(MfaFactor.EmailVerificationCode)) {
+    const isEmailVerificationCodeSignIn = signIn.methods.some(
+      (method) => method.identifier === SignInIdentifier.Email && method.verificationCode
+    );
+    assertThat(
+      !isEmailVerificationCodeSignIn,
+      'sign_in_experiences.email_verification_code_cannot_be_used_for_mfa'
+    );
+  }
+
+  if (signIn && mfa.factors.includes(MfaFactor.PhoneVerificationCode)) {
+    const isPhoneVerificationCodeSignIn = signIn.methods.some(
+      (method) => method.identifier === SignInIdentifier.Phone && method.verificationCode
+    );
+    assertThat(
+      !isPhoneVerificationCodeSignIn,
+      'sign_in_experiences.phone_verification_code_cannot_be_used_for_mfa'
+    );
   }
 };

--- a/packages/core/src/routes/sign-in-experience/index.ts
+++ b/packages/core/src/routes/sign-in-experience/index.ts
@@ -113,7 +113,9 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
         if (mfa.factors.length > 0) {
           await quota.guardTenantUsageByKey('mfaEnabled');
         }
-        validateMfa(mfa);
+        // Get the current sign-in configuration
+        const { signIn: currentSignIn } = signIn ? { signIn } : await findDefaultSignInExperience();
+        validateMfa(mfa, currentSignIn);
       }
 
       /* eslint-disable @typescript-eslint/prefer-nullish-coalescing */

--- a/packages/integration-tests/src/tests/api/sign-in-experience.test.ts
+++ b/packages/integration-tests/src/tests/api/sign-in-experience.test.ts
@@ -1,4 +1,9 @@
-import { MfaPolicy, OrganizationRequiredMfaPolicy, SignInIdentifier } from '@logto/schemas';
+import {
+  MfaFactor,
+  MfaPolicy,
+  OrganizationRequiredMfaPolicy,
+  SignInIdentifier,
+} from '@logto/schemas';
 import { HTTPError, type ResponsePromise } from 'ky';
 
 import {
@@ -8,9 +13,9 @@ import {
   getSignInExperience,
   updateSignInExperience,
 } from '#src/api/index.js';
-import { setEmailConnector } from '#src/helpers/connector.js';
+import { setEmailConnector, setSmsConnector } from '#src/helpers/connector.js';
 import { expectRejects } from '#src/helpers/index.js';
-import { generatePassword } from '#src/utils.js';
+import { devFeatureTest, generatePassword } from '#src/utils.js';
 
 describe('admin console sign-in experience', () => {
   it('should get sign-in experience successfully', async () => {
@@ -171,5 +176,128 @@ describe('password policy', () => {
         })
         .json()
     ).resolves.toHaveProperty('result', true);
+
+    await deleteUser(user.id);
   });
+});
+
+devFeatureTest.describe('MFA validation', () => {
+  beforeEach(async () => {
+    await Promise.all([setEmailConnector(), setSmsConnector()]);
+  });
+
+  devFeatureTest.it(
+    'should reject email verification code MFA when email verification is used for sign-in',
+    async () => {
+      await updateSignInExperience({
+        signIn: {
+          methods: [
+            {
+              identifier: SignInIdentifier.Email,
+              password: false,
+              verificationCode: true,
+              isPasswordPrimary: false,
+            },
+          ],
+        },
+      });
+
+      await expectRejects(
+        updateSignInExperience({
+          mfa: {
+            policy: MfaPolicy.Mandatory,
+            factors: [MfaFactor.EmailVerificationCode, MfaFactor.TOTP],
+          },
+        }),
+        {
+          code: 'sign_in_experiences.email_verification_code_cannot_be_used_for_mfa',
+          status: 400,
+        }
+      );
+    }
+  );
+
+  devFeatureTest.it(
+    'should reject phone verification code MFA when phone verification is used for sign-in',
+    async () => {
+      await updateSignInExperience({
+        signIn: {
+          methods: [
+            {
+              identifier: SignInIdentifier.Phone,
+              password: false,
+              verificationCode: true,
+              isPasswordPrimary: false,
+            },
+          ],
+        },
+      });
+
+      await expectRejects(
+        updateSignInExperience({
+          mfa: {
+            policy: MfaPolicy.Mandatory,
+            factors: [MfaFactor.PhoneVerificationCode, MfaFactor.BackupCode],
+          },
+        }),
+        {
+          code: 'sign_in_experiences.phone_verification_code_cannot_be_used_for_mfa',
+          status: 400,
+        }
+      );
+    }
+  );
+
+  it('should allow email verification code MFA when email is used with password for sign-in', async () => {
+    await updateSignInExperience({
+      signIn: {
+        methods: [
+          {
+            identifier: SignInIdentifier.Email,
+            password: true,
+            verificationCode: false,
+            isPasswordPrimary: true,
+          },
+        ],
+      },
+    });
+
+    const result = await updateSignInExperience({
+      mfa: {
+        policy: MfaPolicy.Mandatory,
+        factors: [MfaFactor.EmailVerificationCode, MfaFactor.TOTP],
+      },
+    });
+
+    expect(result.mfa.factors).toContain(MfaFactor.EmailVerificationCode);
+    expect(result.mfa.factors).toContain(MfaFactor.TOTP);
+  });
+
+  devFeatureTest.it(
+    'should allow phone verification code MFA when phone is used with password for sign-in',
+    async () => {
+      await updateSignInExperience({
+        signIn: {
+          methods: [
+            {
+              identifier: SignInIdentifier.Phone,
+              password: true,
+              verificationCode: false,
+              isPasswordPrimary: true,
+            },
+          ],
+        },
+      });
+
+      const result = await updateSignInExperience({
+        mfa: {
+          policy: MfaPolicy.Mandatory,
+          factors: [MfaFactor.PhoneVerificationCode, MfaFactor.TOTP],
+        },
+      });
+
+      expect(result.mfa.factors).toContain(MfaFactor.PhoneVerificationCode);
+      expect(result.mfa.factors).toContain(MfaFactor.TOTP);
+    }
+  );
 });

--- a/packages/phrases/src/locales/en/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/en/errors/sign-in-experiences.ts
@@ -17,6 +17,10 @@ const sign_in_experiences = {
   at_least_one_authentication_factor: 'You have to select at least one authentication factor.',
   backup_code_cannot_be_enabled_alone: 'Backup code cannot be enabled alone.',
   duplicated_mfa_factors: 'Duplicated MFA factors.',
+  email_verification_code_cannot_be_used_for_mfa:
+    'Email verification code cannot be used for MFA when email verification is enabled for sign-in.',
+  phone_verification_code_cannot_be_used_for_mfa:
+    'SMS verification code cannot be used for MFA when SMS verification is enabled for sign-in.',
   duplicated_sign_up_identifiers: 'Duplicate sign-up identifiers detected.',
   missing_sign_up_identifiers: 'Primary sign-up identifier cannot be empty.',
   invalid_custom_email_blocklist_format:

--- a/packages/phrases/src/locales/en/translation/admin-console/mfa.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/mfa.ts
@@ -46,6 +46,10 @@ const mfa = {
   set_up_organization_required_mfa_prompt:
     'MFA setup prompt for users after organization enables MFA',
   prompt_at_sign_in_no_skip: 'Ask users to set up MFA on next sign-in (no skipping)',
+  email_primary_method_tip:
+    "Email verification code is already your primary sign-in method. To maintain security, it can't be reused for MFA.",
+  phone_primary_method_tip:
+    "SMS verification code is already your primary sign-in method. To maintain security, it can't be reused for MFA.",
 };
 
 export default Object.freeze(mfa);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Handle MFA and sign in method conflict: disable Email/SMS factor if used by sign in method.

<img width="1012" height="340" alt="截屏2025-07-23 下午12 00 28" src="https://github.com/user-attachments/assets/7f837ca0-e795-48cb-b2ca-8c87a0d6a9bd" />

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
