### PR TITLE
feat(core,experience,schemas): allow skipping binding passkey for sign-in

### DIFF
--- a/packages/core/src/routes/experience/profile-routes.openapi.json
+++ b/packages/core/src/routes/experience/profile-routes.openapi.json
@@ -164,6 +164,24 @@
           }
         }
       }
+    },
+    "/api/experience/profile/mfa/passkey-skipped": {
+      "post": {
+        "operationId": "SkipPasskeyBinding",
+        "summary": "Skip passkey binding",
+        "description": "Skip passkey binding flow. The users can temporarily skip the passkey binding flow by calling this API during sign-up. On sign-in, the skip flag will be persisted to user config.",
+        "responses": {
+          "204": {
+            "description": "The passkey binding flow has been permanently skipped."
+          },
+          "400": {
+            "description": "Not supported for the current interaction event. This API can only be used in the `SignIn` or `Register` interaction."
+          },
+          "404": {
+            "description": "The user has not been identified yet. The `passkey-skipped` configuration must be associated with a identified user."
+          }
+        }
+      }
     }
   }
 }

--- a/packages/core/src/routes/experience/profile-routes.ts
+++ b/packages/core/src/routes/experience/profile-routes.ts
@@ -187,12 +187,28 @@ export default function interactionProfileRoutes<T extends ExperienceInteraction
   // Mark optional additional MFA binding suggestion as skipped in current interaction
   router.post(
     `${experienceRoutes.mfa}/mfa-suggestion-skipped`,
-    koaGuard({ status: [204, 400, 403, 404, 422] }),
+    koaGuard({ status: [204, 400, 404] }),
     verifiedInteractionGuard(),
     async (ctx, next) => {
       const { experienceInteraction } = ctx;
 
       experienceInteraction.mfa.skipAdditionalBindingSuggestion();
+      await experienceInteraction.save();
+
+      ctx.status = 204;
+
+      return next();
+    }
+  );
+
+  router.post(
+    `${experienceRoutes.mfa}/passkey-skipped`,
+    koaGuard({ status: [204, 400, 404] }),
+    verifiedInteractionGuard(),
+    async (ctx, next) => {
+      const { experienceInteraction } = ctx;
+
+      experienceInteraction.mfa.skipPasskey();
       await experienceInteraction.save();
 
       ctx.status = 204;

--- a/packages/experience/src/apis/experience/passkey-sign-in.ts
+++ b/packages/experience/src/apis/experience/passkey-sign-in.ts
@@ -8,7 +8,7 @@ import {
 import api from '../api';
 
 import { experienceApiRoutes } from './const';
-import { identifyAndSubmitInteraction } from './interaction';
+import { identifyAndSubmitInteraction, submitInteraction } from './interaction';
 import { bindMfa } from './mfa';
 
 export { createWebAuthnRegistration as createSignInWebAuthnRegistrationOptions } from './mfa';
@@ -29,4 +29,15 @@ export const verifySignInWebAuthn = async (payload: WebAuthnVerificationPayload)
     .json<{ verificationId: string }>();
 
   return identifyAndSubmitInteraction({ verificationId });
+};
+
+/**
+ * Skip binding passkey for the current user.
+ *
+ * Note: When calling this API on sign-up, the skip is temporary for the current interaction.
+ * On sign-in, the skip flag will be persisted to user config.
+ */
+export const skipPasskeyBinding = async () => {
+  await api.post(`${experienceApiRoutes.profile}/mfa/passkey-skipped`);
+  return submitInteraction();
 };

--- a/packages/schemas/src/types/user-logto-config.ts
+++ b/packages/schemas/src/types/user-logto-config.ts
@@ -5,6 +5,11 @@ import { z } from 'zod';
  */
 export const userMfaDataKey = 'mfa';
 
+/*
+ * The key for passkey sign-in data in user's logto_config
+ */
+export const userPasskeySignInDataKey = 'passkey_sign_in';
+
 /**
  * Schema for MFA-related data stored in user's logto_config
  */
@@ -16,10 +21,23 @@ export const userMfaDataGuard = z.object({
 export type UserMfaData = z.infer<typeof userMfaDataGuard>;
 
 /**
+ * Schema for passkey sign-in related data stored in user's logto_config
+ */
+export const userPasskeySignInDataGuard = z.object({
+  /**
+   * Whether the user has skipped binding passkey for sign-in persistently
+   */
+  skipped: z.boolean().optional(),
+});
+
+export type UserPasskeySignInData = z.infer<typeof userPasskeySignInDataGuard>;
+
+/**
  * Schema for user's logto_config field
  */
 export const userLogtoConfigGuard = z.object({
   [userMfaDataKey]: userMfaDataGuard.optional(),
+  [userPasskeySignInDataKey]: userPasskeySignInDataGuard.optional(),
 });
 
 export type UserLogtoConfig = z.infer<typeof userLogtoConfigGuard>;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add the ability to allow skipping binding passkey on both new user registration and the next sign-in attempt.
- When skipping on new registration: The status is only saved in the current interaction session.
- When skipping on sign-in: The status is persisted in DB and thus will not prompt again on next sign-in.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
