### PR TITLE
feat(core): store ip and user agent in sign-in context

### DIFF
--- a/packages/core/src/routes/experience/classes/libraries/adaptive-mfa-validator/index.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/adaptive-mfa-validator/index.test.ts
@@ -4,6 +4,7 @@ import { InteractionEvent, type User } from '@logto/schemas';
 
 import { mockUser } from '#src/__mocks__/user.js';
 import { EnvSet } from '#src/env-set/index.js';
+import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
 import { defaultInjectedHeaderMapping } from '#src/utils/injected-header-mapping.js';
 
 import type { SignInExperienceValidator } from '../sign-in-experience-validator.js';
@@ -87,11 +88,13 @@ const buildInjectedHeadersFromAdaptiveMfaContext = (
   return Object.fromEntries(headers);
 };
 
-const buildMockContext = (context: AdaptiveMfaContext) => ({
-  request: {
-    headers: buildInjectedHeadersFromAdaptiveMfaContext(context),
-  },
-});
+const buildMockContext = (context: AdaptiveMfaContext) =>
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- mock headers only
+  ({
+    request: {
+      headers: buildInjectedHeadersFromAdaptiveMfaContext(context),
+    },
+  }) as WithLogContext;
 
 describe('AdaptiveMfaValidator', () => {
   beforeEach(() => {
@@ -240,15 +243,14 @@ describe('AdaptiveMfaValidator', () => {
       lastSignInAt: Date.now(),
     };
     const queries = createQueries();
-    const ctx = {
-      request: {
-        headers: {
-          'x-logto-cf-country': 'US',
-          'x-logto-cf-latitude': '12.3',
-          'x-logto-cf-longitude': '45.6',
-        },
+
+    const ctx = buildMockContext({
+      location: {
+        country: 'US',
+        latitude: 12.3,
+        longitude: 45.6,
       },
-    };
+    });
 
     const validator = new AdaptiveMfaValidator({
       queries,
@@ -277,14 +279,12 @@ describe('AdaptiveMfaValidator', () => {
       lastSignInAt: Date.now(),
     };
     const queries = createQueries();
-    const ctx = {
-      request: {
-        headers: {
-          'x-logto-cf-latitude': '0',
-          'x-logto-cf-longitude': '0',
-        },
+    const ctx = buildMockContext({
+      location: {
+        latitude: 0,
+        longitude: 0,
       },
-    };
+    });
 
     const validator = new AdaptiveMfaValidator({
       queries,
@@ -308,6 +308,7 @@ describe('AdaptiveMfaValidator', () => {
     'parses bot verification signal from injected header %s as %s',
     (botVerifiedHeader, expectedBotVerified) => {
       const queries = createQueries();
+
       const ctx = {
         request: {
           headers: {
@@ -318,6 +319,7 @@ describe('AdaptiveMfaValidator', () => {
 
       const validator = new AdaptiveMfaValidator({
         queries,
+        /* @ts-expect-error -- partial context for testing parsing logic only */
         ctx,
         interactionContext: createInteractionContext(mockUser),
         signInExperienceValidator: createSignInExperienceValidator(),
@@ -337,15 +339,13 @@ describe('AdaptiveMfaValidator', () => {
       lastSignInAt: Date.now(),
     };
     const queries = createQueries();
-    const ctx = {
-      request: {
-        headers: {
-          'x-logto-cf-country': 'US',
-          'x-logto-cf-latitude': '12.3',
-          'x-logto-cf-longitude': '45.6',
-        },
+    const ctx = buildMockContext({
+      location: {
+        country: 'US',
+        latitude: 12.3,
+        longitude: 45.6,
       },
-    };
+    });
 
     const validator = new AdaptiveMfaValidator({
       queries,
@@ -376,15 +376,13 @@ describe('AdaptiveMfaValidator', () => {
       lastSignInAt: Date.now(),
     };
     const queries = createQueries();
-    const ctx = {
-      request: {
-        headers: {
-          'x-logto-cf-country': 'US',
-          'x-logto-cf-latitude': '12.3',
-          'x-logto-cf-longitude': '45.6',
-        },
+    const ctx = buildMockContext({
+      location: {
+        country: 'US',
+        latitude: 12.3,
+        longitude: 45.6,
       },
-    };
+    });
 
     const validator = new AdaptiveMfaValidator({
       queries,
@@ -406,15 +404,13 @@ describe('AdaptiveMfaValidator', () => {
       lastSignInAt: Date.now(),
     };
     const queries = createQueries();
-    const ctx = {
-      request: {
-        headers: {
-          'x-logto-cf-country': 'US',
-          'x-logto-cf-latitude': '12.3',
-          'x-logto-cf-longitude': '45.6',
-        },
+    const ctx = buildMockContext({
+      location: {
+        country: 'US',
+        latitude: 12.3,
+        longitude: 45.6,
       },
-    };
+    });
 
     const validator = new AdaptiveMfaValidator({
       queries,

--- a/packages/core/src/routes/experience/classes/libraries/adaptive-mfa-validator/types.ts
+++ b/packages/core/src/routes/experience/classes/libraries/adaptive-mfa-validator/types.ts
@@ -1,7 +1,6 @@
-import type { IncomingHttpHeaders } from 'node:http';
-
 import type { User, UserSignInCountry } from '@logto/schemas';
 
+import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
 import type Queries from '#src/tenants/Queries.js';
 
 import { type InteractionContext } from '../../../types.js';
@@ -82,19 +81,13 @@ export type AdaptiveMfaResult = {
   triggeredRules: TriggeredRule[];
 };
 
-export type AdaptiveMfaValidatorContext = {
-  request: {
-    headers: IncomingHttpHeaders;
-  };
-};
-
 export type AdaptiveMfaInteractionContext = Pick<InteractionContext, 'getIdentifiedUser'>;
 
 export type AdaptiveMfaValidatorOptions = {
   queries: Pick<Queries, 'userGeoLocations' | 'userSignInCountries'>;
   signInExperienceValidator: SignInExperienceValidator;
   interactionContext: AdaptiveMfaInteractionContext;
-  ctx?: AdaptiveMfaValidatorContext;
+  ctx?: WithLogContext;
 };
 
 export type AdaptiveMfaEvaluationState = {


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Store ip and user agent value to the experience interaction `signInContext`.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally

<img width="2330" height="616" alt="image" src="https://github.com/user-attachments/assets/f96309cf-6149-476b-ac81-899c75d41c6a" />


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
