### PR TITLE
fix(core): set default mfa.enabled to false for newly registered users

### DIFF
--- a/packages/core/src/routes/experience/classes/experience-interaction.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.test.ts
@@ -207,6 +207,9 @@ describe('ExperienceInteraction class', () => {
         {
           id: 'uid',
           primaryEmail: mockEmail,
+          logtoConfig: {
+            mfa: { enabled: false },
+          },
         },
         { isInteractive: true, roleNames: ['user', 'default:admin'] }
       );

--- a/packages/core/src/routes/experience/classes/helpers.ts
+++ b/packages/core/src/routes/experience/classes/helpers.ts
@@ -335,7 +335,7 @@ export const parseMfaPropertiesToUserConfig = (
       ...userMfaData,
       // Force cast optional value to boolean since the `enabled` field is newly introduced and legacy users may NOT have this field
       // in their config. The absence of `enabled` field will be treated as MFA not enabled after the next sign-in attempt.
-      ...conditional(userMfaData?.enabled === undefined && { enabled: mfaEnabled === true }),
+      ...conditional(mfaEnabled !== undefined && { enabled: mfaEnabled }),
       // For users who have explicitly skipped MFA, set `skipped` to true to persist the skipped status.
       ...conditional(mfaSkipped && { skipped: true }),
       // Persist optional additional MFA suggestion skipped status when user explicitly skips it.

--- a/packages/core/src/routes/experience/classes/libraries/provision-library.ts
+++ b/packages/core/src/routes/experience/classes/libraries/provision-library.ts
@@ -11,6 +11,7 @@ import {
   OrganizationInvitationStatus,
   SignInMode,
   TenantRole,
+  userMfaDataKey,
   userOnboardingDataKey,
   type User,
   type UserOnboardingData,
@@ -80,6 +81,9 @@ export class ProvisionLibrary {
         ...rest,
         ...conditional(socialIdentity && { identities: toUserSocialIdentityData(socialIdentity) }),
         ...conditional(customData && { customData }),
+        logtoConfig: {
+          [userMfaDataKey]: { enabled: false },
+        },
       },
       { roleNames: initialUserRoles, isInteractive: true }
     );

--- a/packages/integration-tests/src/helpers/sign-in-experience.ts
+++ b/packages/integration-tests/src/helpers/sign-in-experience.ts
@@ -212,6 +212,11 @@ export const enableMandatoryMfaWithWebAuthnAndBackupCode = async () =>
 export const resetMfaSettings = async () =>
   updateSignInExperience({ mfa: { policy: MfaPolicy.PromptAtSignInAndSignUp, factors: [] } });
 
+export const resetPasskeySignInSettings = async () =>
+  updateSignInExperience({
+    passkeySignIn: { enabled: false, showPasskeyButton: false, allowAutofill: false },
+  });
+
 /** Enable only username and password sign-in and sign-up. */
 export const setUsernamePasswordOnly = async () => {
   await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);

--- a/packages/integration-tests/src/tests/api/account/mfa-settings.test.ts
+++ b/packages/integration-tests/src/tests/api/account/mfa-settings.test.ts
@@ -202,7 +202,7 @@ describe('my-account (mfa-settings)', () => {
 
       const response = await updateMyLogtoConfig(api, { mfa: { skipped: true } });
       expect(response).toEqual({
-        mfa: { skipped: true, skipMfaOnSignIn: false, enabled: false },
+        mfa: { skipped: true, skipMfaOnSignIn: false },
         passkeySignIn: { skipped: false },
       });
 
@@ -211,7 +211,7 @@ describe('my-account (mfa-settings)', () => {
 
       const response2 = await updateMyLogtoConfig(api, { mfa: { skipped: false } });
       expect(response2).toEqual({
-        mfa: { skipped: false, skipMfaOnSignIn: false, enabled: false },
+        mfa: { skipped: false, skipMfaOnSignIn: false },
         passkeySignIn: { skipped: false },
       });
 

--- a/packages/integration-tests/src/tests/api/experience-api/bind-mfa/happpy-path.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/bind-mfa/happpy-path.test.ts
@@ -138,6 +138,26 @@ describe('Bind MFA APIs happy path', () => {
       await enableUserControlledMfaWithTotp();
     });
 
+    it('should persist mfa.enabled as false by default right after identification during register', async () => {
+      const { username, password } = generateNewUserProfile({ username: true, password: true });
+
+      const client = await initExperienceClient({
+        interactionEvent: InteractionEvent.Register,
+      });
+
+      await client.updateProfile({ type: SignInIdentifier.Username, value: username });
+      await client.updateProfile({ type: 'password', value: password });
+      await client.identifyUser();
+
+      const { userId } = await client.getInteractionData();
+      expect(userId).toBeDefined();
+
+      const config = await getUserLogtoConfig(userId!);
+      expect(config.mfa.enabled).toBe(false);
+
+      await deleteUser(userId!);
+    });
+
     it('should able to skip MFA binding on register', async () => {
       const { username, password } = generateNewUserProfile({ username: true, password: true });
       const client = await initExperienceClient({

--- a/packages/integration-tests/src/tests/experience/mfa/webauthn/index.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/webauthn/index.test.ts
@@ -16,6 +16,7 @@ import { signInWithEnterpriseSso } from '#src/helpers/experience/index.js';
 import {
   enableMandatoryMfaWithWebAuthn,
   resetMfaSettings,
+  resetPasskeySignInSettings,
 } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
 import ExpectWebAuthnExperience from '#src/ui-helpers/expect-webauthn-experience.js';
@@ -104,7 +105,7 @@ describe('MFA - WebAuthn', () => {
   });
 });
 
-devFeatureTest.describe('MFA - Passkey sign-in should skip MFA verification', () => {
+devFeatureTest.describe('Passkey sign-in', () => {
   beforeAll(async () => {
     await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms, ConnectorType.Social]);
     // Enable mandatory MFA with WebAuthn so passkey is registered during registration
@@ -131,14 +132,53 @@ devFeatureTest.describe('MFA - Passkey sign-in should skip MFA verification', ()
 
   afterAll(async () => {
     await resetMfaSettings();
-    // Reset passkey sign-in settings
+    await resetPasskeySignInSettings();
+  });
+
+  it('should prompt enable MFA if new registered user has no MFA but has bound sign-in passkey', async () => {
     await updateSignInExperience({
+      mfa: {
+        factors: [MfaFactor.WebAuthn, MfaFactor.TOTP],
+        policy: MfaPolicy.PromptAtSignInAndSignUp,
+      },
       passkeySignIn: {
-        enabled: false,
-        showPasskeyButton: false,
+        enabled: true,
+        showPasskeyButton: true,
         allowAutofill: false,
       },
     });
+
+    const username = generateUsername();
+    const password = 'l0gt0_T3st_P@ssw0rd';
+
+    const experience = new ExpectWebAuthnExperience(await browser.newPage());
+    await experience.setupVirtualAuthenticator();
+
+    // Register with username and password
+    await experience.startWith(demoAppUrl, 'register');
+    await experience.toFillInput('identifier', username, { submit: true });
+    experience.toBeAt('register/password');
+    await experience.toFillNewPasswords(password);
+
+    // Bind a sign-in passkey during registration
+    await experience.waitForPathname('create-passkey');
+    await experience.toClickButton('Create a passkey');
+
+    // After passkey is created, user should be prompted to enable MFA since the user has no MFA factor bound but has a sign-in passkey
+    await experience.waitForPathname('mfa-onboarding');
+    await experience.toClick('button', 'Enable 2-step verification');
+
+    // SKip enabling MFA
+    await experience.toClick('div[role=button][class$=skipButton]');
+
+    await experience.page.waitForNetworkIdle();
+    const userId = await experience.getUserIdFromDemoAppPage();
+    await experience.clearVirtualAuthenticator();
+    await experience.verifyThenEnd();
+
+    await enableMandatoryMfaWithWebAuthn();
+    await resetPasskeySignInSettings();
+    await deleteUser(userId);
   });
 
   it('should sign in with passkey and skip MFA verification even when mandatory TOTP MFA is enabled', async () => {


### PR DESCRIPTION
## Summary

### What's changed?

- Ensure newly registered users have `user.logto_config.mfa.enabled` initialized to `false` instead of `undefined`.
- Update MFA property parsing to persist explicit `mfa.enabled` values from interaction state.

### Test updates:

- Add integration coverage for the register identification stage to verify `mfa.enabled` defaults to `false`.
- Adjust passkey sign-in MFA experience tests to align with the new default behavior.

## Testing
Integration tests

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments