### PR TITLE
fix(console): correct quota guard logic for dev plan

### DIFF
--- a/packages/console/src/containers/AppContent/index.tsx
+++ b/packages/console/src/containers/AppContent/index.tsx
@@ -16,6 +16,7 @@ import {
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import useScroll from '@/hooks/use-scroll';
 import useUserPreferences from '@/hooks/use-user-preferences';
+import { shouldEnforcePaywallInUI } from '@/utils/paywall';
 
 import { getPath } from '../ConsoleContent/Sidebar';
 import { useSidebarMenuItems } from '../ConsoleContent/Sidebar/hook';
@@ -53,23 +54,33 @@ export default function AppContent() {
         hasSurpassedSubscriptionQuotaLimit: <T extends keyof NewSubscriptionCountBasedUsage>(
           quotaKey: T,
           usage?: NewSubscriptionCountBasedUsage[T]
-        ) =>
-          hasSurpassedSubscriptionQuotaLimit({
+        ) => {
+          if (!shouldEnforcePaywallInUI(newSubscriptionData.currentSubscription.planId, quotaKey)) {
+            return false;
+          }
+
+          return hasSurpassedSubscriptionQuotaLimit({
             quotaKey,
             usage,
             subscriptionUsage: newSubscriptionData.currentSubscriptionUsage,
             subscriptionQuota: newSubscriptionData.currentSubscriptionQuota,
-          }),
+          });
+        },
         hasReachedSubscriptionQuotaLimit: <T extends keyof NewSubscriptionCountBasedUsage>(
           quotaKey: T,
           usage?: NewSubscriptionCountBasedUsage[T]
-        ) =>
-          hasReachedSubscriptionQuotaLimit({
+        ) => {
+          if (!shouldEnforcePaywallInUI(newSubscriptionData.currentSubscription.planId, quotaKey)) {
+            return false;
+          }
+
+          return hasReachedSubscriptionQuotaLimit({
             quotaKey,
             usage,
             subscriptionUsage: newSubscriptionData.currentSubscriptionUsage,
             subscriptionQuota: newSubscriptionData.currentSubscriptionQuota,
-          }),
+          });
+        },
       }}
     >
       <div className={styles.app}>

--- a/packages/console/src/contexts/SubscriptionDataProvider/types.ts
+++ b/packages/console/src/contexts/SubscriptionDataProvider/types.ts
@@ -31,10 +31,24 @@ type NewSubscriptionSupplementContext = {
 };
 
 type NewSubscriptionResourceStatus = {
+  /**
+   * Quota checking function with business rules applied.
+   *
+   * This function wraps the pure calculation utilities from SubscriptionDataProvider/utils
+   * and applies plan-specific enforcement policies (e.g., Development plan unlimited features).
+   * Backend still enforces actual limits; this function only controls UI behavior.
+   */
   hasSurpassedSubscriptionQuotaLimit: <T extends keyof NewSubscriptionCountBasedUsage>(
     quotaKey: T,
     usage?: NewSubscriptionCountBasedUsage[T]
   ) => boolean;
+  /**
+   * Quota checking function with business rules applied.
+   *
+   * This function wraps the pure calculation utilities from SubscriptionDataProvider/utils
+   * and applies plan-specific enforcement policies (e.g., Development plan unlimited features).
+   * Backend still enforces actual limits; this function only controls UI behavior.
+   */
   hasReachedSubscriptionQuotaLimit: <T extends keyof NewSubscriptionCountBasedUsage>(
     quotaKey: T,
     usage?: NewSubscriptionCountBasedUsage[T]

--- a/packages/console/src/utils/paywall.ts
+++ b/packages/console/src/utils/paywall.ts
@@ -1,0 +1,42 @@
+import { ReservedPlanId } from '@logto/schemas';
+
+import { type NewSubscriptionCountBasedUsage } from '@/cloud/types/router';
+
+/**
+ * Determines whether a paywall should be enforced in the UI for a given plan.
+ *
+ * @param planId - The subscription plan ID
+ * @param quotaKey - The quota key to check
+ * @returns true if the paywall should be enforced (show paywall/limit), false otherwise
+ *
+ * @example
+ * ```typescript
+ * // Development plan user creating an application
+ * shouldEnforcePaywallInUI(ReservedPlanId.Development, 'applicationsLimit')
+ * // => false (no paywall shown)
+ *
+ * // Development plan user inviting 21st team member
+ * shouldEnforcePaywallInUI(ReservedPlanId.Development, 'tenantMembersLimit')
+ * // => true (shows "Contact us" message)
+ *
+ * // Free plan user creating 4th application
+ * shouldEnforcePaywallInUI(ReservedPlanId.Free, 'applicationsLimit')
+ * // => true (shows upgrade prompt)
+ * ```
+ */
+export const shouldEnforcePaywallInUI = <T extends keyof NewSubscriptionCountBasedUsage>(
+  planId: string,
+  quotaKey: T
+): boolean => {
+  if (planId === ReservedPlanId.Development) {
+    // Currently, only tenant members paywall is enforced for Development plan
+    if (quotaKey === 'tenantMembersLimit') {
+      return true;
+    }
+
+    return false;
+  }
+
+  // All other plans: Always enforce paywalls
+  return true;
+};


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
### Problem
Development plan had incorrect paywall/upsell guard logic, frontend paywall/upsell UI should not be shown (those are designed for Free plan users to upgrade).

The previous implementation incorrectly applied the same paywall logic to Development plan as Free plan, showing unnecessary upgrade prompts.

### Solution
Extract quota enforcement policy to properly handle Development plan:

- **Backend guards Development plan limits** - frontend doesn't need to block
- **Paywall/upsell UI is for Free plan only** - to encourage upgrades
- **Development plan gets clean UX** - no upgrade prompts for most features
- **Exception: tenant members limit** - still shows "Contact us" prompt (soft limit)

Implemented via `shouldEnforceQuotaInUI()` with explicit blacklist of quotas that shouldn't show UI guards for Development plan.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
