### PR TITLE
refactor(core): remove duplicate getIdTokenConfig from library

### DIFF
--- a/packages/core/src/libraries/logto-config.ts
+++ b/packages/core/src/libraries/logto-config.ts
@@ -8,7 +8,6 @@ import {
   LogtoConfigs,
   LogtoJwtTokenKey,
   LogtoOidcConfigKey,
-  LogtoTenantConfigKey,
   cloudApiIndicator,
   cloudConnectionDataGuard,
   idTokenConfigGuard,
@@ -137,16 +136,6 @@ export const createLogtoConfigLibrary = ({
     return updatedRow.value;
   };
 
-  const getIdTokenConfig = async () => {
-    const { rows } = await getRowsByKeys([LogtoTenantConfigKey.IdToken]);
-
-    if (rows.length === 0) {
-      return;
-    }
-
-    return idTokenConfigGuard.parse(rows[0]?.value);
-  };
-
   const upsertIdTokenConfig = async (idTokenConfig: IdTokenConfig) => {
     const { value } = await queryUpsertIdTokenConfig(idTokenConfig);
     return idTokenConfigGuard.parse(value);
@@ -159,7 +148,6 @@ export const createLogtoConfigLibrary = ({
     getJwtCustomizer,
     getJwtCustomizers,
     updateJwtCustomizer,
-    getIdTokenConfig,
     upsertIdTokenConfig,
   };
 };

--- a/packages/core/src/routes/logto-config/id-token.ts
+++ b/packages/core/src/routes/logto-config/id-token.ts
@@ -7,7 +7,7 @@ import { koaQuotaGuard } from '#src/middleware/koa-quota-guard.js';
 import type { ManagementApiRouter, RouterInitArgs } from '../types.js';
 
 export default function idTokenRoutes<T extends ManagementApiRouter>(
-  ...[router, { logtoConfigs, libraries }]: RouterInitArgs<T>
+  ...[router, { logtoConfigs, libraries, queries }]: RouterInitArgs<T>
 ) {
   router.get(
     '/configs/id-token',
@@ -16,7 +16,7 @@ export default function idTokenRoutes<T extends ManagementApiRouter>(
       status: [200, 404],
     }),
     async (ctx, next) => {
-      const config = await logtoConfigs.getIdTokenConfig();
+      const config = await queries.logtoConfigs.getIdTokenConfig();
 
       if (!config) {
         throw new RequestError({ code: 'entity.not_found', status: 404 });

--- a/packages/core/src/test-utils/mock-libraries.ts
+++ b/packages/core/src/test-utils/mock-libraries.ts
@@ -14,7 +14,6 @@ export const mockLogtoConfigsLibrary: jest.Mocked<LogtoConfigLibrary> = {
   getJwtCustomizer: jest.fn(),
   getJwtCustomizers: jest.fn(),
   updateJwtCustomizer: jest.fn(),
-  getIdTokenConfig: jest.fn(),
   upsertIdTokenConfig: jest.fn(),
 };
 


### PR DESCRIPTION
## Summary

The `getIdTokenConfig` in library was a duplicate of the query layer version, but without `wellKnownCache` memoization. Removed it and updated the route to use the cached query version directly.

## Testing

Test locally.

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments