### PR TITLE
feat(core): add list user grants account API

### DIFF
--- a/packages/core/src/routes/account/grants.ts
+++ b/packages/core/src/routes/account/grants.ts
@@ -1,0 +1,62 @@
+import { UserScope } from '@logto/core-kit';
+import { AccountCenterControlValue, getUserApplicationGrantsResponseGuard } from '@logto/schemas';
+import { z } from 'zod';
+
+import { EnvSet } from '#src/env-set/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
+import koaGuard from '#src/middleware/koa-guard.js';
+import assertThat from '#src/utils/assert-that.js';
+
+import { type UserRouter, type RouterInitArgs } from '../types.js';
+
+import { accountApiPrefix } from './constants.js';
+
+export default function accountGrantRoutes<T extends UserRouter>(
+  ...[router, { libraries }]: RouterInitArgs<T>
+) {
+  if (!EnvSet.values.isDevFeaturesEnabled) {
+    return;
+  }
+
+  const { session: sessionLibrary } = libraries;
+
+  router.get(
+    `${accountApiPrefix}/grants`,
+    koaGuard({
+      query: z.object({
+        appType: z.enum(['firstParty', 'thirdParty']).optional(),
+      }),
+      status: [200, 400, 401, 500],
+      response: getUserApplicationGrantsResponseGuard,
+    }),
+    async (ctx, next) => {
+      const { id: userId, scopes, identityVerified } = ctx.auth;
+      const { fields } = ctx.accountCenter;
+      const { appType } = ctx.guard.query;
+
+      assertThat(
+        identityVerified,
+        new RequestError({ code: 'verification_record.permission_denied', status: 401 })
+      );
+
+      assertThat(
+        fields.session === AccountCenterControlValue.Edit ||
+          fields.session === AccountCenterControlValue.ReadOnly,
+        'account_center.field_not_enabled'
+      );
+
+      assertThat(
+        scopes.has(UserScope.Sessions),
+        new RequestError({ code: 'auth.unauthorized', status: 401 })
+      );
+
+      const grants = await sessionLibrary.findUserActiveApplicationGrants(userId, appType);
+
+      ctx.body = {
+        grants,
+      };
+
+      return next();
+    }
+  );
+}

--- a/packages/core/src/routes/account/index.openapi.json
+++ b/packages/core/src/routes/account/index.openapi.json
@@ -588,6 +588,32 @@
         "responses": {
           "200": {
             "description": "Return a list of non-expired sessions of the user."
+          },
+          "401": {
+            "description": "Permission denied, the verification record is invalid or the session does not have the required scope to access session details."
+          }
+        }
+      }
+    },
+    "/api/my-account/grants": {
+      "get": {
+        "tags": ["Dev feature"],
+        "operationId": "GetGrants",
+        "summary": "Get all active grants",
+        "description": "Retrieve all active application grants for the user. A logto-verification-id in header is required for checking grant details.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "appType",
+            "description": "Optional application type filter. Use 'firstParty' to return grants from first-party applications only, or 'thirdParty' for third-party applications only."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Return a list of active application grants of the user."
+          },
+          "401": {
+            "description": "Permission denied, the verification record is invalid or the session does not have the required scope to access grant details."
           }
         }
       }
@@ -613,6 +639,9 @@
           },
           "404": {
             "description": "The session does not exist."
+          },
+          "401": {
+            "description": "Permission denied, the verification record is invalid or the session does not have the required scope to revoke sessions."
           }
         }
       }

--- a/packages/core/src/routes/account/index.ts
+++ b/packages/core/src/routes/account/index.ts
@@ -11,16 +11,18 @@ import {
 import { conditional } from '@silverhand/essentials';
 import { z } from 'zod';
 
+import { EnvSet } from '#src/env-set/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
+import { encryptUserPassword } from '#src/libraries/user.utils.js';
 import koaGuard from '#src/middleware/koa-guard.js';
+import assertThat from '#src/utils/assert-that.js';
 
-import RequestError from '../../errors/RequestError/index.js';
-import { encryptUserPassword } from '../../libraries/user.utils.js';
-import assertThat from '../../utils/assert-that.js';
 import { PasswordValidator } from '../experience/classes/libraries/password-validator.js';
 import type { UserRouter, RouterInitArgs } from '../types.js';
 
 import { accountApiPrefix } from './constants.js';
 import emailAndPhoneRoutes from './email-and-phone.js';
+import accountGrantRoutes from './grants.js';
 import identitiesRoutes from './identities.js';
 import logtoConfigRoutes from './logto-config.js';
 import mfaVerificationsRoutes from './mfa-verifications.js';
@@ -288,4 +290,8 @@ export default function accountRoutes<T extends UserRouter>(...args: RouterInitA
   identitiesRoutes(...args);
   mfaVerificationsRoutes(...args);
   accountSessionRoutes(...args);
+
+  if (EnvSet.values.isDevFeaturesEnabled) {
+    accountGrantRoutes(...args);
+  }
 }

--- a/packages/core/src/routes/admin-user/grants.ts
+++ b/packages/core/src/routes/admin-user/grants.ts
@@ -2,10 +2,10 @@ import { getUserApplicationGrantsResponseGuard } from '@logto/schemas';
 import { trySafe } from '@silverhand/essentials';
 import { object, string, enum as zodEnum } from 'zod';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 
-import { EnvSet } from '../../env-set/index.js';
 import { type ManagementApiRouter, type RouterInitArgs } from '../types.js';
 
 export default function adminUserGrantRoutes<T extends ManagementApiRouter>(

--- a/packages/integration-tests/src/api/my-account.ts
+++ b/packages/integration-tests/src/api/my-account.ts
@@ -1,4 +1,5 @@
 import type {
+  GetUserApplicationGrantsResponse,
   GetUserSessionsResponse,
   GetThirdPartyAccessTokenResponse,
   SessionGrantRevokeTarget,
@@ -168,6 +169,20 @@ export const getSessions = async (api: KyInstance, verificationRecordId: string)
       headers: { [verificationRecordIdHeader]: verificationRecordId },
     })
     .json<GetUserSessionsResponse>();
+
+export const getMyAccountGrants = async (
+  api: KyInstance,
+  verificationRecordId: string,
+  appType?: 'firstParty' | 'thirdParty'
+) =>
+  api
+    .get('api/my-account/grants', {
+      searchParams: new URLSearchParams({
+        ...conditional(appType && { appType }),
+      }),
+      headers: { [verificationRecordIdHeader]: verificationRecordId },
+    })
+    .json<GetUserApplicationGrantsResponse>();
 
 export const deleteSession = async (
   api: KyInstance,

--- a/packages/integration-tests/src/tests/api/account/grants.test.ts
+++ b/packages/integration-tests/src/tests/api/account/grants.test.ts
@@ -1,0 +1,118 @@
+import { UserScope } from '@logto/core-kit';
+
+import { enableAllAccountCenterFields } from '#src/api/account-center.js';
+import { authedAdminApi } from '#src/api/api.js';
+import { deleteApplication } from '#src/api/application.js';
+import { getMyAccountGrants } from '#src/api/my-account.js';
+import { createVerificationRecordByPassword } from '#src/api/verification-record.js';
+import { expectRejects } from '#src/helpers/index.js';
+import {
+  createDefaultTenantUserWithPassword,
+  deleteDefaultTenantUser,
+  signInAndGetUserApi,
+} from '#src/helpers/profile.js';
+import { createAppAndSignInWithPassword } from '#src/helpers/session.js';
+import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
+import { devFeatureTest } from '#src/utils.js';
+
+devFeatureTest.describe('account center grant management', () => {
+  beforeAll(async () => {
+    await enableAllPasswordSignInMethods();
+    await enableAllAccountCenterFields(authedAdminApi);
+  });
+
+  describe('GET /my-account/grants', () => {
+    it('should fail if scope is missing', async () => {
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
+      const api = await signInAndGetUserApi(username, password);
+
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
+
+      await expectRejects(getMyAccountGrants(api, verificationRecordId), {
+        code: 'auth.unauthorized',
+        status: 401,
+      });
+
+      await deleteDefaultTenantUser(user.id);
+    });
+
+    it('should fail if identity is not verified', async () => {
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
+      const api = await signInAndGetUserApi(username, password, {
+        scopes: [UserScope.Sessions],
+      });
+
+      await expectRejects(getMyAccountGrants(api, ''), {
+        code: 'verification_record.permission_denied',
+        status: 401,
+      });
+
+      await deleteDefaultTenantUser(user.id);
+    });
+
+    it('should get grants successfully and support appType filters', async () => {
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
+
+      const firstPartySignIn = await createAppAndSignInWithPassword({
+        username,
+        password,
+        isThirdParty: false,
+        scopes: [UserScope.Profile],
+      });
+
+      const thirdPartySignIn = await createAppAndSignInWithPassword({
+        username,
+        password,
+        isThirdParty: true,
+        scopes: [UserScope.Profile],
+      });
+
+      const api = await signInAndGetUserApi(username, password, {
+        scopes: [UserScope.Sessions],
+      });
+
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
+
+      const { grants: allGrants } = await getMyAccountGrants(api, verificationRecordId);
+      expect(allGrants.length).toBeGreaterThanOrEqual(2);
+      expect(allGrants.some((grant) => grant.payload.clientId === firstPartySignIn.app.id)).toBe(
+        true
+      );
+      expect(allGrants.some((grant) => grant.payload.clientId === thirdPartySignIn.app.id)).toBe(
+        true
+      );
+
+      const { grants: firstPartyGrants } = await getMyAccountGrants(
+        api,
+        verificationRecordId,
+        'firstParty'
+      );
+      expect(firstPartyGrants.length).toBeGreaterThanOrEqual(1);
+      expect(
+        firstPartyGrants.some((grant) => grant.payload.clientId === firstPartySignIn.app.id)
+      ).toBe(true);
+      expect(
+        firstPartyGrants.some((grant) => grant.payload.clientId === thirdPartySignIn.app.id)
+      ).toBe(false);
+
+      const { grants: thirdPartyGrants } = await getMyAccountGrants(
+        api,
+        verificationRecordId,
+        'thirdParty'
+      );
+      expect(thirdPartyGrants.length).toBeGreaterThanOrEqual(1);
+      expect(
+        thirdPartyGrants.some((grant) => grant.payload.clientId === thirdPartySignIn.app.id)
+      ).toBe(true);
+      expect(
+        thirdPartyGrants.some((grant) => grant.payload.clientId === firstPartySignIn.app.id)
+      ).toBe(false);
+
+      await Promise.all([
+        deleteApplication(firstPartySignIn.app.id),
+        deleteApplication(thirdPartySignIn.app.id),
+      ]);
+      await deleteDefaultTenantUser(user.id);
+    });
+  });
+});


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add `GET /my-account/grants` to expose the current user’s active application grants, with the same grant data behavior as management API `GET /users/:userId/grants` and the same session-scoped permission model as `GET /my-account/sessions`.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Integration tests added

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
