### PR TITLE
feat: added migration to add index on identities

### DIFF
--- a/packages/schemas/alterations/next-1755769809-add-identities-index.ts
+++ b/packages/schemas/alterations/next-1755769809-add-identities-index.ts
@@ -1,0 +1,19 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      create index users_identities_gin
+      on users using GIN (identities);
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      drop index users_identities_gin;
+    `);
+  },
+};
+
+export default alteration;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
As discussed through the Discord channel, I've added a GIN index on the `identities` column of the users table to speed up this query
```
const findUserByIdentity = async (target: string, userId: string) =>
    pool.maybeOne<User>(
      sql`
        select ${sql.join(Object.values(fields), sql`,`)}
        from ${table}
        where ${fields.identities}::json#>>'{${sql.identifier([target])},userId}' = ${userId}
      `
    );
```
That starts slowing down while users are incrementing


<!-- MANDATORY -->
## Testing
Tested locally running tests and manually invoking APIs


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
