### PR TITLE
fix(console): display a full list of applications

### DIFF
--- a/packages/phrases/src/locales/ar/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/user-details.ts
@@ -145,7 +145,7 @@ const user_details = {
 
     browser_on_os: '{{browser}} على {{os}}',
     user: 'المستخدم',
-    application: 'التطبيق',
+    applications: 'التطبيقات',
     signed_in_at: 'آخر تسجيل دخول',
     ip: 'عنوان IP',
     browser_name: 'اسم المتصفح',

--- a/packages/phrases/src/locales/de/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/user-details.ts
@@ -152,7 +152,7 @@ const user_details = {
 
     browser_on_os: '{{browser}} unter {{os}}',
     user: 'Benutzer',
-    application: 'Anwendung',
+    applications: 'Anwendungen',
     signed_in_at: 'Zuletzt angemeldet',
     ip: 'IP-Adresse',
     browser_name: 'Browsername',

--- a/packages/phrases/src/locales/en/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/user-details.ts
@@ -145,7 +145,7 @@ const user_details = {
     location_column: 'Location',
     browser_on_os: '{{browser}} on {{os}}',
     user: 'User',
-    application: 'Application',
+    applications: 'Applications',
     signed_in_at: 'Last signed in',
     ip: 'IP',
     browser_name: 'Browser name',

--- a/packages/phrases/src/locales/es/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/user-details.ts
@@ -151,7 +151,7 @@ const user_details = {
 
     browser_on_os: '{{browser}} en {{os}}',
     user: 'Usuario',
-    application: 'Aplicación',
+    applications: 'Aplicaciones',
     signed_in_at: 'Último inicio de sesión',
     ip: 'IP',
     browser_name: 'Nombre del navegador',

--- a/packages/phrases/src/locales/fr/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/user-details.ts
@@ -152,7 +152,7 @@ const user_details = {
 
     browser_on_os: '{{browser}} sur {{os}}',
     user: 'Utilisateur',
-    application: 'Application',
+    applications: 'Applications',
     signed_in_at: 'Dernière connexion',
     ip: 'IP',
     browser_name: 'Nom du navigateur',

--- a/packages/phrases/src/locales/it/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/user-details.ts
@@ -151,7 +151,7 @@ const user_details = {
 
     browser_on_os: '{{browser}} su {{os}}',
     user: 'Utente',
-    application: 'Applicazione',
+    applications: 'Applicazioni',
     signed_in_at: 'Ultimo accesso',
     ip: 'IP',
     browser_name: 'Nome browser',

--- a/packages/phrases/src/locales/ja/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/user-details.ts
@@ -145,7 +145,7 @@ const user_details = {
 
     browser_on_os: '{{os}} 上の {{browser}}',
     user: 'ユーザー',
-    application: 'アプリケーション',
+    applications: 'アプリケーション',
     signed_in_at: '最終サインイン',
     ip: 'IP',
     browser_name: 'ブラウザー名',

--- a/packages/phrases/src/locales/ko/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/user-details.ts
@@ -144,7 +144,7 @@ const user_details = {
 
     browser_on_os: '{{os}}의 {{browser}}',
     user: '사용자',
-    application: '애플리케이션',
+    applications: '애플리케이션',
     signed_in_at: '마지막 로그인',
     ip: 'IP',
     browser_name: '브라우저 이름',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/user-details.ts
@@ -147,7 +147,7 @@ const user_details = {
 
     browser_on_os: '{{browser}} na {{os}}',
     user: 'Użytkownik',
-    application: 'Aplikacja',
+    applications: 'Aplikacje',
     signed_in_at: 'Ostatnie logowanie',
     ip: 'IP',
     browser_name: 'Nazwa przeglądarki',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/user-details.ts
@@ -149,7 +149,7 @@ const user_details = {
 
     browser_on_os: '{{browser}} no {{os}}',
     user: 'Usuário',
-    application: 'Aplicativo',
+    applications: 'Aplicativos',
     signed_in_at: 'Último login',
     ip: 'IP',
     browser_name: 'Nome do navegador',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/user-details.ts
@@ -151,7 +151,7 @@ const user_details = {
 
     browser_on_os: '{{browser}} em {{os}}',
     user: 'Utilizador',
-    application: 'Aplicação',
+    applications: 'Aplicações',
     signed_in_at: 'Último início de sessão',
     ip: 'IP',
     browser_name: 'Nome do navegador',

--- a/packages/phrases/src/locales/ru/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/user-details.ts
@@ -148,7 +148,7 @@ const user_details = {
 
     browser_on_os: '{{browser}} на {{os}}',
     user: 'Пользователь',
-    application: 'Приложение',
+    applications: 'Приложения',
     signed_in_at: 'Последний вход',
     ip: 'IP',
     browser_name: 'Название браузера',

--- a/packages/phrases/src/locales/th/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/user-details.ts
@@ -145,7 +145,7 @@ const user_details = {
 
     browser_on_os: '{{browser}} บน {{os}}',
     user: 'ผู้ใช้',
-    application: 'แอปพลิเคชัน',
+    applications: 'แอปพลิเคชัน',
     signed_in_at: 'การลงชื่อเข้าใช้ล่าสุด',
     ip: 'IP',
     browser_name: 'ชื่อเบราว์เซอร์',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/user-details.ts
@@ -149,7 +149,7 @@ const user_details = {
 
     browser_on_os: '{{os}} üzerinde {{browser}}',
     user: 'Kullanıcı',
-    application: 'Uygulama',
+    applications: 'Uygulamalar',
     signed_in_at: 'Son oturum açma',
     ip: 'IP',
     browser_name: 'Tarayıcı adı',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/user-details.ts
@@ -138,7 +138,7 @@ const user_details = {
 
     browser_on_os: '在 {{os}} 上的 {{browser}}',
     user: '用户',
-    application: '应用',
+    applications: '应用',
     signed_in_at: '最近登录',
     ip: 'IP',
     browser_name: '浏览器名称',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/user-details.ts
@@ -138,7 +138,7 @@ const user_details = {
 
     browser_on_os: '在 {{os}} 上的 {{browser}}',
     user: '使用者',
-    application: '應用程式',
+    applications: '應用程式',
     signed_in_at: '最近登入',
     ip: 'IP',
     browser_name: '瀏覽器名稱',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/user-details.ts
@@ -137,7 +137,7 @@ const user_details = {
 
     browser_on_os: '在 {{os}} 上的 {{browser}}',
     user: '使用者',
-    application: '應用程式',
+    applications: '應用程式',
     signed_in_at: '最近登入',
     ip: 'IP',
     browser_name: '瀏覽器名稱',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Updated `Application` to `Applications` in the User session details page and now renders all authorized client IDs from `Object.keys(session.payload.authorizations)` using `ApplicationName`, joined by commas.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally
<img width="2756" height="668" alt="image" src="https://github.com/user-attachments/assets/3b572fb2-9de2-4eb2-b001-a35902b533d0" />


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] ~`.changeset`~
- [ ] ~unit tests~
- [ ] ~integration tests~
- [x] necessary TSDoc comments
