### PR TITLE
refactor(core): refactor findPayloadByPayloadField query

### DIFF
--- a/packages/core/src/queries/oidc-model-instance.ts
+++ b/packages/core/src/queries/oidc-model-instance.ts
@@ -85,9 +85,9 @@ export const createOidcModelInstanceQueries = (pool: CommonQueryMethods) => {
     and ${fields.payload}->>${field}=${value}
   `);
 
-    // In a rare case, when duplicate uid is created for different session instances.
-    // This query may lead to DataIntegrityError.
-    // To handle this case, we delete all duplicates and return null.
+    // Rarely, duplicate UIDs can exist for different sessions.
+    // This query may throw `DataIntegrityError`.
+    // If that happens, delete all duplicates and return `null`.
     if (results.length > 1) {
       // Delete all duplicates
       await pool.query(sql`


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Handle duplicate payload field in `findPayloadByPayloadField` and clean up duplicates.  

### Context
We have observed unexpected 500 exceptions in production when calling the Experience API. Investigation revealed that `Session.findByUid` in `oidc-provider` was throwing a `DataIntegrity` error, which was caused by duplicate session `uid` values stored in the `oidc-model-instances` payload field. This is a very rare case, but when it occurs, it breaks the assumption of unique session identifiers and causes the API to fail.

To address this issue, we have updated the findPayloadByPayloadField query logic:
- The function now uses `pool.any` to fetch all matching records.
- If more than one record is found (i.e., duplicates), it deletes all of them as corrupted data and returns null.
- If exactly one record is found, it returns the result as before.
- If no records are found, it returns null.

This change ensures that the system gracefully handles rare data corruption scenarios, prevents further DataIntegrity errors, and keeps the database clean.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
