### PR TITLE
chore: add missing changeset for MFA Sentinel support

### DIFF
--- a/.changeset/bright-squids-share.md
+++ b/.changeset/bright-squids-share.md
@@ -1,0 +1,10 @@
+---
+"@logto/core": minor
+"@logto/schemas": minor
+---
+
+support sentinel protection for MFA verification routes
+
+TOTP, WebAuthn, and backup code MFA verifications now report activity to Sentinel so repeated failures can be detected and blocked consistently during multi-factor authentication.
+
+The new MFA-specific Sentinel actions keep MFA attempts isolated from the shared primary sign-in pool, which avoids lockouts leaking across unrelated verification stages or factors.


### PR DESCRIPTION
## Summary

add the missing changeset for the shipped MFA Sentinel support so the `@logto/core` and `@logto/schemas` package releases reflect the behavior introduced by #8232 and #8575


## Testing

Tested locally


## Checklist

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
