### PR TITLE
refactor: add minLength and maxLength default values to profile fulfilling text fields

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/data-parser.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/data-parser.ts
@@ -53,6 +53,7 @@ const getDefaultParts = (type: CustomProfileFieldType) => {
       type: CustomProfileFieldType.Text,
       required: true,
       enabled: name === 'formatted',
+      config: { minLength: 1, maxLength: 100 },
     }));
   }
   if (type === CustomProfileFieldType.Fullname) {
@@ -61,6 +62,7 @@ const getDefaultParts = (type: CustomProfileFieldType) => {
       type: CustomProfileFieldType.Text,
       required: true,
       enabled: name !== 'middleName',
+      config: { minLength: 1, maxLength: 100 },
     }));
   }
 };
@@ -77,6 +79,7 @@ export const getInitialRequestPayloadByFieldName = (name: string) => {
         format: cond(type === CustomProfileFieldType.Date && SupportedDateFormat.US),
         parts: getDefaultParts(type),
         options: getDefaultOptions(name),
+        ...cond(type === CustomProfileFieldType.Text && { minLength: 1, maxLength: 100 }),
       },
     },
     { emptyArrays: false, emptyObjects: false }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Introduces default values (1, 100) to `minLength` and `maxLength` configs for text-type custom profile fields.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="2524" height="1316" alt="image" src="https://github.com/user-attachments/assets/64478b51-d577-476d-8e56-08c1845c0ff3" />

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
