### PR TITLE
refactor: tenant usage handling

### DIFF
--- a/packages/core/src/libraries/quota.test.ts
+++ b/packages/core/src/libraries/quota.test.ts
@@ -1,0 +1,425 @@
+import { ConnectorType, ReservedPlanId } from '@logto/schemas';
+import { createMockUtils } from '@logto/shared/esm';
+
+import { mockSubscriptionData } from '#src/__mocks__/cloud-connection.js';
+
+const { jest } = import.meta;
+const { mockEsmWithActual } = createMockUtils(jest);
+
+const mockGetTenantSubscription = jest.fn();
+const mockGetTenantUsageData = jest.fn();
+const mockReportSubscriptionUpdates = jest.fn();
+
+await mockEsmWithActual('#src/utils/subscription/index.js', () => ({
+  getTenantSubscription: mockGetTenantSubscription,
+  getTenantUsageData: mockGetTenantUsageData,
+  reportSubscriptionUpdates: mockReportSubscriptionUpdates,
+}));
+
+const { EnvSet } = await import('#src/env-set/index.js');
+const { MockTenant } = await import('#src/test-utils/tenant.js');
+const { QuotaLibrary } = await import('./quota.js');
+
+const originalIsCloud = EnvSet.values.isCloud;
+const originalIsIntegrationTest = EnvSet.values.isIntegrationTest;
+
+/**
+ * These tests spin up a full MockTenant, which instantiates the real EnvSet and runs its load sequence.
+ * If we fully mocked `#src/env-set/index.js` (like social-verification tests do), that constructor would
+ * lose the class implementation and crash. At the same time the compiled QuotaLibrary already holds a
+ * reference to the original EnvSet singleton. Mutating the live flags keeps both MockTenant and
+ * QuotaLibrary aligned with the test scenarios without breaking their dependency chain.
+ */
+const setEnvFlag = (key: 'isCloud' | 'isIntegrationTest', value: boolean) => {
+  Reflect.set(EnvSet.values, key, value);
+};
+
+const createQuotaLibrary = ({
+  queriesOverride,
+  connectorsOverride,
+}: {
+  queriesOverride?: ConstructorParameters<typeof MockTenant>[1];
+  connectorsOverride?: ConstructorParameters<typeof MockTenant>[2];
+} = {}) => {
+  const tenant = new MockTenant(undefined, queriesOverride, connectorsOverride);
+  const quotaLibrary = new QuotaLibrary(
+    tenant.id,
+    tenant.queries,
+    tenant.connectors,
+    tenant.cloudConnection,
+    tenant.subscription
+  );
+
+  return { tenant, quotaLibrary };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setEnvFlag('isCloud', true);
+  setEnvFlag('isIntegrationTest', false);
+
+  mockGetTenantSubscription.mockResolvedValue(mockSubscriptionData);
+  mockGetTenantUsageData.mockResolvedValue({
+    quota: mockSubscriptionData.quota,
+    usage: {
+      tenantMembersLimit: 0,
+      socialConnectorsLimit: 0,
+    },
+    resources: {},
+    roles: {},
+  });
+});
+
+afterEach(() => {
+  setEnvFlag('isCloud', originalIsCloud);
+  setEnvFlag('isIntegrationTest', originalIsIntegrationTest);
+});
+
+describe('guardTenantUsageByKey', () => {
+  it('skips guard in non-cloud environment', async () => {
+    setEnvFlag('isCloud', false);
+
+    const getSelfComputedUsageByKey = jest.fn();
+    const { quotaLibrary } = createQuotaLibrary({
+      queriesOverride: {
+        tenantUsage: { getSelfComputedUsageByKey },
+      },
+    });
+
+    await expect(quotaLibrary.guardTenantUsageByKey('applicationsLimit')).resolves.not.toThrow();
+
+    expect(mockGetTenantSubscription).not.toHaveBeenCalled();
+    expect(getSelfComputedUsageByKey).not.toHaveBeenCalled();
+  });
+
+  it('skips guard when quota limit is null', async () => {
+    mockGetTenantSubscription.mockResolvedValueOnce({
+      ...mockSubscriptionData,
+      quota: {
+        ...mockSubscriptionData.quota,
+        applicationsLimit: null,
+      },
+    });
+
+    const getSelfComputedUsageByKey = jest.fn();
+    const { quotaLibrary } = createQuotaLibrary({
+      queriesOverride: {
+        tenantUsage: { getSelfComputedUsageByKey },
+      },
+    });
+
+    await quotaLibrary.guardTenantUsageByKey('applicationsLimit');
+
+    expect(getSelfComputedUsageByKey).not.toHaveBeenCalled();
+  });
+
+  it('throws when boolean quota limit is disabled', async () => {
+    const { quotaLibrary } = createQuotaLibrary();
+
+    await expect(quotaLibrary.guardTenantUsageByKey('mfaEnabled')).rejects.toMatchObject({
+      code: 'subscription.limit_exceeded',
+      status: 403,
+    });
+  });
+
+  it('throws when boolean quota limit is not boolean type', async () => {
+    mockGetTenantSubscription.mockResolvedValueOnce({
+      ...mockSubscriptionData,
+      quota: {
+        ...mockSubscriptionData.quota,
+        mfaEnabled: 'true' as unknown as boolean,
+      },
+    });
+
+    const { quotaLibrary } = createQuotaLibrary();
+
+    await expect(quotaLibrary.guardTenantUsageByKey('mfaEnabled')).rejects.toThrow(
+      'Feature availability settings must be boolean type.'
+    );
+  });
+
+  it('allows boolean quota when enabled', async () => {
+    mockGetTenantSubscription.mockResolvedValueOnce({
+      ...mockSubscriptionData,
+      quota: {
+        ...mockSubscriptionData.quota,
+        mfaEnabled: true,
+      },
+    });
+
+    const { quotaLibrary } = createQuotaLibrary();
+
+    await expect(quotaLibrary.guardTenantUsageByKey('mfaEnabled')).resolves.not.toThrow();
+  });
+
+  it('passes when usage is below quota limit', async () => {
+    const getSelfComputedUsageByKey = jest.fn().mockResolvedValue(2);
+
+    const { tenant, quotaLibrary } = createQuotaLibrary({
+      queriesOverride: {
+        tenantUsage: { getSelfComputedUsageByKey },
+      },
+    });
+
+    await quotaLibrary.guardTenantUsageByKey('applicationsLimit');
+
+    expect(getSelfComputedUsageByKey).toHaveBeenCalledWith(
+      tenant.id,
+      'applicationsLimit',
+      undefined
+    );
+  });
+
+  it('throws when numeric quota limit is not number type', async () => {
+    mockGetTenantSubscription.mockResolvedValueOnce({
+      ...mockSubscriptionData,
+      quota: {
+        ...mockSubscriptionData.quota,
+        applicationsLimit: '3' as unknown as number,
+      },
+    });
+
+    const getSelfComputedUsageByKey = jest.fn();
+
+    const { quotaLibrary } = createQuotaLibrary({
+      queriesOverride: {
+        tenantUsage: { getSelfComputedUsageByKey },
+      },
+    });
+
+    await expect(quotaLibrary.guardTenantUsageByKey('applicationsLimit')).rejects.toThrow(
+      'Usage limit must be number type for numeric limits.'
+    );
+
+    expect(getSelfComputedUsageByKey).not.toHaveBeenCalled();
+  });
+
+  it('throws when usage exceeds quota limit', async () => {
+    const getSelfComputedUsageByKey = jest.fn().mockResolvedValue(5);
+
+    const { quotaLibrary } = createQuotaLibrary({
+      queriesOverride: {
+        tenantUsage: { getSelfComputedUsageByKey },
+      },
+    });
+
+    await expect(quotaLibrary.guardTenantUsageByKey('applicationsLimit')).rejects.toMatchObject({
+      code: 'subscription.limit_exceeded',
+      status: 403,
+    });
+  });
+
+  it('uses cloud usage data for tenantMembersLimit', async () => {
+    mockGetTenantSubscription.mockResolvedValueOnce({
+      ...mockSubscriptionData,
+      quota: {
+        ...mockSubscriptionData.quota,
+        tenantMembersLimit: 10,
+      },
+    });
+    mockGetTenantUsageData.mockResolvedValueOnce({
+      quota: mockSubscriptionData.quota,
+      usage: { tenantMembersLimit: 5 },
+      resources: {},
+      roles: {},
+    });
+
+    const getSelfComputedUsageByKey = jest.fn();
+
+    const { quotaLibrary, tenant } = createQuotaLibrary({
+      queriesOverride: {
+        tenantUsage: { getSelfComputedUsageByKey },
+      },
+    });
+
+    await quotaLibrary.guardTenantUsageByKey('tenantMembersLimit');
+
+    expect(mockGetTenantUsageData).toHaveBeenCalledWith(tenant.cloudConnection);
+    expect(getSelfComputedUsageByKey).not.toHaveBeenCalled();
+  });
+
+  it('uses connector library for socialConnectorsLimit', async () => {
+    mockGetTenantSubscription.mockResolvedValueOnce({
+      ...mockSubscriptionData,
+      quota: {
+        ...mockSubscriptionData.quota,
+        socialConnectorsLimit: 3,
+      },
+    });
+
+    const getLogtoConnectors = jest.fn().mockResolvedValue([
+      { type: ConnectorType.Social, metadata: { target: 'google' } },
+      { type: ConnectorType.Email, metadata: { target: 'email' } },
+    ]);
+
+    const { quotaLibrary } = createQuotaLibrary({
+      connectorsOverride: { getLogtoConnectors },
+      queriesOverride: {
+        tenantUsage: { getSelfComputedUsageByKey: jest.fn() },
+      },
+    });
+
+    await quotaLibrary.guardTenantUsageByKey('socialConnectorsLimit');
+
+    expect(getLogtoConnectors).toHaveBeenCalled();
+  });
+
+  it('passes entity context to tenant usage query', async () => {
+    mockGetTenantSubscription.mockResolvedValueOnce({
+      ...mockSubscriptionData,
+      quota: {
+        ...mockSubscriptionData.quota,
+        scopesPerResourceLimit: 10,
+      },
+    });
+
+    const getSelfComputedUsageByKey = jest.fn().mockResolvedValue(4);
+
+    const { tenant, quotaLibrary } = createQuotaLibrary({
+      queriesOverride: {
+        tenantUsage: { getSelfComputedUsageByKey },
+      },
+    });
+
+    await quotaLibrary.guardTenantUsageByKey('scopesPerResourceLimit', {
+      entityId: 'resource_1',
+    });
+
+    expect(getSelfComputedUsageByKey).toHaveBeenCalledWith(tenant.id, 'scopesPerResourceLimit', {
+      entityId: 'resource_1',
+    });
+  });
+
+  it('throws when entity usage exceeds limit', async () => {
+    mockGetTenantSubscription.mockResolvedValueOnce({
+      ...mockSubscriptionData,
+      quota: {
+        ...mockSubscriptionData.quota,
+        scopesPerRoleLimit: 3,
+      },
+    });
+
+    const getSelfComputedUsageByKey = jest.fn().mockResolvedValue(3);
+
+    const { quotaLibrary } = createQuotaLibrary({
+      queriesOverride: {
+        tenantUsage: { getSelfComputedUsageByKey },
+      },
+    });
+
+    await expect(
+      quotaLibrary.guardTenantUsageByKey('scopesPerRoleLimit', { entityId: 'role_1' })
+    ).rejects.toMatchObject({
+      code: 'subscription.limit_exceeded',
+      status: 403,
+    });
+  });
+
+  it('skips guard for add-on usage keys on paid plans', async () => {
+    mockGetTenantSubscription.mockResolvedValueOnce({
+      ...mockSubscriptionData,
+      planId: ReservedPlanId.Pro,
+      quota: {
+        ...mockSubscriptionData.quota,
+        machineToMachineLimit: 1,
+      },
+    });
+
+    const getSelfComputedUsageByKey = jest.fn();
+
+    const { quotaLibrary } = createQuotaLibrary({
+      queriesOverride: {
+        tenantUsage: { getSelfComputedUsageByKey },
+      },
+    });
+
+    await quotaLibrary.guardTenantUsageByKey('machineToMachineLimit');
+
+    expect(getSelfComputedUsageByKey).not.toHaveBeenCalled();
+  });
+});
+
+describe('reportSubscriptionUpdatesUsage', () => {
+  it('skips in non-cloud environment', async () => {
+    setEnvFlag('isCloud', false);
+
+    const { quotaLibrary } = createQuotaLibrary();
+
+    await quotaLibrary.reportSubscriptionUpdatesUsage('machineToMachineLimit');
+
+    expect(mockReportSubscriptionUpdates).not.toHaveBeenCalled();
+    expect(mockGetTenantSubscription).not.toHaveBeenCalled();
+  });
+
+  it('skips in integration test environment', async () => {
+    setEnvFlag('isIntegrationTest', true);
+
+    const { quotaLibrary } = createQuotaLibrary();
+
+    await quotaLibrary.reportSubscriptionUpdatesUsage('machineToMachineLimit');
+
+    expect(mockReportSubscriptionUpdates).not.toHaveBeenCalled();
+  });
+
+  it('reports usage updates for Pro plan add-on keys', async () => {
+    mockGetTenantSubscription.mockResolvedValueOnce({
+      ...mockSubscriptionData,
+      planId: ReservedPlanId.Pro,
+      isEnterprisePlan: false,
+    });
+
+    const { quotaLibrary, tenant } = createQuotaLibrary();
+
+    await quotaLibrary.reportSubscriptionUpdatesUsage('machineToMachineLimit');
+
+    expect(mockReportSubscriptionUpdates).toHaveBeenCalledWith(
+      tenant.cloudConnection,
+      'machineToMachineLimit'
+    );
+  });
+
+  it('reports usage updates for enterprise plans', async () => {
+    mockGetTenantSubscription.mockResolvedValueOnce({
+      ...mockSubscriptionData,
+      planId: 'enterprise-plan',
+      isEnterprisePlan: true,
+    });
+
+    const { quotaLibrary, tenant } = createQuotaLibrary();
+
+    await quotaLibrary.reportSubscriptionUpdatesUsage('resourcesLimit');
+
+    expect(mockReportSubscriptionUpdates).toHaveBeenCalledWith(
+      tenant.cloudConnection,
+      'resourcesLimit'
+    );
+  });
+
+  it('does not report for Free plan', async () => {
+    mockGetTenantSubscription.mockResolvedValueOnce({
+      ...mockSubscriptionData,
+      planId: ReservedPlanId.Free,
+      isEnterprisePlan: false,
+    });
+
+    const { quotaLibrary } = createQuotaLibrary();
+
+    await quotaLibrary.reportSubscriptionUpdatesUsage('machineToMachineLimit');
+
+    expect(mockReportSubscriptionUpdates).not.toHaveBeenCalled();
+  });
+
+  it('does not report for non add-on usage keys', async () => {
+    mockGetTenantSubscription.mockResolvedValueOnce({
+      ...mockSubscriptionData,
+      planId: ReservedPlanId.Pro,
+      isEnterprisePlan: false,
+    });
+
+    const { quotaLibrary } = createQuotaLibrary();
+
+    await quotaLibrary.reportSubscriptionUpdatesUsage('applicationsLimit');
+
+    expect(mockReportSubscriptionUpdates).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/middleware/koa-quota-guard.ts
+++ b/packages/core/src/middleware/koa-quota-guard.ts
@@ -2,12 +2,13 @@ import { type Nullable } from '@silverhand/essentials';
 import type { MiddlewareType } from 'koa';
 
 import { type QuotaLibrary } from '#src/libraries/quota.js';
+import { type EntityBasedUsageKey, type AllLimitKey } from '#src/queries/tenant-usage/types.js';
 import { type SubscriptionUsage } from '#src/utils/subscription/types.js';
 
 type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'COPY' | 'HEAD' | 'OPTIONS';
 
 type UsageGuardConfig = {
-  key: keyof SubscriptionUsage;
+  key: Exclude<AllLimitKey, EntityBasedUsageKey>;
   quota: QuotaLibrary;
   /** Guard usage only for the specified method types. Guard all if not provided. */
   methods?: Method[];
@@ -27,11 +28,18 @@ export function koaQuotaGuard<StateT, ContextT, ResponseBodyT>({
   };
 }
 
+type UsageReportConfig = {
+  key: keyof SubscriptionUsage;
+  quota: QuotaLibrary;
+  /** Report usage only for the specified method types. Report for all if not provided. */
+  methods?: Method[];
+};
+
 export function koaReportSubscriptionUpdates<StateT, ContextT, ResponseBodyT>({
   key,
   quota,
   methods = ['POST', 'PUT', 'DELETE'],
-}: UsageGuardConfig): MiddlewareType<StateT, ContextT, Nullable<ResponseBodyT>> {
+}: UsageReportConfig): MiddlewareType<StateT, ContextT, Nullable<ResponseBodyT>> {
   return async (ctx, next) => {
     await next();
 

--- a/packages/core/src/queries/tenant-usage/types.ts
+++ b/packages/core/src/queries/tenant-usage/types.ts
@@ -1,67 +1,123 @@
-import { type ToZodObject } from '@logto/connector-kit';
 import { z } from 'zod';
 
-import { type SubscriptionUsage } from '#src/utils/subscription/types.js';
+import { type SubscriptionQuota } from '#src/utils/subscription/types.js';
+import { type ToZodEnum } from '#src/utils/type.js';
+
+type AllLimitMap = Omit<SubscriptionQuota, 'mauLimit' | 'tokenLimit'>;
+/**
+ * All limit keys - currently from SubscriptionQuota
+ *
+ * @remarks
+ * Future extension point: Can be extended to union with SystemLimit keys
+ * Example: `export type AllLimitKey = keyof SubscriptionQuota | keyof SystemLimit;`
+ */
+export type AllLimitKey = keyof AllLimitMap;
 
 /**
- * TenantUsage type that is based on SubscriptionUsage but with specific fields omitted
+ * Boolean feature keys - feature flags (enabled/disabled)
+ *
+ * @remarks
+ * These represent boolean feature flags that control feature availability.
+ *
+ * @example
+ * - mfaEnabled
+ * - customJwtEnabled
+ * - securityFeaturesEnabled
  */
-type TenantUsage = Omit<
-  SubscriptionUsage,
-  'socialConnectorsLimit' | 'subjectTokenEnabled' | 'tenantMembersLimit'
+type BooleanFeatureKey = {
+  [K in keyof AllLimitMap]: AllLimitMap[K] extends boolean ? K : never;
+}[keyof AllLimitMap];
+
+const booleanFeatureKeyGuard = z.enum([
+  'customJwtEnabled',
+  'subjectTokenEnabled',
+  'bringYourUiEnabled',
+  'collectUserProfileEnabled',
+  'mfaEnabled',
+  'idpInitiatedSsoEnabled',
+  'securityFeaturesEnabled',
+]) satisfies ToZodEnum<BooleanFeatureKey>;
+
+export const isBooleanFeatureKey = (key: string): key is BooleanFeatureKey =>
+  booleanFeatureKeyGuard.safeParse(key).success;
+
+/**
+ * Numeric limit keys - numeric usage limits
+ *
+ * @remarks
+ * These represent countable limits that can be queried for current usage.
+ *
+ * @example
+ * - applicationsLimit
+ * - hooksLimit
+ * - organizationsLimit
+ */
+export type NumericLimitKey = {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  [K in keyof AllLimitMap]: AllLimitMap[K] extends number | null ? K : never;
+}[keyof AllLimitMap];
+
+const numericLimitKeyGuard = z.enum([
+  'applicationsLimit',
+  'thirdPartyApplicationsLimit',
+  'machineToMachineLimit',
+  'userRolesLimit',
+  'machineToMachineRolesLimit',
+  'scopesPerRoleLimit',
+  'scopesPerResourceLimit',
+  'hooksLimit',
+  'resourcesLimit',
+  'enterpriseSsoLimit',
+  'organizationsLimit',
+  'samlApplicationsLimit',
+  'socialConnectorsLimit',
+  'tenantMembersLimit',
+]) satisfies ToZodEnum<NumericLimitKey>;
+
+export const isNumericLimitKey = (key: AllLimitKey): key is NumericLimitKey =>
+  numericLimitKeyGuard.safeParse(key).success;
+/**
+ * Self-computed usage keys - usage data queried from local tenant database
+ *
+ * @remarks
+ * These usage values are calculated from the tenant's own database.
+ *
+ * **Why only numeric limits:**
+ * During quota checks, boolean features (feature availability) are checked directly
+ * against the plan quota - `true` means allowed, `false` means not allowed.
+ * Only consumable/numeric limits require actual usage calculation by querying
+ * the database to compare current usage against the limit.
+ *
+ * **Excluded keys:**
+ * Not all numeric limits are self-computed. The following require external data sources:
+ * - `tenantMembersLimit`: queried from Cloud API
+ * - `socialConnectorsLimit`: queried from Connector Library
+ */
+export type SelfComputedUsageKey = Exclude<
+  NumericLimitKey,
+  'tenantMembersLimit' | 'socialConnectorsLimit'
 >;
 
-export const tenantUsageGuard = z.object({
-  applicationsLimit: z.number(),
-  thirdPartyApplicationsLimit: z.number(),
-  scopesPerResourceLimit: z.number(),
-  userRolesLimit: z.number(),
-  machineToMachineRolesLimit: z.number(),
-  scopesPerRoleLimit: z.number(),
-  hooksLimit: z.number(),
-  customJwtEnabled: z.boolean(),
-  bringYourUiEnabled: z.boolean(),
-  collectUserProfileEnabled: z.boolean(),
-  /** Add-on quotas start */
-  machineToMachineLimit: z.number(),
-  resourcesLimit: z.number(),
-  enterpriseSsoLimit: z.number(),
-  mfaEnabled: z.boolean(),
-  organizationsLimit: z.number(),
-  securityFeaturesEnabled: z.boolean(),
-  /** Enterprise only add-on quotas */
-  idpInitiatedSsoEnabled: z.boolean(),
-  samlApplicationsLimit: z.number(),
-  /** Add-on quotas end */
-}) satisfies ToZodObject<TenantUsage>;
-
-export type SelfComputedTenantUsage = Omit<SubscriptionUsage, 'tenantMembersLimit'>;
+/**
+ * Entity-based usage keys - requires specific entity context
+ *
+ * @remarks
+ * These keys require a { entityId: string } context parameter.
+ * The semantic meaning of entityId depends on the key:
+ * - scopesPerResourceLimit: entityId = resourceId
+ * - scopesPerRoleLimit: entityId = roleId
+ */
+export type EntityBasedUsageKey = 'scopesPerResourceLimit' | 'scopesPerRoleLimit';
 
 /**
- * Guard for SubscriptionUsage that uses number validators for all number properties
+ * Tenant-based usage keys - queryable at tenant level without entity context
+ *
+ * @remarks
+ * These keys represent tenant-wide counts.
+ *
+ * @example
+ * - applicationsLimit (total applications in tenant)
+ * - hooksLimit (total hooks in tenant)
+ * - organizationsLimit (total organizations in tenant)
  */
-export const selfComputedSubscriptionUsageGuard = z.object({
-  applicationsLimit: z.number(),
-  thirdPartyApplicationsLimit: z.number(),
-  scopesPerResourceLimit: z.number(),
-  socialConnectorsLimit: z.number(),
-  userRolesLimit: z.number(),
-  machineToMachineRolesLimit: z.number(),
-  scopesPerRoleLimit: z.number(),
-  hooksLimit: z.number(),
-  customJwtEnabled: z.boolean(),
-  subjectTokenEnabled: z.boolean(),
-  bringYourUiEnabled: z.boolean(),
-  collectUserProfileEnabled: z.boolean(),
-  /** Add-on quotas start */
-  machineToMachineLimit: z.number(),
-  resourcesLimit: z.number(),
-  enterpriseSsoLimit: z.number(),
-  mfaEnabled: z.boolean(),
-  organizationsLimit: z.number(),
-  securityFeaturesEnabled: z.boolean(),
-  /** Enterprise only add-on quotas */
-  idpInitiatedSsoEnabled: z.boolean(),
-  samlApplicationsLimit: z.number(),
-  /** Add-on quotas end */
-}) satisfies ToZodObject<SelfComputedTenantUsage>;
+export type TenantBasedUsageKey = Exclude<SelfComputedUsageKey, EntityBasedUsageKey>;

--- a/packages/core/src/routes/resource.scope.ts
+++ b/packages/core/src/routes/resource.scope.ts
@@ -89,7 +89,7 @@ export default function resourceScopeRoutes<T extends ManagementApiRouter>(
         body,
       } = ctx.guard;
 
-      await quota.guardEntityScopesUsage('resources', resourceId);
+      await quota.guardTenantUsageByKey('scopesPerResourceLimit', { entityId: resourceId });
 
       assertThat(!/\s/.test(body.name), 'scope.name_with_space');
 

--- a/packages/core/src/routes/role.scope.ts
+++ b/packages/core/src/routes/role.scope.ts
@@ -93,7 +93,7 @@ export default function roleScopeRoutes<T extends ManagementApiRouter>(
         body: { scopeIds },
       } = ctx.guard;
 
-      await quota.guardEntityScopesUsage('roles', id);
+      await quota.guardTenantUsageByKey('scopesPerRoleLimit', { entityId: id });
 
       await validateRoleScopeAssignment(scopeIds, id);
       await insertRolesScopes(

--- a/packages/core/src/routes/role.ts
+++ b/packages/core/src/routes/role.ts
@@ -148,7 +148,7 @@ export default function roleRoutes<T extends ManagementApiRouter>(
       body: Roles.createGuard
         .omit({ id: true })
         .extend({ scopeIds: z.string().min(1).array().optional() }),
-      status: [200, 400, 404, 422], // Throws 404 when invalid `scopeId(s)` are provided.
+      status: [200, 400, 404, 422, 403], // Throws 404 when invalid `scopeId(s)` are provided.
       response: Roles.guard,
     }),
     async (ctx, next) => {

--- a/packages/core/src/test-utils/quota.ts
+++ b/packages/core/src/test-utils/quota.ts
@@ -25,8 +25,6 @@ class MockQuotaLibrary extends QuotaLibrary {
   // eslint-disable-next-line @typescript-eslint/member-ordering
   guardTenantUsageByKey = jest.fn();
   // eslint-disable-next-line @typescript-eslint/member-ordering
-  guardEntityScopesUsage = jest.fn();
-  // eslint-disable-next-line @typescript-eslint/member-ordering
   reportSubscriptionUpdatesUsage = jest.fn();
 }
 

--- a/packages/core/src/utils/subscription/types.ts
+++ b/packages/core/src/utils/subscription/types.ts
@@ -3,6 +3,8 @@ import { type ToZodObject } from '@logto/connector-kit';
 import { type RouterRoutes } from '@withtyped/client';
 import { z, type ZodType } from 'zod';
 
+import { type OmitBooleanValueKeys } from '#src/utils/type.js';
+
 type GetRoutes = RouterRoutes<typeof router>['get'];
 type PostRoutes = RouterRoutes<typeof router>['post'];
 
@@ -11,10 +13,6 @@ type RouteResponseType<T extends { search?: unknown; body?: unknown; response?: 
 type RouteRequestBodyType<T extends { search?: unknown; body?: ZodType; response?: unknown }> =
   z.infer<NonNullable<T['body']>>;
 
-type OmitBooleanValueKeys<T> = Omit<
-  T,
-  { [K in keyof T]: T[K] extends boolean ? K : never }[keyof T]
->;
 /**
  * The subscription data is fetched from the Cloud API.
  * All the dates are in ISO 8601 format, we need to manually fix the type to string here.

--- a/packages/core/src/utils/type.ts
+++ b/packages/core/src/utils/type.ts
@@ -1,3 +1,12 @@
+import { type z } from 'zod';
+
 export const isEnum = <T extends string>(list: T[], value: unknown): value is T =>
   // @ts-expect-error the easiest way to perform type checking for a string enum
   list.includes(value);
+
+export type OmitBooleanValueKeys<T> = Omit<
+  T,
+  { [K in keyof T]: T[K] extends boolean ? K : never }[keyof T]
+>;
+
+export type ToZodEnum<T extends string> = z.ZodEnum<[T, ...T[]]>;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary

Refactor tenant usage handling in Core to eliminate unnecessary database queries and align with the actual usage patterns. This change reduces code complexity by ~250 lines while improving performance through on-demand usage computation.

## Background

### Historical Context

Previously, tenant usage calculation logic was aligned with Cloud API's batch computation model. When the computation was moved from Cloud to Core for optimization, the implementation continued to use the same batch approach even though Core's actual usage pattern is different:

- **Cloud**: Needs all usage data at once for `/api/tenants/:tenantId/subscription-usage` endpoint
- **Core**: Only queries one specific usage key at a time (e.g., `applicationsLimit` when creating an application)

This mismatch resulted in:
1. Computing all usage values even when only one is needed
2. Type definitions following Cloud's return format despite data being computed locally
3. Boolean feature usage queries that were never used in quota enforcement

### System Limit Design Insight

After analyzing `systemLimitGuard` in `utils/subscription/types.ts`, we found it explicitly **excludes all boolean features**:
- Boolean quotas are feature gates controlled by plan configuration (true = allowed, false = blocked)
- Number quotas require usage comparison (current usage < limit)
- System limit only includes measurable, countable resources

## Changes

### 1. Tenant-Usage Scope Refinement

**Before**: Computed all usage values regardless of what was needed
**After**: On-demand computation for specific usage keys only

Updated `TenantUsageQuery` to:
- Accept specific `key` parameter for targeted queries
- Only include number-based usage (aligned with system limit design)
- Exclude boolean features (enforced at plan quota level)

### 2. Removed Dead Code (~150 lines)

**Boolean usage queries** (never used in quota enforcement):
- `isCustomJwtEnabled`
- `isMfaEnabled`
- `isBringYourUiEnabled`
- `isCollectUserProfileEnabled`
- `isIdpInitiatedSsoEnabled`
- `isSecurityFeaturesEnabled`

**Unused batch queries**:
- `getScopesForRolesTenantUsage()`
- `getScopesForResourcesTenantUsage()`
- `countScopesForRoles()`
- `countScopesForResources()`

### 3. Enhanced Type Safety

Created `SelfComputedUsage` type with compile-time guarantees:
```typescript
type SelfComputedUsage = Omit<
  OmitBooleanValueKeys<SubscriptionUsage>,
  'tenantMembersLimit' | 'socialConnectorsLimit'
>;
```

The `satisfies ToZodObject<SelfComputedUsage>` ensures:
- New number-based usage keys must be added to `selfComputedUsageGuard`
- TypeScript compilation fails if coverage is incomplete
- Runtime type validation matches compile-time types

### 4. Clarified Quota Enforcement Logic

Added comments in `QuotaLibrary.guardTenantUsageByKey`:
```typescript
// Boolean features: enforce directly by plan quota configuration (true = allowed, false = blocked)
if (typeof limit === 'boolean') { ... }

// Number-based limits: query current usage and compare with limit
const usage = await this.getTenantUsageByKey(key, context);
```

## Technical Details

### Data Flow

**Boolean Features**:
```
Plan Quota (Cloud) → guardTenantUsageByKey → Direct enforcement
(No usage query needed - plan config is source of truth)
```

**Number-Based Limits**:
```
Plan Quota (Cloud) → guardTenantUsageByKey → getTenantUsageByKey → Database Query
(Usage must be counted and compared)
```

### Special Cases Handling

Three usage keys have special handling in `getTenantUsageByKey`:
1. **`tenantMembersLimit`**: Queried from Cloud API (stored in admin tenant)
2. **`socialConnectorsLimit`**: Queried from connector library (in-memory state)

All other number-based usage is queried from local tenant database.

## Performance Impact

✅ **Improved**:
- Reduced database queries (no longer computing unused boolean usage)
- On-demand computation only queries what's needed
- Smaller code surface area (258 fewer lines)

✅ **No breaking changes**:
- Console continues to work without changes
- Quota enforcement logic unchanged for consumers


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally && UT added.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
