### PR TITLE
chore(core,console): remove dev feature guard for custom JWT application context

### DIFF
--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/index.tsx
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/index.tsx
@@ -5,7 +5,6 @@ import { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
-import { isDevFeaturesEnabled } from '@/consts/env';
 import { type JwtCustomizerForm } from '@/pages/CustomizeJwtDetails/type';
 import {
   denyAccessCodeExample,
@@ -118,25 +117,22 @@ function InstructionTab({ isActive }: Props) {
           />
         </GuideCard>
       )}
-      {/* DEV: application context in JWT customizer */}
-      {isDevFeaturesEnabled && (
-        <GuideCard
-          name={CardType.ApplicationData}
-          isExpanded={expendCard === CardType.ApplicationData}
-          setExpanded={(expand) => {
-            setExpendCard(expand ? CardType.ApplicationData : undefined);
-          }}
-        >
-          <Editor
-            language="typescript"
-            className={styles.sampleCode}
-            value={`declare ${jwtCustomizerApplicationContextTypeDefinition}`}
-            height="400px"
-            theme="logto-dark"
-            options={typeDefinitionCodeEditorOptions}
-          />
-        </GuideCard>
-      )}
+      <GuideCard
+        name={CardType.ApplicationData}
+        isExpanded={expendCard === CardType.ApplicationData}
+        setExpanded={(expand) => {
+          setExpendCard(expand ? CardType.ApplicationData : undefined);
+        }}
+      >
+        <Editor
+          language="typescript"
+          className={styles.sampleCode}
+          value={`declare ${jwtCustomizerApplicationContextTypeDefinition}`}
+          height="400px"
+          theme="logto-dark"
+          options={typeDefinitionCodeEditorOptions}
+        />
+      </GuideCard>
       <GuideCard
         name={CardType.FetchExternalData}
         isExpanded={expendCard === CardType.FetchExternalData}

--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/TestTab/index.tsx
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/TestTab/index.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Controller, useFormContext, type ControllerRenderProps } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
-import { isDevFeaturesEnabled } from '@/consts/env';
 import MonacoCodeEditor, {
   type ModelControl,
 } from '@/pages/CustomizeJwtDetails/MainContent/MonacoCodeEditor';
@@ -25,10 +24,7 @@ type Props = {
 };
 
 const accessTokenModelSettings = [accessTokenPayloadTestModel, userContextTestModel];
-// DEV: application context in JWT customizer
-const clientCredentialsModelSettings = isDevFeaturesEnabled
-  ? [clientCredentialsPayloadTestModel, m2mContextTestModel]
-  : [clientCredentialsPayloadTestModel];
+const clientCredentialsModelSettings = [clientCredentialsPayloadTestModel, m2mContextTestModel];
 
 function TestTab({ isActive }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console.jwt_claims' });

--- a/packages/console/src/pages/CustomizeJwtDetails/utils/config.tsx
+++ b/packages/console/src/pages/CustomizeJwtDetails/utils/config.tsx
@@ -14,7 +14,6 @@ import { type EditorProps } from '@monaco-editor/react';
 
 import TokenFileIcon from '@/assets/icons/token-file-icon.svg?react';
 import UserFileIcon from '@/assets/icons/user-file-icon.svg?react';
-import { isDevFeaturesEnabled } from '@/consts/env';
 
 import type { ModelSettings } from '../MainContent/MonacoCodeEditor/type.js';
 
@@ -36,7 +35,8 @@ declare interface CustomJwtClaims extends Record<string, any> {}
  *
  * @param {${JwtCustomizerTypeDefinitionKey.JwtCustomizerUserContext}} user - The user info associated with the token.
  * @param {${JwtCustomizerTypeDefinitionKey.JwtCustomizerGrantContext}} [grant] - The grant context associated with the token.
- * @param {${JwtCustomizerTypeDefinitionKey.JwtCustomizerUserInteractionContext}} [interaction] - The user interaction context associated with the token.${isDevFeaturesEnabled ? `\n * @param {${JwtCustomizerTypeDefinitionKey.JwtCustomizerApplicationContext}} [application] - The application info associated with the token.` : ''}
+ * @param {${JwtCustomizerTypeDefinitionKey.JwtCustomizerUserInteractionContext}} [interaction] - The user interaction context associated with the token.
+ * @param {${JwtCustomizerTypeDefinitionKey.JwtCustomizerApplicationContext}} [application] - The application info associated with the token.
  */
 declare type Context = {
   /**
@@ -50,7 +50,11 @@ declare type Context = {
   /**
    * The user interaction context associated with the token.
    */
-  interaction?: ${JwtCustomizerTypeDefinitionKey.JwtCustomizerUserInteractionContext};${isDevFeaturesEnabled ? `\n  /**\n   * The application data associated with the token.\n   */\n  application?: ${JwtCustomizerTypeDefinitionKey.JwtCustomizerApplicationContext};` : ''}
+  interaction?: ${JwtCustomizerTypeDefinitionKey.JwtCustomizerUserInteractionContext};
+  /**
+   * The application data associated with the token.
+   */
+  application?: ${JwtCustomizerTypeDefinitionKey.JwtCustomizerApplicationContext};
 }
 
 declare type Payload = {
@@ -63,7 +67,8 @@ declare type Payload = {
    *
    * @params {${JwtCustomizerTypeDefinitionKey.JwtCustomizerUserContext}} user
    * @params {${JwtCustomizerTypeDefinitionKey.JwtCustomizerGrantContext}} [grant]
-   * @params {${JwtCustomizerTypeDefinitionKey.JwtCustomizerUserInteractionContext}} [interaction]${isDevFeaturesEnabled ? `\n   * @params {${JwtCustomizerTypeDefinitionKey.JwtCustomizerApplicationContext}} [application]` : ''}
+   * @params {${JwtCustomizerTypeDefinitionKey.JwtCustomizerUserInteractionContext}} [interaction]
+   * @params {${JwtCustomizerTypeDefinitionKey.JwtCustomizerApplicationContext}} [application]
    */
   context: Context;
   /**
@@ -86,9 +91,7 @@ declare type Payload = {
 const clientCredentialsJwtCustomizerDefinition = `
 declare interface CustomJwtClaims extends Record<string, any> {}
 
-${
-  isDevFeaturesEnabled
-    ? `/** Logto internal data that can be used to pass additional information
+/** Logto internal data that can be used to pass additional information
  *
  * @param {${JwtCustomizerTypeDefinitionKey.JwtCustomizerApplicationContext}} application - The application info associated with the token.
  */
@@ -99,23 +102,17 @@ declare type Context = {
   application?: ${JwtCustomizerTypeDefinitionKey.JwtCustomizerApplicationContext};
 }
 
-`
-    : ''
-}declare type Payload = {
+declare type Payload = {
   /**
    * Token payload.
    */
-  token: ${JwtCustomizerTypeDefinitionKey.ClientCredentialsPayload};${
-    isDevFeaturesEnabled
-      ? `
+  token: ${JwtCustomizerTypeDefinitionKey.ClientCredentialsPayload};
   /**
    * Logto internal data that can be used to pass additional information.
    *
    * @params {${JwtCustomizerTypeDefinitionKey.JwtCustomizerApplicationContext}} application
    */
-  context: Context;`
-      : ''
-  }
+  context: Context;
   /**
    * Custom environment variables.
    */
@@ -135,7 +132,7 @@ export const defaultAccessTokenJwtCustomizerCode = `/**
  * \`context.interaction\` also includes injected header context.
  *
  * @param {Payload} payload - The input argument of the function.
- * 
+ *
  * @returns The custom claims.
  */
 const getCustomJwtClaims = async ({ token, context, environmentVariables, api }) => {
@@ -150,7 +147,7 @@ export const defaultClientCredentialsJwtCustomizerCode = `/**
  *
  * @returns The custom claims.
  */
-const getCustomJwtClaims = async ({ token, ${isDevFeaturesEnabled ? 'context, ' : ''}environmentVariables, api }) => {
+const getCustomJwtClaims = async ({ token, context, environmentVariables, api }) => {
   return {};
 }`;
 
@@ -243,7 +240,7 @@ export const denyAccessCodeExample = `/**
  * @param {Payload} payload - The input payload of the function.
  */
 getCustomJwtClaims = async ({ api }) => {
-  // Conditionally deny access 
+  // Conditionally deny access
   return api.denyAccess('Access denied');
 };`;
 

--- a/packages/console/src/pages/CustomizeJwtDetails/utils/type-definitions.ts
+++ b/packages/console/src/pages/CustomizeJwtDetails/utils/type-definitions.ts
@@ -1,4 +1,3 @@
-import { isDevFeaturesEnabled } from '@/consts/env';
 import {
   JwtCustomizerTypeDefinitionKey,
   accessTokenPayloadTypeDefinition,
@@ -31,12 +30,16 @@ export const buildAccessTokenJwtCustomizerContextTsDefinition = () => {
 
   declare ${accessTokenPayloadTypeDefinition}
 
-  declare ${jwtCustomizerUserInteractionContextTypeDefinition}${isDevFeaturesEnabled ? `\n\n  declare ${jwtCustomizerApplicationContextTypeDefinition}` : ''}`;
+  declare ${jwtCustomizerUserInteractionContextTypeDefinition}
+
+  declare ${jwtCustomizerApplicationContextTypeDefinition}`;
 };
 
 export const buildClientCredentialsJwtCustomizerContextTsDefinition = () =>
   `declare ${clientCredentialsPayloadTypeDefinition}
-${isDevFeaturesEnabled ? `\n  declare ${jwtCustomizerApplicationContextTypeDefinition}\n` : ''}
+
+  declare ${jwtCustomizerApplicationContextTypeDefinition}
+
   declare ${jwtCustomizerApiContextTypeDefinition}`;
 
 export const buildEnvironmentVariablesTypeDefinition = (

--- a/packages/core/src/oidc/extra-token-claims.ts
+++ b/packages/core/src/oidc/extra-token-claims.ts
@@ -220,12 +220,9 @@ export const getExtraTokenClaimsForJwtCustomization = async (
       !isClientCredentialsToken && (await getAssociatedSubjectToken(queries, token))
     );
 
-    // DEV: application context in JWT customizer
     const clientId = token.clientId ?? ctx.oidc.client?.clientId;
     const applicationContext = conditional(
-      EnvSet.values.isDevFeaturesEnabled &&
-        clientId &&
-        (await libraries.jwtCustomizers.getApplicationContext(envSet.tenantId, clientId))
+      clientId && (await libraries.jwtCustomizers.getApplicationContext(envSet.tenantId, clientId))
     );
 
     const logEntry = ctx.createLog(


### PR DESCRIPTION
## Summary

Remove the dev feature guard (`isDevFeaturesEnabled`) for the custom JWT application context feature, graduating it to production.

Changes:
- **core**: Remove `isDevFeaturesEnabled` check in `extra-token-claims.ts`, so `applicationContext` is always fetched and passed to the JWT customizer
- **console**: Remove all `isDevFeaturesEnabled` guards in the CustomizeJwt pages:
  - `config.tsx`: Application context type definitions and default code templates are always included for both access token and client credentials
  - `InstructionTab`: ApplicationData guide card is always rendered
  - `TestTab`: M2M context test model is always included in client credentials settings
  - `type-definitions.ts`: Application context type definition is always included in both access token and client credentials TS definitions

## Testing

N/A

## Checklist

- [x] `.changeset` (see https://github.com/logto-io/logto/pull/8351)
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments