### PR TITLE
fix(experience): replace `||=` operator with compatible assignments for broader browser stability

### DIFF
--- a/packages/experience/src/pages/OneTimeToken/index.tsx
+++ b/packages/experience/src/pages/OneTimeToken/index.tsx
@@ -157,7 +157,7 @@ const OneTimeToken = () => {
         return;
       }
       // eslint-disable-next-line @silverhand/fp/no-mutation
-      isSubmitted.current ||= true;
+      isSubmitted.current = true;
 
       setIsLoading(true);
       const [error, result] = await asyncSignInWithOneTimeToken({


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The `||=` operator is an ES2021 feature and is supported in Chrome/WebView 85+. Devices with outdated WebView/embedded browsers may throw a SyntaxError when parsing this operator. To ensure broader compatibility (especially on older Android WebView versions), replace `||=` with equivalent, widely supported assignments.



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
