### PR TITLE
fix(experience): should hide "webauthn not found" error toast on identifier submit

### DIFF
--- a/packages/experience/src/components/IdentifierSignInForm/use-on-submit.ts
+++ b/packages/experience/src/components/IdentifierSignInForm/use-on-submit.ts
@@ -17,7 +17,9 @@ const useOnSubmit = (signInMethods: SignIn['methods']) => {
   const { onSubmit: checkSingleSignOn } = useCheckSingleSignOn();
   const { setIdentifierInputValue } = useContext(UserInteractionContext);
   const { startProcessing: startIdentifierPasskeySignInProcessing } =
-    useStartIdentifierPasskeySignInProcessing();
+    useStartIdentifierPasskeySignInProcessing({
+      hideErrorToast: true,
+    });
 
   const navigateToPasswordPage = useCallback(() => {
     navigate({

--- a/packages/experience/src/hooks/use-start-identifier-passkey-sign-in-processing.ts
+++ b/packages/experience/src/hooks/use-start-identifier-passkey-sign-in-processing.ts
@@ -13,7 +13,7 @@ import useErrorHandler, { type ErrorHandlers } from './use-error-handler';
 import useToast from './use-toast';
 
 type Props = {
-  readonly hideErrorToast?: boolean;
+  readonly hideErrorToast: boolean;
 };
 
 /**
@@ -29,7 +29,7 @@ type Props = {
  * Only passes WebAuthn options in navigation state. Identifier and available
  * methods are read from UserInteractionContext and useSieMethods() by the target page.
  */
-const useStartIdentifierPasskeySignInProcessing = (props?: Props) => {
+const useStartIdentifierPasskeySignInProcessing = ({ hideErrorToast }: Props) => {
   const { setToast } = useToast();
   const navigate = useNavigateWithPreservedSearchParams();
   const asyncCreateAuthentication = useApi(createIdentifierPasskeyAuthentication);
@@ -42,13 +42,13 @@ const useStartIdentifierPasskeySignInProcessing = (props?: Props) => {
     () => ({
       'session.mfa.webauthn_verification_not_found': async (error) => {
         // No passkeys registered
-        if (!props?.hideErrorToast) {
+        if (!hideErrorToast) {
           setToast(error.message);
         }
         // Do nothing and silently fall back to other methods if hideErrorToast is true
       },
     }),
-    [setToast, props?.hideErrorToast]
+    [setToast, hideErrorToast]
   );
 
   /**


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Should hide the "Webauthn verification not found" error toast when submitting the identifier in the first step.
In such case, the user has not yet bound any passkey, we should silently fall back to the other verification method instead.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested OK

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
