### PR TITLE
fix(core,schemas): persist additional MFA suggestion skip status

### DIFF
--- a/packages/core/src/routes/experience/classes/helpers.test.ts
+++ b/packages/core/src/routes/experience/classes/helpers.test.ts
@@ -112,4 +112,23 @@ describe('parseMfaPropertiesToUserConfig', () => {
       },
     });
   });
+
+  it('persists additionalBindingSuggestionSkipped to user mfa config', () => {
+    expect(
+      parseMfaPropertiesToUserConfig(
+        {},
+        {
+          mfaEnabled: true,
+          additionalBindingSuggestionSkipped: true,
+          mfaVerifications: [],
+        },
+        InteractionEvent.SignIn
+      )
+    ).toEqual({
+      [userMfaDataKey]: {
+        enabled: true,
+        additionalBindingSuggestionSkipped: true,
+      },
+    });
+  });
 });

--- a/packages/core/src/routes/experience/classes/helpers.ts
+++ b/packages/core/src/routes/experience/classes/helpers.ts
@@ -316,6 +316,7 @@ export const getAllUserEnabledMfaVerifications = (
  *   otherwise, it will be false. This is because the `enabled` field is newly introduced and legacy users may not have this field in their config.
  *   The absence of `enabled` field will be treated as MFA not enabled after the next sign-in attempt.
  * - The `skipped` field is only set when the user has explicitly skipped MFA. This is to persist the skipped status for users who have chosen to skip MFA.
+ * - The `additionalBindingSuggestionSkipped` field is only set when user has explicitly skipped the optional additional MFA suggestion.
  * - The `passkeySkipped` status is only persisted during sign-in event. This is to allow users who skipped binding passkey during registration to be prompted
  *   again during the first sign-in attempt.
  * - The returned object is structured to be directly used for updating the user account with the new MFA settings.
@@ -325,7 +326,8 @@ export const parseMfaPropertiesToUserConfig = (
   mfaVerificationData: UserMfaVerificationsData,
   interactionEvent: InteractionEvent
 ): UserLogtoConfig => {
-  const { mfaEnabled, mfaSkipped, passkeySkipped } = mfaVerificationData;
+  const { mfaEnabled, mfaSkipped, additionalBindingSuggestionSkipped, passkeySkipped } =
+    mfaVerificationData;
   const userMfaData = userLogtoConfigGuard.safeParse(logtoConfig).data?.[userMfaDataKey];
   return {
     ...logtoConfig,
@@ -336,6 +338,10 @@ export const parseMfaPropertiesToUserConfig = (
       ...conditional(userMfaData?.enabled === undefined && { enabled: mfaEnabled === true }),
       // For users who have explicitly skipped MFA, set `skipped` to true to persist the skipped status.
       ...conditional(mfaSkipped && { skipped: true }),
+      // Persist optional additional MFA suggestion skipped status when user explicitly skips it.
+      ...conditional(
+        additionalBindingSuggestionSkipped && { additionalBindingSuggestionSkipped: true }
+      ),
     },
     ...conditional(
       // Only persist passkey skipped status on sign-in event. So users who skipped binding passkey during registration will be prompted

--- a/packages/core/src/routes/experience/classes/mfa.test.ts
+++ b/packages/core/src/routes/experience/classes/mfa.test.ts
@@ -4,6 +4,7 @@ import {
   type Mfa as MfaSettings,
   MfaPolicy,
   OrganizationRequiredMfaPolicy,
+  userMfaDataKey,
   type User,
 } from '@logto/schemas';
 
@@ -23,6 +24,7 @@ const createMfa = ({
     factors: [],
     organizationRequiredMfaPolicy: OrganizationRequiredMfaPolicy.NoPrompt,
   },
+  interactionEvent = InteractionEvent.SignIn,
   user = {
     id: 'user-id',
     logtoConfig: {},
@@ -31,12 +33,13 @@ const createMfa = ({
   currentProfile = {},
 }: {
   mfaSettings?: MfaSettings;
+  interactionEvent?: InteractionEvent;
   user?: Partial<User>;
   currentProfile?: Record<string, unknown>;
 } = {}) => {
   const getIdentifiedUser = jest.fn(async () => user as User);
   const interactionContext: InteractionContext = {
-    getInteractionEvent: () => InteractionEvent.SignIn,
+    getInteractionEvent: () => interactionEvent,
     getIdentifiedUser,
     getVerificationRecordById: () => {
       throw new Error('should not be called');
@@ -166,6 +169,31 @@ describe('Mfa.assertMfaFulfilled', () => {
         availableFactors: [MfaFactor.TOTP],
       },
     });
+  });
+
+  it('skips additional MFA suggestion when user has persisted skipped flag', async () => {
+    const mandatoryMfaSettings: MfaSettings = {
+      policy: MfaPolicy.Mandatory,
+      factors: [MfaFactor.EmailVerificationCode, MfaFactor.TOTP],
+      organizationRequiredMfaPolicy: OrganizationRequiredMfaPolicy.NoPrompt,
+    };
+
+    const { mfa } = createMfa({
+      interactionEvent: InteractionEvent.Register,
+      mfaSettings: mandatoryMfaSettings,
+      user: {
+        id: 'user-id',
+        logtoConfig: {
+          [userMfaDataKey]: {
+            additionalBindingSuggestionSkipped: true,
+          },
+        },
+        primaryEmail: 'foo@example.com',
+        mfaVerifications: [],
+      },
+    });
+
+    await expect(mfa.assertMfaFulfilled()).resolves.toBeUndefined();
   });
 });
 

--- a/packages/core/src/routes/experience/classes/mfa.ts
+++ b/packages/core/src/routes/experience/classes/mfa.ts
@@ -50,8 +50,8 @@ export type MfaData = {
   mfaEnabled?: boolean;
   mfaSkipped?: boolean;
   /**
-   * Whether user skipped the optional suggestion to add another MFA factor during registration.
-   * This flag lives only in the current interaction and should NOT be persisted to user profile.
+   * Whether user skipped the optional suggestion to add another MFA factor.
+   * This value is persisted to user profile and can be overridden in current interaction.
    */
   additionalBindingSuggestionSkipped?: boolean;
   passkeySkipped?: boolean;
@@ -88,7 +88,9 @@ export const sanitizedMfaDataGuard = z.object({
   backupCode: bindBackupCodeGuard.pick({ type: true }).optional(),
 }) satisfies ToZodObject<SanitizedMfaData>;
 
-const parseUserMfaData = (logtoConfig: JsonObject): { enabled?: boolean; skipped?: boolean } => {
+const parseUserMfaData = (
+  logtoConfig: JsonObject
+): { enabled?: boolean; skipped?: boolean; additionalBindingSuggestionSkipped?: boolean } => {
   const parsed = z.object({ [userMfaDataKey]: userMfaDataGuard }).safeParse(logtoConfig);
   return parsed.success ? parsed.data[userMfaDataKey] : {};
 };
@@ -98,6 +100,10 @@ const parseUserMfaData = (logtoConfig: JsonObject): { enabled?: boolean; skipped
  */
 const isMfaSkipped = (logtoConfig: JsonObject): boolean => {
   return parseUserMfaData(logtoConfig).skipped === true;
+};
+
+const isAdditionalBindingSuggestionSkipped = (logtoConfig: JsonObject): boolean => {
+  return parseUserMfaData(logtoConfig).additionalBindingSuggestionSkipped === true;
 };
 
 const isPasskeySkipped = (logtoConfig: JsonObject): boolean => {
@@ -205,6 +211,7 @@ export class Mfa {
     return {
       mfaEnabled: this.mfaEnabled,
       mfaSkipped: this.mfaSkipped,
+      additionalBindingSuggestionSkipped: this.additionalBindingSuggestionSkipped,
       passkeySkipped: this.#passkeySkipped,
       mfaVerifications: [...verificationSet],
     };
@@ -331,8 +338,7 @@ export class Mfa {
   }
 
   /**
-   * Mark the optional suggestion as skipped for this interaction.
-   * No persistence to user account.
+   * Mark the optional suggestion as skipped and persist to user config.
    */
   skipAdditionalBindingSuggestion() {
     this.#additionalBindingSuggestionSkipped = true;
@@ -526,7 +532,7 @@ export class Mfa {
     );
 
     // Optional suggestion: Let Mfa decide whether to suggest additional binding during registration
-    await this.guardAdditionalBindingSuggestion(factorsInUser, configuredFactors);
+    await this.guardAdditionalBindingSuggestion(factorsInUser, configuredFactors, identifiedUser);
 
     // Assert backup code
     assertThat(
@@ -548,9 +554,10 @@ export class Mfa {
   // eslint-disable-next-line complexity
   private async guardAdditionalBindingSuggestion(
     factorsInUser: MfaFactor[],
-    availableFactors: MfaFactor[]
+    availableFactors: MfaFactor[],
+    identifiedUser: User
   ) {
-    // Respect user's choice to skip suggestion for this interaction
+    // Respect user's choice to skip suggestion for this interaction.
     if (this.additionalBindingSuggestionSkipped) {
       return;
     }
@@ -559,6 +566,13 @@ export class Mfa {
       !EnvSet.values.isDevFeaturesEnabled &&
       this.interactionContext.getInteractionEvent() !== InteractionEvent.Register
     ) {
+      return;
+    }
+
+    const { logtoConfig, primaryEmail, primaryPhone } = identifiedUser;
+
+    // Respect user's persisted choice to skip additional MFA suggestion.
+    if (isAdditionalBindingSuggestionSkipped(logtoConfig)) {
       return;
     }
 
@@ -604,8 +618,6 @@ export class Mfa {
     ) {
       return;
     }
-
-    const { primaryEmail, primaryPhone } = await this.interactionContext.getIdentifiedUser();
 
     // Build masked identifiers for bound factors
     const maskedIdentifiers = condObject({

--- a/packages/core/src/routes/experience/profile-routes.ts
+++ b/packages/core/src/routes/experience/profile-routes.ts
@@ -204,7 +204,7 @@ export default function interactionProfileRoutes<T extends ExperienceInteraction
     }
   );
 
-  // Mark optional additional MFA binding suggestion as skipped in current interaction
+  // Mark optional additional MFA binding suggestion as skipped.
   router.post(
     `${experienceRoutes.mfa}/mfa-suggestion-skipped`,
     koaGuard({ status: [204, 400, 404] }),

--- a/packages/core/src/routes/experience/types.ts
+++ b/packages/core/src/routes/experience/types.ts
@@ -248,6 +248,7 @@ export const webAuthnAuthenticationOptionsInteractionStorageGuard = z.object({
 export type UserMfaVerificationsData = {
   mfaEnabled?: boolean;
   mfaSkipped?: boolean;
+  additionalBindingSuggestionSkipped?: boolean;
   passkeySkipped?: boolean;
   mfaVerifications: User['mfaVerifications'];
 };

--- a/packages/schemas/src/types/user-logto-config.ts
+++ b/packages/schemas/src/types/user-logto-config.ts
@@ -28,6 +28,10 @@ export const userMfaDataGuard = z.object({
    */
   skipped: z.boolean().optional(),
   /**
+   * Whether the user has skipped optional additional MFA binding suggestion
+   */
+  additionalBindingSuggestionSkipped: z.boolean().optional(),
+  /**
    * Whether the user has skipped MFA verification on sign-in
    *
    * Users can manually disable MFA verification requirement for sign-in,


### PR DESCRIPTION
## Summary
This PR builds on the previous MFA config merge fix and completes persistence support for optional additional MFA suggestion skip status.

- Persist `additionalBindingSuggestionSkipped` to `user.logto_config.mfa`.
- Respect persisted `additionalBindingSuggestionSkipped` in MFA suggestion flow, so users who skip once are not prompted again unexpectedly.
- Update related schema/types and route comments to align with the persisted behavior.
- Add/adjust unit tests for:
  - persisting `additionalBindingSuggestionSkipped`,
  - honoring persisted skip status in MFA fulfillment logic.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments