### PR TITLE
feat(console): handle get current user 401 error

### DIFF
--- a/packages/console/src/hooks/use-current-user.ts
+++ b/packages/console/src/hooks/use-current-user.ts
@@ -1,22 +1,41 @@
 import { useLogto } from '@logto/react';
-import type { JsonObject, UserProfileResponse } from '@logto/schemas';
+import type { JsonObject, RequestErrorBody, UserProfileResponse } from '@logto/schemas';
+import { HTTPError } from 'ky';
 import { useCallback } from 'react';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 
 import useAccountApi from './use-account-api';
-import type { RequestError } from './use-api';
+import { RequestError } from './use-api';
+import useRedirectUri from './use-redirect-uri';
+import useSignOut from './use-sign-out';
 
 const useCurrentUser = () => {
   const { isAuthenticated } = useLogto();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const { signOut } = useSignOut();
+  const postSignOutRedirectUri = useRedirectUri('signOut');
 
   const accountApi = useAccountApi();
-  const accountApiFetcher = useCallback(
-    async () => accountApi.get('').json<UserProfileResponse>(),
-    [accountApi]
-  );
+  const accountApiFetcher = useCallback(async () => {
+    try {
+      return await accountApi.get('').json<UserProfileResponse>();
+    } catch (error: unknown) {
+      if (error instanceof HTTPError) {
+        const { response } = error;
+        const data = await response.clone().json<RequestErrorBody>();
+
+        if (response.status === 401 && data.code === 'auth.unauthorized') {
+          await signOut(postSignOutRedirectUri.href);
+        } else {
+          throw new RequestError(response.status, data);
+        }
+      }
+
+      throw error;
+    }
+  }, [accountApi, postSignOutRedirectUri.href, signOut]);
 
   const {
     data: user,


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Handle the get current user request 401 error. 

Should sign out the user and redirect to the console sign-in page when the getCurrentUser request throws a 401 'unauthorized` error. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
