### PR TITLE
feat(console): add account center ui

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/index.module.scss
@@ -1,0 +1,44 @@
+@use '@/scss/underscore' as _;
+
+.cardContent {
+  display: flex;
+  flex-direction: column;
+  gap: _.unit(3);
+}
+
+.error {
+  margin-bottom: _.unit(2);
+}
+
+.groupFields {
+  display: flex;
+  flex-direction: column;
+  gap: _.unit(3);
+}
+
+.fieldRow {
+  justify-content: space-between;
+  display: flex;
+  gap: _.unit(6);
+  align-items: center;
+  border: 1px solid var(--color-neutral-90);
+  border-radius: _.unit(2);
+  padding: _.unit(4);
+}
+
+.fieldLabel {
+  display: flex;
+  flex-direction: column;
+  gap: _.unit(1);
+}
+
+.fieldName {
+  font: var(--font-body-2);
+  color: var(--color-text);
+}
+
+.fieldControl {
+  min-width: 160px;
+  display: flex;
+  justify-content: flex-end;
+}

--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/index.tsx
@@ -1,0 +1,212 @@
+import type { AdminConsoleKey } from '@logto/phrases';
+import { AccountCenterControlValue } from '@logto/schemas';
+import { useCallback, useMemo, type ChangeEvent } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+
+import FormCard from '@/components/FormCard';
+import PageMeta from '@/components/PageMeta';
+import DynamicT from '@/ds-components/DynamicT';
+import FormField from '@/ds-components/FormField';
+import Select, { type Option } from '@/ds-components/Select';
+import Switch from '@/ds-components/Switch';
+
+import {
+  type AccountCenterFormValues,
+  type AccountCenterFieldKey,
+  type SignInExperienceForm,
+} from '../../types';
+import SignInExperienceTabWrapper from '../components/SignInExperienceTabWrapper';
+
+import styles from './index.module.scss';
+
+type AccountCenterFieldItem = {
+  readonly key: AccountCenterFieldKey;
+  readonly title: AdminConsoleKey;
+  readonly description?: AdminConsoleKey;
+};
+
+type AccountCenterFieldGroup = {
+  readonly key: string;
+  readonly title: AdminConsoleKey;
+  readonly items: readonly AccountCenterFieldItem[];
+};
+
+type AccountCenterFieldSection = {
+  readonly key: string;
+  readonly title: AdminConsoleKey;
+  readonly description: AdminConsoleKey;
+  readonly groups: readonly AccountCenterFieldGroup[];
+};
+
+const accountCenterSections: AccountCenterFieldSection[] = [
+  {
+    key: 'accountSecurity',
+    title: 'sign_in_exp.account_center.sections.account_security.title',
+    description: 'sign_in_exp.account_center.sections.account_security.description',
+    groups: [
+      {
+        key: 'identifiers',
+        title: 'sign_in_exp.account_center.sections.account_security.groups.identifiers.title',
+        items: [
+          { key: 'email', title: 'sign_in_exp.account_center.fields.email' },
+          { key: 'phone', title: 'sign_in_exp.account_center.fields.phone' },
+          { key: 'social', title: 'sign_in_exp.account_center.fields.social' },
+        ],
+      },
+      {
+        key: 'authentication',
+        title:
+          'sign_in_exp.account_center.sections.account_security.groups.authentication_factors.title',
+        items: [
+          { key: 'password', title: 'sign_in_exp.account_center.fields.password' },
+          {
+            key: 'mfa',
+            title: 'sign_in_exp.account_center.fields.mfa',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    key: 'userProfile',
+    title: 'sign_in_exp.account_center.sections.user_profile.title',
+    description: 'sign_in_exp.account_center.sections.user_profile.description',
+    groups: [
+      {
+        key: 'profileData',
+        title: 'sign_in_exp.account_center.sections.user_profile.groups.profile_data.title',
+        items: [
+          { key: 'username', title: 'sign_in_exp.account_center.fields.username' },
+          { key: 'name', title: 'sign_in_exp.account_center.fields.name' },
+          { key: 'avatar', title: 'sign_in_exp.account_center.fields.avatar' },
+          {
+            key: 'profile',
+            title: 'sign_in_exp.account_center.fields.profile',
+          },
+          {
+            key: 'customData',
+            title: 'sign_in_exp.account_center.fields.custom_data',
+          },
+        ],
+      },
+    ],
+  },
+];
+
+type Props = {
+  readonly isActive: boolean;
+};
+
+function AccountCenter({ isActive }: Props) {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const {
+    watch,
+    setValue,
+    formState: { isSubmitting },
+  } = useFormContext<SignInExperienceForm & { accountCenter: AccountCenterFormValues }>();
+
+  const fieldOptions = useMemo<Array<Option<AccountCenterControlValue>>>(
+    () => [
+      {
+        value: AccountCenterControlValue.Off,
+        title: t('sign_in_exp.account_center.field_options.off'),
+      },
+      {
+        value: AccountCenterControlValue.Edit,
+        title: t('sign_in_exp.account_center.field_options.edit'),
+      },
+      {
+        value: AccountCenterControlValue.ReadOnly,
+        title: t('sign_in_exp.account_center.field_options.read_only'),
+      },
+    ],
+    [t]
+  );
+
+  const { enabled, fields } = watch('accountCenter');
+  const isAccountApiEnabled = enabled;
+
+  const handleToggle = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setValue('accountCenter.enabled', event.target.checked, { shouldDirty: true });
+    },
+    [setValue]
+  );
+
+  const handleFieldChange = useCallback(
+    (field: AccountCenterFieldKey, value?: AccountCenterControlValue) => {
+      if (!value) {
+        return;
+      }
+
+      setValue(`accountCenter.fields.${field}`, value, { shouldDirty: true });
+    },
+    [setValue]
+  );
+
+  return (
+    <SignInExperienceTabWrapper isActive={isActive}>
+      {isActive && (
+        <PageMeta titleKey={['sign_in_exp.tabs.account_center', 'sign_in_exp.page_title']} />
+      )}
+      <FormCard
+        title="sign_in_exp.account_center.title"
+        description="sign_in_exp.account_center.description"
+        learnMoreLink={{ href: 'end-user-flows/account-settings/by-account-api' }}
+      >
+        <div className={styles.cardContent}>
+          <FormField title="sign_in_exp.account_center.enable_account_api">
+            <Switch
+              checked={enabled}
+              disabled={isSubmitting}
+              description="sign_in_exp.account_center.enable_account_api_description"
+              onChange={handleToggle}
+            />
+          </FormField>
+        </div>
+      </FormCard>
+      {accountCenterSections.map((section) => (
+        <FormCard key={section.key} title={section.title} description={section.description}>
+          <div className={styles.cardContent}>
+            {section.groups.map((group) => (
+              <FormField key={group.key} title={group.title}>
+                <div className={styles.groupFields}>
+                  {group.items.map((item) => {
+                    const isReadOnly = !isAccountApiEnabled || isSubmitting;
+
+                    return (
+                      <div
+                        key={item.key}
+                        className={styles.fieldRow}
+                        data-disabled={isReadOnly || undefined}
+                      >
+                        <div className={styles.fieldLabel}>
+                          <div className={styles.fieldName}>
+                            <DynamicT forKey={item.title} />
+                          </div>
+                        </div>
+                        <div className={styles.fieldControl}>
+                          <Select<AccountCenterControlValue>
+                            value={fields[item.key]}
+                            options={fieldOptions}
+                            isReadOnly={isReadOnly}
+                            onChange={(value) => {
+                              handleFieldChange(item.key, value);
+                            }}
+                          />
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </FormField>
+            ))}
+          </div>
+        </FormCard>
+      ))}
+    </SignInExperienceTabWrapper>
+  );
+}
+
+export default AccountCenter;

--- a/packages/console/src/pages/SignInExperience/types.ts
+++ b/packages/console/src/pages/SignInExperience/types.ts
@@ -1,4 +1,6 @@
 import {
+  AccountCenterControlValue,
+  type AccountCenter as AccountCenterConfig,
   type SignUp,
   type SignInExperience,
   type SignInIdentifier,
@@ -18,8 +20,47 @@ export enum SignInExperienceTab {
   Branding = 'branding',
   SignUpAndSignIn = 'sign-up-and-sign-in',
   CollectUserProfile = 'collect-user-profile',
+  AccountCenter = 'account-center',
   Content = 'content',
 }
+
+const accountCenterFieldKeys = [
+  'email',
+  'phone',
+  'social',
+  'password',
+  'mfa',
+  'username',
+  'name',
+  'avatar',
+  'profile',
+  'customData',
+] as const;
+
+export type AccountCenterFieldKey = (typeof accountCenterFieldKeys)[number];
+
+export type AccountCenterFormValues = {
+  enabled: boolean;
+  fields: Record<AccountCenterFieldKey, AccountCenterControlValue>;
+};
+
+const createDefaultAccountCenterFormValues = (): AccountCenterFormValues => ({
+  enabled: false,
+  // eslint-disable-next-line no-restricted-syntax
+  fields: Object.fromEntries(
+    accountCenterFieldKeys.map((key) => [key, AccountCenterControlValue.Off])
+  ) as Record<AccountCenterFieldKey, AccountCenterControlValue>,
+});
+
+export const convertAccountCenterToForm = (
+  accountCenter?: AccountCenterConfig
+): AccountCenterFormValues => ({
+  enabled: accountCenter?.enabled ?? false,
+  fields: {
+    ...createDefaultAccountCenterFormValues().fields,
+    ...accountCenter?.fields,
+  },
+});
 
 /**
  * @deprecated

--- a/packages/integration-tests/src/tests/console/sign-in-experience/branding.test.ts
+++ b/packages/integration-tests/src/tests/console/sign-in-experience/branding.test.ts
@@ -1,4 +1,4 @@
-import { logtoConsoleUrl as logtoConsoleUrlString } from '#src/constants.js';
+import { isDevFeaturesEnabled, logtoConsoleUrl as logtoConsoleUrlString } from '#src/constants.js';
 import { goToAdminConsole } from '#src/ui-helpers/index.js';
 import { expectNavigation, appendPathname, waitFor } from '#src/utils.js';
 
@@ -24,7 +24,7 @@ describe('sign-in experience: branding', () => {
     await expect(page).toMatchElement(
       'div[class$=main] div[class$=container] div[class$=cardTitle] div[class$=titleEllipsis]',
       {
-        text: 'Sign-in experience',
+        text: isDevFeaturesEnabled ? 'Sign-in & account' : 'Sign-in experience',
       }
     );
 

--- a/packages/integration-tests/src/tests/console/sign-in-experience/sign-in-preview.test.ts
+++ b/packages/integration-tests/src/tests/console/sign-in-experience/sign-in-preview.test.ts
@@ -1,7 +1,11 @@
 import { type Nullable } from '@silverhand/essentials';
 import { type Page, type Target } from 'puppeteer';
 
-import { logtoConsoleUrl as logtoConsoleUrlString, logtoUrl } from '#src/constants.js';
+import {
+  isDevFeaturesEnabled,
+  logtoConsoleUrl as logtoConsoleUrlString,
+  logtoUrl,
+} from '#src/constants.js';
 import { goToAdminConsole } from '#src/ui-helpers/index.js';
 import { expectNavigation, appendPathname } from '#src/utils.js';
 
@@ -24,7 +28,7 @@ describe('sign-in experience: sign-in preview', () => {
     await expect(page).toMatchElement(
       'div[class$=main] div[class$=container] div[class$=cardTitle] div[class$=titleEllipsis]',
       {
-        text: 'Sign-in experience',
+        text: isDevFeaturesEnabled ? 'Sign-in & account' : 'Sign-in experience',
       }
     );
 

--- a/packages/phrases/src/locales/ar/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/sign-in-exp/index.ts
@@ -4,13 +4,16 @@ import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
   page_title: 'تجربة تسجيل الدخول',
+  page_title_with_account: 'تسجيل الدخول والحساب',
   title: 'تجربة تسجيل الدخول',
+  title_with_account: 'تسجيل الدخول والحساب',
   description: 'تخصيص تدفقات المصادقة وواجهة المستخدم، ومعاينة التجربة الافتراضية في الوقت الفعلي.',
   tabs: {
     branding: 'العلامة التجارية',
     sign_up_and_sign_in: 'التسجيل وتسجيل الدخول',
-    content: 'المحتوى',
     collect_user_profile: 'جمع ملف تعريف المستخدم',
+    account_center: 'مركز الحساب',
+    content: 'المحتوى',
     password_policy: 'سياسة كلمة المرور',
   },
   welcome: {
@@ -83,6 +86,58 @@ const sign_in_exp = {
       'قم بتحميل حزمة مضغوطة (.zip) لاستبدال واجهة المستخدم المُعدة مسبقًا في Logto بالشفرة الخاصة بك. <a>تعلم المزيد</a>',
     preview_with_bring_your_ui_description:
       'تم تحميل أصول واجهة المستخدم المخصصة الخاصة بك بنجاح ويتم تقديمها الآن. وبالتالي ، تم تعطيل نافذة المعاينة المدمجة.\nلتجربة واجهة تسجيل الدخول المخصصة الخاصة بك ، انقر فوق زر "المعاينة المباشرة" لفتحها في علامة تبويب مستعرض جديدة.',
+  },
+  account_center: {
+    title: 'مركز الحساب',
+    description: 'خصص تدفقات مركز الحساب باستخدام واجهات Logto.',
+    enable_account_api: 'تفعيل Account API',
+    enable_account_api_description:
+      'فعّل Account API لبناء مركز حساب مخصص ومنح المستخدمين وصولًا مباشرًا إلى الواجهات دون استخدام Logto Management API.',
+    field_options: {
+      off: 'Off',
+      edit: 'Edit',
+      read_only: 'Read only',
+    },
+    sections: {
+      account_security: {
+        title: 'ACCOUNT SECURITY',
+        description:
+          'Manage access to the Account API, enabling users to view or edit their identity information and authentication factors after signing into the application. Users must verify their identity to get a valid 10-minute verification record ID before making these security-related changes.',
+        groups: {
+          identifiers: {
+            title: 'Identifiers',
+          },
+          authentication_factors: {
+            title: 'Authentication factors',
+          },
+        },
+      },
+      user_profile: {
+        title: 'USER PROFILE',
+        description:
+          'Manage access to the Account API, enabling users to view or edit basic or custom profile data after signing into the application.',
+        groups: {
+          profile_data: {
+            title: 'Profile data',
+          },
+        },
+      },
+    },
+    fields: {
+      email: 'Email address',
+      phone: 'Phone number',
+      social: 'Social identities',
+      password: 'Password',
+      mfa: 'Multi-factor authentication',
+      mfa_description: 'Let users manage their MFA methods from the account center.',
+      username: 'Username',
+      name: 'Name',
+      avatar: 'Avatar',
+      profile: 'Profile',
+      profile_description: 'Control access to structured profile attributes.',
+      custom_data: 'Custom data',
+      custom_data_description: 'Control access to custom JSON data stored on the user.',
+    },
   },
   sign_up_and_sign_in,
   content,

--- a/packages/phrases/src/locales/ar/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/tabs.ts
@@ -4,6 +4,7 @@ const tabs = {
   applications: 'التطبيقات',
   api_resources: 'موارد API',
   sign_in_experience: 'تجربة تسجيل الدخول',
+  sign_in_experience_with_account: 'تسجيل الدخول والحساب',
   connectors: 'الموصلات',
   enterprise_sso: 'SSO المؤسسات',
   security: 'الأمان',

--- a/packages/phrases/src/locales/de/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/sign-in-exp/index.ts
@@ -4,14 +4,17 @@ import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
   page_title: 'Anmeldeoberfläche',
+  page_title_with_account: 'Anmeldung & Konto',
   title: 'Anmeldeoberfläche',
+  title_with_account: 'Anmeldung & Konto',
   description:
     'Passen Sie die Authentifizierungsabläufe und die Benutzeroberfläche an, und sehen Sie sich das Erlebnis sofort an.',
   tabs: {
     branding: 'Branding',
     sign_up_and_sign_in: 'Anmeldung und Registrierung',
-    content: 'Inhalt',
     collect_user_profile: 'Benutzerprofil sammeln',
+    account_center: 'Account Center',
+    content: 'Inhalt',
     password_policy: 'Passwortrichtlinie',
   },
   welcome: {
@@ -85,6 +88,58 @@ const sign_in_exp = {
       'Laden Sie ein komprimiertes Paket (.zip) hoch, um die vorgefertigte Benutzeroberfläche von Logto durch Ihren eigenen Code zu ersetzen. <a>Erfahren Sie mehr</a>',
     preview_with_bring_your_ui_description:
       'Ihre benutzerdefinierten UI-Assets wurden erfolgreich hochgeladen und werden jetzt bereitgestellt. Daher wurde das eingebaute Vorschaufenster deaktiviert.\nUm Ihre personalisierte Anmelde-Benutzeroberfläche zu testen, klicken Sie auf die Schaltfläche "Live-Vorschau", um sie in einem neuen Browser-Tab zu öffnen.',
+  },
+  account_center: {
+    title: 'Account Center',
+    description: 'Passe deine Account-Center-Flows mit den Logto-APIs an.',
+    enable_account_api: 'Account API aktivieren',
+    enable_account_api_description:
+      'Aktiviere die Account API, um ein individuelles Account Center aufzubauen und Endnutzer*innen direkten API-Zugriff ohne Logto Management API zu geben.',
+    field_options: {
+      off: 'Off',
+      edit: 'Edit',
+      read_only: 'Read only',
+    },
+    sections: {
+      account_security: {
+        title: 'ACCOUNT SECURITY',
+        description:
+          'Manage access to the Account API, enabling users to view or edit their identity information and authentication factors after signing into the application. Users must verify their identity to get a valid 10-minute verification record ID before making these security-related changes.',
+        groups: {
+          identifiers: {
+            title: 'Identifiers',
+          },
+          authentication_factors: {
+            title: 'Authentication factors',
+          },
+        },
+      },
+      user_profile: {
+        title: 'USER PROFILE',
+        description:
+          'Manage access to the Account API, enabling users to view or edit basic or custom profile data after signing into the application.',
+        groups: {
+          profile_data: {
+            title: 'Profile data',
+          },
+        },
+      },
+    },
+    fields: {
+      email: 'Email address',
+      phone: 'Phone number',
+      social: 'Social identities',
+      password: 'Password',
+      mfa: 'Multi-factor authentication',
+      mfa_description: 'Let users manage their MFA methods from the account center.',
+      username: 'Username',
+      name: 'Name',
+      avatar: 'Avatar',
+      profile: 'Profile',
+      profile_description: 'Control access to structured profile attributes.',
+      custom_data: 'Custom data',
+      custom_data_description: 'Control access to custom JSON data stored on the user.',
+    },
   },
   sign_up_and_sign_in,
   content,

--- a/packages/phrases/src/locales/de/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/tabs.ts
@@ -4,6 +4,7 @@ const tabs = {
   applications: 'Anwendungen',
   api_resources: 'API Ressourcen',
   sign_in_experience: 'Anmeldeoberfläche',
+  sign_in_experience_with_account: 'Anmeldung & Konto',
   connectors: 'Connectoren',
   enterprise_sso: 'Unternehmens-SSO',
   security: 'Sicherheit',

--- a/packages/phrases/src/locales/en/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/sign-in-exp/index.ts
@@ -4,14 +4,17 @@ import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
   page_title: 'Sign-in experience',
+  page_title_with_account: 'Sign-in & account',
   title: 'Sign-in experience',
+  title_with_account: 'Sign-in & account',
   description:
     'Customize the authentication flows and UI, and preview the out-of-the-box experience in real time.',
   tabs: {
     branding: 'Branding',
     sign_up_and_sign_in: 'Sign-up and sign-in',
-    content: 'Content',
     collect_user_profile: 'Collect user profile',
+    account_center: 'Account center',
+    content: 'Content',
     password_policy: 'Password policy',
   },
   welcome: {
@@ -86,6 +89,58 @@ const sign_in_exp = {
       'Upload a compressed package (.zip) to replace the Logto prebuilt UI with your own code. <a>Learn more</a>',
     preview_with_bring_your_ui_description:
       'Your custom UI assets have been successfully uploaded and are now being served. Consequently, the built-in preview window has been disabled.\nTo test your personalized sign-in UI, click the "Live Preview" button to open it in a new browser tab.',
+  },
+  account_center: {
+    title: 'ACCOUNT CENTER',
+    description: 'Customize your account center flows using Logto APIs.',
+    enable_account_api: 'Enable Account API',
+    enable_account_api_description:
+      'Enable the Account API to build custom account center, giving end users direct API access without using Logto Management API.',
+    field_options: {
+      off: 'Off',
+      edit: 'Edit',
+      read_only: 'Read only',
+    },
+    sections: {
+      account_security: {
+        title: 'ACCOUNT SECURITY',
+        description:
+          'Manage access to the Account API, enabling users to view or edit their identity information and authentication factors after signing into the application. Users must verify their identity to get a valid 10-minute verification record ID before making these security-related changes.',
+        groups: {
+          identifiers: {
+            title: 'Identifiers',
+          },
+          authentication_factors: {
+            title: 'Authentication factors',
+          },
+        },
+      },
+      user_profile: {
+        title: 'USER PROFILE',
+        description:
+          'Manage access to the Account API, enabling users to view or edit basic or custom profile data after signing into the application.',
+        groups: {
+          profile_data: {
+            title: 'Profile data',
+          },
+        },
+      },
+    },
+    fields: {
+      email: 'Email address',
+      phone: 'Phone number',
+      social: 'Social identities',
+      password: 'Password',
+      mfa: 'Multi-factor authentication',
+      mfa_description: 'Let users manage their MFA methods from the account center.',
+      username: 'Username',
+      name: 'Name',
+      avatar: 'Avatar',
+      profile: 'Profile',
+      profile_description: 'Control access to structured profile attributes.',
+      custom_data: 'Custom data',
+      custom_data_description: 'Control access to custom JSON data stored on the user.',
+    },
   },
   sign_up_and_sign_in,
   content,

--- a/packages/phrases/src/locales/en/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/tabs.ts
@@ -4,6 +4,7 @@ const tabs = {
   applications: 'Applications',
   api_resources: 'API resources',
   sign_in_experience: 'Sign-in experience',
+  sign_in_experience_with_account: 'Sign-in & account',
   connectors: 'Connectors',
   enterprise_sso: 'Enterprise SSO',
   security: 'Security',

--- a/packages/phrases/src/locales/es/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/sign-in-exp/index.ts
@@ -4,14 +4,17 @@ import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
   page_title: 'Experiencia de inicio de sesión',
+  page_title_with_account: 'Inicio de sesión y cuenta',
   title: 'Experiencia de inicio de sesión',
+  title_with_account: 'Inicio de sesión y cuenta',
   description:
     'Personaliza los flujos de autenticación y la interfaz de usuario, y previsualiza la experiencia lista para usar en tiempo real.',
   tabs: {
     branding: 'Branding',
     sign_up_and_sign_in: 'Registro e inicio de sesión',
-    content: 'Contenido',
     collect_user_profile: 'Recopilar perfil de usuario',
+    account_center: 'Centro de cuentas',
+    content: 'Contenido',
     password_policy: 'Política de contraseña',
   },
   welcome: {
@@ -86,6 +89,58 @@ const sign_in_exp = {
       'Sube un paquete comprimido (.zip) para reemplazar la interfaz de usuario preconstruida de Logto con tu propio código. <a>Aprende más</a>',
     preview_with_bring_your_ui_description:
       'Tus activos de la interfaz de usuario personalizada se han subido con éxito y ahora se están sirviendo. En consecuencia, la ventana de vista previa incorporada se ha deshabilitado.\nPara probar tu interfaz de inicio de sesión personalizada, haz clic en el botón "Vista previa en vivo" para abrirla en una nueva pestaña del navegador.',
+  },
+  account_center: {
+    title: 'Centro de cuentas',
+    description: 'Personaliza los flujos de tu centro de cuentas usando las APIs de Logto.',
+    enable_account_api: 'Habilitar Account API',
+    enable_account_api_description:
+      'Habilita la Account API para crear un centro de cuentas personalizado y ofrecer a los usuarios finales acceso directo sin usar la Logto Management API.',
+    field_options: {
+      off: 'Off',
+      edit: 'Edit',
+      read_only: 'Read only',
+    },
+    sections: {
+      account_security: {
+        title: 'ACCOUNT SECURITY',
+        description:
+          'Manage access to the Account API, enabling users to view or edit their identity information and authentication factors after signing into the application. Users must verify their identity to get a valid 10-minute verification record ID before making these security-related changes.',
+        groups: {
+          identifiers: {
+            title: 'Identifiers',
+          },
+          authentication_factors: {
+            title: 'Authentication factors',
+          },
+        },
+      },
+      user_profile: {
+        title: 'USER PROFILE',
+        description:
+          'Manage access to the Account API, enabling users to view or edit basic or custom profile data after signing into the application.',
+        groups: {
+          profile_data: {
+            title: 'Profile data',
+          },
+        },
+      },
+    },
+    fields: {
+      email: 'Email address',
+      phone: 'Phone number',
+      social: 'Social identities',
+      password: 'Password',
+      mfa: 'Multi-factor authentication',
+      mfa_description: 'Let users manage their MFA methods from the account center.',
+      username: 'Username',
+      name: 'Name',
+      avatar: 'Avatar',
+      profile: 'Profile',
+      profile_description: 'Control access to structured profile attributes.',
+      custom_data: 'Custom data',
+      custom_data_description: 'Control access to custom JSON data stored on the user.',
+    },
   },
   sign_up_and_sign_in,
   content,

--- a/packages/phrases/src/locales/es/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/tabs.ts
@@ -4,6 +4,7 @@ const tabs = {
   applications: 'Aplicaciones',
   api_resources: 'Recursos de API',
   sign_in_experience: 'Experiencia de inicio de sesión',
+  sign_in_experience_with_account: 'Inicio de sesión y cuenta',
   connectors: 'Conectores',
   enterprise_sso: 'SSO empresarial',
   security: 'Seguridad',

--- a/packages/phrases/src/locales/fr/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/sign-in-exp/index.ts
@@ -4,14 +4,17 @@ import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
   page_title: 'Expérience de connexion',
+  page_title_with_account: 'Connexion et compte',
   title: 'Expérience de connexion',
+  title_with_account: 'Connexion et compte',
   description:
     "Personnalisez les flux d'authentification et l'interface utilisateur, et prévisualisez l'expérience prête à l'emploi en temps réel.",
   tabs: {
     branding: 'Image de marque',
     sign_up_and_sign_in: 'Inscription et connexion',
-    content: 'Contenu',
     collect_user_profile: 'Collecter le profil utilisateur',
+    account_center: 'Centre de compte',
+    content: 'Contenu',
     password_policy: 'Politique de mot de passe',
   },
   welcome: {
@@ -86,6 +89,58 @@ const sign_in_exp = {
       "Téléchargez un package compressé (.zip) pour remplacer l'UI préconstruite de Logto par votre propre code. <a>En savoir plus</a>",
     preview_with_bring_your_ui_description:
       'Vos ressources UI personnalisées ont été téléchargées avec succès et sont maintenant servies. En conséquence, la fenêtre de prévisualisation intégrée a été désactivée.\nPour tester votre UI de connexion personnalisée, cliquez sur le bouton "Aperçu en direct" pour l\'ouvrir dans un nouvel onglet du navigateur.',
+  },
+  account_center: {
+    title: 'Centre de compte',
+    description: 'Personnalisez les parcours de votre centre de compte avec les API Logto.',
+    enable_account_api: "Activer l'Account API",
+    enable_account_api_description:
+      "Activez l'Account API pour créer un centre de compte personnalisé et offrir aux utilisateurs finaux un accès direct sans utiliser la Logto Management API.",
+    field_options: {
+      off: 'Off',
+      edit: 'Edit',
+      read_only: 'Read only',
+    },
+    sections: {
+      account_security: {
+        title: 'ACCOUNT SECURITY',
+        description:
+          'Manage access to the Account API, enabling users to view or edit their identity information and authentication factors after signing into the application. Users must verify their identity to get a valid 10-minute verification record ID before making these security-related changes.',
+        groups: {
+          identifiers: {
+            title: 'Identifiers',
+          },
+          authentication_factors: {
+            title: 'Authentication factors',
+          },
+        },
+      },
+      user_profile: {
+        title: 'USER PROFILE',
+        description:
+          'Manage access to the Account API, enabling users to view or edit basic or custom profile data after signing into the application.',
+        groups: {
+          profile_data: {
+            title: 'Profile data',
+          },
+        },
+      },
+    },
+    fields: {
+      email: 'Email address',
+      phone: 'Phone number',
+      social: 'Social identities',
+      password: 'Password',
+      mfa: 'Multi-factor authentication',
+      mfa_description: 'Let users manage their MFA methods from the account center.',
+      username: 'Username',
+      name: 'Name',
+      avatar: 'Avatar',
+      profile: 'Profile',
+      profile_description: 'Control access to structured profile attributes.',
+      custom_data: 'Custom data',
+      custom_data_description: 'Control access to custom JSON data stored on the user.',
+    },
   },
   sign_up_and_sign_in,
   content,

--- a/packages/phrases/src/locales/fr/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/tabs.ts
@@ -4,6 +4,7 @@ const tabs = {
   applications: 'Applications',
   api_resources: 'Ressources API',
   sign_in_experience: 'Expérience de connexion',
+  sign_in_experience_with_account: 'Connexion et compte',
   connectors: 'Connecteurs',
   enterprise_sso: "SSO d'entreprise",
   security: 'Sécurité',

--- a/packages/phrases/src/locales/it/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/sign-in-exp/index.ts
@@ -4,14 +4,17 @@ import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
   page_title: 'Esperienza di accesso',
+  page_title_with_account: 'Accesso e account',
   title: 'Esperienza di accesso',
+  title_with_account: 'Accesso e account',
   description:
     "Personalizza i flussi di autenticazione e l'interfaccia utente, e visualizza in anteprima l'esperienza predefinita in tempo reale.",
   tabs: {
     branding: 'Marchio',
     sign_up_and_sign_in: 'Registrazione e accesso',
-    content: 'Contenuto',
     collect_user_profile: 'Raccogli profilo utente',
+    account_center: 'Centro account',
+    content: 'Contenuto',
     password_policy: 'Politica sulla password',
   },
   welcome: {
@@ -85,6 +88,58 @@ const sign_in_exp = {
       'Carica un pacchetto compresso (.zip) per sostituire la UI precaricata di Logto con il tuo codice. <a>Scopri di più</a>',
     preview_with_bring_your_ui_description:
       'I tuoi asset della UI personalizzata sono stati caricati con successo e ora vengono serviti. Di conseguenza, la finestra di anteprima integrata è stata disabilitata.\nPer testare la tua UI di accesso personalizzata, fai clic sul pulsante "Live Preview" per aprirla in una nuova scheda del browser.',
+  },
+  account_center: {
+    title: 'Centro account',
+    description: 'Personalizza i flussi del tuo centro account con le API Logto.',
+    enable_account_api: 'Abilita Account API',
+    enable_account_api_description:
+      "Abilita l'Account API per creare un centro account personalizzato e offrire agli utenti finali l'accesso diretto senza utilizzare la Logto Management API.",
+    field_options: {
+      off: 'Off',
+      edit: 'Edit',
+      read_only: 'Read only',
+    },
+    sections: {
+      account_security: {
+        title: 'ACCOUNT SECURITY',
+        description:
+          'Manage access to the Account API, enabling users to view or edit their identity information and authentication factors after signing into the application. Users must verify their identity to get a valid 10-minute verification record ID before making these security-related changes.',
+        groups: {
+          identifiers: {
+            title: 'Identifiers',
+          },
+          authentication_factors: {
+            title: 'Authentication factors',
+          },
+        },
+      },
+      user_profile: {
+        title: 'USER PROFILE',
+        description:
+          'Manage access to the Account API, enabling users to view or edit basic or custom profile data after signing into the application.',
+        groups: {
+          profile_data: {
+            title: 'Profile data',
+          },
+        },
+      },
+    },
+    fields: {
+      email: 'Email address',
+      phone: 'Phone number',
+      social: 'Social identities',
+      password: 'Password',
+      mfa: 'Multi-factor authentication',
+      mfa_description: 'Let users manage their MFA methods from the account center.',
+      username: 'Username',
+      name: 'Name',
+      avatar: 'Avatar',
+      profile: 'Profile',
+      profile_description: 'Control access to structured profile attributes.',
+      custom_data: 'Custom data',
+      custom_data_description: 'Control access to custom JSON data stored on the user.',
+    },
   },
   sign_up_and_sign_in,
   content,

--- a/packages/phrases/src/locales/it/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/tabs.ts
@@ -4,6 +4,7 @@ const tabs = {
   applications: 'Applicazioni',
   api_resources: 'Risorse API',
   sign_in_experience: 'Esperienza di accesso',
+  sign_in_experience_with_account: 'Accesso e account',
   connectors: 'Connettori',
   enterprise_sso: 'SSO Enterprise',
   security: 'Sicurezza',

--- a/packages/phrases/src/locales/ja/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/sign-in-exp/index.ts
@@ -4,14 +4,17 @@ import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
   page_title: 'サインインエクスペリエンス',
+  page_title_with_account: 'サインインとアカウント',
   title: 'サインインエクスペリエンス',
+  title_with_account: 'サインインとアカウント',
   description:
     '認証フローと UI をカスタマイズし、すぐに使えるエクスペリエンスをリアルタイムでプレビューします。',
   tabs: {
     branding: 'ブランディング',
     sign_up_and_sign_in: 'サインアップとサインイン',
-    content: '内容',
     collect_user_profile: 'ユーザープロフィールを収集',
+    account_center: 'アカウントセンター',
+    content: '内容',
     password_policy: 'パスワードポリシー',
   },
   welcome: {
@@ -85,6 +88,58 @@ const sign_in_exp = {
       '圧縮パッケージ (.zip) をアップロードして、Logto のビルトイン UI を独自のコードで置き換えます。<a>詳しくはこちら</a>',
     preview_with_bring_your_ui_description:
       'カスタム UI のアセットは正常にアップロードされ、現在提供されています。したがって、組み込みのプレビューウィンドウは無効になりました。\nパーソナライズされたサインイン UI をテストするには、「ライブプレビュー」ボタンをクリックして新しいブラウザタブで開きます。',
+  },
+  account_center: {
+    title: 'アカウントセンター',
+    description: 'Logto API を使用してアカウントセンターのフローをカスタマイズします。',
+    enable_account_api: 'Account API を有効化',
+    enable_account_api_description:
+      'Account API を有効化すると、Logto Management API を使わずにエンドユーザーに直接 API アクセスを提供するカスタムアカウントセンターを構築できます。',
+    field_options: {
+      off: 'Off',
+      edit: 'Edit',
+      read_only: 'Read only',
+    },
+    sections: {
+      account_security: {
+        title: 'ACCOUNT SECURITY',
+        description:
+          'Manage access to the Account API, enabling users to view or edit their identity information and authentication factors after signing into the application. Users must verify their identity to get a valid 10-minute verification record ID before making these security-related changes.',
+        groups: {
+          identifiers: {
+            title: 'Identifiers',
+          },
+          authentication_factors: {
+            title: 'Authentication factors',
+          },
+        },
+      },
+      user_profile: {
+        title: 'USER PROFILE',
+        description:
+          'Manage access to the Account API, enabling users to view or edit basic or custom profile data after signing into the application.',
+        groups: {
+          profile_data: {
+            title: 'Profile data',
+          },
+        },
+      },
+    },
+    fields: {
+      email: 'Email address',
+      phone: 'Phone number',
+      social: 'Social identities',
+      password: 'Password',
+      mfa: 'Multi-factor authentication',
+      mfa_description: 'Let users manage their MFA methods from the account center.',
+      username: 'Username',
+      name: 'Name',
+      avatar: 'Avatar',
+      profile: 'Profile',
+      profile_description: 'Control access to structured profile attributes.',
+      custom_data: 'Custom data',
+      custom_data_description: 'Control access to custom JSON data stored on the user.',
+    },
   },
   sign_up_and_sign_in,
   content,

--- a/packages/phrases/src/locales/ja/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/tabs.ts
@@ -4,6 +4,7 @@ const tabs = {
   applications: 'アプリケーション',
   api_resources: 'API リソース',
   sign_in_experience: 'サインイン',
+  sign_in_experience_with_account: 'サインインとアカウント',
   connectors: 'コネクタ',
   enterprise_sso: 'エンタープライズSSO',
   security: 'セキュリティ',

--- a/packages/phrases/src/locales/ko/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/sign-in-exp/index.ts
@@ -4,13 +4,16 @@ import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
   page_title: '로그인 경험',
+  page_title_with_account: '로그인 및 계정',
   title: '로그인 경험',
+  title_with_account: '로그인 및 계정',
   description: '인증 흐름과 UI 를 사용자 지정하고 실시간으로 기본 제공 경험을 미리 볼 수 있습니다.',
   tabs: {
     branding: '브랜딩',
     sign_up_and_sign_in: '회원가입/로그인',
-    content: '내용',
     collect_user_profile: '사용자 프로필 수집',
+    account_center: '계정 센터',
+    content: '내용',
     password_policy: '암호 정책',
   },
   welcome: {
@@ -82,6 +85,58 @@ const sign_in_exp = {
       'Logto 가미리 제공하는 UI 를 나만의 코드로 대체하기 위해 압축 패키지 (.zip)를 업로드하세요. <a>더 알아보기</a>',
     preview_with_bring_your_ui_description:
       '커스텀 UI 자산이 성공적으로 업로드되어 현재 제공되고 있습니다. 따라서 기본 제공 미리보기 창이 비활성화되었습니다.\n개인화된 로그인 UI 를 테스트하려면 "실시간 미리보기" 버튼을 클릭하여 새 브라우저 탭에서 엽니다.',
+  },
+  account_center: {
+    title: '계정 센터',
+    description: 'Logto API로 계정 센터 흐름을 사용자화하세요.',
+    enable_account_api: 'Account API 활성화',
+    enable_account_api_description:
+      'Account API를 활성화하여 Logto 관리 API 없이도 엔드유저에게 직접 API 접근을 제공하는 맞춤형 계정 센터를 구축하세요.',
+    field_options: {
+      off: 'Off',
+      edit: 'Edit',
+      read_only: 'Read only',
+    },
+    sections: {
+      account_security: {
+        title: 'ACCOUNT SECURITY',
+        description:
+          'Manage access to the Account API, enabling users to view or edit their identity information and authentication factors after signing into the application. Users must verify their identity to get a valid 10-minute verification record ID before making these security-related changes.',
+        groups: {
+          identifiers: {
+            title: 'Identifiers',
+          },
+          authentication_factors: {
+            title: 'Authentication factors',
+          },
+        },
+      },
+      user_profile: {
+        title: 'USER PROFILE',
+        description:
+          'Manage access to the Account API, enabling users to view or edit basic or custom profile data after signing into the application.',
+        groups: {
+          profile_data: {
+            title: 'Profile data',
+          },
+        },
+      },
+    },
+    fields: {
+      email: 'Email address',
+      phone: 'Phone number',
+      social: 'Social identities',
+      password: 'Password',
+      mfa: 'Multi-factor authentication',
+      mfa_description: 'Let users manage their MFA methods from the account center.',
+      username: 'Username',
+      name: 'Name',
+      avatar: 'Avatar',
+      profile: 'Profile',
+      profile_description: 'Control access to structured profile attributes.',
+      custom_data: 'Custom data',
+      custom_data_description: 'Control access to custom JSON data stored on the user.',
+    },
   },
   sign_up_and_sign_in,
   content,

--- a/packages/phrases/src/locales/ko/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/tabs.ts
@@ -4,6 +4,7 @@ const tabs = {
   applications: '어플리케이션',
   api_resources: 'API 리소스',
   sign_in_experience: '로그인 경험',
+  sign_in_experience_with_account: '로그인 및 계정',
   connectors: '연동',
   enterprise_sso: '기업 SSO',
   security: '보안',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/sign-in-exp/index.ts
@@ -4,14 +4,17 @@ import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
   page_title: 'Doświadczenie logowania',
+  page_title_with_account: 'Logowanie i konto',
   title: 'Doświadczenie logowania',
+  title_with_account: 'Logowanie i konto',
   description:
     'Dostosuj przepływy uwierzytelniania i interfejs użytkownika, a także podglądaj gotowe rozwiązanie w czasie rzeczywistym.',
   tabs: {
     branding: 'Marka',
     sign_up_and_sign_in: 'Rejestracja i logowanie',
-    content: 'Treść',
     collect_user_profile: 'Zbieraj profil użytkownika',
+    account_center: 'Centrum konta',
+    content: 'Treść',
     password_policy: 'Polityka hasła',
   },
   welcome: {
@@ -85,6 +88,58 @@ const sign_in_exp = {
       'Prześlij skompresowany pakiet (.zip), aby zastąpić predefiniowany interfejs użytkownika Logto swoim własnym kodem. <a>Dowiedz się więcej</a>',
     preview_with_bring_your_ui_description:
       'Twoje niestandardowe zasoby interfejsu użytkownika zostały pomyślnie przesłane i są teraz dostępne. W rezultacie wbudowane okno podglądu zostało wyłączone.\nAby przetestować swoje spersonalizowane UI logowania, kliknij przycisk "Podgląd na żywo", aby otworzyć go w nowej karcie przeglądarki.',
+  },
+  account_center: {
+    title: 'Centrum konta',
+    description: 'Dostosuj procesy centrum konta z wykorzystaniem interfejsów Logto.',
+    enable_account_api: 'Włącz Account API',
+    enable_account_api_description:
+      'Włącz Account API, aby budować własne centrum konta i dać użytkownikom bezpośredni dostęp do API bez użycia Logto Management API.',
+    field_options: {
+      off: 'Off',
+      edit: 'Edit',
+      read_only: 'Read only',
+    },
+    sections: {
+      account_security: {
+        title: 'ACCOUNT SECURITY',
+        description:
+          'Manage access to the Account API, enabling users to view or edit their identity information and authentication factors after signing into the application. Users must verify their identity to get a valid 10-minute verification record ID before making these security-related changes.',
+        groups: {
+          identifiers: {
+            title: 'Identifiers',
+          },
+          authentication_factors: {
+            title: 'Authentication factors',
+          },
+        },
+      },
+      user_profile: {
+        title: 'USER PROFILE',
+        description:
+          'Manage access to the Account API, enabling users to view or edit basic or custom profile data after signing into the application.',
+        groups: {
+          profile_data: {
+            title: 'Profile data',
+          },
+        },
+      },
+    },
+    fields: {
+      email: 'Email address',
+      phone: 'Phone number',
+      social: 'Social identities',
+      password: 'Password',
+      mfa: 'Multi-factor authentication',
+      mfa_description: 'Let users manage their MFA methods from the account center.',
+      username: 'Username',
+      name: 'Name',
+      avatar: 'Avatar',
+      profile: 'Profile',
+      profile_description: 'Control access to structured profile attributes.',
+      custom_data: 'Custom data',
+      custom_data_description: 'Control access to custom JSON data stored on the user.',
+    },
   },
   sign_up_and_sign_in,
   content,

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/tabs.ts
@@ -4,6 +4,7 @@ const tabs = {
   applications: 'Aplikacje',
   api_resources: 'Zasoby API',
   sign_in_experience: 'Doświadczenie przy logowaniu',
+  sign_in_experience_with_account: 'Logowanie i konto',
   connectors: 'Konnektory',
   enterprise_sso: 'Enterprise SSO',
   security: 'Bezpieczeństwo',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/sign-in-exp/index.ts
@@ -4,14 +4,17 @@ import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
   page_title: 'Experiência de login',
+  page_title_with_account: 'Login e conta',
   title: 'Experiência de login',
+  title_with_account: 'Login e conta',
   description:
     'Personalize os fluxos de autenticação e a interface do usuário, e visualize a experiência pronta para uso em tempo real.',
   tabs: {
     branding: 'Marca',
     sign_up_and_sign_in: 'Inscreva-se e faça login',
-    content: 'Conteúdo',
     collect_user_profile: 'Coletar perfil do usuário',
+    account_center: 'Centro de contas',
+    content: 'Conteúdo',
     password_policy: 'Política de senhas',
   },
   welcome: {
@@ -85,6 +88,58 @@ const sign_in_exp = {
       'Carregue um pacote compactado (.zip) para substituir a UI pré-construída do Logto pelo seu próprio código. <a>Saiba mais</a>',
     preview_with_bring_your_ui_description:
       'Seus ativos de UI personalizados foram carregados com sucesso e agora estão sendo servidos. Consequentemente, a janela de visualização interna foi desativada.\nPara testar sua UI de login personalizada, clique no botão "Visualização em tempo real" para abri-la em uma nova aba do navegador.',
+  },
+  account_center: {
+    title: 'Centro de contas',
+    description: 'Personalize os fluxos do centro de contas com as APIs Logto.',
+    enable_account_api: 'Ativar Account API',
+    enable_account_api_description:
+      'Ative a Account API para criar um centro de contas personalizado e oferecer aos usuários finais acesso direto sem usar a Logto Management API.',
+    field_options: {
+      off: 'Off',
+      edit: 'Edit',
+      read_only: 'Read only',
+    },
+    sections: {
+      account_security: {
+        title: 'ACCOUNT SECURITY',
+        description:
+          'Manage access to the Account API, enabling users to view or edit their identity information and authentication factors after signing into the application. Users must verify their identity to get a valid 10-minute verification record ID before making these security-related changes.',
+        groups: {
+          identifiers: {
+            title: 'Identifiers',
+          },
+          authentication_factors: {
+            title: 'Authentication factors',
+          },
+        },
+      },
+      user_profile: {
+        title: 'USER PROFILE',
+        description:
+          'Manage access to the Account API, enabling users to view or edit basic or custom profile data after signing into the application.',
+        groups: {
+          profile_data: {
+            title: 'Profile data',
+          },
+        },
+      },
+    },
+    fields: {
+      email: 'Email address',
+      phone: 'Phone number',
+      social: 'Social identities',
+      password: 'Password',
+      mfa: 'Multi-factor authentication',
+      mfa_description: 'Let users manage their MFA methods from the account center.',
+      username: 'Username',
+      name: 'Name',
+      avatar: 'Avatar',
+      profile: 'Profile',
+      profile_description: 'Control access to structured profile attributes.',
+      custom_data: 'Custom data',
+      custom_data_description: 'Control access to custom JSON data stored on the user.',
+    },
   },
   sign_up_and_sign_in,
   content,

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/tabs.ts
@@ -4,6 +4,7 @@ const tabs = {
   applications: 'Aplicativos',
   api_resources: 'Recursos da API',
   sign_in_experience: 'Experiência de login',
+  sign_in_experience_with_account: 'Login e conta',
   connectors: 'Conectores',
   enterprise_sso: 'SSO Empresarial',
   security: 'Segurança',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/sign-in-exp/index.ts
@@ -4,14 +4,17 @@ import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
   page_title: 'Experiência de login',
+  page_title_with_account: 'Início de sessão e conta',
   title: 'Experiência de login',
+  title_with_account: 'Início de sessão e conta',
   description:
     'Personalize os fluxos de autenticação e a interface do usuário, e visualize a experiência pronta para uso em tempo real.',
   tabs: {
     branding: 'Marca',
     sign_up_and_sign_in: 'Registo e login',
-    content: 'Conteúdo',
     collect_user_profile: 'Recolher perfil do utilizador',
+    account_center: 'Centro de contas',
+    content: 'Conteúdo',
     password_policy: 'Política de senha',
   },
   welcome: {
@@ -84,6 +87,58 @@ const sign_in_exp = {
       'Carregue um pacote comprimido (.zip) para substituir o UI predefinido do Logto pelo seu próprio código. <a>Saiba mais</a>',
     preview_with_bring_your_ui_description:
       'Os seus recursos de UI personalizados foram carregados com êxito e agora estão sendo servidos. Consequentemente, a janela de visualização incorporada foi desativada.\nPara testar o seu UI de início de sessão personalizado, clique no botão "Visualização ao vivo" para abri-lo num novo separador do navegador.',
+  },
+  account_center: {
+    title: 'Centro de contas',
+    description: 'Personaliza os fluxos do centro de contas com as APIs Logto.',
+    enable_account_api: 'Ativar Account API',
+    enable_account_api_description:
+      'Ativa a Account API para criar um centro de contas personalizado, dando aos utilizadores acesso direto sem usar a Logto Management API.',
+    field_options: {
+      off: 'Off',
+      edit: 'Edit',
+      read_only: 'Read only',
+    },
+    sections: {
+      account_security: {
+        title: 'ACCOUNT SECURITY',
+        description:
+          'Manage access to the Account API, enabling users to view or edit their identity information and authentication factors after signing into the application. Users must verify their identity to get a valid 10-minute verification record ID before making these security-related changes.',
+        groups: {
+          identifiers: {
+            title: 'Identifiers',
+          },
+          authentication_factors: {
+            title: 'Authentication factors',
+          },
+        },
+      },
+      user_profile: {
+        title: 'USER PROFILE',
+        description:
+          'Manage access to the Account API, enabling users to view or edit basic or custom profile data after signing into the application.',
+        groups: {
+          profile_data: {
+            title: 'Profile data',
+          },
+        },
+      },
+    },
+    fields: {
+      email: 'Email address',
+      phone: 'Phone number',
+      social: 'Social identities',
+      password: 'Password',
+      mfa: 'Multi-factor authentication',
+      mfa_description: 'Let users manage their MFA methods from the account center.',
+      username: 'Username',
+      name: 'Name',
+      avatar: 'Avatar',
+      profile: 'Profile',
+      profile_description: 'Control access to structured profile attributes.',
+      custom_data: 'Custom data',
+      custom_data_description: 'Control access to custom JSON data stored on the user.',
+    },
   },
   sign_up_and_sign_in,
   content,

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/tabs.ts
@@ -4,6 +4,7 @@ const tabs = {
   applications: 'Aplicações',
   api_resources: 'Recursos API',
   sign_in_experience: 'Experiência de login',
+  sign_in_experience_with_account: 'Início de sessão e conta',
   connectors: 'Conectores',
   enterprise_sso: 'SSO empresarial',
   security: 'Segurança',

--- a/packages/phrases/src/locales/ru/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/sign-in-exp/index.ts
@@ -4,14 +4,17 @@ import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
   page_title: 'Опыт входа в систему',
+  page_title_with_account: 'Вход и аккаунт',
   title: 'Опыт входа в систему',
+  title_with_account: 'Вход и аккаунт',
   description:
     'Настройте потоки аутентификации и пользовательский интерфейс, и просматривайте готовый опыт в реальном времени.',
   tabs: {
     branding: 'Брендирование',
     sign_up_and_sign_in: 'Регистрация и вход в систему',
-    content: 'Содержание',
     collect_user_profile: 'Сбор профиля пользователя',
+    account_center: 'Центр аккаунта',
+    content: 'Содержание',
     password_policy: 'Политика пароля',
   },
   welcome: {
@@ -85,6 +88,58 @@ const sign_in_exp = {
       'Загрузите сжатый пакет (.zip), чтобы заменить предустановленный интерфейс Logto вашим собственным кодом. <a>Узнать больше</a>',
     preview_with_bring_your_ui_description:
       'Ваши пользовательские ресурсы интерфейса успешно загружены и теперь доступны. Встроенное окно предварительного просмотра отключено.\nДля тестирования персонализированного интерфейса входа нажмите кнопку "Прямая трансляция" для открытия в новой вкладке браузера.',
+  },
+  account_center: {
+    title: 'Центр аккаунта',
+    description: 'Настраивайте процессы центра аккаунта с помощью API Logto.',
+    enable_account_api: 'Включить Account API',
+    enable_account_api_description:
+      'Включите Account API, чтобы создать собственный центр аккаунта и дать пользователям прямой доступ к API без использования Logto Management API.',
+    field_options: {
+      off: 'Off',
+      edit: 'Edit',
+      read_only: 'Read only',
+    },
+    sections: {
+      account_security: {
+        title: 'ACCOUNT SECURITY',
+        description:
+          'Manage access to the Account API, enabling users to view or edit their identity information and authentication factors after signing into the application. Users must verify their identity to get a valid 10-minute verification record ID before making these security-related changes.',
+        groups: {
+          identifiers: {
+            title: 'Identifiers',
+          },
+          authentication_factors: {
+            title: 'Authentication factors',
+          },
+        },
+      },
+      user_profile: {
+        title: 'USER PROFILE',
+        description:
+          'Manage access to the Account API, enabling users to view or edit basic or custom profile data after signing into the application.',
+        groups: {
+          profile_data: {
+            title: 'Profile data',
+          },
+        },
+      },
+    },
+    fields: {
+      email: 'Email address',
+      phone: 'Phone number',
+      social: 'Social identities',
+      password: 'Password',
+      mfa: 'Multi-factor authentication',
+      mfa_description: 'Let users manage their MFA methods from the account center.',
+      username: 'Username',
+      name: 'Name',
+      avatar: 'Avatar',
+      profile: 'Profile',
+      profile_description: 'Control access to structured profile attributes.',
+      custom_data: 'Custom data',
+      custom_data_description: 'Control access to custom JSON data stored on the user.',
+    },
   },
   sign_up_and_sign_in,
   content,

--- a/packages/phrases/src/locales/ru/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/tabs.ts
@@ -4,6 +4,7 @@ const tabs = {
   applications: 'Приложения',
   api_resources: 'Ресурсы API',
   sign_in_experience: 'Опыт входа в систему',
+  sign_in_experience_with_account: 'Вход и аккаунт',
   connectors: 'Коннекторы',
   enterprise_sso: 'Единый вход в систему предприятия',
   security: 'Безопасность',

--- a/packages/phrases/src/locales/th/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/sign-in-exp/index.ts
@@ -4,14 +4,17 @@ import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
   page_title: 'ประสบการณ์การเข้าสู่ระบบ',
+  page_title_with_account: 'การเข้าสู่ระบบและบัญชี',
   title: 'ประสบการณ์การเข้าสู่ระบบ',
+  title_with_account: 'การเข้าสู่ระบบและบัญชี',
   description:
     'ปรับแต่งกระบวนการยืนยันตัวตนและ UI พร้อมดูตัวอย่างประสบการณ์ใช้งานทันทีแบบเรียลไทม์',
   tabs: {
     branding: 'การสร้างแบรนด์',
     sign_up_and_sign_in: 'สมัครและเข้าสู่ระบบ',
-    content: 'เนื้อหา',
     collect_user_profile: 'เก็บข้อมูลโปรไฟล์ผู้ใช้',
+    account_center: 'ศูนย์บัญชี',
+    content: 'เนื้อหา',
     password_policy: 'นโยบายรหัสผ่าน',
   },
   welcome: {
@@ -84,6 +87,58 @@ const sign_in_exp = {
       'อัปโหลดไฟล์บีบอัด (.zip) เพื่อแทนที่ UI สำเร็จรูปของ Logto ด้วยโค้ดของคุณเอง <a>เรียนรู้เพิ่มเติม</a>',
     preview_with_bring_your_ui_description:
       'ไฟล์ UI ที่คุณกำหนดเองถูกอัปโหลดเรียบร้อยแล้วและกำลังใช้งานอยู่ ดังนั้นหน้าต่างตัวอย่างแบบฝังจึงถูกปิดใช้งาน\nหากต้องการทดสอบหน้าเข้าสู่ระบบแบบกำหนดเอง ให้คลิกปุ่ม "แสดงตัวอย่างสด" เพื่อเปิดในแท็บใหม่',
+  },
+  account_center: {
+    title: 'ศูนย์บัญชี',
+    description: 'ปรับแต่งขั้นตอนศูนย์บัญชีด้วย Logto APIs',
+    enable_account_api: 'เปิดใช้งาน Account API',
+    enable_account_api_description:
+      'เปิดใช้งาน Account API เพื่อสร้างศูนย์บัญชีแบบกำหนดเอง ให้ผู้ใช้ปลายทางเข้าถึง API ได้โดยตรงโดยไม่ต้องใช้ Logto Management API.',
+    field_options: {
+      off: 'Off',
+      edit: 'Edit',
+      read_only: 'Read only',
+    },
+    sections: {
+      account_security: {
+        title: 'ACCOUNT SECURITY',
+        description:
+          'Manage access to the Account API, enabling users to view or edit their identity information and authentication factors after signing into the application. Users must verify their identity to get a valid 10-minute verification record ID before making these security-related changes.',
+        groups: {
+          identifiers: {
+            title: 'Identifiers',
+          },
+          authentication_factors: {
+            title: 'Authentication factors',
+          },
+        },
+      },
+      user_profile: {
+        title: 'USER PROFILE',
+        description:
+          'Manage access to the Account API, enabling users to view or edit basic or custom profile data after signing into the application.',
+        groups: {
+          profile_data: {
+            title: 'Profile data',
+          },
+        },
+      },
+    },
+    fields: {
+      email: 'Email address',
+      phone: 'Phone number',
+      social: 'Social identities',
+      password: 'Password',
+      mfa: 'Multi-factor authentication',
+      mfa_description: 'Let users manage their MFA methods from the account center.',
+      username: 'Username',
+      name: 'Name',
+      avatar: 'Avatar',
+      profile: 'Profile',
+      profile_description: 'Control access to structured profile attributes.',
+      custom_data: 'Custom data',
+      custom_data_description: 'Control access to custom JSON data stored on the user.',
+    },
   },
   sign_up_and_sign_in,
   content,

--- a/packages/phrases/src/locales/th/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/tabs.ts
@@ -4,6 +4,7 @@ const tabs = {
   applications: 'แอปพลิเคชัน',
   api_resources: 'API ทรัพยากร',
   sign_in_experience: 'ประสบการณ์การเข้าสู่ระบบ',
+  sign_in_experience_with_account: 'การเข้าสู่ระบบและบัญชี',
   connectors: 'ตัวเชื่อมต่อ',
   enterprise_sso: 'SSO สำหรับองค์กร',
   security: 'ความปลอดภัย',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/sign-in-exp/index.ts
@@ -4,14 +4,17 @@ import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
   page_title: 'Oturum Açma Deneyimi',
+  page_title_with_account: 'Oturum açma ve hesap',
   title: 'Oturum Açma Deneyimi',
+  title_with_account: 'Oturum açma ve hesap',
   description:
     "Kimlik doğrulama akışlarını ve UI'yı özelleştirin ve hazır deneyimi gerçek zamanlı olarak önizleyin.",
   tabs: {
     branding: 'Markalaşma',
     sign_up_and_sign_in: 'Kaydol ve Oturum Aç',
-    content: 'İçerik',
     collect_user_profile: 'Kullanıcı profili topla',
+    account_center: 'Hesap merkezi',
+    content: 'İçerik',
     password_policy: 'Şifre politikası',
   },
   welcome: {
@@ -85,6 +88,58 @@ const sign_in_exp = {
       "Logto'nun önceden oluşturulmuş UI'sini kendi kodunuzla değiştirmek için sıkıştırılmış bir paket (.zip) yükleyin. <a>Daha fazla bilgi edinin</a>",
     preview_with_bring_your_ui_description:
       'Özelleştirilmiş UI varlıklarınız başarıyla yüklendi ve şimdi sunuluyor. Sonuç olarak, yerleşik önizleme penceresi devre dışı bırakıldı.\nKişiselleştirilmiş oturum açma UI\'nizi test etmek için "Canlı Önizleme" düğmesine tıklayarak yeni bir tarayıcı sekmesinde açın.',
+  },
+  account_center: {
+    title: 'Hesap merkezi',
+    description: "Logto API'leri ile hesap merkezi akışlarını özelleştirin.",
+    enable_account_api: "Account API'yi etkinleştir",
+    enable_account_api_description:
+      "Account API'yi etkinleştirerek Logto Management API'sini kullanmadan son kullanıcılara doğrudan API erişimi sağlayan özel bir hesap merkezi oluşturun.",
+    field_options: {
+      off: 'Off',
+      edit: 'Edit',
+      read_only: 'Read only',
+    },
+    sections: {
+      account_security: {
+        title: 'ACCOUNT SECURITY',
+        description:
+          'Manage access to the Account API, enabling users to view or edit their identity information and authentication factors after signing into the application. Users must verify their identity to get a valid 10-minute verification record ID before making these security-related changes.',
+        groups: {
+          identifiers: {
+            title: 'Identifiers',
+          },
+          authentication_factors: {
+            title: 'Authentication factors',
+          },
+        },
+      },
+      user_profile: {
+        title: 'USER PROFILE',
+        description:
+          'Manage access to the Account API, enabling users to view or edit basic or custom profile data after signing into the application.',
+        groups: {
+          profile_data: {
+            title: 'Profile data',
+          },
+        },
+      },
+    },
+    fields: {
+      email: 'Email address',
+      phone: 'Phone number',
+      social: 'Social identities',
+      password: 'Password',
+      mfa: 'Multi-factor authentication',
+      mfa_description: 'Let users manage their MFA methods from the account center.',
+      username: 'Username',
+      name: 'Name',
+      avatar: 'Avatar',
+      profile: 'Profile',
+      profile_description: 'Control access to structured profile attributes.',
+      custom_data: 'Custom data',
+      custom_data_description: 'Control access to custom JSON data stored on the user.',
+    },
   },
   sign_up_and_sign_in,
   content,

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/tabs.ts
@@ -4,6 +4,7 @@ const tabs = {
   applications: 'Uygulamalar',
   api_resources: 'API Kaynakları',
   sign_in_experience: 'Oturum Açma Deneyimi',
+  sign_in_experience_with_account: 'Oturum açma ve hesap',
   connectors: 'Connectors',
   enterprise_sso: 'Kurumsal SSO',
   security: 'Güvenlik',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/sign-in-exp/index.ts
@@ -4,13 +4,16 @@ import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
   page_title: '登录体验',
+  page_title_with_account: '登录与账户',
   title: '登录体验',
+  title_with_account: '登录与账户',
   description: '自定义身份验证流程和用户界面，并实时预览开箱即用的体验。',
   tabs: {
     branding: '品牌',
     sign_up_and_sign_in: '注册与登录',
-    content: '内容',
     collect_user_profile: '收集用户资料',
+    account_center: '账户中心',
+    content: '内容',
     password_policy: '密码策略',
   },
   welcome: {
@@ -82,6 +85,58 @@ const sign_in_exp = {
       '上传一个压缩包 (.zip) 以使用你自己的代码替换 Logto 预构建的 UI。<a>了解更多</a>',
     preview_with_bring_your_ui_description:
       '你自定义的 UI 资源已经成功上传，现在正在提供服务。因此，内置预览窗口已被禁用。\n要测试你个性化的登录 UI，请单击“实时预览”按钮在新的浏览器标签中打开它。',
+  },
+  account_center: {
+    title: '账户中心',
+    description: '使用 Logto API 自定义你的账户中心流程。',
+    enable_account_api: '启用 Account API',
+    enable_account_api_description:
+      '启用 Account API，构建自定义账户中心，让终端用户无需使用 Logto 管理 API 即可直接访问 API。',
+    field_options: {
+      off: 'Off',
+      edit: 'Edit',
+      read_only: 'Read only',
+    },
+    sections: {
+      account_security: {
+        title: 'ACCOUNT SECURITY',
+        description:
+          'Manage access to the Account API, enabling users to view or edit their identity information and authentication factors after signing into the application. Users must verify their identity to get a valid 10-minute verification record ID before making these security-related changes.',
+        groups: {
+          identifiers: {
+            title: 'Identifiers',
+          },
+          authentication_factors: {
+            title: 'Authentication factors',
+          },
+        },
+      },
+      user_profile: {
+        title: 'USER PROFILE',
+        description:
+          'Manage access to the Account API, enabling users to view or edit basic or custom profile data after signing into the application.',
+        groups: {
+          profile_data: {
+            title: 'Profile data',
+          },
+        },
+      },
+    },
+    fields: {
+      email: 'Email address',
+      phone: 'Phone number',
+      social: 'Social identities',
+      password: 'Password',
+      mfa: 'Multi-factor authentication',
+      mfa_description: 'Let users manage their MFA methods from the account center.',
+      username: 'Username',
+      name: 'Name',
+      avatar: 'Avatar',
+      profile: 'Profile',
+      profile_description: 'Control access to structured profile attributes.',
+      custom_data: 'Custom data',
+      custom_data_description: 'Control access to custom JSON data stored on the user.',
+    },
   },
   sign_up_and_sign_in,
   content,

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/tabs.ts
@@ -4,6 +4,7 @@ const tabs = {
   applications: '全部应用',
   api_resources: 'API 资源',
   sign_in_experience: '登录体验',
+  sign_in_experience_with_account: '登录与账户',
   connectors: '连接器',
   enterprise_sso: '企业SSO',
   security: '安全',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/sign-in-exp/index.ts
@@ -4,13 +4,16 @@ import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
   page_title: '登錄體驗',
+  page_title_with_account: '登錄與帳戶',
   title: '登錄體驗',
+  title_with_account: '登錄與帳戶',
   description: '自定義身份驗證流程和 UI，並實時預覽開箱即用的體驗。',
   tabs: {
     branding: '品牌',
     sign_up_and_sign_in: '註冊與登錄',
-    content: '內容',
     collect_user_profile: '收集用戶資料',
+    account_center: '帳戶中心',
+    content: '內容',
     password_policy: '密碼政策',
   },
   welcome: {
@@ -82,6 +85,58 @@ const sign_in_exp = {
       '上傳壓縮包 (.zip) 以用自己的代碼替換 Logto 預建的 UI。<a>了解更多</a>',
     preview_with_bring_your_ui_description:
       '你的自定義 UI 資源已成功上傳，現在正在提供服務。因此，內建預覽窗口已被禁用。\n要測試你的個性化登錄 UI，請點擊“實時預覽”按鈕在新瀏覽器標籤頁中打開。',
+  },
+  account_center: {
+    title: '帳戶中心',
+    description: '使用 Logto API 自定義你的帳戶中心流程。',
+    enable_account_api: '啟用 Account API',
+    enable_account_api_description:
+      '啟用 Account API，以建立自定義帳戶中心，讓最終使用者無需使用 Logto 管理 API 即可直接存取 API。',
+    field_options: {
+      off: 'Off',
+      edit: 'Edit',
+      read_only: 'Read only',
+    },
+    sections: {
+      account_security: {
+        title: 'ACCOUNT SECURITY',
+        description:
+          'Manage access to the Account API, enabling users to view or edit their identity information and authentication factors after signing into the application. Users must verify their identity to get a valid 10-minute verification record ID before making these security-related changes.',
+        groups: {
+          identifiers: {
+            title: 'Identifiers',
+          },
+          authentication_factors: {
+            title: 'Authentication factors',
+          },
+        },
+      },
+      user_profile: {
+        title: 'USER PROFILE',
+        description:
+          'Manage access to the Account API, enabling users to view or edit basic or custom profile data after signing into the application.',
+        groups: {
+          profile_data: {
+            title: 'Profile data',
+          },
+        },
+      },
+    },
+    fields: {
+      email: 'Email address',
+      phone: 'Phone number',
+      social: 'Social identities',
+      password: 'Password',
+      mfa: 'Multi-factor authentication',
+      mfa_description: 'Let users manage their MFA methods from the account center.',
+      username: 'Username',
+      name: 'Name',
+      avatar: 'Avatar',
+      profile: 'Profile',
+      profile_description: 'Control access to structured profile attributes.',
+      custom_data: 'Custom data',
+      custom_data_description: 'Control access to custom JSON data stored on the user.',
+    },
   },
   sign_up_and_sign_in,
   content,

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/tabs.ts
@@ -4,6 +4,7 @@ const tabs = {
   applications: '全部應用',
   api_resources: 'API 資源',
   sign_in_experience: '登錄體驗',
+  sign_in_experience_with_account: '登錄與帳戶',
   connectors: '連接器',
   enterprise_sso: '企業SSO',
   security: '安全',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/sign-in-exp/index.ts
@@ -4,13 +4,16 @@ import sign_up_and_sign_in from './sign-up-and-sign-in.js';
 
 const sign_in_exp = {
   page_title: '登錄體驗',
+  page_title_with_account: '登錄與帳戶',
   title: '登錄體驗',
+  title_with_account: '登錄與帳戶',
   description: '自定義身份驗證流程和用戶界面，並實時預覽現成的體驗。',
   tabs: {
     branding: '品牌',
     sign_up_and_sign_in: '註冊與登錄',
-    content: '內容',
     collect_user_profile: '收集用戶資料',
+    account_center: '帳戶中心',
+    content: '內容',
     password_policy: '密碼規則',
   },
   welcome: {
@@ -82,6 +85,58 @@ const sign_in_exp = {
       '上傳壓縮包 (.zip) 來用你的代碼替換 Logto 的預構建界面。<a>了解更多</a>',
     preview_with_bring_your_ui_description:
       '你的自定義界面資源已成功上傳並正在服務。因此，內置預覽窗口已被禁用。\n若要測試你的個性化登錄界面，請點擊「實時預覽」按鈕在新瀏覽器標籤頁中打開。',
+  },
+  account_center: {
+    title: '帳戶中心',
+    description: '使用 Logto API 自定義你的帳戶中心流程。',
+    enable_account_api: '啟用 Account API',
+    enable_account_api_description:
+      '啟用 Account API，以建立自定義帳戶中心，讓最終使用者無需使用 Logto 管理 API 即可直接存取 API。',
+    field_options: {
+      off: 'Off',
+      edit: 'Edit',
+      read_only: 'Read only',
+    },
+    sections: {
+      account_security: {
+        title: 'ACCOUNT SECURITY',
+        description:
+          'Manage access to the Account API, enabling users to view or edit their identity information and authentication factors after signing into the application. Users must verify their identity to get a valid 10-minute verification record ID before making these security-related changes.',
+        groups: {
+          identifiers: {
+            title: 'Identifiers',
+          },
+          authentication_factors: {
+            title: 'Authentication factors',
+          },
+        },
+      },
+      user_profile: {
+        title: 'USER PROFILE',
+        description:
+          'Manage access to the Account API, enabling users to view or edit basic or custom profile data after signing into the application.',
+        groups: {
+          profile_data: {
+            title: 'Profile data',
+          },
+        },
+      },
+    },
+    fields: {
+      email: 'Email address',
+      phone: 'Phone number',
+      social: 'Social identities',
+      password: 'Password',
+      mfa: 'Multi-factor authentication',
+      mfa_description: 'Let users manage their MFA methods from the account center.',
+      username: 'Username',
+      name: 'Name',
+      avatar: 'Avatar',
+      profile: 'Profile',
+      profile_description: 'Control access to structured profile attributes.',
+      custom_data: 'Custom data',
+      custom_data_description: 'Control access to custom JSON data stored on the user.',
+    },
   },
   sign_up_and_sign_in,
   content,

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/tabs.ts
@@ -4,6 +4,7 @@ const tabs = {
   applications: '全部應用',
   api_resources: 'API 資源',
   sign_in_experience: '登入體驗',
+  sign_in_experience_with_account: '登入與帳戶',
   connectors: '連接器',
   enterprise_sso: '企業 SSO',
   security: '安全',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Add a new tab "Account center" to sign-in experience page, and change this page's title to "sign-in & account".

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

<img width="1390" height="1119" alt="截屏2025-10-08 下午3 23 59" src="https://github.com/user-attachments/assets/d6cabf76-f3b2-4d9e-9325-97d083c0ba12" />

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
