### PR TITLE
fix(test): use more specific search pattern in user search test

### DIFF
--- a/packages/integration-tests/src/tests/api/admin-user.search.test.ts
+++ b/packages/integration-tests/src/tests/api/admin-user.search.test.ts
@@ -72,7 +72,7 @@ describe('admin console user search params', () => {
     });
 
     it('should search primaryPhone', async () => {
-      const { headers, json } = await getUsers<User[]>([['search', '%000%']]);
+      const { headers, json } = await getUsers<User[]>([['search', '%1310805000%']]);
 
       expect(headers.get('total-number')).toEqual('10');
       expect(


### PR DESCRIPTION
## Summary
- Use a more specific search pattern (`%1310805000%` instead of `%000%`) in the user search test to avoid flaky failures caused by matching unrelated test data

## Testing
N/A

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments