### PR TITLE
fix(console): profile field deletion and data parsing logic

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/ProfileFieldDetails/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/ProfileFieldDetails/index.tsx
@@ -3,7 +3,7 @@ import { useCallback, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
-import useSWR from 'swr';
+import useSWR, { useSWRConfig } from 'swr';
 
 import Delete from '@/assets/icons/delete.svg?react';
 import DetailsPage from '@/components/DetailsPage';
@@ -27,6 +27,7 @@ function ProfileFieldDetails() {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { fieldName } = useParams();
   const api = useApi();
+  const { mutate: mutateGlobal } = useSWRConfig();
   const { navigate } = useTenantPathname();
 
   const isBuiltInFieldName = isBuiltInCustomProfileFieldKey(fieldName);
@@ -51,11 +52,12 @@ function ProfileFieldDetails() {
       toast.success(
         t('sign_in_exp.custom_profile_fields.details.field_deleted', { name: data?.name })
       );
+      await mutateGlobal('api/custom-profile-fields', true);
       navigate(parentPathname);
     } finally {
       setIsDeleting(false);
     }
-  }, [api, fieldName, t, data?.name, navigate]);
+  }, [api, fieldName, t, data?.name, navigate, mutateGlobal]);
 
   if (!fieldName) {
     return null;

--- a/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/hooks.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/hooks.ts
@@ -5,8 +5,7 @@ import {
   userProfileAddressKeys,
   supportedDateFormat,
 } from '@logto/schemas';
-import { cond, condString, type Optional } from '@silverhand/essentials';
-import cleanDeep from 'clean-deep';
+import { cond, type Optional } from '@silverhand/essentials';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -151,11 +150,11 @@ export const useDataParser = () => {
         parts,
       } = data;
 
-      return cleanDeep({
+      return {
         name,
         type,
         label,
-        description: condString(description),
+        description,
         required,
         config: {
           options: parseOptionsStringToArray(options),
@@ -185,7 +184,7 @@ export const useDataParser = () => {
             },
           })),
         },
-      });
+      };
     },
     []
   );


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- After deleting a custom profile field, the global SWR cache for 'api/custom-profile-fields' is now invalidated to ensure UI consistency.
- Fix a bug that prevents user from deleting "Description" value from the profile field details form, caused by using "cleandeep" util. The empty strings were trimmed off from the payload and thus the API cannot update the DB entry.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
