### PR TITLE
fix: honor read-only InputField

### DIFF
--- a/packages/experience/src/shared/components/InputFields/InputField/index.module.scss
+++ b/packages/experience/src/shared/components/InputFields/InputField/index.module.scss
@@ -102,6 +102,16 @@
     }
   }
 
+  &.readOnly {
+    .inputField {
+      /* stylelint-disable-next-line no-descending-specificity */
+      input {
+        cursor: default;
+        user-select: none;
+      }
+    }
+  }
+
   // override for firefox & safari focus outline since we are using custom notchedOutline
   &:focus-visible {
     outline: none;

--- a/packages/experience/src/shared/components/InputFields/InputField/index.tsx
+++ b/packages/experience/src/shared/components/InputFields/InputField/index.tsx
@@ -47,6 +47,7 @@ const InputField = (
     onChange,
     value,
     required = true,
+    readOnly,
     ...props
   }: Props,
   reference: Ref<Nullable<HTMLInputElement>>
@@ -95,7 +96,8 @@ const InputField = (
           styles.container,
           isDanger && styles.danger,
           isActive && styles.active,
-          !label && styles.noLabel
+          !label && styles.noLabel,
+          readOnly && styles.readOnly
         )}
       >
         <div
@@ -111,9 +113,12 @@ const InputField = (
             {...props}
             ref={innerRef}
             value={value}
+            readOnly={readOnly}
             onAnimationStart={handleAnimationStart}
             onFocus={(event) => {
-              setIsFocused(true);
+              if (!readOnly) {
+                setIsFocused(true);
+              }
               return onFocus?.(event);
             }}
             onBlur={(event) => {


### PR DESCRIPTION
## Summary
- stop toggling focus styles when the field is readOnly and pass the prop to the input
- add read-only styling to disable cursor and selection for verification fields

## Testing

Local tested
