### PR TITLE
fix(test): run package vitest tests in non-watch mode

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -35,6 +35,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage"
   },
   "engines": {

--- a/packages/app-insights/package.json
+++ b/packages/app-insights/package.json
@@ -25,6 +25,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepack": "pnpm build"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,6 +32,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepack": "pnpm build"
   },

--- a/packages/connectors/connector-alipay-native/package.json
+++ b/packages/connectors/connector-alipay-native/package.json
@@ -47,6 +47,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-alipay-web/package.json
+++ b/packages/connectors/connector-alipay-web/package.json
@@ -46,6 +46,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-aliyun-dm/package.json
+++ b/packages/connectors/connector-aliyun-dm/package.json
@@ -28,6 +28,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-aliyun-sms/package.json
+++ b/packages/connectors/connector-aliyun-sms/package.json
@@ -28,6 +28,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-amazon/package.json
+++ b/packages/connectors/connector-amazon/package.json
@@ -30,6 +30,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-apple/package.json
+++ b/packages/connectors/connector-apple/package.json
@@ -30,6 +30,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-aws-ses/package.json
+++ b/packages/connectors/connector-aws-ses/package.json
@@ -31,6 +31,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-azuread/package.json
+++ b/packages/connectors/connector-azuread/package.json
@@ -30,6 +30,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-dingtalk-web/package.json
+++ b/packages/connectors/connector-dingtalk-web/package.json
@@ -46,6 +46,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-discord/package.json
+++ b/packages/connectors/connector-discord/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-facebook/package.json
+++ b/packages/connectors/connector-facebook/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-feishu-web/package.json
+++ b/packages/connectors/connector-feishu-web/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-gatewayapi-sms/package.json
+++ b/packages/connectors/connector-gatewayapi-sms/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-github/package.json
+++ b/packages/connectors/connector-github/package.json
@@ -30,6 +30,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-gitlab/package.json
+++ b/packages/connectors/connector-gitlab/package.json
@@ -32,6 +32,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-google/package.json
+++ b/packages/connectors/connector-google/package.json
@@ -30,6 +30,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-http-email/package.json
+++ b/packages/connectors/connector-http-email/package.json
@@ -28,6 +28,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-http-sms/package.json
+++ b/packages/connectors/connector-http-sms/package.json
@@ -28,6 +28,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-huggingface/package.json
+++ b/packages/connectors/connector-huggingface/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-kakao/package.json
+++ b/packages/connectors/connector-kakao/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-kook/package.json
+++ b/packages/connectors/connector-kook/package.json
@@ -21,6 +21,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-line/package.json
+++ b/packages/connectors/connector-line/package.json
@@ -30,6 +30,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-linkedin/package.json
+++ b/packages/connectors/connector-linkedin/package.json
@@ -30,6 +30,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-logto-email/package.json
+++ b/packages/connectors/connector-logto-email/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-logto-social-demo/package.json
+++ b/packages/connectors/connector-logto-social-demo/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-mailgun/package.json
+++ b/packages/connectors/connector-mailgun/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-mock-email-alternative/package.json
+++ b/packages/connectors/connector-mock-email-alternative/package.json
@@ -18,6 +18,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-mock-email/package.json
+++ b/packages/connectors/connector-mock-email/package.json
@@ -18,6 +18,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-mock-sms/package.json
+++ b/packages/connectors/connector-mock-sms/package.json
@@ -18,6 +18,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-mock-social/package.json
+++ b/packages/connectors/connector-mock-social/package.json
@@ -18,6 +18,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-naver/package.json
+++ b/packages/connectors/connector-naver/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-oauth2/package.json
+++ b/packages/connectors/connector-oauth2/package.json
@@ -32,6 +32,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build",
     "prepack": "pnpm build",

--- a/packages/connectors/connector-oidc/package.json
+++ b/packages/connectors/connector-oidc/package.json
@@ -32,6 +32,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-patreon/package.json
+++ b/packages/connectors/connector-patreon/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-postmark/package.json
+++ b/packages/connectors/connector-postmark/package.json
@@ -43,6 +43,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-qq/package.json
+++ b/packages/connectors/connector-qq/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-saml/package.json
+++ b/packages/connectors/connector-saml/package.json
@@ -31,6 +31,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-sendgrid-email/package.json
+++ b/packages/connectors/connector-sendgrid-email/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-slack/package.json
+++ b/packages/connectors/connector-slack/package.json
@@ -30,6 +30,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-smsaero/package.json
+++ b/packages/connectors/connector-smsaero/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-smtp/package.json
+++ b/packages/connectors/connector-smtp/package.json
@@ -46,6 +46,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-tencent-sms/package.json
+++ b/packages/connectors/connector-tencent-sms/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-twilio-sms/package.json
+++ b/packages/connectors/connector-twilio-sms/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-vonage-sms/package.json
+++ b/packages/connectors/connector-vonage-sms/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-wechat-native/package.json
+++ b/packages/connectors/connector-wechat-native/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-wechat-web/package.json
+++ b/packages/connectors/connector-wechat-web/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-wecom/package.json
+++ b/packages/connectors/connector-wecom/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-x/package.json
+++ b/packages/connectors/connector-x/package.json
@@ -30,6 +30,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-xiaomi/package.json
+++ b/packages/connectors/connector-xiaomi/package.json
@@ -28,6 +28,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/connector-yunpian-sms/package.json
+++ b/packages/connectors/connector-yunpian-sms/package.json
@@ -28,6 +28,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/connectors/templates/package.json
+++ b/packages/connectors/templates/package.json
@@ -18,6 +18,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepublishOnly": "pnpm build"
   },

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -33,6 +33,7 @@
     "prepublishOnly": "! ls alterations/next-*",
     "prepack": "pnpm build",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage"
   },
   "engines": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -34,6 +34,7 @@
     "lint:report": "pnpm lint --format json --output-file report.json",
     "prepack": "pnpm build",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage"
   },
   "devDependencies": {

--- a/packages/toolkit/connector-kit/package.json
+++ b/packages/toolkit/connector-kit/package.json
@@ -31,6 +31,7 @@
     "lint:report": "pnpm lint --format json --output-file report.json",
     "prepack": "pnpm build",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage"
   },
   "dependencies": {

--- a/packages/toolkit/core-kit/package.json
+++ b/packages/toolkit/core-kit/package.json
@@ -39,6 +39,7 @@
     "prepack": "pnpm build",
     "stylelint": "stylelint \"scss/**/*.scss\"",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage"
   },
   "engines": {

--- a/packages/toolkit/language-kit/package.json
+++ b/packages/toolkit/language-kit/package.json
@@ -27,6 +27,7 @@
     "lint:report": "pnpm lint --format json --output-file report.json",
     "prepack": "pnpm build",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage"
   },
   "engines": {

--- a/packages/tunnel/package.json
+++ b/packages/tunnel/package.json
@@ -31,6 +31,7 @@
     "lint": "eslint --ext .ts src",
     "lint:report": "pnpm lint --format json --output-file report.json",
     "test": "vitest run src",
+    "test:watch": "vitest src --watch",
     "test:ci": "pnpm run test --silent --coverage",
     "prepack": "pnpm build"
   },


### PR DESCRIPTION
## Summary
This PR makes Vitest behavior explicit across packages so `pnpm test` runs once and exits by default, while watch mode stays available through a separate script.

- Replace `test` scripts from `vitest src` to `vitest run src` across affected packages.
- Add `test:watch` scripts as `vitest src --watch` for local watch/dev workflows.
- In coding-agent workflows, the agent typically runs `pnpm test` after each change for verification. With `vitest src`, that can enter watch mode in an interactive environment and leave Node.js watcher processes behind after the verification step finishes.
- Those leftover watcher processes can accumulate over time and gradually consume more CPU on the machine.
- Making `pnpm test` single-run by default avoids that failure mode, and keeping `pnpm test:watch` explicit preserves the local developer workflow when watch mode is actually wanted.
- Why script changes instead of default config changes: this monorepo does not have one shared Vitest config consumed by all packages, and some Vitest packages do not even have local `vitest.config.*`; updating scripts is the smallest reliable way to enforce single-run behavior everywhere while keeping watch mode explicit via `test:watch`.

References:
- [Vitest CLI: `vitest` / `vitest run` / `vitest watch`](https://vitest.dev/guide/cli)
- [Vitest config `watch` default behavior](https://v3.vitest.dev/config/)

## Testing
Tested locally

## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
