### PR TITLE
fix(account): clear verification record on sign-in callback

### DIFF
--- a/packages/account/src/Callback.tsx
+++ b/packages/account/src/Callback.tsx
@@ -1,11 +1,14 @@
 import { useHandleSignInCallback, useLogto } from '@logto/react';
 import { useEffect } from 'react';
 
+import { clearVerificationRecord } from './Providers/PageContextProvider/verification-storage';
+
 const Callback = () => {
   const { clearAllTokens } = useLogto();
 
   useEffect(() => {
     void clearAllTokens();
+    clearVerificationRecord();
   }, [clearAllTokens]);
 
   const { error } = useHandleSignInCallback(() => {


### PR DESCRIPTION
## Summary
- Clear the cached verification record from localStorage when handling sign-in callback
- Prevents using a stale verification record from a previous user session

## Test plan
- [ ] Sign in with user A, perform a verification action that caches verification record
- [ ] Sign out and sign in with user B
- [ ] Verify the verification record from user A is cleared