### PR TITLE
fix(console): use consistent field tags across list page and details page

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/ProfileFieldDetails/ProfileFieldDetailsForm/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/ProfileFieldDetails/ProfileFieldDetailsForm/index.tsx
@@ -24,7 +24,7 @@ import { collectUserProfilePathname } from '../../consts';
 import { parseResponseToFormData, parseFormDataToRequestPayload } from '../../data-parser';
 import { type ProfileFieldForm } from '../../types';
 import useI18nFieldLabel from '../../use-i18n-field-label';
-import { isBuiltInCustomProfileFieldKey } from '../../utils';
+import { getFieldTags, isBuiltInCustomProfileFieldKey } from '../../utils';
 
 import styles from './index.module.scss';
 
@@ -120,11 +120,7 @@ function ProfileFieldDetailsForm({ data }: Props) {
         title={watch('label') || getI18nLabel(data.name)}
         identifier={{
           name: t('sign_in_exp.custom_profile_fields.details.key'),
-          tags: compositionParts
-            ?.filter(({ enabled }) => enabled)
-            .map(({ name }) => (data.name === 'address' ? `address.${name}` : name)) ?? [
-            isBuiltInFieldName ? data.name : `customData.${data.name}`,
-          ],
+          tags: getFieldTags(data.name, compositionParts),
         }}
         actionMenuItems={[
           {

--- a/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/ProfileFieldList/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/ProfileFieldList/index.tsx
@@ -13,6 +13,7 @@ import { trySubmitSafe } from '@/utils/form';
 
 import { collectUserProfilePathname } from '../consts';
 import useI18nFieldLabel from '../use-i18n-field-label';
+import { getFieldTags } from '../utils';
 
 import styles from './index.module.scss';
 
@@ -79,11 +80,7 @@ function ProfileFieldList({ data }: Props) {
             <div className={styles.cell}>{t(`sign_in_exp.custom_profile_fields.type.${type}`)}</div>
             <div className={styles.cell}>
               <div className={styles.tags}>
-                {(
-                  config.parts
-                    ?.filter(({ enabled }) => Boolean(enabled))
-                    .map((part) => part.name) ?? [name]
-                ).map((key) => (
+                {getFieldTags(name, config.parts).map((key) => (
                   <Tag key={key} variant="cell">
                     {key}
                   </Tag>

--- a/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/utils.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/utils.ts
@@ -1,6 +1,7 @@
 import {
   builtInCustomProfileFieldKeys,
   CustomProfileFieldType,
+  type FieldPart,
   userProfileAddressKeys,
 } from '@logto/schemas';
 
@@ -47,4 +48,20 @@ export const getProfileFieldTypeByName = (name: string): CustomProfileFieldType 
       return CustomProfileFieldType.Text;
     }
   }
+};
+
+/**
+ * Generates field tags based on the field name and its composition parts.
+ * For address fields, it prefixes the field name with 'address.'.
+ * For custom fields, it prefixes with 'customData.'.
+ * Other built-in fields are used as-is.
+ */
+export const getFieldTags = (fieldName: string, compositionParts?: FieldPart[]): string[] => {
+  if (compositionParts) {
+    return compositionParts
+      .filter(({ enabled }) => enabled)
+      .map(({ name }) => (fieldName === 'address' ? `address.${name}` : name));
+  }
+
+  return isBuiltInCustomProfileFieldKey(fieldName) ? [fieldName] : [`customData.${fieldName}`];
 };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Extract a util function to generate profile field tags, and use it on both the list page and details page. Providing consistent tags on both sides.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

<img width="2378" height="772" alt="image" src="https://github.com/user-attachments/assets/6ed697d3-38e9-4b93-baad-3ca4991a70f7" />

<img width="2378" height="964" alt="image" src="https://github.com/user-attachments/assets/d1e02dd3-fa1b-4844-bd97-ec6bba0e1f49" />

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
