### PR TITLE
feat(core,experience): add a dedicated bind passkey api endpoint

### DIFF
--- a/packages/core/src/routes/experience/profile-routes.openapi.json
+++ b/packages/core/src/routes/experience/profile-routes.openapi.json
@@ -182,6 +182,37 @@
           }
         }
       }
+    },
+    "/api/experience/profile/mfa/passkey": {
+      "post": {
+        "operationId": "BindPasskey",
+        "summary": "Bind passkey for sign-in",
+        "description": "Bind a WebAuthn credential as a passkey for sign-in purposes. Unlike `POST /api/experience/profile/mfa` with `type: WebAuthn`, this endpoint is exclusively for adding a passkey as a sign-in method and does NOT mark the user's optional MFA as enabled.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "verificationId": {
+                    "description": "The ID of the WebAuthn verification record to bind as a passkey."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "The passkey has been successfully bound to the user profile."
+          },
+          "400": {
+            "description": "Invalid request. <br/>- `session.verification_failed:` The WebAuthn verification record is invalid or not verified. <br/>- `session.mfa.pending_info_not_found:` The verification record does not have the required registration data."
+          },
+          "404": {
+            "description": "Entity not found. <br/>- `session.identifier_not_found:` The user has not been identified yet. <br/>- `session.verification_session_not_found:` The WebAuthn verification record is not found."
+          }
+        }
+      }
     }
   }
 }

--- a/packages/core/src/routes/experience/profile-routes.ts
+++ b/packages/core/src/routes/experience/profile-routes.ts
@@ -218,6 +218,37 @@ export default function interactionProfileRoutes<T extends ExperienceInteraction
   );
 
   router.post(
+    `${experienceRoutes.mfa}/passkey`,
+    koaGuard({
+      body: z.object({
+        verificationId: z.string(),
+      }),
+      status: [204, 400, 404],
+    }),
+    verifiedInteractionGuard(),
+    async (ctx, next) => {
+      const { experienceInteraction, guard } = ctx;
+      const { verificationId } = guard.body;
+
+      const log = ctx.createLog(
+        `Interaction.${experienceInteraction.interactionEvent}.BindMfa.${MfaFactor.WebAuthn}.Submit`
+      );
+
+      log.append({
+        verificationId,
+      });
+
+      await experienceInteraction.mfa.addWebAuthnByVerificationId(verificationId, log);
+
+      await experienceInteraction.save();
+
+      ctx.status = 204;
+
+      return next();
+    }
+  );
+
+  router.post(
     `${experienceRoutes.mfa}`,
     koaGuard({
       body: z.object({

--- a/packages/experience/src/apis/experience/passkey-sign-in.ts
+++ b/packages/experience/src/apis/experience/passkey-sign-in.ts
@@ -1,7 +1,6 @@
 import {
   type BindWebAuthnPayload,
   InteractionEvent,
-  MfaFactor,
   type SignInIdentifier,
   type WebAuthnAuthenticationOptions,
   type WebAuthnVerificationPayload,
@@ -11,12 +10,23 @@ import api from '../api';
 
 import { experienceApiRoutes } from './const';
 import { identifyAndSubmitInteraction, initInteraction, submitInteraction } from './interaction';
-import { bindMfa } from './mfa';
 
 export { createWebAuthnRegistration as createSignInWebAuthnRegistrationOptions } from './mfa';
 
-export const bindSignInWebAuthn = async (payload: BindWebAuthnPayload, verificationId: string) =>
-  bindMfa(MfaFactor.WebAuthn, verificationId, payload);
+export const bindSignInWebAuthn = async (payload: BindWebAuthnPayload, verificationId: string) => {
+  await api.post(`${experienceApiRoutes.verification}/web-authn/registration/verify`, {
+    json: {
+      verificationId,
+      payload,
+    },
+  });
+  await api.post(`${experienceApiRoutes.profile}/mfa/passkey`, {
+    json: {
+      verificationId,
+    },
+  });
+  return submitInteraction();
+};
 
 export const createSignInWebAuthnAuthenticationOptions = async () =>
   api.post(`${experienceApiRoutes.prefix}/preflight/sign-in-web-authn/authentication`).json<{


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Introduce a dedicated passkey bind API and wiring for sign-in passkeys.

## Changes: 
1. New `POST /api/experience/profile/mfa/passkey` to bind a WebAuthn verification record as a sign-in passkey (does not enable MFA). The `POST /api/experience/profile/mfa` endpoint will call `markMfaEnabled()` in a follow-up PR (#8392).
2. The client side `bindSignInWebAuthn` now calls the new `profile/mfa/passkey` endpoint with the verificationId, and submits the interaction.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
