### PR TITLE
fix(account): use regenerate route for generating new backup codes

### DIFF
--- a/packages/account/src/App.tsx
+++ b/packages/account/src/App.tsx
@@ -26,6 +26,7 @@ import {
   authenticatorAppRoute,
   authenticatorAppSuccessRoute,
   backupCodesGenerateRoute,
+  backupCodesRegenerateRoute,
   backupCodesSuccessRoute,
   backupCodesManageRoute,
   passkeyAddRoute,
@@ -116,6 +117,7 @@ const Main = () => {
       <Route path={usernameRoute} element={<Username />} />
       <Route path={authenticatorAppRoute} element={<TotpBinding />} />
       <Route path={backupCodesGenerateRoute} element={<BackupCodeBinding />} />
+      <Route path={backupCodesRegenerateRoute} element={<BackupCodeBinding isRegenerate />} />
       <Route path={backupCodesManageRoute} element={<BackupCodeView />} />
       <Route path={passkeyAddRoute} element={<PasskeyBinding />} />
       <Route path={passkeyManageRoute} element={<PasskeyView />} />

--- a/packages/account/src/constants/routes.ts
+++ b/packages/account/src/constants/routes.ts
@@ -9,6 +9,7 @@ export const passwordSuccessRoute = '/password/success';
 export const authenticatorAppRoute = '/authenticator-app';
 export const authenticatorAppSuccessRoute = '/authenticator-app/success';
 export const backupCodesGenerateRoute = '/backup-codes/generate';
+export const backupCodesRegenerateRoute = '/backup-codes/regenerate';
 export const backupCodesManageRoute = '/backup-codes/manage';
 export const backupCodesSuccessRoute = '/backup-codes/success';
 export const passkeyAddRoute = '/passkey/add';

--- a/packages/account/src/pages/BackupCodeView/index.tsx
+++ b/packages/account/src/pages/BackupCodeView/index.tsx
@@ -8,7 +8,7 @@ import PageContext from '@ac/Providers/PageContextProvider/PageContext';
 import { type BackupCodeItem, getBackupCodesList } from '@ac/apis/mfa';
 import ErrorPage from '@ac/components/ErrorPage';
 import VerificationMethodList from '@ac/components/VerificationMethodList';
-import { backupCodesGenerateRoute } from '@ac/constants/routes';
+import { backupCodesRegenerateRoute } from '@ac/constants/routes';
 import useApi from '@ac/hooks/use-api';
 import SecondaryPageLayout from '@ac/layouts/SecondaryPageLayout';
 
@@ -117,7 +117,7 @@ const BackupCodeView = () => {
             title="account_center.backup_code.generate_new"
             type="secondary"
             onClick={() => {
-              void navigate(backupCodesGenerateRoute);
+              void navigate(backupCodesRegenerateRoute);
             }}
           />
         </div>


### PR DESCRIPTION
## Summary

Fix the "Generate new backup codes" button in Account Center backup codes view page that was not working properly.

The issue was that clicking the button would redirect to the `/backup-codes/generate` route and immediately redirect back to the manage page. This happened because `BackupCodeBinding` component checks if backup codes already exist on mount, and if `isRegenerate` prop is false (the default), it redirects back.

Changes:
- Add a new `backupCodesRegenerateRoute` (`/backup-codes/regenerate`) constant
- Add a new route that renders `<BackupCodeBinding isRegenerate />` 
- Update `BackupCodeView` to navigate to the regenerate route when clicking "Generate new backup codes"

## Testing

- TypeScript compilation passes
- ESLint passes

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments