### PR TITLE
feat(core): add `passkeySignIn,skipped` and `mfa.skipMfaOnSignIn` flags in user logto-configs

### DIFF
--- a/packages/integration-tests/src/api/admin-user.ts
+++ b/packages/integration-tests/src/api/admin-user.ts
@@ -134,13 +134,18 @@ export const createUserMfaVerification = async (userId: string, type: MfaFactor)
       | { type: MfaFactor.BackupCode; codes: string[] }
     >();
 
-export const getUserLogtoConfig = async (userId: string) =>
-  authedAdminApi.get(`users/${userId}/logto-configs`).json<{ mfa: { skipped: boolean } }>();
+type UserLogtoConfig = {
+  mfa: { skipped: boolean; skipMfaOnSignIn: boolean };
+  passkeySignIn: { skipped: boolean };
+};
 
-export const updateUserLogtoConfig = async (userId: string, skipped: boolean) =>
+export const getUserLogtoConfig = async (userId: string) =>
+  authedAdminApi.get(`users/${userId}/logto-configs`).json<UserLogtoConfig>();
+
+export const updateUserLogtoConfig = async (userId: string, logtoConfig: UserLogtoConfig) =>
   authedAdminApi
-    .patch(`users/${userId}/logto-configs`, { json: { mfa: { skipped } } })
-    .json<{ mfa: { skipped: boolean } }>();
+    .patch(`users/${userId}/logto-configs`, { json: logtoConfig })
+    .json<UserLogtoConfig>();
 
 export const getUserOrganizations = async (userId: string) =>
   authedAdminApi.get(`users/${userId}/organizations`).json<OrganizationWithRoles[]>();

--- a/packages/integration-tests/src/tests/api/admin-user.mfa-verifications.test.ts
+++ b/packages/integration-tests/src/tests/api/admin-user.mfa-verifications.test.ts
@@ -61,19 +61,47 @@ describe('admin console user management (mfa verifications)', () => {
     const user = await createUserByAdmin();
 
     const config = await getUserLogtoConfig(user.id);
-    expect(config.mfa.skipped).toBe(false);
+    expect(config).toEqual({
+      mfa: { skipped: false, skipMfaOnSignIn: false },
+      passkeySignIn: { skipped: false },
+    });
 
-    const response = await updateUserLogtoConfig(user.id, true);
-    expect(response).toEqual({ mfa: { skipped: true } });
+    const response = await updateUserLogtoConfig(user.id, {
+      mfa: { skipped: true, skipMfaOnSignIn: false },
+      passkeySignIn: { skipped: false },
+    });
+    expect(response).toEqual({
+      mfa: { skipped: true, skipMfaOnSignIn: false },
+      passkeySignIn: { skipped: false },
+    });
 
     const updatedConfig = await getUserLogtoConfig(user.id);
     expect(updatedConfig.mfa.skipped).toBe(true);
+    expect(updatedConfig.mfa.skipMfaOnSignIn).toBe(false);
 
-    const response2 = await updateUserLogtoConfig(user.id, false);
-    expect(response2).toEqual({ mfa: { skipped: false } });
+    const response2 = await updateUserLogtoConfig(user.id, {
+      mfa: { skipped: false, skipMfaOnSignIn: true },
+      passkeySignIn: { skipped: true },
+    });
+    expect(response2).toEqual({
+      mfa: { skipped: false, skipMfaOnSignIn: true },
+      passkeySignIn: { skipped: true },
+    });
 
     const updatedConfig2 = await getUserLogtoConfig(user.id);
     expect(updatedConfig2.mfa.skipped).toBe(false);
+    expect(updatedConfig2.mfa.skipMfaOnSignIn).toBe(true);
+    expect(updatedConfig2.passkeySignIn.skipped).toBe(true);
+
+    // Reset all flags
+    const response3 = await updateUserLogtoConfig(user.id, {
+      mfa: { skipped: false, skipMfaOnSignIn: false },
+      passkeySignIn: { skipped: false },
+    });
+    expect(response3).toEqual({
+      mfa: { skipped: false, skipMfaOnSignIn: false },
+      passkeySignIn: { skipped: false },
+    });
 
     await deleteUser(user.id);
   });

--- a/packages/integration-tests/src/tests/api/experience-api/bind-mfa/happpy-path.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/bind-mfa/happpy-path.test.ts
@@ -212,7 +212,10 @@ describe('Bind MFA APIs happy path', () => {
         password,
       });
 
-      await updateUserLogtoConfig(userId, false);
+      await updateUserLogtoConfig(userId, {
+        mfa: { skipped: false, skipMfaOnSignIn: false },
+        passkeySignIn: { skipped: false },
+      });
       const resetConfig = await getUserLogtoConfig(userId);
       expect(resetConfig.mfa.skipped).toBe(false);
 

--- a/packages/schemas/src/types/user-logto-config.ts
+++ b/packages/schemas/src/types/user-logto-config.ts
@@ -14,7 +14,16 @@ export const userPasskeySignInDataKey = 'passkey_sign_in';
  * Schema for MFA-related data stored in user's logto_config
  */
 export const userMfaDataGuard = z.object({
+  /**
+   * Whether the user has skipped MFA binding flow
+   */
   skipped: z.boolean().optional(),
+  /**
+   * Whether the user has skipped MFA verification on sign-in
+   *
+   * Users can manually disable MFA verification requirement for sign-in,
+   * but if the MFA policy is set to mandatory, this setting will be ignored.
+   */
   skipMfaOnSignIn: z.boolean().optional(),
 });
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Extend admin-user basics routes to support `passkeySignIn.skipped` and the `mfa.skipMfaOnSignIn` options.
- adds imports for the new guard/key, updates request and response schemas to include `mfa.skipMfaOnSignIn` and `passkeySignIn.skipped`
- reads existing values from `user.logtoConfig` (with false defaults)
- persists updates to both `mfa` and `passkeySignIn` entries, and returns the updated flags in the response.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
