### PR TITLE
fix(account): remove background color from passkey item card

### DIFF
--- a/packages/account/src/pages/PasskeyView/index.module.scss
+++ b/packages/account/src/pages/PasskeyView/index.module.scss
@@ -19,7 +19,6 @@
   padding: _.unit(4);
   border: 1px solid var(--color-line-divider);
   border-radius: var(--radius);
-  background-color: var(--color-bg-body);
 }
 
 .passkeyInfo {


### PR DESCRIPTION
## Summary
- Remove `background-color: var(--color-bg-body)` from passkey item cards in the PasskeyView page
- Fixes dark mode styling issue where cards had inconsistent background color compared to the container

## Test plan
- [ ] Verify passkey cards display correctly in dark mode
- [ ] Verify passkey cards display correctly in light mode