### PR TITLE
fix(account): prevent confirm modal button text overflow in German

### DIFF
--- a/packages/account/src/components/ConfirmModal/index.module.scss
+++ b/packages/account/src/components/ConfirmModal/index.module.scss
@@ -14,7 +14,7 @@
   background: var(--color-bg-float);
   border-radius: _.unit(4);
   padding: _.unit(6);
-  max-width: 400px;
+  max-width: 480px;
   width: calc(100% - _.unit(8));
   box-shadow: var(--shadow-2);
 }

--- a/packages/account/src/components/ConfirmModal/index.tsx
+++ b/packages/account/src/components/ConfirmModal/index.tsx
@@ -43,8 +43,9 @@ const ConfirmModal = ({
       </div>
       <div className={styles.content}>{children}</div>
       <div className={styles.footer}>
-        <Button title={cancelText} type="secondary" onClick={onCancel} />
+        <Button size="small" title={cancelText} type="secondary" onClick={onCancel} />
         <Button
+          size="small"
           title={confirmText}
           type={confirmButtonType}
           isLoading={isLoading}


### PR DESCRIPTION
## Summary

Use `size="small"` for ConfirmModal buttons to allow natural content width instead of stretching to 100%, fixing overflow with long German text like "2-Faktor-Verifizierung deaktivieren" in the disable 2FA confirmation dialog.

## Testing

Tested locally

<img width="566" height="265" alt="image" src="https://github.com/user-attachments/assets/735b4fac-0831-4f1c-b596-ef3bacb1d72d" />


## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments