### PR TITLE
fix(account): clear route cache after restoration to prevent unintended redirects

### DIFF
--- a/packages/account/src/utils/account-center-route.ts
+++ b/packages/account/src/utils/account-center-route.ts
@@ -115,8 +115,10 @@ export const handleAccountCenterRoute = () => {
   // Restore the stored route if the current path is the base path.
   if (window.location.pathname === accountCenterBasePath) {
     const storedRoute = parseStoredRoute(sessionStorage.getItem(routeStorageKey) ?? undefined);
+    // Always clear the stored route to ensure one-time restoration
+    sessionStorage.removeItem(routeStorageKey);
+
     if (!storedRoute) {
-      sessionStorage.removeItem(routeStorageKey);
       return;
     }
 


### PR DESCRIPTION
## Summary
- Fix an issue where users were unexpectedly redirected to a previously cached route when manually navigating to the account center homepage
- The stored route in sessionStorage is now cleared immediately after reading, ensuring one-time restoration

## Test plan
- [ ] Navigate to `/account/email` in account center
- [ ] Leave the page (but keep the browser tab open)
- [ ] Manually navigate back to `/account` homepage
- [ ] Verify that you stay on the homepage instead of being redirected to `/account/email`