### PR TITLE
fix(test): resolve intermittent timeout in organization-user test

### DIFF
--- a/packages/integration-tests/src/tests/api/organization/organization-user.test.ts
+++ b/packages/integration-tests/src/tests/api/organization/organization-user.test.ts
@@ -14,9 +14,14 @@ describe('organization user APIs', () => {
 
     beforeAll(async () => {
       const organization = await organizationApi.create({ name: 'test' });
-      const createdUsers = await Promise.all(
-        Array.from({ length: 30 }).map(async () => userApi.create({ username: generateTestName() }))
-      );
+      // Create users sequentially to avoid database connection pool exhaustion
+      const createdUsers = [];
+      for (const _index of Array.from({ length: 30 })) {
+        // eslint-disable-next-line no-await-in-loop
+        const user = await userApi.create({ username: generateTestName() });
+        // eslint-disable-next-line @silverhand/fp/no-mutating-methods
+        createdUsers.push(user);
+      }
       await organizationApi.addUsers(
         organization.id,
         createdUsers.map((user) => user.id)


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

The `organization-user.test.ts` would fail randomly with `TimeoutError: Request timed out` failures in three specific test cases:
- "should be able to get organization users with pagination"
- "should be able to get organization users with search" 
- "should be able to get organization users with their roles"

The cause is that the test setup was creating 30 users concurrently using `Promise.all()`, and could run out db connection pool.

Solution: replaced concurrent user creation with sequential approach.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Integration tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
