### PR TITLE
fix: resolve custom languages like Vietnamese in account settings

### DIFF
--- a/packages/account/src/Providers/PageContextProvider/index.tsx
+++ b/packages/account/src/Providers/PageContextProvider/index.tsx
@@ -7,7 +7,7 @@ import { getAccountCenterSettings } from '@ac/apis/account-center';
 import { getSignInExperienceSettings } from '@ac/apis/sign-in-experience';
 import { getUserInfo } from '@ac/apis/user';
 import useApi from '@ac/hooks/use-api';
-import { changeLanguage, getPreferredLanguage } from '@ac/i18n/utils';
+import { changeLanguage, getPreferredLanguageCandidates } from '@ac/i18n/utils';
 import { getUiLocales } from '@ac/utils/account-center-route';
 import { getThemeBySystemPreference, subscribeToSystemTheme } from '@ac/utils/theme';
 
@@ -134,7 +134,7 @@ const PageContextProvider = ({ children }: Props) => {
           getAccountCenterSettings(),
         ]);
         await changeLanguage(
-          getPreferredLanguage({
+          getPreferredLanguageCandidates({
             languageSettings: settings.languageInfo,
             uiLocales: getUiLocales(),
           })

--- a/packages/account/src/i18n/init.ts
+++ b/packages/account/src/i18n/init.ts
@@ -1,4 +1,3 @@
-import type { LanguageTag } from '@logto/language-kit';
 import resources from '@logto/phrases-experience';
 import i18next from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
@@ -8,7 +7,7 @@ import { resolveLanguage, storageKey } from '@ac/i18n/utils';
 
 i18next.use(initReactI18next).use(LanguageDetector);
 
-const initI18n = async (initialLanguage?: LanguageTag) => {
+const initI18n = async (initialLanguage?: string) => {
   const normalizedLanguage =
     typeof initialLanguage === 'string' ? resolveLanguage(initialLanguage) : undefined;
 

--- a/packages/account/src/i18n/init.ts
+++ b/packages/account/src/i18n/init.ts
@@ -3,18 +3,15 @@ import i18next from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
 
-import { resolveLanguage, storageKey } from '@ac/i18n/utils';
+import { storageKey } from '@ac/i18n/utils';
 
 i18next.use(initReactI18next).use(LanguageDetector);
 
 const initI18n = async (initialLanguage?: string) => {
-  const normalizedLanguage =
-    typeof initialLanguage === 'string' ? resolveLanguage(initialLanguage) : undefined;
-
   await i18next.init({
     resources: {},
     fallbackLng: 'en',
-    lng: normalizedLanguage,
+    lng: initialLanguage,
     detection: {
       lookupLocalStorage: storageKey,
       lookupSessionStorage: storageKey,

--- a/packages/account/src/i18n/utils.test.ts
+++ b/packages/account/src/i18n/utils.test.ts
@@ -3,37 +3,17 @@ import test from 'node:test';
 
 import type * as I18nUtilsModule from './utils';
 
-const { resolveLanguage, resolveUiLocalesLanguage, getPreferredLanguage } = (await import(
-  new URL('utils.ts', import.meta.url).href
-)) as typeof I18nUtilsModule;
+const { resolveUiLocalesLanguage, getPreferredLanguage, getPreferredLanguageCandidates } =
+  (await import(new URL('utils.ts', import.meta.url).href)) as typeof I18nUtilsModule;
 
-void test('resolveLanguage returns the best supported built-in language', () => {
-  assert.equal(resolveLanguage('pl'), 'pl-PL');
-  assert.equal(resolveLanguage('zh-HK'), 'zh-HK');
-  assert.equal(resolveLanguage('xx'), undefined);
+void test('resolveUiLocalesLanguage forwards the first raw ui_locales tag (built-in or custom)', () => {
+  assert.equal(resolveUiLocalesLanguage('xx pl fr'), 'xx');
+  assert.equal(resolveUiLocalesLanguage('vi-VN en'), 'vi-VN');
+  assert.equal(resolveUiLocalesLanguage('   '), undefined);
+  assert.equal(resolveUiLocalesLanguage(), undefined);
 });
 
-void test('resolveLanguage resolves manually added (custom) language tags', () => {
-  // Vietnamese is not built-in but is in the language-kit catalogue
-  assert.equal(resolveLanguage('vi'), 'vi-VN');
-  assert.equal(resolveLanguage('vi-VN'), 'vi-VN');
-  // Finnish
-  assert.equal(resolveLanguage('fi'), 'fi');
-  // Still undefined for truly unknown tags
-  assert.equal(resolveLanguage('xx'), undefined);
-});
-
-void test('resolveUiLocalesLanguage returns the first supported locale with fallback support', () => {
-  assert.equal(resolveUiLocalesLanguage('xx pl fr'), 'pl-PL');
-  assert.equal(resolveUiLocalesLanguage('zh-HK zh'), 'zh-HK');
-  assert.equal(resolveUiLocalesLanguage('xx yy'), undefined);
-});
-
-void test('resolveUiLocalesLanguage resolves custom language tags from ui_locales', () => {
-  assert.equal(resolveUiLocalesLanguage('xx vi fr'), 'vi-VN');
-});
-
-void test('getPreferredLanguage respects ui_locales fallback before language settings', () => {
+void test('getPreferredLanguage returns the first raw ui_locales candidate before language settings', () => {
   assert.equal(
     getPreferredLanguage({
       uiLocales: 'xx pl',
@@ -42,18 +22,32 @@ void test('getPreferredLanguage respects ui_locales fallback before language set
         fallbackLanguage: 'fr',
       },
     }),
-    'pl-PL'
+    'xx'
   );
 });
 
-void test('getPreferredLanguage resolves custom fallback language', () => {
-  assert.equal(
-    getPreferredLanguage({
+void test('getPreferredLanguageCandidates carries ui_locales + configured fallback when auto-detect is off', () => {
+  assert.deepEqual(
+    getPreferredLanguageCandidates({
+      uiLocales: 'xx pl',
       languageSettings: {
         autoDetect: false,
-        fallbackLanguage: 'vi-VN',
+        fallbackLanguage: 'fi-FI',
       },
     }),
-    'vi-VN'
+    ['xx', 'pl', 'fi-FI']
+  );
+});
+
+void test('getPreferredLanguageCandidates preserves custom tags like Vietnamese without filtering', () => {
+  assert.deepEqual(
+    getPreferredLanguageCandidates({
+      uiLocales: 'vi-VN fi-FI en',
+      languageSettings: {
+        autoDetect: false,
+        fallbackLanguage: 'en',
+      },
+    }),
+    ['vi-VN', 'fi-FI', 'en']
   );
 });

--- a/packages/account/src/i18n/utils.test.ts
+++ b/packages/account/src/i18n/utils.test.ts
@@ -13,10 +13,24 @@ void test('resolveLanguage returns the best supported built-in language', () => 
   assert.equal(resolveLanguage('xx'), undefined);
 });
 
+void test('resolveLanguage resolves manually added (custom) language tags', () => {
+  // Vietnamese is not built-in but is in the language-kit catalogue
+  assert.equal(resolveLanguage('vi'), 'vi-VN');
+  assert.equal(resolveLanguage('vi-VN'), 'vi-VN');
+  // Finnish
+  assert.equal(resolveLanguage('fi'), 'fi');
+  // Still undefined for truly unknown tags
+  assert.equal(resolveLanguage('xx'), undefined);
+});
+
 void test('resolveUiLocalesLanguage returns the first supported locale with fallback support', () => {
   assert.equal(resolveUiLocalesLanguage('xx pl fr'), 'pl-PL');
   assert.equal(resolveUiLocalesLanguage('zh-HK zh'), 'zh-HK');
   assert.equal(resolveUiLocalesLanguage('xx yy'), undefined);
+});
+
+void test('resolveUiLocalesLanguage resolves custom language tags from ui_locales', () => {
+  assert.equal(resolveUiLocalesLanguage('xx vi fr'), 'vi-VN');
 });
 
 void test('getPreferredLanguage respects ui_locales fallback before language settings', () => {
@@ -29,5 +43,17 @@ void test('getPreferredLanguage respects ui_locales fallback before language set
       },
     }),
     'pl-PL'
+  );
+});
+
+void test('getPreferredLanguage resolves custom fallback language', () => {
+  assert.equal(
+    getPreferredLanguage({
+      languageSettings: {
+        autoDetect: false,
+        fallbackLanguage: 'vi-VN',
+      },
+    }),
+    'vi-VN'
   );
 });

--- a/packages/account/src/i18n/utils.ts
+++ b/packages/account/src/i18n/utils.ts
@@ -1,19 +1,39 @@
-import { matchSupportedLanguageTag } from '@logto/language-kit';
-import { builtInLanguages, type BuiltInLanguageTag } from '@logto/phrases-experience';
+import { languages as allLanguageTags, matchSupportedLanguageTag } from '@logto/language-kit';
+import type { LocalePhrase } from '@logto/phrases-experience';
+import { builtInLanguages, isBuiltInLanguageTag } from '@logto/phrases-experience';
 import type { LanguageInfo } from '@logto/schemas';
 import i18next from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
+import ky from 'ky';
 
 const storageKey = 'i18nextAccountCenterLng';
 export { storageKey };
 
-export const resolveLanguage = (language?: string): BuiltInLanguageTag | undefined =>
-  language
-    ? builtInLanguages.find(
-        (tag): tag is BuiltInLanguageTag =>
-          tag === matchSupportedLanguageTag([language], builtInLanguages).match
-      )
-    : undefined;
+/**
+ * All language tags the system knows about, including both built-in languages and
+ * those available for manual/custom addition (e.g. Vietnamese, Finnish, etc.).
+ */
+const allSupportedTags = Object.keys(allLanguageTags);
+
+/**
+ * Resolve a raw language string to the best matching supported language tag.
+ * Checks built-in languages first, then falls back to the full language-kit
+ * catalogue so that manually added locales (custom phrases) are also accepted.
+ */
+export const resolveLanguage = (language?: string): string | undefined => {
+  if (!language) {
+    return;
+  }
+
+  // Try built-in languages first (they always have bundled resources).
+  const builtIn = matchSupportedLanguageTag([language], builtInLanguages).match;
+  if (builtIn) {
+    return builtIn;
+  }
+
+  // Fall back to the full language-kit catalogue so custom languages are recognised.
+  return matchSupportedLanguageTag([language], allSupportedTags).match;
+};
 
 export const resolveUiLocalesLanguage = (uiLocales?: string) => {
   if (!uiLocales) {
@@ -44,7 +64,7 @@ export const detectLanguage = (languageSettings?: LanguageInfo) => {
   const detected = languageDetector.detect();
 
   if (Array.isArray(detected)) {
-    return matchSupportedLanguageTag(detected, builtInLanguages).match ?? 'en';
+    return matchSupportedLanguageTag(detected, allSupportedTags).match ?? 'en';
   }
 
   return resolveLanguage(detected) ?? 'en';
@@ -58,6 +78,22 @@ export const getPreferredLanguage = ({
   uiLocales?: string;
 }) => resolveUiLocalesLanguage(uiLocales) ?? detectLanguage(languageSettings);
 
+/**
+ * Fetch merged phrases (built-in base + custom overrides) from the server for a
+ * given language.  The server's `/.well-known/phrases` endpoint handles the merge.
+ */
+const fetchPhrases = async (language: string): Promise<LocalePhrase> =>
+  ky.get('/api/.well-known/phrases', { searchParams: { lng: language } }).json<LocalePhrase>();
+
 export const changeLanguage = async (language: string) => {
-  await i18next.changeLanguage(resolveLanguage(language) ?? 'en');
+  const resolved = resolveLanguage(language) ?? 'en';
+
+  // For custom (non-built-in) languages we need to pull the phrase bundle from
+  // the server because it is not included in the static resource bundle.
+  if (!isBuiltInLanguageTag(resolved)) {
+    const phrases = await fetchPhrases(resolved);
+    i18next.addResourceBundle(resolved, 'translation', phrases.translation, true);
+  }
+
+  await i18next.changeLanguage(resolved);
 };

--- a/packages/account/src/i18n/utils.ts
+++ b/packages/account/src/i18n/utils.ts
@@ -1,6 +1,4 @@
-import { languages as allLanguageTags, matchSupportedLanguageTag } from '@logto/language-kit';
 import type { LocalePhrase } from '@logto/phrases-experience';
-import { builtInLanguages, isBuiltInLanguageTag } from '@logto/phrases-experience';
 import type { LanguageInfo } from '@logto/schemas';
 import i18next from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
@@ -10,48 +8,26 @@ const storageKey = 'i18nextAccountCenterLng';
 export { storageKey };
 
 /**
- * All language tags the system knows about, including both built-in languages and
- * those available for manual/custom addition (e.g. Vietnamese, Finnish, etc.).
+ * Account-center i18n helpers.
+ *
+ * Language resolution (built-in + custom) is owned by the server via
+ * `/.well-known/phrases`, which picks the best match using the same policy as
+ * `getExperienceLanguage` and returns the resolved tag in the
+ * `Content-Language` response header.  These helpers therefore only collect
+ * raw candidate tags (from `ui_locales`, the language-info fallback, the
+ * browser detector) and forward them to the server without any client-side
+ * filtering, so custom/manually-added languages work identically to built-in
+ * ones.
  */
-const allSupportedTags = Object.keys(allLanguageTags);
+
+const splitTags = (value?: string): string[] =>
+  value ? value.trim().split(/\s+/).filter(Boolean) : [];
 
 /**
- * Resolve a raw language string to the best matching supported language tag.
- * Checks built-in languages first, then falls back to the full language-kit
- * catalogue so that manually added locales (custom phrases) are also accepted.
+ * Collect raw locale candidates from the browser language detector in
+ * priority order.
  */
-export const resolveLanguage = (language?: string): string | undefined => {
-  if (!language) {
-    return;
-  }
-
-  // Try built-in languages first (they always have bundled resources).
-  const builtIn = matchSupportedLanguageTag([language], builtInLanguages).match;
-  if (builtIn) {
-    return builtIn;
-  }
-
-  // Fall back to the full language-kit catalogue so custom languages are recognised.
-  return matchSupportedLanguageTag([language], allSupportedTags).match;
-};
-
-export const resolveUiLocalesLanguage = (uiLocales?: string) => {
-  if (!uiLocales) {
-    return;
-  }
-
-  return uiLocales
-    .trim()
-    .split(/\s+/)
-    .map((language) => resolveLanguage(language))
-    .find(Boolean);
-};
-
-export const detectLanguage = (languageSettings?: LanguageInfo) => {
-  if (languageSettings?.autoDetect === false) {
-    return resolveLanguage(languageSettings.fallbackLanguage) ?? 'en';
-  }
-
+const detectBrowserCandidates = (): string[] => {
   const languageDetector = new LanguageDetector();
   languageDetector.init(
     { languageUtils: {} },
@@ -64,36 +40,87 @@ export const detectLanguage = (languageSettings?: LanguageInfo) => {
   const detected = languageDetector.detect();
 
   if (Array.isArray(detected)) {
-    return matchSupportedLanguageTag(detected, allSupportedTags).match ?? 'en';
+    return detected.filter((tag): tag is string => typeof tag === 'string' && tag.length > 0);
   }
 
-  return resolveLanguage(detected) ?? 'en';
+  return typeof detected === 'string' && detected.length > 0 ? [detected] : [];
 };
 
-export const getPreferredLanguage = ({
+/**
+ * Build the ordered list of raw locale candidates for the server to resolve.
+ *
+ * Order of precedence, matching the server-side `getExperienceLanguage`
+ * policy:
+ *   1. `ui_locales` query (space-separated, first-match-wins)
+ *   2. Configured fallback language (when auto-detect is disabled)
+ *   3. Browser language detector (when auto-detect is enabled)
+ *
+ * The caller is expected to forward the first entry to
+ * `/.well-known/phrases` as the `lng` hint; the rest are carried along so the
+ * caller can fall back to them if needed without re-running detection.
+ */
+export const getPreferredLanguageCandidates = ({
   languageSettings,
   uiLocales,
 }: {
   languageSettings?: LanguageInfo;
   uiLocales?: string;
-}) => resolveUiLocalesLanguage(uiLocales) ?? detectLanguage(languageSettings);
+}): string[] => {
+  const uiLocaleCandidates = splitTags(uiLocales);
+
+  const settingsCandidates =
+    languageSettings?.autoDetect === false
+      ? splitTags(languageSettings.fallbackLanguage)
+      : detectBrowserCandidates();
+
+  // De-duplicate while preserving order.
+  const ordered = [...uiLocaleCandidates, ...settingsCandidates];
+  return Array.from(new Set(ordered));
+};
 
 /**
- * Fetch merged phrases (built-in base + custom overrides) from the server for a
- * given language.  The server's `/.well-known/phrases` endpoint handles the merge.
+ * Thin wrapper preserved for callers that only need a single language hint.
+ * Returns the first raw candidate, or `undefined` when nothing is available;
+ * the server still performs the final match and returns the resolved tag in
+ * `Content-Language`.
  */
-const fetchPhrases = async (language: string): Promise<LocalePhrase> =>
-  ky.get('/api/.well-known/phrases', { searchParams: { lng: language } }).json<LocalePhrase>();
+export const getPreferredLanguage = (input: {
+  languageSettings?: LanguageInfo;
+  uiLocales?: string;
+}): string | undefined => getPreferredLanguageCandidates(input)[0];
 
-export const changeLanguage = async (language: string) => {
-  const resolved = resolveLanguage(language) ?? 'en';
+/**
+ * Extract the first raw `ui_locales` candidate without any filtering so the
+ * server can resolve built-in and custom languages uniformly.
+ */
+export const resolveUiLocalesLanguage = (uiLocales?: string): string | undefined =>
+  splitTags(uiLocales)[0];
 
-  // For custom (non-built-in) languages we need to pull the phrase bundle from
-  // the server because it is not included in the static resource bundle.
-  if (!isBuiltInLanguageTag(resolved)) {
-    const phrases = await fetchPhrases(resolved);
-    i18next.addResourceBundle(resolved, 'translation', phrases.translation, true);
+/**
+ * Fetch merged phrases (built-in base + custom overrides) from the server for
+ * a given raw locale candidate list.  The server owns the resolution policy
+ * and returns the resolved language tag via the `Content-Language` response
+ * header, so custom languages (e.g. Vietnamese, Finnish) resolve identically
+ * to built-in ones.
+ */
+export const changeLanguage = async (
+  language: string | readonly string[] | undefined
+): Promise<void> => {
+  const candidates = typeof language === 'string' ? [language] : [...(language ?? [])];
+  const primary = candidates[0];
+
+  const response = await ky.get('/api/.well-known/phrases', {
+    searchParams: primary ? { lng: primary } : undefined,
+    headers: candidates.length > 0 ? { 'Accept-Language': candidates.join(',') } : undefined,
+  });
+  const phrases = await response.json<LocalePhrase>();
+  // Trust the server's resolved tag.  Fall back to the primary candidate only
+  // when the server does not advertise one (e.g. older deployments).
+  const lng = response.headers.get('Content-Language') ?? primary ?? 'en';
+
+  for (const [namespace, resource] of Object.entries(phrases)) {
+    i18next.addResourceBundle(lng, namespace, resource);
   }
 
-  await i18next.changeLanguage(resolved);
+  await i18next.changeLanguage(lng);
 };


### PR DESCRIPTION
resolveLanguage was only checking builtInLanguages, so manually added languages (like Vietnamese, Finnish, etc.) never matched. The user would see the UI fall back to English even though they configured a custom language in the admin console.

Now checks the full @logto/language-kit catalogue instead of just the built-in subset. changeLanguage also fetches phrase bundles from the server for non-built-in languages before switching the i18n instance.

Includes tests covering custom language resolution and fallback behavior.

Fixes #8640