### PR TITLE
fix(schemas): make context optional in customJwtFetcherGuard for client credentials

### DIFF
--- a/packages/schemas/src/types/logto-config/jwt-customizer.ts
+++ b/packages/schemas/src/types/logto-config/jwt-customizer.ts
@@ -229,7 +229,9 @@ export const customJwtFetcherGuard = z.discriminatedUnion('tokenType', [
   }),
   commonJwtCustomizerGuard.extend({
     tokenType: z.literal(LogtoJwtTokenKeyType.ClientCredentials),
-    context: jsonObjectGuard,
+    // TODO: @xiaoyijun Make `context` required once the application context feature is fully launched
+    // and all core instances are sending `context` for client credentials requests.
+    context: jsonObjectGuard.optional(),
   }),
 ]);
 


### PR DESCRIPTION
## Summary

Make `context` field optional for `ClientCredentials` token type in `customJwtFetcherGuard`.

This ensures backward compatibility during deployment: the worker template (which uses this guard) is deployed before the core service, so the old core that doesn't send `context` for `ClientCredentials` requests won't get a 400 error.

## Testing

N/A

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments