### PR TITLE
fix(account): navigate back instead of showing empty method list when only one verification method

### DIFF
--- a/packages/account/src/components/VerificationMethodList/index.tsx
+++ b/packages/account/src/components/VerificationMethodList/index.tsx
@@ -1,4 +1,5 @@
 import { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import PageContext from '@ac/Providers/PageContextProvider/PageContext';
 import SecondaryPageLayout from '@ac/layouts/SecondaryPageLayout';
@@ -14,6 +15,7 @@ const isVerificationMethod = (value: VerificationMethod | false): value is Verif
 
 const VerificationMethodList = () => {
   const { userInfo } = useContext(PageContext);
+  const navigate = useNavigate();
   const [verifyingMethod, setVerifyingMethod] = useState<VerificationMethod>();
   // Track if we already auto-selected the only available method to avoid re-trigger on Back.
   const hasAutoSelectedMethod = useRef(false);
@@ -51,13 +53,21 @@ const VerificationMethodList = () => {
 
   const hasAlternativeMethod = availableMethods.length > 1;
 
+  // When auto-selected (only one method), back should navigate away instead of
+  // returning to the method list since there's nothing else to choose.
+  const handleBack = hasAlternativeMethod
+    ? () => {
+        setVerifyingMethod(undefined);
+      }
+    : () => {
+        navigate(-1);
+      };
+
   if (verifyingMethod === VerificationMethod.Password) {
     return (
       <PasswordVerification
         hasAlternativeMethod={hasAlternativeMethod}
-        onBack={() => {
-          setVerifyingMethod(undefined);
-        }}
+        onBack={handleBack}
         onSwitchMethod={() => {
           setVerifyingMethod(undefined);
         }}
@@ -69,9 +79,7 @@ const VerificationMethodList = () => {
     return (
       <EmailVerification
         hasAlternativeMethod={hasAlternativeMethod}
-        onBack={() => {
-          setVerifyingMethod(undefined);
-        }}
+        onBack={handleBack}
         onSwitchMethod={() => {
           setVerifyingMethod(undefined);
         }}
@@ -83,9 +91,7 @@ const VerificationMethodList = () => {
     return (
       <PhoneVerification
         hasAlternativeMethod={hasAlternativeMethod}
-        onBack={() => {
-          setVerifyingMethod(undefined);
-        }}
+        onBack={handleBack}
         onSwitchMethod={() => {
           setVerifyingMethod(undefined);
         }}


### PR DESCRIPTION
## Summary
When only one verification method is available in the account center verification flow, it is auto-selected and the method list is correctly skipped. However, the back button on the verification page still navigated back to the (now-pointless) method list page. This PR changes the back button to perform a browser back (`navigate(-1)`) when there's only one available method, consistent with other back navigation in the app.

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments