### PR TITLE
fix(account): add placeholder for TOTP QR code while loading

### DIFF
--- a/packages/account/src/pages/TotpBinding/index.module.scss
+++ b/packages/account/src/pages/TotpBinding/index.module.scss
@@ -31,19 +31,24 @@
   gap: _.unit(4);
   margin-top: _.unit(2);
 
-  .qrCode {
+  .qrCode,
+  .qrCodePlaceholder {
     border: 1px solid var(--color-line-divider);
     border-radius: var(--radius);
     overflow: hidden;
     height: 136px;
     width: 136px;
+  }
 
-    > img {
-      width: 100%;
-      height: 100%;
-      display: block;
-      @include _.image-align-center;
-    }
+  .qrCode > img {
+    width: 100%;
+    height: 100%;
+    display: block;
+    @include _.image-align-center;
+  }
+
+  .qrCodePlaceholder {
+    background-color: var(--color-bg-light);
   }
 
   .rawSecret {

--- a/packages/account/src/pages/TotpBinding/index.tsx
+++ b/packages/account/src/pages/TotpBinding/index.tsx
@@ -106,8 +106,13 @@ const TotpBinding = ({ isReplace }: Props) => {
         const service = window.location.hostname;
         // Build the otpauth URI manually for QR code
         const keyUri = `otpauth://totp/${encodeURIComponent(service)}:${encodeURIComponent(displayName)}?secret=${result.secret}&issuer=${encodeURIComponent(service)}`;
-        const qrCodeDataUrl = await qrcode.toDataURL(keyUri);
-        setSecretQrCode(qrCodeDataUrl);
+        try {
+          const qrCodeDataUrl = await qrcode.toDataURL(keyUri);
+          setSecretQrCode(qrCodeDataUrl);
+        } catch (error) {
+          // QR code generation failed; fall back to raw secret display
+          console.error('Failed to generate TOTP QR code:', error);
+        }
       }
     };
 
@@ -262,6 +267,17 @@ const TotpBinding = ({ isReplace }: Props) => {
               (secretQrCode ? (
                 <div className={styles.qrCode}>
                   <img src={secretQrCode} alt="QR code" />
+                </div>
+              ) : secret ? (
+                <div className={styles.copySecret}>
+                  <div className={styles.rawSecret}>{secret}</div>
+                  <Button
+                    title="action.copy"
+                    type="secondary"
+                    onClick={() => {
+                      void copySecret();
+                    }}
+                  />
                 </div>
               ) : (
                 <div className={styles.qrCodePlaceholder} />

--- a/packages/account/src/pages/TotpBinding/index.tsx
+++ b/packages/account/src/pages/TotpBinding/index.tsx
@@ -258,11 +258,14 @@ const TotpBinding = ({ isReplace }: Props) => {
             />
           </div>
           <div className={styles.secretContent}>
-            {isQrCodeFormat && secretQrCode && (
-              <div className={styles.qrCode}>
-                <img src={secretQrCode} alt="QR code" />
-              </div>
-            )}
+            {isQrCodeFormat &&
+              (secretQrCode ? (
+                <div className={styles.qrCode}>
+                  <img src={secretQrCode} alt="QR code" />
+                </div>
+              ) : (
+                <div className={styles.qrCodePlaceholder} />
+              ))}
             {!isQrCodeFormat && secret && (
               <div className={styles.copySecret}>
                 <div className={styles.rawSecret}>{secret}</div>

--- a/packages/account/src/pages/TotpBinding/index.tsx
+++ b/packages/account/src/pages/TotpBinding/index.tsx
@@ -4,6 +4,7 @@ import VerificationCodeInput, {
   defaultLength,
 } from '@experience/shared/components/VerificationCode';
 import { AccountCenterControlValue, MfaFactor, type Mfa } from '@logto/schemas';
+import type { TFuncKey } from 'i18next';
 import qrcode from 'qrcode';
 import { useCallback, useContext, useEffect, useState, type FormEvent } from 'react';
 import { isMobile } from 'react-device-detect';
@@ -26,11 +27,29 @@ import { sessionStorage } from '@ac/utils/session-storage';
 
 import styles from './index.module.scss';
 
-const isCodeReady = (code: string[]) => {
-  return code.length === defaultLength && code.every(Boolean);
-};
-
+const isCodeReady = (code: string[]) => code.length === defaultLength && code.every(Boolean);
 const isTotpEnabled = (mfa?: Mfa) => mfa?.factors.includes(MfaFactor.TOTP) ?? false;
+const errorPage = (messageKey: TFuncKey) => (
+  <ErrorPage titleKey="error.something_went_wrong" messageKey={messageKey} />
+);
+const CopySecretButton = ({
+  secret,
+  onCopy,
+}: {
+  readonly secret: string;
+  readonly onCopy: () => void;
+}) => (
+  <div className={styles.copySecret}>
+    <div className={styles.rawSecret}>{secret}</div>
+    <Button
+      title="action.copy"
+      type="secondary"
+      onClick={() => {
+        onCopy();
+      }}
+    />
+  </div>
+);
 
 type Props = {
   readonly isReplace?: boolean;
@@ -59,26 +78,17 @@ const TotpBinding = ({ isReplace }: Props) => {
   const [codeInput, setCodeInput] = useState<string[]>([]);
   const [errorMessage, setErrorMessage] = useState<string>();
   const [hasTotpAlready, setHasTotpAlready] = useState<boolean>();
-
-  // Check if TOTP already exists on mount
   useEffect(() => {
     const checkExistingMfa = async () => {
       const [error, result] = await getMfaRequest();
-
       if (error) {
-        // If there's an error, we'll let the user continue and the backend will validate
         setHasTotpAlready(false);
         return;
       }
-
-      const hasTotp = result?.some((mfa) => mfa.type === MfaFactor.TOTP) ?? false;
-      setHasTotpAlready(hasTotp);
+      setHasTotpAlready(result?.some((mfa) => mfa.type === MfaFactor.TOTP) ?? false);
     };
-
     void checkExistingMfa();
   }, [getMfaRequest]);
-
-  // Generate TOTP secret on mount
   useEffect(() => {
     if (
       !verificationId ||
@@ -88,10 +98,8 @@ const TotpBinding = ({ isReplace }: Props) => {
     ) {
       return;
     }
-
     const generateSecret = async () => {
       const [error, result] = await generateSecretRequest();
-
       if (error) {
         await handleError(error);
         return;
@@ -99,23 +107,17 @@ const TotpBinding = ({ isReplace }: Props) => {
 
       if (result) {
         setSecret(result.secret);
-
-        // Generate QR code locally
         const displayName =
           userInfo?.username ?? userInfo?.primaryEmail ?? userInfo?.primaryPhone ?? 'User';
         const service = window.location.hostname;
-        // Build the otpauth URI manually for QR code
         const keyUri = `otpauth://totp/${encodeURIComponent(service)}:${encodeURIComponent(displayName)}?secret=${result.secret}&issuer=${encodeURIComponent(service)}`;
         try {
-          const qrCodeDataUrl = await qrcode.toDataURL(keyUri);
-          setSecretQrCode(qrCodeDataUrl);
+          setSecretQrCode(await qrcode.toDataURL(keyUri));
         } catch (error) {
-          // QR code generation failed; fall back to raw secret display
           console.error('Failed to generate TOTP QR code:', error);
         }
       }
     };
-
     void generateSecret();
   }, [
     generateSecretRequest,
@@ -126,18 +128,15 @@ const TotpBinding = ({ isReplace }: Props) => {
     userInfo,
     verificationId,
   ]);
-
   useEffect(() => {
     if (verificationId && hasTotpAlready === false) {
       sessionStorage.clearRouteRestore();
     }
   }, [hasTotpAlready, verificationId]);
-
   const copySecret = useCallback(async () => {
     if (!secret) {
       return;
     }
-
     await navigator.clipboard.writeText(secret);
     setToast(t('mfa.secret_key_copied'));
   }, [secret, setToast, t]);
@@ -148,9 +147,7 @@ const TotpBinding = ({ isReplace }: Props) => {
       if (!verificationId || !secret || loading || !isCodeReady(codeInput)) {
         return;
       }
-
       setErrorMessage(undefined);
-
       const codeString = codeInput.join('');
       const [error] = await createOrReplaceTotpRequest(verificationId, {
         secret,
@@ -174,8 +171,7 @@ const TotpBinding = ({ isReplace }: Props) => {
         return;
       }
 
-      // Clear code input to prevent duplicate submission from the auto-submit useEffect
-      // (when loading state changes, handleSubmit gets recreated, which triggers the effect again)
+      // Clear code input to prevent duplicate submission
       setCodeInput([]);
 
       navigate(isReplace ? authenticatorAppReplaceSuccessRoute : authenticatorAppSuccessRoute, {
@@ -204,34 +200,18 @@ const TotpBinding = ({ isReplace }: Props) => {
     }
     void handleSubmit();
   }, [codeInput, handleSubmit]);
-
   if (
     !accountCenterSettings?.enabled ||
     accountCenterSettings.fields.mfa !== AccountCenterControlValue.Edit
   ) {
-    return (
-      <ErrorPage titleKey="error.something_went_wrong" messageKey="error.feature_not_enabled" />
-    );
+    return errorPage('error.feature_not_enabled');
   }
-
   if (!isTotpEnabled(experienceSettings?.mfa)) {
-    return (
-      <ErrorPage
-        titleKey="error.something_went_wrong"
-        messageKey="account_center.mfa.totp_not_enabled"
-      />
-    );
+    return errorPage('account_center.mfa.totp_not_enabled');
   }
-
   if (hasTotpAlready && !isReplace) {
-    return (
-      <ErrorPage
-        titleKey="error.something_went_wrong"
-        messageKey="account_center.mfa.totp_already_added"
-      />
-    );
+    return errorPage('account_center.mfa.totp_already_added');
   }
-
   if (!verificationId) {
     return <VerificationMethodList />;
   }
@@ -269,31 +249,11 @@ const TotpBinding = ({ isReplace }: Props) => {
                   <img src={secretQrCode} alt="QR code" />
                 </div>
               ) : secret ? (
-                <div className={styles.copySecret}>
-                  <div className={styles.rawSecret}>{secret}</div>
-                  <Button
-                    title="action.copy"
-                    type="secondary"
-                    onClick={() => {
-                      void copySecret();
-                    }}
-                  />
-                </div>
+                <CopySecretButton secret={secret} onCopy={copySecret} />
               ) : (
                 <div className={styles.qrCodePlaceholder} />
               ))}
-            {!isQrCodeFormat && secret && (
-              <div className={styles.copySecret}>
-                <div className={styles.rawSecret}>{secret}</div>
-                <Button
-                  title="action.copy"
-                  type="secondary"
-                  onClick={() => {
-                    void copySecret();
-                  }}
-                />
-              </div>
-            )}
+            {!isQrCodeFormat && secret && <CopySecretButton secret={secret} onCopy={copySecret} />}
             <button
               type="button"
               className={styles.switchLink}
@@ -314,10 +274,7 @@ const TotpBinding = ({ isReplace }: Props) => {
           <div className={styles.stepTitle}>
             <DynamicT
               forKey="mfa.step"
-              interpolation={{
-                step: 2,
-                content: t('mfa.enter_one_time_code'),
-              }}
+              interpolation={{ step: 2, content: t('mfa.enter_one_time_code') }}
             />
           </div>
           <div className={styles.stepDescription}>
@@ -328,9 +285,7 @@ const TotpBinding = ({ isReplace }: Props) => {
             className={styles.codeInput}
             value={codeInput}
             error={errorMessage}
-            onChange={(code) => {
-              setCodeInput(code);
-            }}
+            onChange={setCodeInput}
           />
           <Button
             title="action.continue"


### PR DESCRIPTION
## Summary
Add a 136x136px placeholder for the TOTP QR code in the account center. Previously, the QR code area was completely empty before the image loaded, causing a visible layout shift. Now a placeholder with matching border and background is shown while the QR code generates.


## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments