### PR TITLE
fix(phrases): remove redundant word in MFA copy

### DIFF
--- a/packages/phrases-experience/src/locales/en/mfa.ts
+++ b/packages/phrases-experience/src/locales/en/mfa.ts
@@ -25,7 +25,7 @@ const mfa = {
   add_mfa_factors: 'Add 2-step verification',
   add_mfa_description:
     'Two-factor verification is enabled. Select your second verification method for secure sign-in.',
-  add_another_mfa_factor: 'Add another one 2-step verification',
+  add_another_mfa_factor: 'Add another 2-step verification',
   add_another_mfa_description:
     'Select another way to add for verifying your identity when sign-in.',
   verify_mfa_factors: '2-step verification',


### PR DESCRIPTION
## Summary
Fix the English MFA copy for `add_another_mfa_factor` by removing the redundant word "one" to improve grammar and readability.

## Testing
Tested locally

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
