### PR TITLE
fix(schemas): add sign-in passkey interaction log key

### DIFF
--- a/packages/core/src/routes/experience/profile-routes.ts
+++ b/packages/core/src/routes/experience/profile-routes.ts
@@ -251,7 +251,7 @@ export default function interactionProfileRoutes<T extends ExperienceInteraction
       const { verificationId } = guard.body;
 
       const log = ctx.createLog(
-        `Interaction.${experienceInteraction.interactionEvent}.BindMfa.${MfaFactor.WebAuthn}.Submit`
+        `Interaction.${experienceInteraction.interactionEvent}.SignInPasskey.Submit`
       );
 
       log.append({

--- a/packages/schemas/src/types/log/interaction.ts
+++ b/packages/schemas/src/types/log/interaction.ts
@@ -12,9 +12,11 @@ export enum Field {
   Identifier = 'Identifier',
   Profile = 'Profile',
   BindMfa = 'BindMfa',
+  /** @deprecated */
   Mfa = 'Mfa',
   Verification = 'Verification',
   Captcha = 'Captcha',
+  SignInPasskey = 'SignInPasskey',
 }
 
 /** Method to verify the identifier */
@@ -108,6 +110,7 @@ export type LogKey =
   | `${Prefix}.${InteractionEvent}.${Action.Create | Action.Update | Action.Submit}`
   | `${Prefix}.${InteractionEvent}.${Field.Profile}.${Action.Update}`
   | `${Prefix}.${InteractionEvent}.${Field.BindMfa}.${MfaFactor}.${Action.Submit}`
+  | `${Prefix}.${InteractionEvent}.${Field.SignInPasskey}.${Action.Submit}`
   | `${Prefix}.${InteractionEvent}.${Field.Verification}.${VerificationType}.${Action}`
   | `${Prefix}.${InteractionEvent}.${Field.Identifier}.${Action.Submit}`
   // IdpInitiatedSingleSignOn log, used upon receiving a SAML request from the IdP


### PR DESCRIPTION
## Summary
- Add `SignInPasskey` to interaction log `Field` enum.
- Mark legacy `Mfa` field as deprecated.
- Add `Interaction.${InteractionEvent}.SignInPasskey.Submit` to interaction log key union.

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments