### PR TITLE
feat(console): defer MFA settings save until save button clicked

### DIFF
--- a/packages/console/src/pages/TenantSettings/TenantBasicSettings/ProfileForm/TenantMfa/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantBasicSettings/ProfileForm/TenantMfa/index.tsx
@@ -1,58 +1,31 @@
-import { useContext, useState } from 'react';
-import { toast } from 'react-hot-toast';
+import { Controller, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import useSWR from 'swr';
 
-import { useAuthedCloudApi } from '@/cloud/hooks/use-cloud-api';
-import { type TenantSettingsResponse } from '@/cloud/types/router';
-import { TenantsContext } from '@/contexts/TenantsProvider';
 import Switch from '@/ds-components/Switch';
-import { type RequestError } from '@/hooks/use-api';
+
+import { type TenantSettingsForm } from '../../types.js';
 
 import useTenantMfaFeature from './use-tenant-mfa-feature.js';
 
 function TenantMfa() {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
-  const cloudApi = useAuthedCloudApi();
-  const { currentTenantId } = useContext(TenantsContext);
   const { isFeatureAvailable } = useTenantMfaFeature();
-
-  const [isUpdating, setIsUpdating] = useState(false);
-
-  const { data, error, isLoading, mutate } = useSWR<TenantSettingsResponse, RequestError>(
-    `api/tenants/${currentTenantId}/settings`,
-    async () =>
-      cloudApi.get(`/api/tenants/:tenantId/settings`, {
-        params: { tenantId: currentTenantId },
-      })
-  );
-
-  const handleToggle = async (checked: boolean) => {
-    if (isUpdating || !isFeatureAvailable) {
-      return;
-    }
-
-    setIsUpdating(true);
-    try {
-      const updated = await cloudApi.patch(`/api/tenants/:tenantId/settings`, {
-        params: { tenantId: currentTenantId },
-        body: { isMfaRequired: checked },
-      });
-      void mutate(updated);
-      toast.success(t('general.saved'));
-    } catch {
-      toast.error(t('general.unknown_error'));
-    } finally {
-      setIsUpdating(false);
-    }
-  };
+  const { control } = useFormContext<TenantSettingsForm>();
 
   return (
-    <Switch
-      label={t('tenants.settings.tenant_mfa_description')}
-      disabled={!isFeatureAvailable || isLoading || isUpdating || Boolean(error)}
-      checked={data?.isMfaRequired ?? false}
-      onChange={async ({ currentTarget: { checked } }) => handleToggle(checked)}
+    <Controller
+      name="isMfaRequired"
+      control={control}
+      render={({ field: { value, onChange } }) => (
+        <Switch
+          label={t('tenants.settings.tenant_mfa_description')}
+          disabled={!isFeatureAvailable}
+          checked={value}
+          onChange={({ currentTarget: { checked } }) => {
+            onChange(checked);
+          }}
+        />
+      )}
     />
   );
 }

--- a/packages/console/src/pages/TenantSettings/TenantBasicSettings/types.ts
+++ b/packages/console/src/pages/TenantSettings/TenantBasicSettings/types.ts
@@ -4,4 +4,5 @@ export type TenantSettingsForm = {
   profile: Pick<TenantModel, 'name' | 'tag'> & {
     regionName: string;
   };
+  isMfaRequired: boolean;
 };


### PR DESCRIPTION
## Summary
Change MFA toggle behavior in tenant settings from immediate save to form-based save with action bar at the bottom, consistent with sign-in & account page and other fields in tenant settings.

- MFA switch now uses `react-hook-form` Controller instead of direct API calls
- Changes are saved together with other tenant profile settings when clicking "Save Changes"
- Bottom action bar appears when form is dirty, showing "Discard" and "Save Changes" buttons

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments