### PR TITLE
fix(experience): fix page flashing issue on page load

### DIFF
--- a/packages/experience/src/Providers/SettingsProvider/use-sign-in-experience.ts
+++ b/packages/experience/src/Providers/SettingsProvider/use-sign-in-experience.ts
@@ -4,10 +4,10 @@ import PageContext from '@/Providers/PageContextProvider/PageContext';
 import initI18n from '@/i18n/init';
 import { getSignInExperienceSettings } from '@/utils/sign-in-experience';
 
-import useTheme from './use-theme';
+import useTheme, { getThemeBySystemConfiguration } from './use-theme';
 
 const useSignInExperience = () => {
-  const { isPreview, setExperienceSettings } = useContext(PageContext);
+  const { isPreview, setExperienceSettings, setTheme } = useContext(PageContext);
 
   useTheme();
 
@@ -15,10 +15,15 @@ const useSignInExperience = () => {
     (async () => {
       const [settings] = await Promise.all([getSignInExperienceSettings(), initI18n()]);
 
-      // Init the page settings and render
+      // Ensure theme is set before page rendering with new settings to avoid page flashing
+      if (settings.color.isDarkModeEnabled) {
+        setTheme(getThemeBySystemConfiguration());
+      }
+
+      // Init the page settings and render the page content
       setExperienceSettings(settings);
     })();
-  }, [isPreview, setExperienceSettings]);
+  }, [isPreview, setExperienceSettings, setTheme]);
 };
 
 export default useSignInExperience;

--- a/packages/experience/src/Providers/SettingsProvider/use-theme.ts
+++ b/packages/experience/src/Providers/SettingsProvider/use-theme.ts
@@ -20,6 +20,8 @@ export default function useTheme() {
       setTheme(getThemeBySystemConfiguration());
     };
 
+    changeTheme();
+
     darkThemeWatchMedia.addEventListener('change', changeTheme);
 
     return () => {

--- a/packages/experience/src/Providers/SettingsProvider/use-theme.ts
+++ b/packages/experience/src/Providers/SettingsProvider/use-theme.ts
@@ -4,7 +4,8 @@ import { useEffect, useContext } from 'react';
 import PageContext from '@/Providers/PageContextProvider/PageContext';
 
 const darkThemeWatchMedia = window.matchMedia('(prefers-color-scheme: dark)');
-const getThemeBySystemConfiguration = (): Theme =>
+
+export const getThemeBySystemConfiguration = (): Theme =>
   darkThemeWatchMedia.matches ? Theme.Dark : Theme.Light;
 
 export default function useTheme() {
@@ -18,8 +19,6 @@ export default function useTheme() {
     const changeTheme = () => {
       setTheme(getThemeBySystemConfiguration());
     };
-
-    changeTheme();
 
     darkThemeWatchMedia.addEventListener('change', changeTheme);
 


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Fix initial render flash when dark mode is enabled in the sign-in experience settings (#7615).



- **Issue**: When dark mode is enabled in sign-in experience settings, the sign-in page flashes on first render.
- **Root cause**: We always use the `Light` theme as the default value when rendering the `PageContext` component. The `theme` context update runs in the same render cycle as the page content (`useTheme`), after the `experienceSettings` value is fetched and updated in `PageContext`. Since the color theme is applied via JavaScript, it lags one cycle behind content rendering, causing a flash from Light to Dark.
  - <img width="1494" height="454" alt="image" src="https://github.com/user-attachments/assets/cac71e6e-61c9-4aa3-91c2-1a372d85ad08" />
- **Fix**: Set the `theme` value before updating `experienceSettings` to ensure it is applied correctly before the page content is rendered.



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
