### PR TITLE
fix(core): batch role enrichment queries in GET /api/roles

### DIFF
--- a/packages/core/src/queries/applications-roles.ts
+++ b/packages/core/src/queries/applications-roles.ts
@@ -75,11 +75,36 @@ export const createApplicationsRolesQueries = (pool: CommonQueryMethods) => {
     }
   };
 
+  const countApplicationsRolesByRoleIds = async (roleIds: string[]) =>
+    roleIds.length > 0
+      ? pool.any<{ roleId: string; count: number }>(sql`
+        select ${fields.roleId} as "roleId", count(*)
+        from ${table}
+        where ${fields.roleId} in (${sql.join(roleIds, sql`, `)})
+        group by ${fields.roleId}
+      `)
+      : [];
+
+  const findApplicationsRolesByRoleIds = async (roleIds: string[], limit = 3) =>
+    roleIds.length > 0
+      ? pool.any<ApplicationsRole>(sql`
+        select ${sql.join(Object.values(insertFields), sql`,`)}
+        from (
+          select *, row_number() over (partition by ${fields.roleId}) as rn
+          from ${table}
+          where ${fields.roleId} in (${sql.join(roleIds, sql`, `)})
+        ) as ranked
+        where ranked.rn <= ${limit}
+      `)
+      : [];
+
   return {
     findFirstApplicationsRolesByRoleIdAndApplicationIds,
     countApplicationsRolesByRoleId,
+    countApplicationsRolesByRoleIds,
     findApplicationsRolesByApplicationId,
     findApplicationsRolesByRoleId,
+    findApplicationsRolesByRoleIds,
     insertApplicationsRoles,
     deleteApplicationRole,
   };

--- a/packages/core/src/queries/users-roles.ts
+++ b/packages/core/src/queries/users-roles.ts
@@ -67,11 +67,36 @@ export const createUsersRolesQueries = (pool: CommonQueryMethods) => {
     }
   };
 
+  const countUsersRolesByRoleIds = async (roleIds: string[]) =>
+    roleIds.length > 0
+      ? pool.any<{ roleId: string; count: number }>(sql`
+        select ${fields.roleId} as "roleId", count(*)
+        from ${table}
+        where ${fields.roleId} in (${sql.join(roleIds, sql`, `)})
+        group by ${fields.roleId}
+      `)
+      : [];
+
+  const findUsersRolesByRoleIds = async (roleIds: string[], limit = 3) =>
+    roleIds.length > 0
+      ? pool.any<UsersRole>(sql`
+        select ${sql.join(Object.values(fields), sql`,`)}
+        from (
+          select *, row_number() over (partition by ${fields.roleId}) as rn
+          from ${table}
+          where ${fields.roleId} in (${sql.join(roleIds, sql`, `)})
+        ) as ranked
+        where ranked.rn <= ${limit}
+      `)
+      : [];
+
   return {
     countUsersRolesByRoleId,
+    countUsersRolesByRoleIds,
     findFirstUsersRolesByRoleIdAndUserIds,
     findUsersRolesByUserId,
     findUsersRolesByRoleId,
+    findUsersRolesByRoleIds,
     insertUsersRoles,
     deleteUsersRolesByUserIdAndRoleId,
   };

