### PR TITLE
fix(console): allow dev tenants to use tenant MFA setting

### DIFF
--- a/packages/console/src/pages/TenantSettings/TenantBasicSettings/ProfileForm/TenantMfa/use-tenant-mfa-feature.ts
+++ b/packages/console/src/pages/TenantSettings/TenantBasicSettings/ProfileForm/TenantMfa/use-tenant-mfa-feature.ts
@@ -1,8 +1,8 @@
-import { ReservedPlanId } from '@logto/schemas';
 import { useContext } from 'react';
 
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import { TenantsContext } from '@/contexts/TenantsProvider';
+import { isPaidPlan } from '@/utils/subscription';
 
 const useTenantMfaFeature = () => {
   const { isDevTenant } = useContext(TenantsContext);
@@ -10,13 +10,14 @@ const useTenantMfaFeature = () => {
     currentSubscription: { planId, isEnterprisePlan },
   } = useContext(SubscriptionDataContext);
 
-  const isFreeOrDevPlan =
-    planId === ReservedPlanId.Free || planId === ReservedPlanId.Development || isDevTenant;
-  const isFeatureAvailable = !isFreeOrDevPlan || isEnterprisePlan;
+  const isPaidTenant = isPaidPlan(planId, isEnterprisePlan);
 
   return {
-    isFreeOrDevPlan,
-    isFeatureAvailable,
+    // Whether to show the paywall tag. Note: FeatureTag component handles dev tenant display
+    // automatically, so we don't need to include isDevTenant here.
+    shouldShowPaywallTag: !isPaidTenant,
+    // Dev tenants can use all features for testing purposes
+    isFeatureAvailable: isDevTenant || isPaidTenant,
   };
 };
 

--- a/packages/console/src/pages/TenantSettings/TenantBasicSettings/ProfileForm/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantBasicSettings/ProfileForm/index.tsx
@@ -28,7 +28,7 @@ function ProfileForm({ currentTenantId }: Props) {
     formState: { errors },
     getValues,
   } = useFormContext<TenantSettingsForm>();
-  const { isFreeOrDevPlan } = useTenantMfaFeature();
+  const { shouldShowPaywallTag } = useTenantMfaFeature();
 
   return (
     <FormCard title="tenants.settings.title" description="tenants.settings.description">
@@ -52,7 +52,7 @@ function ProfileForm({ currentTenantId }: Props) {
         <FormField
           title="tenants.settings.tenant_mfa"
           featureTag={{
-            isVisible: isFreeOrDevPlan,
+            isVisible: shouldShowPaywallTag,
             plan: ReservedPlanId.Pro,
           }}
         >


### PR DESCRIPTION
## Summary
Dev tenants should be able to use all features for testing purposes. The paywall tag will still be shown (handled by FeatureTag component) to inform developers which features require payment in production.

- Use `isPaidPlan` utility for consistency with other features
- Rename `isFreeOrDevPlan` to `shouldShowPaywallTag` for clarity
- `isFeatureAvailable` now returns true for dev tenants

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments