### PR TITLE
fix(experience): do not show disabled button state in SIE preview

### DIFF
--- a/packages/experience/src/components/Button/PasskeySignInButton/index.tsx
+++ b/packages/experience/src/components/Button/PasskeySignInButton/index.tsx
@@ -5,6 +5,7 @@ import { useCallback, useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDebouncedLoader } from 'use-debounced-loader';
 
+import PageContext from '@/Providers/PageContextProvider/PageContext';
 import WebAuthnContext from '@/Providers/WebAuthnContextProvider/WebAuthnContext';
 import PasskeyIcon from '@/assets/icons/passkey-icon.svg?react';
 import usePasskeySignIn from '@/hooks/use-passkey-sign-in';
@@ -16,6 +17,7 @@ import styles from './index.module.scss';
 
 const PasskeySignInButton = () => {
   const { t } = useTranslation();
+  const { isPreview } = useContext(PageContext);
   const {
     authenticationOptions,
     isLoading: isPreparing,
@@ -60,13 +62,13 @@ const PasskeySignInButton = () => {
 
   return (
     <button
-      disabled={isDisabled}
+      disabled={isDisabled && !isPreview}
       className={classNames(
         buttonStyles.button,
         buttonStyles.secondary,
         buttonStyles.large,
         styles.button,
-        isDisabled && buttonStyles.disabled
+        isDisabled && !isPreview && buttonStyles.disabled
       )}
       type="button"
       onClick={onPasskeySignIn}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Do not show disabled "Continue with passkey" button state in SIE preview frame.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
<img width="1270" height="1508" alt="image" src="https://github.com/user-attachments/assets/4650d0af-b096-4268-a646-fa0cbb22353f" />

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
