### PR TITLE
refactor(account): use toast instead of redirect page for passkey deletion

### DIFF
--- a/packages/account/src/App.tsx
+++ b/packages/account/src/App.tsx
@@ -31,7 +31,6 @@ import {
   passkeyAddRoute,
   passkeyManageRoute,
   passkeySuccessRoute,
-  passkeyDeletedRoute,
 } from './constants/routes';
 import initI18n from './i18n/init';
 import BackupCodeBinding from './pages/BackupCodeBinding';
@@ -106,10 +105,6 @@ const Main = () => {
         element={<UpdateSuccess identifierType="backup_code" />}
       />
       <Route path={passkeySuccessRoute} element={<UpdateSuccess identifierType="passkey" />} />
-      <Route
-        path={passkeyDeletedRoute}
-        element={<UpdateSuccess identifierType="passkey_deleted" />}
-      />
       <Route path={emailRoute} element={<Email />} />
       <Route path={phoneRoute} element={<Phone />} />
       <Route path={passwordRoute} element={<Password />} />

--- a/packages/account/src/constants/routes.ts
+++ b/packages/account/src/constants/routes.ts
@@ -14,4 +14,3 @@ export const backupCodesSuccessRoute = '/backup-codes/success';
 export const passkeyAddRoute = '/passkey/add';
 export const passkeyManageRoute = '/passkey/manage';
 export const passkeySuccessRoute = '/passkey/success';
-export const passkeyDeletedRoute = '/passkey/deleted';

--- a/packages/account/src/pages/PasskeyView/index.tsx
+++ b/packages/account/src/pages/PasskeyView/index.tsx
@@ -17,7 +17,7 @@ import { getMfaVerifications, deleteMfaVerification, updateWebAuthnName } from '
 import ConfirmModal from '@ac/components/ConfirmModal';
 import ErrorPage from '@ac/components/ErrorPage';
 import VerificationMethodList from '@ac/components/VerificationMethodList';
-import { passkeyDeletedRoute, passkeyAddRoute } from '@ac/constants/routes';
+import { passkeyAddRoute } from '@ac/constants/routes';
 import useApi from '@ac/hooks/use-api';
 import useErrorHandler from '@ac/hooks/use-error-handler';
 import SecondaryPageLayout from '@ac/layouts/SecondaryPageLayout';
@@ -102,12 +102,12 @@ const PasskeyView = () => {
       return;
     }
 
+    setPasskeys((previous) => previous?.filter((passkey) => passkey.id !== selectedPasskey.id));
     setShowDeleteConfirm(false);
-    void navigate(passkeyDeletedRoute, { replace: true });
+    setToast(t('account_center.passkey.deleted'));
   }, [
     deletePasskeyRequest,
     handleError,
-    navigate,
     selectedPasskey,
     setToast,
     setVerificationId,

--- a/packages/account/src/pages/UpdateSuccess/index.tsx
+++ b/packages/account/src/pages/UpdateSuccess/index.tsx
@@ -11,8 +11,8 @@ type IdentifierType =
   | 'password'
   | 'totp'
   | 'backup_code'
-  | 'passkey'
-  | 'passkey_deleted';
+  | 'backup_code_deleted'
+  | 'passkey';
 
 type TranslationMap = Partial<
   Record<IdentifierType, { readonly titleKey: TFuncKey; readonly messageKey: TFuncKey }>
@@ -48,10 +48,6 @@ const translationMap: TranslationMap = {
   passkey: {
     titleKey: 'account_center.update_success.passkey.title',
     messageKey: 'account_center.update_success.passkey.description',
-  },
-  passkey_deleted: {
-    titleKey: 'account_center.update_success.passkey_deleted.title',
-    messageKey: 'account_center.update_success.passkey_deleted.description',
   },
   default: {
     titleKey: 'account_center.update_success.default.title',

--- a/packages/phrases-experience/src/locales/ar/account-center.ts
+++ b/packages/phrases-experience/src/locales/ar/account-center.ts
@@ -141,10 +141,6 @@ const account_center = {
       title: 'تمت إضافة مفتاح المرور!',
       description: 'تم ربط مفتاح المرور بحسابك بنجاح.',
     },
-    passkey_deleted: {
-      title: 'تم حذف مفتاح المرور!',
-      description: 'تم حذف مفتاح المرور من حسابك.',
-    },
   },
   backup_code: {
     title: 'رموز النسخ الاحتياطي',
@@ -161,6 +157,7 @@ const account_center = {
     never_used: 'أبدًا',
     unnamed: 'مفتاح مرور بدون اسم',
     renamed: 'تم تغيير اسم مفتاح المرور بنجاح.',
+    deleted: 'تم حذف مفتاح المرور بنجاح.',
     add_another_title: 'إضافة مفتاح مرور آخر',
     add_another_description:
       'قم بتسجيل مفتاح المرور الخاص بك باستخدام المقاييس الحيوية للجهاز أو مفاتيح الأمان (مثل YubiKey) أو الطرق الأخرى المتاحة.',

--- a/packages/phrases-experience/src/locales/de/account-center.ts
+++ b/packages/phrases-experience/src/locales/de/account-center.ts
@@ -155,10 +155,6 @@ const account_center = {
       title: 'Passkey hinzugefügt!',
       description: 'Ihr Passkey wurde erfolgreich mit Ihrem Konto verknüpft.',
     },
-    passkey_deleted: {
-      title: 'Passkey entfernt!',
-      description: 'Ihr Passkey wurde von Ihrem Konto entfernt.',
-    },
     social: {
       title: 'Soziales Konto verknüpft!',
       description: 'Ihr soziales Konto wurde erfolgreich verknüpft.',
@@ -179,6 +175,7 @@ const account_center = {
     never_used: 'Nie',
     unnamed: 'Unbenannter Passkey',
     renamed: 'Passkey erfolgreich umbenannt.',
+    deleted: 'Passkey erfolgreich entfernt.',
     add_another_title: 'Weiteren Passkey hinzufügen',
     add_another_description:
       'Registrieren Sie Ihren Passkey mit Geräte-Biometrie, Sicherheitsschlüsseln (z.B. YubiKey) oder anderen verfügbaren Methoden.',

--- a/packages/phrases-experience/src/locales/en/account-center.ts
+++ b/packages/phrases-experience/src/locales/en/account-center.ts
@@ -144,10 +144,6 @@ const account_center = {
       title: 'Passkey added!',
       description: 'Your passkey has been successfully linked to your account.',
     },
-    passkey_deleted: {
-      title: 'Passkey removed!',
-      description: 'Your passkey has been removed from your account.',
-    },
     social: {
       title: 'Social account linked!',
       description: 'Your social account has been successfully linked.',
@@ -168,6 +164,7 @@ const account_center = {
     never_used: 'Never',
     unnamed: 'Unnamed passkey',
     renamed: 'Passkey renamed successfully.',
+    deleted: 'Passkey removed successfully.',
     add_another_title: 'Add another passkey',
     add_another_description:
       'Register your passkey using device biometrics, security keys (e.g., YubiKey), or other available methods.',

--- a/packages/phrases-experience/src/locales/es/account-center.ts
+++ b/packages/phrases-experience/src/locales/es/account-center.ts
@@ -150,10 +150,6 @@ const account_center = {
       title: '¡Passkey añadido!',
       description: 'Tu passkey se ha vinculado correctamente a tu cuenta.',
     },
-    passkey_deleted: {
-      title: '¡Passkey eliminado!',
-      description: 'Tu passkey ha sido eliminado de tu cuenta.',
-    },
     social: {
       title: '¡Cuenta social vinculada!',
       description: 'Tu cuenta social ha sido vinculada exitosamente.',
@@ -174,6 +170,7 @@ const account_center = {
     never_used: 'Nunca',
     unnamed: 'Passkey sin nombre',
     renamed: 'Passkey renombrado correctamente.',
+    deleted: 'Passkey eliminado correctamente.',
     add_another_title: 'Añadir otro passkey',
     add_another_description:
       'Registra tu passkey usando biometría del dispositivo, llaves de seguridad (ej. YubiKey) u otros métodos disponibles.',

--- a/packages/phrases-experience/src/locales/fr/account-center.ts
+++ b/packages/phrases-experience/src/locales/fr/account-center.ts
@@ -154,10 +154,6 @@ const account_center = {
       title: 'Passkey ajouté !',
       description: 'Votre passkey a été lié avec succès à votre compte.',
     },
-    passkey_deleted: {
-      title: 'Passkey supprimé !',
-      description: 'Votre passkey a été supprimé de votre compte.',
-    },
   },
   backup_code: {
     title: 'Codes de secours',
@@ -174,6 +170,7 @@ const account_center = {
     never_used: 'Jamais',
     unnamed: 'Passkey sans nom',
     renamed: 'Passkey renommé avec succès.',
+    deleted: 'Passkey supprimé avec succès.',
     add_another_title: 'Ajouter un autre passkey',
     add_another_description:
       "Enregistrez votre passkey à l'aide de la biométrie de l'appareil, des clés de sécurité (ex. YubiKey) ou d'autres méthodes disponibles.",

--- a/packages/phrases-experience/src/locales/it/account-center.ts
+++ b/packages/phrases-experience/src/locales/it/account-center.ts
@@ -152,10 +152,6 @@ const account_center = {
       title: 'Passkey aggiunto!',
       description: 'Il tuo passkey è stato collegato con successo al tuo account.',
     },
-    passkey_deleted: {
-      title: 'Passkey rimosso!',
-      description: 'Il tuo passkey è stato rimosso dal tuo account.',
-    },
   },
   backup_code: {
     title: 'Codici di backup',
@@ -172,6 +168,7 @@ const account_center = {
     never_used: 'Mai',
     unnamed: 'Passkey senza nome',
     renamed: 'Passkey rinominato con successo.',
+    deleted: 'Passkey rimosso con successo.',
     add_another_title: 'Aggiungi un altro passkey',
     add_another_description:
       'Registra il tuo passkey utilizzando la biometria del dispositivo, le chiavi di sicurezza (es. YubiKey) o altri metodi disponibili.',

--- a/packages/phrases-experience/src/locales/ja/account-center.ts
+++ b/packages/phrases-experience/src/locales/ja/account-center.ts
@@ -146,10 +146,6 @@ const account_center = {
       title: 'パスキーが追加されました！',
       description: 'パスキーがアカウントに正常にリンクされました。',
     },
-    passkey_deleted: {
-      title: 'パスキーが削除されました！',
-      description: 'パスキーがアカウントから削除されました。',
-    },
   },
   backup_code: {
     title: 'バックアップコード',
@@ -166,6 +162,7 @@ const account_center = {
     never_used: '未使用',
     unnamed: '名前なしのパスキー',
     renamed: 'パスキーの名前を変更しました。',
+    deleted: 'パスキーが削除されました。',
     add_another_title: '別のパスキーを追加',
     add_another_description:
       'デバイスの生体認証、セキュリティキー（例: YubiKey）、またはその他の利用可能な方法を使用してパスキーを登録してください。',

--- a/packages/phrases-experience/src/locales/ko/account-center.ts
+++ b/packages/phrases-experience/src/locales/ko/account-center.ts
@@ -139,10 +139,6 @@ const account_center = {
       title: '패스키가 추가되었습니다!',
       description: '패스키가 계정에 성공적으로 연결되었습니다.',
     },
-    passkey_deleted: {
-      title: '패스키가 삭제되었습니다!',
-      description: '패스키가 계정에서 삭제되었습니다.',
-    },
     social: {
       title: '소셜 계정 연결됨!',
       description: '소셜 계정이 성공적으로 연결되었습니다.',
@@ -163,6 +159,7 @@ const account_center = {
     never_used: '사용 안 함',
     unnamed: '이름 없는 패스키',
     renamed: '패스키 이름이 변경되었습니다.',
+    deleted: '패스키가 삭제되었습니다.',
     add_another_title: '다른 패스키 추가',
     add_another_description:
       '기기 생체 인증, 보안 키(예: YubiKey) 또는 기타 사용 가능한 방법을 사용하여 패스키를 등록하세요.',

--- a/packages/phrases-experience/src/locales/pl-pl/account-center.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/account-center.ts
@@ -145,10 +145,6 @@ const account_center = {
       title: 'Passkey dodany!',
       description: 'Twój passkey został pomyślnie połączony z kontem.',
     },
-    passkey_deleted: {
-      title: 'Passkey usunięty!',
-      description: 'Twój passkey został usunięty z konta.',
-    },
     social: {
       title: 'Konto społecznościowe połączone!',
       description: 'Twoje konto społecznościowe zostało pomyślnie połączone.',
@@ -169,6 +165,7 @@ const account_center = {
     never_used: 'Nigdy',
     unnamed: 'Passkey bez nazwy',
     renamed: 'Passkey został pomyślnie zmieniony.',
+    deleted: 'Passkey został pomyślnie usunięty.',
     add_another_title: 'Dodaj kolejny passkey',
     add_another_description:
       'Zarejestruj swój passkey używając biometrii urządzenia, kluczy bezpieczeństwa (np. YubiKey) lub innych dostępnych metod.',

--- a/packages/phrases-experience/src/locales/pt-br/account-center.ts
+++ b/packages/phrases-experience/src/locales/pt-br/account-center.ts
@@ -147,10 +147,6 @@ const account_center = {
       title: 'Passkey adicionado!',
       description: 'Seu passkey foi vinculado com sucesso à sua conta.',
     },
-    passkey_deleted: {
-      title: 'Passkey removido!',
-      description: 'Seu passkey foi removido da sua conta.',
-    },
     social: {
       title: 'Conta social vinculada!',
       description: 'Sua conta social foi vinculada com sucesso.',
@@ -171,6 +167,7 @@ const account_center = {
     never_used: 'Nunca',
     unnamed: 'Passkey sem nome',
     renamed: 'Passkey renomeado com sucesso.',
+    deleted: 'Passkey removido com sucesso.',
     add_another_title: 'Adicionar outro passkey',
     add_another_description:
       'Registre seu passkey usando biometria do dispositivo, chaves de segurança (ex: YubiKey) ou outros métodos disponíveis.',

--- a/packages/phrases-experience/src/locales/pt-pt/account-center.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/account-center.ts
@@ -149,10 +149,6 @@ const account_center = {
       title: 'Passkey adicionado!',
       description: 'O seu passkey foi associado com sucesso à sua conta.',
     },
-    passkey_deleted: {
-      title: 'Passkey removido!',
-      description: 'O seu passkey foi removido da sua conta.',
-    },
     social: {
       title: 'Conta social associada!',
       description: 'A sua conta social foi associada com sucesso.',
@@ -173,6 +169,7 @@ const account_center = {
     never_used: 'Nunca',
     unnamed: 'Passkey sem nome',
     renamed: 'Passkey renomeado com sucesso.',
+    deleted: 'Passkey removido com sucesso.',
     add_another_title: 'Adicionar outro passkey',
     add_another_description:
       'Registe o seu passkey utilizando biometria do dispositivo, chaves de segurança (ex: YubiKey) ou outros métodos disponíveis.',

--- a/packages/phrases-experience/src/locales/ru/account-center.ts
+++ b/packages/phrases-experience/src/locales/ru/account-center.ts
@@ -144,10 +144,6 @@ const account_center = {
       title: 'Passkey добавлен!',
       description: 'Ваш passkey был успешно привязан к вашему аккаунту.',
     },
-    passkey_deleted: {
-      title: 'Passkey удалён!',
-      description: 'Ваш passkey был удалён из вашего аккаунта.',
-    },
     social: {
       title: 'Социальный аккаунт привязан!',
       description: 'Ваш социальный аккаунт был успешно привязан.',
@@ -168,6 +164,7 @@ const account_center = {
     never_used: 'Никогда',
     unnamed: 'Безымянный passkey',
     renamed: 'Passkey успешно переименован.',
+    deleted: 'Passkey успешно удалён.',
     add_another_title: 'Добавить другой passkey',
     add_another_description:
       'Зарегистрируйте свой passkey с помощью биометрии устройства, ключей безопасности (например, YubiKey) или других доступных методов.',

--- a/packages/phrases-experience/src/locales/th/account-center.ts
+++ b/packages/phrases-experience/src/locales/th/account-center.ts
@@ -138,10 +138,6 @@ const account_center = {
       title: 'เพิ่ม Passkey แล้ว!',
       description: 'Passkey ของคุณได้รับการเชื่อมต่อกับบัญชีของคุณเรียบร้อยแล้ว',
     },
-    passkey_deleted: {
-      title: 'ลบ Passkey แล้ว!',
-      description: 'Passkey ของคุณถูกลบออกจากบัญชีแล้ว',
-    },
     social: {
       title: 'เชื่อมต่อบัญชีโซเชียลแล้ว!',
       description: 'บัญชีโซเชียลของคุณได้รับการเชื่อมต่อเรียบร้อยแล้ว',
@@ -162,6 +158,7 @@ const account_center = {
     never_used: 'ไม่เคยใช้',
     unnamed: 'Passkey ไม่มีชื่อ',
     renamed: 'เปลี่ยนชื่อ Passkey เรียบร้อยแล้ว',
+    deleted: 'ลบ Passkey เรียบร้อยแล้ว',
     add_another_title: 'เพิ่ม Passkey อีกอัน',
     add_another_description:
       'ลงทะเบียน Passkey ของคุณโดยใช้ไบโอเมตริกซ์ของอุปกรณ์ กุญแจความปลอดภัย (เช่น YubiKey) หรือวิธีอื่นที่มี',

--- a/packages/phrases-experience/src/locales/tr-tr/account-center.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/account-center.ts
@@ -143,10 +143,6 @@ const account_center = {
       title: 'Passkey eklendi!',
       description: 'Passkey başarıyla hesabınıza bağlandı.',
     },
-    passkey_deleted: {
-      title: 'Passkey kaldırıldı!',
-      description: 'Passkey hesabınızdan kaldırıldı.',
-    },
     social: {
       title: 'Sosyal hesap bağlandı!',
       description: 'Sosyal hesabınız başarıyla bağlandı.',
@@ -167,6 +163,7 @@ const account_center = {
     never_used: 'Hiç',
     unnamed: 'İsimsiz passkey',
     renamed: 'Passkey başarıyla yeniden adlandırıldı.',
+    deleted: 'Passkey başarıyla kaldırıldı.',
     add_another_title: 'Başka bir passkey ekle',
     add_another_description:
       "Cihaz biyometriği, güvenlik anahtarları (örn. YubiKey) veya diğer mevcut yöntemleri kullanarak passkey'inizi kaydedin.",

--- a/packages/phrases-experience/src/locales/uk-ua/account-center.ts
+++ b/packages/phrases-experience/src/locales/uk-ua/account-center.ts
@@ -151,10 +151,6 @@ const account_center = {
       title: 'Passkey додано!',
       description: "Ваш passkey успішно під'єднано до вашого облікового запису.",
     },
-    passkey_deleted: {
-      title: 'Passkey видалено!',
-      description: 'Ваш passkey було видалено з вашого облікового запису.',
-    },
   },
   backup_code: {
     title: 'Резервні коди',
@@ -171,6 +167,7 @@ const account_center = {
     never_used: 'Ніколи',
     unnamed: 'Passkey без назви',
     renamed: 'Passkey успішно перейменовано.',
+    deleted: 'Passkey успішно видалено.',
     add_another_title: 'Додати інший passkey',
     add_another_description:
       'Зареєструйте свій passkey за допомогою біометрії пристрою, ключів безпеки (наприклад, YubiKey) або інших доступних методів.',

--- a/packages/phrases-experience/src/locales/zh-cn/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/account-center.ts
@@ -134,10 +134,6 @@ const account_center = {
       title: 'Passkey 已添加！',
       description: 'Passkey 已成功关联到你的账号。',
     },
-    passkey_deleted: {
-      title: 'Passkey 已移除！',
-      description: 'Passkey 已从你的账号中移除。',
-    },
     social: {
       title: '社交账号已关联！',
       description: '社交账号已成功关联到你的账号。',
@@ -158,6 +154,7 @@ const account_center = {
     never_used: '从未使用',
     unnamed: '未命名的 Passkey',
     renamed: 'Passkey 已重命名。',
+    deleted: 'Passkey 已移除。',
     add_another_title: '添加另一个 Passkey',
     add_another_description:
       '使用设备生物识别、安全密钥（例如 YubiKey）或其他可用方法注册您的 Passkey。',

--- a/packages/phrases-experience/src/locales/zh-hk/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/account-center.ts
@@ -135,10 +135,6 @@ const account_center = {
       title: 'Passkey 已添加！',
       description: 'Passkey 已成功連結到你的帳戶。',
     },
-    passkey_deleted: {
-      title: 'Passkey 已移除！',
-      description: 'Passkey 已從你的帳戶中移除。',
-    },
     social: {
       title: '社交帳號已連結！',
       description: '你的社交帳號已成功連結。',
@@ -159,6 +155,7 @@ const account_center = {
     never_used: '從未使用',
     unnamed: '未命名的 Passkey',
     renamed: 'Passkey 已成功重新命名。',
+    deleted: 'Passkey 已移除。',
     add_another_title: '添加另一個 Passkey',
     add_another_description:
       '使用設備生物識別、安全密鑰（例如 YubiKey）或其他可用方法註冊你的 Passkey。',

--- a/packages/phrases-experience/src/locales/zh-tw/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/account-center.ts
@@ -135,10 +135,6 @@ const account_center = {
       title: 'Passkey 已新增！',
       description: 'Passkey 已成功連結至您的帳戶。',
     },
-    passkey_deleted: {
-      title: 'Passkey 已移除！',
-      description: 'Passkey 已從您的帳戶中移除。',
-    },
     social: {
       title: '社群帳號已連結！',
       description: '您的社群帳號已成功連結。',
@@ -159,6 +155,7 @@ const account_center = {
     never_used: '從未使用',
     unnamed: '未命名的 Passkey',
     renamed: 'Passkey 已成功重新命名。',
+    deleted: 'Passkey 已移除。',
     add_another_title: '新增另一個 Passkey',
     add_another_description:
       '使用設備生物識別、安全金鑰（例如 YubiKey）或其他可用方法註冊您的 Passkey。',


### PR DESCRIPTION
## Summary
- Changed the passkey deletion behavior in account center
- After deleting a passkey, show a toast message instead of redirecting to a success page
- This improves UX by keeping users on the passkey management page

## Changes
- Modified `PasskeyView` component to use toast notification and update local state after deletion
- Removed unused `passkeyDeletedRoute` and related code
- Cleaned up `UpdateSuccess` component by removing `passkey_deleted` type
- Updated translation files (18 languages) to add `deleted` key in passkey section and remove `passkey_deleted` from update_success

## Test plan
- Navigate to account center > Passkeys
- Delete a passkey
- Verify a toast notification appears instead of redirecting to a success page
- Verify the passkey is removed from the list