### PR TITLE
fix(console): hide preview button for social connector routes with placeholder

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/IntegratePrebuiltUi/PrebuiltUiUrlItem.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/IntegratePrebuiltUi/PrebuiltUiUrlItem.tsx
@@ -15,10 +15,10 @@ type Props = {
   readonly path: string;
   readonly tooltip: string;
   readonly tenantEndpoint?: URL;
-  readonly hidePreview?: boolean;
+  readonly isPreviewHidden?: boolean;
 };
 
-function PrebuiltUiUrlItem({ path, tooltip, tenantEndpoint, hidePreview }: Props) {
+function PrebuiltUiUrlItem({ path, tooltip, tenantEndpoint, isPreviewHidden }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console.general' });
   const copyIconRef = useRef<HTMLButtonElement>(null);
   const [copyState, setCopyState] = useState<CopyState>('copy');
@@ -61,7 +61,7 @@ function PrebuiltUiUrlItem({ path, tooltip, tenantEndpoint, hidePreview }: Props
             <Copy className={styles.icon} />
           </IconButton>
         </Tooltip>
-        {!hidePreview && (
+        {!isPreviewHidden && (
           <Tooltip content={t('live_preview')}>
             <IconButton size="small" className={styles.iconButton} onClick={handleLivePreview}>
               <Start className={styles.icon} />

--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/IntegratePrebuiltUi/PrebuiltUiUrlItem.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/IntegratePrebuiltUi/PrebuiltUiUrlItem.tsx
@@ -15,9 +15,10 @@ type Props = {
   readonly path: string;
   readonly tooltip: string;
   readonly tenantEndpoint?: URL;
+  readonly hidePreview?: boolean;
 };
 
-function PrebuiltUiUrlItem({ path, tooltip, tenantEndpoint }: Props) {
+function PrebuiltUiUrlItem({ path, tooltip, tenantEndpoint, hidePreview }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console.general' });
   const copyIconRef = useRef<HTMLButtonElement>(null);
   const [copyState, setCopyState] = useState<CopyState>('copy');
@@ -60,11 +61,13 @@ function PrebuiltUiUrlItem({ path, tooltip, tenantEndpoint }: Props) {
             <Copy className={styles.icon} />
           </IconButton>
         </Tooltip>
-        <Tooltip content={t('live_preview')}>
-          <IconButton size="small" className={styles.iconButton} onClick={handleLivePreview}>
-            <Start className={styles.icon} />
-          </IconButton>
-        </Tooltip>
+        {!hidePreview && (
+          <Tooltip content={t('live_preview')}>
+            <IconButton size="small" className={styles.iconButton} onClick={handleLivePreview}>
+              <Start className={styles.icon} />
+            </IconButton>
+          </Tooltip>
+        )}
       </div>
     </div>
   );

--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/IntegratePrebuiltUi/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/IntegratePrebuiltUi/index.tsx
@@ -169,6 +169,7 @@ function IntegratePrebuiltUi() {
                   path={path}
                   tooltip={t(tooltipKey)}
                   tenantEndpoint={tenantEndpoint}
+                  hidePreview
                 />
               ))}
           </div>

--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/IntegratePrebuiltUi/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/IntegratePrebuiltUi/index.tsx
@@ -166,10 +166,10 @@ function IntegratePrebuiltUi() {
               devPrebuiltRoutes.map(({ path, tooltipKey }) => (
                 <PrebuiltUiUrlItem
                   key={path}
+                  isPreviewHidden
                   path={path}
                   tooltip={t(tooltipKey)}
                   tenantEndpoint={tenantEndpoint}
-                  hidePreview
                 />
               ))}
           </div>


### PR DESCRIPTION
## Summary
Hide the live preview icon button for social connector routes (`/account/social/:connectorId` and `/account/social/:connectorId/remove`) in the account center prebuilt UI configuration tab. These routes contain a `:connectorId` placeholder, so clicking the preview button would always result in a 404.

The info tooltip and copy buttons remain functional for these routes.

## Testing
Tested locally

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments