### PR TITLE
feat(core,toolkit): add ui_locales support in email template variables

### DIFF
--- a/packages/core/src/libraries/passcode.ts
+++ b/packages/core/src/libraries/passcode.ts
@@ -28,7 +28,7 @@ export const passcodeMaxTryCount = 10;
 
 export type PasscodeLibrary = ReturnType<typeof createPasscodeLibrary>;
 
-export type SendPasscodeContextPayload = Pick<SendMessagePayload, 'locale'> &
+export type SendPasscodeContextPayload = Pick<SendMessagePayload, 'locale' | 'uiLocales'> &
   VerificationCodeContextInfo;
 
 export const createPasscodeLibrary = (queries: Queries, connectorLibrary: ConnectorLibrary) => {

--- a/packages/core/src/routes-me/verification-code.ts
+++ b/packages/core/src/routes-me/verification-code.ts
@@ -7,6 +7,7 @@ import type { RouterInitArgs } from '#src/routes/types.js';
 
 import RequestError from '../errors/RequestError/index.js';
 import assertThat from '../utils/assert-that.js';
+import { getLogtoCookie } from '../utils/cookie.js';
 
 import type { AuthedMeRouter } from './types.js';
 
@@ -31,7 +32,11 @@ export default function verificationCodeRoutes<T extends AuthedMeRouter>(
     }),
     async (ctx, next) => {
       const code = await createPasscode(undefined, codeType, ctx.guard.body);
-      await sendPasscode(code, { locale: ctx.locale });
+      const { uiLocales } = getLogtoCookie(ctx);
+      await sendPasscode(code, {
+        locale: ctx.locale,
+        uiLocales,
+      });
 
       ctx.status = 204;
 

--- a/packages/core/src/routes/interaction/utils/verification-code-validation.ts
+++ b/packages/core/src/routes/interaction/utils/verification-code-validation.ts
@@ -26,6 +26,7 @@ export const sendVerificationCodeToIdentifier = async (
   payload: RequestVerificationCodePayload & {
     event: InteractionEvent;
     locale?: string;
+    uiLocales?: string;
     messageContext?: VerificationCodeContextInfo;
   },
   jti: string,

--- a/packages/core/src/routes/verification/index.ts
+++ b/packages/core/src/routes/verification/index.ts
@@ -13,6 +13,7 @@ import {
 import { z } from 'zod';
 
 import koaGuard from '#src/middleware/koa-guard.js';
+import { getLogtoCookie } from '#src/utils/cookie.js';
 
 import {
   buildVerificationRecordByIdAndType,
@@ -107,8 +108,11 @@ export default function verificationRoutes<T extends UserRouter>(
           ? await libraries.passcodes.buildVerificationCodeContext({ user, applicationId })
           : undefined;
 
+      const { uiLocales } = getLogtoCookie(ctx);
+
       await codeVerification.sendVerificationCode({
         locale: ctx.locale,
+        uiLocales,
         ...emailContextPayload,
       });
 

--- a/packages/core/src/utils/cookie.ts
+++ b/packages/core/src/utils/cookie.ts
@@ -1,0 +1,7 @@
+import { logtoUiCookieGuard, logtoCookieKey } from '@logto/schemas';
+import { trySafe } from '@silverhand/essentials';
+import { type Context } from 'koa';
+
+export const getLogtoCookie = (ctx: Context) =>
+  trySafe(() => logtoUiCookieGuard.parse(JSON.parse(ctx.cookies.get(logtoCookieKey) ?? '{}'))) ??
+  {};

--- a/packages/toolkit/connector-kit/src/types/passwordless.ts
+++ b/packages/toolkit/connector-kit/src/types/passwordless.ts
@@ -66,6 +66,19 @@ export type SendMessagePayload = {
    * @example 'en-US'
    */
   locale?: string;
+  /**
+   * The `ui_locales` parameter from the authentication request, which can be used to localize the message.
+   * This is different from `locale` as it is the original request parameter and may contain multiple language
+   * tags sorted by user's preference.
+   * The `locale` field, is the single language tag resolved from multiple sources, and the precedence is:
+   * `ui_locales` > HTTP `Accept-Language` header > default fallback (en).
+   *
+   * @remarks
+   * For email connectors that handle email templates at the provider side, use this field to indicate the user's preferred language.
+   *
+   * @example 'en-US en'
+   */
+  uiLocales?: string;
 } & Record<string, unknown>;
 
 /** The guard for {@link SendMessagePayload}. */
@@ -74,6 +87,7 @@ export const sendMessagePayloadGuard = z
     code: z.string().optional(),
     link: z.string().optional(),
     locale: z.string().optional(),
+    uiLocales: z.string().optional(),
   })
   .catchall(z.unknown()) satisfies z.ZodType<SendMessagePayload>;
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add `ui_locales` support to the email template context, so that users can also fetch the original parameter value of via variables.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
