### PR TITLE
fix(core): bind WebAuthn rpId to request domain for account api

### DIFF
--- a/.changeset/thin-walls-tap.md
+++ b/.changeset/thin-walls-tap.md
@@ -3,7 +3,7 @@
 "@logto/core": patch
 ---
 
-fix(core): bind WebAuthn rpId to request domain for account api
+fix(core): bind WebAuthn `rpId` to request domain for account api
 
 - Before: WebAuthn registration via the account API always bound passkeys to the Logto default domain.
-- After: The rpId now matches the domain you use to access the API (including custom domains), consistent with the experience flow.
+- After: The `rpId` now matches the domain you use to access the API (including custom domains), consistent with the sign-in experience.

--- a/.changeset/thin-walls-tap.md
+++ b/.changeset/thin-walls-tap.md
@@ -1,0 +1,9 @@
+---
+"@logto/integration-tests": patch
+"@logto/core": patch
+---
+
+fix(core): bind WebAuthn rpId to request domain for account api
+
+- Before: WebAuthn registration via the account API always bound passkeys to the Logto default domain.
+- After: The rpId now matches the domain you use to access the API (including custom domains), consistent with the experience flow.

--- a/packages/integration-tests/src/tests/api/account/mfa-webauthn.test.ts
+++ b/packages/integration-tests/src/tests/api/account/mfa-webauthn.test.ts
@@ -6,6 +6,7 @@ import {
   createWebAuthnRegistrationOptions,
   verifyWebAuthnRegistration,
 } from '#src/api/verification-record.js';
+import { logtoUrl } from '#src/constants.js';
 import { expectRejects } from '#src/helpers/index.js';
 import {
   createDefaultTenantUserWithPassword,
@@ -40,7 +41,7 @@ describe('my-account (mfa - WebAuthn)', () => {
         await createWebAuthnRegistrationOptions(api);
 
       expect(verificationRecordId).toBeTruthy();
-      expect(registrationOptions.rp.name).toBe('localhost');
+      expect(registrationOptions.rp.name).toBe(new URL(logtoUrl).hostname);
       expect(registrationOptions.user.displayName).toBe(user.username);
 
       await deleteDefaultTenantUser(user.id);
@@ -60,7 +61,8 @@ describe('my-account (mfa - WebAuthn)', () => {
         },
       } = await createWebAuthnRegistrationOptions(api);
 
-      const rawId = Buffer.from(rpId ?? 'localhost')
+      const expectedHost = new URL(logtoUrl).hostname;
+      const rawId = Buffer.from(rpId ?? expectedHost)
         .toString('base64')
         .replaceAll('+', '-')
         .replaceAll('/', '_')
@@ -78,7 +80,7 @@ describe('my-account (mfa - WebAuthn)', () => {
               JSON.stringify({
                 type: 'webauthn.create',
                 challenge,
-                origin: 'http://localhost:3001',
+                origin: logtoUrl,
                 crossOrigin: false,
               })
             ).toString('base64url'),


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix account API WebAuthn registration to bind rpId to the request domain.

Background: The API mistakenly called `findActiveDomain` with a tenant id instead of a domain value. As a result, generated WebAuthn registration options used the Logto default domain as rpId, causing passkeys to bind to the Logto domain even when a custom domain was in use. This diverged from the intended behavior where passkeys should bind to a custom domain when available.

Change: Derive rpId from the incoming request hostname (the domain used to access this API). This aligns account API behavior with the experience flow: whichever domain the client uses to call the endpoint becomes the rpId.

Impact and rationale: We have not received any user reports for this issue, which suggests that no one is actively binding passkeys via custom domains. We therefore treat this as a bugfix that corrects the API behavior without requiring configuration changes. Existing behavior on the default Logto domain remains unchanged; custom domains now bind rpId as expected.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally and tests updated.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
