### PR TITLE
feat(account,console): integrate authenticator app change flow

### DIFF
--- a/packages/account/src/pages/Security/MfaSection/use-mfa-rows.ts
+++ b/packages/account/src/pages/Security/MfaSection/use-mfa-rows.ts
@@ -14,6 +14,7 @@ import TotpIcon from '@ac/assets/icons/factor-totp.svg?react';
 import WebAuthnIcon from '@ac/assets/icons/factor-webauthn.svg?react';
 import PhoneIcon from '@ac/assets/icons/phone.svg?react';
 import {
+  authenticatorAppReplaceRoute,
   authenticatorAppRoute,
   backupCodesGenerateRoute,
   backupCodesManageRoute,
@@ -99,22 +100,24 @@ const useMfaRows = (
       if (!enabledFactors.includes(MfaFactor.TOTP)) {
         return [];
       }
+      const isConfigured = Boolean(totpVerification);
       return [
         {
           key: 'totp',
           icon: factorIcon[MfaFactor.TOTP],
           label: t('account_center.security.authenticator_app'),
           value: totpVerification ? t('account_center.security.configured') : undefined,
-          isConfigured: Boolean(totpVerification),
-          action:
-            isEditable && !totpVerification
-              ? {
-                  label: t('account_center.security.add'),
-                  handler: () => {
-                    navigateTo(authenticatorAppRoute);
-                  },
-                }
-              : undefined,
+          isConfigured,
+          action: isEditable
+            ? {
+                label: isConfigured
+                  ? t('account_center.security.change')
+                  : t('account_center.security.add'),
+                handler: () => {
+                  navigateTo(isConfigured ? authenticatorAppReplaceRoute : authenticatorAppRoute);
+                },
+              }
+            : undefined,
         },
       ];
     };

--- a/packages/console/src/pages/Profile/components/MfaSection/index.tsx
+++ b/packages/console/src/pages/Profile/components/MfaSection/index.tsx
@@ -130,7 +130,12 @@ function MfaSection({ user, signInExperience }: Props) {
               <span>{t('profile.mfa.not_configured')}</span>
             ),
           action: hasTotp
-            ? undefined
+            ? {
+                name: 'profile.change',
+                handler: () => {
+                  navigateToAccountPage('/account/authenticator-app/replace');
+                },
+              }
             : {
                 name: 'profile.mfa.add',
                 handler: () => {


### PR DESCRIPTION
## Summary

Integrate the existing authenticator app (TOTP) replace/change route into both the console profile page and the account center security page.

### Changes

**Account center security page** (`packages/account/src/pages/Security/MfaSection/use-mfa-rows.ts`):
- When TOTP is configured and editable, show a **Change** button (previously no action was shown)
- Navigates to `/authenticator-app/replace` route which uses the existing `TotpBinding` component with `isReplace` prop

**Console profile page** (`packages/console/src/pages/Profile/components/MfaSection/index.tsx`):
- When TOTP is configured, show a **Change** button (previously no action was shown)
- Navigates to `/account/authenticator-app/replace` in the account center

### Context

The `/authenticator-app/replace` route and the `TotpBinding` component with `isReplace` support were already fully implemented but not wired up in the UI. This PR connects them.

No new phrases needed — reuses existing `account_center.security.change` and `profile.change` translation keys.