### PR TITLE
fix(core,console): sort custom domains by creation time descending

### DIFF
--- a/packages/console/src/hooks/use-custom-domain.ts
+++ b/packages/console/src/hooks/use-custom-domain.ts
@@ -44,17 +44,27 @@ const useCustomDomain = (autoSync = false) => {
         return;
       }
 
-      // New domain added
-      void mutate([...data, domain]);
+      // New domain added - insert at the beginning to maintain sort order (newest first)
+      void mutate([domain, ...data]);
     },
     [mutate, data]
   );
 
+  /**
+   * Note: Sorted by creation time (newest first).
+   * Newly created domains will appear at the top of the list.
+   */
+  const allDomains = useMemo(() => {
+    if (!data) {
+      return [];
+    }
+    return data.slice().sort((domainA, domainB) => domainB.createdAt - domainA.createdAt);
+  }, [data]);
+
   const activeCustomDomains = useMemo(
     () =>
-      data?.filter(({ status }) => status === DomainStatus.Active).map(({ domain }) => domain) ??
-      [],
-    [data]
+      allDomains.filter(({ status }) => status === DomainStatus.Active).map(({ domain }) => domain),
+    [allDomains]
   );
 
   return {
@@ -71,7 +81,7 @@ const useCustomDomain = (autoSync = false) => {
      * - Full array of custom domains returned from the API.
      * - Will eventually replace the legacy `data` field.
      */
-    allDomains: data,
+    allDomains,
     isLoading,
     mutate: mutateDomain,
     activeCustomDomains,

--- a/packages/console/src/pages/TenantSettings/TenantDomainSettings/MultipleCustomDomainsFormField/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantDomainSettings/MultipleCustomDomainsFormField/index.tsx
@@ -87,7 +87,7 @@ function MultipleCustomDomainsFormField() {
           isDevFeaturesEnabled && <PaywallNotification />
         }
       </FormField>
-      {allDomains && allDomains.length > 0 && (
+      {allDomains.length > 0 && (
         <FormField title="domain.custom.custom_domain_field">
           {allDomains.map((domain) => (
             <CustomDomain

--- a/packages/core/src/__mocks__/domain.ts
+++ b/packages/core/src/__mocks__/domain.ts
@@ -17,6 +17,7 @@ export const mockDomainResponse: DomainResponse = {
   status: DomainStatus.PendingVerification,
   errorMessage: null,
   dnsRecords: [],
+  createdAt: mockCreatedAtForDomain,
 };
 
 export const mockDomain: Domain = {

--- a/packages/schemas/src/types/domain.ts
+++ b/packages/schemas/src/types/domain.ts
@@ -8,6 +8,7 @@ export const domainSelectFields = Object.freeze([
   'status',
   'errorMessage',
   'dnsRecords',
+  'createdAt',
 ] as const);
 
 export const domainResponseGuard = Domains.guard.pick({
@@ -16,6 +17,7 @@ export const domainResponseGuard = Domains.guard.pick({
   status: true,
   errorMessage: true,
   dnsRecords: true,
+  createdAt: true,
 });
 
 export type DomainResponse = z.infer<typeof domainResponseGuard>;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
According to the design requirements, multiple custom domains should be displayed in reverse chronological order with newly created domains appearing at the top of the list.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
