### PR TITLE
fix(account): prevent duplicate TOTP submission toast on success

### DIFF
--- a/packages/account/src/pages/TotpBinding/index.tsx
+++ b/packages/account/src/pages/TotpBinding/index.tsx
@@ -139,6 +139,10 @@ const TotpBinding = () => {
         return;
       }
 
+      // Clear code input to prevent duplicate submission from the auto-submit useEffect
+      // (when loading state changes, handleSubmit gets recreated, which triggers the effect again)
+      setCodeInput([]);
+
       void navigate(authenticatorAppSuccessRoute, { replace: true });
     },
     [


### PR DESCRIPTION
## Summary

- Fixed duplicate "TOTP is already in use" toast appearing after successful TOTP binding

## Root Cause

When user enters 6 digits for TOTP verification:
1. The auto-submit `useEffect` triggers `handleSubmit` 
2. API call succeeds and `loading` state changes from `true` to `false`
3. Since `handleSubmit` depends on `loading`, it gets recreated (new function reference)
4. The `useEffect` triggers again because `handleSubmit` is in its dependency array
5. With `codeInput` still containing 6 digits, `isCodeReady()` returns true
6. A second API call is made, which returns "TOTP is already in use" error

## Solution

Clear `codeInput` immediately after successful TOTP binding, before navigation. This causes `isCodeReady(codeInput)` to return `false` when the effect re-triggers, preventing the duplicate submission.

## Test plan

- [x] Bind TOTP authenticator app in account center
- [x] Verify only success page shows without "TOTP is already in use" toast