### PR TITLE
test: fix race condition in email MFA verification test

### DIFF
--- a/packages/integration-tests/src/tests/experience/mfa/email-verification/index.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/email-verification/index.test.ts
@@ -77,13 +77,19 @@ describe('email MFA verification', () => {
     await waitFor(300);
     experience2.toBeAt(`mfa-verification/${MfaFactor.EmailVerificationCode}`);
 
-    // Read email code and fill inputs named mfaCode_0..5
+    /**
+     * Read email code and fill inputs named mfaCode_0..5
+     * Note: The frontend automatically submits when all 6 digits are filled.
+     * See packages/experience/src/containers/MfaCodeVerification/index.tsx:74-79
+     * The onChange handler checks if all 6 digits are ready and auto-submits,
+     * so we don't need to manually click the Continue button here.
+     */
     const { code } = await readConnectorMessage('Email');
     for (const [index, char] of code.split('').entries()) {
       // eslint-disable-next-line no-await-in-loop
       await experience2.toFillInput(`mfaCode_${index}`, char);
     }
-    await experience2.toClick('button', 'Continue');
+    // No need to click Continue button - auto-submit happens after filling the 6th digit
     await experience2.verifyThenEnd();
 
     await deleteUser(user.id);


### PR DESCRIPTION
## Summary

Fixed a flaky integration test that was failing intermittently with `Execution context was destroyed` error in the email MFA verification test.

## Root Cause

The test was experiencing a **race condition** between:
1. Frontend auto-submit behavior (triggered when all 6 verification code digits are filled)
2. Manual "Continue" button click in the test

The frontend MFA verification component automatically submits when all 6 digits are entered:
- See `packages/experience/src/containers/MfaCodeVerification/index.tsx:74-79`
- The `onChange` handler detects when all digits are filled and calls `handleSubmit()`
- This triggers page navigation

The test was then trying to manually click the "Continue" button, which caused:
- ✅ **Pass**: If the button click happened before navigation started
- ❌ **Fail**: If navigation completed before the click → "Execution context was destroyed"

## Changes

- Removed the redundant manual click on the "Continue" button (line 86)
- Added detailed comments explaining the auto-submit behavior
- This aligns with other MFA tests (email/phone binding) that use `toCompleteVerification()` helper, which also relies on auto-submit

## Test Plan

- The fix follows the same pattern used in other MFA tests:
  - `packages/integration-tests/src/tests/experience/mfa/email/index.test.ts` (lines 57, 78)
  - `packages/integration-tests/src/tests/experience/mfa/phone/index.test.ts` (lines 57, 78)
- CI should verify the test is no longer flaky