### PR TITLE
feat(account-center): restore route after sign-in redirects

### DIFF
--- a/packages/account-center/src/App.tsx
+++ b/packages/account-center/src/App.tsx
@@ -12,10 +12,12 @@ import BrandingHeader from './components/BrandingHeader';
 import ErrorPage from './components/ErrorPage';
 import initI18n from './i18n/init';
 import Home from './pages/Home';
+import { handleAccountCenterRoute } from './utils/account-center-route';
 
 import '@experience/shared/scss/normalized.scss';
 
 void initI18n();
+handleAccountCenterRoute();
 
 const redirectUri = `${window.location.origin}/account-center`;
 

--- a/packages/account-center/src/utils/account-center-route.ts
+++ b/packages/account-center/src/utils/account-center-route.ts
@@ -1,0 +1,45 @@
+const accountCenterBasePath = '/account-center';
+const storageKey = 'account-center-route-cache';
+
+const knownRoutePrefixes: readonly string[] = ['/email', '/phone', '/username', '/password'];
+
+const isKnownRoute = (pathname?: string): pathname is string =>
+  pathname !== undefined &&
+  knownRoutePrefixes.some((prefix) =>
+    pathname.replace(accountCenterBasePath, '').startsWith(prefix)
+  );
+
+const parseStoredRoute = (storedRoute: string | undefined): string | undefined => {
+  if (storedRoute && isKnownRoute(storedRoute)) {
+    return storedRoute;
+  }
+  return undefined;
+};
+
+const shouldSkipHandling = (search: string) => {
+  const parameters = new URLSearchParams(search);
+  return parameters.has('code') || parameters.has('error');
+};
+
+/**
+ * Handle Account Center route restoration for sign in redirect.
+ */
+export const handleAccountCenterRoute = () => {
+  if (shouldSkipHandling(window.location.search)) {
+    return;
+  }
+
+  // Restore the stored route if the current path is the base path.
+  if (window.location.pathname === accountCenterBasePath) {
+    const storedRoute = parseStoredRoute(sessionStorage.getItem(storageKey) ?? undefined);
+    if (!storedRoute) {
+      sessionStorage.removeItem(storageKey);
+      return;
+    }
+
+    const { search, hash } = window.location;
+    window.history.replaceState({}, '', `${storedRoute}${search}${hash}`);
+  } else if (isKnownRoute(window.location.pathname)) {
+    sessionStorage.setItem(storageKey, window.location.pathname);
+  }
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4566,6 +4566,7 @@ importers:
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
+
   packages/phrases-experience:
     dependencies:
       '@logto/core-kit':


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Restore route after sign-in redirects: store unknown route in session storage, then restore after sign-in redirects.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
