### PR TITLE
feat(account): add social section to security page

### DIFF
--- a/packages/account/src/App.tsx
+++ b/packages/account/src/App.tsx
@@ -80,8 +80,14 @@ const Main = () => {
   const isInCallback = isSocialCallback || isAuthCallback;
   const uiLocales = getUiLocales();
   const { isAuthenticated, isLoading, signIn } = useLogto();
-  const { accountCenterSettings, isLoadingExperience, isLoadingUserInfo, userInfo, userInfoError } =
-    useContext(PageContext);
+  const {
+    accountCenterSettings,
+    experienceSettings,
+    isLoadingExperience,
+    isLoadingUserInfo,
+    userInfo,
+    userInfoError,
+  } = useContext(PageContext);
   const isInitialAuthLoading = !isAuthenticated && isLoading;
 
   useEffect(() => {
@@ -130,7 +136,7 @@ const Main = () => {
   }
 
   const showsSecurityPage =
-    isDevFeaturesEnabled && hasVisibleSecuritySection(accountCenterSettings);
+    isDevFeaturesEnabled && hasVisibleSecuritySection(accountCenterSettings, experienceSettings);
   const indexElement = showsSecurityPage ? <Security /> : <Home />;
 
   return (
@@ -191,7 +197,9 @@ const Layout = () => {
   const hideLogtoBranding = experienceSettings?.hideLogtoBranding === true;
   const { pathname } = useLocation();
   const isHomePage =
-    pathname === '/' && isDevFeaturesEnabled && hasVisibleSecuritySection(accountCenterSettings);
+    pathname === '/' &&
+    isDevFeaturesEnabled &&
+    hasVisibleSecuritySection(accountCenterSettings, experienceSettings);
 
   return (
     <div className={styles.app}>

--- a/packages/account/src/pages/Security/SocialSection/index.module.scss
+++ b/packages/account/src/pages/Security/SocialSection/index.module.scss
@@ -1,0 +1,116 @@
+@use '@experience/shared/scss/underscore' as _;
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: _.unit(1.5);
+}
+
+.sectionTitle {
+  padding-left: _.unit(1);
+  font: var(--font-label-2);
+  color: var(--color-type-primary);
+}
+
+.card {
+  background: var(--color-bg-body);
+  border-radius: 12px;
+  overflow: clip;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: _.unit(4);
+  padding: _.unit(4.5) _.unit(6);
+  min-height: 76px;
+
+  &:not(:last-child) {
+    border-bottom: 1px solid var(--color-line-divider);
+  }
+}
+
+.connectorInfo {
+  flex: 0 0 220px;
+  display: flex;
+  align-items: center;
+  gap: _.unit(4);
+  min-width: 0;
+}
+
+.connectorLogo {
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+  flex-shrink: 0;
+}
+
+.connectorName {
+  min-width: 0;
+  font: var(--font-label-2);
+  color: var(--color-type-primary);
+}
+
+.identityInfo {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: _.unit(3);
+  min-width: 0;
+}
+
+.avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.textGroup {
+  min-width: 0;
+}
+
+.primaryText {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font: var(--font-body-2);
+  color: var(--color-type-primary);
+}
+
+.secondaryText {
+  margin-top: _.unit(0.5);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font: var(--font-body-3);
+  color: var(--color-type-secondary);
+}
+
+.notLinked {
+  font: var(--font-body-2);
+  color: var(--color-type-secondary);
+}
+
+.actions {
+  flex-shrink: 0;
+}
+
+.actionButton {
+  font: var(--font-label-2);
+  color: var(--color-type-link);
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: _.unit(0.5) 0;
+  white-space: nowrap;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.removeButton {
+  color: var(--color-danger-default);
+}

--- a/packages/account/src/pages/Security/SocialSection/index.tsx
+++ b/packages/account/src/pages/Security/SocialSection/index.tsx
@@ -1,0 +1,186 @@
+import DynamicT from '@experience/shared/components/DynamicT';
+import { getLogoUrl } from '@experience/shared/utils/logo';
+import { AccountCenterControlValue, type Identity } from '@logto/schemas';
+import { useContext, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+
+import PageContext from '@ac/Providers/PageContextProvider/PageContext';
+import ConfirmModal from '@ac/components/ConfirmModal';
+import { getSocialAddRoute, getSocialRemoveRoute } from '@ac/constants/routes';
+import { getRedirectUrl, setRedirectUrl } from '@ac/utils/account-center-route';
+import { hasVisibleSocialSection } from '@ac/utils/security-page';
+import {
+  getAvailableSocialConnectors,
+  getLocalizedConnectorName,
+} from '@ac/utils/social-connector';
+
+import styles from './index.module.scss';
+
+type SocialIdentityDetails = Partial<{
+  name: string;
+  email: string;
+  avatar: string;
+}>;
+
+const getSocialIdentityDetail = (identity: Identity, key: keyof SocialIdentityDetails) => {
+  const value = identity.details?.[key];
+
+  return typeof value === 'string' ? value : undefined;
+};
+
+const truncateSocialUserId = (userId: string) =>
+  userId.length <= 14 ? userId : `${userId.slice(0, 8)}...${userId.slice(-4)}`;
+
+const getDisplayProfile = (identity: Identity, fallbackText: string) => {
+  const displayName = getSocialIdentityDetail(identity, 'name')?.trim();
+  const email = getSocialIdentityDetail(identity, 'email')?.trim();
+  const avatar = getSocialIdentityDetail(identity, 'avatar');
+  const safeUserId = identity.userId ? truncateSocialUserId(identity.userId) : undefined;
+  const primaryText = displayName ?? email ?? safeUserId ?? fallbackText;
+  const secondaryText = [email, displayName, safeUserId].find(
+    (value) => value && value !== primaryText
+  );
+
+  return {
+    avatar,
+    primaryText,
+    secondaryText,
+  };
+};
+
+const SocialSection = () => {
+  const {
+    t,
+    i18n: { language },
+  } = useTranslation();
+  const navigate = useNavigate();
+  const { accountCenterSettings, experienceSettings, theme, userInfo } = useContext(PageContext);
+  const [selectedConnectorId, setSelectedConnectorId] = useState<string>();
+
+  const socialControl = accountCenterSettings?.fields.social;
+
+  const connectors = useMemo(
+    () => getAvailableSocialConnectors(experienceSettings?.socialConnectors ?? []),
+    [experienceSettings?.socialConnectors]
+  );
+
+  const items = useMemo(
+    () =>
+      connectors
+        .map((connector) => ({
+          connector,
+          connectorName: getLocalizedConnectorName(connector, language),
+          identity: userInfo?.identities?.[connector.target],
+        }))
+        .slice()
+        .sort((left, right) => Number(Boolean(right.identity)) - Number(Boolean(left.identity))),
+    [connectors, language, userInfo?.identities]
+  );
+
+  const selectedConnector = connectors.find(({ id }) => id === selectedConnectorId);
+  const selectedConnectorName =
+    selectedConnector && getLocalizedConnectorName(selectedConnector, language);
+
+  if (!hasVisibleSocialSection(socialControl, experienceSettings)) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className={styles.section}>
+        <div className={styles.sectionTitle}>{t('account_center.security.social_sign_in')}</div>
+        <div className={styles.card}>
+          {items.map(({ connector, connectorName, identity }) => {
+            const profile = identity && getDisplayProfile(identity, connectorName);
+
+            return (
+              <div key={connector.id} className={styles.row}>
+                <div className={styles.connectorInfo}>
+                  <img
+                    className={styles.connectorLogo}
+                    src={getLogoUrl({
+                      theme,
+                      logoUrl: connector.logo,
+                      darkLogoUrl: connector.logoDark,
+                      isApple: connector.target === 'apple',
+                    })}
+                    alt={connectorName}
+                  />
+                  <div className={styles.connectorName}>{connectorName}</div>
+                </div>
+                <div className={styles.identityInfo}>
+                  {profile ? (
+                    <>
+                      {profile.avatar && (
+                        <img
+                          className={styles.avatar}
+                          src={profile.avatar}
+                          alt={profile.primaryText}
+                        />
+                      )}
+                      <div className={styles.textGroup}>
+                        <div className={styles.primaryText}>{profile.primaryText}</div>
+                        {profile.secondaryText && (
+                          <div className={styles.secondaryText}>{profile.secondaryText}</div>
+                        )}
+                      </div>
+                    </>
+                  ) : (
+                    <div className={styles.notLinked}>
+                      {t('account_center.security.social_not_linked')}
+                    </div>
+                  )}
+                </div>
+                {socialControl === AccountCenterControlValue.Edit && (
+                  <div className={styles.actions}>
+                    <button
+                      type="button"
+                      className={`${styles.actionButton} ${identity ? styles.removeButton : ''}`}
+                      onClick={() => {
+                        setRedirectUrl(getRedirectUrl() ?? window.location.href);
+
+                        if (identity) {
+                          setSelectedConnectorId(connector.id);
+                          return;
+                        }
+
+                        navigate(getSocialAddRoute(connector.id));
+                      }}
+                    >
+                      {identity
+                        ? t('account_center.security.remove')
+                        : t('account_center.security.add')}
+                    </button>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+      {selectedConnector && selectedConnectorName && (
+        <ConfirmModal
+          isOpen
+          title="action.remove"
+          confirmText="action.remove"
+          confirmButtonType="danger"
+          onCancel={() => {
+            setSelectedConnectorId(undefined);
+          }}
+          onConfirm={() => {
+            navigate(getSocialRemoveRoute(selectedConnector.id));
+            setSelectedConnectorId(undefined);
+          }}
+        >
+          <DynamicT
+            forKey="account_center.social.remove_confirmation_description"
+            interpolation={{ connector: selectedConnectorName }}
+          />
+        </ConfirmModal>
+      )}
+    </>
+  );
+};
+
+export default SocialSection;

--- a/packages/account/src/pages/Security/index.tsx
+++ b/packages/account/src/pages/Security/index.tsx
@@ -6,6 +6,7 @@ import styles from '../Home/index.module.scss';
 
 import EmailPhoneSection from './EmailPhoneSection';
 import PasswordSection from './PasswordSection';
+import SocialSection from './SocialSection';
 import UsernameSection from './UsernameSection';
 
 const Security = () => {
@@ -21,6 +22,7 @@ const Security = () => {
         <UsernameSection />
         <EmailPhoneSection />
         <PasswordSection />
+        <SocialSection />
       </div>
       <PageFooter />
     </div>

--- a/packages/account/src/utils/security-page.test.ts
+++ b/packages/account/src/utils/security-page.test.ts
@@ -1,13 +1,12 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { AccountCenterControlValue } from '@logto/schemas';
+import { AccountCenterControlValue, ConnectorPlatform } from '@logto/schemas';
 
 import type * as SecurityPageModule from './security-page';
 
-const { canOpenPasswordEditFlow, hasVisibleSecuritySection } = (await import(
-  new URL('security-page.ts', import.meta.url).href
-)) as typeof SecurityPageModule;
+const { canOpenPasswordEditFlow, hasVisibleSecuritySection, hasVisibleSocialSection } =
+  (await import(new URL('security-page.ts', import.meta.url).href)) as typeof SecurityPageModule;
 
 void test('hasVisibleSecuritySection returns false when account center is disabled', () => {
   assert.equal(
@@ -18,6 +17,7 @@ void test('hasVisibleSecuritySection returns false when account center is disabl
         email: AccountCenterControlValue.Off,
         phone: AccountCenterControlValue.Off,
         password: AccountCenterControlValue.Off,
+        social: AccountCenterControlValue.Off,
       },
     }),
     false
@@ -33,9 +33,59 @@ void test('hasVisibleSecuritySection returns true when any supported field is vi
         email: AccountCenterControlValue.Off,
         phone: AccountCenterControlValue.Off,
         password: AccountCenterControlValue.Off,
+        social: AccountCenterControlValue.Off,
       },
     }),
     true
+  );
+});
+
+void test('hasVisibleSecuritySection returns true when social field is visible', () => {
+  assert.equal(
+    hasVisibleSecuritySection(
+      {
+        enabled: true,
+        fields: {
+          username: AccountCenterControlValue.Off,
+          email: AccountCenterControlValue.Off,
+          phone: AccountCenterControlValue.Off,
+          password: AccountCenterControlValue.Off,
+          social: AccountCenterControlValue.Edit,
+        },
+      },
+      {
+        socialConnectors: [
+          {
+            id: 'google-web',
+            target: 'google',
+            platform: ConnectorPlatform.Web,
+            name: { en: 'Google' },
+            logo: '',
+            logoDark: '',
+          },
+        ],
+      }
+    ),
+    true
+  );
+});
+
+void test('hasVisibleSocialSection returns false when no available social connector exists', () => {
+  assert.equal(hasVisibleSocialSection(AccountCenterControlValue.Edit), false);
+  assert.equal(
+    hasVisibleSocialSection(AccountCenterControlValue.Edit, {
+      socialConnectors: [
+        {
+          id: 'google-native',
+          target: 'google',
+          platform: ConnectorPlatform.Native,
+          name: { en: 'Google' },
+          logo: '',
+          logoDark: '',
+        },
+      ],
+    }),
+    false
   );
 });
 

--- a/packages/account/src/utils/security-page.ts
+++ b/packages/account/src/utils/security-page.ts
@@ -1,25 +1,38 @@
+import type { SignInExperienceResponse } from '@experience/shared/types';
 import type { AccountCenter, UserProfileResponse } from '@logto/schemas';
 import { AccountCenterControlValue } from '@logto/schemas';
 
+import { getAvailableSocialConnectors } from './social-connector.js';
+
 type SecurityPageSettings = Pick<AccountCenter, 'enabled' | 'fields'>;
+type SecurityPageExperienceSettings = Pick<SignInExperienceResponse, 'socialConnectors'>;
 
 const isVisibleField = (value?: AccountCenterControlValue): boolean =>
   value !== undefined && value !== AccountCenterControlValue.Off;
 
+export const hasVisibleSocialSection = (
+  socialControl: AccountCenterControlValue | undefined,
+  experienceSettings?: SecurityPageExperienceSettings
+): boolean =>
+  isVisibleField(socialControl) &&
+  getAvailableSocialConnectors(experienceSettings?.socialConnectors ?? []).length > 0;
+
 export const hasVisibleSecuritySection = (
-  accountCenterSettings?: SecurityPageSettings
+  accountCenterSettings?: SecurityPageSettings,
+  experienceSettings?: SecurityPageExperienceSettings
 ): boolean => {
   if (!accountCenterSettings?.enabled) {
     return false;
   }
 
-  const { username, email, phone, password } = accountCenterSettings.fields;
+  const { username, email, phone, password, social } = accountCenterSettings.fields;
 
   return (
     isVisibleField(username) ||
     isVisibleField(email) ||
     isVisibleField(phone) ||
-    isVisibleField(password)
+    isVisibleField(password) ||
+    hasVisibleSocialSection(social, experienceSettings)
   );
 };
 


### PR DESCRIPTION
## Summary
- add the social section to the account security page
- render available social connectors with linked profile details and add/remove entry points
- update security-page visibility checks so the social section can make the security page visible on its own
- stacked on https://github.com/logto-io/logto/pull/8534

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
