### PR TITLE
fix(console): hide token exchange settings for protected apps

### DIFF
--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/index.tsx
@@ -240,7 +240,7 @@ function ApplicationDetailsContent({ data, secrets, oidcConfig, onApplicationUpd
               <RefreshTokenSettings data={data} />
             )}
             {data.type !== ApplicationType.MachineToMachine && <BackchannelLogout />}
-            <TokenExchangeSettings data={data} />
+            {data.type !== ApplicationType.Protected && <TokenExchangeSettings data={data} />}
             {isDevFeaturesEnabled &&
               ![ApplicationType.MachineToMachine, ApplicationType.Protected].includes(
                 data.type


### PR DESCRIPTION
## Summary

Hide the token exchange settings section from the protected app details page. Protected apps are reverse proxies where token exchange configuration is not applicable in the current UI context.

## Testing

Tested locally

## Checklist

- [x] `.changeset`