### PR TITLE
fix(experience): should not prefetch webauthn authentication options in preview mode

### DIFF
--- a/packages/experience/src/Providers/WebAuthnContextProvider/index.tsx
+++ b/packages/experience/src/Providers/WebAuthnContextProvider/index.tsx
@@ -1,15 +1,18 @@
 import { type WebAuthnAuthenticationOptions } from '@logto/schemas';
 import { browserSupportsWebAuthn } from '@simplewebauthn/browser';
-import { useState, useMemo, type ReactNode, useEffect, useCallback } from 'react';
+import { useState, useMemo, type ReactNode, useEffect, useCallback, useContext } from 'react';
 
 import { createSignInWebAuthnAuthenticationOptions } from '@/apis/experience/passkey-sign-in';
 import useApi from '@/hooks/use-api';
 import useErrorHandler from '@/hooks/use-error-handler';
 import { useSieMethods } from '@/hooks/use-sie';
 
+import PageContext from '../PageContextProvider/PageContext';
+
 import WebAuthnContext from './WebAuthnContext';
 
 const WebAuthnContextProvider = ({ children }: { readonly children: ReactNode }) => {
+  const { isPreview } = useContext(PageContext);
   const { passkeySignIn } = useSieMethods();
   const handleError = useErrorHandler();
   const asyncCreateAuthenticationOptions = useApi(createSignInWebAuthnAuthenticationOptions);
@@ -17,7 +20,8 @@ const WebAuthnContextProvider = ({ children }: { readonly children: ReactNode })
     useState<WebAuthnAuthenticationOptions>();
   const [isLoading, setIsLoading] = useState(false);
   const [isConsumed, setIsConsumed] = useState(false);
-  const shouldFetch = Boolean(passkeySignIn?.enabled) && (!authenticationOptions || isConsumed);
+  const shouldFetch =
+    !!passkeySignIn?.enabled && !isPreview && (!authenticationOptions || isConsumed);
 
   const markAuthenticationOptionsConsumed = useCallback(() => {
     setAuthenticationOptions(undefined);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Should not pre-fetch the WebAuthn authentication options data in preview mode (Sign-in Experience preview iFrame).

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
