### PR TITLE
refactor(account): remove auto backup code generation after MFA binding

### DIFF
--- a/packages/account/src/pages/TotpBinding/index.tsx
+++ b/packages/account/src/pages/TotpBinding/index.tsx
@@ -15,7 +15,7 @@ import PageContext from '@ac/Providers/PageContextProvider/PageContext';
 import { getMfaVerifications, generateTotpSecret, addTotpMfa } from '@ac/apis/mfa';
 import ErrorPage from '@ac/components/ErrorPage';
 import VerificationMethodList from '@ac/components/VerificationMethodList';
-import { authenticatorAppSuccessRoute, backupCodesGenerateRoute } from '@ac/constants/routes';
+import { authenticatorAppSuccessRoute } from '@ac/constants/routes';
 import useApi from '@ac/hooks/use-api';
 import useErrorHandler from '@ac/hooks/use-error-handler';
 import SecondaryPageLayout from '@ac/layouts/SecondaryPageLayout';
@@ -27,7 +27,6 @@ const isCodeReady = (code: string[]) => {
 };
 
 const isTotpEnabled = (mfa?: Mfa) => mfa?.factors.includes(MfaFactor.TOTP) ?? false;
-const isBackupCodeEnabled = (mfa?: Mfa) => mfa?.factors.includes(MfaFactor.BackupCode) ?? false;
 
 const TotpBinding = () => {
   const { t } = useTranslation();
@@ -52,7 +51,6 @@ const TotpBinding = () => {
   const [codeInput, setCodeInput] = useState<string[]>([]);
   const [errorMessage, setErrorMessage] = useState<string>();
   const [hasTotpAlready, setHasTotpAlready] = useState<boolean>();
-  const [hasBackupCodes, setHasBackupCodes] = useState<boolean>();
 
   // Check if TOTP already exists on mount
   useEffect(() => {
@@ -62,14 +60,11 @@ const TotpBinding = () => {
       if (error) {
         // If there's an error, we'll let the user continue and the backend will validate
         setHasTotpAlready(false);
-        setHasBackupCodes(false);
         return;
       }
 
       const hasTotp = result?.some((mfa) => mfa.type === MfaFactor.TOTP) ?? false;
-      const hasBackup = result?.some((mfa) => mfa.type === MfaFactor.BackupCode) ?? false;
       setHasTotpAlready(hasTotp);
-      setHasBackupCodes(hasBackup);
     };
 
     void checkExistingMfa();
@@ -144,19 +139,12 @@ const TotpBinding = () => {
         return;
       }
 
-      if (isBackupCodeEnabled(experienceSettings?.mfa) && !hasBackupCodes) {
-        void navigate(backupCodesGenerateRoute, { replace: true });
-        return;
-      }
-
       void navigate(authenticatorAppSuccessRoute, { replace: true });
     },
     [
       addTotpRequest,
       codeInput,
-      experienceSettings?.mfa,
       handleError,
-      hasBackupCodes,
       loading,
       navigate,
       secret,


### PR DESCRIPTION
## Summary

Remove the automatic backup code generation check and navigation after binding passkey or TOTP in the Account Center.

Previously, after successfully binding a passkey or TOTP, the system would automatically check if the user has backup codes and redirect them to the backup code generation page if they don't. This behavior has been removed.

Changes:
- Remove backup code existence check after passkey binding
- Remove backup code existence check after TOTP binding
- Remove auto-navigation to backup code generation page
- Clean up unused imports and helper functions

Users can still manually set up backup codes through the account center if needed.

## Testing

- TypeScript compilation passes
- ESLint passes

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments