### PR TITLE
feat(account): show specific error when passkey already registered

### DIFF
--- a/packages/phrases-experience/src/locales/ar/account-center.ts
+++ b/packages/phrases-experience/src/locales/ar/account-center.ts
@@ -100,6 +100,8 @@ const account_center = {
     backup_code_not_enabled: 'رمز النسخ الاحتياطي غير ممكّن. يرجى الاتصال بالمسؤول لتمكينه.',
     backup_code_requires_other_mfa: 'تتطلب رموز النسخ الاحتياطي إعداد طريقة MFA أخرى أولاً.',
     passkey_not_enabled: 'مفتاح المرور غير مفعّل. يرجى التواصل مع المسؤول لتفعيله.',
+    passkey_already_registered:
+      'This passkey is already registered to your account. Please use a different authenticator.',
   },
   update_success: {
     default: {

--- a/packages/phrases-experience/src/locales/de/account-center.ts
+++ b/packages/phrases-experience/src/locales/de/account-center.ts
@@ -117,6 +117,8 @@ const account_center = {
       'Für Backup-Codes muss zuerst eine andere MFA-Methode eingerichtet werden.',
     passkey_not_enabled:
       'Passkey ist nicht aktiviert. Bitte kontaktieren Sie Ihren Administrator, um es zu aktivieren.',
+    passkey_already_registered:
+      'This passkey is already registered to your account. Please use a different authenticator.',
   },
   update_success: {
     default: {

--- a/packages/phrases-experience/src/locales/en/account-center.ts
+++ b/packages/phrases-experience/src/locales/en/account-center.ts
@@ -108,6 +108,8 @@ const account_center = {
       'Backup code is not enabled. Please contact your administrator to enable it.',
     backup_code_requires_other_mfa: 'Backup codes require another MFA method to be set up first.',
     passkey_not_enabled: 'Passkey is not enabled. Please contact your administrator to enable it.',
+    passkey_already_registered:
+      'This passkey is already registered to your account. Please use a different authenticator.',
   },
   update_success: {
     default: {

--- a/packages/phrases-experience/src/locales/es/account-center.ts
+++ b/packages/phrases-experience/src/locales/es/account-center.ts
@@ -113,6 +113,8 @@ const account_center = {
       'Los códigos de respaldo requieren que se configure otro método MFA primero.',
     passkey_not_enabled:
       'Passkey no está habilitado. Por favor, contacta a tu administrador para habilitarlo.',
+    passkey_already_registered:
+      'This passkey is already registered to your account. Please use a different authenticator.',
   },
   update_success: {
     default: {

--- a/packages/phrases-experience/src/locales/fr/account-center.ts
+++ b/packages/phrases-experience/src/locales/fr/account-center.ts
@@ -114,6 +114,8 @@ const account_center = {
       "Les codes de secours nécessitent qu'une autre méthode MFA soit d'abord configurée.",
     passkey_not_enabled:
       "Passkey n'est pas activé. Veuillez contacter votre administrateur pour l'activer.",
+    passkey_already_registered:
+      'This passkey is already registered to your account. Please use a different authenticator.',
   },
   update_success: {
     default: {

--- a/packages/phrases-experience/src/locales/it/account-center.ts
+++ b/packages/phrases-experience/src/locales/it/account-center.ts
@@ -112,6 +112,8 @@ const account_center = {
     backup_code_requires_other_mfa:
       'I codici di backup richiedono che venga prima configurato un altro metodo MFA.',
     passkey_not_enabled: "Passkey non è abilitato. Contatta l'amministratore per abilitarlo.",
+    passkey_already_registered:
+      'This passkey is already registered to your account. Please use a different authenticator.',
   },
   update_success: {
     default: {

--- a/packages/phrases-experience/src/locales/ja/account-center.ts
+++ b/packages/phrases-experience/src/locales/ja/account-center.ts
@@ -105,6 +105,8 @@ const account_center = {
     backup_code_requires_other_mfa:
       'バックアップコードを使用するには、まず他の MFA メソッドを設定する必要があります。',
     passkey_not_enabled: 'パスキーが有効になっていません。管理者に連絡して有効にしてください。',
+    passkey_already_registered:
+      'This passkey is already registered to your account. Please use a different authenticator.',
   },
   update_success: {
     default: {

--- a/packages/phrases-experience/src/locales/ko/account-center.ts
+++ b/packages/phrases-experience/src/locales/ko/account-center.ts
@@ -102,6 +102,8 @@ const account_center = {
       '백업 코드가 활성화되지 않았습니다. 관리자에게 문의하여 활성화하십시오.',
     backup_code_requires_other_mfa: '백업 코드를 사용하려면 다른 MFA 방법을 먼저 설정해야 합니다.',
     passkey_not_enabled: '패스키가 활성화되지 않았습니다. 관리자에게 문의하여 활성화하세요.',
+    passkey_already_registered:
+      'This passkey is already registered to your account. Please use a different authenticator.',
   },
   update_success: {
     default: {

--- a/packages/phrases-experience/src/locales/pl-pl/account-center.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/account-center.ts
@@ -108,6 +108,8 @@ const account_center = {
       'Kody zapasowe wymagają wcześniejszego skonfigurowania innej metody MFA.',
     passkey_not_enabled:
       'Passkey nie jest włączony. Skontaktuj się z administratorem, aby go włączyć.',
+    passkey_already_registered:
+      'This passkey is already registered to your account. Please use a different authenticator.',
   },
   update_success: {
     default: {

--- a/packages/phrases-experience/src/locales/pt-br/account-center.ts
+++ b/packages/phrases-experience/src/locales/pt-br/account-center.ts
@@ -111,6 +111,8 @@ const account_center = {
       'Os códigos de backup exigem que outro método MFA seja configurado primeiro.',
     passkey_not_enabled:
       'Passkey não está ativado. Entre em contato com o administrador para ativá-lo.',
+    passkey_already_registered:
+      'This passkey is already registered to your account. Please use a different authenticator.',
   },
   update_success: {
     default: {

--- a/packages/phrases-experience/src/locales/pt-pt/account-center.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/account-center.ts
@@ -111,6 +111,8 @@ const account_center = {
     backup_code_requires_other_mfa:
       'Os códigos de cópia de segurança requerem que outro método MFA seja configurado primeiro.',
     passkey_not_enabled: 'Passkey não está ativado. Contacte o administrador para o ativar.',
+    passkey_already_registered:
+      'This passkey is already registered to your account. Please use a different authenticator.',
   },
   update_success: {
     default: {

--- a/packages/phrases-experience/src/locales/ru/account-center.ts
+++ b/packages/phrases-experience/src/locales/ru/account-center.ts
@@ -107,6 +107,8 @@ const account_center = {
     backup_code_requires_other_mfa:
       'Резервные коды требуют предварительной настройки другого метода MFA.',
     passkey_not_enabled: 'Passkey не включен. Свяжитесь с администратором, чтобы включить его.',
+    passkey_already_registered:
+      'This passkey is already registered to your account. Please use a different authenticator.',
   },
   update_success: {
     default: {

--- a/packages/phrases-experience/src/locales/th/account-center.ts
+++ b/packages/phrases-experience/src/locales/th/account-center.ts
@@ -101,6 +101,8 @@ const account_center = {
     backup_code_not_enabled: 'รหัสสำรองไม่ได้เปิดใช้งาน โปรดติดต่อผู้ดูแลระบบของคุณเพื่อเปิดใช้งาน',
     backup_code_requires_other_mfa: 'รหัสสำรองต้องมีการตั้งค่าวิธี MFA อื่นก่อน',
     passkey_not_enabled: 'Passkey ไม่ได้เปิดใช้งาน โปรดติดต่อผู้ดูแลระบบเพื่อเปิดใช้งาน',
+    passkey_already_registered:
+      'This passkey is already registered to your account. Please use a different authenticator.',
   },
   update_success: {
     default: {

--- a/packages/phrases-experience/src/locales/tr-tr/account-center.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/account-center.ts
@@ -106,6 +106,8 @@ const account_center = {
     backup_code_requires_other_mfa:
       'Yedek kodlar, önce başka bir MFA yönteminin ayarlanmasını gerektirir.',
     passkey_not_enabled: 'Passkey etkin değil. Etkinleştirmek için lütfen yöneticinize başvurun.',
+    passkey_already_registered:
+      'This passkey is already registered to your account. Please use a different authenticator.',
   },
   update_success: {
     default: {

--- a/packages/phrases-experience/src/locales/uk-ua/account-center.ts
+++ b/packages/phrases-experience/src/locales/uk-ua/account-center.ts
@@ -110,6 +110,8 @@ const account_center = {
       'Резервні коди вимагають попереднього налаштування іншого методу MFA.',
     passkey_not_enabled:
       'Passkey не увімкнено. Будь ласка, зверніться до адміністратора, щоб увімкнути його.',
+    passkey_already_registered:
+      'This passkey is already registered to your account. Please use a different authenticator.',
   },
   update_success: {
     default: {

--- a/packages/phrases-experience/src/locales/zh-cn/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/account-center.ts
@@ -98,6 +98,7 @@ const account_center = {
     backup_code_not_enabled: '备份码未启用，请联系管理员启用。',
     backup_code_requires_other_mfa: '备份码需要先设置其他 MFA 方式。',
     passkey_not_enabled: 'Passkey 未启用，请联系管理员启用。',
+    passkey_already_registered: '此 Passkey 已绑定到您的账户，请使用其他认证器。',
   },
   update_success: {
     default: {

--- a/packages/phrases-experience/src/locales/zh-hk/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/account-center.ts
@@ -98,6 +98,8 @@ const account_center = {
     backup_code_not_enabled: '備份碼未啟用，請聯繫管理員啟用。',
     backup_code_requires_other_mfa: '備份碼需要先設置其他 MFA 方式。',
     passkey_not_enabled: 'Passkey 未啟用，請聯繫管理員啟用。',
+    passkey_already_registered:
+      'This passkey is already registered to your account. Please use a different authenticator.',
   },
   update_success: {
     default: {

--- a/packages/phrases-experience/src/locales/zh-tw/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/account-center.ts
@@ -98,6 +98,8 @@ const account_center = {
     backup_code_not_enabled: '備份碼未啟用，請聯繫管理員啟用。',
     backup_code_requires_other_mfa: '備份碼需要先設定其他 MFA 方式。',
     passkey_not_enabled: 'Passkey 未啟用，請聯繫管理員啟用。',
+    passkey_already_registered:
+      'This passkey is already registered to your account. Please use a different authenticator.',
   },
   update_success: {
     default: {


### PR DESCRIPTION
## Summary
- Handle WebAuthn error codes in passkey binding flow to show more specific error messages
- Show "passkey already registered" error when `ERROR_AUTHENTICATOR_PREVIOUSLY_REGISTERED` is returned
- Silently handle user cancellation (`ERROR_CEREMONY_ABORTED`) without showing error toast
- Add `passkey_already_registered` translation key to all 18 locales

## Test plan
- [ ] Try to add a passkey that is already registered, verify the specific error message is shown
- [ ] Cancel the passkey creation flow, verify no error toast is displayed