### PR TITLE
chore: remove dev feature guard for device flow

### DIFF
--- a/.changeset/beige-ladybugs-promise.md
+++ b/.changeset/beige-ladybugs-promise.md
@@ -1,0 +1,27 @@
+---
+"@logto/integration-tests": minor
+"@logto/experience": minor
+"@logto/console": minor
+"@logto/core": minor
+"@logto/phrases": minor
+"@logto/phrases-experience": minor
+"@logto/schemas": minor
+---
+
+support OAuth 2.0 Device Authorization Grant (device flow)
+
+Device flow lets users sign in on input-limited devices such as smart TVs, CLI tools, IoT gadgets, and gaming consoles by completing authentication on a separate device like a phone or laptop.
+
+How it works:
+
+1. The device displays a short user code and a verification URL.
+2. The user opens the URL on another device, enters the code, and signs in.
+3. Once approved, the original device receives tokens and completes authentication.
+
+To create a device flow application in Console:
+
+- Select "Input-limited app / CLI" under the Native framework list, or
+- Create an app without framework, then choose "Device flow" as the authorization flow, or
+- Create a third-party Native app, then choose "Device flow" as the authorization flow.
+
+The application settings page shows a device-flow-specific guide and a built-in demo you can try immediately.

--- a/packages/console/src/components/ApplicationCreation/CreateForm/index.tsx
+++ b/packages/console/src/components/ApplicationCreation/CreateForm/index.tsx
@@ -12,7 +12,7 @@ import useSWR, { useSWRConfig } from 'swr';
 import { GtagConversionId, reportToGoogle } from '@/components/Conversion/utils';
 import LearnMore from '@/components/LearnMore';
 import { pricingLink, defaultPageSize, integrateLogto, thirdPartyApp } from '@/consts';
-import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
+import { isCloud } from '@/consts/env';
 import { latestProPlanId } from '@/consts/subscriptions';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import { TenantsContext } from '@/contexts/TenantsProvider';
@@ -210,7 +210,6 @@ function CreateForm({
       );
     }
 
-    // DEV: Device flow create form description
     if (isDefaultCreateDeviceFlow) {
       return <DynamicT forKey="applications.create_device_flow_description" />;
     }
@@ -340,9 +339,7 @@ function CreateForm({
                 placeholder={t('applications.application_description_placeholder')}
               />
             </FormField>
-            {/* DEV: Device flow authorization flow selector */}
-            {isDevFeaturesEnabled &&
-              applicationType === ApplicationType.Native &&
+            {applicationType === ApplicationType.Native &&
               (!defaultCreateFrameworkName || isDefaultCreateThirdParty) && (
                 <AuthorizationFlowSelector />
               )}

--- a/packages/console/src/components/ItemPreview/ApplicationPreview.tsx
+++ b/packages/console/src/components/ItemPreview/ApplicationPreview.tsx
@@ -2,7 +2,6 @@ import { type Application } from '@logto/schemas';
 import { useTranslation } from 'react-i18next';
 
 import ApplicationIcon from '@/components/ApplicationIcon';
-import { isDevFeaturesEnabled } from '@/consts/env';
 import { applicationTypeI18nKey } from '@/types/applications';
 
 import ItemPreview from '.';
@@ -23,7 +22,7 @@ function ApplicationPreview({
 }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
-  const isDeviceFlow = isDevFeaturesEnabled && customClientMetadata.isDeviceFlow;
+  const { isDeviceFlow } = customClientMetadata;
   const subtitle = [
     t(`${applicationTypeI18nKey[type]}.title`),
     isDeviceFlow && t('application_details.device_flow_tag'),

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Settings.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Settings.tsx
@@ -9,7 +9,6 @@ import ExternalLinkIcon from '@/assets/icons/external-link.svg?react';
 import FormCard from '@/components/FormCard';
 import MultiTextInputField from '@/components/MultiTextInputField';
 import { applicationDataStructure, deviceFlow, thirdPartyApp } from '@/consts';
-import { isDevFeaturesEnabled } from '@/consts/env';
 import { AppDataContext } from '@/contexts/AppDataProvider';
 import Button from '@/ds-components/Button';
 import CodeEditor from '@/ds-components/CodeEditor';
@@ -94,8 +93,7 @@ function Settings({ data }: Props) {
 
   const { type: applicationType, isThirdParty, customClientMetadata } = data;
 
-  // DEV: Device flow
-  const isDeviceFlow = isDevFeaturesEnabled && Boolean(customClientMetadata.isDeviceFlow);
+  const isDeviceFlow = Boolean(customClientMetadata.isDeviceFlow);
   const isProtectedApp = applicationType === ApplicationType.Protected;
   const redirectUriValidator = createRedirectUriValidator(applicationType);
   const uriPatternRules: MultiTextInputRule = {
@@ -124,7 +122,6 @@ function Settings({ data }: Props) {
       description={`application_details.${isThirdParty ? 'third_party_' : ''}settings_description`}
       learnMoreLink={{ href: isThirdParty ? thirdPartyApp : applicationDataStructure }}
     >
-      {/* DEV: Device flow notification banner */}
       {isDeviceFlow && (
         <div className={styles.deviceFlowBanner}>
           <span className={styles.deviceFlowEmoji}>🎉</span>

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/index.tsx
@@ -20,7 +20,6 @@ import EmptyDataPlaceholder from '@/components/EmptyDataPlaceholder';
 import OrganizationList from '@/components/OrganizationList';
 import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
 import { ApplicationDetailsTabs, logtoThirdPartyGuideLink, protectedApp } from '@/consts';
-import { isDevFeaturesEnabled } from '@/consts/env';
 import DeleteConfirmModal from '@/ds-components/DeleteConfirmModal';
 import TabNav, { TabNavItem } from '@/ds-components/TabNav';
 import TabWrapper from '@/ds-components/TabWrapper';
@@ -135,10 +134,7 @@ function ApplicationDetailsContent({ data, secrets, oidcConfig, onApplicationUpd
         primaryTag={condArray(
           data.isThirdParty && t(`${applicationTypeI18nKey.thirdParty}.title`),
           t(`${applicationTypeI18nKey[data.type]}.title`),
-          // DEV: Show device flow tag
-          isDevFeaturesEnabled &&
-            data.customClientMetadata.isDeviceFlow &&
-            t('application_details.device_flow_tag')
+          data.customClientMetadata.isDeviceFlow && t('application_details.device_flow_tag')
         )}
         identifier={{ name: 'App ID', value: data.id }}
         additionalActionButton={{

--- a/packages/core/src/oidc/device-flow.ts
+++ b/packages/core/src/oidc/device-flow.ts
@@ -1,8 +1,6 @@
 import { deviceFlowXsrfCookieKey, experience, logtoCookieKey } from '@logto/schemas';
 import type { KoaContextWithOIDC, errors } from 'oidc-provider';
 
-import { EnvSet } from '#src/env-set/index.js';
-
 import {
   appendSharedExperienceSearchParams,
   buildSharedExperienceCookie,
@@ -134,7 +132,7 @@ export const buildDeviceFlowSuccessPageUrl = (): string => `/${experience.routes
  * of Experience without inheriting login-only prompt parameters.
  */
 export const deviceFlowConfig = {
-  enabled: EnvSet.values.isDevFeaturesEnabled,
+  enabled: true,
   userCodeInputSource: async (
     ctx: KoaContextWithOIDC,
     _form: string,

--- a/packages/core/src/oidc/utils.ts
+++ b/packages/core/src/oidc/utils.ts
@@ -18,7 +18,7 @@ import {
 import { condArray, conditional, removeUndefinedKeys, trySafe } from '@silverhand/essentials';
 import { type AllClientMetadata, type ClientAuthMethod, errors } from 'oidc-provider';
 
-import { EnvSet } from '#src/env-set/index.js';
+import type { EnvSet } from '#src/env-set/index.js';
 
 /**
  * Build constant client metadata for an application based on its type and optional flags.
@@ -68,12 +68,7 @@ export const getConstantClientMetadata = (
    * `response_types` is set to an empty array on purpose to override oidc-provider's default
    * value, because device authorization does not use the `/authorize` response contract.
    */
-  // DEV: Device flow
-  if (
-    EnvSet.values.isDevFeaturesEnabled &&
-    type === ApplicationType.Native &&
-    options?.isDeviceFlow
-  ) {
+  if (type === ApplicationType.Native && options?.isDeviceFlow) {
     return {
       ...constantMetadata,
       grant_types: [GrantType.DeviceCode, GrantType.RefreshToken, ...optionalGrantTypes],

--- a/packages/experience/src/App.tsx
+++ b/packages/experience/src/App.tsx
@@ -10,7 +10,6 @@ import LoadingLayerProvider from './Providers/LoadingLayerProvider';
 import PageContextProvider from './Providers/PageContextProvider';
 import SettingsProvider from './Providers/SettingsProvider';
 import UserInteractionContextProvider from './Providers/UserInteractionContextProvider';
-import { isDevFeaturesEnabled } from './constants/env';
 import DevelopmentTenantNotification from './containers/DevelopmentTenantNotification';
 import Callback from './pages/Callback';
 import Consent from './pages/Consent';
@@ -179,15 +178,11 @@ const App = () => {
                       <Route path="consent" element={<Consent />} />
 
                       {/* Device flow */}
-                      {isDevFeaturesEnabled && (
-                        <>
-                          <Route path={experience.routes.device} element={<Device />} />
-                          <Route
-                            path={`${experience.routes.device}/success`}
-                            element={<DeviceSuccess />}
-                          />
-                        </>
-                      )}
+                      <Route path={experience.routes.device} element={<Device />} />
+                      <Route
+                        path={`${experience.routes.device}/success`}
+                        element={<DeviceSuccess />}
+                      />
 
                       {/*
                        * Identifier sign-in (first screen)

--- a/packages/integration-tests/src/tests/api/interaction/consent/device-flow.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/consent/device-flow.test.ts
@@ -15,7 +15,6 @@ import { createApplication, deleteApplication } from '#src/api/application.js';
 import { getConsentInfo } from '#src/api/interaction.js';
 import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
-import { devFeatureTest } from '#src/utils.js';
 
 type DeviceAuthorizationResponse = {
   device_code: string;
@@ -107,7 +106,7 @@ const followRedirects = async (
   return followRedirects(location, nextCookieJar, attempts - 1);
 };
 
-devFeatureTest.describe('consent api for device flow', () => {
+describe('consent api for device flow', () => {
   beforeAll(async () => {
     await enableAllPasswordSignInMethods();
   });

--- a/packages/integration-tests/src/tests/api/oidc/device-flow-shortcut.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/device-flow-shortcut.test.ts
@@ -4,7 +4,7 @@ import ky from 'ky';
 import { oidcApi } from '#src/api/api.js';
 import { createApplication, deleteApplication } from '#src/api/application.js';
 import { logtoUrl } from '#src/constants.js';
-import { devFeatureTest, randomString } from '#src/utils.js';
+import { randomString } from '#src/utils.js';
 
 type DeviceAuthorizationResponse = {
   device_code: string;
@@ -14,7 +14,7 @@ type DeviceAuthorizationResponse = {
   expires_in: number;
 };
 
-devFeatureTest.describe('device flow shortcut', () => {
+describe('device flow shortcut', () => {
   const baseApi = ky.extend({
     prefixUrl: new URL(logtoUrl),
     redirect: 'manual',


### PR DESCRIPTION
## Summary

Remove all dev feature guards for the device flow feature to make it generally available in production.

Changes across 8 files:
- `packages/core/src/oidc/device-flow.ts` - always enable device flow config
- `packages/core/src/oidc/utils.ts` - remove `isDevFeaturesEnabled` check from device flow client metadata
- `packages/console/src/components/ApplicationCreation/CreateForm/index.tsx` - always show authorization flow selector for Native apps
- `packages/console/src/components/ItemPreview/ApplicationPreview.tsx` - always show device flow tag
- `packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Settings.tsx` - always show device flow banner and hide redirect URIs for device flow apps
- `packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/index.tsx` - always show device flow tag in header
- `packages/experience/src/App.tsx` - always register device flow routes
- `packages/integration-tests/src/tests/api/oidc/device-flow-shortcut.test.ts` - use regular `describe` instead of `devFeatureTest.describe`

## Testing

N/A

## Checklist

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments