### PR TITLE
fix(schemas,console): make application optional in client credentials JWT customizer context

### DIFF
--- a/packages/console/src/pages/CustomizeJwtDetails/utils/config.tsx
+++ b/packages/console/src/pages/CustomizeJwtDetails/utils/config.tsx
@@ -96,7 +96,7 @@ declare type Context = {
   /**
    * The application data associated with the token.
    */
-  application: ${JwtCustomizerTypeDefinitionKey.JwtCustomizerApplicationContext};
+  application?: ${JwtCustomizerTypeDefinitionKey.JwtCustomizerApplicationContext};
 }
 
 `

--- a/packages/schemas/src/types/logto-config/jwt-customizer.ts
+++ b/packages/schemas/src/types/logto-config/jwt-customizer.ts
@@ -178,7 +178,7 @@ export const clientCredentialsJwtCustomizerGuard = jwtCustomizerGuard
     tokenSample: clientCredentialsPayloadGuard.partial().optional(),
     contextSample: z
       .object({
-        application: jwtCustomizerApplicationContextGuard.partial(),
+        application: jwtCustomizerApplicationContextGuard.partial().optional(),
       })
       .optional(),
   })


### PR DESCRIPTION
## Summary

The `application` field in the client credentials JWT customizer context was incorrectly marked as required, while the same field in the user access token context was optional. Since the application context feature is still behind the dev feature flag (`isDevFeaturesEnabled`), both should be optional for consistency.

Changes:
- `clientCredentialsJwtCustomizerGuard`: added `.optional()` to the `application` field in `contextSample`
- Console M2M context type definition: changed `application` to `application?`

## Testing

N/A

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments