### PR TITLE
fix(account): prevent homepage auto-redirect to security page

### DIFF
--- a/packages/account/src/App.tsx
+++ b/packages/account/src/App.tsx
@@ -3,7 +3,7 @@ import { LogtoProvider, Prompt, ReservedScope, useLogto, UserScope } from '@logt
 import { accountCenterApplicationId, ExtraParamsKey, SignInIdentifier } from '@logto/schemas';
 import classNames from 'classnames';
 import { useContext, useEffect } from 'react';
-import { BrowserRouter, Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { BrowserRouter, Route, Routes, useLocation } from 'react-router-dom';
 
 import AppBoundary from '@ac/Providers/AppBoundary';
 import LoadingContextProvider from '@ac/Providers/LoadingContextProvider';
@@ -199,14 +199,8 @@ const Main = () => {
           />
         </>
       )}
-      <Route
-        path={securityRoute}
-        element={showsSecurityPage ? <Security /> : <Navigate replace to=".." relative="path" />}
-      />
-      <Route
-        index
-        element={showsSecurityPage ? <Navigate replace to={securityRoute} /> : <Home />}
-      />
+      <Route path={securityRoute} element={showsSecurityPage ? <Security /> : <Home />} />
+      <Route index element={<Home />} />
       <Route path="*" element={<Home />} />
     </Routes>
   );

--- a/packages/account/src/App.tsx
+++ b/packages/account/src/App.tsx
@@ -199,7 +199,7 @@ const Main = () => {
           />
         </>
       )}
-      <Route path={securityRoute} element={showsSecurityPage ? <Security /> : <Home />} />
+      {showsSecurityPage && <Route path={securityRoute} element={<Security />} />}
       <Route index element={<Home />} />
       <Route path="*" element={<Home />} />
     </Routes>


### PR DESCRIPTION
## Summary
- Account center homepage (`/account`) was automatically redirecting to `/security` when `showsSecurityPage` was true
- Homepage should remain in a 404/"Page not found" state as a placeholder; the security page is an independent route
- Security page now shows 404 when not enabled (instead of redirecting back to parent)

## Changes
- Removed `<Navigate>` redirect from the index route — homepage now always renders `<Home />` (404)
- Security route now renders `<Home />` instead of `<Navigate to=".." />` when disabled
- Cleaned up unused `Navigate` import

## Test plan
- [x] Verify `/account` (homepage) shows "Page not found" in both dev and production
- [x] Verify `/account/security` renders the security page when dev features are enabled
- [x] Verify `/account/security` shows "Page not found" when dev features are disabled