### PR TITLE
fix(console): copy path instead of full URL in account center prebuilt UI section

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/IntegratePrebuiltUi/PrebuiltUiUrlItem.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/IntegratePrebuiltUi/PrebuiltUiUrlItem.tsx
@@ -34,7 +34,7 @@ function PrebuiltUiUrlItem({ path, tooltip, tenantEndpoint }: Props) {
   const handleCopy = async () => {
     copyIconRef.current?.blur();
     setCopyState('copying');
-    await navigator.clipboard.writeText(fullUrl);
+    await navigator.clipboard.writeText(path);
     setCopyState('copied');
   };
 


### PR DESCRIPTION
## Summary

In the "Integrate Prebuilt UI" section of the Account Center page, the copy button was copying the full URL (including the tenant endpoint) instead of just the path shown in the input field.

This PR fixes the copy button to copy only the path (e.g., `/account/email`) as displayed in the UI.

## Test plan

- Go to Console → Sign-in Experience → Account Center
- In the "Integrate Prebuilt UI" section, click the copy button next to any path
- Verify that only the path (e.g., `/account/email`) is copied, not the full URL