### PR TITLE
feat(account): add name step during passkey creation

### DIFF
--- a/packages/phrases-experience/src/locales/ar/account-center.ts
+++ b/packages/phrases-experience/src/locales/ar/account-center.ts
@@ -169,7 +169,11 @@ const account_center = {
     delete_confirmation_description:
       'هل أنت متأكد أنك تريد حذف "{{name}}"؟ لن تتمكن من استخدام مفتاح المرور هذا لتسجيل الدخول بعد الآن.',
     rename_passkey: 'إعادة تسمية مفتاح المرور',
-    rename_description: 'أدخل اسمًا جديدًا لمفتاح المرور هذا.',
+    rename_description: 'Enter a new name for this passkey.',
+    name_this_passkey: 'Name this device passkey',
+    name_passkey_description:
+      'You have successfully verified this device for 2-step authentication. Customize the name to recognize if you have multiple keys.',
+    name_input_label: 'Name',
   },
 };
 

--- a/packages/phrases-experience/src/locales/de/account-center.ts
+++ b/packages/phrases-experience/src/locales/de/account-center.ts
@@ -187,7 +187,11 @@ const account_center = {
     delete_confirmation_description:
       'Sind Sie sicher, dass Sie "{{name}}" entfernen möchten? Sie können sich danach nicht mehr mit diesem Passkey anmelden.',
     rename_passkey: 'Passkey umbenennen',
-    rename_description: 'Geben Sie einen neuen Namen für diesen Passkey ein.',
+    rename_description: 'Enter a new name for this passkey.',
+    name_this_passkey: 'Name this device passkey',
+    name_passkey_description:
+      'You have successfully verified this device for 2-step authentication. Customize the name to recognize if you have multiple keys.',
+    name_input_label: 'Name',
   },
 };
 

--- a/packages/phrases-experience/src/locales/en/account-center.ts
+++ b/packages/phrases-experience/src/locales/en/account-center.ts
@@ -177,6 +177,10 @@ const account_center = {
       'Are you sure you want to remove "{{name}}"? You will no longer be able to use this passkey to sign in.',
     rename_passkey: 'Rename passkey',
     rename_description: 'Enter a new name for this passkey.',
+    name_this_passkey: 'Name this device passkey',
+    name_passkey_description:
+      'You have successfully verified this device for 2-step authentication. Customize the name to recognize if you have multiple keys.',
+    name_input_label: 'Name',
   },
 };
 

--- a/packages/phrases-experience/src/locales/es/account-center.ts
+++ b/packages/phrases-experience/src/locales/es/account-center.ts
@@ -182,7 +182,11 @@ const account_center = {
     delete_confirmation_description:
       '¿Estás seguro de que deseas eliminar "{{name}}"? Ya no podrás usar este passkey para iniciar sesión.',
     rename_passkey: 'Renombrar passkey',
-    rename_description: 'Ingresa un nuevo nombre para este passkey.',
+    rename_description: 'Enter a new name for this passkey.',
+    name_this_passkey: 'Name this device passkey',
+    name_passkey_description:
+      'You have successfully verified this device for 2-step authentication. Customize the name to recognize if you have multiple keys.',
+    name_input_label: 'Name',
   },
 };
 

--- a/packages/phrases-experience/src/locales/fr/account-center.ts
+++ b/packages/phrases-experience/src/locales/fr/account-center.ts
@@ -182,7 +182,11 @@ const account_center = {
     delete_confirmation_description:
       'Êtes-vous sûr de vouloir supprimer « {{name}} » ? Vous ne pourrez plus utiliser ce passkey pour vous connecter.',
     rename_passkey: 'Renommer le passkey',
-    rename_description: 'Entrez un nouveau nom pour ce passkey.',
+    rename_description: 'Enter a new name for this passkey.',
+    name_this_passkey: 'Name this device passkey',
+    name_passkey_description:
+      'You have successfully verified this device for 2-step authentication. Customize the name to recognize if you have multiple keys.',
+    name_input_label: 'Name',
   },
 };
 

--- a/packages/phrases-experience/src/locales/it/account-center.ts
+++ b/packages/phrases-experience/src/locales/it/account-center.ts
@@ -180,7 +180,11 @@ const account_center = {
     delete_confirmation_description:
       'Sei sicuro di voler rimuovere "{{name}}"? Non potrai più utilizzare questo passkey per accedere.',
     rename_passkey: 'Rinomina passkey',
-    rename_description: 'Inserisci un nuovo nome per questo passkey.',
+    rename_description: 'Enter a new name for this passkey.',
+    name_this_passkey: 'Name this device passkey',
+    name_passkey_description:
+      'You have successfully verified this device for 2-step authentication. Customize the name to recognize if you have multiple keys.',
+    name_input_label: 'Name',
   },
 };
 

--- a/packages/phrases-experience/src/locales/ja/account-center.ts
+++ b/packages/phrases-experience/src/locales/ja/account-center.ts
@@ -174,7 +174,11 @@ const account_center = {
     delete_confirmation_description:
       '「{{name}}」を削除してもよろしいですか？このパスキーでログインできなくなります。',
     rename_passkey: 'パスキー名を変更',
-    rename_description: 'このパスキーの新しい名前を入力してください。',
+    rename_description: 'Enter a new name for this passkey.',
+    name_this_passkey: 'Name this device passkey',
+    name_passkey_description:
+      'You have successfully verified this device for 2-step authentication. Customize the name to recognize if you have multiple keys.',
+    name_input_label: 'Name',
   },
 };
 

--- a/packages/phrases-experience/src/locales/ko/account-center.ts
+++ b/packages/phrases-experience/src/locales/ko/account-center.ts
@@ -171,7 +171,11 @@ const account_center = {
     delete_confirmation_description:
       '"{{name}}"을(를) 삭제하시겠습니까? 이 패스키로 더 이상 로그인할 수 없습니다.',
     rename_passkey: '패스키 이름 변경',
-    rename_description: '이 패스키의 새 이름을 입력하세요.',
+    rename_description: 'Enter a new name for this passkey.',
+    name_this_passkey: 'Name this device passkey',
+    name_passkey_description:
+      'You have successfully verified this device for 2-step authentication. Customize the name to recognize if you have multiple keys.',
+    name_input_label: 'Name',
   },
 };
 

--- a/packages/phrases-experience/src/locales/pl-pl/account-center.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/account-center.ts
@@ -177,7 +177,11 @@ const account_center = {
     delete_confirmation_description:
       'Czy na pewno chcesz usunąć "{{name}}"? Nie będziesz mógł używać tego passkey do logowania.',
     rename_passkey: 'Zmień nazwę passkey',
-    rename_description: 'Wprowadź nową nazwę dla tego passkey.',
+    rename_description: 'Enter a new name for this passkey.',
+    name_this_passkey: 'Name this device passkey',
+    name_passkey_description:
+      'You have successfully verified this device for 2-step authentication. Customize the name to recognize if you have multiple keys.',
+    name_input_label: 'Name',
   },
 };
 

--- a/packages/phrases-experience/src/locales/pt-br/account-center.ts
+++ b/packages/phrases-experience/src/locales/pt-br/account-center.ts
@@ -179,7 +179,11 @@ const account_center = {
     delete_confirmation_description:
       'Tem certeza de que deseja remover "{{name}}"? Você não poderá mais usar este passkey para fazer login.',
     rename_passkey: 'Renomear passkey',
-    rename_description: 'Digite um novo nome para este passkey.',
+    rename_description: 'Enter a new name for this passkey.',
+    name_this_passkey: 'Name this device passkey',
+    name_passkey_description:
+      'You have successfully verified this device for 2-step authentication. Customize the name to recognize if you have multiple keys.',
+    name_input_label: 'Name',
   },
 };
 

--- a/packages/phrases-experience/src/locales/pt-pt/account-center.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/account-center.ts
@@ -181,7 +181,11 @@ const account_center = {
     delete_confirmation_description:
       'Tem a certeza de que deseja remover "{{name}}"? Não poderá utilizar este passkey para iniciar sessão.',
     rename_passkey: 'Renomear passkey',
-    rename_description: 'Introduza um novo nome para este passkey.',
+    rename_description: 'Enter a new name for this passkey.',
+    name_this_passkey: 'Name this device passkey',
+    name_passkey_description:
+      'You have successfully verified this device for 2-step authentication. Customize the name to recognize if you have multiple keys.',
+    name_input_label: 'Name',
   },
 };
 

--- a/packages/phrases-experience/src/locales/ru/account-center.ts
+++ b/packages/phrases-experience/src/locales/ru/account-center.ts
@@ -176,7 +176,11 @@ const account_center = {
     delete_confirmation_description:
       'Вы уверены, что хотите удалить "{{name}}"? Вы больше не сможете использовать этот passkey для входа.',
     rename_passkey: 'Переименовать passkey',
-    rename_description: 'Введите новое имя для этого passkey.',
+    rename_description: 'Enter a new name for this passkey.',
+    name_this_passkey: 'Name this device passkey',
+    name_passkey_description:
+      'You have successfully verified this device for 2-step authentication. Customize the name to recognize if you have multiple keys.',
+    name_input_label: 'Name',
   },
 };
 

