### PR TITLE
fix(core): skip subscription updates reporting for admin tenant

### DIFF
--- a/packages/core/src/libraries/quota.ts
+++ b/packages/core/src/libraries/quota.ts
@@ -1,4 +1,4 @@
-import { ConnectorType } from '@logto/schemas';
+import { adminTenantId, ConnectorType } from '@logto/schemas';
 
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
@@ -156,6 +156,11 @@ export class QuotaLibrary {
       return;
     }
 
+    // Admin tenant is not subject to quota & system limits
+    if (this.tenantId === adminTenantId) {
+      return;
+    }
+
     const subscriptionData = await this.subscription.getSubscriptionData();
 
     const tenantUsageQuery = new TenantUsageQuery(
@@ -190,6 +195,11 @@ export class QuotaLibrary {
 
     // Cloud only feature, skip in non-cloud environments
     if (!isCloud) {
+      return;
+    }
+
+    // Admin tenant is not subject to subscription updates reporting
+    if (this.tenantId === adminTenantId) {
       return;
     }
 


### PR DESCRIPTION
## Summary
Skip subscription updates reporting for admin tenant in `QuotaLibrary.reportSubscriptionUpdatesUsage` method. Admin tenant should not be subject to subscription updates reporting since it's an internal tenant.

## Testing
- Code review

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments