### PR TITLE
fix(console): should be able to clear the label of custom data field

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/components/ProfileFieldPartSubForm/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/components/ProfileFieldPartSubForm/index.tsx
@@ -121,12 +121,13 @@ function ProfileFieldPartSubForm({ index }: Props) {
               }),
           }}
           render={({ field: { value, onChange } }) => {
+            const fallbackValue = isBuiltInFieldName ? getI18nLabel(name) : '';
             return (
               <TextInput
                 disabled={isBuiltInFieldName}
                 error={formErrors?.label?.message}
                 placeholder={t('sign_in_exp.custom_profile_fields.details.label_placeholder')}
-                value={value || getI18nLabel(name)}
+                value={value || fallbackValue}
                 onChange={onChange}
               />
             );


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the bug that custom data profile field label cannot be cleared in the input field. Previously when clearing the last character, the label will be reset to its field data key as fallback.

The correct logic should be that only the basic user profile fields (built-in) can have a fallback value, as the field label is not editable in that case.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested and it can be cleared now

<img width="1486" height="1180" alt="image" src="https://github.com/user-attachments/assets/7043d1cb-667a-41fe-81a7-acdbcd00e2bb" />

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
