### PR TITLE
chore: fix package.json exports condition order

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -11,9 +11,9 @@
   },
   "exports": {
     "./management": {
-      "default": "./lib/management.js",
       "types": "./lib/management.d.ts",
-      "import": "./lib/management.js"
+      "import": "./lib/management.js",
+      "default": "./lib/management.js"
     }
   },
   "files": [

--- a/packages/toolkit/connector-kit/package.json
+++ b/packages/toolkit/connector-kit/package.json
@@ -12,9 +12,9 @@
   "main": "./lib/index.js",
   "exports": {
     ".": {
-      "default": "./lib/index.js",
       "types": "./lib/index.d.ts",
-      "import": "./lib/index.js"
+      "import": "./lib/index.js",
+      "default": "./lib/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/toolkit/core-kit/package.json
+++ b/packages/toolkit/core-kit/package.json
@@ -12,15 +12,15 @@
   "main": "./lib/index.js",
   "exports": {
     ".": {
-      "default": "./lib/index.js",
       "types": "./lib/index.d.ts",
-      "import": "./lib/index.js"
+      "import": "./lib/index.js",
+      "default": "./lib/index.js"
     },
     "./declaration": "./declaration/index.ts",
     "./scss/*": "./scss/*.scss",
     "./custom-jwt": {
-      "node": "./lib/custom-jwt/index.js",
-      "types": "./lib/custom-jwt/index.d.ts"
+      "types": "./lib/custom-jwt/index.d.ts",
+      "node": "./lib/custom-jwt/index.js"
     }
   },
   "types": "./lib/index.d.ts",

--- a/packages/toolkit/language-kit/package.json
+++ b/packages/toolkit/language-kit/package.json
@@ -11,9 +11,9 @@
   "type": "module",
   "main": "./lib/index.js",
   "exports": {
-    "default": "./lib/index.js",
     "types": "./lib/index.d.ts",
-    "import": "./lib/index.js"
+    "import": "./lib/index.js",
+    "default": "./lib/index.js"
   },
   "types": "./lib/index.d.ts",
   "files": [


### PR DESCRIPTION
## Summary
- Fix the order of conditions in `exports` field of package.json files
- The `types` condition should come first for TypeScript resolution, followed by `import`, and `default` should be last as a fallback
- This fixes bundler warnings like: "The conditions 'types' and 'import' here will never be used as they come after 'default'"
<img width="839" height="170" alt="image" src="https://github.com/user-attachments/assets/4bf4ad84-f9d6-4ac0-848f-058e3d6fba01" />


Affected packages:
- `@logto/connector-kit`
- `@logto/language-kit`
- `@logto/core-kit`
- `@logto/api`

## Testing
N/A

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments