### PR TITLE
fix(console): hide tenant MFA field title when user cannot manage tenant

### DIFF
--- a/packages/console/src/pages/TenantSettings/TenantBasicSettings/ProfileForm/TenantMfa/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantBasicSettings/ProfileForm/TenantMfa/index.tsx
@@ -5,11 +5,9 @@ import useSWR from 'swr';
 
 import { useAuthedCloudApi } from '@/cloud/hooks/use-cloud-api';
 import { type TenantSettingsResponse } from '@/cloud/types/router';
-import { isCloud } from '@/consts/env';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import Switch from '@/ds-components/Switch';
 import { type RequestError } from '@/hooks/use-api';
-import useCurrentTenantScopes from '@/hooks/use-current-tenant-scopes';
 
 import useTenantMfaFeature from './use-tenant-mfa-feature.js';
 
@@ -17,15 +15,12 @@ function TenantMfa() {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const cloudApi = useAuthedCloudApi();
   const { currentTenantId } = useContext(TenantsContext);
-  const {
-    access: { canManageTenant },
-  } = useCurrentTenantScopes();
   const { isFeatureAvailable } = useTenantMfaFeature();
 
   const [isUpdating, setIsUpdating] = useState(false);
 
   const { data, error, isLoading, mutate } = useSWR<TenantSettingsResponse, RequestError>(
-    isCloud && `api/tenants/${currentTenantId}/settings`,
+    `api/tenants/${currentTenantId}/settings`,
     async () =>
       cloudApi.get(`/api/tenants/:tenantId/settings`, {
         params: { tenantId: currentTenantId },
@@ -51,10 +46,6 @@ function TenantMfa() {
       setIsUpdating(false);
     }
   };
-
-  if (!isCloud || !canManageTenant) {
-    return null;
-  }
 
   return (
     <Switch

--- a/packages/console/src/pages/TenantSettings/TenantBasicSettings/ProfileForm/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantBasicSettings/ProfileForm/index.tsx
@@ -48,7 +48,7 @@ function ProfileForm({ currentTenantId }: Props) {
       <FormField title="tenants.settings.tenant_type">
         <TenantEnvironment tag={getValues('profile.tag')} />
       </FormField>
-      {isDevFeaturesEnabled && (
+      {isDevFeaturesEnabled && canManageTenant && (
         <FormField
           title="tenants.settings.tenant_mfa"
           featureTag={{


### PR DESCRIPTION
## Summary
The TenantMfa component was returning null when `canManageTenant` was false, but the parent FormField title was still being rendered. This caused an empty field with just the title to be displayed for users without management permissions.

This PR:
- Moves the `canManageTenant` check to the parent ProfileForm component so the entire FormField (including title) is hidden
- Removes redundant `isCloud` and `canManageTenant` checks from TenantMfa since the tenant settings route is already cloud-only (guarded at the router level)

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments