### PR TITLE
fix(core): prevent account enumeration and spam during password reset

### DIFF
--- a/packages/core/src/routes/experience/verification-routes/verification-code.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code.ts
@@ -76,6 +76,7 @@ export default function verificationCodeRoutes<T extends ExperienceInteractionRo
             isBindingEmailForMfa ? TemplateType.BindMfa : getTemplateTypeByEvent(interactionEvent)
           ),
         libraries,
+        queries,
         ctx,
       });
 
@@ -139,6 +140,7 @@ export default function verificationCodeRoutes<T extends ExperienceInteractionRo
         createVerificationRecord: () =>
           createNewMfaCodeVerificationRecord(libraries, queries, identifier),
         libraries,
+        queries,
         ctx,
       });
 


### PR DESCRIPTION
This PR addresses two security and operational issues in the password reset flow:
1. **Account Enumeration**: Consistently reports "code sent" (204 No Content) regardless of account existence, preventing attackers from identifying valid users.
2. **Spam Prevention**: Only triggers actual message delivery via connectors if the identifier (email/phone) is registered in the system. This prevents Logto from being used as a spam relay.

**Changes:**
- Added user existence checks in both `additionalRoutes` and Experience API `sendCode` helper.
- For `ForgotPassword` events, if the user doesn't exist, we skip sending the message but still return `204 No Content`.
- Added an audit log entry (`userExists: false`) for these non-delivery attempts to help identify potential enumeration attacks.