### PR TITLE
fix(console): origin field disable state

### DIFF
--- a/packages/console/src/ds-components/MultiTextInput/index.tsx
+++ b/packages/console/src/ds-components/MultiTextInput/index.tsx
@@ -24,6 +24,7 @@ export type Props = {
   readonly error?: MultiTextInputError;
   readonly placeholder?: string;
   readonly className?: string;
+  readonly isDisabled?: boolean;
 };
 
 function MultiTextInput({
@@ -34,6 +35,7 @@ function MultiTextInput({
   error,
   placeholder,
   className,
+  isDisabled = false,
 }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
@@ -74,6 +76,7 @@ function MultiTextInput({
               error={Boolean(error?.inputs?.[fieldIndex] ?? (fieldIndex === 0 && error?.required))}
               value={fieldValue}
               placeholder={placeholder}
+              disabled={isDisabled}
               onChange={({ currentTarget: { value } }) => {
                 handleInputChange(value, fieldIndex);
               }}
@@ -81,6 +84,7 @@ function MultiTextInput({
             />
             {fieldIndex > 0 && (
               <IconButton
+                disabled={isDisabled}
                 onClick={() => {
                   if (fieldValue.trim().length === 0) {
                     handleRemove(fieldIndex);
@@ -107,6 +111,7 @@ function MultiTextInput({
         title="general.add_another"
         className={styles.addAnother}
         icon={<CirclePlus />}
+        disabled={isDisabled}
         onClick={handleAdd}
       />
       <ConfirmModal

--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/WebauthnRelatedOriginsField.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/WebauthnRelatedOriginsField.tsx
@@ -15,7 +15,11 @@ import type { SignInExperienceForm, AccountCenterFormValues } from '../../types'
 
 import styles from './index.module.scss';
 
-function WebauthnRelatedOriginsField() {
+type Props = {
+  readonly isAccountApiEnabled: boolean;
+};
+
+function WebauthnRelatedOriginsField({ isAccountApiEnabled }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { control } = useFormContext<
     SignInExperienceForm & { accountCenter: AccountCenterFormValues }
@@ -49,6 +53,7 @@ function WebauthnRelatedOriginsField() {
             value={value}
             error={convertRhfErrorMessage(error?.message)}
             placeholder="https://account.example.com"
+            isDisabled={!isAccountApiEnabled}
             onChange={onChange}
           />
         )}

--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/index.tsx
@@ -119,7 +119,9 @@ function AccountCenter({ isActive, data }: Props) {
                 </div>
               </FormField>
             ))}
-            {section.key === 'accountSecurity' && <WebauthnRelatedOriginsField />}
+            {section.key === 'accountSecurity' && (
+              <WebauthnRelatedOriginsField isAccountApiEnabled={isAccountApiEnabled} />
+            )}
           </div>
         </FormCard>
       ))}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Disable webauthn allowed origins field when account center gobal control is off.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
