### PR TITLE
perf(core): add index on logs table for tenant_id, created_at and id

### DIFF
--- a/packages/schemas/alterations/next-1765183934-add-logs-created-at-id-index.ts
+++ b/packages/schemas/alterations/next-1765183934-add-logs-created-at-id-index.ts
@@ -1,0 +1,39 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  beforeUp: async (pool) => {
+    /**
+     * Use 'if not exists' to ensure idempotency.
+     * If the subsequent transaction in 'up' fails, the migration can be safely re-run without failing on an already created index.
+     */
+    await pool.query(sql`
+      create index concurrently if not exists logs__created_at_id
+      on logs (tenant_id, created_at, id);
+    `);
+  },
+  up: async () => {
+    /**
+     * The index on the logs table must be created outside of a transaction to avoid table locks.
+     * 'concurrently' cannot be used inside a transaction, so this up is intentionally left empty.
+     */
+  },
+  beforeDown: async (pool) => {
+    /**
+     * Use 'if exists' to ensure idempotency. If the subsequent transaction in 'down' fails,
+     * the rollback can be safely re-run without failing on a non-existent index.
+     */
+    await pool.query(sql`
+      drop index concurrently if exists logs__created_at_id;
+    `);
+  },
+  down: async () => {
+    /**
+     * The index on the logs table must be dropped outside of a transaction to avoid table locks.
+     * 'concurrently' cannot be used inside a transaction, so this down is intentionally left empty.
+     */
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/types/alteration.ts
+++ b/packages/schemas/src/types/alteration.ts
@@ -1,6 +1,16 @@
-import type { DatabaseTransactionConnection } from '@silverhand/slonik';
+import type { CommonQueryMethods, DatabaseTransactionConnection } from '@silverhand/slonik';
 
 export type AlterationScript = {
+  /**
+   * Optional hook that runs before `up` outside of a transaction.
+   * Use for operations that cannot be wrapped in a transaction (e.g., CREATE INDEX CONCURRENTLY).
+   */
+  beforeUp?: (connection: CommonQueryMethods) => Promise<void>;
+  /**
+   * Optional hook that runs before `down` outside of a transaction.
+   * Use for operations that cannot be wrapped in a transaction (e.g., DROP INDEX CONCURRENTLY).
+   */
+  beforeDown?: (connection: CommonQueryMethods) => Promise<void>;
   up: (connection: DatabaseTransactionConnection) => Promise<void>;
   down: (connection: DatabaseTransactionConnection) => Promise<void>;
 };

--- a/packages/schemas/tables/logs.sql
+++ b/packages/schemas/tables/logs.sql
@@ -24,3 +24,6 @@ create index logs__application_id
 
 create index logs__hook_id
   on logs (tenant_id, (payload->>'hookId'));
+
+create index logs__created_at_id
+  on logs (tenant_id, created_at, id);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Context https://github.com/logto-io/cloud/pull/1516

And this PR also introduces `beforeUp` and `beforeDown` hooks in the alteration script system to support operations that cannot be executed within a transaction. The primary motivation is to handle the logs table, which can grow very large in production environments. Creating or dropping indexes on this table without the CONCURRENTLY option would lock the table for writes.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
