### PR TITLE
fix(account): suppress toast when user cancels passkey creation

### DIFF
--- a/packages/account/src/pages/PasskeyBinding/index.tsx
+++ b/packages/account/src/pages/PasskeyBinding/index.tsx
@@ -104,10 +104,11 @@ const PasskeyBinding = () => {
     const credential = await trySafe(
       async () => startRegistration(registrationOptions),
       (error) => {
-        console.error('WebAuthn registration failed:', error);
-
         // User cancelled the WebAuthn dialog, no need to show error
-        if (error instanceof DOMException && error.name === 'NotAllowedError') {
+        if (
+          (error instanceof DOMException || error instanceof Error) &&
+          error.name === 'NotAllowedError'
+        ) {
           return;
         }
 
@@ -127,6 +128,7 @@ const PasskeyBinding = () => {
           }
         }
 
+        console.error('WebAuthn registration failed:', error);
         setToast(t('mfa.webauthn_failed_to_create'));
       }
     );

--- a/packages/account/src/pages/PasskeyBinding/index.tsx
+++ b/packages/account/src/pages/PasskeyBinding/index.tsx
@@ -106,6 +106,11 @@ const PasskeyBinding = () => {
       (error) => {
         console.error('WebAuthn registration failed:', error);
 
+        // User cancelled the WebAuthn dialog, no need to show error
+        if (error instanceof DOMException && error.name === 'NotAllowedError') {
+          return;
+        }
+
         if (error instanceof WebAuthnError) {
           switch (error.code) {
             case 'ERROR_AUTHENTICATOR_PREVIOUSLY_REGISTERED': {
@@ -113,7 +118,6 @@ const PasskeyBinding = () => {
               return;
             }
             case 'ERROR_CEREMONY_ABORTED': {
-              // User cancelled the operation, no need to show error
               return;
             }
             default: {

--- a/packages/account/src/pages/PasskeyBinding/index.tsx
+++ b/packages/account/src/pages/PasskeyBinding/index.tsx
@@ -118,6 +118,7 @@ const PasskeyBinding = () => {
               return;
             }
             case 'ERROR_CEREMONY_ABORTED': {
+              // User cancelled the operation, no need to show error
               return;
             }
             default: {


### PR DESCRIPTION
## Summary

- Add a direct `NotAllowedError` DOMException check in `PasskeyBinding` to reliably detect when the user cancels the browser's passkey creation dialog
- This check runs before the `WebAuthnError` code matching, aligning with how the experience package handles cancellation in `use-passkey-sign-in.ts`
- Prevents showing the misleading "Failed to create" toast when the user intentionally cancels the operation

## Test plan

- [ ] Go to account center → passkey binding flow
- [ ] Click "Continue" to trigger the browser's passkey creation dialog
- [ ] Click "Cancel" in the browser dialog
- [ ] Verify no error toast appears

<details><summary>Closes LOG-13168</summary>

https://linear.app/logto/issue/LOG-13168/better-error-message-when-user-cancelabort-the-passkey

</details>