### PR TITLE
fix(core): include custom domain account redirect URI for account center

### DIFF
--- a/packages/core/src/oidc/adapter.ts
+++ b/packages/core/src/oidc/adapter.ts
@@ -5,7 +5,7 @@ import {
   adminConsoleApplicationId,
   demoAppApplicationId,
 } from '@logto/schemas';
-import { appendPath, tryThat, conditional } from '@silverhand/essentials';
+import { appendPath, conditional, deduplicate, tryThat } from '@silverhand/essentials';
 import { addSeconds } from 'date-fns';
 import type { AdapterFactory, AllClientMetadata } from 'oidc-provider';
 import { errors } from 'oidc-provider';
@@ -58,9 +58,10 @@ const buildDemoAppClientMetadata = (envSet: EnvSet): AllClientMetadata => {
 };
 
 const buildAccountCenterClientMetadata = (envSet: EnvSet): AllClientMetadata => {
-  const urlStrings = getTenantUrls(envSet.tenantId, EnvSet.values).map(
-    (url) => appendPath(url, '/account').href
-  );
+  const urlStrings = deduplicate([
+    ...getTenantUrls(envSet.tenantId, EnvSet.values).map(String),
+    envSet.endpoint.toString(),
+  ]).map((url) => appendPath(new URL(url), '/account').href);
 
   return {
     ...getConstantClientMetadata(envSet, ApplicationType.SPA),


### PR DESCRIPTION
## Summary
- include the tenant custom endpoint (`envSet.endpoint`) when building Account Center client metadata redirect URLs
- keep redirect and post logout redirect URIs aligned for `account-center` by deduplicating default tenant URLs and the active custom domain endpoint
- add a unit test that verifies `client_id=account-center` includes `https://<custom-domain>/account` in both `redirect_uris` and `post_logout_redirect_uris`


## Testing
Unit tests


## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
