### PR TITLE
fix(experience): add WebAuthn conditional UI abort handling

### DIFF
--- a/packages/experience/src/Providers/WebAuthnContextProvider/WebAuthnContext.tsx
+++ b/packages/experience/src/Providers/WebAuthnContextProvider/WebAuthnContext.tsx
@@ -5,7 +5,21 @@ import { createContext } from 'react';
 export type WebAuthnContextType = {
   authenticationOptions: WebAuthnAuthenticationOptions | undefined;
   isLoading: boolean;
+  /**
+   * Mark the current authentication options as consumed, and immediately fetch new options data.
+   */
   markAuthenticationOptionsConsumed: () => void;
+  /**
+   * Abort any pending conditional UI WebAuthn request.
+   * This must be called before starting a new `navigator.credentials.get()` request
+   * to avoid `OperationError: A request is already pending`.
+   */
+  abortConditionalUI: () => void;
+  /**
+   * Register a new AbortController for the conditional UI request so that
+   * it can be aborted externally (e.g. when the user clicks "Continue with passkey").
+   */
+  setConditionalUIAbortController: (controller: AbortController | undefined) => void;
 };
 
 /**
@@ -15,6 +29,8 @@ const WebAuthnContext = createContext<WebAuthnContextType>({
   authenticationOptions: undefined,
   isLoading: false,
   markAuthenticationOptionsConsumed: noop,
+  abortConditionalUI: noop,
+  setConditionalUIAbortController: noop,
 });
 
 export default WebAuthnContext;

--- a/packages/experience/src/components/Button/PasskeySignInButton/index.tsx
+++ b/packages/experience/src/components/Button/PasskeySignInButton/index.tsx
@@ -20,6 +20,7 @@ const PasskeySignInButton = () => {
     authenticationOptions,
     isLoading: isPreparing,
     markAuthenticationOptionsConsumed,
+    abortConditionalUI,
   } = useContext(WebAuthnContext);
   const { handleVerifyPasskey } = usePasskeySignIn();
 
@@ -35,6 +36,9 @@ const PasskeySignInButton = () => {
     if (!authenticationOptions) {
       return;
     }
+    // Abort any pending conditional UI request before starting manual passkey sign-in
+    // to prevent `OperationError: A request is already pending`.
+    abortConditionalUI();
     setIsSubmitting(true);
     try {
       await handleVerifyPasskey(authenticationOptions, preSignInErrorHandler);
@@ -43,6 +47,7 @@ const PasskeySignInButton = () => {
       setIsSubmitting(false);
     }
   }, [
+    abortConditionalUI,
     authenticationOptions,
     handleVerifyPasskey,
     markAuthenticationOptionsConsumed,

--- a/packages/experience/src/hooks/use-passkey-sign-in.ts
+++ b/packages/experience/src/hooks/use-passkey-sign-in.ts
@@ -75,7 +75,14 @@ const usePasskeySignIn = () => {
       }
       const response = await trySafe(
         async () => startAuthentication(options),
-        () => {
+        (error: unknown) => {
+          // User cancelled the WebAuthn dialog, no need to show an error toast
+          if (
+            (error instanceof DOMException && error.name === 'NotAllowedError') ||
+            (error instanceof Error && error.name === 'NotAllowedError')
+          ) {
+            return;
+          }
           setToast(t('mfa.webauthn_failed_to_verify'));
         }
       );


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fixed a bug that clicking "Continue with passkey" button throws an error instead of normally proceeding to the passkey authentication process.

The root cause is that the WebAuthn standard mandates only 1 pending `navigator.credentials.get()` request at a time. Therefore, before clicking the "Continue with passkey" button, we need to manually abort the pending request that already triggered by the passkey conditional UI.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested with both autofill and continue button. Both worked as expected.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
