### PR TITLE
style(console): fix mdx Tabs underline position in guide pages

### DIFF
--- a/packages/console/src/mdx-components/Tabs/index.module.scss
+++ b/packages/console/src/mdx-components/Tabs/index.module.scss
@@ -11,11 +11,12 @@
     margin: _.unit(1) 0;
     padding: 0;
 
-    li {
+    // Use `> li` to increase specificity and override Guide's `.content section ul > li` styles
+    > li {
       position: relative;
       list-style: none;
       padding-inline-start: unset;
-      margin-block: 0 unset;
+      margin-block: 0 _.unit(1);
       margin-inline: 0 _.unit(6);
       padding: _.unit(0.5) _.unit(1.5);
       font: var(--font-label-2);
@@ -28,7 +29,7 @@
       }
     }
 
-    li[aria-selected='true'] {
+    > li[aria-selected='true'] {
       color: var(--color-text-link);
       outline: none;
 
@@ -37,7 +38,7 @@
         content: '';
         display: block;
         position: absolute;
-        // Underline position = item's margin-bottom (_.unit(1)) + tab item list's border-bottom width (1px)
+        // Underline position = li's margin-bottom (4px) + ul's border-bottom width (1px)
         bottom: -5px;
         left: 0;
         right: 0;


### PR DESCRIPTION
## Summary
- Fix the gap between tab underline and border-bottom in MDX Tabs component when rendered in guide pages
- Use `> li` selector to increase specificity and override Guide's `.content section ul > li` styles
- Explicitly set `margin-block: 0 _.unit(1)` to ensure consistent spacing

## Testing
Tested locally
Before：
<img width="597" height="89" alt="image" src="https://github.com/user-attachments/assets/d4497253-a317-44af-9d2b-c0247e402eb3" />

After:
<img width="129" height="74" alt="image" src="https://github.com/user-attachments/assets/3e87c14f-df51-45f6-8e9d-d9654e7750d2" />


## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments