### PR TITLE
fix(cloud): handle socialSignIn field default value

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/utils/parser.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/utils/parser.ts
@@ -123,6 +123,7 @@ export const sieFormDataParser = {
       captchaPolicy,
       sentinelPolicy,
       emailBlocklistPolicy,
+      socialSignIn,
       // End: Remove the omitted fields from the data
       ...rest
     } = data;
@@ -132,6 +133,11 @@ export const sieFormDataParser = {
       signUp: signUpFormDataParser.fromSignUp(signUp),
       createAccountEnabled: rest.signInMode !== SignInMode.SignIn,
       customCss: customCss ?? undefined,
+      socialSignIn: {
+        automaticAccountLinking: false,
+        skipRequiredIdentifiers: false,
+        ...socialSignIn,
+      },
       branding: {
         ...emptyBranding,
         ...branding,
@@ -139,12 +145,13 @@ export const sieFormDataParser = {
     };
   },
   toSignInExperience: (formData: SignInExperienceForm): SignInExperiencePageManagedData => {
-    const { branding, createAccountEnabled, signUp, customCss, forgotPasswordMethods } = formData;
+    const { branding, createAccountEnabled, signUp, customCss, socialSignIn } = formData;
 
     return {
       ...formData,
       branding: removeFalsyValues(branding),
       signUp: signUpFormDataParser.toSignUp(signUp),
+      socialSignIn,
       signInMode: createAccountEnabled ? SignInMode.SignInAndRegister : SignInMode.SignIn,
       customCss: customCss?.length ? customCss : null,
     };


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Handle the default form value of the `socialSignIn` field. Fallback `undefined` properties to `false`. This is to avoid an unexpected dirty form status. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
