### PR TITLE
chore(core): remove stale SAML OpenAPI gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,3 @@ dump.rdb
 
 # console auto generated files
 /packages/console/src/consts/jwt-customizer-type-definition.ts
-
-# Temporarily ignore SAML OpenAPI spec file (will be needed later)
-packages/core/src/saml-applications/routes/index.openapi.json


### PR DESCRIPTION
## Summary
Remove the stale `.gitignore` entry for `packages/core/src/saml-applications/routes/index.openapi.json`. That old spec path is no longer used because the OpenAPI file has moved to [index.openapi.json](packages/core/src/routes/saml-application/index.openapi.json).

## Testing
N/A

## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
