### PR TITLE
feat(core,connector): add new verification code type for mfa

### DIFF
--- a/.changeset/tasty-panthers-cross.md
+++ b/.changeset/tasty-panthers-cross.md
@@ -1,0 +1,9 @@
+---
+"@logto/connector-mock-email": minor
+"@logto/connector-mock-sms": minor
+"@logto/connector-kit": minor
+---
+
+add new template type MfaVerification for verification code
+
+If you are using Email/SMS as a MFA method, you should update your connector configuration to include the new template type `MfaVerification` for verification code.

--- a/packages/connectors/connector-logto-email/src/index.ts
+++ b/packages/connectors/connector-logto-email/src/index.ts
@@ -40,6 +40,7 @@ const sendMessage =
         body: {
           data: {
             to,
+            // @ts-expect-error: TODO @wangsijie, remove this once the connector-kit package is updated in cloud
             type,
             payload: {
               ...payload,

--- a/packages/connectors/connector-mock-email/docs/config-template.json
+++ b/packages/connectors/connector-mock-email/docs/config-template.json
@@ -22,6 +22,12 @@
       "content": "This is for resetting password purposes only. Your verification code is {{code}}."
     },
     {
+      "usageType": "MfaVerification",
+      "type": "text/plain",
+      "subject": "Logto MfaVerification Template",
+      "content": "This is for MFA verification purposes only. Your verification code is {{code}}."
+    },
+    {
       "usageType": "Generic",
       "type": "text/plain",
       "subject": "Logto Generic Template",

--- a/packages/connectors/connector-mock-sms/docs/config-template.json
+++ b/packages/connectors/connector-mock-sms/docs/config-template.json
@@ -16,6 +16,10 @@
       "content": "This is for resetting password purposes only. Your verification code is {{code}}."
     },
     {
+      "usageType": "MfaVerification",
+      "content": "This is for MFA verification purposes only. Your verification code is {{code}}."
+    },
+    {
       "usageType": "Generic",
       "content": "This is for generic purpose through management API only. Your verification code is {{code}}."
     }

--- a/packages/core/src/routes/experience/classes/verifications/code-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/code-verification.ts
@@ -313,8 +313,7 @@ export const createNewMfaCodeVerificationRecord = (
         id: generateStandardId(),
         type: VerificationType.MfaEmailVerificationCode,
         identifier,
-        // TODO @wangsijie: replace to new template type
-        templateType: TemplateType.SignIn,
+        templateType: TemplateType.MfaVerification,
         verified,
       });
     }
@@ -323,8 +322,7 @@ export const createNewMfaCodeVerificationRecord = (
         id: generateStandardId(),
         type: VerificationType.MfaPhoneVerificationCode,
         identifier,
-        // TODO @wangsijie: replace to new template type
-        templateType: TemplateType.SignIn,
+        templateType: TemplateType.MfaVerification,
         verified,
       });
     }

--- a/packages/core/src/routes/experience/verification-routes/verification-code.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code.ts
@@ -1,3 +1,4 @@
+import { TemplateType } from '@logto/connector-kit';
 import {
   InteractionEvent,
   SignInIdentifier,
@@ -54,7 +55,10 @@ export default function verificationCodeRoutes<T extends ExperienceInteractionRo
             libraries,
             queries,
             identifier,
-            getTemplateTypeByEvent(interactionEvent)
+            // If the interaction already identified a user, we are binding a new identifier
+            ctx.experienceInteraction.identifiedUserId
+              ? TemplateType.BindNewIdentifier
+              : getTemplateTypeByEvent(interactionEvent)
           ),
         libraries,
         ctx,

--- a/packages/integration-tests/src/__mocks__/connectors-mock.ts
+++ b/packages/integration-tests/src/__mocks__/connectors-mock.ts
@@ -126,6 +126,10 @@ export const mockSmsConnectorConfig = {
       usageType: 'BindNewIdentifier',
       content: 'This is for binding new identifier purposes only. Your passcode is {{code}}.',
     },
+    {
+      usageType: 'MfaVerification',
+      content: 'This is for MFA verification purposes only. Your passcode is {{code}}.',
+    },
   ],
 };
 
@@ -182,6 +186,12 @@ export const mockEmailConnectorConfig = {
       type: 'text/plain',
       subject: 'Logto Bind New Identifier Template',
       content: 'This is for binding new identifier purposes only. Your passcode is {{code}}.',
+    },
+    {
+      usageType: 'MfaVerification',
+      type: 'text/plain',
+      subject: 'Logto MFA Verification Template',
+      content: 'This is for MFA verification purposes only. Your passcode is {{code}}.',
     },
   ],
 };

--- a/packages/toolkit/connector-kit/src/types/passwordless.ts
+++ b/packages/toolkit/connector-kit/src/types/passwordless.ts
@@ -34,6 +34,8 @@ export enum TemplateType {
   UserPermissionValidation = 'UserPermissionValidation',
   /** The template for binding a new identifier to an existing account. */
   BindNewIdentifier = 'BindNewIdentifier',
+  /** The template for sending MFA verification code. */
+  MfaVerification = 'MfaVerification',
 }
 
 export const templateTypeGuard = z.nativeEnum(TemplateType);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Apply template type of verification code to MFA flows:

1. Bind Email/Phone MFA: use `BindNewIdentifier` type,
2. Verification: use new `MfaVerification` type.

I had to use `@ts-expect-error` due to the circular dependency, the cloud module imports `@logto/connector-kit`. I need to update this side first.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
