### PR TITLE
feat(account-center): view and manage passkeys

### DIFF
--- a/packages/account-center/package.json
+++ b/packages/account-center/package.json
@@ -29,16 +29,17 @@
     "@silverhand/eslint-config": "6.0.1",
     "@silverhand/eslint-config-react": "6.0.2",
     "@silverhand/essentials": "^2.9.1",
-    "@simplewebauthn/browser": "^10.0.0",
-    "@simplewebauthn/types": "^10.0.0",
     "@silverhand/ts-config": "6.0.0",
     "@silverhand/ts-config-react": "6.0.0",
+    "@simplewebauthn/browser": "^10.0.0",
+    "@simplewebauthn/types": "^10.0.0",
     "@types/color": "^4.2.0",
     "@types/qrcode": "^1.5.5",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@types/react-helmet": "^6.1.6",
     "@types/react-modal": "^3.13.1",
+    "@types/ua-parser-js": "^0.7.39",
     "@vitejs/plugin-react": "^4.3.1",
     "classnames": "^2.3.1",
     "color": "^4.2.3",
@@ -49,10 +50,10 @@
     "lint-staged": "^15.0.0",
     "prettier": "^3.5.3",
     "react": "^18.3.1",
+    "react-device-detect": "^2.2.3",
     "react-dom": "^18.3.1",
     "react-helmet": "^6.1.0",
     "react-i18next": "^12.3.1",
-    "react-device-detect": "^2.2.3",
     "react-modal": "^3.15.1",
     "react-top-loading-bar": "^2.3.1",
     "stylelint": "^15.0.0",
@@ -74,7 +75,9 @@
   },
   "prettier": "@silverhand/eslint-config/.prettierrc",
   "dependencies": {
+    "date-fns": "^2.29.3",
     "qrcode": "^1.5.4",
-    "react-router-dom": "^7.9.6"
+    "react-router-dom": "^7.9.6",
+    "ua-parser-js": "^2.0.3"
   }
 }

--- a/packages/account-center/src/App.tsx
+++ b/packages/account-center/src/App.tsx
@@ -31,7 +31,9 @@ import {
   backupCodeDeletedRoute,
   backupCodeViewRoute,
   passkeyRoute,
+  passkeyViewRoute,
   passkeySuccessRoute,
+  passkeyDeletedRoute,
 } from './constants/routes';
 import initI18n from './i18n/init';
 import BackupCodeBinding from './pages/BackupCodeBinding';
@@ -39,6 +41,7 @@ import BackupCodeView from './pages/BackupCodeView';
 import Email from './pages/Email';
 import Home from './pages/Home';
 import PasskeyBinding from './pages/PasskeyBinding';
+import PasskeyView from './pages/PasskeyView';
 import Password from './pages/Password';
 import Phone from './pages/Phone';
 import TotpBinding from './pages/TotpBinding';
@@ -106,6 +109,10 @@ const Main = () => {
         element={<UpdateSuccess identifierType="backup_code_deleted" />}
       />
       <Route path={passkeySuccessRoute} element={<UpdateSuccess identifierType="passkey" />} />
+      <Route
+        path={passkeyDeletedRoute}
+        element={<UpdateSuccess identifierType="passkey_deleted" />}
+      />
       <Route path={emailRoute} element={<Email />} />
       <Route path={phoneRoute} element={<Phone />} />
       <Route path={passwordRoute} element={<Password />} />
@@ -115,6 +122,7 @@ const Main = () => {
       <Route path={backupCodeRegenerateRoute} element={<BackupCodeBinding isRegenerate />} />
       <Route path={backupCodeViewRoute} element={<BackupCodeView />} />
       <Route path={passkeyRoute} element={<PasskeyBinding />} />
+      <Route path={passkeyViewRoute} element={<PasskeyView />} />
       <Route index element={<Home />} />
       <Route path="*" element={<Home />} />
     </Routes>

--- a/packages/account-center/src/apis/mfa.ts
+++ b/packages/account-center/src/apis/mfa.ts
@@ -127,3 +127,18 @@ export const addWebAuthnMfa = async (
     headers: { [verificationRecordIdHeader]: verificationRecordId },
   });
 };
+
+export const updateWebAuthnName = async (
+  accessToken: string,
+  verificationRecordId: string,
+  mfaVerificationId: string,
+  name: string
+) => {
+  await createAuthenticatedKy(accessToken).patch(
+    `/api/my-account/mfa-verifications/${mfaVerificationId}/name`,
+    {
+      json: { name },
+      headers: { [verificationRecordIdHeader]: verificationRecordId },
+    }
+  );
+};

--- a/packages/account-center/src/constants/routes.ts
+++ b/packages/account-center/src/constants/routes.ts
@@ -14,4 +14,6 @@ export const backupCodeRegenerateRoute = '/mfa/backup-code/regenerate';
 export const backupCodeSuccessRoute = '/mfa/backup-code/success';
 export const backupCodeDeletedRoute = '/mfa/backup-code/deleted';
 export const passkeyRoute = '/mfa/passkey';
+export const passkeyViewRoute = '/mfa/passkey/view';
 export const passkeySuccessRoute = '/mfa/passkey/success';
+export const passkeyDeletedRoute = '/mfa/passkey/deleted';

--- a/packages/account-center/src/pages/BackupCodeView/index.module.scss
+++ b/packages/account-center/src/pages/BackupCodeView/index.module.scss
@@ -49,7 +49,7 @@
 
 .divider {
   height: 1px;
-  background-color: var(--color-divider);
+  background-color: var(--color-line-divider);
   margin: _.unit(2) 0;
 }
 

--- a/packages/account-center/src/pages/PasskeyView/index.module.scss
+++ b/packages/account-center/src/pages/PasskeyView/index.module.scss
@@ -1,0 +1,101 @@
+@use '@experience/shared/scss/underscore' as _;
+
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: _.unit(4);
+}
+
+.passkeyList {
+  display: flex;
+  flex-direction: column;
+  gap: _.unit(3);
+}
+
+.passkeyItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: _.unit(4);
+  border: 1px solid var(--color-line-divider);
+  border-radius: var(--radius);
+  background-color: var(--color-bg-body);
+}
+
+.passkeyInfo {
+  display: flex;
+  flex-direction: column;
+  gap: _.unit(1);
+  flex: 1;
+  min-width: 0;
+}
+
+.passkeyName {
+  font: var(--font-label-2);
+  color: var(--color-type-primary);
+  word-break: break-word;
+}
+
+.passkeyMeta {
+  font: var(--font-body-3);
+  color: var(--color-type-secondary);
+}
+
+.passkeyActions {
+  display: flex;
+  gap: _.unit(4);
+  flex-shrink: 0;
+  margin-left: _.unit(4);
+}
+
+.editButton {
+  all: unset;
+  font: var(--font-label-2);
+  color: var(--color-brand-default);
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover {
+    color: var(--color-brand-hover);
+  }
+}
+
+.removeButton {
+  all: unset;
+  font: var(--font-label-2);
+  color: var(--color-danger-default);
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover {
+    color: var(--color-danger-hover);
+  }
+}
+
+.divider {
+  height: 1px;
+  background-color: var(--color-line-divider);
+  margin: _.unit(2) 0;
+}
+
+.addSection {
+  display: flex;
+  flex-direction: column;
+  gap: _.unit(3);
+}
+
+.addTitle {
+  font: var(--font-title-2);
+  color: var(--color-type-primary);
+}
+
+.addDescription {
+  font: var(--font-body-2);
+  color: var(--color-type-secondary);
+}
+
+.editModalContent {
+  display: flex;
+  flex-direction: column;
+  gap: _.unit(3);
+}

--- a/packages/account-center/src/pages/PasskeyView/index.tsx
+++ b/packages/account-center/src/pages/PasskeyView/index.tsx
@@ -1,0 +1,315 @@
+import Button from '@experience/shared/components/Button';
+import DynamicT from '@experience/shared/components/DynamicT';
+import InputField from '@experience/shared/components/InputFields/InputField';
+import {
+  AccountCenterControlValue,
+  MfaFactor,
+  type Mfa,
+  type UserMfaVerificationResponse,
+} from '@logto/schemas';
+import { format } from 'date-fns';
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+
+import PageContext from '@ac/Providers/PageContextProvider/PageContext';
+import { getMfaVerifications, deleteMfaVerification, updateWebAuthnName } from '@ac/apis/mfa';
+import ConfirmModal from '@ac/components/ConfirmModal';
+import ErrorPage from '@ac/components/ErrorPage';
+import VerificationMethodList from '@ac/components/VerificationMethodList';
+import { passkeyDeletedRoute, passkeyRoute } from '@ac/constants/routes';
+import useApi from '@ac/hooks/use-api';
+import useErrorHandler from '@ac/hooks/use-error-handler';
+import SecondaryPageLayout from '@ac/layouts/SecondaryPageLayout';
+import { formatPasskeyName } from '@ac/utils/passkey';
+
+import styles from './index.module.scss';
+
+type PasskeyInfo = {
+  id: string;
+  name?: string;
+  agent?: string;
+  createdAt: string;
+  lastUsedAt?: string;
+};
+
+const isWebAuthnEnabled = (mfa?: Mfa) => mfa?.factors.includes(MfaFactor.WebAuthn) ?? false;
+
+const formatDate = (dateString: string): string => format(new Date(dateString), 'MMMM d, yyyy');
+
+const PasskeyView = () => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { accountCenterSettings, experienceSettings, verificationId, setVerificationId, setToast } =
+    useContext(PageContext);
+  const getMfaRequest = useApi(getMfaVerifications);
+  const deletePasskeyRequest = useApi(deleteMfaVerification);
+  const updatePasskeyNameRequest = useApi(updateWebAuthnName);
+  const handleError = useErrorHandler();
+
+  const [passkeys, setPasskeys] = useState<PasskeyInfo[]>();
+  const [hasError, setHasError] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [showEditModal, setShowEditModal] = useState(false);
+  const [selectedPasskey, setSelectedPasskey] = useState<PasskeyInfo>();
+  const [editName, setEditName] = useState('');
+
+  // Fetch passkeys on mount
+  useEffect(() => {
+    if (!verificationId) {
+      return;
+    }
+
+    const fetchData = async () => {
+      const [error, result] = await getMfaRequest();
+      if (error || !result) {
+        setHasError(true);
+        return;
+      }
+
+      const webAuthnVerifications: UserMfaVerificationResponse = result.filter(
+        (verification) => verification.type === MfaFactor.WebAuthn
+      );
+
+      setPasskeys(
+        webAuthnVerifications.map((verification) => ({
+          id: verification.id,
+          name: verification.name,
+          agent: verification.agent,
+          createdAt: verification.createdAt,
+          lastUsedAt: verification.lastUsedAt,
+        }))
+      );
+    };
+
+    void fetchData();
+  }, [getMfaRequest, verificationId]);
+
+  const handleDelete = useCallback(async () => {
+    if (!verificationId || !selectedPasskey) {
+      return;
+    }
+
+    const [error] = await deletePasskeyRequest(verificationId, selectedPasskey.id);
+    if (error) {
+      await handleError(error, {
+        'verification_record.permission_denied': async () => {
+          setVerificationId(undefined);
+          setToast(t('account_center.verification.verification_required'));
+        },
+      });
+      setShowDeleteConfirm(false);
+      return;
+    }
+
+    setShowDeleteConfirm(false);
+    void navigate(passkeyDeletedRoute, { replace: true });
+  }, [
+    deletePasskeyRequest,
+    handleError,
+    navigate,
+    selectedPasskey,
+    setToast,
+    setVerificationId,
+    t,
+    verificationId,
+  ]);
+
+  const handleEditSubmit = useCallback(async () => {
+    if (!verificationId || !selectedPasskey || !editName.trim()) {
+      return;
+    }
+
+    const [error] = await updatePasskeyNameRequest(
+      verificationId,
+      selectedPasskey.id,
+      editName.trim()
+    );
+    if (error) {
+      await handleError(error, {
+        'verification_record.permission_denied': async () => {
+          setVerificationId(undefined);
+          setToast(t('account_center.verification.verification_required'));
+        },
+      });
+      setShowEditModal(false);
+      return;
+    }
+
+    // Update local state
+    setPasskeys((previous) =>
+      previous?.map((passkey) =>
+        passkey.id === selectedPasskey.id ? { ...passkey, name: editName.trim() } : passkey
+      )
+    );
+    setShowEditModal(false);
+    setToast(t('account_center.passkey.renamed'));
+  }, [
+    editName,
+    handleError,
+    selectedPasskey,
+    setToast,
+    setVerificationId,
+    t,
+    updatePasskeyNameRequest,
+    verificationId,
+  ]);
+
+  const passkeyDisplayName = useMemo(() => {
+    if (!selectedPasskey) {
+      return '';
+    }
+    return (
+      formatPasskeyName(selectedPasskey.name, selectedPasskey.agent) ??
+      t('account_center.passkey.unnamed')
+    );
+  }, [selectedPasskey, t]);
+
+  if (
+    !accountCenterSettings?.enabled ||
+    accountCenterSettings.fields.mfa !== AccountCenterControlValue.Edit
+  ) {
+    return (
+      <ErrorPage titleKey="error.something_went_wrong" messageKey="error.feature_not_enabled" />
+    );
+  }
+
+  if (!isWebAuthnEnabled(experienceSettings?.mfa)) {
+    return (
+      <ErrorPage
+        titleKey="error.something_went_wrong"
+        messageKey="account_center.mfa.passkey_not_enabled"
+      />
+    );
+  }
+
+  if (!verificationId) {
+    return <VerificationMethodList />;
+  }
+
+  if (hasError) {
+    return <ErrorPage titleKey="error.something_went_wrong" />;
+  }
+
+  if (!passkeys) {
+    return null;
+  }
+
+  return (
+    <>
+      <SecondaryPageLayout title="account_center.passkey.title">
+        <div className={styles.container}>
+          <div className={styles.passkeyList}>
+            {passkeys.map((passkey) => {
+              const displayName =
+                formatPasskeyName(passkey.name, passkey.agent) ??
+                t('account_center.passkey.unnamed');
+              return (
+                <div key={passkey.id} className={styles.passkeyItem}>
+                  <div className={styles.passkeyInfo}>
+                    <div className={styles.passkeyName}>{displayName}</div>
+                    <div className={styles.passkeyMeta}>
+                      <DynamicT
+                        forKey="account_center.passkey.added"
+                        interpolation={{ date: formatDate(passkey.createdAt) }}
+                      />
+                    </div>
+                    <div className={styles.passkeyMeta}>
+                      <DynamicT
+                        forKey="account_center.passkey.last_used"
+                        interpolation={{
+                          date: passkey.lastUsedAt
+                            ? formatDate(passkey.lastUsedAt)
+                            : t('account_center.passkey.never_used'),
+                        }}
+                      />
+                    </div>
+                  </div>
+                  <div className={styles.passkeyActions}>
+                    <button
+                      type="button"
+                      className={styles.editButton}
+                      onClick={() => {
+                        setSelectedPasskey(passkey);
+                        setEditName(formatPasskeyName(passkey.name, passkey.agent) ?? '');
+                        setShowEditModal(true);
+                      }}
+                    >
+                      <DynamicT forKey="action.edit" />
+                    </button>
+                    <button
+                      type="button"
+                      className={styles.removeButton}
+                      onClick={() => {
+                        setSelectedPasskey(passkey);
+                        setShowDeleteConfirm(true);
+                      }}
+                    >
+                      <DynamicT forKey="action.remove" />
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          <div className={styles.divider} />
+          <div className={styles.addSection}>
+            <div className={styles.addTitle}>
+              <DynamicT forKey="account_center.passkey.add_another_title" />
+            </div>
+            <div className={styles.addDescription}>
+              <DynamicT forKey="account_center.passkey.add_another_description" />
+            </div>
+            <Button
+              title="account_center.passkey.add_passkey"
+              type="primary"
+              onClick={() => {
+                void navigate(passkeyRoute);
+              }}
+            />
+          </div>
+        </div>
+      </SecondaryPageLayout>
+      <ConfirmModal
+        isOpen={showDeleteConfirm}
+        title="account_center.passkey.delete_confirmation_title"
+        onConfirm={() => {
+          void handleDelete();
+        }}
+        onCancel={() => {
+          setShowDeleteConfirm(false);
+        }}
+      >
+        <DynamicT
+          forKey="account_center.passkey.delete_confirmation_description"
+          interpolation={{ name: passkeyDisplayName }}
+        />
+      </ConfirmModal>
+      <ConfirmModal
+        isOpen={showEditModal}
+        title="account_center.passkey.rename_passkey"
+        confirmText="action.save"
+        onConfirm={() => {
+          void handleEditSubmit();
+        }}
+        onCancel={() => {
+          setShowEditModal(false);
+        }}
+      >
+        <div className={styles.editModalContent}>
+          <DynamicT forKey="account_center.passkey.rename_description" />
+          <InputField
+            name="passkeyName"
+            value={editName}
+            required={false}
+            onChange={({ currentTarget }) => {
+              setEditName(currentTarget.value);
+            }}
+          />
+        </div>
+      </ConfirmModal>
+    </>
+  );
+};
+
+export default PasskeyView;

--- a/packages/account-center/src/pages/UpdateSuccess/index.tsx
+++ b/packages/account-center/src/pages/UpdateSuccess/index.tsx
@@ -11,7 +11,8 @@ type IdentifierType =
   | 'totp'
   | 'backup_code'
   | 'backup_code_deleted'
-  | 'passkey';
+  | 'passkey'
+  | 'passkey_deleted';
 
 type TranslationMap = Partial<
   Record<IdentifierType, { readonly titleKey: TFuncKey; readonly messageKey: TFuncKey }>
@@ -51,6 +52,10 @@ const translationMap: TranslationMap = {
   passkey: {
     titleKey: 'account_center.update_success.passkey.title',
     messageKey: 'account_center.update_success.passkey.description',
+  },
+  passkey_deleted: {
+    titleKey: 'account_center.update_success.passkey_deleted.title',
+    messageKey: 'account_center.update_success.passkey_deleted.description',
   },
   default: {
     titleKey: 'account_center.update_success.default.title',

--- a/packages/account-center/src/utils/passkey.ts
+++ b/packages/account-center/src/utils/passkey.ts
@@ -1,0 +1,29 @@
+import { UAParser as parseUa } from 'ua-parser-js';
+
+/**
+ * Format passkey display name from user-agent string.
+ * If the agent is a user-agent string, parse it to get "Browser on OS" format.
+ * Otherwise, return the original name.
+ */
+export const formatPasskeyName = (name?: string, agent?: string): string | undefined => {
+  // If user has set a custom name, use it
+  if (name) {
+    return name;
+  }
+
+  // If no agent string, return undefined
+  if (!agent) {
+    return undefined;
+  }
+
+  // Try to parse as user-agent string
+  const { browser, os } = parseUa(agent);
+
+  // If we can extract browser and OS info, format it
+  if (browser.name && os.name) {
+    return `${browser.name} on ${os.name}`;
+  }
+
+  // If parsing fails, return the original agent string (it might already be formatted)
+  return agent;
+};

--- a/packages/core/src/utils/user.ts
+++ b/packages/core/src/utils/user.ts
@@ -24,9 +24,9 @@ export const transpileUserMfaVerifications = (
     }
 
     if (type === MfaFactor.WebAuthn) {
-      const { agent, name } = verification;
+      const { agent, name, lastUsedAt } = verification;
 
-      return { id, createdAt, type, agent, name };
+      return { id, createdAt, lastUsedAt, type, agent, name };
     }
 
     return { id, createdAt, type };

--- a/packages/experience/src/shared/components/InputFields/InputField/index.module.scss
+++ b/packages/experience/src/shared/components/InputFields/InputField/index.module.scss
@@ -102,16 +102,6 @@
     }
   }
 
-  &.readOnly {
-    .inputField {
-      /* stylelint-disable-next-line no-descending-specificity */
-      input {
-        cursor: default;
-        user-select: none;
-      }
-    }
-  }
-
   // override for firefox & safari focus outline since we are using custom notchedOutline
   &:focus-visible {
     outline: none;

--- a/packages/experience/src/shared/components/InputFields/InputField/index.tsx
+++ b/packages/experience/src/shared/components/InputFields/InputField/index.tsx
@@ -47,7 +47,6 @@ const InputField = (
     onChange,
     value,
     required = true,
-    readOnly,
     ...props
   }: Props,
   reference: Ref<Nullable<HTMLInputElement>>
@@ -96,8 +95,7 @@ const InputField = (
           styles.container,
           isDanger && styles.danger,
           isActive && styles.active,
-          !label && styles.noLabel,
-          readOnly && styles.readOnly
+          !label && styles.noLabel
         )}
       >
         <div
@@ -113,12 +111,9 @@ const InputField = (
             {...props}
             ref={innerRef}
             value={value}
-            readOnly={readOnly}
             onAnimationStart={handleAnimationStart}
             onFocus={(event) => {
-              if (!readOnly) {
-                setIsFocused(true);
-              }
+              setIsFocused(true);
               return onFocus?.(event);
             }}
             onBlur={(event) => {

--- a/packages/phrases-experience/src/locales/ar/account-center.ts
+++ b/packages/phrases-experience/src/locales/ar/account-center.ts
@@ -143,6 +143,10 @@ const account_center = {
       title: 'تمت إضافة مفتاح المرور!',
       description: 'تم ربط مفتاح المرور بحسابك بنجاح.',
     },
+    passkey_deleted: {
+      title: 'تم حذف مفتاح المرور!',
+      description: 'تم حذف مفتاح المرور من حسابك.',
+    },
   },
   backup_code: {
     title: 'رموز النسخ الاحتياطي',
@@ -154,6 +158,23 @@ const account_center = {
     delete_confirmation_title: 'حذف رموز النسخ الاحتياطي',
     delete_confirmation_description:
       'إذا قمت بحذف رموز النسخ الاحتياطي هذه، فلن تتمكن من استخدامها للتحقق.',
+  },
+  passkey: {
+    title: 'مفاتيح المرور',
+    added: 'تمت الإضافة: {{date}}',
+    last_used: 'آخر استخدام: {{date}}',
+    never_used: 'أبدًا',
+    unnamed: 'مفتاح مرور بدون اسم',
+    renamed: 'تم تغيير اسم مفتاح المرور بنجاح.',
+    add_another_title: 'إضافة مفتاح مرور آخر',
+    add_another_description:
+      'قم بتسجيل مفتاح المرور الخاص بك باستخدام المقاييس الحيوية للجهاز أو مفاتيح الأمان (مثل YubiKey) أو الطرق الأخرى المتاحة.',
+    add_passkey: 'إضافة مفتاح مرور',
+    delete_confirmation_title: 'حذف مفتاح المرور',
+    delete_confirmation_description:
+      'هل أنت متأكد أنك تريد حذف "{{name}}"؟ لن تتمكن من استخدام مفتاح المرور هذا لتسجيل الدخول بعد الآن.',
+    rename_passkey: 'إعادة تسمية مفتاح المرور',
+    rename_description: 'أدخل اسمًا جديدًا لمفتاح المرور هذا.',
   },
 };
 

--- a/packages/phrases-experience/src/locales/ar/action.ts
+++ b/packages/phrases-experience/src/locales/ar/action.ts
@@ -30,6 +30,8 @@ const action = {
   verify_via_passkey: 'التحقق عبر مفتاح التحقق',
   download: 'تحميل',
   remove: 'إزالة',
+  edit: 'تعديل',
+  save: 'حفظ',
   single_sign_on: 'تسجيل الدخول الموحد',
   authorize: 'التفويض',
   use_another_account: 'استخدام حساب آخر',

--- a/packages/phrases-experience/src/locales/de/account-center.ts
+++ b/packages/phrases-experience/src/locales/de/account-center.ts
@@ -151,11 +151,15 @@ const account_center = {
     },
     backup_code_deleted: {
       title: 'Backup-Codes entfernt!',
-      description: 'Ihre Backup-Codes wurden aus Ihrem Konto entfernt.',
+      description: 'Ihre Backup-Codes wurden von Ihrem Konto entfernt.',
     },
     passkey: {
       title: 'Passkey hinzugefügt!',
       description: 'Ihr Passkey wurde erfolgreich mit Ihrem Konto verknüpft.',
+    },
+    passkey_deleted: {
+      title: 'Passkey entfernt!',
+      description: 'Ihr Passkey wurde von Ihrem Konto entfernt.',
     },
     social: {
       title: 'Soziales Konto verknüpft!',
@@ -171,7 +175,24 @@ const account_center = {
     generate_new: 'Neue Backup-Codes generieren',
     delete_confirmation_title: 'Backup-Codes entfernen',
     delete_confirmation_description:
-      'Wenn Sie diese Backup-Codes entfernen, können Sie sie nicht mehr zur Verifizierung verwenden.',
+      'Wenn Sie diese Backup-Codes entfernen, können Sie sich nicht mehr damit verifizieren.',
+  },
+  passkey: {
+    title: 'Passkeys',
+    added: 'Hinzugefügt: {{date}}',
+    last_used: 'Zuletzt verwendet: {{date}}',
+    never_used: 'Nie',
+    unnamed: 'Unbenannter Passkey',
+    renamed: 'Passkey erfolgreich umbenannt.',
+    add_another_title: 'Weiteren Passkey hinzufügen',
+    add_another_description:
+      'Registrieren Sie Ihren Passkey mit Geräte-Biometrie, Sicherheitsschlüsseln (z.B. YubiKey) oder anderen verfügbaren Methoden.',
+    add_passkey: 'Passkey hinzufügen',
+    delete_confirmation_title: 'Passkey entfernen',
+    delete_confirmation_description:
+      'Sind Sie sicher, dass Sie "{{name}}" entfernen möchten? Sie können sich danach nicht mehr mit diesem Passkey anmelden.',
+    rename_passkey: 'Passkey umbenennen',
+    rename_description: 'Geben Sie einen neuen Namen für diesen Passkey ein.',
   },
 };
 

--- a/packages/phrases-experience/src/locales/de/action.ts
+++ b/packages/phrases-experience/src/locales/de/action.ts
@@ -30,6 +30,8 @@ const action = {
   verify_via_passkey: 'Überprüfen über Passkey',
   download: 'Herunterladen',
   remove: 'Entfernen',
+  edit: 'Bearbeiten',
+  save: 'Speichern',
   single_sign_on: 'Single Sign-On',
   authorize: 'Autorisieren',
   use_another_account: 'Anderes Konto verwenden',

--- a/packages/phrases-experience/src/locales/en/account-center.ts
+++ b/packages/phrases-experience/src/locales/en/account-center.ts
@@ -146,6 +146,10 @@ const account_center = {
       title: 'Passkey added!',
       description: 'Your passkey has been successfully linked to your account.',
     },
+    passkey_deleted: {
+      title: 'Passkey removed!',
+      description: 'Your passkey has been removed from your account.',
+    },
     social: {
       title: 'Social account linked!',
       description: 'Your social account has been successfully linked.',
@@ -161,6 +165,23 @@ const account_center = {
     delete_confirmation_title: 'Remove your backup codes',
     delete_confirmation_description:
       'If you remove these backup codes, you will not be able to verify with it.',
+  },
+  passkey: {
+    title: 'Passkeys',
+    added: 'Added: {{date}}',
+    last_used: 'Last used: {{date}}',
+    never_used: 'Never',
+    unnamed: 'Unnamed passkey',
+    renamed: 'Passkey renamed successfully.',
+    add_another_title: 'Add another passkey',
+    add_another_description:
+      'Register your passkey using device biometrics, security keys (e.g., YubiKey), or other available methods.',
+    add_passkey: 'Add a passkey',
+    delete_confirmation_title: 'Remove passkey',
+    delete_confirmation_description:
+      'Are you sure you want to remove "{{name}}"? You will no longer be able to use this passkey to sign in.',
+    rename_passkey: 'Rename passkey',
+    rename_description: 'Enter a new name for this passkey.',
   },
 };
 

--- a/packages/phrases-experience/src/locales/en/action.ts
+++ b/packages/phrases-experience/src/locales/en/action.ts
@@ -30,6 +30,8 @@ const action = {
   verify_via_passkey: 'Verify via passkey',
   download: 'Download',
   remove: 'Remove',
+  edit: 'Edit',
+  save: 'Save',
   single_sign_on: 'Single Sign-On',
   authorize: 'Authorize',
   use_another_account: 'Use another account',

--- a/packages/phrases-experience/src/locales/es/account-center.ts
+++ b/packages/phrases-experience/src/locales/es/account-center.ts
@@ -102,7 +102,7 @@ const account_center = {
   },
   mfa: {
     totp_already_added:
-      'Ya has añadido una aplicación de autenticación. Por favor, elimina la existente primero.',
+      'You have already added an authenticator app. Please remove the existing one first.',
     totp_not_enabled:
       'La aplicación de autenticación no está habilitada. Por favor, contacta a tu administrador para habilitarla.',
     backup_code_already_added:
@@ -152,6 +152,10 @@ const account_center = {
       title: '¡Passkey añadido!',
       description: 'Tu passkey se ha vinculado correctamente a tu cuenta.',
     },
+    passkey_deleted: {
+      title: '¡Passkey eliminado!',
+      description: 'Tu passkey ha sido eliminado de tu cuenta.',
+    },
     social: {
       title: '¡Cuenta social vinculada!',
       description: 'Tu cuenta social ha sido vinculada exitosamente.',
@@ -166,7 +170,24 @@ const account_center = {
     generate_new: 'Generar nuevos códigos de respaldo',
     delete_confirmation_title: 'Eliminar tus códigos de respaldo',
     delete_confirmation_description:
-      'Si eliminas estos códigos de respaldo, no podrás usarlos para verificar.',
+      'Si eliminas estos códigos de respaldo, no podrás verificarte con ellos.',
+  },
+  passkey: {
+    title: 'Passkeys',
+    added: 'Añadido: {{date}}',
+    last_used: 'Último uso: {{date}}',
+    never_used: 'Nunca',
+    unnamed: 'Passkey sin nombre',
+    renamed: 'Passkey renombrado correctamente.',
+    add_another_title: 'Añadir otro passkey',
+    add_another_description:
+      'Registra tu passkey usando biometría del dispositivo, llaves de seguridad (ej. YubiKey) u otros métodos disponibles.',
+    add_passkey: 'Añadir un passkey',
+    delete_confirmation_title: 'Eliminar passkey',
+    delete_confirmation_description:
+      '¿Estás seguro de que deseas eliminar "{{name}}"? Ya no podrás usar este passkey para iniciar sesión.',
+    rename_passkey: 'Renombrar passkey',
+    rename_description: 'Ingresa un nuevo nombre para este passkey.',
   },
 };
 

--- a/packages/phrases-experience/src/locales/es/action.ts
+++ b/packages/phrases-experience/src/locales/es/action.ts
@@ -30,6 +30,8 @@ const action = {
   verify_via_passkey: 'Verificar mediante clave de acceso',
   download: 'Descargar',
   remove: 'Eliminar',
+  edit: 'Editar',
+  save: 'Guardar',
   single_sign_on: 'Inicio de sesión único',
   authorize: 'Autorizar',
   use_another_account: 'Usar otra cuenta',

--- a/packages/phrases-experience/src/locales/fr/account-center.ts
+++ b/packages/phrases-experience/src/locales/fr/account-center.ts
@@ -156,6 +156,10 @@ const account_center = {
       title: 'Passkey ajouté !',
       description: 'Votre passkey a été lié avec succès à votre compte.',
     },
+    passkey_deleted: {
+      title: 'Passkey supprimé !',
+      description: 'Votre passkey a été supprimé de votre compte.',
+    },
   },
   backup_code: {
     title: 'Codes de secours',
@@ -167,6 +171,23 @@ const account_center = {
     delete_confirmation_title: 'Supprimer vos codes de secours',
     delete_confirmation_description:
       'Si vous supprimez ces codes de secours, vous ne pourrez plus les utiliser pour la vérification.',
+  },
+  passkey: {
+    title: 'Passkeys',
+    added: 'Ajouté : {{date}}',
+    last_used: 'Dernière utilisation : {{date}}',
+    never_used: 'Jamais',
+    unnamed: 'Passkey sans nom',
+    renamed: 'Passkey renommé avec succès.',
+    add_another_title: 'Ajouter un autre passkey',
+    add_another_description:
+      "Enregistrez votre passkey à l'aide de la biométrie de l'appareil, des clés de sécurité (ex. YubiKey) ou d'autres méthodes disponibles.",
+    add_passkey: 'Ajouter un passkey',
+    delete_confirmation_title: 'Supprimer le passkey',
+    delete_confirmation_description:
+      'Êtes-vous sûr de vouloir supprimer « {{name}} » ? Vous ne pourrez plus utiliser ce passkey pour vous connecter.',
+    rename_passkey: 'Renommer le passkey',
+    rename_description: 'Entrez un nouveau nom pour ce passkey.',
   },
 };
 

--- a/packages/phrases-experience/src/locales/fr/action.ts
+++ b/packages/phrases-experience/src/locales/fr/action.ts
@@ -30,6 +30,8 @@ const action = {
   verify_via_passkey: "Vérifier via la clé d'accès",
   download: 'Télécharger',
   remove: 'Supprimer',
+  edit: 'Modifier',
+  save: 'Enregistrer',
   single_sign_on: 'Connexion unique',
   authorize: 'Autoriser',
   use_another_account: 'Utiliser un autre compte',

--- a/packages/phrases-experience/src/locales/it/account-center.ts
+++ b/packages/phrases-experience/src/locales/it/account-center.ts
@@ -154,6 +154,10 @@ const account_center = {
       title: 'Passkey aggiunto!',
       description: 'Il tuo passkey è stato collegato con successo al tuo account.',
     },
+    passkey_deleted: {
+      title: 'Passkey rimosso!',
+      description: 'Il tuo passkey è stato rimosso dal tuo account.',
+    },
   },
   backup_code: {
     title: 'Codici di backup',
@@ -164,7 +168,24 @@ const account_center = {
     generate_new: 'Genera nuovi codici di backup',
     delete_confirmation_title: 'Rimuovi i tuoi codici di backup',
     delete_confirmation_description:
-      'Se rimuovi questi codici di backup, non potrai più utilizzarli per la verifica.',
+      'Se rimuovi questi codici di backup, non potrai più usarli per la verifica.',
+  },
+  passkey: {
+    title: 'Passkeys',
+    added: 'Aggiunto: {{date}}',
+    last_used: 'Ultimo utilizzo: {{date}}',
+    never_used: 'Mai',
+    unnamed: 'Passkey senza nome',
+    renamed: 'Passkey rinominato con successo.',
+    add_another_title: 'Aggiungi un altro passkey',
+    add_another_description:
+      'Registra il tuo passkey utilizzando la biometria del dispositivo, le chiavi di sicurezza (es. YubiKey) o altri metodi disponibili.',
+    add_passkey: 'Aggiungi un passkey',
+    delete_confirmation_title: 'Rimuovi passkey',
+    delete_confirmation_description:
+      'Sei sicuro di voler rimuovere "{{name}}"? Non potrai più utilizzare questo passkey per accedere.',
+    rename_passkey: 'Rinomina passkey',
+    rename_description: 'Inserisci un nuovo nome per questo passkey.',
   },
 };
 

--- a/packages/phrases-experience/src/locales/it/action.ts
+++ b/packages/phrases-experience/src/locales/it/action.ts
@@ -30,6 +30,8 @@ const action = {
   verify_via_passkey: 'Verifica tramite passkey',
   download: 'Scarica',
   remove: 'Rimuovi',
+  edit: 'Modifica',
+  save: 'Salva',
   single_sign_on: 'Single Sign-On',
   authorize: 'Autorizza',
   use_another_account: 'Usa un altro account',

--- a/packages/phrases-experience/src/locales/ja/account-center.ts
+++ b/packages/phrases-experience/src/locales/ja/account-center.ts
@@ -96,7 +96,7 @@ const account_center = {
     error_invalid_code: '認証コードが無効か、有効期限が切れています。',
   },
   mfa: {
-    totp_already_added: '認証アプリは既に追加されています。まず既存のものを削除してください。',
+    totp_already_added: '認証アプリはすでに追加されています。まず既存のものを削除してください。',
     totp_not_enabled: '認証アプリは有効になっていません。管理者に連絡して有効にしてください。',
     backup_code_already_added:
       'すでに有効なバックアップコードがあります。新しいコードを生成する前に、これらを使用するか削除してください。',
@@ -148,6 +148,10 @@ const account_center = {
       title: 'パスキーが追加されました！',
       description: 'パスキーがアカウントに正常にリンクされました。',
     },
+    passkey_deleted: {
+      title: 'パスキーが削除されました！',
+      description: 'パスキーがアカウントから削除されました。',
+    },
   },
   backup_code: {
     title: 'バックアップコード',
@@ -159,6 +163,23 @@ const account_center = {
     delete_confirmation_title: 'バックアップコードを削除',
     delete_confirmation_description:
       'これらのバックアップコードを削除すると、認証に使用できなくなります。',
+  },
+  passkey: {
+    title: 'パスキー',
+    added: '追加日: {{date}}',
+    last_used: '最後の使用: {{date}}',
+    never_used: '未使用',
+    unnamed: '名前なしのパスキー',
+    renamed: 'パスキーの名前を変更しました。',
+    add_another_title: '別のパスキーを追加',
+    add_another_description:
+      'デバイスの生体認証、セキュリティキー（例: YubiKey）、またはその他の利用可能な方法を使用してパスキーを登録してください。',
+    add_passkey: 'パスキーを追加',
+    delete_confirmation_title: 'パスキーを削除',
+    delete_confirmation_description:
+      '「{{name}}」を削除してもよろしいですか？このパスキーでログインできなくなります。',
+    rename_passkey: 'パスキー名を変更',
+    rename_description: 'このパスキーの新しい名前を入力してください。',
   },
 };
 

--- a/packages/phrases-experience/src/locales/ja/action.ts
+++ b/packages/phrases-experience/src/locales/ja/action.ts
@@ -30,6 +30,8 @@ const action = {
   verify_via_passkey: 'パスキー経由で確認',
   download: 'ダウンロード',
   remove: '削除',
+  edit: '編集',
+  save: '保存',
   single_sign_on: 'シングルサインオン',
   authorize: '認証する',
   use_another_account: '別のアカウントを使用する',

--- a/packages/phrases-experience/src/locales/ko/account-center.ts
+++ b/packages/phrases-experience/src/locales/ko/account-center.ts
@@ -141,6 +141,10 @@ const account_center = {
       title: '패스키가 추가되었습니다!',
       description: '패스키가 계정에 성공적으로 연결되었습니다.',
     },
+    passkey_deleted: {
+      title: '패스키가 삭제되었습니다!',
+      description: '패스키가 계정에서 삭제되었습니다.',
+    },
     social: {
       title: '소셜 계정 연결됨!',
       description: '소셜 계정이 성공적으로 연결되었습니다.',
@@ -155,6 +159,23 @@ const account_center = {
     generate_new: '새 백업 코드 생성',
     delete_confirmation_title: '백업 코드 삭제',
     delete_confirmation_description: '이 백업 코드를 삭제하면 더 이상 인증에 사용할 수 없습니다.',
+  },
+  passkey: {
+    title: '패스키',
+    added: '추가됨: {{date}}',
+    last_used: '마지막 사용: {{date}}',
+    never_used: '사용 안 함',
+    unnamed: '이름 없는 패스키',
+    renamed: '패스키 이름이 변경되었습니다.',
+    add_another_title: '다른 패스키 추가',
+    add_another_description:
+      '기기 생체 인증, 보안 키(예: YubiKey) 또는 기타 사용 가능한 방법을 사용하여 패스키를 등록하세요.',
+    add_passkey: '패스키 추가',
+    delete_confirmation_title: '패스키 삭제',
+    delete_confirmation_description:
+      '"{{name}}"을(를) 삭제하시겠습니까? 이 패스키로 더 이상 로그인할 수 없습니다.',
+    rename_passkey: '패스키 이름 변경',
+    rename_description: '이 패스키의 새 이름을 입력하세요.',
   },
 };
 

--- a/packages/phrases-experience/src/locales/ko/action.ts
+++ b/packages/phrases-experience/src/locales/ko/action.ts
@@ -30,6 +30,8 @@ const action = {
   verify_via_passkey: '패스키로 확인',
   download: '다운로드',
   remove: '삭제',
+  edit: '편집',
+  save: '저장',
   single_sign_on: '단일 로그인',
   authorize: '권한 부여',
   use_another_account: '다른 계정 사용',

--- a/packages/phrases-experience/src/locales/pl-pl/account-center.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/account-center.ts
@@ -147,6 +147,10 @@ const account_center = {
       title: 'Passkey dodany!',
       description: 'Twój passkey został pomyślnie połączony z kontem.',
     },
+    passkey_deleted: {
+      title: 'Passkey usunięty!',
+      description: 'Twój passkey został usunięty z konta.',
+    },
     social: {
       title: 'Konto społecznościowe połączone!',
       description: 'Twoje konto społecznościowe zostało pomyślnie połączone.',
@@ -162,6 +166,23 @@ const account_center = {
     delete_confirmation_title: 'Usuń kody zapasowe',
     delete_confirmation_description:
       'Jeśli usuniesz te kody zapasowe, nie będziesz mógł ich użyć do weryfikacji.',
+  },
+  passkey: {
+    title: 'Passkeys',
+    added: 'Dodano: {{date}}',
+    last_used: 'Ostatnie użycie: {{date}}',
+    never_used: 'Nigdy',
+    unnamed: 'Passkey bez nazwy',
+    renamed: 'Passkey został pomyślnie zmieniony.',
+    add_another_title: 'Dodaj kolejny passkey',
+    add_another_description:
+      'Zarejestruj swój passkey używając biometrii urządzenia, kluczy bezpieczeństwa (np. YubiKey) lub innych dostępnych metod.',
+    add_passkey: 'Dodaj passkey',
+    delete_confirmation_title: 'Usuń passkey',
+    delete_confirmation_description:
+      'Czy na pewno chcesz usunąć "{{name}}"? Nie będziesz mógł używać tego passkey do logowania.',
+    rename_passkey: 'Zmień nazwę passkey',
+    rename_description: 'Wprowadź nową nazwę dla tego passkey.',
   },
 };
 

--- a/packages/phrases-experience/src/locales/pl-pl/action.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/action.ts
@@ -30,6 +30,8 @@ const action = {
   verify_via_passkey: 'Weryfikacja za pomocą klucza dostępu',
   download: 'Pobierz',
   remove: 'Usuń',
+  edit: 'Edytuj',
+  save: 'Zapisz',
   single_sign_on: 'Pojedyncze logowanie',
   authorize: 'Autoryzuj',
   use_another_account: 'Użyj innego konta',

--- a/packages/phrases-experience/src/locales/pt-br/account-center.ts
+++ b/packages/phrases-experience/src/locales/pt-br/account-center.ts
@@ -149,6 +149,10 @@ const account_center = {
       title: 'Passkey adicionado!',
       description: 'Seu passkey foi vinculado com sucesso à sua conta.',
     },
+    passkey_deleted: {
+      title: 'Passkey removido!',
+      description: 'Seu passkey foi removido da sua conta.',
+    },
     social: {
       title: 'Conta social vinculada!',
       description: 'Sua conta social foi vinculada com sucesso.',
@@ -164,6 +168,23 @@ const account_center = {
     delete_confirmation_title: 'Remover seus códigos de backup',
     delete_confirmation_description:
       'Se você remover estes códigos de backup, não poderá usá-los para verificação.',
+  },
+  passkey: {
+    title: 'Passkeys',
+    added: 'Adicionado: {{date}}',
+    last_used: 'Último uso: {{date}}',
+    never_used: 'Nunca',
+    unnamed: 'Passkey sem nome',
+    renamed: 'Passkey renomeado com sucesso.',
+    add_another_title: 'Adicionar outro passkey',
+    add_another_description:
+      'Registre seu passkey usando biometria do dispositivo, chaves de segurança (ex: YubiKey) ou outros métodos disponíveis.',
+    add_passkey: 'Adicionar um passkey',
+    delete_confirmation_title: 'Remover passkey',
+    delete_confirmation_description:
+      'Tem certeza de que deseja remover "{{name}}"? Você não poderá mais usar este passkey para fazer login.',
+    rename_passkey: 'Renomear passkey',
+    rename_description: 'Digite um novo nome para este passkey.',
   },
 };
 

--- a/packages/phrases-experience/src/locales/pt-br/action.ts
+++ b/packages/phrases-experience/src/locales/pt-br/action.ts
@@ -30,6 +30,8 @@ const action = {
   verify_via_passkey: 'Verificar via chave de acesso',
   download: 'Baixar',
   remove: 'Remover',
+  edit: 'Editar',
+  save: 'Salvar',
   single_sign_on: 'Single Sign-On',
   authorize: 'Autorizar',
   use_another_account: 'Usar outra conta',

--- a/packages/phrases-experience/src/locales/pt-pt/account-center.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/account-center.ts
@@ -151,6 +151,10 @@ const account_center = {
       title: 'Passkey adicionado!',
       description: 'O seu passkey foi associado com sucesso à sua conta.',
     },
+    passkey_deleted: {
+      title: 'Passkey removido!',
+      description: 'O seu passkey foi removido da sua conta.',
+    },
     social: {
       title: 'Conta social associada!',
       description: 'A sua conta social foi associada com sucesso.',
@@ -166,6 +170,23 @@ const account_center = {
     delete_confirmation_title: 'Remover os seus códigos de cópia de segurança',
     delete_confirmation_description:
       'Se remover estes códigos de cópia de segurança, não poderá utilizá-los para verificação.',
+  },
+  passkey: {
+    title: 'Passkeys',
+    added: 'Adicionado: {{date}}',
+    last_used: 'Última utilização: {{date}}',
+    never_used: 'Nunca',
+    unnamed: 'Passkey sem nome',
+    renamed: 'Passkey renomeado com sucesso.',
+    add_another_title: 'Adicionar outro passkey',
+    add_another_description:
+      'Registe o seu passkey utilizando biometria do dispositivo, chaves de segurança (ex: YubiKey) ou outros métodos disponíveis.',
+    add_passkey: 'Adicionar um passkey',
+    delete_confirmation_title: 'Remover passkey',
+    delete_confirmation_description:
+      'Tem a certeza de que deseja remover "{{name}}"? Não poderá utilizar este passkey para iniciar sessão.',
+    rename_passkey: 'Renomear passkey',
+    rename_description: 'Introduza um novo nome para este passkey.',
   },
 };
 

--- a/packages/phrases-experience/src/locales/pt-pt/action.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/action.ts
@@ -30,6 +30,8 @@ const action = {
   verify_via_passkey: 'Verificar através de chave de acesso',
   download: 'Transferir',
   remove: 'Remover',
+  edit: 'Editar',
+  save: 'Guardar',
   single_sign_on: 'Logon Único',
   authorize: 'Autorizar',
   use_another_account: 'Usar outra conta',

--- a/packages/phrases-experience/src/locales/ru/account-center.ts
+++ b/packages/phrases-experience/src/locales/ru/account-center.ts
@@ -146,6 +146,10 @@ const account_center = {
       title: 'Passkey добавлен!',
       description: 'Ваш passkey был успешно привязан к вашему аккаунту.',
     },
+    passkey_deleted: {
+      title: 'Passkey удалён!',
+      description: 'Ваш passkey был удалён из вашего аккаунта.',
+    },
     social: {
       title: 'Социальный аккаунт привязан!',
       description: 'Ваш социальный аккаунт был успешно привязан.',
@@ -161,6 +165,23 @@ const account_center = {
     delete_confirmation_title: 'Удалить резервные коды',
     delete_confirmation_description:
       'Если вы удалите эти резервные коды, вы не сможете использовать их для подтверждения.',
+  },
+  passkey: {
+    title: 'Passkeys',
+    added: 'Добавлен: {{date}}',
+    last_used: 'Последнее использование: {{date}}',
+    never_used: 'Никогда',
+    unnamed: 'Безымянный passkey',
+    renamed: 'Passkey успешно переименован.',
+    add_another_title: 'Добавить другой passkey',
+    add_another_description:
+      'Зарегистрируйте свой passkey с помощью биометрии устройства, ключей безопасности (например, YubiKey) или других доступных методов.',
+    add_passkey: 'Добавить passkey',
+    delete_confirmation_title: 'Удалить passkey',
+    delete_confirmation_description:
+      'Вы уверены, что хотите удалить "{{name}}"? Вы больше не сможете использовать этот passkey для входа.',
+    rename_passkey: 'Переименовать passkey',
+    rename_description: 'Введите новое имя для этого passkey.',
   },
 };
 

--- a/packages/phrases-experience/src/locales/ru/action.ts
+++ b/packages/phrases-experience/src/locales/ru/action.ts
@@ -30,6 +30,8 @@ const action = {
   verify_via_passkey: 'Проверить с помощью ключа доступа',
   download: 'Скачать',
   remove: 'Удалить',
+  edit: 'Редактировать',
+  save: 'Сохранить',
   single_sign_on: 'Единый вход',
   authorize: 'Авторизовать',
   use_another_account: 'Использовать другой аккаунт',

--- a/packages/phrases-experience/src/locales/th/account-center.ts
+++ b/packages/phrases-experience/src/locales/th/account-center.ts
@@ -140,6 +140,10 @@ const account_center = {
       title: 'เพิ่ม Passkey แล้ว!',
       description: 'Passkey ของคุณได้รับการเชื่อมต่อกับบัญชีของคุณเรียบร้อยแล้ว',
     },
+    passkey_deleted: {
+      title: 'ลบ Passkey แล้ว!',
+      description: 'Passkey ของคุณถูกลบออกจากบัญชีแล้ว',
+    },
     social: {
       title: 'เชื่อมต่อบัญชีโซเชียลแล้ว!',
       description: 'บัญชีโซเชียลของคุณได้รับการเชื่อมต่อเรียบร้อยแล้ว',
@@ -154,6 +158,23 @@ const account_center = {
     generate_new: 'สร้างรหัสสำรองใหม่',
     delete_confirmation_title: 'ลบรหัสสำรองของคุณ',
     delete_confirmation_description: 'หากคุณลบรหัสสำรองเหล่านี้ คุณจะไม่สามารถใช้ยืนยันตัวตนได้',
+  },
+  passkey: {
+    title: 'Passkeys',
+    added: 'เพิ่มเมื่อ: {{date}}',
+    last_used: 'ใช้ล่าสุด: {{date}}',
+    never_used: 'ไม่เคยใช้',
+    unnamed: 'Passkey ไม่มีชื่อ',
+    renamed: 'เปลี่ยนชื่อ Passkey เรียบร้อยแล้ว',
+    add_another_title: 'เพิ่ม Passkey อีกอัน',
+    add_another_description:
+      'ลงทะเบียน Passkey ของคุณโดยใช้ไบโอเมตริกซ์ของอุปกรณ์ กุญแจความปลอดภัย (เช่น YubiKey) หรือวิธีอื่นที่มี',
+    add_passkey: 'เพิ่ม Passkey',
+    delete_confirmation_title: 'ลบ Passkey',
+    delete_confirmation_description:
+      'คุณแน่ใจหรือไม่ว่าต้องการลบ "{{name}}"? คุณจะไม่สามารถใช้ Passkey นี้เข้าสู่ระบบได้อีก',
+    rename_passkey: 'เปลี่ยนชื่อ Passkey',
+    rename_description: 'ป้อนชื่อใหม่สำหรับ Passkey นี้',
   },
 };
 

--- a/packages/phrases-experience/src/locales/th/action.ts
+++ b/packages/phrases-experience/src/locales/th/action.ts
@@ -30,6 +30,8 @@ const action = {
   verify_via_passkey: 'ยืนยันด้วยกุญแจรหัสผ่าน',
   download: 'ดาวน์โหลด',
   remove: 'ลบ',
+  edit: 'แก้ไข',
+  save: 'บันทึก',
   single_sign_on: 'เข้าสู่ระบบ SSO',
   authorize: 'อนุมัติ',
   use_another_account: 'ใช้บัญชีอื่น',

--- a/packages/phrases-experience/src/locales/th/error/password-rejected.ts
+++ b/packages/phrases-experience/src/locales/th/error/password-rejected.ts
@@ -1,3 +1,13 @@
+import { type PasswordRejectionCode } from '@logto/core-kit';
+
+type BreakdownKeysToObject<Key extends string> = {
+  [K in Key as K extends `${infer A}.${string}` ? A : K]: K extends `${string}.${infer B}`
+    ? BreakdownKeysToObject<B>
+    : string;
+};
+
+type RejectionPhrases = BreakdownKeysToObject<PasswordRejectionCode>;
+
 const password_rejected = {
   too_short: 'ความยาวขั้นต่ำคือ {{min}} ตัวอักษร',
   too_long: 'ความยาวสูงสุดคือ {{max}} ตัวอักษร',
@@ -11,6 +21,9 @@ const password_rejected = {
     user_info: 'ข้อมูลส่วนตัวของคุณ',
     words: 'บริบทของผลิตภัณฑ์',
   },
+} satisfies RejectionPhrases & {
+  // Use for displaying a list of restricted issues
+  restricted_found: string;
 };
 
 export default Object.freeze(password_rejected);

--- a/packages/phrases-experience/src/locales/th/index.ts
+++ b/packages/phrases-experience/src/locales/th/index.ts
@@ -1,7 +1,3 @@
-import { type DeepPartial } from '@silverhand/essentials';
-
-import type { LocalePhrase } from '../../types.js';
-
 import account_center from './account-center.js';
 import action from './action.js';
 import description from './description.js';
@@ -14,7 +10,7 @@ import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
 
-const th = {
+const en = {
   translation: {
     input,
     secondary,
@@ -28,6 +24,6 @@ const th = {
     profile,
     account_center,
   },
-} satisfies DeepPartial<LocalePhrase>;
+};
 
-export default Object.freeze(th);
+export default Object.freeze(en);

--- a/packages/phrases-experience/src/locales/tr-tr/account-center.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/account-center.ts
@@ -145,6 +145,10 @@ const account_center = {
       title: 'Passkey eklendi!',
       description: 'Passkey başarıyla hesabınıza bağlandı.',
     },
+    passkey_deleted: {
+      title: 'Passkey kaldırıldı!',
+      description: 'Passkey hesabınızdan kaldırıldı.',
+    },
     social: {
       title: 'Sosyal hesap bağlandı!',
       description: 'Sosyal hesabınız başarıyla bağlandı.',
@@ -160,6 +164,23 @@ const account_center = {
     delete_confirmation_title: 'Yedek kodlarınızı kaldırın',
     delete_confirmation_description:
       'Bu yedek kodları kaldırırsanız, bunlarla doğrulama yapamayacaksınız.',
+  },
+  passkey: {
+    title: "Passkey'ler",
+    added: 'Eklendi: {{date}}',
+    last_used: 'Son kullanım: {{date}}',
+    never_used: 'Hiç',
+    unnamed: 'İsimsiz passkey',
+    renamed: 'Passkey başarıyla yeniden adlandırıldı.',
+    add_another_title: 'Başka bir passkey ekle',
+    add_another_description:
+      "Cihaz biyometriği, güvenlik anahtarları (örn. YubiKey) veya diğer mevcut yöntemleri kullanarak passkey'inizi kaydedin.",
+    add_passkey: 'Bir passkey ekle',
+    delete_confirmation_title: "Passkey'i kaldır",
+    delete_confirmation_description:
+      '"{{name}}" kaldırmak istediğinizden emin misiniz? Bu passkey ile artık giriş yapamayacaksınız.',
+    rename_passkey: "Passkey'i yeniden adlandır",
+    rename_description: 'Bu passkey için yeni bir ad girin.',
   },
 };
 

--- a/packages/phrases-experience/src/locales/tr-tr/action.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/action.ts
@@ -30,6 +30,8 @@ const action = {
   verify_via_passkey: 'Parola ile doğrula',
   download: 'İndir',
   remove: 'Kaldır',
+  edit: 'Düzenle',
+  save: 'Kaydet',
   single_sign_on: 'Tek oturum açma',
   authorize: 'Yetkilendir',
   use_another_account: 'Başka bir hesap kullan',

--- a/packages/phrases-experience/src/locales/uk-ua/account-center.ts
+++ b/packages/phrases-experience/src/locales/uk-ua/account-center.ts
@@ -153,6 +153,10 @@ const account_center = {
       title: 'Passkey додано!',
       description: "Ваш passkey успішно під'єднано до вашого облікового запису.",
     },
+    passkey_deleted: {
+      title: 'Passkey видалено!',
+      description: 'Ваш passkey було видалено з вашого облікового запису.',
+    },
   },
   backup_code: {
     title: 'Резервні коди',
@@ -164,6 +168,23 @@ const account_center = {
     delete_confirmation_title: 'Видалити ваші резервні коди',
     delete_confirmation_description:
       'Якщо ви видалите ці резервні коди, ви не зможете використовувати їх для підтвердження.',
+  },
+  passkey: {
+    title: 'Passkeys',
+    added: 'Додано: {{date}}',
+    last_used: 'Останнє використання: {{date}}',
+    never_used: 'Ніколи',
+    unnamed: 'Passkey без назви',
+    renamed: 'Passkey успішно перейменовано.',
+    add_another_title: 'Додати інший passkey',
+    add_another_description:
+      'Зареєструйте свій passkey за допомогою біометрії пристрою, ключів безпеки (наприклад, YubiKey) або інших доступних методів.',
+    add_passkey: 'Додати passkey',
+    delete_confirmation_title: 'Видалити passkey',
+    delete_confirmation_description:
+      'Ви впевнені, що хочете видалити "{{name}}"? Ви більше не зможете використовувати цей passkey для входу.',
+    rename_passkey: 'Перейменувати passkey',
+    rename_description: 'Введіть нову назву для цього passkey.',
   },
 };
 

--- a/packages/phrases-experience/src/locales/uk-ua/action.ts
+++ b/packages/phrases-experience/src/locales/uk-ua/action.ts
@@ -30,6 +30,8 @@ const action = {
   verify_via_passkey: 'Підтвердити за допомогою ключа доступу',
   download: 'Завантажити',
   remove: 'Видалити',
+  edit: 'Редагувати',
+  save: 'Зберегти',
   single_sign_on: 'Єдиний вхід (SSO)',
   authorize: 'Авторизуватися',
   use_another_account: 'Використати інший обліковий запис',

--- a/packages/phrases-experience/src/locales/zh-cn/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/account-center.ts
@@ -137,6 +137,10 @@ const account_center = {
       title: 'Passkey 已添加！',
       description: 'Passkey 已成功关联到你的账号。',
     },
+    passkey_deleted: {
+      title: 'Passkey 已移除！',
+      description: 'Passkey 已从你的账号中移除。',
+    },
     social: {
       title: '社交账号已关联！',
       description: '社交账号已成功关联到你的账号。',
@@ -151,6 +155,22 @@ const account_center = {
     generate_new: '生成新的备用码',
     delete_confirmation_title: '移除备用码',
     delete_confirmation_description: '如果移除这些备用码，您将无法使用它们进行验证。',
+  },
+  passkey: {
+    title: 'Passkey',
+    added: '添加时间：{{date}}',
+    last_used: '上次使用：{{date}}',
+    never_used: '从未使用',
+    unnamed: '未命名的 Passkey',
+    renamed: 'Passkey 已重命名。',
+    add_another_title: '添加另一个 Passkey',
+    add_another_description:
+      '使用设备生物识别、安全密钥（例如 YubiKey）或其他可用方法注册您的 Passkey。',
+    add_passkey: '添加 Passkey',
+    delete_confirmation_title: '移除 Passkey',
+    delete_confirmation_description: '确定要移除"{{name}}"吗？移除后您将无法使用此 Passkey 登录。',
+    rename_passkey: '重命名 Passkey',
+    rename_description: '为此 Passkey 输入新名称。',
   },
 };
 

--- a/packages/phrases-experience/src/locales/zh-cn/action.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/action.ts
@@ -30,6 +30,8 @@ const action = {
   verify_via_passkey: '通过 Passkey 验证',
   download: '下载',
   remove: '移除',
+  edit: '编辑',
+  save: '保存',
   single_sign_on: '单点登录',
   authorize: '授权',
   use_another_account: '使用另一个账号',

--- a/packages/phrases-experience/src/locales/zh-hk/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/account-center.ts
@@ -137,6 +137,10 @@ const account_center = {
       title: 'Passkey 已添加！',
       description: 'Passkey 已成功連結到你的帳戶。',
     },
+    passkey_deleted: {
+      title: 'Passkey 已移除！',
+      description: 'Passkey 已從你的帳戶中移除。',
+    },
     social: {
       title: '社交帳號已連結！',
       description: '你的社交帳號已成功連結。',
@@ -151,6 +155,22 @@ const account_center = {
     generate_new: '產生新的備用碼',
     delete_confirmation_title: '移除你的備用碼',
     delete_confirmation_description: '如果你移除這些備用碼，你將無法使用它們進行驗證。',
+  },
+  passkey: {
+    title: 'Passkeys',
+    added: '添加於：{{date}}',
+    last_used: '上次使用：{{date}}',
+    never_used: '從未使用',
+    unnamed: '未命名的 Passkey',
+    renamed: 'Passkey 已成功重新命名。',
+    add_another_title: '添加另一個 Passkey',
+    add_another_description:
+      '使用設備生物識別、安全密鑰（例如 YubiKey）或其他可用方法註冊你的 Passkey。',
+    add_passkey: '添加 Passkey',
+    delete_confirmation_title: '移除 Passkey',
+    delete_confirmation_description: '你確定要移除「{{name}}」嗎？你將無法再使用此 Passkey 登入。',
+    rename_passkey: '重新命名 Passkey',
+    rename_description: '為此 Passkey 輸入新名稱。',
   },
 };
 

--- a/packages/phrases-experience/src/locales/zh-hk/action.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/action.ts
@@ -30,6 +30,8 @@ const action = {
   verify_via_passkey: '透過 Passkey 驗證',
   download: '下載',
   remove: '移除',
+  edit: '編輯',
+  save: '儲存',
   single_sign_on: '單點登錄',
   authorize: '授權',
   use_another_account: '使用其他帳戶',

--- a/packages/phrases-experience/src/locales/zh-tw/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/account-center.ts
@@ -137,6 +137,10 @@ const account_center = {
       title: 'Passkey 已新增！',
       description: 'Passkey 已成功連結至您的帳戶。',
     },
+    passkey_deleted: {
+      title: 'Passkey 已移除！',
+      description: 'Passkey 已從您的帳戶中移除。',
+    },
     social: {
       title: '社群帳號已連結！',
       description: '您的社群帳號已成功連結。',
@@ -151,6 +155,22 @@ const account_center = {
     generate_new: '產生新的備用碼',
     delete_confirmation_title: '移除您的備用碼',
     delete_confirmation_description: '如果您移除這些備用碼，您將無法使用它們進行驗證。',
+  },
+  passkey: {
+    title: 'Passkeys',
+    added: '新增於：{{date}}',
+    last_used: '上次使用：{{date}}',
+    never_used: '從未使用',
+    unnamed: '未命名的 Passkey',
+    renamed: 'Passkey 已成功重新命名。',
+    add_another_title: '新增另一個 Passkey',
+    add_another_description:
+      '使用設備生物識別、安全金鑰（例如 YubiKey）或其他可用方法註冊您的 Passkey。',
+    add_passkey: '新增 Passkey',
+    delete_confirmation_title: '移除 Passkey',
+    delete_confirmation_description: '您確定要移除「{{name}}」嗎？您將無法再使用此 Passkey 登入。',
+    rename_passkey: '重新命名 Passkey',
+    rename_description: '為此 Passkey 輸入新名稱。',
   },
 };
 

--- a/packages/phrases-experience/src/locales/zh-tw/action.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/action.ts
@@ -30,6 +30,8 @@ const action = {
   verify_via_passkey: '透過 Passkey 驗證',
   download: '下載',
   remove: '移除',
+  edit: '編輯',
+  save: '儲存',
   single_sign_on: '單點登錄',
   authorize: '授權',
   use_another_account: '使用其他帳戶',

--- a/packages/schemas/src/types/user.ts
+++ b/packages/schemas/src/types/user.ts
@@ -46,6 +46,7 @@ export const userMfaVerificationResponseGuard = z
   .object({
     id: z.string(),
     createdAt: z.string(),
+    lastUsedAt: z.string().optional(),
     type: z.nativeEnum(MfaFactor),
     agent: z.string().optional(),
     name: z.string().optional(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,12 +64,18 @@ importers:
 
   packages/account-center:
     dependencies:
+      date-fns:
+        specifier: ^2.29.3
+        version: 2.29.3
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
       react-router-dom:
         specifier: ^7.9.6
         version: 7.9.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      ua-parser-js:
+        specifier: ^2.0.3
+        version: 2.0.3
     devDependencies:
       '@logto/core-kit':
         specifier: workspace:^
@@ -128,6 +134,9 @@ importers:
       '@types/react-modal':
         specifier: ^3.13.1
         version: 3.13.1
+      '@types/ua-parser-js':
+        specifier: ^0.7.39
+        version: 0.7.39
       '@vitejs/plugin-react':
         specifier: ^4.3.1
         version: 4.3.1(vite@6.4.1(@types/node@22.14.1)(jiti@1.21.0)(lightningcss@1.25.1)(sass@1.77.8)(yaml@2.4.5))
@@ -8086,6 +8095,9 @@ packages:
   '@types/tunnel@0.0.3':
     resolution: {integrity: sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==}
 
+  '@types/ua-parser-js@0.7.39':
+    resolution: {integrity: sha512-P/oDfpofrdtF5xw433SPALpdSchtJmY7nsJItf8h3KXqOslkbySh8zq4dSWXH2oTjRvJ5PczVEoCZPow6GicLg==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -15937,7 +15949,7 @@ snapshots:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/core-util': 1.2.0
       '@azure/logger': 1.0.4
-      '@types/node-fetch': 2.6.11
+      '@types/node-fetch': 2.6.12
       '@types/tunnel': 0.0.3
       form-data: 4.0.4
       node-fetch: 2.7.0
@@ -18402,7 +18414,7 @@ snapshots:
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-consistent-default-export-name: 0.0.15
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-n: 17.2.1(eslint@8.57.0)
       eslint-plugin-no-use-extend-native: 0.5.0
       eslint-plugin-prettier: 5.1.3(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.5.3)
@@ -19274,12 +19286,12 @@ snapshots:
   '@types/node-fetch@2.6.11':
     dependencies:
       '@types/node': 22.14.1
-      form-data: 4.0.4
+      form-data: 4.0.5
 
   '@types/node-fetch@2.6.12':
     dependencies:
       '@types/node': 22.14.1
-      form-data: 4.0.4
+      form-data: 4.0.5
 
   '@types/node-forge@1.3.11':
     dependencies:
@@ -19437,6 +19449,8 @@ snapshots:
   '@types/tunnel@0.0.3':
     dependencies:
       '@types/node': 22.14.1
+
+  '@types/ua-parser-js@0.7.39': {}
 
   '@types/unist@2.0.11': {}
 
@@ -21788,7 +21802,7 @@ snapshots:
       enhanced-resolve: 5.16.0
       eslint: 8.57.0
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.3
       is-core-module: 2.13.1
@@ -21828,7 +21842,7 @@ snapshots:
       eslint: 8.57.0
       ignore: 5.3.1
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -22347,7 +22361,6 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
-    optional: true
 
   format@0.2.2: {}
 
@@ -25456,7 +25469,7 @@ snapshots:
   openai@4.78.1(zod@3.24.3):
     dependencies:
       '@types/node': 18.19.86
-      '@types/node-fetch': 2.6.11
+      '@types/node-fetch': 2.6.12
       abort-controller: 3.0.0
       agentkeepalive: 4.6.0
       form-data-encoder: 1.7.2


### PR DESCRIPTION
## Summary
- Add passkey management page in account center to view, rename, and delete registered passkeys
- Parse user-agent strings using `ua-parser-js` library to display friendly device names (e.g., "Chrome on macOS")

## Testing

<img width="652" height="763" alt="Screenshot 2025-12-16 at 11 56 54 AM" src="https://github.com/user-attachments/assets/05bc7b10-6f5d-460e-b680-70ce3d109d48" />
