### PR TITLE
fix(core): update default expiresIn description for one-time tokens

### DIFF
--- a/packages/core/src/routes/one-time-tokens.openapi.json
+++ b/packages/core/src/routes/one-time-tokens.openapi.json
@@ -42,7 +42,7 @@
                     "description": "The email address to associate with the one-time token."
                   },
                   "expiresIn": {
-                    "description": "The expiration time in seconds. If not provided, defaults to 2 days (172,800 seconds)."
+                    "description": "The expiration time in seconds. If not provided, defaults to 10 mins (600 seconds)."
                   },
                   "context": {
                     "description": "Additional context to store with the one-time token. This can be used to store arbitrary data that will be associated with the token."


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Changed the expiresIn field description in the OpenAPI spec to reflect a new default of 10 minutes (600 seconds) instead of 2 days (172,800 seconds).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
