### PR TITLE
feat(account): auto switch account when user ID mismatch

### DIFF
--- a/packages/account/src/App.tsx
+++ b/packages/account/src/App.tsx
@@ -1,5 +1,5 @@
 import LogtoSignature from '@experience/shared/components/LogtoSignature';
-import { LogtoProvider, useLogto, UserScope } from '@logto/react';
+import { LogtoProvider, Prompt, useLogto, UserScope } from '@logto/react';
 import { accountCenterApplicationId, SignInIdentifier } from '@logto/schemas';
 import { useContext, useEffect } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
@@ -56,8 +56,9 @@ const redirectUri = `${window.location.origin}${accountCenterBasePath}`;
 const Main = () => {
   const params = new URLSearchParams(window.location.search);
   const isInCallback = Boolean(params.get('code'));
+  const expectedUserId = params.get('user_id');
   const { isAuthenticated, isLoading, signIn } = useLogto();
-  const { isLoadingExperience } = useContext(PageContext);
+  const { isLoadingExperience, userInfo } = useContext(PageContext);
   const isInitialAuthLoading = !isAuthenticated && isLoading;
 
   useEffect(() => {
@@ -69,6 +70,18 @@ const Main = () => {
       void signIn({ redirectUri });
     }
   }, [isAuthenticated, isInCallback, isInitialAuthLoading, signIn]);
+
+  // Check if the current user matches the expected user ID from URL parameter
+  useEffect(() => {
+    if (!isAuthenticated || !userInfo?.id || !expectedUserId) {
+      return;
+    }
+
+    // If user ID doesn't match, force re-login
+    if (userInfo.id !== expectedUserId) {
+      void signIn({ redirectUri, prompt: Prompt.Login });
+    }
+  }, [expectedUserId, isAuthenticated, signIn, userInfo?.id]);
 
   if (isInCallback) {
     return <Callback />;


### PR DESCRIPTION
## Summary
- Add functionality to detect when the logged-in user doesn't match the expected user ID from URL parameter (`user_id`)
- Force re-login with `Prompt.Login` when user ID mismatch is detected
- This ensures Account Center always shows the correct user's data when accessed from external links

## Test plan
- [ ] Access Account Center with `?user_id=<different_user_id>` parameter while logged in as a different user
- [ ] Verify that re-login is triggered automatically
- [ ] Access Account Center with matching `user_id` parameter and verify no re-login occurs
- [ ] Access Account Center without `user_id` parameter and verify normal behavior