### PR TITLE
fix(account): prevent infinite login loop when account center is disabled

### DIFF
--- a/packages/account/src/App.tsx
+++ b/packages/account/src/App.tsx
@@ -97,28 +97,38 @@ const Main = () => {
   const isInitialAuthLoading = !isAuthenticated && isLoading;
 
   useEffect(() => {
-    if (isInCallback || isInitialAuthLoading) {
+    if (isInCallback || isInitialAuthLoading || isLoadingExperience) {
       return;
     }
 
-    if (!isAuthenticated) {
+    if (!isAuthenticated && accountCenterSettings?.enabled) {
       const extraParams = uiLocales ? { [ExtraParamsKey.UiLocales]: uiLocales } : undefined;
       setRouteRestore(window.location.pathname);
       void signIn({ redirectUri, extraParams });
     }
-  }, [isAuthenticated, isInCallback, isInitialAuthLoading, signIn, uiLocales]);
+  }, [
+    isAuthenticated,
+    isInCallback,
+    isInitialAuthLoading,
+    isLoadingExperience,
+    accountCenterSettings,
+    signIn,
+    uiLocales,
+  ]);
 
   useEffect(() => {
     if (isInCallback || isInitialAuthLoading || !isAuthenticated || isLoadingUserInfo) {
       return;
     }
 
-    if (userInfoError) {
+    // Don't re-authenticate when account center is disabled - the API will always reject
+    if (userInfoError && accountCenterSettings?.enabled) {
       const extraParams = uiLocales ? { [ExtraParamsKey.UiLocales]: uiLocales } : undefined;
       setRouteRestore(window.location.pathname);
       void signIn({ redirectUri, prompt: Prompt.Login, extraParams });
     }
   }, [
+    accountCenterSettings,
     isAuthenticated,
     isInCallback,
     isInitialAuthLoading,
@@ -137,6 +147,15 @@ const Main = () => {
 
   if (isInitialAuthLoading || isLoadingExperience || isLoadingUserInfo) {
     return <GlobalLoading />;
+  }
+
+  // Account center is explicitly disabled - show error page for all routes
+  if (accountCenterSettings?.enabled === false) {
+    return (
+      <Routes>
+        <Route path="*" element={<Home />} />
+      </Routes>
+    );
   }
 
   if (!userInfo) {


### PR DESCRIPTION
## Summary

When account center is globally disabled (via the Console toggle), navigating to any `/account` page (e.g. `/account/security`) triggers an infinite sign-in loop:

1. User visits `/account/security` → redirected to sign-in
2. After sign-in, `/api/my-account` returns **400 `account_center.not_enabled`** (server middleware blocks all account routes when disabled)
3. `userInfoError` is set → app redirects to sign-in with `prompt: login` → back to step 2

**Fix** (3 changes in `packages/account/src/App.tsx`):

- **Auth redirect effect**: Wait for settings to load and check `accountCenterSettings?.enabled` before redirecting to sign-in — skip auth entirely when account center is disabled
- **userInfoError re-auth effect**: Only trigger re-authentication when `accountCenterSettings?.enabled` is true — the API will always reject when disabled
- **Rendering gate**: When `accountCenterSettings?.enabled === false`, render the existing `<Home />` error page ("Page not found" / "This page is not available.") for all routes, instead of requiring `userInfo`

## Testing

Tested locally

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments