### PR TITLE
chore: update Google connector scopes instructions

### DIFF
--- a/packages/connectors/connector-google/README.md
+++ b/packages/connectors/connector-google/README.md
@@ -70,7 +70,7 @@ Scopes define the permissions your app requests from users and control which dat
 
 ### Configure scopes in Google Cloud Console
 
-1. Navigate to **APIs & Services > OAuth consent screen > Scopes**.
+1. Navigate to **APIs & Services > OAuth consent screen > Data Access**.
 2. Click **Add or Remove Scopes** and select only the scopes your app requires:
    - **Authentication (Required)**:
      - `https://www.googleapis.com/auth/userinfo.email`

--- a/packages/console/src/assets/docs/single-sign-on/google-workspace/README.mdx
+++ b/packages/console/src/assets/docs/single-sign-on/google-workspace/README.mdx
@@ -96,7 +96,7 @@ Scopes define the permissions your app requests from users and control which dat
 
 **In Google Cloud Console:**
 
-1. Navigate to **APIs & Services > OAuth consent screen > Scopes**.
+1. Navigate to **APIs & Services > OAuth consent screen > Data Access**.
 2. Click **Add or Remove Scopes** and select only the scopes your app requires:
    - Authentication (Required):
      - `https://www.googleapis.com/auth/userinfo.email`


### PR DESCRIPTION
## Summary

The Google connector README instructions differ slightly from the Google Cloud console experience - likely because the Google Cloud Console recently changed.

This is what is currently displayed : 

<img width="944" height="140" alt="image" src="https://github.com/user-attachments/assets/4ac52884-fe62-45ec-a7e7-688a82d586d1" />


Below is a screenshot of the current side Google Console - OAuth side menu :

<img width="1550" height="750" alt="image" src="https://github.com/user-attachments/assets/7f7b32c1-4b79-445b-b872-422970b7f294" />

I changed documentation to reflect the current console.

## Testing

This is a chore / documentation, no testing is necessary (no code affected).

Considering the small chore/docs nature of this, I did not create an issue (non-bug, non-feature), nor did I affect the changeset. Please let me know if I should do either of those things.

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
