### PR TITLE
refactor(console): update change email and password flows to use account center

### DIFF
--- a/packages/console/src/pages/Profile/components/LinkAccountSection/index.tsx
+++ b/packages/console/src/pages/Profile/components/LinkAccountSection/index.tsx
@@ -13,12 +13,14 @@ import FormCard from '@/components/FormCard';
 import UnnamedTrans from '@/components/UnnamedTrans';
 import UserInfoCard from '@/components/UserInfoCard';
 import { adminTenantEndpoint, meApi, storageKeys } from '@/consts';
+import { isDevFeaturesEnabled } from '@/consts/env';
 import ImageWithErrorFallback from '@/ds-components/ImageWithErrorFallback';
 import { useStaticApi } from '@/hooks/use-api';
 import { useConfirmModal } from '@/hooks/use-confirm-modal';
 import useTenantPathname from '@/hooks/use-tenant-pathname';
 import useTheme from '@/hooks/use-theme';
 
+import { useNavigateToAccountCenter } from '../../hooks';
 import { popupWindow } from '../../utils';
 import type { Row } from '../CardContent';
 import CardContent from '../CardContent';
@@ -35,6 +37,7 @@ type Props = {
 function LinkAccountSection({ user, connectors, onUpdate }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { navigate } = useTenantPathname();
+  const navigateToAccountCenter = useNavigateToAccountCenter();
   const theme = useTheme();
   const { show: showConfirm } = useConfirmModal();
   const api = useStaticApi({ prefixUrl: adminTenantEndpoint, resourceIndicator: meApi.indicator });
@@ -151,6 +154,10 @@ function LinkAccountSection({ user, connectors, onUpdate }: Props) {
             action: {
               name: user.primaryEmail ? 'profile.change' : 'profile.link',
               handler: () => {
+                if (isDevFeaturesEnabled) {
+                  navigateToAccountCenter('/account/email');
+                  return;
+                }
                 navigate('link-email', {
                   state: { email: user.primaryEmail, action: 'changeEmail' },
                 });

--- a/packages/console/src/pages/Profile/hooks.ts
+++ b/packages/console/src/pages/Profile/hooks.ts
@@ -1,0 +1,13 @@
+import { useCallback } from 'react';
+
+import { adminTenantEndpoint } from '@/consts';
+
+export const useNavigateToAccountCenter = () => {
+  return useCallback((path: string) => {
+    const currentProfileUrl = `${window.location.origin}${window.location.pathname}`;
+    const accountUrl = new URL(path, adminTenantEndpoint);
+    accountUrl.searchParams.set('redirect', currentProfileUrl);
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    window.location.href = accountUrl.toString();
+  }, []);
+};

--- a/packages/console/src/pages/Profile/index.tsx
+++ b/packages/console/src/pages/Profile/index.tsx
@@ -32,11 +32,13 @@ import MfaSection from './components/MfaSection';
 import NotSet from './components/NotSet';
 import Skeleton from './components/Skeleton';
 import DeleteAccountModal from './containers/DeleteAccountModal';
+import { useNavigateToAccountCenter } from './hooks';
 import styles from './index.module.scss';
 
 function Profile() {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { navigate } = useTenantPathname();
+  const navigateToAccountCenter = useNavigateToAccountCenter();
   const childrenRoutes = useRoutes(profile);
   usePlausiblePageview(profile, 'profile');
 
@@ -96,6 +98,10 @@ function Profile() {
                         action: {
                           name: 'profile.change',
                           handler: () => {
+                            if (isDevFeaturesEnabled) {
+                              navigateToAccountCenter('/account/password');
+                              return;
+                            }
                             navigate(user.hasPassword ? 'verify-password' : 'change-password', {
                               state: { email: user.primaryEmail, action: 'changePassword' },
                             });


### PR DESCRIPTION
## Summary
Update the change email and password flows in the Profile page to use the account center when dev features are enabled, similar to the MFA binding implementation.

Changes:
- Add `useNavigateToAccountCenter` hook for redirecting to account center pages
- Update password change handler to use `/account/password` when `isDevFeaturesEnabled`
- Update email change handler to use `/account/email` when `isDevFeaturesEnabled`

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments