### PR TITLE
refactor(core,experience,schemas): use constant timeout for WebAuthn options

### DIFF
--- a/packages/core/src/__mocks__/webauthn.ts
+++ b/packages/core/src/__mocks__/webauthn.ts
@@ -5,6 +5,7 @@ import {
   type WebAuthnRegistrationOptions,
   type BindWebAuthn,
   type WebAuthnVerificationPayload,
+  webAuthnAuthenticationOptionsTimeout,
 } from '@logto/schemas';
 
 export const mockWebAuthnRegistrationOptions: WebAuthnRegistrationOptions = {
@@ -36,7 +37,7 @@ export const mockWebAuthnAuthenticationOptions: WebAuthnAuthenticationOptions = 
     },
   ],
   userVerification: 'preferred',
-  timeout: 60_000,
+  timeout: webAuthnAuthenticationOptionsTimeout,
   rpId: 'logto.io',
 };
 

--- a/packages/core/src/routes/interaction/utils/webauthn.ts
+++ b/packages/core/src/routes/interaction/utils/webauthn.ts
@@ -7,6 +7,7 @@ import {
   type MfaVerifications,
   type WebAuthnVerificationPayload,
   type VerifyMfaResult,
+  webAuthnAuthenticationOptionsTimeout,
 } from '@logto/schemas';
 import { getUserDisplayName } from '@logto/shared';
 import {
@@ -47,7 +48,7 @@ export const generateWebAuthnRegistrationOptions = async ({
     userName: getUserDisplayName({ username, primaryEmail, primaryPhone }) ?? 'Unnamed User',
     userDisplayName:
       getUserDisplayName({ name, username, primaryEmail, primaryPhone }) ?? 'Unnamed User',
-    timeout: 60_000,
+    timeout: webAuthnAuthenticationOptionsTimeout,
     attestationType: 'none',
     excludeCredentials: mfaVerifications
       .filter(
@@ -123,7 +124,7 @@ export const generateWebAuthnAuthenticationOptions = async ({
   }
 
   const options: GenerateAuthenticationOptionsOpts = {
-    timeout: 60_000,
+    timeout: webAuthnAuthenticationOptionsTimeout,
     allowCredentials: webAuthnVerifications.map(({ credentialId, transports }) => ({
       id: credentialId,
       type: 'public-key',

--- a/packages/experience/src/hooks/use-passkey-autofill-conditional-ui.ts
+++ b/packages/experience/src/hooks/use-passkey-autofill-conditional-ui.ts
@@ -1,4 +1,9 @@
-import { InteractionEvent, MfaFactor, type WebAuthnAuthenticationOptions } from '@logto/schemas';
+import {
+  InteractionEvent,
+  MfaFactor,
+  webAuthnAuthenticationOptionsTimeout,
+  type WebAuthnAuthenticationOptions,
+} from '@logto/schemas';
 import { browserSupportsWebAuthnAutofill } from '@simplewebauthn/browser';
 import { useCallback, useContext, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -43,7 +48,7 @@ const usePasskeyAutofillConditionalUI = () => {
 
         window.setTimeout(() => {
           abortController.abort();
-        }, 60_000);
+        }, webAuthnAuthenticationOptionsTimeout);
 
         const credential = await navigator.credentials.get({
           mediation: 'conditional',

--- a/packages/schemas/src/consts/system.ts
+++ b/packages/schemas/src/consts/system.ts
@@ -12,3 +12,8 @@ export const ossConsolePath = '/console';
 
 /** The prefix for keys and values that need to be explicitly marked as internal. */
 export const internalPrefix = '#internal:';
+
+/**
+ * The timeout for WebAuthn authentication options, in milliseconds.
+ */
+export const webAuthnAuthenticationOptionsTimeout = 60_000;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Use a constant value in schemas package for the WebAuthn authentication timeout.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
