### PR TITLE
feat(core): add optional BindMfa template to verification code API

### DIFF
--- a/packages/core/src/routes/verification/index.openapi.json
+++ b/packages/core/src/routes/verification/index.openapi.json
@@ -60,6 +60,9 @@
                 "properties": {
                   "identifier": {
                     "description": "The identifier (email address or phone number) to send the verification code to."
+                  },
+                  "templateType": {
+                    "description": "Optional override for the template type used to send the verification code. If the identifier is new, BindNewIdentifier will be used regardless."
                   }
                 }
               }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Adds an optional flag to send verification codes using the BindMfa template via the user verification API (part of the Account API).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Integration tests.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
