### PR TITLE
fix(account): add missing routes to known route prefixes for proper restoration

### DIFF
--- a/packages/account/src/utils/account-center-route.ts
+++ b/packages/account/src/utils/account-center-route.ts
@@ -9,6 +9,15 @@ import {
   passwordSuccessRoute,
   usernameRoute,
   usernameSuccessRoute,
+  authenticatorAppRoute,
+  authenticatorAppSuccessRoute,
+  backupCodesGenerateRoute,
+  backupCodesRegenerateRoute,
+  backupCodesManageRoute,
+  backupCodesSuccessRoute,
+  passkeyAddRoute,
+  passkeyManageRoute,
+  passkeySuccessRoute,
 } from '@ac/constants/routes';
 
 import { sessionStorage } from './session-storage';
@@ -27,6 +36,15 @@ const knownRoutePrefixes: readonly string[] = [
   passwordSuccessRoute,
   usernameRoute,
   usernameSuccessRoute,
+  authenticatorAppRoute,
+  authenticatorAppSuccessRoute,
+  backupCodesGenerateRoute,
+  backupCodesRegenerateRoute,
+  backupCodesManageRoute,
+  backupCodesSuccessRoute,
+  passkeyAddRoute,
+  passkeyManageRoute,
+  passkeySuccessRoute,
 ];
 
 const isKnownRoute = (pathname?: string): pathname is string =>


### PR DESCRIPTION
## Summary
Add missing passkey, totp, and backup codes routes to `knownRoutePrefixes` in account center.

When users access account center with a specific route (e.g., `/account/passkey/add?redirect=xxx`) without being logged in, the system should save the route and restore it after sign-in callback. However, the restoration was failing for passkey, totp, and backup codes routes because they were not included in the `knownRoutePrefixes` list.

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments