### PR TITLE
fix(experience): fix loading spinner style on passkey sign-in button

### DIFF
--- a/packages/experience/src/components/Button/PasskeySignInButton/index.module.scss
+++ b/packages/experience/src/components/Button/PasskeySignInButton/index.module.scss
@@ -4,7 +4,7 @@
   justify-content: normal;
   padding: 0 _.unit(4);
 
-  svg {
+  .icon {
     width: 24px;
     height: 24px;
     color: var(--color-type-primary);

--- a/packages/experience/src/components/Button/PasskeySignInButton/index.tsx
+++ b/packages/experience/src/components/Button/PasskeySignInButton/index.tsx
@@ -73,7 +73,7 @@ const PasskeySignInButton = () => {
       type="button"
       onClick={onPasskeySignIn}
     >
-      {!isLoadingActive && <PasskeyIcon />}
+      {!isLoadingActive && <PasskeyIcon className={styles.icon} />}
       {isLoadingActive && (
         <span className={styles.loadingIcon}>
           <RotatingRingIcon />


### PR DESCRIPTION
## Summary
The loading spinner on the passkey sign-in button was being styled incorrectly because the CSS rule targeted all `svg` elements inside the button, including the `RotatingRingIcon` used as a loading indicator.

Fixed by scoping the color/size rule to an `.icon` class and applying that class only to the `PasskeyIcon`, leaving the loading spinner unaffected.

## Testing
Tested locally

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
