### PR TITLE
fix(experience): prevent theme flash on initial page load

### DIFF
--- a/packages/experience/index.html
+++ b/packages/experience/index.html
@@ -8,6 +8,10 @@
   <script>
     /* See {@link packages/schemas/src/types/ssr.ts} */
     window.logtoSsr = "__LOGTO_SSR__";
+    
+    /* Minimal theme detection to prevent flash - using actual theme colors */
+    document.documentElement.style.backgroundColor = 
+      window.matchMedia('(prefers-color-scheme: dark)').matches ? '#000' : '#eff1f1';
   </script>
 </head>
 

--- a/packages/experience/src/Providers/PageContextProvider/index.tsx
+++ b/packages/experience/src/Providers/PageContextProvider/index.tsx
@@ -24,12 +24,21 @@ type Props = {
   >;
 };
 
+const getInitialTheme = (preset?: Theme): Theme => {
+  if (preset) {
+    return preset;
+  }
+
+  const darkThemeWatchMedia = window.matchMedia('(prefers-color-scheme: dark)');
+  return darkThemeWatchMedia.matches ? Theme.Dark : Theme.Light;
+};
+
 const PageContextProvider = ({ children, preset }: Props) => {
   const [searchParameters] = useSearchParams();
 
   const [loading, setLoading] = useState(preset?.loading ?? false);
   const [toast, setToast] = useState(preset?.toast ?? '');
-  const [theme, setTheme] = useState<Theme>(preset?.theme ?? Theme.Light);
+  const [theme, setTheme] = useState<Theme>(getInitialTheme(preset?.theme));
 
   const [platform, setPlatform] = useState<Platform>(
     preset?.platform ?? (isMobile ? 'mobile' : 'web')


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

This PR fixed the white background flash that occurred when loading the experience UI in dark mode, resolved #7615

1. Theme now correctly initializes based on system preferences before the first render
2. Added minimal inline script to set background color immediately, preventing visual flash

Problem & cause:

1. PageContextProvider always initializing with Theme.Light by default
2. Theme detection happening after React components mounted
3. CSS loading asynchronously, leaving unstyled content briefly visible

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
