### PR TITLE
fix(account): show error page when no verification methods are available

### DIFF
--- a/packages/account/src/components/VerificationMethodList/index.tsx
+++ b/packages/account/src/components/VerificationMethodList/index.tsx
@@ -1,6 +1,7 @@
 import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 
 import PageContext from '@ac/Providers/PageContextProvider/PageContext';
+import ErrorPage from '@ac/components/ErrorPage';
 import SecondaryPageLayout from '@ac/layouts/SecondaryPageLayout';
 import { VerificationMethod } from '@ac/types';
 
@@ -89,6 +90,15 @@ const VerificationMethodList = () => {
         onSwitchMethod={() => {
           setVerifyingMethod(undefined);
         }}
+      />
+    );
+  }
+
+  if (availableMethods.length === 0) {
+    return (
+      <ErrorPage
+        titleKey="account_center.verification.no_available_methods_title"
+        messageKey="account_center.verification.no_available_methods_description"
       />
     );
   }

--- a/packages/phrases-experience/src/locales/ar/account-center.ts
+++ b/packages/phrases-experience/src/locales/ar/account-center.ts
@@ -18,6 +18,9 @@ const account_center = {
     error_verify_failed: 'فشل التحقق. يرجى إدخال الرمز مرة أخرى.',
     verification_required: 'انتهت صلاحية التحقق. يرجى التحقق من هويتك مرة أخرى.',
     try_another_method: 'جرّب طريقة أخرى للتحقق',
+    no_available_methods_title: 'No verification methods available',
+    no_available_methods_description:
+      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
   },
   password_verification: {
     title: 'التحقق من كلمة المرور',

--- a/packages/phrases-experience/src/locales/ar/account-center.ts
+++ b/packages/phrases-experience/src/locales/ar/account-center.ts
@@ -18,9 +18,9 @@ const account_center = {
     error_verify_failed: 'فشل التحقق. يرجى إدخال الرمز مرة أخرى.',
     verification_required: 'انتهت صلاحية التحقق. يرجى التحقق من هويتك مرة أخرى.',
     try_another_method: 'جرّب طريقة أخرى للتحقق',
-    no_available_methods_title: 'No verification methods available',
+    no_available_methods_title: 'لا توجد طرق تحقق متاحة',
     no_available_methods_description:
-      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
+      'لم تقم بإعداد أي طرق للتحقق. يرجى إضافة كلمة مرور أو بريد إلكتروني أو رقم هاتف إلى حسابك أولًا.',
   },
   password_verification: {
     title: 'التحقق من كلمة المرور',

--- a/packages/phrases-experience/src/locales/cs/account-center.ts
+++ b/packages/phrases-experience/src/locales/cs/account-center.ts
@@ -18,6 +18,9 @@ const account_center = {
     error_verify_failed: 'Ověření se nezdařilo. Zadej kód znovu.',
     verification_required: 'Ověření vypršelo. Prosím ověř svou identitu znovu.',
     try_another_method: 'Vyzkoušej jinou metodu ověření',
+    no_available_methods_title: 'No verification methods available',
+    no_available_methods_description:
+      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
   },
   password_verification: {
     title: 'Ověřit heslo',

--- a/packages/phrases-experience/src/locales/cs/account-center.ts
+++ b/packages/phrases-experience/src/locales/cs/account-center.ts
@@ -18,9 +18,9 @@ const account_center = {
     error_verify_failed: 'Ověření se nezdařilo. Zadej kód znovu.',
     verification_required: 'Ověření vypršelo. Prosím ověř svou identitu znovu.',
     try_another_method: 'Vyzkoušej jinou metodu ověření',
-    no_available_methods_title: 'No verification methods available',
+    no_available_methods_title: 'Nejsou k dispozici žádné metody ověření',
     no_available_methods_description:
-      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
+      'Nemáš nastavenou žádnou metodu ověření. Nejprve si ke svému účtu přidej heslo, e-mail nebo telefonní číslo.',
   },
   password_verification: {
     title: 'Ověřit heslo',

--- a/packages/phrases-experience/src/locales/de/account-center.ts
+++ b/packages/phrases-experience/src/locales/de/account-center.ts
@@ -20,9 +20,9 @@ const account_center = {
     error_verify_failed: 'Verifizierung fehlgeschlagen. Bitte gib den Code erneut ein.',
     verification_required: 'Verifizierung abgelaufen. Bitte bestätige deine Identität erneut.',
     try_another_method: 'Versuche eine andere Verifizierungsmethode',
-    no_available_methods_title: 'No verification methods available',
+    no_available_methods_title: 'Keine Verifizierungsmethoden verfügbar',
     no_available_methods_description:
-      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
+      'Du hast noch keine Verifizierungsmethoden eingerichtet. Bitte füge zuerst ein Passwort, eine E-Mail-Adresse oder eine Telefonnummer zu deinem Konto hinzu.',
   },
   password_verification: {
     title: 'Passwort bestätigen',

--- a/packages/phrases-experience/src/locales/de/account-center.ts
+++ b/packages/phrases-experience/src/locales/de/account-center.ts
@@ -20,6 +20,9 @@ const account_center = {
     error_verify_failed: 'Verifizierung fehlgeschlagen. Bitte gib den Code erneut ein.',
     verification_required: 'Verifizierung abgelaufen. Bitte bestätige deine Identität erneut.',
     try_another_method: 'Versuche eine andere Verifizierungsmethode',
+    no_available_methods_title: 'No verification methods available',
+    no_available_methods_description:
+      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
   },
   password_verification: {
     title: 'Passwort bestätigen',

--- a/packages/phrases-experience/src/locales/en/account-center.ts
+++ b/packages/phrases-experience/src/locales/en/account-center.ts
@@ -18,6 +18,9 @@ const account_center = {
     error_verify_failed: 'Verification failed. Please enter the code again.',
     verification_required: 'Verification expired. Please verify your identity again.',
     try_another_method: 'Try another method to verify',
+    no_available_methods_title: 'No verification methods available',
+    no_available_methods_description:
+      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
   },
   password_verification: {
     title: 'Verify password',

--- a/packages/phrases-experience/src/locales/es/account-center.ts
+++ b/packages/phrases-experience/src/locales/es/account-center.ts
@@ -18,9 +18,9 @@ const account_center = {
     error_verify_failed: 'La verificación falló. Ingresa el código nuevamente.',
     verification_required: 'La verificación expiró. Vuelve a comprobar tu identidad.',
     try_another_method: 'Prueba otro método de verificación',
-    no_available_methods_title: 'No verification methods available',
+    no_available_methods_title: 'No hay métodos de verificación disponibles',
     no_available_methods_description:
-      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
+      'No tienes ningún método de verificación configurado. Primero agrega una contraseña, un correo electrónico o un número de teléfono a tu cuenta.',
   },
   password_verification: {
     title: 'Verifica la contraseña',

--- a/packages/phrases-experience/src/locales/es/account-center.ts
+++ b/packages/phrases-experience/src/locales/es/account-center.ts
@@ -18,6 +18,9 @@ const account_center = {
     error_verify_failed: 'La verificación falló. Ingresa el código nuevamente.',
     verification_required: 'La verificación expiró. Vuelve a comprobar tu identidad.',
     try_another_method: 'Prueba otro método de verificación',
+    no_available_methods_title: 'No verification methods available',
+    no_available_methods_description:
+      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
   },
   password_verification: {
     title: 'Verifica la contraseña',

--- a/packages/phrases-experience/src/locales/fr/account-center.ts
+++ b/packages/phrases-experience/src/locales/fr/account-center.ts
@@ -19,6 +19,9 @@ const account_center = {
     error_verify_failed: 'Échec de la vérification. Veuillez saisir le code à nouveau.',
     verification_required: 'La vérification a expiré. Veuillez confirmer à nouveau votre identité.',
     try_another_method: 'Essayez une autre méthode de vérification',
+    no_available_methods_title: 'No verification methods available',
+    no_available_methods_description:
+      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
   },
   password_verification: {
     title: 'Vérifier le mot de passe',

--- a/packages/phrases-experience/src/locales/fr/account-center.ts
+++ b/packages/phrases-experience/src/locales/fr/account-center.ts
@@ -19,9 +19,9 @@ const account_center = {
     error_verify_failed: 'Échec de la vérification. Veuillez saisir le code à nouveau.',
     verification_required: 'La vérification a expiré. Veuillez confirmer à nouveau votre identité.',
     try_another_method: 'Essayez une autre méthode de vérification',
-    no_available_methods_title: 'No verification methods available',
+    no_available_methods_title: 'Aucune méthode de vérification disponible',
     no_available_methods_description:
-      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
+      "Vous n'avez configuré aucune méthode de vérification. Veuillez d'abord ajouter un mot de passe, une adresse e-mail ou un numéro de téléphone à votre compte.",
   },
   password_verification: {
     title: 'Vérifier le mot de passe',

--- a/packages/phrases-experience/src/locales/it/account-center.ts
+++ b/packages/phrases-experience/src/locales/it/account-center.ts
@@ -19,9 +19,9 @@ const account_center = {
     error_verify_failed: 'Verifica non riuscita. Inserisci di nuovo il codice.',
     verification_required: 'Verifica scaduta. Conferma di nuovo la tua identità.',
     try_another_method: 'Prova un altro metodo di verifica',
-    no_available_methods_title: 'No verification methods available',
+    no_available_methods_title: 'Nessun metodo di verifica disponibile',
     no_available_methods_description:
-      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
+      'Non hai configurato alcun metodo di verifica. Aggiungi prima una password, un indirizzo e-mail o un numero di telefono al tuo account.',
   },
   password_verification: {
     title: 'Verifica la password',

--- a/packages/phrases-experience/src/locales/it/account-center.ts
+++ b/packages/phrases-experience/src/locales/it/account-center.ts
@@ -19,6 +19,9 @@ const account_center = {
     error_verify_failed: 'Verifica non riuscita. Inserisci di nuovo il codice.',
     verification_required: 'Verifica scaduta. Conferma di nuovo la tua identità.',
     try_another_method: 'Prova un altro metodo di verifica',
+    no_available_methods_title: 'No verification methods available',
+    no_available_methods_description:
+      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
   },
   password_verification: {
     title: 'Verifica la password',

--- a/packages/phrases-experience/src/locales/ja/account-center.ts
+++ b/packages/phrases-experience/src/locales/ja/account-center.ts
@@ -18,6 +18,9 @@ const account_center = {
     error_verify_failed: '認証に失敗しました。もう一度コードを入力してください。',
     verification_required: '認証の有効期限が切れました。もう一度本人確認を行ってください。',
     try_another_method: '別の方法で確認する',
+    no_available_methods_title: 'No verification methods available',
+    no_available_methods_description:
+      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
   },
   password_verification: {
     title: 'パスワードを確認',

--- a/packages/phrases-experience/src/locales/ja/account-center.ts
+++ b/packages/phrases-experience/src/locales/ja/account-center.ts
@@ -18,9 +18,9 @@ const account_center = {
     error_verify_failed: '認証に失敗しました。もう一度コードを入力してください。',
     verification_required: '認証の有効期限が切れました。もう一度本人確認を行ってください。',
     try_another_method: '別の方法で確認する',
-    no_available_methods_title: 'No verification methods available',
+    no_available_methods_title: '利用可能な認証方法がありません',
     no_available_methods_description:
-      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
+      '認証方法が設定されていません。まずアカウントにパスワード、メールアドレス、または電話番号を追加してください。',
   },
   password_verification: {
     title: 'パスワードを確認',

--- a/packages/phrases-experience/src/locales/ko/account-center.ts
+++ b/packages/phrases-experience/src/locales/ko/account-center.ts
@@ -17,9 +17,9 @@ const account_center = {
     error_verify_failed: '인증에 실패했습니다. 코드를 다시 입력해주세요.',
     verification_required: '인증이 만료되었습니다. 다시 신원을 확인해주세요.',
     try_another_method: '다른 방법으로 인증하기',
-    no_available_methods_title: 'No verification methods available',
+    no_available_methods_title: '사용 가능한 인증 방법이 없습니다',
     no_available_methods_description:
-      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
+      '설정된 인증 방법이 없습니다. 먼저 계정에 비밀번호, 이메일 또는 전화번호를 추가해 주세요.',
   },
   password_verification: {
     title: '비밀번호 확인',

--- a/packages/phrases-experience/src/locales/ko/account-center.ts
+++ b/packages/phrases-experience/src/locales/ko/account-center.ts
@@ -17,6 +17,9 @@ const account_center = {
     error_verify_failed: '인증에 실패했습니다. 코드를 다시 입력해주세요.',
     verification_required: '인증이 만료되었습니다. 다시 신원을 확인해주세요.',
     try_another_method: '다른 방법으로 인증하기',
+    no_available_methods_title: 'No verification methods available',
+    no_available_methods_description:
+      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
   },
   password_verification: {
     title: '비밀번호 확인',

--- a/packages/phrases-experience/src/locales/pl-pl/account-center.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/account-center.ts
@@ -19,9 +19,9 @@ const account_center = {
     error_verify_failed: 'Weryfikacja nie powiodła się. Wprowadź kod ponownie.',
     verification_required: 'Weryfikacja wygasła. Zweryfikuj swoją tożsamość ponownie.',
     try_another_method: 'Wypróbuj inny sposób weryfikacji',
-    no_available_methods_title: 'No verification methods available',
+    no_available_methods_title: 'Brak dostępnych metod weryfikacji',
     no_available_methods_description:
-      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
+      'Nie masz skonfigurowanych żadnych metod weryfikacji. Najpierw dodaj do swojego konta hasło, adres e-mail lub numer telefonu.',
   },
   password_verification: {
     title: 'Zweryfikuj hasło',

--- a/packages/phrases-experience/src/locales/pl-pl/account-center.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/account-center.ts
@@ -19,6 +19,9 @@ const account_center = {
     error_verify_failed: 'Weryfikacja nie powiodła się. Wprowadź kod ponownie.',
     verification_required: 'Weryfikacja wygasła. Zweryfikuj swoją tożsamość ponownie.',
     try_another_method: 'Wypróbuj inny sposób weryfikacji',
+    no_available_methods_title: 'No verification methods available',
+    no_available_methods_description:
+      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
   },
   password_verification: {
     title: 'Zweryfikuj hasło',

--- a/packages/phrases-experience/src/locales/pt-br/account-center.ts
+++ b/packages/phrases-experience/src/locales/pt-br/account-center.ts
@@ -19,9 +19,9 @@ const account_center = {
     error_verify_failed: 'Falha na verificação. Digite o código novamente.',
     verification_required: 'A verificação expirou. Confirme sua identidade novamente.',
     try_another_method: 'Tente outro método para verificar',
-    no_available_methods_title: 'No verification methods available',
+    no_available_methods_title: 'Nenhum método de verificação disponível',
     no_available_methods_description:
-      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
+      'Você não tem nenhum método de verificação configurado. Adicione uma senha, e-mail ou número de telefone à sua conta primeiro.',
   },
   password_verification: {
     title: 'Verificar senha',

--- a/packages/phrases-experience/src/locales/pt-br/account-center.ts
+++ b/packages/phrases-experience/src/locales/pt-br/account-center.ts
@@ -19,6 +19,9 @@ const account_center = {
     error_verify_failed: 'Falha na verificação. Digite o código novamente.',
     verification_required: 'A verificação expirou. Confirme sua identidade novamente.',
     try_another_method: 'Tente outro método para verificar',
+    no_available_methods_title: 'No verification methods available',
+    no_available_methods_description:
+      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
   },
   password_verification: {
     title: 'Verificar senha',

--- a/packages/phrases-experience/src/locales/pt-pt/account-center.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/account-center.ts
@@ -18,6 +18,9 @@ const account_center = {
     error_verify_failed: 'Falha na verificação. Introduza novamente o código.',
     verification_required: 'A verificação expirou. Confirme novamente a sua identidade.',
     try_another_method: 'Tente outro método para verificar',
+    no_available_methods_title: 'No verification methods available',
+    no_available_methods_description:
+      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
   },
   password_verification: {
     title: 'Verificar palavra-passe',

--- a/packages/phrases-experience/src/locales/pt-pt/account-center.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/account-center.ts
@@ -18,9 +18,9 @@ const account_center = {
     error_verify_failed: 'Falha na verificação. Introduza novamente o código.',
     verification_required: 'A verificação expirou. Confirme novamente a sua identidade.',
     try_another_method: 'Tente outro método para verificar',
-    no_available_methods_title: 'No verification methods available',
+    no_available_methods_title: 'Não há métodos de verificação disponíveis',
     no_available_methods_description:
-      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
+      'Não tem qualquer método de verificação configurado. Adicione primeiro uma palavra-passe, e-mail ou número de telefone à sua conta.',
   },
   password_verification: {
     title: 'Verificar palavra-passe',

--- a/packages/phrases-experience/src/locales/ru/account-center.ts
+++ b/packages/phrases-experience/src/locales/ru/account-center.ts
@@ -18,6 +18,9 @@ const account_center = {
     error_verify_failed: 'Не удалось подтвердить. Введите код ещё раз.',
     verification_required: 'Срок действия проверки истёк. Подтвердите личность ещё раз.',
     try_another_method: 'Попробовать другой способ подтверждения',
+    no_available_methods_title: 'No verification methods available',
+    no_available_methods_description:
+      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
   },
   password_verification: {
     title: 'Подтвердите пароль',

--- a/packages/phrases-experience/src/locales/ru/account-center.ts
+++ b/packages/phrases-experience/src/locales/ru/account-center.ts
@@ -18,9 +18,9 @@ const account_center = {
     error_verify_failed: 'Не удалось подтвердить. Введите код ещё раз.',
     verification_required: 'Срок действия проверки истёк. Подтвердите личность ещё раз.',
     try_another_method: 'Попробовать другой способ подтверждения',
-    no_available_methods_title: 'No verification methods available',
+    no_available_methods_title: 'Нет доступных способов подтверждения',
     no_available_methods_description:
-      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
+      'У вас не настроены способы подтверждения. Сначала добавьте к аккаунту пароль, email или номер телефона.',
   },
   password_verification: {
     title: 'Подтвердите пароль',

--- a/packages/phrases-experience/src/locales/th/account-center.ts
+++ b/packages/phrases-experience/src/locales/th/account-center.ts
@@ -18,6 +18,9 @@ const account_center = {
     error_verify_failed: 'ยืนยันไม่สำเร็จ กรุณากรอกรหัสอีกครั้ง',
     verification_required: 'การยืนยันหมดอายุ โปรดยืนยันตัวตนอีกครั้ง',
     try_another_method: 'ลองใช้วิธีอื่นเพื่อยืนยันตัวตน',
+    no_available_methods_title: 'No verification methods available',
+    no_available_methods_description:
+      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
   },
   password_verification: {
     title: 'ยืนยันรหัสผ่าน',

--- a/packages/phrases-experience/src/locales/th/account-center.ts
+++ b/packages/phrases-experience/src/locales/th/account-center.ts
@@ -18,9 +18,9 @@ const account_center = {
     error_verify_failed: 'ยืนยันไม่สำเร็จ กรุณากรอกรหัสอีกครั้ง',
     verification_required: 'การยืนยันหมดอายุ โปรดยืนยันตัวตนอีกครั้ง',
     try_another_method: 'ลองใช้วิธีอื่นเพื่อยืนยันตัวตน',
-    no_available_methods_title: 'No verification methods available',
+    no_available_methods_title: 'ไม่มีวิธีการยืนยันตัวตนที่พร้อมใช้งาน',
     no_available_methods_description:
-      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
+      'คุณยังไม่ได้ตั้งค่าวิธีการยืนยันตัวตน กรุณาเพิ่มรหัสผ่าน อีเมล หรือหมายเลขโทรศัพท์ให้กับบัญชีของคุณก่อน',
   },
   password_verification: {
     title: 'ยืนยันรหัสผ่าน',

--- a/packages/phrases-experience/src/locales/tr-tr/account-center.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/account-center.ts
@@ -19,6 +19,9 @@ const account_center = {
     error_verify_failed: 'Doğrulama başarısız. Lütfen kodu tekrar gir.',
     verification_required: 'Doğrulama süresi doldu. Lütfen kimliğini yeniden doğrula.',
     try_another_method: 'Başka bir doğrulama yöntemi deneyin',
+    no_available_methods_title: 'No verification methods available',
+    no_available_methods_description:
+      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
   },
   password_verification: {
     title: 'Parolayı doğrula',

--- a/packages/phrases-experience/src/locales/tr-tr/account-center.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/account-center.ts
@@ -19,9 +19,9 @@ const account_center = {
     error_verify_failed: 'Doğrulama başarısız. Lütfen kodu tekrar gir.',
     verification_required: 'Doğrulama süresi doldu. Lütfen kimliğini yeniden doğrula.',
     try_another_method: 'Başka bir doğrulama yöntemi deneyin',
-    no_available_methods_title: 'No verification methods available',
+    no_available_methods_title: 'Kullanılabilir doğrulama yöntemi yok',
     no_available_methods_description:
-      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
+      'Ayarlanmış herhangi bir doğrulama yönteminiz yok. Lütfen önce hesabınıza bir parola, e-posta adresi veya telefon numarası ekleyin.',
   },
   password_verification: {
     title: 'Parolayı doğrula',

--- a/packages/phrases-experience/src/locales/uk-ua/account-center.ts
+++ b/packages/phrases-experience/src/locales/uk-ua/account-center.ts
@@ -18,6 +18,9 @@ const account_center = {
     error_verify_failed: 'Не вдалося підтвердити. Будь ласка, введіть код ще раз.',
     verification_required: 'Термін перевірки минув. Підтвердіть свою особу ще раз.',
     try_another_method: 'Спробуйте інший спосіб підтвердження',
+    no_available_methods_title: 'No verification methods available',
+    no_available_methods_description:
+      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
   },
   password_verification: {
     title: 'Підтвердьте пароль',

--- a/packages/phrases-experience/src/locales/uk-ua/account-center.ts
+++ b/packages/phrases-experience/src/locales/uk-ua/account-center.ts
@@ -18,9 +18,9 @@ const account_center = {
     error_verify_failed: 'Не вдалося підтвердити. Будь ласка, введіть код ще раз.',
     verification_required: 'Термін перевірки минув. Підтвердіть свою особу ще раз.',
     try_another_method: 'Спробуйте інший спосіб підтвердження',
-    no_available_methods_title: 'No verification methods available',
+    no_available_methods_title: 'Немає доступних способів підтвердження',
     no_available_methods_description:
-      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
+      'У вас не налаштовано жодного способу підтвердження. Спочатку додайте до свого облікового запису пароль, email або номер телефону.',
   },
   password_verification: {
     title: 'Підтвердьте пароль',

--- a/packages/phrases-experience/src/locales/zh-cn/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/account-center.ts
@@ -17,6 +17,9 @@ const account_center = {
     error_verify_failed: '验证失败，请重新输入验证码。',
     verification_required: '验证已失效，请重新验证身份。',
     try_another_method: '尝试其他验证方式',
+    no_available_methods_title: 'No verification methods available',
+    no_available_methods_description:
+      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
   },
   password_verification: {
     title: '验证密码',

--- a/packages/phrases-experience/src/locales/zh-cn/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/account-center.ts
@@ -17,9 +17,9 @@ const account_center = {
     error_verify_failed: '验证失败，请重新输入验证码。',
     verification_required: '验证已失效，请重新验证身份。',
     try_another_method: '尝试其他验证方式',
-    no_available_methods_title: 'No verification methods available',
+    no_available_methods_title: '没有可用的验证方式',
     no_available_methods_description:
-      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
+      '你尚未设置任何验证方式。请先为你的账户添加密码、邮箱或手机号。',
   },
   password_verification: {
     title: '验证密码',

--- a/packages/phrases-experience/src/locales/zh-hk/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/account-center.ts
@@ -17,6 +17,9 @@ const account_center = {
     error_verify_failed: '驗證失敗，請重新輸入驗證碼。',
     verification_required: '驗證已失效，請再次驗證你的身份。',
     try_another_method: '嘗試其他驗證方式',
+    no_available_methods_title: 'No verification methods available',
+    no_available_methods_description:
+      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
   },
   password_verification: {
     title: '驗證密碼',

--- a/packages/phrases-experience/src/locales/zh-hk/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/account-center.ts
@@ -17,9 +17,9 @@ const account_center = {
     error_verify_failed: '驗證失敗，請重新輸入驗證碼。',
     verification_required: '驗證已失效，請再次驗證你的身份。',
     try_another_method: '嘗試其他驗證方式',
-    no_available_methods_title: 'No verification methods available',
+    no_available_methods_title: '沒有可用的驗證方式',
     no_available_methods_description:
-      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
+      '你尚未設定任何驗證方式。請先為你的帳戶新增密碼、電郵地址或電話號碼。',
   },
   password_verification: {
     title: '驗證密碼',

--- a/packages/phrases-experience/src/locales/zh-tw/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/account-center.ts
@@ -17,6 +17,9 @@ const account_center = {
     error_verify_failed: '驗證失敗，請重新輸入驗證碼。',
     verification_required: '驗證已失效，請再次驗證您的身分。',
     try_another_method: '嘗試其他驗證方式',
+    no_available_methods_title: 'No verification methods available',
+    no_available_methods_description:
+      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
   },
   password_verification: {
     title: '驗證密碼',

--- a/packages/phrases-experience/src/locales/zh-tw/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/account-center.ts
@@ -17,9 +17,9 @@ const account_center = {
     error_verify_failed: '驗證失敗，請重新輸入驗證碼。',
     verification_required: '驗證已失效，請再次驗證您的身分。',
     try_another_method: '嘗試其他驗證方式',
-    no_available_methods_title: 'No verification methods available',
+    no_available_methods_title: '沒有可用的驗證方式',
     no_available_methods_description:
-      "You don't have any verification methods set up. Please add a password, email, or phone number to your account first.",
+      '您尚未設定任何驗證方式。請先在您的帳戶中新增密碼、電子郵件或電話號碼。',
   },
   password_verification: {
     title: '驗證密碼',


### PR DESCRIPTION
## Summary

When a user has no password, email, or phone number set up, the `VerificationMethodList` component previously rendered an empty list with no buttons. This PR adds an `ErrorPage` fallback that shows a clear error message guiding the user to set up a verification method first.

This affects all flows that use `VerificationMethodList`: VerifiedAction, Password, TotBinding, PasskeyBinding, BackupCodeBinding, BackupCodeView, PasskeyView, Username, SocialFlow, and IdentifierBindingPage.

## Testing

Tested locally

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments