### PR TITLE
feat(console): add OSS onboarding flow with localized copy

### DIFF
--- a/packages/console/src/assets/icons/briefcase.svg
+++ b/packages/console/src/assets/icons/briefcase.svg
@@ -1,0 +1,20 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7 17C7 14.7909 8.79086 13 11 13L37 13C39.2091 13 41 14.7909 41 17V35C41 37.2091 39.2091 39 37 39H11C8.79086 39 7 37.2091 7 35L7 17Z" fill="url(#paint0_linear_2212_2083)"/>
+<path d="M37.6 13H10.4C8.52223 13 7 14.7909 7 17V23C7 25.2091 8.52223 27 10.4 27H17.2H18H19H20H20.6H27.4H28H29H30H30.8H37.6C39.4778 27 41 25.2091 41 23V17C41 14.7909 39.4778 13 37.6 13Z" fill="url(#paint1_linear_2212_2083)"/>
+<rect opacity="0.6" x="17" y="22" width="3" height="8" rx="1.5" fill="#7B0093"/>
+<rect opacity="0.6" x="28" y="22" width="3" height="8" rx="1.5" fill="#7B0093"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M15 12C15 10.3431 16.3431 9 18 9H30C31.6569 9 33 10.3431 33 12V13C33 13.5523 32.5523 14 32 14C31.4477 14 31 13.5523 31 13V12C31 11.4477 30.5523 11 30 11H18C17.4477 11 17 11.4477 17 12V13C17 13.5523 16.5523 14 16 14C15.4477 14 15 13.5523 15 13V12Z" fill="#34353F"/>
+<circle cx="7" cy="19" r="1.5" stroke="#FFD5FF"/>
+<rect x="36.879" y="7" width="3" height="3" rx="0.5" transform="rotate(-45 36.879 7)" stroke="#E6DEFF"/>
+<rect x="18.7071" y="44.8284" width="3" height="3" rx="0.5" transform="rotate(-45 18.7071 44.8284)" stroke="#E6DEFF"/>
+<defs>
+<linearGradient id="paint0_linear_2212_2083" x1="35.5104" y1="15.9792" x2="20.4222" y2="40.5618" gradientUnits="userSpaceOnUse">
+<stop stop-color="#F07EFF"/>
+<stop offset="1" stop-color="#FFF480"/>
+</linearGradient>
+<linearGradient id="paint1_linear_2212_2083" x1="32.5" y1="27" x2="14.3879" y2="10.0847" gradientUnits="userSpaceOnUse">
+<stop stop-color="#5D34F2"/>
+<stop offset="1" stop-color="#FAABFF"/>
+</linearGradient>
+</defs>
+</svg>

--- a/packages/console/src/containers/ConsoleRoutes/index.tsx
+++ b/packages/console/src/containers/ConsoleRoutes/index.tsx
@@ -55,7 +55,9 @@ export function ConsoleRoutes() {
           <Route element={<ProtectedRoutes />}>
             <Route path={dropLeadingSlash(GlobalRoute.Profile) + '/*'} element={<Profile />} />
             <Route element={<TenantAccess />}>
-              {!isCloud && <Route path="onboarding" element={<OssOnboarding />} />}
+              {!isCloud && isDevFeaturesEnabled && (
+                <Route path="onboarding" element={<OssOnboarding />} />
+              )}
               {isCloud && (
                 <Route
                   path={dropLeadingSlash(GlobalRoute.CheckoutSuccessCallback)}

--- a/packages/console/src/containers/ConsoleRoutes/index.tsx
+++ b/packages/console/src/containers/ConsoleRoutes/index.tsx
@@ -9,6 +9,7 @@ import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
 import AppBoundary from '@/containers/AppBoundary';
 import AppContent, { RedirectToFirstItem } from '@/containers/AppContent';
 import ConsoleContent from '@/containers/ConsoleContent';
+import OssOnboardingGuard from '@/containers/OssOnboardingGuard';
 import ProtectedRoutes from '@/containers/ProtectedRoutes';
 import TenantAccess from '@/containers/TenantAccess';
 import { GlobalRoute } from '@/contexts/TenantsProvider';
@@ -21,6 +22,7 @@ import { __Internal__ImportError } from './internal';
 
 const Welcome = safeLazy(async () => import('@/pages/Welcome'));
 const Profile = safeLazy(async () => import('@/pages/Profile'));
+const OssOnboarding = safeLazy(async () => import('@/pages/OssOnboarding'));
 
 function Layout() {
   const swrOptions = useSwrOptions();
@@ -53,15 +55,18 @@ export function ConsoleRoutes() {
           <Route element={<ProtectedRoutes />}>
             <Route path={dropLeadingSlash(GlobalRoute.Profile) + '/*'} element={<Profile />} />
             <Route element={<TenantAccess />}>
+              {!isCloud && <Route path="onboarding" element={<OssOnboarding />} />}
               {isCloud && (
                 <Route
                   path={dropLeadingSlash(GlobalRoute.CheckoutSuccessCallback)}
                   element={<CheckoutSuccessCallback />}
                 />
               )}
-              <Route element={<AppContent />}>
-                <Route index element={<RedirectToFirstItem />} />
-                <Route path="*" element={<ConsoleContent />} />
+              <Route element={<OssOnboardingGuard />}>
+                <Route element={<AppContent />}>
+                  <Route index element={<RedirectToFirstItem />} />
+                  <Route path="*" element={<ConsoleContent />} />
+                </Route>
               </Route>
             </Route>
           </Route>

--- a/packages/console/src/containers/OssOnboardingGuard/index.tsx
+++ b/packages/console/src/containers/OssOnboardingGuard/index.tsx
@@ -1,0 +1,35 @@
+import { useParams, Navigate, Outlet, useLocation } from 'react-router-dom';
+
+import AppLoading from '@/components/AppLoading';
+import { isCloud } from '@/consts/env';
+import useOssOnboardingData from '@/hooks/use-oss-onboarding-data';
+
+import { getOssOnboardingRedirectPath } from './utils';
+
+function OssOnboardingGuard() {
+  const { tenantId } = useParams();
+  const { pathname } = useLocation();
+  const { isLoading, isOnboardingDone } = useOssOnboardingData();
+
+  if (isLoading) {
+    return <AppLoading />;
+  }
+
+  const redirectPath = tenantId
+    ? getOssOnboardingRedirectPath({
+        isCloud,
+        isLoading,
+        isOnboardingDone,
+        tenantId,
+        pathname,
+      })
+    : undefined;
+
+  if (redirectPath) {
+    return <Navigate replace to={redirectPath} />;
+  }
+
+  return <Outlet />;
+}
+
+export default OssOnboardingGuard;

--- a/packages/console/src/containers/OssOnboardingGuard/index.tsx
+++ b/packages/console/src/containers/OssOnboardingGuard/index.tsx
@@ -9,7 +9,7 @@ import { getOssOnboardingRedirectPath } from './utils';
 function OssOnboardingGuard() {
   const { tenantId } = useParams();
   const { pathname } = useLocation();
-  const { isLoading, isOnboardingDone } = useOssOnboardingData();
+  const { error, isLoading, isOnboardingDone } = useOssOnboardingData();
 
   if (isLoading) {
     return <AppLoading />;
@@ -19,6 +19,7 @@ function OssOnboardingGuard() {
     ? getOssOnboardingRedirectPath({
         isCloud,
         isDevFeaturesEnabled,
+        hasError: Boolean(error),
         isLoading,
         isOnboardingDone,
         tenantId,

--- a/packages/console/src/containers/OssOnboardingGuard/index.tsx
+++ b/packages/console/src/containers/OssOnboardingGuard/index.tsx
@@ -1,7 +1,7 @@
 import { useParams, Navigate, Outlet, useLocation } from 'react-router-dom';
 
 import AppLoading from '@/components/AppLoading';
-import { isCloud } from '@/consts/env';
+import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
 import useOssOnboardingData from '@/hooks/use-oss-onboarding-data';
 
 import { getOssOnboardingRedirectPath } from './utils';
@@ -18,6 +18,7 @@ function OssOnboardingGuard() {
   const redirectPath = tenantId
     ? getOssOnboardingRedirectPath({
         isCloud,
+        isDevFeaturesEnabled,
         isLoading,
         isOnboardingDone,
         tenantId,

--- a/packages/console/src/containers/OssOnboardingGuard/utils.test.ts
+++ b/packages/console/src/containers/OssOnboardingGuard/utils.test.ts
@@ -1,0 +1,49 @@
+import { getOssOnboardingRedirectPath } from './utils';
+
+describe('OSS onboarding guard utils', () => {
+  test('redirects unfinished OSS users to the onboarding route', () => {
+    expect(
+      getOssOnboardingRedirectPath({
+        isCloud: false,
+        isLoading: false,
+        isOnboardingDone: false,
+        tenantId: 'console',
+        pathname: '/console/get-started',
+      })
+    ).toBe('/console/onboarding');
+  });
+
+  test('does not redirect when onboarding is already complete or when already on onboarding', () => {
+    expect(
+      getOssOnboardingRedirectPath({
+        isCloud: false,
+        isLoading: false,
+        isOnboardingDone: true,
+        tenantId: 'console',
+        pathname: '/console/get-started',
+      })
+    ).toBeUndefined();
+
+    expect(
+      getOssOnboardingRedirectPath({
+        isCloud: false,
+        isLoading: false,
+        isOnboardingDone: false,
+        tenantId: 'console',
+        pathname: '/console/onboarding',
+      })
+    ).toBeUndefined();
+  });
+
+  test('never redirects cloud routes', () => {
+    expect(
+      getOssOnboardingRedirectPath({
+        isCloud: true,
+        isLoading: false,
+        isOnboardingDone: false,
+        tenantId: 'console',
+        pathname: '/console/get-started',
+      })
+    ).toBeUndefined();
+  });
+});

--- a/packages/console/src/containers/OssOnboardingGuard/utils.test.ts
+++ b/packages/console/src/containers/OssOnboardingGuard/utils.test.ts
@@ -5,6 +5,7 @@ describe('OSS onboarding guard utils', () => {
     expect(
       getOssOnboardingRedirectPath({
         isCloud: false,
+        isDevFeaturesEnabled: true,
         isLoading: false,
         isOnboardingDone: false,
         tenantId: 'console',
@@ -17,6 +18,7 @@ describe('OSS onboarding guard utils', () => {
     expect(
       getOssOnboardingRedirectPath({
         isCloud: false,
+        isDevFeaturesEnabled: true,
         isLoading: false,
         isOnboardingDone: true,
         tenantId: 'console',
@@ -27,6 +29,7 @@ describe('OSS onboarding guard utils', () => {
     expect(
       getOssOnboardingRedirectPath({
         isCloud: false,
+        isDevFeaturesEnabled: true,
         isLoading: false,
         isOnboardingDone: false,
         tenantId: 'console',
@@ -39,6 +42,20 @@ describe('OSS onboarding guard utils', () => {
     expect(
       getOssOnboardingRedirectPath({
         isCloud: true,
+        isDevFeaturesEnabled: true,
+        isLoading: false,
+        isOnboardingDone: false,
+        tenantId: 'console',
+        pathname: '/console/get-started',
+      })
+    ).toBeUndefined();
+  });
+
+  test('does not redirect when the OSS onboarding feature is disabled', () => {
+    expect(
+      getOssOnboardingRedirectPath({
+        isCloud: false,
+        isDevFeaturesEnabled: false,
         isLoading: false,
         isOnboardingDone: false,
         tenantId: 'console',

--- a/packages/console/src/containers/OssOnboardingGuard/utils.test.ts
+++ b/packages/console/src/containers/OssOnboardingGuard/utils.test.ts
@@ -6,6 +6,7 @@ describe('OSS onboarding guard utils', () => {
       getOssOnboardingRedirectPath({
         isCloud: false,
         isDevFeaturesEnabled: true,
+        hasError: false,
         isLoading: false,
         isOnboardingDone: false,
         tenantId: 'console',
@@ -19,6 +20,7 @@ describe('OSS onboarding guard utils', () => {
       getOssOnboardingRedirectPath({
         isCloud: false,
         isDevFeaturesEnabled: true,
+        hasError: false,
         isLoading: false,
         isOnboardingDone: true,
         tenantId: 'console',
@@ -30,6 +32,7 @@ describe('OSS onboarding guard utils', () => {
       getOssOnboardingRedirectPath({
         isCloud: false,
         isDevFeaturesEnabled: true,
+        hasError: false,
         isLoading: false,
         isOnboardingDone: false,
         tenantId: 'console',
@@ -43,6 +46,7 @@ describe('OSS onboarding guard utils', () => {
       getOssOnboardingRedirectPath({
         isCloud: true,
         isDevFeaturesEnabled: true,
+        hasError: false,
         isLoading: false,
         isOnboardingDone: false,
         tenantId: 'console',
@@ -56,6 +60,21 @@ describe('OSS onboarding guard utils', () => {
       getOssOnboardingRedirectPath({
         isCloud: false,
         isDevFeaturesEnabled: false,
+        hasError: false,
+        isLoading: false,
+        isOnboardingDone: false,
+        tenantId: 'console',
+        pathname: '/console/get-started',
+      })
+    ).toBeUndefined();
+  });
+
+  test('does not redirect when onboarding state failed to load', () => {
+    expect(
+      getOssOnboardingRedirectPath({
+        isCloud: false,
+        isDevFeaturesEnabled: true,
+        hasError: true,
         isLoading: false,
         isOnboardingDone: false,
         tenantId: 'console',

--- a/packages/console/src/containers/OssOnboardingGuard/utils.ts
+++ b/packages/console/src/containers/OssOnboardingGuard/utils.ts
@@ -1,0 +1,23 @@
+type GetOssOnboardingRedirectPathOptions = {
+  isCloud: boolean;
+  isLoading: boolean;
+  isOnboardingDone: boolean;
+  tenantId: string;
+  pathname: string;
+};
+
+const onboardingPath = 'onboarding';
+
+export const getOssOnboardingRedirectPath = ({
+  isCloud,
+  isLoading,
+  isOnboardingDone,
+  tenantId,
+  pathname,
+}: GetOssOnboardingRedirectPathOptions): string | undefined => {
+  if (isCloud || isLoading || isOnboardingDone || pathname.endsWith(`/${onboardingPath}`)) {
+    return;
+  }
+
+  return `/${tenantId}/${onboardingPath}`;
+};

--- a/packages/console/src/containers/OssOnboardingGuard/utils.ts
+++ b/packages/console/src/containers/OssOnboardingGuard/utils.ts
@@ -1,6 +1,7 @@
 type GetOssOnboardingRedirectPathOptions = {
   isCloud: boolean;
   isDevFeaturesEnabled: boolean;
+  hasError: boolean;
   isLoading: boolean;
   isOnboardingDone: boolean;
   tenantId: string;
@@ -12,6 +13,7 @@ const onboardingPath = 'onboarding';
 export const getOssOnboardingRedirectPath = ({
   isCloud,
   isDevFeaturesEnabled,
+  hasError,
   isLoading,
   isOnboardingDone,
   tenantId,
@@ -20,6 +22,7 @@ export const getOssOnboardingRedirectPath = ({
   if (
     isCloud ||
     !isDevFeaturesEnabled ||
+    hasError ||
     isLoading ||
     isOnboardingDone ||
     pathname.endsWith(`/${onboardingPath}`)

--- a/packages/console/src/containers/OssOnboardingGuard/utils.ts
+++ b/packages/console/src/containers/OssOnboardingGuard/utils.ts
@@ -1,5 +1,6 @@
 type GetOssOnboardingRedirectPathOptions = {
   isCloud: boolean;
+  isDevFeaturesEnabled: boolean;
   isLoading: boolean;
   isOnboardingDone: boolean;
   tenantId: string;
@@ -10,12 +11,19 @@ const onboardingPath = 'onboarding';
 
 export const getOssOnboardingRedirectPath = ({
   isCloud,
+  isDevFeaturesEnabled,
   isLoading,
   isOnboardingDone,
   tenantId,
   pathname,
 }: GetOssOnboardingRedirectPathOptions): string | undefined => {
-  if (isCloud || isLoading || isOnboardingDone || pathname.endsWith(`/${onboardingPath}`)) {
+  if (
+    isCloud ||
+    !isDevFeaturesEnabled ||
+    isLoading ||
+    isOnboardingDone ||
+    pathname.endsWith(`/${onboardingPath}`)
+  ) {
     return;
   }
 

--- a/packages/console/src/hooks/use-current-user.ts
+++ b/packages/console/src/hooks/use-current-user.ts
@@ -51,12 +51,31 @@ const useCurrentUser = () => {
         return;
       }
 
-      // Account API uses 'replace' mode, so we need to merge with existing customData
-      const mergedCustomData = { ...user.customData, ...customData };
-      const data = await accountApi
-        .patch('', { json: { customData: mergedCustomData } })
-        .json<UserProfileResponse>();
-      await mutate({ ...user, customData: data.customData });
+      try {
+        // Account API uses 'replace' mode, so we need to merge with existing customData
+        const mergedCustomData = { ...user.customData, ...customData };
+        const data = await accountApi
+          .patch('', { json: { customData: mergedCustomData } })
+          .json<UserProfileResponse>();
+        await mutate({ ...user, customData: data.customData });
+      } catch (error: unknown) {
+        if (error instanceof HTTPError) {
+          const { response } = error;
+
+          try {
+            const data = await response.clone().json<RequestErrorBody>();
+            toast.error(
+              [data.message, data.details].join('\n') || t('errors.unknown_server_error')
+            );
+          } catch {
+            toast.error(t('errors.unknown_server_error'));
+          }
+
+          return;
+        }
+
+        throw error;
+      }
     },
     [accountApi, mutate, t, user]
   );

--- a/packages/console/src/hooks/use-current-user.ts
+++ b/packages/console/src/hooks/use-current-user.ts
@@ -59,6 +59,8 @@ const useCurrentUser = () => {
           .json<UserProfileResponse>();
         await mutate({ ...user, customData: data.customData });
       } catch (error: unknown) {
+        // TODO: Move shared Account API error handling into `useAccountApi()` once we define
+        // how callers opt into the right UX (for example toast versus modal feedback).
         if (error instanceof HTTPError) {
           const { response } = error;
 

--- a/packages/console/src/hooks/use-oss-onboarding-data.ts
+++ b/packages/console/src/hooks/use-oss-onboarding-data.ts
@@ -1,0 +1,53 @@
+import {
+  type OssUserOnboardingData,
+  ossUserOnboardingDataGuard,
+  ossUserOnboardingDataKey,
+} from '@logto/schemas';
+import { useCallback, useMemo } from 'react';
+import { z } from 'zod';
+
+import { isCloud } from '@/consts/env';
+
+import useCurrentUser from './use-current-user';
+
+const useOssOnboardingData = (): {
+  data: OssUserOnboardingData;
+  error: unknown;
+  isLoading: boolean;
+  isLoaded: boolean;
+  isOnboardingDone: boolean;
+  update: (data: Partial<OssUserOnboardingData>) => Promise<void>;
+} => {
+  const { customData, error, isLoading, isLoaded, updateCustomData } = useCurrentUser();
+
+  const ossOnboardingData = useMemo(() => {
+    const parsed = z
+      .object({ [ossUserOnboardingDataKey]: ossUserOnboardingDataGuard })
+      .safeParse(customData);
+
+    return parsed.success ? parsed.data[ossUserOnboardingDataKey] : {};
+  }, [customData]);
+
+  const update = useCallback(
+    async (data: Partial<OssUserOnboardingData>) => {
+      await updateCustomData({
+        [ossUserOnboardingDataKey]: {
+          ...ossOnboardingData,
+          ...data,
+        },
+      });
+    },
+    [ossOnboardingData, updateCustomData]
+  );
+
+  return {
+    data: ossOnboardingData,
+    error,
+    isLoading,
+    isLoaded,
+    isOnboardingDone: isCloud || Boolean(ossOnboardingData.isOnboardingDone),
+    update,
+  };
+};
+
+export default useOssOnboardingData;

--- a/packages/console/src/hooks/use-oss-onboarding-data.ts
+++ b/packages/console/src/hooks/use-oss-onboarding-data.ts
@@ -30,6 +30,8 @@ const useOssOnboardingData = (): {
 
   const update = useCallback(
     async (data: Partial<OssUserOnboardingData>) => {
+      // TODO: sync OSS onboarding submissions to a dedicated server-side endpoint for
+      // analysis and future marketing email outreach instead of relying only on user custom data.
       await updateCustomData({
         [ossUserOnboardingDataKey]: {
           ...ossOnboardingData,

--- a/packages/console/src/pages/OssOnboarding/index.module.scss
+++ b/packages/console/src/pages/OssOnboarding/index.module.scss
@@ -1,0 +1,110 @@
+@use '@/scss/underscore' as _;
+
+.page {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-base);
+  overflow: hidden;
+}
+
+.topbar {
+  height: 64px;
+  display: flex;
+  align-items: center;
+  padding: 0 _.unit(4);
+  flex-shrink: 0;
+}
+
+.logo {
+  width: 90px;
+  height: 28px;
+}
+
+.contentContainer {
+  flex: 1;
+  overflow-y: auto;
+  padding: _.unit(6) _.unit(4) calc(80px + _.unit(6));
+}
+
+.content {
+  margin: 0 auto;
+  max-width: 858px;
+  padding: _.unit(12);
+  border-radius: 16px;
+  background: var(--color-layer-1);
+  display: flex;
+  flex-direction: column;
+}
+
+.heroIcon {
+  width: 48px;
+  height: 48px;
+}
+
+.title {
+  margin-top: _.unit(6);
+  font: var(--font-title-1);
+}
+
+.description {
+  margin-top: _.unit(3);
+  color: var(--color-text-secondary);
+  font: var(--font-body-2);
+}
+
+.form {
+  margin-top: _.unit(6);
+  display: flex;
+  flex-direction: column;
+  gap: _.unit(6);
+}
+
+.emailSection {
+  display: flex;
+  flex-direction: column;
+  gap: _.unit(3);
+}
+
+.checkbox {
+  margin-top: 0;
+}
+
+.radioGroup {
+  width: 100%;
+}
+
+.projectGroup {
+  width: 100%;
+}
+
+.projectOptionIcon {
+  width: 20px;
+  height: 20px;
+  color: inherit;
+  flex-shrink: 0;
+}
+
+.projectRadio {
+  min-height: 60px;
+
+  > div {
+    justify-content: flex-start;
+    align-items: center;
+    padding: _.unit(5);
+  }
+}
+
+.error {
+  margin-top: _.unit(2);
+  color: var(--color-danger);
+  font: var(--font-body-3);
+}
+
+.actionBar {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1;
+}

--- a/packages/console/src/pages/OssOnboarding/index.tsx
+++ b/packages/console/src/pages/OssOnboarding/index.tsx
@@ -1,0 +1,217 @@
+import { emailRegEx } from '@logto/core-kit';
+import { CompanySize, Project, Theme } from '@logto/schemas';
+import { useContext, useEffect } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { Navigate } from 'react-router-dom';
+
+import BriefcaseIcon from '@/assets/icons/briefcase.svg?react';
+import BuildingIcon from '@/assets/icons/building.svg?react';
+import PizzaIcon from '@/assets/icons/pizza.svg?react';
+import Logo from '@/assets/images/logo.svg?react';
+import ActionBar from '@/components/ActionBar';
+import PageMeta from '@/components/PageMeta';
+import { AppThemeContext } from '@/contexts/AppThemeProvider';
+import Button from '@/ds-components/Button';
+import Checkbox from '@/ds-components/Checkbox';
+import FormField from '@/ds-components/FormField';
+import OverlayScrollbar from '@/ds-components/OverlayScrollbar';
+import RadioGroup, { Radio } from '@/ds-components/RadioGroup';
+import TextInput from '@/ds-components/TextInput';
+import useOssOnboardingData from '@/hooks/use-oss-onboarding-data';
+import useTenantPathname from '@/hooks/use-tenant-pathname';
+import { trySubmitSafe } from '@/utils/form';
+
+import styles from './index.module.scss';
+import {
+  getOssOnboardingDefaultValues,
+  getOssOnboardingSubmitPayload,
+  shouldRequireCompanyFields,
+  type OssOnboardingFormData,
+} from './utils';
+
+function OssOnboarding() {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const { setThemeOverride } = useContext(AppThemeContext);
+  const { getTo, navigate } = useTenantPathname();
+  const { data, isLoading, isOnboardingDone, update } = useOssOnboardingData();
+  const {
+    control,
+    formState: { errors, isSubmitting },
+    handleSubmit,
+    register,
+    reset,
+    watch,
+  } = useForm<OssOnboardingFormData>({
+    defaultValues: getOssOnboardingDefaultValues(),
+  });
+  const project = watch('project');
+  const isCompanyProject = shouldRequireCompanyFields(project);
+
+  useEffect(() => {
+    setThemeOverride(Theme.Light);
+
+    return () => {
+      setThemeOverride(undefined);
+    };
+  }, [setThemeOverride]);
+
+  useEffect(() => {
+    if (!isLoading) {
+      reset({
+        ...getOssOnboardingDefaultValues(),
+        ...data.questionnaire,
+      });
+    }
+  }, [data.questionnaire, isLoading, reset]);
+
+  const onSubmit = handleSubmit(
+    trySubmitSafe(async (formData) => {
+      await update({
+        questionnaire: getOssOnboardingSubmitPayload(formData),
+        isOnboardingDone: true,
+      });
+      navigate('/get-started', { replace: true });
+    })
+  );
+
+  if (isLoading) {
+    return null;
+  }
+
+  if (isOnboardingDone) {
+    return <Navigate replace to={getTo('/get-started')} />;
+  }
+
+  return (
+    <div className={styles.page}>
+      <PageMeta titleKey="oss_onboarding.page_title" />
+      <div className={styles.topbar}>
+        <Logo className={styles.logo} />
+      </div>
+      <OverlayScrollbar className={styles.contentContainer}>
+        <div className={styles.content}>
+          <BriefcaseIcon className={styles.heroIcon} />
+          <div className={styles.title}>{t('oss_onboarding.title')}</div>
+          <div className={styles.description}>{t('oss_onboarding.description')}</div>
+          <form className={styles.form} onSubmit={onSubmit}>
+            <div className={styles.emailSection}>
+              <FormField
+                title="oss_onboarding.email.label"
+                description="oss_onboarding.email.description"
+                descriptionPosition="top"
+              >
+                <TextInput
+                  // eslint-disable-next-line jsx-a11y/no-autofocus
+                  autoFocus
+                  type="email"
+                  placeholder={t('oss_onboarding.email.placeholder')}
+                  disabled={isSubmitting}
+                  error={errors.emailAddress?.message}
+                  {...register('emailAddress', {
+                    required: t('oss_onboarding.errors.email_required'),
+                    validate: (value) =>
+                      emailRegEx.test(value) || t('oss_onboarding.errors.email_invalid'),
+                  })}
+                />
+              </FormField>
+              <Controller
+                name="newsletter"
+                control={control}
+                render={({ field: { onChange, value } }) => (
+                  <Checkbox
+                    className={styles.checkbox}
+                    checked={value}
+                    label={t('oss_onboarding.newsletter')}
+                    onChange={onChange}
+                  />
+                )}
+              />
+            </div>
+            <FormField title="oss_onboarding.project.label">
+              <Controller
+                name="project"
+                control={control}
+                rules={{ required: true }}
+                render={({ field: { onChange, value, name } }) => (
+                  <RadioGroup
+                    className={styles.projectGroup}
+                    type="compact"
+                    name={name}
+                    value={value}
+                    onChange={onChange}
+                  >
+                    <Radio
+                      className={styles.projectRadio}
+                      title="oss_onboarding.project.personal"
+                      value={Project.Personal}
+                      icon={<PizzaIcon className={styles.projectOptionIcon} />}
+                    />
+                    <Radio
+                      className={styles.projectRadio}
+                      title="oss_onboarding.project.company"
+                      value={Project.Company}
+                      icon={<BuildingIcon className={styles.projectOptionIcon} />}
+                    />
+                  </RadioGroup>
+                )}
+              />
+            </FormField>
+            {isCompanyProject && (
+              <>
+                <FormField isRequired title="oss_onboarding.company_name.label">
+                  <TextInput
+                    placeholder={t('oss_onboarding.company_name.placeholder')}
+                    disabled={isSubmitting}
+                    error={errors.companyName?.message}
+                    {...register('companyName', {
+                      validate: (value) =>
+                        Boolean(value.trim()) || t('oss_onboarding.errors.company_name_required'),
+                    })}
+                  />
+                </FormField>
+                <FormField isRequired title="oss_onboarding.company_size.label">
+                  <Controller
+                    name="companySize"
+                    control={control}
+                    rules={{
+                      validate: (value) =>
+                        Boolean(value) || t('oss_onboarding.errors.company_size_required'),
+                    }}
+                    render={({ field: { onChange, value, name } }) => (
+                      <>
+                        <RadioGroup
+                          className={styles.radioGroup}
+                          type="small"
+                          name={name}
+                          value={value}
+                          onChange={onChange}
+                        >
+                          <Radio value={CompanySize.Scale1}>1</Radio>
+                          <Radio value={CompanySize.Scale2}>2-49</Radio>
+                          <Radio value={CompanySize.Scale3}>50-199</Radio>
+                          <Radio value={CompanySize.Scale4}>200-999</Radio>
+                          <Radio value={CompanySize.Scale5}>1000+</Radio>
+                        </RadioGroup>
+                        {errors.companySize?.message && (
+                          <div className={styles.error}>{errors.companySize.message}</div>
+                        )}
+                      </>
+                    )}
+                  />
+                </FormField>
+              </>
+            )}
+          </form>
+        </div>
+      </OverlayScrollbar>
+      <div className={styles.actionBar}>
+        <ActionBar>
+          <Button title="general.next" type="primary" disabled={isSubmitting} onClick={onSubmit} />
+        </ActionBar>
+      </div>
+    </div>
+  );
+}
+
+export default OssOnboarding;

--- a/packages/console/src/pages/OssOnboarding/index.tsx
+++ b/packages/console/src/pages/OssOnboarding/index.tsx
@@ -92,6 +92,8 @@ function OssOnboarding() {
       </div>
       <OverlayScrollbar className={styles.contentContainer}>
         <div className={styles.content}>
+          {/* This onboarding page currently forces light theme, and the same icon asset is used for
+           both light and dark theme variants by design. */}
           <BriefcaseIcon className={styles.heroIcon} />
           <div className={styles.title}>{t('oss_onboarding.title')}</div>
           <div className={styles.description}>{t('oss_onboarding.description')}</div>

--- a/packages/console/src/pages/OssOnboarding/index.tsx
+++ b/packages/console/src/pages/OssOnboarding/index.tsx
@@ -44,6 +44,7 @@ function OssOnboarding() {
     watch,
   } = useForm<OssOnboardingFormData>({
     defaultValues: getOssOnboardingDefaultValues(),
+    shouldUnregister: true,
   });
   const project = watch('project');
   const isCompanyProject = shouldRequireCompanyFields(project);

--- a/packages/console/src/pages/OssOnboarding/utils.test.ts
+++ b/packages/console/src/pages/OssOnboarding/utils.test.ts
@@ -1,0 +1,59 @@
+import { CompanySize, Project } from '@logto/schemas';
+
+import {
+  getOssOnboardingDefaultValues,
+  getOssOnboardingSubmitPayload,
+  shouldRequireCompanyFields,
+  type OssOnboardingFormData,
+} from './utils';
+
+describe('OSS onboarding form utils', () => {
+  test('uses company project as the default selection and leaves email blank', () => {
+    expect(getOssOnboardingDefaultValues()).toEqual({
+      emailAddress: '',
+      newsletter: false,
+      project: Project.Company,
+      companyName: '',
+      companySize: undefined,
+    });
+  });
+
+  test('requires company-only fields only for company projects', () => {
+    expect(shouldRequireCompanyFields(Project.Company)).toBe(true);
+    expect(shouldRequireCompanyFields(Project.Personal)).toBe(false);
+  });
+
+  test('drops company-only values from the submit payload for personal projects', () => {
+    const payload = getOssOnboardingSubmitPayload({
+      emailAddress: 'dev@example.com',
+      newsletter: true,
+      project: Project.Personal,
+      companyName: 'Should be ignored',
+      companySize: CompanySize.Scale3,
+    });
+
+    expect(payload).toEqual({
+      emailAddress: 'dev@example.com',
+      newsletter: true,
+      project: Project.Personal,
+    });
+  });
+
+  test('keeps company-only values in the submit payload for company projects', () => {
+    const payload = getOssOnboardingSubmitPayload({
+      emailAddress: 'dev@example.com',
+      newsletter: false,
+      project: Project.Company,
+      companyName: 'Acme',
+      companySize: CompanySize.Scale3,
+    });
+
+    expect(payload).toEqual({
+      emailAddress: 'dev@example.com',
+      newsletter: false,
+      project: Project.Company,
+      companyName: 'Acme',
+      companySize: CompanySize.Scale3,
+    } satisfies OssOnboardingFormData);
+  });
+});

--- a/packages/console/src/pages/OssOnboarding/utils.ts
+++ b/packages/console/src/pages/OssOnboarding/utils.ts
@@ -1,0 +1,31 @@
+import { type CompanySize, Project, type JsonObject } from '@logto/schemas';
+
+export type OssOnboardingFormData = {
+  emailAddress: string;
+  newsletter: boolean;
+  project: Project;
+  companyName: string;
+  companySize?: CompanySize;
+};
+
+export const getOssOnboardingDefaultValues = (): OssOnboardingFormData => ({
+  emailAddress: '',
+  newsletter: false,
+  project: Project.Company,
+  companyName: '',
+  companySize: undefined,
+});
+
+export const shouldRequireCompanyFields = (project: Project) => project === Project.Company;
+
+export const getOssOnboardingSubmitPayload = (
+  data: OssOnboardingFormData
+): JsonObject & Partial<OssOnboardingFormData> => {
+  if (!shouldRequireCompanyFields(data.project)) {
+    const { companyName: _companyName, companySize: _companySize, ...rest } = data;
+
+    return rest;
+  }
+
+  return data;
+};

--- a/packages/integration-tests/src/tests/console/bootstrap.test.ts
+++ b/packages/integration-tests/src/tests/console/bootstrap.test.ts
@@ -82,14 +82,17 @@ describe('smoke testing for console admin account creation and sign-in', () => {
 
     await expectNavigation(expect(page).toClick('button[name=submit]'));
 
-    expect(page.url()).toBe(new URL('console/onboarding', logtoConsoleUrl).href);
+    const expectedPathname = isDevFeaturesEnabled ? 'console/onboarding' : 'console/get-started';
+    expect(page.url()).toBe(new URL(expectedPathname, logtoConsoleUrl).href);
 
-    await expect(page).toFill('input[type=email]', 'oss-admin@example.com');
-    await expect(page).toFill('input[placeholder="Acme.co"]', 'Acme');
-    await expect(page).toClick('div[role=radio]', { text: '50-199' });
-    await expectNavigation(expect(page).toClick('button', { text: 'Next' }));
+    if (isDevFeaturesEnabled) {
+      await expect(page).toFill('input[type=email]', 'oss-admin@example.com');
+      await expect(page).toFill('input[placeholder="Acme.co"]', 'Acme');
+      await expect(page).toClick('div[role=radio]', { text: '50-199' });
+      await expectNavigation(expect(page).toClick('button', { text: 'Next' }));
 
-    expect(page.url()).toBe(new URL('console/get-started', logtoConsoleUrl).href);
+      expect(page.url()).toBe(new URL('console/get-started', logtoConsoleUrl).href);
+    }
   });
 
   it('should have html attributes "lang=en" and "dir=ltr" by default', async () => {

--- a/packages/integration-tests/src/tests/console/bootstrap.test.ts
+++ b/packages/integration-tests/src/tests/console/bootstrap.test.ts
@@ -82,6 +82,13 @@ describe('smoke testing for console admin account creation and sign-in', () => {
 
     await expectNavigation(expect(page).toClick('button[name=submit]'));
 
+    expect(page.url()).toBe(new URL('console/onboarding', logtoConsoleUrl).href);
+
+    await expect(page).toFill('input[type=email]', 'oss-admin@example.com');
+    await expect(page).toFill('input[placeholder="Acme.co"]', 'Acme');
+    await expect(page).toClick('div[role=radio]', { text: '50-199' });
+    await expectNavigation(expect(page).toClick('button', { text: 'Next' }));
+
     expect(page.url()).toBe(new URL('console/get-started', logtoConsoleUrl).href);
   });
 

--- a/packages/phrases/src/locales/ar/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/index.ts
@@ -28,6 +28,7 @@ import organization_details from './organization-details.js';
 import organization_role_details from './organization-role-details.js';
 import organization_template from './organization-template.js';
 import organizations from './organizations.js';
+import oss_onboarding from './oss-onboarding.js';
 import permissions from './permissions.js';
 import profile from './profile.js';
 import protected_app from './protected-app.js';
@@ -98,6 +99,7 @@ const admin_console = {
   guide,
   mfa,
   organizations,
+  oss_onboarding,
   oidc_configs,
   organization_details,
   protected_app,

--- a/packages/phrases/src/locales/ar/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/oss-onboarding.ts
@@ -1,0 +1,31 @@
+const oss_onboarding = {
+  page_title: 'الإعداد الأولي',
+  title: 'أخبرنا قليلًا عنك',
+  description: 'أخبرنا قليلًا عنك وعن مشروعك. يساعدنا ذلك على بناء Logto أفضل للجميع.',
+  email: {
+    label: 'البريد الإلكتروني',
+    description: 'سنستخدم هذا العنوان إذا احتجنا إلى التواصل معك بشأن حسابك.',
+    placeholder: 'email@example.com',
+  },
+  newsletter: 'تلقي تحديثات المنتج والتنبيهات الأمنية والمحتوى المختار من Logto.',
+  project: {
+    label: 'أستخدم Logto من أجل',
+    personal: 'مشروع شخصي',
+    company: 'مشروع شركة',
+  },
+  company_name: {
+    label: 'اسم الشركة',
+    placeholder: 'Acme.co',
+  },
+  company_size: {
+    label: 'ما حجم شركتك؟',
+  },
+  errors: {
+    email_required: 'البريد الإلكتروني مطلوب',
+    email_invalid: 'أدخل بريدًا إلكترونيًا صالحًا',
+    company_name_required: 'اسم الشركة مطلوب',
+    company_size_required: 'حجم الشركة مطلوب',
+  },
+};
+
+export default Object.freeze(oss_onboarding);

--- a/packages/phrases/src/locales/de/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/index.ts
@@ -28,6 +28,7 @@ import organization_details from './organization-details.js';
 import organization_role_details from './organization-role-details.js';
 import organization_template from './organization-template.js';
 import organizations from './organizations.js';
+import oss_onboarding from './oss-onboarding.js';
 import permissions from './permissions.js';
 import profile from './profile.js';
 import protected_app from './protected-app.js';
@@ -98,6 +99,7 @@ const admin_console = {
   guide,
   mfa,
   organizations,
+  oss_onboarding,
   oidc_configs,
   organization_details,
   protected_app,

--- a/packages/phrases/src/locales/de/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/oss-onboarding.ts
@@ -1,0 +1,33 @@
+const oss_onboarding = {
+  page_title: 'Einführung',
+  title: 'Erzähl uns etwas über dich',
+  description:
+    'Erzähl uns etwas über dich und dein Projekt. Das hilft uns, Logto für alle besser zu machen.',
+  email: {
+    label: 'E-Mail-Adresse',
+    description:
+      'Wir verwenden diese Adresse, wenn wir dich wegen deines Kontos kontaktieren müssen.',
+    placeholder: 'email@example.com',
+  },
+  newsletter: 'Produktupdates, Sicherheitshinweise und ausgewählte Inhalte von Logto erhalten.',
+  project: {
+    label: 'Ich nutze Logto für',
+    personal: 'Persönliches Projekt',
+    company: 'Unternehmensprojekt',
+  },
+  company_name: {
+    label: 'Firmenname',
+    placeholder: 'Acme.co',
+  },
+  company_size: {
+    label: 'Wie groß ist dein Unternehmen?',
+  },
+  errors: {
+    email_required: 'E-Mail-Adresse ist erforderlich',
+    email_invalid: 'Gib eine gültige E-Mail-Adresse ein',
+    company_name_required: 'Firmenname ist erforderlich',
+    company_size_required: 'Unternehmensgröße ist erforderlich',
+  },
+};
+
+export default Object.freeze(oss_onboarding);

--- a/packages/phrases/src/locales/en/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/index.ts
@@ -28,6 +28,7 @@ import organization_details from './organization-details.js';
 import organization_role_details from './organization-role-details.js';
 import organization_template from './organization-template.js';
 import organizations from './organizations.js';
+import oss_onboarding from './oss-onboarding.js';
 import permissions from './permissions.js';
 import profile from './profile.js';
 import protected_app from './protected-app.js';
@@ -98,6 +99,7 @@ const admin_console = {
   guide,
   mfa,
   organizations,
+  oss_onboarding,
   oidc_configs,
   organization_details,
   protected_app,

--- a/packages/phrases/src/locales/en/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/oss-onboarding.ts
@@ -19,7 +19,7 @@ const oss_onboarding = {
     placeholder: 'Acme.co',
   },
   company_size: {
-    label: 'How’s your company size?',
+    label: 'What’s your company size?',
   },
   errors: {
     email_required: 'Email address is required',

--- a/packages/phrases/src/locales/en/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/oss-onboarding.ts
@@ -1,0 +1,32 @@
+const oss_onboarding = {
+  page_title: 'Onboarding',
+  title: 'A little bit about you',
+  description:
+    'Tell us a bit about yourself and your project. This helps us build a better Logto for everyone.',
+  email: {
+    label: 'Email address',
+    description: 'We’ll use this address if we need to contact you about your account.',
+    placeholder: 'email@example.com',
+  },
+  newsletter: 'Receive product updates, security advisories, and curated content from Logto.',
+  project: {
+    label: 'I’m using Logto for',
+    personal: 'Personal project',
+    company: 'Company project',
+  },
+  company_name: {
+    label: 'Company name',
+    placeholder: 'Acme.co',
+  },
+  company_size: {
+    label: 'How’s your company size?',
+  },
+  errors: {
+    email_required: 'Email address is required',
+    email_invalid: 'Enter a valid email address',
+    company_name_required: 'Company name is required',
+    company_size_required: 'Company size is required',
+  },
+};
+
+export default Object.freeze(oss_onboarding);

--- a/packages/phrases/src/locales/es/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/index.ts
@@ -28,6 +28,7 @@ import organization_details from './organization-details.js';
 import organization_role_details from './organization-role-details.js';
 import organization_template from './organization-template.js';
 import organizations from './organizations.js';
+import oss_onboarding from './oss-onboarding.js';
 import permissions from './permissions.js';
 import profile from './profile.js';
 import protected_app from './protected-app.js';
@@ -98,6 +99,7 @@ const admin_console = {
   guide,
   mfa,
   organizations,
+  oss_onboarding,
   oidc_configs,
   organization_details,
   protected_app,

--- a/packages/phrases/src/locales/es/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/oss-onboarding.ts
@@ -1,0 +1,33 @@
+const oss_onboarding = {
+  page_title: 'Incorporación',
+  title: 'Cuéntanos un poco sobre ti',
+  description:
+    'Cuéntanos un poco sobre ti y tu proyecto. Esto nos ayuda a crear un Logto mejor para todos.',
+  email: {
+    label: 'Correo electrónico',
+    description: 'Usaremos esta dirección si necesitamos contactarte sobre tu cuenta.',
+    placeholder: 'email@example.com',
+  },
+  newsletter:
+    'Recibe actualizaciones del producto, avisos de seguridad y contenido seleccionado de Logto.',
+  project: {
+    label: 'Uso Logto para',
+    personal: 'Proyecto personal',
+    company: 'Proyecto de empresa',
+  },
+  company_name: {
+    label: 'Nombre de la empresa',
+    placeholder: 'Acme.co',
+  },
+  company_size: {
+    label: '¿Cuál es el tamaño de tu empresa?',
+  },
+  errors: {
+    email_required: 'El correo electrónico es obligatorio',
+    email_invalid: 'Introduce un correo electrónico válido',
+    company_name_required: 'El nombre de la empresa es obligatorio',
+    company_size_required: 'El tamaño de la empresa es obligatorio',
+  },
+};
+
+export default Object.freeze(oss_onboarding);

--- a/packages/phrases/src/locales/fr/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/index.ts
@@ -28,6 +28,7 @@ import organization_details from './organization-details.js';
 import organization_role_details from './organization-role-details.js';
 import organization_template from './organization-template.js';
 import organizations from './organizations.js';
+import oss_onboarding from './oss-onboarding.js';
 import permissions from './permissions.js';
 import profile from './profile.js';
 import protected_app from './protected-app.js';
@@ -98,6 +99,7 @@ const admin_console = {
   guide,
   mfa,
   organizations,
+  oss_onboarding,
   oidc_configs,
   organization_details,
   protected_app,

--- a/packages/phrases/src/locales/fr/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/oss-onboarding.ts
@@ -1,0 +1,34 @@
+const oss_onboarding = {
+  page_title: 'Onboarding',
+  title: 'Parlez-nous un peu de vous',
+  description:
+    'Parlez-nous un peu de vous et de votre projet. Cela nous aide a ameliorer Logto pour tout le monde.',
+  email: {
+    label: 'Adresse e-mail',
+    description:
+      'Nous utiliserons cette adresse si nous devons vous contacter au sujet de votre compte.',
+    placeholder: 'email@example.com',
+  },
+  newsletter:
+    'Recevoir les mises a jour produit, les avis de securite et du contenu selectionne de Logto.',
+  project: {
+    label: "J'utilise Logto pour",
+    personal: 'Projet personnel',
+    company: "Projet d'entreprise",
+  },
+  company_name: {
+    label: "Nom de l'entreprise",
+    placeholder: 'Acme.co',
+  },
+  company_size: {
+    label: 'Quelle est la taille de votre entreprise ?',
+  },
+  errors: {
+    email_required: "L'adresse e-mail est requise",
+    email_invalid: 'Saisissez une adresse e-mail valide',
+    company_name_required: "Le nom de l'entreprise est requis",
+    company_size_required: "La taille de l'entreprise est requise",
+  },
+};
+
+export default Object.freeze(oss_onboarding);

--- a/packages/phrases/src/locales/it/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/index.ts
@@ -28,6 +28,7 @@ import organization_details from './organization-details.js';
 import organization_role_details from './organization-role-details.js';
 import organization_template from './organization-template.js';
 import organizations from './organizations.js';
+import oss_onboarding from './oss-onboarding.js';
 import permissions from './permissions.js';
 import profile from './profile.js';
 import protected_app from './protected-app.js';
@@ -98,6 +99,7 @@ const admin_console = {
   guide,
   mfa,
   organizations,
+  oss_onboarding,
   oidc_configs,
   organization_details,
   protected_app,

--- a/packages/phrases/src/locales/it/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/oss-onboarding.ts
@@ -1,0 +1,34 @@
+const oss_onboarding = {
+  page_title: 'Onboarding',
+  title: 'Raccontaci qualcosa di te',
+  description:
+    'Raccontaci qualcosa di te e del tuo progetto. Questo ci aiuta a rendere Logto migliore per tutti.',
+  email: {
+    label: 'Indirizzo email',
+    description:
+      'Useremo questo indirizzo se avremo bisogno di contattarti riguardo al tuo account.',
+    placeholder: 'email@example.com',
+  },
+  newsletter:
+    'Ricevi aggiornamenti sul prodotto, avvisi di sicurezza e contenuti selezionati da Logto.',
+  project: {
+    label: 'Uso Logto per',
+    personal: 'Progetto personale',
+    company: 'Progetto aziendale',
+  },
+  company_name: {
+    label: "Nome dell'azienda",
+    placeholder: 'Acme.co',
+  },
+  company_size: {
+    label: 'Qual e la dimensione della tua azienda?',
+  },
+  errors: {
+    email_required: "L'indirizzo email e obbligatorio",
+    email_invalid: 'Inserisci un indirizzo email valido',
+    company_name_required: "Il nome dell'azienda e obbligatorio",
+    company_size_required: "La dimensione dell'azienda e obbligatoria",
+  },
+};
+
+export default Object.freeze(oss_onboarding);

--- a/packages/phrases/src/locales/ja/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/index.ts
@@ -28,6 +28,7 @@ import organization_details from './organization-details.js';
 import organization_role_details from './organization-role-details.js';
 import organization_template from './organization-template.js';
 import organizations from './organizations.js';
+import oss_onboarding from './oss-onboarding.js';
 import permissions from './permissions.js';
 import profile from './profile.js';
 import protected_app from './protected-app.js';
@@ -98,6 +99,7 @@ const admin_console = {
   guide,
   mfa,
   organizations,
+  oss_onboarding,
   oidc_configs,
   organization_details,
   protected_app,

--- a/packages/phrases/src/locales/ja/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/oss-onboarding.ts
@@ -1,0 +1,32 @@
+const oss_onboarding = {
+  page_title: 'オンボーディング',
+  title: 'あなたについて少し教えてください',
+  description:
+    'あなた自身とプロジェクトについて少し教えてください。Logto をより良くするために役立ちます。',
+  email: {
+    label: 'メールアドレス',
+    description: 'アカウントについて連絡が必要な場合、このアドレスを使用します。',
+    placeholder: 'email@example.com',
+  },
+  newsletter: 'Logto から製品アップデート、セキュリティ通知、厳選コンテンツを受け取る。',
+  project: {
+    label: 'Logto の利用目的',
+    personal: '個人プロジェクト',
+    company: '会社のプロジェクト',
+  },
+  company_name: {
+    label: '会社名',
+    placeholder: 'Acme.co',
+  },
+  company_size: {
+    label: '会社の規模はどれくらいですか？',
+  },
+  errors: {
+    email_required: 'メールアドレスは必須です',
+    email_invalid: '有効なメールアドレスを入力してください',
+    company_name_required: '会社名は必須です',
+    company_size_required: '会社規模は必須です',
+  },
+};
+
+export default Object.freeze(oss_onboarding);

--- a/packages/phrases/src/locales/ko/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/index.ts
@@ -28,6 +28,7 @@ import organization_details from './organization-details.js';
 import organization_role_details from './organization-role-details.js';
 import organization_template from './organization-template.js';
 import organizations from './organizations.js';
+import oss_onboarding from './oss-onboarding.js';
 import permissions from './permissions.js';
 import profile from './profile.js';
 import protected_app from './protected-app.js';
@@ -98,6 +99,7 @@ const admin_console = {
   guide,
   mfa,
   organizations,
+  oss_onboarding,
   oidc_configs,
   organization_details,
   protected_app,

--- a/packages/phrases/src/locales/ko/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/oss-onboarding.ts
@@ -1,0 +1,31 @@
+const oss_onboarding = {
+  page_title: '온보딩',
+  title: '당신에 대해 조금 알려주세요',
+  description: '당신과 프로젝트에 대해 조금 알려주세요. 더 나은 Logto를 만드는 데 도움이 됩니다.',
+  email: {
+    label: '이메일 주소',
+    description: '계정 관련 연락이 필요할 때 이 주소를 사용합니다.',
+    placeholder: 'email@example.com',
+  },
+  newsletter: 'Logto의 제품 업데이트, 보안 공지, 큐레이션된 콘텐츠를 받아보세요.',
+  project: {
+    label: 'Logto를 사용하는 목적',
+    personal: '개인 프로젝트',
+    company: '회사 프로젝트',
+  },
+  company_name: {
+    label: '회사명',
+    placeholder: 'Acme.co',
+  },
+  company_size: {
+    label: '회사의 규모는 어느 정도인가요?',
+  },
+  errors: {
+    email_required: '이메일 주소는 필수입니다',
+    email_invalid: '유효한 이메일 주소를 입력하세요',
+    company_name_required: '회사명은 필수입니다',
+    company_size_required: '회사 규모는 필수입니다',
+  },
+};
+
+export default Object.freeze(oss_onboarding);

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/index.ts
@@ -28,6 +28,7 @@ import organization_details from './organization-details.js';
 import organization_role_details from './organization-role-details.js';
 import organization_template from './organization-template.js';
 import organizations from './organizations.js';
+import oss_onboarding from './oss-onboarding.js';
 import permissions from './permissions.js';
 import profile from './profile.js';
 import protected_app from './protected-app.js';
@@ -98,6 +99,7 @@ const admin_console = {
   guide,
   mfa,
   organizations,
+  oss_onboarding,
   oidc_configs,
   organization_details,
   protected_app,

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/oss-onboarding.ts
@@ -1,0 +1,34 @@
+const oss_onboarding = {
+  page_title: 'Wprowadzenie',
+  title: 'Opowiedz nam troche o sobie',
+  description:
+    'Opowiedz nam troche o sobie i swoim projekcie. To pomaga nam tworzyc lepsze Logto dla wszystkich.',
+  email: {
+    label: 'Adres e-mail',
+    description:
+      'Uzyjemy tego adresu, jesli bedziemy musieli skontaktowac sie z Toba w sprawie konta.',
+    placeholder: 'email@example.com',
+  },
+  newsletter:
+    'Otrzymuj aktualizacje produktu, powiadomienia bezpieczenstwa i wybrane tresci od Logto.',
+  project: {
+    label: 'Uzywam Logto do',
+    personal: 'Projektu osobistego',
+    company: 'Projektu firmowego',
+  },
+  company_name: {
+    label: 'Nazwa firmy',
+    placeholder: 'Acme.co',
+  },
+  company_size: {
+    label: 'Jaka jest wielkosc Twojej firmy?',
+  },
+  errors: {
+    email_required: 'Adres e-mail jest wymagany',
+    email_invalid: 'Wprowadz prawidlowy adres e-mail',
+    company_name_required: 'Nazwa firmy jest wymagana',
+    company_size_required: 'Wielkosc firmy jest wymagana',
+  },
+};
+
+export default Object.freeze(oss_onboarding);

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/index.ts
@@ -28,6 +28,7 @@ import organization_details from './organization-details.js';
 import organization_role_details from './organization-role-details.js';
 import organization_template from './organization-template.js';
 import organizations from './organizations.js';
+import oss_onboarding from './oss-onboarding.js';
 import permissions from './permissions.js';
 import profile from './profile.js';
 import protected_app from './protected-app.js';
@@ -98,6 +99,7 @@ const admin_console = {
   guide,
   mfa,
   organizations,
+  oss_onboarding,
   oidc_configs,
   organization_details,
   protected_app,

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/oss-onboarding.ts
@@ -1,0 +1,33 @@
+const oss_onboarding = {
+  page_title: 'Onboarding',
+  title: 'Conte um pouco sobre voce',
+  description:
+    'Conte um pouco sobre voce e seu projeto. Isso nos ajuda a construir um Logto melhor para todos.',
+  email: {
+    label: 'Endereco de e-mail',
+    description: 'Usaremos este endereco se precisarmos entrar em contato sobre sua conta.',
+    placeholder: 'email@example.com',
+  },
+  newsletter:
+    'Receba atualizacoes do produto, avisos de seguranca e conteudo selecionado da Logto.',
+  project: {
+    label: 'Estou usando o Logto para',
+    personal: 'Projeto pessoal',
+    company: 'Projeto da empresa',
+  },
+  company_name: {
+    label: 'Nome da empresa',
+    placeholder: 'Acme.co',
+  },
+  company_size: {
+    label: 'Qual e o tamanho da sua empresa?',
+  },
+  errors: {
+    email_required: 'O endereco de e-mail e obrigatorio',
+    email_invalid: 'Digite um endereco de e-mail valido',
+    company_name_required: 'O nome da empresa e obrigatorio',
+    company_size_required: 'O tamanho da empresa e obrigatorio',
+  },
+};
+
+export default Object.freeze(oss_onboarding);

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/index.ts
@@ -28,6 +28,7 @@ import organization_details from './organization-details.js';
 import organization_role_details from './organization-role-details.js';
 import organization_template from './organization-template.js';
 import organizations from './organizations.js';
+import oss_onboarding from './oss-onboarding.js';
 import permissions from './permissions.js';
 import profile from './profile.js';
 import protected_app from './protected-app.js';
@@ -98,6 +99,7 @@ const admin_console = {
   guide,
   mfa,
   organizations,
+  oss_onboarding,
   oidc_configs,
   organization_details,
   protected_app,

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/oss-onboarding.ts
@@ -1,0 +1,34 @@
+const oss_onboarding = {
+  page_title: 'Onboarding',
+  title: 'Conte-nos um pouco sobre si',
+  description:
+    'Conte-nos um pouco sobre si e o seu projeto. Isto ajuda-nos a tornar o Logto melhor para todos.',
+  email: {
+    label: 'Endereco de email',
+    description:
+      'Usaremos este endereco se precisarmos de entrar em contacto consigo sobre a sua conta.',
+    placeholder: 'email@example.com',
+  },
+  newsletter:
+    'Receba atualizacoes do produto, avisos de seguranca e conteudo selecionado da Logto.',
+  project: {
+    label: 'Estou a usar o Logto para',
+    personal: 'Projeto pessoal',
+    company: 'Projeto empresarial',
+  },
+  company_name: {
+    label: 'Nome da empresa',
+    placeholder: 'Acme.co',
+  },
+  company_size: {
+    label: 'Qual e a dimensao da sua empresa?',
+  },
+  errors: {
+    email_required: 'O endereco de email e obrigatorio',
+    email_invalid: 'Introduza um endereco de email valido',
+    company_name_required: 'O nome da empresa e obrigatorio',
+    company_size_required: 'A dimensao da empresa e obrigatoria',
+  },
+};
+
+export default Object.freeze(oss_onboarding);

--- a/packages/phrases/src/locales/ru/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/index.ts
@@ -28,6 +28,7 @@ import organization_details from './organization-details.js';
 import organization_role_details from './organization-role-details.js';
 import organization_template from './organization-template.js';
 import organizations from './organizations.js';
+import oss_onboarding from './oss-onboarding.js';
 import permissions from './permissions.js';
 import profile from './profile.js';
 import protected_app from './protected-app.js';
@@ -98,6 +99,7 @@ const admin_console = {
   guide,
   mfa,
   organizations,
+  oss_onboarding,
   oidc_configs,
   organization_details,
   protected_app,

--- a/packages/phrases/src/locales/ru/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/oss-onboarding.ts
@@ -1,0 +1,34 @@
+const oss_onboarding = {
+  page_title: 'Онбординг',
+  title: 'Расскажите немного о себе',
+  description:
+    'Расскажите немного о себе и своем проекте. Это помогает нам делать Logto лучше для всех.',
+  email: {
+    label: 'Электронная почта',
+    description:
+      'Мы будем использовать этот адрес, если понадобится связаться с вами по поводу аккаунта.',
+    placeholder: 'email@example.com',
+  },
+  newsletter:
+    'Получать обновления продукта, уведомления о безопасности и подборку материалов от Logto.',
+  project: {
+    label: 'Я использую Logto для',
+    personal: 'Личного проекта',
+    company: 'Проекта компании',
+  },
+  company_name: {
+    label: 'Название компании',
+    placeholder: 'Acme.co',
+  },
+  company_size: {
+    label: 'Каков размер вашей компании?',
+  },
+  errors: {
+    email_required: 'Электронная почта обязательна',
+    email_invalid: 'Введите корректный адрес электронной почты',
+    company_name_required: 'Название компании обязательно',
+    company_size_required: 'Размер компании обязателен',
+  },
+};
+
+export default Object.freeze(oss_onboarding);

--- a/packages/phrases/src/locales/th/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/index.ts
@@ -28,6 +28,7 @@ import organization_details from './organization-details.js';
 import organization_role_details from './organization-role-details.js';
 import organization_template from './organization-template.js';
 import organizations from './organizations.js';
+import oss_onboarding from './oss-onboarding.js';
 import permissions from './permissions.js';
 import profile from './profile.js';
 import protected_app from './protected-app.js';
@@ -98,6 +99,7 @@ const admin_console = {
   guide,
   mfa,
   organizations,
+  oss_onboarding,
   oidc_configs,
   organization_details,
   protected_app,

--- a/packages/phrases/src/locales/th/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/oss-onboarding.ts
@@ -1,0 +1,32 @@
+const oss_onboarding = {
+  page_title: 'เริ่มต้นใช้งาน',
+  title: 'บอกเราเกี่ยวกับคุณสักเล็กน้อย',
+  description:
+    'บอกเราเกี่ยวกับตัวคุณและโปรเจกต์ของคุณสักเล็กน้อย เพื่อช่วยให้เราสร้าง Logto ที่ดีขึ้นสำหรับทุกคน',
+  email: {
+    label: 'อีเมล',
+    description: 'เราจะใช้อีเมลนี้หากจำเป็นต้องติดต่อคุณเกี่ยวกับบัญชีของคุณ',
+    placeholder: 'email@example.com',
+  },
+  newsletter: 'รับอัปเดตผลิตภัณฑ์ คำแนะนำด้านความปลอดภัย และเนื้อหาคัดสรรจาก Logto',
+  project: {
+    label: 'ฉันใช้ Logto สำหรับ',
+    personal: 'โปรเจกต์ส่วนตัว',
+    company: 'โปรเจกต์ของบริษัท',
+  },
+  company_name: {
+    label: 'ชื่อบริษัท',
+    placeholder: 'Acme.co',
+  },
+  company_size: {
+    label: 'บริษัทของคุณมีขนาดเท่าไร?',
+  },
+  errors: {
+    email_required: 'จำเป็นต้องกรอกอีเมล',
+    email_invalid: 'กรุณากรอกอีเมลที่ถูกต้อง',
+    company_name_required: 'จำเป็นต้องกรอกชื่อบริษัท',
+    company_size_required: 'จำเป็นต้องเลือกขนาดบริษัท',
+  },
+};
+
+export default Object.freeze(oss_onboarding);

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/index.ts
@@ -28,6 +28,7 @@ import organization_details from './organization-details.js';
 import organization_role_details from './organization-role-details.js';
 import organization_template from './organization-template.js';
 import organizations from './organizations.js';
+import oss_onboarding from './oss-onboarding.js';
 import permissions from './permissions.js';
 import profile from './profile.js';
 import protected_app from './protected-app.js';
@@ -98,6 +99,7 @@ const admin_console = {
   guide,
   mfa,
   organizations,
+  oss_onboarding,
   oidc_configs,
   organization_details,
   protected_app,

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/oss-onboarding.ts
@@ -1,0 +1,33 @@
+const oss_onboarding = {
+  page_title: 'Onboarding',
+  title: 'Bize biraz kendinizden bahsedin',
+  description:
+    'Bize kendinizden ve projenizden biraz bahsedin. Bu, herkes icin daha iyi bir Logto oluşturmamiza yardimci olur.',
+  email: {
+    label: 'E-posta adresi',
+    description: 'Hesabinizla ilgili sizinle iletisime gecmemiz gerekirse bu adresi kullanacagiz.',
+    placeholder: 'email@example.com',
+  },
+  newsletter:
+    'Logto’dan urun guncellemeleri, guvenlik bildirimleri ve ozenle secilmis icerikler alin.',
+  project: {
+    label: 'Logto’yu su amacla kullaniyorum',
+    personal: 'Kisisel proje',
+    company: 'Sirket projesi',
+  },
+  company_name: {
+    label: 'Sirket adi',
+    placeholder: 'Acme.co',
+  },
+  company_size: {
+    label: 'Sirketinizin buyuklugu nedir?',
+  },
+  errors: {
+    email_required: 'E-posta adresi gerekli',
+    email_invalid: 'Gecerli bir e-posta adresi girin',
+    company_name_required: 'Sirket adi gerekli',
+    company_size_required: 'Sirket buyuklugu gerekli',
+  },
+};
+
+export default Object.freeze(oss_onboarding);

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/index.ts
@@ -28,6 +28,7 @@ import organization_details from './organization-details.js';
 import organization_role_details from './organization-role-details.js';
 import organization_template from './organization-template.js';
 import organizations from './organizations.js';
+import oss_onboarding from './oss-onboarding.js';
 import permissions from './permissions.js';
 import profile from './profile.js';
 import protected_app from './protected-app.js';
@@ -98,6 +99,7 @@ const admin_console = {
   guide,
   mfa,
   organizations,
+  oss_onboarding,
   oidc_configs,
   organization_details,
   protected_app,

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/oss-onboarding.ts
@@ -18,7 +18,7 @@ const oss_onboarding = {
     placeholder: 'Acme.co',
   },
   company_size: {
-    label: '你的公司规模是？',
+    label: '你的公司规模有多大？',
   },
   errors: {
     email_required: '邮箱地址为必填项',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/oss-onboarding.ts
@@ -1,0 +1,31 @@
+const oss_onboarding = {
+  page_title: '入门',
+  title: '简单介绍一下你自己',
+  description: '告诉我们一点关于你和你的项目的信息，这将帮助我们为所有人打造更好的 Logto。',
+  email: {
+    label: '邮箱地址',
+    description: '如果我们需要就你的账户联系你，会使用这个邮箱地址。',
+    placeholder: 'email@example.com',
+  },
+  newsletter: '接收来自 Logto 的产品更新、安全通知和精选内容。',
+  project: {
+    label: '我使用 Logto 是为了',
+    personal: '个人项目',
+    company: '公司项目',
+  },
+  company_name: {
+    label: '公司名称',
+    placeholder: 'Acme.co',
+  },
+  company_size: {
+    label: '你的公司规模是？',
+  },
+  errors: {
+    email_required: '邮箱地址为必填项',
+    email_invalid: '请输入有效的邮箱地址',
+    company_name_required: '公司名称为必填项',
+    company_size_required: '公司规模为必填项',
+  },
+};
+
+export default Object.freeze(oss_onboarding);

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/index.ts
@@ -28,6 +28,7 @@ import organization_details from './organization-details.js';
 import organization_role_details from './organization-role-details.js';
 import organization_template from './organization-template.js';
 import organizations from './organizations.js';
+import oss_onboarding from './oss-onboarding.js';
 import permissions from './permissions.js';
 import profile from './profile.js';
 import protected_app from './protected-app.js';
@@ -98,6 +99,7 @@ const admin_console = {
   guide,
   mfa,
   organizations,
+  oss_onboarding,
   oidc_configs,
   organization_details,
   protected_app,

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/oss-onboarding.ts
@@ -1,0 +1,31 @@
+const oss_onboarding = {
+  page_title: '入門',
+  title: '簡單介紹一下你自己',
+  description: '告訴我們一些關於你和你的項目的資訊，這將幫助我們為所有人打造更好的 Logto。',
+  email: {
+    label: '電郵地址',
+    description: '如果我們需要就你的帳戶聯絡你，會使用這個電郵地址。',
+    placeholder: 'email@example.com',
+  },
+  newsletter: '接收來自 Logto 的產品更新、安全通知和精選內容。',
+  project: {
+    label: '我使用 Logto 是為了',
+    personal: '個人項目',
+    company: '公司項目',
+  },
+  company_name: {
+    label: '公司名稱',
+    placeholder: 'Acme.co',
+  },
+  company_size: {
+    label: '你的公司規模是？',
+  },
+  errors: {
+    email_required: '電郵地址為必填項',
+    email_invalid: '請輸入有效的電郵地址',
+    company_name_required: '公司名稱為必填項',
+    company_size_required: '公司規模為必填項',
+  },
+};
+
+export default Object.freeze(oss_onboarding);

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/oss-onboarding.ts
@@ -18,7 +18,7 @@ const oss_onboarding = {
     placeholder: 'Acme.co',
   },
   company_size: {
-    label: '你的公司規模是？',
+    label: '你的公司規模有多大？',
   },
   errors: {
     email_required: '電郵地址為必填項',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/index.ts
@@ -28,6 +28,7 @@ import organization_details from './organization-details.js';
 import organization_role_details from './organization-role-details.js';
 import organization_template from './organization-template.js';
 import organizations from './organizations.js';
+import oss_onboarding from './oss-onboarding.js';
 import permissions from './permissions.js';
 import profile from './profile.js';
 import protected_app from './protected-app.js';
@@ -98,6 +99,7 @@ const admin_console = {
   guide,
   mfa,
   organizations,
+  oss_onboarding,
   oidc_configs,
   organization_details,
   protected_app,

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/oss-onboarding.ts
@@ -18,7 +18,7 @@ const oss_onboarding = {
     placeholder: 'Acme.co',
   },
   company_size: {
-    label: '你的公司規模是？',
+    label: '你的公司規模有多大？',
   },
   errors: {
     email_required: '電子郵件地址為必填項',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/oss-onboarding.ts
@@ -1,0 +1,31 @@
+const oss_onboarding = {
+  page_title: '入門',
+  title: '簡單介紹一下你自己',
+  description: '告訴我們一些關於你和你的專案的資訊，這將幫助我們為所有人打造更好的 Logto。',
+  email: {
+    label: '電子郵件地址',
+    description: '如果我們需要就你的帳戶聯絡你，會使用這個電子郵件地址。',
+    placeholder: 'email@example.com',
+  },
+  newsletter: '接收來自 Logto 的產品更新、安全通知和精選內容。',
+  project: {
+    label: '我使用 Logto 是為了',
+    personal: '個人專案',
+    company: '公司專案',
+  },
+  company_name: {
+    label: '公司名稱',
+    placeholder: 'Acme.co',
+  },
+  company_size: {
+    label: '你的公司規模是？',
+  },
+  errors: {
+    email_required: '電子郵件地址為必填項',
+    email_invalid: '請輸入有效的電子郵件地址',
+    company_name_required: '公司名稱為必填項',
+    company_size_required: '公司規模為必填項',
+  },
+};
+
+export default Object.freeze(oss_onboarding);

--- a/packages/schemas/src/types/custom-profile-fields.ts
+++ b/packages/schemas/src/types/custom-profile-fields.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { type ToZodObject } from '@logto/connector-kit';
 import { z } from 'zod';
 
@@ -11,7 +12,7 @@ import {
   userProfileGuard,
 } from '../foundations/index.js';
 
-import { userOnboardingDataKey } from './onboarding.js';
+import { ossUserOnboardingDataKey, userOnboardingDataKey } from './onboarding.js';
 import { defaultTenantIdKey } from './tenant.js';
 import { consoleUserPreferenceKey, guideRequestsKey } from './user.js';
 
@@ -286,7 +287,6 @@ export const updateCustomProfileFieldDataGuard = z.discriminatedUnion('type', [
 ]);
 
 export type UpdateCustomProfileFieldData = z.infer<typeof updateCustomProfileFieldDataGuard>;
-
 export const updateCustomProfileFieldSieOrderGuard = z.object({
   name: z.string(),
   sieOrder: z.number(),
@@ -295,24 +295,18 @@ export const updateCustomProfileFieldSieOrderGuard = z.object({
 export type UpdateCustomProfileFieldSieOrder = z.infer<
   typeof updateCustomProfileFieldSieOrderGuard
 >;
-
-/**
- * Reserved custom data keys, which are used by the system and should not be used by custom profile fields.
- */
+/** Reserved custom data keys, which are used by the system and should not be used by custom profile fields. */
 export const reservedCustomDataKeyGuard = z
   .object({
     [userOnboardingDataKey]: z.string(),
+    [ossUserOnboardingDataKey]: z.string(),
     [guideRequestsKey]: z.string(),
     [consoleUserPreferenceKey]: z.string(),
     [defaultTenantIdKey]: z.string(),
   })
   .partial();
 export const reservedCustomDataKeys = Object.freeze(reservedCustomDataKeyGuard.keyof().options);
-
-/**
- * Disallow sign-in identifiers related field keys in custom profile fields, as this is conflicting
- * with the built-in sign-in/sign-up experience flows.
- */
+/** Disallow sign-in identifier related field keys in custom profile fields to avoid conflicts with built-in sign-in/sign-up flows. */
 export const signInIdentifierKeyGuard = Users.createGuard
   .pick({
     username: true,
@@ -325,11 +319,7 @@ export const signInIdentifierKeyGuard = Users.createGuard
   });
 export const reservedSignInIdentifierKeys = Object.freeze(signInIdentifierKeyGuard.keyof().options);
 
-/**
- * Reserved user profile keys.
- * Currently only `preferredUsername` is reserved since it is the standard username property used
- * by most identity providers. Should not allow user updating this field via profile related APIs.
- */
+/** Reserved user profile keys. Currently only `preferredUsername` is reserved for standard IdP usage. */
 export const reservedBuiltInProfileKeyGuard = userProfileGuard.pick({ preferredUsername: true });
 export const reservedBuiltInProfileKeys = Object.freeze(
   reservedBuiltInProfileKeyGuard.keyof().options
@@ -347,3 +337,4 @@ export enum Gender {
   Male = 'male',
   Other = 'prefer_not_to_say',
 }
+/* eslint-enable max-lines */

--- a/packages/schemas/src/types/onboarding.ts
+++ b/packages/schemas/src/types/onboarding.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 export const userOnboardingDataKey = 'onboarding';
+export const ossUserOnboardingDataKey = 'ossOnboarding';
 
 export enum Project {
   Personal = 'personal',
@@ -23,7 +24,6 @@ export enum Title {
   Others = 'others',
 }
 
-/** @deprecated */
 export enum CompanySize {
   Scale1 = '1',
   Scale2 = '2-49',
@@ -31,6 +31,7 @@ export enum CompanySize {
   Scale4 = '200-999',
   Scale5 = '1000+',
 }
+// Kept as a shared enum for OSS onboarding and existing questionnaire payloads.
 
 /** @deprecated */
 export enum Reason {
@@ -74,9 +75,26 @@ const questionnaireGuard = z.object({
 
 export type Questionnaire = z.infer<typeof questionnaireGuard>;
 
+const ossQuestionnaireGuard = z.object({
+  emailAddress: z.string().optional(),
+  newsletter: z.boolean().optional(),
+  project: z.nativeEnum(Project).optional(),
+  companyName: z.string().optional(),
+  companySize: z.nativeEnum(CompanySize).optional(),
+});
+
+export type OssQuestionnaire = z.infer<typeof ossQuestionnaireGuard>;
+
 export const userOnboardingDataGuard = z.object({
   questionnaire: questionnaireGuard.optional(),
   isOnboardingDone: z.boolean().optional(),
 });
 
 export type UserOnboardingData = z.infer<typeof userOnboardingDataGuard>;
+
+export const ossUserOnboardingDataGuard = z.object({
+  questionnaire: ossQuestionnaireGuard.optional(),
+  isOnboardingDone: z.boolean().optional(),
+});
+
+export type OssUserOnboardingData = z.infer<typeof ossUserOnboardingDataGuard>;


### PR DESCRIPTION
## Summary
<!-- Describe the current net changes in this branch relative to the base branch. -->
<!-- Treat this as a snapshot, not a changelog of how the branch evolved. -->

- Add an OSS-only onboarding route and guard in the console so newly signed-in admin users must complete a user-level onboarding form before entering the rest of the tenant UI.
- Add the OSS onboarding page, form helpers, and user custom-data hook, including company-project defaults, company-only fields, a screen-fixed bottom action bar, and reserved schema keys for the new OSS onboarding payload.
- Add localized admin-console copy for the OSS onboarding experience across the supported locale set, and update the bootstrap coverage plus unit tests for the onboarding guard and form payload behavior.
- Keep the current OSS onboarding submission stored in user custom data only; a follow-up TODO notes that dedicated server-side sync for analysis and future marketing email outreach is still out of scope for this PR.

## Testing
<!-- How did you test this PR? -->

Unit tests, Integration tests
<img width="6720" height="3634" alt="image" src="https://github.com/user-attachments/assets/1be591b7-11f6-42c7-b288-64a345b16b19" />

## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
