### PR TITLE
chore: remove email phone MFA feature flag

### DIFF
--- a/packages/console/src/components/SignInExperiencePreview/index.tsx
+++ b/packages/console/src/components/SignInExperiencePreview/index.tsx
@@ -9,7 +9,6 @@ import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 
 import PhoneInfo from '@/assets/images/phone-info.svg?react';
-import { isDevFeaturesEnabled } from '@/consts/env';
 import { AppDataContext } from '@/contexts/AppDataProvider';
 import type { RequestError } from '@/hooks/use-api';
 import useUiLanguages from '@/hooks/use-ui-languages';
@@ -78,9 +77,9 @@ function SignInExperiencePreview({
      * This logic aligns with the core library implementation in sign-in-experience/index.ts
      */
     const forgotPassword = (() => {
-      // If forgotPasswordMethods is null (production compatibility) or dev features are not enabled,
+      // If forgotPasswordMethods is null (production compatibility)
       // fall back to connector-based availability only
-      if (!signInExperience.forgotPasswordMethods || !isDevFeaturesEnabled) {
+      if (!signInExperience.forgotPasswordMethods) {
         return {
           email: hasEmailConnector,
           phone: hasSmsConnector,

--- a/packages/console/src/pages/Mfa/MfaForm/index.tsx
+++ b/packages/console/src/pages/Mfa/MfaForm/index.tsx
@@ -217,60 +217,52 @@ function MfaForm({ data, signInMethods, onMfaUpdated }: Props) {
                 label={<FactorLabel type={MfaFactor.TOTP} />}
                 {...register('totpEnabled')}
               />
-              {isDevFeaturesEnabled && (
-                <>
-                  <div>
-                    <Switch
-                      disabled={isMfaDisabled || isPhoneCodePrimarySignInMethod}
-                      label={<FactorLabel type={MfaFactor.PhoneVerificationCode} />}
-                      tooltip={
-                        isPhoneCodePrimarySignInMethod
-                          ? t('mfa.phone_primary_method_tip')
-                          : undefined
-                      }
-                      {...register('phoneVerificationCodeEnabled')}
-                    />
-                    {formValues.phoneVerificationCodeEnabled && !hasSmsConnector && (
-                      <InlineNotification className={styles.connectorWarning}>
-                        <Trans
-                          components={{
-                            a: <TextLink to="/connectors" />,
-                          }}
-                        >
-                          {t('mfa.no_sms_connector_warning', {
-                            link: t('mfa.setup_link'),
-                          })}
-                        </Trans>
-                      </InlineNotification>
-                    )}
-                  </div>
-                  <div>
-                    <Switch
-                      disabled={isMfaDisabled || isEmailCodePrimarySignInMethod}
-                      label={<FactorLabel type={MfaFactor.EmailVerificationCode} />}
-                      tooltip={
-                        isEmailCodePrimarySignInMethod
-                          ? t('mfa.email_primary_method_tip')
-                          : undefined
-                      }
-                      {...register('emailVerificationCodeEnabled')}
-                    />
-                    {formValues.emailVerificationCodeEnabled && !hasEmailConnector && (
-                      <InlineNotification className={styles.connectorWarning}>
-                        <Trans
-                          components={{
-                            a: <TextLink to="/connectors" />,
-                          }}
-                        >
-                          {t('mfa.no_email_connector_warning', {
-                            link: t('mfa.setup_link'),
-                          })}
-                        </Trans>
-                      </InlineNotification>
-                    )}
-                  </div>
-                </>
-              )}
+              <div>
+                <Switch
+                  disabled={isMfaDisabled || isPhoneCodePrimarySignInMethod}
+                  label={<FactorLabel type={MfaFactor.PhoneVerificationCode} />}
+                  tooltip={
+                    isPhoneCodePrimarySignInMethod ? t('mfa.phone_primary_method_tip') : undefined
+                  }
+                  {...register('phoneVerificationCodeEnabled')}
+                />
+                {formValues.phoneVerificationCodeEnabled && !hasSmsConnector && (
+                  <InlineNotification className={styles.connectorWarning}>
+                    <Trans
+                      components={{
+                        a: <TextLink to="/connectors" />,
+                      }}
+                    >
+                      {t('mfa.no_sms_connector_warning', {
+                        link: t('mfa.setup_link'),
+                      })}
+                    </Trans>
+                  </InlineNotification>
+                )}
+              </div>
+              <div>
+                <Switch
+                  disabled={isMfaDisabled || isEmailCodePrimarySignInMethod}
+                  label={<FactorLabel type={MfaFactor.EmailVerificationCode} />}
+                  tooltip={
+                    isEmailCodePrimarySignInMethod ? t('mfa.email_primary_method_tip') : undefined
+                  }
+                  {...register('emailVerificationCodeEnabled')}
+                />
+                {formValues.emailVerificationCodeEnabled && !hasEmailConnector && (
+                  <InlineNotification className={styles.connectorWarning}>
+                    <Trans
+                      components={{
+                        a: <TextLink to="/connectors" />,
+                      }}
+                    >
+                      {t('mfa.no_email_connector_warning', {
+                        link: t('mfa.setup_link'),
+                      })}
+                    </Trans>
+                  </InlineNotification>
+                )}
+              </div>
               <div className={styles.backupCodeField}>
                 <div className={styles.backupCodeDescription}>
                   <DynamicT forKey="mfa.backup_code_setup_hint" />

--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignInForm/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignInForm/index.tsx
@@ -2,7 +2,6 @@ import type { SignInExperience } from '@logto/schemas';
 import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
-import { isDevFeaturesEnabled } from '@/consts/env';
 import Card from '@/ds-components/Card';
 import FormField from '@/ds-components/FormField';
 
@@ -33,7 +32,7 @@ function SignInForm({ signInExperience }: Props) {
         </FormFieldDescription>
         <SignInMethodEditBox signInExperience={signInExperience} />
       </FormField>
-      {isDevFeaturesEnabled && hasPasswordMethod && <ForgotPasswordMethodEditBox />}
+      {hasPasswordMethod && <ForgotPasswordMethodEditBox />}
     </Card>
   );
 }

--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignInChangePreview/SignUpAndSignInDiffSection/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignInChangePreview/SignUpAndSignInDiffSection/index.tsx
@@ -1,4 +1,3 @@
-import { isDevFeaturesEnabled } from '@/consts/env';
 import { type SignInExperiencePageManagedData } from '@/pages/SignInExperience/types';
 
 import ForgotPasswordMethodsDiffSection from './ForgotPasswordMethodsDiffSection';
@@ -26,13 +25,11 @@ function SignUpAndSignInDiffSection({ before, after, isAfter = false }: Props) {
         after={after.socialSignInConnectorTargets}
         isAfter={isAfter}
       />
-      {isDevFeaturesEnabled && (
-        <ForgotPasswordMethodsDiffSection
-          before={before.forgotPasswordMethods ?? undefined}
-          after={after.forgotPasswordMethods ?? undefined}
-          isAfter={isAfter}
-        />
-      )}
+      <ForgotPasswordMethodsDiffSection
+        before={before.forgotPasswordMethods ?? undefined}
+        after={after.forgotPasswordMethods ?? undefined}
+        isAfter={isAfter}
+      />
     </>
   );
 }

--- a/packages/console/src/pages/SignInExperience/PageContent/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/index.tsx
@@ -8,7 +8,6 @@ import { useParams } from 'react-router-dom';
 
 import SubmitFormChangesActionBar from '@/components/SubmitFormChangesActionBar';
 import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
-import { isDevFeaturesEnabled } from '@/consts/env';
 import ConfirmModal from '@/ds-components/ConfirmModal';
 import TabNav, { TabNavItem } from '@/ds-components/TabNav';
 import useApi from '@/hooks/use-api';
@@ -132,10 +131,6 @@ function PageContent({ data, onSignInExperienceUpdated }: Props) {
 
   // Forgot password migration from null to normal array
   useEffect(() => {
-    if (!isDevFeaturesEnabled) {
-      return;
-    }
-
     // Wait for connectors list loading to be ready
     if (!isConnectorsReady) {
       return;

--- a/packages/console/src/pages/SignInExperience/PageContent/utils/form.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/utils/form.ts
@@ -2,8 +2,6 @@ import type { SignUp, ForgotPasswordMethod } from '@logto/schemas';
 import { diff } from 'deep-object-diff';
 import type { DeepRequired, FieldErrorsImpl } from 'react-hook-form';
 
-import { isDevFeaturesEnabled } from '@/consts/env';
-
 import type {
   SignInExperienceForm,
   SignInExperiencePageManagedData,
@@ -34,9 +32,7 @@ const hasSocialTargetsChanged = (before: string[], after: string[]) =>
 const hasForgotPasswordMethodsChanged = (
   before: readonly ForgotPasswordMethod[] | undefined,
   after: readonly ForgotPasswordMethod[] | undefined
-) =>
-  isDevFeaturesEnabled &&
-  Object.keys(diff((before ?? []).slice().sort(), (after ?? []).slice().sort())).length > 0;
+) => Object.keys(diff((before ?? []).slice().sort(), (after ?? []).slice().sort())).length > 0;
 
 export const hasSignUpAndSignInConfigChanged = (
   before: SignInExperiencePageManagedData,

--- a/packages/console/src/pages/SignInExperience/PageContent/utils/parser.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/utils/parser.ts
@@ -7,7 +7,6 @@ import {
 } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
 
-import { isDevFeaturesEnabled } from '@/consts/env';
 import { emptyBranding } from '@/types/sign-in-experience';
 import { removeFalsyValues } from '@/utils/object';
 
@@ -148,8 +147,6 @@ export const sieFormDataParser = {
       signUp: signUpFormDataParser.toSignUp(signUp),
       signInMode: createAccountEnabled ? SignInMode.SignInAndRegister : SignInMode.SignIn,
       customCss: customCss?.length ? customCss : null,
-      // TODO @wangsijie: Remove this once forgot password methods feature is ready for production.
-      forgotPasswordMethods: isDevFeaturesEnabled ? forgotPasswordMethods : null,
     };
   },
 };

--- a/packages/core/src/libraries/sign-in-experience/index.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.ts
@@ -284,9 +284,9 @@ export const createSignInExperienceLibrary = (
       const hasEmailConnector = logtoConnectors.some(({ type }) => type === ConnectorType.Email);
       const hasSmsConnector = logtoConnectors.some(({ type }) => type === ConnectorType.Sms);
 
-      // If forgotPasswordMethods is null (production compatibility) or dev features are not enabled,
+      // If forgotPasswordMethods is null (production compatibility),
       // fall back to connector-based availability only
-      if (!signInExperience.forgotPasswordMethods || !EnvSet.values.isDevFeaturesEnabled) {
+      if (!signInExperience.forgotPasswordMethods) {
         return {
           email: hasEmailConnector,
           phone: hasSmsConnector,

--- a/packages/core/src/libraries/sign-in-experience/mfa.ts
+++ b/packages/core/src/libraries/sign-in-experience/mfa.ts
@@ -2,8 +2,6 @@ import { MfaFactor, SignInIdentifier, type Mfa, type SignIn } from '@logto/schem
 
 import assertThat from '#src/utils/assert-that.js';
 
-import { EnvSet } from '../../env-set/index.js';
-
 export const validateMfa = (mfa: Mfa, signIn?: SignIn) => {
   assertThat(
     new Set(mfa.factors).size === mfa.factors.length,
@@ -14,15 +12,6 @@ export const validateMfa = (mfa: Mfa, signIn?: SignIn) => {
 
   if (backupCodeEnabled) {
     assertThat(mfa.factors.length > 1, 'sign_in_experiences.backup_code_cannot_be_enabled_alone');
-  }
-
-  // TODO @wangsijie: Remove this guard when features are ready
-  if (
-    !EnvSet.values.isDevFeaturesEnabled &&
-    (mfa.factors.includes(MfaFactor.EmailVerificationCode) ||
-      mfa.factors.includes(MfaFactor.PhoneVerificationCode))
-  ) {
-    throw new Error('Not implemented');
   }
 
   // Validate that email/phone verification codes are not used as both sign-in method and MFA

--- a/packages/core/src/routes/account/index.openapi.json
+++ b/packages/core/src/routes/account/index.openapi.json
@@ -147,7 +147,6 @@
       "get": {
         "operationId": "GetMfaSettings",
         "summary": "Get MFA settings",
-        "tags": ["Dev feature"],
         "description": "Get MFA settings for the user. This endpoint requires the Identities scope. Returns current MFA configuration preferences.",
         "responses": {
           "200": {
@@ -161,7 +160,6 @@
       "patch": {
         "operationId": "UpdateMfaSettings",
         "summary": "Update MFA settings",
-        "tags": ["Dev feature"],
         "description": "Update MFA settings for the user. This endpoint requires identity verification and the Identities scope. Controls whether MFA verification is required during sign-in when the user has MFA configured.",
         "responses": {
           "200": {

--- a/packages/core/src/routes/experience/classes/helpers.ts
+++ b/packages/core/src/routes/experience/classes/helpers.ts
@@ -237,10 +237,6 @@ export const getAllUserEnabledMfaVerifications = (
     })
     .map(({ type }) => type);
 
-  if (!EnvSet.values.isDevFeaturesEnabled) {
-    return storedVerifications;
-  }
-
   const email = currentProfile?.primaryEmail ?? user.primaryEmail;
   const phone = currentProfile?.primaryPhone ?? user.primaryPhone;
 

--- a/packages/core/src/routes/experience/classes/libraries/sign-in-experience-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/sign-in-experience-validator.ts
@@ -9,7 +9,6 @@ import {
   VerificationType,
 } from '@logto/schemas';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { validateEmailAgainstBlocklistPolicy } from '#src/libraries/sign-in-experience/index.js';
 import type Libraries from '#src/tenants/Libraries.js';
@@ -351,24 +350,22 @@ export class SignInExperienceValidator {
       new RequestError({ code: 'session.not_supported_for_forgot_password', status: 422 })
     );
 
-    if (EnvSet.values.isDevFeaturesEnabled) {
-      const { forgotPasswordMethods } = await this.getSignInExperienceData();
+    const { forgotPasswordMethods } = await this.getSignInExperienceData();
 
-      // If forgotPasswordMethods is null, fallback to connector-based validation (allow all)
-      if (forgotPasswordMethods) {
-        if (verificationRecord.type === VerificationType.EmailVerificationCode) {
-          assertThat(
-            forgotPasswordMethods.includes(ForgotPasswordMethod.EmailVerificationCode),
-            new RequestError({ code: 'session.not_supported_for_forgot_password', status: 422 })
-          );
-        }
+    // If forgotPasswordMethods is null, fallback to connector-based validation (allow all)
+    if (forgotPasswordMethods) {
+      if (verificationRecord.type === VerificationType.EmailVerificationCode) {
+        assertThat(
+          forgotPasswordMethods.includes(ForgotPasswordMethod.EmailVerificationCode),
+          new RequestError({ code: 'session.not_supported_for_forgot_password', status: 422 })
+        );
+      }
 
-        if (verificationRecord.type === VerificationType.PhoneVerificationCode) {
-          assertThat(
-            forgotPasswordMethods.includes(ForgotPasswordMethod.PhoneVerificationCode),
-            new RequestError({ code: 'session.not_supported_for_forgot_password', status: 422 })
-          );
-        }
+      if (verificationRecord.type === VerificationType.PhoneVerificationCode) {
+        assertThat(
+          forgotPasswordMethods.includes(ForgotPasswordMethod.PhoneVerificationCode),
+          new RequestError({ code: 'session.not_supported_for_forgot_password', status: 422 })
+        );
       }
     }
   }

--- a/packages/core/src/routes/experience/classes/mfa.ts
+++ b/packages/core/src/routes/experience/classes/mfa.ts
@@ -27,7 +27,6 @@ import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
-import { EnvSet } from '../../../env-set/index.js';
 import { type InteractionContext } from '../types.js';
 
 import { getAllUserEnabledMfaVerifications } from './helpers.js';
@@ -440,10 +439,8 @@ export class Mfa {
       )
     );
 
-    if (EnvSet.values.isDevFeaturesEnabled) {
-      // Optional suggestion: Let Mfa decide whether to suggest additional binding during registration
-      await this.guardAdditionalBindingSuggestion(factorsInUser, availableFactors);
-    }
+    // Optional suggestion: Let Mfa decide whether to suggest additional binding during registration
+    await this.guardAdditionalBindingSuggestion(factorsInUser, availableFactors);
 
     // Assert backup code
     assertThat(

--- a/packages/core/src/routes/experience/profile-routes.openapi.json
+++ b/packages/core/src/routes/experience/profile-routes.openapi.json
@@ -108,7 +108,6 @@
       "post": {
         "operationId": "SkipMfaSuggestion",
         "summary": "Skip additional MFA suggestion",
-        "tags": ["Dev feature"],
         "description": "Mark the optional additional MFA binding suggestion as skipped for the current interaction. When multiple MFA factors are enabled and only an email/phone factor is configured, a suggestion to add another factor may be shown; this endpoint records the choice to skip.",
         "responses": {
           "204": {

--- a/packages/core/src/routes/experience/profile-routes.ts
+++ b/packages/core/src/routes/experience/profile-routes.ts
@@ -14,8 +14,6 @@ import koaGuard from '#src/middleware/koa-guard.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 
-import { EnvSet } from '../../env-set/index.js';
-
 import { createNewMfaCodeVerificationRecord } from './classes/verifications/code-verification.js';
 import { experienceRoutes } from './const.js';
 import { type ExperienceInteractionRouterContext } from './types.js';
@@ -187,23 +185,21 @@ export default function interactionProfileRoutes<T extends ExperienceInteraction
   );
 
   // Mark optional additional MFA binding suggestion as skipped in current interaction
-  if (EnvSet.values.isDevFeaturesEnabled) {
-    router.post(
-      `${experienceRoutes.mfa}/mfa-suggestion-skipped`,
-      koaGuard({ status: [204, 400, 403, 404, 422] }),
-      verifiedInteractionGuard(),
-      async (ctx, next) => {
-        const { experienceInteraction } = ctx;
+  router.post(
+    `${experienceRoutes.mfa}/mfa-suggestion-skipped`,
+    koaGuard({ status: [204, 400, 403, 404, 422] }),
+    verifiedInteractionGuard(),
+    async (ctx, next) => {
+      const { experienceInteraction } = ctx;
 
-        experienceInteraction.mfa.skipAdditionalBindingSuggestion();
-        await experienceInteraction.save();
+      experienceInteraction.mfa.skipAdditionalBindingSuggestion();
+      await experienceInteraction.save();
 
-        ctx.status = 204;
+      ctx.status = 204;
 
-        return next();
-      }
-    );
-  }
+      return next();
+    }
+  );
 
   router.post(
     `${experienceRoutes.mfa}`,
@@ -241,10 +237,6 @@ export default function interactionProfileRoutes<T extends ExperienceInteraction
           break;
         }
         case MfaFactor.EmailVerificationCode: {
-          if (!EnvSet.values.isDevFeaturesEnabled) {
-            throw new Error('Not implemented yet');
-          }
-
           await experienceInteraction.profile.setProfileByVerificationId(
             SignInIdentifier.Email,
             verificationId,
@@ -268,10 +260,6 @@ export default function interactionProfileRoutes<T extends ExperienceInteraction
           break;
         }
         case MfaFactor.PhoneVerificationCode: {
-          if (!EnvSet.values.isDevFeaturesEnabled) {
-            throw new Error('Not implemented yet');
-          }
-
           await experienceInteraction.profile.setProfileByVerificationId(
             SignInIdentifier.Phone,
             verificationId,

--- a/packages/core/src/routes/sign-in-experience/index.ts
+++ b/packages/core/src/routes/sign-in-experience/index.ts
@@ -4,7 +4,6 @@ import { ConnectorType, SignInExperiences, ForgotPasswordMethod } from '@logto/s
 import { conditional, tryThat } from '@silverhand/essentials';
 import { literal, object, string, z } from 'zod';
 
-import { EnvSet } from '#src/env-set/index.js';
 import {
   validateSignUp,
   validateSignIn,
@@ -127,7 +126,7 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
         validateMfa(mfa, currentSignIn);
       }
 
-      if (forgotPasswordMethods && EnvSet.values.isDevFeaturesEnabled) {
+      if (forgotPasswordMethods) {
         const hasEmailConnector = connectors.some(({ type }) => type === ConnectorType.Email);
         const hasSmsConnector = connectors.some(({ type }) => type === ConnectorType.Sms);
 

--- a/packages/experience/src/App.tsx
+++ b/packages/experience/src/App.tsx
@@ -8,7 +8,6 @@ import LoadingLayerProvider from './Providers/LoadingLayerProvider';
 import PageContextProvider from './Providers/PageContextProvider';
 import SettingsProvider from './Providers/SettingsProvider';
 import UserInteractionContextProvider from './Providers/UserInteractionContextProvider';
-import { isDevFeaturesEnabled } from './constants/env';
 import DevelopmentTenantNotification from './containers/DevelopmentTenantNotification';
 import Callback from './pages/Callback';
 import Consent from './pages/Consent';
@@ -107,18 +106,14 @@ const App = () => {
                         <Route path={MfaFactor.TOTP} element={<TotpBinding />} />
                         <Route path={MfaFactor.WebAuthn} element={<WebAuthnBinding />} />
                         <Route path={MfaFactor.BackupCode} element={<BackupCodeBinding />} />
-                        {isDevFeaturesEnabled && (
-                          <Route
-                            path={MfaFactor.EmailVerificationCode}
-                            element={<EmailMfaBinding />}
-                          />
-                        )}
-                        {isDevFeaturesEnabled && (
-                          <Route
-                            path={MfaFactor.PhoneVerificationCode}
-                            element={<PhoneMfaBinding />}
-                          />
-                        )}
+                        <Route
+                          path={MfaFactor.EmailVerificationCode}
+                          element={<EmailMfaBinding />}
+                        />
+                        <Route
+                          path={MfaFactor.PhoneVerificationCode}
+                          element={<PhoneMfaBinding />}
+                        />
                       </Route>
 
                       {/* Mfa verification */}

--- a/packages/integration-tests/src/tests/api/account/mfa-settings.test.ts
+++ b/packages/integration-tests/src/tests/api/account/mfa-settings.test.ts
@@ -11,16 +11,15 @@ import {
   signInAndGetUserApi,
 } from '#src/helpers/profile.js';
 import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
-import { devFeatureTest } from '#src/utils.js';
 
-devFeatureTest.describe('my-account (mfa-settings)', () => {
+describe('my-account (mfa-settings)', () => {
   beforeAll(async () => {
     await enableAllPasswordSignInMethods();
     await enableAllAccountCenterFields();
   });
 
-  devFeatureTest.describe('GET /api/my-account/mfa-settings', () => {
-    devFeatureTest.it('should get default MFA settings', async () => {
+  describe('GET /api/my-account/mfa-settings', () => {
+    it('should get default MFA settings', async () => {
       const { user, username, password } = await createDefaultTenantUserWithPassword();
       const api = await signInAndGetUserApi(username, password, {
         scopes: [UserScope.Profile, UserScope.Identities],
@@ -35,7 +34,7 @@ devFeatureTest.describe('my-account (mfa-settings)', () => {
       await deleteDefaultTenantUser(user.id);
     });
 
-    devFeatureTest.it('should throw error if user does not have Identities scope', async () => {
+    it('should throw error if user does not have Identities scope', async () => {
       const { user, username, password } = await createDefaultTenantUserWithPassword();
       const api = await signInAndGetUserApi(username, password, {
         scopes: [UserScope.Profile], // Missing Identities scope
@@ -49,30 +48,27 @@ devFeatureTest.describe('my-account (mfa-settings)', () => {
       await deleteDefaultTenantUser(user.id);
     });
 
-    devFeatureTest.it(
-      'should throw error if MFA field is not enabled in account center',
-      async () => {
-        await updateAccountCenter({
-          enabled: true,
-          fields: { mfa: AccountCenterControlValue.Off },
-        });
+    it('should throw error if MFA field is not enabled in account center', async () => {
+      await updateAccountCenter({
+        enabled: true,
+        fields: { mfa: AccountCenterControlValue.Off },
+      });
 
-        const { user, username, password } = await createDefaultTenantUserWithPassword();
-        const api = await signInAndGetUserApi(username, password, {
-          scopes: [UserScope.Profile, UserScope.Identities],
-        });
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
+      const api = await signInAndGetUserApi(username, password, {
+        scopes: [UserScope.Profile, UserScope.Identities],
+      });
 
-        await expectRejects(getMfaSettings(api), {
-          code: 'account_center.field_not_enabled',
-          status: 400,
-        });
+      await expectRejects(getMfaSettings(api), {
+        code: 'account_center.field_not_enabled',
+        status: 400,
+      });
 
-        await deleteDefaultTenantUser(user.id);
-        await enableAllAccountCenterFields(); // Reset for other tests
-      }
-    );
+      await deleteDefaultTenantUser(user.id);
+      await enableAllAccountCenterFields(); // Reset for other tests
+    });
 
-    devFeatureTest.it('should work when MFA field is ReadOnly', async () => {
+    it('should work when MFA field is ReadOnly', async () => {
       await updateAccountCenter({
         enabled: true,
         fields: { mfa: AccountCenterControlValue.ReadOnly },
@@ -94,8 +90,8 @@ devFeatureTest.describe('my-account (mfa-settings)', () => {
     });
   });
 
-  devFeatureTest.describe('PATCH /api/my-account/mfa-settings', () => {
-    devFeatureTest.it('should update MFA settings successfully', async () => {
+  describe('PATCH /api/my-account/mfa-settings', () => {
+    it('should update MFA settings successfully', async () => {
       const { user, username, password } = await createDefaultTenantUserWithPassword();
       const api = await signInAndGetUserApi(username, password, {
         scopes: [UserScope.Profile, UserScope.Identities],
@@ -116,7 +112,7 @@ devFeatureTest.describe('my-account (mfa-settings)', () => {
       await deleteDefaultTenantUser(user.id);
     });
 
-    devFeatureTest.it('should throw error if user does not have Identities scope', async () => {
+    it('should throw error if user does not have Identities scope', async () => {
       const { user, username, password } = await createDefaultTenantUserWithPassword();
       const api = await signInAndGetUserApi(username, password, {
         scopes: [UserScope.Profile], // Missing Identities scope
@@ -132,7 +128,7 @@ devFeatureTest.describe('my-account (mfa-settings)', () => {
       await deleteDefaultTenantUser(user.id);
     });
 
-    devFeatureTest.it('should throw error if identity is not verified', async () => {
+    it('should throw error if identity is not verified', async () => {
       const { user, username, password } = await createDefaultTenantUserWithPassword();
       const api = await signInAndGetUserApi(username, password, {
         scopes: [UserScope.Profile, UserScope.Identities],
@@ -147,7 +143,7 @@ devFeatureTest.describe('my-account (mfa-settings)', () => {
       await deleteDefaultTenantUser(user.id);
     });
 
-    devFeatureTest.it('should throw error if MFA field is not editable', async () => {
+    it('should throw error if MFA field is not editable', async () => {
       await updateAccountCenter({
         enabled: true,
         fields: { mfa: AccountCenterControlValue.ReadOnly },
@@ -169,7 +165,7 @@ devFeatureTest.describe('my-account (mfa-settings)', () => {
       await enableAllAccountCenterFields(); // Reset for other tests
     });
 
-    devFeatureTest.it('should throw error if MFA field is disabled', async () => {
+    it('should throw error if MFA field is disabled', async () => {
       await updateAccountCenter({
         enabled: true,
         fields: { mfa: AccountCenterControlValue.Off },

--- a/packages/integration-tests/src/tests/api/experience-api/bind-mfa/email-phone.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/bind-mfa/email-phone.test.ts
@@ -23,9 +23,7 @@ import {
   resetMfaSettings,
 } from '#src/helpers/sign-in-experience.js';
 import { generateNewUserProfile, UserApiTest } from '#src/helpers/user.js';
-import { devFeatureTest, generateEmail, generatePhone } from '#src/utils.js';
-
-const { describe, it } = devFeatureTest;
+import { generateEmail, generatePhone } from '#src/utils.js';
 
 const mfaConfigs = [
   {

--- a/packages/integration-tests/src/tests/api/experience-api/bind-mfa/email-with-signup.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/bind-mfa/email-with-signup.test.ts
@@ -12,9 +12,7 @@ import {
   successfullyVerifyVerificationCode,
 } from '#src/helpers/experience/verification-code.js';
 import { enableMandatoryMfaWithEmail, resetMfaSettings } from '#src/helpers/sign-in-experience.js';
-import { devFeatureTest, generateEmail, generatePassword } from '#src/utils.js';
-
-const { describe, it } = devFeatureTest;
+import { generateEmail, generatePassword } from '#src/utils.js';
 
 describe('Register with email identifier and bind as email MFA automaticly', () => {
   beforeAll(async () => {

--- a/packages/integration-tests/src/tests/api/experience-api/bind-mfa/mfa-suggestion.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/bind-mfa/mfa-suggestion.test.ts
@@ -12,9 +12,6 @@ import {
 import { expectRejects } from '#src/helpers/index.js';
 import { resetMfaSettings } from '#src/helpers/sign-in-experience.js';
 import { generateNewUserProfile } from '#src/helpers/user.js';
-import { devFeatureTest } from '#src/utils.js';
-
-const { describe, it } = devFeatureTest;
 
 describe('Register interaction - optional additional MFA suggestion', () => {
   beforeAll(async () => {

--- a/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/skip-mfa-on-sign-in.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/skip-mfa-on-sign-in.test.ts
@@ -15,9 +15,8 @@ import {
 } from '#src/helpers/profile.js';
 import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
 import { UserApiTest } from '#src/helpers/user.js';
-import { devFeatureTest } from '#src/utils.js';
 
-devFeatureTest.describe('skipMfaOnSignIn user setting', () => {
+describe('skipMfaOnSignIn user setting', () => {
   const userApi = new UserApiTest();
 
   beforeAll(async () => {
@@ -39,8 +38,8 @@ devFeatureTest.describe('skipMfaOnSignIn user setting', () => {
     await userApi.cleanUp();
   });
 
-  devFeatureTest.describe('MFA bypass functionality', () => {
-    devFeatureTest.it('should bypass MFA when skipMfaOnSignIn is true', async () => {
+  describe('MFA bypass functionality', () => {
+    it('should bypass MFA when skipMfaOnSignIn is true', async () => {
       const { user, username, password } = await createDefaultTenantUserWithPassword();
       const api = await signInAndGetUserApi(username, password, {
         scopes: [UserScope.Profile, UserScope.Identities],
@@ -63,8 +62,8 @@ devFeatureTest.describe('skipMfaOnSignIn user setting', () => {
     });
   });
 
-  devFeatureTest.describe('Mandatory MFA policy override', () => {
-    devFeatureTest.it('should ignore user setting when MFA policy is Mandatory', async () => {
+  describe('Mandatory MFA policy override', () => {
+    it('should ignore user setting when MFA policy is Mandatory', async () => {
       const { user, username, password } = await createDefaultTenantUserWithPassword();
 
       // First, set up MFA factor and disable MFA requirement using the user API

--- a/packages/integration-tests/src/tests/api/experience-api/verifications/email-phone-mfa-verification.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/verifications/email-phone-mfa-verification.test.ts
@@ -23,9 +23,6 @@ import {
   resetMfaSettings,
 } from '#src/helpers/sign-in-experience.js';
 import { generateNewUserProfile, UserApiTest } from '#src/helpers/user.js';
-import { devFeatureTest } from '#src/utils.js';
-
-const { describe, it } = devFeatureTest;
 
 const mfaTestCases = [
   {

--- a/packages/integration-tests/src/tests/api/sign-in-experience.forgot-password.test.ts
+++ b/packages/integration-tests/src/tests/api/sign-in-experience.forgot-password.test.ts
@@ -7,14 +7,13 @@ import {
   setSmsConnector,
 } from '#src/helpers/connector.js';
 import { expectRejects } from '#src/helpers/index.js';
-import { devFeatureTest } from '#src/utils.js';
 
-devFeatureTest.describe('forgot password methods', () => {
+describe('forgot password methods', () => {
   afterEach(async () => {
     await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);
   });
 
-  devFeatureTest.it('should update forgot password methods successfully', async () => {
+  it('should update forgot password methods successfully', async () => {
     await Promise.all([setEmailConnector(), setSmsConnector()]);
 
     const forgotPasswordMethods = [
@@ -29,37 +28,31 @@ devFeatureTest.describe('forgot password methods', () => {
     expect(result.forgotPasswordMethods).toEqual(forgotPasswordMethods);
   });
 
-  devFeatureTest.it(
-    'should reject email forgot password method when no email connector exists',
-    async () => {
-      await clearConnectorsByTypes([ConnectorType.Email]);
+  it('should reject email forgot password method when no email connector exists', async () => {
+    await clearConnectorsByTypes([ConnectorType.Email]);
 
-      await expectRejects(
-        updateSignInExperience({
-          forgotPasswordMethods: [ForgotPasswordMethod.EmailVerificationCode],
-        }),
-        {
-          code: 'sign_in_experiences.forgot_password_method_requires_connector',
-          status: 400,
-        }
-      );
-    }
-  );
+    await expectRejects(
+      updateSignInExperience({
+        forgotPasswordMethods: [ForgotPasswordMethod.EmailVerificationCode],
+      }),
+      {
+        code: 'sign_in_experiences.forgot_password_method_requires_connector',
+        status: 400,
+      }
+    );
+  });
 
-  devFeatureTest.it(
-    'should reject phone forgot password method when no SMS connector exists',
-    async () => {
-      await clearConnectorsByTypes([ConnectorType.Sms]);
+  it('should reject phone forgot password method when no SMS connector exists', async () => {
+    await clearConnectorsByTypes([ConnectorType.Sms]);
 
-      await expectRejects(
-        updateSignInExperience({
-          forgotPasswordMethods: [ForgotPasswordMethod.PhoneVerificationCode],
-        }),
-        {
-          code: 'sign_in_experiences.forgot_password_method_requires_connector',
-          status: 400,
-        }
-      );
-    }
-  );
+    await expectRejects(
+      updateSignInExperience({
+        forgotPasswordMethods: [ForgotPasswordMethod.PhoneVerificationCode],
+      }),
+      {
+        code: 'sign_in_experiences.forgot_password_method_requires_connector',
+        status: 400,
+      }
+    );
+  });
 });

--- a/packages/integration-tests/src/tests/api/sign-in-experience.test.ts
+++ b/packages/integration-tests/src/tests/api/sign-in-experience.test.ts
@@ -20,6 +20,7 @@ import {
   setSmsConnector,
 } from '#src/helpers/connector.js';
 import { expectRejects } from '#src/helpers/index.js';
+import { defaultSignInSignUpConfigs } from '#src/helpers/sign-in-experience.js';
 import { generatePassword } from '#src/utils.js';
 
 describe('admin console sign-in experience', () => {
@@ -196,16 +197,7 @@ describe('MFA validation', () => {
     await Promise.all([setEmailConnector(), setSmsConnector()]);
     // Clear sign in experience before each test
     await updateSignInExperience({
-      signIn: {
-        methods: [
-          {
-            identifier: SignInIdentifier.Username,
-            password: true,
-            verificationCode: false,
-            isPasswordPrimary: true,
-          },
-        ],
-      },
+      ...defaultSignInSignUpConfigs,
       mfa: {
         policy: MfaPolicy.NoPrompt,
         factors: [],

--- a/packages/integration-tests/src/tests/api/sign-in-experience.test.ts
+++ b/packages/integration-tests/src/tests/api/sign-in-experience.test.ts
@@ -20,7 +20,7 @@ import {
   setSmsConnector,
 } from '#src/helpers/connector.js';
 import { expectRejects } from '#src/helpers/index.js';
-import { devFeatureTest, generatePassword } from '#src/utils.js';
+import { generatePassword } from '#src/utils.js';
 
 describe('admin console sign-in experience', () => {
   afterAll(async () => {
@@ -191,7 +191,7 @@ describe('password policy', () => {
   });
 });
 
-devFeatureTest.describe('MFA validation', () => {
+describe('MFA validation', () => {
   beforeEach(async () => {
     await Promise.all([setEmailConnector(), setSmsConnector()]);
     // Clear sign in experience before each test
@@ -217,183 +217,165 @@ devFeatureTest.describe('MFA validation', () => {
     await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);
   });
 
-  devFeatureTest.it(
-    'should reject email verification code MFA when email verification is used for sign-in',
-    async () => {
-      await updateSignInExperience({
-        signIn: {
-          methods: [
-            {
-              identifier: SignInIdentifier.Email,
-              password: false,
-              verificationCode: true,
-              isPasswordPrimary: false,
-            },
-          ],
-        },
-      });
-
-      await expectRejects(
-        updateSignInExperience({
-          mfa: {
-            policy: MfaPolicy.Mandatory,
-            factors: [MfaFactor.EmailVerificationCode, MfaFactor.TOTP],
+  it('should reject email verification code MFA when email verification is used for sign-in', async () => {
+    await updateSignInExperience({
+      signIn: {
+        methods: [
+          {
+            identifier: SignInIdentifier.Email,
+            password: false,
+            verificationCode: true,
+            isPasswordPrimary: false,
           },
-        }),
-        {
-          code: 'sign_in_experiences.email_verification_code_cannot_be_used_for_mfa',
-          status: 400,
-        }
-      );
-    }
-  );
+        ],
+      },
+    });
 
-  devFeatureTest.it(
-    'should reject phone verification code MFA when phone verification is used for sign-in',
-    async () => {
-      await updateSignInExperience({
-        signIn: {
-          methods: [
-            {
-              identifier: SignInIdentifier.Phone,
-              password: false,
-              verificationCode: true,
-              isPasswordPrimary: false,
-            },
-          ],
-        },
-      });
-
-      await expectRejects(
-        updateSignInExperience({
-          mfa: {
-            policy: MfaPolicy.Mandatory,
-            factors: [MfaFactor.PhoneVerificationCode, MfaFactor.BackupCode],
-          },
-        }),
-        {
-          code: 'sign_in_experiences.phone_verification_code_cannot_be_used_for_mfa',
-          status: 400,
-        }
-      );
-    }
-  );
-
-  devFeatureTest.it(
-    'should allow email verification code MFA when email is used with password for sign-in',
-    async () => {
-      await updateSignInExperience({
-        signIn: {
-          methods: [
-            {
-              identifier: SignInIdentifier.Email,
-              password: true,
-              verificationCode: false,
-              isPasswordPrimary: true,
-            },
-          ],
-        },
-      });
-
-      const result = await updateSignInExperience({
+    await expectRejects(
+      updateSignInExperience({
         mfa: {
           policy: MfaPolicy.Mandatory,
           factors: [MfaFactor.EmailVerificationCode, MfaFactor.TOTP],
         },
-      });
+      }),
+      {
+        code: 'sign_in_experiences.email_verification_code_cannot_be_used_for_mfa',
+        status: 400,
+      }
+    );
+  });
 
-      expect(result.mfa.factors).toContain(MfaFactor.EmailVerificationCode);
-      expect(result.mfa.factors).toContain(MfaFactor.TOTP);
-    }
-  );
+  it('should reject phone verification code MFA when phone verification is used for sign-in', async () => {
+    await updateSignInExperience({
+      signIn: {
+        methods: [
+          {
+            identifier: SignInIdentifier.Phone,
+            password: false,
+            verificationCode: true,
+            isPasswordPrimary: false,
+          },
+        ],
+      },
+    });
 
-  devFeatureTest.it(
-    'should allow phone verification code MFA when phone is used with password for sign-in',
-    async () => {
-      await updateSignInExperience({
-        signIn: {
-          methods: [
-            {
-              identifier: SignInIdentifier.Phone,
-              password: true,
-              verificationCode: false,
-              isPasswordPrimary: true,
-            },
-          ],
-        },
-      });
-
-      const result = await updateSignInExperience({
+    await expectRejects(
+      updateSignInExperience({
         mfa: {
           policy: MfaPolicy.Mandatory,
-          factors: [MfaFactor.PhoneVerificationCode, MfaFactor.TOTP],
-        },
-      });
-
-      expect(result.mfa.factors).toContain(MfaFactor.PhoneVerificationCode);
-      expect(result.mfa.factors).toContain(MfaFactor.TOTP);
-    }
-  );
-
-  devFeatureTest.it(
-    'should reject email verification code sign-in when email MFA is enabled',
-    async () => {
-      await updateSignInExperience({
-        mfa: {
-          policy: MfaPolicy.NoPrompt,
-          factors: [MfaFactor.EmailVerificationCode, MfaFactor.TOTP],
-        },
-      });
-
-      await expectRejects(
-        updateSignInExperience({
-          signIn: {
-            methods: [
-              {
-                identifier: SignInIdentifier.Email,
-                password: false,
-                verificationCode: true,
-                isPasswordPrimary: false,
-              },
-            ],
-          },
-        }),
-        {
-          code: 'sign_in_experiences.email_verification_code_cannot_be_used_for_sign_in',
-          status: 400,
-        }
-      );
-    }
-  );
-
-  devFeatureTest.it(
-    'should reject phone verification code sign-in when phone MFA is enabled',
-    async () => {
-      await updateSignInExperience({
-        mfa: {
-          policy: MfaPolicy.NoPrompt,
           factors: [MfaFactor.PhoneVerificationCode, MfaFactor.BackupCode],
         },
-      });
+      }),
+      {
+        code: 'sign_in_experiences.phone_verification_code_cannot_be_used_for_mfa',
+        status: 400,
+      }
+    );
+  });
 
-      await expectRejects(
-        updateSignInExperience({
-          signIn: {
-            methods: [
-              {
-                identifier: SignInIdentifier.Phone,
-                password: false,
-                verificationCode: true,
-                isPasswordPrimary: false,
-              },
-            ],
+  it('should allow email verification code MFA when email is used with password for sign-in', async () => {
+    await updateSignInExperience({
+      signIn: {
+        methods: [
+          {
+            identifier: SignInIdentifier.Email,
+            password: true,
+            verificationCode: false,
+            isPasswordPrimary: true,
           },
-        }),
-        {
-          code: 'sign_in_experiences.phone_verification_code_cannot_be_used_for_sign_in',
-          status: 400,
-        }
-      );
-    }
-  );
+        ],
+      },
+    });
+
+    const result = await updateSignInExperience({
+      mfa: {
+        policy: MfaPolicy.Mandatory,
+        factors: [MfaFactor.EmailVerificationCode, MfaFactor.TOTP],
+      },
+    });
+
+    expect(result.mfa.factors).toContain(MfaFactor.EmailVerificationCode);
+    expect(result.mfa.factors).toContain(MfaFactor.TOTP);
+  });
+
+  it('should allow phone verification code MFA when phone is used with password for sign-in', async () => {
+    await updateSignInExperience({
+      signIn: {
+        methods: [
+          {
+            identifier: SignInIdentifier.Phone,
+            password: true,
+            verificationCode: false,
+            isPasswordPrimary: true,
+          },
+        ],
+      },
+    });
+
+    const result = await updateSignInExperience({
+      mfa: {
+        policy: MfaPolicy.Mandatory,
+        factors: [MfaFactor.PhoneVerificationCode, MfaFactor.TOTP],
+      },
+    });
+
+    expect(result.mfa.factors).toContain(MfaFactor.PhoneVerificationCode);
+    expect(result.mfa.factors).toContain(MfaFactor.TOTP);
+  });
+
+  it('should reject email verification code sign-in when email MFA is enabled', async () => {
+    await updateSignInExperience({
+      mfa: {
+        policy: MfaPolicy.NoPrompt,
+        factors: [MfaFactor.EmailVerificationCode, MfaFactor.TOTP],
+      },
+    });
+
+    await expectRejects(
+      updateSignInExperience({
+        signIn: {
+          methods: [
+            {
+              identifier: SignInIdentifier.Email,
+              password: false,
+              verificationCode: true,
+              isPasswordPrimary: false,
+            },
+          ],
+        },
+      }),
+      {
+        code: 'sign_in_experiences.email_verification_code_cannot_be_used_for_sign_in',
+        status: 400,
+      }
+    );
+  });
+
+  it('should reject phone verification code sign-in when phone MFA is enabled', async () => {
+    await updateSignInExperience({
+      mfa: {
+        policy: MfaPolicy.NoPrompt,
+        factors: [MfaFactor.PhoneVerificationCode, MfaFactor.BackupCode],
+      },
+    });
+
+    await expectRejects(
+      updateSignInExperience({
+        signIn: {
+          methods: [
+            {
+              identifier: SignInIdentifier.Phone,
+              password: false,
+              verificationCode: true,
+              isPasswordPrimary: false,
+            },
+          ],
+        },
+      }),
+      {
+        code: 'sign_in_experiences.phone_verification_code_cannot_be_used_for_sign_in',
+        status: 400,
+      }
+    );
+  });
 });

--- a/packages/integration-tests/src/tests/experience/mfa/email-verification/index.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/email-verification/index.test.ts
@@ -9,9 +9,9 @@ import { readConnectorMessage } from '#src/helpers/index.js';
 import { enableMandatoryMfaWithEmail, resetMfaSettings } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
 import ExpectExperience from '#src/ui-helpers/expect-experience.js';
-import { devFeatureTest, generateEmail, waitFor } from '#src/utils.js';
+import { generateEmail, waitFor } from '#src/utils.js';
 
-devFeatureTest.describe('email MFA verification', () => {
+describe('email MFA verification', () => {
   beforeAll(async () => {
     await clearConnectorsByTypes([ConnectorType.Email]);
     await setEmailConnector();

--- a/packages/integration-tests/src/tests/experience/mfa/email/index.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/email/index.test.ts
@@ -8,15 +8,9 @@ import { clearConnectorsByTypes, setEmailConnector } from '#src/helpers/connecto
 import { enableMandatoryMfaWithEmail, resetMfaSettings } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
 import ExpectExperience from '#src/ui-helpers/expect-experience.js';
-import {
-  devFeatureTest,
-  generateEmail,
-  generatePassword,
-  generateUsername,
-  waitFor,
-} from '#src/utils.js';
+import { generateEmail, generatePassword, generateUsername, waitFor } from '#src/utils.js';
 
-devFeatureTest.describe('email MFA binding', () => {
+describe('email MFA binding', () => {
   beforeAll(async () => {
     await clearConnectorsByTypes([ConnectorType.Email]);
     await setEmailConnector();

--- a/packages/integration-tests/src/tests/experience/mfa/phone/index.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/phone/index.test.ts
@@ -8,15 +8,9 @@ import { clearConnectorsByTypes, setSmsConnector } from '#src/helpers/connector.
 import { enableMandatoryMfaWithPhone, resetMfaSettings } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
 import ExpectExperience from '#src/ui-helpers/expect-experience.js';
-import {
-  devFeatureTest,
-  generatePhone,
-  generatePassword,
-  generateUsername,
-  waitFor,
-} from '#src/utils.js';
+import { generatePhone, generatePassword, generateUsername, waitFor } from '#src/utils.js';
 
-devFeatureTest.describe('phone MFA binding', () => {
+describe('phone MFA binding', () => {
   beforeAll(async () => {
     await clearConnectorsByTypes([ConnectorType.Sms]);
     await setSmsConnector();

--- a/packages/integration-tests/src/tests/experience/mfa/suggest-additional-on-register.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/suggest-additional-on-register.test.ts
@@ -8,9 +8,9 @@ import { clearConnectorsByTypes, setEmailConnector } from '#src/helpers/connecto
 import { resetMfaSettings } from '#src/helpers/sign-in-experience.js';
 import ExpectMfaExperience from '#src/ui-helpers/expect-mfa-experience.js';
 import ExpectTotpExperience from '#src/ui-helpers/expect-totp-experience.js';
-import { devFeatureTest, generateEmail } from '#src/utils.js';
+import { generateEmail } from '#src/utils.js';
 
-devFeatureTest.describe('Experience - suggest additional MFA after email registration', () => {
+describe('Experience - suggest additional MFA after email registration', () => {
   beforeAll(async () => {
     await clearConnectorsByTypes([ConnectorType.Email]);
     await setEmailConnector();

--- a/packages/schemas/alterations/next-1756954492-add-default-to-forgot-password-methods.ts
+++ b/packages/schemas/alterations/next-1756954492-add-default-to-forgot-password-methods.ts
@@ -10,11 +10,24 @@ const alteration: AlterationScript = {
       alter table sign_in_experiences
         alter column forgot_password_methods set default '[]'::jsonb;
     `);
+
+    // Update default and admin tenant to [], bypass the alter comparison
+    await pool.query(sql`
+      update sign_in_experiences
+      set forgot_password_methods = '[]'::jsonb
+      where forgot_password_methods is null and (tenant_id = 'admin' or tenant_id = 'default');
+    `);
   },
   down: async (pool) => {
     await pool.query(sql`
       alter table sign_in_experiences
         alter column forgot_password_methods drop default;
+    `);
+
+    await pool.query(sql`
+      update sign_in_experiences
+      set forgot_password_methods = null
+      where forgot_password_methods = '[]'::jsonb and (tenant_id = 'admin' or tenant_id = 'default');
     `);
   },
 };

--- a/packages/schemas/alterations/next-1756954492-add-default-to-forgot-password-methods.ts
+++ b/packages/schemas/alterations/next-1756954492-add-default-to-forgot-password-methods.ts
@@ -1,0 +1,22 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    // Set default value for new rows, but keep the column nullable
+    // to preserve existing null values as migration markers
+    await pool.query(sql`
+      alter table sign_in_experiences
+        alter column forgot_password_methods set default '[]'::jsonb;
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      alter table sign_in_experiences
+        alter column forgot_password_methods drop default;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/gen/schema.ts
+++ b/packages/schemas/src/gen/schema.ts
@@ -52,7 +52,7 @@ export const generateSchema = ({ name, comments, fields }: TableWithType) => {
         `  ${camelcase(name)}${conditionalString(
           (nullable || hasDefaultValue || name === tenantId) && '?'
         )}: ${type}${conditionalString(isArray && '[]')}${conditionalString(
-          nullable && !hasDefaultValue && ' | null'
+          nullable && ' | null'
         )};`
     ),
     '};',
@@ -63,7 +63,7 @@ export const generateSchema = ({ name, comments, fields }: TableWithType) => {
       ({ name, comments, type, isArray, nullable, hasDefaultValue }) =>
         printComments(comments) +
         `  ${camelcase(name)}: ${type}${conditionalString(isArray && '[]')}${
-          nullable && !hasDefaultValue ? ' | null' : ''
+          nullable ? ' | null' : ''
         };`
     ),
     '};',

--- a/packages/schemas/tables/sign_in_experiences.sql
+++ b/packages/schemas/tables/sign_in_experiences.sql
@@ -29,6 +29,6 @@ create table sign_in_experiences (
   captcha_policy jsonb /* @use CaptchaPolicy */ not null default '{}'::jsonb,
   sentinel_policy jsonb /* @use SentinelPolicy */ not null default '{}'::jsonb,
   email_blocklist_policy jsonb /* @use EmailBlocklistPolicy */ not null default '{}'::jsonb,
-  forgot_password_methods jsonb /* @use ForgotPasswordMethods */,
+  forgot_password_methods jsonb /* @use ForgotPasswordMethods */ default '[]'::jsonb,
   primary key (tenant_id, id)
 );


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

This PR removes the email/phone MFA feature flag and sets a default value for the `forgot_password_methods` column. After this PR, there is no need to migrate forgot password methods, so we can safely set all new data to default value `[]`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
