### PR TITLE
style(experience): fix floating label overlapping with autofill value

### DIFF
--- a/packages/experience/src/shared/components/InputFields/InputField/index.module.scss
+++ b/packages/experience/src/shared/components/InputFields/InputField/index.module.scss
@@ -51,7 +51,13 @@
          * JavaScript will then be able to hook onto the 'animationstart' event.
          * see https://stackoverflow.com/questions/11708092/detecting-browser-autofill/41530164#41530164
          */
-        animation-name: onAutoFillStart;
+        /* stylelint-disable-next-line time-min-milliseconds -- Short duration needed for autofill detection */
+        animation: onAutoFillStart 0.01s forwards;
+      }
+
+      &:not(:-webkit-autofill) {
+        /* stylelint-disable-next-line time-min-milliseconds -- Short duration needed for autofill detection */
+        animation: onAutoFillCancel 0.01s forwards;
       }
     }
 
@@ -139,6 +145,14 @@
 * see https://stackoverflow.com/questions/11708092/detecting-browser-autofill/41530164#41530164
 */
 @keyframes onAutoFillStart {
+  /* stylelint-disable-next-line block-no-empty */
+  from {}
+
+  /* stylelint-disable-next-line block-no-empty */
+  to {}
+}
+
+@keyframes onAutoFillCancel {
   /* stylelint-disable-next-line block-no-empty */
   from {}
 

--- a/packages/experience/src/shared/components/InputFields/InputField/index.tsx
+++ b/packages/experience/src/shared/components/InputFields/InputField/index.tsx
@@ -76,10 +76,15 @@ const InputField = (
    */
   const handleAnimationStart = useCallback((event: AnimationEvent<HTMLInputElement>) => {
     /**
-     * Because SCSS adds some random characters to the ‘onAutoFillStart’ animation name during the build process, we can’t use the exact name here.
+     * Because SCSS adds some random characters to the animation name during the build process,
+     * we can't use the exact name here.
      */
     if (event.animationName.includes('onAutoFillStart')) {
       setHasValue(true);
+    }
+
+    if (event.animationName.includes('onAutoFillCancel')) {
+      setHasValue(Boolean(innerRef.current?.value));
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- Fix the issue where the floating label and autofill value occasionally overlap on page refresh
- Add explicit animation duration (0.01s) to ensure `animationstart` event fires reliably
- Add `onAutoFillCancel` animation to handle autofill cancellation

## Testing
tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments