### PR TITLE
fix(account): use replace instead of assign to prevent back button issue

### DIFF
--- a/packages/account/src/Callback.tsx
+++ b/packages/account/src/Callback.tsx
@@ -9,7 +9,7 @@ const Callback = () => {
   }, [clearAllTokens]);
 
   const { error } = useHandleSignInCallback(() => {
-    window.location.assign('/account');
+    window.location.replace('/account');
   });
 
   if (error) {
@@ -20,7 +20,7 @@ const Callback = () => {
         <button
           type="button"
           onClick={() => {
-            window.location.assign('/account');
+            window.location.replace('/account');
           }}
         >
           Back to sign in


### PR DESCRIPTION
## Summary
- Use `window.location.replace` instead of `window.location.assign` when redirecting after sign-in callback
- This prevents the code parameter URL from remaining in browser history, which would cause issues when users click the back button

## Problem
When users sign in to account center:
1. User visits `/account` (not authenticated)
2. Redirected to sign-in page
3. After sign-in, callback to `/account?code=xxx`
4. Code is processed and user is redirected to `/account`

The issue was that `window.location.assign` adds a new entry to browser history, leaving `/account?code=xxx` in the history. When users click the back button, they return to this expired code URL and get stuck.

## Solution
Using `window.location.replace` instead replaces the current history entry, so the code URL is not preserved in browser history.

## Test plan
- [ ] Sign in to account center
- [ ] Verify successful redirect after callback
- [ ] Click browser back button - should not return to code URL