### PR TITLE
fix(core): validate sub-component types in address and fullname fields

### DIFF
--- a/packages/core/src/libraries/custom-profile-fields/utils.ts
+++ b/packages/core/src/libraries/custom-profile-fields/utils.ts
@@ -67,6 +67,12 @@ const validateRegexProfileField: ValidateCustomProfileField = (data, isStrict) =
 const validateAddressProfileField: ValidateCustomProfileField = (data, isStrict) => {
   const { config } = addressProfileFieldGuard.parse(data);
   assertThat(config.parts.length > 0, 'custom_profile_fields.invalid_address_parts');
+  assertThat(
+    !config.parts.some(({ type }) =>
+      [CustomProfileFieldType.Address, CustomProfileFieldType.Fullname].includes(type)
+    ),
+    'custom_profile_fields.invalid_sub_component_type'
+  );
 
   if (isStrict) {
     for (const part of config.parts) {
@@ -78,6 +84,12 @@ const validateAddressProfileField: ValidateCustomProfileField = (data, isStrict)
 const validateFullnameProfileField: ValidateCustomProfileField = (data, isStrict) => {
   const { config } = fullnameProfileFieldGuard.parse(data);
   assertThat(config.parts.length > 0, 'custom_profile_fields.invalid_fullname_parts');
+  assertThat(
+    !config.parts.some(({ type }) =>
+      [CustomProfileFieldType.Address, CustomProfileFieldType.Fullname].includes(type)
+    ),
+    'custom_profile_fields.invalid_sub_component_type'
+  );
 
   if (isStrict) {
     for (const part of config.parts) {

--- a/packages/integration-tests/src/tests/api/custom-profile-fields.test.ts
+++ b/packages/integration-tests/src/tests/api/custom-profile-fields.test.ts
@@ -66,6 +66,96 @@ describe('custom profile fields API', () => {
     );
   });
 
+  it('should fail to create if address field contains invalid sub-component type', async () => {
+    await expectRejects(
+      createCustomProfileField({
+        name: 'address',
+        type: CustomProfileFieldType.Address,
+        required: true,
+        config: {
+          parts: [
+            {
+              name: 'formatted',
+              type: CustomProfileFieldType.Address,
+              enabled: true,
+              required: true,
+            },
+          ],
+        },
+      }),
+      {
+        code: 'custom_profile_fields.invalid_sub_component_type',
+        status: 400,
+      }
+    );
+    await expectRejects(
+      createCustomProfileField({
+        name: 'address',
+        type: CustomProfileFieldType.Address,
+        required: true,
+        config: {
+          parts: [
+            {
+              name: 'formatted',
+              type: CustomProfileFieldType.Fullname,
+              enabled: true,
+              required: true,
+            },
+          ],
+        },
+      }),
+      {
+        code: 'custom_profile_fields.invalid_sub_component_type',
+        status: 400,
+      }
+    );
+  });
+
+  it('should fail to create if fullname field contains invalid sub-component type', async () => {
+    await expectRejects(
+      createCustomProfileField({
+        name: 'fullname',
+        type: CustomProfileFieldType.Fullname,
+        required: true,
+        config: {
+          parts: [
+            {
+              name: 'givenName',
+              type: CustomProfileFieldType.Fullname,
+              enabled: true,
+              required: true,
+            },
+          ],
+        },
+      }),
+      {
+        code: 'custom_profile_fields.invalid_sub_component_type',
+        status: 400,
+      }
+    );
+    await expectRejects(
+      createCustomProfileField({
+        name: 'fullname',
+        type: CustomProfileFieldType.Fullname,
+        required: true,
+        config: {
+          parts: [
+            {
+              name: 'middleName',
+              type: CustomProfileFieldType.Address,
+              enabled: true,
+              required: true,
+            },
+          ],
+        },
+      }),
+      {
+        code: 'custom_profile_fields.invalid_sub_component_type',
+        status: 400,
+      }
+    );
+  });
+
   it('should fail to create if field name is conflicted', async () => {
     const nameField = await createCustomProfileField(nameData);
     await expectRejects(createCustomProfileField(nameData), {

--- a/packages/phrases/src/locales/ar/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/ar/errors/custom-profile-fields.ts
@@ -1,10 +1,12 @@
 const custom_profile_fields = {
   entity_not_exists_with_names: 'تعذر العثور على الكيانات بالأسماء المقدمة: {{names}}',
   invalid_min_max_input: 'إدخال الحد الأدنى أو الأقصى غير صالح.',
+  invalid_default_value: 'القيمة الافتراضية غير صالحة.',
   invalid_options: 'خيارات الحقل غير صالحة.',
   invalid_regex_format: 'تنسيق التعبير النمطي غير صالح.',
   invalid_address_parts: 'أجزاء العنوان غير صالحة.',
   invalid_fullname_parts: 'أجزاء الاسم الكامل غير صالحة.',
+  invalid_sub_component_type: 'نوع المكوّن الفرعي غير صالح.',
   name_exists: 'هناك حقل بالفعل بهذا الاسم.',
   conflicted_sie_order: 'هناك تعارض في ترتيب الحقول لتجربة تسجيل الدخول.',
   invalid_name: 'اسم الحقل غير صالح ، يُسمح فقط بالأحرف أو الأرقام ، مع مراعاة حالة الأحرف.',

--- a/packages/phrases/src/locales/de/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/de/errors/custom-profile-fields.ts
@@ -2,10 +2,12 @@ const custom_profile_fields = {
   entity_not_exists_with_names:
     'Entitäten mit den angegebenen Namen können nicht gefunden werden: {{names}}',
   invalid_min_max_input: 'Ungültige Eingabe für Minimum und Maximum.',
+  invalid_default_value: 'Ungültiger Standardwert.',
   invalid_options: 'Ungültige Feldoptionen.',
   invalid_regex_format: 'Ungültiges Regex-Format.',
   invalid_address_parts: 'Ungültige Adressbestandteile.',
   invalid_fullname_parts: 'Ungültige Vor- und Nachnamenangaben.',
+  invalid_sub_component_type: 'Ungültiger Unterkomponententyp.',
   name_exists: 'Ein Feld mit diesem Namen existiert bereits.',
   conflicted_sie_order: 'Konflikt im Feldreihenfolgewert für die Sign-in Experience.',
   invalid_name:

--- a/packages/phrases/src/locales/en/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/en/errors/custom-profile-fields.ts
@@ -6,6 +6,7 @@ const custom_profile_fields = {
   invalid_regex_format: 'Invalid regex format.',
   invalid_address_parts: 'Invalid address parts.',
   invalid_fullname_parts: 'Invalid fullname parts.',
+  invalid_sub_component_type: 'Invalid sub-component type.',
   name_exists: 'Field already exists with the given name.',
   conflicted_sie_order: 'Conflicted field order value for Sign-in Experience.',
   invalid_name: 'Invalid field name, only letters or numbers are allowed, case sensitive.',

--- a/packages/phrases/src/locales/es/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/es/errors/custom-profile-fields.ts
@@ -1,10 +1,12 @@
 const custom_profile_fields = {
   entity_not_exists_with_names: 'No se pueden encontrar entidades con los nombres dados: {{names}}',
   invalid_min_max_input: 'Entrada de mínimo y máximo no válida.',
+  invalid_default_value: 'Valor por defecto no válido.',
   invalid_options: 'Opciones de campo no válidas.',
   invalid_regex_format: 'Formato de expresión regular no válido.',
   invalid_address_parts: 'Partes de dirección no válidas.',
   invalid_fullname_parts: 'Partes de nombre completo no válidas.',
+  invalid_sub_component_type: 'Tipo de subcomponente no válido.',
   name_exists: 'Ya existe un campo con el nombre proporcionado.',
   conflicted_sie_order:
     'Valor de orden de campo en conflicto para la experiencia de inicio de sesión.',

--- a/packages/phrases/src/locales/fr/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/fr/errors/custom-profile-fields.ts
@@ -2,10 +2,12 @@ const custom_profile_fields = {
   entity_not_exists_with_names:
     'Impossible de trouver des entités avec les noms donnés : {{names}}',
   invalid_min_max_input: 'Entrée min et max invalide.',
+  invalid_default_value: 'Valeur par défaut invalide.',
   invalid_options: 'Options de champ invalides.',
   invalid_regex_format: 'Format de regex invalide.',
   invalid_address_parts: "Parties d'adresse invalides.",
   invalid_fullname_parts: 'Parties de nom complet invalides.',
+  invalid_sub_component_type: 'Type de sous-composant invalide.',
   name_exists: 'Un champ existe déjà avec ce nom.',
   conflicted_sie_order: "Valeur d'ordre de champ en conflit pour l'expérience de connexion.",
   invalid_name:

--- a/packages/phrases/src/locales/it/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/it/errors/custom-profile-fields.ts
@@ -1,10 +1,12 @@
 const custom_profile_fields = {
   entity_not_exists_with_names: 'Impossibile trovare le entità con i nomi forniti: {{names}}',
   invalid_min_max_input: 'Input minimo e massimo non valido.',
+  invalid_default_value: 'Valore predefinito non valido.',
   invalid_options: 'Opzioni del campo non valide.',
   invalid_regex_format: 'Formato regex non valido.',
   invalid_address_parts: "Parti dell'indirizzo non valide.",
   invalid_fullname_parts: 'Parti del nome completo non valide.',
+  invalid_sub_component_type: 'Tipo di sottocomponente non valido.',
   name_exists: 'Esiste già un campo con il nome fornito.',
   conflicted_sie_order: "Valore dell'ordine del campo in conflitto per Sign-in Experience.",
   invalid_name:

--- a/packages/phrases/src/locales/ja/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/ja/errors/custom-profile-fields.ts
@@ -1,10 +1,12 @@
 const custom_profile_fields = {
   entity_not_exists_with_names: '指定された名前のエンティティが見つかりません: {{names}}',
   invalid_min_max_input: '最小値と最大値の入力が無効です。',
+  invalid_default_value: 'デフォルト値が無効です。',
   invalid_options: 'フィールドオプションが無効です。',
   invalid_regex_format: '正規表現の形式が無効です。',
   invalid_address_parts: '住所の構成要素が無効です。',
   invalid_fullname_parts: '氏名の構成要素が無効です。',
+  invalid_sub_component_type: 'サブコンポーネントタイプが無効です。',
   name_exists: '指定された名前のフィールドはすでに存在します。',
   conflicted_sie_order: 'サインイン体験のフィールド順序の値が重複しています。',
   invalid_name:

--- a/packages/phrases/src/locales/ko/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/ko/errors/custom-profile-fields.ts
@@ -1,10 +1,12 @@
 const custom_profile_fields = {
   entity_not_exists_with_names: '주어진 이름과 일치하는 엔티티를 찾을 수 없습니다: {{names}}',
   invalid_min_max_input: '최소값과 최대값 입력이 올바르지 않습니다.',
+  invalid_default_value: '기본값이 올바르지 않습니다.',
   invalid_options: '필드 옵션이 올바르지 않습니다.',
   invalid_regex_format: '정규식 형식이 올바르지 않습니다.',
   invalid_address_parts: '주소 구성 요소가 올바르지 않습니다.',
   invalid_fullname_parts: '이름 구성 요소가 올바르지 않습니다.',
+  invalid_sub_component_type: '하위 구성 요소 유형이 올바르지 않습니다.',
   name_exists: '해당 이름의 필드가 이미 존재합니다.',
   conflicted_sie_order: 'Sign-in Experience 용 필드 순서 값이 충돌합니다.',
   invalid_name: '필드 이름이 올바르지 않습니다. 대소문자를 구분하며, 문자 또는 숫자만 허용됩니다.',

--- a/packages/phrases/src/locales/pl-pl/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/custom-profile-fields.ts
@@ -1,10 +1,12 @@
 const custom_profile_fields = {
   entity_not_exists_with_names: 'Nie można znaleźć jednostek o podanych nazwach: {{names}}',
   invalid_min_max_input: 'Nieprawidłowe wartości minimalne lub maksymalne.',
+  invalid_default_value: 'Nieprawidłowa wartość domyślna.',
   invalid_options: 'Nieprawidłowe opcje pól.',
   invalid_regex_format: 'Nieprawidłowy format wyrażenia regularnego.',
   invalid_address_parts: 'Nieprawidłowe części adresu.',
   invalid_fullname_parts: 'Nieprawidłowe części pełnego imienia i nazwiska.',
+  invalid_sub_component_type: 'Nieprawidłowy typ podkomponentu.',
   name_exists: 'Pole o podanej nazwie już istnieje.',
   conflicted_sie_order: 'Konfliktowa wartość kolejności pola dla Sign-in Experience.',
   invalid_name:

--- a/packages/phrases/src/locales/pt-br/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/pt-br/errors/custom-profile-fields.ts
@@ -2,10 +2,12 @@ const custom_profile_fields = {
   entity_not_exists_with_names:
     'Não é possível encontrar entidades com os nomes fornecidos: {{names}}',
   invalid_min_max_input: 'Entrada mínima e máxima inválida.',
+  invalid_default_value: 'Valor padrão inválido.',
   invalid_options: 'Opções de campo inválidas.',
   invalid_regex_format: 'Formato de regex inválido.',
   invalid_address_parts: 'Partes de endereço inválidas.',
   invalid_fullname_parts: 'Partes do nome completo inválidas.',
+  invalid_sub_component_type: 'Tipo de subcomponente inválido.',
   name_exists: 'Já existe um campo com o nome fornecido.',
   conflicted_sie_order: 'Valor de ordem de campo em conflito para a Experiência de Login.',
   invalid_name:

--- a/packages/phrases/src/locales/pt-pt/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/custom-profile-fields.ts
@@ -2,10 +2,12 @@ const custom_profile_fields = {
   entity_not_exists_with_names:
     'Não é possível encontrar entidades com os nomes fornecidos: {{names}}',
   invalid_min_max_input: 'Entrada mínima ou máxima inválida.',
+  invalid_default_value: 'Valor predefinido inválido.',
   invalid_options: 'Opções de campo inválidas.',
   invalid_regex_format: 'Formato de regex inválido.',
   invalid_address_parts: 'Partes do endereço inválidas.',
   invalid_fullname_parts: 'Partes do nome completo inválidas.',
+  invalid_sub_component_type: 'Tipo de subcomponente inválido.',
   name_exists: 'Já existe um campo com o nome fornecido.',
   conflicted_sie_order:
     'Valor de ordem do campo em conflito para a experiência de início de sessão.',

--- a/packages/phrases/src/locales/ru/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/ru/errors/custom-profile-fields.ts
@@ -1,10 +1,12 @@
 const custom_profile_fields = {
   entity_not_exists_with_names: 'Не удается найти сущности с указанными именами: {{names}}',
   invalid_min_max_input: 'Некорректный ввод min и max.',
+  invalid_default_value: 'Некорректное значение по умолчанию.',
   invalid_options: 'Некорректные параметры поля.',
   invalid_regex_format: 'Неверный формат регулярного выражения.',
   invalid_address_parts: 'Некорректные части адреса.',
   invalid_fullname_parts: 'Некорректные части полного имени.',
+  invalid_sub_component_type: 'Некорректный тип подкомпонента.',
   name_exists: 'Поле с таким именем уже существует.',
   conflicted_sie_order: 'Конфликт значения порядка поля для опыта входа.',
   invalid_name: 'Неверное имя поля, допускаются только буквы или цифры, чувствительно к регистру.',

--- a/packages/phrases/src/locales/tr-tr/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/custom-profile-fields.ts
@@ -1,10 +1,12 @@
 const custom_profile_fields = {
   entity_not_exists_with_names: 'Verilen isimlerle varlıklar bulunamadı: {{names}}',
   invalid_min_max_input: 'Geçersiz minimum ve maksimum giriş.',
+  invalid_default_value: 'Geçersiz varsayılan değer.',
   invalid_options: 'Geçersiz alan seçenekleri.',
   invalid_regex_format: 'Geçersiz regex formatı.',
   invalid_address_parts: 'Geçersiz adres bölümleri.',
   invalid_fullname_parts: 'Geçersiz tam ad bölümleri.',
+  invalid_sub_component_type: 'Geçersiz alt bileşen türü.',
   name_exists: 'Bu isimle zaten bir alan mevcut.',
   conflicted_sie_order: 'Oturum Açma Deneyimi için çakışan alan sırası değeri.',
   invalid_name:

--- a/packages/phrases/src/locales/zh-cn/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/custom-profile-fields.ts
@@ -1,10 +1,12 @@
 const custom_profile_fields = {
   entity_not_exists_with_names: '无法找到具有给定名称的实体：{{names}}',
   invalid_min_max_input: '最小值和最大值输入无效。',
+  invalid_default_value: '默认值无效。',
   invalid_options: '字段选项无效。',
   invalid_regex_format: '正则表达式格式无效。',
   invalid_address_parts: '地址部分无效。',
   invalid_fullname_parts: '全名部分无效。',
+  invalid_sub_component_type: '子组件类型无效。',
   name_exists: '已存在具有该名称的字段。',
   conflicted_sie_order: '登录体验的字段顺序值冲突。',
   invalid_name: '无效的字段名称，只允许字母或数字，区分大小写。',

--- a/packages/phrases/src/locales/zh-hk/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/custom-profile-fields.ts
@@ -1,10 +1,12 @@
 const custom_profile_fields = {
   entity_not_exists_with_names: '找不到具備以下名稱的實體：{{names}}',
   invalid_min_max_input: '最小值與最大值輸入無效。',
+  invalid_default_value: '預設值無效。',
   invalid_options: '欄位選項無效。',
   invalid_regex_format: '正則表達式格式無效。',
   invalid_address_parts: '地址部分無效。',
   invalid_fullname_parts: '全名部分無效。',
+  invalid_sub_component_type: '子組件類型無效。',
   name_exists: '已有具有該名稱的欄位存在。',
   conflicted_sie_order: '登入體驗欄位順序值有衝突。',
   invalid_name: '欄位名稱無效，只允許字母或數字，區分大小寫。',

--- a/packages/phrases/src/locales/zh-tw/errors/custom-profile-fields.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/custom-profile-fields.ts
@@ -1,10 +1,12 @@
 const custom_profile_fields = {
   entity_not_exists_with_names: '找不到具有給定名稱的實體：{{names}}',
   invalid_min_max_input: '最小值與最大值輸入無效。',
+  invalid_default_value: '預設值無效。',
   invalid_options: '欄位選項無效。',
   invalid_regex_format: '正則表達式格式無效。',
   invalid_address_parts: '地址組成部分無效。',
   invalid_fullname_parts: '全名組成部分無效。',
+  invalid_sub_component_type: '子組件類型無效。',
   name_exists: '已存在具有該名稱的欄位。',
   conflicted_sie_order: '登入體驗的欄位順序值衝突。',
   invalid_name: '欄位名稱無效，只允許字母或數字，區分大小寫。',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- Check the sub-component types of both the `Address` and `Fullname` composition type fields, as they can't have nested `Address` or `Fullname` type sub-components.
- Add new error message and sync translation of the phrases.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
New API test case should cover the change. See CI for result.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
