### PR TITLE
fix(core): fix session relation not found error

### DIFF
--- a/packages/core/src/queries/oidc-model-instance.ts
+++ b/packages/core/src/queries/oidc-model-instance.ts
@@ -91,8 +91,9 @@ export const createOidcModelInstanceQueries = (pool: CommonQueryMethods) => {
     if (results.length > 1) {
       // Delete all duplicates
       await pool.query(sql`
-      delete from ${sql.identifier([modelName])}
-      where ${fields.payload}->>${field}=${value}
+      delete from ${table}
+      where ${fields.modelName}=${modelName}
+      and ${fields.payload}->>${field}=${value}
     `);
       return;
     }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Hot fix session relation not found error.

Related PR: #7650.

Previously, we observed an expected 500 error in production caused by a data integrity issue when querying a session by its UID — multiple session records with the same UID were found.

To address this, the previous PR introduced a fallback logic: if multiple records are found, delete the duplicates and return null. However, the SQL script mistakenly used the payload model name instead of the actual table name, which resulted in a Session relation not found error.

This PR fixes the query.



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally with mock duplicate session record

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
