### PR TITLE
fix(core): add ip param when calling sendVerificationCode

### DIFF
--- a/.changeset/tiny-cougars-breathe.md
+++ b/.changeset/tiny-cougars-breathe.md
@@ -2,4 +2,4 @@
 "@logto/core": patch
 ---
 
-include missing client IP in verification code flow
+fix: pass request IP to connector when sending verification codes

--- a/.changeset/tiny-cougars-breathe.md
+++ b/.changeset/tiny-cougars-breathe.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": patch
+---
+
+include missing client IP in verification code flow

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
@@ -1,0 +1,87 @@
+import { InteractionEvent, SignInIdentifier } from '@logto/schemas';
+
+const { jest } = import.meta;
+
+async function resolveVoid(): Promise<void> {
+  await Promise.resolve();
+}
+
+const { sendCode } = await import('./verification-code-helpers.js');
+
+describe('Verification The function sendCode parameters passing', () => {
+  // To make a void callable function/method
+  const mockSendVerificationCode = jest.fn().mockImplementation(resolveVoid);
+
+  const mockCodeVerification = {
+    id: 'helper-test-verification-id',
+    sendVerificationCode: mockSendVerificationCode,
+  };
+
+  const mockExperienceInteraction = {
+    interactionEvent: InteractionEvent.SignIn,
+    setVerificationRecord: jest.fn().mockImplementation(resolveVoid),
+    save: jest.fn().mockImplementation(resolveVoid),
+    signInExperienceValidator: {
+      guardEmailBlocklist: jest.fn().mockImplementation(resolveVoid),
+    },
+  };
+
+  const mockBuildVerificationCodeContext = jest.fn().mockImplementation(resolveVoid);
+  const mockPasscodeLibrary = {
+    buildVerificationCodeContext: mockBuildVerificationCodeContext,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSendVerificationCode.mockImplementation(resolveVoid);
+    mockExperienceInteraction.save.mockImplementation(resolveVoid);
+    mockBuildVerificationCodeContext.mockResolvedValue({});
+  });
+
+  it('should pass ctx.ip to sendVerificationCode', async () => {
+    const SAMPLE_IP = '192.168.1.225';
+
+    const ctx = {
+      ip: SAMPLE_IP,
+      createLog: jest.fn(() => ({ append: jest.fn().mockImplementation(resolveVoid) })),
+      experienceInteraction: mockExperienceInteraction,
+      emailI18n: { locale: 'jp' },
+    };
+
+    // Only verify the ip parameter so use never to ignore others at here to bypass type check
+    const libraries = { passcodes: mockPasscodeLibrary };
+    await sendCode({
+      identifier: { type: SignInIdentifier.Phone, value: '+8613123456789' },
+      createVerificationRecord: () => mockCodeVerification as never,
+      libraries: libraries as never,
+      ctx: ctx as never,
+    });
+
+    expect(mockSendVerificationCode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ip: SAMPLE_IP,
+      })
+    );
+  });
+  it('should handle undefined ctx.ip', async () => {
+    const ctx = {
+      createLog: jest.fn(() => ({ append: jest.fn().mockImplementation(resolveVoid) })),
+      experienceInteraction: mockExperienceInteraction,
+      emailI18n: { locale: 'jp' },
+    };
+
+    const libraries = { passcodes: mockPasscodeLibrary };
+    await sendCode({
+      identifier: { type: SignInIdentifier.Phone, value: '+8613123456789' },
+      createVerificationRecord: () => mockCodeVerification as never,
+      libraries: libraries as never,
+      ctx: ctx as never,
+    });
+
+    expect(mockSendVerificationCode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ip: undefined,
+      })
+    );
+  });
+});

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
@@ -1,5 +1,19 @@
 import { InteractionEvent, SignInIdentifier } from '@logto/schemas';
 
+import type Libraries from '#src/tenants/Libraries.js';
+
+import type { EmailCodeVerification } from '../classes/verifications/code-verification.js';
+import type { ExperienceInteractionRouterContext } from '../types.js';
+
+type MockExperienceInteraction = {
+  interactionEvent: InteractionEvent;
+  setVerificationRecord: jest.MockedFunction<() => Promise<void>>;
+  save: jest.MockedFunction<() => Promise<void>>;
+  signInExperienceValidator: {
+    guardEmailBlocklist: jest.MockedFunction<() => Promise<void>>;
+  };
+};
+
 const { jest } = import.meta;
 
 async function resolveVoid(): Promise<void> {
@@ -8,16 +22,16 @@ async function resolveVoid(): Promise<void> {
 
 const { sendCode } = await import('./verification-code-helpers.js');
 
-describe('Verification The function sendCode parameters passing', () => {
+describe('sendCode parameter passing', () => {
   // To make a void callable function/method
   const mockSendVerificationCode = jest.fn().mockImplementation(resolveVoid);
 
   const mockCodeVerification = {
     id: 'helper-test-verification-id',
     sendVerificationCode: mockSendVerificationCode,
-  };
+  } as unknown as EmailCodeVerification;
 
-  const mockExperienceInteraction = {
+  const mockExperienceInteraction: MockExperienceInteraction = {
     interactionEvent: InteractionEvent.SignIn,
     setVerificationRecord: jest.fn().mockImplementation(resolveVoid),
     save: jest.fn().mockImplementation(resolveVoid),
@@ -38,49 +52,28 @@ describe('Verification The function sendCode parameters passing', () => {
     mockBuildVerificationCodeContext.mockResolvedValue({});
   });
 
-  it('should pass ctx.ip to sendVerificationCode', async () => {
+  it('should pass ctx.request.ip to sendVerificationCode', async () => {
     const SAMPLE_IP = '192.168.1.225';
 
     const ctx = {
-      ip: SAMPLE_IP,
+      request: { ip: SAMPLE_IP },
       createLog: jest.fn(() => ({ append: jest.fn().mockImplementation(resolveVoid) })),
       experienceInteraction: mockExperienceInteraction,
       emailI18n: { locale: 'jp' },
     };
 
     // Only verify the ip parameter so use never to ignore others at here to bypass type check
-    const libraries = { passcodes: mockPasscodeLibrary };
+    const libraries = { passcodes: mockPasscodeLibrary } as unknown as Partial<Libraries>;
     await sendCode({
       identifier: { type: SignInIdentifier.Phone, value: '+8613123456789' },
-      createVerificationRecord: () => mockCodeVerification as never,
-      libraries: libraries as never,
-      ctx: ctx as never,
+      createVerificationRecord: () => mockCodeVerification,
+      libraries: libraries as unknown as Libraries,
+      ctx: ctx as unknown as ExperienceInteractionRouterContext,
     });
 
     expect(mockSendVerificationCode).toHaveBeenCalledWith(
       expect.objectContaining({
         ip: SAMPLE_IP,
-      })
-    );
-  });
-  it('should handle undefined ctx.ip', async () => {
-    const ctx = {
-      createLog: jest.fn(() => ({ append: jest.fn().mockImplementation(resolveVoid) })),
-      experienceInteraction: mockExperienceInteraction,
-      emailI18n: { locale: 'jp' },
-    };
-
-    const libraries = { passcodes: mockPasscodeLibrary };
-    await sendCode({
-      identifier: { type: SignInIdentifier.Phone, value: '+8613123456789' },
-      createVerificationRecord: () => mockCodeVerification as never,
-      libraries: libraries as never,
-      ctx: ctx as never,
-    });
-
-    expect(mockSendVerificationCode).toHaveBeenCalledWith(
-      expect.objectContaining({
-        ip: undefined,
       })
     );
   });

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
@@ -116,7 +116,7 @@ export const sendCode = async ({
     ...ctx.emailI18n,
     ...templateContext,
     /** The client IP address for rate limiting and fraud detection. */
-    ip: ctx.ip,
+    ...(ctx.request.ip && { ip: ctx.request.ip }),
   });
 
   // Save state

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
@@ -115,6 +115,8 @@ export const sendCode = async ({
   await codeVerification.sendVerificationCode({
     ...ctx.emailI18n,
     ...templateContext,
+    /** The client IP address for rate limiting and fraud detection. */
+    ip: ctx.ip,
   });
 
   // Save state


### PR DESCRIPTION
## Summary

Closes #8614 
Add the missing parameter in payload at `sendCode`(`packages/src/routes/experience/verification-routes/verification-code-helpers.ts`) 
That when calling `sendVerificationCode` in `sendCode` .  Ensure the ipAddress can correctly passed down to `connectors` that can receive `ip` from `SendMessageData`.

## Root cause 
 In the flow of ipAddress passing from `core` to `connectors` ,  `sendCode` (`packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts`)'s `ip` property from the Koa (`ctx.request.ip`) was omitted when calling `sendVerificationCode`.  It impact on when destructure the payload in connectors to captured the `ip` value , it always be `undefined`.


<!-- MANDATORY -->
<!-- How did you test this PR? -->
## Testing
Add unit test `packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts` to verify:

- `ctx.request.ip` should be correctly passed to next function 


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
