### PR TITLE
feat(experience,phrases): setup passkey for sign-in upon new user registration

### DIFF
--- a/packages/experience/src/App.tsx
+++ b/packages/experience/src/App.tsx
@@ -10,6 +10,7 @@ import LoadingLayerProvider from './Providers/LoadingLayerProvider';
 import PageContextProvider from './Providers/PageContextProvider';
 import SettingsProvider from './Providers/SettingsProvider';
 import UserInteractionContextProvider from './Providers/UserInteractionContextProvider';
+import { isDevFeaturesEnabled } from './constants/env';
 import DevelopmentTenantNotification from './containers/DevelopmentTenantNotification';
 import Callback from './pages/Callback';
 import Consent from './pages/Consent';
@@ -33,6 +34,7 @@ import TotpVerification from './pages/MfaVerification/TotpVerification';
 import WebAuthnVerification from './pages/MfaVerification/WebAuthnVerification';
 import OneTimeToken from './pages/OneTimeToken';
 import OneTimeTokenErrorPage from './pages/OneTimeToken/Error';
+import PasskeySetup from './pages/PasskeySetup';
 import Register from './pages/Register';
 import RegisterPassword from './pages/RegisterPassword';
 import ResetPassword from './pages/ResetPassword';
@@ -90,6 +92,11 @@ const App = () => {
                         <Route index element={<SignIn />} />
                         <Route path="password" element={<SignInPassword />} />
                       </Route>
+
+                      {/* Create passkey for sign-in */}
+                      {isDevFeaturesEnabled && (
+                        <Route path="create-passkey" element={<PasskeySetup />} />
+                      )}
 
                       {/* Register */}
                       <Route path={experience.routes.register}>

--- a/packages/experience/src/apis/experience/index.ts
+++ b/packages/experience/src/apis/experience/index.ts
@@ -29,6 +29,7 @@ export {
 export * from './mfa';
 export * from './social';
 export * from './one-time-token';
+export * from './passkey-sign-in';
 
 /**
  * For sign-in flow user identity not found error handling use.

--- a/packages/experience/src/apis/experience/passkey-sign-in.ts
+++ b/packages/experience/src/apis/experience/passkey-sign-in.ts
@@ -1,0 +1,32 @@
+import {
+  type BindWebAuthnPayload,
+  MfaFactor,
+  type WebAuthnAuthenticationOptions,
+  type WebAuthnVerificationPayload,
+} from '@logto/schemas';
+
+import api from '../api';
+
+import { experienceApiRoutes } from './const';
+import { identifyAndSubmitInteraction } from './interaction';
+import { bindMfa } from './mfa';
+
+export { createWebAuthnRegistration as createSignInWebAuthnRegistrationOptions } from './mfa';
+
+export const bindSignInWebAuthn = async (payload: BindWebAuthnPayload, verificationId: string) =>
+  bindMfa(MfaFactor.WebAuthn, verificationId, payload);
+
+export const createSignInWebAuthnAuthenticationOptions = async () =>
+  api.post(`${experienceApiRoutes.prefix}/preflight/sign-in-web-authn/authentication`).json<{
+    options: WebAuthnAuthenticationOptions;
+  }>();
+
+export const verifySignInWebAuthn = async (payload: WebAuthnVerificationPayload) => {
+  const { verificationId } = await api
+    .post(`${experienceApiRoutes.verification}/sign-in-web-authn/authentication/verify`, {
+      json: { payload },
+    })
+    .json<{ verificationId: string }>();
+
+  return identifyAndSubmitInteraction({ verificationId });
+};

--- a/packages/experience/src/hooks/use-missing-passkey-error-handler.ts
+++ b/packages/experience/src/hooks/use-missing-passkey-error-handler.ts
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+
+import { type ContinueFlowInteractionEvent } from '@/types';
+
+import { type ErrorHandlers } from './use-error-handler';
+import useNavigateWithPreservedSearchParams from './use-navigate-with-preserved-search-params';
+
+const useMissingPasskeyErrorHandler = (interactionEvent: ContinueFlowInteractionEvent) => {
+  const navigate = useNavigateWithPreservedSearchParams();
+
+  return useMemo<ErrorHandlers>(
+    () => ({
+      'user.passkey_preferred': async () => {
+        navigate({ pathname: '/create-passkey' }, { replace: true, state: { interactionEvent } });
+      },
+    }),
+    [interactionEvent, navigate]
+  );
+};
+
+export default useMissingPasskeyErrorHandler;

--- a/packages/experience/src/hooks/use-passkey-sign-in.ts
+++ b/packages/experience/src/hooks/use-passkey-sign-in.ts
@@ -1,0 +1,112 @@
+import {
+  MfaFactor,
+  type WebAuthnAuthenticationOptions,
+  type WebAuthnRegistrationOptions,
+} from '@logto/schemas';
+import { trySafe } from '@silverhand/essentials';
+import {
+  browserSupportsWebAuthn,
+  startAuthentication,
+  startRegistration,
+} from '@simplewebauthn/browser';
+import { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { bindSignInWebAuthn, verifySignInWebAuthn } from '@/apis/experience';
+
+import useApi from './use-api';
+import useErrorHandler, { type ErrorHandlers } from './use-error-handler';
+import useGlobalRedirectTo from './use-global-redirect-to';
+import useToast from './use-toast';
+
+const usePasskeySignIn = () => {
+  const { t } = useTranslation();
+  const { setToast } = useToast();
+  const asyncBindSignInWebAuthn = useApi(bindSignInWebAuthn);
+  const asyncVerifySignInWebAuthn = useApi(verifySignInWebAuthn);
+  const handleError = useErrorHandler();
+  const redirectTo = useGlobalRedirectTo();
+
+  const handleBindPasskey = useCallback(
+    async (
+      options: WebAuthnRegistrationOptions,
+      verificationId: string,
+      errorHandlers: ErrorHandlers
+    ) => {
+      if (!browserSupportsWebAuthn()) {
+        setToast(t('mfa.webauthn_not_supported'));
+        return;
+      }
+
+      const response = await trySafe(
+        async () => startRegistration(options),
+        () => {
+          setToast(t('mfa.webauthn_failed_to_create'));
+        }
+      );
+
+      if (!response) {
+        return;
+      }
+
+      const [error, result] = await asyncBindSignInWebAuthn(
+        { ...response, type: MfaFactor.WebAuthn },
+        verificationId
+      );
+
+      if (error) {
+        await handleError(error, errorHandlers);
+        return;
+      }
+
+      if (result) {
+        await redirectTo(result.redirectTo);
+      }
+    },
+    [asyncBindSignInWebAuthn, handleError, redirectTo, setToast, t]
+  );
+
+  const handleVerifyPasskey = useCallback(
+    async (options: WebAuthnAuthenticationOptions, errorHandlers: ErrorHandlers) => {
+      if (!browserSupportsWebAuthn()) {
+        setToast(t('mfa.webauthn_not_supported'));
+        return;
+      }
+      const response = await trySafe(
+        async () => startAuthentication(options),
+        () => {
+          setToast(t('mfa.webauthn_failed_to_verify'));
+        }
+      );
+
+      if (!response) {
+        return;
+      }
+
+      const [error, result] = await asyncVerifySignInWebAuthn({
+        ...response,
+        type: MfaFactor.WebAuthn,
+      });
+
+      if (error) {
+        await handleError(error, errorHandlers);
+        return;
+      }
+
+      if (result) {
+        await redirectTo(result.redirectTo);
+      }
+    },
+    [asyncVerifySignInWebAuthn, handleError, redirectTo, setToast, t]
+  );
+
+  return useMemo(
+    () => ({
+      handleBindPasskey,
+      handleVerifyPasskey,
+    }),
+    [handleBindPasskey, handleVerifyPasskey]
+  );
+};
+
+export default usePasskeySignIn;

--- a/packages/experience/src/hooks/use-submit-interaction-error-handler.ts
+++ b/packages/experience/src/hooks/use-submit-interaction-error-handler.ts
@@ -1,5 +1,7 @@
+import { cond } from '@silverhand/essentials';
 import { useMemo } from 'react';
 
+import { isDevFeaturesEnabled } from '@/constants/env';
 import { type ContinueFlowInteractionEvent } from '@/types';
 
 import useEmailBlockedErrorHandler from './use-email-blocked-error-handler';
@@ -7,6 +9,7 @@ import { type ErrorHandlers } from './use-error-handler';
 import useMfaErrorHandler, {
   type Options as UseMfaVerificationErrorHandlerOptions,
 } from './use-mfa-error-handler';
+import useMissingPasskeyErrorHandler from './use-missing-passkey-error-handler';
 import useRequiredProfileErrorHandler, {
   type Options as UseRequiredProfileErrorHandlerOptions,
 } from './use-required-profile-error-handler';
@@ -38,14 +41,21 @@ const useSubmitInteractionErrorHandler = (
   });
   const mfaErrorHandler = useMfaErrorHandler({ replace });
   const emailBlockedErrorHandler = useEmailBlockedErrorHandler();
+  const passkeySignInErrorHandler = useMissingPasskeyErrorHandler(interactionEvent);
 
   return useMemo(
     () => ({
       ...emailBlockedErrorHandler,
       ...requiredProfileErrorHandler,
       ...mfaErrorHandler,
+      ...cond(isDevFeaturesEnabled && passkeySignInErrorHandler),
     }),
-    [emailBlockedErrorHandler, mfaErrorHandler, requiredProfileErrorHandler]
+    [
+      emailBlockedErrorHandler,
+      mfaErrorHandler,
+      passkeySignInErrorHandler,
+      requiredProfileErrorHandler,
+    ]
   );
 };
 

--- a/packages/experience/src/pages/PasskeySetup/index.module.scss
+++ b/packages/experience/src/pages/PasskeySetup/index.module.scss
@@ -1,0 +1,5 @@
+@use '@/shared/scss/underscore' as _;
+
+.button {
+  margin: _.unit(4) 0;
+}

--- a/packages/experience/src/pages/PasskeySetup/index.tsx
+++ b/packages/experience/src/pages/PasskeySetup/index.tsx
@@ -1,0 +1,105 @@
+import { InteractionEvent, type WebAuthnRegistrationOptions } from '@logto/schemas';
+import { browserSupportsWebAuthn } from '@simplewebauthn/browser';
+import { useCallback, useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { validate } from 'superstruct';
+
+import SecondaryPageLayout from '@/Layout/SecondaryPageLayout';
+import SectionLayout from '@/Layout/SectionLayout';
+import { createSignInWebAuthnRegistrationOptions } from '@/apis/experience';
+import useApi from '@/hooks/use-api';
+import useErrorHandler from '@/hooks/use-error-handler';
+import usePasskeySignIn from '@/hooks/use-passkey-sign-in';
+import useSubmitInteractionErrorHandler from '@/hooks/use-submit-interaction-error-handler';
+import ErrorPage from '@/pages/ErrorPage';
+import Button from '@/shared/components/Button';
+import { continueFlowStateGuard } from '@/types/guard';
+
+import styles from './index.module.scss';
+
+type RegistrationState = {
+  verificationId: string;
+  options: WebAuthnRegistrationOptions;
+};
+
+const PasskeySetup = () => {
+  const { state } = useLocation();
+  const [, continueFlowState] = validate(state, continueFlowStateGuard);
+
+  const { handleBindPasskey } = usePasskeySignIn();
+  const asyncCreateRegistrationOptions = useApi(createSignInWebAuthnRegistrationOptions);
+
+  const [registrationResult, setRegistrationResult] = useState<RegistrationState>();
+  const [isPreparing, setIsPreparing] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleError = useErrorHandler();
+  const onSubmitErrorHandlers = useSubmitInteractionErrorHandler(
+    continueFlowState?.interactionEvent ?? InteractionEvent.SignIn,
+    {
+      replace: true,
+    }
+  );
+
+  useEffect(() => {
+    if (!browserSupportsWebAuthn()) {
+      return;
+    }
+
+    (async () => {
+      setIsPreparing(true);
+      const [error, result] = await asyncCreateRegistrationOptions();
+      setIsPreparing(false);
+
+      if (error) {
+        await handleError(error);
+        return;
+      }
+
+      if (result) {
+        setRegistrationResult(result);
+      }
+    })();
+  }, [asyncCreateRegistrationOptions, handleError]);
+
+  const onCreatePasskey = useCallback(async () => {
+    if (!registrationResult) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    await handleBindPasskey(
+      registrationResult.options,
+      registrationResult.verificationId,
+      onSubmitErrorHandlers
+    );
+    setIsSubmitting(false);
+  }, [handleBindPasskey, registrationResult, onSubmitErrorHandlers]);
+
+  const onSkip = useCallback(() => {
+    // TODO: Skip adding passkey for sign-in and redirect to the next step
+  }, []);
+
+  if (!browserSupportsWebAuthn()) {
+    return <ErrorPage title="mfa.webauthn_not_supported" />;
+  }
+
+  return (
+    <SecondaryPageLayout title="passkey_sign_in.setup_page.title" onSkip={onSkip}>
+      <SectionLayout
+        title="passkey_sign_in.setup_page.subtitle"
+        description="passkey_sign_in.setup_page.description"
+      >
+        <Button
+          className={styles.button}
+          title="passkey_sign_in.setup_page.subtitle"
+          isLoading={isSubmitting || isPreparing}
+          disabled={isPreparing && !registrationResult}
+          onClick={onCreatePasskey}
+        />
+      </SectionLayout>
+    </SecondaryPageLayout>
+  );
+};
+
+export default PasskeySetup;

--- a/packages/phrases-experience/src/locales/ar/index.ts
+++ b/packages/phrases-experience/src/locales/ar/index.ts
@@ -10,6 +10,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import passkey_sign_in from './passkey-sign-in.js';
 import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
@@ -27,6 +28,7 @@ const ar = {
     user_scopes,
     profile,
     account_center,
+    passkey_sign_in,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/ar/passkey-sign-in.ts
+++ b/packages/phrases-experience/src/locales/ar/passkey-sign-in.ts
@@ -1,0 +1,10 @@
+const passkey_sign_in = {
+  setup_page: {
+    title: 'بسّط عملية تسجيل الدخول',
+    subtitle: 'أنشئ مفتاح مرور',
+    description:
+      'سجّل مفتاح المرور باستخدام القياسات الحيوية للجهاز، أو مفاتيح الأمان مثل YubiKey، أو أي طرق متاحة أخرى.',
+  },
+};
+
+export default Object.freeze(passkey_sign_in);

--- a/packages/phrases-experience/src/locales/de/index.ts
+++ b/packages/phrases-experience/src/locales/de/index.ts
@@ -10,6 +10,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import passkey_sign_in from './passkey-sign-in.js';
 import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
@@ -27,6 +28,7 @@ const de = {
     user_scopes,
     profile,
     account_center,
+    passkey_sign_in,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/de/passkey-sign-in.ts
+++ b/packages/phrases-experience/src/locales/de/passkey-sign-in.ts
@@ -1,0 +1,10 @@
+const passkey_sign_in = {
+  setup_page: {
+    title: 'Vereinfache deine Anmeldung',
+    subtitle: 'Passkey erstellen',
+    description:
+      'Registriere deinen Passkey mit Gerätebiometrie, Sicherheitsschlüsseln wie YubiKey oder anderen verfügbaren Methoden.',
+  },
+};
+
+export default Object.freeze(passkey_sign_in);

--- a/packages/phrases-experience/src/locales/en/index.ts
+++ b/packages/phrases-experience/src/locales/en/index.ts
@@ -6,6 +6,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import passkey_sign_in from './passkey-sign-in.js';
 import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
@@ -23,6 +24,7 @@ const en = {
     user_scopes,
     profile,
     account_center,
+    passkey_sign_in,
   },
 };
 

--- a/packages/phrases-experience/src/locales/en/passkey-sign-in.ts
+++ b/packages/phrases-experience/src/locales/en/passkey-sign-in.ts
@@ -1,0 +1,10 @@
+const passkey_sign_in = {
+  setup_page: {
+    title: 'Simplify your sign-in',
+    subtitle: 'Create a passkey',
+    description:
+      'Register your passkey using device biometrics, security keys like YubiKey, or other available methods.',
+  },
+};
+
+export default Object.freeze(passkey_sign_in);

--- a/packages/phrases-experience/src/locales/es/index.ts
+++ b/packages/phrases-experience/src/locales/es/index.ts
@@ -10,6 +10,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import passkey_sign_in from './passkey-sign-in.js';
 import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
@@ -27,6 +28,7 @@ const es = {
     user_scopes,
     profile,
     account_center,
+    passkey_sign_in,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/es/passkey-sign-in.ts
+++ b/packages/phrases-experience/src/locales/es/passkey-sign-in.ts
@@ -1,0 +1,10 @@
+const passkey_sign_in = {
+  setup_page: {
+    title: 'Simplifica tu inicio de sesión',
+    subtitle: 'Crea una clave de acceso',
+    description:
+      'Registra tu clave de acceso usando la biometría del dispositivo, llaves de seguridad como YubiKey u otros métodos disponibles.',
+  },
+};
+
+export default Object.freeze(passkey_sign_in);

--- a/packages/phrases-experience/src/locales/fr/index.ts
+++ b/packages/phrases-experience/src/locales/fr/index.ts
@@ -10,6 +10,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import passkey_sign_in from './passkey-sign-in.js';
 import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
@@ -27,6 +28,7 @@ const fr = {
     user_scopes,
     profile,
     account_center,
+    passkey_sign_in,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/fr/passkey-sign-in.ts
+++ b/packages/phrases-experience/src/locales/fr/passkey-sign-in.ts
@@ -1,0 +1,10 @@
+const passkey_sign_in = {
+  setup_page: {
+    title: 'Simplifiez votre connexion',
+    subtitle: 'Créez une clé d’accès',
+    description:
+      'Enregistrez votre clé d’accès à l’aide des données biométriques de l’appareil, de clés de sécurité comme YubiKey ou d’autres méthodes disponibles.',
+  },
+};
+
+export default Object.freeze(passkey_sign_in);

--- a/packages/phrases-experience/src/locales/it/index.ts
+++ b/packages/phrases-experience/src/locales/it/index.ts
@@ -10,6 +10,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import passkey_sign_in from './passkey-sign-in.js';
 import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
@@ -27,6 +28,7 @@ const it = {
     user_scopes,
     profile,
     account_center,
+    passkey_sign_in,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/it/passkey-sign-in.ts
+++ b/packages/phrases-experience/src/locales/it/passkey-sign-in.ts
@@ -1,0 +1,10 @@
+const passkey_sign_in = {
+  setup_page: {
+    title: "Semplifica l'accesso",
+    subtitle: 'Crea una passkey',
+    description:
+      'Registra la tua passkey usando i dati biometrici del dispositivo, chiavi di sicurezza come YubiKey o altri metodi disponibili.',
+  },
+};
+
+export default Object.freeze(passkey_sign_in);

--- a/packages/phrases-experience/src/locales/ja/index.ts
+++ b/packages/phrases-experience/src/locales/ja/index.ts
@@ -10,6 +10,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import passkey_sign_in from './passkey-sign-in.js';
 import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
@@ -27,6 +28,7 @@ const ja = {
     user_scopes,
     profile,
     account_center,
+    passkey_sign_in,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/ja/passkey-sign-in.ts
+++ b/packages/phrases-experience/src/locales/ja/passkey-sign-in.ts
@@ -1,0 +1,10 @@
+const passkey_sign_in = {
+  setup_page: {
+    title: 'サインインをもっとシンプルに',
+    subtitle: 'パスキーを作成',
+    description:
+      'デバイスの生体認証、YubiKeyなどのセキュリティキー、その他利用可能な方法でパスキーを登録します。',
+  },
+};
+
+export default Object.freeze(passkey_sign_in);

--- a/packages/phrases-experience/src/locales/ko/index.ts
+++ b/packages/phrases-experience/src/locales/ko/index.ts
@@ -10,6 +10,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import passkey_sign_in from './passkey-sign-in.js';
 import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
@@ -27,6 +28,7 @@ const ko = {
     user_scopes,
     profile,
     account_center,
+    passkey_sign_in,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/ko/passkey-sign-in.ts
+++ b/packages/phrases-experience/src/locales/ko/passkey-sign-in.ts
@@ -1,0 +1,10 @@
+const passkey_sign_in = {
+  setup_page: {
+    title: '로그인을 더 간편하게',
+    subtitle: '패스키 만들기',
+    description:
+      '기기 생체인증, YubiKey 같은 보안 키 또는 다른 사용 가능한 방법으로 패스키를 등록하세요.',
+  },
+};
+
+export default Object.freeze(passkey_sign_in);

--- a/packages/phrases-experience/src/locales/pl-pl/index.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/index.ts
@@ -10,6 +10,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import passkey_sign_in from './passkey-sign-in.js';
 import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
@@ -27,6 +28,7 @@ const pl_pl = {
     user_scopes,
     profile,
     account_center,
+    passkey_sign_in,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/pl-pl/passkey-sign-in.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/passkey-sign-in.ts
@@ -1,0 +1,10 @@
+const passkey_sign_in = {
+  setup_page: {
+    title: 'Uprość logowanie',
+    subtitle: 'Utwórz klucz dostępu',
+    description:
+      'Zarejestruj klucz dostępu za pomocą biometrii urządzenia, kluczy zabezpieczających, takich jak YubiKey, lub innych dostępnych metod.',
+  },
+};
+
+export default Object.freeze(passkey_sign_in);

--- a/packages/phrases-experience/src/locales/pt-br/index.ts
+++ b/packages/phrases-experience/src/locales/pt-br/index.ts
@@ -10,6 +10,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import passkey_sign_in from './passkey-sign-in.js';
 import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
@@ -27,6 +28,7 @@ const pt_br = {
     user_scopes,
     profile,
     account_center,
+    passkey_sign_in,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/pt-br/passkey-sign-in.ts
+++ b/packages/phrases-experience/src/locales/pt-br/passkey-sign-in.ts
@@ -1,0 +1,10 @@
+const passkey_sign_in = {
+  setup_page: {
+    title: 'Simplifique seu login',
+    subtitle: 'Crie uma chave de acesso',
+    description:
+      'Registre sua chave de acesso usando a biometria do dispositivo, chaves de segurança como a YubiKey ou outros métodos disponíveis.',
+  },
+};
+
+export default Object.freeze(passkey_sign_in);

--- a/packages/phrases-experience/src/locales/pt-pt/index.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/index.ts
@@ -10,6 +10,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import passkey_sign_in from './passkey-sign-in.js';
 import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
@@ -27,6 +28,7 @@ const pt_pt = {
     user_scopes,
     profile,
     account_center,
+    passkey_sign_in,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/pt-pt/passkey-sign-in.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/passkey-sign-in.ts
@@ -1,0 +1,10 @@
+const passkey_sign_in = {
+  setup_page: {
+    title: 'Simplifique o seu início de sessão',
+    subtitle: 'Crie uma chave de acesso',
+    description:
+      'Registe a sua chave de acesso utilizando a biometria do dispositivo, chaves de segurança como a YubiKey ou outros métodos disponíveis.',
+  },
+};
+
+export default Object.freeze(passkey_sign_in);

--- a/packages/phrases-experience/src/locales/ru/index.ts
+++ b/packages/phrases-experience/src/locales/ru/index.ts
@@ -10,6 +10,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import passkey_sign_in from './passkey-sign-in.js';
 import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
@@ -27,6 +28,7 @@ const ru = {
     user_scopes,
     profile,
     account_center,
+    passkey_sign_in,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/ru/passkey-sign-in.ts
+++ b/packages/phrases-experience/src/locales/ru/passkey-sign-in.ts
@@ -1,0 +1,10 @@
+const passkey_sign_in = {
+  setup_page: {
+    title: 'Упростите вход',
+    subtitle: 'Создайте ключ-пароль',
+    description:
+      'Зарегистрируйте ключ-пароль с помощью биометрии устройства, ключей безопасности вроде YubiKey или других доступных способов.',
+  },
+};
+
+export default Object.freeze(passkey_sign_in);

--- a/packages/phrases-experience/src/locales/th/index.ts
+++ b/packages/phrases-experience/src/locales/th/index.ts
@@ -6,6 +6,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import passkey_sign_in from './passkey-sign-in.js';
 import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
@@ -23,6 +24,7 @@ const en = {
     user_scopes,
     profile,
     account_center,
+    passkey_sign_in,
   },
 };
 

--- a/packages/phrases-experience/src/locales/th/passkey-sign-in.ts
+++ b/packages/phrases-experience/src/locales/th/passkey-sign-in.ts
@@ -1,0 +1,10 @@
+const passkey_sign_in = {
+  setup_page: {
+    title: 'ทำให้การลงชื่อเข้าใช้ของคุณง่ายขึ้น',
+    subtitle: 'สร้างกุญแจผ่าน',
+    description:
+      'ลงทะเบียนกุญแจผ่านของคุณด้วยไบโอเมตริกบนอุปกรณ์ กุญแจความปลอดภัยอย่าง YubiKey หรือวิธีอื่นที่มีให้ใช้',
+  },
+};
+
+export default Object.freeze(passkey_sign_in);

--- a/packages/phrases-experience/src/locales/tr-tr/index.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/index.ts
@@ -10,6 +10,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import passkey_sign_in from './passkey-sign-in.js';
 import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
@@ -27,6 +28,7 @@ const tr_tr = {
     user_scopes,
     profile,
     account_center,
+    passkey_sign_in,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/tr-tr/passkey-sign-in.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/passkey-sign-in.ts
@@ -1,0 +1,10 @@
+const passkey_sign_in = {
+  setup_page: {
+    title: 'Oturum açmayı kolaylaştır',
+    subtitle: 'Geçiş anahtarı oluştur',
+    description:
+      'Geçiş anahtarını cihaz biyometrisi, YubiKey gibi güvenlik anahtarları veya diğer kullanılabilir yöntemlerle kaydet.',
+  },
+};
+
+export default Object.freeze(passkey_sign_in);

--- a/packages/phrases-experience/src/locales/uk-ua/index.ts
+++ b/packages/phrases-experience/src/locales/uk-ua/index.ts
@@ -10,6 +10,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import passkey_sign_in from './passkey-sign-in.js';
 import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
@@ -27,6 +28,7 @@ const uk_ua = {
     user_scopes,
     profile,
     account_center,
+    passkey_sign_in,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/uk-ua/passkey-sign-in.ts
+++ b/packages/phrases-experience/src/locales/uk-ua/passkey-sign-in.ts
@@ -1,0 +1,10 @@
+const passkey_sign_in = {
+  setup_page: {
+    title: 'Спростіть вхід',
+    subtitle: 'Створіть ключ-пароль',
+    description:
+      'Зареєструйте ключ-пароль за допомогою біометрії пристрою, ключів безпеки на кшталт YubiKey чи інших доступних методів.',
+  },
+};
+
+export default Object.freeze(passkey_sign_in);

--- a/packages/phrases-experience/src/locales/zh-cn/index.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/index.ts
@@ -10,6 +10,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import passkey_sign_in from './passkey-sign-in.js';
 import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
@@ -27,6 +28,7 @@ const zh_cn = {
     user_scopes,
     profile,
     account_center,
+    passkey_sign_in,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/zh-cn/passkey-sign-in.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/passkey-sign-in.ts
@@ -1,0 +1,9 @@
+const passkey_sign_in = {
+  setup_page: {
+    title: '简化你的登录',
+    subtitle: '创建通行密钥',
+    description: '使用设备生物识别、YubiKey 等安全密钥或其他可用方式注册你的通行密钥。',
+  },
+};
+
+export default Object.freeze(passkey_sign_in);

--- a/packages/phrases-experience/src/locales/zh-hk/index.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/index.ts
@@ -10,6 +10,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import passkey_sign_in from './passkey-sign-in.js';
 import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
@@ -27,6 +28,7 @@ const zh_hk = {
     user_scopes,
     profile,
     account_center,
+    passkey_sign_in,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/zh-hk/passkey-sign-in.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/passkey-sign-in.ts
@@ -1,0 +1,9 @@
+const passkey_sign_in = {
+  setup_page: {
+    title: '簡化你的登入',
+    subtitle: '建立通行密鑰',
+    description: '使用裝置生物辨識、YubiKey 等安全金鑰或其他可用方式註冊你的通行密鑰。',
+  },
+};
+
+export default Object.freeze(passkey_sign_in);

--- a/packages/phrases-experience/src/locales/zh-tw/index.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/index.ts
@@ -10,6 +10,7 @@ import error from './error/index.js';
 import input from './input.js';
 import list from './list.js';
 import mfa from './mfa.js';
+import passkey_sign_in from './passkey-sign-in.js';
 import profile from './profile.js';
 import secondary from './secondary.js';
 import user_scopes from './user-scopes.js';
@@ -27,6 +28,7 @@ const zh_tw = {
     user_scopes,
     profile,
     account_center,
+    passkey_sign_in,
   },
 } satisfies DeepPartial<LocalePhrase>;
 

--- a/packages/phrases-experience/src/locales/zh-tw/passkey-sign-in.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/passkey-sign-in.ts
@@ -1,0 +1,9 @@
+const passkey_sign_in = {
+  setup_page: {
+    title: '簡化你的登入',
+    subtitle: '建立通行密鑰',
+    description: '使用裝置生物辨識、YubiKey 等安全金鑰或其他可用方式註冊你的通行密鑰。',
+  },
+};
+
+export default Object.freeze(passkey_sign_in);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Added a new Experience page to setup passkey for sign-in upon successful new user registration.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested.

<img width="567" height="625" alt="image" src="https://github.com/user-attachments/assets/400168ec-b3e9-49af-a8d5-75bd1b351649" />

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
