### PR TITLE
chore: release account center

### DIFF
--- a/packages/console/src/pages/Profile/components/LinkAccountSection/index.tsx
+++ b/packages/console/src/pages/Profile/components/LinkAccountSection/index.tsx
@@ -13,11 +13,9 @@ import FormCard from '@/components/FormCard';
 import UnnamedTrans from '@/components/UnnamedTrans';
 import UserInfoCard from '@/components/UserInfoCard';
 import { adminTenantEndpoint, meApi, storageKeys } from '@/consts';
-import { isDevFeaturesEnabled } from '@/consts/env';
 import ImageWithErrorFallback from '@/ds-components/ImageWithErrorFallback';
 import { useStaticApi } from '@/hooks/use-api';
 import { useConfirmModal } from '@/hooks/use-confirm-modal';
-import useTenantPathname from '@/hooks/use-tenant-pathname';
 import useTheme from '@/hooks/use-theme';
 
 import { useNavigateToAccountCenter } from '../../hooks';
@@ -36,7 +34,6 @@ type Props = {
 
 function LinkAccountSection({ user, connectors, onUpdate }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
-  const { navigate } = useTenantPathname();
   const navigateToAccountCenter = useNavigateToAccountCenter();
   const theme = useTheme();
   const { show: showConfirm } = useConfirmModal();
@@ -154,13 +151,7 @@ function LinkAccountSection({ user, connectors, onUpdate }: Props) {
             action: {
               name: user.primaryEmail ? 'profile.change' : 'profile.link',
               handler: () => {
-                if (isDevFeaturesEnabled) {
-                  navigateToAccountCenter('/account/email');
-                  return;
-                }
-                navigate('link-email', {
-                  state: { email: user.primaryEmail, action: 'changeEmail' },
-                });
+                navigateToAccountCenter('/account/email');
               },
             },
           },

--- a/packages/console/src/pages/Profile/containers/BasicUserInfoUpdateModal/index.tsx
+++ b/packages/console/src/pages/Profile/containers/BasicUserInfoUpdateModal/index.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from 'react-i18next';
 import ReactModal from 'react-modal';
 
 import { adminTenantEndpoint, meApi } from '@/consts';
-import { isDevFeaturesEnabled } from '@/consts/env';
 import Button from '@/ds-components/Button';
 import ModalLayout from '@/ds-components/ModalLayout';
 import TextInput from '@/ds-components/TextInput';
@@ -88,11 +87,11 @@ function BasicUserInfoUpdateModal({ field, value: initialValue, isOpen, onClose 
     clearErrors();
     void handleSubmit(async (data) => {
       try {
-        // Use Account API for name and username fields when dev features enabled,
-        // Me API for avatar (image upload not supported in Account API yet) and fallback
-        await (isDevFeaturesEnabled && field !== 'avatar'
-          ? accountApi.patch('', { json: { [field]: data[field] } })
-          : meApi_.patch('me', { json: { [field]: data[field] } }));
+        // Use Account API for name and username fields,
+        // Me API for avatar (image upload not supported in Account API yet).
+        await (field === 'avatar'
+          ? meApi_.patch('me', { json: { [field]: data[field] } })
+          : accountApi.patch('', { json: { [field]: data[field] } }));
         toast.success(t('profile.updated', { target: t(`profile.settings.${field}`) }));
         onClose();
       } catch (error: unknown) {

--- a/packages/console/src/pages/Profile/index.tsx
+++ b/packages/console/src/pages/Profile/index.tsx
@@ -10,7 +10,7 @@ import FormCard from '@/components/FormCard';
 import PageMeta from '@/components/PageMeta';
 import Topbar from '@/components/Topbar';
 import { adminTenantEndpoint, meApi } from '@/consts';
-import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
+import { isCloud } from '@/consts/env';
 import AppBoundary from '@/containers/AppBoundary';
 import Button from '@/ds-components/Button';
 import CardTitle from '@/ds-components/CardTitle';
@@ -21,7 +21,6 @@ import { profile } from '@/hooks/use-console-routes/routes/profile';
 import useCurrentUser from '@/hooks/use-current-user';
 import { usePlausiblePageview } from '@/hooks/use-plausible-pageview';
 import useSwrFetcher from '@/hooks/use-swr-fetcher';
-import useTenantPathname from '@/hooks/use-tenant-pathname';
 import useUserAssetsService from '@/hooks/use-user-assets-service';
 import pageLayout from '@/scss/page-layout.module.scss';
 
@@ -37,7 +36,6 @@ import styles from './index.module.scss';
 
 function Profile() {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
-  const { navigate } = useTenantPathname();
   const navigateToAccountCenter = useNavigateToAccountCenter();
   const childrenRoutes = useRoutes(profile);
   usePlausiblePageview(profile, 'profile');
@@ -98,22 +96,14 @@ function Profile() {
                         action: {
                           name: 'profile.change',
                           handler: () => {
-                            if (isDevFeaturesEnabled) {
-                              navigateToAccountCenter('/account/password');
-                              return;
-                            }
-                            navigate(user.hasPassword ? 'verify-password' : 'change-password', {
-                              state: { email: user.primaryEmail, action: 'changePassword' },
-                            });
+                            navigateToAccountCenter('/account/password');
                           },
                         },
                       },
                     ]}
                   />
                 </FormCard>
-                {isDevFeaturesEnabled && (
-                  <MfaSection user={user} signInExperience={signInExperience} />
-                )}
+                <MfaSection user={user} signInExperience={signInExperience} />
                 {isCloud && (
                   <FormCard title="profile.delete_account.title">
                     <div className={styles.deleteAccount}>

--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/index.tsx
@@ -5,7 +5,6 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import FormCard from '@/components/FormCard';
 import PageMeta from '@/components/PageMeta';
-import { isDevFeaturesEnabled } from '@/consts/env';
 import FormField from '@/ds-components/FormField';
 import InlineNotification from '@/ds-components/InlineNotification';
 import type { Option } from '@/ds-components/Select';
@@ -103,7 +102,7 @@ function AccountCenter({ isActive, data }: Props) {
           </FormField>
         </div>
       </FormCard>
-      {isDevFeaturesEnabled && <IntegratePrebuiltUi />}
+      <IntegratePrebuiltUi />
       {accountCenterSections.map((section) => (
         <FormCard key={section.key} title={section.title} description={section.description}>
           <div className={styles.cardContent}>

--- a/packages/core/src/routes/well-known/index.ts
+++ b/packages/core/src/routes/well-known/index.ts
@@ -84,17 +84,15 @@ export default function wellKnownRoutes<T extends AnonymousRouter>(
 
   experienceRoutes(router, libraries);
 
-  if (EnvSet.values.isDevFeaturesEnabled) {
-    router.get(
-      '/.well-known/account-center',
-      koaGuard({
-        response: AccountCenters.guard,
-        status: 200,
-      }),
-      async (ctx, next) => {
-        ctx.body = await findDefaultAccountCenter();
-        return next();
-      }
-    );
-  }
+  router.get(
+    '/.well-known/account-center',
+    koaGuard({
+      response: AccountCenters.guard,
+      status: 200,
+    }),
+    async (ctx, next) => {
+      ctx.body = await findDefaultAccountCenter();
+      return next();
+    }
+  );
 }

--- a/packages/core/src/routes/well-known/well-known.openapi.json
+++ b/packages/core/src/routes/well-known/well-known.openapi.json
@@ -49,9 +49,8 @@
     },
     "/api/.well-known/account-center": {
       "get": {
-        "tags": ["Dev feature"],
         "summary": "Get default account center",
-        "description": "Get the default account center configuration. Available only when developer features are enabled.",
+        "description": "Get the default account center configuration.",
         "responses": {
           "200": {
             "description": "The default account center configuration."

--- a/packages/core/src/tenants/Tenant.ts
+++ b/packages/core/src/tenants/Tenant.ts
@@ -202,20 +202,18 @@ export default class Tenant implements TenantContext {
     }
 
     // Mount account center for all tenants (including admin tenant for profile MFA management)
-    if (EnvSet.values.isDevFeaturesEnabled) {
-      app.use(
-        mount(
-          '/' + UserApps.AccountCenter,
-          koaSpaProxy({
-            mountedApps,
-            queries,
-            packagePath: UserApps.AccountCenter,
-            port: 5004,
-            prefix: UserApps.AccountCenter,
-          })
-        )
-      );
-    }
+    app.use(
+      mount(
+        '/' + UserApps.AccountCenter,
+        koaSpaProxy({
+          mountedApps,
+          queries,
+          packagePath: UserApps.AccountCenter,
+          port: 5004,
+          prefix: UserApps.AccountCenter,
+        })
+      )
+    );
 
     // Mount experience app
     app.use(


### PR DESCRIPTION
## Summary
- Remove dev feature gates for account center/profile flows in console and backend.
- Always mount account center and expose well-known account-center.
- Update OpenAPI tag/description for account-center.

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments