### PR TITLE
feat(schemas,core): add maxAllowedGrants to app customClientMetadata

### DIFF
--- a/packages/core/src/oidc/utils.test.ts
+++ b/packages/core/src/oidc/utils.test.ts
@@ -158,22 +158,22 @@ describe('validateMetadata', () => {
     });
   });
 
-  describe('maxAllowedSessions', () => {
+  describe('maxAllowedGrants', () => {
     it('should not throw when it is a positive integer', () => {
       expect(() => {
-        validateCustomClientMetadata('maxAllowedSessions', 3);
+        validateCustomClientMetadata('maxAllowedGrants', 3);
       }).not.toThrow();
     });
 
     it('should throw when it is not an integer', () => {
       expect(() => {
-        validateCustomClientMetadata('maxAllowedSessions', 3.2);
+        validateCustomClientMetadata('maxAllowedGrants', 3.2);
       }).toThrow();
     });
 
     it('should throw when it is not a positive integer', () => {
       expect(() => {
-        validateCustomClientMetadata('maxAllowedSessions', 0);
+        validateCustomClientMetadata('maxAllowedGrants', 0);
       }).toThrow();
     });
   });

--- a/packages/core/src/routes/applications/application.ts
+++ b/packages/core/src/routes/applications/application.ts
@@ -190,7 +190,7 @@ export default function applicationRoutes<T extends ManagementApiRouter>(
 
       if (
         !EnvSet.values.isDevFeaturesEnabled &&
-        rest.customClientMetadata?.maxAllowedSessions !== undefined
+        rest.customClientMetadata?.maxAllowedGrants !== undefined
       ) {
         throw new RequestError('request.invalid_input');
       }
@@ -340,7 +340,7 @@ export default function applicationRoutes<T extends ManagementApiRouter>(
 
       if (
         !EnvSet.values.isDevFeaturesEnabled &&
-        rest.customClientMetadata?.maxAllowedSessions !== undefined
+        rest.customClientMetadata?.maxAllowedGrants !== undefined
       ) {
         throw new RequestError('request.invalid_input');
       }

--- a/packages/integration-tests/src/tests/api/application/application.max-allowed-grants.test.ts
+++ b/packages/integration-tests/src/tests/api/application/application.max-allowed-grants.test.ts
@@ -8,40 +8,40 @@ import {
 } from '#src/api/index.js';
 import { devFeatureTest, generateTestName } from '#src/utils.js';
 
-devFeatureTest.describe('application maxAllowedSessions', () => {
-  devFeatureTest.it('should create application with maxAllowedSessions and get it', async () => {
+devFeatureTest.describe('application maxAllowedGrants', () => {
+  devFeatureTest.it('should create application with maxAllowedGrants and get it', async () => {
     const application = await createApplication(generateTestName(), ApplicationType.Traditional, {
-      customClientMetadata: { maxAllowedSessions: 2 },
+      customClientMetadata: { maxAllowedGrants: 2 },
     });
 
     try {
-      expect(application.customClientMetadata.maxAllowedSessions).toBe(2);
+      expect(application.customClientMetadata.maxAllowedGrants).toBe(2);
 
       const fetched = await getApplication(application.id);
-      expect(fetched.customClientMetadata.maxAllowedSessions).toBe(2);
+      expect(fetched.customClientMetadata.maxAllowedGrants).toBe(2);
     } finally {
       await deleteApplication(application.id);
     }
   });
 
-  devFeatureTest.it('should update maxAllowedSessions and get updated value', async () => {
+  devFeatureTest.it('should update maxAllowedGrants and get updated value', async () => {
     const application = await createApplication(generateTestName(), ApplicationType.Traditional);
 
     try {
       await updateApplication(application.id, {
-        customClientMetadata: { maxAllowedSessions: 5 },
+        customClientMetadata: { maxAllowedGrants: 5 },
       });
 
       const fetched = await getApplication(application.id);
-      expect(fetched.customClientMetadata.maxAllowedSessions).toBe(5);
+      expect(fetched.customClientMetadata.maxAllowedGrants).toBe(5);
     } finally {
       await deleteApplication(application.id);
     }
   });
 
-  devFeatureTest.it('should remove maxAllowedSessions after update without the field', async () => {
+  devFeatureTest.it('should remove maxAllowedGrants after update without the field', async () => {
     const application = await createApplication(generateTestName(), ApplicationType.Traditional, {
-      customClientMetadata: { maxAllowedSessions: 4 },
+      customClientMetadata: { maxAllowedGrants: 4 },
     });
 
     try {
@@ -50,7 +50,7 @@ devFeatureTest.describe('application maxAllowedSessions', () => {
       });
 
       const fetched = await getApplication(application.id);
-      expect(fetched.customClientMetadata.maxAllowedSessions).toBeUndefined();
+      expect(fetched.customClientMetadata.maxAllowedGrants).toBeUndefined();
     } finally {
       await deleteApplication(application.id);
     }

--- a/packages/schemas/src/foundations/jsonb-types/oidc-module.ts
+++ b/packages/schemas/src/foundations/jsonb-types/oidc-module.ts
@@ -101,7 +101,7 @@ export enum CustomClientMetadataKey {
    *
    * When exceeded, old sessions should be revoked according to server policy.
    */
-  MaxAllowedSessions = 'maxAllowedSessions',
+  MaxAllowedGrants = 'maxAllowedGrants',
 }
 
 export const customClientMetadataGuard = z.object({
@@ -114,7 +114,7 @@ export const customClientMetadataGuard = z.object({
   [CustomClientMetadataKey.RotateRefreshToken]: z.boolean().optional(),
   [CustomClientMetadataKey.AllowTokenExchange]: z.boolean().optional(),
   [CustomClientMetadataKey.IsDeviceFlow]: z.boolean().optional(),
-  [CustomClientMetadataKey.MaxAllowedSessions]: z.number().int().positive().optional(),
+  [CustomClientMetadataKey.MaxAllowedGrants]: z.number().int().positive().optional(),
 } satisfies Record<CustomClientMetadataKey, z.ZodType>);
 
 /**


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Introduced a new `maxAllowedGrants` field to the application's `customClientMetadata`.  This new field will be used to guard the maximum allowed grants (devices) of an app for a given user. 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
