### PR TITLE
fix(account): hide MFA identifier actions for readonly fields

### DIFF
--- a/packages/account/src/pages/Security/MfaSection/use-mfa-rows.ts
+++ b/packages/account/src/pages/Security/MfaSection/use-mfa-rows.ts
@@ -23,7 +23,7 @@ import {
   passkeyManageRoute,
   phoneRoute,
 } from '@ac/constants/routes';
-import { hasVisibleMfaSection } from '@ac/utils/security-page';
+import { hasVisibleMfaSection, isEditableField } from '@ac/utils/security-page';
 
 const factorIcon = {
   [MfaFactor.TOTP]: TotpIcon,
@@ -51,6 +51,8 @@ const useMfaRows = (
   const { accountCenterSettings, experienceSettings, userInfo } = useContext(PageContext);
 
   const mfaControl = accountCenterSettings?.fields.mfa;
+  const emailControl = accountCenterSettings?.fields.email;
+  const phoneControl = accountCenterSettings?.fields.phone;
   const enabledFactors = useMemo(() => experienceSettings?.mfa.factors ?? [], [experienceSettings]);
   const isEditable = mfaControl === AccountCenterControlValue.Edit;
 
@@ -164,14 +166,15 @@ const useMfaRows = (
           value: userInfo.primaryEmail,
           isPlainValue: true,
           isConfigured: true,
-          action: isEditable
-            ? {
-                label: t('account_center.security.change'),
-                handler: () => {
-                  navigateTo(emailRoute);
-                },
-              }
-            : undefined,
+          action:
+            isEditable && isEditableField(emailControl)
+              ? {
+                  label: t('account_center.security.change'),
+                  handler: () => {
+                    navigateTo(emailRoute);
+                  },
+                }
+              : undefined,
         },
       ];
     };
@@ -188,14 +191,15 @@ const useMfaRows = (
           value: formatToInternationalPhoneNumber(userInfo.primaryPhone),
           isPlainValue: true,
           isConfigured: true,
-          action: isEditable
-            ? {
-                label: t('account_center.security.change'),
-                handler: () => {
-                  navigateTo(phoneRoute);
-                },
-              }
-            : undefined,
+          action:
+            isEditable && isEditableField(phoneControl)
+              ? {
+                  label: t('account_center.security.change'),
+                  handler: () => {
+                    navigateTo(phoneRoute);
+                  },
+                }
+              : undefined,
         },
       ];
     };
@@ -209,6 +213,8 @@ const useMfaRows = (
     ];
   }, [
     mfaControl,
+    emailControl,
+    phoneControl,
     experienceSettings,
     mfaVerifications,
     enabledFactors,

--- a/packages/account/src/utils/security-page.test.ts
+++ b/packages/account/src/utils/security-page.test.ts
@@ -5,8 +5,12 @@ import { AccountCenterControlValue, ConnectorPlatform, MfaPolicy } from '@logto/
 
 import type * as SecurityPageModule from './security-page';
 
-const { canOpenPasswordEditFlow, hasVisibleSecuritySection, hasVisibleSocialSection } =
-  (await import(new URL('security-page.ts', import.meta.url).href)) as typeof SecurityPageModule;
+const {
+  isEditableField,
+  canOpenPasswordEditFlow,
+  hasVisibleSecuritySection,
+  hasVisibleSocialSection,
+} = (await import(new URL('security-page.ts', import.meta.url).href)) as typeof SecurityPageModule;
 
 void test('hasVisibleSecuritySection returns false when account center is disabled', () => {
   assert.equal(
@@ -89,6 +93,12 @@ void test('hasVisibleSocialSection returns false when no available social connec
     }),
     false
   );
+});
+
+void test('isEditableField returns true only for edit control', () => {
+  assert.equal(isEditableField(AccountCenterControlValue.Edit), true);
+  assert.equal(isEditableField(AccountCenterControlValue.ReadOnly), false);
+  assert.equal(isEditableField(), false);
 });
 
 void test('canOpenPasswordEditFlow requires editable password control and a usable identifier', () => {

--- a/packages/account/src/utils/security-page.ts
+++ b/packages/account/src/utils/security-page.ts
@@ -10,6 +10,9 @@ type SecurityPageExperienceSettings = Pick<SignInExperienceResponse, 'socialConn
 const isVisibleField = (value?: AccountCenterControlValue): boolean =>
   value !== undefined && value !== AccountCenterControlValue.Off;
 
+export const isEditableField = (value?: AccountCenterControlValue): boolean =>
+  value === AccountCenterControlValue.Edit;
+
 export const hasVisibleSocialSection = (
   socialControl: AccountCenterControlValue | undefined,
   experienceSettings?: SecurityPageExperienceSettings
@@ -46,7 +49,7 @@ export const canOpenPasswordEditFlow = (
   passwordControl: AccountCenterControlValue | undefined,
   userInfo?: Partial<UserProfileResponse>
 ): boolean =>
-  passwordControl === AccountCenterControlValue.Edit &&
+  isEditableField(passwordControl) &&
   (Boolean(userInfo?.hasPassword) ||
     Boolean(userInfo?.primaryEmail) ||
     Boolean(userInfo?.primaryPhone));


### PR DESCRIPTION
### Depth

- [x] Light — bug fix, typo, config, < 50 LOC
- [ ] Standard — feature, refactor, 50-500 LOC
- [ ] Full — large feature, breaking change, > 500 LOC, multi-PR

---

### Summary

Hide writable MFA email/phone actions on the account security page when the
underlying identifier field is read only. This keeps readonly identifiers
visible while removing indirect edit entry points from the MFA section.

---

### Plan

**Approach**
- Gate MFA email/phone row actions on both the MFA field permission and the
  corresponding identifier field permission.
- Reuse a shared editability helper so security-page permission checks stay
  consistent.

**Files changed**
- `packages/account/src/pages/Security/MfaSection/use-mfa-rows.ts` — hide
  email/phone MFA actions unless both controls are editable.
- `packages/account/src/utils/security-page.ts` — export `isEditableField()`
  and reuse it in password edit gating.
- `packages/account/src/utils/security-page.test.ts` — add regression coverage
  for the shared editability helper.

**Test plan**
- [x] `pnpm --filter @logto/account lint`
- [x] `pnpm --filter @logto/account check`
- [x] Manual: set email to read only and MFA to edit, then verify the Security
      page keeps the email value visible but hides writable email actions in
      both the Email / Phone and MFA sections.
- [x] Manual: keep phone editable in the same setup and verify its writable
      action still appears.

---

### Changes

- Hide MFA email change action when the email field is not editable.
- Hide MFA phone change action when the phone field is not editable.
- Add a shared `isEditableField()` helper and cover it with a unit test.

---

### Self-check

**Review readiness**
- [x] I have reviewed the full diff and verified every change works as intended

**Correctness**
- [x] Code does what the summary says — no more, no less
- [x] Edge cases and error paths are handled

**Tests**
- [x] New/changed behavior has test coverage
- [x] All existing tests still pass

**Security**
- [x] No secrets, tokens, or credentials in the diff

**Consistency**
- [x] Follows existing codebase patterns and naming conventions
- [x] No debug artifacts (`console.log`, `TODO: remove`, commented-out code)

---

### Reviewer focus

- Check the permission gating in `use-mfa-rows.ts` and confirm readonly
  identifiers no longer expose indirect write actions from the MFA section.