### PR TITLE
fix(core): correct RequestError interpolation for entity.not_exists

### DIFF
--- a/packages/core/src/libraries/jwt-customizer.ts
+++ b/packages/core/src/libraries/jwt-customizer.ts
@@ -214,7 +214,7 @@ export class JwtCustomizerLibrary {
       this.logtoConfigs.getJwtCustomizers(consoleLog),
     ]);
 
-    assert(jwtCustomizers[key], new RequestError({ code: 'entity.not_exists', key }));
+    assert(jwtCustomizers[key], new RequestError({ code: 'entity.not_exists', name: key }));
 
     // Undeploy the worker directly if the only JWT customizer is being deleted.
     if (Object.entries(jwtCustomizers).length === 1) {

--- a/packages/core/src/routes/applications/application.ts
+++ b/packages/core/src/routes/applications/application.ts
@@ -349,7 +349,7 @@ export default function applicationRoutes<T extends ManagementApiRouter>(
           new RequestError({
             code: 'entity.not_exists',
             status: 500,
-            data: { name: InternalRole.Admin },
+            name: InternalRole.Admin,
           })
         );
 


### PR DESCRIPTION
## Summary
Fixed incorrect `RequestError` usage where i18n interpolation variables were not properly passed, causing error messages like `The {{name}} does not exist.` instead of the actual entity name.

The `RequestError` constructor expects interpolation variables (like `name`) to be passed directly in the input object, not nested inside a `data` property. The `data` property is for additional error context, not for i18n interpolation.

Changes:
- `application.ts`: Changed `data: { name: InternalRole.Admin }` to `name: InternalRole.Admin`
- `jwt-customizer.ts`: Changed `key` to `name: key`

## Testing
N/A

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments