### PR TITLE
fix: add missing core-kit changeset for extended id token claims

### DIFF
--- a/.changeset/smart-buttons-allow.md
+++ b/.changeset/smart-buttons-allow.md
@@ -1,0 +1,5 @@
+---
+"@logto/core-kit": patch
+---
+
+add extended id token claims exports


### PR DESCRIPTION
## Summary

Add missing changeset for `@logto/core-kit`. The extended id token claims exports were added in #8317 but the changeset was missing, causing core-kit version not to be bumped in the last release.

## Testing

N/A

## Checklist

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments