### PR TITLE
fix(account): remove duplicate error message in phone number binding

### DIFF
--- a/packages/account/src/pages/CodeFlow/IdentifierSendStep.tsx
+++ b/packages/account/src/pages/CodeFlow/IdentifierSendStep.tsx
@@ -1,5 +1,4 @@
 import Button from '@experience/shared/components/Button';
-import ErrorMessage from '@experience/shared/components/ErrorMessage';
 import SmartInputField from '@experience/shared/components/InputFields/SmartInputField';
 import { emailRegEx } from '@logto/core-kit';
 import { SignInIdentifier, type SignInIdentifier as SignInIdentifierType } from '@logto/schemas';
@@ -138,7 +137,6 @@ const IdentifierSendStep = ({
             }
           }}
         />
-        {displayError && <ErrorMessage>{displayError}</ErrorMessage>}
         <Button
           title="account_center.code_verification.send"
           type="primary"


### PR DESCRIPTION
## Summary
Remove duplicate error message in the phone number binding page. The `SmartInputField` component already displays error messages via its `errorMessage` prop (rendered internally by `InputField`). The additional `ErrorMessage` component was causing the same error to appear twice when submitting an empty phone number.

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments