### PR TITLE
fix: fix boolean header value parser

### DIFF
--- a/packages/core/src/routes/experience/classes/libraries/adaptive-mfa-validator/context.ts
+++ b/packages/core/src/routes/experience/classes/libraries/adaptive-mfa-validator/context.ts
@@ -38,7 +38,12 @@ const parseNumber = (
 
 const parseBoolean = (value: Optional<string>): Optional<boolean> => {
   const normalized = normalizeString(value)?.toLowerCase();
-  return conditional(normalized && yes(normalized));
+
+  if (!normalized) {
+    return;
+  }
+
+  return yes(normalized);
 };
 
 export const parseAdaptiveMfaContext = (

--- a/packages/core/src/routes/experience/classes/libraries/adaptive-mfa-validator/index.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/adaptive-mfa-validator/index.test.ts
@@ -226,6 +226,38 @@ describe('AdaptiveMfaValidator', () => {
     expect(queries.userGeoLocations.upsertUserGeoLocation).toHaveBeenCalledWith(user.id, 0, 0);
   });
 
+  it.each([
+    ['false', false],
+    ['0', false],
+    ['no', false],
+    ['maybe', false],
+    ['yes', true],
+  ])(
+    'parses bot verification signal from injected header %s as %s',
+    (botVerifiedHeader, expectedBotVerified) => {
+      const queries = createQueries();
+      const ctx = {
+        request: {
+          headers: {
+            'x-logto-cf-bot-verified': botVerifiedHeader,
+          },
+        },
+      };
+
+      const validator = new AdaptiveMfaValidator({
+        queries,
+        ctx,
+        signInExperienceValidator: createSignInExperienceValidator(),
+      });
+
+      expect(validator.getCurrentContext()).toEqual({
+        ipRiskSignals: {
+          botVerified: expectedBotVerified,
+        },
+      });
+    }
+  );
+
   it('skips persisting context when adaptive MFA is disabled', async () => {
     const user: User = {
       ...mockUser,


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
This PR fixes an Adaptive MFA parsing issue where botVerified could be dropped from context and audit logs when the injected header value was a non-empty string that evaluates to false (for example: "false").

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
CI.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
