### PR TITLE
fix(console,core): include accept-language header in cloud apis and revert #8008

### DIFF
--- a/packages/console/src/cloud/hooks/use-cloud-api.ts
+++ b/packages/console/src/cloud/hooks/use-cloud-api.ts
@@ -6,6 +6,7 @@ import { conditional, trySafe } from '@silverhand/essentials';
 import Client, { ResponseError } from '@withtyped/client';
 import { useContext, useMemo } from 'react';
 import { toast } from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
 
 import { cloudApi } from '@/consts';
@@ -41,6 +42,7 @@ type UseCloudApiProps = {
 export const useCloudApi = ({ hideErrorToast = false }: UseCloudApiProps = {}): Client<
   typeof router
 > => {
+  const { i18n } = useTranslation();
   const { isAuthenticated, getAccessToken } = useLogto();
   const api = useMemo(
     () =>
@@ -48,7 +50,10 @@ export const useCloudApi = ({ hideErrorToast = false }: UseCloudApiProps = {}): 
         baseUrl: window.location.origin,
         headers: async () => {
           if (isAuthenticated) {
-            return { Authorization: `Bearer ${(await getAccessToken(cloudApi.indicator)) ?? ''}` };
+            return {
+              Authorization: `Bearer ${(await getAccessToken(cloudApi.indicator)) ?? ''}`,
+              'Accept-Language': i18n.language,
+            };
           }
         },
         before: {

--- a/packages/core/src/routes/organization-invitation/index.ts
+++ b/packages/core/src/routes/organization-invitation/index.ts
@@ -4,7 +4,6 @@ import {
   OrganizationInvitations,
   organizationInvitationEntityGuard,
 } from '@logto/schemas';
-import { isObject } from '@silverhand/essentials';
 import { z } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
@@ -12,7 +11,6 @@ import koaGuard from '#src/middleware/koa-guard.js';
 import SchemaRouter from '#src/utils/SchemaRouter.js';
 import assertThat from '#src/utils/assert-that.js';
 
-import koaEmailI18n from '../../middleware/koa-email-i18n.js';
 import { errorHandler } from '../organization/utils.js';
 import { type ManagementApiRouter, type RouterInitArgs } from '../types.js';
 
@@ -96,22 +94,11 @@ export default function organizationInvitationRoutes<T extends ManagementApiRout
       body: sendMessagePayloadGuard,
       status: [204],
     }),
-    koaEmailI18n(queries),
     async (ctx, next) => {
       const {
         params: { id },
         body,
       } = ctx.guard;
-      // The `koaEmailI18n` properties are not available in the `SchemaRouter` context.
-      // So we have to assert its existence here to make TypeScript happy.
-      assertThat(
-        'emailI18n' in ctx && isObject(ctx.emailI18n),
-        new RequestError({
-          status: 422,
-          code: 'request.invalid_input',
-          details: 'The email i18n context is missing.',
-        })
-      );
       const { invitee, organizationId, inviterId } = await invitations.findById(id);
 
       const templateContext =
@@ -121,7 +108,6 @@ export default function organizationInvitationRoutes<T extends ManagementApiRout
         );
 
       await organizationInvitations.sendEmail(invitee, {
-        ...ctx.emailI18n,
         ...templateContext,
         ...body,
       });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- Include `Accept-Language` HTTP header in the Cloud API requests. And will be used in the Cloud service (https://github.com/logto-io/cloud/pull/1501).
- Revert a prior PR #8008 as the email i18n context is missing in such use case, so it didn't work as expected.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
