### PR TITLE
fix(console): adjust column ratios in permissions card tables

### DIFF
--- a/packages/console/src/pages/ApplicationDetails/components/Permissions/OidcPermissionsCard/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/components/Permissions/OidcPermissionsCard/index.tsx
@@ -67,7 +67,7 @@ function OidcPermissionsCard() {
             {
               title: t('application_details.permissions.guide_column'),
               dataIndex: 'description',
-              colSpan: 5,
+              colSpan: 6,
               render: ({ description }) => (
                 <Breakable>
                   <span className={styles.guideText}>{description}</span>

--- a/packages/console/src/pages/ApplicationDetails/components/Permissions/PermissionsCard/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/components/Permissions/PermissionsCard/index.tsx
@@ -102,6 +102,7 @@ function PermissionsCard({ applicationId, scopeLevel }: Props) {
           {
             title: null,
             dataIndex: 'delete',
+            colSpan: 1,
             render: (data) => (
               <ActionsButton
                 fieldName="application_details.permissions.name"


### PR DESCRIPTION
## Summary

- Adjust the guide column `colSpan` from 5 to 6 in `OidcPermissionsCard` for better proportions
- Add explicit `colSpan: 1` to the delete action column in `PermissionsCard` for consistent column sizing

## Testing

Verified locally that the permissions card tables display correctly with the adjusted column ratios.

## Checklist

~~- [ ] `.changeset` file~~
~~- [ ] Unit tests~~
~~- [] Integration tests~~
~~- [] TSDoc comments~~