### PR TITLE
fix(experience): preserve app_id param via Link component navigation

### DIFF
--- a/packages/experience/src/components/TextLink/index.tsx
+++ b/packages/experience/src/components/TextLink/index.tsx
@@ -7,6 +7,7 @@ import type { LinkProps } from 'react-router-dom';
 import { Link } from 'react-router-dom';
 
 import { useIframeModal } from '@/Providers/IframeModalProvider';
+import { usePreserveSearchParams } from '@/hooks/use-navigate-with-preserved-search-params';
 import usePlatform from '@/hooks/use-platform';
 
 import DynamicT from '../DynamicT';
@@ -23,6 +24,7 @@ export type Props = AnchorHTMLAttributes<HTMLAnchorElement> & {
 
 const TextLink = ({ className, children, text, icon, type = 'primary', to, ...rest }: Props) => {
   const { t } = useTranslation();
+  const { getTo } = usePreserveSearchParams();
   const { isMobile } = usePlatform();
   const { setModalState } = useIframeModal();
 
@@ -54,7 +56,7 @@ const TextLink = ({ className, children, text, icon, type = 'primary', to, ...re
 
   if (to) {
     return (
-      <Link className={classNames(styles.link, styles[type], className)} to={to} {...rest}>
+      <Link className={classNames(styles.link, styles[type], className)} to={getTo(to)} {...rest}>
         {icon}
         {children ?? <DynamicT forKey={text} />}
       </Link>

--- a/packages/integration-tests/src/tests/experience/identifier-input-cache.test.ts
+++ b/packages/integration-tests/src/tests/experience/identifier-input-cache.test.ts
@@ -1,5 +1,5 @@
 import { ConnectorType } from '@logto/connector-kit';
-import { SignInIdentifier, SignInMode } from '@logto/schemas';
+import { demoAppApplicationId, SignInIdentifier, SignInMode } from '@logto/schemas';
 import { appendPath } from '@silverhand/essentials';
 
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
@@ -54,7 +54,9 @@ describe('identifier input cache', () => {
 
   it('cached identifier(email) should not be apply to register form (only username is allowed)', async () => {
     await experience.toClick('a', 'Create account');
-    experience.toMatchUrl(appendPath(new URL(logtoUrl), 'register').href);
+    experience.toMatchUrl(
+      appendPath(new URL(logtoUrl), `register?app_id=${demoAppApplicationId}`).href
+    );
     // The input should be empty
     await experience.toMatchElement('input[name=identifier][value=""]');
   });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Preserve `app_id` search parameter in the `<Link>` component navigation.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested switching between sign-in and register links, and it worked properly.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
