### PR TITLE
fix(experience): add localStorage fallback for sessionStorage in in-app browsers

### DIFF
--- a/packages/experience/src/utils/social-connectors.ts
+++ b/packages/experience/src/utils/social-connectors.ts
@@ -26,7 +26,7 @@ export const generateState = () => {
  * opens a new view or window. To handle this, we also persist values in localStorage
  * and fall back to it when sessionStorage is empty after a redirect.
  */
-const getStorageItem = (key: string): string | null => {
+const getStorageItem = (key: string) => {
   const sessionValue = sessionStorage.getItem(key);
 
   if (sessionValue !== null) {


### PR DESCRIPTION
## Problem

Closes #7604

In certain in-app browsers (e.g. WeChat, Facebook, LINE), sessionStorage is cleared when the OAuth redirect opens in a new window or WebView context. This causes the social sign-in callback to fail with `Sign-in session not found.` because the auth state stored before the redirect is no longer accessible after returning.

## Root cause

`storeState`, `validateState`, `storeCallbackLink`, `getCallbackLinkFromStorage`, and `removeCallbackLinkFromStorage` all write/read exclusively from `sessionStorage`. In-app browsers that treat each redirect as a new window context reset sessionStorage between navigations.

## Fix

Introduce three thin storage helpers in `social-connectors.ts`:

- **`setStorageItem`** — writes to both `sessionStorage` and `localStorage`
- **`getStorageItem`** — reads from `sessionStorage` first; if missing, falls back to `localStorage`, restores it to `sessionStorage`, and removes the localStorage copy
- **`removeStorageItem`** — removes from both stores

All existing public functions (`storeState`, `validateState`, `storeCallbackLink`, etc.) are updated to use these helpers. Logic and public API are otherwise unchanged.

**Security note:** the localStorage copy is short-lived — it is removed immediately after being read back. The state value is a random nonce used only for CSRF protection within the sign-in flow.

## Testing

- Normal browser: behaviour unchanged (sessionStorage hit on first read, localStorage copy cleaned up)
- In-app browser (WeChat/Facebook): after redirect, sessionStorage is empty → localStorage fallback returns the state → sign-in completes successfully