### PR TITLE
refactor(account): use text button style for QR code toggle link

### DIFF
--- a/packages/account/src/pages/TotpBinding/index.module.scss
+++ b/packages/account/src/pages/TotpBinding/index.module.scss
@@ -83,11 +83,18 @@
   background: transparent;
   border: none;
   padding: 0;
-  font: var(--font-body-2);
-  color: var(--color-primary-50);
+  font: var(--font-label-2);
+  color: var(--color-brand-default);
   cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
 
-  &:hover {
-    text-decoration: underline;
+  &:active {
+    color: var(--color-brand-hover);
+  }
+}
+
+:global(body.desktop) {
+  .switchLink:hover {
+    color: var(--color-brand-hover);
   }
 }


### PR DESCRIPTION
## Summary

Update the QR code toggle link style in TOTP binding page to match the `TextLink` component style from experience package.

### Changes
- Replace `--font-body-2` with `--font-label-2`
- Replace `--color-primary-50` with `--color-brand-default`
- Remove hover underline, use color change (`--color-brand-hover`) instead
- Add `-webkit-tap-highlight-color: transparent` for better mobile experience
- Add desktop hover state

## Test plan

- [ ] Verify the QR code toggle link ("Can't scan the QR code?" / "Want to scan QR code?") in TOTP binding page has the correct style