### PR TITLE
feat(core): expose logto config for mfa skip

### DIFF
--- a/.changeset/little-suits-whisper.md
+++ b/.changeset/little-suits-whisper.md
@@ -1,0 +1,9 @@
+---
+"@logto/core": minor
+---
+
+add API for MFA skip controls
+
+expose logto_config endpoints in account and management APIs for managing MFA skip controls
+- /api/my-account/logto-config
+- /api/admin/users/:userId/logto-config

--- a/packages/core/src/routes/account/index.openapi.json
+++ b/packages/core/src/routes/account/index.openapi.json
@@ -174,6 +174,59 @@
         }
       }
     },
+    "/api/my-account/logto-configs": {
+      "get": {
+        "tags": ["Dev feature"],
+        "operationId": "GetLogtoConfig",
+        "summary": "Get logto config",
+        "description": "Retrieve the exposed portion of the current user's logto config. This endpoint currently includes only the MFA skip state.",
+        "responses": {
+          "200": {
+            "description": "The exposed logto config fields were retrieved successfully."
+          },
+          "400": {
+            "description": "MFA is not available in the account center."
+          },
+          "401": {
+            "description": "Permission denied due to insufficient scope."
+          }
+        }
+      },
+      "patch": {
+        "tags": ["Dev feature"],
+        "operationId": "UpdateLogtoConfig",
+        "summary": "Update logto config",
+        "description": "Update the exposed portion of the current user's logto config. This endpoint currently allows updating only the MFA skip state.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "mfa": {
+                    "properties": {
+                      "skipped": {
+                        "description": "Set whether the user is marked as having skipped MFA binding."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The exposed logto_config fields were updated successfully."
+          },
+          "400": {
+            "description": "The request body is invalid."
+          },
+          "401": {
+            "description": "Permission denied due to insufficient scope."
+          }
+        }
+      }
+    },
     "/api/my-account/primary-email": {
       "post": {
         "operationId": "UpdatePrimaryEmail",

--- a/packages/core/src/routes/account/index.ts
+++ b/packages/core/src/routes/account/index.ts
@@ -22,6 +22,7 @@ import type { UserRouter, RouterInitArgs } from '../types.js';
 import { accountApiPrefix } from './constants.js';
 import emailAndPhoneRoutes from './email-and-phone.js';
 import identitiesRoutes from './identities.js';
+import logtoConfigRoutes from './logto-config.js';
 import mfaVerificationsRoutes from './mfa-verifications.js';
 import koaAccountCenter from './middlewares/koa-account-center.js';
 import thirdPartyTokensRoutes from './third-party-tokens.js';
@@ -280,6 +281,7 @@ export default function accountRoutes<T extends UserRouter>(...args: RouterInitA
     }
   );
 
+  logtoConfigRoutes(...args);
   thirdPartyTokensRoutes(...args);
   emailAndPhoneRoutes(...args);
   identitiesRoutes(...args);

--- a/packages/core/src/routes/account/logto-config.ts
+++ b/packages/core/src/routes/account/logto-config.ts
@@ -1,0 +1,121 @@
+import { UserScope } from '@logto/core-kit';
+import { AccountCenterControlValue, userMfaDataGuard, userMfaDataKey } from '@logto/schemas';
+import { z } from 'zod';
+
+import koaGuard from '#src/middleware/koa-guard.js';
+
+import { EnvSet } from '../../env-set/index.js';
+import RequestError from '../../errors/RequestError/index.js';
+import assertThat from '../../utils/assert-that.js';
+import type { UserRouter, RouterInitArgs } from '../types.js';
+
+import { accountApiPrefix } from './constants.js';
+
+export default function logtoConfigRoutes<T extends UserRouter>(...args: RouterInitArgs<T>) {
+  if (!EnvSet.values.isDevFeaturesEnabled) {
+    return;
+  }
+
+  const [router, { queries }] = args;
+  const {
+    users: { updateUserById, findUserById },
+  } = queries;
+
+  router.get(
+    `${accountApiPrefix}/logto-configs`,
+    koaGuard({
+      response: z.object({
+        mfa: z.object({
+          skipped: z.boolean(),
+        }),
+      }),
+      status: [200, 400, 401],
+    }),
+    async (ctx, next) => {
+      const { id: userId, scopes } = ctx.auth;
+
+      assertThat(
+        scopes.has(UserScope.Identities),
+        new RequestError({ code: 'auth.unauthorized', status: 401 })
+      );
+
+      const { fields } = ctx.accountCenter;
+      // Currently, only the MFA skip state is exposed in logto_config
+      // so we only need to check the MFA field
+      assertThat(
+        fields.mfa === AccountCenterControlValue.Edit ||
+          fields.mfa === AccountCenterControlValue.ReadOnly,
+        new RequestError({ code: 'account_center.field_not_enabled', status: 400 })
+      );
+
+      const user = await findUserById(userId);
+      const mfaData = userMfaDataGuard.safeParse(user.logtoConfig[userMfaDataKey]);
+      const skipped = mfaData.success ? (mfaData.data.skipped ?? false) : false;
+
+      ctx.body = {
+        mfa: {
+          skipped,
+        },
+      };
+
+      return next();
+    }
+  );
+
+  router.patch(
+    `${accountApiPrefix}/logto-configs`,
+    koaGuard({
+      body: z.object({
+        mfa: z.object({
+          skipped: z.boolean(),
+        }),
+      }),
+      response: z.object({
+        mfa: z.object({
+          skipped: z.boolean(),
+        }),
+      }),
+      status: [200, 400, 401],
+    }),
+    async (ctx, next) => {
+      const { id: userId, scopes } = ctx.auth;
+      assertThat(
+        scopes.has(UserScope.Identities),
+        new RequestError({ code: 'auth.unauthorized', status: 401 })
+      );
+      const {
+        mfa: { skipped },
+      } = ctx.guard.body;
+      const { fields } = ctx.accountCenter;
+      // Currently, only the MFA skip state is exposed in logto_config
+      // so we only need to check the MFA field
+      assertThat(
+        fields.mfa === AccountCenterControlValue.Edit,
+        new RequestError({ code: 'account_center.field_not_editable', status: 400 })
+      );
+
+      const user = await findUserById(userId);
+      const existingMfaData = userMfaDataGuard.safeParse(user.logtoConfig[userMfaDataKey]);
+
+      const updatedUser = await updateUserById(userId, {
+        logtoConfig: {
+          ...user.logtoConfig,
+          [userMfaDataKey]: {
+            ...(existingMfaData.success ? existingMfaData.data : {}),
+            skipped,
+          },
+        },
+      });
+
+      ctx.appendDataHookContext('User.Data.Updated', { user: updatedUser });
+
+      ctx.body = {
+        mfa: {
+          skipped,
+        },
+      };
+
+      return next();
+    }
+  );
+}

--- a/packages/core/src/routes/admin-user/basic.openapi.json
+++ b/packages/core/src/routes/admin-user/basic.openapi.json
@@ -108,6 +108,45 @@
         "description": "Update custom data for the given user ID. This method performs a partial update of the custom data object."
       }
     },
