### PR TITLE
feat(console): make audit log event filter searchable

### DIFF
--- a/packages/console/src/components/AuditLogTable/components/EventSelector/index.tsx
+++ b/packages/console/src/components/AuditLogTable/components/EventSelector/index.tsx
@@ -19,6 +19,7 @@ function EventSelector({ value, onChange, options }: Props) {
 
   return (
     <Select
+      isSearchEnabled
       isClearable
       value={value}
       options={options ?? defaultEventOptions}

--- a/packages/console/src/ds-components/Select/index.tsx
+++ b/packages/console/src/ds-components/Select/index.tsx
@@ -57,11 +57,19 @@ function Select<T extends string>({
   const anchorRef = useRef<HTMLInputElement>(null);
   const current = options.find((option) => value && option.value === value);
   const filteredOptions = useMemo(() => {
-    return searchInputValue
-      ? options.filter(({ value }) =>
-          value.toLocaleLowerCase().includes(searchInputValue.toLocaleLowerCase())
-        )
-      : options;
+    const query = searchInputValue.trim().toLocaleLowerCase();
+    if (!query) {
+      return options;
+    }
+    return options.filter(({ value, title }) => {
+      if (value.toLocaleLowerCase().includes(query)) {
+        return true;
+      }
+      if (typeof title === 'string' && title.toLocaleLowerCase().includes(query)) {
+        return true;
+      }
+      return false;
+    });
   }, [searchInputValue, options]);
 
   const handleSelect = (value: T) => {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary

Closes #7656.

The audit log and webhook log **Event** filters used a long dropdown that was hard to scan and did not support searching by the labels users actually read.

This PR:

- Enables `isSearchEnabled` on the shared `EventSelector`, which is used for **Audit logs** and **Webhook → Logs** event filtering.
- Updates the design-system `Select` component so that, when search is active, the trimmed query matches each option’s **value** (internal log key) and, when `title` is a string, the **visible label** as well. A whitespace-only query shows the full option list.

Users can now narrow events with everyday keywords (for example “captcha” or “passkey”) instead of scrolling the entire list or guessing internal key names.

<!-- MANDATORY -->
## Testing

Manual verification in the Admin Console (local development):

1. Open **Audit logs**, open the **Event** dropdown, and confirm the **Type to search** field appears.
2. Enter a word that appears mainly in the visible label (for example `captcha`) and confirm only matching events remain in the list.
3. Enter a substring of an internal key (for example `Interaction`) and confirm filtering still works.
4. Clear the search text, close and reopen the dropdown, and use the clear control on the selector; confirm the table and filter behavior match expectations.
5. Open **Webhooks** → select a webhook → **Logs**, open the **Event** dropdown, and repeat a quick search to confirm the shared selector behaves correctly there too.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments