### PR TITLE
refactor(console): refactor is dev tenant detection logic

### DIFF
--- a/packages/console/src/containers/AppContent/index.tsx
+++ b/packages/console/src/containers/AppContent/index.tsx
@@ -27,7 +27,7 @@ import { type AppContentOutletContext } from './types';
 
 export default function AppContent() {
   const { isLoading: isLoadingPreference } = useUserPreferences();
-  const { currentTenant } = useContext(TenantsContext);
+  const { currentTenant, isDevTenant } = useContext(TenantsContext);
   const isTenantSuspended = isCloud && currentTenant?.isSuspended;
 
   const { isLoading: isLoadingSubscriptionData, ...subscriptionData } = useSubscriptionData();
@@ -49,7 +49,7 @@ export default function AppContent() {
           quotaKey: T,
           usage?: SubscriptionCountBasedUsage[T]
         ) => {
-          if (!shouldEnforcePaywallInUI(subscriptionData.currentSubscription.planId, quotaKey)) {
+          if (!shouldEnforcePaywallInUI(isDevTenant, quotaKey)) {
             return false;
           }
 
@@ -64,7 +64,7 @@ export default function AppContent() {
           quotaKey: T,
           usage?: SubscriptionCountBasedUsage[T]
         ) => {
-          if (!shouldEnforcePaywallInUI(subscriptionData.currentSubscription.planId, quotaKey)) {
+          if (!shouldEnforcePaywallInUI(isDevTenant, quotaKey)) {
             return false;
           }
 

--- a/packages/console/src/contexts/TenantsProvider.tsx
+++ b/packages/console/src/contexts/TenantsProvider.tsx
@@ -1,4 +1,4 @@
-import { defaultTenantId, TenantTag } from '@logto/schemas';
+import { adminTenantId, defaultTenantId, TenantTag } from '@logto/schemas';
 import { conditionalArray, noop } from '@silverhand/essentials';
 import type { ReactNode } from 'react';
 import { useCallback, useMemo, createContext, useState } from 'react';
@@ -169,7 +169,8 @@ function TenantsProvider({ children }: Props) {
       updateTenant,
       isInitComplete,
       currentTenantId,
-      isDevTenant: currentTenant?.tag === TenantTag.Development,
+      isDevTenant:
+        currentTenant?.tag === TenantTag.Development && currentTenant.id !== adminTenantId,
       currentTenant,
       navigateTenant,
     }),

--- a/packages/console/src/pages/Profile/containers/DeleteAccountModal/index.tsx
+++ b/packages/console/src/pages/Profile/containers/DeleteAccountModal/index.tsx
@@ -1,9 +1,9 @@
-import { ReservedPlanId } from '@logto/schemas';
 import { useContext } from 'react';
 import ReactModal from 'react-modal';
 
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import modalStyles from '@/scss/modal.module.scss';
+import { isPaidPlan } from '@/utils/subscription';
 
 import DeletionConfirmationModal from './components/DeletionConfirmationModal';
 import TenantsIssuesModal from './components/TenantsIssuesModal';
@@ -15,8 +15,9 @@ type Props = {
 
 export default function DeleteAccountModal({ isOpen, onClose }: Props) {
   const { tenants } = useContext(TenantsContext);
-  const paidPlans = tenants.filter(
-    ({ planId }) => planId !== ReservedPlanId.Free && planId !== ReservedPlanId.Development
+
+  const paidPlans = tenants.filter(({ subscription: { planId, isEnterprisePlan } }) =>
+    isPaidPlan(planId, isEnterprisePlan)
   );
   const subscriptionStatusIssues = tenants.filter(
     ({ subscription }) => subscription.status !== 'active'

--- a/packages/console/src/pages/TenantSettings/TenantMembers/InviteMemberModal/Footer/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantMembers/InviteMemberModal/Footer/index.tsx
@@ -6,6 +6,7 @@ import ContactUsPhraseLink from '@/components/ContactUsPhraseLink';
 import QuotaGuardFooter from '@/components/QuotaGuardFooter';
 import { contactEmailLink } from '@/consts';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
+import { TenantsContext } from '@/contexts/TenantsProvider';
 import Button, { LinkButton } from '@/ds-components/Button';
 
 import useTenantMembersUsage from '../../hooks';
@@ -22,6 +23,7 @@ function Footer({ newInvitationCount = 0, isLoading, onSubmit }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console.upsell.paywall' });
 
   const { currentSku, currentSubscriptionQuota } = useContext(SubscriptionDataContext);
+  const { isDevTenant } = useContext(TenantsContext);
 
   const { hasTenantMembersReachedLimit, limit, usage } = useTenantMembersUsage();
 
@@ -39,10 +41,7 @@ function Footer({ newInvitationCount = 0, isLoading, onSubmit }: Props) {
     );
   }
 
-  if (
-    currentSku.id === ReservedPlanId.Development &&
-    (hasTenantMembersReachedLimit || usage + newInvitationCount > limit)
-  ) {
+  if (isDevTenant && (hasTenantMembersReachedLimit || usage + newInvitationCount > limit)) {
     // Display a custom "Contact us" footer instead of asking for upgrade
     return (
       <div className={styles.container}>

--- a/packages/console/src/utils/paywall.ts
+++ b/packages/console/src/utils/paywall.ts
@@ -1,34 +1,32 @@
-import { ReservedPlanId } from '@logto/schemas';
-
 import { type SubscriptionCountBasedUsage } from '@/cloud/types/router';
 
 /**
  * Determines whether a paywall should be enforced in the UI for a given plan.
  *
- * @param planId - The subscription plan ID
+ * @param isDevTenant - Whether the tenant is on a Development plan
  * @param quotaKey - The quota key to check
  * @returns true if the paywall should be enforced (show paywall/limit), false otherwise
  *
  * @example
  * ```typescript
  * // Development plan user creating an application
- * shouldEnforcePaywallInUI(ReservedPlanId.Development, 'applicationsLimit')
+ * shouldEnforcePaywallInUI(true, 'applicationsLimit')
  * // => false (no paywall shown)
  *
  * // Development plan user inviting 21st team member
- * shouldEnforcePaywallInUI(ReservedPlanId.Development, 'tenantMembersLimit')
+ * shouldEnforcePaywallInUI(true, 'tenantMembersLimit')
  * // => true (shows "Contact us" message)
  *
  * // Free plan user creating 4th application
- * shouldEnforcePaywallInUI(ReservedPlanId.Free, 'applicationsLimit')
+ * shouldEnforcePaywallInUI(false, 'applicationsLimit')
  * // => true (shows upgrade prompt)
  * ```
  */
 export const shouldEnforcePaywallInUI = <T extends keyof SubscriptionCountBasedUsage>(
-  planId: string,
+  isDevTenant: boolean,
   quotaKey: T
 ): boolean => {
-  if (planId === ReservedPlanId.Development) {
+  if (isDevTenant) {
     // Currently, only tenant members paywall is enforced for Development plan
     if (quotaKey === 'tenantMembersLimit') {
       return true;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR refactors and aligns the usages of `isDevTenant` and `isPaidPlan` detection logic. 

### `isDevTenant` detection:

Replace all direct `skuId === ReservedPlanId.Development` comparisons with the `isDevTenant` flag from `TenantContext`. This flag determines whether a tenant is a development tenant by checking `tenant.tag === TenantTag.Development`.

Since we may have custom development plan IDs, we can no longer rely on comparisons against `ReservedPlanId.Development`. The tenant tag should be used as the single source of truth (SSOT).

Refactor the shouldEnforcePaywallInUI utility method to use isDevTenant instead of planId when determining whether a given plan is a development plan.

### `isPaidPlan`  detection:

In the `DeleteAccountModal` component, replace the legacy paid-plan filter logic
`planId !== ReservedPlanId.Free && planId !== ReservedPlanId.Development`
with the `isPaidPlan` utility method, which is used globally to determine whether a tenant subscription is a paid plan.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally
<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
