### PR TITLE
feat(core,schemas): add support for passkey sign-in in existing webauthn verification logic

### DIFF
--- a/packages/console/src/consts/logs.ts
+++ b/packages/console/src/consts/logs.ts
@@ -31,6 +31,10 @@ export const auditLogEventTitle = Object.freeze({
   'Interaction.SignIn.Verification.Totp.Submit': 'Sign-in: Verify TOTP code',
   'Interaction.SignIn.Verification.WebAuthn.Create': 'Sign-in: Create WebAuthn authentication',
   'Interaction.SignIn.Verification.WebAuthn.Submit': 'Sign-in: Verify WebAuthn authentication',
+  'Interaction.SignIn.Verification.SignInWebAuthn.Create':
+    'Sign-in: Create passkey sign-in authentication',
+  'Interaction.SignIn.Verification.SignInWebAuthn.Submit':
+    'Sign-in: Verify passkey sign-in authentication',
   'Interaction.SignIn.Verification.EmailVerificationCode.Create':
     'Create and send sign-in email verification code',
   'Interaction.SignIn.Verification.EmailVerificationCode.Submit':

--- a/packages/core/src/routes/experience/anonymous-routes/index.openapi.json
+++ b/packages/core/src/routes/experience/anonymous-routes/index.openapi.json
@@ -32,6 +32,36 @@
           }
         }
       }
+    },
+    "/api/experience/preflight/sign-in-web-authn/authentication": {
+      "post": {
+        "tags": ["Dev feature"],
+        "operationId": "CreateSignInWebAuthnAuthentication",
+        "summary": "Create passkey sign-in WebAuthn authentication",
+        "description": "Create WebAuthn authentication options for passkey sign-in. The user will be resolved later by the credential during verification.",
+        "responses": {
+          "200": {
+            "description": "Passkey sign-in WebAuthn authentication options have been successfully created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "authenticationOptions": {
+                      "description": "The WebAuthn authentication options for initiating passkey sign-in."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request."
+          },
+          "404": {
+            "description": "Verification session not found."
+          }
+        }
+      }
     }
   }
 }

--- a/packages/core/src/routes/experience/anonymous-routes/index.ts
+++ b/packages/core/src/routes/experience/anonymous-routes/index.ts
@@ -1,12 +1,15 @@
+import { webAuthnAuthenticationOptionsGuard } from '@logto/schemas';
 import type Router from 'koa-router';
 import { z } from 'zod';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import { type WithInteractionDetailsContext } from '#src/middleware/koa-interaction-details.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 
+import { generateWebAuthnAuthenticationOptions } from '../../interaction/utils/webauthn.js';
 import { SignInExperienceValidator } from '../classes/libraries/sign-in-experience-validator.js';
 import { experienceRoutes } from '../const.js';
 
@@ -14,7 +17,7 @@ export default function experienceAnonymousRoutes<T extends WithInteractionDetai
   router: Router<unknown, T>,
   tenantContext: TenantContext
 ) {
-  const { libraries, queries } = tenantContext;
+  const { libraries, queries, provider } = tenantContext;
 
   router.get(
     `${experienceRoutes.prefix}/sso-connectors`,
@@ -45,4 +48,40 @@ export default function experienceAnonymousRoutes<T extends WithInteractionDetai
       return next();
     }
   );
+
+  if (EnvSet.values.isDevFeaturesEnabled) {
+    router.post(
+      `${experienceRoutes.prefix}/preflight/sign-in-web-authn/authentication`,
+      koaGuard({
+        response: z.object({
+          authenticationOptions: webAuthnAuthenticationOptionsGuard,
+        }),
+        status: [200, 400, 404],
+      }),
+      async (ctx, next) => {
+        const { hostname } = ctx.URL;
+        const authenticationOptions = await generateWebAuthnAuthenticationOptions({
+          mfaVerifications: [],
+          rpId: hostname,
+          // Generate discoverable credential options on initiating passkey sign-in. The user
+          // will be resolved later by credentialId/rpId on verification.
+          allowDiscoverable: true,
+        });
+
+        const details = await provider.interactionDetails(ctx.req, ctx.res);
+        await provider.interactionResult(ctx.req, ctx.res, {
+          ...details.result,
+          signInWebAuthn: { authenticationOptions },
+        });
+
+        ctx.body = {
+          authenticationOptions,
+        };
+
+        ctx.status = 200;
+
+        return next();
+      }
+    );
+  }
 }

--- a/packages/core/src/routes/experience/classes/helpers.ts
+++ b/packages/core/src/routes/experience/classes/helpers.ts
@@ -119,7 +119,8 @@ export const identifyUserByVerificationRecord = async (
     case VerificationType.EmailVerificationCode:
     case VerificationType.PhoneVerificationCode:
     case VerificationType.MfaEmailVerificationCode:
-    case VerificationType.MfaPhoneVerificationCode: {
+    case VerificationType.MfaPhoneVerificationCode:
+    case VerificationType.SignInWebAuthn: {
       return {
         user: await verificationRecord.identifyUser(),
       };

--- a/packages/core/src/routes/experience/classes/libraries/sign-in-experience-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/sign-in-experience-validator.ts
@@ -169,6 +169,12 @@ export class SignInExperienceValidator {
     return mfa;
   }
 
+  public async getPasskeySignInSettings() {
+    const { passkeySignIn } = await this.getSignInExperienceData();
+
+    return passkeySignIn;
+  }
+
   public async getPasswordPolicy() {
     const { passwordPolicy } = await this.getSignInExperienceData();
 
@@ -307,6 +313,7 @@ export class SignInExperienceValidator {
     const {
       signIn: { methods: signInMethods },
       singleSignOnEnabled,
+      passkeySignIn,
     } = await this.getSignInExperienceData();
 
     switch (verificationRecord.type) {
@@ -337,6 +344,13 @@ export class SignInExperienceValidator {
       case VerificationType.EnterpriseSso: {
         assertThat(
           singleSignOnEnabled,
+          new RequestError({ code: 'user.sign_in_method_not_enabled', status: 422 })
+        );
+        break;
+      }
+      case VerificationType.SignInWebAuthn: {
+        assertThat(
+          passkeySignIn.enabled,
           new RequestError({ code: 'user.sign_in_method_not_enabled', status: 422 })
         );
         break;

--- a/packages/core/src/routes/experience/classes/mfa.ts
+++ b/packages/core/src/routes/experience/classes/mfa.ts
@@ -486,10 +486,14 @@ export class Mfa {
     };
   }
 
-  private async checkMfaFactorsEnabledInSignInExperience(factors: MfaFactor[]) {
-    const { factors: enabledFactors } = await this.signInExperienceValidator.getMfaSettings();
+  private async checkMfaFactorsEnabledInSignInExperience(newBindMfaFactors: MfaFactor[]) {
+    const { mfa, passkeySignIn } = await this.signInExperienceValidator.getSignInExperienceData();
 
-    const isFactorsEnabled = factors.every((factor) => enabledFactors.includes(factor));
+    const isFactorsEnabled = newBindMfaFactors.every(
+      (newBindFactor) =>
+        mfa.factors.includes(newBindFactor) ||
+        (newBindFactor === MfaFactor.WebAuthn && passkeySignIn.enabled)
+    );
 
     assertThat(isFactorsEnabled, new RequestError({ code: 'session.mfa.mfa_factor_not_enabled' }));
   }

--- a/packages/core/src/routes/experience/classes/verifications/index.ts
+++ b/packages/core/src/routes/experience/classes/verifications/index.ts
@@ -1,7 +1,15 @@
 import {
   mfaEmailCodeVerificationRecordDataGuard,
   mfaPhoneCodeVerificationRecordDataGuard,
+  type WebAuthnVerificationRecordData,
+  type SignInWebAuthnVerificationRecordData,
+  type SanitizedWebAuthnVerificationRecordData,
+  sanitizedWebAuthnVerificationRecordDataGuard,
+  type SanitizedSignInWebAuthnVerificationRecordData,
+  sanitizedSignInWebAuthnVerificationRecordDataGuard,
   VerificationType,
+  webAuthnVerificationRecordDataGuard,
+  signInWebAuthnVerificationRecordDataGuard,
 } from '@logto/schemas';
 import { z } from 'zod';
 
@@ -63,13 +71,7 @@ import {
   type SanitizedTotpVerificationRecordData,
 } from './totp-verification.js';
 import { type VerificationRecord as GenericVerificationRecord } from './verification-record.js';
-import {
-  WebAuthnVerification,
-  webAuthnVerificationRecordDataGuard,
-  sanitizedWebAuthnVerificationRecordDataGuard,
-  type WebAuthnVerificationRecordData,
-  type SanitizedWebAuthnVerificationRecordData,
-} from './web-authn-verification.js';
+import { WebAuthnVerification, SignInWebAuthnVerification } from './web-authn-verification.js';
 
 export type VerificationRecordData =
   | PasswordVerificationRecordData
@@ -82,6 +84,7 @@ export type VerificationRecordData =
   | TotpVerificationRecordData
   | BackupCodeVerificationRecordData
   | WebAuthnVerificationRecordData
+  | SignInWebAuthnVerificationRecordData
   | NewPasswordIdentityVerificationRecordData
   | OneTimeTokenVerificationRecordData;
 
@@ -96,6 +99,7 @@ export type SanitizedVerificationRecordData =
   | SanitizedTotpVerificationRecordData
   | SanitizedBackupCodeVerificationRecordData
   | SanitizedWebAuthnVerificationRecordData
+  | SanitizedSignInWebAuthnVerificationRecordData
   | SanitizedNewPasswordIdentityVerificationRecordData
   | OneTimeTokenVerificationRecordData;
 
@@ -116,6 +120,7 @@ export type VerificationRecordMap = AssertVerificationMap<{
   [VerificationType.TOTP]: TotpVerification;
   [VerificationType.BackupCode]: BackupCodeVerification;
   [VerificationType.WebAuthn]: WebAuthnVerification;
+  [VerificationType.SignInWebAuthn]: SignInWebAuthnVerification;
   [VerificationType.NewPasswordIdentity]: NewPasswordIdentityVerification;
   [VerificationType.OneTimeToken]: OneTimeTokenVerification;
 }>;
@@ -142,6 +147,7 @@ export const verificationRecordDataGuard = z.discriminatedUnion('type', [
   totpVerificationRecordDataGuard,
   backupCodeVerificationRecordDataGuard,
   webAuthnVerificationRecordDataGuard,
+  signInWebAuthnVerificationRecordDataGuard,
   newPasswordIdentityVerificationRecordDataGuard,
   oneTimeTokenVerificationRecordDataGuard,
 ]);
@@ -157,6 +163,7 @@ export const publicVerificationRecordDataGuard = z.discriminatedUnion('type', [
   sanitizedTotpVerificationRecordDataGuard,
   sanitizedBackupCodeVerificationRecordDataGuard,
   sanitizedWebAuthnVerificationRecordDataGuard,
+  sanitizedSignInWebAuthnVerificationRecordDataGuard,
   sanitizedNewPasswordIdentityVerificationRecordDataGuard,
   oneTimeTokenVerificationRecordDataGuard,
 ]);
@@ -200,6 +207,9 @@ export const buildVerificationRecord = (
     }
     case VerificationType.WebAuthn: {
       return new WebAuthnVerification(libraries, queries, data);
+    }
+    case VerificationType.SignInWebAuthn: {
+      return new SignInWebAuthnVerification(libraries, queries, data);
     }
     case VerificationType.NewPasswordIdentity: {
       return new NewPasswordIdentityVerification(libraries, queries, data);

--- a/packages/core/src/routes/experience/classes/verifications/web-authn-verification.test.ts
+++ b/packages/core/src/routes/experience/classes/verifications/web-authn-verification.test.ts
@@ -39,7 +39,7 @@ await mockEsmWithActual('@simplewebauthn/server/helpers', () => ({
 const { WebAuthnVerification } = await import('./web-authn-verification.js');
 
 describe('WebAuthnVerification', () => {
-  const userId = 'user-id';
+  const userId = mockUser.id;
   const rpId = 'example.com';
 
   const findUserById = jest.fn().mockResolvedValue(mockUser);

--- a/packages/core/src/routes/experience/middleware/koa-experience-interaction.ts
+++ b/packages/core/src/routes/experience/middleware/koa-experience-interaction.ts
@@ -27,6 +27,11 @@ const whiteListedEndpoint = [
     method: 'GET',
     path: `${experienceRoutes.prefix}/sso-connectors`,
   },
+  // POST /experience/preflight/sign-in-web-authn/authentication:  Generate WebAuthn authentication options for passkey sign-in, no interaction needed.
+  {
+    method: 'POST',
+    path: `${experienceRoutes.prefix}/preflight/sign-in-web-authn/authentication`,
+  },
 ];
 
 /**

--- a/packages/core/src/routes/experience/types.ts
+++ b/packages/core/src/routes/experience/types.ts
@@ -9,6 +9,7 @@ import {
   Users,
   UserSsoIdentities,
   type UserSsoIdentity,
+  webAuthnAuthenticationOptionsGuard,
 } from '@logto/schemas';
 import type { Provider } from 'oidc-provider';
 import { z } from 'zod';
@@ -226,3 +227,9 @@ export const sanitizedInteractionStorageGuard = z.object({
     })
     .optional(),
 }) satisfies ToZodObject<SanitizedInteractionStorageData>;
+
+export const webAuthnAuthenticationOptionsInteractionStorageGuard = z.object({
+  signInWebAuthn: z.object({
+    authenticationOptions: webAuthnAuthenticationOptionsGuard,
+  }),
+});

--- a/packages/core/src/routes/experience/verification-routes/web-authn-verification.openapi.json
+++ b/packages/core/src/routes/experience/verification-routes/web-authn-verification.openapi.json
@@ -150,6 +150,49 @@
           }
         }
       }
+    },
+    "/api/experience/verification/sign-in-web-authn/authentication/verify": {
+      "post": {
+        "tags": ["Dev feature"],
+        "operationId": "VerifySignInWebAuthnAuthentication",
+        "summary": "Verify passkey sign-in WebAuthn authentication",
+        "description": "Verify the passkey sign-in WebAuthn authentication response against the stored authentication challenge. Upon successful verification, the verification record will be marked as verified and the user will be resolved by the credential.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "payload": {
+                    "description": "The WebAuthn assertion response from the user's passkey credential."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The passkey sign-in WebAuthn authentication has been successfully verified.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "verificationId": {
+                      "description": "The unique verification ID of the passkey sign-in WebAuthn authentication verification record."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request. <br/> - `session.mfa.pending_info_not_found:` The WebAuthn authentication challenge is missing in the current verification record. <br/>- `session.mfa.webauthn_verification_failed:` The WebAuthn assertion response is invalid or cannot be verified."
+          },
+          "404": {
+            "description": "Verification session not found."
+          }
+        }
+      }
     }
   }
 }

--- a/packages/core/src/sentinel/basic-sentinel.test.ts
+++ b/packages/core/src/sentinel/basic-sentinel.test.ts
@@ -144,7 +144,7 @@ describe('BasicSentinel -> action pools', () => {
 
   const isolatedMfaActions = [
     SentinelActivityAction.MfaTotp,
-    SentinelActivityAction.MfaWebAuthn,
+    SentinelActivityAction.WebAuthn,
     SentinelActivityAction.MfaBackupCode,
   ];
 

--- a/packages/core/src/sentinel/basic-sentinel.ts
+++ b/packages/core/src/sentinel/basic-sentinel.ts
@@ -35,7 +35,7 @@ export default class BasicSentinel extends Sentinel {
 
   static isolatedActions = Object.freeze([
     SentinelActivityAction.MfaTotp,
-    SentinelActivityAction.MfaWebAuthn,
+    SentinelActivityAction.WebAuthn,
     SentinelActivityAction.MfaBackupCode,
   ] as const);
 

--- a/packages/schemas/src/foundations/jsonb-types/sentinel.ts
+++ b/packages/schemas/src/foundations/jsonb-types/sentinel.ts
@@ -37,7 +37,7 @@ export enum SentinelActivityAction {
   /**
    * The subject tries to pass a WebAuthn MFA verification.
    */
-  MfaWebAuthn = 'MfaWebAuthn',
+  WebAuthn = 'WebAuthn',
   /**
    * The subject tries to pass a backup code MFA verification.
    */

--- a/packages/schemas/src/types/logto-config/jwt-customizer.ts
+++ b/packages/schemas/src/types/logto-config/jwt-customizer.ts
@@ -25,7 +25,10 @@ import { oneTimeTokenVerificationRecordDataGuard } from '../verification-records
 import { passwordVerificationRecordDataGuard } from '../verification-records/password-verification.js';
 import { socialVerificationRecordDataGuard } from '../verification-records/social-verification.js';
 import { totpVerificationRecordDataGuard } from '../verification-records/totp-verification.js';
-import { webAuthnVerificationRecordDataGuard } from '../verification-records/web-authn-verification.js';
+import {
+  webAuthnVerificationRecordDataGuard,
+  signInWebAuthnVerificationRecordDataGuard,
+} from '../verification-records/web-authn-verification.js';
 
 import { accessTokenPayloadGuard, clientCredentialsPayloadGuard } from './oidc-provider.js';
 
@@ -119,6 +122,12 @@ const jwtCustomizerUserInteractionVerificationRecordGuard = z.discriminatedUnion
     registrationChallenge: true,
     authenticationChallenge: true,
     registrationInfo: true,
+  }),
+  signInWebAuthnVerificationRecordDataGuard.omit({
+    registrationChallenge: true,
+    authenticationChallenge: true,
+    registrationInfo: true,
+    authenticationRpId: true,
   }),
   oneTimeTokenVerificationRecordDataGuard,
   newPasswordIdentityVerificationRecordDataGuard.omit({

--- a/packages/schemas/src/types/verification-records/verification-type.ts
+++ b/packages/schemas/src/types/verification-records/verification-type.ts
@@ -10,6 +10,7 @@ export enum VerificationType {
   EnterpriseSso = 'EnterpriseSso',
   TOTP = 'Totp',
   WebAuthn = 'WebAuthn',
+  SignInWebAuthn = 'SignInWebAuthn',
   BackupCode = 'BackupCode',
   NewPasswordIdentity = 'NewPasswordIdentity',
   OneTimeToken = 'OneTimeToken',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- Added support for passkey (WebAuthn) sign-in, enabling users to authenticate using discoverable credentials (passkeys).
- Added `findUserByWebAuthnCredential` query to locate users via WebAuthn credential ID and optional RP ID, enabling authentication without prior user identification.
- Refactored `WebAuthnVerification` to support both identified and non-identified flows, allowing user resolution during authentication and updating the verification record accordingly.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
