### PR TITLE
chore(demo-app): fix dev panel being covered by browser console

### DIFF
--- a/packages/demo-app/src/App.module.scss
+++ b/packages/demo-app/src/App.module.scss
@@ -83,8 +83,15 @@
       position: fixed;
       inset-inline-start: _.unit(2);
       top: _.unit(2);
+      max-height: calc(100vh - _.unit(4));
+      overflow-y: auto;
       padding: _.unit(4);
       gap: _.unit(3);
+      scrollbar-width: none;
+
+      &::-webkit-scrollbar {
+        display: none;
+      }
 
       .item {
         margin: _.unit(2) 0;


### PR DESCRIPTION
## Summary

The dev panel in demo-app is fixed-positioned at the top-left corner. When opening the browser DevTools console, the panel would be covered and become inaccessible, making it impossible to interact with the panel while viewing console logs.


## Testing

tested locally

<img width="1129" height="718" alt="image" src="https://github.com/user-attachments/assets/59ec3423-cf19-4b9e-bede-7633a16e4435" />


## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments