### PR TITLE
refactor(console): redirect enterprise SSO contact us button to landing page

### DIFF
--- a/packages/console/src/pages/TenantSettings/TenantBasicSettings/ProfileForm/EnterpriseSso/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantBasicSettings/ProfileForm/EnterpriseSso/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 
-import { contactEmailLink } from '@/consts';
+import { officialWebsiteContactPageLink } from '@/consts';
 import { LinkButton } from '@/ds-components/Button';
 
 import styles from './index.module.scss';
@@ -11,7 +11,7 @@ function EnterpriseSso() {
   return (
     <div className={styles.container}>
       <div className={styles.description}>{t('tenants.settings.enterprise_sso_description')}</div>
-      <LinkButton title="general.contact_us_action" href={contactEmailLink} />
+      <LinkButton title="general.contact_us_action" href={officialWebsiteContactPageLink} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Change the "Contact us" button in the enterprise SSO card from mailto link to the official contact page (https://logto.io/contact).

## Testing
N/A

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments