### PR TITLE
refactor(core): remove unused cloudConnection parameter from initOidc

### DIFF
--- a/packages/core/src/oidc/init.test.ts
+++ b/packages/core/src/oidc/init.test.ts
@@ -5,11 +5,10 @@ import initOidc from './init.js';
 
 describe('oidc provider init', () => {
   it('init should not throw', async () => {
-    const { id, queries, libraries, logtoConfigs, cloudConnection, subscription } =
-      new MockTenant();
+    const { id, queries, libraries, logtoConfigs, subscription } = new MockTenant();
 
     expect(() =>
-      initOidc(id, mockEnvSet, queries, libraries, logtoConfigs, cloudConnection, subscription)
+      initOidc(id, mockEnvSet, queries, libraries, logtoConfigs, subscription)
     ).not.toThrow();
   });
 });

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -24,7 +24,6 @@ import snakecaseKeys from 'snakecase-keys';
 
 import { EnvSet } from '#src/env-set/index.js';
 import { addOidcEventListeners } from '#src/event-listeners/index.js';
-import { type CloudConnectionLibrary } from '#src/libraries/cloud-connection.js';
 import { type LogtoConfigLibrary } from '#src/libraries/logto-config.js';
 import koaAppSecretTranspilation from '#src/middleware/koa-app-secret-transpilation.js';
 import koaAuditLog, { type WithLogContext } from '#src/middleware/koa-audit-log.js';
@@ -69,7 +68,6 @@ export default function initOidc(
   queries: Queries,
   libraries: Libraries,
   logtoConfigs: LogtoConfigLibrary,
-  cloudConnection: CloudConnectionLibrary,
   subscription: SubscriptionLibrary
 ): Provider {
   const {

--- a/packages/core/src/tenants/Tenant.ts
+++ b/packages/core/src/tenants/Tenant.ts
@@ -122,15 +122,7 @@ export default class Tenant implements TenantContext {
     app.use(koaSecurityHeaders(mountedApps, id));
 
     // Mount OIDC
-    const provider = initOidc(
-      id,
-      envSet,
-      queries,
-      libraries,
-      logtoConfigs,
-      cloudConnection,
-      subscription
-    );
+    const provider = initOidc(id, envSet, queries, libraries, logtoConfigs, subscription);
     app.use(mount('/oidc', provider.app));
 
     const tenantContext: TenantContext = {


### PR DESCRIPTION
## Summary

Remove the unused `cloudConnection` parameter from the `initOidc` function. This parameter was being passed through but never actually used in the function body.

Changes:
- Removed `cloudConnection: CloudConnectionLibrary` parameter from `initOidc` function signature
- Removed the corresponding import statement
- Updated the call site in `Tenant.ts`
- Updated the test file accordingly

## Testing

tested locally

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments