### PR TITLE
feat(api): add createManagementApiClient for custom authentication

### DIFF
--- a/.changeset/shy-tips-refuse.md
+++ b/.changeset/shy-tips-refuse.md
@@ -1,0 +1,7 @@
+---
+"@logto/api": minor
+---
+
+add `createApiClient` function for custom token authentication
+
+This new function allows you to create a type-safe API client with your own token retrieval logic, useful for scenarios like custom authentication flows.

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -7,7 +7,7 @@ const config: UserConfig = {
   extends: ['@commitlint/config-conventional'],
   rules: {
     'type-enum': [2, 'always', [...conventional.rules['type-enum'][2], 'api', 'release']],
-    'scope-enum': [2, 'always', ['connector', 'console', 'core', 'demo-app', 'test', 'phrases', 'schemas', 'shared', 'experience', 'experience-legacy', 'deps', 'deps-dev', 'cli', 'toolkit', 'cloud', 'app-insights', 'elements', 'translate', 'tunnel', 'account-elements', 'account']],
+    'scope-enum': [2, 'always', ['connector', 'console', 'core', 'demo-app', 'test', 'phrases', 'schemas', 'shared', 'experience', 'experience-legacy', 'deps', 'deps-dev', 'cli', 'toolkit', 'cloud', 'app-insights', 'elements', 'translate', 'tunnel', 'account-elements', 'account', 'api']],
     // Slightly increase the tolerance to allow the appending PR number
     ...(isCi && { 'header-max-length': [2, 'always', 110] }),
     'body-max-line-length': [2, 'always', 110],

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -51,6 +51,27 @@ const { apiClient } = createManagementApi('default', {
 });
 ```
 
+#### Custom authentication
+
+For advanced use cases where you need full control over the authentication logic, use `createApiClient`:
+
+```ts
+import { createApiClient } from '@logto/api/management';
+
+const client = createApiClient({
+  baseUrl: 'https://your-logto-instance.com',
+  getToken: async () => {
+    // Your custom token retrieval logic
+    return getYourToken();
+  },
+});
+
+// Type-safe API calls
+const response = await client.GET('/api/applications/{id}', {
+  params: { path: { id: 'your-app-id' } },
+});
+```
+
 ### API documentation
 
 For detailed API documentation, refer to the [Logto Management API documentation](https://openapi.logto.io/).


### PR DESCRIPTION
## Summary

Add `createApiClient` function for custom token authentication scenarios.

- **`createApiClient`** (new): Custom token authentication, returns `Client<paths>` directly
- **`createManagementApi`** (refactored): Now internally uses `createApiClient`, reducing code duplication

**Why this change?**

The existing `createManagementApi` is designed for M2M authentication. However, some use cases (like MCP Server) require custom token sources (e.g., organization tokens) while still benefiting from:
- Type-safe API calls via OpenAPI-generated types
- Built-in middleware logic (skipping auth for `.well-known` endpoints)

By extracting `createApiClient` as the base function, `createManagementApi` can reuse it internally, keeping middleware logic in one place.

## Testing

unit tests

## Checklist

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments