### PR TITLE
fix(console): merge existing customData when using Account API

### DIFF
--- a/packages/console/src/hooks/use-current-user.ts
+++ b/packages/console/src/hooks/use-current-user.ts
@@ -47,8 +47,10 @@ const useCurrentUser = () => {
       }
 
       if (isDevFeaturesEnabled) {
+        // Account API uses 'replace' mode, so we need to merge with existing customData
+        const mergedCustomData = { ...user.customData, ...customData };
         const data = await accountApi
-          .patch('', { json: { customData } })
+          .patch('', { json: { customData: mergedCustomData } })
           .json<UserProfileResponse>();
         await mutate({ ...user, customData: data.customData });
       } else {


### PR DESCRIPTION
## Summary
Fix a regression introduced in #8198 (commit f007c653) where the `updateCustomData` function would completely overwrite existing customData instead of merging it.

The Account API uses `'replace'` mode for `updateUserById`, which means the entire customData object gets replaced. The fix merges existing customData with the new data before sending the request.

This was causing onboarding data to be lost when other customData updates were made, potentially causing users to re-enter the onboarding flow.

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments