### PR TITLE
chore: exclude root package from start:dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prepack": "pnpm -r prepack",
     "dev": "pnpm -r prepack && pnpm start:dev",
     "dev:cloud": "IS_CLOUD=1 CONSOLE_PUBLIC_URL=/ pnpm dev",
-    "start:dev": "pnpm -r --parallel --filter=!@logto/integration-tests --filter \"!./packages/connectors/connector-*\" dev",
+    "start:dev": "pnpm -r --parallel --filter=!@logto/root --filter=!@logto/integration-tests --filter \"!./packages/connectors/connector-*\" dev",
     "start": "cd packages/core && NODE_ENV=production node .",
     "cli": "logto",
     "translate": "logto-translate",


### PR DESCRIPTION
## Summary

Exclude `@logto/root` package from the `start:dev` script to avoid unnecessary process spawning during parallel development execution.

## Test plan

- Run `pnpm dev` and verify all packages start correctly without the root package being included.