### PR TITLE
feat(core,experience,console): support recaptcha checkbox mode

### DIFF
--- a/.changeset/witty-cars-end.md
+++ b/.changeset/witty-cars-end.md
@@ -1,0 +1,16 @@
+---
+'@logto/experience': minor
+'@logto/console': minor
+'@logto/phrases': minor
+'@logto/schemas': minor
+'@logto/core': minor
+---
+
+support reCAPTCHA Enterprise checkbox mode
+
+You can now choose between two verification modes for reCAPTCHA Enterprise:
+
+- **Invisible**: Score-based verification that runs automatically in the background (default)
+- **Checkbox**: Displays the "I'm not a robot" widget for user interaction
+
+Note: The verification mode must match your reCAPTCHA key type configured in Google Cloud Console.

--- a/packages/console/src/pages/CaptchaDetails/CaptchaContent/index.tsx
+++ b/packages/console/src/pages/CaptchaDetails/CaptchaContent/index.tsx
@@ -30,6 +30,7 @@ function CaptchaContent({ isDeleted, captchaProvider, onUpdate }: Props) {
     handleSubmit,
     reset,
     register,
+    control,
   } = useForm<CaptchaFormType>({
     reValidateMode: 'onBlur',
     defaultValues: captchaProvider.config,
@@ -77,7 +78,12 @@ function CaptchaContent({ isDeleted, captchaProvider, onUpdate }: Props) {
           description={metadata.description}
           learnMoreLink={{ href: '/security/captcha' }}
         >
-          <CaptchaFormFields metadata={metadata} errors={errors} register={register} />
+          <CaptchaFormFields
+            metadata={metadata}
+            errors={errors}
+            register={register}
+            control={control}
+          />
         </FormCard>
       </DetailsForm>
       <UnsavedChangesAlertModal hasUnsavedChanges={!isDeleted && isDirty} />

--- a/packages/console/src/pages/Security/Captcha/CaptchaFormFields/index.module.scss
+++ b/packages/console/src/pages/Security/Captcha/CaptchaFormFields/index.module.scss
@@ -1,0 +1,5 @@
+@use '@/scss/underscore' as _;
+
+.modeNotice {
+  margin-top: _.unit(3);
+}

--- a/packages/console/src/pages/Security/Captcha/CaptchaFormFields/index.tsx
+++ b/packages/console/src/pages/Security/Captcha/CaptchaFormFields/index.tsx
@@ -1,23 +1,30 @@
-import { type UseFormRegister, type FieldErrors } from 'react-hook-form';
+import { RecaptchaEnterpriseMode } from '@logto/schemas';
+import { type UseFormRegister, type FieldErrors, Controller, type Control } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
 import FormField from '@/ds-components/FormField';
+import InlineNotification from '@/ds-components/InlineNotification';
+import RadioGroup, { Radio } from '@/ds-components/RadioGroup';
 import TextInput from '@/ds-components/TextInput';
 
 import { type CaptchaProviderMetadata } from '../CreateCaptchaForm/types';
 import { type CaptchaFormType } from '../types';
 
+import styles from './index.module.scss';
+
 type Props = {
   readonly metadata: CaptchaProviderMetadata;
   readonly errors: FieldErrors;
   readonly register: UseFormRegister<CaptchaFormType>;
+  readonly control: Control<CaptchaFormType>;
 };
 
-function CaptchaFormFields({ metadata, errors, register }: Props) {
+function CaptchaFormFields({ metadata, errors, register, control }: Props) {
   const siteKeyField = metadata.requiredFields.find((field) => field.field === 'siteKey');
   const secretKeyField = metadata.requiredFields.find((field) => field.field === 'secretKey');
   const projectIdField = metadata.requiredFields.find((field) => field.field === 'projectId');
   const domainField = metadata.requiredFields.find((field) => field.field === 'domain');
+  const modeField = metadata.requiredFields.find((field) => field.field === 'mode');
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
   return (
@@ -57,6 +64,32 @@ function CaptchaFormFields({ metadata, errors, register }: Props) {
             {...register('domain', { required: !domainField.isOptional })}
           />
         </FormField>
+      )}
+      {modeField && (
+        <>
+          <FormField title={modeField.label}>
+            <Controller
+              name="mode"
+              control={control}
+              defaultValue={RecaptchaEnterpriseMode.Invisible}
+              render={({ field: { onChange, value } }) => (
+                <RadioGroup name="mode" value={value} onChange={onChange}>
+                  <Radio
+                    title="security.captcha_details.mode_invisible"
+                    value={RecaptchaEnterpriseMode.Invisible}
+                  />
+                  <Radio
+                    title="security.captcha_details.mode_checkbox"
+                    value={RecaptchaEnterpriseMode.Checkbox}
+                  />
+                </RadioGroup>
+              )}
+            />
+          </FormField>
+          <InlineNotification className={styles.modeNotice} severity="alert">
+            {t('security.captcha_details.mode_notice')}
+          </InlineNotification>
+        </>
       )}
     </>
   );

--- a/packages/console/src/pages/Security/Captcha/CreateCaptchaForm/constants.ts
+++ b/packages/console/src/pages/Security/Captcha/CreateCaptchaForm/constants.ts
@@ -83,6 +83,11 @@ export const captchaProviders: CaptchaProviderMetadata[] = [
     readme: reCAPTCHAEnterpriseReadme,
     requiredFields: [
       {
+        field: 'mode',
+        label: 'security.captcha_details.mode',
+        placeholder: 'security.captcha_details.mode',
+      },
+      {
         field: 'siteKey',
         label: 'security.captcha_details.recaptcha_key_id',
         placeholder: 'security.captcha_details.recaptcha_key_id',

--- a/packages/console/src/pages/Security/Captcha/CreateCaptchaForm/types.ts
+++ b/packages/console/src/pages/Security/Captcha/CreateCaptchaForm/types.ts
@@ -1,7 +1,7 @@
 import { type AdminConsoleKey } from '@logto/phrases';
 import { type CaptchaType } from '@logto/schemas';
 
-type FormField = 'siteKey' | 'secretKey' | 'projectId' | 'domain';
+type FormField = 'siteKey' | 'secretKey' | 'projectId' | 'domain' | 'mode';
 
 export type CaptchaProviderMetadata = {
   name: AdminConsoleKey;

--- a/packages/console/src/pages/Security/Captcha/Guide/index.tsx
+++ b/packages/console/src/pages/Security/Captcha/Guide/index.tsx
@@ -1,4 +1,4 @@
-import type { CaptchaProvider, CaptchaType } from '@logto/schemas';
+import { RecaptchaEnterpriseMode, type CaptchaProvider, type CaptchaType } from '@logto/schemas';
 import { FormProvider, useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
@@ -43,6 +43,7 @@ function Guide({ type, onClose }: Props) {
       siteKey: '',
       secretKey: '',
       projectId: '',
+      mode: RecaptchaEnterpriseMode.Invisible,
     },
   });
 
@@ -50,6 +51,7 @@ function Guide({ type, onClose }: Props) {
     formState: { isSubmitting, errors },
     handleSubmit,
     register,
+    control,
   } = methods;
 
   const onSubmit = handleSubmit(
@@ -122,6 +124,7 @@ function Guide({ type, onClose }: Props) {
                     metadata={captchaMetadata}
                     errors={errors}
                     register={register}
+                    control={control}
                   />
                 </div>
                 <div className={styles.footer}>

--- a/packages/console/src/pages/Security/Captcha/types.tsx
+++ b/packages/console/src/pages/Security/Captcha/types.tsx
@@ -1,6 +1,9 @@
+import { type RecaptchaEnterpriseMode } from '@logto/schemas';
+
 export type CaptchaFormType = {
   siteKey: string;
   secretKey: string;
   projectId: string;
   domain?: string;
+  mode?: RecaptchaEnterpriseMode;
 };

--- a/packages/core/src/libraries/sign-in-experience/index.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.ts
@@ -188,6 +188,9 @@ export const createSignInExperienceLibrary = (
       ...(type === 'RecaptchaEnterprise' &&
         'domain' in provider.config &&
         provider.config.domain && { domain: provider.config.domain }),
+      ...(type === 'RecaptchaEnterprise' &&
+        'mode' in provider.config &&
+        provider.config.mode && { mode: provider.config.mode }),
     };
   };
 

--- a/packages/core/src/routes/experience/classes/libraries/captcha-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/captcha-validator.ts
@@ -1,5 +1,6 @@
 import {
   CaptchaType,
+  RecaptchaEnterpriseMode,
   type CaptchaProvider,
   type RecaptchaEnterpriseConfig,
   type TurnstileConfig,
@@ -108,12 +109,16 @@ export class CaptchaValidator {
         riskAnalysis: { score },
       } = responseGuard.parse(result);
 
+      // For checkbox mode, only check if the token is valid (skip score threshold)
+      // Checkbox challenges are interactive and provide binary pass/fail
+      const isCheckboxMode = config.mode === RecaptchaEnterpriseMode.Checkbox;
       // TODO: customize the score threshold
-      const success = valid && score >= 0.5;
+      const success = isCheckboxMode ? valid : valid && score >= 0.5;
 
       this.log.append({
         success,
         score,
+        mode: config.mode ?? RecaptchaEnterpriseMode.Invisible,
       });
 
       return success;

--- a/packages/experience/src/Providers/CaptchaContextProvider/index.tsx
+++ b/packages/experience/src/Providers/CaptchaContextProvider/index.tsx
@@ -1,4 +1,4 @@
-import { CaptchaType, Theme } from '@logto/schemas';
+import { CaptchaType, RecaptchaEnterpriseMode, Theme } from '@logto/schemas';
 import { useMemo, useContext, useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -22,9 +22,6 @@ const CaptchaContextProvider = ({ children }: Props) => {
 
   const captchaPolicy = experienceSettings?.captchaPolicy;
   const captchaConfig = experienceSettings?.captchaConfig;
-
-  console.log('captchaPolicy', captchaPolicy);
-  console.log('captchaConfig', captchaConfig);
 
   const isCaptchaRequired = Boolean(captchaPolicy?.enabled);
 
@@ -82,6 +79,33 @@ const CaptchaContextProvider = ({ children }: Props) => {
       return;
     }
 
+    // Handle checkbox mode for reCAPTCHA Enterprise
+    if (captchaConfig.mode === RecaptchaEnterpriseMode.Checkbox) {
+      return new Promise<string | undefined>((resolve, reject) => {
+        if (!window.grecaptcha || !widgetRef.current) {
+          resolve(undefined);
+          return;
+        }
+
+        // Clear the dom element first
+        // eslint-disable-next-line @silverhand/fp/no-mutation
+        widgetRef.current.innerHTML = '';
+
+        window.grecaptcha.enterprise.render(widgetRef.current, {
+          sitekey: captchaConfig.siteKey,
+          theme: theme === Theme.Light ? 'light' : 'dark',
+          callback: (token: string) => {
+            resolve(token);
+          },
+          'error-callback': (errorCode) => {
+            setToast(t('error.captcha_verification_failed'));
+            reject(new Error(`reCAPTCHA error: ${errorCode}`));
+          },
+        });
+      });
+    }
+
+    // Default invisible mode
     return window.grecaptcha.enterprise.execute(captchaConfig.siteKey, {
       action: 'interaction',
     });

--- a/packages/experience/src/Providers/CaptchaContextProvider/utils.ts
+++ b/packages/experience/src/Providers/CaptchaContextProvider/utils.ts
@@ -1,4 +1,4 @@
-import { CaptchaType } from '@logto/schemas';
+import { CaptchaType, RecaptchaEnterpriseMode } from '@logto/schemas';
 
 import { type SignInExperienceResponse } from '@/types';
 
@@ -13,5 +13,12 @@ export const getScript = (config: SignInExperienceResponse['captchaConfig']) => 
   }
 
   const domain = config.domain ?? 'www.google.com';
+
+  // For checkbox mode, use explicit render to manually render the widget
+  if (config.mode === RecaptchaEnterpriseMode.Checkbox) {
+    return `https://${domain}/recaptcha/enterprise.js?render=explicit`;
+  }
+
+  // For invisible mode (default), render with siteKey for automatic execution
   return `https://${domain}/recaptcha/enterprise.js?render=${config.siteKey}`;
 };

--- a/packages/experience/src/containers/CaptchaBox/index.tsx
+++ b/packages/experience/src/containers/CaptchaBox/index.tsx
@@ -1,4 +1,4 @@
-import { CaptchaType } from '@logto/schemas';
+import { CaptchaType, RecaptchaEnterpriseMode } from '@logto/schemas';
 import { useContext } from 'react';
 
 import CaptchaContext from '@/Providers/CaptchaContextProvider/CaptchaContext';
@@ -8,8 +8,15 @@ import styles from './index.module.scss';
 const CaptchaBox = () => {
   const { captchaConfig, widgetRef, isCaptchaRequired } = useContext(CaptchaContext);
 
-  // Currently only Turnstile needs a widget to be rendered
-  if (!isCaptchaRequired || captchaConfig?.type !== CaptchaType.Turnstile) {
+  // Check if widget rendering is needed
+  // Turnstile always needs a widget, reCAPTCHA Enterprise needs it only in checkbox mode
+  const needsWidget =
+    isCaptchaRequired &&
+    captchaConfig &&
+    (captchaConfig.type === CaptchaType.Turnstile ||
+      captchaConfig.mode === RecaptchaEnterpriseMode.Checkbox);
+
+  if (!needsWidget) {
     return null;
   }
 

--- a/packages/experience/src/include.d/global.d.ts
+++ b/packages/experience/src/include.d/global.d.ts
@@ -25,6 +25,15 @@ declare global {
       enterprise: {
         ready: (callback: () => void) => void;
         execute: (sitekey: string, options: { action: string }) => Promise<string>;
+        render: (
+          element: HTMLElement,
+          options: {
+            sitekey: string;
+            callback: (token: string) => void;
+            theme?: 'light' | 'dark';
+            'error-callback'?: (errorCode?: string) => void;
+          }
+        ) => number;
       };
     };
     turnstile?: {

--- a/packages/phrases/src/locales/ar/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/security.ts
@@ -53,6 +53,11 @@ const security = {
     deletion_description: 'هل أنت متأكد أنك تريد حذف مزود CAPTCHA هذا؟',
     captcha_deleted: 'تم حذف موفر CAPTCHA بنجاح',
     setup_captcha: 'إعداد CAPTCHA',
+    mode: 'وضع التحقق',
+    mode_invisible: 'غير مرئي',
+    mode_checkbox: 'مربع اختيار',
+    mode_notice:
+      'يتم تحديد وضع التحقق في إعدادات مفتاح reCAPTCHA في Google Cloud Console. يتطلب تغيير الوضع هنا نوع مفتاح مطابق.',
   },
   password_policy: {
     password_requirements: 'متطلبات كلمة المرور',

--- a/packages/phrases/src/locales/de/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/security.ts
@@ -54,6 +54,11 @@ const security = {
     deletion_description: 'Sind Sie sicher, dass Sie diesen CAPTCHA-Anbieter löschen möchten?',
     captcha_deleted: 'CAPTCHA-Anbieter erfolgreich gelöscht',
     setup_captcha: 'CAPTCHA einrichten',
+    mode: 'Überprüfungsmodus',
+    mode_invisible: 'Unsichtbar',
+    mode_checkbox: 'Kontrollkästchen',
+    mode_notice:
+      'Der Überprüfungsmodus wird in Ihren reCAPTCHA-Schlüsseleinstellungen in der Google Cloud Console definiert. Zum Ändern des Modus hier ist ein passender Schlüsseltyp erforderlich.',
   },
   password_policy: {
     password_requirements: 'Passwortanforderungen',

--- a/packages/phrases/src/locales/en/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/security.ts
@@ -54,6 +54,11 @@ const security = {
     deletion_description: 'Are you sure you want to delete this CAPTCHA provider?',
     captcha_deleted: 'CAPTCHA provider deleted successfully',
     setup_captcha: 'Setup CAPTCHA',
+    mode: 'Verification mode',
+    mode_invisible: 'Invisible',
+    mode_checkbox: 'Checkbox',
+    mode_notice:
+      'The verification mode is defined in your reCAPTCHA key settings in Google Cloud Console. Changing the mode here requires a matching key type.',
   },
   password_policy: {
     password_requirements: 'Password requirements',

--- a/packages/phrases/src/locales/es/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/security.ts
@@ -54,6 +54,11 @@ const security = {
     deletion_description: '¿Estás seguro de que quieres eliminar este proveedor de CAPTCHA?',
     captcha_deleted: 'Proveedor de CAPTCHA eliminado con éxito',
     setup_captcha: 'Configurar CAPTCHA',
+    mode: 'Modo de verificación',
+    mode_invisible: 'Invisible',
+    mode_checkbox: 'Casilla de verificación',
+    mode_notice:
+      'El modo de verificación se define en la configuración de tu clave reCAPTCHA en Google Cloud Console. Cambiar el modo aquí requiere un tipo de clave coincidente.',
   },
   password_policy: {
     password_requirements: 'Requisitos de contraseña',

--- a/packages/phrases/src/locales/fr/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/security.ts
@@ -54,6 +54,11 @@ const security = {
     deletion_description: 'Êtes-vous sûr de vouloir supprimer ce fournisseur CAPTCHA ?',
     captcha_deleted: 'Fournisseur CAPTCHA supprimé avec succès',
     setup_captcha: 'Configurer CAPTCHA',
+    mode: 'Mode de vérification',
+    mode_invisible: 'Invisible',
+    mode_checkbox: 'Case à cocher',
+    mode_notice:
+      'Le mode de vérification est défini dans les paramètres de votre clé reCAPTCHA dans Google Cloud Console. Changer le mode ici nécessite un type de clé correspondant.',
   },
   password_policy: {
     password_requirements: 'Exigences relatives au mot de passe',

--- a/packages/phrases/src/locales/it/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/security.ts
@@ -54,6 +54,11 @@ const security = {
     deletion_description: 'Sei sicuro di voler eliminare questo fornitore di CAPTCHA?',
     captcha_deleted: 'Fornitore di CAPTCHA eliminato con successo',
     setup_captcha: 'Configura CAPTCHA',
+    mode: 'Modalità di verifica',
+    mode_invisible: 'Invisibile',
+    mode_checkbox: 'Casella di controllo',
+    mode_notice:
+      'La modalità di verifica è definita nelle impostazioni della chiave reCAPTCHA in Google Cloud Console. Per cambiare la modalità qui è necessario un tipo di chiave corrispondente.',
   },
   password_policy: {
     password_requirements: 'Requisiti per la password',

--- a/packages/phrases/src/locales/ja/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/security.ts
@@ -54,6 +54,11 @@ const security = {
     deletion_description: 'この CAPTCHA プロバイダーを削除してもよろしいですか？',
     captcha_deleted: 'CAPTCHA プロバイダーが正常に削除されました',
     setup_captcha: 'CAPTCHA をセットアップ',
+    mode: '認証モード',
+    mode_invisible: '非表示',
+    mode_checkbox: 'チェックボックス',
+    mode_notice:
+      '認証モードは Google Cloud Console の reCAPTCHA キー設定で定義されています。ここでモードを変更するには、一致するキータイプが必要です。',
   },
   password_policy: {
     password_requirements: 'パスワードの要件',

--- a/packages/phrases/src/locales/ko/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/security.ts
@@ -54,6 +54,11 @@ const security = {
     deletion_description: '이 CAPTCHA 제공자를 삭제하시겠습니까?',
     captcha_deleted: 'CAPTCHA 제공자가 성공적으로 삭제되었습니다',
     setup_captcha: 'CAPTCHA 설정',
+    mode: '인증 모드',
+    mode_invisible: '보이지 않음',
+    mode_checkbox: '체크박스',
+    mode_notice:
+      '인증 모드는 Google Cloud Console의 reCAPTCHA 키 설정에서 정의됩니다. 여기서 모드를 변경하려면 일치하는 키 유형이 필요합니다.',
   },
   password_policy: {
     password_requirements: '비밀번호 요구사항',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/security.ts
@@ -54,6 +54,11 @@ const security = {
     deletion_description: 'Czy na pewno chcesz usunąć tego dostawcę CAPTCHA?',
     captcha_deleted: 'Pomyślnie usunięto dostawcę CAPTCHA',
     setup_captcha: 'Skonfiguruj CAPTCHA',
+    mode: 'Tryb weryfikacji',
+    mode_invisible: 'Niewidoczny',
+    mode_checkbox: 'Pole wyboru',
+    mode_notice:
+      'Tryb weryfikacji jest zdefiniowany w ustawieniach klucza reCAPTCHA w Google Cloud Console. Zmiana trybu tutaj wymaga odpowiedniego typu klucza.',
   },
   password_policy: {
     password_requirements: 'Wymagania dotyczące hasła',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/security.ts
@@ -54,6 +54,11 @@ const security = {
     deletion_description: 'Tem certeza de que deseja excluir este provedor de CAPTCHA?',
     captcha_deleted: 'Provedor de CAPTCHA excluído com sucesso',
     setup_captcha: 'Configurar CAPTCHA',
+    mode: 'Modo de verificação',
+    mode_invisible: 'Invisível',
+    mode_checkbox: 'Caixa de seleção',
+    mode_notice:
+      'O modo de verificação é definido nas configurações da chave reCAPTCHA no Google Cloud Console. Alterar o modo aqui requer um tipo de chave correspondente.',
   },
   password_policy: {
     password_requirements: 'Requisitos de senha',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/security.ts
@@ -54,6 +54,11 @@ const security = {
     deletion_description: 'Tem a certeza de que deseja eliminar este fornecedor de CAPTCHA?',
     captcha_deleted: 'Fornecedor de CAPTCHA eliminado com sucesso',
     setup_captcha: 'Configurar CAPTCHA',
+    mode: 'Modo de verificação',
+    mode_invisible: 'Invisível',
+    mode_checkbox: 'Caixa de seleção',
+    mode_notice:
+      'O modo de verificação é definido nas definições da chave reCAPTCHA na Google Cloud Console. Alterar o modo aqui requer um tipo de chave correspondente.',
   },
   password_policy: {
     password_requirements: 'Requisitos de password',

--- a/packages/phrases/src/locales/ru/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/security.ts
@@ -54,6 +54,11 @@ const security = {
     deletion_description: 'Вы уверены, что хотите удалить этого поставщика CAPTCHA?',
     captcha_deleted: 'Поставщик CAPTCHA успешно удалён',
     setup_captcha: 'Настройка CAPTCHA',
+    mode: 'Режим проверки',
+    mode_invisible: 'Невидимый',
+    mode_checkbox: 'Флажок',
+    mode_notice:
+      'Режим проверки определяется в настройках ключа reCAPTCHA в Google Cloud Console. Для изменения режима здесь требуется соответствующий тип ключа.',
   },
   password_policy: {
     password_requirements: 'Требования к паролю',

--- a/packages/phrases/src/locales/th/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/security.ts
@@ -54,6 +54,11 @@ const security = {
     deletion_description: 'คุณแน่ใจหรือไม่ว่าต้องการลบผู้ให้บริการ CAPTCHA นี้?',
     captcha_deleted: 'ลบผู้ให้บริการ CAPTCHA เรียบร้อยแล้ว',
     setup_captcha: 'ตั้งค่า CAPTCHA',
+    mode: 'โหมดการตรวจสอบ',
+    mode_invisible: 'มองไม่เห็น',
+    mode_checkbox: 'ช่องทำเครื่องหมาย',
+    mode_notice:
+      'โหมดการตรวจสอบถูกกำหนดในการตั้งค่าคีย์ reCAPTCHA ใน Google Cloud Console การเปลี่ยนโหมดที่นี่ต้องใช้ประเภทคีย์ที่ตรงกัน',
   },
   password_policy: {
     password_requirements: 'ข้อกำหนดรหัสผ่าน',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/security.ts
@@ -54,6 +54,11 @@ const security = {
     deletion_description: 'Bu CAPTCHA sağlayıcısını silmek istediğinizden emin misiniz?',
     captcha_deleted: 'CAPTCHA sağlayıcısı başarıyla silindi',
     setup_captcha: "CAPTCHA'yı ayarla",
+    mode: 'Doğrulama modu',
+    mode_invisible: 'Görünmez',
+    mode_checkbox: 'Onay kutusu',
+    mode_notice:
+      "Doğrulama modu, Google Cloud Console'daki reCAPTCHA anahtar ayarlarında tanımlanır. Buradaki modu değiştirmek için eşleşen bir anahtar türü gerekir.",
   },
   password_policy: {
     password_requirements: 'Parola gereksinimleri',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/security.ts
@@ -52,6 +52,11 @@ const security = {
     deletion_description: '你确定要删除此验证码提供商吗？',
     captcha_deleted: '验证码提供商删除成功',
     setup_captcha: '设置验证码',
+    mode: '验证模式',
+    mode_invisible: '无感验证',
+    mode_checkbox: '复选框验证',
+    mode_notice:
+      '验证模式在 Google Cloud Console 的 reCAPTCHA 密钥设置中定义。更改此处的模式需要匹配的密钥类型。',
   },
   password_policy: {
     password_requirements: '密码要求',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/security.ts
@@ -52,6 +52,11 @@ const security = {
     deletion_description: '你確定要刪除此 CAPTCHA 供應商嗎？',
     captcha_deleted: 'CAPTCHA 供應商已成功刪除',
     setup_captcha: '設定 CAPTCHA',
+    mode: '驗證模式',
+    mode_invisible: '無感驗證',
+    mode_checkbox: '複選框驗證',
+    mode_notice:
+      '驗證模式在 Google Cloud Console 的 reCAPTCHA 金鑰設定中定義。更改此處的模式需要匹配的金鑰類型。',
   },
   password_policy: {
     password_requirements: '密碼要求',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/security.ts
@@ -52,6 +52,11 @@ const security = {
     deletion_description: '你確定要刪除此 CAPTCHA 提供商嗎？',
     captcha_deleted: 'CAPTCHA 提供商刪除成功',
     setup_captcha: '設定 CAPTCHA',
+    mode: '驗證模式',
+    mode_invisible: '無感驗證',
+    mode_checkbox: '複選框驗證',
+    mode_notice:
+      '驗證模式在 Google Cloud Console 的 reCAPTCHA 金鑰設定中定義。更改此處的模式需要匹配的金鑰類型。',
   },
   password_policy: {
     password_requirements: '密碼需求',

--- a/packages/schemas/src/foundations/jsonb-types/captcha.ts
+++ b/packages/schemas/src/foundations/jsonb-types/captcha.ts
@@ -5,6 +5,11 @@ export enum CaptchaType {
   Turnstile = 'Turnstile',
 }
 
+export enum RecaptchaEnterpriseMode {
+  Invisible = 'invisible',
+  Checkbox = 'checkbox',
+}
+
 export const turnstileConfigGuard = z.object({
   type: z.literal(CaptchaType.Turnstile),
   siteKey: z.string(),
@@ -19,6 +24,7 @@ export const recaptchaEnterpriseConfigGuard = z.object({
   secretKey: z.string(),
   projectId: z.string(),
   domain: z.string().optional(),
+  mode: z.nativeEnum(RecaptchaEnterpriseMode).optional(),
 });
 
 export type RecaptchaEnterpriseConfig = z.infer<typeof recaptchaEnterpriseConfigGuard>;

--- a/packages/schemas/src/types/sign-in-experience.ts
+++ b/packages/schemas/src/types/sign-in-experience.ts
@@ -12,7 +12,7 @@ import {
   type SignInExperience,
   SignInExperiences,
 } from '../db-entries/index.js';
-import { CaptchaType } from '../foundations/jsonb-types/index.js';
+import { CaptchaType, RecaptchaEnterpriseMode } from '../foundations/jsonb-types/index.js';
 import { type ToZodObject } from '../utils/zod.js';
 
 import { type SsoConnectorMetadata, ssoConnectorMetadataGuard } from './sso-connector.js';
@@ -49,6 +49,7 @@ export type FullSignInExperience = Omit<SignInExperience, 'forgotPasswordMethods
     type: CaptchaType;
     siteKey: string;
     domain?: string;
+    mode?: RecaptchaEnterpriseMode;
   };
   customProfileFields?: Readonly<CustomProfileField[]>;
 };
@@ -76,6 +77,7 @@ export const fullSignInExperienceGuard = SignInExperiences.guard
         type: z.nativeEnum(CaptchaType),
         siteKey: z.string(),
         domain: z.string().optional(),
+        mode: z.nativeEnum(RecaptchaEnterpriseMode).optional(),
       })
       .optional(),
     customProfileFields: CustomProfileFields.guard.array(),


### PR DESCRIPTION
resolved #7716

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

- Add verification mode selection for reCAPTCHA Enterprise (invisible/checkbox)
- Support checkbox widget rendering in sign-in experience
- Add informational notice about key type matching in Console

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

<img width="889" height="198" alt="截屏2025-12-04 下午4 10 26" src="https://github.com/user-attachments/assets/dde49e7b-b348-4752-886c-c68c49a96bbd" />

<img width="700" height="578" alt="截屏2025-12-04 下午3 56 25" src="https://github.com/user-attachments/assets/cea63676-76ef-46e0-8019-87def5dd8db7" />

<img width="667" height="775" alt="截屏2025-12-04 下午3 56 29" src="https://github.com/user-attachments/assets/7a09b16d-e4f5-41e9-bbf7-1239cb7a3713" />

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
