### PR TITLE
fix(core,schemas): align refresh token grant lifetime

### DIFF
--- a/.changeset/afraid-stingrays-sparkle.md
+++ b/.changeset/afraid-stingrays-sparkle.md
@@ -1,0 +1,10 @@
+---
+'@logto/schemas': patch
+'@logto/core': patch
+---
+
+align refresh token grant lifetime with 180-day TTL
+
+Refresh tokens were expiring after 14 days because the provider grant TTL was still capped at the default two weeks, regardless of the configured refresh token TTL.
+
+Now set the OIDC grant TTL to 180 days so refresh tokens can live for their configured duration, also expand the refresh token TTL up to 180 days.

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -362,7 +362,8 @@ export default function initOidc(
       },
       Interaction: 3600 /* 1 hour in seconds */,
       Session: 1_209_600 /* 14 days in seconds */,
-      Grant: 1_209_600 /* 14 days in seconds */,
+      // Set this to the longest allowed duration of the refresh token
+      Grant: 180 * 3600 * 24 /* 180 days in seconds */,
     },
     rotateRefreshToken: (ctx) => {
       const { Client: client } = ctx.oidc.entities;

--- a/packages/schemas/src/foundations/jsonb-types/oidc-module.ts
+++ b/packages/schemas/src/foundations/jsonb-types/oidc-module.ts
@@ -84,7 +84,7 @@ export const customClientMetadataGuard = z.object({
   [CustomClientMetadataKey.CorsAllowedOrigins]: z.string().min(1).array().optional(),
   [CustomClientMetadataKey.IdTokenTtl]: z.number().optional(),
   [CustomClientMetadataKey.RefreshTokenTtl]: z.number().optional(),
-  [CustomClientMetadataKey.RefreshTokenTtlInDays]: z.number().int().min(1).max(90).optional(),
+  [CustomClientMetadataKey.RefreshTokenTtlInDays]: z.number().int().min(1).max(180).optional(),
   [CustomClientMetadataKey.TenantId]: z.string().optional(),
   [CustomClientMetadataKey.AlwaysIssueRefreshToken]: z.boolean().optional(),
   [CustomClientMetadataKey.RotateRefreshToken]: z.boolean().optional(),


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Refresh tokens were expiring after 14 days because the provider grant TTL was still capped at the default two weeks, regardless of the configured refresh token TTL.

Now set the OIDC grant TTL to 180 days so refresh tokens can live for their configured duration, also expand the refresh token TTL up to 180 days.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested with different type of apps and configurations.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
