### PR TITLE
fix(console): focus on input field after country code update

### DIFF
--- a/packages/experience/src/components/InputFields/SmartInputField/index.tsx
+++ b/packages/experience/src/components/InputFields/SmartInputField/index.tsx
@@ -78,7 +78,12 @@ const SmartInputField = (
             inputRef={innerRef.current}
             onChange={(value) => {
               onCountryCodeChange(value);
-              innerRef.current?.focus();
+
+              // Focus the input field after the animation is complete
+              // because the animation will cause the input field to lose focus
+              setTimeout(() => {
+                innerRef.current?.focus();
+              }, 300);
             }}
           />
         </AnimatedPrefix>


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Should focus on the input field after country code selection. 

This PR fixes the bug that the phone number input box loses focus after country code selection.  This is due to the input field animation effect we added. Fixed the issue by adding a timeout delay. Should call the element focus method after the animation has ended. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
