### PR TITLE
fix(account-center): support Enter key to submit forms

### DIFF
--- a/packages/account-center/src/components/CodeVerification/index.tsx
+++ b/packages/account-center/src/components/CodeVerification/index.tsx
@@ -104,7 +104,7 @@ const CodeVerification = ({
   }, [countdown]);
 
   const handleSendCode = useCallback(
-    async (event?: FormEvent) => {
+    async (event?: FormEvent<HTMLFormElement>) => {
       event?.preventDefault();
       if (!identifier || loading) {
         return;

--- a/packages/account-center/src/pages/CodeFlow/IdentifierSendStep.tsx
+++ b/packages/account-center/src/pages/CodeFlow/IdentifierSendStep.tsx
@@ -55,7 +55,7 @@ const IdentifierSendStep = ({
     setPendingValue(value);
   }, [value]);
 
-  const handleSend = async (event?: FormEvent) => {
+  const handleSend = async (event?: FormEvent<HTMLFormElement>) => {
     event?.preventDefault();
     const target = pendingValue.trim();
 

--- a/packages/account-center/src/pages/TotpBinding/index.tsx
+++ b/packages/account-center/src/pages/TotpBinding/index.tsx
@@ -116,7 +116,7 @@ const TotpBinding = () => {
   }, [secret, setToast, t]);
 
   const handleSubmit = useCallback(
-    async (event?: FormEvent) => {
+    async (event?: FormEvent<HTMLFormElement>) => {
       event?.preventDefault();
       if (!verificationId || !secret || loading || !isCodeReady(codeInput)) {
         return;


### PR DESCRIPTION
## Summary
- Wrap form containers in `<form>` elements with `onSubmit` handlers
- Use `htmlType="submit"` on buttons instead of `onClick` handlers
- Users can now press Enter/Return in text inputs to submit forms

## Test plan
- [ ] Navigate to email/phone change flow, enter value, press Enter - should send code
- [ ] On verification code screen, press Enter - should verify (if code is complete)
- [ ] On TOTP binding page, enter code, press Enter - should submit