### PR TITLE
Revert "release(api): release @logto/api v1.36.0"

### DIFF
--- a/.changeset/shy-tips-refuse.md
+++ b/.changeset/shy-tips-refuse.md
@@ -1,0 +1,7 @@
+---
+"@logto/api": minor
+---
+
+add `createApiClient` function for custom token authentication
+
+This new function allows you to create a type-safe API client with your own token retrieval logic, useful for scenarios like custom authentication flows.

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @logto/api
 
-## 1.36.0
-
-### Minor Changes
-
-- add `createApiClient` function for custom token authentication
-
-  This new function allows you to create a type-safe API client with your own token retrieval logic, useful for scenarios like custom authentication flows.
-
 ## 1.35.0
 
 ## 1.34.0

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logto/api",
-  "version": "1.36.0",
+  "version": "1.35.0",
   "description": "Logto API types and clients.",
   "author": "Silverhand Inc. <contact@silverhand.io>",
   "homepage": "https://github.com/logto-io/logto#readme",


### PR DESCRIPTION
Reverts logto-io/logto#8203

The release didn't actually publish to npm because @logto/api is in the fixed group in .changeset/config.json, which means it's tied to @logto/core and other packages. The publish.js script only tags and publishes the first package in the fixed group (@logto/core), so @logto/api won't be released independently.

This revert restores @logto/api to v1.35.0 to keep it in sync with other packages in the fixed group.