### PR TITLE
fix(phrases): add missing account removal keys to Czech locale

### DIFF
--- a/packages/phrases-experience/src/locales/cs/account-center.ts
+++ b/packages/phrases-experience/src/locales/cs/account-center.ts
@@ -84,6 +84,9 @@ const account_center = {
     backup_codes_count_other: 'zbývá {{count}} kódů',
     view: 'Zobrazit',
     manage: 'Spravovat',
+    account_removal: 'Smazání účtu',
+    delete_your_account: 'Smazat svůj účet',
+    delete_account: 'Smazat účet',
   },
   social: {
     linked: '{{connector}} byl úspěšně propojen.',


### PR DESCRIPTION
## Summary
Fix master CI breakage caused by missing translation keys in the Czech (cs) locale.

The commit `ba217c0a3` (feat: support account removal url in account center) added three new keys to the `security` section in `account-center.ts` for all locales, but missed the Czech locale which was added more recently. This caused a TypeScript TS2719 build error because the incomplete Czech locale type was structurally incompatible with `LocalePhrase = typeof en`.

Added the missing keys to `packages/phrases-experience/src/locales/cs/account-center.ts`:
- `account_removal`: 'Smazání účtu'
- `delete_your_account`: 'Smazat svůj účet'
- `delete_account`: 'Smazat účet'

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments