### PR TITLE
chore: optimize memory usage on dockerizing core packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ ENV CI=true
 
 # No need for Docker build
 ENV PUPPETEER_SKIP_DOWNLOAD=true
+ENV NODE_OPTIONS=--max-old-space-size=4096
+
+ARG build_concurrency=2
+ENV BUILD_CONCURRENCY=${build_concurrency}
 
 ### Install toolchain ###
 RUN npm add --location=global pnpm@^10.0.0
@@ -14,7 +18,7 @@ RUN apk add --no-cache python3 make g++ rsync
 COPY . .
 
 ### Install dependencies and build ###
-RUN pnpm i
+RUN pnpm i --frozen-lockfile --child-concurrency=${BUILD_CONCURRENCY}
 
 ### Set if dev features enabled ###
 ARG dev_features_enabled
@@ -23,7 +27,7 @@ ENV DEV_FEATURES_ENABLED=${dev_features_enabled}
 ARG applicationinsights_connection_string
 ENV APPLICATIONINSIGHTS_CONNECTION_STRING=${applicationinsights_connection_string}
 
-RUN pnpm -r build
+RUN pnpm -r --workspace-concurrency=${BUILD_CONCURRENCY} build
 
 ### Add official connectors ###
 ARG additional_connector_args
@@ -32,7 +36,7 @@ RUN pnpm cli connector link $ADDITIONAL_CONNECTOR_ARGS -p .
 
 ### Prune dependencies for production ###
 RUN rm -rf node_modules packages/**/node_modules
-RUN NODE_ENV=production pnpm i
+RUN NODE_ENV=production pnpm i --frozen-lockfile --child-concurrency=${BUILD_CONCURRENCY}
 
 ### Clean up ###
 RUN rm -rf .scripts pnpm-*.yaml packages/cloud


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Optimize memory usage when dockerizing core packages.
- Limit `--max-old-space-size` to 4096
- Introduce a new `build_concurrency` input and set default to `2`. The value can be overriden when building Logto Cloud with GitHub Actions.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Pending Cloud CI test

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
