### PR TITLE
feat(schemas): add AccessMcpApi to CloudScope enum

### DIFF
--- a/packages/schemas/src/seeds/cloud-api.ts
+++ b/packages/schemas/src/seeds/cloud-api.ts
@@ -30,6 +30,8 @@ export enum CloudScope {
   ManageAffiliate = 'manage:affiliate',
   /** The user can create new affiliates and logs. */
   CreateAffiliate = 'create:affiliate',
+  /** Allow accessing Logto MCP API (part of Logto Cloud API). This scope is only available to M2M MCP server. */
+  AccessMcpApi = 'access:mcp:api',
 }
 
 export const createCloudApi = (): Readonly<[UpdateAdminData, ...CreateScope[]]> => {


### PR DESCRIPTION
## Summary

Add `AccessMcpApi` scope to `CloudScope` enum for M2M MCP server access to Logto MCP API (part of Logto Cloud API).

## Testing

N/A - enum addition only.

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments