### PR TITLE
fix(core): validate batch usage consumption in quota guard

### DIFF
--- a/packages/core/src/routes/resource.scope.ts
+++ b/packages/core/src/routes/resource.scope.ts
@@ -89,7 +89,7 @@ export default function resourceScopeRoutes<T extends ManagementApiRouter>(
         body,
       } = ctx.guard;
 
-      await quota.guardTenantUsageByKey('scopesPerResourceLimit', resourceId);
+      await quota.guardTenantUsageByKey('scopesPerResourceLimit', { entityId: resourceId });
 
       assertThat(!/\s/.test(body.name), 'scope.name_with_space');
 

--- a/packages/core/src/routes/role.scope.ts
+++ b/packages/core/src/routes/role.scope.ts
@@ -93,7 +93,10 @@ export default function roleScopeRoutes<T extends ManagementApiRouter>(
         body: { scopeIds },
       } = ctx.guard;
 
-      await quota.guardTenantUsageByKey('scopesPerRoleLimit', id);
+      await quota.guardTenantUsageByKey('scopesPerRoleLimit', {
+        entityId: id,
+        consumeUsageCount: scopeIds.length,
+      });
 
       await validateRoleScopeAssignment(scopeIds, id);
       await insertRolesScopes(


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The quota guard previously only validated single-unit increments, allowing batch operations (e.g., assigning N permissions to a role where N > 1) to bypass quota limits. 

Add `consumeUsageCount` parameter to `guardTenantUsageByKey` to properly validate the total usage impact of batch operations.

Changes:
- Add optional `consumeUsageCount` to guard context for batch operations
- Ensure usage check validates `currentUsage + consumeUsageCount` against limits
- Add comprehensive test coverage for batch scenarios

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally && UT added.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
