### PR TITLE
fix(console): fix select dropdown fullwidth

### DIFF
--- a/packages/console/src/ds-components/Select/index.tsx
+++ b/packages/console/src/ds-components/Select/index.tsx
@@ -45,7 +45,7 @@ function Select<T extends string>({
   isClearable,
   size = 'large',
   isSearchEnabled,
-  isDropdownFullWidth = false,
+  isDropdownFullWidth = true,
 }: Props<T>) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const [isOpen, setIsOpen] = useState(false);

--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/AccountCenterField.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/AccountCenterField.tsx
@@ -71,7 +71,7 @@ function AccountCenterField({
         </div>
         <div className={styles.fieldControl}>
           <Select<AccountCenterControlValue>
-            isDropdownFullWidth
+            isDropdownFullWidth={false}
             value={isGlobalDisabled ? AccountCenterControlValue.Off : value}
             options={fieldOptions}
             isReadOnly={isGlobalDisabled}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

The prop `isDropdownFullWidth` means the dropdown menu's width if equal to the selected option. So the default value should be true, and `false` for account center.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
