### PR TITLE
feat(core): save rpid for passkey

### DIFF
--- a/packages/core/src/__mocks__/mfa-verification.ts
+++ b/packages/core/src/__mocks__/mfa-verification.ts
@@ -7,6 +7,7 @@ export const mockTotpBind: BindMfa = {
 
 export const mockWebAuthnBind: BindWebAuthn = {
   type: MfaFactor.WebAuthn,
+  rpId: 'rpId',
   credentialId: 'credentialId',
   publicKey: 'publicKey',
   counter: 0,

--- a/packages/core/src/__mocks__/webauthn.ts
+++ b/packages/core/src/__mocks__/webauthn.ts
@@ -53,6 +53,7 @@ export const mockBindWebAuthnPayload: BindWebAuthnPayload = {
 
 export const mockBindWebAuthn: BindWebAuthn = {
   type: MfaFactor.WebAuthn,
+  rpId: 'rpId',
   credentialId: 'credentialId',
   publicKey: 'publicKey',
   transports: [],

--- a/packages/core/src/routes/experience/classes/verifications/web-authn-verification.test.ts
+++ b/packages/core/src/routes/experience/classes/verifications/web-authn-verification.test.ts
@@ -1,0 +1,164 @@
+import { MfaFactor, VerificationType } from '@logto/schemas';
+import { createMockUtils } from '@logto/shared/esm';
+
+import { mockUser, mockUserWebAuthnMfaVerification } from '#src/__mocks__/user.js';
+import { mockWebAuthnVerificationPayload } from '#src/__mocks__/webauthn.js';
+import RequestError from '#src/errors/RequestError/index.js';
+import type { WithLogContext } from '#src/middleware/koa-audit-log.js';
+import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
+import { MockTenant } from '#src/test-utils/tenant.js';
+import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
+
+const { jest } = import.meta;
+const { mockEsmWithActual } = createMockUtils(jest);
+
+// Mock the underlying @simplewebauthn/server to return successful verification
+await mockEsmWithActual('@simplewebauthn/server', () => ({
+  generateRegistrationOptions: jest.fn().mockResolvedValue({ challenge: 'challenge' }),
+  verifyRegistrationResponse: jest.fn().mockResolvedValue({
+    verified: true,
+    registrationInfo: {
+      credentialID: 'credentialId',
+      credentialPublicKey: 'publicKey',
+      counter: 0,
+    },
+  }),
+  generateAuthenticationOptions: jest
+    .fn()
+    .mockResolvedValue({ challenge: 'auth-challenge', allowCredentials: [] }),
+  verifyAuthenticationResponse: jest
+    .fn()
+    .mockResolvedValue({ verified: true, authenticationInfo: { newCounter: 2 } }),
+}));
+
+// Make isoBase64URL.fromBuffer passthrough for simple assertions
+await mockEsmWithActual('@simplewebauthn/server/helpers', () => ({
+  isoBase64URL: { fromBuffer: jest.fn((value) => value), toBuffer: jest.fn((value) => value) },
+}));
+
+const { WebAuthnVerification } = await import('./web-authn-verification.js');
+
+describe('WebAuthnVerification', () => {
+  const userId = 'user-id';
+  const rpId = 'example.com';
+
+  const findUserById = jest.fn().mockResolvedValue(mockUser);
+  const updateUserById = jest.fn();
+  const findDefaultAccountCenter = jest
+    .fn()
+    .mockResolvedValue({ webauthnRelatedOrigins: [] as string[] });
+
+  const tenant = new MockTenant(undefined, {
+    users: { findUserById, updateUserById },
+    accountCenters: { findDefaultAccountCenter },
+  });
+
+  const baseCtx: WithLogContext = {
+    ...createContextWithRouteParameters({
+      url: 'https://example.com/path',
+      encrypted: true,
+      host: rpId,
+    }),
+    ...createMockLogContext(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('verifyWebAuthnRegistration', () => {
+    it('should throw when registrationRpId is missing', async () => {
+      const verification = new WebAuthnVerification(tenant.libraries, tenant.queries, {
+        id: 'v-id',
+        userId,
+        type: VerificationType.WebAuthn,
+        verified: false,
+        registrationChallenge: 'challenge-only',
+      });
+
+      await expect(
+        verification.verifyWebAuthnRegistration(baseCtx, {
+          id: 'id',
+          rawId: 'id',
+          response: { clientDataJSON: 'a', attestationObject: 'b' },
+          clientExtensionResults: {},
+        })
+      ).rejects.toEqual(new RequestError('session.mfa.pending_info_not_found'));
+    });
+
+    it('should verify and produce BindWebAuthn with rpId', async () => {
+      const verification = new WebAuthnVerification(tenant.libraries, tenant.queries, {
+        id: 'v-id',
+        userId,
+        type: VerificationType.WebAuthn,
+        verified: false,
+        registrationChallenge: 'challenge',
+        registrationRpId: rpId,
+      });
+
+      const ctx: WithLogContext = {
+        ...createContextWithRouteParameters({
+          url: 'https://example.com/any',
+          encrypted: true,
+          host: rpId,
+          headers: { 'user-agent': 'agent-x' },
+        }),
+        ...createMockLogContext(),
+      } as unknown as WithLogContext;
+
+      await verification.verifyWebAuthnRegistration(ctx, {
+        id: 'id',
+        rawId: 'id',
+        response: { clientDataJSON: 'a', attestationObject: 'b' },
+        clientExtensionResults: {},
+      });
+
+      expect(verification.isVerified).toBe(true);
+      expect(verification.toBindMfa()).toMatchObject({
+        type: MfaFactor.WebAuthn,
+        rpId,
+        credentialId: 'credentialId',
+        counter: 0,
+        agent: 'agent-x',
+      });
+    });
+  });
+
+  describe('verifyWebAuthnAuthentication', () => {
+    it('should backfill rpId', async () => {
+      // User with an existing WebAuthn MFA missing rpId
+      findUserById.mockResolvedValueOnce({
+        ...mockUser,
+        mfaVerifications: [mockUserWebAuthnMfaVerification],
+      });
+
+      const verification = new WebAuthnVerification(tenant.libraries, tenant.queries, {
+        id: 'v-id',
+        userId,
+        type: VerificationType.WebAuthn,
+        verified: false,
+        authenticationChallenge: 'auth-challenge',
+      });
+
+      await verification.verifyWebAuthnAuthentication(baseCtx, {
+        ...mockWebAuthnVerificationPayload,
+        id: mockUserWebAuthnMfaVerification.credentialId,
+      });
+
+      // Persisted backfill: rpId set to hostname and counter updated
+      expect(updateUserById).toHaveBeenCalledWith(userId, {
+        mfaVerifications: [
+          expect.objectContaining({
+            id: mockUserWebAuthnMfaVerification.id,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            rpId: expect.any(String),
+            counter: 2,
+            type: MfaFactor.WebAuthn,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            lastUsedAt: expect.any(String),
+          }),
+        ],
+      });
+    });
+  });
+});

--- a/packages/core/src/routes/interaction/verifications/mfa-payload-verification.test.ts
+++ b/packages/core/src/routes/interaction/verifications/mfa-payload-verification.test.ts
@@ -147,7 +147,10 @@ describe('bindMfaPayloadVerification', () => {
           },
           additionalParameters
         )
-      ).resolves.toMatchObject(mockBindWebAuthn);
+      ).resolves.toMatchObject({
+        ...mockBindWebAuthn,
+        rpId: additionalParameters.rpId,
+      });
 
       expect(verifyWebAuthnRegistration).toHaveBeenCalled();
     });

--- a/packages/core/src/routes/interaction/verifications/mfa-payload-verification.ts
+++ b/packages/core/src/routes/interaction/verifications/mfa-payload-verification.ts
@@ -103,6 +103,7 @@ const verifyBindWebAuthn = async (
 
   return {
     type,
+    rpId,
     credentialId: credentialID,
     publicKey: isoBase64URL.fromBuffer(credentialPublicKey),
     counter,

--- a/packages/schemas/src/foundations/jsonb-types/users.ts
+++ b/packages/schemas/src/foundations/jsonb-types/users.ts
@@ -93,6 +93,7 @@ export const webAuthnTransportGuard = z.enum([
 export const mfaVerificationWebAuthn = z.object({
   type: z.literal(MfaFactor.WebAuthn),
   ...baseMfaVerification,
+  rpId: z.string().optional(),
   credentialId: z.string(),
   publicKey: z.string(),
   transports: webAuthnTransportGuard.array().optional(),

--- a/packages/schemas/src/types/interactions.ts
+++ b/packages/schemas/src/types/interactions.ts
@@ -446,6 +446,7 @@ export type BindTotp = z.infer<typeof bindTotpGuard>;
 
 export const bindWebAuthnGuard = z.object({
   type: z.literal(MfaFactor.WebAuthn),
+  rpId: z.string(),
   credentialId: z.string(),
   publicKey: z.string(),
   transports: webAuthnTransportGuard.array(),

--- a/packages/schemas/src/types/verification-records/web-authn-verification.ts
+++ b/packages/schemas/src/types/verification-records/web-authn-verification.ts
@@ -13,6 +13,8 @@ export type WebAuthnVerificationRecordData = {
   verified: boolean;
   /** The challenge generated for the WebAuthn registration */
   registrationChallenge?: string;
+  /** The rpId used when generating the registration options */
+  registrationRpId?: string;
   /** The challenge generated for the WebAuthn authentication */
   authenticationChallenge?: string;
   registrationInfo?: BindWebAuthn;
@@ -24,18 +26,20 @@ export const webAuthnVerificationRecordDataGuard = z.object({
   userId: z.string(),
   verified: z.boolean(),
   registrationChallenge: z.string().optional(),
+  registrationRpId: z.string().optional(),
   authenticationChallenge: z.string().optional(),
   registrationInfo: bindWebAuthnGuard.optional(),
 }) satisfies ToZodObject<WebAuthnVerificationRecordData>;
 
 export type SanitizedWebAuthnVerificationRecordData = Omit<
   WebAuthnVerificationRecordData,
-  'registrationInfo' | 'registrationChallenge' | 'authenticationChallenge'
+  'registrationInfo' | 'registrationChallenge' | 'registrationRpId' | 'authenticationChallenge'
 >;
 
 export const sanitizedWebAuthnVerificationRecordDataGuard =
   webAuthnVerificationRecordDataGuard.omit({
     registrationInfo: true,
     registrationChallenge: true,
+    registrationRpId: true,
     authenticationChallenge: true,
   }) satisfies ToZodObject<SanitizedWebAuthnVerificationRecordData>;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
Background:
- Historically, we did not persist the WebAuthn rpId with passkeys.
- As we plan to support multiple custom domains, each passkey must be validated against the correct relying party ID (rpId). Without storing rpId, domain-to-passkey mapping can drift and cause ambiguous or incorrect validations over time.

What this PR does:
- Persist rpId for every passkey at registration time and ensure the correct rpId is used at authentication time.
- Save `registrationRpId` alongside the registration challenge during passkey setup; on successful registration, include `rpId` in `BindWebAuthn` and persist to the user’s MFA list.
- During authentication, derive `expectedRpId` from the request hostname and verify against it; if an existing WebAuthn MFA lacks `rpId` (legacy record), backfill it and update `counter`/`lastUsedAt` to contain further drift.
- Schema updates:
  - `BindWebAuthn` now requires `rpId`.
  - `User.mfaVerifications[WebAuthn]` allows optional `rpId` for legacy compatibility and backfill.
  - `WebAuthnVerificationRecordData` adds optional `registrationRpId`.

Compatibility and migration:
- No blocking data migration is required.
- Existing passkeys without `rpId` remain valid; rpId will be lazily backfilled on the next successful authentication.
- New registrations always persist rpId, preventing future mismatches.

<!-- MANDATORY -->
## Testing
Tested locally and confirmed legacy passkeys authenticate successfully and receive rpId backfilled from the request hostname.

<!-- MANDATORY -->
## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments

