### PR TITLE
fix: add --if-present to husky pre-commit script

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,3 @@
 # Keep concurrency 1 to avoid lint-staged issue
 # Which may cause ALL your work LOST WITHOUT STASH
-FORCE_COLOR=1 pnpm -r --workspace-concurrency 1 --filter "[HEAD]" precommit
+FORCE_COLOR=1 pnpm -r --workspace-concurrency 1 --filter "[HEAD]" --if-present precommit


### PR DESCRIPTION
## Summary

Add `--if-present` flag to the husky pre-commit script to prevent the hook from failing when no matching packages have a `precommit` script.

## Testing

N/A

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments