### PR TITLE
fix(console): should use medium size for the create profile field but…

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/index.tsx
@@ -34,7 +34,7 @@ type Props = {
 
 type CreateButtonProps = {
   readonly className?: string;
-  readonly size: 'large' | 'small';
+  readonly size: 'medium' | 'large';
 };
 
 function CreateButton({ size, className }: CreateButtonProps) {
@@ -132,7 +132,7 @@ function CollectUserProfile({ isActive }: Props) {
         )}
         <div className={styles.tableContainer}>
           <div className={styles.buttonWrapper}>
-            <CreateButton size="small" />
+            <CreateButton size="medium" />
           </div>
           <div className={classNames(styles.row, styles.header)}>
             <div className={styles.cell}>


### PR DESCRIPTION
…ton on the list header

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Should use "medium" size for the create button on the profile field list header. Previously it was set to "small" by mistake.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
