### PR TITLE
refactor(console): unused code cleanup

### DIFF
--- a/packages/console/src/components/CreateConnectorForm/Footer/index.tsx
+++ b/packages/console/src/components/CreateConnectorForm/Footer/index.tsx
@@ -16,7 +16,7 @@ type Props = {
 function Footer({ isCreatingSocialConnector, isCreateButtonDisabled, onClickCreateButton }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console.upsell.paywall' });
   const {
-    currentSubscription: { planId, isEnterprisePlan },
+    currentSubscription: { planId },
     currentSubscriptionQuota,
     hasReachedSubscriptionQuotaLimit,
   } = useContext(SubscriptionDataContext);

--- a/packages/console/src/components/FeatureTag/index.tsx
+++ b/packages/console/src/components/FeatureTag/index.tsx
@@ -15,12 +15,9 @@ export { default as BetaTag } from './BetaTag';
  * The display tag mapping for each plan type.
  */
 const planTagMap = {
-  [ReservedPlanId.Free]: 'free',
   [ReservedPlanId.Pro]: 'pro',
   [ReservedPlanId.Pro202411]: 'pro',
   [ReservedPlanId.Pro202509]: 'pro',
-  [ReservedPlanId.Development]: 'dev',
-  [ReservedPlanId.Admin]: 'admin',
   enterprise: 'enterprise',
 } as const;
 

--- a/packages/console/src/components/Guide/GuideCard/index.tsx
+++ b/packages/console/src/components/Guide/GuideCard/index.tsx
@@ -1,10 +1,9 @@
 import { Theme } from '@logto/schemas';
 import classNames from 'classnames';
-import { type ReactNode, Suspense, useCallback, useContext } from 'react';
+import { type ReactNode, Suspense, useCallback } from 'react';
 
 import { type Guide, type GuideMetadata } from '@/assets/docs/guides/types';
 import { BetaTag } from '@/components/FeatureTag';
-import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import Button from '@/ds-components/Button';
 import useTheme from '@/hooks/use-theme';
 import { onKeyDownHandler } from '@/utils/a11y';
@@ -27,9 +26,6 @@ type Props = {
 
 function GuideCard({ data, onClick, hasBorder, hasButton, paywallTag, isBeta }: Props) {
   const { id, Logo, DarkLogo, metadata } = data;
-  const {
-    currentSubscription: { isEnterprisePlan },
-  } = useContext(SubscriptionDataContext);
 
   const { target, name, description } = metadata;
   const buttonText = target === 'API' ? 'guide.get_started' : 'guide.start_building';

--- a/packages/console/src/components/SkuName/index.tsx
+++ b/packages/console/src/components/SkuName/index.tsx
@@ -24,12 +24,11 @@ const getRegisteredSkuNamePhrase = (
 
 type Props = {
   readonly skuId: string;
-  readonly isEnterprise?: boolean;
 };
 
-function SkuName({ skuId, isEnterprise = false }: Props) {
+function SkuName({ skuId }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console.subscription' });
-  const skuNamePhrase = isEnterprise ? 'enterprise' : getRegisteredSkuNamePhrase(skuId);
+  const skuNamePhrase = getRegisteredSkuNamePhrase(skuId);
   return <span>{String(t(skuNamePhrase))}</span>;
 }
 

--- a/packages/console/src/hooks/use-system-limit-error-message.tsx
+++ b/packages/console/src/hooks/use-system-limit-error-message.tsx
@@ -64,7 +64,7 @@ const systemLimitEntityPhrases: Record<SystemLimitKey, AdminConsoleKey> = {
 export const useSystemLimitErrorMessage = () => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const {
-    currentSubscription: { planId, isEnterprisePlan },
+    currentSubscription: { planId },
   } = useContext(SubscriptionDataContext);
 
   const parseSystemLimitErrorMessage = useCallback(
@@ -85,14 +85,14 @@ export const useSystemLimitErrorMessage = () => {
         <Trans
           components={{
             a: <TextLink href={entityPolicyLink} targetBlank="noopener" />,
-            planName: <SkuName skuId={planId} isEnterprise={isEnterprisePlan} />,
+            planName: <SkuName skuId={planId} />,
           }}
         >
           {t('system_limit.limit_exceeded', { entity })}
         </Trans>
       );
     },
-    [t, planId, isEnterprisePlan]
+    [t, planId]
   );
 
   return {

--- a/packages/console/src/pages/ApiResourceDetails/ApiResourcePermissions/components/CreatePermissionModal/index.tsx
+++ b/packages/console/src/pages/ApiResourceDetails/ApiResourcePermissions/components/CreatePermissionModal/index.tsx
@@ -20,18 +20,16 @@ import { trySubmitSafe } from '@/utils/form';
 
 type Props = {
   readonly resourceId: string;
-  /** @deprecated get usage from cloud API after migrating to new pricing model */
-  readonly totalResourceCount: number;
   readonly onClose: (scope?: Scope) => void;
 };
 
 type CreatePermissionFormData = Pick<CreateScope, 'name' | 'description'>;
 
-function CreatePermissionModal({ resourceId, totalResourceCount, onClose }: Props) {
+function CreatePermissionModal({ resourceId, onClose }: Props) {
   const {
     currentSubscriptionQuota,
     currentSubscriptionResourceScopeUsage,
-    currentSubscription: { planId, isEnterprisePlan },
+    currentSubscription: { planId },
     hasReachedSubscriptionQuotaLimit,
   } = useContext(SubscriptionDataContext);
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });

--- a/packages/console/src/pages/ApiResourceDetails/ApiResourcePermissions/index.tsx
+++ b/packages/console/src/pages/ApiResourceDetails/ApiResourcePermissions/index.tsx
@@ -101,7 +101,6 @@ function ApiResourcePermissions() {
       {isCreateFormOpen && totalCount !== undefined && (
         <CreatePermissionModal
           resourceId={resourceId}
-          totalResourceCount={totalCount}
           onClose={(scope) => {
             if (scope) {
               toast.success(

--- a/packages/console/src/pages/Applications/components/ProtectedAppForm/index.tsx
+++ b/packages/console/src/pages/Applications/components/ProtectedAppForm/index.tsx
@@ -48,7 +48,7 @@ function ProtectedAppForm({
   const { data } = useSWRImmutable<ProtectedAppsDomainConfig>(isCloud && 'api/systems/application');
   const {
     currentSubscriptionQuota,
-    currentSubscription: { planId, isEnterprisePlan },
+    currentSubscription: { planId },
   } = useContext(SubscriptionDataContext);
   const { hasAppsReachedLimit } = useApplicationsUsage();
   const defaultDomain = data?.protectedApps.defaultDomain ?? '';

--- a/packages/console/src/pages/CustomizeJwt/index.tsx
+++ b/packages/console/src/pages/CustomizeJwt/index.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from 'react-i18next';
 import FormCard, { FormCardSkeleton } from '@/components/FormCard';
 import { latestProPlanId } from '@/consts/subscriptions';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
-import { TenantsContext } from '@/contexts/TenantsProvider';
 import CardTitle from '@/ds-components/CardTitle';
 import FormField from '@/ds-components/FormField';
 import useDocumentationUrl from '@/hooks/use-documentation-url';
@@ -22,10 +21,8 @@ import useJwtCustomizer from './use-jwt-customizer';
 function CustomizeJwt() {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
-  const { isDevTenant } = useContext(TenantsContext);
   const {
     currentSubscription: { planId, isEnterprisePlan },
-    currentSubscriptionQuota: { customJwtEnabled },
   } = useContext(SubscriptionDataContext);
 
   const { getDocumentationUrl } = useDocumentationUrl();

--- a/packages/console/src/pages/RoleDetails/RolePermissions/components/AssignPermissionsModal/index.tsx
+++ b/packages/console/src/pages/RoleDetails/RolePermissions/components/AssignPermissionsModal/index.tsx
@@ -24,7 +24,7 @@ type Props = {
 function AssignPermissionsModal({ roleId, roleType, onClose }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const {
-    currentSubscription: { planId, isEnterprisePlan },
+    currentSubscription: { planId },
     currentSubscriptionRoleScopeUsage,
     currentSubscriptionQuota,
     hasSurpassedSubscriptionQuotaLimit,


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR cleans up some deprecated and unused console codes.

1. Clean up unused `isEnterprisePlan`  parameter declarations. 
2. Clean up unused planTagMapping definitions in the `FeatureTag` component. 
3. Clean up unused code references and imports in the `GuideCard` and `CreatePermissionModal` components.
4. Clean up the duplicate `enterprise` sku name display logic in the `SkuName` component.  We will always fallback any unknown custom SKU ID to `enterprise`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
