### PR TITLE
fix(console): clear fields when account center is disabled

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/AccountCenterField.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/AccountCenterField.tsx
@@ -18,6 +18,7 @@ type Props = {
   readonly value: AccountCenterControlValue;
   readonly isReadOnly: boolean;
   readonly isMfaEnabled: boolean;
+  readonly isGlobalDisabled: boolean;
   readonly onChange: (field: AccountCenterFieldKey, value?: AccountCenterControlValue) => void;
   readonly fieldOptions: Array<Option<AccountCenterControlValue>>;
 };
@@ -40,6 +41,9 @@ function AccountCenterField({
   value,
   isReadOnly,
   isMfaEnabled,
+  // When Account Center is disabled, all fields should show "off" state but keep the current value
+  // then when Account Center is enabled again, the fields will restore to previous values
+  isGlobalDisabled,
   onChange,
   fieldOptions,
 }: Props) {
@@ -50,10 +54,14 @@ function AccountCenterField({
   const shouldShowConnectorWarning =
     connectorType &&
     value !== AccountCenterControlValue.Off &&
+    !isGlobalDisabled &&
     !isConnectorTypeEnabled(connectorType);
 
   const shouldShowMfaWarning =
-    item.key === 'mfa' && value !== AccountCenterControlValue.Off && !isMfaEnabled;
+    item.key === 'mfa' &&
+    value !== AccountCenterControlValue.Off &&
+    !isGlobalDisabled &&
+    !isMfaEnabled;
 
   return (
     <div>
@@ -66,7 +74,7 @@ function AccountCenterField({
         <div className={styles.fieldControl}>
           <Select<AccountCenterControlValue>
             isDropdownFullWidth
-            value={value}
+            value={isGlobalDisabled ? AccountCenterControlValue.Off : value}
             options={fieldOptions}
             isReadOnly={isReadOnly}
             onChange={(value) => {

--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/index.tsx
@@ -112,6 +112,7 @@ function AccountCenter({ isActive, data }: Props) {
                       value={fields[item.key]}
                       isReadOnly={!isAccountApiEnabled || isSubmitting}
                       isMfaEnabled={isMfaEnabled}
+                      isGlobalDisabled={!isAccountApiEnabled}
                       fieldOptions={fieldOptions}
                       onChange={handleFieldChange}
                     />

--- a/packages/console/src/pages/SignInExperience/PageContent/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/index.tsx
@@ -109,7 +109,8 @@ function PageContent({ data, onSignInExperienceUpdated, onAccountCenterUpdated }
           .patch('api/account-center', {
             json: {
               enabled: accountCenter.enabled,
-              fields: accountCenter.fields,
+              // Disable all fields when account center is disabled
+              fields: accountCenter.enabled ? accountCenter.fields : {},
               webauthnRelatedOrigins: accountCenter.webauthnRelatedOrigins,
             },
           })


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

When Account Center is disabled, all fields should show "off" state but keep the current value then when Account Center is enabled again, the fields will restore to previous values.

And clear all fields on save.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
