### PR TITLE
refactor(console, core): add offline access to google SSO connector

### DIFF
--- a/packages/console/src/pages/EnterpriseSsoDetails/Connection/OidcMetadataForm/index.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Connection/OidcMetadataForm/index.tsx
@@ -2,6 +2,7 @@ import { SsoProviderName } from '@logto/schemas';
 import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
+import { isDevFeaturesEnabled } from '@/consts/env';
 import CopyToClipboard from '@/ds-components/CopyToClipboard';
 import FormField from '@/ds-components/FormField';
 import InlineNotification from '@/ds-components/InlineNotification';
@@ -92,6 +93,17 @@ function OidcMetadataForm({ providerConfig, config, providerName }: Props) {
           <Switch
             label={t('enterprise_sso_details.trust_unverified_email_label')}
             {...register('trustUnverifiedEmail')}
+          />
+        </FormField>
+      )}
+      {providerName === SsoProviderName.GOOGLE_WORKSPACE && isDevFeaturesEnabled && (
+        <FormField
+          title="enterprise_sso_details.offline_access.label"
+          tip={t('enterprise_sso_details.offline_access.tooltip')}
+        >
+          <Switch
+            label={t('enterprise_sso_details.offline_access.description')}
+            {...register('offlineAccess')}
           />
         </FormField>
       )}

--- a/packages/console/src/pages/EnterpriseSsoDetails/types/oidc.ts
+++ b/packages/console/src/pages/EnterpriseSsoDetails/types/oidc.ts
@@ -22,6 +22,8 @@ export const oidcConnectorConfigGuard = z
     scope: z.string().optional(),
     // The following fields are only available for EntraID (OIDC) connector
     trustUnverifiedEmail: z.boolean().optional(),
+    // The following fields are only available for Google Workspace connector
+    offlineAccess: z.boolean().optional(),
   })
   .partial();
 

--- a/packages/phrases/src/locales/en/translation/admin-console/enterprise-sso-details.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/enterprise-sso-details.ts
@@ -116,6 +116,13 @@ const enterprise_sso_details = {
     'Always trust the unverified email addresses returned from the identity provider',
   trust_unverified_email_tip:
     'The Entra ID (OIDC) connector does not return the `email_verified` claim, meaning that email addresses from Azure are not guaranteed to be verified. By default, Logto will not sync unverified email addresses to the user profile. Enable this option only if you trust all the email addresses from the Entra ID directory.',
+  offline_access: {
+    label: 'Enable offline access',
+    description:
+      'Set `access_type` to `offline` to allow the connector to request a refresh token from Google Workspace.',
+    tooltip:
+      'Unlike the standard OIDC connector, Google Workspace SSO does not support `offline_access` scope by default. It uses the `access_type=offline` parameter to request a refresh token. Enable this option to allow the connector to request a refresh token from Google Workspace.',
+  },
 };
 
 export default Object.freeze(enterprise_sso_details);


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Enable offline access in the Google Workspace SSO connector.

Unlike standard OAuth/OIDC connectors, Google Workspace does not support the `offline_access` scope. Instead, it uses an additional authorization parameter: `access_type=offline` to indicate that offline access is requested and a refresh token should be issued.

To support this, we've added a configuration option `offlineAccess` to the Google SSO connector. When enabled, the connector will include `access_type=offline` in the authorization request to Google.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
<img width="1291" height="290" alt="image" src="https://github.com/user-attachments/assets/88b5e238-8b6e-4bf1-b5ea-23f1601e6e13" />
<img width="898" height="203" alt="image" src="https://github.com/user-attachments/assets/49c28f72-b655-45b1-aedb-901b7a832c86" />


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
