### PR TITLE
fix: use color token for link color in dark mode

### DIFF
--- a/packages/device-demo-app/src/App.module.scss
+++ b/packages/device-demo-app/src/App.module.scss
@@ -87,7 +87,7 @@
 }
 
 .verificationLink {
-  color: #5d34f2;
+  color: var(--color-text-link);
   text-decoration: none;
   word-break: break-all;
 
@@ -318,7 +318,7 @@
 
 .openDevPanel {
   margin-top: _.unit(6);
-  color: #5d34f2;
+  color: var(--color-text-link);
   font-size: 14px;
   cursor: pointer;
   background: none;


### PR DESCRIPTION
## Summary
- Replace hardcoded `#5d34f2` with `var(--color-text-link)` in `.verificationLink` and `.openDevPanel` so link colors adapt correctly in dark mode.

LOG-13092