### PR TITLE
feat(core): add account social callback form-post shim

### DIFF
--- a/packages/core/src/routes/callback.test.ts
+++ b/packages/core/src/routes/callback.test.ts
@@ -15,5 +15,14 @@ describe('social connector form post callback', () => {
     expect(response.header.location).toBe('/callback/some_connector_id?some=data');
   });
 
+  it('should redirect account social callback form post to the same path with query string', async () => {
+    const response = await request
+      .post('/account/callback/social/some_connector_id')
+      .send({ some: 'data' });
+
+    expect(response.status).toBe(303);
+    expect(response.header.location).toBe('/account/callback/social/some_connector_id?some=data');
+  });
+
   // No counter-case here since `koa-body` has a high tolerance for invalid requests
 });

--- a/packages/core/src/routes/callback.ts
+++ b/packages/core/src/routes/callback.ts
@@ -11,28 +11,16 @@ import { z } from 'zod';
 import RequestError from '#src/errors/RequestError/index.js';
 import assertThat from '#src/utils/assert-that.js';
 
-// Edited from https://stackoverflow.com/a/74743075/12514940
-function isStringRecord(object: unknown): object is Record<string, string> {
-  if (typeof object !== 'object' || object === null) {
-    return false;
-  }
-
-  if (Array.isArray(object)) {
-    return false;
-  }
-
-  if (Object.getOwnPropertySymbols(object).length > 0) {
-    return false;
-  }
-
-  return Object.getOwnPropertyNames(object).every(
-    // @ts-expect-error This is a type guard
-    (property) => typeof object[property] === 'string'
-  );
-}
-
 function callbackRoutes<T extends Router>(router: T) {
   router.post('/callback/:connectorId', koaBody(), async (ctx) => {
+    const parsed = z.record(z.string()).safeParse(ctx.request.body);
+
+    assertThat(parsed.success, new RequestError('oidc.invalid_request'));
+
+    ctx.status = 303;
+    ctx.set('Location', ctx.request.path + '?' + new URLSearchParams(parsed.data).toString());
+  });
+  router.post('/account/callback/social/:connectorId', koaBody(), async (ctx) => {
     const parsed = z.record(z.string()).safeParse(ctx.request.body);
 
     assertThat(parsed.success, new RequestError('oidc.invalid_request'));


### PR DESCRIPTION
## Summary
- some social connectors return to the callback URL with an HTTP `POST` instead of a normal query-string redirect
- the account-center social linking flow now uses `/account/callback/social/:connectorId` as its callback URL, so those form-post providers would otherwise post raw form data to the account callback path and break the frontend resume flow
- this PR adds a small server-side shim for `/account/callback/social/:connectorId` that mirrors the existing `/callback/:connectorId` behavior: accept the form post, validate it as a string record, and redirect back to the same path with the payload encoded as query params
- keeping this behavior in `core` lets the account-center callback page stay frontend-only and handle both redirect-based and form-post-based providers through the same code path
- add unit coverage for the new account social callback route

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
