### PR TITLE
feat(core): add id token config API

### DIFF
--- a/packages/core/src/libraries/logto-config.ts
+++ b/packages/core/src/libraries/logto-config.ts
@@ -1,10 +1,17 @@
-import type { CloudConnectionData, JwtCustomizerType, LogtoOidcConfigType } from '@logto/schemas';
+import type {
+  CloudConnectionData,
+  IdTokenConfig,
+  JwtCustomizerType,
+  LogtoOidcConfigType,
+} from '@logto/schemas';
 import {
   LogtoConfigs,
   LogtoJwtTokenKey,
   LogtoOidcConfigKey,
+  LogtoTenantConfigKey,
   cloudApiIndicator,
   cloudConnectionDataGuard,
+  idTokenConfigGuard,
   jwtCustomizerConfigGuard,
   logtoOidcConfigGuard,
 } from '@logto/schemas';
@@ -22,6 +29,7 @@ export const createLogtoConfigLibrary = ({
     getRowsByKeys,
     getCloudConnectionData: queryCloudConnectionData,
     upsertJwtCustomizer: queryUpsertJwtCustomizer,
+    upsertIdTokenConfig: queryUpsertIdTokenConfig,
   },
 }: Pick<Queries, 'logtoConfigs'>) => {
   const getOidcConfigs = async (consoleLog: ConsoleLog): Promise<LogtoOidcConfigType> => {
@@ -129,6 +137,21 @@ export const createLogtoConfigLibrary = ({
     return updatedRow.value;
   };
 
+  const getIdTokenConfig = async () => {
+    const { rows } = await getRowsByKeys([LogtoTenantConfigKey.IdToken]);
+
+    if (rows.length === 0) {
+      return;
+    }
+
+    return idTokenConfigGuard.parse(rows[0]?.value);
+  };
+
+  const upsertIdTokenConfig = async (idTokenConfig: IdTokenConfig) => {
+    const { value } = await queryUpsertIdTokenConfig(idTokenConfig);
+    return idTokenConfigGuard.parse(value);
+  };
+
   return {
     getOidcConfigs,
     getCloudConnectionData,
@@ -136,5 +159,7 @@ export const createLogtoConfigLibrary = ({
     getJwtCustomizer,
     getJwtCustomizers,
     updateJwtCustomizer,
+    getIdTokenConfig,
+    upsertIdTokenConfig,
   };
 };

--- a/packages/core/src/routes/logto-config/id-token.ts
+++ b/packages/core/src/routes/logto-config/id-token.ts
@@ -1,0 +1,43 @@
+import { idTokenConfigGuard } from '@logto/schemas';
+
+import RequestError from '#src/errors/RequestError/index.js';
+import koaGuard from '#src/middleware/koa-guard.js';
+import { koaQuotaGuard } from '#src/middleware/koa-quota-guard.js';
+
+import type { ManagementApiRouter, RouterInitArgs } from '../types.js';
+
+export default function idTokenRoutes<T extends ManagementApiRouter>(
+  ...[router, { logtoConfigs, libraries }]: RouterInitArgs<T>
+) {
+  router.get(
+    '/configs/id-token',
+    koaGuard({
+      response: idTokenConfigGuard,
+      status: [200, 404],
+    }),
+    async (ctx, next) => {
+      const config = await logtoConfigs.getIdTokenConfig();
+
+      if (!config) {
+        throw new RequestError({ code: 'entity.not_found', status: 404 });
+      }
+
+      ctx.body = config;
+      return next();
+    }
+  );
+
+  router.put(
+    '/configs/id-token',
+    koaGuard({
+      body: idTokenConfigGuard,
+      response: idTokenConfigGuard,
+      status: [200, 403],
+    }),
+    koaQuotaGuard({ key: 'customJwtEnabled', quota: libraries.quota }),
+    async (ctx, next) => {
+      ctx.body = await logtoConfigs.upsertIdTokenConfig(ctx.guard.body);
+      return next();
+    }
+  );
+}

--- a/packages/core/src/routes/logto-config/index.ts
+++ b/packages/core/src/routes/logto-config/index.ts
@@ -15,6 +15,7 @@ import {
 } from '@logto/schemas';
 import { z } from 'zod';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import { getConsoleLogFromContext } from '#src/utils/console.js';
@@ -22,6 +23,7 @@ import { exportJWK } from '#src/utils/jwks.js';
 
 import type { ManagementApiRouter, RouterInitArgs } from '../types.js';
 
+import idTokenRoutes from './id-token.js';
 import logtoConfigJwtCustomizerRoutes from './jwt-customizer.js';
 
 /**
@@ -187,4 +189,9 @@ export default function logtoConfigRoutes<T extends ManagementApiRouter>(
   );
 
   logtoConfigJwtCustomizerRoutes(router, tenant);
+
+  // DEV: ID token claims configuration
+  if (EnvSet.values.isDevFeaturesEnabled) {
+    idTokenRoutes(router, tenant);
+  }
 }

--- a/packages/core/src/routes/logto-config/logto-config.openapi.json
+++ b/packages/core/src/routes/logto-config/logto-config.openapi.json
@@ -292,6 +292,47 @@
           }
         }
       }
+    },
+    "/api/configs/id-token": {
+      "get": {
+        "tags": ["Dev feature"],
+        "summary": "Get ID token claims configuration",
+        "description": "Get the ID token extended claims configuration for the tenant. This configuration controls which extended claims (e.g., `custom_data`, `identities`, `roles`, `organizations`, `organization_roles`) are included in ID tokens.",
+        "responses": {
+          "200": {
+            "description": "The ID token claims configuration."
+          },
+          "404": {
+            "description": "Configuration not found."
+          }
+        }
+      },
+      "put": {
+        "tags": ["Dev feature"],
+        "summary": "Upsert ID token claims configuration",
+        "description": "Create or update the ID token extended claims configuration for the tenant. This controls which extended claims are included in ID tokens when the corresponding scopes are requested.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "enabledExtendedClaims": {
+                    "description": "An array of extended claims to include in ID tokens. Possible values: `custom_data`, `identities`, `sso_identities`, `roles`, `organizations`, `organization_data`, `organization_roles`."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The updated ID token claims configuration."
+          },
+          "403": {
+            "description": "The tenant's subscription plan does not support this feature."
+          }
+        }
+      }
     }
   }
 }

--- a/packages/core/src/routes/swagger/utils/operation-id.ts
+++ b/packages/core/src/routes/swagger/utils/operation-id.ts
@@ -27,7 +27,11 @@ const methodToVerb = Object.freeze({
 
 type RouteDictionary = Record<`${OpenAPIV3.HttpMethods} ${string}`, string>;
 
-const devFeatureCustomRoutes: RouteDictionary = Object.freeze({});
+const devFeatureCustomRoutes: RouteDictionary = Object.freeze({
+  // DEV: ID token claims configuration
+  'get /configs/id-token': 'GetIdTokenConfig',
+  'put /configs/id-token': 'UpsertIdTokenConfig',
+});
 
 export const customRoutes: Readonly<RouteDictionary> = Object.freeze({
   // Authn

--- a/packages/core/src/test-utils/mock-libraries.ts
+++ b/packages/core/src/test-utils/mock-libraries.ts
@@ -14,6 +14,8 @@ export const mockLogtoConfigsLibrary: jest.Mocked<LogtoConfigLibrary> = {
   getJwtCustomizer: jest.fn(),
   getJwtCustomizers: jest.fn(),
   updateJwtCustomizer: jest.fn(),
+  getIdTokenConfig: jest.fn(),
+  upsertIdTokenConfig: jest.fn(),
 };
 
 export const mockCloudClient = new Client<typeof router>({ baseUrl: 'http://localhost:3001' });

--- a/packages/integration-tests/src/api/logto-config.ts
+++ b/packages/integration-tests/src/api/logto-config.ts
@@ -8,6 +8,7 @@ import {
   type JwtCustomizerConfigs,
   type JwtCustomizerTestRequestBody,
   type Json,
+  type IdTokenConfig,
 } from '@logto/schemas';
 
 import { authedAdminApi } from './api.js';
@@ -69,3 +70,9 @@ export const testJwtCustomizer = async (payload: JwtCustomizerTestRequestBody) =
       json: payload,
     })
     .json<Json>();
+
+export const getIdTokenConfig = async () =>
+  authedAdminApi.get('configs/id-token').json<IdTokenConfig>();
+
+export const upsertIdTokenConfig = async (payload: IdTokenConfig) =>
+  authedAdminApi.put('configs/id-token', { json: payload }).json<IdTokenConfig>();

--- a/packages/integration-tests/src/tests/api/logto-config.id-token.test.ts
+++ b/packages/integration-tests/src/tests/api/logto-config.id-token.test.ts
@@ -1,0 +1,31 @@
+import { type IdTokenConfig } from '@logto/schemas';
+
+import { getIdTokenConfig, upsertIdTokenConfig } from '#src/api/index.js';
+import { devFeatureTest } from '#src/utils.js';
+
+const defaultIdTokenConfig: IdTokenConfig = {
+  enabledExtendedClaims: ['roles', 'organizations', 'organization_roles'],
+};
+
+devFeatureTest.describe('id token config', () => {
+  devFeatureTest.it('should get id token config successfully', async () => {
+    const config = await getIdTokenConfig();
+    expect(config).toMatchObject(defaultIdTokenConfig);
+  });
+
+  devFeatureTest.it('should update id token config successfully', async () => {
+    const newConfig: IdTokenConfig = {
+      enabledExtendedClaims: ['custom_data', 'identities', 'roles'],
+    };
+
+    const updatedConfig = await upsertIdTokenConfig(newConfig);
+    expect(updatedConfig).toMatchObject(newConfig);
+
+    // Verify the update persisted
+    const fetchedConfig = await getIdTokenConfig();
+    expect(fetchedConfig).toMatchObject(newConfig);
+
+    // Restore default config
+    await upsertIdTokenConfig(defaultIdTokenConfig);
+  });
+});


### PR DESCRIPTION
## Summary

Add management API endpoints for ID token extended claims configuration:
- `GET /api/configs/id-token` - Get current ID token config (returns 404 if not found)
- `PUT /api/configs/id-token` - Upsert ID token config (creates or updates)

Key changes:
- Upsert uses `INSERT ... ON CONFLICT ... DO UPDATE` for robustness
- PUT endpoint is guarded by `customJwtEnabled` quota (reuses existing subscription plan check)
- Upsert invalidates the well-known cache for `id-token-config` to ensure OIDC token issuance picks up new config

This is a dev feature that allows configuring which extended claims (e.g., `custom_data`, `identities`, `roles`, `organizations`, `organization_roles`) are included in ID tokens.

## Testing

Integration tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments