### PR TITLE
refactor(core): introduce new env for multiple custom domains feature

### DIFF
--- a/packages/core/src/routes/domain.test.ts
+++ b/packages/core/src/routes/domain.test.ts
@@ -72,10 +72,10 @@ describe('domain routes', () => {
     expect(response.body.domain).toEqual('test.com');
   });
 
-  it('POST /domains allows creating multiple domains', async () => {
-    const response = await domainRequest.post('/domains').send({ domain: 'another.com' });
-    expect(response.status).toEqual(201);
-    expect(addDomain).toBeCalledWith('another.com');
+  it('POST /domains should fail when there is already a domain', async () => {
+    await expect(
+      domainRequest.post('/domains').send({ domain: mockDomain.domain })
+    ).resolves.toHaveProperty('status', 422);
   });
 
   it('DELETE /domains/:id', async () => {

--- a/packages/core/src/routes/domain.ts
+++ b/packages/core/src/routes/domain.ts
@@ -77,7 +77,7 @@ export default function domainRoutes<T extends ManagementApiRouter>(
       status: [201, 422, 400],
     }),
     async (ctx, next) => {
-      if (!EnvSet.values.isDevFeaturesEnabled) {
+      if (!EnvSet.values.isMultipleCustomDomainsEnabled) {
         const existingDomains = await findAllDomains();
         assertThat(
           existingDomains.length === 0,

--- a/packages/integration-tests/src/tests/api/domains.test.ts
+++ b/packages/integration-tests/src/tests/api/domains.test.ts
@@ -1,7 +1,7 @@
 import { HTTPError } from 'ky';
 
 import { createDomain, deleteDomain, getDomain, getDomains } from '#src/api/domain.js';
-import { devFeatureDisabledTest, devFeatureTest, generateDomain } from '#src/utils.js';
+import { generateDomain } from '#src/utils.js';
 
 describe('domains', () => {
   afterEach(async () => {
@@ -23,22 +23,11 @@ describe('domains', () => {
     expect(domain.domain).toBe(domainName);
   });
 
-  // Todo: @xiaoyijun [Multiple Custom Domains] Remove legacy tests
-  devFeatureDisabledTest.it('should fail when already has a domain', async () => {
+  it('should fail when already has a domain', async () => {
     await createDomain();
 
     const response = await createDomain().catch((error: unknown) => error);
     expect(response instanceof HTTPError && response.response.status).toBe(422);
-  });
-
-  // Todo: @xiaoyijun [Multiple Custom Domains] Remove legacy tests
-  devFeatureTest.it('should create multiple domains', async () => {
-    const first = await createDomain();
-    const second = await createDomain();
-
-    expect(first.id).toBeTruthy();
-    expect(second.id).toBeTruthy();
-    expect(first.id).not.toEqual(second.id);
   });
 
   it('should get domain detail successfully', async () => {

--- a/packages/shared/src/node/env/GlobalValues.ts
+++ b/packages/shared/src/node/env/GlobalValues.ts
@@ -90,6 +90,16 @@ export default class GlobalValues {
   /** If the env explicitly indicates it's in the cloud environment. */
   public readonly isCloud = yes(getEnv('IS_CLOUD'));
 
+  /**
+   * Indicates whether this Logto instance supports multiple custom domains.
+   *
+   * **NOTE: Only available to enterprise customers running private instances that need this feature.**
+   *
+   * Controlled by the `MULTIPLE_CUSTOM_DOMAINS_ENABLED` environment variable. When enabled, the instance
+   * can operate with multiple custom domains across both development and production tenants.
+   */
+  public readonly isMultipleCustomDomainsEnabled = yes(getEnv('MULTIPLE_CUSTOM_DOMAINS_ENABLED'));
+
   // eslint-disable-next-line unicorn/consistent-function-scoping
   public readonly databaseUrl = tryThat(() => assertEnv('DB_URL'), throwErrorWithDsnMessage);
   public readonly developmentTenantId = getEnv('DEVELOPMENT_TENANT_ID');


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
We introduce a new env `MULTIPLE_CUSTOM_DOMAINS_ENABLED` for multiple custom domains feature, since this feature is only available to some enterprise customers running private instances.

This PR also reverts related tests, since it's not a public feature at this moment.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
