### PR TITLE
feat(core): skip MFA verification when user is signing in with passkey

### DIFF
--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -344,12 +344,13 @@ export default class ExperienceInteraction {
    *
    * @remarks
    * - EnterpriseSso verified interaction does not require MFA verification.
+   * - Users signing in with passkey does not require MFA verification.
    *
    * @throws {RequestError} with 404 if the if the user is not identified or not found
    * @throws {RequestError} with 403 if the mfa verification is required but not verified
    */
   public async guardMfaVerificationStatus(log?: LogEntry) {
-    if (this.hasVerifiedSsoIdentity) {
+    if (this.hasVerifiedSsoIdentity || this.hasVerifiedSignInWebAuthn) {
       return;
     }
 
@@ -738,6 +739,13 @@ export default class ExperienceInteraction {
   private get hasVerifiedSocialIdentity() {
     const socialVerificationRecord = this.verificationRecords.get(VerificationType.Social);
     return Boolean(socialVerificationRecord?.isVerified);
+  }
+
+  private get hasVerifiedSignInWebAuthn() {
+    const webAuthnVerificationRecord = this.verificationRecords.get(
+      VerificationType.SignInWebAuthn
+    );
+    return Boolean(webAuthnVerificationRecord?.isVerified);
   }
 
   /**

--- a/packages/integration-tests/src/tests/experience/mfa/webauthn/index.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/webauthn/index.test.ts
@@ -1,7 +1,7 @@
 import { ConnectorType } from '@logto/connector-kit';
-import { SignInIdentifier } from '@logto/schemas';
+import { MfaFactor, MfaPolicy, SignInIdentifier } from '@logto/schemas';
 
-import { deleteUser } from '#src/api/admin-user.js';
+import { createUserMfaVerification, deleteUser } from '#src/api/admin-user.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
 import { demoAppUrl } from '#src/constants.js';
 import { clearConnectorsByTypes } from '#src/helpers/connector.js';
@@ -11,7 +11,7 @@ import {
 } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
 import ExpectWebAuthnExperience from '#src/ui-helpers/expect-webauthn-experience.js';
-import { generateUsername, waitFor } from '#src/utils.js';
+import { devFeatureTest, generateUsername, waitFor } from '#src/utils.js';
 
 describe('MFA - WebAuthn', () => {
   beforeAll(async () => {
@@ -93,5 +93,94 @@ describe('MFA - WebAuthn', () => {
     await experience.verifyThenEnd();
 
     await deleteUser(user.id);
+  });
+});
+
+devFeatureTest.describe('MFA - Passkey sign-in should skip MFA verification', () => {
+  beforeAll(async () => {
+    await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms, ConnectorType.Social]);
+    // Enable mandatory MFA with WebAuthn so passkey is registered during registration
+    await enableMandatoryMfaWithWebAuthn();
+    await updateSignInExperience({
+      signUp: {
+        identifiers: [SignInIdentifier.Username],
+        password: true,
+        verify: false,
+      },
+      signIn: {
+        methods: [
+          {
+            identifier: SignInIdentifier.Username,
+            password: true,
+            verificationCode: false,
+            isPasswordPrimary: true,
+          },
+        ],
+      },
+      forgotPasswordMethods: [],
+    });
+  });
+
+  afterAll(async () => {
+    await resetMfaSettings();
+    // Reset passkey sign-in settings
+    await updateSignInExperience({
+      passkeySignIn: {
+        enabled: false,
+        showPasskeyButton: false,
+        allowAutofill: false,
+      },
+    });
+  });
+
+  it('should sign in with passkey and skip MFA verification even when mandatory TOTP MFA is enabled', async () => {
+    const username = generateUsername();
+    const password = 'l0gt0_T3st_P@ssw0rd';
+
+    // Step 1: Register a user with passkey (WebAuthn MFA binding during registration)
+    const experience = new ExpectWebAuthnExperience(await browser.newPage());
+    await experience.setupVirtualAuthenticator();
+    await experience.startWith(demoAppUrl, 'register');
+    await experience.toFillInput('identifier', username, { submit: true });
+    experience.toBeAt('register/password');
+    await experience.toFillNewPasswords(password);
+    await experience.toCreatePasskey();
+    const userId = await experience.getUserIdFromDemoAppPage();
+    await experience.verifyThenEnd(false);
+
+    // Step 2: Add TOTP MFA to the user via admin API, so the user has mandatory TOTP MFA
+    await createUserMfaVerification(userId, MfaFactor.TOTP);
+
+    // Step 3: Enable mandatory TOTP MFA and passkey sign-in
+    await updateSignInExperience({
+      mfa: {
+        factors: [MfaFactor.TOTP],
+        policy: MfaPolicy.Mandatory,
+      },
+      passkeySignIn: {
+        enabled: true,
+        showPasskeyButton: true,
+        allowAutofill: false,
+      },
+    });
+
+    // Step 4: Sign in using the passkey sign-in button
+    // The passkey sign-in creates a SignInWebAuthn verification record,
+    // which should skip MFA verification according to the new logic
+    await experience.startWith(demoAppUrl, 'sign-in');
+
+    // Wait for the page and passkey sign-in button to load
+    await waitFor(1000);
+
+    // Click the "Continue with Passkey" button
+    await experience.toClick('button', 'Continue with Passkey');
+
+    // Step 5: Verify the user is signed in successfully without MFA verification prompt
+    // If MFA was not skipped, the user would be redirected to the MFA verification page
+    await experience.verifyThenEnd(false);
+
+    await experience.clearVirtualAuthenticator();
+    await experience.page.close();
+    await deleteUser(userId);
   });
 });


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Users who are signing in with a passkey (WebAuthn) should bypass the mandatory MFA verification, aligning the experience with SSO (Single Sign-On) users.

Also adds an integration test to verify that passkey sign-in correctly skips MFA, even when TOTP MFA is mandatory.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
