### PR TITLE
feat(console): add passkey list in user details if passkey sign-in is enabled

### DIFF
--- a/packages/console/src/ds-components/Table/index.module.scss
+++ b/packages/console/src/ds-components/Table/index.module.scss
@@ -59,6 +59,10 @@
     background-color: var(--color-layer-1);
     border-radius: 0 0 12px 12px;
 
+    &.roundedTopCorners {
+      border-radius: 12px;
+    }
+
     tbody {
       tr {
         cursor: default;
@@ -167,6 +171,22 @@
     td:first-child,
     td:last-child {
       border-radius: 0;
+    }
+  }
+
+  &.hasBorder .bodyTable.roundedTopCorners {
+    tr:first-child {
+      td {
+        border-top: 1px solid var(--color-divider);
+      }
+
+      td:first-child {
+        border-top-left-radius: 12px;
+      }
+
+      td:last-child {
+        border-top-right-radius: 12px;
+      }
     }
   }
 }

--- a/packages/console/src/ds-components/Table/index.tsx
+++ b/packages/console/src/ds-components/Table/index.tsx
@@ -102,6 +102,7 @@ function Table<
     return result + (colSpan ?? 1);
   }, 0);
 
+  const hasTableHeader = columns.some(({ title }) => !!title);
   const hasData = rowGroups.some(({ data }) => data?.length);
   const hasError = !isLoading && !hasData && errorMessage;
   const isEmpty = !isLoading && !hasData && !errorMessage;
@@ -115,26 +116,29 @@ function Table<
             <div className={styles.filter}>{filter}</div>
           </div>
         )}
-        <table
-          className={classNames(
-            styles.headerTable,
-            filter && styles.hideTopBorderRadius,
-            headerTableClassName
-          )}
-        >
-          <thead>
-            <tr>
-              {columns.map(({ title, colSpan, dataIndex }) => (
-                <th key={dataIndex} colSpan={colSpan}>
-                  {title}
-                </th>
-              ))}
-            </tr>
-          </thead>
-        </table>
+        {hasTableHeader && (
+          <table
+            className={classNames(
+              styles.headerTable,
+              filter && styles.hideTopBorderRadius,
+              headerTableClassName
+            )}
+          >
+            <thead>
+              <tr>
+                {columns.map(({ title, colSpan, dataIndex }) => (
+                  <th key={dataIndex} colSpan={colSpan}>
+                    {title}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+          </table>
+        )}
         <OverlayScrollbar
           className={classNames(
             styles.bodyTable,
+            !hasTableHeader && styles.roundedTopCorners,
             isEmpty && styles.empty,
             bodyTableWrapperClassName
           )}

--- a/packages/console/src/pages/UserDetails/UserSettings/UserMfaVerifications/index.tsx
+++ b/packages/console/src/pages/UserDetails/UserSettings/UserMfaVerifications/index.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useOutletContext } from 'react-router-dom';
 import useSWR from 'swr';
+import useSWRImmutable from 'swr/immutable';
 
 import MfaFactorName from '@/components/MfaFactorName';
 import MfaFactorTitle from '@/components/MfaFactorTitle';
@@ -30,7 +31,9 @@ function UserMfaVerifications({ userId }: Props) {
     mutate,
   } = useSWR<UserMfaVerificationResponse, RequestError>(`api/users/${userId}/mfa-verifications`);
 
-  const { data: signInExperience } = useSWR<SignInExperience, RequestError>('api/sign-in-exp');
+  const { data: signInExperience } = useSWRImmutable<SignInExperience, RequestError>(
+    'api/sign-in-exp'
+  );
 
   const api = useApi();
   const { show: showConfirm } = useConfirmModal();
@@ -146,7 +149,9 @@ function UserMfaVerifications({ userId }: Props) {
               render: (mfaVerification) => {
                 if (
                   mfaVerification.id === 'email-factor' ||
-                  mfaVerification.id === 'phone-factor'
+                  mfaVerification.id === 'phone-factor' ||
+                  (mfaVerification.type === MfaFactor.WebAuthn &&
+                    signInExperience?.passkeySignIn.enabled)
                 ) {
                   return null;
                 }

--- a/packages/console/src/pages/UserDetails/UserSettings/UserSignInPasskeys/index.module.scss
+++ b/packages/console/src/pages/UserDetails/UserSettings/UserSignInPasskeys/index.module.scss
@@ -1,0 +1,7 @@
+@use '@/scss/underscore' as _;
+
+.fieldDescription {
+  font: var(--font-body-2);
+  color: var(--color-text-secondary);
+  margin: _.unit(1) 0 _.unit(2);
+}

--- a/packages/console/src/pages/UserDetails/UserSettings/UserSignInPasskeys/index.tsx
+++ b/packages/console/src/pages/UserDetails/UserSettings/UserSignInPasskeys/index.tsx
@@ -1,0 +1,120 @@
+import { type UserMfaVerificationResponse, MfaFactor, type SignInExperience } from '@logto/schemas';
+import { useCallback, useMemo } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+import useSWR from 'swr';
+import useSWRImmutable from 'swr/immutable';
+
+import MfaFactorName from '@/components/MfaFactorName';
+import MfaFactorTitle from '@/components/MfaFactorTitle';
+import Button from '@/ds-components/Button';
+import Table from '@/ds-components/Table';
+import useApi, { type RequestError } from '@/hooks/use-api';
+import { useConfirmModal } from '@/hooks/use-confirm-modal';
+import { type UserMfaVerification } from '@/types/mfa';
+
+import styles from './index.module.scss';
+
+type Props = {
+  readonly userId: string;
+};
+
+function UserSignInPasskeys({ userId }: Props) {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console.user_details.passkey' });
+  const {
+    data: mfaVerifications,
+    error,
+    isLoading: isLoadingMfaVerifications,
+    mutate,
+  } = useSWR<UserMfaVerificationResponse, RequestError>(`api/users/${userId}/mfa-verifications`);
+
+  const { data: signInExperience, isLoading: isLoadingSignInExp } = useSWRImmutable<
+    SignInExperience,
+    RequestError
+  >('api/sign-in-exp');
+
+  const isLoading = isLoadingMfaVerifications || isLoadingSignInExp;
+  const isEmpty =
+    !mfaVerifications || mfaVerifications.length === 0 || !signInExperience?.passkeySignIn.enabled;
+
+  const api = useApi();
+  const { show: showConfirm } = useConfirmModal();
+
+  const handleDelete = useCallback(
+    async (mfaVerification: UserMfaVerification) => {
+      const [result] = await showConfirm({
+        ModalContent: () => (
+          <Trans
+            t={t}
+            i18nKey="deletion_confirmation"
+            components={{
+              name: <MfaFactorName {...mfaVerification} />,
+            }}
+          />
+        ),
+        confirmButtonText: 'general.remove',
+      });
+
+      if (!result) {
+        return;
+      }
+
+      await api.delete(`api/users/${userId}/mfa-verifications/${mfaVerification.id}`);
+      void mutate(mfaVerifications?.filter((item) => item.id !== mfaVerification.id));
+    },
+    [api, mfaVerifications, mutate, showConfirm, t, userId]
+  );
+
+  const data = useMemo(() => {
+    if (!mfaVerifications) {
+      return [];
+    }
+
+    return mfaVerifications.filter((verification) => verification.type === MfaFactor.WebAuthn);
+  }, [mfaVerifications]);
+
+  return (
+    <>
+      {!isLoading && !error && isEmpty && (
+        <div className={styles.fieldDescription}>{t('field_description_empty')}</div>
+      )}
+      {(isLoading || !isEmpty || error) && (
+        <Table
+          isRowHoverEffectDisabled
+          hasBorder
+          rowGroups={[{ key: 'mfaVerifications', data }]}
+          rowIndexKey="id"
+          isLoading={isLoading}
+          errorMessage={error?.body?.message ?? error?.message}
+          columns={[
+            {
+              title: null,
+              dataIndex: 'name',
+              colSpan: 13,
+              render: (mfaVerification) => <MfaFactorTitle {...mfaVerification} />,
+            },
+            {
+              title: null,
+              dataIndex: 'action',
+              colSpan: 3,
+              render: (mfaVerification) => (
+                <Button
+                  title="general.remove"
+                  type="text"
+                  size="small"
+                  onClick={() => {
+                    void handleDelete(mfaVerification);
+                  }}
+                />
+              ),
+            },
+          ]}
+          onRetry={() => {
+            void mutate();
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+export default UserSignInPasskeys;

--- a/packages/console/src/pages/UserDetails/UserSettings/index.tsx
+++ b/packages/console/src/pages/UserDetails/UserSettings/index.tsx
@@ -33,6 +33,7 @@ import UserConnections from './UserConnections';
 import UserMfaVerifications from './UserMfaVerifications';
 import UserPassword from './UserPassword';
 import UserSessions from './UserSessions';
+import UserSignInPasskeys from './UserSignInPasskeys';
 
 function UserSettings() {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
@@ -161,6 +162,11 @@ function UserSettings() {
               }}
             />
           </FormField>
+          {isDevFeaturesEnabled && (
+            <FormField title="user_details.passkey.field_name">
+              <UserSignInPasskeys userId={user.id} />
+            </FormField>
+          )}
           <FormField title="user_details.mfa.field_name">
             <UserMfaVerifications userId={user.id} />
           </FormField>

--- a/packages/phrases/src/locales/ar/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/user-details.ts
@@ -70,6 +70,12 @@ const user_details = {
     deletion_confirmation:
       'أنت تقوم بإزالة <name/> الحالية للتحقق المتعدد من عوامل التحقق. هل أنت متأكد أنك تريد المتابعة؟',
   },
+  passkey: {
+    field_name: 'مفاتيح المرور',
+    field_description_empty: 'لم يقم هذا المستخدم بتمكين تسجيل الدخول بمفاتيح المرور.',
+    deletion_confirmation:
+      'أنت تقوم بإزالة <name/> الحالية لتسجيل الدخول بمفاتيح المرور. هل أنت متأكد أنك تريد المتابعة؟',
+  },
   suspended: 'موقوف',
   suspend_user: 'تعليق المستخدم',
   suspend_user_reminder:

--- a/packages/phrases/src/locales/de/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/user-details.ts
@@ -75,6 +75,12 @@ const user_details = {
     deletion_confirmation:
       'Sie entfernen die bestehende <name/> für die Zwei-Faktor-Authentifizierung. Sind Sie sicher, dass Sie fortfahren möchten?',
   },
+  passkey: {
+    field_name: 'Passkeys',
+    field_description_empty: 'Dieser Benutzer hat die Passkey-Anmeldung nicht aktiviert.',
+    deletion_confirmation:
+      'Sie entfernen den vorhandenen <name/> für die Passkey-Anmeldung. Sind Sie sicher, dass Sie fortfahren möchten?',
+  },
   suspended: 'Gesperrt',
   suspend_user: 'Benutzer sperren',
   suspend_user_reminder:

--- a/packages/phrases/src/locales/en/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/user-details.ts
@@ -71,6 +71,12 @@ const user_details = {
     deletion_confirmation:
       'You are removing the existing <name/> for the 2-step verification. Are you sure you want to continue?',
   },
+  passkey: {
+    field_name: 'Passkeys',
+    field_description_empty: 'This user has not enabled passkey sign-in.',
+    deletion_confirmation:
+      'You are removing the existing <name/> for passkey sign-in. Are you sure you want to continue?',
+  },
   suspended: 'Suspended',
   suspend_user: 'Suspend user',
   suspend_user_reminder:

--- a/packages/phrases/src/locales/es/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/user-details.ts
@@ -74,6 +74,13 @@ const user_details = {
     deletion_confirmation:
       'Estás eliminando la existente <name/> para la verificación en dos pasos. ¿Estás seguro/a de que deseas continuar?',
   },
+  passkey: {
+    field_name: 'Claves de acceso',
+    field_description_empty:
+      'Este usuario no ha habilitado el inicio de sesión con clave de acceso.',
+    deletion_confirmation:
+      'Estás eliminando el/la existente <name/> para el inicio de sesión con clave de acceso. ¿Estás seguro/a de que deseas continuar?',
+  },
   suspended: 'Suspendido',
   suspend_user: 'Suspender usuario',
   suspend_user_reminder:

--- a/packages/phrases/src/locales/fr/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/user-details.ts
@@ -75,6 +75,12 @@ const user_details = {
     deletion_confirmation:
       "Vous supprimez l'existence actuelle de <name/> pour la vérification en deux étapes. Êtes-vous sûr(e) de vouloir continuer?",
   },
+  passkey: {
+    field_name: "Clés d'accès",
+    field_description_empty: "Cet utilisateur n'a pas activé la connexion par clé d'accès.",
+    deletion_confirmation:
+      "Vous supprimez la clé d'accès existante <name/> pour la connexion. Êtes-vous sûr(e) de vouloir continuer?",
+  },
   suspended: 'Suspendu',
   suspend_user: "Suspendre l'utilisateur",
   suspend_user_reminder:

--- a/packages/phrases/src/locales/it/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/user-details.ts
@@ -75,6 +75,12 @@ const user_details = {
     deletion_confirmation:
       "Stai rimuovendo l'esistente <name/> per la verifica in due passaggi. Sei sicuro di voler continuare?",
   },
+  passkey: {
+    field_name: 'Passkeys',
+    field_description_empty: "Questo utente non ha abilitato l'accesso con passkey.",
+    deletion_confirmation:
+      "Stai rimuovendo il passkey esistente <name/> per l'accesso. Sei sicuro di voler continuare?",
+  },
   suspended: 'Sospeso',
   suspend_user: 'Sospendi utente',
   suspend_user_reminder:

--- a/packages/phrases/src/locales/ja/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/user-details.ts
@@ -70,6 +70,12 @@ const user_details = {
     field_description_empty: 'このユーザーは2段階認証の要因を有効にしていません。',
     deletion_confirmation: '2段階認証の既存の<name/>を削除しています。本当に続行しますか？',
   },
+  passkey: {
+    field_name: 'パスキー',
+    field_description_empty: 'このユーザーはパスキーサインインを有効にしていません。',
+    deletion_confirmation:
+      'パスキーサインインのために既存の<name/>を削除しています。本当に続行しますか？',
+  },
   suspended: '停止中',
   suspend_user: 'ユーザーを一時停止',
   suspend_user_reminder:

--- a/packages/phrases/src/locales/ko/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/user-details.ts
@@ -69,6 +69,12 @@ const user_details = {
     deletion_confirmation:
       '기존의 2단계 인증에서 <name/>을(를) 제거하고 있습니다. 계속 진행하시겠습니까?',
   },
+  passkey: {
+    field_name: '패스키',
+    field_description_empty: '이 사용자는 패스키 로그인을 활성화하지 않았습니다.',
+    deletion_confirmation:
+      '패스키 로그인에 대해 기존의 <name/>을(를) 제거하고 있습니다. 계속 진행하시겠습니까?',
+  },
   suspended: '정지됨',
   suspend_user: '사용자 정지',
   suspend_user_reminder:

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/user-details.ts
@@ -71,6 +71,12 @@ const user_details = {
     deletion_confirmation:
       'Usuwasz istniejące <name/> w celu weryfikacji dwuetapowej. Czy na pewno chcesz kontynuować?',
   },
+  passkey: {
+    field_name: 'Klucze dostępu',
+    field_description_empty: 'Ten użytkownik nie włączył logowania za pomocą klucza dostępu.',
+    deletion_confirmation:
+      'Usuwasz istniejący <name/> do logowania za pomocą klucza dostępu. Czy na pewno chcesz kontynuować?',
+  },
   suspended: 'Zawieszony',
   suspend_user: 'Zawieś użytkownika',
   suspend_user_reminder:

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/user-details.ts
@@ -72,6 +72,12 @@ const user_details = {
     deletion_confirmation:
       'Você está removendo o existente <name/> para a verificação em duas etapas. Tem certeza de que deseja continuar?',
   },
+  passkey: {
+    field_name: 'Chaves de acesso',
+    field_description_empty: 'Este usuário não habilitou o login com chave de acesso.',
+    deletion_confirmation:
+      'Você está removendo a chave de acesso existente <name/> para login. Tem certeza de que deseja continuar?',
+  },
   suspended: 'Suspenso',
   suspend_user: 'Suspender usuário',
   suspend_user_reminder:

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/user-details.ts
@@ -74,6 +74,12 @@ const user_details = {
     deletion_confirmation:
       'Está a remover o existente <name/> para a verificação em duas etapas. Tem a certeza de que deseja continuar?',
   },
+  passkey: {
+    field_name: 'Chaves de acesso',
+    field_description_empty: 'Este utilizador não ativou o início de sessão com chave de acesso.',
+    deletion_confirmation:
+      'Está a remover a chave de acesso existente <name/> para o início de sessão. Tem a certeza de que deseja continuar?',
+  },
   suspended: 'suspenso',
   suspend_user: 'Suspender utilizador',
   suspend_user_reminder:

--- a/packages/phrases/src/locales/ru/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/user-details.ts
@@ -72,6 +72,12 @@ const user_details = {
     deletion_confirmation:
       'Вы удаляете существующий <name/> для двухэтапной верификации. Вы уверены, что хотите продолжить?',
   },
+  passkey: {
+    field_name: 'Ключи доступа',
+    field_description_empty: 'Этот пользователь не включил вход с ключом доступа.',
+    deletion_confirmation:
+      'Вы удаляете существующий <name/> для входа с ключом доступа. Вы уверены, что хотите продолжить?',
+  },
   suspended: 'Приостановлен',
   suspend_user: 'Приостановить пользователя',
   suspend_user_reminder:

--- a/packages/phrases/src/locales/th/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/user-details.ts
@@ -71,6 +71,12 @@ const user_details = {
     deletion_confirmation:
       'คุณกำลังนำ <name/> สำหรับ ขั้นตอนยืนยันสองขั้น ออก คุณแน่ใจหรือว่าต้องการดำเนินการต่อ?',
   },
+  passkey: {
+    field_name: 'พาสคีย์',
+    field_description_empty: 'ผู้ใช้นี้ยังไม่ได้เปิดใช้งานการลงชื่อเข้าใช้ด้วยพาสคีย์',
+    deletion_confirmation:
+      'คุณกำลังนำ <name/> สำหรับการลงชื่อเข้าใช้ด้วยพาสคีย์ ออก คุณแน่ใจหรือว่าต้องการดำเนินการต่อ?',
+  },
   suspended: 'ระงับ',
   suspend_user: 'ระงับผู้ใช้',
   suspend_user_reminder:

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/user-details.ts
@@ -73,6 +73,12 @@ const user_details = {
     deletion_confirmation:
       'Varolan 2 aşamalı doğrulama için <name/> kaldırıyorsunuz. Devam etmek istediğinizden emin misiniz?',
   },
+  passkey: {
+    field_name: "Passkey'ler",
+    field_description_empty: 'Bu kullanıcı passkey girişini etkinleştirmedi.',
+    deletion_confirmation:
+      'Passkey girişi için mevcut <name/> kaldırıyorsunuz. Devam etmek istediğinizden emin misiniz?',
+  },
   suspended: 'Askıya alınmış',
   suspend_user: 'Kullanıcıyı Askıya Al',
   suspend_user_reminder:

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/user-details.ts
@@ -67,6 +67,11 @@ const user_details = {
     field_description_empty: '此用户尚未启用两步身份验证因素。',
     deletion_confirmation: '你正在删除现有的两步验证中的 <name/>。你确定要继续吗？',
   },
+  passkey: {
+    field_name: '通行密钥',
+    field_description_empty: '该用户尚未启用通行密钥登录。',
+    deletion_confirmation: '你正在删除用于通行密钥登录的现有 <name/>。你确定要继续吗？',
+  },
   suspended: '已禁用',
   suspend_user: '禁用用户',
   suspend_user_reminder:

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/user-details.ts
@@ -67,6 +67,11 @@ const user_details = {
     field_description_empty: '此用戶尚未啟用兩步驟身份驗證因素。',
     deletion_confirmation: '你正在刪除現有的雙步驗證中的 <name/>。你確定要繼續嗎？',
   },
+  passkey: {
+    field_name: '通行密鑰',
+    field_description_empty: '此用戶尚未啟用通行密鑰登錄。',
+    deletion_confirmation: '你正在刪除用於通行密鑰登錄的現有 <name/>。你確定要繼續嗎？',
+  },
   suspended: '已禁用',
   suspend_user: '禁用用戶',
   suspend_user_reminder:

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/user-details.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/user-details.ts
@@ -67,6 +67,11 @@ const user_details = {
     field_description_empty: '此使用者尚未啟用兩步驗證因素。',
     deletion_confirmation: '你正在刪除現有的雙步驗證中的 <name/>。你確定要繼續嗎？',
   },
+  passkey: {
+    field_name: '通行金鑰',
+    field_description_empty: '此使用者尚未啟用通行金鑰登入。',
+    deletion_confirmation: '你正在刪除用於通行金鑰登入的現有 <name/>。你確定要繼續嗎？',
+  },
   suspended: '已禁用',
   suspend_user: '禁用用戶',
   suspend_user_reminder:


### PR DESCRIPTION
## Summary
Add a new "Sign-in passkeys" section to the user details settings page in the admin console. The section lists all registered passkeys for a user and is only displayed when passkey sign-in is enabled. This includes:

- New `UserSignInPasskeys` component that fetches and displays passkeys associated with a user
- Translation strings for the passkey section added across all supported locales
- Table component enhancements to support the passkey list display

## Testing
Tested locally

## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
