### PR TITLE
fix(account): add MFA feature check to BackupCodeView page

### DIFF
--- a/packages/account/src/pages/BackupCodeView/index.tsx
+++ b/packages/account/src/pages/BackupCodeView/index.tsx
@@ -1,5 +1,6 @@
 import Button from '@experience/shared/components/Button';
 import DynamicT from '@experience/shared/components/DynamicT';
+import { AccountCenterControlValue, MfaFactor, type Mfa } from '@logto/schemas';
 import { useCallback, useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -14,10 +15,13 @@ import SecondaryPageLayout from '@ac/layouts/SecondaryPageLayout';
 
 import styles from './index.module.scss';
 
+const isBackupCodeEnabled = (mfa?: Mfa) => mfa?.factors.includes(MfaFactor.BackupCode) ?? false;
+
 const BackupCodeView = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { verificationId, setToast } = useContext(PageContext);
+  const { accountCenterSettings, experienceSettings, verificationId, setToast } =
+    useContext(PageContext);
   const getBackupCodesRequest = useApi(getBackupCodesList);
 
   const [codes, setCodes] = useState<BackupCodeItem[]>();
@@ -58,6 +62,24 @@ const BackupCodeView = () => {
     downloadLink.download = filename;
     downloadLink.click();
   }, []);
+
+  if (
+    !accountCenterSettings?.enabled ||
+    accountCenterSettings.fields.mfa !== AccountCenterControlValue.Edit
+  ) {
+    return (
+      <ErrorPage titleKey="error.something_went_wrong" messageKey="error.feature_not_enabled" />
+    );
+  }
+
+  if (!isBackupCodeEnabled(experienceSettings?.mfa)) {
+    return (
+      <ErrorPage
+        titleKey="error.something_went_wrong"
+        messageKey="account_center.mfa.backup_code_not_enabled"
+      />
+    );
+  }
 
   if (!verificationId) {
     return <VerificationMethodList />;


### PR DESCRIPTION
## Summary

Add account center and MFA feature validation to `BackupCodeView` page, consistent with other MFA pages.

Previously, when backup code feature was disabled in sign-in experience MFA settings, the `BackupCodeView` page would still render normally instead of showing an error page. This was inconsistent with other MFA pages like `PasskeyView`, `TotpBinding`, and `BackupCodeBinding` which all check if their respective MFA feature is enabled.

## Changes

- Import `AccountCenterControlValue` and `Mfa` type from `@logto/schemas`
- Add `isBackupCodeEnabled` helper function
- Get `accountCenterSettings` and `experienceSettings` from `PageContext`
- Add validation checks before rendering:
  - Check if account center is enabled and MFA field is editable
  - Check if backup code is enabled in `experienceSettings.mfa`

## Testing

- TypeScript compilation passes
- ESLint passes