+    "/api/users/{userId}/logto-configs": {
+      "get": {
+        "tags": ["Dev feature"],
+        "responses": {
+          "200": {
+            "description": "Returns the exposed user logto config fields. Currently, only the MFA skip state is available."
+          }
+        },
+        "summary": "Get user logto config",
+        "description": "Retrieve the exposed portion of a user's logto config. This endpoint currently includes only the MFA skip state."
+      },
+      "patch": {
+        "tags": ["Dev feature"],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "mfa": {
+                    "properties": {
+                      "skipped": {
+                        "description": "Set whether the user is marked as having skipped MFA binding."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The exposed logto config fields were updated successfully."
+          }
+        },
+        "summary": "Update user logto config",
+        "description": "Update the exposed portion of a user's logto config. This endpoint currently allows updating only the MFA skip state."
+      }
+    },
     "/api/users/{userId}/profile": {
       "patch": {
         "requestBody": {

--- a/packages/core/src/routes/admin-user/basics.ts
+++ b/packages/core/src/routes/admin-user/basics.ts
@@ -5,6 +5,8 @@ import {
   UsersPasswordEncryptionMethod,
   adminTenantId,
   jsonObjectGuard,
+  userMfaDataGuard,
+  userMfaDataKey,
   userProfileGuard,
   userProfileResponseGuard,
 } from '@logto/schemas';
@@ -17,6 +19,7 @@ import { encryptUserPassword } from '#src/libraries/user.utils.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import assertThat from '#src/utils/assert-that.js';
 
+import { EnvSet } from '../../env-set/index.js';
 import { parseLegacyPassword } from '../../utils/password.js';
 import { captureDeveloperEvent } from '../../utils/posthog.js';
 import { transpileUserProfileResponse } from '../../utils/user.js';
@@ -117,6 +120,84 @@ export default function adminUserBasicsRoutes<T extends ManagementApiRouter>(
       return next();
     }
   );
+
+  if (EnvSet.values.isDevFeaturesEnabled) {
+    router.get(
+      '/users/:userId/logto-configs',
+      koaGuard({
+        params: object({ userId: string() }),
+        response: object({
+          mfa: object({
+            skipped: boolean(),
+          }),
+        }),
+        status: [200, 404],
+      }),
+      async (ctx, next) => {
+        const {
+          params: { userId },
+        } = ctx.guard;
+
+        const user = await findUserById(userId);
+        const existingMfaData = userMfaDataGuard.safeParse(user.logtoConfig[userMfaDataKey]);
+
+        ctx.body = {
+          mfa: {
+            skipped: existingMfaData.success ? Boolean(existingMfaData.data.skipped) : false,
+          },
+        };
+
+        return next();
+      }
+    );
+
+    router.patch(
+      '/users/:userId/logto-configs',
+      koaGuard({
+        params: object({ userId: string() }),
+        body: object({
+          mfa: object({
+            skipped: boolean(),
+          }),
+        }),
+        response: object({
+          mfa: object({
+            skipped: boolean(),
+          }),
+        }),
+        status: [200, 404],
+      }),
+      async (ctx, next) => {
+        const {
+          params: { userId },
+          body: {
+            mfa: { skipped },
+          },
+        } = ctx.guard;
+
+        const user = await findUserById(userId);
+        const existingMfaData = userMfaDataGuard.safeParse(user.logtoConfig[userMfaDataKey]);
+
+        const updatedUser = await updateUserById(userId, {
+          logtoConfig: {
+            ...user.logtoConfig,
+            [userMfaDataKey]: {
+              ...(existingMfaData.success ? existingMfaData.data : {}),
+              skipped,
+            },
+          },
+        });
+
+        ctx.appendDataHookContext('User.Data.Updated', { user: updatedUser });
+
+        ctx.body = {
+          mfa: { skipped },
+        };
+
+        return next();
+      }
+    );
+  }
 
   router.patch(
     '/users/:userId/profile',

--- a/packages/integration-tests/src/api/admin-user.ts
+++ b/packages/integration-tests/src/api/admin-user.ts
@@ -132,6 +132,14 @@ export const createUserMfaVerification = async (userId: string, type: MfaFactor)
       | { type: MfaFactor.BackupCode; codes: string[] }
     >();
 
+export const getUserLogtoConfig = async (userId: string) =>
+  authedAdminApi.get(`users/${userId}/logto-configs`).json<{ mfa: { skipped: boolean } }>();
+
+export const updateUserLogtoConfig = async (userId: string, skipped: boolean) =>
+  authedAdminApi
+    .patch(`users/${userId}/logto-configs`, { json: { mfa: { skipped } } })
+    .json<{ mfa: { skipped: boolean } }>();
+
 export const getUserOrganizations = async (userId: string) =>
   authedAdminApi.get(`users/${userId}/organizations`).json<OrganizationWithRoles[]>();
 

--- a/packages/integration-tests/src/api/my-account.ts
+++ b/packages/integration-tests/src/api/my-account.ts
@@ -129,6 +129,19 @@ export const updateMfaSettings = async (
     })
     .json<{ skipMfaOnSignIn: boolean }>();
 
+export const getMyLogtoConfig = async (api: KyInstance) =>
+  api.get('api/my-account/logto-configs').json<{ mfa: { skipped: boolean } }>();
+
+export const updateMyLogtoConfig = async (
+  api: KyInstance,
+  logtoConfig: { mfa: { skipped: boolean } }
+) =>
+  api
+    .patch('api/my-account/logto-configs', {
+      json: logtoConfig,
+    })
+    .json<{ mfa: { skipped: boolean } }>();
+
 export const getSocialAccessToken = async (api: KyInstance, target: string) => {
   return api
     .get(`api/my-account/identities/${target}/access-token`)

--- a/packages/integration-tests/src/tests/api/admin-user.mfa-verifications.test.ts
+++ b/packages/integration-tests/src/tests/api/admin-user.mfa-verifications.test.ts
@@ -4,9 +4,12 @@ import {
   createUserMfaVerification,
   deleteUser,
   deleteUserMfaVerification,
+  getUserLogtoConfig,
   getUserMfaVerifications,
+  updateUserLogtoConfig,
 } from '#src/api/index.js';
 import { createUserByAdmin } from '#src/helpers/index.js';
+import { devFeatureTest } from '#src/utils.js';
 
 describe('admin console user management (mfa verifications)', () => {
   it('should get empty list successfully', async () => {
@@ -52,6 +55,27 @@ describe('admin console user management (mfa verifications)', () => {
       const mfaVerifications2 = await getUserMfaVerifications(user.id);
       expect(mfaVerifications2.length).toBe(0);
     }
+    await deleteUser(user.id);
+  });
+
+  devFeatureTest.it('should update logto_config MFA skip state successfully', async () => {
+    const user = await createUserByAdmin();
+
+    const config = await getUserLogtoConfig(user.id);
+    expect(config.mfa.skipped).toBe(false);
+
+    const response = await updateUserLogtoConfig(user.id, true);
+    expect(response).toEqual({ mfa: { skipped: true } });
+
+    const updatedConfig = await getUserLogtoConfig(user.id);
+    expect(updatedConfig.mfa.skipped).toBe(true);
+
+    const response2 = await updateUserLogtoConfig(user.id, false);
+    expect(response2).toEqual({ mfa: { skipped: false } });
+
+    const updatedConfig2 = await getUserLogtoConfig(user.id);
+    expect(updatedConfig2.mfa.skipped).toBe(false);
+
     await deleteUser(user.id);
   });
 });

--- a/packages/integration-tests/src/tests/api/experience-api/bind-mfa/happpy-path.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/bind-mfa/happpy-path.test.ts
@@ -1,7 +1,12 @@
 import { InteractionEvent, MfaFactor, SignInIdentifier } from '@logto/schemas';
 import { authenticator } from 'otplib';
 
-import { createUserMfaVerification, deleteUser } from '#src/api/admin-user.js';
+import {
+  createUserMfaVerification,
+  deleteUser,
+  getUserLogtoConfig,
+  updateUserLogtoConfig,
+} from '#src/api/admin-user.js';
 import { initExperienceClient, logoutClient, processSession } from '#src/helpers/client.js';
 import {
   identifyUserWithUsernamePassword,
@@ -21,6 +26,7 @@ import {
   enableUserControlledMfaWithTotpOnlyAtSignIn,
 } from '#src/helpers/sign-in-experience.js';
 import { generateNewUserProfile, UserApiTest } from '#src/helpers/user.js';
+import { devFeatureTest } from '#src/utils.js';
 
 describe('Bind MFA APIs happy path', () => {
   const userApi = new UserApiTest();
@@ -168,6 +174,61 @@ describe('Bind MFA APIs happy path', () => {
 
       await deleteUser(userId);
     });
+
+    devFeatureTest.it(
+      'should prompt again after resetting skip state via management API',
+      async () => {
+        const { username, password } = generateNewUserProfile({ username: true, password: true });
+        const client = await initExperienceClient({
+          interactionEvent: InteractionEvent.Register,
+        });
+
+        const { verificationId } = await client.createNewPasswordIdentityVerification({
+          identifier: {
+            type: SignInIdentifier.Username,
+            value: username,
+          },
+          password,
+        });
+
+        await client.identifyUser({ verificationId });
+
+        await expectRejects(client.submitInteraction(), {
+          code: 'user.missing_mfa',
+          status: 422,
+        });
+
+        await client.skipMfaBinding();
+
+        const { redirectTo } = await client.submitInteraction();
+        const userId = await processSession(client, redirectTo);
+        await logoutClient(client);
+
+        const skippedConfig = await getUserLogtoConfig(userId);
+        expect(skippedConfig.mfa.skipped).toBe(true);
+
+        await signInWithPassword({
+          identifier: {
+            type: SignInIdentifier.Username,
+            value: username,
+          },
+          password,
+        });
+
+        await updateUserLogtoConfig(userId, false);
+        const resetConfig = await getUserLogtoConfig(userId);
+        expect(resetConfig.mfa.skipped).toBe(false);
+
+        const client2 = await initExperienceClient();
+        await identifyUserWithUsernamePassword(client2, username, password);
+        await expectRejects(client2.submitInteraction(), {
+          code: 'user.missing_mfa',
+          status: 422,
+        });
+
+        await deleteUser(userId);
+      }
+    );
 
     it('should able to skip MFA binding on sign-in', async () => {
       const { username, password } = generateNewUserProfile({ username: true, password: true });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Expose logto_config endpoints in account and management APIs for managing MFA skip controls

- /api/my-account/logto-config
- /api/admin/users/:userId/logto-config

With these endpoints, develepers can reset the MFA skip state so that the end user get prompted again.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Integration tests with API and experience flow.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
