### PR TITLE
refactor(account-center): change route from /account-center to /account

### DIFF
--- a/packages/account-center/src/Callback.tsx
+++ b/packages/account-center/src/Callback.tsx
@@ -9,7 +9,7 @@ const Callback = () => {
   }, [clearAllTokens]);
 
   const { error } = useHandleSignInCallback(() => {
-    window.location.assign('/account-center');
+    window.location.assign('/account');
   });
 
   if (error) {
@@ -20,7 +20,7 @@ const Callback = () => {
         <button
           type="button"
           onClick={() => {
-            window.location.assign('/account-center');
+            window.location.assign('/account');
           }}
         >
           Back to sign in

--- a/packages/account-center/src/utils/account-center-route.ts
+++ b/packages/account-center/src/utils/account-center-route.ts
@@ -9,7 +9,7 @@ import {
   usernameSuccessRoute,
 } from '@ac/constants/routes';
 
-export const accountCenterBasePath = '/account-center';
+export const accountCenterBasePath = '/account';
 const storageKey = 'account-center-route-cache';
 
 const knownRoutePrefixes: readonly string[] = [

--- a/packages/account-center/vite.config.ts
+++ b/packages/account-center/vite.config.ts
@@ -30,7 +30,7 @@ const experienceAliasPlugin = (): Plugin => ({
 });
 
 const buildConfig = (mode: string): UserConfig => ({
-  base: '/account-center',
+  base: '/account',
   server: {
     port: 5004,
     hmr: {

--- a/packages/core/src/oidc/adapter.ts
+++ b/packages/core/src/oidc/adapter.ts
@@ -59,7 +59,7 @@ const buildDemoAppClientMetadata = (envSet: EnvSet): AllClientMetadata => {
 
 const buildAccountCenterClientMetadata = (envSet: EnvSet): AllClientMetadata => {
   const urlStrings = getTenantUrls(envSet.tenantId, EnvSet.values).map(
-    (url) => appendPath(url, '/account-center').href
+    (url) => appendPath(url, '/account').href
   );
 
   return {


### PR DESCRIPTION
## Summary
- Change account center front-end route from `/account-center` to `/account`
- Update vite base config, OIDC redirect URLs, and callback handlers

## Testing
N/A - route path change only