### PR TITLE
fix(core): check MFA verifications for passkey sign-in

### DIFF
--- a/packages/core/src/routes/experience/classes/mfa.ts
+++ b/packages/core/src/routes/experience/classes/mfa.ts
@@ -495,10 +495,12 @@ export class Mfa {
 
   async checkPasskeySignInAvailability() {
     const { passkeySignIn } = await this.signInExperienceValidator.getSignInExperienceData();
-    const { logtoConfig } = await this.interactionContext.getIdentifiedUser();
+    const { logtoConfig, mfaVerifications } = await this.interactionContext.getIdentifiedUser();
 
     if (passkeySignIn.enabled && !(this.#passkeySkipped ?? isPasskeySkipped(logtoConfig))) {
-      const hasPasskey = this.data.webAuthn?.length;
+      const hasPasskey =
+        Boolean(this.data.webAuthn?.length) ||
+        mfaVerifications.some((verification) => verification.type === MfaFactor.WebAuthn);
 
       assertThat(hasPasskey, new RequestError({ code: 'user.passkey_preferred', status: 422 }));
     }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fetch `mfaVerifications` from the identified user and include them when determining passkey availability.
This fixes the master CI failure.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested with integration test

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
