### PR TITLE
chore: add cross-repo sync comments for alteration logic

### DIFF
--- a/packages/cli/src/commands/database/alteration/index.ts
+++ b/packages/cli/src/commands/database/alteration/index.ts
@@ -55,6 +55,12 @@ export const getAvailableAlterations = async (
   );
 };
 
+/**
+ * IMPORTANT: Logto Cloud has a parallel implementation of this logic in `CoreAlterationClient`
+ * (logto-cloud repo: `packages/azure-functions/src/utils/core-alteration-client.ts`).
+ * Any changes to the alteration execution behavior here (e.g., new hooks, execution order)
+ * must be synchronized with the Cloud implementation.
+ */
 const deployAlteration = async (
   pool: DatabasePool,
   { path: filePath, filename }: AlterationFile,

--- a/packages/schemas/src/types/alteration.ts
+++ b/packages/schemas/src/types/alteration.ts
@@ -1,5 +1,10 @@
 import type { CommonQueryMethods, DatabaseTransactionConnection } from '@silverhand/slonik';
 
+/**
+ * IMPORTANT: Logto Cloud has a parallel `AlterationScript` type in `@logto/cloud-alterations`
+ * (logto-cloud repo: `packages/cloud-alterations/src/types.ts`).
+ * Any changes to this type must be synchronized with the Cloud type definition.
+ */
 export type AlterationScript = {
   /**
    * Optional hook that runs before `up` outside of a transaction.


### PR DESCRIPTION
## Summary

Add comments to `AlterationScript` type and `deployAlteration` function, noting that Logto Cloud has a parallel implementation (`CoreAlterationClient`) that must be kept in sync.

This is a follow-up to https://github.com/logto-io/cloud/pull/1768, where we discovered that Cloud's `CoreAlterationClient` was missing `beforeUp`/`beforeDown` hook support because it was originally copied from CLI without these hooks, and no one was reminded to sync when they were added.

## Testing

N/A

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments