### PR TITLE
feat(account): use save button for username setting page

### DIFF
--- a/packages/account/src/pages/Username/index.tsx
+++ b/packages/account/src/pages/Username/index.tsx
@@ -132,7 +132,7 @@ const Username = () => {
         />
         <Button
           className={styles.submit}
-          title="action.continue"
+          title="action.save"
           htmlType="submit"
           isLoading={loading}
         />


### PR DESCRIPTION
## Summary
- Change the CTA button text from "Continue" to "Save" on the set username page for better clarity

## Test plan
- Go to Account Center username settings
- Verify the button text shows "Save" instead of "Continue"