### PR TITLE
fix(console): passkey sign-in option checkboxes should be checked by default

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/PasskeySignInForm/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/PasskeySignInForm/index.tsx
@@ -1,5 +1,5 @@
 import { cond } from '@silverhand/essentials';
-import { useContext, useEffect } from 'react';
+import { useContext } from 'react';
 import { useFormContext, Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -20,7 +20,7 @@ import styles from './index.module.scss';
 
 function PasskeySignInForm() {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
-  const { control, register, setValue, watch } = useFormContext<SignInExperienceForm>();
+  const { control, register, watch } = useFormContext<SignInExperienceForm>();
 
   const {
     currentSubscriptionQuota,
@@ -29,13 +29,6 @@ function PasskeySignInForm() {
   const isPasskeySignInEnabled = currentSubscriptionQuota.passkeySignInEnabled || !isCloud;
   const isPaidTenant = isPaidPlan(planId, isEnterprisePlan);
   const watchEnableSwitch = watch('passkeySignIn.enabled');
-
-  useEffect(() => {
-    if (isPasskeySignInEnabled && watchEnableSwitch) {
-      setValue('passkeySignIn.showPasskeyButton', true);
-      setValue('passkeySignIn.allowAutofill', true);
-    }
-  }, [isPasskeySignInEnabled, watchEnableSwitch, setValue]);
 
   return (
     <Card>

--- a/packages/console/src/pages/SignInExperience/PageContent/utils/parser.test.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/utils/parser.test.ts
@@ -159,8 +159,8 @@ describe('sign-in experience parser', () => {
     });
     expect(formData.passkeySignIn).toEqual({
       enabled: false,
-      showPasskeyButton: false,
-      allowAutofill: false,
+      showPasskeyButton: true,
+      allowAutofill: true,
     });
   });
 

--- a/packages/console/src/pages/SignInExperience/PageContent/utils/parser.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/utils/parser.ts
@@ -145,8 +145,8 @@ export const sieFormDataParser = {
       },
       passkeySignIn: {
         enabled: false,
-        showPasskeyButton: false,
-        allowAutofill: false,
+        showPasskeyButton: true,
+        allowAutofill: true,
         ...rest.passkeySignIn,
       },
     };


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Passkey sign-in config options ("Show button" and "Allow autofill") should be checked by default, but instead of setting them to `true` with React side effects on page render, we should provide it as the default values. This would avoid unexpectedly setting the form to dirty.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
