### PR TITLE
feat: add application context to JWT customizer

### DIFF
--- a/packages/console/scripts/generate-jwt-customizer-type-definition.ts
+++ b/packages/console/scripts/generate-jwt-customizer-type-definition.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import {
   accessTokenPayloadGuard,
   clientCredentialsPayloadGuard,
+  jwtCustomizerApplicationContextGuard,
   jwtCustomizerGrantContextGuard,
   jwtCustomizerUserContextGuard,
   jwtCustomizerUserInteractionContextGuard,
@@ -19,6 +20,7 @@ const typeIdentifiers = `export enum JwtCustomizerTypeDefinitionKey {
   JwtCustomizerUserContext = 'JwtCustomizerUserContext',
   JwtCustomizerGrantContext = 'JwtCustomizerGrantContext',
   JwtCustomizerUserInteractionContext = 'JwtCustomizerUserInteractionContext',
+  JwtCustomizerApplicationContext = 'JwtCustomizerApplicationContext',
   AccessTokenPayload = 'AccessTokenPayload',
   ClientCredentialsPayload = 'ClientCredentialsPayload',
   EnvironmentVariables = 'EnvironmentVariables',
@@ -87,6 +89,11 @@ const createJwtCustomizerTypeDefinitions = async () => {
       )
     );
 
+  const jwtCustomizerApplicationContextTypeDefinition = inferTsDefinitionFromZod(
+    jwtCustomizerApplicationContextGuard,
+    'JwtCustomizerApplicationContext'
+  );
+
   const accessTokenPayloadTypeDefinition = inferTsDefinitionFromZod(
     accessTokenPayloadGuard,
     'AccessTokenPayload'
@@ -105,6 +112,8 @@ export const jwtCustomizerUserContextTypeDefinition = \`${jwtCustomizerUserConte
 export const jwtCustomizerGrantContextTypeDefinition = \`${jwtCustomizerGrantContextTypeDefinition}\`;
 
 export const jwtCustomizerUserInteractionContextTypeDefinition = \`${jwtCustomizerUserInteractionContextTypeDefinition}\`;
+
+export const jwtCustomizerApplicationContextTypeDefinition = \`${jwtCustomizerApplicationContextTypeDefinition}\`;
 
 export const accessTokenPayloadTypeDefinition = \`${accessTokenPayloadTypeDefinition}\`;
 

--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/GuideCard/index.tsx
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/GuideCard/index.tsx
@@ -11,6 +11,7 @@ export enum CardType {
   UserData = 'user_data',
   GrantData = 'grant_data',
   InteractionData = 'interaction_data',
+  ApplicationData = 'application_data',
   TokenData = 'token_data',
   FetchExternalData = 'fetch_external_data',
   EnvironmentVariables = 'environment_variables',

--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/index.tsx
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/index.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
+import { isDevFeaturesEnabled } from '@/consts/env';
 import { type JwtCustomizerForm } from '@/pages/CustomizeJwtDetails/type';
 import {
   denyAccessCodeExample,
@@ -19,6 +20,7 @@ import {
   jwtCustomizerUserContextTypeDefinition,
   jwtCustomizerGrantContextTypeDefinition,
   jwtCustomizerUserInteractionContextTypeDefinition,
+  jwtCustomizerApplicationContextTypeDefinition,
 } from '@/pages/CustomizeJwtDetails/utils/type-definitions';
 
 import tabContentStyles from '../index.module.scss';
@@ -110,6 +112,25 @@ function InstructionTab({ isActive }: Props) {
             language="typescript"
             className={styles.sampleCode}
             value={`declare ${jwtCustomizerUserInteractionContextTypeDefinition}`}
+            height="400px"
+            theme="logto-dark"
+            options={typeDefinitionCodeEditorOptions}
+          />
+        </GuideCard>
+      )}
+      {/* DEV: application context in JWT customizer */}
+      {isDevFeaturesEnabled && (
+        <GuideCard
+          name={CardType.ApplicationData}
+          isExpanded={expendCard === CardType.ApplicationData}
+          setExpanded={(expand) => {
+            setExpendCard(expand ? CardType.ApplicationData : undefined);
+          }}
+        >
+          <Editor
+            language="typescript"
+            className={styles.sampleCode}
+            value={`declare ${jwtCustomizerApplicationContextTypeDefinition}`}
             height="400px"
             theme="logto-dark"
             options={typeDefinitionCodeEditorOptions}

--- a/packages/console/src/pages/CustomizeJwtDetails/utils/format.ts
+++ b/packages/console/src/pages/CustomizeJwtDetails/utils/format.ts
@@ -7,6 +7,7 @@ import {
   defaultAccessTokenPayload,
   defaultClientCredentialsJwtCustomizerCode,
   defaultClientCredentialsPayload,
+  defaultM2mTokenContextData,
   defaultUserTokenContextData,
 } from './config';
 
@@ -64,7 +65,7 @@ const defaultValues = Object.freeze({
   [LogtoJwtTokenKeyType.ClientCredentials]: {
     script: defaultClientCredentialsJwtCustomizerCode,
     tokenSample: defaultClientCredentialsPayload,
-    contextSample: undefined,
+    contextSample: defaultM2mTokenContextData,
   },
 });
 

--- a/packages/console/src/pages/CustomizeJwtDetails/utils/type-definitions.ts
+++ b/packages/console/src/pages/CustomizeJwtDetails/utils/type-definitions.ts
@@ -1,3 +1,4 @@
+import { isDevFeaturesEnabled } from '@/consts/env';
 import {
   JwtCustomizerTypeDefinitionKey,
   accessTokenPayloadTypeDefinition,
@@ -5,6 +6,7 @@ import {
   jwtCustomizerUserContextTypeDefinition,
   jwtCustomizerGrantContextTypeDefinition,
   jwtCustomizerUserInteractionContextTypeDefinition,
+  jwtCustomizerApplicationContextTypeDefinition,
   jwtCustomizerApiContextTypeDefinition,
 } from '@/consts/jwt-customizer-type-definition';
 
@@ -17,6 +19,7 @@ export {
   jwtCustomizerUserContextTypeDefinition,
   jwtCustomizerGrantContextTypeDefinition,
   jwtCustomizerUserInteractionContextTypeDefinition,
+  jwtCustomizerApplicationContextTypeDefinition,
 } from '@/consts/jwt-customizer-type-definition';
 
 export const buildAccessTokenJwtCustomizerContextTsDefinition = () => {
@@ -27,13 +30,13 @@ export const buildAccessTokenJwtCustomizerContextTsDefinition = () => {
   declare ${jwtCustomizerApiContextTypeDefinition}
 
   declare ${accessTokenPayloadTypeDefinition}
-  
-  declare ${jwtCustomizerUserInteractionContextTypeDefinition}`;
+
+  declare ${jwtCustomizerUserInteractionContextTypeDefinition}${isDevFeaturesEnabled ? `\n\n  declare ${jwtCustomizerApplicationContextTypeDefinition}` : ''}`;
 };
 
 export const buildClientCredentialsJwtCustomizerContextTsDefinition = () =>
   `declare ${clientCredentialsPayloadTypeDefinition}
-
+${isDevFeaturesEnabled ? `\n  declare ${jwtCustomizerApplicationContextTypeDefinition}\n` : ''}
   declare ${jwtCustomizerApiContextTypeDefinition}`;
 
 export const buildEnvironmentVariablesTypeDefinition = (

--- a/packages/core/src/oidc/extra-token-claims.test.ts
+++ b/packages/core/src/oidc/extra-token-claims.test.ts
@@ -42,6 +42,8 @@ describe('getExtraTokenClaimsForJwtCustomization', () => {
       {
         jwtCustomizers: {
           getUserContext: jest.fn().mockResolvedValue({ id: accountId }),
+          // eslint-disable-next-line unicorn/no-useless-undefined
+          getApplicationContext: jest.fn().mockResolvedValue(undefined),
         },
       },
       {

--- a/packages/core/src/routes/logto-config/jwt-customizer.test.ts
+++ b/packages/core/src/routes/logto-config/jwt-customizer.test.ts
@@ -166,6 +166,7 @@ describe('configs JWT customizer routes', () => {
       script: mockJwtCustomizerConfigForClientCredentials.value.script,
       environmentVariables: mockJwtCustomizerConfigForClientCredentials.value.environmentVariables,
       token: {},
+      context: { application: { id: 'my-app' } },
     };
 
     await routeRequester.post('/configs/jwt-customizer/test').send(payload);

--- a/packages/integration-tests/src/__mocks__/jwt-customizer.ts
+++ b/packages/integration-tests/src/__mocks__/jwt-customizer.ts
@@ -33,7 +33,12 @@ export const clientCredentialsJwtCustomizerPayload = {
     foo: 'bar',
     API_KEY: '12345',
   },
-  contextSample: {},
+  contextSample: {
+    application: {
+      id: 'my-app',
+      name: 'My M2M App',
+    },
+  },
   tokenSample: clientCredentialsTokenSample,
 };
 

--- a/packages/integration-tests/src/tests/api/logto-config.test.ts
+++ b/packages/integration-tests/src/tests/api/logto-config.test.ts
@@ -265,6 +265,7 @@ describe('logto config', () => {
     const testResult = await testJwtCustomizer({
       tokenType: LogtoJwtTokenKeyType.ClientCredentials,
       token: clientCredentialsJwtCustomizerPayload.tokenSample,
+      context: clientCredentialsJwtCustomizerPayload.contextSample,
       script: clientCredentialsSampleScript,
       environmentVariables: clientCredentialsJwtCustomizerPayload.environmentVariables,
     });
@@ -292,6 +293,7 @@ describe('logto config', () => {
       testJwtCustomizer({
         tokenType: LogtoJwtTokenKeyType.ClientCredentials,
         token: clientCredentialsJwtCustomizerPayload.tokenSample,
+        context: clientCredentialsJwtCustomizerPayload.contextSample,
         script: clientCredentialsAccessDeniedSampleScript,
         environmentVariables: clientCredentialsJwtCustomizerPayload.environmentVariables,
       }),

--- a/packages/phrases/src/locales/ar/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/jwt-claims.ts
@@ -50,6 +50,11 @@ const jwt_claims = {
     subtitle:
       'استخدم المعلمة `context.interaction` للوصول إلى تفاصيل تفاعل المستخدم في جلسة المصادقة الحالية، بما في ذلك `interactionEvent`, `userId`, و `verificationRecords`.',
   },
+  application_data: {
+    title: 'سياق التطبيق',
+    subtitle:
+      'استخدم معامل الإدخال `context.application` لتوفير معلومات التطبيق المرتبطة بالرمز المميز.',
+  },
   token_data: {
     title: 'بيانات الرمز',
     subtitle: 'استخدم معلمة الإدخال `token` لحمولة رمز الوصول الحالي.',

--- a/packages/phrases/src/locales/de/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/jwt-claims.ts
@@ -56,6 +56,11 @@ const jwt_claims = {
     subtitle:
       'Verwenden Sie den Parameter `context.interaction`, um auf die Interaktionsdetails des Benutzers der aktuellen Authentifizierungssitzung zuzugreifen, einschließlich `interactionEvent`, `userId` und `verificationRecords`.',
   },
+  application_data: {
+    title: 'Anwendungskontext',
+    subtitle:
+      'Verwenden Sie den Eingabeparameter `context.application`, um Anwendungsinformationen bereitzustellen, die dem Token zugeordnet sind.',
+  },
   token_data: {
     title: 'Token-Daten',
     subtitle: 'Verwenden Sie den `token` Eingabeparameter für die aktuelle Zugriffstoken-Payload.',

--- a/packages/phrases/src/locales/en/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/jwt-claims.ts
@@ -51,6 +51,11 @@ const jwt_claims = {
     subtitle:
       "Use the `context.interaction` parameter to access the user's interaction details for the current authentication session, including `interactionEvent`, `userId`, and `verificationRecords`.",
   },
+  application_data: {
+    title: 'Application context',
+    subtitle:
+      'Use `context.application` input parameter to provide the application info associated with the token.',
+  },
   token_data: {
     title: 'Token payload',
     subtitle: 'Use `token` input parameter for current access token payload. ',

--- a/packages/phrases/src/locales/es/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/jwt-claims.ts
@@ -54,6 +54,11 @@ const jwt_claims = {
     subtitle:
       'Use el parámetro `context.interaction` para acceder a los detalles de la interacción del usuario para la sesión de autenticación actual, incluidos `interactionEvent`, `userId` y `verificationRecords`.',
   },
+  application_data: {
+    title: 'Contexto de la aplicación',
+    subtitle:
+      'Use el parámetro de entrada `context.application` para proporcionar la información de la aplicación asociada con el token.',
+  },
   token_data: {
     title: 'Datos del token',
     subtitle:

--- a/packages/phrases/src/locales/fr/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/jwt-claims.ts
@@ -55,6 +55,11 @@ const jwt_claims = {
     subtitle:
       "Utilisez le paramètre `context.interaction` pour accéder aux détails de l'interaction de l'utilisateur pour la session d'authentification en cours, y compris `interactionEvent`, `userId` et `verificationRecords`.",
   },
+  application_data: {
+    title: "Contexte de l'application",
+    subtitle:
+      "Utilisez le paramètre d'entrée `context.application` pour fournir les informations d'application associées au jeton.",
+  },
   token_data: {
     title: 'Données du jeton',
     subtitle: "Utilisez le paramètre d'entrée `token` pour le payload du jeton d'accès actuel. ",

--- a/packages/phrases/src/locales/it/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/jwt-claims.ts
@@ -54,6 +54,11 @@ const jwt_claims = {
     subtitle:
       "Utilizza il parametro `context.interaction` per accedere ai dettagli dell'interazione dell'utente per la sessione di autenticazione corrente, inclusi `interactionEvent`, `userId` e `verificationRecords`.",
   },
+  application_data: {
+    title: "Contesto dell'applicazione",
+    subtitle:
+      "Utilizza il parametro di input `context.application` per fornire le informazioni dell'applicazione associate al token.",
+  },
   token_data: {
     title: 'Dati token',
     subtitle:

--- a/packages/phrases/src/locales/ja/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/jwt-claims.ts
@@ -51,6 +51,11 @@ const jwt_claims = {
     subtitle:
       '`context.interaction` パラメーターを使用して、現在の認証セッションにおけるユーザーのインタラクション詳細にアクセスします。包含されるのは `interactionEvent`、`userId`、`verificationRecords` です。',
   },
+  application_data: {
+    title: 'アプリケーションコンテキスト',
+    subtitle:
+      '`context.application` 入力パラメータを使用して、トークンに関連するアプリケーション情報を提供します。',
+  },
   token_data: {
     title: 'トークンデータ',
     subtitle: '現在のアクセストークンペイロードに対して`token`入力パラメータを使用します。',

--- a/packages/phrases/src/locales/ko/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/jwt-claims.ts
@@ -50,6 +50,11 @@ const jwt_claims = {
     subtitle:
       '`context.interaction` 매개변수를 사용하여 현재 인증 세션에 대한 사용자의 상호작용 세부 정보에 접근합니다. 여기에는 `interactionEvent`, `userId`, `verificationRecords`가 포함됩니다.',
   },
+  application_data: {
+    title: '애플리케이션 컨텍스트',
+    subtitle:
+      '`context.application` 입력 매개변수를 사용하여 토큰과 관련된 애플리케이션 정보를 제공합니다.',
+  },
   token_data: {
     title: '토큰 데이터',
     subtitle: '현재 액세스 토큰 페이로드에 대한 `token` 입력 매개변수 사용.',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/jwt-claims.ts
@@ -54,6 +54,11 @@ const jwt_claims = {
     subtitle:
       'Użyj parametru `context.interaction`, aby uzyskać dostęp do szczegółów interakcji użytkownika dla bieżącej sesji uwierzytelniania, w tym `interactionEvent`, `userId`, i `verificationRecords`.',
   },
+  application_data: {
+    title: 'Kontekst aplikacji',
+    subtitle:
+      'Użyj parametru wejściowego `context.application`, aby dostarczć informacje o aplikacji powiązanej z tokenem.',
+  },
   token_data: {
     title: 'Dane tokenu',
     subtitle: 'Użyj parametru wejściowego `token`, aby uzyskać bieżący ładunek tokenu dostępu.',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/jwt-claims.ts
@@ -53,6 +53,11 @@ const jwt_claims = {
     subtitle:
       'Use o parâmetro `context.interaction` para acessar os detalhes da interação do usuário na sessão de autenticação atual, incluindo `interactionEvent`, `userId` e `verificationRecords`.',
   },
+  application_data: {
+    title: 'Contexto da aplicação',
+    subtitle:
+      'Use o parâmetro de entrada `context.application` para fornecer as informações da aplicação associadas ao token.',
+  },
   token_data: {
     title: 'Dados do token',
     subtitle: 'Use o parâmetro de entrada `token` para a carga útil do token de acesso atual. ',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/jwt-claims.ts
@@ -54,6 +54,11 @@ const jwt_claims = {
     subtitle:
       'Use o parâmetro `context.interaction` para aceder aos detalhes da interação do utilizador para a sessão de autenticação atual, incluindo `interactionEvent`, `userId` e `verificationRecords`.',
   },
+  application_data: {
+    title: 'Contexto da aplicação',
+    subtitle:
+      'Utilize o parâmetro de entrada `context.application` para fornecer as informações da aplicação associadas ao token.',
+  },
   token_data: {
     title: 'Dados do token',
     subtitle: 'Utilize o parâmetro de entrada `token` para a carga util atual do token de acesso.',

--- a/packages/phrases/src/locales/ru/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/jwt-claims.ts
@@ -54,6 +54,11 @@ const jwt_claims = {
     subtitle:
       'Используйте параметр `context.interaction` для доступа к деталям взаимодействия пользователя для текущей сессии аутентификации, включая `interactionEvent`, `userId` и `verificationRecords`.',
   },
+  application_data: {
+    title: 'Контекст приложения',
+    subtitle:
+      'Используйте входной параметр `context.application` для предоставления информации о приложении, связанной с токеном.',
+  },
   token_data: {
     title: 'Данные токена',
     subtitle: 'Используйте параметр ввода `token` для полезной нагрузки текущего токена доступа. ',

--- a/packages/phrases/src/locales/th/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/jwt-claims.ts
@@ -50,6 +50,11 @@ const jwt_claims = {
     subtitle:
       'ใช้พารามิเตอร์ `context.interaction` เพื่อเข้าถึงรายละเอียดการโต้ตอบของผู้ใช้ใน session การยืนยันตัวตนปัจจุบัน รวมถึง `interactionEvent`, `userId` และ `verificationRecords`',
   },
+  application_data: {
+    title: 'บริบทของแอปพลิเคชัน',
+    subtitle:
+      'ใช้พารามิเตอร์อินพุต `context.application` เพื่อให้ข้อมูลแอปพลิเคชันที่เกี่ยวข้องกับโทเค็น',
+  },
   token_data: {
     title: 'payload ของ token',
     subtitle: 'ใช้พารามิเตอร์ `token` เพื่อ payload ของ access token ปัจจุบัน',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/jwt-claims.ts
@@ -53,6 +53,11 @@ const jwt_claims = {
     subtitle:
       'Kullanıcının etkileşim ayrıntılarına, mevcut kimlik doğrulama oturumu için `context.interaction` parametresini kullanarak erişin, `interactionEvent`, `userId` ve `verificationRecords` dahil.',
   },
+  application_data: {
+    title: 'Uygulama bağlamı',
+    subtitle:
+      'Token ile ilişkili uygulama bilgilerini sağlamak için `context.application` giriş parametresini kullanın.',
+  },
   token_data: {
     title: 'Belge verisi',
     subtitle: '`belge` giriş parametresini mevcut erişim belgesi yükü için kullanın. ',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/jwt-claims.ts
@@ -47,6 +47,10 @@ const jwt_claims = {
     subtitle:
       '使用 `context.interaction` 参数访问当前身份验证会话的用户交互详细信息，包括 `interactionEvent`、`userId` 和 `verificationRecords`。',
   },
+  application_data: {
+    title: '应用程序上下文',
+    subtitle: '使用 `context.application` 输入参数提供与令牌关联的应用程序信息。',
+  },
   token_data: {
     title: '令牌数据',
     subtitle: '使用`token`输入参数查看当前访问令牌负载。',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/jwt-claims.ts
@@ -47,6 +47,10 @@ const jwt_claims = {
     subtitle:
       '使用 `context.interaction` 參數訪問當前身份驗證會話的用戶交互詳情，包括 `interactionEvent`、`userId` 和 `verificationRecords`。',
   },
+  application_data: {
+    title: '應用程式上下文',
+    subtitle: '使用 `context.application` 輸入參數提供與令牌關聯的應用程式資訊。',
+  },
   token_data: {
     title: '權杖數據',
     subtitle: '使用 `token` 輸入參數查看當前存取權杖有效負載。',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/jwt-claims.ts
@@ -47,6 +47,10 @@ const jwt_claims = {
     subtitle:
       '使用 `context.interaction` 參數訪問當前身份驗證會話的用戶交互詳細信息，包括 `interactionEvent`、`userId` 和 `verificationRecords`。',
   },
+  application_data: {
+    title: '應用程式上下文',
+    subtitle: '使用 `context.application` 輸入參數提供與令牌關聯的應用程式資訊。',
+  },
   token_data: {
     title: '令牌數據',
     subtitle: '使用 `token` 輸入參數獲取當前訪問令牌有效載荷。',

--- a/packages/schemas/src/types/logto-config/jwt-customizer.test.ts
+++ b/packages/schemas/src/types/logto-config/jwt-customizer.test.ts
@@ -13,7 +13,12 @@ const optionalFields = ['environmentVariables', 'contextSample', 'tokenSample'] 
 const testClientCredentialsTokenPayload = {
   script: '',
   environmentVariables: {},
-  contextSample: {},
+  contextSample: {
+    application: {
+      id: 'my-app',
+      name: 'My M2M App',
+    },
+  },
   tokenSample: {},
 };
 


### PR DESCRIPTION
## Summary

Add application context (including `customData`) to the JWT customizer for both user access token and client credentials token types. This allows custom JWT scripts to access application info via `context.application`.

### Changes

- **schemas**: Add `JwtCustomizerApplicationContext` type and guard; extend access token and client credentials JWT customizer guards to include application context
- **core**: Add `getApplicationContext` method to `JwtCustomizerLibrary` that handles both built-in apps (`demo-app`, `account-center`) and database apps, with secret omitted (SSOT); wire it into `extra-token-claims.ts`
- **console**: Add application context type definitions, guide card, and test model for the JWT customizer editor UI
- **phrases**: Add `application_data` translation entries

Guarded behind `isDevFeaturesEnabled`.

## Testing

tested locally

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments