### PR TITLE
style(experience): fix resend notic text color

### DIFF
--- a/packages/experience/src/containers/MfaCodeVerification/index.module.scss
+++ b/packages/experience/src/containers/MfaCodeVerification/index.module.scss
@@ -10,6 +10,8 @@
 
 .message {
   margin-top: _.unit(3);
+  font: var(--font-body-2);
+  color: var(--color-type-secondary);
 }
 
 .link {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

fix resend notic text color, should be grey (secondary).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
