### PR TITLE
fix(account): hide loading state on passkey creation button

### DIFF
--- a/packages/account/src/pages/PasskeyBinding/index.tsx
+++ b/packages/account/src/pages/PasskeyBinding/index.tsx
@@ -200,7 +200,8 @@ const PasskeyBinding = () => {
           title="action.continue"
           type="primary"
           className={styles.submitButton}
-          isLoading={loading || !registrationData}
+          isLoading={loading}
+          isDisabled={!registrationData}
           onClick={() => {
             void handleAddPasskey();
           }}


### PR DESCRIPTION
## Summary
- Hide the loading spinner on the passkey creation button while WebAuthn
  registration options are being pre-fetched
- Use `isDisabled` instead of `isLoading` to disable the button until
  registration data is ready

## Test plan
- [ ] Navigate to account center → MFA → Create passkey
- [ ] Verify button is disabled but not showing loading spinner on initial load
- [ ] Verify loading spinner appears during actual passkey registration