### PR TITLE
feat: enable adaptive MFA rules configuration

### DIFF
--- a/packages/core/src/routes/experience/classes/libraries/adaptive-mfa-validator/constants.ts
+++ b/packages/core/src/routes/experience/classes/libraries/adaptive-mfa-validator/constants.ts
@@ -1,7 +1,14 @@
-export const adaptiveMfaNewCountryWindowDays = 180;
-export const adaptiveMfaGeoVelocityThresholdKmh = 900;
-export const adaptiveMfaLongInactivityThresholdDays = 30;
-export const adaptiveMfaMinBotScore = 30;
+const adaptiveMfaNewCountryWindowDays = 180;
+const adaptiveMfaGeoVelocityThresholdKmh = 900;
+const adaptiveMfaLongInactivityThresholdDays = 30;
+const adaptiveMfaMinBotScore = 30;
 
 export const msPerHour = 1000 * 60 * 60;
 export const msPerDay = msPerHour * 24;
+
+export const adaptiveMfaDefaultThresholds = {
+  geoVelocityKmh: adaptiveMfaGeoVelocityThresholdKmh,
+  longInactivityDays: adaptiveMfaLongInactivityThresholdDays,
+  newCountryWindowDays: adaptiveMfaNewCountryWindowDays,
+  minBotScore: adaptiveMfaMinBotScore,
+};

--- a/packages/core/src/routes/experience/classes/libraries/adaptive-mfa-validator/index.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/adaptive-mfa-validator/index.test.ts
@@ -5,7 +5,7 @@ import { EnvSet } from '#src/env-set/index.js';
 
 import type { SignInExperienceValidator } from '../sign-in-experience-validator.js';
 
-import { AdaptiveMfaValidator, adaptiveMfaNewCountryWindowDays } from './index.js';
+import { AdaptiveMfaValidator } from './index.js';
 
 const { jest } = import.meta;
 const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
@@ -33,10 +33,18 @@ const createQueries = (overrides?: {
   };
 };
 
-const createSignInExperienceValidator = (enabled = true) =>
+const createSignInExperienceValidator = (
+  enabled = true,
+  thresholds?: {
+    geoVelocityKmh?: number;
+    longInactivityDays?: number;
+    newCountryWindowDays?: number;
+    minBotScore?: number;
+  }
+) =>
   ({
     getSignInExperienceData: jest.fn().mockResolvedValue({
-      adaptiveMfa: { enabled },
+      adaptiveMfa: { enabled, ...(thresholds && { thresholds }) },
     }),
   }) as unknown as SignInExperienceValidator;
 
@@ -87,7 +95,12 @@ describe('AdaptiveMfaValidator', () => {
       lastSignInAt: now.getTime() - 2 * 60 * 60 * 1000,
     };
     const queries = createQueries({
-      recentCountries: [],
+      recentCountries: [
+        {
+          country: 'DE',
+          lastSignInAt: now.getTime() - 3 * 60 * 60 * 1000,
+        },
+      ],
       geoLocation: { latitude: 0, longitude: 0 },
     });
 
@@ -114,6 +127,42 @@ describe('AdaptiveMfaValidator', () => {
     );
   });
 
+  it('honors geoVelocityKmh override', async () => {
+    const now = new Date('2024-01-02T00:00:00Z');
+    const user: User = {
+      ...mockUser,
+      lastSignInAt: now.getTime() - 2 * 60 * 60 * 1000,
+    };
+    const queries = createQueries({
+      recentCountries: [
+        {
+          country: 'DE',
+          lastSignInAt: now.getTime() - 3 * 60 * 60 * 1000,
+        },
+      ],
+      geoLocation: { latitude: 0, longitude: 0 },
+    });
+
+    const validator = new AdaptiveMfaValidator({
+      queries,
+      signInExperienceValidator: createSignInExperienceValidator(true, { geoVelocityKmh: 20_000 }),
+    });
+
+    const result = await validator.getResult(user, {
+      now,
+      currentContext: {
+        location: {
+          latitude: 50,
+          longitude: 0,
+          country: 'DE',
+          city: 'Frankfurt',
+        },
+      },
+    });
+
+    expect(result?.requiresMfa).toBe(false);
+  });
+
   it('triggers long inactivity rule after threshold', async () => {
     const now = new Date('2024-01-02T00:00:00Z');
     const user: User = {
@@ -136,6 +185,29 @@ describe('AdaptiveMfaValidator', () => {
     expect(result?.triggeredRules).toEqual(
       expect.arrayContaining([expect.objectContaining({ rule: 'long_inactivity' })])
     );
+  });
+
+  it('honors longInactivityDays override', async () => {
+    const now = new Date('2024-01-02T00:00:00Z');
+    const user: User = {
+      ...mockUser,
+      lastSignInAt: now.getTime() - 40 * 24 * 60 * 60 * 1000,
+    };
+    const queries = createQueries();
+
+    const validator = new AdaptiveMfaValidator({
+      queries,
+      signInExperienceValidator: createSignInExperienceValidator(true, {
+        longInactivityDays: 100,
+      }),
+    });
+
+    const result = await validator.getResult(user, {
+      now,
+      currentContext: {},
+    });
+
+    expect(result?.requiresMfa).toBe(false);
   });
 
   it('triggers untrusted ip rule when bot score is low', async () => {
@@ -163,6 +235,55 @@ describe('AdaptiveMfaValidator', () => {
     expect(result?.requiresMfa).toBe(true);
     expect(result?.triggeredRules).toEqual(
       expect.arrayContaining([expect.objectContaining({ rule: 'untrusted_ip' })])
+    );
+  });
+
+  it('honors minBotScore override', async () => {
+    const now = new Date('2024-01-02T00:00:00Z');
+    const user: User = {
+      ...mockUser,
+      lastSignInAt: null,
+    };
+    const queries = createQueries();
+
+    const validator = new AdaptiveMfaValidator({
+      queries,
+      signInExperienceValidator: createSignInExperienceValidator(true, { minBotScore: 5 }),
+    });
+
+    const result = await validator.getResult(user, {
+      now,
+      currentContext: {
+        ipRiskSignals: {
+          botScore: 10,
+        },
+      },
+    });
+
+    expect(result?.requiresMfa).toBe(false);
+  });
+
+  it('passes newCountryWindowDays to recent countries query', async () => {
+    const now = new Date('2024-01-02T00:00:00Z');
+    const user: User = {
+      ...mockUser,
+      lastSignInAt: now.getTime() - 60 * 60 * 1000,
+    };
+    const queries = createQueries({ recentCountries: [] });
+
+    const validator = new AdaptiveMfaValidator({
+      queries,
+      signInExperienceValidator: createSignInExperienceValidator(true, { newCountryWindowDays: 7 }),
+    });
+
+    await validator.getResult(user, {
+      now,
+      currentContext: { location: { country: 'FR' } },
+    });
+
+    expect(queries.userSignInCountries.findRecentSignInCountriesByUserId).toHaveBeenCalledWith(
+      user.id,
+      7
     );
   });
 
@@ -194,10 +315,7 @@ describe('AdaptiveMfaValidator', () => {
       45.6
     );
     expect(queries.userSignInCountries.upsertUserSignInCountry).toHaveBeenCalledWith(user.id, 'US');
-    expect(queries.userSignInCountries.pruneUserSignInCountriesByUserId).toHaveBeenCalledWith(
-      user.id,
-      adaptiveMfaNewCountryWindowDays
-    );
+    expect(queries.userSignInCountries.pruneUserSignInCountriesByUserId).not.toHaveBeenCalled();
   });
 
   it('parses zero coordinates from injected headers', async () => {

--- a/packages/core/src/routes/experience/classes/libraries/adaptive-mfa-validator/rules/base-rule.ts
+++ b/packages/core/src/routes/experience/classes/libraries/adaptive-mfa-validator/rules/base-rule.ts
@@ -9,7 +9,7 @@ import type {
 } from '../types.js';
 
 export type RuleDependencies = {
-  getRecentCountries: (user: User) => Promise<RecentCountry[]>;
+  getRecentCountries: (user: User, windowDays: number) => Promise<RecentCountry[]>;
   getUserGeoLocation: (user: User) => Promise<Nullable<UserGeoLocation>>;
 };
 

--- a/packages/core/src/routes/experience/classes/libraries/adaptive-mfa-validator/rules/geo-velocity.ts
+++ b/packages/core/src/routes/experience/classes/libraries/adaptive-mfa-validator/rules/geo-velocity.ts
@@ -1,6 +1,6 @@
 import type { Optional } from '@silverhand/essentials';
 
-import { adaptiveMfaGeoVelocityThresholdKmh, msPerHour } from '../constants.js';
+import { msPerHour } from '../constants.js';
 import type { AdaptiveMfaEvaluationState, TriggeredRuleByRule } from '../types.js';
 import { AdaptiveMfaRule } from '../types.js';
 import { haversineDistance, roundTo } from '../utils.js';
@@ -37,11 +37,14 @@ export class GeoVelocityRule extends AdaptiveMfaRuleValidator<AdaptiveMfaRule.Ge
 
     const speedKmh = distanceKm / durationHours;
 
-    if (speedKmh <= adaptiveMfaGeoVelocityThresholdKmh) {
+    if (speedKmh <= state.thresholds.geoVelocityKmh) {
       return;
     }
 
-    const recentCountries = await this.dependencies.getRecentCountries(state.user);
+    const recentCountries = await this.dependencies.getRecentCountries(
+      state.user,
+      state.thresholds.newCountryWindowDays
+    );
     const previousCountry = recentCountries[0];
 
     return {
@@ -59,7 +62,7 @@ export class GeoVelocityRule extends AdaptiveMfaRuleValidator<AdaptiveMfaRule.Ge
         distanceKm: roundTo(distanceKm),
         durationHours: roundTo(durationHours),
         speedKmh: roundTo(speedKmh),
-        thresholdKmh: adaptiveMfaGeoVelocityThresholdKmh,
+        thresholdKmh: state.thresholds.geoVelocityKmh,
       },
     };
   }

--- a/packages/core/src/routes/experience/classes/libraries/adaptive-mfa-validator/rules/long-inactivity.ts
+++ b/packages/core/src/routes/experience/classes/libraries/adaptive-mfa-validator/rules/long-inactivity.ts
@@ -1,6 +1,6 @@
 import type { Optional } from '@silverhand/essentials';
 
-import { adaptiveMfaLongInactivityThresholdDays, msPerDay } from '../constants.js';
+import { msPerDay } from '../constants.js';
 import type { AdaptiveMfaEvaluationState, TriggeredRuleByRule } from '../types.js';
 import { AdaptiveMfaRule } from '../types.js';
 import { roundTo } from '../utils.js';
@@ -17,7 +17,7 @@ export class LongInactivityRule extends AdaptiveMfaRuleValidator<AdaptiveMfaRule
 
     const inactivityDays = (state.now.getTime() - state.user.lastSignInAt) / msPerDay;
 
-    if (inactivityDays <= adaptiveMfaLongInactivityThresholdDays) {
+    if (inactivityDays <= state.thresholds.longInactivityDays) {
       return;
     }
 
@@ -26,7 +26,7 @@ export class LongInactivityRule extends AdaptiveMfaRuleValidator<AdaptiveMfaRule
       details: {
         lastSignInAt: new Date(state.user.lastSignInAt).toISOString(),
         inactivityDays: roundTo(inactivityDays),
-        thresholdDays: adaptiveMfaLongInactivityThresholdDays,
+        thresholdDays: state.thresholds.longInactivityDays,
       },
     };
   }

--- a/packages/core/src/routes/experience/classes/libraries/adaptive-mfa-validator/rules/new-country.ts
+++ b/packages/core/src/routes/experience/classes/libraries/adaptive-mfa-validator/rules/new-country.ts
@@ -1,6 +1,5 @@
 import { conditional, type Optional } from '@silverhand/essentials';
 
-import { adaptiveMfaNewCountryWindowDays } from '../constants.js';
 import type { AdaptiveMfaEvaluationState, TriggeredRuleByRule } from '../types.js';
 import { AdaptiveMfaRule } from '../types.js';
 
@@ -19,7 +18,10 @@ export class NewCountryRule extends AdaptiveMfaRuleValidator<AdaptiveMfaRule.New
       return;
     }
 
-    const recentCountries = await this.dependencies.getRecentCountries(state.user);
+    const recentCountries = await this.dependencies.getRecentCountries(
+      state.user,
+      state.thresholds.newCountryWindowDays
+    );
     const normalizedCurrent = currentCountry.toUpperCase();
     const hasRecentVisit = recentCountries.some(
       ({ country }) => country.toUpperCase() === normalizedCurrent
@@ -33,7 +35,7 @@ export class NewCountryRule extends AdaptiveMfaRuleValidator<AdaptiveMfaRule.New
       rule: AdaptiveMfaRule.NewCountry,
       details: {
         currentCountry,
-        windowDays: adaptiveMfaNewCountryWindowDays,
+        windowDays: state.thresholds.newCountryWindowDays,
         recentCountries: conditional(recentCountries.length > 0 && recentCountries),
       },
     };

--- a/packages/core/src/routes/experience/classes/libraries/adaptive-mfa-validator/rules/untrusted-ip.ts
+++ b/packages/core/src/routes/experience/classes/libraries/adaptive-mfa-validator/rules/untrusted-ip.ts
@@ -1,6 +1,5 @@
 import type { Optional } from '@silverhand/essentials';
 
-import { adaptiveMfaMinBotScore } from '../constants.js';
 import type { AdaptiveMfaEvaluationState, IpRiskSignals, TriggeredRuleByRule } from '../types.js';
 import { AdaptiveMfaRule } from '../types.js';
 
@@ -28,9 +27,9 @@ export class UntrustedIpRule extends AdaptiveMfaRuleValidator<AdaptiveMfaRule.Un
 
     const matchedSignals: string[] = [];
 
-    if (typeof signals.botScore === 'number' && signals.botScore < adaptiveMfaMinBotScore) {
+    if (typeof signals.botScore === 'number' && signals.botScore < state.thresholds.minBotScore) {
       // eslint-disable-next-line @silverhand/fp/no-mutating-methods
-      matchedSignals.push(`botScore<${adaptiveMfaMinBotScore}`);
+      matchedSignals.push(`botScore<${state.thresholds.minBotScore}`);
     }
 
     if (signals.botVerified === true) {

--- a/packages/core/src/routes/experience/classes/libraries/adaptive-mfa-validator/types.ts
+++ b/packages/core/src/routes/experience/classes/libraries/adaptive-mfa-validator/types.ts
@@ -1,6 +1,10 @@
 import type { IncomingHttpHeaders } from 'node:http';
 
-import type { User, UserSignInCountry } from '@logto/schemas';
+import type {
+  AdaptiveMfaThresholds as AdaptiveMfaThresholdsConfig,
+  User,
+  UserSignInCountry,
+} from '@logto/schemas';
 
 import type Queries from '#src/tenants/Queries.js';
 
@@ -98,10 +102,13 @@ export type AdaptiveMfaEvaluationOptions = {
   now?: Date;
 };
 
+export type AdaptiveMfaThresholds = Required<AdaptiveMfaThresholdsConfig>;
+
 export type AdaptiveMfaEvaluationState = {
   user: User;
   now: Date;
   context?: AdaptiveMfaContext;
+  thresholds: AdaptiveMfaThresholds;
 };
 
 export type RecentCountry = Pick<UserSignInCountry, 'country' | 'lastSignInAt'>;

--- a/packages/core/src/routes/sign-in-experience/index.test.ts
+++ b/packages/core/src/routes/sign-in-experience/index.test.ts
@@ -269,6 +269,35 @@ describe('PATCH /sign-in-exp', () => {
     });
   });
 
+  it('should accept adaptive mfa thresholds when mfa is enabled', async () => {
+    const adaptiveMfa = {
+      enabled: true,
+      thresholds: {
+        geoVelocityKmh: 1200,
+        longInactivityDays: 10,
+        newCountryWindowDays: 60,
+        minBotScore: 20,
+      },
+    };
+    const mfa = {
+      policy: MfaPolicy.PromptAtSignInAndSignUp,
+      factors: [MfaFactor.TOTP],
+    };
+
+    const response = await signInExperienceRequester
+      .patch('/sign-in-exp')
+      .send({ adaptiveMfa, mfa });
+
+    expect(response).toMatchObject({
+      status: 200,
+      body: {
+        ...mockSignInExperience,
+        adaptiveMfa,
+        mfa,
+      },
+    });
+  });
+
   it('should update adaptive mfa config when mfa is already enabled', async () => {
     findDefaultSignInExperience.mockResolvedValueOnce({
       ...mockSignInExperience,

--- a/packages/schemas/src/foundations/jsonb-types/sign-in-experience.test.ts
+++ b/packages/schemas/src/foundations/jsonb-types/sign-in-experience.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { adaptiveMfaGuard } from './sign-in-experience.js';
+
+describe('adaptiveMfaGuard', () => {
+  it('accepts thresholds within range', () => {
+    const result = adaptiveMfaGuard.safeParse({
+      enabled: true,
+      thresholds: {
+        minBotScore: 20,
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects minBotScore above 99', () => {
+    const result = adaptiveMfaGuard.safeParse({
+      enabled: true,
+      thresholds: {
+        minBotScore: 100,
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/schemas/src/foundations/jsonb-types/sign-in-experience.ts
+++ b/packages/schemas/src/foundations/jsonb-types/sign-in-experience.ts
@@ -236,10 +236,24 @@ export const mfaGuard = z.object({
 }) satisfies ToZodObject<Mfa>;
 
 /**
+ * Adaptive MFA thresholds for the sign-in experience.
+ */
+export type AdaptiveMfaThresholds = {
+  geoVelocityKmh?: number;
+  longInactivityDays?: number;
+  newCountryWindowDays?: number;
+  /**
+   * Cloudflare bot scores range from 1 to 99. (0 means not computed.)
+   * https://developers.cloudflare.com/bots/concepts/bot-score/#bot-groupings
+   */
+  minBotScore?: number;
+};
+
+/**
  * Adaptive MFA configuration for the sign-in experience.
  *
  * @remarks
- * This is a single enable switch for the rule-based Adaptive MFA flow.
+ * This is a single enable switch for the rule-based Adaptive MFA flow with optional thresholds.
  * Use it in Management API sign-in experience updates (`PATCH /api/sign-in-exp`).
  * When enabled, the server evaluates fixed risk rules from request signals
  * (IP, User-Agent, edge-injected headers) and may require MFA verification.
@@ -256,10 +270,22 @@ export const mfaGuard = z.object({
  */
 export type AdaptiveMfa = {
   enabled?: boolean;
+  thresholds?: AdaptiveMfaThresholds;
 };
+
+const adaptiveMfaThresholdsGuard = z
+  .object({
+    geoVelocityKmh: z.number().min(0),
+    longInactivityDays: z.number().min(0),
+    newCountryWindowDays: z.number().min(0),
+    // Cloudflare bot score is 1-99; keep 0 for "not computed".
+    minBotScore: z.number().min(0).max(99),
+  })
+  .partial() satisfies ToZodObject<AdaptiveMfaThresholds>;
 
 export const adaptiveMfaGuard = z.object({
   enabled: z.boolean().optional(),
+  thresholds: adaptiveMfaThresholdsGuard.optional(),
 }) satisfies ToZodObject<AdaptiveMfa>;
 
 export const customUiAssetsGuard = z.object({


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- Add configurable Adaptive MFA thresholds (geo velocity, long inactivity, new country window, min bot score) to sign‑in experience schema.
- Resolve thresholds at runtime and use them in rule evaluation; keep defaults when not configured.
- Stop pruning sign‑in countries to allow flexible window changes; keep evaluation based on window.
- Add coverage for threshold overrides and schema validation (including minBotScore <= 99).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
CI.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
