### PR TITLE
fix(account): prevent loading state during passkey options prefetch

### DIFF
--- a/packages/account/src/pages/PasskeyBinding/index.tsx
+++ b/packages/account/src/pages/PasskeyBinding/index.tsx
@@ -32,7 +32,7 @@ const PasskeyBinding = () => {
   const { loading } = useContext(LoadingContext);
   const { accountCenterSettings, experienceSettings, verificationId, setVerificationId, setToast } =
     useContext(PageContext);
-  const createRegistrationRequest = useApi(createWebAuthnRegistration);
+  const createRegistrationRequest = useApi(createWebAuthnRegistration, { silent: true });
   const verifyRegistrationRequest = useApi(verifyWebAuthnRegistration);
   const addWebAuthnRequest = useApi(addWebAuthnMfa);
   const handleError = useErrorHandler();


### PR DESCRIPTION
## Summary
The "Continue" button on the passkey binding page was showing a loading state while prefetching WebAuthn registration options in the background. This misled users because they hadn't clicked the button yet.

Fixed by making the prefetch request silent so it doesn't affect the global loading state.

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments