### PR TITLE
refactor(core): use precise return type for logto config queries

### DIFF
--- a/packages/core/src/queries/logto-config.ts
+++ b/packages/core/src/queries/logto-config.ts
@@ -26,13 +26,13 @@ export const createLogtoConfigQueries = (
   wellKnownCache: WellKnownCache
 ) => {
   const getAdminConsoleConfig = async () =>
-    pool.one<Record<string, unknown>>(sql`
+    pool.one<{ value: unknown }>(sql`
       select ${fields.value} from ${table}
       where ${fields.key} = ${LogtoTenantConfigKey.AdminConsole}
     `);
 
   const updateAdminConsoleConfig = async (value: Partial<AdminConsoleData>) =>
-    pool.one<Record<string, unknown>>(sql`
+    pool.one<{ value: unknown }>(sql`
       update ${table}
       set ${fields.value} = coalesce(${fields.value},'{}'::jsonb) || ${sql.jsonb(value)}
       where ${fields.key} = ${LogtoTenantConfigKey.AdminConsole}
@@ -40,7 +40,7 @@ export const createLogtoConfigQueries = (
     `);
 
   const getCloudConnectionData = async () =>
-    pool.one<Record<string, unknown>>(sql`
+    pool.one<{ value: unknown }>(sql`
       select ${fields.value} from ${table}
       where ${fields.key} = ${LogtoTenantConfigKey.CloudConnection}
     `);
@@ -100,7 +100,7 @@ export const createLogtoConfigQueries = (
 
   const upsertIdTokenConfig = wellKnownCache.mutate(
     async (value: IdTokenConfig) =>
-      pool.one<Record<string, unknown>>(sql`
+      pool.one<{ value: unknown }>(sql`
         insert into ${table} (${fields.key}, ${fields.value})
           values (${LogtoTenantConfigKey.IdToken}, ${sql.jsonb(value)})
           on conflict (${fields.tenantId}, ${fields.key}) do update set ${fields.value} = ${sql.jsonb(value)}


### PR DESCRIPTION
## Summary

Replace `Record<string, unknown>` with `{ value: unknown }` for config query return types (`getAdminConsoleConfig`, `updateAdminConsoleConfig`, `getCloudConnectionData`, `upsertIdTokenConfig`), since these queries only select/return the `value` column.

## Testing

N/A

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments