### PR TITLE
feat(console): show device flow tag in application list subtitle

### DIFF
--- a/packages/console/src/components/ItemPreview/ApplicationPreview.tsx
+++ b/packages/console/src/components/ItemPreview/ApplicationPreview.tsx
@@ -2,6 +2,7 @@ import { type Application } from '@logto/schemas';
 import { useTranslation } from 'react-i18next';
 
 import ApplicationIcon from '@/components/ApplicationIcon';
+import { isDevFeaturesEnabled } from '@/consts/env';
 import { applicationTypeI18nKey } from '@/types/applications';
 
 import ItemPreview from '.';
@@ -22,10 +23,18 @@ function ApplicationPreview({
 }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
+  const isDeviceFlow = isDevFeaturesEnabled && customClientMetadata.isDeviceFlow;
+  const subtitle = [
+    t(`${applicationTypeI18nKey[type]}.title`),
+    isDeviceFlow && t('application_details.device_flow_tag'),
+  ]
+    .filter(Boolean)
+    .join(' | ');
+
   return (
     <ItemPreview
       title={name}
-      subtitle={t(`${applicationTypeI18nKey[type]}.title`)}
+      subtitle={subtitle}
       icon={
         <ApplicationIcon
           className={styles.icon}


### PR DESCRIPTION
## Summary

Show a "Device flow" tag in the application list subtitle for native device flow apps, displaying as "Native App | Device flow" to help distinguish them from regular native apps. This applies to both "My applications" and "Third-party applications" tabs.

## Testing

Tested locally

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments