### PR TITLE
chore: add dev feature and API development docs

### DIFF
--- a/docs/api-development-checklist.md
+++ b/docs/api-development-checklist.md
@@ -1,0 +1,154 @@
+# API Development Checklist
+
+When developing new API routes in Logto core, follow this checklist to ensure everything is properly configured.
+
+## 1. Route Definition
+
+Define your route in `packages/core/src/routes/`.
+
+```typescript
+router.get(
+  '/configs/your-route',
+  koaGuard({
+    response: yourGuard,
+    status: [200],
+  }),
+  async (ctx, next) => {
+    ctx.body = await yourService.getData();
+    return next();
+  }
+);
+```
+
+> For dev features, see [Dev Feature](./dev-feature.md) documentation.
+
+## 2. Custom Operation ID
+
+If your route path doesn't follow the standard pattern `[name, :parameter]`, you need to add a custom operation ID.
+
+### When is it needed?
+
+The OpenAPI generator expects paths like:
+- `/resources/:resourceId` - ✅ Works automatically
+- `/resources/:resourceId/scopes/:scopeId` - ✅ Works automatically
+- `/configs/admin-console` - ❌ Needs custom operation ID
+- `/configs/jwt-customizer/test` - ❌ Needs custom operation ID
+
+### How to add
+
+Edit `packages/core/src/routes/swagger/utils/operation-id.ts`:
+
+```typescript
+export const customRoutes: Readonly<RouteDictionary> = Object.freeze({
+  // ... existing routes
+  // Configs
+  'get /configs/your-route': 'GetYourRouteConfig',
+  'patch /configs/your-route': 'UpdateYourRouteConfig',
+  // ...
+});
+```
+
+## 3. OpenAPI Documentation
+
+Add API documentation to the appropriate `.openapi.json` file.
+
+### Find the right file
+
+- Config routes → `packages/core/src/routes/logto-config/logto-config.openapi.json`
+- User routes → `packages/core/src/routes/admin-user/*.openapi.json`
+- Application routes → `packages/core/src/routes/applications/*.openapi.json`
+- etc.
+
+### Add documentation
+
+```json
+"/api/configs/your-route": {
+  "get": {
+    "summary": "Get your route config",
+    "description": "Get the configuration for your feature.",
+    "responses": {
+      "200": {
+        "description": "The configuration object."
+      }
+    }
+  },
+  "patch": {
+    "summary": "Update your route config",
+    "description": "Update the configuration for your feature.",
+    "requestBody": {
+      "content": {
+        "application/json": {
+          "schema": {
+            "properties": {
+              "yourProperty": {
+                "description": "Description of the property."
+              }
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "200": {
+        "description": "The updated configuration object."
+      }
+    }
+  }
+}
+```
+
+### Required fields
+
+Every operation must have:
+- `summary` - Short description
+- `description` - Detailed description
+- `responses` - At least one response
+
+## 4. Validation
+
+### Build check
+
+```bash
+pnpm -F @logto/core build
+```
+
+### Integration tests
+
+Integration tests validate:
+- Swagger JSON generation (`swagger-check.test.js`)
+- OpenAPI JSON endpoints (`well-known.openapi.test.js`)
+
+## Common Errors and Solutions
+
+### "Invalid path for generating operation ID: get /your/path"
+
+**Cause**: Route path doesn't match the expected pattern `[name, :parameter]`
+
+**Solution**: Add custom operation ID to `customRoutes` in `operation-id.ts`
+
+### "Path `/api/your/path` and operation `get` must have a summary"
+
+**Cause**: Missing openapi.json documentation for the route
+
+**Solution**: Add the route to the appropriate `.openapi.json` file with `summary` and `description`
+
+### "Supplement document contains extra path: `/api/your/path`"
+
+**Cause**: openapi.json has path definition but route doesn't exist (common with dev features when `isDevFeaturesEnabled=false`)
+
+**Solution**: Add `"tags": ["Dev feature"]` to the operations in openapi.json (see [Dev Feature](./dev-feature.md))
+
+### "Not all custom routes are built" / "There are extra routes that are built but not defined"
+
+**Cause**: Mismatch between `customRoutes` entries and actual routes
+
+**Solution**: Ensure every entry in `customRoutes` has a corresponding route, and vice versa
+
+## Files Reference
+
+| Purpose | Location |
+|---------|----------|
+| Route definitions | `packages/core/src/routes/` |
+| Custom operation IDs | `packages/core/src/routes/swagger/utils/operation-id.ts` |
+| OpenAPI supplements | `packages/core/src/routes/**/*.openapi.json` |
+| Swagger validation | `packages/core/src/routes/swagger/utils/general.ts` |

--- a/docs/dev-feature.md
+++ b/docs/dev-feature.md
@@ -1,0 +1,154 @@
+# Dev Feature
+
+This document describes how to work with dev features in Logto.
+
+## What is a Dev Feature?
+
+Dev features are experimental features that are not yet ready for production. They are controlled by the `isDevFeaturesEnabled` flag.
+
+## Usage in Code
+
+### Core Package
+
+Import from `EnvSet`:
+
+```typescript
+import { EnvSet } from '#src/env-set/index.js';
+
+// DEV: <feature description>
+if (EnvSet.values.isDevFeaturesEnabled) {
+  router.get(
+    '/your-route',
+    koaGuard({ /* ... */ }),
+    async (ctx, next) => {
+      // Implementation
+    }
+  );
+}
+```
+
+### Console Package
+
+Import from `@/consts/env`:
+
+```typescript
+import { isDevFeaturesEnabled } from '@/consts/env';
+
+// DEV: <feature description>
+{isDevFeaturesEnabled && <YourDevFeatureComponent />}
+```
+
+The flag is determined by (from `packages/console/src/consts/env.ts`):
+
+```typescript
+export const isDevFeaturesEnabled =
+  !isProduction ||
+  yes(normalizeEnv(import.meta.env.DEV_FEATURES_ENABLED)) ||
+  yes(localStorage.getItem(storageKeys.isDevFeaturesEnabled));
+```
+
+- `!isProduction` - Always enabled in non-production builds
+- `import.meta.env.DEV_FEATURES_ENABLED` - Environment variable
+- `localStorage.getItem(storageKeys.isDevFeaturesEnabled)` - Can be enabled via localStorage for testing
+
+### Comment Convention
+
+Use consistent comments to mark dev features for easy search and cleanup during release:
+
+```typescript
+// DEV: <feature description>
+```
+
+This makes it easy to find all dev feature code when graduating features to production.
+
+## Usage in Integration Tests
+
+The integration tests run twice: once with `isDevFeaturesEnabled=true` and once with `isDevFeaturesEnabled=false`.
+
+Import test utilities from `packages/integration-tests/src/utils.ts`:
+
+```typescript
+import { devFeatureTest, devFeatureDisabledTest } from '#src/utils.js';
+```
+
+### `devFeatureTest`
+
+Use when tests should **only run when dev features are enabled**:
+
+```typescript
+devFeatureTest.describe('My dev feature', () => {
+  devFeatureTest.it('should work when dev features enabled', async () => {
+    // This test only runs when isDevFeaturesEnabled=true
+  });
+});
+```
+
+### `devFeatureDisabledTest`
+
+Use when tests should **only run when dev features are disabled**:
+
+```typescript
+devFeatureDisabledTest.describe('My feature disabled behavior', () => {
+  devFeatureDisabledTest.it('should not expose route when dev features disabled', async () => {
+    // This test only runs when isDevFeaturesEnabled=false
+  });
+});
+```
+
+### Implementation Details
+
+```typescript
+// From packages/integration-tests/src/utils.ts
+export const devFeatureTest = Object.freeze({
+  it: isDevFeaturesEnabled ? it : it.skip,
+  describe: isDevFeaturesEnabled ? describe : describe.skip,
+});
+
+export const devFeatureDisabledTest = Object.freeze({
+  it: isDevFeaturesEnabled ? it.skip : it,
+  describe: isDevFeaturesEnabled ? describe.skip : describe,
+});
+```
+
+## Usage in OpenAPI Documentation
+
+When adding OpenAPI documentation for dev feature routes, include the `"Dev feature"` tag. This ensures the routes are automatically removed from the OpenAPI spec when `isDevFeaturesEnabled=false`.
+
+```json
+"/api/your-route": {
+  "get": {
+    "tags": ["Dev feature"],
+    "summary": "Your route summary",
+    "description": "Your route description.",
+    "responses": {
+      "200": {
+        "description": "Success response."
+      }
+    }
+  }
+}
+```
+
+The `removeUnnecessaryOperations` function in `packages/core/src/routes/swagger/utils/general.ts` will automatically filter out operations tagged with `"Dev feature"` when the flag is disabled.
+
+## Usage in Custom Route Operation IDs
+
+If your dev feature route needs a custom operation ID, add it to `devFeatureCustomRoutes` in `packages/core/src/routes/swagger/utils/operation-id.ts`:
+
+```typescript
+const devFeatureCustomRoutes: RouteDictionary = Object.freeze({
+  // DEV: <feature description>
+  'get /your-route': 'GetYourRoute',
+  'patch /your-route': 'UpdateYourRoute',
+});
+```
+
+## Graduating a Dev Feature
+
+When a dev feature is ready for production:
+
+1. Remove `isDevFeaturesEnabled` condition from route registration
+2. Move entries from `devFeatureCustomRoutes` to `customRoutes`
+3. Remove `"tags": ["Dev feature"]` from openapi.json
+4. Remove `// DEV: <feature description>` comments
+5. Update tests from `devFeatureTest` to regular `it`/`describe`


### PR DESCRIPTION
## Summary

Add documentation for dev feature development workflow and API development checklist:

- `docs/dev-feature.md` - How to work with dev features in Logto
  - Usage in Core package (`EnvSet.values.isDevFeaturesEnabled`)
  - Usage in Console package (`@/consts/env`)
  - Usage in integration tests (`devFeatureTest` / `devFeatureDisabledTest`)
  - OpenAPI documentation with `"Dev feature"` tag
  - Custom operation IDs in `devFeatureCustomRoutes`
  - Graduation checklist

- `docs/api-development-checklist.md` - Checklist for API development
  - Route definition
  - Custom operation ID configuration
  - OpenAPI documentation requirements
  - Common errors and solutions

## Testing

N/A

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments