### PR TITLE
fix(experience): fix signature position in mobile

### DIFF
--- a/packages/experience/src/components/LogtoSignature/index.tsx
+++ b/packages/experience/src/components/LogtoSignature/index.tsx
@@ -121,7 +121,6 @@ const LogtoSignature = ({ className }: Props) => {
         container.style.setProperty('display', 'block', 'important');
         container.style.setProperty('visibility', 'visible', 'important');
         container.style.setProperty('opacity', '1', 'important');
-        container.style.setProperty('position', 'absolute', 'important');
       }
 
       anchor.removeAttribute('hidden');


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Fix "powered by Logto" position in mobile.

The css `position` is `absolute` in desktop, but `static` in mobile:

```css
:global(body.desktop) {
  .signature {
    position: absolute;
    bottom: 0;
    transform: translateY(calc(100% + _.unit(7)));
    // Have to use padding instead of margin. Overflow margin spacing will be ignored by the browser.
    padding-bottom: _.unit(7);
  }
}
```

So we can not force to set the `position` to `absolute` directly.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
