### PR TITLE
fix(console): remove plain variant to show correct info banner color

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/IntegratePrebuiltUi/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/IntegratePrebuiltUi/index.tsx
@@ -71,7 +71,6 @@ function IntegratePrebuiltUi() {
           </div>
           {!prebuiltUiPermissionNoticeAcknowledged && (
             <InlineNotification
-              variant="plain"
               className={styles.notice}
               action="general.got_it"
               onClick={() => {


### PR DESCRIPTION
## Summary
- Remove `variant="plain"` from the prebuilt UI permission notice banner
- The plain variant was overriding the background to `none`, causing the banner to display with incorrect colors
- Now the banner correctly uses the default info severity background color

## Test plan
- [ ] Navigate to Sign-in Experience > Account center > Prebuilt UI section
- [ ] Verify the permission notice banner displays with the correct info background color (blue tint)