### PR TITLE
feat(console): add OIDC permissions card to 3rd-party app details page

### DIFF
--- a/packages/console/src/pages/ApplicationDetails/components/Permissions/OidcPermissionsCard/index.module.scss
+++ b/packages/console/src/pages/ApplicationDetails/components/Permissions/OidcPermissionsCard/index.module.scss
@@ -1,0 +1,16 @@
+@use '@/scss/underscore' as _;
+
+.section {
+  display: flex;
+  flex-direction: column;
+  align-items: baseline;
+  gap: _.unit(3);
+}
+
+.title {
+  font: var(--font-label-2);
+}
+
+.guideText {
+  white-space: pre-line;
+}

--- a/packages/console/src/pages/ApplicationDetails/components/Permissions/OidcPermissionsCard/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/components/Permissions/OidcPermissionsCard/index.tsx
@@ -1,0 +1,84 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import Breakable from '@/components/Breakable';
+import FormCard from '@/components/FormCard';
+import Table from '@/ds-components/Table';
+import { type RowGroup } from '@/ds-components/Table/types';
+import Tag from '@/ds-components/Tag';
+
+import styles from './index.module.scss';
+
+type OidcPermissionRow = {
+  id: string;
+  name: string;
+  description: string;
+};
+
+function OidcPermissionsCard() {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+
+  const rowGroups: Array<RowGroup<OidcPermissionRow>> = useMemo(
+    () => [
+      {
+        key: 'oidc_permissions',
+        data: [
+          {
+            id: 'openid',
+            name: t('application_details.permissions.openid_permission'),
+            description: t('application_details.permissions.openid_permission_guide'),
+          },
+          {
+            id: 'offline_access',
+            name: t('application_details.permissions.offline_access_permission'),
+            description: t('application_details.permissions.offline_access_permission_guide'),
+          },
+        ],
+      },
+    ],
+    [t]
+  );
+
+  return (
+    <FormCard
+      title="application_details.permissions.oidc_title"
+      description="application_details.permissions.oidc_description"
+    >
+      <section className={styles.section}>
+        <header className={styles.title}>
+          {t('application_details.permissions.default_oidc_permissions')}
+        </header>
+        <Table
+          hasBorder
+          isRowHoverEffectDisabled
+          rowIndexKey="id"
+          rowGroups={rowGroups}
+          columns={[
+            {
+              title: t('application_details.permissions.permission_column'),
+              dataIndex: 'name',
+              colSpan: 5,
+              render: ({ name }) => (
+                <Tag variant="cell">
+                  <Breakable>{name}</Breakable>
+                </Tag>
+              ),
+            },
+            {
+              title: t('application_details.permissions.guide_column'),
+              dataIndex: 'description',
+              colSpan: 5,
+              render: ({ description }) => (
+                <Breakable>
+                  <span className={styles.guideText}>{description}</span>
+                </Breakable>
+              ),
+            },
+          ]}
+        />
+      </section>
+    </FormCard>
+  );
+}
+
+export default OidcPermissionsCard;

--- a/packages/console/src/pages/ApplicationDetails/components/Permissions/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/components/Permissions/index.tsx
@@ -1,5 +1,6 @@
 import { type Application } from '@logto/schemas';
 
+import OidcPermissionsCard from './OidcPermissionsCard';
 import PermissionsCard from './PermissionsCard';
 import { ScopeLevel } from './PermissionsCard/ApplicationScopesAssignmentModal/type';
 import styles from './index.module.scss';
@@ -14,6 +15,7 @@ function Permissions({ application }: Props) {
       {[ScopeLevel.User, ScopeLevel.Organization].map((scopeLevel) => (
         <PermissionsCard key={scopeLevel} applicationId={application.id} scopeLevel={scopeLevel} />
       ))}
+      <OidcPermissionsCard />
     </div>
   );
 }

--- a/packages/phrases/src/locales/ar/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/application-details.ts
@@ -155,6 +155,18 @@ const application_details = {
     organization_description:
       'Select the permissions requested by the third-party app for accessing specific organization data.',
     grant_organization_level_permissions: 'Grant permissions of organization data',
+    oidc_title: 'OIDC',
+    oidc_description:
+      'يتم تكوين أذونات OIDC الأساسية تلقائيًا لتطبيقك. هذه النطاقات ضرورية للمصادقة ولا يتم عرضها على شاشة موافقة المستخدم.',
+    default_oidc_permissions: 'أذونات OIDC الافتراضية',
+    permission_column: 'الإذن',
+    guide_column: 'الدليل',
+    openid_permission: 'openid',
+    openid_permission_guide:
+      "اختياري للوصول إلى موارد OAuth.\nمطلوب لمصادقة OIDC. يمنح الوصول إلى رمز مميز للهوية (ID token) ويسمح بالوصول إلى 'userinfo_endpoint'.",
+    offline_access_permission: 'offline_access',
+    offline_access_permission_guide:
+      'اختياري. يسترجع رموز التحديث للوصول طويل الأمد أو للمهام في الخلفية.',
   },
   roles: {
     assign_button: 'Assign roles',

--- a/packages/phrases/src/locales/de/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/application-details.ts
@@ -163,6 +163,18 @@ const application_details = {
     organization_description:
       'Wählen Sie die Berechtigungen aus, die von der Drittanbieter-App für den Zugriff auf bestimmte Organisationsdaten angefordert werden.',
     grant_organization_level_permissions: 'Berechtigungen für Organisationdaten erteilen',
+    oidc_title: 'OIDC',
+    oidc_description:
+      'Kern-OIDC-Berechtigungen werden automatisch für Ihre App konfiguriert. Diese Scopes sind für die Authentifizierung erforderlich und werden nicht auf dem Einwilligungsbildschirm angezeigt.',
+    default_oidc_permissions: 'Standard-OIDC-Berechtigungen',
+    permission_column: 'Berechtigung',
+    guide_column: 'Anleitung',
+    openid_permission: 'openid',
+    openid_permission_guide:
+      "Optional für den Zugriff auf OAuth-Ressourcen.\nErforderlich für die OIDC-Authentifizierung. Gewährt Zugriff auf ein ID-Token und ermöglicht den Zugriff auf den 'userinfo_endpoint'.",
+    offline_access_permission: 'offline_access',
+    offline_access_permission_guide:
+      'Optional. Ruft Refresh-Tokens für langfristigen Zugriff oder Hintergrundaufgaben ab.',
   },
   roles: {
     assign_button: 'Rollen von Maschine zu Maschine zuweisen',

--- a/packages/phrases/src/locales/en/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/application-details.ts
@@ -156,6 +156,18 @@ const application_details = {
     organization_description:
       'Select the permissions requested by the third-party app for accessing specific organization data.',
     grant_organization_level_permissions: 'Grant permissions of organization data',
+    oidc_title: 'OIDC',
+    oidc_description:
+      'Core OIDC permissions are automatically configured for your app. These scopes are essential for authentication and are not displayed on the user consent screen.',
+    default_oidc_permissions: 'Default OIDC permissions',
+    permission_column: 'Permission',
+    guide_column: 'Guide',
+    openid_permission: 'openid',
+    openid_permission_guide:
+      "Optional for OAuth resource access.\nRequired for OIDC authentication. Grants access to an ID token and allows access to the 'userinfo_endpoint'.",
+    offline_access_permission: 'offline_access',
+    offline_access_permission_guide:
+      'Optional. Retrieves refresh tokens for long-lived access or background tasks.',
   },
   roles: {
     assign_button: 'Assign roles',

--- a/packages/phrases/src/locales/es/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/application-details.ts
@@ -159,6 +159,18 @@ const application_details = {
     organization_description:
       'Selecciona los permisos solicitados por la aplicación de terceros para acceder a datos específicos de la organización.',
     grant_organization_level_permissions: 'Conceder permisos de datos de organización',
+    oidc_title: 'OIDC',
+    oidc_description:
+      'Los permisos OIDC principales se configuran automáticamente para tu aplicación. Estos scopes son esenciales para la autenticación y no se muestran en la pantalla de consentimiento del usuario.',
+    default_oidc_permissions: 'Permisos OIDC predeterminados',
+    permission_column: 'Permiso',
+    guide_column: 'Guía',
+    openid_permission: 'openid',
+    openid_permission_guide:
+      "Opcional para el acceso a recursos OAuth.\nObligatorio para la autenticación OIDC. Concede acceso a un token de ID y permite acceder al 'userinfo_endpoint'.",
+    offline_access_permission: 'offline_access',
+    offline_access_permission_guide:
+      'Opcional. Obtiene tokens de actualización para acceso prolongado o tareas en segundo plano.',
   },
   roles: {
     assign_button: 'Asignar roles de máquina a máquina',

--- a/packages/phrases/src/locales/fr/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/application-details.ts
@@ -159,6 +159,18 @@ const application_details = {
     organization_description:
       "Sélectionnez les permissions demandées par l'application tierce pour accéder à des données d'organisation spécifiques.",
     grant_organization_level_permissions: "Accorder des permissions des données d'organisation",
+    oidc_title: 'OIDC',
+    oidc_description:
+      'Les permissions OIDC de base sont configurées automatiquement pour votre application. Ces scopes sont essentiels à l’authentification et ne sont pas affichés sur l’écran de consentement de l’utilisateur.',
+    default_oidc_permissions: 'Permissions OIDC par défaut',
+    permission_column: 'Permission',
+    guide_column: 'Guide',
+    openid_permission: 'openid',
+    openid_permission_guide:
+      "Optionnel pour l’accès aux ressources OAuth.\nRequis pour l’authentification OIDC. Donne accès à un jeton d’identification (ID token) et permet d’accéder à 'userinfo_endpoint'.",
+    offline_access_permission: 'offline_access',
+    offline_access_permission_guide:
+      'Optionnel. Récupère des jetons d’actualisation (refresh tokens) pour un accès de longue durée ou des tâches en arrière-plan.',
   },
   roles: {
     assign_button: 'Attribuer des rôles de machine à machine',

--- a/packages/phrases/src/locales/it/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/application-details.ts
@@ -159,6 +159,18 @@ const application_details = {
     organization_description:
       "Seleziona le autorizzazioni richieste dall'applicazione di terze parti per accedere a tipi specifici di dati organizzazione.",
     grant_organization_level_permissions: 'Concedi autorizzazioni dei dati organizzazione',
+    oidc_title: 'OIDC',
+    oidc_description:
+      "Le autorizzazioni OIDC principali sono configurate automaticamente per la tua app. Questi scope sono essenziali per l'autenticazione e non vengono visualizzati nella schermata di consenso dell'utente.",
+    default_oidc_permissions: 'Autorizzazioni OIDC predefinite',
+    permission_column: 'Autorizzazione',
+    guide_column: 'Guida',
+    openid_permission: 'openid',
+    openid_permission_guide:
+      "Opzionale per l'accesso alle risorse OAuth.\nObbligatorio per l'autenticazione OIDC. Concede accesso a un token ID e consente l'accesso a 'userinfo_endpoint'.",
+    offline_access_permission: 'offline_access',
+    offline_access_permission_guide:
+      'Opzionale. Recupera refresh token per accessi di lunga durata o attività in background.',
   },
   roles: {
     assign_button: 'Assegna ruoli da macchina a macchina',

--- a/packages/phrases/src/locales/ja/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/application-details.ts
@@ -157,6 +157,18 @@ const application_details = {
     organization_description:
       '特定の組織データにアクセスするためにサードパーティアプリケーションが要求する権限を選択します。',
     grant_organization_level_permissions: '組織データの権限を付与する',
+    oidc_title: 'OIDC',
+    oidc_description:
+      '主要な OIDC 権限はアプリに自動的に設定されます。これらのスコープは認証に必須であり、ユーザーの同意画面には表示されません。',
+    default_oidc_permissions: '既定の OIDC 権限',
+    permission_column: '権限',
+    guide_column: 'ガイド',
+    openid_permission: 'openid',
+    openid_permission_guide:
+      "OAuth リソースへのアクセスでは任意です。\nOIDC 認証では必須です。ID トークンへのアクセスを許可し、'userinfo_endpoint' にアクセスできるようにします。",
+    offline_access_permission: 'offline_access',
+    offline_access_permission_guide:
+      '任意。長期アクセスやバックグラウンド処理のためのリフレッシュトークンを取得します。',
   },
   roles: {
     assign_button: 'マシン間の役割を割り当てる',

--- a/packages/phrases/src/locales/ko/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/application-details.ts
@@ -153,6 +153,18 @@ const application_details = {
     organization_title: '조직',
     organization_description: '제3자 앱에서 특정 조직 데이터에 액세스하려는 권한을 선택하세요.',
     grant_organization_level_permissions: '조직 데이터의 권한 부여',
+    oidc_title: 'OIDC',
+    oidc_description:
+      '핵심 OIDC 권한은 앱에 자동으로 구성됩니다. 이러한 스코프는 인증에 필수이며 사용자 동의 화면에 표시되지 않습니다.',
+    default_oidc_permissions: '기본 OIDC 권한',
+    permission_column: '권한',
+    guide_column: '가이드',
+    openid_permission: 'openid',
+    openid_permission_guide:
+      "OAuth 리소스 접근에는 선택 사항입니다.\nOIDC 인증에는 필수입니다. ID 토큰에 대한 접근을 부여하며 'userinfo_endpoint'에 접근할 수 있습니다.",
+    offline_access_permission: 'offline_access',
+    offline_access_permission_guide:
+      '선택 사항입니다. 장기 접근 또는 백그라운드 작업을 위한 리프레시 토큰을 가져옵니다.',
   },
   roles: {
     assign_button: '머신 간 역할 할당',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/application-details.ts
@@ -157,6 +157,18 @@ const application_details = {
     organization_description:
       'Wybierz uprawnienia żądane przez aplikację innej firmy do uzyskania dostępu do określonych danych organizacyjnych.',
     grant_organization_level_permissions: 'Udziel uprawnień do danych organizacyjnych',
+    oidc_title: 'OIDC',
+    oidc_description:
+      'Podstawowe uprawnienia OIDC są automatycznie konfigurowane dla Twojej aplikacji. Te zakresy (scopes) są niezbędne do uwierzytelniania i nie są wyświetlane na ekranie zgody użytkownika.',
+    default_oidc_permissions: 'Domyślne uprawnienia OIDC',
+    permission_column: 'Uprawnienie',
+    guide_column: 'Przewodnik',
+    openid_permission: 'openid',
+    openid_permission_guide:
+      "Opcjonalne dla dostępu do zasobów OAuth.\nWymagane do uwierzytelniania OIDC. Umożliwia dostęp do tokenu ID oraz do 'userinfo_endpoint'.",
+    offline_access_permission: 'offline_access',
+    offline_access_permission_guide:
+      'Opcjonalne. Pobiera tokeny odświeżania do długotrwałego dostępu lub zadań w tle.',
   },
   roles: {
     assign_button: 'Przypisz role między maszynami',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/application-details.ts
@@ -159,6 +159,18 @@ const application_details = {
     organization_description:
       'Selecione as permissões solicitadas pelo aplicativo de terceiros para acessar tipos específicos de dados da organização.',
     grant_organization_level_permissions: 'Conceder permissões de dados da organização',
+    oidc_title: 'OIDC',
+    oidc_description:
+      'As permissões principais do OIDC são configuradas automaticamente para seu app. Esses escopos são essenciais para autenticação e não são exibidos na tela de consentimento do usuário.',
+    default_oidc_permissions: 'Permissões OIDC padrão',
+    permission_column: 'Permissão',
+    guide_column: 'Guia',
+    openid_permission: 'openid',
+    openid_permission_guide:
+      "Opcional para acesso a recursos OAuth.\nObrigatório para autenticação OIDC. Concede acesso a um token de ID e permite acesso ao 'userinfo_endpoint'.",
+    offline_access_permission: 'offline_access',
+    offline_access_permission_guide:
+      'Opcional. Obtém tokens de atualização para acesso de longa duração ou tarefas em segundo plano.',
   },
   roles: {
     assign_button: 'Atribuir funções de máquina para máquina',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/application-details.ts
@@ -158,6 +158,18 @@ const application_details = {
     organization_description:
       'Selecione as permissões solicitadas pela aplicação de terceiros para aceder a dados específicos da organização.',
     grant_organization_level_permissions: 'Conceder permissões de dados da organização',
+    oidc_title: 'OIDC',
+    oidc_description:
+      'As permissões principais de OIDC são configuradas automaticamente para a sua aplicação. Estes escopos são essenciais para autenticação e não são apresentados no ecrã de consentimento do utilizador.',
+    default_oidc_permissions: 'Permissões OIDC predefinidas',
+    permission_column: 'Permissão',
+    guide_column: 'Guia',
+    openid_permission: 'openid',
+    openid_permission_guide:
+      "Opcional para acesso a recursos OAuth.\nObrigatório para autenticação OIDC. Concede acesso a um token de ID e permite acesso ao 'userinfo_endpoint'.",
+    offline_access_permission: 'offline_access',
+    offline_access_permission_guide:
+      'Opcional. Obtém tokens de atualização para acesso de longa duração ou tarefas em segundo plano.',
   },
   roles: {
     assign_button: 'Atribuir funções de máquina a máquina',

--- a/packages/phrases/src/locales/ru/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/application-details.ts
@@ -158,6 +158,18 @@ const application_details = {
     organization_description:
       'Выберите разрешения, которые запрашиваются сторонним приложением для доступа к определенным данным организации.',
     grant_organization_level_permissions: 'Предоставить разрешения на данные организации',
+    oidc_title: 'OIDC',
+    oidc_description:
+      'Основные разрешения OIDC автоматически настраиваются для вашего приложения. Эти области (scopes) необходимы для аутентификации и не отображаются на экране согласия пользователя.',
+    default_oidc_permissions: 'Разрешения OIDC по умолчанию',
+    permission_column: 'Разрешение',
+    guide_column: 'Руководство',
+    openid_permission: 'openid',
+    openid_permission_guide:
+      "Необязательно для доступа к ресурсам OAuth.\nОбязательно для аутентификации OIDC. Предоставляет доступ к ID-токену и позволяет обращаться к 'userinfo_endpoint'.",
+    offline_access_permission: 'offline_access',
+    offline_access_permission_guide:
+      'Необязательно. Получает refresh-токены для долгосрочного доступа или фоновых задач.',
   },
   roles: {
     assign_button: 'Назначить роли между машинами',

--- a/packages/phrases/src/locales/th/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/application-details.ts
@@ -152,6 +152,18 @@ const application_details = {
     organization_title: 'องค์กร',
     organization_description: 'เลือกสิทธิ์ที่แอปบุคคลที่สามร้องขอสำหรับใช้เข้าถึงข้อมูลองค์กร',
     grant_organization_level_permissions: 'ให้สิทธิ์ข้อมูลองค์กร',
+    oidc_title: 'OIDC',
+    oidc_description:
+      'สิทธิ์ OIDC หลักจะถูกกำหนดค่าโดยอัตโนมัติสำหรับแอปของคุณ สโคปเหล่านี้จำเป็นสำหรับการยืนยันตัวตนและจะไม่แสดงบนหน้าจอความยินยอมของผู้ใช้',
+    default_oidc_permissions: 'สิทธิ์ OIDC เริ่มต้น',
+    permission_column: 'สิทธิ์',
+    guide_column: 'คู่มือ',
+    openid_permission: 'openid',
+    openid_permission_guide:
+      "ไม่จำเป็นสำหรับการเข้าถึงทรัพยากร OAuth\nจำเป็นสำหรับการยืนยันตัวตนแบบ OIDC ให้สิทธิ์เข้าถึง ID token และอนุญาตให้เข้าถึง 'userinfo_endpoint'",
+    offline_access_permission: 'offline_access',
+    offline_access_permission_guide:
+      'ไม่จำเป็น รับ refresh token สำหรับการเข้าถึงระยะยาวหรือการทำงานเบื้องหลัง',
   },
   roles: {
     assign_button: 'กำหนดบทบาท',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/application-details.ts
@@ -156,6 +156,18 @@ const application_details = {
     organization_description:
       'Üçüncü taraf uygulamanın belirli organizasyon verilerine erişmek için istediği izinleri seçin.',
     grant_organization_level_permissions: 'Organizasyon veri izinlerini ver',
+    oidc_title: 'OIDC',
+    oidc_description:
+      'Temel OIDC izinleri uygulamanız için otomatik olarak yapılandırılır. Bu kapsamlar kimlik doğrulama için gereklidir ve kullanıcı onay ekranında gösterilmez.',
+    default_oidc_permissions: 'Varsayılan OIDC izinleri',
+    permission_column: 'İzin',
+    guide_column: 'Kılavuz',
+    openid_permission: 'openid',
+    openid_permission_guide:
+      "OAuth kaynak erişimi için isteğe bağlıdır.\nOIDC kimlik doğrulaması için gereklidir. Bir ID token'a erişim sağlar ve 'userinfo_endpoint'e erişime izin verir.",
+    offline_access_permission: 'offline_access',
+    offline_access_permission_guide:
+      'İsteğe bağlıdır. Uzun süreli erişim veya arka plan görevleri için yenileme belirteçleri (refresh token) alır.',
   },
   roles: {
     assign_button: 'Makineden makineye rolleri atayın',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/application-details.ts
@@ -145,6 +145,17 @@ const application_details = {
     organization_title: '组织',
     organization_description: '选择第三方应用程序需要访问特定组织数据的权限。',
     grant_organization_level_permissions: '授予组织数据权限',
+    oidc_title: 'OIDC',
+    oidc_description:
+      '核心 OIDC 权限会自动为你的应用配置。这些 scope 对认证至关重要，并且不会显示在用户授权屏幕上。',
+    default_oidc_permissions: '默认 OIDC 权限',
+    permission_column: '权限',
+    guide_column: '指南',
+    openid_permission: 'openid',
+    openid_permission_guide:
+      "用于访问 OAuth 资源时可选。\n用于 OIDC 认证时必需。授予访问 ID Token 的权限，并允许访问 'userinfo_endpoint'。",
+    offline_access_permission: 'offline_access',
+    offline_access_permission_guide: '可选。获取刷新令牌，用于长时访问或后台任务。',
   },
   roles: {
     assign_button: '分配机器对机器角色',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/application-details.ts
@@ -145,6 +145,17 @@ const application_details = {
     organization_title: '組織',
     organization_description: '選擇第三方應用程式為存取特定組織數據所需的權限。',
     grant_organization_level_permissions: '授予組織數據的權限',
+    oidc_title: 'OIDC',
+    oidc_description:
+      '核心 OIDC 權限會自動為你的應用程式設定。這些 scope 對驗證至關重要，且不會顯示於使用者同意畫面。',
+    default_oidc_permissions: '預設 OIDC 權限',
+    permission_column: '權限',
+    guide_column: '指南',
+    openid_permission: 'openid',
+    openid_permission_guide:
+      "用於存取 OAuth 資源時為選填。\n用於 OIDC 驗證時為必填。授予存取 ID Token 的權限，並允許存取 'userinfo_endpoint'。",
+    offline_access_permission: 'offline_access',
+    offline_access_permission_guide: '選填。取得刷新令牌，用於長期存取或背景任務。',
   },
   roles: {
     assign_button: '分配機器對機器角色',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/application-details.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/application-details.ts
@@ -144,6 +144,17 @@ const application_details = {
     organization_title: '組織',
     organization_description: '選擇由第三方應用程式請求的用於訪問特定組織資料的權限。',
     grant_organization_level_permissions: '授予組織資料權限',
+    oidc_title: 'OIDC',
+    oidc_description:
+      '核心 OIDC 權限會自動為你的應用程式設定。這些 scope 對驗證至關重要，且不會顯示於使用者同意畫面。',
+    default_oidc_permissions: '預設 OIDC 權限',
+    permission_column: '權限',
+    guide_column: '指南',
+    openid_permission: 'openid',
+    openid_permission_guide:
+      "用於存取 OAuth 資源時為選填。\n用於 OIDC 驗證時為必填。授予存取 ID Token 的權限，並允許存取 'userinfo_endpoint'。",
+    offline_access_permission: 'offline_access',
+    offline_access_permission_guide: '選填。取得刷新令牌，用於長期存取或背景任務。',
   },
   roles: {
     assign_button: '分配機器對機器角色',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Display OIDC permissions on 3rd-party app details page.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

<img width="1323" height="303" alt="image" src="https://github.com/user-attachments/assets/64fe28f8-13ea-4548-b3ec-3b65def1617d" />


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
