### PR TITLE
refactor(experience): select field should cut off overflow text and have extra dropdown padding

### DIFF
--- a/packages/experience/src/components/Dropdown/index.module.scss
+++ b/packages/experience/src/components/Dropdown/index.module.scss
@@ -18,6 +18,7 @@
   background: var(--color-bg-float-overlay);
   border: 1px solid var(--color-line-divider);
   border-radius: 8px;
+  padding: _.unit(1);
 }
 
 .overlay {

--- a/packages/experience/src/components/InputFields/PrimitiveProfileInputField/index.tsx
+++ b/packages/experience/src/components/InputFields/PrimitiveProfileInputField/index.tsx
@@ -47,6 +47,7 @@ const PrimitiveProfileInputField = ({
         options={options}
         value={value}
         description={description}
+        errorMessage={errorMessage}
         onBlur={onBlur}
         onChange={onChange}
       />

--- a/packages/experience/src/components/InputFields/SelectField/index.module.scss
+++ b/packages/experience/src/components/InputFields/SelectField/index.module.scss
@@ -11,6 +11,8 @@
     position: relative;
 
     input {
+      text-overflow: ellipsis;
+      padding-inline-end: _.unit(8);
       cursor: pointer;
     }
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Refactor the select field component in Experience, including:
- Add extra padding (8px) around the dropdown area
- Cut off overflow text content and append ellipsis to the end

<img width="838" height="476" alt="image" src="https://github.com/user-attachments/assets/189eccd8-d1bb-49d2-b4a6-bec61887d6d2" />

<img width="836" height="132" alt="image" src="https://github.com/user-attachments/assets/d0d31d4b-f6f2-4286-a9df-eb146e57987e" />

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
