### PR TITLE
feat(console): add device flow documentation links

### DIFF
--- a/packages/console/src/assets/docs/guides/native-device-flow/README.mdx
+++ b/packages/console/src/assets/docs/guides/native-device-flow/README.mdx
@@ -10,7 +10,7 @@ import CustomDomainEndpointNotice from '@/mdx-components/CustomDomainEndpointNot
   subtitle="How it works"
 >
 
-The [OAuth 2.0 device authorization grant](https://datatracker.ietf.org/doc/html/rfc8628) (device flow) is designed for devices with limited input capabilities (e.g., smart TVs, CLI tools, IoT devices). The device displays a code and a URL, while the user completes authentication on a separate device such as a phone or laptop.
+The [OAuth 2.0 device authorization grant](https://auth.wiki/device-flow) (device flow) is designed for devices with limited input capabilities (e.g., smart TVs, CLI tools, IoT devices). The device displays a code and a URL, while the user completes authentication on a separate device such as a phone or laptop.
 
 ```mermaid
 sequenceDiagram

--- a/packages/console/src/assets/docs/guides/native-device-flow/index.ts
+++ b/packages/console/src/assets/docs/guides/native-device-flow/index.ts
@@ -7,6 +7,7 @@ const metadata: Readonly<GuideMetadata> = Object.freeze({
   description:
     'Use OAuth device flow for input-limited devices or headless apps (e.g., TVs, Game console, CLI)',
   target: ApplicationType.Native,
+  fullGuide: 'device-flow',
   isDevFeature: true,
 });
 

--- a/packages/console/src/consts/external-links.ts
+++ b/packages/console/src/consts/external-links.ts
@@ -44,6 +44,7 @@ export const thirdPartyApp =
 export const protectedApp = '/integrate-logto/protected-app';
 export const protectedAppLocalDev = '/integrate-logto/protected-app#local-development';
 export const protectOriginServer = '/integrate-logto/protected-app#protect-your-origin-server';
+export const deviceFlow = '/quick-starts/device-flow';
 export const backchannelLogout = '/end-user-flows/sign-out#federated-sign-out-back-channel-logout';
 export const authFlows = '/end-user-flows#authentication-flows';
 export const termsAndPrivacy = '/end-user-flows/sign-up-and-sign-in/terms-and-privacy';

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Settings.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Settings.tsx
@@ -8,7 +8,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import ExternalLinkIcon from '@/assets/icons/external-link.svg?react';
 import FormCard from '@/components/FormCard';
 import MultiTextInputField from '@/components/MultiTextInputField';
-import { applicationDataStructure, thirdPartyApp } from '@/consts';
+import { applicationDataStructure, deviceFlow, thirdPartyApp } from '@/consts';
 import { isDevFeaturesEnabled } from '@/consts/env';
 import { AppDataContext } from '@/contexts/AppDataProvider';
 import Button from '@/ds-components/Button';
@@ -23,6 +23,7 @@ import {
 } from '@/ds-components/MultiTextInput/utils';
 import TextInput from '@/ds-components/TextInput';
 import TextLink from '@/ds-components/TextLink';
+import useDocumentationUrl from '@/hooks/use-documentation-url';
 import { isJsonObject } from '@/utils/json';
 
 import ProtectedAppSettings from './ProtectedAppSettings';
@@ -89,6 +90,7 @@ function Settings({ data }: Props) {
     formState: { errors },
   } = useFormContext<ApplicationForm>();
   const { tenantEndpoint } = useContext(AppDataContext);
+  const { getDocumentationUrl } = useDocumentationUrl();
 
   const { type: applicationType, isThirdParty, customClientMetadata } = data;
 
@@ -129,8 +131,7 @@ function Settings({ data }: Props) {
           <span>
             <Trans
               components={{
-                // TODO: Replace with actual documentation link when available
-                a: <TextLink href="" />,
+                a: <TextLink targetBlank="noopener" href={getDocumentationUrl(deviceFlow)} />,
               }}
             >
               {t('application_details.device_flow_notification')}


### PR DESCRIPTION
## Summary

Add documentation links for the device flow feature in the console:

- Add "Learn more" link in the device flow notification banner on app details settings page, pointing to the device flow quick start guide
- Add `fullGuide: 'device-flow'` to the native-device-flow guide metadata, enabling the "Complete guide" link in the guide's Further readings section
- Update the auth wiki link in the device flow guide (RFC → auth.wiki)
- Add `deviceFlow` constant to external-links

## Testing

N/A

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments