### PR TITLE
fix(schemas): mark session authorizations field optional

### DIFF
--- a/packages/console/src/pages/UserSessionDetails/index.tsx
+++ b/packages/console/src/pages/UserSessionDetails/index.tsx
@@ -97,7 +97,7 @@ function UserSessionDetails() {
     // `authorizations` is a clientId-keyed record map that stores all apps authorized by this session.
     // We use the keys of this record to get the authorized application IDs.
     const authorizedApplicationIds = sessionData
-      ? Object.keys(sessionData.payload.authorizations)
+      ? Object.keys(sessionData.payload.authorizations ?? {})
       : [];
 
     if (authorizedApplicationIds.length === 0) {

--- a/packages/integration-tests/src/helpers/session.ts
+++ b/packages/integration-tests/src/helpers/session.ts
@@ -31,7 +31,7 @@ type CreateAppAndSignInOptions = {
 type UserSession = GetUserSessionsResponse['sessions'][number];
 
 export const findSessionByAppId = (sessions: UserSession[], appId: string) =>
-  sessions.find((session) => session.payload.authorizations[appId]);
+  sessions.find((session) => session.payload.authorizations?.[appId]);
 
 const tokenEndpoint = `${defaultConfig.endpoint}/oidc/token`;
 

--- a/packages/schemas/src/foundations/jsonb-types/oidc-module.ts
+++ b/packages/schemas/src/foundations/jsonb-types/oidc-module.ts
@@ -157,7 +157,7 @@ export const oidcSessionInstancePayloadGuard = z
     /**
      * A map of client_id to session authorization details. @see OidcSessionAuthorizationDetails
      */
-    authorizations: z.record(z.string(), oidcSessionAuthorizationDetailsGuard),
+    authorizations: z.record(z.string(), oidcSessionAuthorizationDetailsGuard).optional(),
   })
   .catchall(z.unknown());
 


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Mark the session authorizations field as optional.

We have observed several production exceptions that throws zod validaiton error. 

```
{"message":"Invalid session payload.","name":"RequestError","expose":true,"code":"oidc.invalid_session_payload","status":500,"data":{"cause":{"issues":[{"code":"invalid_type","expected":"object","received":"undefined","path":["authorizations"],"message":"Required"}],"name":"ZodError"}}}
```

To make the request more robust, fix the Zod guard and mark the authorizations field as optional. 


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally. 

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
