### PR TITLE
fix(core): update account center mount path to /account

### DIFF
--- a/packages/core/src/env-set/index.ts
+++ b/packages/core/src/env-set/index.ts
@@ -17,7 +17,7 @@ export enum UserApps {
   Api = 'api',
   Oidc = 'oidc',
   DemoApp = 'demo-app',
-  AccountCenter = 'account-center',
+  AccountCenter = 'account',
   WellKnown = '.well-known',
 }
 


### PR DESCRIPTION
## Summary

- Fix 404 error when accessing account center routes like `/account/email` in production

The recent refactor (53a410412) changed the account center frontend paths from `/account-center` to `/account` but missed updating the server-side `UserApps.AccountCenter` enum value. This caused 404 errors when accessing routes like `/account/email` in production since the server was still mounting the app at `/account-center`.

## Test plan

- [ ] Access `/account/email` directly in production environment
- [ ] Verify all account center sub-routes work correctly (`/account/phone`, `/account/password`, etc.)
- [ ] Verify OAuth callback redirect works correctly