### PR TITLE
fix(account-center): use font-title-1 and branding color for error/success page

### DIFF
--- a/packages/account-center/src/components/ErrorPage/index.module.scss
+++ b/packages/account-center/src/components/ErrorPage/index.module.scss
@@ -19,7 +19,8 @@
 }
 
 .title {
-  @include _.title;
+  font: var(--font-title-1);
+  color: var(--color-type-primary);
 }
 
 .message {
@@ -38,7 +39,7 @@
 }
 
 .supportLink {
-  color: var(--color-primary);
+  color: var(--color-brand-default);
   text-decoration: none;
 
   &:hover {


### PR DESCRIPTION
## Summary

Fix UI issues for the account-center success and error pages:

- Use `--font-title-1` for the page title (instead of `--font-headline-1`)
- Use `--color-brand-default` (branding color) for the "email address" and "website URL" support links

## Test plan

<img width="674" height="600" alt="Screenshot 2025-12-16 at 1 06 39 PM" src="https://github.com/user-attachments/assets/9308dfd4-d233-464e-9bd1-f8f6de525a69" />
