### PR TITLE
feat(schemas): add i18n template support to the email service config guard

### DIFF
--- a/packages/schemas/src/types/system.ts
+++ b/packages/schemas/src/types/system.ts
@@ -88,9 +88,11 @@ export enum EmailServiceProvider {
 export const sendgridEmailServiceConfigGuard = z.object({
   provider: z.literal(EmailServiceProvider.SendGrid),
   apiKey: z.string(),
+  /** @deprecated Use i18nTemplates instead */
   templateId: z.string(),
   fromName: z.string(),
   fromEmail: z.string(),
+  i18nTemplates: z.record(z.string()).optional(),
 });
 
 export type SendgridEmailServiceConfig = z.infer<typeof sendgridEmailServiceConfigGuard>;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add i18n template support to the Logto email service config guard, and deprecate the previous `templateId` property, keeping it only for backward compatibility purposes.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested with Cloud repo.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
- [x] necessary TSDoc comments
