### PR TITLE
fix(account-center): format phone number with + sign and space in verification description

### DIFF
--- a/packages/account-center/src/components/PhoneVerification/index.tsx
+++ b/packages/account-center/src/components/PhoneVerification/index.tsx
@@ -1,3 +1,4 @@
+import { formatPhoneNumberWithCountryCallingCode } from '@experience/utils/country-code';
 import { useContext } from 'react';
 
 import PageContext from '@ac/Providers/PageContextProvider/PageContext';
@@ -31,7 +32,9 @@ const PhoneVerification = ({ onBack, onSwitchMethod, hasAlternativeMethod }: Pro
       codeInputName="phoneCode"
       translationKeys={phoneTranslationKeys}
       identifierLabelKey="account_center.phone_verification.phone_label"
-      descriptionPropsBuilder={(value) => ({ phone: value })}
+      descriptionPropsBuilder={(value) => ({
+        phone: formatPhoneNumberWithCountryCallingCode(value),
+      })}
       sendCode={sendPhoneVerificationCode}
       verifyCode={async (accessToken, payload) =>
         verifyPhoneVerificationCode(accessToken, {

--- a/packages/account-center/src/pages/Phone/index.tsx
+++ b/packages/account-center/src/pages/Phone/index.tsx
@@ -1,3 +1,4 @@
+import { formatPhoneNumberWithCountryCallingCode } from '@experience/utils/country-code';
 import { SignInIdentifier } from '@logto/schemas';
 
 import { updatePrimaryPhone } from '@ac/apis/account';
@@ -19,7 +20,9 @@ const Phone = () => (
     verifyStep={{
       titleKey: 'account_center.phone.verification_title',
       descriptionKey: 'account_center.phone.verification_description',
-      descriptionPropsBuilder: (identifier) => ({ phone_number: identifier }),
+      descriptionPropsBuilder: (identifier) => ({
+        phone_number: formatPhoneNumberWithCountryCallingCode(identifier),
+      }),
       codeInputName: 'phoneCode',
     }}
     mismatchErrorCode="verification_code.phone_mismatch"


### PR DESCRIPTION
## Summary

Format phone numbers displayed in verification code descriptions with proper formatting:
- Add "+" sign prefix
- Add space after country code (e.g., "+1 8888888888" instead of "18888888888")

Uses the existing `formatPhoneNumberWithCountryCallingCode` utility from the experience package.

## Testing

Local tested

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments