### PR TITLE
fix(console): hide prompt checkboxes when passkey sign-in switch is turned off

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/PasskeySignInForm/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/PasskeySignInForm/index.tsx
@@ -19,7 +19,7 @@ import styles from './index.module.scss';
 
 function PasskeySignInForm() {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
-  const { control, register } = useFormContext<SignInExperienceForm>();
+  const { control, register, watch } = useFormContext<SignInExperienceForm>();
 
   const {
     currentSubscriptionQuota,
@@ -48,37 +48,39 @@ function PasskeySignInForm() {
           )}
         />
       </FormField>
-      <FormField title="sign_in_exp.sign_up_and_sign_in.passkey_sign_in.prompts">
-        <div className={styles.checkboxes}>
-          <Controller
-            control={control}
-            name="passkeySignIn.showPasskeyButton"
-            render={({ field: { value, onChange } }) => (
-              <Checkbox
-                disabled={!isPasskeySignInEnabled}
-                label={t('sign_in_exp.sign_up_and_sign_in.passkey_sign_in.show_passkey_button')}
-                suffixTooltip={t(
-                  'sign_in_exp.sign_up_and_sign_in.passkey_sign_in.show_passkey_button_tip'
-                )}
-                checked={value}
-                onChange={onChange}
-              />
-            )}
-          />
-          <Controller
-            control={control}
-            name="passkeySignIn.allowAutofill"
-            render={({ field: { value, onChange } }) => (
-              <Checkbox
-                disabled={!isPasskeySignInEnabled}
-                label={t('sign_in_exp.sign_up_and_sign_in.passkey_sign_in.allow_autofill')}
-                checked={value}
-                onChange={onChange}
-              />
-            )}
-          />
-        </div>
-      </FormField>
+      {watch('passkeySignIn.enabled') && (
+        <FormField title="sign_in_exp.sign_up_and_sign_in.passkey_sign_in.prompts">
+          <div className={styles.checkboxes}>
+            <Controller
+              control={control}
+              name="passkeySignIn.showPasskeyButton"
+              render={({ field: { value, onChange } }) => (
+                <Checkbox
+                  disabled={!isPasskeySignInEnabled}
+                  label={t('sign_in_exp.sign_up_and_sign_in.passkey_sign_in.show_passkey_button')}
+                  suffixTooltip={t(
+                    'sign_in_exp.sign_up_and_sign_in.passkey_sign_in.show_passkey_button_tip'
+                  )}
+                  checked={value}
+                  onChange={onChange}
+                />
+              )}
+            />
+            <Controller
+              control={control}
+              name="passkeySignIn.allowAutofill"
+              render={({ field: { value, onChange } }) => (
+                <Checkbox
+                  disabled={!isPasskeySignInEnabled}
+                  label={t('sign_in_exp.sign_up_and_sign_in.passkey_sign_in.allow_autofill')}
+                  checked={value}
+                  onChange={onChange}
+                />
+              )}
+            />
+          </div>
+        </FormField>
+      )}
     </Card>
   );
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Hide prompt checkboxes when passkey sign-in switch is turned off.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
On:
<img width="623" height="304" alt="image" src="https://github.com/user-attachments/assets/15917894-0cdb-441e-af4a-974d2f2ebe7b" />

Off:
<img width="627" height="200" alt="image" src="https://github.com/user-attachments/assets/93a699b8-3e2d-4d57-8c44-48600e2aa6bb" />

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
