### PR TITLE
refactor(schemas): revert the email service config schema change in #8042

### DIFF
--- a/packages/schemas/src/types/system.ts
+++ b/packages/schemas/src/types/system.ts
@@ -88,11 +88,9 @@ export enum EmailServiceProvider {
 export const sendgridEmailServiceConfigGuard = z.object({
   provider: z.literal(EmailServiceProvider.SendGrid),
   apiKey: z.string(),
-  /** @deprecated Use i18nTemplates instead */
   templateId: z.string(),
   fromName: z.string(),
   fromEmail: z.string(),
-  i18nTemplates: z.record(z.string()).optional(),
 });
 
 export type SendgridEmailServiceConfig = z.infer<typeof sendgridEmailServiceConfigGuard>;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Revert the schema changes done in #8042. Turn out we can just provide both i18n-ready and backward compatible email template without introducing new config properties.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Manually tested in DEV environment.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