--- a/packages/phrases-experience/src/locales/th/account-center.ts
+++ b/packages/phrases-experience/src/locales/th/account-center.ts
@@ -170,7 +170,11 @@ const account_center = {
     delete_confirmation_description:
       'คุณแน่ใจหรือไม่ว่าต้องการลบ "{{name}}"? คุณจะไม่สามารถใช้ Passkey นี้เข้าสู่ระบบได้อีก',
     rename_passkey: 'เปลี่ยนชื่อ Passkey',
-    rename_description: 'ป้อนชื่อใหม่สำหรับ Passkey นี้',
+    rename_description: 'Enter a new name for this passkey.',
+    name_this_passkey: 'Name this device passkey',
+    name_passkey_description:
+      'You have successfully verified this device for 2-step authentication. Customize the name to recognize if you have multiple keys.',
+    name_input_label: 'Name',
   },
 };
 

--- a/packages/phrases-experience/src/locales/tr-tr/account-center.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/account-center.ts
@@ -175,7 +175,11 @@ const account_center = {
     delete_confirmation_description:
       '"{{name}}" kaldırmak istediğinizden emin misiniz? Bu passkey ile artık giriş yapamayacaksınız.',
     rename_passkey: "Passkey'i yeniden adlandır",
-    rename_description: 'Bu passkey için yeni bir ad girin.',
+    rename_description: 'Enter a new name for this passkey.',
+    name_this_passkey: 'Name this device passkey',
+    name_passkey_description:
+      'You have successfully verified this device for 2-step authentication. Customize the name to recognize if you have multiple keys.',
+    name_input_label: 'Name',
   },
 };
 

--- a/packages/phrases-experience/src/locales/uk-ua/account-center.ts
+++ b/packages/phrases-experience/src/locales/uk-ua/account-center.ts
@@ -179,7 +179,11 @@ const account_center = {
     delete_confirmation_description:
       'Ви впевнені, що хочете видалити "{{name}}"? Ви більше не зможете використовувати цей passkey для входу.',
     rename_passkey: 'Перейменувати passkey',
-    rename_description: 'Введіть нову назву для цього passkey.',
+    rename_description: 'Enter a new name for this passkey.',
+    name_this_passkey: 'Name this device passkey',
+    name_passkey_description:
+      'You have successfully verified this device for 2-step authentication. Customize the name to recognize if you have multiple keys.',
+    name_input_label: 'Name',
   },
 };
 

--- a/packages/phrases-experience/src/locales/zh-cn/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/account-center.ts
@@ -166,6 +166,10 @@ const account_center = {
     delete_confirmation_description: '确定要移除"{{name}}"吗？移除后您将无法使用此 Passkey 登录。',
     rename_passkey: '重命名 Passkey',
     rename_description: '为此 Passkey 输入新名称。',
+    name_this_passkey: '为此设备 Passkey 命名',
+    name_passkey_description:
+      '您已成功验证此设备用于两步验证。自定义名称以便在拥有多个密钥时进行识别。',
+    name_input_label: '名称',
   },
 };
 

--- a/packages/phrases-experience/src/locales/zh-hk/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/account-center.ts
@@ -166,7 +166,11 @@ const account_center = {
     delete_confirmation_title: '移除 Passkey',
     delete_confirmation_description: '你確定要移除「{{name}}」嗎？你將無法再使用此 Passkey 登入。',
     rename_passkey: '重新命名 Passkey',
-    rename_description: '為此 Passkey 輸入新名稱。',
+    rename_description: 'Enter a new name for this passkey.',
+    name_this_passkey: 'Name this device passkey',
+    name_passkey_description:
+      'You have successfully verified this device for 2-step authentication. Customize the name to recognize if you have multiple keys.',
+    name_input_label: 'Name',
   },
 };
 

--- a/packages/phrases-experience/src/locales/zh-tw/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/account-center.ts
@@ -166,7 +166,11 @@ const account_center = {
     delete_confirmation_title: '移除 Passkey',
     delete_confirmation_description: '您確定要移除「{{name}}」嗎？您將無法再使用此 Passkey 登入。',
     rename_passkey: '重新命名 Passkey',
-    rename_description: '為此 Passkey 輸入新名稱。',
+    rename_description: 'Enter a new name for this passkey.',
+    name_this_passkey: 'Name this device passkey',
+    name_passkey_description:
+      'You have successfully verified this device for 2-step authentication. Customize the name to recognize if you have multiple keys.',
+    name_input_label: 'Name',
   },
 };
 


### PR DESCRIPTION
## Summary
- Add a naming step after WebAuthn registration is verified during passkey creation
- Users can customize the passkey name for better identification when they have multiple keys
- Default name is auto-generated from user-agent (e.g., "Chrome on macOS")
- Add i18n translations for the new naming step UI

## Test plan
- [ ] Create a new passkey and verify the naming step appears after WebAuthn verification
- [ ] Verify the default passkey name is auto-generated from the browser/OS
- [ ] Test custom passkey name input
- [ ] Verify the passkey is created successfully with the custom name