### PR TITLE
fix(schemas): add tenant-aware foreign key constraint

### DIFF
--- a/.changeset/brave-boats-travel.md
+++ b/.changeset/brave-boats-travel.md
@@ -1,0 +1,17 @@
+---
+"@logto/schemas": patch
+---
+
+fix: add tenant-aware foreign key constrant to organization_user_relations table
+
+### Problem
+
+Developers could mistakenly assign a `user_id` from other tenants to an organization, causing 500 errors on organization users API endpoints. The original `organization_user_relations` table only had a foreign key constraint on `users (id)`, allowing any existing user ID to be assigned regardless of tenant isolation.
+
+### Root cause
+
+Logto applies Row Level Security (RLS) on all tables to isolate tenant data access. When joining the `users` table with `organization_user_relations`, the actual user data becomes inaccessible to the current tenant due to RLS restrictions, causing user data to return `null` and triggering 500 server errors.
+
+### Solution
+
+Added a composite foreign key constraint `(tenant_id, user_id)` referencing `users (tenant_id, id)` to ensure the organization-user relation's tenant ID matches the user's tenant ID. This enforces proper tenant isolation at the database level.

--- a/.changeset/brave-boats-travel.md
+++ b/.changeset/brave-boats-travel.md
@@ -2,7 +2,7 @@
 "@logto/schemas": patch
 ---
 
-fix: add tenant-aware foreign key constrant to organization_user_relations table
+fix: add tenant-aware foreign key constraint to organization_user_relations table
 
 ### Problem
 

--- a/packages/schemas/alterations/next-1753669579-add-organization-user-relations-foreign-key.ts
+++ b/packages/schemas/alterations/next-1753669579-add-organization-user-relations-foreign-key.ts
@@ -1,0 +1,46 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    // Drop the existing index in users table
+    await pool.query(sql`
+      drop index if exists users__id;
+    `);
+
+    // Create a new unique index in users table
+    await pool.query(sql`
+      create unique index users__id
+        on users (tenant_id, id);
+    `);
+
+    // Apply the foreign key constraint to organization_user_relations table
+    await pool.query(sql`
+      alter table organization_user_relations
+       add constraint organization_user_relations__user_id__fk
+        foreign key (tenant_id, user_id)
+        references users (tenant_id, id)
+        on update cascade on delete cascade;
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      alter table organization_user_relations
+       drop constraint organization_user_relations__user_id__fk;
+    `);
+
+    // Drop the unique index in users table
+    await pool.query(sql`
+      drop index if exists users__id;
+    `);
+
+    // Recreate the old index in users table
+    await pool.query(sql`
+      create index users__id
+        on users (tenant_id, id);
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/organization_user_relations.sql
+++ b/packages/schemas/tables/organization_user_relations.sql
@@ -8,5 +8,8 @@ create table organization_user_relations (
     references organizations (id) on update cascade on delete cascade,
   user_id varchar(21) not null
     references users (id) on update cascade on delete cascade,
-  primary key (tenant_id, organization_id, user_id)
+  primary key (tenant_id, organization_id, user_id),
+  constraint organization_user_relations__user_id__fk
+    foreign key (tenant_id, user_id)
+      references users (tenant_id, id) on update cascade on delete cascade
 );

--- a/packages/schemas/tables/users.sql
+++ b/packages/schemas/tables/users.sql
@@ -34,7 +34,7 @@ create table users (
     unique (tenant_id, primary_phone)
 );
 
-create index users__id
+create unique index users__id
   on users (tenant_id, id);
 
 create index users__name

--- a/packages/schemas/tables/users.sql
+++ b/packages/schemas/tables/users.sql
@@ -34,6 +34,7 @@ create table users (
     unique (tenant_id, primary_phone)
 );
 
+/* Unique index on (tenant_id, id) required for foreign key constraint in organization_user_relations table. */
 create unique index users__id
   on users (tenant_id, id);
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add a tenant-aware foreign key constraint to `organization_user_relations` table


### Problem

Developers could mistakenly assign a `user_id` from other tenants to an organization, causing 500 errors on organization users API endpoints. The original `organization_user_relations` table only had a foreign key constraint on `users (id)`, allowing any existing user ID to be assigned regardless of tenant isolation.

### Root cause

Logto applies Row Level Security (RLS) on all tables to isolate tenant data access. When joining the `users` table with `organization_user_relations`, the actual user data becomes inaccessible to the current tenant due to RLS restrictions, causing user data to return `null` and triggering 500 server errors.

### Solution

Added a composite foreign key constraint `(tenant_id, user_id)` referencing `users (tenant_id, id)` to ensure the organization-user relation's tenant ID matches the user's tenant ID. This enforces proper tenant isolation at the database level.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
