### PR TITLE
refactor(core): remove unused email sms mfa code

### DIFF
--- a/packages/core/src/libraries/user.utils.ts
+++ b/packages/core/src/libraries/user.utils.ts
@@ -47,11 +47,6 @@ export const convertBindMfaToMfaVerification = (bindMfa: BindMfa): MfaVerificati
     };
   }
 
-  if (type === MfaFactor.EmailVerificationCode || type === MfaFactor.PhoneVerificationCode) {
-    // TODO @wangsijie: Implement this later
-    throw new Error('Not implemented yet');
-  }
-
   const { credentialId, counter, publicKey, transports, agent } = bindMfa;
   return {
     ...base,

--- a/packages/core/src/routes/experience/classes/mfa.ts
+++ b/packages/core/src/routes/experience/classes/mfa.ts
@@ -391,7 +391,7 @@ export class Mfa {
       currentProfile
     );
     return [
-      ...existingVerifications.map(({ type }) => type),
+      ...existingVerifications,
       ...(this.#totp ? [MfaFactor.TOTP] : []),
       ...(this.#webAuthn?.length ? [MfaFactor.WebAuthn] : []),
     ].filter(Boolean);

--- a/packages/core/src/routes/interaction/actions/submit-interaction.ts
+++ b/packages/core/src/routes/interaction/actions/submit-interaction.ts
@@ -67,13 +67,6 @@ const parseBindMfas = ({
       };
     }
 
-    if (
-      bindMfa.type === MfaFactor.EmailVerificationCode ||
-      bindMfa.type === MfaFactor.PhoneVerificationCode
-    ) {
-      throw new Error('Not implemented yet');
-    }
-
     // MfaFactor.PhoneVerificationCode
     return {
       id: generateStandardId(),

--- a/packages/experience/src/apis/experience/mfa.ts
+++ b/packages/experience/src/apis/experience/mfa.ts
@@ -60,40 +60,40 @@ export const skipMfa = async () => {
   return submitInteraction();
 };
 
-export const bindMfa = async (payload: BindMfaPayload, verificationId: string) => {
-  switch (payload.type) {
-    case MfaFactor.TOTP: {
-      const { code } = payload;
-      await api.post(`${experienceApiRoutes.verification}/totp/verify`, {
-        json: {
-          code,
-          verificationId,
-        },
-      });
-      break;
-    }
-    case MfaFactor.WebAuthn: {
-      await api.post(`${experienceApiRoutes.verification}/web-authn/registration/verify`, {
-        json: {
-          verificationId,
-          payload,
-        },
-      });
-      break;
-    }
-    case MfaFactor.BackupCode: {
-      // No need to verify backup codes
-      break;
-    }
-    case MfaFactor.EmailVerificationCode:
-    case MfaFactor.PhoneVerificationCode: {
-      // Email/Phone MFA factors use special binding logic, but don't submit immediately
-      // to allow additional MFA factors to be bound in the same session
-      break;
+export const bindMfa = async (
+  type: MfaFactor,
+  verificationId: string,
+  payload?: BindMfaPayload
+) => {
+  if (payload) {
+    switch (payload.type) {
+      case MfaFactor.TOTP: {
+        const { code } = payload;
+        await api.post(`${experienceApiRoutes.verification}/totp/verify`, {
+          json: {
+            code,
+            verificationId,
+          },
+        });
+        break;
+      }
+      case MfaFactor.WebAuthn: {
+        await api.post(`${experienceApiRoutes.verification}/web-authn/registration/verify`, {
+          json: {
+            verificationId,
+            payload,
+          },
+        });
+        break;
+      }
+      case MfaFactor.BackupCode: {
+        // No need to verify backup codes
+        break;
+      }
     }
   }
 
-  await addMfa(payload.type, verificationId);
+  await addMfa(type, verificationId);
   return submitInteraction();
 };
 
@@ -124,11 +124,6 @@ export const verifyMfa = async (payload: VerifyMfaPayload, verificationId?: stri
           code,
         },
       });
-      break;
-    }
-    case MfaFactor.EmailVerificationCode:
-    case MfaFactor.PhoneVerificationCode: {
-      // TODO: Implement email and phone verification code verification
       break;
     }
   }

--- a/packages/experience/src/containers/VerificationCode/use-continue-flow-code-verification.ts
+++ b/packages/experience/src/containers/VerificationCode/use-continue-flow-code-verification.ts
@@ -141,7 +141,7 @@ const useContinueFlowCodeVerification = (
         }
 
         const [bindError, bindResult] = await asyncBindMfa(
-          { type: MfaFactor.EmailVerificationCode },
+          MfaFactor.EmailVerificationCode,
           verificationId
         );
 

--- a/packages/experience/src/hooks/use-send-mfa-payload.ts
+++ b/packages/experience/src/hooks/use-send-mfa-payload.ts
@@ -23,7 +23,7 @@ export type SendMfaPayloadApiOptions =
 
 const sendMfaPayloadApi = async ({ flow, payload, verificationId }: SendMfaPayloadApiOptions) => {
   if (flow === UserMfaFlow.MfaBinding) {
-    return bindMfa(payload, verificationId);
+    return bindMfa(payload.type, verificationId, payload);
   }
   return verifyMfa(payload, verificationId);
 };

--- a/packages/schemas/src/foundations/jsonb-types/users.ts
+++ b/packages/schemas/src/foundations/jsonb-types/users.ts
@@ -111,31 +111,10 @@ export const mfaVerificationBackupCode = z.object({
 
 export type MfaVerificationBackupCode = z.infer<typeof mfaVerificationBackupCode>;
 
-// TODO @wangsijie: Implement this later
-export const mfaVerificationEmailVerificationCode = z.object({
-  type: z.literal(MfaFactor.EmailVerificationCode),
-  ...baseMfaVerification,
-});
-
-export type MfaVerificationEmailVerificationCode = z.infer<
-  typeof mfaVerificationEmailVerificationCode
->;
-
-export const mfaVerificationPhoneVerificationCode = z.object({
-  type: z.literal(MfaFactor.PhoneVerificationCode),
-  ...baseMfaVerification,
-});
-
-export type MfaVerificationPhoneVerificationCode = z.infer<
-  typeof mfaVerificationPhoneVerificationCode
->;
-
 export const mfaVerificationGuard = z.discriminatedUnion('type', [
   mfaVerificationTotp,
   mfaVerificationWebAuthn,
   mfaVerificationBackupCode,
-  mfaVerificationEmailVerificationCode,
-  mfaVerificationPhoneVerificationCode,
 ]);
 
 export type MfaVerification = z.infer<typeof mfaVerificationGuard>;

--- a/packages/schemas/src/types/interactions.ts
+++ b/packages/schemas/src/types/interactions.ts
@@ -351,29 +351,10 @@ export const bindBackupCodePayloadGuard = z.object({
 
 export type BindBackupCodePayload = z.infer<typeof bindBackupCodePayloadGuard>;
 
-// TODO @sijie: Implement binding
-export const bindEmailVerificationCodePayloadGuard = z.object({
-  type: z.literal(MfaFactor.EmailVerificationCode),
-});
-
-export type BindEmailVerificationCodePayload = z.infer<
-  typeof bindEmailVerificationCodePayloadGuard
->;
-
-export const bindPhoneVerificationCodePayloadGuard = z.object({
-  type: z.literal(MfaFactor.PhoneVerificationCode),
-});
-
-export type BindPhoneVerificationCodePayload = z.infer<
-  typeof bindPhoneVerificationCodePayloadGuard
->;
-
 export const bindMfaPayloadGuard = z.discriminatedUnion('type', [
   bindTotpPayloadGuard,
   bindWebAuthnPayloadGuard,
   bindBackupCodePayloadGuard,
-  bindEmailVerificationCodePayloadGuard,
-  bindPhoneVerificationCodePayloadGuard,
 ]);
 
 export type BindMfaPayload = z.infer<typeof bindMfaPayloadGuard>;
@@ -404,32 +385,10 @@ export const backupCodeVerificationPayloadGuard = z.object({
 
 export type BackupCodeVerificationPayload = z.infer<typeof backupCodeVerificationPayloadGuard>;
 
-export const emailVerificationCodeVerificationPayloadGuard = z.object({
-  type: z.literal(MfaFactor.EmailVerificationCode),
-  email: z.string(),
-  code: z.string(),
-});
-
-export type EmailVerificationCodeVerificationPayload = z.infer<
-  typeof emailVerificationCodeVerificationPayloadGuard
->;
-
-export const phoneVerificationCodeVerificationPayloadGuard = z.object({
-  type: z.literal(MfaFactor.PhoneVerificationCode),
-  phone: z.string(),
-  code: z.string(),
-});
-
-export type PhoneVerificationCodeVerificationPayload = z.infer<
-  typeof phoneVerificationCodeVerificationPayloadGuard
->;
-
 export const verifyMfaPayloadGuard = z.discriminatedUnion('type', [
   totpVerificationPayloadGuard,
   webAuthnVerificationPayloadGuard,
   backupCodeVerificationPayloadGuard,
-  emailVerificationCodeVerificationPayloadGuard,
-  phoneVerificationCodeVerificationPayloadGuard,
 ]);
 
 export type VerifyMfaPayload = z.infer<typeof verifyMfaPayloadGuard>;
@@ -501,27 +460,11 @@ export const bindBackupCodeGuard = pendingBackupCodeGuard;
 
 export type BindBackupCode = z.infer<typeof bindBackupCodeGuard>;
 
-export const bindEmailVerificationCodeGuard = z.object({
-  type: z.literal(MfaFactor.EmailVerificationCode),
-  email: z.string(),
-});
-
-export type BindEmailVerificationCode = z.infer<typeof bindEmailVerificationCodeGuard>;
-
-export const bindPhoneVerificationCodeGuard = z.object({
-  type: z.literal(MfaFactor.PhoneVerificationCode),
-  phone: z.string(),
-});
-
-export type BindPhoneVerificationCode = z.infer<typeof bindPhoneVerificationCodeGuard>;
-
 // The type for binding new mfa verification to a user, not always equals to the pending type.
 export const bindMfaGuard = z.discriminatedUnion('type', [
   bindTotpGuard,
   bindWebAuthnGuard,
   bindBackupCodeGuard,
-  bindEmailVerificationCodeGuard,
-  bindPhoneVerificationCodeGuard,
 ]);
 
 export type BindMfa = z.infer<typeof bindMfaGuard>;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Clean up unused code related to email SMS MFA functionality that is no longer needed after recent MFA implementation changes.

New binding information is stored in user profile, not `bindMfa` object. Verification information is stored as verification records.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Existing MFA tests continue to pass

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
