### PR TITLE
refactor(console): hide integrate prebuilt UI section behind dev feature flag

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/index.tsx
@@ -5,6 +5,7 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import FormCard from '@/components/FormCard';
 import PageMeta from '@/components/PageMeta';
+import { isDevFeaturesEnabled } from '@/consts/env';
 import FormField from '@/ds-components/FormField';
 import InlineNotification from '@/ds-components/InlineNotification';
 import type { Option } from '@/ds-components/Select';
@@ -102,7 +103,7 @@ function AccountCenter({ isActive, data }: Props) {
           </FormField>
         </div>
       </FormCard>
-      <IntegratePrebuiltUi />
+      {isDevFeaturesEnabled && <IntegratePrebuiltUi />}
       {accountCenterSections.map((section) => (
         <FormCard key={section.key} title={section.title} description={section.description}>
           <div className={styles.cardContent}>


### PR DESCRIPTION
## Summary
Hide the "Integrate Prebuilt UI" section in the account center tab using `isDevFeaturesEnabled` guard.

## Testing
N/A

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments