### PR TITLE
fix(console): add upsell banner for passkey sign-in on free plan

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/PasskeySignInForm/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/PasskeySignInForm/index.module.scss
@@ -5,3 +5,8 @@
     margin-top: _.unit(3);
   }
 }
+
+.inlineNote {
+  margin-top: _.unit(3);
+  padding: _.unit(3) _.unit(4);
+}

--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/PasskeySignInForm/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/PasskeySignInForm/index.tsx
@@ -3,6 +3,7 @@ import { useContext, useEffect } from 'react';
 import { useFormContext, Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
+import InlineUpsell from '@/components/InlineUpsell';
 import { isCloud } from '@/consts/env';
 import { latestProPlanId } from '@/consts/subscriptions';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
@@ -88,6 +89,13 @@ function PasskeySignInForm() {
             />
           </div>
         </FormField>
+      )}
+      {!isPasskeySignInEnabled && (
+        <InlineUpsell
+          for="passkey_sign_in"
+          actionButtonText="upsell.view_plans"
+          className={styles.inlineNote}
+        />
       )}
     </Card>
   );


### PR DESCRIPTION
## Summary
The passkey sign-in section in Sign-in Experience was missing an upsell banner for free plan tenants. Added an `InlineUpsell` component that is displayed when `isPasskeySignInEnabled` is false (i.e. the tenant is on a free plan), pointing users to view available plans.

## Testing
Tested locally

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
