### PR TITLE
fix(console): ignore PaymentOverdue Modal for enterprise tenants

### DIFF
--- a/packages/console/src/components/PaymentOverdueModal/index.tsx
+++ b/packages/console/src/components/PaymentOverdueModal/index.tsx
@@ -26,7 +26,11 @@ function PaymentOverdueModal() {
 
   const [hasClosed, setHasClosed] = useState(false);
 
+  // TODO: this is a temporary fix to hide the modal for enterprise tenants
+  // Enterprise tenants' invoices are manually paid and has a due date in the future
+  // Should show the modal only if the invoices are overdue
   const isEnterprise = currentTenant?.subscription.isEnterprisePlan;
+
   const handleCloseModal = () => {
     setHasClosed(true);
   };


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR updates the `PaymentOverdue` modal behavior for enterprise tenants.

Previously, the system would show a payment overdue alert and block access if any open invoices existed. This assumed all invoices were auto-collected and subscriptions were pre-paid.

For enterprise plans, invoices are not automatically collected and have a due date. Users should not be blocked unless the invoice is actually overdue. Since the current DB does not store `payment_method` or `due_date`, we cannot distinguish these cases.

To quickly unblock enterprise users, this PR hides the PaymentOverdue modal for enterprise tenants.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
