### PR TITLE
refactor(console): support posthog ui host

### DIFF
--- a/packages/console/src/App.tsx
+++ b/packages/console/src/App.tsx
@@ -22,7 +22,7 @@ import 'react-color-palette/css';
 
 import CloudAppRoutes from '@/cloud/AppRoutes';
 import AppLoading from '@/components/AppLoading';
-import { isCloud, postHogHost, postHogKey } from '@/consts/env';
+import { isCloud, postHogHost, postHogUiHost, postHogKey } from '@/consts/env';
 import { cloudApi, getManagementApi, meApi } from '@/consts/resources';
 import { ConsoleRoutes } from '@/containers/ConsoleRoutes';
 
@@ -105,6 +105,7 @@ function Providers() {
     <PostHogProvider
       apiKey={postHogKey ?? ''} // Empty key will disable PostHog
       options={{
+        ui_host: postHogUiHost,
         api_host: postHogHost,
         defaults: '2025-05-24',
       }}

--- a/packages/console/src/consts/env.ts
+++ b/packages/console/src/consts/env.ts
@@ -20,4 +20,16 @@ export const consoleEmbeddedPricingUrl =
 
 export const inkeepApiKey = normalizeEnv(import.meta.env.INKEEP_API_KEY);
 export const postHogKey = normalizeEnv(import.meta.env.POSTHOG_PUBLIC_KEY);
+/**
+ * The PostHog API host URL. When using a self-hosted PostHog instance or a custom domain,
+ * {@link postHogUiHost} should also be set accordingly.
+ *
+ * @see https://posthog.com/docs/libraries/js/config for more details.
+ */
 export const postHogHost = normalizeEnv(import.meta.env.POSTHOG_PUBLIC_HOST);
+/**
+ * The PostHog UI host URL. If {@link postHogHost} is set to a custom host, this should also be set accordingly.
+ *
+ * @see https://posthog.com/docs/libraries/js/config for more details.
+ */
+export const postHogUiHost = normalizeEnv(import.meta.env.POSTHOG_PUBLIC_UI_HOST);

--- a/packages/console/vite.config.ts
+++ b/packages/console/vite.config.ts
@@ -54,6 +54,7 @@ const buildConfig = (mode: string): UserConfig => ({
     'import.meta.env.INKEEP_API_KEY': JSON.stringify(process.env.INKEEP_API_KEY),
     'import.meta.env.POSTHOG_PUBLIC_KEY': JSON.stringify(process.env.POSTHOG_PUBLIC_KEY),
     'import.meta.env.POSTHOG_PUBLIC_HOST': JSON.stringify(process.env.POSTHOG_PUBLIC_HOST),
+    'import.meta.env.POSTHOG_PUBLIC_UI_HOST': JSON.stringify(process.env.POSTHOG_PUBLIC_UI_HOST),
     // `@withtyped/client` needs this to be defined. We can optimize this later.
     'process.env': {},
   },


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
`ui_host` is [required](https://posthog.com/docs/libraries/js/config) when using a custom domain (or reverse proxy). the pull supports this config.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
local tested with a custom domain

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
