### PR TITLE
feat(schemas): add signing key rotation config types

### DIFF
--- a/packages/schemas/src/types/logto-config/index.test.ts
+++ b/packages/schemas/src/types/logto-config/index.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type LogtoOidcConfigType,
+  LogtoOidcConfigKey,
+  LogtoTenantConfigKey,
+  OidcSigningKeyStatus,
+  logtoOidcConfigGuard,
+  logtoTenantConfigGuard,
+  oidcConfigKeysResponseGuard,
+} from './index.js';
+
+describe('logto config guards', () => {
+  it('accepts legacy private keys without status', () => {
+    const privateKeys: LogtoOidcConfigType[LogtoOidcConfigKey.PrivateKeys] = [
+      {
+        id: 'key_1',
+        value: 'private-key-1',
+        createdAt: 1_710_000_000_000,
+      },
+    ];
+
+    const result = logtoOidcConfigGuard[LogtoOidcConfigKey.PrivateKeys].safeParse(privateKeys);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts signing key status in OIDC key responses', () => {
+    const result = oidcConfigKeysResponseGuard.safeParse({
+      id: 'key_1',
+      createdAt: 1_710_000_000_000,
+      status: OidcSigningKeyStatus.Current,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts partial signing key rotation state', () => {
+    const result = logtoTenantConfigGuard[LogtoTenantConfigKey.SigningKeyRotationState].safeParse({
+      signingKeyRotationAt: 1_710_000_000_000,
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/schemas/src/types/logto-config/index.ts
+++ b/packages/schemas/src/types/logto-config/index.ts
@@ -45,6 +45,17 @@ export const oidcConfigKeyGuard = z.object({
 });
 export type OidcConfigKey = z.infer<typeof oidcConfigKeyGuard>;
 
+export enum OidcSigningKeyStatus {
+  Next = 'Next',
+  Current = 'Current',
+  Previous = 'Previous',
+}
+
+export const oidcPrivateKeyGuard = oidcConfigKeyGuard.extend({
+  status: z.nativeEnum(OidcSigningKeyStatus).optional(),
+});
+export type OidcPrivateKey = z.infer<typeof oidcPrivateKeyGuard>;
+
 export const oidcSessionConfigGuard = z.object({
   ttl: z.number().int().min(1).max(31_536_000).optional(),
 });
@@ -52,7 +63,7 @@ export const oidcSessionConfigGuard = z.object({
 export type OidcSessionConfig = z.infer<typeof oidcSessionConfigGuard>;
 
 export type LogtoOidcConfigType = {
-  [LogtoOidcConfigKey.PrivateKeys]: OidcConfigKey[];
+  [LogtoOidcConfigKey.PrivateKeys]: OidcPrivateKey[];
   [LogtoOidcConfigKey.CookieKeys]: OidcConfigKey[];
   [LogtoOidcConfigKey.Session]: OidcSessionConfig;
 };
@@ -64,7 +75,7 @@ export const logtoOidcConfigGuard: Readonly<{
     Optional<Nullable<LogtoOidcConfigType[key]>>
   >;
 }> = Object.freeze({
-  [LogtoOidcConfigKey.PrivateKeys]: oidcConfigKeyGuard.array(),
+  [LogtoOidcConfigKey.PrivateKeys]: oidcPrivateKeyGuard.array(),
   [LogtoOidcConfigKey.CookieKeys]: oidcConfigKeyGuard.array(),
   // Session config is optional, if not set, it will fallback to default value in core.
   [LogtoOidcConfigKey.Session]: oidcSessionConfigGuard.nullish().transform((data) => data ?? {}),
@@ -145,6 +156,12 @@ export const idTokenConfigGuard = z.object({
 });
 export type IdTokenConfig = z.infer<typeof idTokenConfigGuard>;
 
+export const signingKeyRotationStateGuard = z.object({
+  tenantCacheExpiresAt: z.number().optional(),
+  signingKeyRotationAt: z.number().optional(),
+});
+export type SigningKeyRotationState = z.infer<typeof signingKeyRotationStateGuard>;
+
 export enum LogtoTenantConfigKey {
   AdminConsole = 'adminConsole',
   CloudConnection = 'cloudConnection',
@@ -152,12 +169,15 @@ export enum LogtoTenantConfigKey {
   SessionNotFoundRedirectUrl = 'sessionNotFoundRedirectUrl',
   /** ID token configuration for extended claims. */
   IdToken = 'idToken',
+  /** Tenant-scoped rotation state for staged private signing key activation. */
+  SigningKeyRotationState = 'signingKeyRotationState',
 }
 export type LogtoTenantConfigType = {
   [LogtoTenantConfigKey.AdminConsole]: AdminConsoleData;
   [LogtoTenantConfigKey.CloudConnection]: CloudConnectionData;
   [LogtoTenantConfigKey.SessionNotFoundRedirectUrl]: { url: string };
   [LogtoTenantConfigKey.IdToken]: IdTokenConfig;
+  [LogtoTenantConfigKey.SigningKeyRotationState]: SigningKeyRotationState;
 };
 
 export const logtoTenantConfigGuard: Readonly<{
@@ -167,6 +187,7 @@ export const logtoTenantConfigGuard: Readonly<{
   [LogtoTenantConfigKey.CloudConnection]: cloudConnectionDataGuard,
   [LogtoTenantConfigKey.SessionNotFoundRedirectUrl]: z.object({ url: z.string() }),
   [LogtoTenantConfigKey.IdToken]: idTokenConfigGuard,
+  [LogtoTenantConfigKey.SigningKeyRotationState]: signingKeyRotationStateGuard,
 });
 
 /* --- Summary --- */
@@ -188,8 +209,11 @@ export const logtoConfigGuards: LogtoConfigGuard = Object.freeze({
   ...logtoTenantConfigGuard,
 });
 
-export const oidcConfigKeysResponseGuard = oidcConfigKeyGuard
-  .omit({ value: true })
-  .merge(z.object({ signingKeyAlgorithm: z.nativeEnum(SupportedSigningKeyAlgorithm).optional() }));
+export const oidcConfigKeysResponseGuard = oidcConfigKeyGuard.omit({ value: true }).merge(
+  z.object({
+    signingKeyAlgorithm: z.nativeEnum(SupportedSigningKeyAlgorithm).optional(),
+    status: z.nativeEnum(OidcSigningKeyStatus).optional(),
+  })
+);
 
 export type OidcConfigKeysResponse = z.infer<typeof oidcConfigKeysResponseGuard>;


### PR DESCRIPTION
## Summary
- add explicit signing key status types for OIDC private keys
- add tenant signing key rotation state schema definitions
- extend OIDC key response guards and add schema compatibility tests

## Testing
- pnpm -C packages/schemas test -- src/types/logto-config/index.test.ts src/types/logto-config/jwt-customizer.test.ts
- pnpm -C packages/schemas build:test

## Linear
- LOG-13192
