### PR TITLE
refactor(experience): improve a11y and keyboard control on the select field

### DIFF
--- a/packages/experience/src/components/Dropdown/DropdownItem.module.scss
+++ b/packages/experience/src/components/Dropdown/DropdownItem.module.scss
@@ -9,6 +9,7 @@
   align-items: center;
   overflow: hidden;
   gap: _.unit(4);
+  border: 1px solid transparent;
 
   &:hover {
     background: var(--color-overlay-neutral-hover);
@@ -16,6 +17,11 @@
 
   &.danger {
     color: var(--color-overlay-danger-hover);
+  }
+
+  &:focus-visible {
+    border: solid 1px var(--color-brand-default);
+    outline: none;
   }
 
   .icon {

--- a/packages/experience/src/components/Dropdown/DropdownItem.tsx
+++ b/packages/experience/src/components/Dropdown/DropdownItem.tsx
@@ -1,42 +1,59 @@
 import classNames from 'classnames';
-import type { MouseEvent, KeyboardEvent, ReactNode } from 'react';
+import type { MouseEvent, KeyboardEvent, ReactNode, Ref } from 'react';
+import { forwardRef } from 'react';
 
 import { onKeyDownHandler } from '@/utils/a11y';
 
 import styles from './DropdownItem.module.scss';
 
 export type Props = {
-  readonly onClick?: (event: MouseEvent<HTMLDivElement> | KeyboardEvent<HTMLDivElement>) => void;
   readonly className?: string;
   readonly children: ReactNode;
   readonly icon?: ReactNode;
   readonly iconClassName?: string;
   readonly type?: 'default' | 'danger';
+  readonly onClick?: (event: MouseEvent<HTMLDivElement> | KeyboardEvent<HTMLDivElement>) => void;
+  readonly onArrowNavigate?: (direction: 1 | -1) => void;
 };
 
-const DropdownItem = ({
-  onClick,
-  className,
-  children,
-  icon,
-  iconClassName,
-  type = 'default',
-}: Props) => {
-  return (
-    <div
-      className={classNames(styles.item, styles[type], className)}
-      role="menuitem"
-      tabIndex={0}
-      onMouseDown={(event) => {
+const DropdownItem = (
+  {
+    className = '',
+    children,
+    icon,
+    iconClassName = '',
+    type = 'default',
+    onClick,
+    onArrowNavigate,
+  }: Props,
+  ref: Ref<HTMLDivElement>
+) => (
+  <div
+    ref={ref}
+    className={classNames(styles.item, styles[type], className)}
+    role="menuitem"
+    tabIndex={0}
+    onMouseDown={(event) => {
+      event.preventDefault();
+    }}
+    onKeyDown={(event) => {
+      if (event.key === 'ArrowDown') {
+        onArrowNavigate?.(1);
         event.preventDefault();
-      }}
-      onKeyDown={onKeyDownHandler(onClick)}
-      onClick={onClick}
-    >
-      {icon && <span className={classNames(styles.icon, iconClassName)}>{icon}</span>}
-      {children}
-    </div>
-  );
-};
+        return;
+      }
+      if (event.key === 'ArrowUp') {
+        onArrowNavigate?.(-1);
+        event.preventDefault();
+        return;
+      }
+      onKeyDownHandler(onClick)(event);
+    }}
+    onClick={onClick}
+  >
+    {icon && <span className={classNames(styles.icon, iconClassName)}>{icon}</span>}
+    {children}
+  </div>
+);
 
-export default DropdownItem;
+export default forwardRef<HTMLDivElement, Props>(DropdownItem);

--- a/packages/experience/src/components/InputFields/SelectField/index.module.scss
+++ b/packages/experience/src/components/InputFields/SelectField/index.module.scss
@@ -29,6 +29,11 @@
       color: var(--color-type-secondary);
       transition: transform 0.2s ease-in-out;
 
+      &:focus-visible {
+        border-radius: 6px;
+        outline: solid 1px var(--color-brand-default);
+      }
+
       &.up {
         transform: translateY(-50%) rotate(180deg);
       }
@@ -49,4 +54,8 @@
   .errorMessage {
     color: var(--color-danger-default);
   }
+}
+
+.focused {
+  background: var(--color-overlay-neutral-hover);
 }

--- a/packages/experience/src/components/InputFields/SelectField/index.test.tsx
+++ b/packages/experience/src/components/InputFields/SelectField/index.test.tsx
@@ -1,0 +1,161 @@
+import { render, fireEvent, act, waitFor } from '@testing-library/react';
+import { useState } from 'react';
+
+import SelectField from '.';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { dir: () => 'ltr' },
+  }),
+}));
+
+const options = [
+  { value: 'a', label: 'Apple' },
+  { value: 'b', label: 'Banana' },
+  { value: 'c', label: 'Cherry' },
+];
+
+// Controlled wrapper
+const Controlled = (
+  props: Readonly<
+    Omit<React.ComponentProps<typeof SelectField>, 'onChange'> & {
+      onChange?: (value: string) => void;
+    }
+  >
+) => {
+  const [value, setValue] = useState(props.value ?? '');
+  return (
+    <SelectField
+      {...props}
+      value={value}
+      onChange={(value) => {
+        setValue(value);
+        props.onChange?.(value);
+      }}
+    />
+  );
+};
+
+const queryOption = (label: string) =>
+  Array.from(document.querySelectorAll('[role="menuitem"], li, div')).find(
+    (element) => element.textContent === label
+  );
+
+describe('SelectField', () => {
+  test('click open and select by mouse', () => {
+    const handleChange = jest.fn();
+    const { container } = render(
+      <Controlled label="Favorite" name="favorite" options={options} onChange={handleChange} />
+    );
+    const input = container.querySelector('input[name="favorite"]')!;
+    act(() => {
+      fireEvent.click(input);
+    });
+    const banana = queryOption('Banana');
+    expect(banana).toBeTruthy();
+    act(() => {
+      fireEvent.click(banana!);
+    });
+    expect(handleChange).toHaveBeenCalledWith('b');
+    expect((input as HTMLInputElement).value).toBe('Banana');
+  });
+
+  test('ArrowDown first focuses first item then Enter selects', () => {
+    const handleChange = jest.fn();
+    const { container } = render(
+      <Controlled label="Favorite" name="favorite" options={options} onChange={handleChange} />
+    );
+    const input = container.querySelector('input[name="favorite"]')!;
+    act(() => {
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+    });
+    const first = queryOption('Apple');
+    expect(first).toBeTruthy();
+    act(() => {
+      fireEvent.keyDown(input, { key: 'Enter' });
+    });
+    expect(handleChange).toHaveBeenLastCalledWith('a');
+    expect((input as HTMLInputElement).value).toBe('Apple');
+  });
+
+  test('ArrowUp first focuses last item then Space selects', () => {
+    const handleChange = jest.fn();
+    const { container } = render(
+      <Controlled label="Favorite" name="favorite" options={options} onChange={handleChange} />
+    );
+    const input = container.querySelector('input[name="favorite"]')!;
+    act(() => {
+      fireEvent.keyDown(input, { key: 'ArrowUp' });
+    });
+    const last = queryOption('Cherry');
+    expect(last).toBeTruthy();
+    act(() => {
+      fireEvent.keyDown(input, { key: ' ' });
+    });
+    expect(handleChange).toHaveBeenLastCalledWith('c');
+    expect((input as HTMLInputElement).value).toBe('Cherry');
+  });
+
+  test('wrap-around ArrowDown navigation', async () => {
+    const handleChange = jest.fn();
+    const { container } = render(
+      <Controlled label="Favorite" name="favorite" options={options} onChange={handleChange} />
+    );
+    const input = container.querySelector('input[name="favorite"]')!;
+    act(() => {
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+    }); // Apple
+    act(() => {
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+    }); // Banana
+    act(() => {
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+    }); // Cherry
+    act(() => {
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+    }); // Wrap to Apple
+    act(() => {
+      fireEvent.keyDown(input, { key: 'Enter' });
+    }); // Select Apple
+    await waitFor(() => {
+      expect(handleChange).toHaveBeenLastCalledWith('a');
+    });
+    // Reopen and ArrowUp wrap from first to last
+    act(() => {
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+    }); // Reopen -> Apple
+    act(() => {
+      fireEvent.keyDown(input, { key: 'ArrowUp' });
+    }); // Wrap -> Cherry
+    act(() => {
+      fireEvent.keyDown(input, { key: 'Enter' });
+    });
+    await waitFor(() => {
+      expect(handleChange).toHaveBeenLastCalledWith('c');
+    });
+  });
+
+  test('Escape closes without selection', async () => {
+    const handleChange = jest.fn();
+    const { container } = render(
+      <Controlled label="Favorite" name="favorite" options={options} onChange={handleChange} />
+    );
+    const input = container.querySelector('input[name="favorite"]')!;
+    act(() => {
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      fireEvent.keyDown(input, { key: 'Escape' });
+    });
+    expect(handleChange).not.toHaveBeenCalled();
+    // Ensure still functional after close
+    act(() => {
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+    });
+    act(() => {
+      fireEvent.keyDown(input, { key: 'Enter' });
+    });
+    await waitFor(() => {
+      expect(handleChange).toHaveBeenLastCalledWith('a');
+    });
+  });
+});

--- a/packages/experience/src/jest.setup.ts
+++ b/packages/experience/src/jest.setup.ts
@@ -2,7 +2,22 @@ import { type LocalePhrase } from '@logto/phrases-experience';
 import { ssrPlaceholder } from '@logto/schemas';
 import { type DeepPartial } from '@silverhand/essentials';
 import i18next from 'i18next';
+import { createElement, forwardRef, type ReactNode } from 'react';
 import { initReactI18next } from 'react-i18next';
+import ReactModal from 'react-modal';
+
+// Ensure react-modal has an appElement in test env to prevent accessibility warning.
+if (typeof document !== 'undefined') {
+  ReactModal.setAppElement(document.body);
+}
+
+// Mock overlayscrollbars-react to prevent warning
+jest.mock('overlayscrollbars-react', () => {
+  const OverlayScrollbarsComponent = forwardRef<HTMLDivElement, Readonly<{ children?: ReactNode }>>(
+    ({ children }, ref) => createElement('div', { ref }, children)
+  );
+  return { __esModule: true, OverlayScrollbarsComponent };
+});
 
 // Simple resources for testing
 const defaultI18nResources: DeepPartial<LocalePhrase> = {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- Add better a11y and keyboard support to the SelectField component in Experience.
- Add unit test cases for the SelectField component.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
https://github.com/user-attachments/assets/ea2fd23e-360b-4e6d-a5a9-fcd2f053d80a

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
