### PR TITLE
feat(experience): add in-app browser redirect storage fallback

### DIFF
--- a/.changeset/brave-birds-sing.md
+++ b/.changeset/brave-birds-sing.md
@@ -6,7 +6,7 @@ fix: add localStorage fallback for social/SSO redirect state in in-app browsers
 
 Some in-app browsers (e.g., Instagram, Facebook, LINE) open OAuth IdP pages in a new WebView, causing sessionStorage to be lost when redirecting back. This change adds a localStorage-based fallback mechanism:
 
-- Before redirecting to the IdP, store the redirect context (state, verificationId, connectorId) in both sessionStorage and localStorage
+- Before redirecting to the IdP, continue storing state in sessionStorage and also store a fallback redirect context bundle (state, verificationId, connectorId) in localStorage
 - On callback, if sessionStorage state is missing, attempt to restore from localStorage
 - localStorage entries are consumed on read and auto-swept after 10 minutes
 - If both storages are empty, show an error toast to the user

--- a/.changeset/brave-birds-sing.md
+++ b/.changeset/brave-birds-sing.md
@@ -1,0 +1,12 @@
+---
+"@logto/experience": patch
+---
+
+fix: add localStorage fallback for social/SSO redirect state in in-app browsers
+
+Some in-app browsers (e.g., Instagram, Facebook, LINE) open OAuth IdP pages in a new WebView, causing sessionStorage to be lost when redirecting back. This change adds a localStorage-based fallback mechanism:
+
+- Before redirecting to the IdP, store the redirect context (state, verificationId, connectorId) in both sessionStorage and localStorage
+- On callback, if sessionStorage state is missing, attempt to restore from localStorage
+- localStorage entries are consumed on read and auto-swept after 10 minutes
+- If both storages are empty, show an error toast to the user

--- a/packages/experience/src/containers/SocialSignInList/use-social.ts
+++ b/packages/experience/src/containers/SocialSignInList/use-social.ts
@@ -13,8 +13,10 @@ import useApi from '@/hooks/use-api';
 import useErrorHandler from '@/hooks/use-error-handler';
 import useGlobalRedirectTo from '@/hooks/use-global-redirect-to';
 import useTerms from '@/hooks/use-terms';
+import { searchKeys } from '@/shared/utils/search-parameters';
 import { getLogtoNativeSdk, isNativeWebview } from '@/utils/native-sdk';
 import { generateState, storeState, buildSocialLandingUri } from '@/utils/social-connectors';
+import { storeRedirectContext } from '@/utils/social-redirect-fallback-context';
 
 const useSocial = () => {
   const { experienceSettings, theme } = useContext(PageContext);
@@ -80,6 +82,17 @@ const useSocial = () => {
       const { verificationId, authorizationUri } = result;
 
       setVerificationId(VerificationType.Social, verificationId);
+
+      // Write fallback bundle to localStorage for in-app browser session recovery
+      storeRedirectContext({
+        state,
+        flow: 'social',
+        connectorId,
+        verificationId,
+        appId: sessionStorage.getItem(searchKeys.appId) ?? undefined,
+        organizationId: sessionStorage.getItem(searchKeys.organizationId) ?? undefined,
+        uiLocales: sessionStorage.getItem(searchKeys.uiLocales) ?? undefined,
+      });
 
       // Invoke native social sign-in flow
       if (isNativeWebview()) {

--- a/packages/experience/src/hooks/use-redirect-callback-validation.ts
+++ b/packages/experience/src/hooks/use-redirect-callback-validation.ts
@@ -1,0 +1,100 @@
+import { type VerificationType } from '@logto/schemas';
+import { useCallback, useContext, useRef } from 'react';
+
+import UserInteractionContext from '@/Providers/UserInteractionContextProvider/UserInteractionContext';
+import { searchKeys } from '@/shared/utils/search-parameters';
+import { validateState } from '@/utils/social-connectors';
+import {
+  consumeRedirectContext,
+  removeRedirectContext,
+} from '@/utils/social-redirect-fallback-context';
+
+type ValidationSuccess = { valid: true; verificationId: string };
+type ValidationFailure = {
+  valid: false;
+  error: 'invalid_connector_auth' | 'invalid_session';
+};
+
+export type ValidationResult = ValidationSuccess | ValidationFailure;
+
+/**
+ * Hook that encapsulates state validation + localStorage fallback restore + verificationId
+ * management for social/SSO redirect callbacks.
+ *
+ * Shared by both the social and SSO callback listeners so all fallback logic stays in one place.
+ */
+const useRedirectCallbackValidation = ({
+  connectorId,
+  flow,
+  verificationType,
+}: {
+  connectorId: string;
+  flow: 'social' | 'sso';
+  verificationType: VerificationType;
+}) => {
+  const { verificationIdsMap, setVerificationId } = useContext(UserInteractionContext);
+  const verificationId = verificationIdsMap[verificationType];
+  const verificationIdRef = useRef(verificationId);
+
+  const validateAndRestore = useCallback(
+    (state: string | undefined): ValidationResult => {
+      // No state in URL — nothing to validate or look up
+      if (!state) {
+        return { valid: false, error: 'invalid_connector_auth' };
+      }
+
+      const stateResult = validateState(state, connectorId);
+
+      if (stateResult === 'match') {
+        // Normal path — session intact, clean up fallback bundle (best effort)
+        removeRedirectContext(state);
+
+        if (!verificationIdRef.current) {
+          return { valid: false, error: 'invalid_session' };
+        }
+
+        return { valid: true, verificationId: verificationIdRef.current };
+      }
+
+      if (stateResult === 'mismatch') {
+        // Hard fail — state exists in session but doesn't match URL (potential CSRF)
+        // Do NOT consult fallback
+        return { valid: false, error: 'invalid_connector_auth' };
+      }
+
+      // 'missing' — session lost, attempt localStorage fallback
+      const fallback = consumeRedirectContext(state);
+
+      if (!fallback) {
+        return { valid: false, error: 'invalid_connector_auth' };
+      }
+
+      // Ownership validation — flow and connector must match
+      if (fallback.flow !== flow || fallback.connectorId !== connectorId) {
+        return { valid: false, error: 'invalid_connector_auth' };
+      }
+
+      // Critical: global API interceptor reads app_id for Logto-App-Id header
+      if (fallback.appId) {
+        sessionStorage.setItem(searchKeys.appId, fallback.appId);
+      }
+      if (fallback.organizationId) {
+        sessionStorage.setItem(searchKeys.organizationId, fallback.organizationId);
+      }
+      if (fallback.uiLocales) {
+        sessionStorage.setItem(searchKeys.uiLocales, fallback.uiLocales);
+      }
+
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      verificationIdRef.current = fallback.verificationId;
+      setVerificationId(verificationType, fallback.verificationId);
+
+      return { valid: true, verificationId: fallback.verificationId };
+    },
+    [connectorId, flow, setVerificationId, verificationType]
+  );
+
+  return { verificationIdRef, validateAndRestore };
+};
+
+export default useRedirectCallbackValidation;

--- a/packages/experience/src/hooks/use-single-sign-on.ts
+++ b/packages/experience/src/hooks/use-single-sign-on.ts
@@ -5,8 +5,10 @@ import UserInteractionContext from '@/Providers/UserInteractionContextProvider/U
 import { getSsoAuthorizationUrl } from '@/apis/experience';
 import useApi from '@/hooks/use-api';
 import useErrorHandler from '@/hooks/use-error-handler';
+import { searchKeys } from '@/shared/utils/search-parameters';
 import { getLogtoNativeSdk, isNativeWebview } from '@/utils/native-sdk';
 import { buildSocialLandingUri, generateState, storeState } from '@/utils/social-connectors';
+import { storeRedirectContext } from '@/utils/social-redirect-fallback-context';
 
 import useGlobalRedirectTo from './use-global-redirect-to';
 
@@ -66,6 +68,17 @@ const useSingleSignOn = () => {
       const { authorizationUri, verificationId } = result;
 
       setVerificationId(VerificationType.EnterpriseSso, verificationId);
+
+      // Write fallback bundle to localStorage for in-app browser session recovery
+      storeRedirectContext({
+        state,
+        flow: 'sso',
+        connectorId,
+        verificationId,
+        appId: sessionStorage.getItem(searchKeys.appId) ?? undefined,
+        organizationId: sessionStorage.getItem(searchKeys.organizationId) ?? undefined,
+        uiLocales: sessionStorage.getItem(searchKeys.uiLocales) ?? undefined,
+      });
 
       // Invoke Native Sign In flow
       if (isNativeWebview()) {

--- a/packages/experience/src/pages/SocialSignInWebCallback/social-callback.test.tsx
+++ b/packages/experience/src/pages/SocialSignInWebCallback/social-callback.test.tsx
@@ -1,0 +1,219 @@
+import { VerificationType } from '@logto/schemas';
+import { renderHook, waitFor } from '@testing-library/react';
+import { Navigate, Route, Routes, useSearchParams } from 'react-router-dom';
+
+import UserInteractionContextProvider from '@/Providers/UserInteractionContextProvider';
+import renderWithPageContext from '@/__mocks__/RenderWithPageContext';
+import SettingsProvider from '@/__mocks__/RenderWithPageContext/SettingsProvider';
+import { socialConnectors } from '@/__mocks__/social-connectors';
+import { verifySocialVerification } from '@/apis/experience';
+import useSessionStorage, { StorageKeys } from '@/hooks/use-session-storages';
+import { generateState, storeState } from '@/utils/social-connectors';
+import { storeRedirectContext } from '@/utils/social-redirect-fallback-context';
+
+import SocialCallback from '.';
+
+jest.mock('i18next', () => ({
+  ...jest.requireActual('i18next'),
+  language: 'en',
+}));
+
+jest.mock('@/apis/experience', () => ({
+  verifySocialVerification: jest.fn().mockResolvedValue({ verificationId: 'foo' }),
+  identifyAndSubmitInteraction: jest.fn().mockResolvedValue({ redirectTo: `/sign-in` }),
+  signInWithSso: jest.fn().mockResolvedValue({ redirectTo: `/sign-in` }),
+}));
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useSearchParams: jest.fn(),
+  Navigate: jest.fn(() => null),
+}));
+
+const mockUseSearchParameters = useSearchParams as jest.Mock;
+const mockNavigate = Navigate as jest.Mock;
+
+const verificationIdsMap = {
+  [VerificationType.Social]: 'foo',
+  [VerificationType.EnterpriseSso]: 'bar',
+};
+
+describe('SocialCallbackPage — social sign-in', () => {
+  const { result } = renderHook(() => useSessionStorage());
+  const { set } = result.current;
+
+  beforeAll(() => {
+    set(StorageKeys.verificationIds, verificationIdsMap);
+  });
+
+  beforeEach(() => {
+    (verifySocialVerification as jest.Mock).mockClear();
+  });
+
+  describe('fallback', () => {
+    it('should redirect to /sign-in if connectorId is not found', async () => {
+      mockUseSearchParameters.mockReturnValue([new URLSearchParams('code=foo'), jest.fn()]);
+
+      renderWithPageContext(
+        <SettingsProvider>
+          <Routes>
+            <Route path="/callback/social/:connectorId" element={<SocialCallback />} />
+          </Routes>
+        </SettingsProvider>,
+        { initialEntries: ['/callback/social/invalid'] }
+      );
+
+      await waitFor(() => {
+        expect(verifySocialVerification).not.toBeCalled();
+        expect(mockNavigate.mock.calls[0][0].to).toBe('/sign-in');
+      });
+    });
+  });
+
+  describe('normal path', () => {
+    const connectorId = socialConnectors[0]!.id;
+    const state = generateState();
+    storeState(state, connectorId);
+
+    it('callback validation and signIn with social', async () => {
+      mockUseSearchParameters.mockReturnValue([
+        new URLSearchParams(`state=${state}&code=foo`),
+        jest.fn(),
+      ]);
+
+      renderWithPageContext(
+        <SettingsProvider>
+          <UserInteractionContextProvider>
+            <Routes>
+              <Route path="/callback/social/:connectorId" element={<SocialCallback />} />
+            </Routes>
+          </UserInteractionContextProvider>
+        </SettingsProvider>,
+        { initialEntries: [`/callback/social/${connectorId}`] }
+      );
+
+      await waitFor(() => {
+        expect(verifySocialVerification).toBeCalled();
+      });
+    });
+
+    it('callback with invalid state should not call signInWithSocial', async () => {
+      mockUseSearchParameters.mockReturnValue([
+        new URLSearchParams(`state=bar&code=foo`),
+        jest.fn(),
+      ]);
+
+      renderWithPageContext(
+        <SettingsProvider>
+          <UserInteractionContextProvider>
+            <Routes>
+              <Route path="/callback/social/:connectorId" element={<SocialCallback />} />
+            </Routes>
+          </UserInteractionContextProvider>
+        </SettingsProvider>,
+        { initialEntries: [`/callback/social/${connectorId}`] }
+      );
+
+      await waitFor(() => {
+        expect(verifySocialVerification).not.toBeCalled();
+      });
+    });
+  });
+
+  describe('fallback path', () => {
+    const connectorId = socialConnectors[0]!.id;
+
+    afterEach(() => {
+      localStorage.clear();
+    });
+
+    it('should recover from localStorage fallback when sessionStorage is lost', async () => {
+      const state = generateState();
+
+      storeRedirectContext({
+        state,
+        flow: 'social',
+        connectorId,
+        verificationId: 'fallback-verification-id',
+      });
+
+      mockUseSearchParameters.mockReturnValue([
+        new URLSearchParams(`state=${state}&code=foo`),
+        jest.fn(),
+      ]);
+
+      renderWithPageContext(
+        <SettingsProvider>
+          <UserInteractionContextProvider>
+            <Routes>
+              <Route path="/callback/social/:connectorId" element={<SocialCallback />} />
+            </Routes>
+          </UserInteractionContextProvider>
+        </SettingsProvider>,
+        { initialEntries: [`/callback/social/${connectorId}`] }
+      );
+
+      await waitFor(() => {
+        expect(verifySocialVerification).toBeCalled();
+      });
+    });
+
+    it('should show error when session lost and no fallback exists', async () => {
+      const state = generateState();
+
+      mockUseSearchParameters.mockReturnValue([
+        new URLSearchParams(`state=${state}&code=foo`),
+        jest.fn(),
+      ]);
+
+      renderWithPageContext(
+        <SettingsProvider>
+          <UserInteractionContextProvider>
+            <Routes>
+              <Route path="/callback/social/:connectorId" element={<SocialCallback />} />
+            </Routes>
+          </UserInteractionContextProvider>
+        </SettingsProvider>,
+        { initialEntries: [`/callback/social/${connectorId}`] }
+      );
+
+      await waitFor(() => {
+        expect(verifySocialVerification).not.toBeCalled();
+      });
+    });
+
+    it('should not consult fallback on state mismatch', async () => {
+      const state = generateState();
+      const differentState = generateState();
+
+      storeState(differentState, connectorId);
+
+      storeRedirectContext({
+        state,
+        flow: 'social',
+        connectorId,
+        verificationId: 'fallback-verification-id',
+      });
+
+      mockUseSearchParameters.mockReturnValue([
+        new URLSearchParams(`state=${state}&code=foo`),
+        jest.fn(),
+      ]);
+
+      renderWithPageContext(
+        <SettingsProvider>
+          <UserInteractionContextProvider>
+            <Routes>
+              <Route path="/callback/social/:connectorId" element={<SocialCallback />} />
+            </Routes>
+          </UserInteractionContextProvider>
+        </SettingsProvider>,
+        { initialEntries: [`/callback/social/${connectorId}`] }
+      );
+
+      await waitFor(() => {
+        expect(verifySocialVerification).not.toBeCalled();
+      });
+    });
+  });
+});

--- a/packages/experience/src/pages/SocialSignInWebCallback/sso-callback.test.tsx
+++ b/packages/experience/src/pages/SocialSignInWebCallback/sso-callback.test.tsx
@@ -1,16 +1,16 @@
 import { VerificationType } from '@logto/schemas';
 import { renderHook, waitFor } from '@testing-library/react';
-import { Navigate, Route, Routes, useSearchParams } from 'react-router-dom';
+import { Route, Routes, useSearchParams } from 'react-router-dom';
 
 import UserInteractionContextProvider from '@/Providers/UserInteractionContextProvider';
 import renderWithPageContext from '@/__mocks__/RenderWithPageContext';
 import SettingsProvider from '@/__mocks__/RenderWithPageContext/SettingsProvider';
 import { mockSignInExperienceSettings, mockSsoConnectors } from '@/__mocks__/logto';
-import { socialConnectors } from '@/__mocks__/social-connectors';
-import { verifySocialVerification, signInWithSso } from '@/apis/experience';
+import { signInWithSso } from '@/apis/experience';
 import useSessionStorage, { StorageKeys } from '@/hooks/use-session-storages';
 import { type SignInExperienceResponse } from '@/types';
 import { generateState, storeState } from '@/utils/social-connectors';
+import { storeRedirectContext } from '@/utils/social-redirect-fallback-context';
 
 import SocialCallback from '.';
 
@@ -32,14 +32,18 @@ jest.mock('react-router-dom', () => ({
 }));
 
 const mockUseSearchParameters = useSearchParams as jest.Mock;
-const mockNavigate = Navigate as jest.Mock;
 
 const verificationIdsMap = {
   [VerificationType.Social]: 'foo',
   [VerificationType.EnterpriseSso]: 'bar',
 };
 
-describe('SocialCallbackPage with code', () => {
+const sieSettings: SignInExperienceResponse = {
+  ...mockSignInExperienceSettings,
+  ssoConnectors: mockSsoConnectors,
+};
+
+describe('SocialCallbackPage — single sign-on', () => {
   const { result } = renderHook(() => useSessionStorage());
   const { set } = result.current;
 
@@ -47,86 +51,13 @@ describe('SocialCallbackPage with code', () => {
     set(StorageKeys.verificationIds, verificationIdsMap);
   });
 
-  describe('fallback', () => {
-    it('should redirect to /sign-in if connectorId is not found', async () => {
-      mockUseSearchParameters.mockReturnValue([new URLSearchParams('code=foo'), jest.fn()]);
-
-      renderWithPageContext(
-        <SettingsProvider>
-          <Routes>
-            <Route path="/callback/social/:connectorId" element={<SocialCallback />} />
-          </Routes>
-        </SettingsProvider>,
-        { initialEntries: ['/callback/social/invalid'] }
-      );
-
-      await waitFor(() => {
-        expect(verifySocialVerification).not.toBeCalled();
-        expect(mockNavigate.mock.calls[0][0].to).toBe('/sign-in');
-      });
-    });
+  beforeEach(() => {
+    (signInWithSso as jest.Mock).mockClear();
   });
 
-  describe('signIn with social', () => {
-    const connectorId = socialConnectors[0]!.id;
-    const state = generateState();
-    storeState(state, connectorId);
-
-    it('callback validation and signIn with social', async () => {
-      mockUseSearchParameters.mockReturnValue([
-        new URLSearchParams(`state=${state}&code=foo`),
-        jest.fn(),
-      ]);
-
-      renderWithPageContext(
-        <SettingsProvider>
-          <UserInteractionContextProvider>
-            <Routes>
-              <Route path="/callback/social/:connectorId" element={<SocialCallback />} />
-            </Routes>
-          </UserInteractionContextProvider>
-        </SettingsProvider>,
-        { initialEntries: [`/callback/social/${connectorId}`] }
-      );
-
-      await waitFor(() => {
-        expect(verifySocialVerification).toBeCalled();
-      });
-    });
-
-    it('callback with invalid state should not call signInWithSocial', async () => {
-      (verifySocialVerification as jest.Mock).mockClear();
-
-      mockUseSearchParameters.mockReturnValue([
-        new URLSearchParams(`state=bar&code=foo`),
-        jest.fn(),
-      ]);
-
-      renderWithPageContext(
-        <SettingsProvider>
-          <UserInteractionContextProvider>
-            <Routes>
-              <Route path="/callback/social/:connectorId" element={<SocialCallback />} />
-            </Routes>
-          </UserInteractionContextProvider>
-        </SettingsProvider>,
-        { initialEntries: [`/callback/social/${connectorId}`] }
-      );
-
-      await waitFor(() => {
-        expect(verifySocialVerification).not.toBeCalled();
-      });
-    });
-  });
-
-  describe('single sign-on', () => {
-    const sieSettings: SignInExperienceResponse = {
-      ...mockSignInExperienceSettings,
-      ssoConnectors: mockSsoConnectors,
-    };
+  describe('normal path', () => {
     const connectorId = mockSsoConnectors[0]!.id;
     const state = generateState();
-
     storeState(state, connectorId);
 
     it('callback validation and single sign on', async () => {
@@ -152,10 +83,71 @@ describe('SocialCallbackPage with code', () => {
     });
 
     it('callback with invalid state should not call signInWithSso', async () => {
-      (signInWithSso as jest.Mock).mockClear();
-
       mockUseSearchParameters.mockReturnValue([
         new URLSearchParams(`state=bar&code=foo`),
+        jest.fn(),
+      ]);
+
+      renderWithPageContext(
+        <SettingsProvider settings={sieSettings}>
+          <UserInteractionContextProvider>
+            <Routes>
+              <Route path="/callback/social/:connectorId" element={<SocialCallback />} />
+            </Routes>
+          </UserInteractionContextProvider>
+        </SettingsProvider>,
+        { initialEntries: [`/callback/social/${connectorId}`] }
+      );
+
+      await waitFor(() => {
+        expect(signInWithSso).not.toBeCalled();
+      });
+    });
+  });
+
+  describe('fallback path', () => {
+    const connectorId = mockSsoConnectors[0]!.id;
+
+    afterEach(() => {
+      localStorage.clear();
+    });
+
+    it('should recover from localStorage fallback when sessionStorage is lost', async () => {
+      const state = generateState();
+
+      storeRedirectContext({
+        state,
+        flow: 'sso',
+        connectorId,
+        verificationId: 'fallback-sso-verification-id',
+      });
+
+      mockUseSearchParameters.mockReturnValue([
+        new URLSearchParams(`state=${state}&code=foo`),
+        jest.fn(),
+      ]);
+
+      renderWithPageContext(
+        <SettingsProvider settings={sieSettings}>
+          <UserInteractionContextProvider>
+            <Routes>
+              <Route path="/callback/social/:connectorId" element={<SocialCallback />} />
+            </Routes>
+          </UserInteractionContextProvider>
+        </SettingsProvider>,
+        { initialEntries: [`/callback/social/${connectorId}`] }
+      );
+
+      await waitFor(() => {
+        expect(signInWithSso).toBeCalled();
+      });
+    });
+
+    it('should show error when session lost and no fallback exists', async () => {
+      const state = generateState();
+
+      mockUseSearchParameters.mockReturnValue([
+        new URLSearchParams(`state=${state}&code=foo`),
         jest.fn(),
       ]);
 

--- a/packages/experience/src/pages/SocialSignInWebCallback/use-single-sign-on-listener.ts
+++ b/packages/experience/src/pages/SocialSignInWebCallback/use-single-sign-on-listener.ts
@@ -1,20 +1,19 @@
 import { AgreeToTermsPolicy, SignInMode, VerificationType, experience } from '@logto/schemas';
-import { useCallback, useContext, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 
-import UserInteractionContext from '@/Providers/UserInteractionContextProvider/UserInteractionContext';
 import { registerWithVerifiedIdentifier, signInWithSso } from '@/apis/experience';
 import useApi from '@/hooks/use-api';
 import useEmailBlockedErrorHandler from '@/hooks/use-email-blocked-error-handler';
 import useErrorHandler from '@/hooks/use-error-handler';
 import useGlobalRedirectTo from '@/hooks/use-global-redirect-to';
 import useNavigateWithPreservedSearchParams from '@/hooks/use-navigate-with-preserved-search-params';
+import useRedirectCallbackValidation from '@/hooks/use-redirect-callback-validation';
 import { useSieMethods } from '@/hooks/use-sie';
 import useTerms from '@/hooks/use-terms';
 import useToast from '@/hooks/use-toast';
 import { parseQueryParameters } from '@/utils';
-import { validateState } from '@/utils/social-connectors';
 
 const useSingleSignOnRegister = () => {
   const handleError = useErrorHandler();
@@ -79,8 +78,12 @@ const useSingleSignOnListener = (connectorId: string) => {
   const { setToast } = useToast();
   const redirectTo = useGlobalRedirectTo();
   const { signInMode } = useSieMethods();
-  const { verificationIdsMap } = useContext(UserInteractionContext);
-  const verificationId = verificationIdsMap[VerificationType.EnterpriseSso];
+
+  const { verificationIdRef, validateAndRestore } = useRedirectCallbackValidation({
+    connectorId,
+    flow: 'sso',
+    verificationType: VerificationType.EnterpriseSso,
+  });
 
   const handleError = useErrorHandler();
   const navigate = useNavigateWithPreservedSearchParams();
@@ -149,21 +152,15 @@ const useSingleSignOnListener = (connectorId: string) => {
     // Cleanup the search parameters once it's consumed
     setSearchParameters({}, { replace: true });
 
-    // Validate the state parameter
-    if (!validateState(state, connectorId)) {
-      setToast(t('error.invalid_connector_auth'));
+    const result = validateAndRestore(state);
+
+    if (!result.valid) {
+      setToast(t(`error.${result.error}`));
       navigate('/' + experience.routes.signIn);
       return;
     }
 
-    // Validate the verificationId
-    if (!verificationId) {
-      setToast(t('error.invalid_session'));
-      navigate('/' + experience.routes.signIn);
-      return;
-    }
-
-    void singleSignOnHandler(connectorId, verificationId, rest);
+    void singleSignOnHandler(connectorId, result.verificationId, rest);
   }, [
     connectorId,
     isConsumed,
@@ -173,7 +170,7 @@ const useSingleSignOnListener = (connectorId: string) => {
     setToast,
     singleSignOnHandler,
     t,
-    verificationId,
+    validateAndRestore,
   ]);
 
   return { loading };

--- a/packages/experience/src/pages/SocialSignInWebCallback/use-single-sign-on-listener.ts
+++ b/packages/experience/src/pages/SocialSignInWebCallback/use-single-sign-on-listener.ts
@@ -79,7 +79,7 @@ const useSingleSignOnListener = (connectorId: string) => {
   const redirectTo = useGlobalRedirectTo();
   const { signInMode } = useSieMethods();
 
-  const { verificationIdRef, validateAndRestore } = useRedirectCallbackValidation({
+  const { validateAndRestore } = useRedirectCallbackValidation({
     connectorId,
     flow: 'sso',
     verificationType: VerificationType.EnterpriseSso,

--- a/packages/experience/src/pages/SocialSignInWebCallback/use-social-sign-in-listener.ts
+++ b/packages/experience/src/pages/SocialSignInWebCallback/use-social-sign-in-listener.ts
@@ -4,7 +4,7 @@ import {
 } from '@logto/connector-kit';
 import type { RequestErrorBody } from '@logto/schemas';
 import { InteractionEvent, SignInMode, VerificationType, experience } from '@logto/schemas';
-import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 import { validate } from 'superstruct';
@@ -21,13 +21,14 @@ import type { ErrorHandlers } from '@/hooks/use-error-handler';
 import useErrorHandler from '@/hooks/use-error-handler';
 import useGlobalRedirectTo from '@/hooks/use-global-redirect-to';
 import useNavigateWithPreservedSearchParams from '@/hooks/use-navigate-with-preserved-search-params';
+import useRedirectCallbackValidation from '@/hooks/use-redirect-callback-validation';
 import { useSieMethods } from '@/hooks/use-sie';
 import useSocialRegister from '@/hooks/use-social-register';
 import useSubmitInteractionErrorHandler from '@/hooks/use-submit-interaction-error-handler';
 import useToast from '@/hooks/use-toast';
 import { socialAccountNotExistErrorDataGuard } from '@/types/guard';
 import { parseQueryParameters } from '@/utils';
-import { getAuthValidationResult, getSessionValidationResult } from '@/utils/social-connectors';
+import { validateGoogleOneTapCredential } from '@/utils/social-connectors';
 
 import { normalizeExternalWebsiteGoogleOneTapConnectorData } from './utils';
 
@@ -38,12 +39,13 @@ const useSocialSignInListener = (connectorId: string) => {
   const { t } = useTranslation();
   const [isConsumed, setIsConsumed] = useState(false);
   const [searchParameters, setSearchParameters] = useSearchParams();
-  const { verificationIdsMap, setVerificationId } = useContext(UserInteractionContext);
-  const verificationId = verificationIdsMap[VerificationType.Social];
+  const { setVerificationId } = useContext(UserInteractionContext);
 
-  // Google One Tap will mutate the verificationId after the initial render
-  // We need to store a up to date reference of the verificationId
-  const verificationIdRef = useRef(verificationId);
+  const { verificationIdRef, validateAndRestore } = useRedirectCallbackValidation({
+    connectorId,
+    flow: 'social',
+    verificationType: VerificationType.Social,
+  });
 
   const navigate = useNavigateWithPreservedSearchParams();
   const handleError = useErrorHandler();
@@ -99,6 +101,7 @@ const useSocialSignInListener = (connectorId: string) => {
       signInMode,
       socialSignInSettings.automaticAccountLinking,
       t,
+      verificationIdRef,
     ]
   );
 
@@ -157,7 +160,14 @@ const useSocialSignInListener = (connectorId: string) => {
 
       return verificationId;
     },
-    [asyncInitInteraction, globalErrorHandler, handleError, setVerificationId, verifySocial]
+    [
+      asyncInitInteraction,
+      globalErrorHandler,
+      handleError,
+      setVerificationId,
+      verifySocial,
+      verificationIdRef,
+    ]
   );
 
   const signInWithSocialHandler = useCallback(
@@ -201,42 +211,37 @@ const useSocialSignInListener = (connectorId: string) => {
     const { state, ...rest } = parseQueryParameters(searchParameters);
     const data = normalizeExternalWebsiteGoogleOneTapConnectorData(rest);
 
-    // Google One Tap always contains the `credential`
     const isGoogleOneTap = isGoogleOneTapChecker(data);
-    // External Google One Tap always contains the `credential` and doesn't contain the `csrfToken`
-    // Experience built-in Google One Tap always contains the `csrfToken`
-    const isExternalCredential = isExternalGoogleOneTapChecker(data);
 
     // Cleanup the search parameters once it's consumed
     setSearchParameters({}, { replace: true });
 
-    const isValidAuth = getAuthValidationResult({
-      isGoogleOneTap,
-      state,
-      connectorId,
-      isExternalCredential,
-      params: data,
-    });
+    if (isGoogleOneTap) {
+      // === Google One Tap flow ===
+      const isExternalCredential = isExternalGoogleOneTapChecker(data);
 
-    if (!isValidAuth) {
-      setToast(t('error.invalid_connector_auth'));
-      navigate('/' + experience.routes.signIn);
-      return;
+      const result = validateGoogleOneTapCredential({
+        isExternalCredential,
+        params: data,
+      });
+
+      if (!result.valid) {
+        setToast(t(`error.${result.error}`));
+        navigate('/' + experience.routes.signIn);
+        return;
+      }
+    } else {
+      // === Normal OAuth redirect flow (social) ===
+      const result = validateAndRestore(state);
+
+      if (!result.valid) {
+        setToast(t(`error.${result.error}`));
+        navigate('/' + experience.routes.signIn);
+        return;
+      }
     }
 
-    const isValidSession = getSessionValidationResult({
-      verificationId: verificationIdRef.current,
-      isGoogleOneTap,
-      isExternalCredential,
-      params: data,
-    });
-
-    if (!isValidSession) {
-      setToast(t('error.invalid_session'));
-      navigate('/' + experience.routes.signIn);
-      return;
-    }
-
+    // Common path — both Google One Tap and normal flow proceed here
     void signInWithSocialHandler(connectorId, data);
   }, [
     connectorId,
@@ -247,6 +252,7 @@ const useSocialSignInListener = (connectorId: string) => {
     setToast,
     signInWithSocialHandler,
     t,
+    validateAndRestore,
   ]);
 
   return { loading };

--- a/packages/experience/src/utils/social-connectors.test.ts
+++ b/packages/experience/src/utils/social-connectors.test.ts
@@ -10,8 +10,8 @@ import {
   filterSocialConnectors,
   filterPreviewSocialConnectors,
   buildSocialLandingUri,
-  getAuthValidationResult,
-  getSessionValidationResult,
+  validateState,
+  validateGoogleOneTapCredential,
 } from './social-connectors';
 
 const mockConnectors = [
@@ -164,261 +164,97 @@ describe('buildSocialLandingUri', () => {
   });
 });
 
-describe('getAuthValidationResult', () => {
+describe('validateState', () => {
   const mockConnectorId = 'test-connector-id';
   const mockState = 'test-state';
-  const mockParams = { [GoogleConnector.oneTapParams.csrfToken]: 'test-csrf' };
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  describe('Normal social login', () => {
-    it('should return true when state is valid', () => {
-      // Mock the actual sessionStorage that validateState uses
-      const mockGetItem = jest.spyOn(Storage.prototype, 'getItem').mockReturnValue(mockState);
-      const mockRemoveItem = jest.spyOn(Storage.prototype, 'removeItem').mockImplementation();
+  it('should return match when state matches stored value', () => {
+    const mockGetItem = jest.spyOn(Storage.prototype, 'getItem').mockReturnValue(mockState);
+    const mockRemoveItem = jest.spyOn(Storage.prototype, 'removeItem').mockImplementation();
 
-      const result = getAuthValidationResult({
-        isGoogleOneTap: false,
-        connectorId: mockConnectorId,
-        isExternalCredential: false,
-        params: mockParams,
-        state: mockState,
-      });
+    expect(validateState(mockState, mockConnectorId)).toBe('match');
+    expect(mockGetItem).toHaveBeenCalledWith(`social_auth_state:${mockConnectorId}`);
+    expect(mockRemoveItem).toHaveBeenCalledWith(`social_auth_state:${mockConnectorId}`);
 
-      expect(result).toBe(true);
-      expect(mockGetItem).toHaveBeenCalledWith(`social_auth_state:${mockConnectorId}`);
-      expect(mockRemoveItem).toHaveBeenCalledWith(`social_auth_state:${mockConnectorId}`);
-
-      // Restore the mocks
-      mockGetItem.mockRestore();
-      mockRemoveItem.mockRestore();
-    });
-
-    it('should return false when state is invalid', () => {
-      const mockGetItem = jest
-        .spyOn(Storage.prototype, 'getItem')
-        .mockReturnValue('different-state');
-      const mockRemoveItem = jest.spyOn(Storage.prototype, 'removeItem').mockImplementation();
-
-      const result = getAuthValidationResult({
-        isGoogleOneTap: false,
-        connectorId: mockConnectorId,
-        isExternalCredential: false,
-        params: mockParams,
-        state: mockState,
-      });
-
-      expect(result).toBe(false);
-
-      mockGetItem.mockRestore();
-      mockRemoveItem.mockRestore();
-    });
-
-    it('should return false when state is undefined', () => {
-      const result = getAuthValidationResult({
-        isGoogleOneTap: false,
-        connectorId: mockConnectorId,
-        isExternalCredential: false,
-        params: mockParams,
-        state: undefined,
-      });
-
-      expect(result).toBe(false);
-    });
+    mockGetItem.mockRestore();
+    mockRemoveItem.mockRestore();
   });
 
-  describe('Google One Tap - External credentials', () => {
-    it('should return true for external credentials', () => {
-      const result = getAuthValidationResult({
-        isGoogleOneTap: true,
-        connectorId: mockConnectorId,
-        isExternalCredential: true,
-        params: mockParams,
-        state: mockState,
-      });
+  it('should return mismatch when state differs from stored value', () => {
+    const mockGetItem = jest.spyOn(Storage.prototype, 'getItem').mockReturnValue('different-state');
+    const mockRemoveItem = jest.spyOn(Storage.prototype, 'removeItem').mockImplementation();
 
-      expect(result).toBe(true);
-      expect(getCookieMock).not.toHaveBeenCalled();
-    });
+    expect(validateState(mockState, mockConnectorId)).toBe('mismatch');
+
+    mockGetItem.mockRestore();
+    mockRemoveItem.mockRestore();
   });
 
-  describe('Google One Tap - Experience app', () => {
-    it('should return true when CSRF token is valid', () => {
-      getCookieMock.mockReturnValue('test-csrf');
+  it('should return missing when no stored value exists', () => {
+    const mockGetItem = jest.spyOn(Storage.prototype, 'getItem').mockReturnValue(null);
+    const mockRemoveItem = jest.spyOn(Storage.prototype, 'removeItem').mockImplementation();
 
-      const result = getAuthValidationResult({
-        isGoogleOneTap: true,
-        connectorId: mockConnectorId,
-        isExternalCredential: false,
-        params: mockParams,
-      });
+    expect(validateState(mockState, mockConnectorId)).toBe('missing');
 
-      expect(result).toBe(true);
-      expect(getCookieMock).toHaveBeenCalledWith(GoogleConnector.oneTapParams.csrfToken);
-    });
-
-    it('should return false when CSRF token is invalid', () => {
-      getCookieMock.mockReturnValue('different-csrf');
-
-      const result = getAuthValidationResult({
-        isGoogleOneTap: true,
-        connectorId: mockConnectorId,
-        isExternalCredential: false,
-        params: mockParams,
-      });
-
-      expect(result).toBe(false);
-    });
-
-    it('should return false when CSRF token is missing from params', () => {
-      const result = getAuthValidationResult({
-        isGoogleOneTap: true,
-        connectorId: mockConnectorId,
-        isExternalCredential: false,
-        params: {},
-      });
-
-      expect(result).toBe(false);
-    });
+    mockGetItem.mockRestore();
+    mockRemoveItem.mockRestore();
   });
 });
 
-describe('getSessionValidationResult', () => {
-  const mockVerificationId = 'test-verification-id';
+describe('validateGoogleOneTapCredential', () => {
   const mockParams = { [GoogleConnector.oneTapParams.csrfToken]: 'test-csrf' };
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  describe('With verificationId present', () => {
-    it('should return true when verificationId is provided', () => {
-      const result = getSessionValidationResult({
-        verificationId: mockVerificationId,
-        isGoogleOneTap: false,
-        isExternalCredential: false,
-        params: mockParams,
-      });
-
-      expect(result).toBe(true);
-      expect(getCookieMock).not.toHaveBeenCalled();
-    });
-
-    it('should return true for Google One Tap with verificationId', () => {
-      const result = getSessionValidationResult({
-        verificationId: mockVerificationId,
-        isGoogleOneTap: true,
-        isExternalCredential: false,
-        params: mockParams,
-      });
-
-      expect(result).toBe(true);
-    });
-  });
-
-  describe('Without verificationId', () => {
-    it('should return false for normal social login', () => {
-      const result = getSessionValidationResult({
-        verificationId: undefined,
-        isGoogleOneTap: false,
-        isExternalCredential: false,
-        params: mockParams,
-      });
-
-      expect(result).toBe(false);
-    });
-
-    it('should return true for external Google One Tap', () => {
-      const result = getSessionValidationResult({
-        verificationId: undefined,
-        isGoogleOneTap: true,
+  describe('External credentials', () => {
+    it('should return valid for external credentials', () => {
+      const result = validateGoogleOneTapCredential({
         isExternalCredential: true,
         params: mockParams,
       });
 
-      expect(result).toBe(true);
+      expect(result).toEqual({ valid: true });
       expect(getCookieMock).not.toHaveBeenCalled();
     });
+  });
 
-    it('should return true when Experience Google One Tap has valid CSRF', () => {
+  describe('Experience app (non-external)', () => {
+    it('should return valid when CSRF token matches', () => {
       getCookieMock.mockReturnValue('test-csrf');
 
-      const result = getSessionValidationResult({
-        verificationId: undefined,
-        isGoogleOneTap: true,
+      const result = validateGoogleOneTapCredential({
         isExternalCredential: false,
         params: mockParams,
       });
 
-      expect(result).toBe(true);
+      expect(result).toEqual({ valid: true });
       expect(getCookieMock).toHaveBeenCalledWith(GoogleConnector.oneTapParams.csrfToken);
     });
 
-    it('should return false when Experience Google One Tap has invalid CSRF', () => {
+    it('should return invalid when CSRF token does not match', () => {
       getCookieMock.mockReturnValue('different-csrf');
 
-      const result = getSessionValidationResult({
-        verificationId: undefined,
-        isGoogleOneTap: true,
+      const result = validateGoogleOneTapCredential({
         isExternalCredential: false,
         params: mockParams,
       });
 
-      expect(result).toBe(false);
+      expect(result).toEqual({ valid: false, error: 'invalid_connector_auth' });
     });
 
-    it('should return false when Experience Google One Tap missing CSRF token', () => {
-      const result = getSessionValidationResult({
-        verificationId: undefined,
-        isGoogleOneTap: true,
+    it('should return invalid when CSRF token is missing from params', () => {
+      const result = validateGoogleOneTapCredential({
         isExternalCredential: false,
         params: {},
       });
 
-      expect(result).toBe(false);
-    });
-  });
-
-  describe('Edge cases', () => {
-    it('should handle empty string verificationId as falsy', () => {
-      const result = getSessionValidationResult({
-        verificationId: '',
-        isGoogleOneTap: false,
-        isExternalCredential: false,
-        params: {},
-      });
-
-      expect(result).toBe(false);
-    });
-
-    it('should prioritize verificationId over other checks', () => {
-      getCookieMock.mockReturnValue('different-csrf');
-
-      const result = getSessionValidationResult({
-        verificationId: mockVerificationId,
-        isGoogleOneTap: true,
-        isExternalCredential: false,
-        params: mockParams,
-      });
-
-      expect(result).toBe(true);
-      expect(getCookieMock).not.toHaveBeenCalled();
-    });
-
-    it('should prioritize external credential over CSRF validation', () => {
-      getCookieMock.mockReturnValue('different-csrf');
-
-      const result = getSessionValidationResult({
-        verificationId: undefined,
-        isGoogleOneTap: true,
-        isExternalCredential: true,
-        params: mockParams,
-      });
-
-      expect(result).toBe(true);
-      expect(getCookieMock).not.toHaveBeenCalled();
+      expect(result).toEqual({ valid: false, error: 'invalid_connector_auth' });
     });
   });
 });

--- a/packages/experience/src/utils/social-connectors.ts
+++ b/packages/experience/src/utils/social-connectors.ts
@@ -28,109 +28,61 @@ const deleteState = (connectorId: string) => {
   sessionStorage.removeItem(storageKey);
 };
 
-/**
- * Validate the state parameter from the social connector callback. If the state parameter is empty
- * or invalid, it will return false.
- */
-export const validateState = (state: string | undefined, connectorId: string): boolean => {
-  if (!state) {
-    return false;
-  }
+export type StateValidationResult = 'match' | 'missing' | 'mismatch';
 
+/**
+ * Validate the state parameter from the social connector callback.
+ * Returns a tri-state result distinguishing "session lost" from "state mismatch".
+ *
+ * Callers must guard against `undefined` state before calling this function.
+ *
+ * @param state - The state parameter from the callback URL (must be defined).
+ * @param connectorId - The connector id used to look up the stored state.
+ * @returns `'match'` if valid, `'missing'` if session lost, `'mismatch'` if tampered.
+ */
+export const validateState = (state: string, connectorId: string): StateValidationResult => {
   const storageKey = `${storageStateKeyPrefix}:${connectorId}`;
   const stateStorage = sessionStorage.getItem(storageKey);
   deleteState(connectorId);
 
-  return stateStorage === state;
+  if (stateStorage === null) {
+    return 'missing';
+  }
+
+  return stateStorage === state ? 'match' : 'mismatch';
 };
 
 const validateGoogleOneTapCsrfToken = (csrfToken?: string): boolean =>
   Boolean(csrfToken && getCookie(GoogleConnector.oneTapParams.csrfToken) === csrfToken);
 
 /**
- * Validate authentication parameters based on different scenarios:
- * 1. Normal social login: requires valid state parameter for CSRF protection
- * 2. Google One Tap from external website: no validation needed (already verified by Google)
- * 3. Google One Tap from Experience app: validate CSRF token if present
+ * Validate a Google One Tap credential (both external and experience-built-in).
  *
- * @param isGoogleOneTap - Whether the login is Google One Tap
- * @param connectorId - The connector id
- * @param isExternalCredential - Whether the login is from external website Google One Tap
- * @param params - The parameters to validate
- * @param state - The state parameter to validate
- * @returns Whether the authentication parameters are valid
- */
-export const getAuthValidationResult = ({
-  isGoogleOneTap,
-  connectorId,
-  isExternalCredential,
-  params,
-  state,
-}: {
-  isGoogleOneTap: boolean;
-  connectorId: string;
-  isExternalCredential: boolean;
-  params: Record<string, string>;
-  state?: string;
-}): boolean => {
-  if (!isGoogleOneTap) {
-    // Case 1: Normal social login (not Google One Tap) - validate state parameter
-    return validateState(state, connectorId);
-  }
-
-  if (isExternalCredential) {
-    // Case 2: Google One Tap from external website (no CSRF token) - always valid
-    return true;
-  }
-
-  // Case 3: Google One Tap from Experience app
-  // Check if CSRF token is present and validate it
-  // This handles the case where Google One Tap doesn't properly set CSRF token
-  const csrfToken = params[GoogleConnector.oneTapParams.csrfToken];
-  return validateGoogleOneTapCsrfToken(csrfToken);
-};
-
-/**
- * Validate the session based on different scenarios:
- * 1. Normal social login: requires valid verificationId
- * 2. Google One Tap from Experience app: allow if CSRF token valid
- * 3. Google One Tap from external website: always valid (Google verified)
+ * - External credentials (from host website): already verified by Google, always valid.
+ * - Experience built-in: validates the CSRF cookie token.
  *
- * @param verificationId - The verification record id
- * @param isGoogleOneTap - Whether the login is Google One Tap
- * @param isExternalCredential - Whether the login is from external website Google One Tap
- * @param params - The parameters to validate
- * @returns Whether the session is valid
+ * @returns A discriminated result — `{ valid: true }` or `{ valid: false, error }`.
  */
-export const getSessionValidationResult = ({
-  verificationId,
-  isGoogleOneTap,
+export const validateGoogleOneTapCredential = ({
   isExternalCredential,
   params,
 }: {
-  verificationId?: string;
-  isGoogleOneTap: boolean;
   isExternalCredential: boolean;
   params: Record<string, string>;
-}): boolean => {
-  // If we have a verificationId, it's always valid (normal flow)
-  if (verificationId) {
-    return true;
-  }
-
-  if (!isGoogleOneTap) {
-    // Normal social login without verificationId is invalid
-    return false;
-  }
-
+}): { valid: true } | { valid: false; error: 'invalid_connector_auth' } => {
+  // External Google One Tap — credential already verified by Google
   if (isExternalCredential) {
-    // External Google One Tap always valid
-    return true;
+    return { valid: true };
   }
 
-  // Experience Google One Tap: allow if CSRF token valid or missing
+  // Experience built-in Google One Tap — validate CSRF cookie token
   const csrfToken = params[GoogleConnector.oneTapParams.csrfToken];
-  return validateGoogleOneTapCsrfToken(csrfToken);
+
+  if (!validateGoogleOneTapCsrfToken(csrfToken)) {
+    return { valid: false, error: 'invalid_connector_auth' };
+  }
+
+  return { valid: true };
 };
 
 /**

--- a/packages/experience/src/utils/social-redirect-fallback-context.test.ts
+++ b/packages/experience/src/utils/social-redirect-fallback-context.test.ts
@@ -159,14 +159,11 @@ describe('sweepExpiredRedirectContexts', () => {
 
 describe('localStorage unavailable', () => {
   it('should not throw when localStorage operations fail', () => {
-    const originalSetItem = localStorage.setItem.bind(localStorage);
-    const originalGetItem = localStorage.getItem.bind(localStorage);
-
     // Mock localStorage to throw
-    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+    const setItemSpy = jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
       throw new Error('Storage unavailable');
     });
-    jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+    const getItemSpy = jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
       throw new Error('Storage unavailable');
     });
 
@@ -186,7 +183,7 @@ describe('localStorage unavailable', () => {
     }).not.toThrow();
 
     // Restore
-    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(originalSetItem);
-    jest.spyOn(Storage.prototype, 'getItem').mockImplementation(originalGetItem);
+    setItemSpy.mockRestore();
+    getItemSpy.mockRestore();
   });
 });

--- a/packages/experience/src/utils/social-redirect-fallback-context.test.ts
+++ b/packages/experience/src/utils/social-redirect-fallback-context.test.ts
@@ -1,0 +1,192 @@
+import type { RedirectContext } from './social-redirect-fallback-context';
+import {
+  consumeRedirectContext,
+  getRedirectContextByState,
+  removeRedirectContext,
+  storeRedirectContext,
+  sweepExpiredRedirectContexts,
+} from './social-redirect-fallback-context';
+
+const createTestInput = (
+  overrides?: Partial<Omit<RedirectContext, 'createdAt' | 'expiresAt'>>
+): Omit<RedirectContext, 'createdAt' | 'expiresAt'> => ({
+  state: 'test-state-123',
+  flow: 'social',
+  connectorId: 'mock-connector',
+  verificationId: 'verification-456',
+  appId: 'app-789',
+  organizationId: 'org-001',
+  uiLocales: 'en',
+  ...overrides,
+});
+
+const fallbackKeyPrefix = 'logto:redirect-context:fallback:';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('storeRedirectContext + getRedirectContextByState', () => {
+  it('should round-trip: store then get returns same context', () => {
+    const input = createTestInput();
+    storeRedirectContext(input);
+
+    const result = getRedirectContextByState(input.state);
+    expect(result).toMatchObject(input);
+    expect(result?.createdAt).toEqual(expect.any(Number));
+    expect(result?.expiresAt).toEqual(expect.any(Number));
+    expect(result!.expiresAt).toBeGreaterThan(result!.createdAt);
+  });
+
+  it('should return undefined for non-existent state', () => {
+    expect(getRedirectContextByState('non-existent')).toBeUndefined();
+  });
+});
+
+describe('consumeRedirectContext', () => {
+  it('should return context and delete the key', () => {
+    const input = createTestInput();
+    storeRedirectContext(input);
+
+    const result = consumeRedirectContext(input.state);
+    expect(result).toMatchObject(input);
+
+    // Subsequent get should return undefined
+    expect(getRedirectContextByState(input.state)).toBeUndefined();
+    expect(localStorage.getItem(`${fallbackKeyPrefix}${input.state}`)).toBeNull();
+  });
+
+  it('should return undefined for non-existent state', () => {
+    expect(consumeRedirectContext('non-existent')).toBeUndefined();
+  });
+});
+
+describe('removeRedirectContext', () => {
+  it('should remove an existing key', () => {
+    const input = createTestInput();
+    storeRedirectContext(input);
+
+    removeRedirectContext(input.state);
+    expect(getRedirectContextByState(input.state)).toBeUndefined();
+  });
+
+  it('should not throw when removing a non-existent key', () => {
+    expect(() => {
+      removeRedirectContext('non-existent');
+    }).not.toThrow();
+  });
+
+  it('should be idempotent — calling twice does not throw', () => {
+    const input = createTestInput();
+    storeRedirectContext(input);
+
+    removeRedirectContext(input.state);
+    expect(() => {
+      removeRedirectContext(input.state);
+    }).not.toThrow();
+  });
+});
+
+describe('expired context handling', () => {
+  it('should return undefined for expired context and delete the key', () => {
+    const input = createTestInput();
+    storeRedirectContext(input);
+
+    // Manually tamper with the stored bundle to make it expired
+    const key = `${fallbackKeyPrefix}${input.state}`;
+    const stored = JSON.parse(localStorage.getItem(key)!) as RedirectContext;
+    localStorage.setItem(key, JSON.stringify({ ...stored, expiresAt: Date.now() - 1000 }));
+
+    expect(getRedirectContextByState(input.state)).toBeUndefined();
+    // Key should be cleaned up
+    expect(localStorage.getItem(key)).toBeNull();
+  });
+});
+
+describe('malformed data handling', () => {
+  it('should return undefined for malformed JSON and delete the key', () => {
+    const key = `${fallbackKeyPrefix}bad-json`;
+    localStorage.setItem(key, '{not valid json!!!');
+
+    expect(getRedirectContextByState('bad-json')).toBeUndefined();
+    expect(localStorage.getItem(key)).toBeNull();
+  });
+
+  it('should return undefined for schema-invalid record and delete the key', () => {
+    const key = `${fallbackKeyPrefix}schema-invalid`;
+    localStorage.setItem(key, JSON.stringify({ state: 'schema-invalid' }));
+
+    expect(getRedirectContextByState('schema-invalid')).toBeUndefined();
+    expect(localStorage.getItem(key)).toBeNull();
+  });
+});
+
+describe('sweepExpiredRedirectContexts', () => {
+  it('should delete only expired bundles and keep valid ones', () => {
+    // Store two valid contexts
+    const valid1 = createTestInput({ state: 'valid-1' });
+    const valid2 = createTestInput({ state: 'valid-2' });
+    storeRedirectContext(valid1);
+    storeRedirectContext(valid2);
+
+    // Manually expire one of them
+    const expiredKey = `${fallbackKeyPrefix}valid-1`;
+    const stored = JSON.parse(localStorage.getItem(expiredKey)!) as RedirectContext;
+    localStorage.setItem(expiredKey, JSON.stringify({ ...stored, expiresAt: Date.now() - 1000 }));
+
+    // Also add a malformed entry
+    localStorage.setItem(`${fallbackKeyPrefix}malformed`, 'not-json');
+
+    sweepExpiredRedirectContexts();
+
+    // Expired and malformed should be removed
+    expect(localStorage.getItem(expiredKey)).toBeNull();
+    expect(localStorage.getItem(`${fallbackKeyPrefix}malformed`)).toBeNull();
+
+    // Valid one should remain
+    expect(getRedirectContextByState('valid-2')).toMatchObject(valid2);
+  });
+
+  it('should not affect keys without the fallback prefix', () => {
+    localStorage.setItem('other-key', 'other-value');
+    storeRedirectContext(createTestInput());
+
+    sweepExpiredRedirectContexts();
+
+    expect(localStorage.getItem('other-key')).toBe('other-value');
+  });
+});
+
+describe('localStorage unavailable', () => {
+  it('should not throw when localStorage operations fail', () => {
+    const originalSetItem = localStorage.setItem.bind(localStorage);
+    const originalGetItem = localStorage.getItem.bind(localStorage);
+
+    // Mock localStorage to throw
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('Storage unavailable');
+    });
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('Storage unavailable');
+    });
+
+    expect(() => {
+      storeRedirectContext(createTestInput());
+    }).not.toThrow();
+
+    expect(getRedirectContextByState('test-state-123')).toBeUndefined();
+    expect(consumeRedirectContext('test-state-123')).toBeUndefined();
+
+    expect(() => {
+      removeRedirectContext('test-state-123');
+    }).not.toThrow();
+
+    expect(() => {
+      sweepExpiredRedirectContexts();
+    }).not.toThrow();
+
+    // Restore
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(originalSetItem);
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation(originalGetItem);
+  });
+});

--- a/packages/experience/src/utils/social-redirect-fallback-context.ts
+++ b/packages/experience/src/utils/social-redirect-fallback-context.ts
@@ -1,0 +1,176 @@
+import * as s from 'superstruct';
+
+/**
+ * Social / SSO Redirect Fallback Context
+ *
+ * Provides a `localStorage`-based fallback mechanism for preserving redirect context
+ * (state, verificationId, session parameters) across in-app browser redirects where
+ * `sessionStorage` may be lost due to the browser opening a new WebView/tab.
+ *
+ * The primary session storage (`sessionStorage`) remains the source of truth. This
+ * fallback is only consulted when `sessionStorage` state is missing (not mismatched).
+ */
+
+const fallbackKeyPrefix = 'logto:redirect-context:fallback:';
+
+/** Time-to-live for fallback bundles: 10 minutes. */
+const ttlMs = 10 * 60 * 1000;
+
+const redirectContextStruct = s.object({
+  state: s.string(),
+  flow: s.enums(['social', 'sso']),
+  connectorId: s.string(),
+  verificationId: s.string(),
+  createdAt: s.number(),
+  expiresAt: s.number(),
+  appId: s.optional(s.string()),
+  organizationId: s.optional(s.string()),
+  uiLocales: s.optional(s.string()),
+});
+
+export type RedirectContext = s.Infer<typeof redirectContextStruct>;
+
+const safeParse = (raw: string): unknown => {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+};
+
+const parseAndValidate = (raw: string): RedirectContext | undefined => {
+  const parsed = safeParse(raw);
+
+  if (!parsed) {
+    return undefined;
+  }
+
+  const [error, context] = s.validate(parsed, redirectContextStruct);
+
+  if (error) {
+    return undefined;
+  }
+
+  if (Date.now() > context.expiresAt) {
+    return undefined;
+  }
+
+  return context;
+};
+
+/**
+ * Store a redirect context bundle in `localStorage` as a fallback for in-app browsers
+ * that may lose `sessionStorage` during external redirects.
+ *
+ * Timestamps (`createdAt`, `expiresAt`) are set internally.
+ * Expired / malformed bundles are swept before writing to prevent orphan accumulation.
+ *
+ * @param input - The redirect context fields (excluding timestamps).
+ */
+export const storeRedirectContext = (
+  input: Omit<RedirectContext, 'createdAt' | 'expiresAt'>
+): void => {
+  try {
+    const now = Date.now();
+    const context: RedirectContext = {
+      ...input,
+      createdAt: now,
+      expiresAt: now + ttlMs,
+    };
+
+    s.assert(context, redirectContextStruct);
+
+    // Sweep stale entries before writing — only scans our prefixed keys
+    sweepExpiredRedirectContexts();
+
+    localStorage.setItem(`${fallbackKeyPrefix}${input.state}`, JSON.stringify(context));
+  } catch {
+    // LocalStorage unavailable or quota exceeded
+  }
+};
+
+/**
+ * Retrieve a redirect context bundle by its state parameter.
+ *
+ * Returns `undefined` if the bundle is not found, malformed, schema-invalid, or expired.
+ * Invalid or expired bundles are deleted from `localStorage` as a side effect.
+ *
+ * @param state - The OAuth state parameter used as the lookup key.
+ * @returns The validated redirect context, or `undefined`.
+ */
+export const getRedirectContextByState = (state: string): RedirectContext | undefined => {
+  try {
+    const key = `${fallbackKeyPrefix}${state}`;
+    const raw = localStorage.getItem(key);
+
+    if (raw === null) {
+      return undefined;
+    }
+
+    const context = parseAndValidate(raw);
+
+    // Clean up invalid, malformed, or expired entries
+    if (!context) {
+      localStorage.removeItem(key);
+      return undefined;
+    }
+
+    return context;
+  } catch {
+    return undefined;
+  }
+};
+
+/** Consume (read then delete) a redirect context bundle to prevent replay. */
+export const consumeRedirectContext = (state: string): RedirectContext | undefined => {
+  const context = getRedirectContextByState(state);
+
+  if (context) {
+    removeRedirectContext(state);
+  }
+
+  return context;
+};
+
+/** Remove a redirect context bundle. Idempotent, never throws. */
+export const removeRedirectContext = (state: string): void => {
+  try {
+    localStorage.removeItem(`${fallbackKeyPrefix}${state}`);
+  } catch {
+    // LocalStorage unavailable
+  }
+};
+
+/**
+ * Sweep all expired or malformed redirect context bundles from `localStorage`.
+ * Only processes keys with the correct prefix to avoid interfering with other data.
+ * Reuses {@link parseAndValidate} so validation rules stay in one place.
+ *
+ * Called by {@link storeRedirectContext} before each write to clean up orphaned entries
+ * from abandoned flows (user never returned from IdP). Only scans keys with our prefix.
+ */
+export const sweepExpiredRedirectContexts = (): void => {
+  try {
+    const keys = Array.from({ length: localStorage.length }, (_, index) => localStorage.key(index));
+
+    const keysToRemove = keys.filter((key): key is string => {
+      if (!key?.startsWith(fallbackKeyPrefix)) {
+        return false;
+      }
+
+      const raw = localStorage.getItem(key);
+
+      if (raw === null) {
+        return false;
+      }
+
+      return !parseAndValidate(raw);
+    });
+
+    for (const key of keysToRemove) {
+      localStorage.removeItem(key);
+    }
+  } catch {
+    // LocalStorage unavailable
+  }
+};

--- a/packages/integration-tests/src/tests/experience/social-sign-in-session-fallback.test.ts
+++ b/packages/integration-tests/src/tests/experience/social-sign-in-session-fallback.test.ts
@@ -1,0 +1,139 @@
+import crypto from 'node:crypto';
+
+import { ConnectorType } from '@logto/connector-kit';
+import { AgreeToTermsPolicy, SignInMode } from '@logto/schemas';
+
+import { updateSignInExperience } from '#src/api/sign-in-experience.js';
+import { demoAppUrl, mockSocialAuthPageUrl } from '#src/constants.js';
+import { clearConnectorsByTypes, setSocialConnector } from '#src/helpers/connector.js';
+import ExpectExperience from '#src/ui-helpers/expect-experience.js';
+
+const randomString = () => crypto.randomBytes(8).toString('hex');
+
+/**
+ * NOTE: This test suite assumes test cases will run sequentially (which is Jest default).
+ *
+ * Tests the localStorage-based fallback mechanism for social sign-in when
+ * sessionStorage is lost (e.g., in-app browsers opening a new WebView for OAuth).
+ */
+describe('social sign-in session fallback', () => {
+  // eslint-disable-next-line @silverhand/fp/no-let
+  let experience: ExpectExperience;
+  const socialUserId = 'fallback_' + randomString();
+
+  beforeAll(async () => {
+    await clearConnectorsByTypes([ConnectorType.Social, ConnectorType.Email, ConnectorType.Sms]);
+    await setSocialConnector();
+
+    await updateSignInExperience({
+      termsOfUseUrl: '',
+      privacyPolicyUrl: '',
+      agreeToTermsPolicy: AgreeToTermsPolicy.ManualRegistrationOnly,
+      signUp: { identifiers: [], password: false, verify: false },
+      signIn: {
+        methods: [],
+      },
+      signInMode: SignInMode.SignInAndRegister,
+      socialSignInConnectorTargets: ['mock-social'],
+    });
+  });
+
+  it('should register a new social user for subsequent fallback test', async () => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    experience = new ExpectExperience(await browser.newPage());
+    await experience.startWith(demoAppUrl, 'sign-in');
+    await experience.toProcessSocialSignIn({ socialUserId });
+    await experience.verifyThenEnd();
+  });
+
+  it('should recover social sign-in via localStorage fallback when sessionStorage is lost', async () => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    experience = new ExpectExperience(await browser.newPage());
+    await experience.startWith(demoAppUrl, 'sign-in');
+
+    // --- Manually replicate the social sign-in initiation ---
+    // 1. Listen for the auth page request
+    const authPageRequestListener = experience.page.waitForRequest((request) =>
+      request.url().startsWith(mockSocialAuthPageUrl)
+    );
+
+    // 2. Click the social button
+    await experience.toClick('button', 'Continue with Mock Social');
+
+    // 3. Intercept to extract redirect_uri and state
+    const result = await authPageRequestListener;
+    const { searchParams } = new URL(result.url());
+    const redirectUri = searchParams.get('redirect_uri') ?? '';
+    const state = searchParams.get('state') ?? '';
+
+    // 4. Inject a one-time script that clears the experience app's social auth state from
+    //    sessionStorage before the callback page's app code runs.
+    //    This simulates in-app browsers losing sessionStorage across redirects.
+    //    We only clear `social_auth_state:*` keys (not all of sessionStorage) to avoid
+    //    wiping the demo app's OIDC PKCE code_verifier on subsequent redirects.
+    const { identifier } = await experience.page.evaluateOnNewDocument(() => {
+      for (const key of Object.keys(sessionStorage)) {
+        if (key.startsWith('social_auth_state:')) {
+          sessionStorage.removeItem(key);
+        }
+      }
+    });
+
+    // 5. Navigate to the callback URL (simulating IdP redirect back)
+    const callbackUrl = new URL(redirectUri);
+    callbackUrl.searchParams.set('state', state);
+    callbackUrl.searchParams.set('code', 'mock-code');
+    callbackUrl.searchParams.set('userId', socialUserId);
+
+    await experience.navigateTo(callbackUrl.toString());
+
+    // Remove the injected script so it doesn't fire on subsequent navigations
+    await experience.page.removeScriptToEvaluateOnNewDocument(identifier);
+
+    // 6. The fallback should restore the session from localStorage and complete sign-in
+    await experience.verifyThenEnd();
+  });
+
+  it('should show error when sessionStorage is lost and no localStorage fallback exists', async () => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    experience = new ExpectExperience(await browser.newPage());
+    await experience.startWith(demoAppUrl, 'sign-in');
+
+    const authPageRequestListener = experience.page.waitForRequest((request) =>
+      request.url().startsWith(mockSocialAuthPageUrl)
+    );
+
+    await experience.toClick('button', 'Continue with Mock Social');
+
+    const result = await authPageRequestListener;
+    const { searchParams } = new URL(result.url());
+    const redirectUri = searchParams.get('redirect_uri') ?? '';
+    const state = searchParams.get('state') ?? '';
+
+    // Clear social auth state from sessionStorage AND the fallback from localStorage
+    const { identifier } = await experience.page.evaluateOnNewDocument(() => {
+      for (const key of Object.keys(sessionStorage)) {
+        if (key.startsWith('social_auth_state:')) {
+          sessionStorage.removeItem(key);
+        }
+      }
+      for (const key of Object.keys(localStorage)) {
+        if (key.startsWith('logto:redirect-context:fallback:')) {
+          localStorage.removeItem(key);
+        }
+      }
+    });
+
+    const callbackUrl = new URL(redirectUri);
+    callbackUrl.searchParams.set('state', state);
+    callbackUrl.searchParams.set('code', 'mock-code');
+    callbackUrl.searchParams.set('userId', socialUserId);
+
+    await experience.navigateTo(callbackUrl.toString());
+    await experience.page.removeScriptToEvaluateOnNewDocument(identifier);
+
+    // Should show an error toast and redirect to sign-in
+    await experience.waitForToast(/invalid/);
+    experience.toBeAt('sign-in');
+  });
+});


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add localStorage fallback for in-app browser social/SSO redirects. This PR is an enhanced version of PR #8415, which addressed issue #7604.

### Context
In-app browsers (Instagram, Facebook, LINE, etc.) often open OAuth redirects in a new WebView or system browser tab. When this happens, `sessionStorage`, which the experience app uses to store the OAuth `state` and `verificationId`, is lost because `sessionStorage` is scoped to a single browsing context. This causes social and SSO sign-in to fail silently with "invalid session" or "invalid auth" errors after the user successfully authenticates with the identity provider.

### Updates
Introduces a `localStorage`-based fallback that preserves redirect context (`state`, `verificationId`, session parameters) across browser context switches. `sessionStorage` remains the primary source of truth; the fallback is only consulted when `sessionStorage` state is genuinely missing (not mismatched).

**Key changes:**
- **New utility** (`social-redirect-fallback-context.ts`): `localStorage` store/consume/sweep functions with superstruct schema validation and a 10-minute TTL. Expired/malformed entries are automatically cleaned up.
- **New hook** (`use-redirect-callback-validation.ts`): Encapsulates state validation + fallback restore logic, shared by both social and SSO callback listeners. Returns a discriminated `ValidationResult` union.
- **Refactored `validateState`**: Now returns `'match' | 'missing' | 'mismatch'` (was `boolean`), enabling the fallback to distinguish "session lost" from "state tampered".
- **Extracted `validateGoogleOneTapCredential`**: Separated Google One Tap CSRF validation from general OAuth state validation. Cleaner separation of concerns.
- **Deleted `getAuthValidationResult` + `getSessionValidationResult`**: Replaced by the above `use-redirect-callback-validation` hook
- **Context writers**: `use-social.ts` and `use-single-sign-on.ts` now write fallback bundles (including `appId`, `organizationId`, `uiLocales`) to `localStorage` before redirect.
- **Callback listeners**: Both social and SSO listeners delegate to the new hook. On fallback recovery, session parameters are restored to `sessionStorage` so the global API interceptor (which reads `app_id` for the `Logto-App-Id` header) continues to work.

### Security considerations
- Fallback is **never consulted** when `sessionStorage` has state, but it doesn't match the URL (`'mismatch'`), preventing CSRF bypass.
- Fallback bundles are **consumed on read** (one-time use) to prevent replay.
- **Ownership validation**: `flow` and `connectorId` in the fallback must match the current route.
- 10-minute TTL with automatic sweep prevents orphan accumulation.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Unit test and integration tests added

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
