### PR TITLE
feat(experience): add danger button type to Button component

### DIFF
--- a/packages/account/src/components/ConfirmModal/index.module.scss
+++ b/packages/account/src/components/ConfirmModal/index.module.scss
@@ -11,7 +11,7 @@
 }
 
 .modal {
-  background-color: var(--color-bg-float);
+  background: var(--color-bg-float);
   border-radius: _.unit(4);
   padding: _.unit(6);
   max-width: 400px;

--- a/packages/account/src/components/ConfirmModal/index.tsx
+++ b/packages/account/src/components/ConfirmModal/index.tsx
@@ -1,4 +1,4 @@
-import Button from '@experience/shared/components/Button';
+import Button, { type ButtonType } from '@experience/shared/components/Button';
 import DynamicT from '@experience/shared/components/DynamicT';
 import type { TFuncKey } from 'i18next';
 import type { ReactNode } from 'react';
@@ -11,6 +11,7 @@ type Props = {
   readonly title: TFuncKey;
   readonly children: ReactNode;
   readonly confirmText?: TFuncKey;
+  readonly confirmButtonType?: ButtonType;
   readonly cancelText?: TFuncKey;
   readonly isLoading?: boolean;
   readonly onConfirm: () => void;
@@ -22,6 +23,7 @@ const ConfirmModal = ({
   title,
   children,
   confirmText = 'action.continue',
+  confirmButtonType = 'primary',
   cancelText = 'action.cancel',
   isLoading,
   onConfirm,
@@ -42,7 +44,12 @@ const ConfirmModal = ({
       <div className={styles.content}>{children}</div>
       <div className={styles.footer}>
         <Button title={cancelText} type="secondary" onClick={onCancel} />
-        <Button title={confirmText} type="primary" isLoading={isLoading} onClick={onConfirm} />
+        <Button
+          title={confirmText}
+          type={confirmButtonType}
+          isLoading={isLoading}
+          onClick={onConfirm}
+        />
       </div>
     </ReactModal>
   );

--- a/packages/account/src/pages/PasskeyView/index.tsx
+++ b/packages/account/src/pages/PasskeyView/index.tsx
@@ -8,7 +8,7 @@ import {
   type UserMfaVerificationResponse,
 } from '@logto/schemas';
 import { format } from 'date-fns';
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
@@ -155,16 +155,6 @@ const PasskeyView = () => {
     verificationId,
   ]);
 
-  const passkeyDisplayName = useMemo(() => {
-    if (!selectedPasskey) {
-      return '';
-    }
-    return (
-      formatPasskeyName(selectedPasskey.name, selectedPasskey.agent) ??
-      t('account_center.passkey.unnamed')
-    );
-  }, [selectedPasskey, t]);
-
   if (
     !accountCenterSettings?.enabled ||
     accountCenterSettings.fields.mfa !== AccountCenterControlValue.Edit
@@ -273,6 +263,8 @@ const PasskeyView = () => {
       <ConfirmModal
         isOpen={showDeleteConfirm}
         title="account_center.passkey.delete_confirmation_title"
+        confirmText="action.remove"
+        confirmButtonType="danger"
         onConfirm={() => {
           void handleDelete();
         }}
@@ -280,10 +272,7 @@ const PasskeyView = () => {
           setShowDeleteConfirm(false);
         }}
       >
-        <DynamicT
-          forKey="account_center.passkey.delete_confirmation_description"
-          interpolation={{ name: passkeyDisplayName }}
-        />
+        <DynamicT forKey="account_center.passkey.delete_confirmation_description" />
       </ConfirmModal>
       <ConfirmModal
         isOpen={showEditModal}

--- a/packages/experience/src/shared/components/Button/index.module.scss
+++ b/packages/experience/src/shared/components/Button/index.module.scss
@@ -85,6 +85,25 @@
   }
 }
 
+.danger {
+  border: none;
+  background: var(--color-danger-default);
+  color: var(--color-static-white);
+
+  &.disabled:not(.loading),
+  &:disabled:not(.loading) {
+    background: var(--color-bg-state-disabled);
+    color: var(--color-type-disable);
+  }
+
+  &:active {
+    background: var(--color-danger-pressed);
+  }
+
+  &.loadingActive {
+    background-color: var(--color-danger-hover);
+  }
+}
 
 :global(body.desktop) {
   .button {
@@ -108,6 +127,16 @@
 
     &:not(:disabled):not(:active):not(.loadingActive):hover {
       background: var(--color-overlay-neutral-hover);
+    }
+  }
+
+  .danger {
+    &:focus-visible {
+      outline: 3px solid var(--color-overlay-danger-focused);
+    }
+
+    &:not(:disabled):not(:active):not(.loadingActive):hover {
+      background: var(--color-danger-hover);
     }
   }
 }

--- a/packages/experience/src/shared/components/Button/index.tsx
+++ b/packages/experience/src/shared/components/Button/index.tsx
@@ -8,7 +8,7 @@ import DynamicT from '@/shared/components/DynamicT';
 import RotatingRingIcon from './RotatingRingIcon';
 import styles from './index.module.scss';
 
-export type ButtonType = 'primary' | 'secondary';
+export type ButtonType = 'primary' | 'secondary' | 'danger';
 
 type BaseProps = Omit<HTMLProps<HTMLButtonElement>, 'type' | 'size' | 'title'> & {
   readonly htmlType?: 'button' | 'submit' | 'reset';

--- a/packages/phrases-experience/src/locales/ar/account-center.ts
+++ b/packages/phrases-experience/src/locales/ar/account-center.ts
@@ -162,9 +162,9 @@ const account_center = {
     add_another_description:
       'قم بتسجيل مفتاح المرور الخاص بك باستخدام المقاييس الحيوية للجهاز أو مفاتيح الأمان (مثل YubiKey) أو الطرق الأخرى المتاحة.',
     add_passkey: 'إضافة مفتاح مرور',
-    delete_confirmation_title: 'حذف مفتاح المرور',
+    delete_confirmation_title: 'إزالة مفتاح المرور الخاص بك',
     delete_confirmation_description:
-      'هل أنت متأكد أنك تريد حذف "{{name}}"؟ لن تتمكن من استخدام مفتاح المرور هذا لتسجيل الدخول بعد الآن.',
+      'إذا قمت بإزالة مفتاح المرور هذا، فلن تتمكن من التحقق باستخدامه.',
     rename_passkey: 'إعادة تسمية مفتاح المرور',
     rename_description: 'Enter a new name for this passkey.',
     name_this_passkey: 'Name this device passkey',

--- a/packages/phrases-experience/src/locales/de/account-center.ts
+++ b/packages/phrases-experience/src/locales/de/account-center.ts
@@ -180,9 +180,9 @@ const account_center = {
     add_another_description:
       'Registrieren Sie Ihren Passkey mit Geräte-Biometrie, Sicherheitsschlüsseln (z.B. YubiKey) oder anderen verfügbaren Methoden.',
     add_passkey: 'Passkey hinzufügen',
-    delete_confirmation_title: 'Passkey entfernen',
+    delete_confirmation_title: 'Ihren Passkey entfernen',
     delete_confirmation_description:
-      'Sind Sie sicher, dass Sie "{{name}}" entfernen möchten? Sie können sich danach nicht mehr mit diesem Passkey anmelden.',
+      'Wenn Sie diesen Passkey entfernen, können Sie ihn nicht mehr zur Verifizierung verwenden.',
     rename_passkey: 'Passkey umbenennen',
     rename_description: 'Enter a new name for this passkey.',
     name_this_passkey: 'Name this device passkey',

--- a/packages/phrases-experience/src/locales/en/account-center.ts
+++ b/packages/phrases-experience/src/locales/en/account-center.ts
@@ -169,9 +169,9 @@ const account_center = {
     add_another_description:
       'Register your passkey using device biometrics, security keys (e.g., YubiKey), or other available methods.',
     add_passkey: 'Add a passkey',
-    delete_confirmation_title: 'Remove passkey',
+    delete_confirmation_title: 'Remove your passkey',
     delete_confirmation_description:
-      'Are you sure you want to remove "{{name}}"? You will no longer be able to use this passkey to sign in.',
+      'If you remove this passkey, you will not be able to verify with it.',
     rename_passkey: 'Rename passkey',
     rename_description: 'Enter a new name for this passkey.',
     name_this_passkey: 'Name this device passkey',

--- a/packages/phrases-experience/src/locales/es/account-center.ts
+++ b/packages/phrases-experience/src/locales/es/account-center.ts
@@ -175,9 +175,8 @@ const account_center = {
     add_another_description:
       'Registra tu passkey usando biometría del dispositivo, llaves de seguridad (ej. YubiKey) u otros métodos disponibles.',
     add_passkey: 'Añadir un passkey',
-    delete_confirmation_title: 'Eliminar passkey',
-    delete_confirmation_description:
-      '¿Estás seguro de que deseas eliminar "{{name}}"? Ya no podrás usar este passkey para iniciar sesión.',
+    delete_confirmation_title: 'Eliminar tu passkey',
+    delete_confirmation_description: 'Si eliminas este passkey, no podrás verificar con él.',
     rename_passkey: 'Renombrar passkey',
     rename_description: 'Enter a new name for this passkey.',
     name_this_passkey: 'Name this device passkey',

--- a/packages/phrases-experience/src/locales/fr/account-center.ts
+++ b/packages/phrases-experience/src/locales/fr/account-center.ts
@@ -175,9 +175,9 @@ const account_center = {
     add_another_description:
       "Enregistrez votre passkey à l'aide de la biométrie de l'appareil, des clés de sécurité (ex. YubiKey) ou d'autres méthodes disponibles.",
     add_passkey: 'Ajouter un passkey',
-    delete_confirmation_title: 'Supprimer le passkey',
+    delete_confirmation_title: 'Supprimer votre passkey',
     delete_confirmation_description:
-      'Êtes-vous sûr de vouloir supprimer « {{name}} » ? Vous ne pourrez plus utiliser ce passkey pour vous connecter.',
+      "Si vous supprimez ce passkey, vous ne pourrez plus l'utiliser pour vous vérifier.",
     rename_passkey: 'Renommer le passkey',
     rename_description: 'Enter a new name for this passkey.',
     name_this_passkey: 'Name this device passkey',

--- a/packages/phrases-experience/src/locales/it/account-center.ts
+++ b/packages/phrases-experience/src/locales/it/account-center.ts
@@ -173,9 +173,9 @@ const account_center = {
     add_another_description:
       'Registra il tuo passkey utilizzando la biometria del dispositivo, le chiavi di sicurezza (es. YubiKey) o altri metodi disponibili.',
     add_passkey: 'Aggiungi un passkey',
-    delete_confirmation_title: 'Rimuovi passkey',
+    delete_confirmation_title: 'Rimuovi la tua passkey',
     delete_confirmation_description:
-      'Sei sicuro di voler rimuovere "{{name}}"? Non potrai più utilizzare questo passkey per accedere.',
+      'Se rimuovi questa passkey, non potrai più utilizzarla per la verifica.',
     rename_passkey: 'Rinomina passkey',
     rename_description: 'Enter a new name for this passkey.',
     name_this_passkey: 'Name this device passkey',

--- a/packages/phrases-experience/src/locales/ja/account-center.ts
+++ b/packages/phrases-experience/src/locales/ja/account-center.ts
@@ -168,8 +168,7 @@ const account_center = {
       'デバイスの生体認証、セキュリティキー（例: YubiKey）、またはその他の利用可能な方法を使用してパスキーを登録してください。',
     add_passkey: 'パスキーを追加',
     delete_confirmation_title: 'パスキーを削除',
-    delete_confirmation_description:
-      '「{{name}}」を削除してもよろしいですか？このパスキーでログインできなくなります。',
+    delete_confirmation_description: 'このパスキーを削除すると、認証に使用できなくなります。',
     rename_passkey: 'パスキー名を変更',
     rename_description: 'Enter a new name for this passkey.',
     name_this_passkey: 'Name this device passkey',

--- a/packages/phrases-experience/src/locales/ko/account-center.ts
+++ b/packages/phrases-experience/src/locales/ko/account-center.ts
@@ -165,8 +165,7 @@ const account_center = {
       '기기 생체 인증, 보안 키(예: YubiKey) 또는 기타 사용 가능한 방법을 사용하여 패스키를 등록하세요.',
     add_passkey: '패스키 추가',
     delete_confirmation_title: '패스키 삭제',
-    delete_confirmation_description:
-      '"{{name}}"을(를) 삭제하시겠습니까? 이 패스키로 더 이상 로그인할 수 없습니다.',
+    delete_confirmation_description: '이 패스키를 삭제하면 더 이상 인증에 사용할 수 없습니다.',
     rename_passkey: '패스키 이름 변경',
     rename_description: 'Enter a new name for this passkey.',
     name_this_passkey: 'Name this device passkey',

--- a/packages/phrases-experience/src/locales/pl-pl/account-center.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/account-center.ts
@@ -170,9 +170,9 @@ const account_center = {
     add_another_description:
       'Zarejestruj swój passkey używając biometrii urządzenia, kluczy bezpieczeństwa (np. YubiKey) lub innych dostępnych metod.',
     add_passkey: 'Dodaj passkey',
-    delete_confirmation_title: 'Usuń passkey',
+    delete_confirmation_title: 'Usuń swój passkey',
     delete_confirmation_description:
-      'Czy na pewno chcesz usunąć "{{name}}"? Nie będziesz mógł używać tego passkey do logowania.',
+      'Jeśli usuniesz ten passkey, nie będziesz mógł go użyć do weryfikacji.',
     rename_passkey: 'Zmień nazwę passkey',
     rename_description: 'Enter a new name for this passkey.',
     name_this_passkey: 'Name this device passkey',

--- a/packages/phrases-experience/src/locales/pt-br/account-center.ts
+++ b/packages/phrases-experience/src/locales/pt-br/account-center.ts
@@ -172,9 +172,9 @@ const account_center = {
     add_another_description:
       'Registre seu passkey usando biometria do dispositivo, chaves de segurança (ex: YubiKey) ou outros métodos disponíveis.',
     add_passkey: 'Adicionar um passkey',
-    delete_confirmation_title: 'Remover passkey',
+    delete_confirmation_title: 'Remover sua passkey',
     delete_confirmation_description:
-      'Tem certeza de que deseja remover "{{name}}"? Você não poderá mais usar este passkey para fazer login.',
+      'Se você remover esta passkey, não poderá mais usá-la para verificação.',
     rename_passkey: 'Renomear passkey',
     rename_description: 'Enter a new name for this passkey.',
     name_this_passkey: 'Name this device passkey',

--- a/packages/phrases-experience/src/locales/pt-pt/account-center.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/account-center.ts
@@ -174,9 +174,8 @@ const account_center = {
     add_another_description:
       'Registe o seu passkey utilizando biometria do dispositivo, chaves de segurança (ex: YubiKey) ou outros métodos disponíveis.',
     add_passkey: 'Adicionar um passkey',
-    delete_confirmation_title: 'Remover passkey',
-    delete_confirmation_description:
-      'Tem a certeza de que deseja remover "{{name}}"? Não poderá utilizar este passkey para iniciar sessão.',
+    delete_confirmation_title: 'Remover a sua passkey',
+    delete_confirmation_description: 'Se remover esta passkey, não poderá usá-la para verificação.',
     rename_passkey: 'Renomear passkey',
     rename_description: 'Enter a new name for this passkey.',
     name_this_passkey: 'Name this device passkey',

--- a/packages/phrases-experience/src/locales/ru/account-center.ts
+++ b/packages/phrases-experience/src/locales/ru/account-center.ts
@@ -169,9 +169,9 @@ const account_center = {
     add_another_description:
       'Зарегистрируйте свой passkey с помощью биометрии устройства, ключей безопасности (например, YubiKey) или других доступных методов.',
     add_passkey: 'Добавить passkey',
-    delete_confirmation_title: 'Удалить passkey',
+    delete_confirmation_title: 'Удалить ваш passkey',
     delete_confirmation_description:
-      'Вы уверены, что хотите удалить "{{name}}"? Вы больше не сможете использовать этот passkey для входа.',
+      'Если вы удалите этот passkey, вы не сможете использовать его для проверки.',
     rename_passkey: 'Переименовать passkey',
     rename_description: 'Enter a new name for this passkey.',
     name_this_passkey: 'Name this device passkey',

--- a/packages/phrases-experience/src/locales/th/account-center.ts
+++ b/packages/phrases-experience/src/locales/th/account-center.ts
@@ -163,9 +163,8 @@ const account_center = {
     add_another_description:
       'ลงทะเบียน Passkey ของคุณโดยใช้ไบโอเมตริกซ์ของอุปกรณ์ กุญแจความปลอดภัย (เช่น YubiKey) หรือวิธีอื่นที่มี',
     add_passkey: 'เพิ่ม Passkey',
-    delete_confirmation_title: 'ลบ Passkey',
-    delete_confirmation_description:
-      'คุณแน่ใจหรือไม่ว่าต้องการลบ "{{name}}"? คุณจะไม่สามารถใช้ Passkey นี้เข้าสู่ระบบได้อีก',
+    delete_confirmation_title: 'ลบ Passkey ของคุณ',
+    delete_confirmation_description: 'หากคุณลบ Passkey นี้ คุณจะไม่สามารถใช้เพื่อยืนยันตัวตนได้',
     rename_passkey: 'เปลี่ยนชื่อ Passkey',
     rename_description: 'Enter a new name for this passkey.',
     name_this_passkey: 'Name this device passkey',

--- a/packages/phrases-experience/src/locales/tr-tr/account-center.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/account-center.ts
@@ -168,9 +168,9 @@ const account_center = {
     add_another_description:
       "Cihaz biyometriği, güvenlik anahtarları (örn. YubiKey) veya diğer mevcut yöntemleri kullanarak passkey'inizi kaydedin.",
     add_passkey: 'Bir passkey ekle',
-    delete_confirmation_title: "Passkey'i kaldır",
+    delete_confirmation_title: "Passkey'inizi kaldırın",
     delete_confirmation_description:
-      '"{{name}}" kaldırmak istediğinizden emin misiniz? Bu passkey ile artık giriş yapamayacaksınız.',
+      "Bu passkey'i kaldırırsanız, onunla doğrulama yapamayacaksınız.",
     rename_passkey: "Passkey'i yeniden adlandır",
     rename_description: 'Enter a new name for this passkey.',
     name_this_passkey: 'Name this device passkey',

--- a/packages/phrases-experience/src/locales/uk-ua/account-center.ts
+++ b/packages/phrases-experience/src/locales/uk-ua/account-center.ts
@@ -172,9 +172,9 @@ const account_center = {
     add_another_description:
       'Зареєструйте свій passkey за допомогою біометрії пристрою, ключів безпеки (наприклад, YubiKey) або інших доступних методів.',
     add_passkey: 'Додати passkey',
-    delete_confirmation_title: 'Видалити passkey',
+    delete_confirmation_title: 'Видалити ваш passkey',
     delete_confirmation_description:
-      'Ви впевнені, що хочете видалити "{{name}}"? Ви більше не зможете використовувати цей passkey для входу.',
+      'Якщо ви видалите цей passkey, ви не зможете використовувати його для підтвердження.',
     rename_passkey: 'Перейменувати passkey',
     rename_description: 'Enter a new name for this passkey.',
     name_this_passkey: 'Name this device passkey',

--- a/packages/phrases-experience/src/locales/zh-cn/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/account-center.ts
@@ -159,8 +159,8 @@ const account_center = {
     add_another_description:
       '使用设备生物识别、安全密钥（例如 YubiKey）或其他可用方法注册您的 Passkey。',
     add_passkey: '添加 Passkey',
-    delete_confirmation_title: '移除 Passkey',
-    delete_confirmation_description: '确定要移除"{{name}}"吗？移除后您将无法使用此 Passkey 登录。',
+    delete_confirmation_title: '移除您的 Passkey',
+    delete_confirmation_description: '如果您移除此 Passkey，您将无法使用它进行验证。',
     rename_passkey: '重命名 Passkey',
     rename_description: '为此 Passkey 输入新名称。',
     name_this_passkey: '为此设备 Passkey 命名',

--- a/packages/phrases-experience/src/locales/zh-hk/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/account-center.ts
@@ -160,8 +160,8 @@ const account_center = {
     add_another_description:
       '使用設備生物識別、安全密鑰（例如 YubiKey）或其他可用方法註冊你的 Passkey。',
     add_passkey: '添加 Passkey',
-    delete_confirmation_title: '移除 Passkey',
-    delete_confirmation_description: '你確定要移除「{{name}}」嗎？你將無法再使用此 Passkey 登入。',
+    delete_confirmation_title: '移除你的 Passkey',
+    delete_confirmation_description: '如果你移除此 Passkey，你將無法使用它進行驗證。',
     rename_passkey: '重新命名 Passkey',
     rename_description: 'Enter a new name for this passkey.',
     name_this_passkey: 'Name this device passkey',

--- a/packages/phrases-experience/src/locales/zh-tw/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/account-center.ts
@@ -160,8 +160,8 @@ const account_center = {
     add_another_description:
       '使用設備生物識別、安全金鑰（例如 YubiKey）或其他可用方法註冊您的 Passkey。',
     add_passkey: '新增 Passkey',
-    delete_confirmation_title: '移除 Passkey',
-    delete_confirmation_description: '您確定要移除「{{name}}」嗎？您將無法再使用此 Passkey 登入。',
+    delete_confirmation_title: '移除您的 Passkey',
+    delete_confirmation_description: '如果您移除此 Passkey，您將無法使用它進行驗證。',
     rename_passkey: '重新命名 Passkey',
     rename_description: 'Enter a new name for this passkey.',
     name_this_passkey: 'Name this device passkey',


### PR DESCRIPTION
## Summary

- Add `danger` button type to the shared Button component with appropriate styling
- Add `confirmButtonType` prop to ConfirmModal for customizable button types
- Update passkey delete confirmation dialog to use danger button styling
- Simplify passkey delete confirmation copy (remove passkey name interpolation)

## Test plan

- [ ] Verify danger button renders correctly with proper colors on desktop and mobile
- [ ] Confirm passkey delete modal shows danger-styled button
- [ ] Test hover/focus/disabled states for danger button type