### PR TITLE
feat(account): add show_success parameter for success page before redirect

### DIFF
--- a/packages/account/src/utils/session-storage.ts
+++ b/packages/account/src/utils/session-storage.ts
@@ -1,0 +1,67 @@
+const storagePrefix = 'logto:account-center:';
+
+const storageKeys = Object.freeze({
+  redirectUrl: `${storagePrefix}redirect-url`,
+  showSuccess: `${storagePrefix}show-success`,
+});
+
+export const sessionStorage = Object.freeze({
+  getRedirectUrl: (): string | undefined => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    return window.sessionStorage.getItem(storageKeys.redirectUrl) ?? undefined;
+  },
+
+  setRedirectUrl: (url: string): boolean => {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+
+    try {
+      const parsed = new URL(url);
+      // Only allow http and https protocols
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        return false;
+      }
+      window.sessionStorage.setItem(storageKeys.redirectUrl, url);
+      return true;
+    } catch {
+      // Invalid URL
+      return false;
+    }
+  },
+
+  clearRedirectUrl: (): void => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    window.sessionStorage.removeItem(storageKeys.redirectUrl);
+  },
+
+  getShowSuccess: (): boolean => {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+    return window.sessionStorage.getItem(storageKeys.showSuccess) === 'true';
+  },
+
+  setShowSuccess: (value: boolean): void => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if (value) {
+      window.sessionStorage.setItem(storageKeys.showSuccess, 'true');
+    } else {
+      window.sessionStorage.removeItem(storageKeys.showSuccess);
+    }
+  },
+
+  clearShowSuccess: (): void => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    window.sessionStorage.removeItem(storageKeys.showSuccess);
+  },
+});

