### PR TITLE
fix(console): enable passkey prompts checkboxes by default when passkey sign-in is enabled

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/PasskeySignInForm/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/PasskeySignInForm/index.tsx
@@ -1,5 +1,5 @@
 import { cond } from '@silverhand/essentials';
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 import { useFormContext, Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -19,7 +19,7 @@ import styles from './index.module.scss';
 
 function PasskeySignInForm() {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
-  const { control, register, watch } = useFormContext<SignInExperienceForm>();
+  const { control, register, setValue, watch } = useFormContext<SignInExperienceForm>();
 
   const {
     currentSubscriptionQuota,
@@ -27,6 +27,14 @@ function PasskeySignInForm() {
   } = useContext(SubscriptionDataContext);
   const isPasskeySignInEnabled = currentSubscriptionQuota.passkeySignInEnabled || !isCloud;
   const isPaidTenant = isPaidPlan(planId, isEnterprisePlan);
+  const watchEnableSwitch = watch('passkeySignIn.enabled');
+
+  useEffect(() => {
+    if (isPasskeySignInEnabled && watchEnableSwitch) {
+      setValue('passkeySignIn.showPasskeyButton', true);
+      setValue('passkeySignIn.allowAutofill', true);
+    }
+  }, [isPasskeySignInEnabled, watchEnableSwitch, setValue]);
 
   return (
     <Card>
@@ -48,7 +56,7 @@ function PasskeySignInForm() {
           )}
         />
       </FormField>
-      {watch('passkeySignIn.enabled') && (
+      {watchEnableSwitch && (
         <FormField title="sign_in_exp.sign_up_and_sign_in.passkey_sign_in.prompts">
           <div className={styles.checkboxes}>
             <Controller


### PR DESCRIPTION
## Summary
When a user enables passkey sign-in in the Sign-in Experience settings, the two passkey prompt options ("Show 'Continue with passkey' button" and "Allow prompting and autofill of registered passkeys") should be checked by default for a better out-of-the-box experience.

Added a `useEffect` in `PasskeySignInForm` that automatically sets `passkeySignIn.showPasskeyButton` and `passkeySignIn.allowAutofill` to `true` whenever the passkey sign-in toggle is turned on.

## Testing
Tested locally

## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
