### PR TITLE
fix(console): show passkey sign-in section in user details page only when enabled

### DIFF
--- a/packages/console/src/pages/UserDetails/UserSettings/index.tsx
+++ b/packages/console/src/pages/UserDetails/UserSettings/index.tsx
@@ -1,5 +1,5 @@
 import { emailRegEx, usernameRegEx } from '@logto/core-kit';
-import type { User } from '@logto/schemas';
+import type { SignInExperience, User } from '@logto/schemas';
 import { parsePhoneNumber } from '@logto/shared/universal';
 import { conditionalString, trySafe } from '@silverhand/essentials';
 import { parsePhoneNumberWithError } from 'libphonenumber-js/mobile';
@@ -7,6 +7,7 @@ import { useForm, useController } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import { Trans, useTranslation } from 'react-i18next';
 import { useOutletContext } from 'react-router-dom';
+import useSWRImmutable from 'swr/immutable';
 
 import DetailsForm from '@/components/DetailsForm';
 import FormCard from '@/components/FormCard';
@@ -18,7 +19,7 @@ import CodeEditor from '@/ds-components/CodeEditor';
 import FormField from '@/ds-components/FormField';
 import TextInput from '@/ds-components/TextInput';
 import TextLink from '@/ds-components/TextLink';
-import useApi from '@/hooks/use-api';
+import useApi, { type RequestError } from '@/hooks/use-api';
 import { useConfirmModal } from '@/hooks/use-confirm-modal';
 import useDocumentationUrl from '@/hooks/use-documentation-url';
 import { trySubmitSafe } from '@/utils/form';
@@ -43,6 +44,10 @@ function UserSettings() {
   const { user, isDeleting, onUserUpdated } = useOutletContext<UserDetailsOutletContext>();
 
   const userFormData = userDetailsParser.toLocalForm(user);
+
+  const { data: signInExperience } = useSWRImmutable<SignInExperience, RequestError>(
+    'api/sign-in-exp'
+  );
 
   const {
     handleSubmit,
@@ -163,9 +168,11 @@ function UserSettings() {
               }}
             />
           </FormField>
-          <FormField title="user_details.passkey.field_name">
-            <UserSignInPasskeys userId={user.id} />
-          </FormField>
+          {signInExperience?.passkeySignIn.enabled && (
+            <FormField title="user_details.passkey.field_name">
+              <UserSignInPasskeys userId={user.id} />
+            </FormField>
+          )}
           <FormField title="user_details.mfa.field_name">
             <UserMfaVerifications userId={user.id} />
           </FormField>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Show "Passkey sign-in" section in user details page only when it's enabled.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested

Passkey sign-in enabled:
<img width="2630" height="1474" alt="image" src="https://github.com/user-attachments/assets/978b721a-1574-43b1-97fa-d775d3e8ff2c" />

Passkey sign-in disabled (The passkey section is hidden):
<img width="2644" height="1246" alt="image" src="https://github.com/user-attachments/assets/7ee66e46-3cc9-499b-97fe-3a99c9429508" />


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
