### PR TITLE
feat(core): add signing key rotation config queries

### DIFF
--- a/packages/core/src/queries/logto-config.test.ts
+++ b/packages/core/src/queries/logto-config.test.ts
@@ -3,9 +3,11 @@ import {
   LogtoConfigs,
   LogtoOidcConfigKey,
   LogtoTenantConfigKey,
+  OidcSigningKeyStatus,
 } from '@logto/schemas';
 import { createMockPool, createMockQueryResult, sql } from '@silverhand/slonik';
 
+import { createMockCommonQueryMethods, expectSqlString } from '#src/test-utils/query.js';
 import { MockWellKnownCache } from '#src/test-utils/tenant.js';
 import { convertToIdentifiers } from '#src/utils/sql.js';
 import { expectSqlAssert, type QueryType } from '#src/utils/test-utils.js';
@@ -26,8 +28,11 @@ const {
   getAdminConsoleConfig,
   getCloudConnectionData,
   getRowsByKeys,
+  getSigningKeyRotationState,
+  upsertSigningKeyRotationState,
   updateAdminConsoleConfig,
   updateOidcConfigsByKey,
+  updatePrivateSigningKeysAndRotationState,
 } = createLogtoConfigQueries(pool, new MockWellKnownCache());
 
 describe('connector queries', () => {
@@ -145,5 +150,99 @@ describe('connector queries', () => {
     });
 
     void updateOidcConfigsByKey(LogtoOidcConfigKey.PrivateKeys, targetValue);
+  });
+
+  test('getSigningKeyRotationState', async () => {
+    const rowData = [
+      {
+        key: LogtoTenantConfigKey.SigningKeyRotationState,
+        value: { signingKeyRotationAt: 123_456_789 },
+      },
+    ];
+    const expectSql = sql`
+      select ${sql.join([fields.key, fields.value], sql`,`)} from ${table}
+        where ${fields.key} in (${sql.join([LogtoTenantConfigKey.SigningKeyRotationState], sql`,`)})
+    `;
+
+    mockQuery.mockImplementationOnce(async (sql, values) => {
+      expectSqlAssert(sql, expectSql.sql);
+      expect(values).toEqual([LogtoTenantConfigKey.SigningKeyRotationState]);
+
+      return createMockQueryResult(rowData as never);
+    });
+
+    const result = await getSigningKeyRotationState();
+    expect(result).toEqual({ signingKeyRotationAt: 123_456_789 });
+  });
+
+  test('upsertSigningKeyRotationState', async () => {
+    const targetValue = { tenantCacheExpiresAt: 123_456_789 };
+    const targetRowData = { value: targetValue };
+    const expectSql = sql`
+      insert into ${table} (${fields.key}, ${fields.value})
+        values (${LogtoTenantConfigKey.SigningKeyRotationState}, ${sql.jsonb(targetValue)})
+        on conflict (${fields.tenantId}, ${fields.key}) do update
+        set ${fields.value} = coalesce(${table}.${fields.value}, '{}'::jsonb) || ${sql.jsonb(
+          targetValue
+        )}
+        returning ${fields.value}
+    `;
+
+    mockQuery.mockImplementationOnce(async (sql, values) => {
+      expectSqlAssert(sql, expectSql.sql);
+      expect(values).toMatchObject([
+        LogtoTenantConfigKey.SigningKeyRotationState,
+        JSON.stringify(targetValue),
+        JSON.stringify(targetValue),
+      ]);
+
+      return createMockQueryResult([targetRowData] as never);
+    });
+
+    const result = await upsertSigningKeyRotationState(targetValue);
+    expect(result).toEqual(targetValue);
+  });
+});
+
+describe('logto config transactional queries', () => {
+  const methods = createMockCommonQueryMethods();
+  const transactionalQueries = createLogtoConfigQueries(methods as never, new MockWellKnownCache());
+
+  test('updatePrivateSigningKeysAndRotationState', async () => {
+    const privateKeys = [
+      {
+        id: 'foo',
+        value: 'bar',
+        createdAt: 123_456_789,
+        status: OidcSigningKeyStatus.Next,
+      },
+    ];
+    const rotationState = { tenantCacheExpiresAt: 222_222_222 };
+
+    methods.transaction.mockImplementation(
+      async (handler: (transaction: typeof methods) => Promise<unknown>) => handler(methods)
+    );
+    methods.query.mockResolvedValueOnce({ rows: [] });
+    methods.one
+      .mockResolvedValueOnce({
+        key: LogtoOidcConfigKey.PrivateKeys,
+        value: privateKeys,
+      })
+      .mockResolvedValueOnce({
+        value: rotationState,
+      });
+
+    const result = await transactionalQueries.updatePrivateSigningKeysAndRotationState(
+      privateKeys,
+      rotationState
+    );
+
+    expect(methods.transaction).toHaveBeenCalledTimes(1);
+    expect(methods.query).toHaveBeenCalledWith(expectSqlString('for update'));
+    expect(methods.one).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({
+      privateKeys,
+      signingKeyRotationState: rotationState,
+    });
   });
 });

--- a/packages/core/src/queries/logto-config.ts
+++ b/packages/core/src/queries/logto-config.ts
@@ -6,10 +6,14 @@ import {
   type IdTokenConfig,
   type LogtoConfig,
   type LogtoConfigKey,
-  type LogtoOidcConfigKey,
+  LogtoOidcConfigKey,
   type LogtoJwtTokenKey,
+  type OidcPrivateKey,
+  oidcPrivateKeyGuard,
   idTokenConfigGuard,
   type LogtoOidcConfigType,
+  signingKeyRotationStateGuard,
+  type SigningKeyRotationState,
 } from '@logto/schemas';
 import type { CommonQueryMethods } from '@silverhand/slonik';
 import { sql } from '@silverhand/slonik';
@@ -25,6 +29,19 @@ export const createLogtoConfigQueries = (
   pool: CommonQueryMethods,
   wellKnownCache: WellKnownCache
 ) => {
+  const upsertPrivateSigningKeys = async (
+    executor: CommonQueryMethods,
+    privateKeys: OidcPrivateKey[]
+  ) =>
+    executor.one<{ key: LogtoOidcConfigKey.PrivateKeys; value: unknown }>(sql`
+      insert into ${table} (${fields.key}, ${fields.value})
+        values (${LogtoOidcConfigKey.PrivateKeys}, ${sql.jsonb(privateKeys)})
+        on conflict (${fields.tenantId}, ${fields.key}) do update set ${fields.value} = ${sql.jsonb(
+          privateKeys
+        )}
+        returning ${fields.key}, ${fields.value}
+    `);
+
   const getAdminConsoleConfig = async () =>
     pool.one<{ value: unknown }>(sql`
       select ${fields.value} from ${table}
@@ -73,6 +90,68 @@ export const createLogtoConfigQueries = (
         returning *
     `);
 
+  const getSigningKeyRotationState = async (): Promise<SigningKeyRotationState | undefined> => {
+    const { rows } = await getRowsByKeys([LogtoTenantConfigKey.SigningKeyRotationState]);
+
+    if (rows.length === 0) {
+      return undefined;
+    }
+
+    return signingKeyRotationStateGuard.parse(rows[0]?.value);
+  };
+
+  const upsertSigningKeyRotationState = async (
+    value: Partial<SigningKeyRotationState>
+  ): Promise<SigningKeyRotationState> => {
+    const { value: rawValue } = await pool.one<{ value: unknown }>(sql`
+      insert into ${table} (${fields.key}, ${fields.value})
+        values (${LogtoTenantConfigKey.SigningKeyRotationState}, ${sql.jsonb(value)})
+        on conflict (${fields.tenantId}, ${fields.key}) do update
+        set ${fields.value} = coalesce(${table}.${fields.value}, '{}'::jsonb) || ${sql.jsonb(value)}
+        returning ${fields.value}
+    `);
+
+    return signingKeyRotationStateGuard.parse(rawValue);
+  };
+
+  const updatePrivateSigningKeysAndRotationState = async (
+    privateKeys: OidcPrivateKey[],
+    signingKeyRotationState: Partial<SigningKeyRotationState>
+  ): Promise<{
+    privateKeys: OidcPrivateKey[];
+    signingKeyRotationState: SigningKeyRotationState;
+  }> =>
+    pool.transaction(async (transaction) => {
+      await transaction.query(sql`
+        select ${fields.key}
+        from ${table}
+        where ${fields.key} in (
+          ${LogtoOidcConfigKey.PrivateKeys},
+          ${LogtoTenantConfigKey.SigningKeyRotationState}
+        )
+        for update
+      `);
+
+      const privateKeysRow = await upsertPrivateSigningKeys(transaction, privateKeys);
+
+      const { value: rotationStateValue } = await transaction.one<{ value: unknown }>(sql`
+        insert into ${table} (${fields.key}, ${fields.value})
+          values (${LogtoTenantConfigKey.SigningKeyRotationState}, ${sql.jsonb(
+            signingKeyRotationState
+          )})
+          on conflict (${fields.tenantId}, ${fields.key}) do update
+          set ${fields.value} = coalesce(${table}.${fields.value}, '{}'::jsonb) || ${sql.jsonb(
+            signingKeyRotationState
+          )}
+          returning ${fields.value}
+      `);
+
+      return {
+        privateKeys: oidcPrivateKeyGuard.array().parse(privateKeysRow.value),
+        signingKeyRotationState: signingKeyRotationStateGuard.parse(rotationStateValue),
+      };
+    });
+
   // Can not narrow down the type of value if we utilize `buildInsertIntoWithPool` method.
   const upsertJwtCustomizer = async <T extends LogtoJwtTokenKey>(
     key: T,
@@ -118,6 +197,9 @@ export const createLogtoConfigQueries = (
     getCloudConnectionData,
     getRowsByKeys,
     updateOidcConfigsByKey,
+    getSigningKeyRotationState,
+    upsertSigningKeyRotationState,
+    updatePrivateSigningKeysAndRotationState,
     upsertJwtCustomizer,
     deleteJwtCustomizer,
     getIdTokenConfig,


### PR DESCRIPTION
## Summary
- add query helpers for tenant signing key rotation state reads and writes
- add a transactional query path for updating private signing keys with rotation state together
- cover the new query behavior with unit tests

## Testing
- pnpm -C packages/core build:test && pnpm -C packages/core test:only -- build/queries/logto-config.test.js

## Linear
- LOG-13193

## Stack
- base: #8653
