### PR TITLE
fix(console): ensure invitation modal is closed after sending invitation

### DIFF
--- a/packages/console/src/pages/TenantSettings/TenantMembers/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantMembers/index.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { useContext, useState } from 'react';
+import { startTransition, useContext, useState } from 'react';
 import { Outlet } from 'react-router-dom';
 import useSWRMutation from 'swr/mutation';
 
@@ -76,7 +76,10 @@ function TenantMembers() {
               if (isInvitationTab) {
                 void mutateInvitations();
               } else {
-                navigate('invitations');
+                // Defer navigation to avoid modal closing render being interrupted
+                startTransition(() => {
+                  navigate('invitations');
+                });
               }
             }
           }}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR fixes the bug that causes the tenant invitation modal to stay open after invitations are sent.

After investigation, we've found that the invitation tab is lazy loaded, and during the lazy loading process, the React subtree is suspended, which interrupts the set modal close action.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested with "Slow 4G" network throttling.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
