### PR TITLE
style(console): fix read-only state drop down icon color for select component

### DIFF
--- a/packages/console/src/ds-components/Select/index.module.scss
+++ b/packages/console/src/ds-components/Select/index.module.scss
@@ -72,13 +72,6 @@
     outline-color: var(--color-focused-variant);
   }
 
-  &.readOnly {
-    background: var(--color-inverse-on-surface);
-    color: var(--color-text);
-    border-color: var(--color-border);
-    cursor: default;
-  }
-
   &.error {
     border-color: var(--color-error);
 
@@ -90,6 +83,17 @@
   .icon {
     display: flex;
     color: var(--color-text-secondary);
+  }
+
+  &.readOnly {
+    background: var(--color-inverse-on-surface);
+    color: var(--color-text);
+    border-color: var(--color-border);
+    cursor: default;
+
+    .icon {
+      color: var(--color-disabled);
+    }
   }
 
   .clear {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix read-only state drop down icon color for select component

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="646" height="119" alt="image" src="https://github.com/user-attachments/assets/17ccc965-171f-4740-ac63-a177488377b3" />

<img width="1031" height="209" alt="image" src="https://github.com/user-attachments/assets/76f4990e-cd59-4f6f-b582-900b97a7eb33" />


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
