### PR TITLE
fix(console): show auth flow selector for third-party native app creation

### DIFF
--- a/packages/console/src/components/ApplicationCreation/CreateForm/index.tsx
+++ b/packages/console/src/components/ApplicationCreation/CreateForm/index.tsx
@@ -341,9 +341,11 @@ function CreateForm({
               />
             </FormField>
             {/* DEV: Device flow authorization flow selector */}
-            {isDevFeaturesEnabled && applicationType === ApplicationType.Native && (
-              <AuthorizationFlowSelector />
-            )}
+            {isDevFeaturesEnabled &&
+              applicationType === ApplicationType.Native &&
+              (!defaultCreateFrameworkName || isDefaultCreateThirdParty) && (
+                <AuthorizationFlowSelector />
+              )}
             {defaultCreateType && <input hidden {...register('type')} value={defaultCreateType} />}
           </form>
         </FormProvider>


### PR DESCRIPTION
## Summary

The authorization flow selector (Authorization Code vs Device Flow) was not showing when creating a third-party native app, while it was visible for first-party native apps.

**Root cause:** The `AuthorizationFlowSelector` component had a `!defaultCreateFrameworkName` condition that prevented it from rendering when a guide was selected. Since creating a third-party native app always goes through the `third-party-oidc-native` guide, `defaultCreateFrameworkName` was always set, hiding the selector.

**Fix:** Added `isDefaultCreateThirdParty` as an additional condition to show the selector. Now the auth flow selector shows when there's no framework guide selected (direct creation) OR when creating a third-party native app. The `isDevFeaturesEnabled` guard is kept.

## Testing

Tested locally

<img width="753" height="638" alt="image" src="https://github.com/user-attachments/assets/10bbb5f5-9199-4f07-be8f-d46395a2d865" />


## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments