### PR TITLE
fix(console): reorder sign-up/sign-in limits display before MFA limits

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignInForm/SignInMethodEditBox/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignInForm/SignInMethodEditBox/index.tsx
@@ -98,6 +98,15 @@ function SignInMethodEditBox({ signInExperience }: Props) {
 
   const getVerificationCodeTooltip = useCallback(
     (identifier: SignInIdentifier) => {
+      // Return the existing tooltip for sign-up required case
+      if (isVerificationCodeCheckable(identifier)) {
+        return;
+      }
+
+      if (!isSignUpPasswordRequired) {
+        return t('sign_in_exp.sign_up_and_sign_in.tip.verification_code_auth');
+      }
+
       // Check if the identifier is already used in MFA factors
       const mfaFactors = signInExperience.mfa.factors;
       if (
@@ -112,13 +121,8 @@ function SignInMethodEditBox({ signInExperience }: Props) {
       ) {
         return t('sign_in_exp.sign_up_and_sign_in.tip.phone_mfa_enabled');
       }
-
-      // Return the existing tooltip for sign-up required case
-      if (!isVerificationCodeCheckable(identifier)) {
-        return t('sign_in_exp.sign_up_and_sign_in.tip.verification_code_auth');
-      }
     },
-    [isVerificationCodeCheckable, t, signInExperience.mfa.factors]
+    [isVerificationCodeCheckable, isSignUpPasswordRequired, signInExperience.mfa.factors, t]
   );
 
   return (

--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/index.tsx
@@ -62,7 +62,7 @@ function SignUpForm({ signInExperience }: Props) {
     setValue('signUp.verify', isSignUpVerify, { shouldDirty: true });
   }, [setValue, signUpIdentifiers]);
 
-  useSignUpPasswordListeners();
+  useSignUpPasswordListeners(signInExperience);
 
   return (
     <Card>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

When the verification code checkbox is disabled, the tooltip order should be:

1. check sign-up/sign-in limitation
2. check MFA conflict

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

<img width="753" height="392" alt="截屏2025-08-29 下午5 12 47" src="https://github.com/user-attachments/assets/aae985e6-04e9-4f38-866e-4cf9132c565c" />

<img width="778" height="381" alt="截屏2025-08-29 下午5 12 52" src="https://github.com/user-attachments/assets/42b98e98-3c91-482c-90ab-812a4591034d" />

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
