### PR TITLE
fix(account): hide divider when no passkeys exist

### DIFF
--- a/packages/account/src/pages/PasskeyView/index.tsx
+++ b/packages/account/src/pages/PasskeyView/index.tsx
@@ -242,7 +242,7 @@ const PasskeyView = () => {
               );
             })}
           </div>
-          <div className={styles.divider} />
+          {passkeys.length > 0 && <div className={styles.divider} />}
           <div className={styles.addSection}>
             <div className={styles.addTitle}>
               <DynamicT forKey="account_center.passkey.add_another_title" />


### PR DESCRIPTION
## Summary
Hide the divider line between the passkey list and the "Add Another Passkey" section when the user has no passkeys on the passkey manage page.

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments