### PR TITLE
feat(console): add collect user profile details page

### DIFF
--- a/packages/console/src/hooks/use-console-routes/routes/sign-in-experience.tsx
+++ b/packages/console/src/hooks/use-console-routes/routes/sign-in-experience.tsx
@@ -4,11 +4,16 @@ import { safeLazy } from 'react-safe-lazy';
 import { SignInExperienceTab } from '@/pages/SignInExperience/types';
 
 const SignInExperience = safeLazy(async () => import('@/pages/SignInExperience'));
+const ProfileFieldDetails = safeLazy(
+  async () => import('@/pages/SignInExperience/PageContent/CollectUserProfile/ProfileFieldDetails')
+);
 
 export const signInExperience: RouteObject = {
   path: 'sign-in-experience',
   children: [
     { index: true, element: <Navigate replace to={SignInExperienceTab.Branding} /> },
+    { path: 'collect-user-profile/create/:fieldName', element: <ProfileFieldDetails /> },
+    { path: 'collect-user-profile/fields/:fieldName', element: <ProfileFieldDetails /> },
     { path: ':tab/*', element: <SignInExperience /> },
   ],
 };

--- a/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/CreateProfileFieldModal/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/CreateProfileFieldModal/index.module.scss
@@ -48,27 +48,12 @@
   &:not(:first-child) {
     margin-top: 0;
   }
+}
 
-  .wrapper {
-    display: flex;
-    width: 100%;
-
-    .prefix {
-      padding: 0 _.unit(2) 0 _.unit(3);
-      border: 1px solid var(--color-border);
-      border-right: none;
-      border-radius: 6px 0 0 6px;
-      background: var(--color-bg-layer-2);
-      font: var(--font-body-2);
-      height: 36px;
-      line-height: 36px;
-    }
-
-    .input {
-      flex: 1;
-      border-radius: 0 6px 6px 0;
-    }
-  }
+.errorMessage {
+  margin-top: _.unit(1);
+  font: var(--font-body-2);
+  color: var(--color-error);
 }
 
 .buttonWrapper {

--- a/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/CreateProfileFieldModal/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/CreateProfileFieldModal/index.tsx
@@ -1,6 +1,6 @@
 import { numberAndAlphabetRegEx } from '@logto/core-kit';
 import { builtInCustomProfileFieldKeys, reservedCustomDataKeys } from '@logto/schemas';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import Modal from 'react-modal';
 
@@ -8,8 +8,9 @@ import Button from '@/ds-components/Button';
 import FormField from '@/ds-components/FormField';
 import ModalLayout from '@/ds-components/ModalLayout';
 import RadioGroup, { Radio } from '@/ds-components/RadioGroup';
-import TextInput from '@/ds-components/TextInput';
 import modalStyles from '@/scss/modal.module.scss';
+
+import CustomDataProfileNameField from '../../components/CustomDataProfileNameField';
 
 import styles from './index.module.scss';
 
@@ -25,8 +26,15 @@ function CreateProfileFieldModal({ existingFieldNames, onClose }: Props) {
   const { t: errorT } = useTranslation('errors');
 
   const [selectedField, setSelectedField] = useState<string>();
+  const [errorMessage, setErrorMessage] = useState<string>();
   const [customDataFieldName, setCustomDataFieldName] = useState<string>('');
   const [fieldNameInputError, setFieldNameInputError] = useState<string>();
+
+  useEffect(() => {
+    if (selectedField) {
+      setErrorMessage(undefined);
+    }
+  }, [selectedField]);
 
   const validateCustomDataFieldNameInput = useCallback((): boolean => {
     if (!customDataFieldName) {
@@ -140,33 +148,33 @@ function CreateProfileFieldModal({ existingFieldNames, onClose }: Props) {
             className={styles.customDataFieldNameInput}
             title="sign_in_exp.custom_profile_fields.modal.custom_data_field_name"
           >
-            <div className={styles.wrapper}>
-              <div className={styles.prefix}>customData.</div>
-              <TextInput
-                className={styles.input}
-                inputContainerClassName={styles.input}
-                placeholder={t(
-                  'sign_in_exp.custom_profile_fields.modal.custom_data_field_input_placeholder'
-                )}
-                value={customDataFieldName}
-                error={fieldNameInputError}
-                onBlur={() => {
-                  validateCustomDataFieldNameInput();
-                }}
-                onChange={(event) => {
-                  setCustomDataFieldName(event.currentTarget.value);
-                  setFieldNameInputError(undefined);
-                }}
-              />
-            </div>
+            <CustomDataProfileNameField
+              value={customDataFieldName}
+              error={fieldNameInputError}
+              placeholder={t(
+                'sign_in_exp.custom_profile_fields.modal.custom_data_field_input_placeholder'
+              )}
+              onBlur={() => {
+                validateCustomDataFieldNameInput();
+              }}
+              onChange={(event) => {
+                setCustomDataFieldName(event.currentTarget.value);
+                setFieldNameInputError(undefined);
+              }}
+            />
           </FormField>
         )}
+        {errorMessage && <div className={styles.errorMessage}>{errorMessage}</div>}
         <div className={styles.buttonWrapper}>
           <Button
             size="large"
             type="primary"
             title="sign_in_exp.custom_profile_fields.modal.create_button"
             onClick={() => {
+              if (!selectedField) {
+                setErrorMessage(t('sign_in_exp.custom_profile_fields.modal.type_required'));
+                return;
+              }
               if (!validateCustomDataFieldNameInput()) {
                 return;
               }

--- a/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/ProfileFieldDetails/hooks.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/ProfileFieldDetails/hooks.ts
@@ -1,0 +1,183 @@
+import {
+  CustomProfileFieldType,
+  type CustomProfileField,
+  fullnameKeys,
+  userProfileAddressKeys,
+} from '@logto/schemas';
+import { condString, type Optional } from '@silverhand/essentials';
+import cleanDeep from 'clean-deep';
+import { useCallback } from 'react';
+import { type DeepPartial } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+
+import { isBuiltInCustomProfileFieldKey, getProfileFieldTypeByName } from '../utils';
+
+import { type ProfileFieldForm } from './types';
+
+const parseOptionsArrayToString = (
+  options?: Array<{ value?: string; label?: string } | undefined>
+): string =>
+  options
+    ?.map((option) => {
+      const { value, label } = option ?? {};
+      return value !== undefined && label !== undefined ? `${value}:${label}` : value;
+    })
+    .filter(Boolean)
+    .join('\n') ?? '';
+
+const parseOptionsStringToArray = (
+  options?: string
+): Optional<Array<{ value: string; label: string }>> =>
+  options
+    ?.split('\n')
+    .map((option) => {
+      const [value = '', label = value] = option.split(':');
+      return { value, label };
+    })
+    .filter(Boolean);
+
+export const useDataParser = () => {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+
+  const getDefaultLabel = useCallback(
+    (fieldName?: string) => {
+      if (isBuiltInCustomProfileFieldKey(fieldName)) {
+        if (fieldName === 'address') {
+          return t('profile.fields.address.formatted');
+        }
+        return t(`profile.fields.${fieldName}`);
+      }
+      return fieldName;
+    },
+    [t]
+  );
+
+  const getDefaultParts = useCallback(
+    (type: CustomProfileFieldType) => {
+      if (type === CustomProfileFieldType.Address) {
+        return userProfileAddressKeys.map((name) => ({
+          name,
+          type: CustomProfileFieldType.Text,
+          label: t(`profile.fields.address.${name}`),
+          required: true,
+          enabled: name === 'formatted',
+        }));
+      }
+      if (type === CustomProfileFieldType.Fullname) {
+        return fullnameKeys.map((name) => ({
+          name,
+          type: CustomProfileFieldType.Text,
+          label: t(`profile.fields.${name}`),
+          required: true,
+          enabled: name !== 'middleName',
+        }));
+      }
+    },
+    [t]
+  );
+
+  const fromResponse = useCallback(
+    (
+      data: DeepPartial<CustomProfileField> & {
+        name: string;
+      }
+    ): ProfileFieldForm => {
+      const { name, type, label, description, required, config } = data;
+      const fieldType = type ?? getProfileFieldTypeByName(name);
+
+      return {
+        name,
+        type: fieldType,
+        label: label ?? getDefaultLabel(name) ?? '',
+        description: description ?? '',
+        required: required ?? true,
+        options: parseOptionsArrayToString(config?.options),
+        placeholder: config?.placeholder ?? '',
+        minLength: config?.minLength === undefined ? '' : config.minLength.toString(),
+        maxLength: config?.maxLength === undefined ? '' : config.maxLength.toString(),
+        minValue: config?.minValue === undefined ? '' : config.minValue.toString(),
+        maxValue: config?.maxValue === undefined ? '' : config.maxValue.toString(),
+        format: config?.format ?? '',
+        customFormat: config?.customFormat ?? '',
+        parts:
+          config?.parts?.map((part) => ({
+            name: part?.name ?? '',
+            type: part?.type ?? CustomProfileFieldType.Text,
+            label: part?.label ?? getDefaultLabel(part?.name) ?? '',
+            description: part?.description ?? '',
+            required: part?.required ?? true,
+            placeholder: part?.config?.placeholder ?? '',
+            minLength: part?.config?.minLength ? String(part.config.minLength) : '',
+            maxLength: part?.config?.maxLength ? String(part.config.maxLength) : '',
+            minValue: part?.config?.minValue ? String(part.config.minValue) : '',
+            maxValue: part?.config?.maxValue ? String(part.config.maxValue) : '',
+            format: part?.config?.format ?? '',
+            options: parseOptionsArrayToString(part?.config?.options),
+            enabled: part?.enabled ?? true,
+          })) ?? getDefaultParts(fieldType),
+      };
+    },
+    [getDefaultLabel, getDefaultParts]
+  );
+
+  const toRequestPayload = useCallback((data: ProfileFieldForm): Partial<CustomProfileField> => {
+    const {
+      name,
+      type,
+      label,
+      description,
+      required,
+      options,
+      placeholder,
+      minLength,
+      maxLength,
+      minValue,
+      maxValue,
+      format,
+      customFormat,
+      parts,
+    } = data;
+
+    return cleanDeep({
+      name,
+      type,
+      label,
+      description: condString(description),
+      required,
+      config: {
+        options: parseOptionsStringToArray(options),
+        placeholder,
+        minLength: minLength ? Number(minLength) : undefined,
+        maxLength: maxLength ? Number(maxLength) : undefined,
+        minValue: minValue ? Number(minValue) : undefined,
+        maxValue: maxValue ? Number(maxValue) : undefined,
+        format,
+        customFormat,
+        parts: parts?.map((part) => ({
+          enabled: part.enabled,
+          name: part.name,
+          type: part.type,
+          label: part.label,
+          description: part.description,
+          required: part.required,
+          config: {
+            placeholder: part.placeholder,
+            minLength: part.minLength ? Number(part.minLength) : undefined,
+            maxLength: part.maxLength ? Number(part.maxLength) : undefined,
+            minValue: part.minValue ? Number(part.minValue) : undefined,
+            maxValue: part.maxValue ? Number(part.maxValue) : undefined,
+            options: parseOptionsStringToArray(part.options),
+            format: part.format,
+            customFormat: part.customFormat,
+          },
+        })),
+      },
+    });
+  }, []);
+
+  return {
+    getDefaultLabel,
+    fromResponse,
+    toRequestPayload,
+  };
+};

--- a/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/ProfileFieldDetails/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/ProfileFieldDetails/index.module.scss
@@ -1,0 +1,14 @@
+@use '@/scss/underscore' as _;
+
+.tabContainer {
+  flex-direction: column;
+  flex-grow: 1;
+
+  &[data-active='true'] {
+    display: flex;
+  }
+}
+
+.hidden {
+  display: none;
+}

--- a/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/ProfileFieldDetails/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/ProfileFieldDetails/index.tsx
@@ -1,0 +1,213 @@
+import { CustomProfileFieldType, type CustomProfileField } from '@logto/schemas';
+import { cond } from '@silverhand/essentials';
+import { useCallback, useEffect, useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { toast } from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+import useSWR from 'swr';
+
+import Delete from '@/assets/icons/delete.svg?react';
+import DetailsForm from '@/components/DetailsForm';
+import DetailsPage from '@/components/DetailsPage';
+import DetailsPageHeader from '@/components/DetailsPage/DetailsPageHeader';
+import FormCard from '@/components/FormCard';
+import PageMeta from '@/components/PageMeta';
+import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
+import { collectUserProfile } from '@/consts';
+import DangerousRaw from '@/ds-components/DangerousRaw';
+import DeleteConfirmModal from '@/ds-components/DeleteConfirmModal';
+import TabWrapper from '@/ds-components/TabWrapper';
+import { type RequestError } from '@/hooks/use-api';
+import useApi from '@/hooks/use-api';
+import useTenantPathname from '@/hooks/use-tenant-pathname';
+import { trySubmitSafe } from '@/utils/form';
+
+import CompositionPartsSelector from '../../components/CompositionPartsSelector';
+import ProfileFieldPartSubForm from '../../components/ProfileFieldPartSubForm';
+import { isBuiltInCustomProfileFieldKey } from '../utils';
+
+import { useDataParser } from './hooks';
+import styles from './index.module.scss';
+import { type ProfileFieldForm } from './types';
+
+const parentPathname = '/sign-in-experience/collect-user-profile';
+const createProfileFieldPathname = `${parentPathname}/create/:fieldName`;
+const profileFieldDetailsPathname = `${parentPathname}/fields/:fieldName`;
+
+function ProfileFieldDetails() {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const api = useApi();
+  const { fieldName } = useParams();
+  const { navigate, match } = useTenantPathname();
+  const isCreating = match(createProfileFieldPathname);
+  const isEditing = match(profileFieldDetailsPathname);
+
+  const isBuiltInFieldName = isBuiltInCustomProfileFieldKey(fieldName);
+
+  const {
+    data,
+    error: requestError,
+    mutate,
+    isLoading,
+  } = useSWR<CustomProfileField, RequestError>(
+    isEditing && `api/custom-profile-fields/${fieldName}`
+  );
+
+  const { getDefaultLabel, fromResponse, toRequestPayload } = useDataParser();
+
+  const formMethods = useForm<ProfileFieldForm>({
+    defaultValues: fromResponse({ name: fieldName ?? '' }),
+    mode: 'onBlur',
+  });
+
+  const {
+    handleSubmit,
+    reset,
+    watch,
+    formState: { isSubmitting, isSubmitted, isDirty },
+  } = formMethods;
+
+  const formValues = watch();
+  const isCompositionType =
+    formValues.type === CustomProfileFieldType.Address ||
+    formValues.type === CustomProfileFieldType.Fullname;
+
+  const [isDeleteFormOpen, setIsDeleteFormOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isDeleted, setIsDeleted] = useState(false);
+
+  useEffect(() => {
+    if (data && !isLoading && !requestError) {
+      reset(fromResponse(data));
+    }
+  }, [data, fromResponse, isLoading, requestError, reset]);
+
+  /**
+   * The `isDirty` flag is not immediately updated when the form values are submitted.
+   * Instead, it is updated after the form is re-rendered. Therefore, we need to use
+   * the `useEffect` to navigate to the parent route if the form is submitted and clean.
+   */
+  useEffect(() => {
+    if (isCreating && isSubmitted && !isDirty) {
+      navigate(parentPathname);
+    }
+  }, [isCreating, isSubmitted, isDirty, navigate]);
+
+  const onSubmit = handleSubmit(
+    trySubmitSafe(async (formData) => {
+      if (isSubmitting) {
+        return;
+      }
+      const payload = toRequestPayload(formData);
+
+      const submitFunction = isCreating
+        ? api.post('api/custom-profile-fields', { json: payload })
+        : api.put(`api/custom-profile-fields/${fieldName}`, { json: payload });
+
+      const result = await submitFunction.json<CustomProfileField>();
+      reset(fromResponse(result));
+      toast.success(t('general.saved'));
+    })
+  );
+
+  const onDelete = useCallback(async () => {
+    setIsDeleting(true);
+
+    try {
+      await api.delete(`api/custom-profile-fields/${fieldName}`);
+      setIsDeleted(true);
+      setIsDeleteFormOpen(false);
+      toast.success(
+        t('sign_in_exp.custom_profile_fields.details.field_deleted', { name: data?.name })
+      );
+      navigate(parentPathname);
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [api, fieldName, t, data?.name, navigate]);
+
+  if (!fieldName) {
+    return null;
+  }
+
+  return (
+    <DetailsPage
+      backLink={parentPathname}
+      backLinkTitle="sign_in_exp.custom_profile_fields.details.back_to_sie"
+      isLoading={isLoading}
+      error={requestError}
+      onRetry={mutate}
+    >
+      <PageMeta titleKey="sign_in_exp.custom_profile_fields.details.page_title" />
+      {(!!data || isCreating) && (
+        <>
+          <DetailsPageHeader
+            title={formValues.label || getDefaultLabel(fieldName)}
+            identifier={{
+              name: t('sign_in_exp.custom_profile_fields.details.key'),
+              tags: formValues.parts
+                ?.filter(({ enabled }) => enabled)
+                .map(({ name }) => (fieldName === 'address' ? `address.${name}` : name)) ?? [
+                isBuiltInFieldName ? fieldName : `customData.${fieldName}`,
+              ],
+            }}
+            actionMenuItems={cond(
+              isEditing && [
+                {
+                  type: 'danger',
+                  title: 'general.delete',
+                  icon: <Delete />,
+                  onClick: () => {
+                    setIsDeleteFormOpen(true);
+                  },
+                },
+              ]
+            )}
+          />
+          <DeleteConfirmModal
+            isOpen={isDeleteFormOpen}
+            isLoading={isDeleting}
+            onCancel={() => {
+              setIsDeleteFormOpen(false);
+            }}
+            onConfirm={onDelete}
+          >
+            {t('sign_in_exp.custom_profile_fields.details.delete_description')}
+          </DeleteConfirmModal>
+          <TabWrapper isActive className={styles.tabContainer}>
+            <FormProvider {...formMethods}>
+              <DetailsForm
+                isDirty={isDirty || isCreating}
+                isSubmitting={isSubmitting}
+                onDiscard={cond(isEditing && reset)}
+                onSubmit={onSubmit}
+              >
+                <FormCard
+                  title="sign_in_exp.custom_profile_fields.details.settings"
+                  description="sign_in_exp.custom_profile_fields.details.settings_description"
+                  learnMoreLink={{ href: collectUserProfile }}
+                >
+                  {isCompositionType ? <CompositionPartsSelector /> : <ProfileFieldPartSubForm />}
+                </FormCard>
+
+                {/* Dynamic composition parts rendering, specifically for `address` and `fullname` types */}
+                {formValues.parts?.map(
+                  ({ name, label, enabled }, index) =>
+                    enabled && (
+                      <FormCard key={`parts.${name}`} title={<DangerousRaw>{label}</DangerousRaw>}>
+                        <ProfileFieldPartSubForm index={index} />
+                      </FormCard>
+                    )
+                )}
+              </DetailsForm>
+            </FormProvider>
+            <UnsavedChangesAlertModal hasUnsavedChanges={!isDeleted && isDirty} onConfirm={reset} />
+          </TabWrapper>
+        </>
+      )}
+    </DetailsPage>
+  );
+}
+
+export default ProfileFieldDetails;

--- a/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/ProfileFieldDetails/types.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/ProfileFieldDetails/types.ts
@@ -1,0 +1,23 @@
+import { type CustomProfileFieldType } from '@logto/schemas';
+
+type ProfileFieldPartSubForm = {
+  enabled: boolean;
+  name: string;
+  type: CustomProfileFieldType;
+  label: string;
+  description?: string;
+  required: boolean;
+  options?: string;
+  placeholder?: string;
+  minLength?: string;
+  maxLength?: string;
+  minValue?: string;
+  maxValue?: string;
+  format?: string;
+  customFormat?: string;
+};
+
+export type ProfileFieldForm = Omit<ProfileFieldPartSubForm, 'type' | 'enabled'> & {
+  type: CustomProfileFieldType;
+  parts?: ProfileFieldPartSubForm[];
+};

--- a/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/index.tsx
@@ -8,7 +8,6 @@ import CollectUserProfileEmpty from '@/assets/images/collect-user-profile-empty.
 import PageMeta from '@/components/PageMeta';
 import { collectUserProfile } from '@/consts';
 import Button from '@/ds-components/Button';
-import DynamicT from '@/ds-components/DynamicT';
 import Table from '@/ds-components/Table';
 import TablePlaceholder from '@/ds-components/Table/TablePlaceholder';
 import Tag from '@/ds-components/Tag';
@@ -16,11 +15,11 @@ import { type RequestError } from '@/hooks/use-api';
 import useTenantPathname from '@/hooks/use-tenant-pathname';
 import pageLayout from '@/scss/page-layout.module.scss';
 
-import CreateProfileFieldModal from '../../components/CreateProfileFieldModal';
 import SignInExperienceTabWrapper from '../components/SignInExperienceTabWrapper';
 
+import CreateProfileFieldModal from './CreateProfileFieldModal';
+import { useDataParser } from './ProfileFieldDetails/hooks';
 import styles from './index.module.scss';
-import { isBuiltInCustomProfileFieldKey } from './utils';
 
 type Props = {
   readonly isActive: boolean;
@@ -63,6 +62,8 @@ function CollectUserProfile({ isActive }: Props) {
     isLoading,
   } = useSWR<CustomProfileField[], RequestError>('api/custom-profile-fields');
 
+  const { getDefaultLabel } = useDataParser();
+
   return (
     <>
       <SignInExperienceTabWrapper isActive={isActive}>
@@ -85,12 +86,7 @@ function CollectUserProfile({ isActive }: Props) {
               title: t('custom_profile_fields.table.title.field_label'),
               dataIndex: 'name',
               colSpan: 3,
-              render: ({ name, label }) =>
-                isBuiltInCustomProfileFieldKey(name) ? (
-                  <DynamicT forKey={`profile.fields.${name}`} />
-                ) : (
-                  label
-                ),
+              render: ({ name, label }) => label || getDefaultLabel(name),
             },
             {
               title: t('custom_profile_fields.table.title.type'),
@@ -105,7 +101,7 @@ function CollectUserProfile({ isActive }: Props) {
               render: ({ name, config }) => {
                 const keys = config.parts
                   ?.filter(({ enabled }) => Boolean(enabled))
-                  .map(({ name }) => name) ?? [name];
+                  .map((part) => part.name) ?? [name];
 
                 return (
                   <div className={styles.tags}>
@@ -142,7 +138,7 @@ function CollectUserProfile({ isActive }: Props) {
           existingFieldNames={customProfileFields?.map(({ name }) => name) ?? []}
           onClose={(fieldName?: string) => {
             if (fieldName) {
-              navigate(collectUserProfileDetailsPathname.replace(':fieldName', fieldName));
+              navigate(`${createCollectUserProfilePathname}/${fieldName}`);
               return;
             }
             navigate(collectUserProfilePathname);

--- a/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/utils.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/utils.ts
@@ -1,7 +1,42 @@
-import { builtInCustomProfileFieldKeys } from '@logto/schemas';
+import {
+  builtInCustomProfileFieldKeys,
+  CustomProfileFieldType,
+  userProfileAddressKeys,
+} from '@logto/schemas';
+
+const builtInKeySet = Object.freeze(
+  new Set<string>([
+    ...builtInCustomProfileFieldKeys,
+    ...Object.values(userProfileAddressKeys).map((key) => `address.${key}`),
+  ])
+);
 
 export const isBuiltInCustomProfileFieldKey = (
-  key: string
-): key is (typeof builtInCustomProfileFieldKeys)[number] => {
-  return key in builtInCustomProfileFieldKeys;
+  key?: string
+): key is (typeof builtInCustomProfileFieldKeys)[number] =>
+  key !== undefined && builtInKeySet.has(key);
+
+export const getProfileFieldTypeByName = (name: string): CustomProfileFieldType => {
+  switch (name) {
+    case 'avatar':
+    case 'profile':
+    case 'website': {
+      return CustomProfileFieldType.Url;
+    }
+    case 'gender': {
+      return CustomProfileFieldType.Select;
+    }
+    case 'birthdate': {
+      return CustomProfileFieldType.Date;
+    }
+    case 'address': {
+      return CustomProfileFieldType.Address;
+    }
+    case 'fullname': {
+      return CustomProfileFieldType.Fullname;
+    }
+    default: {
+      return CustomProfileFieldType.Text;
+    }
+  }
 };

--- a/packages/console/src/pages/SignInExperience/PageContent/components/CompositionPartsSelector/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/PageContent/components/CompositionPartsSelector/index.module.scss
@@ -1,0 +1,11 @@
+@use '@/scss/underscore' as _;
+
+.titleWithTip {
+  display: flex;
+  align-items: center;
+  gap: _.unit(1);
+}
+
+.checkboxGroup {
+  margin-top: _.unit(2);
+}

--- a/packages/console/src/pages/SignInExperience/PageContent/components/CompositionPartsSelector/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/components/CompositionPartsSelector/index.tsx
@@ -1,0 +1,119 @@
+import { CustomProfileFieldType } from '@logto/schemas';
+import { Controller, useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+
+import Tip from '@/assets/icons/tip.svg?react';
+import { CheckboxGroup } from '@/ds-components/Checkbox';
+import DangerousRaw from '@/ds-components/DangerousRaw';
+import FormField from '@/ds-components/FormField';
+import IconButton from '@/ds-components/IconButton';
+import Select from '@/ds-components/Select';
+import { ToggleTip } from '@/ds-components/Tip';
+
+import { useDataParser } from '../../CollectUserProfile/ProfileFieldDetails/hooks';
+import { type ProfileFieldForm } from '../../CollectUserProfile/ProfileFieldDetails/types';
+
+import styles from './index.module.scss';
+
+const addressFormatOptions = Object.freeze([
+  {
+    value: 'singleLine',
+    i18nKey: 'sign_in_exp.custom_profile_fields.details.single_line_address' as const,
+  },
+  {
+    value: 'multiLine',
+    i18nKey: 'sign_in_exp.custom_profile_fields.details.multi_line_address' as const,
+  },
+]);
+
+function CompositionPartsSelector() {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const { control, watch } = useFormContext<ProfileFieldForm>();
+
+  const { getDefaultLabel } = useDataParser();
+  const type = watch('type');
+
+  return (
+    <Controller
+      name="parts"
+      control={control}
+      render={({ field: { value: parts, onChange } }) => {
+        const enabledParts = parts?.filter(({ enabled }) => enabled);
+        const selectValue =
+          enabledParts?.length === 1 && enabledParts[0]?.name === 'formatted'
+            ? 'singleLine'
+            : 'multiLine';
+        return (
+          <>
+            {type === CustomProfileFieldType.Address && (
+              <FormField title="sign_in_exp.custom_profile_fields.details.address_format">
+                <Select
+                  options={addressFormatOptions.map(({ value, i18nKey }) => ({
+                    value,
+                    title: t(i18nKey),
+                  }))}
+                  value={selectValue}
+                  onChange={(value) => {
+                    onChange(
+                      parts?.map((part) => ({
+                        ...part,
+                        enabled:
+                          value === 'singleLine'
+                            ? part.name === 'formatted'
+                            : part.name !== 'formatted',
+                      }))
+                    );
+                  }}
+                />
+              </FormField>
+            )}
+            {(type !== CustomProfileFieldType.Address || selectValue === 'multiLine') && (
+              <FormField
+                title={
+                  <DangerousRaw>
+                    <div className={styles.titleWithTip}>
+                      {t('sign_in_exp.custom_profile_fields.details.composition_parts')}
+                      <ToggleTip
+                        content={t(
+                          'sign_in_exp.custom_profile_fields.details.composition_parts_tip'
+                        )}
+                        horizontalAlign="start"
+                      >
+                        <IconButton size="small">
+                          <Tip />
+                        </IconButton>
+                      </ToggleTip>
+                    </div>
+                  </DangerousRaw>
+                }
+              >
+                <CheckboxGroup
+                  className={styles.checkboxGroup}
+                  options={
+                    parts
+                      ?.filter(({ name }) => name !== 'formatted')
+                      .map(({ name, label }) => ({
+                        value: name,
+                        title: <DangerousRaw>{label || getDefaultLabel(name)}</DangerousRaw>,
+                      })) ?? []
+                  }
+                  value={enabledParts?.map(({ name }) => name) ?? []}
+                  onChange={(values) => {
+                    onChange(
+                      parts?.map((part) => ({
+                        ...part,
+                        enabled: values.includes(part.name),
+                      })) ?? []
+                    );
+                  }}
+                />
+              </FormField>
+            )}
+          </>
+        );
+      }}
+    />
+  );
+}
+
+export default CompositionPartsSelector;

--- a/packages/console/src/pages/SignInExperience/PageContent/components/CustomDataProfileNameField/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/PageContent/components/CustomDataProfileNameField/index.module.scss
@@ -1,0 +1,26 @@
+@use '@/scss/underscore' as _;
+
+.wrapper {
+  display: flex;
+  width: 100%;
+
+  .prefix {
+    padding: 0 _.unit(2) 0 _.unit(3);
+    border: 1px solid var(--color-border);
+    border-right: none;
+    border-radius: 6px 0 0 6px;
+    background: var(--color-bg-layer-2);
+    font: var(--font-body-2);
+    line-height: 34px;
+    cursor: default;
+    user-select: none;
+  }
+
+  .inputContainer {
+    border-radius: 0 6px 6px 0;
+  }
+
+  .input {
+    flex: 1;
+  }
+}

--- a/packages/console/src/pages/SignInExperience/PageContent/components/CustomDataProfileNameField/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/components/CustomDataProfileNameField/index.tsx
@@ -1,0 +1,18 @@
+import TextInput, { type Props } from '@/ds-components/TextInput';
+
+import styles from './index.module.scss';
+
+function CustomDataProfileNameField(props: Props) {
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.prefix}>customData.</div>
+      <TextInput
+        className={styles.input}
+        inputContainerClassName={styles.inputContainer}
+        {...props}
+      />
+    </div>
+  );
+}
+
+export default CustomDataProfileNameField;

--- a/packages/console/src/pages/SignInExperience/PageContent/components/DateFormatSelector/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/PageContent/components/DateFormatSelector/index.module.scss
@@ -1,0 +1,7 @@
+@use '@/scss/underscore' as _;
+
+.dateFormatSelector {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}

--- a/packages/console/src/pages/SignInExperience/PageContent/components/DateFormatSelector/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/components/DateFormatSelector/index.tsx
@@ -1,0 +1,85 @@
+import { supportedDateFormat } from '@logto/schemas';
+import { useEffect } from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+import { Trans, useTranslation } from 'react-i18next';
+
+import FormField from '@/ds-components/FormField';
+import Select from '@/ds-components/Select';
+import TextInput from '@/ds-components/TextInput';
+import TextLink from '@/ds-components/TextLink';
+
+import { type ProfileFieldForm } from '../../CollectUserProfile/ProfileFieldDetails/types';
+
+import styles from './index.module.scss';
+
+type Props = {
+  readonly index?: number;
+};
+
+function DateFormatSelector({ index }: Props) {
+  const { t } = useTranslation(undefined, {
+    keyPrefix: 'admin_console.sign_in_exp.custom_profile_fields.details',
+  });
+  const {
+    control,
+    register,
+    setValue,
+    watch,
+    formState: { errors },
+  } = useFormContext<ProfileFieldForm>();
+
+  const fieldPrefix = index === undefined ? '' : (`parts.${index}.` as const);
+  const formatValue = watch(`${fieldPrefix}format`);
+  const formErrors = index === undefined ? errors : errors.parts?.[index];
+
+  useEffect(() => {
+    if (!formatValue) {
+      setValue(`${fieldPrefix}format`, supportedDateFormat.US);
+      return;
+    }
+    if (formatValue !== supportedDateFormat.Custom) {
+      setValue(`${fieldPrefix}customFormat`, '');
+    }
+  }, [fieldPrefix, formatValue, setValue]);
+
+  return (
+    <div className={styles.dateFormatSelector}>
+      <Controller
+        name={`${fieldPrefix}format`}
+        control={control}
+        render={({ field: { value, onChange } }) => (
+          <Select
+            options={[
+              { value: supportedDateFormat.US, title: t('date_format_us') },
+              { value: supportedDateFormat.UK, title: t('date_format_uk') },
+              { value: supportedDateFormat.ISO, title: t('date_format_iso') },
+              { value: supportedDateFormat.Custom, title: t('custom_date_format') },
+            ]}
+            value={value}
+            onChange={onChange}
+          />
+        )}
+      />
+      {formatValue === supportedDateFormat.Custom && (
+        <FormField isRequired title="sign_in_exp.custom_profile_fields.details.custom_date_format">
+          <TextInput
+            {...register(`${fieldPrefix}customFormat`, { required: true })}
+            error={formErrors?.customFormat?.message}
+            placeholder={t('custom_date_format_placeholder')}
+            description={
+              <Trans
+                components={{
+                  a: <TextLink targetBlank href="https://date-fns.org/v2.30.0/docs/format" />,
+                }}
+              >
+                {t('custom_date_format_tip')}
+              </Trans>
+            }
+          />
+        </FormField>
+      )}
+    </div>
+  );
+}
+
+export default DateFormatSelector;

--- a/packages/console/src/pages/SignInExperience/PageContent/components/ProfileFieldPartSubForm/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/components/ProfileFieldPartSubForm/index.tsx
@@ -1,0 +1,127 @@
+import { CustomProfileFieldType } from '@logto/schemas';
+import { useFormContext, Controller } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+
+import FormField from '@/ds-components/FormField';
+import Select from '@/ds-components/Select';
+import Switch from '@/ds-components/Switch';
+import TextInput from '@/ds-components/TextInput';
+import Textarea from '@/ds-components/Textarea';
+
+import { type ProfileFieldForm } from '../../CollectUserProfile/ProfileFieldDetails/types';
+import { isBuiltInCustomProfileFieldKey } from '../../CollectUserProfile/utils';
+import CustomDataProfileNameField from '../CustomDataProfileNameField';
+import DateFormatSelector from '../DateFormatSelector';
+import RangedNumberInputs from '../RangedNumberInputs';
+
+type Props = {
+  readonly index?: number;
+};
+
+function ProfileFieldPartSubForm({ index }: Props) {
+  const fieldPrefix = index === undefined ? '' : (`parts.${index}.` as const);
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const {
+    control,
+    register,
+    watch,
+    formState: { errors },
+  } = useFormContext<ProfileFieldForm>();
+
+  const name = watch(`${fieldPrefix}name`);
+  const type = watch(`${fieldPrefix}type`);
+  const isBuiltInFieldName = isBuiltInCustomProfileFieldKey(name);
+  const formErrors = index === undefined ? errors : errors.parts?.[index];
+
+  return (
+    <>
+      <FormField isRequired title="sign_in_exp.custom_profile_fields.details.key">
+        <Controller
+          name={`${fieldPrefix}name`}
+          control={control}
+          render={({ field: { onChange, value } }) => {
+            const InputComponent = isBuiltInFieldName ? TextInput : CustomDataProfileNameField;
+            return <InputComponent disabled value={value} onChange={onChange} />;
+          }}
+        />
+      </FormField>
+      <FormField isRequired title="sign_in_exp.custom_profile_fields.details.field_type">
+        <Controller
+          name={`${fieldPrefix}type`}
+          control={control}
+          render={({ field: { onChange, value } }) => {
+            const options = Object.values(CustomProfileFieldType)
+              .filter(
+                (type) =>
+                  !fieldPrefix ||
+                  (type !== CustomProfileFieldType.Address &&
+                    type !== CustomProfileFieldType.Fullname)
+              )
+              .map((type) => ({
+                value: type,
+                title: t(`sign_in_exp.custom_profile_fields.type.${type}`),
+              }));
+            return <Select options={options} value={value} onChange={onChange} />;
+          }}
+        />
+      </FormField>
+      <FormField isRequired title="sign_in_exp.custom_profile_fields.details.label">
+        <TextInput
+          {...register(`${fieldPrefix}label`, { required: true })}
+          error={formErrors?.label?.message}
+          placeholder={t('sign_in_exp.custom_profile_fields.details.label_placeholder')}
+        />
+      </FormField>
+      <FormField title="sign_in_exp.custom_profile_fields.details.description">
+        <TextInput
+          {...register(`${fieldPrefix}description`)}
+          error={formErrors?.description?.message}
+          placeholder={t('sign_in_exp.custom_profile_fields.details.description_placeholder')}
+        />
+      </FormField>
+      {(type === CustomProfileFieldType.Checkbox || type === CustomProfileFieldType.Select) && (
+        <FormField title="sign_in_exp.custom_profile_fields.details.options">
+          <Textarea
+            {...register(`${fieldPrefix}options`)}
+            error={formErrors?.options?.message}
+            placeholder={t('sign_in_exp.custom_profile_fields.details.options_placeholder')}
+            rows={5}
+          />
+        </FormField>
+      )}
+      {type === CustomProfileFieldType.Text && (
+        <FormField title="sign_in_exp.custom_profile_fields.details.input_length">
+          <RangedNumberInputs minValueName="minLength" maxValueName="maxLength" index={index} />
+        </FormField>
+      )}
+      {type === CustomProfileFieldType.Number && (
+        <FormField title="sign_in_exp.custom_profile_fields.details.value_range">
+          <RangedNumberInputs minValueName="minValue" maxValueName="maxValue" index={index} />
+        </FormField>
+      )}
+      {type === CustomProfileFieldType.Regex && (
+        <FormField title="sign_in_exp.custom_profile_fields.details.regex">
+          <TextInput
+            {...register(`${fieldPrefix}format`)}
+            error={formErrors?.format?.message}
+            placeholder={t('sign_in_exp.custom_profile_fields.details.regex_placeholder')}
+            description={t('sign_in_exp.custom_profile_fields.details.regex_tip')}
+          />
+        </FormField>
+      )}
+      {type === CustomProfileFieldType.Date && (
+        <FormField title="sign_in_exp.custom_profile_fields.details.date_format">
+          <DateFormatSelector />
+        </FormField>
+      )}
+      <FormField title="sign_in_exp.custom_profile_fields.details.required">
+        <Switch
+          label={t('sign_in_exp.custom_profile_fields.details.required_description')}
+          {...register(`${fieldPrefix}required`)}
+        />
+      </FormField>
+    </>
+  );
+}
+
+export default ProfileFieldPartSubForm;

--- a/packages/console/src/pages/SignInExperience/PageContent/components/RangedNumberInputs/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/PageContent/components/RangedNumberInputs/index.module.scss
@@ -1,0 +1,51 @@
+@use '@/scss/underscore' as _;
+
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: _.unit(1);
+}
+
+.rangedNumberInput {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: _.unit(2);
+
+  .separator {
+    width: 8px;
+    height: 0;
+    border-top: 1px solid var(--color-border);
+    flex-shrink: 0;
+  }
+
+  .inputWrapper {
+    display: flex;
+    width: 100%;
+
+    .prefix {
+      padding: 0 _.unit(2) 0 _.unit(3);
+      border: 1px solid var(--color-border);
+      border-right: none;
+      border-radius: 6px 0 0 6px;
+      background: var(--color-bg-layer-2);
+      font: var(--font-body-2);
+      line-height: 34px;
+      cursor: default;
+      user-select: none;
+    }
+
+    .inputContainer {
+      border-radius: 0 6px 6px 0;
+    }
+
+    .input {
+      flex: 1;
+    }
+  }
+}
+
+.errorMessage {
+  font: var(--font-body-2);
+  color: var(--color-error);
+}

--- a/packages/console/src/pages/SignInExperience/PageContent/components/RangedNumberInputs/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/components/RangedNumberInputs/index.tsx
@@ -1,0 +1,142 @@
+import { Controller, useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+
+import NumericInput from '@/ds-components/TextInput/NumericInput';
+
+import { type ProfileFieldForm } from '../../CollectUserProfile/ProfileFieldDetails/types';
+
+import styles from './index.module.scss';
+
+type Props =
+  | { minValueName: 'minValue'; maxValueName: 'maxValue'; index?: number }
+  | { minValueName: 'minLength'; maxValueName: 'maxLength'; index?: number };
+
+const onValueUp = (currentValue: string | undefined, onChange: (value: string) => void) => {
+  const currentNumber = Number(currentValue);
+  if (Number.isNaN(currentNumber)) {
+    onChange('0');
+    return;
+  }
+  onChange(String(currentNumber + 1));
+};
+
+const onValueDown = (currentValue: string | undefined, onChange: (value: string) => void) => {
+  const currentNumber = Number(currentValue);
+  if (Number.isNaN(currentNumber)) {
+    onChange('0');
+    return;
+  }
+  onChange(String(currentNumber - 1));
+};
+
+function RangedNumberInputs({ minValueName, maxValueName, index }: Props) {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const { t: errorT } = useTranslation('errors');
+  const {
+    formState: { errors },
+    control,
+    clearErrors,
+    watch,
+  } = useFormContext<ProfileFieldForm>();
+
+  const fieldPrefix = index === undefined ? '' : (`parts.${index}.` as const);
+  const minValueFieldName = `${fieldPrefix}${minValueName}` as const;
+  const maxValueFieldName = `${fieldPrefix}${maxValueName}` as const;
+  const formErrors = index === undefined ? errors : errors.parts?.[index];
+
+  const minValue = watch(minValueFieldName);
+  const maxValue = watch(maxValueFieldName);
+
+  const rangedNumberError = formErrors?.[minValueName] ?? formErrors?.[maxValueName];
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.rangedNumberInput}>
+        <Controller
+          name={`${fieldPrefix}${minValueName}`}
+          control={control}
+          rules={{
+            validate: (value) => {
+              if (value && maxValue && Number(value) > Number(maxValue)) {
+                return errorT('custom_profile_fields.invalid_min_max_input');
+              }
+              return true;
+            },
+          }}
+          render={({ field: { onBlur, onChange, value } }) => (
+            <div className={styles.inputWrapper}>
+              <div className={styles.prefix}>
+                {t('sign_in_exp.custom_profile_fields.details.min')}
+              </div>
+              <NumericInput
+                className={styles.input}
+                inputContainerClassName={styles.inputContainer}
+                value={value ?? ''}
+                min={0}
+                error={!!formErrors?.[minValueName]}
+                onBlur={() => {
+                  clearErrors(maxValueFieldName);
+                  onBlur();
+                }}
+                onChange={(event) => {
+                  onChange(event.currentTarget.value);
+                }}
+                onValueUp={() => {
+                  onValueUp(value, onChange);
+                }}
+                onValueDown={() => {
+                  onValueDown(value, onChange);
+                }}
+              />
+            </div>
+          )}
+        />
+        <div className={styles.separator} />
+        <Controller
+          name={`${fieldPrefix}${maxValueName}`}
+          control={control}
+          rules={{
+            validate: (value) => {
+              if (value && minValue && Number(value) < Number(minValue)) {
+                return errorT('custom_profile_fields.invalid_min_max_input');
+              }
+              return true;
+            },
+          }}
+          render={({ field: { onBlur, onChange, value } }) => (
+            <div className={styles.inputWrapper}>
+              <div className={styles.prefix}>
+                {t('sign_in_exp.custom_profile_fields.details.max')}
+              </div>
+              <NumericInput
+                className={styles.input}
+                inputContainerClassName={styles.inputContainer}
+                value={value ?? ''}
+                min={0}
+                error={!!formErrors?.[maxValueName]}
+                onBlur={() => {
+                  clearErrors(minValueFieldName);
+                  onBlur();
+                }}
+                onChange={(event) => {
+                  onChange(event.currentTarget.value);
+                }}
+                onValueUp={() => {
+                  onValueUp(value, onChange);
+                }}
+                onValueDown={() => {
+                  onValueDown(value, onChange);
+                }}
+              />
+            </div>
+          )}
+        />
+      </div>
+      {rangedNumberError?.message && (
+        <div className={styles.errorMessage}>{rangedNumberError.message}</div>
+      )}
+    </div>
+  );
+}
+
+export default RangedNumberInputs;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Implement field details page of "Collect user profile" feature.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested. Some screenshots attached:

Text type:
<img width="2408" height="1472" alt="image" src="https://github.com/user-attachments/assets/32d9c7c1-61c5-468a-93fa-113b0fa4c61c" />

Date type:
<img width="2402" height="1640" alt="image" src="https://github.com/user-attachments/assets/557b5103-7d98-41b7-8bd6-9b4aa7f442fd" />

Complex "Fullname" type:
<img width="2408" height="2974" alt="image" src="https://github.com/user-attachments/assets/99012b1d-de70-4d86-95e7-afa5ee2f2bc7" />


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
