### PR TITLE
feat(console): move username field from profile data to identifiers section

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/constants.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/constants.ts
@@ -31,6 +31,7 @@ export const accountCenterSections: AccountCenterFieldSection[] = [
         key: 'identifiers',
         title: 'sign_in_exp.account_center.sections.account_security.groups.identifiers.title',
         items: [
+          { key: 'username', title: 'sign_in_exp.account_center.fields.username' },
           { key: 'email', title: 'sign_in_exp.account_center.fields.email' },
           { key: 'phone', title: 'sign_in_exp.account_center.fields.phone' },
           { key: 'social', title: 'sign_in_exp.account_center.fields.social' },
@@ -59,7 +60,6 @@ export const accountCenterSections: AccountCenterFieldSection[] = [
         key: 'profileData',
         title: 'sign_in_exp.account_center.sections.user_profile.groups.profile_data.title',
         items: [
-          { key: 'username', title: 'sign_in_exp.account_center.fields.username' },
           { key: 'name', title: 'sign_in_exp.account_center.fields.name' },
           { key: 'avatar', title: 'sign_in_exp.account_center.fields.avatar' },
           {


### PR DESCRIPTION
## Summary
Move the Username field from the "Profile Data" group to the "Identifiers" group in the Account Center page, placing it before Email address.

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments