### PR TITLE
refactor(console): replace createdAt with loginTs on session details page

### DIFF
--- a/packages/console/src/pages/UserSessionDetails/index.tsx
+++ b/packages/console/src/pages/UserSessionDetails/index.tsx
@@ -86,7 +86,7 @@ function UserSessionDetails() {
     [sessionInfo, t]
   );
 
-  const createdAt = useMemo(() => formatTimestamp(sessionData?.payload.loginTs), [sessionData]);
+  const signedInAt = useMemo(() => formatTimestamp(sessionData?.payload.loginTs), [sessionData]);
 
   const infoFields = useMemo<Array<{ key: string; label: string; value: ReactNode }>>(() => {
     if (!sessionData) {
@@ -117,9 +117,9 @@ function UserSessionDetails() {
         ),
       },
       {
-        key: 'created-at',
-        label: t('user_details.sessions.created_at'),
-        value: createdAt,
+        key: 'signed-in-at',
+        label: t('user_details.sessions.signed_in_at'),
+        value: signedInAt,
       },
       {
         key: 'ip',
@@ -147,7 +147,7 @@ function UserSessionDetails() {
         value: sessionInfo?.deviceModel ?? '-',
       },
     ];
-  }, [createdAt, sessionData, sessionInfo, sessionLocation, t, userId]);
+  }, [sessionData, sessionInfo, sessionLocation, signedInAt, t, userId]);
 
   return (
     <DetailsPage

--- a/packages/phrases/src/locales/ar/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/user-details.ts
@@ -146,7 +146,7 @@ const user_details = {
     browser_on_os: '{{browser}} على {{os}}',
     user: 'المستخدم',
     application: 'التطبيق',
-    created_at: 'تم إنشاؤه في',
+    signed_in_at: 'آخر تسجيل دخول',
     ip: 'عنوان IP',
     browser_name: 'اسم المتصفح',
     os_name: 'اسم نظام التشغيل',

--- a/packages/phrases/src/locales/de/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/user-details.ts
@@ -153,7 +153,7 @@ const user_details = {
     browser_on_os: '{{browser}} unter {{os}}',
     user: 'Benutzer',
     application: 'Anwendung',
-    created_at: 'Erstellt am',
+    signed_in_at: 'Zuletzt angemeldet',
     ip: 'IP-Adresse',
     browser_name: 'Browsername',
     os_name: 'Betriebssystemname',

--- a/packages/phrases/src/locales/en/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/user-details.ts
@@ -146,7 +146,7 @@ const user_details = {
     browser_on_os: '{{browser}} on {{os}}',
     user: 'User',
     application: 'Application',
-    created_at: 'Created at',
+    signed_in_at: 'Last signed in',
     ip: 'IP',
     browser_name: 'Browser name',
     os_name: 'OS name',

--- a/packages/phrases/src/locales/es/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/user-details.ts
@@ -152,7 +152,7 @@ const user_details = {
     browser_on_os: '{{browser}} en {{os}}',
     user: 'Usuario',
     application: 'Aplicación',
-    created_at: 'Creado el',
+    signed_in_at: 'Último inicio de sesión',
     ip: 'IP',
     browser_name: 'Nombre del navegador',
     os_name: 'Nombre del sistema operativo',

--- a/packages/phrases/src/locales/fr/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/user-details.ts
@@ -153,7 +153,7 @@ const user_details = {
     browser_on_os: '{{browser}} sur {{os}}',
     user: 'Utilisateur',
     application: 'Application',
-    created_at: 'Créé le',
+    signed_in_at: 'Dernière connexion',
     ip: 'IP',
     browser_name: 'Nom du navigateur',
     os_name: 'Nom du système d’exploitation',

--- a/packages/phrases/src/locales/it/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/user-details.ts
@@ -152,7 +152,7 @@ const user_details = {
     browser_on_os: '{{browser}} su {{os}}',
     user: 'Utente',
     application: 'Applicazione',
-    created_at: 'Creato il',
+    signed_in_at: 'Ultimo accesso',
     ip: 'IP',
     browser_name: 'Nome browser',
     os_name: 'Nome sistema operativo',

--- a/packages/phrases/src/locales/ja/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/user-details.ts
@@ -146,7 +146,7 @@ const user_details = {
     browser_on_os: '{{os}} 上の {{browser}}',
     user: 'ユーザー',
     application: 'アプリケーション',
-    created_at: '作成日時',
+    signed_in_at: '最終サインイン',
     ip: 'IP',
     browser_name: 'ブラウザー名',
     os_name: 'OS 名',

--- a/packages/phrases/src/locales/ko/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/user-details.ts
@@ -145,7 +145,7 @@ const user_details = {
     browser_on_os: '{{os}}의 {{browser}}',
     user: '사용자',
     application: '애플리케이션',
-    created_at: '생성 시각',
+    signed_in_at: '마지막 로그인',
     ip: 'IP',
     browser_name: '브라우저 이름',
     os_name: 'OS 이름',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/user-details.ts
@@ -148,7 +148,7 @@ const user_details = {
     browser_on_os: '{{browser}} na {{os}}',
     user: 'Użytkownik',
     application: 'Aplikacja',
-    created_at: 'Utworzono',
+    signed_in_at: 'Ostatnie logowanie',
     ip: 'IP',
     browser_name: 'Nazwa przeglądarki',
     os_name: 'Nazwa systemu operacyjnego',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/user-details.ts
@@ -150,7 +150,7 @@ const user_details = {
     browser_on_os: '{{browser}} no {{os}}',
     user: 'Usuário',
     application: 'Aplicativo',
-    created_at: 'Criado em',
+    signed_in_at: 'Último login',
     ip: 'IP',
     browser_name: 'Nome do navegador',
     os_name: 'Nome do sistema operacional',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/user-details.ts
@@ -152,7 +152,7 @@ const user_details = {
     browser_on_os: '{{browser}} em {{os}}',
     user: 'Utilizador',
     application: 'Aplicação',
-    created_at: 'Criado em',
+    signed_in_at: 'Último início de sessão',
     ip: 'IP',
     browser_name: 'Nome do navegador',
     os_name: 'Nome do sistema operativo',

--- a/packages/phrases/src/locales/ru/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/user-details.ts
@@ -149,7 +149,7 @@ const user_details = {
     browser_on_os: '{{browser}} на {{os}}',
     user: 'Пользователь',
     application: 'Приложение',
-    created_at: 'Создано',
+    signed_in_at: 'Последний вход',
     ip: 'IP',
     browser_name: 'Название браузера',
     os_name: 'Название ОС',

--- a/packages/phrases/src/locales/th/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/user-details.ts
@@ -146,7 +146,7 @@ const user_details = {
     browser_on_os: '{{browser}} บน {{os}}',
     user: 'ผู้ใช้',
     application: 'แอปพลิเคชัน',
-    created_at: 'สร้างเมื่อ',
+    signed_in_at: 'การลงชื่อเข้าใช้ล่าสุด',
     ip: 'IP',
     browser_name: 'ชื่อเบราว์เซอร์',
     os_name: 'ชื่อระบบปฏิบัติการ',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/user-details.ts
@@ -150,7 +150,7 @@ const user_details = {
     browser_on_os: '{{os}} üzerinde {{browser}}',
     user: 'Kullanıcı',
     application: 'Uygulama',
-    created_at: 'Oluşturulma zamanı',
+    signed_in_at: 'Son oturum açma',
     ip: 'IP',
     browser_name: 'Tarayıcı adı',
     os_name: 'İşletim sistemi adı',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/user-details.ts
@@ -139,7 +139,7 @@ const user_details = {
     browser_on_os: '在 {{os}} 上的 {{browser}}',
     user: '用户',
     application: '应用',
-    created_at: '创建时间',
+    signed_in_at: '最近登录',
     ip: 'IP',
     browser_name: '浏览器名称',
     os_name: '操作系统名称',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/user-details.ts
@@ -139,7 +139,7 @@ const user_details = {
     browser_on_os: '在 {{os}} 上的 {{browser}}',
     user: '使用者',
     application: '應用程式',
-    created_at: '建立時間',
+    signed_in_at: '最近登入',
     ip: 'IP',
     browser_name: '瀏覽器名稱',
     os_name: '作業系統名稱',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/user-details.ts
@@ -138,7 +138,7 @@ const user_details = {
     browser_on_os: '在 {{os}} 上的 {{browser}}',
     user: '使用者',
     application: '應用程式',
-    created_at: '建立時間',
+    signed_in_at: '最近登入',
     ip: 'IP',
     browser_name: '瀏覽器名稱',
     os_name: '作業系統名稱',


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Updated User session details to show Last signed in using `session.payload.loginTs` instead of the previous created-at timestamp, so the time reflects the user’s actual most recent sign-in and is easier to understand.



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally
<img width="2546" height="562" alt="image" src="https://github.com/user-attachments/assets/7caa0ac0-8fd1-4f9e-8d6f-08b66cfbbe75" />


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [ ] ~necessary TSDoc comments~
