### PR TITLE
fix(console): should close the profile field creation modal on esc

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/CreateProfileFieldModal/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/CollectUserProfile/CreateProfileFieldModal/index.tsx
@@ -143,6 +143,9 @@ function CreateProfileFieldModal({ existingFieldNames, onClose }: Props) {
       isOpen
       className={modalStyles.content}
       overlayClassName={modalStyles.overlay}
+      onRequestClose={() => {
+        onClose?.();
+      }}
     >
       <ModalLayout
         className={styles.content}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Should close the profile field creation modal on clicking ESC button.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Manually tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
