### PR TITLE
feat(console): support magic link type tenant invitations

### DIFF
--- a/packages/console/src/pages/OneTimeTokenLanding/index.tsx
+++ b/packages/console/src/pages/OneTimeTokenLanding/index.tsx
@@ -1,15 +1,18 @@
 import { useLogto } from '@logto/react';
 import { ExtraParamsKey } from '@logto/schemas';
+import { conditional } from '@silverhand/essentials';
 import { useContext, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import AppLoading from '@/components/AppLoading';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import useRedirectUri from '@/hooks/use-redirect-uri';
+import { saveRedirect } from '@/utils/storage';
 
 enum OneTimeTokenLandingSearchParams {
   OneTimeToken = 'one_time_token',
   Email = 'email',
+  Redirect = 'redirect',
 }
 
 /** The one-time token landing page for sign-in with one-time tokens. */
@@ -22,6 +25,7 @@ function OneTimeTokenLanding() {
 
   const oneTimeToken = searchParams.get(OneTimeTokenLandingSearchParams.OneTimeToken);
   const email = searchParams.get(OneTimeTokenLandingSearchParams.Email);
+  const redirectPath = searchParams.get(OneTimeTokenLandingSearchParams.Redirect);
 
   useEffect(() => {
     if (isAuthenticated || !oneTimeToken || !email) {
@@ -29,6 +33,8 @@ function OneTimeTokenLanding() {
       navigate('/', { replace: true });
       return;
     }
+
+    saveRedirect(conditional(redirectPath && new URL(redirectPath)));
 
     void signIn({
       redirectUri,
@@ -42,7 +48,16 @@ function OneTimeTokenLanding() {
         [ExtraParamsKey.LoginHint]: email,
       },
     });
-  }, [isAuthenticated, navigate, navigateTenant, signIn, redirectUri, oneTimeToken, email]);
+  }, [
+    isAuthenticated,
+    navigate,
+    navigateTenant,
+    signIn,
+    redirectUri,
+    oneTimeToken,
+    email,
+    redirectPath,
+  ]);
 
   return <AppLoading />;
 }

--- a/packages/console/src/utils/storage.ts
+++ b/packages/console/src/utils/storage.ts
@@ -5,8 +5,9 @@ import { z } from 'zod';
 import { storageKeys } from '@/consts';
 
 /** Save the current url to session storage so that we can redirect to it after sign in. */
-export const saveRedirect = () => {
-  const { pathname, search, hash } = window.location;
+export const saveRedirect = (target?: URL) => {
+  const isValidTarget = target && target.origin === window.location.origin;
+  const { pathname, search, hash } = isValidTarget ? target : window.location;
   sessionStorage.setItem(
     storageKeys.redirectAfterSignIn,
     JSON.stringify({ pathname, search, hash })


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Support reading magic-link type Logto Cloud tenant invitation links.

The new invitation links will have both the `oneTimeToken` and `loginHint` params, and will automatically sign-in / register the user account before accepting the invitation.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
