### PR TITLE
feat(schemas,console): reserve new pro-202508 planId

### DIFF
--- a/packages/console/src/components/FeatureTag/index.tsx
+++ b/packages/console/src/components/FeatureTag/index.tsx
@@ -18,6 +18,7 @@ const planTagMap = {
   [ReservedPlanId.Free]: 'free',
   [ReservedPlanId.Pro]: 'pro',
   [ReservedPlanId.Pro202411]: 'pro',
+  [ReservedPlanId.Pro202509]: 'pro',
   [ReservedPlanId.Development]: 'dev',
   [ReservedPlanId.Admin]: 'admin',
   enterprise: 'enterprise',
@@ -27,7 +28,10 @@ const planTagMap = {
  * The minimum plan required to use the feature.
  * Currently we only have pro plan paywall.
  */
-export type PaywallPlanId = Extract<ReservedPlanId, ReservedPlanId.Pro | ReservedPlanId.Pro202411>;
+export type PaywallPlanId = Extract<
+  ReservedPlanId,
+  ReservedPlanId.Pro | ReservedPlanId.Pro202411 | ReservedPlanId.Pro202509
+>;
 
 export type Props = {
   /**

--- a/packages/console/src/components/PlanDescription/index.tsx
+++ b/packages/console/src/components/PlanDescription/index.tsx
@@ -10,6 +10,7 @@ const registeredPlanDescriptionPhrasesMap: Record<
   [ReservedPlanId.Free]: 'free_plan_description',
   [ReservedPlanId.Pro]: 'pro_plan_description',
   [ReservedPlanId.Pro202411]: 'pro_plan_description',
+  [ReservedPlanId.Pro202509]: 'pro_plan_description',
 };
 
 const getRegisteredPlanDescriptionPhrase = (

--- a/packages/console/src/components/SkuName/index.tsx
+++ b/packages/console/src/components/SkuName/index.tsx
@@ -9,6 +9,7 @@ const registeredPlanNamePhraseMap: Record<
   [ReservedPlanId.Free]: 'free_plan',
   [ReservedPlanId.Pro]: 'pro_plan',
   [ReservedPlanId.Pro202411]: 'pro_plan',
+  [ReservedPlanId.Pro202509]: 'pro_plan',
   [ReservedPlanId.Development]: 'dev_plan',
   [ReservedPlanId.Admin]: 'admin_plan',
 } satisfies Record<ReservedPlanId, TFuncKey<'translation', 'admin_console.subscription'>>;

--- a/packages/console/src/consts/plan-quotas.ts
+++ b/packages/console/src/consts/plan-quotas.ts
@@ -9,6 +9,7 @@ export const ticketSupportResponseTimeMap: Record<string, number> = {
   [ReservedPlanId.Free]: 0,
   [ReservedPlanId.Pro]: 48,
   [ReservedPlanId.Pro202411]: 48,
+  [ReservedPlanId.Pro202509]: 48,
 };
 
 /**

--- a/packages/console/src/consts/subscriptions.ts
+++ b/packages/console/src/consts/subscriptions.ts
@@ -42,6 +42,7 @@ export const planIdOrder: Record<string, number> = Object.freeze({
   [ReservedPlanId.Free]: 0,
   [ReservedPlanId.Pro]: 1,
   [ReservedPlanId.Pro202411]: 1,
+  [ReservedPlanId.Pro202509]: 1,
 });
 
 export const checkoutStateQueryKey = 'checkout-state';

--- a/packages/console/src/utils/subscription.ts
+++ b/packages/console/src/utils/subscription.ts
@@ -123,9 +123,11 @@ export const isFeatureEnabled = (quota: Nullable<number>): boolean => {
 
 /**
  * We may have more than one pro planId in the future.
- * E.g grandfathered {@link ReservedPlanId.Pro} and new {@link ReservedPlanId.Pro202411}.
+ * E.g grandfathered {@link ReservedPlanId.Pro}, {@link ReservedPlanId.Pro202411} and new {@link ReservedPlanId.Pro202509}.
  * User this function to check if the planId can be considered as a pro plan.
  */
 export const isProPlan = (planId: string) =>
-  // eslint-disable-next-line no-restricted-syntax
-  [ReservedPlanId.Pro, ReservedPlanId.Pro202411].includes(planId as ReservedPlanId);
+  [ReservedPlanId.Pro, ReservedPlanId.Pro202411, ReservedPlanId.Pro202509].includes(
+    // eslint-disable-next-line no-restricted-syntax
+    planId as ReservedPlanId
+  );

--- a/packages/core/src/libraries/quota.ts
+++ b/packages/core/src/libraries/quota.ts
@@ -20,7 +20,11 @@ import type Queries from '../tenants/Queries.js';
 import { type CloudConnectionLibrary } from './cloud-connection.js';
 import { type ConnectorLibrary } from './connector.js';
 
-const paidReservedPlans = new Set<string>([ReservedPlanId.Pro, ReservedPlanId.Pro202411]);
+const paidReservedPlans = new Set<string>([
+  ReservedPlanId.Pro,
+  ReservedPlanId.Pro202411,
+  ReservedPlanId.Pro202509,
+]);
 
 export class QuotaLibrary {
   constructor(

--- a/packages/core/src/libraries/subscription.test.ts
+++ b/packages/core/src/libraries/subscription.test.ts
@@ -79,14 +79,14 @@ describe('get subscription data with cache expiration', () => {
     jest.advanceTimersByTime(60 * 60 * 24);
     mockGetTenantSubscription.mockResolvedValueOnce({
       ...mockSubscription,
-      planId: ReservedPlanId.Pro202411,
+      planId: ReservedPlanId.Pro202509,
     });
 
     // Should get new subscription data
     const refreshedSubscriptionData = await subscription.getSubscriptionData();
     expect(refreshedSubscriptionData).toEqual({
       ...mockSubscription,
-      planId: ReservedPlanId.Pro202411,
+      planId: ReservedPlanId.Pro202509,
     });
     expect(mockGetTenantSubscription).toHaveBeenCalled();
   });
@@ -118,14 +118,14 @@ describe('get subscription data with cache expiration', () => {
     jest.advanceTimersByTime(2 * 60 * 60);
     mockGetTenantSubscription.mockResolvedValueOnce({
       ...mockFarFutureSubscription,
-      planId: ReservedPlanId.Pro202411,
+      planId: ReservedPlanId.Pro202509,
     });
 
     // Should get new subscription data due to max TTL
     const refreshedSubscriptionData = await subscription.getSubscriptionData();
     expect(refreshedSubscriptionData).toEqual({
       ...mockFarFutureSubscription,
-      planId: ReservedPlanId.Pro202411,
+      planId: ReservedPlanId.Pro202509,
     });
     expect(mockGetTenantSubscription).toHaveBeenCalled();
   });
@@ -149,14 +149,14 @@ describe('get subscription data with cache expiration', () => {
     jest.advanceTimersByTime(60 * 60);
     mockGetTenantSubscription.mockResolvedValueOnce({
       ...mockExpiredSubscription,
-      planId: ReservedPlanId.Pro202411,
+      planId: ReservedPlanId.Pro202509,
     });
 
     // Should get new subscription data since the cache should be invalidated
     const refreshedSubscriptionData = await subscription.getSubscriptionData();
     expect(refreshedSubscriptionData).toEqual({
       ...mockExpiredSubscription,
-      planId: ReservedPlanId.Pro202411,
+      planId: ReservedPlanId.Pro202509,
     });
     expect(mockGetTenantSubscription).toHaveBeenCalled();
   });

--- a/packages/schemas/src/consts/subscriptions.ts
+++ b/packages/schemas/src/consts/subscriptions.ts
@@ -19,9 +19,15 @@ export enum ReservedPlanId {
    */
   Admin = 'admin',
   /**
-   * The latest Pro plan ID applied from 2024-11.
+   * @deprecated
+   * Grandfathered Pro plan ID deprecated from 2025-09.
+   * Use {@link Pro202509} instead.
    */
   Pro202411 = 'pro-202411',
+  /**
+   * Latest Pro plan ID applied from 2025-09.
+   */
+  Pro202509 = 'pro-202509',
 }
 
 /**


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR reserves a new Pro plan ID, `pro-202508`, in the Logto schema. This ID will represent the latest Logto Pro plan starting from 2025-09, and we will gradually deprecate the legacy Pro plans.

To satisfy TypeScript requirements, this PR also updates the console package to define the necessary constant value mapping for `pro-202508`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
