### PR TITLE
fix(core): respect secondary sign-up when suggesting MFA

### DIFF
--- a/packages/core/src/routes/experience/classes/mfa.ts
+++ b/packages/core/src/routes/experience/classes/mfa.ts
@@ -321,14 +321,16 @@ export class Mfa {
     // If the user has email, but not registered by email, no suggestion
     if (
       factorsInUser.includes(MfaFactor.EmailVerificationCode) &&
-      !signUp.identifiers.includes(SignInIdentifier.Email)
+      !signUp.identifiers.includes(SignInIdentifier.Email) &&
+      !signUp.secondaryIdentifiers?.some(({ identifier }) => identifier === SignInIdentifier.Email)
     ) {
       return;
     }
     // If the user has phone, but not registered by phone, no suggestion
     if (
       factorsInUser.includes(MfaFactor.PhoneVerificationCode) &&
-      !signUp.identifiers.includes(SignInIdentifier.Phone)
+      !signUp.identifiers.includes(SignInIdentifier.Phone) &&
+      !signUp.secondaryIdentifiers?.some(({ identifier }) => identifier === SignInIdentifier.Phone)
     ) {
       return;
     }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Ensure the MFA suggestion guard considers secondary email/phone identifiers.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Add an integration test that registers with username + secondary email.

Local tested:

<img width="789" height="733" alt="截屏2025-09-24 上午11 17 15" src="https://github.com/user-attachments/assets/d19f51b2-9e68-411f-a88e-8a4af1b3c122" />

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
