### PR TITLE
fix(console): should be able to disable branding settings and save

### DIFF
--- a/packages/console/src/pages/ApplicationDetails/components/Branding/utils.ts
+++ b/packages/console/src/pages/ApplicationDetails/components/Branding/utils.ts
@@ -18,12 +18,12 @@ export type ApplicationSignInExperienceForm = ApplicationSignInExperience & {
 export const formatFormToSubmitData = (
   data: ApplicationSignInExperienceForm
 ): Omit<ApplicationSignInExperience, 'applicationId' | 'tenantId'> => {
-  const { branding, color, applicationId, tenantId, isBrandingEnabled, ...rest } = data;
+  const { branding, color, customCss, applicationId, tenantId, isBrandingEnabled, ...rest } = data;
 
   return {
     ...rest,
     ...(isBrandingEnabled
-      ? { color, branding: removeFalsyValues(branding) }
-      : { color: {}, branding: {} }),
+      ? { color, branding: removeFalsyValues(branding), customCss }
+      : { color: {}, branding: {}, customCss: '' }),
   };
 };

--- a/packages/console/src/pages/OrganizationDetails/utils.ts
+++ b/packages/console/src/pages/OrganizationDetails/utils.ts
@@ -1,6 +1,7 @@
 import { generateDarkColor } from '@logto/core-kit';
 import { defaultPrimaryColor, type Organization } from '@logto/schemas';
 
+import { isDevFeaturesEnabled } from '@/consts/env';
 import { type Option } from '@/ds-components/Select/MultiSelect';
 import { emptyBranding } from '@/types/sign-in-experience';
 import { removeFalsyValues } from '@/utils/object';
@@ -41,10 +42,18 @@ export const assembleData = ({
   jitSsoConnectorIds,
   customData,
   branding,
+  color,
+  customCss,
+  isBrandingEnabled,
   ...data
 }: Partial<FormData>): Partial<Organization> => ({
   ...data,
-  branding: branding && removeFalsyValues(branding),
+  // @charles TODO: Remove the dev features guard later
+  ...(!isDevFeaturesEnabled && { branding: branding && removeFalsyValues(branding) }),
+  ...(isDevFeaturesEnabled &&
+    (isBrandingEnabled
+      ? { color, branding: branding && removeFalsyValues(branding), customCss }
+      : { color: {}, branding: {}, customCss: '' })),
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   customData: JSON.parse(customData ?? '{}'),
 });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Remove the newly added branding configs when the switch is turned off.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
