### PR TITLE
fix(experience): field i18n label should be displayed properly in error message on profile fulfulling page

### DIFF
--- a/packages/experience/src/pages/Continue/ExtraProfileForm/use-field-label.ts
+++ b/packages/experience/src/pages/Continue/ExtraProfileForm/use-field-label.ts
@@ -8,10 +8,10 @@ const useFieldLabel = () => {
   const { t } = useTranslation();
 
   const getFieldLabel = useCallback(
-    (fieldName: string, label?: string) => {
+    (fieldName: string, label = '') => {
       try {
         s.assert(fieldName, extraProfileFieldNamesGuard);
-        return label ?? t(`profile.${fieldName}`);
+        return label || t(`profile.${fieldName}`);
       } catch {
         return label;
       }

--- a/packages/experience/src/types/guard.ts
+++ b/packages/experience/src/types/guard.ts
@@ -174,6 +174,7 @@ export const extraProfileFieldNamesGuard = s.union([
   s.literal('birthdate'),
   s.literal('zoneinfo'),
   s.literal('locale'),
+  s.literal('fullname'),
   s.literal('address.formatted'),
   s.literal('address.streetAddress'),
   s.literal('address.locality'),

--- a/packages/phrases-experience/src/locales/ar/profile.ts
+++ b/packages/phrases-experience/src/locales/ar/profile.ts
@@ -4,7 +4,7 @@ const profile = {
   givenName: 'الاسم الأول',
   familyName: 'اسم العائلة',
   middleName: 'الاسم الأوسط',
-  fullName: 'الاسم الكامل',
+  fullname: 'الاسم الكامل',
   nickname: 'الاسم المستعار',
   preferredUsername: 'اسم المستخدم المفضل',
   profile: 'الملف الشخصي',

--- a/packages/phrases-experience/src/locales/de/profile.ts
+++ b/packages/phrases-experience/src/locales/de/profile.ts
@@ -4,7 +4,7 @@ const profile = {
   givenName: 'Vorname',
   familyName: 'Nachname',
   middleName: 'Zweitname',
-  fullName: 'Vollständiger Name',
+  fullname: 'Vollständiger Name',
   nickname: 'Spitzname',
   preferredUsername: 'Bevorzugter Benutzername',
   profile: 'Profil',

--- a/packages/phrases-experience/src/locales/en/profile.ts
+++ b/packages/phrases-experience/src/locales/en/profile.ts
@@ -4,7 +4,7 @@ const profile = {
   givenName: 'Given Name',
   familyName: 'Family Name',
   middleName: 'Middle Name',
-  fullName: 'Full Name',
+  fullname: 'Full Name',
   nickname: 'Nickname',
   preferredUsername: 'Preferred Username',
   profile: 'Profile',

--- a/packages/phrases-experience/src/locales/es/profile.ts
+++ b/packages/phrases-experience/src/locales/es/profile.ts
@@ -4,7 +4,7 @@ const profile = {
   givenName: 'Nombre de pila',
   familyName: 'Apellido',
   middleName: 'Segundo nombre',
-  fullName: 'Nombre completo',
+  fullname: 'Nombre completo',
   nickname: 'Apodo',
   preferredUsername: 'Nombre de usuario preferido',
   profile: 'Perfil',

--- a/packages/phrases-experience/src/locales/fr/profile.ts
+++ b/packages/phrases-experience/src/locales/fr/profile.ts
@@ -4,7 +4,7 @@ const profile = {
   givenName: 'Prénom',
   familyName: 'Nom de famille',
   middleName: 'Deuxième prénom',
-  fullName: 'Nom complet',
+  fullname: 'Nom complet',
   nickname: 'Surnom',
   preferredUsername: "Nom d'utilisateur préféré",
   profile: 'Profil',

--- a/packages/phrases-experience/src/locales/it/profile.ts
+++ b/packages/phrases-experience/src/locales/it/profile.ts
@@ -4,7 +4,7 @@ const profile = {
   givenName: 'Nome',
   familyName: 'Cognome',
   middleName: 'Secondo nome',
-  fullName: 'Nome completo',
+  fullname: 'Nome completo',
   nickname: 'Soprannome',
   preferredUsername: 'Nome utente preferito',
   profile: 'Profilo',

--- a/packages/phrases-experience/src/locales/ja/profile.ts
+++ b/packages/phrases-experience/src/locales/ja/profile.ts
@@ -4,7 +4,7 @@ const profile = {
   givenName: '名',
   familyName: '姓',
   middleName: 'ミドルネーム',
-  fullName: 'フルネーム',
+  fullname: 'フルネーム',
   nickname: 'ニックネーム',
   preferredUsername: '希望ユーザー名',
   profile: 'プロフィール',

--- a/packages/phrases-experience/src/locales/ko/profile.ts
+++ b/packages/phrases-experience/src/locales/ko/profile.ts
@@ -4,7 +4,7 @@ const profile = {
   givenName: '이름',
   familyName: '성',
   middleName: '중간 이름',
-  fullName: '전체 이름',
+  fullname: '전체 이름',
   nickname: '별명',
   preferredUsername: '선호하는 사용자명',
   profile: '프로필',

--- a/packages/phrases-experience/src/locales/pl-pl/profile.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/profile.ts
@@ -4,7 +4,7 @@ const profile = {
   givenName: 'Imię własne',
   familyName: 'Nazwisko',
   middleName: 'Drugie imię',
-  fullName: 'Pełne imię i nazwisko',
+  fullname: 'Pełne imię i nazwisko',
   nickname: 'Pseudonim',
   preferredUsername: 'Preferowana nazwa użytkownika',
   profile: 'Profil',

--- a/packages/phrases-experience/src/locales/pt-br/profile.ts
+++ b/packages/phrases-experience/src/locales/pt-br/profile.ts
@@ -4,7 +4,7 @@ const profile = {
   givenName: 'Nome',
   familyName: 'Sobrenome',
   middleName: 'Nome do meio',
-  fullName: 'Nome completo',
+  fullname: 'Nome completo',
   nickname: 'Apelido',
   preferredUsername: 'Nome de usuário preferido',
   profile: 'Perfil',

--- a/packages/phrases-experience/src/locales/pt-pt/profile.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/profile.ts
@@ -4,7 +4,7 @@ const profile = {
   givenName: 'Nome próprio',
   familyName: 'Apelido',
   middleName: 'Nome do meio',
-  fullName: 'Nome completo',
+  fullname: 'Nome completo',
   nickname: 'Alcunha',
   preferredUsername: 'Nome de utilizador preferido',
   profile: 'Perfil',

--- a/packages/phrases-experience/src/locales/ru/profile.ts
+++ b/packages/phrases-experience/src/locales/ru/profile.ts
@@ -4,7 +4,7 @@ const profile = {
   givenName: 'Имя',
   familyName: 'Фамилия',
   middleName: 'Отчество',
-  fullName: 'Полное имя',
+  fullname: 'Полное имя',
   nickname: 'Никнейм',
   preferredUsername: 'Предпочитаемое имя пользователя',
   profile: 'Профиль',

--- a/packages/phrases-experience/src/locales/tr-tr/profile.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/profile.ts
@@ -4,7 +4,7 @@ const profile = {
   givenName: 'Ad',
   familyName: 'Soyad',
   middleName: 'İkinci Ad',
-  fullName: 'Tam Ad',
+  fullname: 'Tam Ad',
   nickname: 'Takma Ad',
   preferredUsername: 'Tercih Edilen Kullanıcı Adı',
   profile: 'Profil',

--- a/packages/phrases-experience/src/locales/uk-ua/profile.ts
+++ b/packages/phrases-experience/src/locales/uk-ua/profile.ts
@@ -4,7 +4,7 @@ const profile = {
   givenName: "Ім'я",
   familyName: 'Прізвище',
   middleName: 'По батькові',
-  fullName: "Повне ім'я",
+  fullname: "Повне ім'я",
   nickname: 'Псевдонім',
   preferredUsername: "Бажане ім'я користувача",
   profile: 'Профіль',

--- a/packages/phrases-experience/src/locales/zh-cn/profile.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/profile.ts
@@ -4,7 +4,7 @@ const profile = {
   givenName: '名',
   familyName: '姓',
   middleName: '中间名',
-  fullName: '全名',
+  fullname: '全名',
   nickname: '昵称',
   preferredUsername: '首选用户名',
   profile: '个人资料',

--- a/packages/phrases-experience/src/locales/zh-hk/profile.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/profile.ts
@@ -4,7 +4,7 @@ const profile = {
   givenName: '名字',
   familyName: '姓氏',
   middleName: '中間名',
-  fullName: '全名',
+  fullname: '全名',
   nickname: '暱稱',
   preferredUsername: '偏好用戶名',
   profile: '個人資料',

--- a/packages/phrases-experience/src/locales/zh-tw/profile.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/profile.ts
@@ -4,7 +4,7 @@ const profile = {
   givenName: '名字',
   familyName: '姓氏',
   middleName: '中間名',
-  fullName: '全名',
+  fullname: '全名',
   nickname: '暱稱',
   preferredUsername: '偏好用戶名',
   profile: '個人資料',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix a bug that the field i18n label is missing in error message when fulfilling profile in the SIE. Caused by the `??` operator fallback not being able to fallback empty strings.

Also found the "fullname" field name is mismatch with the i18n phrase key. Update it from `fullName` to `fullname`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested and the field names can be displayed properly in error messages.

<img width="1060" height="956" alt="image" src="https://github.com/user-attachments/assets/a95c87a3-0e77-4017-a600-a72123a2a76f" />

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