--- a/packages/phrases-experience/src/locales/ar/action.ts
+++ b/packages/phrases-experience/src/locales/ar/action.ts
@@ -36,6 +36,7 @@ const action = {
   authorize: 'التفويض',
   use_another_account: 'استخدام حساب آخر',
   back_to_current_account: 'الرجوع إلى الحساب الحالي',
+  done: 'تم',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/de/action.ts
+++ b/packages/phrases-experience/src/locales/de/action.ts
@@ -36,6 +36,7 @@ const action = {
   authorize: 'Autorisieren',
   use_another_account: 'Anderes Konto verwenden',
   back_to_current_account: 'Zurück zum aktuellen Konto',
+  done: 'Fertig',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/en/action.ts
+++ b/packages/phrases-experience/src/locales/en/action.ts
@@ -36,6 +36,7 @@ const action = {
   authorize: 'Authorize',
   use_another_account: 'Use another account',
   back_to_current_account: 'Back to current account',
+  done: 'Done',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/es/action.ts
+++ b/packages/phrases-experience/src/locales/es/action.ts
@@ -36,6 +36,7 @@ const action = {
   authorize: 'Autorizar',
   use_another_account: 'Usar otra cuenta',
   back_to_current_account: 'Regresar a la cuenta actual',
+  done: 'Listo',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/fr/action.ts
+++ b/packages/phrases-experience/src/locales/fr/action.ts
@@ -36,6 +36,7 @@ const action = {
   authorize: 'Autoriser',
   use_another_account: 'Utiliser un autre compte',
   back_to_current_account: 'Retour au compte actuel',
+  done: 'Terminé',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/it/action.ts
+++ b/packages/phrases-experience/src/locales/it/action.ts
@@ -36,6 +36,7 @@ const action = {
   authorize: 'Autorizza',
   use_another_account: 'Usa un altro account',
   back_to_current_account: "Torna all'account attuale",
+  done: 'Fatto',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/ja/action.ts
+++ b/packages/phrases-experience/src/locales/ja/action.ts
@@ -36,6 +36,7 @@ const action = {
   authorize: '認証する',
   use_another_account: '別のアカウントを使用する',
   back_to_current_account: '現在のアカウントに戻る',
+  done: '完了',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/ko/action.ts
+++ b/packages/phrases-experience/src/locales/ko/action.ts
@@ -36,6 +36,7 @@ const action = {
   authorize: '권한 부여',
   use_another_account: '다른 계정 사용',
   back_to_current_account: '현재 계정으로 돌아가기',
+  done: '완료',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/pl-pl/action.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/action.ts
@@ -36,6 +36,7 @@ const action = {
   authorize: 'Autoryzuj',
   use_another_account: 'Użyj innego konta',
   back_to_current_account: 'Powróć do bieżącego konta',
+  done: 'Gotowe',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/pt-br/action.ts
+++ b/packages/phrases-experience/src/locales/pt-br/action.ts
@@ -36,6 +36,7 @@ const action = {
   authorize: 'Autorizar',
   use_another_account: 'Usar outra conta',
   back_to_current_account: 'Voltar para a conta atual',
+  done: 'Concluído',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/pt-pt/action.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/action.ts
@@ -36,6 +36,7 @@ const action = {
   authorize: 'Autorizar',
   use_another_account: 'Usar outra conta',
   back_to_current_account: 'Voltar à conta atual',
+  done: 'Concluído',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/ru/action.ts
+++ b/packages/phrases-experience/src/locales/ru/action.ts
@@ -36,6 +36,7 @@ const action = {
   authorize: 'Авторизовать',
   use_another_account: 'Использовать другой аккаунт',
   back_to_current_account: 'Назад к текущему аккаунту',
+  done: 'Готово',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/th/action.ts
+++ b/packages/phrases-experience/src/locales/th/action.ts
@@ -36,6 +36,7 @@ const action = {
   authorize: 'อนุมัติ',
   use_another_account: 'ใช้บัญชีอื่น',
   back_to_current_account: 'กลับไปยังบัญชีปัจจุบัน',
+  done: 'เสร็จสิ้น',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/tr-tr/action.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/action.ts
@@ -36,6 +36,7 @@ const action = {
   authorize: 'Yetkilendir',
   use_another_account: 'Başka bir hesap kullan',
   back_to_current_account: 'Mevcut hesaba geri dön',
+  done: 'Bitti',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/uk-ua/action.ts
+++ b/packages/phrases-experience/src/locales/uk-ua/action.ts
@@ -36,6 +36,7 @@ const action = {
   authorize: 'Авторизуватися',
   use_another_account: 'Використати інший обліковий запис',
   back_to_current_account: 'Повернутися до поточного облікового запису',
+  done: 'Готово',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/zh-cn/action.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/action.ts
@@ -36,6 +36,7 @@ const action = {
   authorize: '授权',
   use_another_account: '使用另一个账号',
   back_to_current_account: '返回到当前账号',
+  done: '完成',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/zh-hk/action.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/action.ts
@@ -36,6 +36,7 @@ const action = {
   authorize: '授權',
   use_another_account: '使用其他帳戶',
   back_to_current_account: '返回當前帳戶',
+  done: '完成',
 };
 
 export default Object.freeze(action);

--- a/packages/phrases-experience/src/locales/zh-tw/action.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/action.ts
@@ -36,6 +36,7 @@ const action = {
   authorize: '授權',
   use_another_account: '使用其他帳戶',
   back_to_current_account: '返回當前帳戶',
+  done: '完成',
 };
 
 export default Object.freeze(action);


### PR DESCRIPTION
## Summary

Add optional `show_success` parameter that allows displaying the built-in success page with a "Done" button before redirecting to the redirect URL.

### Problem
Currently, when the `redirect` parameter is provided, the account center immediately redirects after a successful operation (e.g., email update, password change). This behavior can be unfriendly as users don't get visual confirmation of the success.

### Solution
Add a new optional `show_success` parameter:
- When `show_success=1` or `show_success=true` is provided along with a `redirect` parameter, the user will see the success confirmation page first
- A "Done" button is displayed on the success page
- Clicking "Done" proceeds to the redirect URL
- Without `show_success`, the existing behavior is preserved (immediate redirect)

### Usage
```
/account/email?redirect=https://example.com&show_success=1
```

### Files changed
- `packages/account/src/utils/account-center-route.ts` - Add show_success parameter handling
- `packages/account/src/pages/UpdateSuccess/index.tsx` - Show Done button when show_success is set
- `packages/phrases-experience/src/locales/*/action.ts` - Add "done" translation for 18 languages

## Test plan

- [ ] Verify `redirect` without `show_success` still redirects immediately after success
- [ ] Verify `redirect` with `show_success=1` shows success page with "Done" button
- [ ] Verify clicking "Done" button redirects to the redirect URL
- [ ] Test across different locales to ensure "Done" button text renders correctly