### PR TITLE
refactor: add default placeholder for date type fields in profile fulfilling

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/data-parser.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/data-parser.ts
@@ -97,6 +97,7 @@ export const getInitialRequestPayloadByFieldName = (name: string) => {
       required: true,
       config: {
         format: cond(type === CustomProfileFieldType.Date && SupportedDateFormat.US),
+        placeholder: cond(type === CustomProfileFieldType.Date && SupportedDateFormat.US),
         parts: getDefaultParts(type),
         options: getDefaultOptions(name),
         ...cond(type === CustomProfileFieldType.Text && { minLength: 1, maxLength: 100 }),

--- a/packages/console/src/pages/SignInExperience/PageContent/components/DateFormatSelector/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/components/DateFormatSelector/index.tsx
@@ -1,5 +1,4 @@
 import { SupportedDateFormat } from '@logto/schemas';
-import { useEffect } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { Trans, useTranslation } from 'react-i18next';
 
@@ -32,16 +31,6 @@ function DateFormatSelector({ index }: Props) {
   const formatValue = watch(`${fieldPrefix}format`);
   const formErrors = index === undefined ? errors : errors.parts?.[index];
 
-  useEffect(() => {
-    if (!formatValue) {
-      setValue(`${fieldPrefix}format`, SupportedDateFormat.US);
-      return;
-    }
-    if (formatValue !== SupportedDateFormat.Custom) {
-      setValue(`${fieldPrefix}customFormat`, '');
-    }
-  }, [fieldPrefix, formatValue, setValue]);
-
   return (
     <div className={styles.dateFormatSelector}>
       <Controller
@@ -56,7 +45,14 @@ function DateFormatSelector({ index }: Props) {
               { value: SupportedDateFormat.Custom, title: t('custom_date_format') },
             ]}
             value={value}
-            onChange={onChange}
+            onChange={(value) => {
+              onChange(value);
+              setValue(
+                `${fieldPrefix}placeholder`,
+                value === SupportedDateFormat.Custom ? '' : value,
+                { shouldDirty: true }
+              );
+            }}
           />
         )}
       />

--- a/packages/console/src/pages/SignInExperience/PageContent/components/ProfileFieldPartSubForm/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/components/ProfileFieldPartSubForm/index.tsx
@@ -101,6 +101,11 @@ function ProfileFieldPartSubForm({ index }: Props) {
           }}
         />
       </FormField>
+      {type === CustomProfileFieldType.Date && (
+        <FormField title="sign_in_exp.custom_profile_fields.details.date_format">
+          <DateFormatSelector />
+        </FormField>
+      )}
       <FormField
         isRequired={!isBuiltInFieldName}
         title="sign_in_exp.custom_profile_fields.details.label"
@@ -182,11 +187,6 @@ function ProfileFieldPartSubForm({ index }: Props) {
             placeholder={t('sign_in_exp.custom_profile_fields.details.regex_placeholder')}
             description={t('sign_in_exp.custom_profile_fields.details.regex_tip')}
           />
-        </FormField>
-      )}
-      {type === CustomProfileFieldType.Date && (
-        <FormField title="sign_in_exp.custom_profile_fields.details.date_format">
-          <DateFormatSelector />
         </FormField>
       )}
       {type === CustomProfileFieldType.Checkbox && (


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Provide default placeholder for "Date" type profile fulling fields in Console configs.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
When selecting built-in provided date formats (US, UK or ISO-8601), the corresponding date format will be populated into the "Placeholder" field. And when selecting "Custom" format, the placeholder will be cleared.

<img width="2514" height="1352" alt="image" src="https://github.com/user-attachments/assets/9df3073b-1f75-4ee7-94fa-cd081f5ee0ad" />

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
