### PR TITLE
refactor(console): remove legacy pro plan filtering logic

### DIFF
--- a/packages/console/src/components/PlanUsage/index.tsx
+++ b/packages/console/src/components/PlanUsage/index.tsx
@@ -19,7 +19,6 @@ import {
   getQuotaByKey,
   getToolTipByKey,
   shouldHideQuotaNotice,
-  filterNewUsageKeysForLegacyPro,
 } from './utils';
 
 type Props = {
@@ -48,10 +47,6 @@ function PlanUsage({ periodicUsage, usageAddOnSkus }: Props) {
       (key) =>
         isPaidTenant || (onlyShowPeriodicUsage && (key === 'mauLimit' || key === 'tokenLimit'))
     )
-    // TODO: remove this filter after the pro plan migration is complete.
-    .filter((key) => {
-      return filterNewUsageKeysForLegacyPro(key, planId);
-    })
     .map((key) => {
       return {
         usage: getUsageByKey(key, {

--- a/packages/console/src/components/PlanUsage/utils.ts
+++ b/packages/console/src/components/PlanUsage/utils.ts
@@ -1,5 +1,4 @@
 import { type AdminConsoleKey } from '@logto/phrases';
-import { ReservedPlanId } from '@logto/schemas';
 import { type TFuncKey } from 'i18next';
 
 import {
@@ -249,28 +248,4 @@ export const shouldHideQuotaNotice = (
 
   // Hide the quota notice if the basic quota is 0;
   return basicQuota[key] === 0;
-};
-
-/**
- * During the pro plan migration,
- * we need to hide the new added usage keys for the legacy Pro plan.
- * - RBAC enabled
- * - thirdPartyApplicationsLimit
- *
- * TODO: clean up this function after the migration is complete.
- */
-export const filterNewUsageKeysForLegacyPro = (key: UsageKey, planId: string) => {
-  const newUsageKeys = Object.freeze([CustomUsageKey.RbacEnabled, 'thirdPartyApplicationsLimit']);
-
-  if (!newUsageKeys.includes(key)) {
-    return true;
-  }
-
-  const isProPlanId = isProPlan(planId);
-
-  if (isProPlanId && planId !== ReservedPlanId.Pro202509) {
-    return false; // Hide new usage keys for legacy Pro plan
-  }
-
-  return true;
 };


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Remove the legacy Pro plan filtering logic. Since all legacy Pro plans have been migrated to the new Pro plan, it’s now safe to remove the filtering logic for the new Pro plan feature usage card.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