--- a/packages/core/src/routes/role.test.ts
+++ b/packages/core/src/routes/role.test.ts
@@ -48,20 +48,22 @@ const users = {
 const { findUsersByIds } = users;
 
 const usersRoles = {
-  countUsersRolesByRoleId: jest.fn(),
-  findUsersRolesByRoleId: jest.fn(),
+  countUsersRolesByRoleIds: jest.fn(),
+  findUsersRolesByRoleIds: jest.fn(),
+  findUsersRolesByUserId: jest.fn(async () => []),
   deleteUsersRolesByUserIdAndRoleId: jest.fn(),
 };
-const { findUsersRolesByRoleId, countUsersRolesByRoleId } = usersRoles;
+const { findUsersRolesByRoleIds, countUsersRolesByRoleIds } = usersRoles;
 
 const applications = { findApplicationsByIds: jest.fn() };
 const { findApplicationsByIds } = applications;
 
 const applicationsRoles = {
-  countApplicationsRolesByRoleId: jest.fn(),
-  findApplicationsRolesByRoleId: jest.fn(),
+  countApplicationsRolesByRoleIds: jest.fn(),
+  findApplicationsRolesByRoleIds: jest.fn(),
+  findApplicationsRolesByApplicationId: jest.fn(async () => []),
 };
-const { countApplicationsRolesByRoleId, findApplicationsRolesByRoleId } = applicationsRoles;
+const { countApplicationsRolesByRoleIds, findApplicationsRolesByRoleIds } = applicationsRoles;
 
 const rolesScopesLibrary = {
   validateRoleScopeAssignment: jest.fn(),
@@ -89,11 +91,13 @@ describe('role routes', () => {
   const roleRequester = createRequester({ authedRoutes: roleRoutes, tenantContext });
 
   it('GET /roles', async () => {
-    countUsersRolesByRoleId.mockResolvedValueOnce({ count: 1 });
+    countUsersRolesByRoleIds.mockResolvedValueOnce([{ roleId: mockAdminUserRole.id, count: 1 }]);
+    findUsersRolesByRoleIds.mockResolvedValueOnce([
+      { roleId: mockAdminUserRole.id, userId: mockUser.id },
+    ]);
     findUsersByIds.mockResolvedValueOnce([mockUser]);
-    findUsersRolesByRoleId.mockResolvedValueOnce([]);
-    countApplicationsRolesByRoleId.mockResolvedValueOnce({ count: 0 });
-    findApplicationsRolesByRoleId.mockResolvedValueOnce([]);
+    countApplicationsRolesByRoleIds.mockResolvedValueOnce([]);
+    findApplicationsRolesByRoleIds.mockResolvedValueOnce([]);
     findApplicationsByIds.mockResolvedValueOnce([]);
     const response = await roleRequester.get('/roles');
     expect(response.status).toEqual(200);

--- a/packages/core/src/routes/role.ts
+++ b/packages/core/src/routes/role.ts
@@ -41,11 +41,11 @@ export default function roleRoutes<T extends ManagementApiRouter>(
       updateRoleById,
     },
     users: { findUsersByIds },
-    usersRoles: { countUsersRolesByRoleId, findUsersRolesByRoleId, findUsersRolesByUserId },
+    usersRoles: { countUsersRolesByRoleIds, findUsersRolesByRoleIds, findUsersRolesByUserId },
     applications: { findApplicationsByIds },
     applicationsRoles: {
-      countApplicationsRolesByRoleId,
-      findApplicationsRolesByRoleId,
+      countApplicationsRolesByRoleIds,
+      findApplicationsRolesByRoleIds,
       findApplicationsRolesByApplicationId,
     },
   } = queries;
@@ -101,27 +101,66 @@ export default function roleRoutes<T extends ManagementApiRouter>(
             findRoles(search, limit, offset, { excludeRoleIds, type }),
           ]);
 
-          const rolesResponse: RoleResponse[] = await Promise.all(
-            roles.map(async (role) => {
-              const { count: usersCount } = await countUsersRolesByRoleId(role.id);
-              const usersRoles = await findUsersRolesByRoleId(role.id, 3);
-              const users = await findUsersByIds(usersRoles.map(({ userId }) => userId));
+          const roleIds = roles.map(({ id }) => id);
 
-              const { count: applicationsCount } = await countApplicationsRolesByRoleId(role.id);
-              const applicationsRoles = await findApplicationsRolesByRoleId(role.id, 3);
-              const applications = await findApplicationsByIds(
-                applicationsRoles.map(({ applicationId }) => applicationId)
-              );
+          const [usersCountsByRole, allUsersRoles, appsCountsByRole, allAppsRoles] =
+            await Promise.all([
+              countUsersRolesByRoleIds(roleIds),
+              findUsersRolesByRoleIds(roleIds),
+              countApplicationsRolesByRoleIds(roleIds),
+              findApplicationsRolesByRoleIds(roleIds),
+            ]);
 
-              return {
-                ...role,
-                usersCount,
-                featuredUsers: users.map(pickState('id', 'avatar', 'name')),
-                applicationsCount,
-                featuredApplications: applications.map(pickState('id', 'name', 'type')),
-              };
-            })
+          // Group featured relations by role; the query layer already caps at 3 per role
+          const usersRolesByRoleId = new Map<string, string[]>();
+          for (const { roleId, userId } of allUsersRoles) {
+            const existing = usersRolesByRoleId.get(roleId) ?? [];
+            usersRolesByRoleId.set(roleId, [...existing, userId]);
+          }
+
+          const appsRolesByRoleId = new Map<string, string[]>();
+          for (const { roleId, applicationId } of allAppsRoles) {
+            const existing = appsRolesByRoleId.get(roleId) ?? [];
+            appsRolesByRoleId.set(roleId, [...existing, applicationId]);
+          }
+
+          // Collect all unique user and application IDs, then batch-fetch
+          const allUserIds = [...new Set([...usersRolesByRoleId.values()].flat())];
+          const allAppIds = [...new Set([...appsRolesByRoleId.values()].flat())];
+
+          const [allUsers, allApps] = await Promise.all([
+            findUsersByIds(allUserIds),
+            findApplicationsByIds(allAppIds),
+          ]);
+
+          const usersById = new Map(allUsers.map((user) => [user.id, user]));
+          const appsById = new Map(allApps.map((app) => [app.id, app]));
+
+          const usersCountMap = new Map(
+            usersCountsByRole.map(({ roleId, count }) => [roleId, count])
           );
+          const appsCountMap = new Map(
+            appsCountsByRole.map(({ roleId, count }) => [roleId, count])
+          );
+
+          const rolesResponse: RoleResponse[] = roles.map((role) => {
+            const featuredUserIds = usersRolesByRoleId.get(role.id) ?? [];
+            const featuredAppIds = appsRolesByRoleId.get(role.id) ?? [];
+
+            return {
+              ...role,
+              usersCount: usersCountMap.get(role.id) ?? 0,
+              featuredUsers: featuredUserIds
+                .map((id) => usersById.get(id))
+                .filter(Boolean)
+                .map(pickState('id', 'avatar', 'name')),
+              applicationsCount: appsCountMap.get(role.id) ?? 0,
+              featuredApplications: featuredAppIds
+                .map((id) => appsById.get(id))
+                .filter(Boolean)
+                .map(pickState('id', 'name', 'type')),
+            };
+          });
 
           // Return totalCount to pagination middleware
           ctx.pagination.totalCount = count;


### PR DESCRIPTION
## Problem

The GET /api/roles endpoint runs 6 individual queries per role in the paginated response (count users, find user relations, find users, count apps, find app relations, find apps). With a default page size of 20, that's 122 queries per page load. The admin console Roles page triggers this on every visit, unconditionally.

## Fix

Replaced the per-role `Promise.all(roles.map(...))` loop with batch queries using `GROUP BY` and `WHERE role_id IN (...)`. Added four batch query functions to `users-roles.ts` and `applications-roles.ts`. The enrichment now runs 6-8 queries regardless of page size.

Before: 122 queries per page load
After: ~8 queries per page load

The existing single-role query functions are unchanged since they're used in other routes.