### PR TITLE
fix(console): use secondary color for MFA section icons

### DIFF
--- a/packages/console/src/pages/Profile/components/CardContent/index.module.scss
+++ b/packages/console/src/pages/Profile/components/CardContent/index.module.scss
@@ -31,6 +31,7 @@
     width: 20px;
     height: 20px;
     margin-inline-end: _.unit(4);
+    color: var(--color-text-secondary);
   }
 
   table {


### PR DESCRIPTION
## Summary
Fix the icon color in the MFA section of the profile page. The icons should use secondary color instead of inheriting the text color.

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments