### PR TITLE
feat(account): add stable CSS class names for custom CSS targeting

### DIFF
--- a/packages/account/src/App.tsx
+++ b/packages/account/src/App.tsx
@@ -8,6 +8,7 @@ import { BrowserRouter, Navigate, Route, Routes, useLocation } from 'react-route
 import AppBoundary from '@ac/Providers/AppBoundary';
 import LoadingContextProvider from '@ac/Providers/LoadingContextProvider';
 import PageHeader from '@ac/components/PageHeader';
+import { layoutClassNames } from '@ac/constants/layout';
 
 import styles from './App.module.scss';
 import Callback from './Callback';
@@ -222,18 +223,39 @@ const Layout = () => {
     hasVisibleSecuritySection(accountCenterSettings, experienceSettings);
 
   return (
-    <div className={styles.app}>
-      <div className={classNames(styles.layout, isHomePage && styles.fullPage)}>
+    <div className={classNames(styles.app, layoutClassNames.app)}>
+      <div
+        className={classNames(
+          styles.layout,
+          isHomePage && styles.fullPage,
+          layoutClassNames.pageContainer
+        )}
+      >
         {isHomePage && <PageHeader />}
-        <div className={classNames(styles.container, !isHomePage && styles.cardContainer)}>
-          <main className={classNames(styles.main, !isHomePage && styles.cardMain)}>
+        <div
+          className={classNames(
+            styles.container,
+            !isHomePage && styles.cardContainer,
+            !isHomePage && layoutClassNames.cardContainer
+          )}
+        >
+          <main
+            className={classNames(
+              styles.main,
+              !isHomePage && styles.cardMain,
+              isHomePage ? layoutClassNames.mainContent : layoutClassNames.cardMain
+            )}
+          >
             <ErrorBoundary>
               <LogtoErrorBoundary>
                 <Main />
               </LogtoErrorBoundary>
             </ErrorBoundary>
             {!isHomePage && !hideLogtoBranding && (
-              <LogtoSignature className={styles.signature} theme={theme} />
+              <LogtoSignature
+                className={classNames(styles.signature, layoutClassNames.signature)}
+                theme={theme}
+              />
             )}
           </main>
         </div>

--- a/packages/account/src/components/PageHeader/index.tsx
+++ b/packages/account/src/components/PageHeader/index.tsx
@@ -1,8 +1,10 @@
 import { getBrandingLogoUrl } from '@experience/shared/utils/logo';
+import classNames from 'classnames';
 import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import PageContext from '@ac/Providers/PageContextProvider/PageContext';
+import { layoutClassNames } from '@ac/constants/layout';
 
 import styles from './index.module.scss';
 
@@ -19,7 +21,7 @@ const PageHeader = () => {
     });
 
   return (
-    <header className={styles.header}>
+    <header className={classNames(styles.header, layoutClassNames.pageHeader)}>
       <div className={styles.left}>
         {logoUrl && <img className={styles.logo} src={logoUrl} alt="logo" />}
         <div className={styles.divider} />

--- a/packages/account/src/constants/layout.ts
+++ b/packages/account/src/constants/layout.ts
@@ -8,7 +8,7 @@
 export const layoutClassNames = Object.freeze({
   /** Root `<div>` wrapping the entire account center app. */
   app: 'logto_ac-app',
-  /** Full-page layout wrapper (used on the Security / Home page). */
+  /** Full-page layout wrapper used across account center routes. */
   pageContainer: 'logto_ac-page-container',
   /** `<main>` that holds the primary content area. */
   mainContent: 'logto_ac-main-content',

--- a/packages/account/src/constants/layout.ts
+++ b/packages/account/src/constants/layout.ts
@@ -1,0 +1,43 @@
+/**
+ * Stable (non-hashed) class names for key account center elements,
+ * so that custom CSS injected via `customCss` can target them easily.
+ *
+ * Mirrors the pattern used by the sign-in experience package
+ * (`packages/experience/src/utils/consts.ts` → `layoutClassNames`).
+ */
+export const layoutClassNames = Object.freeze({
+  /** Root `<div>` wrapping the entire account center app. */
+  app: 'logto_ac-app',
+  /** Full-page layout wrapper (used on the Security / Home page). */
+  pageContainer: 'logto_ac-page-container',
+  /** `<main>` that holds the primary content area. */
+  mainContent: 'logto_ac-main-content',
+  /** Card-style container used on sub-pages (email, phone, password…). */
+  cardContainer: 'logto_ac-card-container',
+  /** Card-style `<main>` inside the card container. */
+  cardMain: 'logto_ac-card-main',
+  /** Logto signature / branding footer. */
+  signature: 'logto_ac-signature',
+  /** Top-level page header (logo + app name bar). */
+  pageHeader: 'logto_ac-page-header',
+  /** Page title text (on Security / Home page). */
+  pageTitle: 'logto_ac-page-title',
+  /** Page description text (on Security / Home page). */
+  pageDescription: 'logto_ac-page-description',
+  /** Scrollable content area on the Security / Home page. */
+  pageContent: 'logto_ac-page-content',
+  /** Each logical section (username, email/phone, password, MFA, social, delete). */
+  section: 'logto_ac-section',
+  /** Section heading text. */
+  sectionTitle: 'logto_ac-section-title',
+  /** Card that groups rows inside a section. */
+  card: 'logto_ac-card',
+  /** A single row inside a card. */
+  row: 'logto_ac-row',
+  /** Wrapper for the secondary (sub-page) layout. */
+  secondaryPageWrapper: 'logto_ac-secondary-page-wrapper',
+  /** Secondary page title. */
+  secondaryPageTitle: 'logto_ac-secondary-page-title',
+  /** Secondary page description. */
+  secondaryPageDescription: 'logto_ac-secondary-page-description',
+});

--- a/packages/account/src/layouts/SecondaryPageLayout/index.tsx
+++ b/packages/account/src/layouts/SecondaryPageLayout/index.tsx
@@ -1,8 +1,11 @@
 import DynamicT from '@experience/shared/components/DynamicT';
 import NavBar from '@experience/shared/components/NavBar';
 import PageMeta from '@experience/shared/components/PageMeta';
+import classNames from 'classnames';
 import type { TFuncKey } from 'i18next';
 import { type ReactElement } from 'react';
+
+import { layoutClassNames } from '@ac/constants/layout';
 
 import styles from './index.module.scss';
 
@@ -30,17 +33,19 @@ const SecondaryPageLayout = ({
   children,
 }: Props) => {
   return (
-    <div className={styles.wrapper}>
+    <div className={classNames(styles.wrapper, layoutClassNames.secondaryPageWrapper)}>
       <PageMeta titleKey={title} />
       <NavBar isHidden={isNavBarHidden} onSkip={onSkip} onClose={onBack} />
       <div className={styles.container}>
         {notification}
         <div className={styles.header}>
-          <div className={styles.title}>
+          <div className={classNames(styles.title, layoutClassNames.secondaryPageTitle)}>
             <DynamicT forKey={title} interpolation={titleProps} />
           </div>
           {description && (
-            <div className={styles.description}>
+            <div
+              className={classNames(styles.description, layoutClassNames.secondaryPageDescription)}
+            >
               {typeof description === 'string' ? (
                 <DynamicT forKey={description} interpolation={descriptionProps} />
               ) : (

--- a/packages/account/src/pages/Security/DeleteAccountSection/index.tsx
+++ b/packages/account/src/pages/Security/DeleteAccountSection/index.tsx
@@ -1,8 +1,10 @@
+import classNames from 'classnames';
 import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import PageContext from '@ac/Providers/PageContextProvider/PageContext';
 import DeleteIcon from '@ac/assets/icons/delete.svg?react';
+import { layoutClassNames } from '@ac/constants/layout';
 
 import styles from './index.module.scss';
 
@@ -17,10 +19,12 @@ const DeleteAccountSection = () => {
   }
 
   return (
-    <div className={styles.section}>
-      <div className={styles.sectionTitle}>{t('account_center.security.account_removal')}</div>
-      <div className={styles.card}>
-        <div className={styles.row}>
+    <div className={classNames(styles.section, layoutClassNames.section)}>
+      <div className={classNames(styles.sectionTitle, layoutClassNames.sectionTitle)}>
+        {t('account_center.security.account_removal')}
+      </div>
+      <div className={classNames(styles.card, layoutClassNames.card)}>
+        <div className={classNames(styles.row, layoutClassNames.row)}>
           <div className={styles.info}>
             <DeleteIcon className={styles.icon} />
             <div className={styles.name}>{t('account_center.security.delete_your_account')}</div>

--- a/packages/account/src/pages/Security/EmailPhoneSection/index.tsx
+++ b/packages/account/src/pages/Security/EmailPhoneSection/index.tsx
@@ -1,5 +1,6 @@
 import { AccountCenterControlValue } from '@logto/schemas';
 import { formatToInternationalPhoneNumber } from '@logto/shared/universal';
+import classNames from 'classnames';
 import { useCallback, useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -9,6 +10,7 @@ import { deletePrimaryEmail, deletePrimaryPhone } from '@ac/apis/account';
 import EmailIcon from '@ac/assets/icons/email.svg?react';
 import PhoneIcon from '@ac/assets/icons/phone.svg?react';
 import ConfirmModal from '@ac/components/ConfirmModal';
+import { layoutClassNames } from '@ac/constants/layout';
 import { emailRoute, verifiedActionRoute, phoneRoute } from '@ac/constants/routes';
 import useApi from '@ac/hooks/use-api';
 import useErrorHandler from '@ac/hooks/use-error-handler';
@@ -106,11 +108,13 @@ const EmailPhoneSection = () => {
 
   return (
     <>
-      <div className={styles.section}>
-        <div className={styles.sectionTitle}>{t('account_center.security.email_phone')}</div>
-        <div className={styles.card}>
+      <div className={classNames(styles.section, layoutClassNames.section)}>
+        <div className={classNames(styles.sectionTitle, layoutClassNames.sectionTitle)}>
+          {t('account_center.security.email_phone')}
+        </div>
+        <div className={classNames(styles.card, layoutClassNames.card)}>
           {showEmail && (
-            <div className={styles.row}>
+            <div className={classNames(styles.row, layoutClassNames.row)}>
               <div className={styles.info}>
                 <div className={styles.name}>
                   <EmailIcon className={styles.icon} />
@@ -149,7 +153,7 @@ const EmailPhoneSection = () => {
             </div>
           )}
           {showPhone && (
-            <div className={styles.row}>
+            <div className={classNames(styles.row, layoutClassNames.row)}>
               <div className={styles.info}>
                 <div className={styles.name}>
                   <PhoneIcon className={styles.icon} />

--- a/packages/account/src/pages/Security/MfaSection/index.tsx
+++ b/packages/account/src/pages/Security/MfaSection/index.tsx
@@ -4,6 +4,7 @@ import {
   MfaPolicy,
   type UserMfaVerificationResponse,
 } from '@logto/schemas';
+import classNames from 'classnames';
 import { useCallback, useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -12,6 +13,7 @@ import PageContext from '@ac/Providers/PageContextProvider/PageContext';
 import ConfirmModal from '@ac/components/ConfirmModal';
 import ToggleSwitch from '@ac/components/ToggleSwitch';
 import { isDevFeaturesEnabled } from '@ac/constants/env';
+import { layoutClassNames } from '@ac/constants/layout';
 import { verifiedActionRoute } from '@ac/constants/routes';
 import { getPendingReturn, setPendingReturn } from '@ac/utils/account-center-route';
 import { sessionStorage } from '@ac/utils/session-storage';
@@ -154,8 +156,8 @@ const MfaSection = () => {
 
   return (
     <>
-      <div className={styles.section}>
-        <div className={styles.sectionTitle}>
+      <div className={classNames(styles.section, layoutClassNames.section)}>
+        <div className={classNames(styles.sectionTitle, layoutClassNames.sectionTitle)}>
           {t('account_center.security.two_step_verification')}
         </div>
         {showToggle && isTwoStepEnabled && !hasConfiguredMfa && (
@@ -165,7 +167,7 @@ const MfaSection = () => {
           />
         )}
         {(showToggle || rows.length > 0) && (
-          <div className={styles.card}>
+          <div className={classNames(styles.card, layoutClassNames.card)}>
             {showToggle && (
               <div className={styles.toggleRow}>
                 <div className={styles.toggleInfo}>
@@ -194,7 +196,7 @@ const MfaSection = () => {
             )}
             {showToggle && rows.length > 0 && <div className={styles.divider} />}
             {rows.map(({ key, icon: Icon, label, value, isPlainValue, isConfigured, action }) => (
-              <div key={key} className={styles.row}>
+              <div key={key} className={classNames(styles.row, layoutClassNames.row)}>
                 <div className={styles.info}>
                   <div className={styles.name}>
                     <Icon className={styles.icon} />

--- a/packages/account/src/pages/Security/PasswordSection/index.tsx
+++ b/packages/account/src/pages/Security/PasswordSection/index.tsx
@@ -1,10 +1,12 @@
 import { AccountCenterControlValue } from '@logto/schemas';
+import classNames from 'classnames';
 import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
 import PageContext from '@ac/Providers/PageContextProvider/PageContext';
 import PasswordIcon from '@ac/assets/icons/password.svg?react';
+import { layoutClassNames } from '@ac/constants/layout';
 import { passwordRoute } from '@ac/constants/routes';
 import { getPendingReturn, setPendingReturn } from '@ac/utils/account-center-route';
 import { canOpenPasswordEditFlow } from '@ac/utils/security-page';
@@ -23,10 +25,12 @@ const PasswordSection = () => {
   }
 
   return (
-    <div className={styles.section}>
-      <div className={styles.sectionTitle}>{t('account_center.security.password')}</div>
-      <div className={styles.card}>
-        <div className={styles.row}>
+    <div className={classNames(styles.section, layoutClassNames.section)}>
+      <div className={classNames(styles.sectionTitle, layoutClassNames.sectionTitle)}>
+        {t('account_center.security.password')}
+      </div>
+      <div className={classNames(styles.card, layoutClassNames.card)}>
+        <div className={classNames(styles.row, layoutClassNames.row)}>
           <div className={styles.info}>
             <div className={styles.name}>
               <PasswordIcon className={styles.icon} />

--- a/packages/account/src/pages/Security/SocialSection/index.tsx
+++ b/packages/account/src/pages/Security/SocialSection/index.tsx
@@ -1,12 +1,14 @@
 import DynamicT from '@experience/shared/components/DynamicT';
 import { getLogoUrl } from '@experience/shared/utils/logo';
 import { AccountCenterControlValue, type Identity } from '@logto/schemas';
+import classNames from 'classnames';
 import { useContext, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
 import PageContext from '@ac/Providers/PageContextProvider/PageContext';
 import ConfirmModal from '@ac/components/ConfirmModal';
+import { layoutClassNames } from '@ac/constants/layout';
 import { getSocialAddRoute, getSocialRemoveRoute } from '@ac/constants/routes';
 import { getPendingReturn, setPendingReturn } from '@ac/utils/account-center-route';
 import { hasVisibleSocialSection } from '@ac/utils/security-page';
@@ -89,14 +91,16 @@ const SocialSection = () => {
 
   return (
     <>
-      <div className={styles.section}>
-        <div className={styles.sectionTitle}>{t('account_center.security.social_sign_in')}</div>
-        <div className={styles.card}>
+      <div className={classNames(styles.section, layoutClassNames.section)}>
+        <div className={classNames(styles.sectionTitle, layoutClassNames.sectionTitle)}>
+          {t('account_center.security.social_sign_in')}
+        </div>
+        <div className={classNames(styles.card, layoutClassNames.card)}>
           {items.map(({ connector, connectorName, identity }) => {
             const profile = identity && getDisplayProfile(identity, connectorName);
 
             return (
-              <div key={connector.id} className={styles.row}>
+              <div key={connector.id} className={classNames(styles.row, layoutClassNames.row)}>
                 <div className={styles.connectorInfo}>
                   <img
                     className={styles.connectorLogo}

--- a/packages/account/src/pages/Security/UsernameSection/index.tsx
+++ b/packages/account/src/pages/Security/UsernameSection/index.tsx
@@ -1,9 +1,11 @@
 import { AccountCenterControlValue } from '@logto/schemas';
+import classNames from 'classnames';
 import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
 import PageContext from '@ac/Providers/PageContextProvider/PageContext';
+import { layoutClassNames } from '@ac/constants/layout';
 import { usernameRoute } from '@ac/constants/routes';
 import { getPendingReturn, setPendingReturn } from '@ac/utils/account-center-route';
 
@@ -21,10 +23,12 @@ const UsernameSection = () => {
   }
 
   return (
-    <div className={styles.section}>
-      <div className={styles.sectionTitle}>{t('input.username')}</div>
-      <div className={styles.card}>
-        <div className={styles.row}>
+    <div className={classNames(styles.section, layoutClassNames.section)}>
+      <div className={classNames(styles.sectionTitle, layoutClassNames.sectionTitle)}>
+        {t('input.username')}
+      </div>
+      <div className={classNames(styles.card, layoutClassNames.card)}>
+        <div className={classNames(styles.row, layoutClassNames.row)}>
           <div className={styles.info}>
             <div className={styles.name}>{t('input.username')}</div>
             <div className={styles.value}>{userInfo?.username ?? '-'}</div>

--- a/packages/account/src/pages/Security/index.tsx
+++ b/packages/account/src/pages/Security/index.tsx
@@ -1,7 +1,9 @@
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 
 import PageFooter from '@ac/components/PageFooter';
 import { isDevFeaturesEnabled } from '@ac/constants/env';
+import { layoutClassNames } from '@ac/constants/layout';
 
 import styles from '../Home/index.module.scss';
 
@@ -18,10 +20,14 @@ const Security = () => {
   return (
     <div className={styles.container}>
       <div className={styles.header}>
-        <div className={styles.title}>{t('account_center.page.security_title')}</div>
-        <div className={styles.description}>{t('account_center.page.security_description')}</div>
+        <div className={classNames(styles.title, layoutClassNames.pageTitle)}>
+          {t('account_center.page.security_title')}
+        </div>
+        <div className={classNames(styles.description, layoutClassNames.pageDescription)}>
+          {t('account_center.page.security_description')}
+        </div>
       </div>
-      <div className={styles.content}>
+      <div className={classNames(styles.content, layoutClassNames.pageContent)}>
         <UsernameSection />
         <EmailPhoneSection />
         <PasswordSection />

--- a/packages/integration-tests/src/tests/experience/mfa/suggest-binding-additional-factor.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/suggest-binding-additional-factor.test.ts
@@ -209,7 +209,10 @@ describe('Experience - suggest additional MFA after WebAuthn binding as sign-in 
     await experience.toFillNewPasswords(password);
 
     await experience.waitForPathname('create-passkey');
-    await experience.toCreatePasskey();
+    // The page is `create-passkey` (sign-in passkey flow), not `mfa-binding/WebAuthn`,
+    // so we click the button directly instead of using `toCreatePasskey()`.
+    await experience.page.waitForNetworkIdle();
+    await experience.toClickButton('Create a passkey');
 
     // Should suggest binding additional MFA factor
     await experience.waitForPathname('mfa-binding');
@@ -252,7 +255,10 @@ describe('Experience - suggest additional MFA after WebAuthn binding as sign-in 
     await experience.toFillNewPasswords(password);
 
     await experience.waitForPathname('create-passkey');
-    await experience.toCreatePasskey();
+    // The page is `create-passkey` (sign-in passkey flow), not `mfa-binding/WebAuthn`,
+    // so we click the button directly instead of using `toCreatePasskey()`.
+    await experience.page.waitForNetworkIdle();
+    await experience.toClickButton('Create a passkey');
 
     // After binding WebAuthn with passkey sign-in enabled, backend suggests binding additional MFA factors
     await experience.waitForPathname('mfa-binding');

--- a/packages/integration-tests/src/tests/experience/mfa/suggest-binding-additional-factor.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/suggest-binding-additional-factor.test.ts
@@ -209,7 +209,7 @@ describe('Experience - suggest additional MFA after WebAuthn binding as sign-in 
     await experience.toFillNewPasswords(password);
 
     await experience.waitForPathname('create-passkey');
-    await experience.toClickButton('Create a passkey');
+    await experience.toCreatePasskey();
 
     // Should suggest binding additional MFA factor
     await experience.waitForPathname('mfa-binding');
@@ -252,7 +252,7 @@ describe('Experience - suggest additional MFA after WebAuthn binding as sign-in 
     await experience.toFillNewPasswords(password);
 
     await experience.waitForPathname('create-passkey');
-    await experience.toClickButton('Create a passkey');
+    await experience.toCreatePasskey();
 
     // After binding WebAuthn with passkey sign-in enabled, backend suggests binding additional MFA factors
     await experience.waitForPathname('mfa-binding');


### PR DESCRIPTION
## Summary

Add stable (non-hashed) `logto_ac-*` CSS class names to key account center elements, making it much easier for users to override built-in styles with custom CSS.

### Problem

The account center only had CSS Module hashed class names (e.g., `vUugRG_container`), making it very difficult for users to write custom CSS that targets specific elements. Users had to resort to fragile attribute selectors like `div[class$="container"]`.

### Solution

Following the same `layoutClassNames` pattern used in the sign-in experience package (`packages/experience/src/utils/consts.ts`), this PR adds stable class names to all key elements:

| Class Name | Element |
|---|---|
| `logto_ac-app` | Root app wrapper |
| `logto_ac-page-container` | Full-page layout wrapper |
| `logto_ac-main-content` | Main content area (full-page) |
| `logto_ac-card-container` | Card-style container (sub-pages) |
| `logto_ac-card-main` | Card main content area |
| `logto_ac-signature` | Logto signature footer |
| `logto_ac-page-header` | Top header bar (logo + app name) |
| `logto_ac-page-title` | Page title text |
| `logto_ac-page-description` | Page description text |
| `logto_ac-page-content` | Scrollable content area |
| `logto_ac-section` | Each logical section |
| `logto_ac-section-title` | Section heading text |
| `logto_ac-card` | Card grouping rows inside a section |
| `logto_ac-row` | A single row inside a card |
| `logto_ac-secondary-page-wrapper` | Secondary page layout wrapper |
| `logto_ac-secondary-page-title` | Secondary page title |
| `logto_ac-secondary-page-description` | Secondary page description |

### Usage Example

```css
/* Target the page header */
.logto_ac-page-header { background: #f0f0f0; }

/* Style all sections */
.logto_ac-section { margin-bottom: 24px; }

/* Customize card appearance */
.logto_ac-card { border: 1px solid #ddd; }

/* Override row height */
.logto_ac-row { height: 72px; }
```

### Files Changed

- **New**: `packages/account/src/constants/layout.ts` — defines `layoutClassNames`
- **Modified**: Layout (`App.tsx`), `PageHeader`, `SecondaryPageLayout`, and all 6 Security sections to apply the stable class names alongside existing CSS module classes