### PR TITLE
feat(schemas): enable MFA for admin tenant

### DIFF
--- a/packages/schemas/alterations/next-1768464306-enable-mfa-for-admin-tenant.ts
+++ b/packages/schemas/alterations/next-1768464306-enable-mfa-for-admin-tenant.ts
@@ -1,0 +1,30 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const adminTenantId = 'admin';
+
+/**
+ * Enable MFA (TOTP and WebAuthn) for the admin tenant with NoPrompt policy.
+ * This allows users to optionally set up MFA via the account center.
+ */
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      update sign_in_experiences
+      set mfa = '{"factors":["Totp","WebAuthn","BackupCode"],"policy":"NoPrompt"}'::jsonb
+      where tenant_id = ${adminTenantId}
+        and id = 'default'
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      update sign_in_experiences
+      set mfa = '{"factors":[],"policy":"UserControlled"}'::jsonb
+      where tenant_id = ${adminTenantId}
+        and id = 'default'
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/seeds/sign-in-experience.ts
+++ b/packages/schemas/src/seeds/sign-in-experience.ts
@@ -2,7 +2,7 @@ import { generateDarkColor } from '@logto/core-kit';
 
 import type { CreateSignInExperience } from '../db-entries/index.js';
 import { SignInMode } from '../db-entries/index.js';
-import { MfaPolicy, SignInIdentifier } from '../foundations/index.js';
+import { MfaFactor, MfaPolicy, SignInIdentifier } from '../foundations/index.js';
 
 import { adminTenantId, defaultTenantId } from './tenant.js';
 
@@ -73,5 +73,9 @@ export const createAdminTenantSignInExperience = (): Readonly<CreateSignInExperi
     branding: {
       logoUrl: 'https://logto.io/logo.svg',
       darkLogoUrl: 'https://logto.io/logo-dark.svg',
+    },
+    mfa: {
+      factors: [MfaFactor.TOTP, MfaFactor.WebAuthn, MfaFactor.BackupCode],
+      policy: MfaPolicy.NoPrompt,
     },
   });


### PR DESCRIPTION
## Summary
- Enable TOTP, WebAuthn, and BackupCode MFA factors for the admin tenant with NoPrompt policy
- This allows users to optionally set up MFA via the account center without being prompted during sign-in
- Does not enable email/phone verification codes since users may not have those connectors configured

## Test plan
- [ ] Verify new admin tenant gets MFA enabled by default
- [ ] Verify existing admin tenant gets MFA enabled after running alteration
- [ ] Verify MFA section appears in console profile page for admin tenant users