### PR TITLE
fix(phrases): remove specific field names from interaction context description

### DIFF
--- a/packages/phrases/src/locales/ar/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/jwt-claims.ts
@@ -48,7 +48,7 @@ const jwt_claims = {
   interaction_data: {
     title: 'سياق تفاعل المستخدم',
     subtitle:
-      'استخدم المعلمة `context.interaction` للوصول إلى تفاصيل تفاعل المستخدم في جلسة المصادقة الحالية، بما في ذلك `interactionEvent`, `userId`, و `verificationRecords`.',
+      'استخدم المعلمة `context.interaction` للوصول إلى تفاصيل تفاعل المستخدم في جلسة المصادقة الحالية.',
   },
   application_data: {
     title: 'سياق التطبيق',

--- a/packages/phrases/src/locales/de/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/jwt-claims.ts
@@ -54,7 +54,7 @@ const jwt_claims = {
   interaction_data: {
     title: 'Benutzerinteraktionskontext',
     subtitle:
-      'Verwenden Sie den Parameter `context.interaction`, um auf die Interaktionsdetails des Benutzers der aktuellen Authentifizierungssitzung zuzugreifen, einschließlich `interactionEvent`, `userId` und `verificationRecords`.',
+      'Verwenden Sie den Parameter `context.interaction`, um auf die Interaktionsdetails des Benutzers der aktuellen Authentifizierungssitzung zuzugreifen.',
   },
   application_data: {
     title: 'Anwendungskontext',

--- a/packages/phrases/src/locales/en/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/jwt-claims.ts
@@ -49,7 +49,7 @@ const jwt_claims = {
   interaction_data: {
     title: 'User interaction context',
     subtitle:
-      "Use the `context.interaction` parameter to access the user's interaction details for the current authentication session, including `interactionEvent`, `userId`, and `verificationRecords`.",
+      "Use the `context.interaction` parameter to access the user's interaction details for the current authentication session.",
   },
   application_data: {
     title: 'Application context',

--- a/packages/phrases/src/locales/es/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/jwt-claims.ts
@@ -52,7 +52,7 @@ const jwt_claims = {
   interaction_data: {
     title: 'Contexto de interacción del usuario',
     subtitle:
-      'Use el parámetro `context.interaction` para acceder a los detalles de la interacción del usuario para la sesión de autenticación actual, incluidos `interactionEvent`, `userId` y `verificationRecords`.',
+      'Use el parámetro `context.interaction` para acceder a los detalles de la interacción del usuario para la sesión de autenticación actual.',
   },
   application_data: {
     title: 'Contexto de la aplicación',

--- a/packages/phrases/src/locales/fr/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/jwt-claims.ts
@@ -53,7 +53,7 @@ const jwt_claims = {
   interaction_data: {
     title: "Contexte d'interaction utilisateur",
     subtitle:
-      "Utilisez le paramètre `context.interaction` pour accéder aux détails de l'interaction de l'utilisateur pour la session d'authentification en cours, y compris `interactionEvent`, `userId` et `verificationRecords`.",
+      "Utilisez le paramètre `context.interaction` pour accéder aux détails de l'interaction de l'utilisateur pour la session d'authentification en cours.",
   },
   application_data: {
     title: "Contexte de l'application",

--- a/packages/phrases/src/locales/it/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/jwt-claims.ts
@@ -52,7 +52,7 @@ const jwt_claims = {
   interaction_data: {
     title: 'Contesto di interazione utente',
     subtitle:
-      "Utilizza il parametro `context.interaction` per accedere ai dettagli dell'interazione dell'utente per la sessione di autenticazione corrente, inclusi `interactionEvent`, `userId` e `verificationRecords`.",
+      "Utilizza il parametro `context.interaction` per accedere ai dettagli dell'interazione dell'utente per la sessione di autenticazione corrente.",
   },
   application_data: {
     title: "Contesto dell'applicazione",

--- a/packages/phrases/src/locales/ja/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/jwt-claims.ts
@@ -49,7 +49,7 @@ const jwt_claims = {
   interaction_data: {
     title: 'ユーザーインタラクションコンテキスト',
     subtitle:
-      '`context.interaction` パラメーターを使用して、現在の認証セッションにおけるユーザーのインタラクション詳細にアクセスします。包含されるのは `interactionEvent`、`userId`、`verificationRecords` です。',
+      '`context.interaction` パラメーターを使用して、現在の認証セッションにおけるユーザーのインタラクション詳細にアクセスします。',
   },
   application_data: {
     title: 'アプリケーションコンテキスト',

--- a/packages/phrases/src/locales/ko/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/jwt-claims.ts
@@ -48,7 +48,7 @@ const jwt_claims = {
   interaction_data: {
     title: '사용자 상호작용 컨텍스트',
     subtitle:
-      '`context.interaction` 매개변수를 사용하여 현재 인증 세션에 대한 사용자의 상호작용 세부 정보에 접근합니다. 여기에는 `interactionEvent`, `userId`, `verificationRecords`가 포함됩니다.',
+      '`context.interaction` 매개변수를 사용하여 현재 인증 세션에 대한 사용자의 상호작용 세부 정보에 접근합니다.',
   },
   application_data: {
     title: '애플리케이션 컨텍스트',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/jwt-claims.ts
@@ -52,7 +52,7 @@ const jwt_claims = {
   interaction_data: {
     title: 'Kontekst interakcji użytkownika',
     subtitle:
-      'Użyj parametru `context.interaction`, aby uzyskać dostęp do szczegółów interakcji użytkownika dla bieżącej sesji uwierzytelniania, w tym `interactionEvent`, `userId`, i `verificationRecords`.',
+      'Użyj parametru `context.interaction`, aby uzyskać dostęp do szczegółów interakcji użytkownika dla bieżącej sesji uwierzytelniania.',
   },
   application_data: {
     title: 'Kontekst aplikacji',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/jwt-claims.ts
@@ -51,7 +51,7 @@ const jwt_claims = {
   interaction_data: {
     title: 'Contexto de interação do usuário',
     subtitle:
-      'Use o parâmetro `context.interaction` para acessar os detalhes da interação do usuário na sessão de autenticação atual, incluindo `interactionEvent`, `userId` e `verificationRecords`.',
+      'Use o parâmetro `context.interaction` para acessar os detalhes da interação do usuário na sessão de autenticação atual.',
   },
   application_data: {
     title: 'Contexto da aplicação',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/jwt-claims.ts
@@ -52,7 +52,7 @@ const jwt_claims = {
   interaction_data: {
     title: 'Contexto de interação do utilizador',
     subtitle:
-      'Use o parâmetro `context.interaction` para aceder aos detalhes da interação do utilizador para a sessão de autenticação atual, incluindo `interactionEvent`, `userId` e `verificationRecords`.',
+      'Use o parâmetro `context.interaction` para aceder aos detalhes da interação do utilizador para a sessão de autenticação atual.',
   },
   application_data: {
     title: 'Contexto da aplicação',

--- a/packages/phrases/src/locales/ru/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/jwt-claims.ts
@@ -52,7 +52,7 @@ const jwt_claims = {
   interaction_data: {
     title: 'Контекст взаимодействия с пользователем',
     subtitle:
-      'Используйте параметр `context.interaction` для доступа к деталям взаимодействия пользователя для текущей сессии аутентификации, включая `interactionEvent`, `userId` и `verificationRecords`.',
+      'Используйте параметр `context.interaction` для доступа к деталям взаимодействия пользователя для текущей сессии аутентификации.',
   },
   application_data: {
     title: 'Контекст приложения',

--- a/packages/phrases/src/locales/th/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/jwt-claims.ts
@@ -48,7 +48,7 @@ const jwt_claims = {
   interaction_data: {
     title: 'บริบทปฏิสัมพันธ์กับผู้ใช้',
     subtitle:
-      'ใช้พารามิเตอร์ `context.interaction` เพื่อเข้าถึงรายละเอียดการโต้ตอบของผู้ใช้ใน session การยืนยันตัวตนปัจจุบัน รวมถึง `interactionEvent`, `userId` และ `verificationRecords`',
+      'ใช้พารามิเตอร์ `context.interaction` เพื่อเข้าถึงรายละเอียดการโต้ตอบของผู้ใช้ใน session การยืนยันตัวตนปัจจุบัน',
   },
   application_data: {
     title: 'บริบทของแอปพลิเคชัน',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/jwt-claims.ts
@@ -51,7 +51,7 @@ const jwt_claims = {
   interaction_data: {
     title: 'Kullanıcı etkileşim bağlamı',
     subtitle:
-      'Kullanıcının etkileşim ayrıntılarına, mevcut kimlik doğrulama oturumu için `context.interaction` parametresini kullanarak erişin, `interactionEvent`, `userId` ve `verificationRecords` dahil.',
+      'Kullanıcının etkileşim ayrıntılarına, mevcut kimlik doğrulama oturumu için `context.interaction` parametresini kullanarak erişin.',
   },
   application_data: {
     title: 'Uygulama bağlamı',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/jwt-claims.ts
@@ -44,8 +44,7 @@ const jwt_claims = {
   },
   interaction_data: {
     title: '用户交互上下文',
-    subtitle:
-      '使用 `context.interaction` 参数访问当前身份验证会话的用户交互详细信息，包括 `interactionEvent`、`userId` 和 `verificationRecords`。',
+    subtitle: '使用 `context.interaction` 参数访问当前身份验证会话的用户交互详细信息。',
   },
   application_data: {
     title: '应用程序上下文',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/jwt-claims.ts
@@ -44,8 +44,7 @@ const jwt_claims = {
   },
   interaction_data: {
     title: '用戶交互上下文',
-    subtitle:
-      '使用 `context.interaction` 參數訪問當前身份驗證會話的用戶交互詳情，包括 `interactionEvent`、`userId` 和 `verificationRecords`。',
+    subtitle: '使用 `context.interaction` 參數訪問當前身份驗證會話的用戶交互詳情。',
   },
   application_data: {
     title: '應用程式上下文',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/jwt-claims.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/jwt-claims.ts
@@ -44,8 +44,7 @@ const jwt_claims = {
   },
   interaction_data: {
     title: '用戶交互上下文',
-    subtitle:
-      '使用 `context.interaction` 參數訪問當前身份驗證會話的用戶交互詳細信息，包括 `interactionEvent`、`userId` 和 `verificationRecords`。',
+    subtitle: '使用 `context.interaction` 參數訪問當前身份驗證會話的用戶交互詳細信息。',
   },
   application_data: {
     title: '應用程式上下文',


### PR DESCRIPTION
## Summary

Remove the specific field names (`interactionEvent`, `userId`, and `verificationRecords`) from the user interaction context card description in the JWT customizer page across all 17 locales.

## Testing

N/A

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments