### PR TITLE
fix(account): prevent continue button loading on authenticator app page enter

### DIFF
--- a/packages/account/src/pages/TotpBinding/index.tsx
+++ b/packages/account/src/pages/TotpBinding/index.tsx
@@ -40,8 +40,8 @@ const TotpBinding = () => {
     setToast,
     userInfo,
   } = useContext(PageContext);
-  const getMfaRequest = useApi(getMfaVerifications);
-  const generateSecretRequest = useApi(generateTotpSecret);
+  const getMfaRequest = useApi(getMfaVerifications, { silent: true });
+  const generateSecretRequest = useApi(generateTotpSecret, { silent: true });
   const addTotpRequest = useApi(addTotpMfa);
   const handleError = useErrorHandler();
 


### PR DESCRIPTION
## Summary
The continue button on the authenticator app binding page (`/account/authenticator-app`) briefly shows a loading state when the page first loads. This happens because the `getMfaVerifications` and `generateTotpSecret` init API calls use the shared global loading context, which the button also reads from. Mark these two init requests as `silent` so they don't trigger the global loading state.

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments