### PR TITLE
refactor(experience): add 48px padding bottom to the secondary page layout container

### DIFF
--- a/packages/experience/src/Layout/SecondaryPageLayout/index.module.scss
+++ b/packages/experience/src/Layout/SecondaryPageLayout/index.module.scss
@@ -6,7 +6,7 @@
 
 .container {
   @include _.full-width;
-  margin-top: _.unit(2);
+  margin-block: _.unit(2);
 }
 
 .header {
@@ -20,7 +20,7 @@
 
 :global(body.mobile) {
   .container {
-    margin-top: _.unit(2);
+    margin-block: _.unit(2);
   }
 
   .title {
@@ -34,7 +34,7 @@
 
 :global(body.desktop) {
   .container {
-    margin-top: _.unit(12);
+    margin-block: _.unit(12);
   }
 
   .header {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add 48px padding bottom to the secondary page layout container.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="1150" height="1400" alt="image" src="https://github.com/user-attachments/assets/6ee603a9-88c1-4631-9342-584994823704" />

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
