### PR TITLE
chore(console): remove dev feature flag from device flow guide

### DIFF
--- a/packages/console/src/assets/docs/guides/native-device-flow/index.ts
+++ b/packages/console/src/assets/docs/guides/native-device-flow/index.ts
@@ -8,7 +8,6 @@ const metadata: Readonly<GuideMetadata> = Object.freeze({
     'Use OAuth device flow for input-limited devices or headless apps (e.g., TVs, Game console, CLI)',
   target: ApplicationType.Native,
   fullGuide: 'device-flow',
-  isDevFeature: true,
 });
 
 export default metadata;


### PR DESCRIPTION
## Summary

Remove `isDevFeature: true` from the device flow guide metadata so it shows up in production.

This was missed in #8518.

## Testing

N/A

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments