### PR TITLE
fix(console): add missing spacing to description text above input fields in account center

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/index.module.scss
@@ -62,6 +62,7 @@
 .description {
   font: var(--font-body-2);
   color: var(--color-text-secondary);
+  margin-bottom: _.unit(1);
 }
 
 .notice {


### PR DESCRIPTION
## Summary
Add `margin-bottom: _.unit(1)` to the `.description` class in Account Center's `index.module.scss`, fixing missing spacing between description text and input fields (e.g. WebAuthn related origins, delete account URL, secret vault).

Closes LOG-13166

## Testing
Tested locally

## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments