### PR TITLE
feat(console): add account center session field permission editor

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/constants.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/constants.ts
@@ -1,4 +1,7 @@
 import type { AdminConsoleKey } from '@logto/phrases';
+import { conditionalArray } from '@silverhand/essentials';
+
+import { isDevFeaturesEnabled } from '@/consts/env';
 
 import type { AccountCenterFieldKey } from '../../types';
 
@@ -49,6 +52,21 @@ export const accountCenterSections: AccountCenterFieldSection[] = [
           },
         ],
       },
+      ...conditionalArray(
+        isDevFeaturesEnabled && [
+          {
+            key: 'sessionManagement',
+            title:
+              'sign_in_exp.account_center.sections.account_security.groups.session_management.title',
+            items: [
+              {
+                key: 'session',
+                title: 'sign_in_exp.account_center.fields.sessions',
+              },
+            ],
+          } satisfies AccountCenterFieldGroup,
+        ]
+      ),
     ],
   },
   {

--- a/packages/console/src/pages/SignInExperience/types.ts
+++ b/packages/console/src/pages/SignInExperience/types.ts
@@ -7,6 +7,9 @@ import {
   type SignUpIdentifier as SignUpIdentifierMethod,
   type AccountCenterFieldControl,
 } from '@logto/schemas';
+import { conditionalArray } from '@silverhand/essentials';
+
+import { isDevFeaturesEnabled } from '@/consts/env';
 
 /**
  * Omit the `mfa`, `captchaPolicy`, 'passwordPolicy', `sentinelPolicy` and `emailBlocklistPolicy` fields from the sign-in experience.
@@ -36,6 +39,7 @@ const accountCenterFieldKeys: Array<keyof AccountCenterFieldControl> = [
   'avatar',
   'profile',
   'customData',
+  ...conditionalArray(isDevFeaturesEnabled && (['session'] as const)),
 ] as const;
 
 export type AccountCenterFieldKey = (typeof accountCenterFieldKeys)[number];

--- a/packages/phrases/src/locales/ar/errors/oidc.ts
+++ b/packages/phrases/src/locales/ar/errors/oidc.ts
@@ -18,12 +18,9 @@ const oidc = {
   provider_error_fallback: 'حدث خطأ OIDC: {{code}}.',
   key_required: 'مطلوب مفتاح واحد على الأقل.',
   key_not_found: 'لم يتم العثور على المفتاح بالمعرف {{id}}.',
-  /** UNTRANSLATED */
-  invalid_session_payload: 'Invalid session payload.',
-  /** UNTRANSLATED */
-  session_not_found: 'Session not found.',
-  /** UNTRANSLATED */
-  invalid_session_account_id: 'Session accountId mismatch.',
+  invalid_session_payload: 'حمولة الجلسة غير صالحة.',
+  session_not_found: 'لم يتم العثور على الجلسة.',
+  invalid_session_account_id: 'عدم توافق معرف حساب الجلسة.',
 };
 
 export default Object.freeze(oidc);

--- a/packages/phrases/src/locales/ar/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/sign-in-exp/index.ts
@@ -120,6 +120,9 @@ const sign_in_exp = {
           authentication_factors: {
             title: 'عوامل المصادقة',
           },
+          session_management: {
+            title: 'إدارة الجلسات',
+          },
         },
       },
       user_profile: {
@@ -160,6 +163,7 @@ const sign_in_exp = {
       profile_description: 'تحكم في الوصول إلى سمات الملف الشخصي المنظمة.',
       custom_data: 'بيانات مخصصة',
       custom_data_description: 'تحكم في الوصول إلى بيانات JSON المخصصة المخزنة للمستخدم.',
+      sessions: 'إدارة الجلسات',
     },
     webauthn_related_origins: 'أصول WebAuthn ذات الصلة',
     webauthn_related_origins_description:

--- a/packages/phrases/src/locales/de/errors/oidc.ts
+++ b/packages/phrases/src/locales/de/errors/oidc.ts
@@ -20,12 +20,9 @@ const oidc = {
   provider_error_fallback: 'Ein OIDC Fehler ist aufgetreten: {{code}}.',
   key_required: 'Mindestens ein Schlüssel ist erforderlich.',
   key_not_found: 'Der Schlüssel mit der ID {{id}} wurde nicht gefunden.',
-  /** UNTRANSLATED */
-  invalid_session_payload: 'Invalid session payload.',
-  /** UNTRANSLATED */
-  session_not_found: 'Session not found.',
-  /** UNTRANSLATED */
-  invalid_session_account_id: 'Session accountId mismatch.',
+  invalid_session_payload: 'Ungültige Sitzungsnutzlast.',
+  session_not_found: 'Sitzung nicht gefunden.',
+  invalid_session_account_id: 'Sitzung accountId stimmt nicht überein.',
 };
 
 export default Object.freeze(oidc);

--- a/packages/phrases/src/locales/de/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/sign-in-exp/index.ts
@@ -122,6 +122,9 @@ const sign_in_exp = {
           authentication_factors: {
             title: 'Authentifizierungsfaktoren',
           },
+          session_management: {
+            title: 'Sitzungsverwaltung',
+          },
         },
       },
       user_profile: {
@@ -163,6 +166,7 @@ const sign_in_exp = {
       custom_data: 'Benutzerdefinierte Daten',
       custom_data_description:
         'Steuern Sie den Zugriff auf benutzerdefinierte JSON-Daten, die beim Benutzer gespeichert sind.',
+      sessions: 'Sitzungen',
     },
     webauthn_related_origins: 'WebAuthn-bezogene Ursprünge',
     webauthn_related_origins_description:

--- a/packages/phrases/src/locales/en/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/sign-in-exp/index.ts
@@ -123,6 +123,9 @@ const sign_in_exp = {
           authentication_factors: {
             title: 'Authentication factors',
           },
+          session_management: {
+            title: 'Session management',
+          },
         },
       },
       user_profile: {
@@ -163,6 +166,7 @@ const sign_in_exp = {
       profile_description: 'Control access to structured profile attributes.',
       custom_data: 'Custom data',
       custom_data_description: 'Control access to custom JSON data stored on the user.',
+      sessions: 'Sessions',
     },
     webauthn_related_origins: 'WebAuthn Related Origins',
     webauthn_related_origins_description:

--- a/packages/phrases/src/locales/es/errors/oidc.ts
+++ b/packages/phrases/src/locales/es/errors/oidc.ts
@@ -19,12 +19,9 @@ const oidc = {
   provider_error_fallback: 'Ocurrió un error de OIDC: {{code}}.',
   key_required: 'Se requiere al menos una clave.',
   key_not_found: 'No se encuentra la clave con ID {{id}}.',
-  /** UNTRANSLATED */
-  invalid_session_payload: 'Invalid session payload.',
-  /** UNTRANSLATED */
-  session_not_found: 'Session not found.',
-  /** UNTRANSLATED */
-  invalid_session_account_id: 'Session accountId mismatch.',
+  invalid_session_payload: 'Carga útil de sesión no válida.',
+  session_not_found: 'Sesión no encontrada.',
+  invalid_session_account_id: 'Entidad de cuenta de sesión no coincide.',
 };
 
 export default Object.freeze(oidc);

--- a/packages/phrases/src/locales/es/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/sign-in-exp/index.ts
@@ -123,6 +123,9 @@ const sign_in_exp = {
           authentication_factors: {
             title: 'Factores de autenticación',
           },
+          session_management: {
+            title: 'Gestión de sesiones',
+          },
         },
       },
       user_profile: {
@@ -165,6 +168,7 @@ const sign_in_exp = {
       custom_data: 'Datos personalizados',
       custom_data_description:
         'Controla el acceso a los datos JSON personalizados almacenados en el usuario.',
+      sessions: 'Sesiones',
     },
     webauthn_related_origins: 'Orígenes relacionados con WebAuthn',
     webauthn_related_origins_description:

--- a/packages/phrases/src/locales/fr/errors/oidc.ts
+++ b/packages/phrases/src/locales/fr/errors/oidc.ts
@@ -19,12 +19,9 @@ const oidc = {
   provider_error_fallback: "Une erreur OIDC s'est produite : {{code}}.",
   key_required: 'Au moins une clé est requise.',
   key_not_found: "La clé avec l'ID {{id}} n'est pas trouvée.",
-  /** UNTRANSLATED */
-  invalid_session_payload: 'Invalid session payload.',
-  /** UNTRANSLATED */
-  session_not_found: 'Session not found.',
-  /** UNTRANSLATED */
-  invalid_session_account_id: 'Session accountId mismatch.',
+  invalid_session_payload: 'Charge utile de session invalide.',
+  session_not_found: 'Session non trouvée.',
+  invalid_session_account_id: "incohérence de l'accountId de session.",
 };
 
 export default Object.freeze(oidc);

--- a/packages/phrases/src/locales/fr/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/sign-in-exp/index.ts
@@ -123,6 +123,9 @@ const sign_in_exp = {
           authentication_factors: {
             title: 'Facteurs d’authentification',
           },
+          session_management: {
+            title: 'Gestion des sessions',
+          },
         },
       },
       user_profile: {
@@ -165,6 +168,7 @@ const sign_in_exp = {
       custom_data: 'Données personnalisées',
       custom_data_description:
         'Contrôlez l’accès aux données JSON personnalisées stockées sur l’utilisateur.',
+      sessions: 'Sessions',
     },
     webauthn_related_origins: 'Origines associées à WebAuthn',
     webauthn_related_origins_description:

--- a/packages/phrases/src/locales/it/errors/oidc.ts
+++ b/packages/phrases/src/locales/it/errors/oidc.ts
@@ -19,12 +19,9 @@ const oidc = {
   provider_error_fallback: 'Si è verificato un errore OIDC: {{code}}.',
   key_required: 'È richiesta almeno una chiave.',
   key_not_found: 'Chiave con ID {{id}} non trovata.',
-  /** UNTRANSLATED */
-  invalid_session_payload: 'Invalid session payload.',
-  /** UNTRANSLATED */
-  session_not_found: 'Session not found.',
-  /** UNTRANSLATED */
-  invalid_session_account_id: 'Session accountId mismatch.',
+  invalid_session_payload: 'Payload di sessione non valido.',
+  session_not_found: 'Sessione non trovata.',
+  invalid_session_account_id: "L'accountId della sessione non corrisponde.",
 };
 
 export default Object.freeze(oidc);

--- a/packages/phrases/src/locales/it/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/sign-in-exp/index.ts
@@ -122,6 +122,9 @@ const sign_in_exp = {
           authentication_factors: {
             title: 'Fattori di autenticazione',
           },
+          session_management: {
+            title: 'Gestione sessioni',
+          },
         },
       },
       user_profile: {
@@ -163,6 +166,7 @@ const sign_in_exp = {
       custom_data: 'Dati personalizzati',
       custom_data_description:
         'Controlla l’accesso ai dati JSON personalizzati archiviati sull’utente.',
+      sessions: 'Sessioni',
     },
     webauthn_related_origins: 'Origini correlate a WebAuthn',
     webauthn_related_origins_description:

--- a/packages/phrases/src/locales/ja/errors/oidc.ts
+++ b/packages/phrases/src/locales/ja/errors/oidc.ts
@@ -19,12 +19,9 @@ const oidc = {
   provider_error_fallback: 'OIDCエラーが発生しました: {{code}}。',
   key_required: '少なくとも1つのキーが必要です。',
   key_not_found: 'IDが{{id}}のキーが見つかりません。',
-  /** UNTRANSLATED */
-  invalid_session_payload: 'Invalid session payload.',
-  /** UNTRANSLATED */
-  session_not_found: 'Session not found.',
-  /** UNTRANSLATED */
-  invalid_session_account_id: 'Session accountId mismatch.',
+  invalid_session_payload: '無効なセッションペイロード。',
+  session_not_found: 'セッションが見つかりません。',
+  invalid_session_account_id: 'セッションの accountId が一致しません。',
 };
 
 export default Object.freeze(oidc);

--- a/packages/phrases/src/locales/ja/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/sign-in-exp/index.ts
@@ -122,6 +122,9 @@ const sign_in_exp = {
           authentication_factors: {
             title: '認証要素',
           },
+          session_management: {
+            title: 'セッション管理',
+          },
         },
       },
       user_profile: {
@@ -163,6 +166,7 @@ const sign_in_exp = {
       custom_data: 'カスタムデータ',
       custom_data_description:
         'ユーザーに保存されているカスタム JSON データへのアクセスを制御します。',
+      sessions: 'セッション',
     },
     webauthn_related_origins: 'WebAuthn 関連オリジン',
     webauthn_related_origins_description:

--- a/packages/phrases/src/locales/ko/errors/oidc.ts
+++ b/packages/phrases/src/locales/ko/errors/oidc.ts
@@ -18,12 +18,9 @@ const oidc = {
   provider_error_fallback: 'OIDC 오류가 발생했어요: {{code}}.',
   key_required: '최소한 하나의 키가 필요해요.',
   key_not_found: 'ID가 {{id}}인 키를 찾을 수 없어요.',
-  /** UNTRANSLATED */
-  invalid_session_payload: 'Invalid session payload.',
-  /** UNTRANSLATED */
-  session_not_found: 'Session not found.',
-  /** UNTRANSLATED */
-  invalid_session_account_id: 'Session accountId mismatch.',
+  invalid_session_payload: '유효하지 않은 세션 페이로드입니다.',
+  session_not_found: '세션을 찾을 수 없습니다.',
+  invalid_session_account_id: '세션 accountId가 일치하지 않습니다.',
 };
 
 export default Object.freeze(oidc);

--- a/packages/phrases/src/locales/ko/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/sign-in-exp/index.ts
@@ -119,6 +119,9 @@ const sign_in_exp = {
           authentication_factors: {
             title: '인증 요소',
           },
+          session_management: {
+            title: '세션 관리',
+          },
         },
       },
       user_profile: {
@@ -159,6 +162,7 @@ const sign_in_exp = {
       profile_description: '구조화된 프로필 속성에 대한 접근을 제어합니다.',
       custom_data: '사용자 정의 데이터',
       custom_data_description: '사용자에 저장된 사용자 정의 JSON 데이터에 대한 접근을 제어합니다.',
+      sessions: '세션',
     },
     webauthn_related_origins: 'WebAuthn 관련 오리진',
     webauthn_related_origins_description:

--- a/packages/phrases/src/locales/pl-pl/errors/oidc.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/oidc.ts
@@ -19,12 +19,9 @@ const oidc = {
   provider_error_fallback: 'Wystąpił błąd OIDC: {{code}}.',
   key_required: 'Wymagany jest co najmniej jeden klucz.',
   key_not_found: 'Nie znaleziono klucza o ID {{id}}.',
-  /** UNTRANSLATED */
-  invalid_session_payload: 'Invalid session payload.',
-  /** UNTRANSLATED */
-  session_not_found: 'Session not found.',
-  /** UNTRANSLATED */
-  invalid_session_account_id: 'Session accountId mismatch.',
+  invalid_session_payload: 'Nieprawidłowy ładunek sesji.',
+  session_not_found: 'Nie znaleziono sesji.',
+  invalid_session_account_id: 'Niezgodność ID konta sesji.',
 };
 
 export default Object.freeze(oidc);

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/sign-in-exp/index.ts
@@ -122,6 +122,9 @@ const sign_in_exp = {
           authentication_factors: {
             title: 'Czynniki uwierzytelniające',
           },
+          session_management: {
+            title: 'Zarządzanie sesją',
+          },
         },
       },
       user_profile: {
@@ -163,6 +166,7 @@ const sign_in_exp = {
       custom_data: 'Dane niestandardowe',
       custom_data_description:
         'Kontroluj dostęp do niestandardowych danych JSON przechowywanych przy użytkowniku.',
+      sessions: 'Sesje',
     },
     webauthn_related_origins: 'Powiązane źródła WebAuthn',
     webauthn_related_origins_description:

--- a/packages/phrases/src/locales/pt-br/errors/oidc.ts
+++ b/packages/phrases/src/locales/pt-br/errors/oidc.ts
@@ -19,12 +19,9 @@ const oidc = {
   provider_error_fallback: 'Ocorreu um erro OIDC: {{code}}.',
   key_required: 'Pelo menos uma chave é necessária.',
   key_not_found: 'Chave com ID {{id}} não encontrada.',
-  /** UNTRANSLATED */
-  invalid_session_payload: 'Invalid session payload.',
-  /** UNTRANSLATED */
-  session_not_found: 'Session not found.',
-  /** UNTRANSLATED */
-  invalid_session_account_id: 'Session accountId mismatch.',
+  invalid_session_payload: 'Conteúdo de sessão inválido.',
+  session_not_found: 'Sessão não encontrada.',
+  invalid_session_account_id: 'Incompatibilidade de accountId da sessão.',
 };
 
 export default Object.freeze(oidc);

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/sign-in-exp/index.ts
@@ -122,6 +122,9 @@ const sign_in_exp = {
           authentication_factors: {
             title: 'Fatores de autenticação',
           },
+          session_management: {
+            title: 'Gerenciamento de sessão',
+          },
         },
       },
       user_profile: {
@@ -164,6 +167,7 @@ const sign_in_exp = {
       custom_data: 'Dados personalizados',
       custom_data_description:
         'Controle o acesso aos dados JSON personalizados armazenados no usuário.',
+      sessions: 'Sessões',
     },
     webauthn_related_origins: 'Origens relacionadas ao WebAuthn',
     webauthn_related_origins_description:

--- a/packages/phrases/src/locales/pt-pt/errors/oidc.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/oidc.ts
@@ -18,12 +18,9 @@ const oidc = {
   provider_error_fallback: 'Ocorreu um erro OIDC: {{code}}.',
   key_required: 'Pelo menos uma chave é necessária.',
   key_not_found: 'A chave com ID {{id}} não foi encontrada.',
-  /** UNTRANSLATED */
-  invalid_session_payload: 'Invalid session payload.',
-  /** UNTRANSLATED */
-  session_not_found: 'Session not found.',
-  /** UNTRANSLATED */
-  invalid_session_account_id: 'Session accountId mismatch.',
+  invalid_session_payload: 'Carga de sessão inválida.',
+  session_not_found: 'Sessão não encontrada.',
+  invalid_session_account_id: 'Incompatibilidade do accountId da sessão.',
 };
 
 export default Object.freeze(oidc);

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/sign-in-exp/index.ts
@@ -121,6 +121,9 @@ const sign_in_exp = {
           authentication_factors: {
             title: 'Fatores de autenticação',
           },
+          session_management: {
+            title: 'Gestão de sessão',
+          },
         },
       },
       user_profile: {
@@ -163,6 +166,7 @@ const sign_in_exp = {
       custom_data: 'Dados personalizados',
       custom_data_description:
         'Controle o acesso aos dados JSON personalizados guardados no utilizador.',
+      sessions: 'Sessões',
     },
     webauthn_related_origins: 'Origens relacionadas com WebAuthn',
     webauthn_related_origins_description:

--- a/packages/phrases/src/locales/ru/errors/oidc.ts
+++ b/packages/phrases/src/locales/ru/errors/oidc.ts
@@ -19,12 +19,9 @@ const oidc = {
   provider_error_fallback: 'Произошла ошибка OIDC: {{code}}.',
   key_required: 'Требуется как минимум один ключ.',
   key_not_found: 'Ключ с идентификатором {{id}} не найден.',
-  /** UNTRANSLATED */
-  invalid_session_payload: 'Invalid session payload.',
-  /** UNTRANSLATED */
-  session_not_found: 'Session not found.',
-  /** UNTRANSLATED */
-  invalid_session_account_id: 'Session accountId mismatch.',
+  invalid_session_payload: 'Недопустимая полезная нагрузка сессии.',
+  session_not_found: 'Сессия не найдена.',
+  invalid_session_account_id: 'Несоответствие accountId сессии.',
 };
 
 export default Object.freeze(oidc);

--- a/packages/phrases/src/locales/ru/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/sign-in-exp/index.ts
@@ -122,6 +122,9 @@ const sign_in_exp = {
           authentication_factors: {
             title: 'Факторы аутентификации',
           },
+          session_management: {
+            title: 'Управление сессиями',
+          },
         },
       },
       user_profile: {
@@ -163,6 +166,7 @@ const sign_in_exp = {
       custom_data: 'Пользовательские данные',
       custom_data_description:
         'Управляйте доступом к пользовательским JSON-данным, хранящимся у пользователя.',
+      sessions: 'Сессии',
     },
     webauthn_related_origins: 'Связанные источники WebAuthn',
     webauthn_related_origins_description:

--- a/packages/phrases/src/locales/th/errors/oidc.ts
+++ b/packages/phrases/src/locales/th/errors/oidc.ts
@@ -18,12 +18,9 @@ const oidc = {
   provider_error_fallback: 'เกิดข้อผิดพลาด OIDC: {{code}}',
   key_required: 'ต้องมีคีย์อย่างน้อยหนึ่งอัน',
   key_not_found: 'ไม่พบคีย์ที่มีรหัส {{id}}',
-  /** UNTRANSLATED */
-  invalid_session_payload: 'Invalid session payload.',
-  /** UNTRANSLATED */
-  session_not_found: 'Session not found.',
-  /** UNTRANSLATED */
-  invalid_session_account_id: 'Session accountId mismatch.',
+  invalid_session_payload: 'ข้อมูลเซสชันไม่ถูกต้อง',
+  session_not_found: 'ไม่พบเซสชัน',
+  invalid_session_account_id: 'Session accountId ไม่ตรงกัน',
 };
 
 export default Object.freeze(oidc);

--- a/packages/phrases/src/locales/th/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/sign-in-exp/index.ts
@@ -121,6 +121,9 @@ const sign_in_exp = {
           authentication_factors: {
             title: 'ปัจจัยการยืนยันตัวตน',
           },
+          session_management: {
+            title: 'การจัดการเซสชัน',
+          },
         },
       },
       user_profile: {
@@ -161,6 +164,7 @@ const sign_in_exp = {
       profile_description: 'ควบคุมการเข้าถึงคุณลักษณะของโปรไฟล์ที่มีโครงสร้าง.',
       custom_data: 'ข้อมูลแบบกำหนดเอง',
       custom_data_description: 'ควบคุมการเข้าถึงข้อมูล JSON แบบกำหนดเองที่เก็บไว้กับผู้ใช้.',
+      sessions: 'การจัดการเซสชัน',
     },
     webauthn_related_origins: 'ต้นทางที่เกี่ยวข้องกับ WebAuthn',
     webauthn_related_origins_description:

--- a/packages/phrases/src/locales/tr-tr/errors/oidc.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/oidc.ts
@@ -19,12 +19,9 @@ const oidc = {
   provider_error_fallback: 'Bir OIDC hatası oluştu: {{code}}.',
   key_required: 'En az bir anahtar gereklidir.',
   key_not_found: "ID'si {{id}} olan anahtar bulunamadı.",
-  /** UNTRANSLATED */
-  invalid_session_payload: 'Invalid session payload.',
-  /** UNTRANSLATED */
-  session_not_found: 'Session not found.',
-  /** UNTRANSLATED */
-  invalid_session_account_id: 'Session accountId mismatch.',
+  invalid_session_payload: 'Geçersiz oturum yükü.',
+  session_not_found: 'Oturum bulunamadı.',
+  invalid_session_account_id: 'Oturum accountId uyumsuzluğu.',
 };
 
 export default Object.freeze(oidc);

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/sign-in-exp/index.ts
@@ -122,6 +122,9 @@ const sign_in_exp = {
           authentication_factors: {
             title: 'Kimlik doğrulama faktörleri',
           },
+          session_management: {
+            title: 'Oturum yönetimi',
+          },
         },
       },
       user_profile: {
@@ -162,6 +165,7 @@ const sign_in_exp = {
       profile_description: 'Yapılandırılmış profil özniteliklerine erişimi kontrol edin.',
       custom_data: 'Özel veriler',
       custom_data_description: 'Kullanıcıda saklanan özel JSON verilerine erişimi kontrol edin.',
+      sessions: 'Oturumlar',
     },
     webauthn_related_origins: 'WebAuthn İlgili Kaynaklar',
     webauthn_related_origins_description:

--- a/packages/phrases/src/locales/zh-cn/errors/oidc.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/oidc.ts
@@ -18,12 +18,9 @@ const oidc = {
   provider_error_fallback: '发生了 OIDC 错误: {{code}}。',
   key_required: '至少需要一个密钥。',
   key_not_found: '未找到 ID 为 {{id}} 的密钥。',
-  /** UNTRANSLATED */
-  invalid_session_payload: 'Invalid session payload.',
-  /** UNTRANSLATED */
-  session_not_found: 'Session not found.',
-  /** UNTRANSLATED */
-  invalid_session_account_id: 'Session accountId mismatch.',
+  invalid_session_payload: '无效的会话负载。',
+  session_not_found: '未找到会话。',
+  invalid_session_account_id: '会话的 accountId 不匹配。',
 };
 
 export default Object.freeze(oidc);

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/sign-in-exp/index.ts
@@ -119,6 +119,9 @@ const sign_in_exp = {
           authentication_factors: {
             title: '认证要素',
           },
+          session_management: {
+            title: '会话管理',
+          },
         },
       },
       user_profile: {
@@ -157,6 +160,7 @@ const sign_in_exp = {
       profile_description: '控制对结构化资料属性的访问。',
       custom_data: '自定义数据',
       custom_data_description: '控制对存储在用户上的自定义 JSON 数据的访问。',
+      sessions: '会话',
     },
     webauthn_related_origins: 'WebAuthn 关联来源',
     webauthn_related_origins_description: '添加允许通过 Account API 注册通行密钥的前端应用域名。',

--- a/packages/phrases/src/locales/zh-hk/errors/oidc.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/oidc.ts
@@ -18,12 +18,9 @@ const oidc = {
   provider_error_fallback: '發生了 OIDC 錯誤: {{code}}.',
   key_required: '至少需要一個金鑰。',
   key_not_found: '未找到 ID 為 {{id}} 的金鑰。',
-  /** UNTRANSLATED */
-  invalid_session_payload: 'Invalid session payload.',
-  /** UNTRANSLATED */
-  session_not_found: 'Session not found.',
-  /** UNTRANSLATED */
-  invalid_session_account_id: 'Session accountId mismatch.',
+  invalid_session_payload: '無效的會話有效載荷。',
+  session_not_found: '未找到會話。',
+  invalid_session_account_id: '會話帳戶 ID 不匹配。',
 };
 
 export default Object.freeze(oidc);

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/sign-in-exp/index.ts
@@ -119,6 +119,9 @@ const sign_in_exp = {
           authentication_factors: {
             title: '驗證因素',
           },
+          session_management: {
+            title: '會話管理',
+          },
         },
       },
       user_profile: {
@@ -157,6 +160,7 @@ const sign_in_exp = {
       profile_description: '控制對結構化檔案屬性的存取權。',
       custom_data: '自訂資料',
       custom_data_description: '控制對儲存在使用者上的自訂 JSON 資料的存取權。',
+      sessions: '會話',
     },
     webauthn_related_origins: 'WebAuthn 關聯來源',
     webauthn_related_origins_description:

--- a/packages/phrases/src/locales/zh-tw/errors/oidc.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/oidc.ts
@@ -18,12 +18,9 @@ const oidc = {
   provider_error_fallback: '發生了一個 OIDC 錯誤: {{code}}。',
   key_required: '至少需要一個金鑰。',
   key_not_found: '未找到 ID 為 {{id}} 的金鑰。',
-  /** UNTRANSLATED */
-  invalid_session_payload: 'Invalid session payload.',
-  /** UNTRANSLATED */
-  session_not_found: 'Session not found.',
-  /** UNTRANSLATED */
-  invalid_session_account_id: 'Session accountId mismatch.',
+  invalid_session_payload: '無效的會話負載。',
+  session_not_found: '未找到會話。',
+  invalid_session_account_id: '會話 accountId 不匹配。',
 };
 
 export default Object.freeze(oidc);

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/sign-in-exp/index.ts
@@ -119,6 +119,9 @@ const sign_in_exp = {
           authentication_factors: {
             title: '驗證因素',
           },
+          session_management: {
+            title: '會話管理',
+          },
         },
       },
       user_profile: {
@@ -157,6 +160,7 @@ const sign_in_exp = {
       profile_description: '控制對結構化檔案屬性的存取。',
       custom_data: '自訂資料',
       custom_data_description: '控制對儲存在使用者上的自訂 JSON 資料的存取。',
+      sessions: '會話',
     },
     webauthn_related_origins: 'WebAuthn 相關來源',
     webauthn_related_origins_description:


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

This PR adds a new Account center session field permission editor to the sign-in experience Account center settings page.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally
<img width="1912" height="962" alt="image" src="https://github.com/user-attachments/assets/8354fdce-e744-41ba-8da0-ae69de971c2d" />


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [ ] ~necessary TSDoc comments~
