### PR TITLE
feat(experience): add noindex meta to experience pages

### DIFF
--- a/packages/experience/index.html
+++ b/packages/experience/index.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="robots" content="noindex,nofollow" />
   <title></title>
   <script>
     /* See {@link packages/schemas/src/types/ssr.ts} */


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add robots noindex metadata to the experience HTML page.

This PR adds a robots meta tag with `noindex,nofollow` content to the experience HTML page to prevent search engines from indexing these pages.

- Experience pages are not meant to be accessed directly by users
- These pages should not appear in search engine results



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
