### PR TITLE
fix(schemas): scope down migration to only affected applications

### DIFF
--- a/packages/schemas/alterations/next-1767193412-allow-token-exchange.ts
+++ b/packages/schemas/alterations/next-1767193412-allow-token-exchange.ts
@@ -20,10 +20,13 @@ const alteration: AlterationScript = {
     `);
   },
   down: async (pool) => {
-    // Remove allowTokenExchange from all applications
+    // Remove allowTokenExchange only from applications that were updated in the `up` migration
     await pool.query(sql`
       update applications
-        set custom_client_metadata = custom_client_metadata - 'allowTokenExchange';
+        set custom_client_metadata = custom_client_metadata - 'allowTokenExchange'
+        where is_third_party = false
+        and type in ('Traditional', 'Native', 'SPA')
+        and id != 'admin-console';
     `);
   },
 };


### PR DESCRIPTION
## Summary

The `down` migration in `next-1767193412-allow-token-exchange.ts` was removing `allowTokenExchange` from **all** applications, but the `up` migration only adds it to first-party Traditional, Native, and SPA applications.

This causes issues when other applications (e.g., M2M apps created by Cloud seed) have `allowTokenExchange` set - they get incorrectly modified during rollback.

This fix scopes the `down` migration to only affect the same applications that were modified in `up`.

## Testing

- Verified locally that the change matches the `up` migration scope

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments