### PR TITLE
feat(connector): enable token storage for OIDC standard connector

### DIFF
--- a/packages/connectors/connector-oidc/src/constant.ts
+++ b/packages/connectors/connector-oidc/src/constant.ts
@@ -68,6 +68,7 @@ export const defaultMetadata: ConnectorMetadata = {
       defaultValue: {},
     },
   ],
+  isTokenStorageSupported: true,
 };
 
 export const defaultTimeout = 5000;

--- a/packages/connectors/connector-oidc/src/index.ts
+++ b/packages/connectors/connector-oidc/src/index.ts
@@ -155,6 +155,7 @@ const getUserInfo =
   async (data, getSession) => {
     const config = await getConfig(defaultMetadata.id);
     validateConfig(config, oidcConnectorConfigGuard);
+    const parsedConfig = oidcConnectorConfigGuard.parse(config);
 
     assert(
       getSession,
@@ -171,9 +172,9 @@ const getUserInfo =
       })
     );
 
-    const tokenResponse = await getIdToken(config, data, redirectUri);
+    const tokenResponse = await getIdToken(parsedConfig, data, redirectUri);
 
-    return parseUserInfoFromIdToken(config, tokenResponse, nonce);
+    return parseUserInfoFromIdToken(parsedConfig, tokenResponse, nonce);
   };
 
 const getTokenResponseAndUserInfo =
@@ -181,6 +182,7 @@ const getTokenResponseAndUserInfo =
   async (data, getSession) => {
     const config = await getConfig(defaultMetadata.id);
     validateConfig(config, oidcConnectorConfigGuard);
+    const parsedConfig = oidcConnectorConfigGuard.parse(config);
 
     assert(
       getSession,
@@ -197,8 +199,8 @@ const getTokenResponseAndUserInfo =
       })
     );
 
-    const tokenResponse = await getIdToken(config, data, redirectUri);
-    const userInfo = await parseUserInfoFromIdToken(config, tokenResponse, nonce);
+    const tokenResponse = await getIdToken(parsedConfig, data, redirectUri);
+    const userInfo = await parseUserInfoFromIdToken(parsedConfig, tokenResponse, nonce);
 
     return {
       tokenResponse,

--- a/packages/connectors/connector-oidc/src/index.ts
+++ b/packages/connectors/connector-oidc/src/index.ts
@@ -6,6 +6,8 @@ import type {
   SocialConnector,
   CreateConnector,
   GetConnectorConfig,
+  GetTokenResponseAndUserInfo,
+  GetAccessTokenByRefreshToken,
 } from '@logto/connector-kit';
 import {
   ConnectorError,
@@ -24,8 +26,13 @@ import {
   idTokenProfileStandardClaimsGuard,
   idTokenClaimsGuardWithStringBooleans,
   oidcConnectorConfigGuard,
+  type OidcConnectorConfig,
+  type AccessTokenResponse,
 } from './types.js';
-import { getIdToken } from './utils.js';
+import {
+  getIdToken,
+  getAccessTokenByRefreshToken as _getAccessTokenByRefreshToken,
+} from './utils.js';
 
 const generateNonce = () => generateStandardId();
 
@@ -67,12 +74,87 @@ const getAuthorizationUri =
     });
   };
 
+const parseUserInfoFromIdToken = async (
+  config: OidcConnectorConfig,
+  tokenResponse: AccessTokenResponse,
+  validationNonce?: string
+) => {
+  const { id_token: idToken } = tokenResponse;
+
+  if (!idToken) {
+    throw new ConnectorError(ConnectorErrorCodes.SocialIdTokenInvalid, {
+      message: 'Cannot find ID Token in the response.',
+    });
+  }
+
+  try {
+    const { payload } = await jwtVerify(
+      idToken,
+      createRemoteJWKSet(new URL(config.idTokenVerificationConfig.jwksUri)),
+      {
+        ...config.idTokenVerificationConfig,
+        audience: config.clientId,
+      }
+    );
+
+    const result = config.acceptStringTypedBooleanClaims
+      ? idTokenClaimsGuardWithStringBooleans.safeParse(payload)
+      : idTokenProfileStandardClaimsGuard.safeParse(payload);
+
+    if (!result.success) {
+      throw new ConnectorError(ConnectorErrorCodes.SocialIdTokenInvalid, result.error);
+    }
+
+    const {
+      sub: id,
+      name,
+      picture,
+      email,
+      email_verified,
+      phone,
+      phone_verified,
+      nonce,
+    } = result.data;
+
+    if (nonce) {
+      // TODO @darcy: need to specify error code
+      assert(
+        validationNonce,
+        new ConnectorError(ConnectorErrorCodes.General, {
+          message: 'Cannot find `nonce` in session storage.',
+        })
+      );
+
+      assert(
+        validationNonce === nonce,
+        new ConnectorError(ConnectorErrorCodes.SocialIdTokenInvalid, {
+          message: 'ID Token validation failed due to `nonce` mismatch.',
+        })
+      );
+    }
+
+    return {
+      id,
+      name: conditional(name),
+      avatar: conditional(picture),
+      email: conditional(email_verified && email),
+      phone: conditional(phone_verified && phone),
+      rawData: jsonGuard.parse(payload),
+    };
+  } catch (error: unknown) {
+    if (error instanceof HTTPError) {
+      throw new ConnectorError(ConnectorErrorCodes.General, JSON.stringify(error.response.body));
+    }
+
+    throw error;
+  }
+};
+
 const getUserInfo =
   (getConfig: GetConnectorConfig): GetUserInfo =>
   async (data, getSession) => {
     const config = await getConfig(defaultMetadata.id);
     validateConfig(config, oidcConnectorConfigGuard);
-    const parsedConfig = oidcConnectorConfigGuard.parse(config);
 
     assert(
       getSession,
@@ -80,7 +162,7 @@ const getUserInfo =
         message: 'Function `getSession()` is not implemented.',
       })
     );
-    const { nonce: validationNonce, redirectUri } = await getSession();
+    const { nonce, redirectUri } = await getSession();
 
     assert(
       redirectUri,
@@ -89,75 +171,47 @@ const getUserInfo =
       })
     );
 
-    const { id_token: idToken } = await getIdToken(parsedConfig, data, redirectUri);
+    const tokenResponse = await getIdToken(config, data, redirectUri);
 
-    if (!idToken) {
-      throw new ConnectorError(ConnectorErrorCodes.SocialIdTokenInvalid, {
-        message: 'Cannot find ID Token.',
-      });
-    }
+    return parseUserInfoFromIdToken(config, tokenResponse, nonce);
+  };
 
-    try {
-      const { payload } = await jwtVerify(
-        idToken,
-        createRemoteJWKSet(new URL(parsedConfig.idTokenVerificationConfig.jwksUri)),
-        {
-          ...parsedConfig.idTokenVerificationConfig,
-          audience: parsedConfig.clientId,
-        }
-      );
+const getTokenResponseAndUserInfo =
+  (getConfig: GetConnectorConfig): GetTokenResponseAndUserInfo =>
+  async (data, getSession) => {
+    const config = await getConfig(defaultMetadata.id);
+    validateConfig(config, oidcConnectorConfigGuard);
 
-      const result = parsedConfig.acceptStringTypedBooleanClaims
-        ? idTokenClaimsGuardWithStringBooleans.safeParse(payload)
-        : idTokenProfileStandardClaimsGuard.safeParse(payload);
+    assert(
+      getSession,
+      new ConnectorError(ConnectorErrorCodes.NotImplemented, {
+        message: 'Function `getSession()` is not implemented.',
+      })
+    );
+    const { nonce, redirectUri } = await getSession();
 
-      if (!result.success) {
-        throw new ConnectorError(ConnectorErrorCodes.SocialIdTokenInvalid, result.error);
-      }
+    assert(
+      redirectUri,
+      new ConnectorError(ConnectorErrorCodes.General, {
+        message: "CAN NOT find 'redirectUri' from connector session.",
+      })
+    );
 
-      const {
-        sub: id,
-        name,
-        picture,
-        email,
-        email_verified,
-        phone,
-        phone_verified,
-        nonce,
-      } = result.data;
+    const tokenResponse = await getIdToken(config, data, redirectUri);
+    const userInfo = await parseUserInfoFromIdToken(config, tokenResponse, nonce);
 
-      if (nonce) {
-        // TODO @darcy: need to specify error code
-        assert(
-          validationNonce,
-          new ConnectorError(ConnectorErrorCodes.General, {
-            message: 'Cannot find `nonce` in session storage.',
-          })
-        );
+    return {
+      tokenResponse,
+      userInfo,
+    };
+  };
 
-        assert(
-          validationNonce === nonce,
-          new ConnectorError(ConnectorErrorCodes.SocialIdTokenInvalid, {
-            message: 'ID Token validation failed due to `nonce` mismatch.',
-          })
-        );
-      }
-
-      return {
-        id,
-        name: conditional(name),
-        avatar: conditional(picture),
-        email: conditional(email_verified && email),
-        phone: conditional(phone_verified && phone),
-        rawData: jsonGuard.parse(payload),
-      };
-    } catch (error: unknown) {
-      if (error instanceof HTTPError) {
-        throw new ConnectorError(ConnectorErrorCodes.General, JSON.stringify(error.response.body));
-      }
-
-      throw error;
-    }
+const getAccessTokenByRefreshToken =
+  (getConfig: GetConnectorConfig): GetAccessTokenByRefreshToken =>
+  async (refreshToken: string) => {
+    const config = await getConfig(defaultMetadata.id);
+    validateConfig(config, oidcConnectorConfigGuard);
+    return _getAccessTokenByRefreshToken(config, refreshToken);
   };
 
 const createOidcConnector: CreateConnector<SocialConnector> = async ({ getConfig }) => {
@@ -167,6 +221,8 @@ const createOidcConnector: CreateConnector<SocialConnector> = async ({ getConfig
     configGuard: oidcConnectorConfigGuard,
     getAuthorizationUri: getAuthorizationUri(getConfig),
     getUserInfo: getUserInfo(getConfig),
+    getTokenResponseAndUserInfo: getTokenResponseAndUserInfo(getConfig),
+    getAccessTokenByRefreshToken: getAccessTokenByRefreshToken(getConfig),
   };
 };
 

--- a/packages/connectors/connector-oidc/src/utils.ts
+++ b/packages/connectors/connector-oidc/src/utils.ts
@@ -56,3 +56,34 @@ export const getIdToken = async (
 
   return accessTokenResponseHandler(tokenResponse);
 };
+
+export const getAccessTokenByRefreshToken = async (
+  config: OidcConnectorConfig,
+  refreshToken: string
+) => {
+  const {
+    tokenEndpoint,
+    clientId,
+    clientSecret,
+    tokenEndpointAuthMethod,
+    clientSecretJwtSigningAlgorithm,
+    customConfig,
+  } = config;
+
+  const tokenResponse = await requestTokenEndpoint({
+    tokenEndpoint,
+    tokenEndpointAuthOptions: {
+      method: tokenEndpointAuthMethod,
+      clientSecretJwtSigningAlgorithm,
+    },
+    tokenRequestBody: {
+      grantType: 'refresh_token',
+      refreshToken,
+      clientId,
+      clientSecret,
+      ...customConfig,
+    },
+  });
+
+  return accessTokenResponseHandler(tokenResponse);
+};


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Enable token storage for the OIDC standard connector.

- introduce the `getTokenResponseAndUserInfo`  method that returns both the userInfo and the token response
- introduce the `getAccessTokenByRefreshToken` method that handle the access token refresh flow. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
<img width="1281" height="737" alt="image" src="https://github.com/user-attachments/assets/ab7be55c-e44c-4c7e-b820-d6d601cd6d7f" />

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
