### PR TITLE
feat(schemas): add applications_type and roles_type indexes

### DIFF
--- a/packages/schemas/alterations/next-1760427166-add-applications-type-index.ts
+++ b/packages/schemas/alterations/next-1760427166-add-applications-type-index.ts
@@ -1,0 +1,19 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      create index applications__type
+      on applications (tenant_id, type);
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      drop index applications__type;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/alterations/next-1760427167-add-roles-type-index.ts
+++ b/packages/schemas/alterations/next-1760427167-add-roles-type-index.ts
@@ -1,0 +1,19 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      create index roles__type
+      on roles (tenant_id, type);
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      drop index roles__type;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/applications.sql
+++ b/packages/schemas/tables/applications.sql
@@ -26,6 +26,9 @@ create index applications__id
 create index applications__is_third_party
   on applications (tenant_id, is_third_party);
 
+create index applications__type
+  on applications (tenant_id, type);
+
 create unique index applications__protected_app_metadata_host
   on applications (
     (protected_app_metadata->>'host')

--- a/packages/schemas/tables/roles.sql
+++ b/packages/schemas/tables/roles.sql
@@ -19,6 +19,9 @@ create table roles (
 create index roles__id
   on roles (tenant_id, id);
 
+create index roles__type
+  on roles (tenant_id, type);
+
 create function public.check_role_type(role_id varchar(21), target_type role_type) returns boolean as
 $$ begin
   return (select type from public.roles where id = role_id) = target_type;


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add `applications_type` and `roles_type` indexes to improve the quota usage query's performance.

In the cloud tenant usage query, we track the following usage metrics: `applicationsLimit`, `machineToMachineLimit`, `userRolesLimit`, and `machineToMachineRolesLimit`.
To calculate these values, we query the applications and roles tables by their `type` field to obtain the total counts.

However, these two tables currently lack proper indexes on the `type` column. To improve the performance of the quota usage queries, we should add indexes for this column in both tables.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
