### PR TITLE
docs(console): use type import for LogtoConfig in integration guides

### DIFF
--- a/packages/console/src/assets/docs/guides/native-expo/README.mdx
+++ b/packages/console/src/assets/docs/guides/native-expo/README.mdx
@@ -31,7 +31,7 @@ If you're installing this in a [bare React Native app](https://docs.expo.dev/bar
 Import and use `LogtoProvider` to provide a Logto context:
 
 <Code className="language-tsx" title="App.tsx">
-    {`import { LogtoProvider, LogtoConfig } from '@logto/rn';
+    {`import { LogtoProvider, type LogtoConfig } from '@logto/rn';
 
 const config: LogtoConfig = {
   endpoint: '${props.endpoint}',

--- a/packages/console/src/assets/docs/guides/spa-react/README.mdx
+++ b/packages/console/src/assets/docs/guides/spa-react/README.mdx
@@ -24,7 +24,7 @@ import RedirectUrisWeb, { defaultRedirectUri, defaultPostSignOutUri } from '../.
 Import and use `LogtoProvider` to provide a Logto context to your app:
 
 <Code className="language-tsx" title="App.tsx">
-    {`import { LogtoProvider, LogtoConfig } from '@logto/react';
+    {`import { LogtoProvider, type LogtoConfig } from '@logto/react';
 
 const config: LogtoConfig = {
   endpoint: '${props.endpoint}',

--- a/packages/console/src/assets/docs/guides/spa-vue/README.mdx
+++ b/packages/console/src/assets/docs/guides/spa-vue/README.mdx
@@ -31,7 +31,7 @@ import { defaultRedirectUri, defaultPostSignOutUri } from '../../fragments/_redi
 Import and use `createLogto` to install Logto plugin:
 
 <Code className="language-ts" title="main.ts">
-    {`import { createLogto, LogtoConfig } from '@logto/vue';
+    {`import { createLogto, type LogtoConfig } from '@logto/vue';
 import { createApp } from 'vue';
 import App from './App.vue';
 


### PR DESCRIPTION
## Summary

Use `type` keyword when importing `LogtoConfig` in React integration guide since it's a pure type import.

This prevents potential ESM module resolution errors in strict TypeScript configurations (e.g., when `verbatimModuleSyntax` is enabled).

## Testing

N/A

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments