### PR TITLE
feat(core): add ACCESS_TOKEN_EXCHANGE_ENABLED env variable

### DIFF
--- a/packages/core/src/oidc/grants/token-exchange/account.ts
+++ b/packages/core/src/oidc/grants/token-exchange/account.ts
@@ -121,8 +121,10 @@ export const validateSubjectToken = async ({
       return validateImpersonationToken(findSubjectToken, subjectToken);
     }
 
-    // TODO: Remove dev feature guard when access token exchange is ready for production
-    if (EnvSet.values.isDevFeaturesEnabled) {
+    // Access token exchange is enabled when:
+    // 1. Dev features are enabled (for development/testing)
+    // 2. ACCESS_TOKEN_EXCHANGE_ENABLED env is set (for enterprise customers)
+    if (EnvSet.values.isDevFeaturesEnabled || EnvSet.values.isAccessTokenExchangeEnabled) {
       // First, try to find the token as an opaque access token
       const opaqueResult = await validateOpaqueAccessToken(subjectToken, AccessToken);
       if (opaqueResult) {

--- a/packages/shared/src/node/env/GlobalValues.ts
+++ b/packages/shared/src/node/env/GlobalValues.ts
@@ -100,6 +100,16 @@ export default class GlobalValues {
    */
   public readonly isMultipleCustomDomainsEnabled = yes(getEnv('MULTIPLE_CUSTOM_DOMAINS_ENABLED'));
 
+  /**
+   * Indicates whether this Logto instance supports access token exchange.
+   *
+   * **NOTE: Only available to enterprise customers running private instances that need this feature.**
+   *
+   * Controlled by the `ACCESS_TOKEN_EXCHANGE_ENABLED` environment variable. When enabled, the instance
+   * supports exchanging access tokens (opaque or JWT) for new tokens via the token exchange grant.
+   */
+  public readonly isAccessTokenExchangeEnabled = yes(getEnv('ACCESS_TOKEN_EXCHANGE_ENABLED'));
+
   // eslint-disable-next-line unicorn/consistent-function-scoping
   public readonly databaseUrl = tryThat(() => assertEnv('DB_URL'), throwErrorWithDsnMessage);
   public readonly developmentTenantId = getEnv('DEVELOPMENT_TENANT_ID');


### PR DESCRIPTION
## Summary

- Add `ACCESS_TOKEN_EXCHANGE_ENABLED` environment variable to allow enabling access token exchange feature without requiring `DEV_FEATURES_ENABLED`
- This provides a dedicated control for enterprise customers running private instances

## Changes

1. **GlobalValues.ts**: Added `isAccessTokenExchangeEnabled` property controlled by `ACCESS_TOKEN_EXCHANGE_ENABLED` env variable
2. **account.ts**: Updated condition to enable access token exchange when either `isDevFeaturesEnabled` OR `isAccessTokenExchangeEnabled` is true

## Usage

Enterprise customers can enable this feature by setting:
```bash
ACCESS_TOKEN_EXCHANGE_ENABLED=true
```

## Test plan

- [ ] Existing token exchange tests should pass
- [ ] Feature should work when `ACCESS_TOKEN_EXCHANGE_ENABLED=true` is set