### PR TITLE
fix(experience): fix country code dropdown positioning in account center

### DIFF
--- a/packages/experience/src/shared/components/InputFields/SmartInputField/CountryCodeSelector/CountryCodeDropdown/index.tsx
+++ b/packages/experience/src/shared/components/InputFields/SmartInputField/CountryCodeSelector/CountryCodeDropdown/index.tsx
@@ -1,4 +1,3 @@
-import type { Nullable } from '@silverhand/essentials';
 import { conditional } from '@silverhand/essentials';
 import classNames from 'classnames';
 import type { KeyboardEventHandler } from 'react';
@@ -21,7 +20,7 @@ type Props = {
   readonly isOpen: boolean;
   readonly countryCode: string;
   readonly countryList: CountryMetaData[];
-  readonly inputRef?: Nullable<HTMLInputElement>;
+  readonly inputRef?: React.RefObject<HTMLInputElement | undefined>;
   readonly onClose: () => void;
   readonly onChange?: (value: string) => void;
 };
@@ -62,7 +61,7 @@ const CountryCodeDropdown = ({
   );
 
   const updatePosition = useCallback(() => {
-    const parent = inputRef?.parentElement;
+    const parent = inputRef?.current?.parentElement;
     const offset = 8;
 
     if (!isMobile && parent) {
@@ -83,7 +82,7 @@ const CountryCodeDropdown = ({
     }
 
     setPosition({});
-  }, [inputRef?.parentElement, isMobile]);
+  }, [inputRef, isMobile]);
 
   useLayoutEffect(() => {
     // Use requestAnimationFrame to ensure the parent element is properly painted

--- a/packages/experience/src/shared/components/InputFields/SmartInputField/CountryCodeSelector/index.tsx
+++ b/packages/experience/src/shared/components/InputFields/SmartInputField/CountryCodeSelector/index.tsx
@@ -1,4 +1,3 @@
-import type { Nullable } from '@silverhand/essentials';
 import classNames from 'classnames';
 import type { ForwardedRef } from 'react';
 import { useState, useMemo, forwardRef } from 'react';
@@ -13,7 +12,7 @@ import styles from './index.module.scss';
 type Props = {
   readonly className?: string;
   readonly value?: string;
-  readonly inputRef?: Nullable<HTMLInputElement>;
+  readonly inputRef?: React.RefObject<HTMLInputElement | undefined>;
   readonly isVisible?: boolean;
   readonly isInteractive?: boolean;
   readonly onChange?: (value: string) => void;

--- a/packages/experience/src/shared/components/InputFields/SmartInputField/index.tsx
+++ b/packages/experience/src/shared/components/InputFields/SmartInputField/index.tsx
@@ -75,7 +75,7 @@ const SmartInputField = (
         <AnimatedPrefix isVisible={isPrefixVisible}>
           <CountryCodeSelector
             value={countryCode}
-            inputRef={innerRef.current}
+            inputRef={innerRef}
             isInteractive={isInputEditable}
             onChange={(value) => {
               onCountryCodeChange(value);


### PR DESCRIPTION
## Summary
- Fix country code dropdown appearing at top-left of page instead of near the phone input field in account center

## Root Cause
The `inputRef` prop was passed as `innerRef.current` which evaluates to `null` on initial render (before the ref is attached to the DOM). This caused the `updatePosition` function to set an empty position object `{}`, resulting in the dropdown defaulting to top-left positioning.

## Fix
Pass the ref object itself instead of `.current` so the dropdown can access the current input element when it actually opens, rather than receiving the stale `null` value from initial render.

## Test plan

<img width="754" height="524" alt="Screenshot 2025-12-16 at 2 54 42 PM" src="https://github.com/user-attachments/assets/8d7d3047-d700-4ad5-9f65-bcb66b1891d4" />
