### PR TITLE
fix(experience): avoid loading flash on passkey setup button

### DIFF
--- a/packages/experience/src/pages/PasskeySetup/index.tsx
+++ b/packages/experience/src/pages/PasskeySetup/index.tsx
@@ -32,7 +32,6 @@ const PasskeySetup = () => {
   const asyncCreateRegistrationOptions = useApi(createSignInWebAuthnRegistrationOptions);
 
   const [registrationResult, setRegistrationResult] = useState<RegistrationState>();
-  const [isPreparing, setIsPreparing] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleError = useErrorHandler();
@@ -51,9 +50,7 @@ const PasskeySetup = () => {
     }
 
     (async () => {
-      setIsPreparing(true);
       const [error, result] = await asyncCreateRegistrationOptions();
-      setIsPreparing(false);
 
       if (error) {
         await handleError(error);
@@ -106,8 +103,8 @@ const PasskeySetup = () => {
         <Button
           className={styles.button}
           title="passkey_sign_in.setup_page.subtitle"
-          isLoading={isSubmitting || isPreparing}
-          disabled={isPreparing && !registrationResult}
+          isLoading={isSubmitting}
+          disabled={!registrationResult}
           onClick={onCreatePasskey}
         />
       </SectionLayout>


### PR DESCRIPTION
## Summary
The passkey setup page was showing a transient loading state on the submit button while registration options were being prepared before the user actually clicked the button.

This change removes the separate `isPreparing` state and keeps the button loading indicator tied only to the actual passkey submission flow. The button remains disabled until `registrationResult` is ready, which avoids the unexpected loading flash.

## Testing
Tested locally

## Checklist

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
