### PR TITLE
feat(schemas): add passkey sign-in support and index for MFA verifications

### DIFF
--- a/packages/core/src/__mocks__/sign-in-experience.ts
+++ b/packages/core/src/__mocks__/sign-in-experience.ts
@@ -108,4 +108,9 @@ export const mockSignInExperience: SignInExperience = {
   sentinelPolicy: {},
   emailBlocklistPolicy: {},
   forgotPasswordMethods: null,
+  passkeySignIn: {
+    enabled: false,
+    showPasskeyButton: false,
+    allowAutofill: false,
+  },
 };

--- a/packages/core/src/queries/sign-in-experience.test.ts
+++ b/packages/core/src/queries/sign-in-experience.test.ts
@@ -40,12 +40,13 @@ describe('sign-in-experience query', () => {
     sentinelPolicy: JSON.stringify(mockSignInExperience.sentinelPolicy),
     emailBlocklistPolicy: JSON.stringify(mockSignInExperience.emailBlocklistPolicy),
     forgotPasswordMethods: JSON.stringify(mockSignInExperience.forgotPasswordMethods),
+    passkeySignIn: JSON.stringify(mockSignInExperience.passkeySignIn),
   };
 
   it('findDefaultSignInExperience', async () => {
     /* eslint-disable sql/no-unsafe-query */
     const expectSql = `
-      select "tenant_id", "id", "color", "branding", "hide_logto_branding", "language_info", "terms_of_use_url", "privacy_policy_url", "agree_to_terms_policy", "sign_in", "sign_up", "social_sign_in", "social_sign_in_connector_targets", "sign_in_mode", "custom_css", "custom_content", "custom_ui_assets", "password_policy", "mfa", "single_sign_on_enabled", "support_email", "support_website_url", "unknown_session_redirect_url", "captcha_policy", "sentinel_policy", "email_blocklist_policy", "forgot_password_methods"
+      select "tenant_id", "id", "color", "branding", "hide_logto_branding", "language_info", "terms_of_use_url", "privacy_policy_url", "agree_to_terms_policy", "sign_in", "sign_up", "social_sign_in", "social_sign_in_connector_targets", "sign_in_mode", "custom_css", "custom_content", "custom_ui_assets", "password_policy", "mfa", "single_sign_on_enabled", "support_email", "support_website_url", "unknown_session_redirect_url", "captcha_policy", "sentinel_policy", "email_blocklist_policy", "forgot_password_methods", "passkey_sign_in"
       from "sign_in_experiences"
       where "id"=$1
     `;

--- a/packages/experience/src/__mocks__/logto.tsx
+++ b/packages/experience/src/__mocks__/logto.tsx
@@ -122,6 +122,7 @@ export const mockSignInExperience: SignInExperience = {
   emailBlocklistPolicy: {},
   forgotPasswordMethods: [],
   hideLogtoBranding: false,
+  passkeySignIn: {},
 };
 
 export const mockSignInExperienceSettings: SignInExperienceResponse = {
@@ -164,6 +165,7 @@ export const mockSignInExperienceSettings: SignInExperienceResponse = {
   captchaPolicy: {},
   sentinelPolicy: {},
   emailBlocklistPolicy: {},
+  passkeySignIn: {},
 };
 
 const usernameSettings = {

--- a/packages/schemas/alterations/next-1767859553-passkey-sign-in.ts
+++ b/packages/schemas/alterations/next-1767859553-passkey-sign-in.ts
@@ -1,0 +1,21 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      alter table sign_in_experiences
+        add column passkey_sign_in jsonb /* @use PasskeySignIn */ not null default '{}'::jsonb;
+      create index users_mfa_verifications_gin on users using gin (mfa_verifications jsonb_path_ops);
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      alter table sign_in_experiences drop column passkey_sign_in;
+      drop index users_mfa_verifications_gin;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/foundations/jsonb-types/sign-in-experience.ts
+++ b/packages/schemas/src/foundations/jsonb-types/sign-in-experience.ts
@@ -289,3 +289,17 @@ export enum ForgotPasswordMethod {
 export const forgotPasswordMethodsGuard = z.nativeEnum(ForgotPasswordMethod).array();
 
 export type ForgotPasswordMethods = z.infer<typeof forgotPasswordMethodsGuard>;
+
+export type PasskeySignIn = {
+  enabled?: boolean;
+  showPasskeyButton?: boolean;
+  allowAutofill?: boolean;
+};
+
+export const passkeySignInGuard = z
+  .object({
+    enabled: z.boolean(),
+    showPasskeyButton: z.boolean(),
+    allowAutofill: z.boolean(),
+  })
+  .partial() satisfies ToZodObject<PasskeySignIn>;

--- a/packages/schemas/tables/sign_in_experiences.sql
+++ b/packages/schemas/tables/sign_in_experiences.sql
@@ -31,5 +31,6 @@ create table sign_in_experiences (
   sentinel_policy jsonb /* @use SentinelPolicy */ not null default '{}'::jsonb,
   email_blocklist_policy jsonb /* @use EmailBlocklistPolicy */ not null default '{}'::jsonb,
   forgot_password_methods jsonb /* @use ForgotPasswordMethods */ default '[]'::jsonb,
+  passkey_sign_in jsonb /* @use PasskeySignIn */ not null default '{}'::jsonb,
   primary key (tenant_id, id)
 );

--- a/packages/schemas/tables/users.sql
+++ b/packages/schemas/tables/users.sql
@@ -41,6 +41,9 @@ create unique index users__id
 create index users__name
   on users (tenant_id, name);
 
+create index users_mfa_verifications_gin
+  on users using gin (mfa_verifications jsonb_path_ops);
+
 create trigger set_updated_at
   before update on users
   for each row


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- Add `passkey_sign-in` column (JSONB) in sign_in_experiences table
- Add a GIN index to the `mfa_verifications` JSONB column in users table, experienmenting a better (supposedly) query performance

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally ran alteration script. Succeeded.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
