### PR TITLE
feat(schemas): add index for organization role type

### DIFF
--- a/packages/schemas/alterations/next-1762338508-add-organization-roles-type-index.ts
+++ b/packages/schemas/alterations/next-1762338508-add-organization-roles-type-index.ts
@@ -1,0 +1,19 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      create index organization_roles__type
+      on organization_roles (tenant_id, type);
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      drop index organization_roles__type;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/organization_roles.sql
+++ b/packages/schemas/tables/organization_roles.sql
@@ -20,6 +20,9 @@ create table organization_roles (
 create index organization_roles__id
   on organization_roles (tenant_id, id);
 
+create index organization_roles__type
+  on organization_roles (tenant_id, type);
+
 create function check_organization_role_type(role_id varchar(21), target_type role_type) returns boolean as
 $$ begin
   return (select type from organization_roles where id = role_id) = target_type;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Since role count is now calculated based on role type, this PR adds a database index on the type column in the organization_roles table to improve query performance when filtering or counting roles by type.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally & CI passed.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
