### PR TITLE
fix(console,experience,schemas): refactor profile field details and improve label handling

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/ProfileFieldDetails/ProfileFieldDetailsForm/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/ProfileFieldDetails/ProfileFieldDetailsForm/index.module.scss
@@ -1,5 +1,3 @@
-@use '@/scss/underscore' as _;
-
 .tabContainer {
   flex-direction: column;
   flex-grow: 1;
@@ -7,8 +5,4 @@
   &[data-active='true'] {
     display: flex;
   }
-}
-
-.hidden {
-  display: none;
 }

--- a/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/ProfileFieldDetails/ProfileFieldDetailsForm/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/ProfileFieldDetails/ProfileFieldDetailsForm/index.tsx
@@ -1,30 +1,44 @@
 import { CustomProfileFieldType, type CustomProfileField } from '@logto/schemas';
+import { useCallback, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
+import { useSWRConfig } from 'swr';
 
+import Delete from '@/assets/icons/delete.svg?react';
 import DetailsForm from '@/components/DetailsForm';
+import DetailsPageHeader from '@/components/DetailsPage/DetailsPageHeader';
 import FormCard from '@/components/FormCard';
 import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
 import { collectUserProfile } from '@/consts';
 import DangerousRaw from '@/ds-components/DangerousRaw';
+import DeleteConfirmModal from '@/ds-components/DeleteConfirmModal';
+import TabWrapper from '@/ds-components/TabWrapper';
 import useApi from '@/hooks/use-api';
+import useTenantPathname from '@/hooks/use-tenant-pathname';
 import { trySubmitSafe } from '@/utils/form';
 
 import CompositionPartsSelector from '../../../components/CompositionPartsSelector';
 import ProfileFieldPartSubForm from '../../../components/ProfileFieldPartSubForm';
+import { collectUserProfilePathname } from '../../consts';
 import { useDataParser } from '../../hooks';
+import { isBuiltInCustomProfileFieldKey } from '../../utils';
 import { type ProfileFieldForm } from '../types';
+
+import styles from './index.module.scss';
 
 type Props = {
   readonly data: CustomProfileField;
-  readonly isDeleted?: boolean;
 };
 
-function ProfileFieldDetailsForm({ data, isDeleted }: Props) {
+function ProfileFieldDetailsForm({ data }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const api = useApi();
+  const { mutate: mutateGlobal } = useSWRConfig();
+  const { navigate } = useTenantPathname();
   const { parseResponseToFormData, parseFormDataToRequestPayload } = useDataParser();
+
+  const isBuiltInFieldName = isBuiltInCustomProfileFieldKey(data.name);
   const isCompositionType =
     data.type === CustomProfileFieldType.Address || data.type === CustomProfileFieldType.Fullname;
 
@@ -42,6 +56,35 @@ function ProfileFieldDetailsForm({ data, isDeleted }: Props) {
 
   const compositionParts = watch('parts');
 
+  const { getDefaultLabel } = useDataParser();
+
+  const [isDeleteFormOpen, setIsDeleteFormOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isDeleted, setIsDeleted] = useState(false);
+
+  const onDelete = useCallback(async () => {
+    setIsDeleting(true);
+
+    try {
+      await api.delete(`api/custom-profile-fields/${data.name}`);
+      setIsDeleted(true);
+      setIsDeleteFormOpen(false);
+      toast.success(
+        t('sign_in_exp.custom_profile_fields.details.field_deleted', { name: data.name })
+      );
+      await mutateGlobal(
+        'api/custom-profile-fields',
+        (currentData?: CustomProfileField[]) =>
+          currentData?.filter((field) => field.name !== data.name) ?? [],
+        { revalidate: false }
+      );
+      // Redirect to the list page after deletion
+      navigate(collectUserProfilePathname, { replace: true });
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [api, t, data.name, mutateGlobal, navigate]);
+
   const onSubmit = handleSubmit(
     trySubmitSafe(async (formData) => {
       if (isSubmitting) {
@@ -54,39 +97,81 @@ function ProfileFieldDetailsForm({ data, isDeleted }: Props) {
         .json<CustomProfileField>();
 
       reset(parseResponseToFormData(result));
+      await mutateGlobal(
+        'api/custom-profile-fields',
+        (currentData?: CustomProfileField[]) =>
+          currentData?.map((field) => (field.name === formData.name ? result : field)) ?? [],
+        { revalidate: false }
+      );
       toast.success(t('general.saved'));
     })
   );
 
   return (
     <>
-      <FormProvider {...formMethods}>
-        <DetailsForm
-          isDirty={isDirty}
-          isSubmitting={isSubmitting}
-          onDiscard={reset}
-          onSubmit={onSubmit}
-        >
-          <FormCard
-            title="sign_in_exp.custom_profile_fields.details.settings"
-            description="sign_in_exp.custom_profile_fields.details.settings_description"
-            learnMoreLink={{ href: collectUserProfile }}
+      <DetailsPageHeader
+        title={watch('label') || getDefaultLabel(data.name)}
+        identifier={{
+          name: t('sign_in_exp.custom_profile_fields.details.key'),
+          tags: compositionParts
+            ?.filter(({ enabled }) => enabled)
+            .map(({ name }) => (data.name === 'address' ? `address.${name}` : name)) ?? [
+            isBuiltInFieldName ? data.name : `customData.${data.name}`,
+          ],
+        }}
+        actionMenuItems={[
+          {
+            type: 'danger',
+            title: 'general.delete',
+            icon: <Delete />,
+            onClick: () => {
+              setIsDeleteFormOpen(true);
+            },
+          },
+        ]}
+      />
+      <TabWrapper isActive className={styles.tabContainer}>
+        <FormProvider {...formMethods}>
+          <DetailsForm
+            isDirty={isDirty}
+            isSubmitting={isSubmitting}
+            onDiscard={reset}
+            onSubmit={onSubmit}
           >
-            {isCompositionType ? <CompositionPartsSelector /> : <ProfileFieldPartSubForm />}
-          </FormCard>
+            <FormCard
+              title="sign_in_exp.custom_profile_fields.details.settings"
+              description="sign_in_exp.custom_profile_fields.details.settings_description"
+              learnMoreLink={{ href: collectUserProfile }}
+            >
+              {isCompositionType ? <CompositionPartsSelector /> : <ProfileFieldPartSubForm />}
+            </FormCard>
 
-          {/* Dynamic composition parts rendering, specifically for `address` and `fullname` types */}
-          {compositionParts?.map(
-            ({ name, label, enabled }, index) =>
-              enabled && (
-                <FormCard key={`parts.${name}`} title={<DangerousRaw>{label}</DangerousRaw>}>
-                  <ProfileFieldPartSubForm index={index} />
-                </FormCard>
-              )
-          )}
-        </DetailsForm>
-      </FormProvider>
-      <UnsavedChangesAlertModal hasUnsavedChanges={!isDeleted && isDirty} onConfirm={reset} />
+            {/* Dynamic composition parts rendering, specifically for `address` and `fullname` types */}
+            {compositionParts?.map(
+              ({ name, label, enabled }, index) =>
+                enabled && (
+                  <FormCard
+                    key={`parts.${name}`}
+                    title={<DangerousRaw>{label || getDefaultLabel(name)}</DangerousRaw>}
+                  >
+                    <ProfileFieldPartSubForm index={index} />
+                  </FormCard>
+                )
+            )}
+          </DetailsForm>
+        </FormProvider>
+        <UnsavedChangesAlertModal hasUnsavedChanges={!isDeleted && isDirty} onConfirm={reset} />
+      </TabWrapper>
+      <DeleteConfirmModal
+        isOpen={isDeleteFormOpen}
+        isLoading={isDeleting}
+        onCancel={() => {
+          setIsDeleteFormOpen(false);
+        }}
+        onConfirm={onDelete}
+      >
+        {t('sign_in_exp.custom_profile_fields.details.delete_description')}
+      </DeleteConfirmModal>
     </>
   );
 }

--- a/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/ProfileFieldDetails/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/ProfileFieldDetails/index.tsx
@@ -1,63 +1,21 @@
 import { type CustomProfileField } from '@logto/schemas';
-import { useCallback, useState } from 'react';
-import { toast } from 'react-hot-toast';
-import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
-import useSWR, { useSWRConfig } from 'swr';
+import useSWR from 'swr';
 
-import Delete from '@/assets/icons/delete.svg?react';
 import DetailsPage from '@/components/DetailsPage';
-import DetailsPageHeader from '@/components/DetailsPage/DetailsPageHeader';
 import PageMeta from '@/components/PageMeta';
-import DeleteConfirmModal from '@/ds-components/DeleteConfirmModal';
-import TabWrapper from '@/ds-components/TabWrapper';
 import { type RequestError } from '@/hooks/use-api';
-import useApi from '@/hooks/use-api';
-import useTenantPathname from '@/hooks/use-tenant-pathname';
 
-import { useDataParser } from '../hooks';
-import { isBuiltInCustomProfileFieldKey } from '../utils';
+import { collectUserProfilePathname } from '../consts';
 
 import ProfileFieldDetailsForm from './ProfileFieldDetailsForm';
-import styles from './index.module.scss';
-
-const parentPathname = '/sign-in-experience/collect-user-profile';
 
 function ProfileFieldDetails() {
-  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { fieldName } = useParams();
-  const api = useApi();
-  const { mutate: mutateGlobal } = useSWRConfig();
-  const { navigate } = useTenantPathname();
-
-  const isBuiltInFieldName = isBuiltInCustomProfileFieldKey(fieldName);
 
   const { data, error, mutate, isLoading } = useSWR<CustomProfileField, RequestError>(
     `api/custom-profile-fields/${fieldName}`
   );
-
-  const { getDefaultLabel } = useDataParser();
-
-  const [isDeleteFormOpen, setIsDeleteFormOpen] = useState(false);
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [isDeleted, setIsDeleted] = useState(false);
-
-  const onDelete = useCallback(async () => {
-    setIsDeleting(true);
-
-    try {
-      await api.delete(`api/custom-profile-fields/${fieldName}`);
-      setIsDeleted(true);
-      setIsDeleteFormOpen(false);
-      toast.success(
-        t('sign_in_exp.custom_profile_fields.details.field_deleted', { name: data?.name })
-      );
-      await mutateGlobal('api/custom-profile-fields', true);
-      navigate(parentPathname);
-    } finally {
-      setIsDeleting(false);
-    }
-  }, [api, fieldName, t, data?.name, navigate, mutateGlobal]);
 
   if (!fieldName) {
     return null;
@@ -65,47 +23,14 @@ function ProfileFieldDetails() {
 
   return (
     <DetailsPage
-      backLink={parentPathname}
+      backLink={collectUserProfilePathname}
       backLinkTitle="sign_in_exp.custom_profile_fields.details.back_to_sie"
       isLoading={isLoading}
       error={error}
       onRetry={mutate}
     >
       <PageMeta titleKey="sign_in_exp.custom_profile_fields.details.page_title" />
-      <DetailsPageHeader
-        title={data?.label ?? getDefaultLabel(fieldName)}
-        identifier={{
-          name: t('sign_in_exp.custom_profile_fields.details.key'),
-          tags: data?.config.parts
-            ?.filter(({ enabled }) => enabled)
-            .map(({ name }) => (fieldName === 'address' ? `address.${name}` : name)) ?? [
-            isBuiltInFieldName ? fieldName : `customData.${fieldName}`,
-          ],
-        }}
-        actionMenuItems={[
-          {
-            type: 'danger',
-            title: 'general.delete',
-            icon: <Delete />,
-            onClick: () => {
-              setIsDeleteFormOpen(true);
-            },
-          },
-        ]}
-      />
-      <DeleteConfirmModal
-        isOpen={isDeleteFormOpen}
-        isLoading={isDeleting}
-        onCancel={() => {
-          setIsDeleteFormOpen(false);
-        }}
-        onConfirm={onDelete}
-      >
-        {t('sign_in_exp.custom_profile_fields.details.delete_description')}
-      </DeleteConfirmModal>
-      <TabWrapper isActive className={styles.tabContainer}>
-        {data && <ProfileFieldDetailsForm data={data} isDeleted={isDeleted} />}
-      </TabWrapper>
+      {data && <ProfileFieldDetailsForm data={data} />}
     </DetailsPage>
   );
 }

--- a/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/utils.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/utils.ts
@@ -4,6 +4,13 @@ import {
   userProfileAddressKeys,
 } from '@logto/schemas';
 
+const addressComponentKeySet = Object.freeze(new Set<string>(userProfileAddressKeys));
+
+export const isBuiltInAddressComponentKey = (
+  key?: string
+): key is (typeof userProfileAddressKeys)[number] =>
+  key !== undefined && addressComponentKeySet.has(key);
+
 const builtInKeySet = Object.freeze(
   new Set<string>([
     ...builtInCustomProfileFieldKeys,

--- a/packages/experience/src/pages/Continue/ExtraProfileForm/AddressSubForm/index.tsx
+++ b/packages/experience/src/pages/Continue/ExtraProfileForm/AddressSubForm/index.tsx
@@ -83,7 +83,7 @@ const AddressSubForm = ({ field }: Props) => {
                 styles.inputField,
                 (part.name === 'locality' || part.name === 'region') && styles.halfSize
               )}
-              label={part.label || t(`profile.address.${part.name}`)}
+              label={part.label ?? t(`profile.address.${part.name}`)}
               value={value ?? ''}
               isDanger={!!errors.address?.[part.name]}
               onBlur={onBlur}

--- a/packages/experience/src/pages/Continue/ExtraProfileForm/FullnameSubForm/index.tsx
+++ b/packages/experience/src/pages/Continue/ExtraProfileForm/FullnameSubForm/index.tsx
@@ -52,7 +52,7 @@ const FullnameSubForm = ({ field }: Props) => {
               <PrimitiveProfileInputField
                 {...part}
                 className={styles.inputField}
-                label={t(`profile.${part.name}`)}
+                label={part.label ?? t(`profile.${part.name}`)}
                 value={value ?? ''}
                 isDanger={!!errors[part.name]}
                 onBlur={onBlur}

--- a/packages/experience/src/types/guard.ts
+++ b/packages/experience/src/types/guard.ts
@@ -203,7 +203,7 @@ export const dateFieldConfigGuard = s.object({
 const baseConfigPartGuard = s.object({
   enabled: s.boolean(),
   type: profileFieldTypeGuard,
-  label: s.string(),
+  label: s.optional(s.string()),
   description: s.optional(s.string()),
   required: s.boolean(),
   config: s.optional(

--- a/packages/schemas/src/foundations/jsonb-types/custom-profile-fields.ts
+++ b/packages/schemas/src/foundations/jsonb-types/custom-profile-fields.ts
@@ -41,7 +41,7 @@ export const fieldPartGuard = z.object({
   enabled: z.boolean(),
   name: z.string(),
   type: customProfileFieldTypeGuard,
-  label: z.string(),
+  label: z.string().min(1).optional(),
   description: z.string().optional(),
   required: z.boolean(),
   config: baseConfigGuard.optional(),

--- a/packages/schemas/src/types/custom-profile-fields.ts
+++ b/packages/schemas/src/types/custom-profile-fields.ts
@@ -26,10 +26,10 @@ export type BaseProfileField = {
 const baseProfileFieldGuard = z.object({
   name: z.string(),
   type: customProfileFieldTypeGuard,
-  label: z.string(),
+  label: z.string().min(1).optional(),
   description: z.string().optional(),
   required: z.boolean(),
-});
+}) satisfies ToZodObject<BaseProfileField>;
 
 export type TextProfileField = BaseProfileField & {
   type: CustomProfileFieldType.Text;
@@ -160,7 +160,7 @@ export type AddressProfileField = BaseProfileField & {
       enabled: boolean;
       name: keyof Exclude<UserProfile['address'], undefined>;
       type: CustomProfileFieldType;
-      label: string;
+      label?: string;
       description?: string;
       required: boolean;
       config?: {
@@ -195,7 +195,7 @@ export type FullnameProfileField = BaseProfileField & {
       enabled: boolean;
       name: keyof Pick<UserProfile, 'givenName' | 'middleName' | 'familyName'>;
       type: CustomProfileFieldType;
-      label: string;
+      label?: string;
       description?: string;
       required: boolean;
       config?: {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Refactors the profile field details page, with the following major updates and fixes:
- Do not set label for built-in field types, leave the label empty and fallback to the i18n translation for display.
- Loose data guard on `label` field, make it optional on creating and updating fields.
- Refactor field details page, put the page header and form content together in one component, so that the header title can watch the form content and render dynamically in-sync with the `label` input.
- Improve the handling of SWR cache pupolation in the profile field list view. The list now updates when updating or deleting fields, without a splash of loading screen.

Fixes log-11929, log-11936, log-11938, log-11942

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
