### PR TITLE
fix(experience): date field should not report type error when fulfilling profile

### DIFF
--- a/packages/experience/src/types/guard.ts
+++ b/packages/experience/src/types/guard.ts
@@ -201,6 +201,7 @@ const dateFormatEnumGuard = s.enums(Object.values(SupportedDateFormat));
 
 export const dateFieldConfigGuard = s.object({
   format: dateFormatEnumGuard,
+  placeholder: s.optional(s.string()),
   customFormat: s.optional(s.string()),
 });
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Date type field should not report a type error when fulfilling missing profile properties. Previously there's a missing `placeholder` config in the superstruct data guard, which ends up with a runtime error on submitting form.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
