### PR TITLE
fix(account): show "incorrect password" in password verification

### DIFF
--- a/packages/account/src/components/PasswordVerification/index.tsx
+++ b/packages/account/src/components/PasswordVerification/index.tsx
@@ -31,8 +31,8 @@ const PasswordVerification = ({ onBack, onSwitchMethod, hasAlternativeMethod }: 
 
   const errorHandlers: ErrorHandlers = useMemo(
     () => ({
-      'session.invalid_credentials': (error) => {
-        setPasswordError(error.message);
+      'session.invalid_credentials': () => {
+        setPasswordError(t('account_center.password_verification.error_failed'));
       },
       global: (error) => {
         setPasswordError(error.message);

--- a/packages/phrases-experience/src/locales/ar/account-center.ts
+++ b/packages/phrases-experience/src/locales/ar/account-center.ts
@@ -16,7 +16,7 @@ const account_center = {
   password_verification: {
     title: 'التحقق من كلمة المرور',
     description: 'لحماية أمان حسابك، أدخل كلمة المرور للتحقق من هويتك.',
-    error_failed: 'فشل التحقق. يرجى التحقق من كلمة المرور.',
+    error_failed: 'كلمة المرور غير صحيحة. يرجى التحقق من المدخلات.',
   },
   verification_method: {
     password: {

--- a/packages/phrases-experience/src/locales/de/account-center.ts
+++ b/packages/phrases-experience/src/locales/de/account-center.ts
@@ -18,7 +18,7 @@ const account_center = {
     title: 'Passwort bestätigen',
     description:
       'Zum Schutz deines Kontos gib dein Passwort ein, um deine Identität zu bestätigen.',
-    error_failed: 'Verifizierung fehlgeschlagen. Bitte überprüfe dein Passwort.',
+    error_failed: 'Falsches Passwort. Bitte überprüfe deine Eingabe.',
   },
   verification_method: {
     password: {

--- a/packages/phrases-experience/src/locales/en/account-center.ts
+++ b/packages/phrases-experience/src/locales/en/account-center.ts
@@ -16,7 +16,7 @@ const account_center = {
   password_verification: {
     title: 'Verify password',
     description: "Verify it's you to protect your account security. Enter your password.",
-    error_failed: 'Verification failed. Please check your password.',
+    error_failed: 'Incorrect password. Please check your input.',
   },
   verification_method: {
     password: {

--- a/packages/phrases-experience/src/locales/es/account-center.ts
+++ b/packages/phrases-experience/src/locales/es/account-center.ts
@@ -16,7 +16,7 @@ const account_center = {
   password_verification: {
     title: 'Verifica la contraseña',
     description: 'Para proteger tu cuenta, ingresa tu contraseña para confirmar tu identidad.',
-    error_failed: 'La verificación falló. Revisa tu contraseña.',
+    error_failed: 'Contraseña incorrecta. Verifica tu entrada.',
   },
   verification_method: {
     password: {

--- a/packages/phrases-experience/src/locales/fr/account-center.ts
+++ b/packages/phrases-experience/src/locales/fr/account-center.ts
@@ -17,7 +17,7 @@ const account_center = {
     title: 'Vérifier le mot de passe',
     description:
       'Pour protéger votre compte, saisissez votre mot de passe afin de confirmer votre identité.',
-    error_failed: 'La vérification a échoué. Vérifiez votre mot de passe.',
+    error_failed: 'Mot de passe incorrect. Veuillez vérifier votre saisie.',
   },
   verification_method: {
     password: {

--- a/packages/phrases-experience/src/locales/it/account-center.ts
+++ b/packages/phrases-experience/src/locales/it/account-center.ts
@@ -17,7 +17,7 @@ const account_center = {
     title: 'Verifica la password',
     description:
       'Per proteggere il tuo account, inserisci la password per confermare la tua identità.',
-    error_failed: 'Verifica non riuscita. Controlla la tua password.',
+    error_failed: 'Password errata. Controlla il tuo inserimento.',
   },
   verification_method: {
     password: {

--- a/packages/phrases-experience/src/locales/ja/account-center.ts
+++ b/packages/phrases-experience/src/locales/ja/account-center.ts
@@ -16,7 +16,7 @@ const account_center = {
   password_verification: {
     title: 'パスワードを確認',
     description: 'アカウントを保護するため、パスワードを入力して本人確認してください。',
-    error_failed: '認証に失敗しました。パスワードを確認してください。',
+    error_failed: 'パスワードが正しくありません。入力内容を確認してください。',
   },
   verification_method: {
     password: {

--- a/packages/phrases-experience/src/locales/ko/account-center.ts
+++ b/packages/phrases-experience/src/locales/ko/account-center.ts
@@ -15,7 +15,7 @@ const account_center = {
   password_verification: {
     title: '비밀번호 확인',
     description: '계정 보안을 위해 비밀번호를 입력해 본인임을 확인하세요.',
-    error_failed: '인증에 실패했습니다. 비밀번호를 확인해주세요.',
+    error_failed: '비밀번호가 올바르지 않습니다. 입력 내용을 확인해주세요.',
   },
   verification_method: {
     password: {

--- a/packages/phrases-experience/src/locales/pl-pl/account-center.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/account-center.ts
@@ -16,7 +16,7 @@ const account_center = {
   password_verification: {
     title: 'Zweryfikuj hasło',
     description: 'Aby chronić konto, wprowadź hasło, aby potwierdzić swoją tożsamość.',
-    error_failed: 'Weryfikacja nie powiodła się. Sprawdź swoje hasło.',
+    error_failed: 'Nieprawidłowe hasło. Sprawdź wprowadzone dane.',
   },
   verification_method: {
     password: {

--- a/packages/phrases-experience/src/locales/pt-br/account-center.ts
+++ b/packages/phrases-experience/src/locales/pt-br/account-center.ts
@@ -16,7 +16,7 @@ const account_center = {
   password_verification: {
     title: 'Verificar senha',
     description: 'Para proteger sua conta, insira sua senha para confirmar sua identidade.',
-    error_failed: 'Falha na verificação. Verifique sua senha.',
+    error_failed: 'Senha incorreta. Verifique sua entrada.',
   },
   verification_method: {
     password: {

--- a/packages/phrases-experience/src/locales/pt-pt/account-center.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/account-center.ts
@@ -17,7 +17,7 @@ const account_center = {
     title: 'Verificar palavra-passe',
     description:
       'Para proteger a sua conta, introduza a sua palavra-passe para confirmar a sua identidade.',
-    error_failed: 'Falha na verificação. Verifique a sua palavra-passe.',
+    error_failed: 'Palavra-passe incorreta. Verifique a sua entrada.',
   },
   verification_method: {
     password: {

--- a/packages/phrases-experience/src/locales/ru/account-center.ts
+++ b/packages/phrases-experience/src/locales/ru/account-center.ts
@@ -16,7 +16,7 @@ const account_center = {
   password_verification: {
     title: 'Подтвердите пароль',
     description: 'Чтобы защитить аккаунт, введите пароль для подтверждения своей личности.',
-    error_failed: 'Проверка не удалась. Проверьте пароль.',
+    error_failed: 'Неверный пароль. Проверьте введённые данные.',
   },
   verification_method: {
     password: {

--- a/packages/phrases-experience/src/locales/th/account-center.ts
+++ b/packages/phrases-experience/src/locales/th/account-center.ts
@@ -16,7 +16,7 @@ const account_center = {
   password_verification: {
     title: 'ยืนยันรหัสผ่าน',
     description: 'เพื่อปกป้องบัญชี กรุณากรอกรหัสผ่านเพื่อยืนยันตัวตน',
-    error_failed: 'การยืนยันล้มเหลว โปรดตรวจสอบรหัสผ่านของคุณ',
+    error_failed: 'รหัสผ่านไม่ถูกต้อง โปรดตรวจสอบข้อมูลที่ป้อน',
   },
   verification_method: {
     password: {

--- a/packages/phrases-experience/src/locales/tr-tr/account-center.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/account-center.ts
@@ -16,7 +16,7 @@ const account_center = {
   password_verification: {
     title: 'Parolayı doğrula',
     description: 'Hesabını korumak için kimliğini doğrula. Parolanı gir.',
-    error_failed: 'Doğrulama başarısız. Lütfen parolanı kontrol et.',
+    error_failed: 'Yanlış parola. Lütfen girişinizi kontrol edin.',
   },
   verification_method: {
     password: {

--- a/packages/phrases-experience/src/locales/uk-ua/account-center.ts
+++ b/packages/phrases-experience/src/locales/uk-ua/account-center.ts
@@ -16,7 +16,7 @@ const account_center = {
   password_verification: {
     title: 'Підтвердьте пароль',
     description: 'Щоб захистити обліковий запис, введіть пароль для підтвердження своєї особи.',
-    error_failed: 'Перевірка не вдалася. Перевірте пароль.',
+    error_failed: 'Невірний пароль. Перевірте введені дані.',
   },
   verification_method: {
     password: {

--- a/packages/phrases-experience/src/locales/zh-cn/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/account-center.ts
@@ -15,7 +15,7 @@ const account_center = {
   password_verification: {
     title: '验证密码',
     description: '为保护账户安全，请输入您的密码完成验证。',
-    error_failed: '验证失败，请检查您的密码。',
+    error_failed: '密码错误，请重新输入。',
   },
   verification_method: {
     password: {

--- a/packages/phrases-experience/src/locales/zh-hk/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/account-center.ts
@@ -15,7 +15,7 @@ const account_center = {
   password_verification: {
     title: '驗證密碼',
     description: '為保障帳戶安全，請輸入你的密碼完成驗證。',
-    error_failed: '驗證失敗，請檢查你的密碼。',
+    error_failed: '密碼錯誤，請重新輸入。',
   },
   verification_method: {
     password: {

--- a/packages/phrases-experience/src/locales/zh-tw/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/account-center.ts
@@ -15,7 +15,7 @@ const account_center = {
   password_verification: {
     title: '驗證密碼',
     description: '為保護帳戶安全，請輸入您的密碼完成驗證。',
-    error_failed: '驗證失敗，請檢查您的密碼。',
+    error_failed: '密碼錯誤，請重新輸入。',
   },
   verification_method: {
     password: {


### PR DESCRIPTION
## Summary

The account center password verification was reusing the login flow's `session.invalid_credentials` error message directly from the API, which says "Incorrect account or password". Since the account is already known in this context (user is logged in), the error should only mention the password.

Changes:
- Override the `session.invalid_credentials` error handler in `PasswordVerification` component to use the local `error_failed` translation key instead of the API error message.
- Update `error_failed` translations across all 18 locales from "Verification failed" to "Incorrect password".

## Testing

Tested locally

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments