### PR TITLE
fix(core): preserve existing mfa.enabled when updating user logto config

### DIFF
--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -553,8 +553,11 @@ export default class ExperienceInteraction {
         }
       ),
       logtoConfig: {
-        ...user.logtoConfig,
-        ...parseMfaPropertiesToUserConfig(userMfaVerifications, this.#interactionEvent),
+        ...parseMfaPropertiesToUserConfig(
+          user.logtoConfig,
+          userMfaVerifications,
+          this.#interactionEvent
+        ),
       },
       lastSignInAt: Date.now(),
     });

--- a/packages/core/src/routes/experience/classes/helpers.test.ts
+++ b/packages/core/src/routes/experience/classes/helpers.test.ts
@@ -1,4 +1,11 @@
-import { MfaFactor, MfaPolicy, type Mfa, type User } from '@logto/schemas';
+import {
+  InteractionEvent,
+  MfaFactor,
+  MfaPolicy,
+  type Mfa,
+  type User,
+  userMfaDataKey,
+} from '@logto/schemas';
 
 import {
   mockUser,
@@ -10,6 +17,7 @@ import {
 import {
   getAllUserEnabledMfaVerifications,
   getProfileMfaFactors,
+  parseMfaPropertiesToUserConfig,
   sortMfaFactors,
 } from './helpers.js';
 
@@ -79,5 +87,29 @@ describe('sortMfaFactors', () => {
       MfaFactor.EmailVerificationCode,
       MfaFactor.BackupCode,
     ]);
+  });
+});
+
+describe('parseMfaPropertiesToUserConfig', () => {
+  it('preserves existing mfa.enabled from db on subsequent interaction submit', () => {
+    const existingLogtoConfig = {
+      [userMfaDataKey]: {
+        enabled: true,
+      },
+    };
+
+    const parsed = parseMfaPropertiesToUserConfig(
+      existingLogtoConfig,
+      {
+        mfaVerifications: [],
+      },
+      InteractionEvent.SignIn
+    );
+
+    expect(parsed).toEqual({
+      [userMfaDataKey]: {
+        enabled: true,
+      },
+    });
   });
 });

--- a/packages/core/src/routes/experience/classes/helpers.ts
+++ b/packages/core/src/routes/experience/classes/helpers.ts
@@ -14,6 +14,8 @@ import {
   type UserLogtoConfig,
   userMfaDataKey,
   userPasskeySignInDataKey,
+  type JsonObject,
+  userLogtoConfigGuard,
 } from '@logto/schemas';
 import { conditional, type Nullable } from '@silverhand/essentials';
 
@@ -319,15 +321,19 @@ export const getAllUserEnabledMfaVerifications = (
  * - The returned object is structured to be directly used for updating the user account with the new MFA settings.
  */
 export const parseMfaPropertiesToUserConfig = (
+  logtoConfig: JsonObject,
   mfaVerificationData: UserMfaVerificationsData,
   interactionEvent: InteractionEvent
 ): UserLogtoConfig => {
   const { mfaEnabled, mfaSkipped, passkeySkipped } = mfaVerificationData;
+  const userMfaData = userLogtoConfigGuard.safeParse(logtoConfig).data?.[userMfaDataKey];
   return {
+    ...logtoConfig,
     [userMfaDataKey]: {
+      ...userMfaData,
       // Force cast optional value to boolean since the `enabled` field is newly introduced and legacy users may NOT have this field
       // in their config. The absence of `enabled` field will be treated as MFA not enabled after the next sign-in attempt.
-      enabled: mfaEnabled === true,
+      ...conditional(userMfaData?.enabled === undefined && { enabled: mfaEnabled === true }),
       // For users who have explicitly skipped MFA, set `skipped` to true to persist the skipped status.
       ...conditional(mfaSkipped && { skipped: true }),
     },


### PR DESCRIPTION
## Summary

`parseMfaPropertiesToUserConfig` was unconditionally overwriting `mfa.enabled` in `user.logtoConfig` on every interaction submission, even when the user had already explicitly set the flag.

The fix passes the current `user.logtoConfig` into `parseMfaPropertiesToUserConfig`, parses it with `userLogtoConfigGuard` to safely extract the existing `mfa` data, spreads it into the returned object, and only writes `enabled` when `userMfaData?.enabled === undefined` (i.e. the field has never been set before).

## Testing

Tested locally

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
