### PR TITLE
feat: add limits for multiple custom domains

### DIFF
--- a/packages/core/src/constants/index.ts
+++ b/packages/core/src/constants/index.ts
@@ -19,3 +19,10 @@ export const spInitiatedSamlSsoSessionCookieName = '_logto_sp_saml_sso_session_i
 export const reservedBuiltInProfileKeySet = new Set<string>(reservedBuiltInProfileKeys);
 export const reservedCustomDataKeySet = new Set<string>(reservedCustomDataKeys);
 export const reservedSignInIdentifierKeySet = new Set<string>(reservedSignInIdentifierKeys);
+
+/**
+ * Maximum number of custom domains allowed per tenant when the multi-domain feature is enabled.
+ * This is a temporary global cap across all tenants.
+ * Note: Future pricing plans may introduce tiered limits and this value will be revisited.
+ */
+export const maxCustomDomains = 10;

--- a/packages/phrases/src/locales/ar/errors/domain.ts
+++ b/packages/phrases/src/locales/ar/errors/domain.ts
@@ -8,6 +8,7 @@ const domain = {
   cloudflare_not_found: 'لا يمكن العثور على اسم المضيف في Cloudflare',
   domain_is_not_allowed: 'هذا النطاق غير مسموح به.',
   domain_in_use: 'النطاق {{domain}} قيد الاستخدام بالفعل.',
+  exceed_domain_limit: 'يمكنك امتلاك ما يصل إلى {{limit}} نطاقات مخصصة كحد أقصى.',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/de/errors/domain.ts
+++ b/packages/phrases/src/locales/de/errors/domain.ts
@@ -9,6 +9,7 @@ const domain = {
   cloudflare_not_found: 'Hostname in Cloudflare nicht gefunden',
   domain_is_not_allowed: 'Diese Domain ist nicht zulässig.',
   domain_in_use: 'Die Domain {{domain}} wird bereits verwendet.',
+  exceed_domain_limit: 'Sie können höchstens {{limit}} benutzerdefinierte Domains haben.',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/en/errors/domain.ts
+++ b/packages/phrases/src/locales/en/errors/domain.ts
@@ -8,6 +8,7 @@ const domain = {
   cloudflare_not_found: 'Can not find hostname in Cloudflare',
   domain_is_not_allowed: 'This domain is not allowed.',
   domain_in_use: 'The domain {{domain}} is already in use',
+  exceed_domain_limit: 'You can have at most {{limit}} custom domains.',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/es/errors/domain.ts
+++ b/packages/phrases/src/locales/es/errors/domain.ts
@@ -8,6 +8,7 @@ const domain = {
   cloudflare_not_found: 'No se puede encontrar el nombre de host en Cloudflare',
   domain_is_not_allowed: 'Este dominio no está permitido.',
   domain_in_use: 'El dominio {{domain}} ya está en uso.',
+  exceed_domain_limit: 'Puedes tener como máximo {{limit}} dominios personalizados.',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/fr/errors/domain.ts
+++ b/packages/phrases/src/locales/fr/errors/domain.ts
@@ -8,6 +8,7 @@ const domain = {
   cloudflare_not_found: "Impossible de trouver le nom d'hôte dans Cloudflare",
   domain_is_not_allowed: "Ce domaine n'est pas autorisé.",
   domain_in_use: 'Le domaine {{domain}} est déjà utilisé.',
+  exceed_domain_limit: 'Vous pouvez avoir au maximum {{limit}} domaines personnalisés.',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/it/errors/domain.ts
+++ b/packages/phrases/src/locales/it/errors/domain.ts
@@ -8,6 +8,7 @@ const domain = {
   cloudflare_not_found: 'Impossibile trovare il nome host in Cloudflare.',
   domain_is_not_allowed: 'Questo dominio non è permesso.',
   domain_in_use: 'Il dominio {{domain}} è già in uso.',
+  exceed_domain_limit: 'Puoi avere al massimo {{limit}} domini personalizzati.',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/ja/errors/domain.ts
+++ b/packages/phrases/src/locales/ja/errors/domain.ts
@@ -8,6 +8,7 @@ const domain = {
   cloudflare_not_found: 'Cloudflare からホスト名が見つかりませんでした。',
   domain_is_not_allowed: 'このドメインは許可されていません。',
   domain_in_use: 'ドメイン {{domain}} はすでに使用されています。',
+  exceed_domain_limit: 'カスタムドメインは最大 {{limit}} 個までです。',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/ko/errors/domain.ts
+++ b/packages/phrases/src/locales/ko/errors/domain.ts
@@ -8,6 +8,7 @@ const domain = {
   cloudflare_not_found: 'Cloudflare에서 호스트 이름을 찾을 수 없습니다.',
   domain_is_not_allowed: '이 도메인은 허용되지 않습니다.',
   domain_in_use: '도메인 {{domain}}은 이미 사용 중입니다.',
+  exceed_domain_limit: '사용자 지정 도메인은 최대 {{limit}}개까지 가능합니다.',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/pl-pl/errors/domain.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/domain.ts
@@ -8,6 +8,7 @@ const domain = {
   cloudflare_not_found: 'Nie można znaleźć nazwy hosta w Cloudflare',
   domain_is_not_allowed: 'Ta domena nie jest dozwolona.',
   domain_in_use: 'Domena {{domain}} jest już używana.',
+  exceed_domain_limit: 'Możesz mieć maksymalnie {{limit}} własnych domen.',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/pt-br/errors/domain.ts
+++ b/packages/phrases/src/locales/pt-br/errors/domain.ts
@@ -8,6 +8,7 @@ const domain = {
   cloudflare_not_found: 'Não é possível encontrar o nome do host no Cloudflare',
   domain_is_not_allowed: 'Este domínio não é permitido.',
   domain_in_use: 'O domínio {{domain}} já está em uso.',
+  exceed_domain_limit: 'Você pode ter no máximo {{limit}} domínios personalizados.',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/pt-pt/errors/domain.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/domain.ts
@@ -8,6 +8,7 @@ const domain = {
   cloudflare_not_found: 'Não é possível encontrar o nome de host no Cloudflare',
   domain_is_not_allowed: 'Este domínio não é permitido.',
   domain_in_use: 'O domínio {{domain}} já está em uso.',
+  exceed_domain_limit: 'Pode ter no máximo {{limit}} domínios personalizados.',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/ru/errors/domain.ts
+++ b/packages/phrases/src/locales/ru/errors/domain.ts
@@ -8,6 +8,7 @@ const domain = {
   cloudflare_not_found: 'Не удается найти имя хоста в Cloudflare',
   domain_is_not_allowed: 'Этот домен не разрешен.',
   domain_in_use: 'Домен {{domain}} уже используется.',
+  exceed_domain_limit: 'Можно иметь не более {{limit}} пользовательских доменов.',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/th/errors/domain.ts
+++ b/packages/phrases/src/locales/th/errors/domain.ts
@@ -8,6 +8,7 @@ const domain = {
   cloudflare_not_found: 'ไม่พบชื่อโฮสต์ใน Cloudflare',
   domain_is_not_allowed: 'ไม่อนุญาตให้ใช้โดเมนนี้',
   domain_in_use: 'โดเมน {{domain}} ถูกใช้งานแล้ว',
+  exceed_domain_limit: 'คุณสามารถมีโดเมนกำหนดเองได้สูงสุด {{limit}} โดเมน',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/tr-tr/errors/domain.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/domain.ts
@@ -8,6 +8,7 @@ const domain = {
   cloudflare_not_found: "Cloudflare'da alan adı bulunamadı.",
   domain_is_not_allowed: 'Bu alan adı izin verilen değildir.',
   domain_in_use: 'Alan adı {{domain}} zaten kullanımda.',
+  exceed_domain_limit: 'En fazla {{limit}} özel alan adına sahip olabilirsiniz.',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/zh-cn/errors/domain.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/domain.ts
@@ -8,6 +8,7 @@ const domain = {
   cloudflare_not_found: '在 Cloudflare 中找不到主机名',
   domain_is_not_allowed: '该域名不允许。',
   domain_in_use: '域名 {{domain}} 已被占用。',
+  exceed_domain_limit: '最多只允许 {{limit}} 个自定义域名。',
 };
 
 export default Object.freeze(domain);

--- a/packages/phrases/src/locales/zh-tw/errors/domain.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/domain.ts
@@ -8,6 +8,7 @@ const domain = {
   cloudflare_not_found: '無法找到 Cloudflare 中的主機名',
   domain_is_not_allowed: '這個網域不允許。',
   domain_in_use: '網域 {{domain}} 已被使用。',
+  exceed_domain_limit: '最多只能有 {{limit}} 個自訂網域。',
 };
 
 export default Object.freeze(domain);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Set a temporary cap of 10 custom domains per tenant when the “multiple custom domains” feature is enabled. We’re not enforcing this via pricing yet because the feature is currently only available to selected private-instance customers.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
