### PR TITLE
fix(console): fix overdue invoices notification

### DIFF
--- a/packages/console/src/components/PaymentOverdueModal/index.tsx
+++ b/packages/console/src/components/PaymentOverdueModal/index.tsx
@@ -19,13 +19,12 @@ import styles from './index.module.scss';
 function PaymentOverdueModal() {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { currentTenant, currentTenantId } = useContext(TenantsContext);
-  const { openInvoices = [] } = currentTenant ?? {};
 
   const { visitManagePaymentPage } = useSubscribe();
   const [isActionLoading, setIsActionLoading] = useState(false);
   const [hasClosed, setHasClosed] = useState(false);
 
-  const { hasOverdueInvoices } = useOverdueInvoices();
+  const { hasOverdueInvoices, overdueInvoices } = useOverdueInvoices(currentTenant);
 
   const handleCloseModal = () => {
     setHasClosed(true);
@@ -73,7 +72,7 @@ function PaymentOverdueModal() {
         )}
         <FormField title="upsell.payment_overdue_modal.unpaid_bills">
           <BillInfo
-            cost={openInvoices.reduce(
+            cost={overdueInvoices.reduce(
               (total, currentInvoice) => total + currentInvoice.amountDue,
               0
             )}

--- a/packages/console/src/components/Topbar/TenantSelector/TenantDropdownItem/TenantStatusTag.tsx
+++ b/packages/console/src/components/Topbar/TenantSelector/TenantDropdownItem/TenantStatusTag.tsx
@@ -17,7 +17,7 @@ function TenantStatusTag({ tenantData, className }: Props) {
     subscription: { planId, isEnterprisePlan },
   } = tenantData;
 
-  const { hasOverdueInvoices } = useOverdueInvoices();
+  const { hasOverdueInvoices } = useOverdueInvoices(tenantData);
 
   /**
    * Tenant status priority:

--- a/packages/console/src/components/Topbar/TenantSelector/TenantDropdownItem/index.tsx
+++ b/packages/console/src/components/Topbar/TenantSelector/TenantDropdownItem/index.tsx
@@ -22,7 +22,7 @@ function TenantDropdownItem({ tenantData, isSelected, onClick }: Props) {
     name,
     tag,
     regionName,
-    subscription: { planId, isEnterprisePlan },
+    subscription: { planId },
   } = tenantData;
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the overdue invoices notifications bug.

This PR includes the following bug fixes:

1. Incorrect overdue tag display in the tenant dropdown menu
  - Previously, the `useOverdueInvoices` hook always retrieved `openInvoices` data from the current tenant context. As a result, if the current tenant had any overdue invoices, the overdue tag was incorrectly shown for all tenants in the dropdown.
  - Refactored the `useOverdueInvoices` hook to accept tenant data as an input argument instead of always relying on the `currentTenant` context.

| before | after |
| ----- | ----- |
| <img width="720" height="1250" alt="image" src="https://github.com/user-attachments/assets/5f4c0f8d-ccb5-4bbb-b245-6a0a1f468874" /> | <img width="738" height="1262" alt="image" src="https://github.com/user-attachments/assets/65176a21-23b9-4b9c-9ec4-a98dfd52db78" /> |


2. Overdue invoice calculation bug
  - The overdue status was previously determined by directly comparing the `dueDate` value with `new Date()`. However, since the `dueDate` returned from the subscription API was a `string` rather than a `Date` type, the comparison was invalid.
  - Fixed the issue by converting the `dueDate` using `dayjs` before performing the comparison.

3. Overdue payment value calculation bug
  - Previously, the overdue notification modal displayed the total amount of all open invoices.
  - It should instead filter the invoices and display only the total amount of overdue invoices.
  
 | before | after |
 | ----- | ----- |
 | <img width="1392" height="880" alt="image" src="https://github.com/user-attachments/assets/a1a40947-28b4-4979-9579-fc34c276eddd" /> | <img width="1268" height="822" alt="image" src="https://github.com/user-attachments/assets/0a49e6e6-a566-4bff-bcfc-5fd3d6cf21fc" /> |


  
<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
