### PR TITLE
fix(core): allow null protectedAppMetadata

### DIFF
--- a/packages/core/src/routes/applications/types.ts
+++ b/packages/core/src/routes/applications/types.ts
@@ -35,5 +35,5 @@ export const applicationPatchGuard = originalApplicationPatchGuard
           )
           .optional(),
       })
-      .optional(),
+      .nullish(),
   });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Changed the application PATCH guard so `protectedAppMetadata` can be `null` or `undefined` (`.nullish()` instead of `.optional()`), matching the GET response and preventing `invalid_type` errors when round-tripping the payload (packages/core/src/routes/applications/types.ts).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

Local tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
