### PR TITLE
chore: add changeset for the `||=` operator patch in experience

### DIFF
--- a/.changeset/curly-planes-doubt.md
+++ b/.changeset/curly-planes-doubt.md
@@ -1,0 +1,7 @@
+---
+"@logto/experience": patch
+---
+
+fix an issue that prevents Logto Experience from working in Android 11 and some older browser versions
+
+The issue is introduced in version 1.32.0 by the usage of the `||=` operator, which is not supported in some older browsers (#7857).


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add changeset for the `||=` operator patch in experience package (#7857)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
