### PR TITLE
fix(experience): show sign-in loading during passkey sign-in

### DIFF
--- a/packages/experience/src/Providers/WebAuthnContextProvider/WebAuthnContext.tsx
+++ b/packages/experience/src/Providers/WebAuthnContextProvider/WebAuthnContext.tsx
@@ -5,10 +5,12 @@ import { createContext } from 'react';
 export type WebAuthnContextType = {
   authenticationOptions: WebAuthnAuthenticationOptions | undefined;
   isLoading: boolean;
+  isPasskeyFlowProcessing: boolean;
   /**
    * Mark the current authentication options as consumed, and immediately fetch new options data.
    */
   markAuthenticationOptionsConsumed: () => void;
+  setIsPasskeyFlowProcessing: (isProcessing: boolean) => void;
   /**
    * Abort any pending conditional UI WebAuthn request.
    * This must be called before starting a new `navigator.credentials.get()` request
@@ -28,7 +30,9 @@ export type WebAuthnContextType = {
 const WebAuthnContext = createContext<WebAuthnContextType>({
   authenticationOptions: undefined,
   isLoading: false,
+  isPasskeyFlowProcessing: false,
   markAuthenticationOptionsConsumed: noop,
+  setIsPasskeyFlowProcessing: noop,
   abortConditionalUI: noop,
   setConditionalUIAbortController: noop,
 });

--- a/packages/experience/src/Providers/WebAuthnContextProvider/index.tsx
+++ b/packages/experience/src/Providers/WebAuthnContextProvider/index.tsx
@@ -27,6 +27,7 @@ const WebAuthnContextProvider = ({ children }: { readonly children: ReactNode })
   const [authenticationOptions, setAuthenticationOptions] =
     useState<WebAuthnAuthenticationOptions>();
   const [isLoading, setIsLoading] = useState(false);
+  const [isPasskeyFlowProcessing, setIsPasskeyFlowProcessing] = useState(false);
   const [isConsumed, setIsConsumed] = useState(false);
   const shouldFetch =
     !!passkeySignIn?.enabled && !isPreview && (!authenticationOptions || isConsumed);
@@ -42,6 +43,7 @@ const WebAuthnContextProvider = ({ children }: { readonly children: ReactNode })
     conditionalUIAbortControllerRef.current?.abort();
     // eslint-disable-next-line @silverhand/fp/no-mutation
     conditionalUIAbortControllerRef.current = undefined;
+    setIsPasskeyFlowProcessing(false);
   }, []);
 
   const setConditionalUIAbortController = useCallback((controller: AbortController | undefined) => {
@@ -75,14 +77,18 @@ const WebAuthnContextProvider = ({ children }: { readonly children: ReactNode })
     () => ({
       authenticationOptions,
       isLoading,
+      isPasskeyFlowProcessing,
       markAuthenticationOptionsConsumed,
+      setIsPasskeyFlowProcessing,
       abortConditionalUI,
       setConditionalUIAbortController,
     }),
     [
       authenticationOptions,
       isLoading,
+      isPasskeyFlowProcessing,
       markAuthenticationOptionsConsumed,
+      setIsPasskeyFlowProcessing,
       abortConditionalUI,
       setConditionalUIAbortController,
     ]

--- a/packages/experience/src/components/Button/PasskeySignInButton/index.tsx
+++ b/packages/experience/src/components/Button/PasskeySignInButton/index.tsx
@@ -21,14 +21,16 @@ const PasskeySignInButton = () => {
   const {
     authenticationOptions,
     isLoading: isPreparing,
+    isPasskeyFlowProcessing,
+    setIsPasskeyFlowProcessing,
     markAuthenticationOptionsConsumed,
     abortConditionalUI,
   } = useContext(WebAuthnContext);
   const { handleVerifyPasskey } = usePasskeySignIn();
 
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const isLoadingActive = useDebouncedLoader(isPreparing || isSubmitting, 300);
-  const isDisabled = isPreparing || !authenticationOptions;
+  const isLoadingActive = useDebouncedLoader(isSubmitting, 300);
+  const isDisabled = isPreparing || !authenticationOptions || isPasskeyFlowProcessing;
 
   const preSignInErrorHandler = useSubmitInteractionErrorHandler(InteractionEvent.SignIn, {
     replace: true,
@@ -42,10 +44,12 @@ const PasskeySignInButton = () => {
     // to prevent `OperationError: A request is already pending`.
     abortConditionalUI();
     setIsSubmitting(true);
+    setIsPasskeyFlowProcessing(true);
     try {
       await handleVerifyPasskey(authenticationOptions, preSignInErrorHandler);
     } finally {
       markAuthenticationOptionsConsumed();
+      setIsPasskeyFlowProcessing(false);
       setIsSubmitting(false);
     }
   }, [
@@ -54,6 +58,7 @@ const PasskeySignInButton = () => {
     handleVerifyPasskey,
     markAuthenticationOptionsConsumed,
     preSignInErrorHandler,
+    setIsPasskeyFlowProcessing,
   ]);
 
   if (!browserSupportsWebAuthn()) {

--- a/packages/experience/src/components/IdentifierSignInForm/index.tsx
+++ b/packages/experience/src/components/IdentifierSignInForm/index.tsx
@@ -5,6 +5,7 @@ import { useForm, Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
 import UserInteractionContext from '@/Providers/UserInteractionContextProvider/UserInteractionContext';
+import WebAuthnContext from '@/Providers/WebAuthnContextProvider/WebAuthnContext';
 import LockIcon from '@/assets/icons/lock.svg?react';
 import { SmartInputField } from '@/components/InputFields';
 import CaptchaBox from '@/containers/CaptchaBox';
@@ -36,6 +37,7 @@ const IdentifierSignInForm = ({ className, autoFocus, signInMethods }: Props) =>
   const { errorMessage, clearErrorMessage, onSubmit } = useOnSubmit(signInMethods);
   const { termsValidation, agreeToTermsPolicy } = useTerms();
   const { setIdentifierInputValue } = useContext(UserInteractionContext);
+  const { isPasskeyFlowProcessing } = useContext(WebAuthnContext);
 
   const enabledSignInMethods = useMemo(
     () => signInMethods.map(({ identifier }) => identifier),
@@ -71,6 +73,10 @@ const IdentifierSignInForm = ({ className, autoFocus, signInMethods }: Props) =>
 
   const onSubmitHandler = useCallback(
     async (event?: React.FormEvent<HTMLFormElement>) => {
+      if (isPasskeyFlowProcessing) {
+        return;
+      }
+
       clearErrorMessage();
 
       void handleSubmit(async ({ identifier: { type, value } }) => {
@@ -102,6 +108,7 @@ const IdentifierSignInForm = ({ className, autoFocus, signInMethods }: Props) =>
       setIdentifierInputValue,
       showSingleSignOnForm,
       termsValidation,
+      isPasskeyFlowProcessing,
     ]
   );
 
@@ -162,7 +169,7 @@ const IdentifierSignInForm = ({ className, autoFocus, signInMethods }: Props) =>
         title={showSingleSignOnForm ? 'action.single_sign_on' : 'action.sign_in'}
         icon={showSingleSignOnForm ? <LockIcon /> : undefined}
         htmlType="submit"
-        isLoading={isSubmitting}
+        isLoading={isSubmitting || isPasskeyFlowProcessing}
       />
 
       <input hidden type="submit" />

--- a/packages/experience/src/components/PasswordSignInForm/index.tsx
+++ b/packages/experience/src/components/PasswordSignInForm/index.tsx
@@ -5,6 +5,7 @@ import { useForm, Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
 import UserInteractionContext from '@/Providers/UserInteractionContextProvider/UserInteractionContext';
+import WebAuthnContext from '@/Providers/WebAuthnContextProvider/WebAuthnContext';
 import LockIcon from '@/assets/icons/lock.svg?react';
 import { SmartInputField, PasswordInputField } from '@/components/InputFields';
 import CaptchaBox from '@/containers/CaptchaBox';
@@ -41,6 +42,7 @@ const PasswordSignInForm = ({ className, autoFocus, signInMethods }: Props) => {
   const { isForgotPasswordEnabled } = useForgotPasswordSettings();
   const { termsValidation, agreeToTermsPolicy } = useTerms();
   const { setIdentifierInputValue } = useContext(UserInteractionContext);
+  const { isPasskeyFlowProcessing } = useContext(WebAuthnContext);
   const prefilledIdentifier = usePrefilledIdentifier({ enabledIdentifiers: signInMethods });
 
   const {
@@ -63,6 +65,10 @@ const PasswordSignInForm = ({ className, autoFocus, signInMethods }: Props) => {
 
   const onSubmitHandler = useCallback(
     async (event?: React.FormEvent<HTMLFormElement>) => {
+      if (isPasskeyFlowProcessing) {
+        return;
+      }
+
       clearErrorMessage();
 
       await handleSubmit(async ({ identifier: { type, value }, password }) => {
@@ -97,6 +103,7 @@ const PasswordSignInForm = ({ className, autoFocus, signInMethods }: Props) => {
       setIdentifierInputValue,
       showSingleSignOnForm,
       termsValidation,
+      isPasskeyFlowProcessing,
     ]
   );
 
@@ -180,7 +187,7 @@ const PasswordSignInForm = ({ className, autoFocus, signInMethods }: Props) => {
         title={showSingleSignOnForm ? 'action.single_sign_on' : 'action.sign_in'}
         icon={showSingleSignOnForm ? <LockIcon /> : undefined}
         htmlType="submit"
-        isLoading={isSubmitting}
+        isLoading={isSubmitting || isPasskeyFlowProcessing}
       />
 
       <input hidden type="submit" />

--- a/packages/experience/src/hooks/use-passkey-autofill-conditional-ui.ts
+++ b/packages/experience/src/hooks/use-passkey-autofill-conditional-ui.ts
@@ -22,8 +22,12 @@ import useToast from './use-toast';
 const usePasskeyAutofillConditionalUI = () => {
   const { t } = useTranslation();
   const { setToast } = useToast();
-  const { authenticationOptions, abortConditionalUI, setConditionalUIAbortController } =
-    useContext(WebAuthnContext);
+  const {
+    authenticationOptions,
+    abortConditionalUI,
+    setConditionalUIAbortController,
+    setIsPasskeyFlowProcessing,
+  } = useContext(WebAuthnContext);
   const { passkeySignIn } = useSieMethods();
   const asyncVerifySignInPasskey = useApi(verifySignInPasskey);
   const handleError = useErrorHandler();
@@ -59,6 +63,7 @@ const usePasskeyAutofillConditionalUI = () => {
           return;
         }
 
+        setIsPasskeyFlowProcessing(true);
         await initInteraction(InteractionEvent.SignIn);
 
         const [error, result] = await asyncVerifySignInPasskey({
@@ -82,6 +87,8 @@ const usePasskeyAutofillConditionalUI = () => {
           return;
         }
         setToast(t('passkey_sign_in.trigger_conditional_ui_failed'));
+      } finally {
+        setIsPasskeyFlowProcessing(false);
       }
     },
     [
@@ -93,6 +100,7 @@ const usePasskeyAutofillConditionalUI = () => {
       t,
       abortConditionalUI,
       setConditionalUIAbortController,
+      setIsPasskeyFlowProcessing,
     ]
   );
 


### PR DESCRIPTION
## Summary
Adjust passkey sign-in loading states on the sign-in page.

- disable the bottom "Continue with passkey" button while passkey processing is in progress
- show loading on the identifier and password form submit buttons while passkey sign-in is processing
- keep passkey processing state in the shared WebAuthn context so the sign-in page stays consistent across autofill and manual passkey flows

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments