### PR TITLE
feat(connector): fetch user profile details via additional API calls

### DIFF
--- a/.changeset/odd-pans-battle.md
+++ b/.changeset/odd-pans-battle.md
@@ -1,0 +1,5 @@
+---
+"@logto/connector-wecom": minor
+---
+
+fetch user profile details via additional APIs

--- a/packages/connectors/connector-wecom/package.json
+++ b/packages/connectors/connector-wecom/package.json
@@ -5,6 +5,7 @@
   "author": "Dove<dove@feegr.cc> fork from Wechat Web connector",
   "dependencies": {
     "@logto/connector-kit": "workspace:^",
+    "@logto/shared": "workspace:^",
     "@silverhand/essentials": "^2.9.1",
     "got": "^14.0.0",
     "snakecase-keys": "^8.0.1",

--- a/packages/connectors/connector-wecom/src/constant.ts
+++ b/packages/connectors/connector-wecom/src/constant.ts
@@ -5,6 +5,9 @@ export const authorizationEndpointInside = 'https://open.weixin.qq.com/connect/o
 export const authorizationEndpointQrcode = 'https://open.work.weixin.qq.com/wwopen/sso/qrConnect';
 export const accessTokenEndpoint = 'https://qyapi.weixin.qq.com/cgi-bin/gettoken';
 export const userInfoEndpoint = 'https://qyapi.weixin.qq.com/cgi-bin/auth/getuserinfo';
+export const userDetailByUserTicketEndpoint =
+  'https://qyapi.weixin.qq.com/cgi-bin/auth/getuserdetail';
+export const userDetailByUserIdEndpoint = 'https://qyapi.weixin.qq.com/cgi-bin/user/get';
 export const scope = 'snsapi_userinfo';
 
 // See https://developer.work.weixin.qq.com/document/path/90313 to know more about WeCom response error code

--- a/packages/connectors/connector-wecom/src/index.test.ts
+++ b/packages/connectors/connector-wecom/src/index.test.ts
@@ -1,6 +1,8 @@
+import { conditional, trySafe } from '@silverhand/essentials';
 import nock from 'nock';
 
 import { ConnectorError, ConnectorErrorCodes } from '@logto/connector-kit';
+import { PhoneNumberParser } from '@logto/shared';
 
 import {
   accessTokenEndpoint,
@@ -215,8 +217,8 @@ describe('getUserInfo', () => {
     expect(socialUserInfo).toMatchObject({
       id: 'zhangsan',
       name: mockedUserDetailByUserIdResponse.name,
-      email: '',
-      phone: '',
+      email: undefined,
+      phone: undefined,
       rawData: mockedUserDetailByUserIdResponse,
     });
   });
@@ -258,7 +260,11 @@ describe('getUserInfo', () => {
       id: 'zhangsan',
       name: userDetail.name,
       email: userDetail.email,
-      phone: normalizePhoneNumebr(userDetail.mobile),
+      phone:
+        conditional(userDetail.mobile) &&
+        trySafe(
+          () => new PhoneNumberParser(normalizePhoneNumebr(userDetail.mobile)).internationalNumber
+        ),
       avatar: userDetail.avatar,
       rawData: userDetail,
     });

--- a/packages/connectors/connector-wecom/src/index.test.ts
+++ b/packages/connectors/connector-wecom/src/index.test.ts
@@ -12,7 +12,7 @@ import {
   userDetailByUserTicketEndpoint,
   userInfoEndpoint,
 } from './constant.js';
-import createConnector, { getAccessToken, normalizePhoneNumebr } from './index.js';
+import createConnector, { getAccessToken, normalizePhoneNumber } from './index.js';
 import {
   mockedConfig,
   mockedUserDetailByUserIdResponse,
@@ -137,16 +137,16 @@ describe('getAccessToken', () => {
 
 describe('normalizePhoneNumebr', () => {
   it('should normalize phone number', () => {
-    expect(normalizePhoneNumebr('12345678901')).toEqual('+8612345678901');
+    expect(normalizePhoneNumber('12345678901')).toEqual('+8612345678901');
   });
 
   it('should return empty string if phone number is not provided', () => {
     const mobile = undefined;
-    expect(normalizePhoneNumebr(mobile)).toEqual('');
+    expect(normalizePhoneNumber(mobile)).toEqual('');
   });
 
   it('should return phone number if it starts with +', () => {
-    expect(normalizePhoneNumebr('+12345678901')).toEqual('+12345678901');
+    expect(normalizePhoneNumber('+12345678901')).toEqual('+12345678901');
   });
 });
 
@@ -263,7 +263,7 @@ describe('getUserInfo', () => {
       phone:
         conditional(userDetail.mobile) &&
         trySafe(
-          () => new PhoneNumberParser(normalizePhoneNumebr(userDetail.mobile)).internationalNumber
+          () => new PhoneNumberParser(normalizePhoneNumber(userDetail.mobile)).internationalNumber
         ),
       avatar: userDetail.avatar,
       rawData: userDetail,

--- a/packages/connectors/connector-wecom/src/index.test.ts
+++ b/packages/connectors/connector-wecom/src/index.test.ts
@@ -135,14 +135,13 @@ describe('getAccessToken', () => {
   });
 });
 
-describe('normalizePhoneNumebr', () => {
+describe('normalizePhoneNumber', () => {
   it('should normalize phone number', () => {
     expect(normalizePhoneNumber('12345678901')).toEqual('+8612345678901');
   });
 
-  it('should return empty string if phone number is not provided', () => {
-    const mobile = undefined;
-    expect(normalizePhoneNumber(mobile)).toEqual('');
+  it('should normalize phone number without country code to +86 prefix', () => {
+    expect(normalizePhoneNumber('13800000000')).toEqual('+8613800000000');
   });
 
   it('should return phone number if it starts with +', () => {

--- a/packages/connectors/connector-wecom/src/index.test.ts
+++ b/packages/connectors/connector-wecom/src/index.test.ts
@@ -270,6 +270,82 @@ describe('getUserInfo', () => {
     });
   });
 
+  it('should fall back to userDetailByUserIdResult when userDetailByUserTicket request fails', async () => {
+    nock(userInfoEndpointUrl.origin)
+      .get(userInfoEndpointUrl.pathname)
+      .query(userInfoParams)
+      .reply(200, {
+        errcode: 0,
+        errmsg: 'ok',
+        userid: 'zhangsan',
+        user_ticket: 'user_ticket',
+      });
+
+    nock(userDetailByUserIdEndpointUrl.origin)
+      .get(userDetailByUserIdEndpointUrl.pathname)
+      .query(userDetailByUserIdParams)
+      .reply(200, mockedUserDetailByUserIdResponse);
+
+    nock(userDetailByUserTicketEndpointUrl.origin)
+      .post(userDetailByUserTicketEndpointUrl.pathname, { user_ticket: 'user_ticket' })
+      .query(userDetailByUserTicketParams)
+      .reply(200, { errcode: 40_001, errmsg: 'invalid credential' });
+
+    const connector = await createConnector({ getConfig });
+    const socialUserInfo = await connector.getUserInfo(
+      {
+        code: 'code',
+      },
+      vi.fn()
+    );
+
+    expect(socialUserInfo).toMatchObject({
+      id: 'zhangsan',
+      name: mockedUserDetailByUserIdResponse.name,
+      email: undefined,
+      phone: undefined,
+      rawData: mockedUserDetailByUserIdResponse,
+    });
+  });
+
+  it('should fall back to userDetailByUserIdResult when userDetailByUserTicket request throws network error', async () => {
+    nock(userInfoEndpointUrl.origin)
+      .get(userInfoEndpointUrl.pathname)
+      .query(userInfoParams)
+      .reply(200, {
+        errcode: 0,
+        errmsg: 'ok',
+        userid: 'zhangsan',
+        user_ticket: 'user_ticket',
+      });
+
+    nock(userDetailByUserIdEndpointUrl.origin)
+      .get(userDetailByUserIdEndpointUrl.pathname)
+      .query(userDetailByUserIdParams)
+      .reply(200, mockedUserDetailByUserIdResponse);
+
+    nock(userDetailByUserTicketEndpointUrl.origin)
+      .post(userDetailByUserTicketEndpointUrl.pathname, { user_ticket: 'user_ticket' })
+      .query(userDetailByUserTicketParams)
+      .replyWithError('network error');
+
+    const connector = await createConnector({ getConfig });
+    const socialUserInfo = await connector.getUserInfo(
+      {
+        code: 'code',
+      },
+      vi.fn()
+    );
+
+    expect(socialUserInfo).toMatchObject({
+      id: 'zhangsan',
+      name: mockedUserDetailByUserIdResponse.name,
+      email: undefined,
+      phone: undefined,
+      rawData: mockedUserDetailByUserIdResponse,
+    });
+  });
+
   it('throws General error if code not provided in input', async () => {
     const connector = await createConnector({ getConfig });
     await expect(connector.getUserInfo({}, vi.fn())).rejects.toStrictEqual(

--- a/packages/connectors/connector-wecom/src/index.ts
+++ b/packages/connectors/connector-wecom/src/index.ts
@@ -3,7 +3,7 @@
  * https://developers.weixin.qq.com/doc/oplatform/Website_App/WeChat_Login/Wechat_Login.html
  */
 
-import { assert } from '@silverhand/essentials';
+import { assert, conditional, trySafe } from '@silverhand/essentials';
 import { got, HTTPError } from 'got';
 
 import type {
@@ -21,6 +21,7 @@ import {
   parseJson,
   parseJsonObject,
 } from '@logto/connector-kit';
+import { PhoneNumberParser } from '@logto/shared';
 
 import {
   authorizationEndpointInside,
@@ -196,7 +197,11 @@ const getUserInfo =
         id,
         avatar: userDetail.avatar ?? '',
         email: userDetail.email ?? '',
-        phone: normalizePhoneNumebr(userDetail.mobile),
+        phone:
+          conditional(userDetail.mobile) &&
+          trySafe(
+            () => new PhoneNumberParser(normalizePhoneNumebr(userDetail.mobile)).internationalNumber
+          ),
         name: userDetail.name ?? id,
         rawData: parseJsonObject(JSON.stringify({ ...rawData, ...userDetail })),
       };

--- a/packages/connectors/connector-wecom/src/index.ts
+++ b/packages/connectors/connector-wecom/src/index.ts
@@ -21,7 +21,7 @@ import {
   parseJson,
   parseJsonObject,
 } from '@logto/connector-kit';
-import { PhoneNumberParser } from '@logto/shared';
+import { parsePhoneNumber, PhoneNumberParser } from '@logto/shared';
 
 import {
   authorizationEndpointInside,
@@ -99,7 +99,7 @@ export const getAccessToken = async (config: WecomConfig): Promise<{ accessToken
   return { accessToken };
 };
 
-export const normalizePhoneNumebr = (mobile?: string) => {
+export const normalizePhoneNumber = (mobile?: string) => {
   if (!mobile) {
     return '';
   }
@@ -201,7 +201,9 @@ const getUserInfo =
         phone:
           conditional(userDetail.mobile) &&
           trySafe(
-            () => new PhoneNumberParser(normalizePhoneNumebr(userDetail.mobile)).internationalNumber
+            () =>
+              new PhoneNumberParser(parsePhoneNumber(normalizePhoneNumber(userDetail.mobile)))
+                .internationalNumber
           ),
         rawData: parseJsonObject(JSON.stringify({ ...rawData, ...userDetail })),
       };

--- a/packages/connectors/connector-wecom/src/index.ts
+++ b/packages/connectors/connector-wecom/src/index.ts
@@ -19,6 +19,7 @@ import {
   validateConfig,
   ConnectorType,
   parseJson,
+  parseJsonObject,
 } from '@logto/connector-kit';
 
 import {
@@ -31,9 +32,12 @@ import {
   defaultTimeout,
   invalidAccessTokenErrcode,
   invalidAuthCodeErrcode,
+  userDetailByUserIdEndpoint,
+  userDetailByUserTicketEndpoint,
 } from './constant.js';
 import type {
   GetAccessTokenErrorHandler,
+  UserDetailResponse,
   UserInfoResponseMessageParser,
   WecomConfig,
 } from './types.js';
@@ -42,6 +46,7 @@ import {
   accessTokenResponseGuard,
   userInfoResponseGuard,
   authResponseGuard,
+  userDetailResponseGuard,
 } from './types.js';
 
 const getAuthorizationUri =
@@ -93,6 +98,67 @@ export const getAccessToken = async (config: WecomConfig): Promise<{ accessToken
   return { accessToken };
 };
 
+export const normalizePhoneNumebr = (mobile?: string) => {
+  if (!mobile) {
+    return '';
+  }
+  if (mobile.startsWith('+')) {
+    return mobile;
+  }
+  return `+86${mobile}`;
+};
+
+const getUserDetail = async ({
+  accessToken,
+  userId,
+  userTicket,
+}: {
+  accessToken: string;
+  userId: string;
+  userTicket?: string;
+}): Promise<UserDetailResponse> => {
+  const userDetailByUserIdResponse = await got.get(userDetailByUserIdEndpoint, {
+    searchParams: { access_token: accessToken, userid: userId },
+    timeout: { request: defaultTimeout },
+  });
+  const userDetailByUserIdResult = userDetailResponseGuard.safeParse(
+    parseJson(userDetailByUserIdResponse.body)
+  );
+
+  if (!userDetailByUserIdResult.success) {
+    throw new ConnectorError(ConnectorErrorCodes.InvalidResponse, userDetailByUserIdResult.error);
+  }
+
+  errorResponseHandler(userDetailByUserIdResult.data);
+
+  if (userTicket) {
+    const userDetailByUserTicketResponse = await got.post(userDetailByUserTicketEndpoint, {
+      searchParams: { access_token: accessToken },
+      json: { user_ticket: userTicket },
+      timeout: { request: defaultTimeout },
+    });
+    const userDetailByUserTicketResult = userDetailResponseGuard.safeParse(
+      parseJson(userDetailByUserTicketResponse.body)
+    );
+
+    if (!userDetailByUserTicketResult.success) {
+      throw new ConnectorError(
+        ConnectorErrorCodes.InvalidResponse,
+        userDetailByUserTicketResult.error
+      );
+    }
+
+    errorResponseHandler(userDetailByUserTicketResult.data);
+
+    return {
+      ...userDetailByUserIdResult.data,
+      ...userDetailByUserTicketResult.data,
+    };
+  }
+
+  return userDetailByUserIdResult.data;
+};
+
 const getUserInfo =
   (getConfig: GetConnectorConfig): GetUserInfo =>
   async (data) => {
@@ -106,7 +172,7 @@ const getUserInfo =
         searchParams: { access_token: accessToken, code },
         timeout: { request: defaultTimeout },
       });
-      const rawData = parseJson(httpResponse.body);
+      const rawData = parseJsonObject(httpResponse.body);
       const result = userInfoResponseGuard.safeParse(rawData);
 
       if (!result.success) {
@@ -117,18 +183,22 @@ const getUserInfo =
       // 'errmsg' and 'errcode' turn to non-empty values or empty values at the same time. Hence, if 'errmsg' is non-empty then 'errcode' should be non-empty.
       errorResponseHandler(result.data);
       //
-      const { userid, openid } = result.data;
+      const { userid, openid, user_ticket } = result.data;
       const id = userid ?? openid;
 
       if (!id) {
         throw new Error('Both userid and openid are undefined or null.');
       }
 
+      const userDetail = await getUserDetail({ accessToken, userId: id, userTicket: user_ticket });
+
       return {
         id,
-        avatar: '',
-        name: id,
-        rawData,
+        avatar: userDetail.avatar ?? '',
+        email: userDetail.email ?? '',
+        phone: normalizePhoneNumebr(userDetail.mobile),
+        name: userDetail.name ?? id,
+        rawData: parseJsonObject(JSON.stringify({ ...rawData, ...userDetail })),
       };
     } catch (error: unknown) {
       return getUserInfoErrorHandler(error);

--- a/packages/connectors/connector-wecom/src/index.ts
+++ b/packages/connectors/connector-wecom/src/index.ts
@@ -195,14 +195,14 @@ const getUserInfo =
 
       return {
         id,
-        avatar: userDetail.avatar ?? '',
-        email: userDetail.email ?? '',
+        avatar: userDetail.avatar,
+        email: userDetail.email,
+        name: userDetail.name,
         phone:
           conditional(userDetail.mobile) &&
           trySafe(
             () => new PhoneNumberParser(normalizePhoneNumebr(userDetail.mobile)).internationalNumber
           ),
-        name: userDetail.name ?? id,
         rawData: parseJsonObject(JSON.stringify({ ...rawData, ...userDetail })),
       };
     } catch (error: unknown) {

--- a/packages/connectors/connector-wecom/src/index.ts
+++ b/packages/connectors/connector-wecom/src/index.ts
@@ -133,28 +133,28 @@ const getUserDetail = async ({
   errorResponseHandler(userDetailByUserIdResult.data);
 
   if (userTicket) {
-    const userDetailByUserTicketResponse = await got.post(userDetailByUserTicketEndpoint, {
-      searchParams: { access_token: accessToken },
-      json: { user_ticket: userTicket },
-      timeout: { request: defaultTimeout },
-    });
-    const userDetailByUserTicketResult = userDetailResponseGuard.safeParse(
-      parseJson(userDetailByUserTicketResponse.body)
-    );
-
-    if (!userDetailByUserTicketResult.success) {
-      throw new ConnectorError(
-        ConnectorErrorCodes.InvalidResponse,
-        userDetailByUserTicketResult.error
+    const userDetailByUserTicketResult = await trySafe(async () => {
+      const userDetailByUserTicketResponse = await got.post(userDetailByUserTicketEndpoint, {
+        searchParams: { access_token: accessToken },
+        json: { user_ticket: userTicket },
+        timeout: { request: defaultTimeout },
+      });
+      const result = userDetailResponseGuard.safeParse(
+        parseJson(userDetailByUserTicketResponse.body)
       );
+      if (!result.success) {
+        throw new ConnectorError(ConnectorErrorCodes.InvalidResponse, result.error);
+      }
+      errorResponseHandler(result.data);
+      return result.data;
+    });
+
+    if (userDetailByUserTicketResult) {
+      return {
+        ...userDetailByUserIdResult.data,
+        ...userDetailByUserTicketResult,
+      };
     }
-
-    errorResponseHandler(userDetailByUserTicketResult.data);
-
-    return {
-      ...userDetailByUserIdResult.data,
-      ...userDetailByUserTicketResult.data,
-    };
   }
 
   return userDetailByUserIdResult.data;

--- a/packages/connectors/connector-wecom/src/index.ts
+++ b/packages/connectors/connector-wecom/src/index.ts
@@ -3,7 +3,7 @@
  * https://developers.weixin.qq.com/doc/oplatform/Website_App/WeChat_Login/Wechat_Login.html
  */
 
-import { assert, conditional, trySafe } from '@silverhand/essentials';
+import { assert, trySafe } from '@silverhand/essentials';
 import { got, HTTPError } from 'got';
 
 import type {
@@ -21,7 +21,7 @@ import {
   parseJson,
   parseJsonObject,
 } from '@logto/connector-kit';
-import { parsePhoneNumber, PhoneNumberParser } from '@logto/shared';
+import { PhoneNumberParser } from '@logto/shared';
 
 import {
   authorizationEndpointInside,
@@ -99,10 +99,7 @@ export const getAccessToken = async (config: WecomConfig): Promise<{ accessToken
   return { accessToken };
 };
 
-export const normalizePhoneNumber = (mobile?: string) => {
-  if (!mobile) {
-    return '';
-  }
+export const normalizePhoneNumber = (mobile: string): string => {
   if (mobile.startsWith('+')) {
     return mobile;
   }
@@ -191,21 +188,20 @@ const getUserInfo =
         throw new Error('Both userid and openid are undefined or null.');
       }
 
-      const userDetail = await getUserDetail({ accessToken, userId: id, userTicket: user_ticket });
+      const userDetail = await trySafe(
+        getUserDetail({ accessToken, userId: id, userTicket: user_ticket })
+      );
+      const mobile = userDetail?.mobile;
 
       return {
         id,
-        avatar: userDetail.avatar,
-        email: userDetail.email,
-        name: userDetail.name,
-        phone:
-          conditional(userDetail.mobile) &&
-          trySafe(
-            () =>
-              new PhoneNumberParser(parsePhoneNumber(normalizePhoneNumber(userDetail.mobile)))
-                .internationalNumber
-          ),
-        rawData: parseJsonObject(JSON.stringify({ ...rawData, ...userDetail })),
+        avatar: userDetail?.avatar,
+        email: userDetail?.email,
+        name: userDetail?.name ?? id,
+        phone: mobile
+          ? trySafe(() => new PhoneNumberParser(normalizePhoneNumber(mobile)).internationalNumber)
+          : undefined,
+        rawData: { ...rawData, ...userDetail },
       };
     } catch (error: unknown) {
       return getUserInfoErrorHandler(error);

--- a/packages/connectors/connector-wecom/src/mock.ts
+++ b/packages/connectors/connector-wecom/src/mock.ts
@@ -4,3 +4,38 @@ export const mockedConfig = {
   agentId: '<agent-id>',
   access_token: 'access_token',
 };
+
+export const mockedUserDetailByUserIdResponse = {
+  errcode: 0,
+  errmsg: 'ok',
+  userid: 'zhangsan',
+  name: '张三',
+  alias: 'jackzhang',
+  department: [1, 2],
+  main_department: 1,
+  telephone: '4001234567',
+  is_leader_in_dept: [1, 0],
+  direct_leader: ['lisi'],
+  order: [1],
+  position: '后台工程师',
+  external_position: '产品经理',
+  external_profile: {
+    foo: 'bar',
+  },
+  extattr: {
+    foo: 'bar',
+  },
+};
+
+export const mockedUserDetailByUserTicketResponse = {
+  errcode: 0,
+  errmsg: 'ok',
+  userid: 'zhangsan',
+  gender: '1',
+  avatar: 'http://shp.qpic.cn/bizmp/xxxxxxxxxxx/0',
+  qr_code: 'https://open.work.weixin.qq.com/wwopen/userQRCode?vcode=vcfc13b01dfs78e981c',
+  mobile: '13800000000',
+  email: 'zhangsan@gzdev.com',
+  biz_mail: 'zhangsan@qyycs2.wecom.work',
+  address: '广州市海珠区新港中路',
+};

--- a/packages/connectors/connector-wecom/src/types.ts
+++ b/packages/connectors/connector-wecom/src/types.ts
@@ -33,32 +33,34 @@ export type UserInfoResponse = z.infer<typeof userInfoResponseGuard>;
 
 export type UserInfoResponseMessageParser = (userInfo: Partial<UserInfoResponse>) => void;
 
-export const userDetailResponseGuard = z.object({
-  errcode: z.number().optional(),
-  errmsg: z.string().optional(),
-  userid: z.string().optional(),
-  name: z.string().optional(),
-  mobile: z.string().optional(),
-  email: z.string().optional(),
-  biz_mail: z.string().optional(),
-  alias: z.string().optional(),
-  qr_code: z.string().optional(),
-  telephone: z.string().optional(),
-  department: z.array(z.number()).optional(),
-  main_department: z.number().optional(),
-  order: z.array(z.number()).optional(),
-  position: z.string().optional(),
-  external_position: z.string().optional(),
-  external_profile: z.record(z.string(), z.unknown()).optional(),
-  extattr: z.record(z.string(), z.unknown()).optional(),
-  avatar: z.string().optional(),
-  thumb_avatar: z.string().optional(),
-  gender: z.string().optional(),
-  status: z.number().optional(),
-  is_leader_in_dept: z.array(z.number()).optional(),
-  direct_leader: z.array(z.string()).optional(),
-  address: z.string().optional(),
-});
+export const userDetailResponseGuard = z
+  .object({
+    errcode: z.number(),
+    errmsg: z.string(),
+    userid: z.string(),
+    name: z.string(),
+    mobile: z.string(),
+    email: z.string(),
+    biz_mail: z.string(),
+    alias: z.string(),
+    qr_code: z.string(),
+    telephone: z.string(),
+    department: z.array(z.number()),
+    main_department: z.number(),
+    order: z.array(z.number()),
+    position: z.string(),
+    external_position: z.string(),
+    external_profile: z.record(z.string(), z.unknown()),
+    extattr: z.record(z.string(), z.unknown()),
+    avatar: z.string(),
+    thumb_avatar: z.string(),
+    gender: z.string(),
+    status: z.number(),
+    is_leader_in_dept: z.array(z.number()),
+    direct_leader: z.array(z.string()),
+    address: z.string(),
+  })
+  .partial();
 
 export type UserDetailResponse = z.infer<typeof userDetailResponseGuard>;
 

--- a/packages/connectors/connector-wecom/src/types.ts
+++ b/packages/connectors/connector-wecom/src/types.ts
@@ -33,4 +33,35 @@ export type UserInfoResponse = z.infer<typeof userInfoResponseGuard>;
 
 export type UserInfoResponseMessageParser = (userInfo: Partial<UserInfoResponse>) => void;
 
+export const userDetailResponseGuard = z.object({
+  errcode: z.number().optional(),
+  errmsg: z.string().optional(),
+  userid: z.string().optional(),
+  name: z.string().optional(),
+  mobile: z.string().optional(),
+  email: z.string().optional(),
+  biz_mail: z.string().optional(),
+  alias: z.string().optional(),
+  qr_code: z.string().optional(),
+  telephone: z.string().optional(),
+  department: z.array(z.number()).optional(),
+  main_department: z.number().optional(),
+  order: z.array(z.number()).optional(),
+  position: z.string().optional(),
+  external_position: z.string().optional(),
+  external_profile: z.record(z.string(), z.unknown()).optional(),
+  extattr: z.record(z.string(), z.unknown()).optional(),
+  avatar: z.string().optional(),
+  thumb_avatar: z.string().optional(),
+  gender: z.string().optional(),
+  status: z.number().optional(),
+  is_leader_in_dept: z.array(z.number()).optional(),
+  direct_leader: z.array(z.string()).optional(),
+  address: z.string().optional(),
+});
+
+export type UserDetailResponse = z.infer<typeof userDetailResponseGuard>;
+
+export type UserDetailResponseMessageParser = (userDetail: Partial<UserDetailResponse>) => void;
+
 export const authResponseGuard = z.object({ code: z.string() });

--- a/packages/connectors/connector-wecom/src/types.ts
+++ b/packages/connectors/connector-wecom/src/types.ts
@@ -50,8 +50,8 @@ export const userDetailResponseGuard = z
     order: z.array(z.number()),
     position: z.string(),
     external_position: z.string(),
-    external_profile: z.record(z.string(), z.unknown()),
-    extattr: z.record(z.string(), z.unknown()),
+    external_profile: z.record(z.string(), z.any()),
+    extattr: z.record(z.string(), z.any()),
     avatar: z.string(),
     thumb_avatar: z.string(),
     gender: z.string(),
@@ -63,7 +63,5 @@ export const userDetailResponseGuard = z
   .partial();
 
 export type UserDetailResponse = z.infer<typeof userDetailResponseGuard>;
-
-export type UserDetailResponseMessageParser = (userDetail: Partial<UserDetailResponse>) => void;
 
 export const authResponseGuard = z.object({ code: z.string() });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3156,6 +3156,9 @@ importers:
       '@logto/connector-kit':
         specifier: workspace:^
         version: link:../../toolkit/connector-kit
+      '@logto/shared':
+        specifier: workspace:^
+        version: link:../../shared
       '@silverhand/essentials':
         specifier: ^2.9.1
         version: 2.9.2
@@ -7175,56 +7178,67 @@ packages:
     resolution: {integrity: sha512-ehSKrewwsESPt1TgSE/na9nIhWCosfGSFqv7vwEtjyAqZcvbGIg4JAcV7ZEh2tfj/IlfBeZjgOXm35iOOjadcg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.40.1':
     resolution: {integrity: sha512-m39iO/aaurh5FVIu/F4/Zsl8xppd76S4qoID8E+dSRQvTyZTOI2gVk3T4oqzfq1PtcvOfAVlwLMK3KRQMaR8lg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.40.1':
     resolution: {integrity: sha512-Y+GHnGaku4aVLSgrT0uWe2o2Rq8te9hi+MwqGF9r9ORgXhmHK5Q71N757u0F8yU1OIwUIFy6YiJtKjtyktk5hg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.40.1':
     resolution: {integrity: sha512-jEwjn3jCA+tQGswK3aEWcD09/7M5wGwc6+flhva7dsQNRZZTe30vkalgIzV4tjkopsTS9Jd7Y1Bsj6a4lzz8gQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.40.1':
     resolution: {integrity: sha512-ySyWikVhNzv+BV/IDCsrraOAZ3UaC8SZB67FZlqVwXwnFhPihOso9rPOxzZbjp81suB1O2Topw+6Ug3JNegejQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.40.1':
     resolution: {integrity: sha512-BvvA64QxZlh7WZWqDPPdt0GH4bznuL6uOO1pmgPnnv86rpUpc8ZxgZwcEgXvo02GRIZX1hQ0j0pAnhwkhwPqWg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.40.1':
     resolution: {integrity: sha512-EQSP+8+1VuSulm9RKSMKitTav89fKbHymTf25n5+Yr6gAPZxYWpj3DzAsQqoaHAk9YX2lwEyAf9S4W8F4l3VBQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.40.1':
     resolution: {integrity: sha512-n/vQ4xRZXKuIpqukkMXZt9RWdl+2zgGNx7Uda8NtmLJ06NL8jiHxUawbwC+hdSq1rrw/9CghCpEONor+l1e2gA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.40.1':
     resolution: {integrity: sha512-h8d28xzYb98fMQKUz0w2fMc1XuGzLLjdyxVIbhbil4ELfk5/orZlSTpF/xdI9C8K0I8lCkq+1En2RJsawZekkg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.40.1':
     resolution: {integrity: sha512-XiK5z70PEFEFqcNj3/zRSz/qX4bp4QIraTy9QjwJAb/Z8GM7kVUsD0Uk8maIPeTyPCP03ChdI+VVmJriKYbRHQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.40.1':
     resolution: {integrity: sha512-2BRORitq5rQ4Da9blVovzNCMaUlyKrzMSvkVR0D4qPuOy/+pMCrh1d7o01RATwVy+6Fa1WBw+da7QPeLWU/1mQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.40.1':
     resolution: {integrity: sha512-b2bcNm9Kbde03H+q+Jjw9tSfhYkzrDUf2d5MAd1bOJuVplXvFhWz7tRtWvD8/ORZi7qSCy0idW6tf2HgxSXQSg==}
@@ -7613,24 +7627,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.3.52':
     resolution: {integrity: sha512-GCxNjTAborAmv4VV1AMZLyejHLGgIzu13tvLUFqybtU4jFxVbE2ZK4ZnPCfDlWN+eBwyRWk1oNFR2hH+66vaUQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.3.52':
     resolution: {integrity: sha512-mrvDBSkLI3Mza2qcu3uzB5JGwMBYDb1++UQ1VB0RXf2AR21/cCper4P44IpfdeqFz9XyXq18Sh3gblICUCGvig==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.3.52':
     resolution: {integrity: sha512-r9RIvKUQv7yBkpXz+QxPAucdoj8ymBlgIm5rLE0b5VmU7dlKBnpAmRBYaITdH6IXhF0pwuG+FHAd5elBcrkIwA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.3.52':
     resolution: {integrity: sha512-YRtEr7tDo0Wes3M2ZhigF4erUjWBXeFP+O+iz6ELBBmPG7B7m/lrA21eiW9/90YGnzi0iNo46shK6PfXuPhP+Q==}
@@ -11810,24 +11828,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.25.1:
     resolution: {integrity: sha512-IhxVFJoTW8wq6yLvxdPvyHv4NjzcpN1B7gjxrY3uaykQNXPHNIpChLB52+wfH+yS58zm1PL4LemUp8u9Cfp6Bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.25.1:
     resolution: {integrity: sha512-RXIaru79KrREPEd6WLXfKfIp4QzoppZvD3x7vuTKkDA64PwTzKJ2jaC43RZHRt8BmyIkRRlmywNhTRMbmkPYpA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.25.1:
     resolution: {integrity: sha512-TdcNqFsAENEEFr8fJWg0Y4fZ/nwuqTRsIr7W7t2wmDUlA8eSXVepeeONYcb+gtTj1RaXn/WgNLB45SFkz+XBZA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-x64-msvc@1.25.1:
     resolution: {integrity: sha512-9KZZkmmy9oGDSrnyHuxP6iMhbsgChUiu/NSgOx+U1I/wTngBStDf2i2aGRCHvFqj19HqqBEI4WuGVQBa2V6e0A==}


### PR DESCRIPTION
closes #8190
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

- Add getUserDetail function to fetch user's avatar, email, phone and name
- Call user.get API with userid for basic profile information
- Call auth/getuserdetail API with user_ticket for sensitive data when available
- Normalize phone numbers with +86 country code prefix
- Merge detailed user data into getUserInfo response and rawData field

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

I'm test it in my local environment.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
