### PR TITLE
feat(core): add get user session by sessionId endpoint

### DIFF
--- a/packages/core/src/routes/admin-user/session.openapi.json
+++ b/packages/core/src/routes/admin-user/session.openapi.json
@@ -14,6 +14,17 @@
       }
     },
     "/api/users/{userId}/sessions/{sessionId}": {
+      "get": {
+        "tags": ["Dev feature"],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Return a non-expired session of the user."
+          }
+        },
+        "summary": "Get user active session",
+        "description": "Retrieve a non-expired session for the user by session ID, including session metadata and interaction details when available."
+      },
       "delete": {
         "tags": ["Dev feature"],
         "parameters": [

--- a/packages/integration-tests/src/api/admin-user.ts
+++ b/packages/integration-tests/src/api/admin-user.ts
@@ -2,6 +2,7 @@ import type {
   CreatePersonalAccessToken,
   DesensitizedEnterpriseSsoTokenSetSecret,
   DesensitizedSocialTokenSetSecret,
+  GetUserSessionResponse,
   GetUserSessionsResponse,
   Identities,
   Identity,
@@ -228,6 +229,9 @@ export const getUserSsoIdentity = async (
 
 export const getUserSessions = async (userId: string) =>
   authedAdminApi.get(`users/${userId}/sessions`).json<GetUserSessionsResponse>();
+
+export const getUserSession = async (userId: string, sessionId: string) =>
+  authedAdminApi.get(`users/${userId}/sessions/${sessionId}`).json<GetUserSessionResponse>();
 
 export const revokeUserSession = async (userId: string, sessionId: string, revokeGrants = false) =>
   authedAdminApi.delete(`users/${userId}/sessions/${sessionId}`, {

--- a/packages/integration-tests/src/tests/api/sessions/index.test.ts
+++ b/packages/integration-tests/src/tests/api/sessions/index.test.ts
@@ -1,7 +1,8 @@
 import { SignInIdentifier, demoAppApplicationId } from '@logto/schemas';
 
-import { getUserSessions, revokeUserSession } from '#src/api/index.js';
+import { getUserSession, getUserSessions, revokeUserSession } from '#src/api/index.js';
 import { signInWithPassword } from '#src/helpers/experience/index.js';
+import { expectRejects } from '#src/helpers/index.js';
 import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
 import { generateNewUserProfile, UserApiTest } from '#src/helpers/user.js';
 import { devFeatureTest } from '#src/utils.js';
@@ -56,5 +57,70 @@ devFeatureTest.describe('Sessions API', () => {
     const { sessions: sessionsAfterRevoke } = await getUserSessions(user.id);
     expect(sessionsAfterRevoke).toHaveLength(1);
     expect(sessionsAfterRevoke[0]!.id).toBe(sessions[1]!.id);
+  });
+
+  it('should get a single user session by session id', async () => {
+    await enableAllPasswordSignInMethods();
+
+    const { username, password } = generateNewUserProfile({ username: true, password: true });
+    const user = await userApi.create({ username, password });
+
+    await signInWithPassword({
+      identifier: {
+        type: SignInIdentifier.Username,
+        value: username,
+      },
+      password,
+    });
+
+    const { sessions } = await getUserSessions(user.id);
+    const sessionId = sessions[0]!.payload.uid;
+
+    const session = await getUserSession(user.id, sessionId);
+
+    expect(session).toHaveProperty('id', sessions[0]!.id);
+    expect(session).toHaveProperty('accountId', user.id);
+    expect(session).toHaveProperty('lastSubmission');
+    expect(session).toHaveProperty('clientId', demoAppApplicationId);
+    expect(session.payload.uid).toBe(sessionId);
+    expect(session.payload.accountId).toBe(user.id);
+    expect(session.payload.authorizations).toHaveProperty(demoAppApplicationId);
+  });
+
+  it('should return 404 when getting a non-existing session id', async () => {
+    await enableAllPasswordSignInMethods();
+
+    const { username, password } = generateNewUserProfile({ username: true, password: true });
+    const user = await userApi.create({ username, password });
+
+    await expectRejects(getUserSession(user.id, 'non-existing-session-id'), {
+      code: 'oidc.session_not_found',
+      status: 404,
+    });
+  });
+
+  it('should return 404 when getting another user session by session id', async () => {
+    await enableAllPasswordSignInMethods();
+
+    const firstUserProfile = generateNewUserProfile({ username: true, password: true });
+    const secondUserProfile = generateNewUserProfile({ username: true, password: true });
+    const firstUser = await userApi.create(firstUserProfile);
+    const secondUser = await userApi.create(secondUserProfile);
+
+    await signInWithPassword({
+      identifier: {
+        type: SignInIdentifier.Username,
+        value: secondUserProfile.username,
+      },
+      password: secondUserProfile.password,
+    });
+
+    const { sessions: secondUserSessions } = await getUserSessions(secondUser.id);
+    const secondUserSessionId = secondUserSessions[0]!.payload.uid;
+
+    await expectRejects(getUserSession(firstUser.id, secondUserSessionId), {
+      code: 'oidc.session_not_found',
+      status: 404,
+    });
   });
 });

--- a/packages/schemas/src/types/user-sessions.ts
+++ b/packages/schemas/src/types/user-sessions.ts
@@ -5,15 +5,19 @@ import { oidcSessionInstancePayloadGuard } from '../foundations/index.js';
 
 import { jwtCustomizerUserInteractionContextGuard } from './logto-config/jwt-customizer.js';
 
+export const userExtendedSessionGuard = OidcModelInstances.guard.extend({
+  payload: oidcSessionInstancePayloadGuard,
+  lastSubmission: jwtCustomizerUserInteractionContextGuard.nullable(),
+  clientId: z.string().nullable(),
+  accountId: z.string().nullable(),
+});
+
 export const getUserSessionsResponseGuard = z.object({
-  sessions: z.array(
-    OidcModelInstances.guard.extend({
-      payload: oidcSessionInstancePayloadGuard,
-      lastSubmission: jwtCustomizerUserInteractionContextGuard.nullable(),
-      clientId: z.string().nullable(),
-      accountId: z.string().nullable(),
-    })
-  ),
+  sessions: z.array(userExtendedSessionGuard),
 });
 
 export type GetUserSessionsResponse = z.infer<typeof getUserSessionsResponseGuard>;
+
+export const getUserSessionResponseGuard = userExtendedSessionGuard;
+
+export type GetUserSessionResponse = z.infer<typeof getUserSessionResponseGuard>;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Added a new admin API endpoint: `GET /api/users/{userId}/sessions/{sessionId}` to fetch one active extended session for a user.

Bug fixes during test validation:
- Corrected `RequestError` construction to use metadata object form:
  - `new RequestError({ code: 'oidc.session_not_found', status: 404 })`
  - `new RequestError({ code: 'oidc.invalid_session_account_id', status: 404 })`



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Integration test added

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
