### PR TITLE
feat(core): normalize signing key lifecycle state

### DIFF
--- a/packages/console/src/components/OidcConfigs/SigningKeysFormCard.tsx
+++ b/packages/console/src/components/OidcConfigs/SigningKeysFormCard.tsx
@@ -1,5 +1,6 @@
 import {
   SupportedSigningKeyAlgorithm,
+  OidcSigningKeyStatus,
   type OidcConfigKeysResponse,
   LogtoOidcConfigKeyType,
 } from '@logto/schemas';
@@ -39,6 +40,40 @@ const keyTypeTabs = [
   },
 ] as const;
 
+const getSigningKeyTagStatus = (status?: OidcSigningKeyStatus) => {
+  switch (status) {
+    case OidcSigningKeyStatus.Current: {
+      return 'success';
+    }
+    case OidcSigningKeyStatus.Next: {
+      return 'info';
+    }
+    case OidcSigningKeyStatus.Previous: {
+      return 'alert';
+    }
+    default: {
+      return 'info';
+    }
+  }
+};
+
+const getSigningKeyLabel = (status?: OidcSigningKeyStatus) => {
+  switch (status) {
+    case OidcSigningKeyStatus.Current: {
+      return 'status.current';
+    }
+    case OidcSigningKeyStatus.Next: {
+      return 'status.next';
+    }
+    case OidcSigningKeyStatus.Previous: {
+      return 'status.previous';
+    }
+    default: {
+      return 'table_column.status';
+    }
+  }
+};
+
 function SigningKeysFormCard() {
   const api = useApi();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console.signing_keys' });
@@ -64,25 +99,37 @@ function SigningKeysFormCard() {
   const tableColumns = useMemo(
     () => [
       {
-        title: t('table_column.id'),
+        title: String(t('table_column.id')),
         dataIndex: 'id',
         colSpan: 8,
         render: ({ id }: OidcConfigKeysResponse) => <span className={styles.idWrapper}>{id}</span>,
       },
       {
-        title: t('table_column.status'),
+        title: String(t('table_column.status')),
         dataIndex: 'status',
         colSpan: 4,
-        render: (_: OidcConfigKeysResponse, rowIndex: number) => (
-          <Tag type="state" variant="plain" status={rowIndex === 0 ? 'success' : 'alert'}>
-            {t(rowIndex === 0 ? 'status.current' : 'status.previous')}
+        render: ({ status }: OidcConfigKeysResponse, rowIndex: number) => (
+          <Tag
+            type="state"
+            variant="plain"
+            status={
+              isPrivateKey ? getSigningKeyTagStatus(status) : rowIndex === 0 ? 'success' : 'alert'
+            }
+          >
+            {t(
+              isPrivateKey
+                ? getSigningKeyLabel(status)
+                : rowIndex === 0
+                  ? 'status.current'
+                  : 'status.previous'
+            )}
           </Tag>
         ),
       },
       ...condArray(
         isPrivateKey && [
           {
-            title: t('table_column.algorithm'),
+            title: String(t('table_column.algorithm')),
             dataIndex: 'signingKeyAlgorithm',
             colSpan: 7,
             render: ({ signingKeyAlgorithm }: OidcConfigKeysResponse) => (
@@ -95,8 +142,8 @@ function SigningKeysFormCard() {
         title: '',
         dataIndex: 'action',
         colSpan: 2,
-        render: ({ id }: OidcConfigKeysResponse, rowIndex: number) =>
-          rowIndex !== 0 && (
+        render: ({ id, status }: OidcConfigKeysResponse, rowIndex: number) =>
+          (isPrivateKey ? status === OidcSigningKeyStatus.Previous : rowIndex !== 0) && (
             <div className={styles.deleteIcon}>
               <IconButton
                 onClick={() => {
@@ -170,7 +217,7 @@ function SigningKeysFormCard() {
               })
               .json<OidcConfigKeysResponse[]>();
             void mutate(keys);
-            toast.success(t('messages.rotate_key_success'));
+            toast.success(String(t('messages.rotate_key_success')));
           } finally {
             setIsRotating(false);
           }
@@ -211,7 +258,7 @@ function SigningKeysFormCard() {
           try {
             await api.delete(`api/configs/oidc/${activeTab}/${deletingKeyId}`);
             void mutate(data?.filter((key) => key.id !== deletingKeyId));
-            toast.success(t('messages.delete_key_success'));
+            toast.success(String(t('messages.delete_key_success')));
           } finally {
             setDeletingKeyId(undefined);
           }

--- a/packages/console/src/components/OidcConfigs/SigningKeysFormCard.tsx
+++ b/packages/console/src/components/OidcConfigs/SigningKeysFormCard.tsx
@@ -1,6 +1,5 @@
 import {
   SupportedSigningKeyAlgorithm,
-  OidcSigningKeyStatus,
   type OidcConfigKeysResponse,
   LogtoOidcConfigKeyType,
 } from '@logto/schemas';
@@ -40,40 +39,6 @@ const keyTypeTabs = [
   },
 ] as const;
 
-const getSigningKeyTagStatus = (status?: OidcSigningKeyStatus) => {
-  switch (status) {
-    case OidcSigningKeyStatus.Current: {
-      return 'success';
-    }
-    case OidcSigningKeyStatus.Next: {
-      return 'info';
-    }
-    case OidcSigningKeyStatus.Previous: {
-      return 'alert';
-    }
-    default: {
-      return 'info';
-    }
-  }
-};
-
-const getSigningKeyLabel = (status?: OidcSigningKeyStatus) => {
-  switch (status) {
-    case OidcSigningKeyStatus.Current: {
-      return 'status.current';
-    }
-    case OidcSigningKeyStatus.Next: {
-      return 'status.next';
-    }
-    case OidcSigningKeyStatus.Previous: {
-      return 'status.previous';
-    }
-    default: {
-      return 'table_column.status';
-    }
-  }
-};
-
 function SigningKeysFormCard() {
   const api = useApi();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console.signing_keys' });
@@ -99,37 +64,25 @@ function SigningKeysFormCard() {
   const tableColumns = useMemo(
     () => [
       {
-        title: String(t('table_column.id')),
+        title: t('table_column.id'),
         dataIndex: 'id',
         colSpan: 8,
         render: ({ id }: OidcConfigKeysResponse) => <span className={styles.idWrapper}>{id}</span>,
       },
       {
-        title: String(t('table_column.status')),
+        title: t('table_column.status'),
         dataIndex: 'status',
         colSpan: 4,
-        render: ({ status }: OidcConfigKeysResponse, rowIndex: number) => (
-          <Tag
-            type="state"
-            variant="plain"
-            status={
-              isPrivateKey ? getSigningKeyTagStatus(status) : rowIndex === 0 ? 'success' : 'alert'
-            }
-          >
-            {t(
-              isPrivateKey
-                ? getSigningKeyLabel(status)
-                : rowIndex === 0
-                  ? 'status.current'
-                  : 'status.previous'
-            )}
+        render: (_: OidcConfigKeysResponse, rowIndex: number) => (
+          <Tag type="state" variant="plain" status={rowIndex === 0 ? 'success' : 'alert'}>
+            {t(rowIndex === 0 ? 'status.current' : 'status.previous')}
           </Tag>
         ),
       },
       ...condArray(
         isPrivateKey && [
           {
-            title: String(t('table_column.algorithm')),
+            title: t('table_column.algorithm'),
             dataIndex: 'signingKeyAlgorithm',
             colSpan: 7,
             render: ({ signingKeyAlgorithm }: OidcConfigKeysResponse) => (
@@ -142,8 +95,8 @@ function SigningKeysFormCard() {
         title: '',
         dataIndex: 'action',
         colSpan: 2,
-        render: ({ id, status }: OidcConfigKeysResponse, rowIndex: number) =>
-          (isPrivateKey ? status === OidcSigningKeyStatus.Previous : rowIndex !== 0) && (
+        render: ({ id }: OidcConfigKeysResponse, rowIndex: number) =>
+          rowIndex !== 0 && (
             <div className={styles.deleteIcon}>
               <IconButton
                 onClick={() => {
@@ -217,7 +170,7 @@ function SigningKeysFormCard() {
               })
               .json<OidcConfigKeysResponse[]>();
             void mutate(keys);
-            toast.success(String(t('messages.rotate_key_success')));
+            toast.success(t('messages.rotate_key_success'));
           } finally {
             setIsRotating(false);
           }
@@ -258,7 +211,7 @@ function SigningKeysFormCard() {
           try {
             await api.delete(`api/configs/oidc/${activeTab}/${deletingKeyId}`);
             void mutate(data?.filter((key) => key.id !== deletingKeyId));
-            toast.success(String(t('messages.delete_key_success')));
+            toast.success(t('messages.delete_key_success'));
           } finally {
             setDeletingKeyId(undefined);
           }

--- a/packages/core/src/env-set/oidc.ts
+++ b/packages/core/src/env-set/oidc.ts
@@ -5,11 +5,17 @@ import { LogtoOidcConfigKey } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
 import { createLocalJWKSet } from 'jose';
 
-import { getOidcProviderPrivateKeys } from '#src/libraries/oidc-private-key.js';
+import {
+  getCurrentOidcPrivateKey,
+  getOidcProviderPrivateKeys,
+} from '#src/libraries/oidc-private-key.js';
 import { exportJWK } from '#src/utils/jwks.js';
 
 const loadOidcValues = async (issuer: string, configs: LogtoOidcConfigType) => {
   const cookieKeys = configs[LogtoOidcConfigKey.CookieKeys].map(({ value }) => value);
+  const currentPrivateKey = crypto.createPrivateKey(
+    getCurrentOidcPrivateKey(configs[LogtoOidcConfigKey.PrivateKeys]).value
+  );
   const privateKeys = getOidcProviderPrivateKeys(configs[LogtoOidcConfigKey.PrivateKeys]).map(
     ({ value }) => crypto.createPrivateKey(value)
   );
@@ -18,10 +24,11 @@ const loadOidcValues = async (issuer: string, configs: LogtoOidcConfigType) => {
   const privateJwks = await Promise.all(privateKeys.map(async (key) => exportJWK(key)));
   const publicJwks = await Promise.all(publicKeys.map(async (key) => exportJWK(key)));
   const localJWKSet = createLocalJWKSet({ keys: publicJwks });
+  const currentPrivateJwk = await exportJWK(currentPrivateKey);
 
   // Use ES384 if it's an Elliptic Curve key, otherwise fall back to default
   // It's for backwards compatibility since we were using RSA keys before v1.0.0-beta.20
-  const jwkSigningAlg = conditional(privateJwks[0]?.kty === 'EC' && 'ES384');
+  const jwkSigningAlg = conditional(currentPrivateJwk.kty === 'EC' && 'ES384');
 
   return Object.freeze({
     cookieKeys,

--- a/packages/core/src/env-set/oidc.ts
+++ b/packages/core/src/env-set/oidc.ts
@@ -5,12 +5,13 @@ import { LogtoOidcConfigKey } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
 import { createLocalJWKSet } from 'jose';
 
+import { getOidcProviderPrivateKeys } from '#src/libraries/oidc-private-key.js';
 import { exportJWK } from '#src/utils/jwks.js';
 
 const loadOidcValues = async (issuer: string, configs: LogtoOidcConfigType) => {
   const cookieKeys = configs[LogtoOidcConfigKey.CookieKeys].map(({ value }) => value);
-  const privateKeys = configs[LogtoOidcConfigKey.PrivateKeys].map(({ value }) =>
-    crypto.createPrivateKey(value)
+  const privateKeys = getOidcProviderPrivateKeys(configs[LogtoOidcConfigKey.PrivateKeys]).map(
+    ({ value }) => crypto.createPrivateKey(value)
   );
   const session = configs[LogtoOidcConfigKey.Session];
   const publicKeys = privateKeys.map((key) => crypto.createPublicKey(key));

--- a/packages/core/src/libraries/logto-config.ts
+++ b/packages/core/src/libraries/logto-config.ts
@@ -19,6 +19,7 @@ import chalk from 'chalk';
 import { ZodError, z } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
+import { normalizeOidcPrivateKeys } from '#src/libraries/oidc-private-key.js';
 import type Queries from '#src/tenants/Queries.js';
 
 export type LogtoConfigLibrary = ReturnType<typeof createLogtoConfigLibrary>;
@@ -26,7 +27,6 @@ export type LogtoConfigLibrary = ReturnType<typeof createLogtoConfigLibrary>;
 export const createLogtoConfigLibrary = ({
   logtoConfigs: {
     getRowsByKeys,
-    getPrivateSigningKeys,
     getCloudConnectionData: queryCloudConnectionData,
     upsertJwtCustomizer: queryUpsertJwtCustomizer,
     upsertIdTokenConfig: queryUpsertIdTokenConfig,
@@ -34,17 +34,16 @@ export const createLogtoConfigLibrary = ({
 }: Pick<Queries, 'logtoConfigs'>) => {
   const getOidcConfigs = async (consoleLog: ConsoleLog): Promise<LogtoOidcConfigType> => {
     try {
-      const [{ rows }, privateKeys] = await Promise.all([
-        getRowsByKeys(Object.values(LogtoOidcConfigKey)),
-        getPrivateSigningKeys(),
-      ]);
+      const { rows } = await getRowsByKeys(Object.values(LogtoOidcConfigKey));
       const configs = z
         .object(logtoOidcConfigGuard)
         .parse(Object.fromEntries(rows.map(({ key, value }) => [key, value])));
 
       return {
         ...configs,
-        [LogtoOidcConfigKey.PrivateKeys]: privateKeys,
+        [LogtoOidcConfigKey.PrivateKeys]: normalizeOidcPrivateKeys(
+          configs[LogtoOidcConfigKey.PrivateKeys]
+        ),
       };
     } catch (error: unknown) {
       if (error instanceof ZodError) {

--- a/packages/core/src/libraries/logto-config.ts
+++ b/packages/core/src/libraries/logto-config.ts
@@ -21,13 +21,12 @@ import { ZodError, z } from 'zod';
 import RequestError from '#src/errors/RequestError/index.js';
 import type Queries from '#src/tenants/Queries.js';
 
-import { normalizeOidcPrivateKeys } from './oidc-private-key.js';
-
 export type LogtoConfigLibrary = ReturnType<typeof createLogtoConfigLibrary>;
 
 export const createLogtoConfigLibrary = ({
   logtoConfigs: {
     getRowsByKeys,
+    getPrivateSigningKeys,
     getCloudConnectionData: queryCloudConnectionData,
     upsertJwtCustomizer: queryUpsertJwtCustomizer,
     upsertIdTokenConfig: queryUpsertIdTokenConfig,
@@ -35,16 +34,17 @@ export const createLogtoConfigLibrary = ({
 }: Pick<Queries, 'logtoConfigs'>) => {
   const getOidcConfigs = async (consoleLog: ConsoleLog): Promise<LogtoOidcConfigType> => {
     try {
-      const { rows } = await getRowsByKeys(Object.values(LogtoOidcConfigKey));
+      const [{ rows }, privateKeys] = await Promise.all([
+        getRowsByKeys(Object.values(LogtoOidcConfigKey)),
+        getPrivateSigningKeys(),
+      ]);
       const configs = z
         .object(logtoOidcConfigGuard)
         .parse(Object.fromEntries(rows.map(({ key, value }) => [key, value])));
 
       return {
         ...configs,
-        [LogtoOidcConfigKey.PrivateKeys]: normalizeOidcPrivateKeys(
-          configs[LogtoOidcConfigKey.PrivateKeys]
-        ),
+        [LogtoOidcConfigKey.PrivateKeys]: privateKeys,
       };
     } catch (error: unknown) {
       if (error instanceof ZodError) {

--- a/packages/core/src/libraries/logto-config.ts
+++ b/packages/core/src/libraries/logto-config.ts
@@ -21,6 +21,8 @@ import { ZodError, z } from 'zod';
 import RequestError from '#src/errors/RequestError/index.js';
 import type Queries from '#src/tenants/Queries.js';
 
+import { normalizeOidcPrivateKeys } from './oidc-private-key.js';
+
 export type LogtoConfigLibrary = ReturnType<typeof createLogtoConfigLibrary>;
 
 export const createLogtoConfigLibrary = ({
@@ -34,10 +36,16 @@ export const createLogtoConfigLibrary = ({
   const getOidcConfigs = async (consoleLog: ConsoleLog): Promise<LogtoOidcConfigType> => {
     try {
       const { rows } = await getRowsByKeys(Object.values(LogtoOidcConfigKey));
-
-      return z
+      const configs = z
         .object(logtoOidcConfigGuard)
         .parse(Object.fromEntries(rows.map(({ key, value }) => [key, value])));
+
+      return {
+        ...configs,
+        [LogtoOidcConfigKey.PrivateKeys]: normalizeOidcPrivateKeys(
+          configs[LogtoOidcConfigKey.PrivateKeys]
+        ),
+      };
     } catch (error: unknown) {
       if (error instanceof ZodError) {
         consoleLog.error(

--- a/packages/core/src/libraries/oidc-private-key.test.ts
+++ b/packages/core/src/libraries/oidc-private-key.test.ts
@@ -1,6 +1,11 @@
 import { OidcSigningKeyStatus } from '@logto/schemas';
 
+import Queries from '#src/tenants/Queries.js';
+import { createMockCommonQueryMethods } from '#src/test-utils/query.js';
+import { MockWellKnownCache } from '#src/test-utils/tenant.js';
+
 import {
+  OidcPrivateKeyLibrary,
   getCanonicalOidcPrivateKeys,
   getCurrentOidcPrivateKey,
   getImmediatelyRotatedOidcPrivateKeys,
@@ -8,6 +13,8 @@ import {
   getOidcProviderPrivateKeys,
   normalizeOidcPrivateKeys,
 } from './oidc-private-key.js';
+
+const { jest } = import.meta;
 
 const createPrivateKey = (id: string, createdAt: number, status?: OidcSigningKeyStatus) => ({
   id,
@@ -141,5 +148,63 @@ describe('getOidcPrivateKeysAfterDeletion', () => {
       createPrivateKey('next', 3, OidcSigningKeyStatus.Next),
       createPrivateKey('current', 2, OidcSigningKeyStatus.Current),
     ]);
+  });
+});
+
+describe('OidcPrivateKeyLibrary', () => {
+  const methods = createMockCommonQueryMethods();
+  const queries = new Queries(methods as never, new MockWellKnownCache());
+  const library = new OidcPrivateKeyLibrary(queries);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    methods.transaction.mockImplementation(
+      async (handler: (transaction: typeof methods) => Promise<unknown>) => handler(methods)
+    );
+  });
+
+  it('rotates private signing keys inside a locked transaction', async () => {
+    methods.query.mockResolvedValueOnce({ rows: [] } as never).mockResolvedValueOnce({
+      rows: [
+        {
+          key: 'oidc.privateKeys',
+          value: [createPrivateKey('current', 2, OidcSigningKeyStatus.Current)],
+        },
+      ],
+    } as never);
+    methods.one.mockResolvedValueOnce({
+      key: 'oidc.privateKeys',
+      value: [
+        createPrivateKey('new', 3, OidcSigningKeyStatus.Current),
+        createPrivateKey('current', 2, OidcSigningKeyStatus.Previous),
+      ],
+    } as never);
+
+    const result = await library.rotatePrivateSigningKeys(createPrivateKey('new', 3));
+
+    expect(methods.transaction).toHaveBeenCalledTimes(1);
+    expect(methods.query).toHaveBeenCalledTimes(2);
+    expect(methods.one).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([
+      createPrivateKey('new', 3, OidcSigningKeyStatus.Current),
+      createPrivateKey('current', 2, OidcSigningKeyStatus.Previous),
+    ]);
+  });
+
+  it('rejects deletion when private signing keys would become empty', async () => {
+    methods.query.mockResolvedValueOnce({ rows: [] } as never).mockResolvedValueOnce({
+      rows: [
+        {
+          key: 'oidc.privateKeys',
+          value: [createPrivateKey('current', 2, OidcSigningKeyStatus.Current)],
+        },
+      ],
+    } as never);
+
+    await expect(library.deletePrivateSigningKey('current')).rejects.toMatchObject({
+      code: 'oidc.key_required',
+      status: 422,
+    });
+    expect(methods.one).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/libraries/oidc-private-key.test.ts
+++ b/packages/core/src/libraries/oidc-private-key.test.ts
@@ -29,6 +29,20 @@ describe('normalizeOidcPrivateKeys', () => {
     ]);
   });
 
+  it('keeps loading legacy private key arrays with more than two unstamped keys', () => {
+    const result = normalizeOidcPrivateKeys([
+      createPrivateKey('current', 1),
+      createPrivateKey('previous-a', 2),
+      createPrivateKey('previous-b', 3),
+    ]);
+
+    expect(result).toEqual([
+      createPrivateKey('current', 1, OidcSigningKeyStatus.Current),
+      createPrivateKey('previous-a', 2, OidcSigningKeyStatus.Previous),
+      createPrivateKey('previous-b', 3, OidcSigningKeyStatus.Previous),
+    ]);
+  });
+
   it('preserves explicit statuses without reordering the input array', () => {
     const result = normalizeOidcPrivateKeys([
       createPrivateKey('previous', 3, OidcSigningKeyStatus.Previous),
@@ -125,5 +139,21 @@ describe('getOidcPrivateKeysAfterDeletion', () => {
     );
 
     expect(result).toEqual([createPrivateKey('current', 2, OidcSigningKeyStatus.Current)]);
+  });
+
+  it('preserves Next and Current statuses when deleting Previous from a staged key set', () => {
+    const result = getOidcPrivateKeysAfterDeletion(
+      [
+        createPrivateKey('next', 3, OidcSigningKeyStatus.Next),
+        createPrivateKey('current', 2, OidcSigningKeyStatus.Current),
+        createPrivateKey('previous', 1, OidcSigningKeyStatus.Previous),
+      ],
+      'previous'
+    );
+
+    expect(result).toEqual([
+      createPrivateKey('next', 3, OidcSigningKeyStatus.Next),
+      createPrivateKey('current', 2, OidcSigningKeyStatus.Current),
+    ]);
   });
 });

--- a/packages/core/src/libraries/oidc-private-key.test.ts
+++ b/packages/core/src/libraries/oidc-private-key.test.ts
@@ -1,6 +1,8 @@
 import { OidcSigningKeyStatus } from '@logto/schemas';
 
 import {
+  getCanonicalOidcPrivateKeys,
+  getCurrentOidcPrivateKey,
   getImmediatelyRotatedOidcPrivateKeys,
   getOidcPrivateKeysAfterDeletion,
   getOidcProviderPrivateKeys,
@@ -27,8 +29,33 @@ describe('normalizeOidcPrivateKeys', () => {
     ]);
   });
 
-  it('sorts explicit statuses into Next, Current, Previous order', () => {
+  it('preserves explicit statuses without reordering the input array', () => {
     const result = normalizeOidcPrivateKeys([
+      createPrivateKey('previous', 3, OidcSigningKeyStatus.Previous),
+      createPrivateKey('current', 2, OidcSigningKeyStatus.Current),
+      createPrivateKey('next', 1, OidcSigningKeyStatus.Next),
+    ]);
+
+    expect(result).toEqual([
+      createPrivateKey('previous', 3, OidcSigningKeyStatus.Previous),
+      createPrivateKey('current', 2, OidcSigningKeyStatus.Current),
+      createPrivateKey('next', 1, OidcSigningKeyStatus.Next),
+    ]);
+  });
+
+  it('throws for malformed status configurations', () => {
+    expect(() =>
+      normalizeOidcPrivateKeys([
+        createPrivateKey('current-a', 1, OidcSigningKeyStatus.Current),
+        createPrivateKey('current-b', 2, OidcSigningKeyStatus.Current),
+      ])
+    ).toThrow('Malformed OIDC private key status configuration');
+  });
+});
+
+describe('getCanonicalOidcPrivateKeys', () => {
+  it('orders private keys as Next, Current, Previous in canonical status order', () => {
+    const result = getCanonicalOidcPrivateKeys([
       createPrivateKey('previous', 3, OidcSigningKeyStatus.Previous),
       createPrivateKey('current', 2, OidcSigningKeyStatus.Current),
       createPrivateKey('next', 1, OidcSigningKeyStatus.Next),
@@ -40,14 +67,17 @@ describe('normalizeOidcPrivateKeys', () => {
       createPrivateKey('previous', 3, OidcSigningKeyStatus.Previous),
     ]);
   });
+});
 
-  it('throws for malformed status configurations', () => {
-    expect(() =>
-      normalizeOidcPrivateKeys([
-        createPrivateKey('current-a', 1, OidcSigningKeyStatus.Current),
-        createPrivateKey('current-b', 2, OidcSigningKeyStatus.Current),
-      ])
-    ).toThrow('Malformed OIDC private key status configuration');
+describe('getCurrentOidcPrivateKey', () => {
+  it('finds the Current signing key by status instead of array index', () => {
+    const result = getCurrentOidcPrivateKey([
+      createPrivateKey('previous', 3, OidcSigningKeyStatus.Previous),
+      createPrivateKey('current', 2, OidcSigningKeyStatus.Current),
+      createPrivateKey('next', 1, OidcSigningKeyStatus.Next),
+    ]);
+
+    expect(result).toEqual(createPrivateKey('current', 2, OidcSigningKeyStatus.Current));
   });
 });
 

--- a/packages/core/src/libraries/oidc-private-key.test.ts
+++ b/packages/core/src/libraries/oidc-private-key.test.ts
@@ -1,6 +1,11 @@
 import { OidcSigningKeyStatus } from '@logto/schemas';
 
-import { normalizeOidcPrivateKeys } from './oidc-private-key.js';
+import {
+  getImmediatelyRotatedOidcPrivateKeys,
+  getOidcPrivateKeysAfterDeletion,
+  getOidcProviderPrivateKeys,
+  normalizeOidcPrivateKeys,
+} from './oidc-private-key.js';
 
 const createPrivateKey = (id: string, createdAt: number, status?: OidcSigningKeyStatus) => ({
   id,
@@ -43,5 +48,52 @@ describe('normalizeOidcPrivateKeys', () => {
         createPrivateKey('current-b', 2, OidcSigningKeyStatus.Current),
       ])
     ).toThrow('Malformed OIDC private key status configuration');
+  });
+});
+
+describe('getOidcProviderPrivateKeys', () => {
+  it('orders private keys as Current, Next, Previous for oidc-provider consumption', () => {
+    const result = getOidcProviderPrivateKeys([
+      createPrivateKey('previous', 3, OidcSigningKeyStatus.Previous),
+      createPrivateKey('current', 2, OidcSigningKeyStatus.Current),
+      createPrivateKey('next', 1, OidcSigningKeyStatus.Next),
+    ]);
+
+    expect(result).toEqual([
+      createPrivateKey('current', 2, OidcSigningKeyStatus.Current),
+      createPrivateKey('next', 1, OidcSigningKeyStatus.Next),
+      createPrivateKey('previous', 3, OidcSigningKeyStatus.Previous),
+    ]);
+  });
+});
+
+describe('getImmediatelyRotatedOidcPrivateKeys', () => {
+  it('persists the new key as Current and demotes the previous Current to Previous', () => {
+    const result = getImmediatelyRotatedOidcPrivateKeys(
+      [
+        createPrivateKey('current', 2, OidcSigningKeyStatus.Current),
+        createPrivateKey('previous', 1, OidcSigningKeyStatus.Previous),
+      ],
+      createPrivateKey('new', 3)
+    );
+
+    expect(result).toEqual([
+      createPrivateKey('new', 3, OidcSigningKeyStatus.Current),
+      createPrivateKey('current', 2, OidcSigningKeyStatus.Previous),
+    ]);
+  });
+});
+
+describe('getOidcPrivateKeysAfterDeletion', () => {
+  it('promotes the remaining key to Current after deleting Previous from the immediate flow', () => {
+    const result = getOidcPrivateKeysAfterDeletion(
+      [
+        createPrivateKey('current', 2, OidcSigningKeyStatus.Current),
+        createPrivateKey('previous', 1, OidcSigningKeyStatus.Previous),
+      ],
+      'previous'
+    );
+
+    expect(result).toEqual([createPrivateKey('current', 2, OidcSigningKeyStatus.Current)]);
   });
 });

--- a/packages/core/src/libraries/oidc-private-key.test.ts
+++ b/packages/core/src/libraries/oidc-private-key.test.ts
@@ -29,20 +29,6 @@ describe('normalizeOidcPrivateKeys', () => {
     ]);
   });
 
-  it('keeps loading legacy private key arrays with more than two unstamped keys', () => {
-    const result = normalizeOidcPrivateKeys([
-      createPrivateKey('current', 1),
-      createPrivateKey('previous-a', 2),
-      createPrivateKey('previous-b', 3),
-    ]);
-
-    expect(result).toEqual([
-      createPrivateKey('current', 1, OidcSigningKeyStatus.Current),
-      createPrivateKey('previous-a', 2, OidcSigningKeyStatus.Previous),
-      createPrivateKey('previous-b', 3, OidcSigningKeyStatus.Previous),
-    ]);
-  });
-
   it('preserves explicit statuses without reordering the input array', () => {
     const result = normalizeOidcPrivateKeys([
       createPrivateKey('previous', 3, OidcSigningKeyStatus.Previous),

--- a/packages/core/src/libraries/oidc-private-key.test.ts
+++ b/packages/core/src/libraries/oidc-private-key.test.ts
@@ -1,0 +1,47 @@
+import { OidcSigningKeyStatus } from '@logto/schemas';
+
+import { normalizeOidcPrivateKeys } from './oidc-private-key.js';
+
+const createPrivateKey = (id: string, createdAt: number, status?: OidcSigningKeyStatus) => ({
+  id,
+  value: `private-key-${id}`,
+  createdAt,
+  status,
+});
+
+describe('normalizeOidcPrivateKeys', () => {
+  it('normalizes legacy private keys without status into Current and Previous', () => {
+    const result = normalizeOidcPrivateKeys([
+      createPrivateKey('current', 1),
+      createPrivateKey('previous', 2),
+    ]);
+
+    expect(result).toEqual([
+      createPrivateKey('current', 1, OidcSigningKeyStatus.Current),
+      createPrivateKey('previous', 2, OidcSigningKeyStatus.Previous),
+    ]);
+  });
+
+  it('sorts explicit statuses into Next, Current, Previous order', () => {
+    const result = normalizeOidcPrivateKeys([
+      createPrivateKey('previous', 3, OidcSigningKeyStatus.Previous),
+      createPrivateKey('current', 2, OidcSigningKeyStatus.Current),
+      createPrivateKey('next', 1, OidcSigningKeyStatus.Next),
+    ]);
+
+    expect(result).toEqual([
+      createPrivateKey('next', 1, OidcSigningKeyStatus.Next),
+      createPrivateKey('current', 2, OidcSigningKeyStatus.Current),
+      createPrivateKey('previous', 3, OidcSigningKeyStatus.Previous),
+    ]);
+  });
+
+  it('throws for malformed status configurations', () => {
+    expect(() =>
+      normalizeOidcPrivateKeys([
+        createPrivateKey('current-a', 1, OidcSigningKeyStatus.Current),
+        createPrivateKey('current-b', 2, OidcSigningKeyStatus.Current),
+      ])
+    ).toThrow('Malformed OIDC private key status configuration');
+  });
+});

--- a/packages/core/src/libraries/oidc-private-key.ts
+++ b/packages/core/src/libraries/oidc-private-key.ts
@@ -1,6 +1,10 @@
 import type { LogtoOidcConfigType, OidcPrivateKey } from '@logto/schemas';
 import { OidcSigningKeyStatus } from '@logto/schemas';
 
+type NormalizedOidcPrivateKey = OidcPrivateKey & {
+  status: OidcSigningKeyStatus;
+};
+
 const oidcPrivateKeyStatusOrder: Record<OidcSigningKeyStatus, number> = {
   [OidcSigningKeyStatus.Next]: 0,
   [OidcSigningKeyStatus.Current]: 1,
@@ -13,12 +17,18 @@ const oidcProviderPrivateKeyOrder: Record<OidcSigningKeyStatus, number> = {
   [OidcSigningKeyStatus.Previous]: 2,
 };
 
+const sortOidcPrivateKeys = (
+  privateKeys: NormalizedOidcPrivateKey[],
+  order: Record<OidcSigningKeyStatus, number>
+): NormalizedOidcPrivateKey[] =>
+  privateKeys.toSorted((left, right) => order[left.status] - order[right.status]);
+
 /**
  * Normalize private signing keys from legacy index-based lifecycle semantics into explicit statuses.
  */
 export const normalizeOidcPrivateKeys = (
   privateKeys: LogtoOidcConfigType['oidc.privateKeys']
-): OidcPrivateKey[] => {
+): NormalizedOidcPrivateKey[] => {
   const normalizedPrivateKeys = privateKeys.map((privateKey, index) => ({
     ...privateKey,
     status:
@@ -42,23 +52,41 @@ export const normalizeOidcPrivateKeys = (
     );
   }
 
-  return normalizedPrivateKeys.toSorted(
-    (left, right) =>
-      oidcPrivateKeyStatusOrder[left.status] - oidcPrivateKeyStatusOrder[right.status]
-  );
+  return normalizedPrivateKeys;
 };
 
 /**
- * Order private signing keys the way oidc-provider should consume them for signing and publication.
+ * Order private signing keys in the canonical business-state order.
+ */
+export const getCanonicalOidcPrivateKeys = (
+  privateKeys: LogtoOidcConfigType['oidc.privateKeys']
+): OidcPrivateKey[] =>
+  sortOidcPrivateKeys(normalizeOidcPrivateKeys(privateKeys), oidcPrivateKeyStatusOrder);
+
+/**
+ * Get the effective current signing key from normalized private key state.
+ */
+export const getCurrentOidcPrivateKey = (
+  privateKeys: LogtoOidcConfigType['oidc.privateKeys']
+): OidcPrivateKey => {
+  const currentKey = normalizeOidcPrivateKeys(privateKeys).find(
+    ({ status }) => status === OidcSigningKeyStatus.Current
+  );
+
+  if (!currentKey) {
+    throw new Error('Malformed OIDC private key status configuration: missing Current key.');
+  }
+
+  return currentKey;
+};
+
+/**
+ * Order private signing keys the way oidc-provider should consume them.
  */
 export const getOidcProviderPrivateKeys = (
   privateKeys: LogtoOidcConfigType['oidc.privateKeys']
 ): OidcPrivateKey[] =>
-  normalizeOidcPrivateKeys(privateKeys).toSorted(
-    (left, right) =>
-      oidcProviderPrivateKeyOrder[left.status ?? OidcSigningKeyStatus.Previous] -
-      oidcProviderPrivateKeyOrder[right.status ?? OidcSigningKeyStatus.Previous]
-  );
+  sortOidcPrivateKeys(normalizeOidcPrivateKeys(privateKeys), oidcProviderPrivateKeyOrder);
 
 /**
  * Build the persisted private-key state for the current immediate-rotation flow.
@@ -67,14 +95,11 @@ export const getImmediatelyRotatedOidcPrivateKeys = (
   privateKeys: LogtoOidcConfigType['oidc.privateKeys'],
   newPrivateKey: OidcPrivateKey
 ): OidcPrivateKey[] => {
-  const normalizedPrivateKeys = normalizeOidcPrivateKeys(privateKeys);
-  const currentKey = normalizedPrivateKeys.find(
-    ({ status }) => status === OidcSigningKeyStatus.Current
-  );
+  const currentKey = getCurrentOidcPrivateKey(privateKeys);
 
   return [
     { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
-    ...(currentKey ? [{ ...currentKey, status: OidcSigningKeyStatus.Previous }] : []),
+    { ...currentKey, status: OidcSigningKeyStatus.Previous },
   ];
 };
 
@@ -85,7 +110,7 @@ export const getOidcPrivateKeysAfterDeletion = (
   privateKeys: LogtoOidcConfigType['oidc.privateKeys'],
   deletedKeyId: string
 ): OidcPrivateKey[] =>
-  normalizeOidcPrivateKeys(privateKeys)
+  getCanonicalOidcPrivateKeys(privateKeys)
     .filter(({ id }) => id !== deletedKeyId)
     .map((privateKey, index) => ({
       ...privateKey,

--- a/packages/core/src/libraries/oidc-private-key.ts
+++ b/packages/core/src/libraries/oidc-private-key.ts
@@ -1,0 +1,43 @@
+import type { LogtoOidcConfigType, OidcPrivateKey } from '@logto/schemas';
+import { OidcSigningKeyStatus } from '@logto/schemas';
+
+const oidcPrivateKeyStatusOrder: Record<OidcSigningKeyStatus, number> = {
+  [OidcSigningKeyStatus.Next]: 0,
+  [OidcSigningKeyStatus.Current]: 1,
+  [OidcSigningKeyStatus.Previous]: 2,
+};
+
+/**
+ * Normalize private signing keys from legacy index-based lifecycle semantics into explicit statuses.
+ */
+export const normalizeOidcPrivateKeys = (
+  privateKeys: LogtoOidcConfigType['oidc.privateKeys']
+): OidcPrivateKey[] => {
+  const normalizedPrivateKeys = privateKeys.map((privateKey, index) => ({
+    ...privateKey,
+    status:
+      privateKey.status ??
+      (index === 0 ? OidcSigningKeyStatus.Current : OidcSigningKeyStatus.Previous),
+  }));
+
+  const currentKeys = normalizedPrivateKeys.filter(
+    ({ status }) => status === OidcSigningKeyStatus.Current
+  );
+  const nextKeys = normalizedPrivateKeys.filter(
+    ({ status }) => status === OidcSigningKeyStatus.Next
+  );
+  const previousKeys = normalizedPrivateKeys.filter(
+    ({ status }) => status === OidcSigningKeyStatus.Previous
+  );
+
+  if (currentKeys.length !== 1 || nextKeys.length > 1 || previousKeys.length > 1) {
+    throw new Error(
+      'Malformed OIDC private key status configuration: expected exactly one Current key and at most one Next and Previous key.'
+    );
+  }
+
+  return normalizedPrivateKeys.toSorted(
+    (left, right) =>
+      oidcPrivateKeyStatusOrder[left.status] - oidcPrivateKeyStatusOrder[right.status]
+  );
+};

--- a/packages/core/src/libraries/oidc-private-key.ts
+++ b/packages/core/src/libraries/oidc-private-key.ts
@@ -7,6 +7,12 @@ const oidcPrivateKeyStatusOrder: Record<OidcSigningKeyStatus, number> = {
   [OidcSigningKeyStatus.Previous]: 2,
 };
 
+const oidcProviderPrivateKeyOrder: Record<OidcSigningKeyStatus, number> = {
+  [OidcSigningKeyStatus.Current]: 0,
+  [OidcSigningKeyStatus.Next]: 1,
+  [OidcSigningKeyStatus.Previous]: 2,
+};
+
 /**
  * Normalize private signing keys from legacy index-based lifecycle semantics into explicit statuses.
  */
@@ -41,3 +47,47 @@ export const normalizeOidcPrivateKeys = (
       oidcPrivateKeyStatusOrder[left.status] - oidcPrivateKeyStatusOrder[right.status]
   );
 };
+
+/**
+ * Order private signing keys the way oidc-provider should consume them for signing and publication.
+ */
+export const getOidcProviderPrivateKeys = (
+  privateKeys: LogtoOidcConfigType['oidc.privateKeys']
+): OidcPrivateKey[] =>
+  normalizeOidcPrivateKeys(privateKeys).toSorted(
+    (left, right) =>
+      oidcProviderPrivateKeyOrder[left.status ?? OidcSigningKeyStatus.Previous] -
+      oidcProviderPrivateKeyOrder[right.status ?? OidcSigningKeyStatus.Previous]
+  );
+
+/**
+ * Build the persisted private-key state for the current immediate-rotation flow.
+ */
+export const getImmediatelyRotatedOidcPrivateKeys = (
+  privateKeys: LogtoOidcConfigType['oidc.privateKeys'],
+  newPrivateKey: OidcPrivateKey
+): OidcPrivateKey[] => {
+  const normalizedPrivateKeys = normalizeOidcPrivateKeys(privateKeys);
+  const currentKey = normalizedPrivateKeys.find(
+    ({ status }) => status === OidcSigningKeyStatus.Current
+  );
+
+  return [
+    { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
+    ...(currentKey ? [{ ...currentKey, status: OidcSigningKeyStatus.Previous }] : []),
+  ];
+};
+
+/**
+ * Rebuild the immediate-flow persisted private-key state after deleting a Previous key.
+ */
+export const getOidcPrivateKeysAfterDeletion = (
+  privateKeys: LogtoOidcConfigType['oidc.privateKeys'],
+  deletedKeyId: string
+): OidcPrivateKey[] =>
+  normalizeOidcPrivateKeys(privateKeys)
+    .filter(({ id }) => id !== deletedKeyId)
+    .map((privateKey, index) => ({
+      ...privateKey,
+      status: index === 0 ? OidcSigningKeyStatus.Current : OidcSigningKeyStatus.Previous,
+    }));

--- a/packages/core/src/libraries/oidc-private-key.ts
+++ b/packages/core/src/libraries/oidc-private-key.ts
@@ -46,9 +46,9 @@ export const normalizeOidcPrivateKeys = (
     ({ status }) => status === OidcSigningKeyStatus.Previous
   );
 
-  if (currentKeys.length !== 1 || nextKeys.length > 1) {
+  if (currentKeys.length !== 1 || nextKeys.length > 1 || previousKeys.length > 1) {
     throw new Error(
-      'Malformed OIDC private key status configuration: expected exactly one Current key and at most one Next key.'
+      'Malformed OIDC private key status configuration: expected exactly one Current key and at most one Next and Previous key.'
     );
   }
 

--- a/packages/core/src/libraries/oidc-private-key.ts
+++ b/packages/core/src/libraries/oidc-private-key.ts
@@ -1,6 +1,10 @@
 import type { LogtoOidcConfigType, OidcPrivateKey } from '@logto/schemas';
 import { OidcSigningKeyStatus } from '@logto/schemas';
 
+import RequestError from '#src/errors/RequestError/index.js';
+import { createLogtoConfigQueries } from '#src/queries/logto-config.js';
+import type Queries from '#src/tenants/Queries.js';
+
 type NormalizedOidcPrivateKey = OidcPrivateKey & {
   status: OidcSigningKeyStatus;
 };
@@ -111,3 +115,62 @@ export const getOidcPrivateKeysAfterDeletion = (
   deletedKeyId: string
 ): OidcPrivateKey[] =>
   getCanonicalOidcPrivateKeys(privateKeys).filter(({ id }) => id !== deletedKeyId);
+
+export class OidcPrivateKeyLibrary {
+  constructor(private readonly queries: Queries) {}
+
+  async deletePrivateSigningKey(keyId: string): Promise<OidcPrivateKey[]> {
+    return this.queries.pool.transaction(async (connection) => {
+      const logtoConfigQueries = createLogtoConfigQueries(connection, this.queries.wellKnownCache);
+
+      await logtoConfigQueries.lockPrivateSigningKeys();
+
+      const privateKeys = normalizeOidcPrivateKeys(
+        await logtoConfigQueries.getPrivateSigningKeys()
+      );
+
+      if (privateKeys.length <= 1) {
+        throw new RequestError({ code: 'oidc.key_required', status: 422 });
+      }
+
+      const deletingKey = privateKeys.find(({ id }) => id === keyId);
+
+      if (!deletingKey) {
+        throw new RequestError({ code: 'oidc.key_not_found', id: keyId, status: 404 });
+      }
+
+      if (deletingKey.status !== OidcSigningKeyStatus.Previous) {
+        throw new RequestError({
+          code: 'oidc.only_previous_key_can_be_deleted',
+          status: 422,
+        });
+      }
+
+      const updatedPrivateKeys = getOidcPrivateKeysAfterDeletion(privateKeys, keyId);
+      await logtoConfigQueries.upsertPrivateSigningKeys(updatedPrivateKeys);
+
+      return updatedPrivateKeys;
+    });
+  }
+
+  async rotatePrivateSigningKeys(newPrivateKey: OidcPrivateKey): Promise<OidcPrivateKey[]> {
+    return this.queries.pool.transaction(async (connection) => {
+      const logtoConfigQueries = createLogtoConfigQueries(connection, this.queries.wellKnownCache);
+
+      await logtoConfigQueries.lockPrivateSigningKeys();
+
+      const privateKeys = normalizeOidcPrivateKeys(
+        await logtoConfigQueries.getPrivateSigningKeys()
+      );
+
+      if (privateKeys.some(({ status }) => status === OidcSigningKeyStatus.Next)) {
+        throw new RequestError({ code: 'oidc.invalid_request', status: 422 });
+      }
+
+      const updatedPrivateKeys = getImmediatelyRotatedOidcPrivateKeys(privateKeys, newPrivateKey);
+      await logtoConfigQueries.upsertPrivateSigningKeys(updatedPrivateKeys);
+
+      return updatedPrivateKeys;
+    });
+  }
+}

--- a/packages/core/src/libraries/oidc-private-key.ts
+++ b/packages/core/src/libraries/oidc-private-key.ts
@@ -46,9 +46,9 @@ export const normalizeOidcPrivateKeys = (
     ({ status }) => status === OidcSigningKeyStatus.Previous
   );
 
-  if (currentKeys.length !== 1 || nextKeys.length > 1 || previousKeys.length > 1) {
+  if (currentKeys.length !== 1 || nextKeys.length > 1) {
     throw new Error(
-      'Malformed OIDC private key status configuration: expected exactly one Current key and at most one Next and Previous key.'
+      'Malformed OIDC private key status configuration: expected exactly one Current key and at most one Next key.'
     );
   }
 
@@ -110,9 +110,4 @@ export const getOidcPrivateKeysAfterDeletion = (
   privateKeys: LogtoOidcConfigType['oidc.privateKeys'],
   deletedKeyId: string
 ): OidcPrivateKey[] =>
-  getCanonicalOidcPrivateKeys(privateKeys)
-    .filter(({ id }) => id !== deletedKeyId)
-    .map((privateKey, index) => ({
-      ...privateKey,
-      status: index === 0 ? OidcSigningKeyStatus.Current : OidcSigningKeyStatus.Previous,
-    }));
+  getCanonicalOidcPrivateKeys(privateKeys).filter(({ id }) => id !== deletedKeyId);

--- a/packages/core/src/queries/logto-config.test.ts
+++ b/packages/core/src/queries/logto-config.test.ts
@@ -3,9 +3,11 @@ import {
   LogtoConfigs,
   LogtoOidcConfigKey,
   LogtoTenantConfigKey,
+  OidcSigningKeyStatus,
 } from '@logto/schemas';
 import { createMockPool, createMockQueryResult, sql } from '@silverhand/slonik';
 
+import { createMockCommonQueryMethods, expectSqlString } from '#src/test-utils/query.js';
 import { MockWellKnownCache } from '#src/test-utils/tenant.js';
 import { convertToIdentifiers } from '#src/utils/sql.js';
 import { expectSqlAssert, type QueryType } from '#src/utils/test-utils.js';
@@ -26,8 +28,11 @@ const {
   getAdminConsoleConfig,
   getCloudConnectionData,
   getRowsByKeys,
+  getSigningKeyRotationState,
+  upsertSigningKeyRotationState,
   updateAdminConsoleConfig,
   updateOidcConfigsByKey,
+  updatePrivateSigningKeysAndRotationState,
 } = createLogtoConfigQueries(pool, new MockWellKnownCache());
 
 describe('connector queries', () => {
@@ -145,5 +150,99 @@ describe('connector queries', () => {
     });
 
     void updateOidcConfigsByKey(LogtoOidcConfigKey.PrivateKeys, targetValue);
+  });
+
+  test('getSigningKeyRotationState', async () => {
+    const rowData = [
+      {
+        key: LogtoTenantConfigKey.SigningKeyRotationState,
+        value: { signingKeyRotationAt: 123_456_789 },
+      },
+    ];
+    const expectSql = sql`
+      select ${sql.join([fields.key, fields.value], sql`,`)} from ${table}
+        where ${fields.key} in (${sql.join([LogtoTenantConfigKey.SigningKeyRotationState], sql`,`)})
+    `;
+
+    mockQuery.mockImplementationOnce(async (sql, values) => {
+      expectSqlAssert(sql, expectSql.sql);
+      expect(values).toEqual([LogtoTenantConfigKey.SigningKeyRotationState]);
+
+      return createMockQueryResult(rowData as never);
+    });
+
+    const result = await getSigningKeyRotationState();
+    expect(result).toEqual({ signingKeyRotationAt: 123_456_789 });
+  });
+
+  test('upsertSigningKeyRotationState', async () => {
+    const targetValue = { tenantCacheExpiresAt: 123_456_789 };
+    const targetRowData = { value: targetValue };
+    const expectSql = sql`
+      insert into ${table} (${fields.key}, ${fields.value})
+        values (${LogtoTenantConfigKey.SigningKeyRotationState}, ${sql.jsonb(targetValue)})
+        on conflict (${fields.tenantId}, ${fields.key}) do update
+        set ${fields.value} = coalesce(${table}.${fields.value}, '{}'::jsonb) || ${sql.jsonb(
+          targetValue
+        )}
+        returning ${fields.value}
+    `;
+
+    mockQuery.mockImplementationOnce(async (sql, values) => {
+      expectSqlAssert(sql, expectSql.sql);
+      expect(values).toMatchObject([
+        LogtoTenantConfigKey.SigningKeyRotationState,
+        JSON.stringify(targetValue),
+        JSON.stringify(targetValue),
+      ]);
+
+      return createMockQueryResult([targetRowData] as never);
+    });
+
+    const result = await upsertSigningKeyRotationState(targetValue);
+    expect(result).toEqual(targetValue);
+  });
+});
+
+describe('logto config transactional queries', () => {
+  const methods = createMockCommonQueryMethods();
+  const transactionalQueries = createLogtoConfigQueries(methods as never, new MockWellKnownCache());
+
+  test('updatePrivateSigningKeysAndRotationState', async () => {
+    const privateKeys = [
+      {
+        id: 'foo',
+        value: 'bar',
+        createdAt: 123_456_789,
+        status: OidcSigningKeyStatus.Next,
+      },
+    ];
+    const rotationState = { tenantCacheExpiresAt: 222_222_222 };
+
+    methods.transaction.mockImplementation(
+      async (handler: (transaction: typeof methods) => Promise<unknown>) => handler(methods)
+    );
+    methods.query.mockResolvedValueOnce({ rows: [] });
+    methods.one
+      .mockResolvedValueOnce({
+        key: LogtoOidcConfigKey.PrivateKeys,
+        value: privateKeys,
+      })
+      .mockResolvedValueOnce({
+        value: rotationState,
+      });
+
+    const result = await transactionalQueries.updatePrivateSigningKeysAndRotationState(
+      privateKeys,
+      rotationState
+    );
+
+    expect(methods.transaction).toHaveBeenCalledTimes(1);
+    expect(methods.query).toHaveBeenCalledWith(expectSqlString('for update'));
+    expect(methods.one).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({
+      privateKeys,
+      signingKeyRotationState: rotationState,
+    });
   });
 });

--- a/packages/core/src/queries/logto-config.test.ts
+++ b/packages/core/src/queries/logto-config.test.ts
@@ -27,7 +27,6 @@ const { createLogtoConfigQueries } = await import('./logto-config.js');
 const {
   getAdminConsoleConfig,
   getCloudConnectionData,
-  getPrivateSigningKeys,
   getRowsByKeys,
   updateAdminConsoleConfig,
   updatePrivateSigningKeys,
@@ -156,42 +155,6 @@ describe('connector queries', () => {
     });
 
     void updatePrivateSigningKeys(targetValue);
-  });
-
-  test('getPrivateSigningKeys', async () => {
-    const rowData = [
-      {
-        key: LogtoOidcConfigKey.PrivateKeys,
-        value: [
-          {
-            id: 'foo',
-            value: 'bar',
-            createdAt: 123_456_789,
-          },
-        ],
-      },
-    ];
-    const expectSql = sql`
-      select ${sql.join([fields.key, fields.value], sql`,`)} from ${table}
-        where ${fields.key} in (${sql.join([LogtoOidcConfigKey.PrivateKeys], sql`,`)})
-    `;
-
-    mockQuery.mockImplementationOnce(async (sql, values) => {
-      expectSqlAssert(sql, expectSql.sql);
-      expect(values).toEqual([LogtoOidcConfigKey.PrivateKeys]);
-
-      return createMockQueryResult(rowData as never);
-    });
-
-    const result = await getPrivateSigningKeys();
-    expect(result).toEqual([
-      {
-        id: 'foo',
-        value: 'bar',
-        createdAt: 123_456_789,
-        status: OidcSigningKeyStatus.Current,
-      },
-    ]);
   });
 
   test('updateOidcConfigsByKey', async () => {

--- a/packages/core/src/queries/logto-config.test.ts
+++ b/packages/core/src/queries/logto-config.test.ts
@@ -31,6 +31,7 @@ const {
   getSigningKeyRotationState,
   upsertSigningKeyRotationState,
   updateAdminConsoleConfig,
+  updatePrivateSigningKeys,
   updateOidcConfigsByKey,
   updatePrivateSigningKeysAndRotationState,
 } = createLogtoConfigQueries(pool, new MockWellKnownCache());
@@ -123,8 +124,15 @@ describe('connector queries', () => {
     expect(result.rows).toEqual(rowData);
   });
 
-  test('updateOidcConfigsByKey', async () => {
-    const targetValue = [{ id: 'foo', value: 'bar', createdAt: 123_456_789 }];
+  test('updatePrivateSigningKeys', async () => {
+    const targetValue = [
+      {
+        id: 'foo',
+        value: 'bar',
+        createdAt: 123_456_789,
+        status: OidcSigningKeyStatus.Current,
+      },
+    ];
     const targetRowData = [
       { key: LogtoOidcConfigKey.PrivateKeys, value: JSON.stringify(targetValue) },
     ];
@@ -135,7 +143,7 @@ describe('connector queries', () => {
         on conflict (${fields.tenantId}, ${fields.key}) do update set ${fields.value} = ${sql.jsonb(
           targetValue
         )}
-        returning *
+        returning ${fields.key}, ${fields.value}
     `;
 
     mockQuery.mockImplementationOnce(async (sql, values) => {
@@ -149,7 +157,34 @@ describe('connector queries', () => {
       return createMockQueryResult(targetRowData);
     });
 
-    void updateOidcConfigsByKey(LogtoOidcConfigKey.PrivateKeys, targetValue);
+    void updatePrivateSigningKeys(targetValue);
+  });
+
+  test('updateOidcConfigsByKey', async () => {
+    const targetValue = { ttl: 123_456_789 };
+    const targetRowData = [{ key: LogtoOidcConfigKey.Session, value: JSON.stringify(targetValue) }];
+
+    const expectSql = sql`
+      insert into ${table} (${fields.key}, ${fields.value})
+        values (${LogtoOidcConfigKey.Session}, ${sql.jsonb(targetValue)})
+        on conflict (${fields.tenantId}, ${fields.key}) do update set ${fields.value} = ${sql.jsonb(
+          targetValue
+        )}
+        returning *
+    `;
+
+    mockQuery.mockImplementationOnce(async (sql, values) => {
+      expectSqlAssert(sql, expectSql.sql);
+      expect(values).toMatchObject([
+        LogtoOidcConfigKey.Session,
+        JSON.stringify(targetValue),
+        JSON.stringify(targetValue),
+      ]);
+
+      return createMockQueryResult(targetRowData);
+    });
+
+    void updateOidcConfigsByKey(LogtoOidcConfigKey.Session, targetValue);
   });
 
   test('getSigningKeyRotationState', async () => {

--- a/packages/core/src/queries/logto-config.test.ts
+++ b/packages/core/src/queries/logto-config.test.ts
@@ -29,7 +29,6 @@ const {
   getCloudConnectionData,
   getRowsByKeys,
   updateAdminConsoleConfig,
-  updatePrivateSigningKeys,
   updateOidcConfigsByKey,
 } = createLogtoConfigQueries(pool, new MockWellKnownCache());
 
@@ -119,42 +118,6 @@ describe('connector queries', () => {
 
     const result = await getRowsByKeys(keys);
     expect(result.rows).toEqual(rowData);
-  });
-
-  test('updatePrivateSigningKeys', async () => {
-    const targetValue = [
-      {
-        id: 'foo',
-        value: 'bar',
-        createdAt: 123_456_789,
-        status: OidcSigningKeyStatus.Current,
-      },
-    ];
-    const targetRowData = [
-      { key: LogtoOidcConfigKey.PrivateKeys, value: JSON.stringify(targetValue) },
-    ];
-
-    const expectSql = sql`
-      insert into ${table} (${fields.key}, ${fields.value})
-        values (${LogtoOidcConfigKey.PrivateKeys}, ${sql.jsonb(targetValue)})
-        on conflict (${fields.tenantId}, ${fields.key}) do update set ${fields.value} = ${sql.jsonb(
-          targetValue
-        )}
-        returning ${fields.key}, ${fields.value}
-    `;
-
-    mockQuery.mockImplementationOnce(async (sql, values) => {
-      expectSqlAssert(sql, expectSql.sql);
-      expect(values).toMatchObject([
-        LogtoOidcConfigKey.PrivateKeys,
-        JSON.stringify(targetValue),
-        JSON.stringify(targetValue),
-      ]);
-
-      return createMockQueryResult(targetRowData);
-    });
-
-    void updatePrivateSigningKeys(targetValue);
   });
 
   test('updateOidcConfigsByKey', async () => {

--- a/packages/core/src/queries/logto-config.test.ts
+++ b/packages/core/src/queries/logto-config.test.ts
@@ -28,6 +28,9 @@ const {
   getAdminConsoleConfig,
   getCloudConnectionData,
   getRowsByKeys,
+  getPrivateSigningKeys,
+  lockPrivateSigningKeys,
+  upsertPrivateSigningKeys,
   updateAdminConsoleConfig,
   updateOidcConfigsByKey,
 } = createLogtoConfigQueries(pool, new MockWellKnownCache());
@@ -156,7 +159,14 @@ describe('logto config transactional queries', () => {
     jest.clearAllMocks();
   });
 
-  test('updatePrivateSigningKeysWithLock', async () => {
+  test('lockPrivateSigningKeys', async () => {
+    await transactionalQueries.lockPrivateSigningKeys();
+
+    expect(methods.query).toHaveBeenCalledTimes(1);
+    expect(methods.query).toHaveBeenCalledWith(expectSqlString('for update'));
+  });
+
+  test('getPrivateSigningKeys', async () => {
     const currentPrivateKeys = [
       {
         id: 'current',
@@ -165,6 +175,18 @@ describe('logto config transactional queries', () => {
         status: OidcSigningKeyStatus.Current,
       },
     ];
+
+    methods.query.mockResolvedValueOnce({
+      rows: [{ key: LogtoOidcConfigKey.PrivateKeys, value: currentPrivateKeys }],
+    } as never);
+
+    const result = await transactionalQueries.getPrivateSigningKeys();
+
+    expect(methods.query).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(currentPrivateKeys);
+  });
+
+  test('upsertPrivateSigningKeys', async () => {
     const updatedPrivateKeys = [
       {
         id: 'next-current',
@@ -180,24 +202,13 @@ describe('logto config transactional queries', () => {
       },
     ];
 
-    methods.transaction.mockImplementation(
-      async (handler: (transaction: typeof methods) => Promise<unknown>) => handler(methods)
-    );
-    methods.query.mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({
-      rows: [{ key: LogtoOidcConfigKey.PrivateKeys, value: currentPrivateKeys }],
-    } as never);
     methods.one.mockResolvedValueOnce({
       key: LogtoOidcConfigKey.PrivateKeys,
       value: updatedPrivateKeys,
     });
 
-    const result = await transactionalQueries.updatePrivateSigningKeysWithLock(
-      () => updatedPrivateKeys
-    );
+    await transactionalQueries.upsertPrivateSigningKeys(updatedPrivateKeys);
 
-    expect(methods.transaction).toHaveBeenCalledTimes(1);
-    expect(methods.query).toHaveBeenNthCalledWith(1, expectSqlString('for update'));
     expect(methods.one).toHaveBeenCalledTimes(1);
-    expect(result).toEqual(updatedPrivateKeys);
   });
 });

--- a/packages/core/src/queries/logto-config.test.ts
+++ b/packages/core/src/queries/logto-config.test.ts
@@ -29,8 +29,6 @@ const {
   getCloudConnectionData,
   getPrivateSigningKeys,
   getRowsByKeys,
-  getSigningKeyRotationState,
-  upsertSigningKeyRotationState,
   updateAdminConsoleConfig,
   updatePrivateSigningKeys,
   updateOidcConfigsByKey,
@@ -222,57 +220,6 @@ describe('connector queries', () => {
 
     void updateOidcConfigsByKey(LogtoOidcConfigKey.Session, targetValue);
   });
-
-  test('getSigningKeyRotationState', async () => {
-    const rowData = [
-      {
-        key: LogtoTenantConfigKey.SigningKeyRotationState,
-        value: { signingKeyRotationAt: 123_456_789 },
-      },
-    ];
-    const expectSql = sql`
-      select ${sql.join([fields.key, fields.value], sql`,`)} from ${table}
-        where ${fields.key} in (${sql.join([LogtoTenantConfigKey.SigningKeyRotationState], sql`,`)})
-    `;
-
-    mockQuery.mockImplementationOnce(async (sql, values) => {
-      expectSqlAssert(sql, expectSql.sql);
-      expect(values).toEqual([LogtoTenantConfigKey.SigningKeyRotationState]);
-
-      return createMockQueryResult(rowData as never);
-    });
-
-    const result = await getSigningKeyRotationState();
-    expect(result).toEqual({ signingKeyRotationAt: 123_456_789 });
-  });
-
-  test('upsertSigningKeyRotationState', async () => {
-    const targetValue = { tenantCacheExpiresAt: 123_456_789 };
-    const targetRowData = { value: targetValue };
-    const expectSql = sql`
-      insert into ${table} (${fields.key}, ${fields.value})
-        values (${LogtoTenantConfigKey.SigningKeyRotationState}, ${sql.jsonb(targetValue)})
-        on conflict (${fields.tenantId}, ${fields.key}) do update
-        set ${fields.value} = coalesce(${table}.${fields.value}, '{}'::jsonb) || ${sql.jsonb(
-          targetValue
-        )}
-        returning ${fields.value}
-    `;
-
-    mockQuery.mockImplementationOnce(async (sql, values) => {
-      expectSqlAssert(sql, expectSql.sql);
-      expect(values).toMatchObject([
-        LogtoTenantConfigKey.SigningKeyRotationState,
-        JSON.stringify(targetValue),
-        JSON.stringify(targetValue),
-      ]);
-
-      return createMockQueryResult([targetRowData] as never);
-    });
-
-    const result = await upsertSigningKeyRotationState(targetValue);
-    expect(result).toEqual(targetValue);
-  });
 });
 
 describe('logto config transactional queries', () => {
@@ -281,44 +228,6 @@ describe('logto config transactional queries', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-  });
-
-  test('updatePrivateSigningKeysAndRotationState', async () => {
-    const privateKeys = [
-      {
-        id: 'foo',
-        value: 'bar',
-        createdAt: 123_456_789,
-        status: OidcSigningKeyStatus.Next,
-      },
-    ];
-    const rotationState = { tenantCacheExpiresAt: 222_222_222 };
-
-    methods.transaction.mockImplementation(
-      async (handler: (transaction: typeof methods) => Promise<unknown>) => handler(methods)
-    );
-    methods.query.mockResolvedValueOnce({ rows: [] });
-    methods.one
-      .mockResolvedValueOnce({
-        key: LogtoOidcConfigKey.PrivateKeys,
-        value: privateKeys,
-      })
-      .mockResolvedValueOnce({
-        value: rotationState,
-      });
-
-    const result = await transactionalQueries.updatePrivateSigningKeysAndRotationState(
-      privateKeys,
-      rotationState
-    );
-
-    expect(methods.transaction).toHaveBeenCalledTimes(1);
-    expect(methods.query).toHaveBeenCalledWith(expectSqlString('for update'));
-    expect(methods.one).toHaveBeenCalledTimes(2);
-    expect(result).toEqual({
-      privateKeys,
-      signingKeyRotationState: rotationState,
-    });
   });
 
   test('updatePrivateSigningKeysWithLock', async () => {

--- a/packages/core/src/queries/logto-config.test.ts
+++ b/packages/core/src/queries/logto-config.test.ts
@@ -33,9 +33,7 @@ const {
   upsertSigningKeyRotationState,
   updateAdminConsoleConfig,
   updatePrivateSigningKeys,
-  updatePrivateSigningKeysWithLock,
   updateOidcConfigsByKey,
-  updatePrivateSigningKeysAndRotationState,
 } = createLogtoConfigQueries(pool, new MockWellKnownCache());
 
 describe('connector queries', () => {

--- a/packages/core/src/queries/logto-config.test.ts
+++ b/packages/core/src/queries/logto-config.test.ts
@@ -27,11 +27,13 @@ const { createLogtoConfigQueries } = await import('./logto-config.js');
 const {
   getAdminConsoleConfig,
   getCloudConnectionData,
+  getPrivateSigningKeys,
   getRowsByKeys,
   getSigningKeyRotationState,
   upsertSigningKeyRotationState,
   updateAdminConsoleConfig,
   updatePrivateSigningKeys,
+  updatePrivateSigningKeysWithLock,
   updateOidcConfigsByKey,
   updatePrivateSigningKeysAndRotationState,
 } = createLogtoConfigQueries(pool, new MockWellKnownCache());
@@ -160,6 +162,42 @@ describe('connector queries', () => {
     void updatePrivateSigningKeys(targetValue);
   });
 
+  test('getPrivateSigningKeys', async () => {
+    const rowData = [
+      {
+        key: LogtoOidcConfigKey.PrivateKeys,
+        value: [
+          {
+            id: 'foo',
+            value: 'bar',
+            createdAt: 123_456_789,
+          },
+        ],
+      },
+    ];
+    const expectSql = sql`
+      select ${sql.join([fields.key, fields.value], sql`,`)} from ${table}
+        where ${fields.key} in (${sql.join([LogtoOidcConfigKey.PrivateKeys], sql`,`)})
+    `;
+
+    mockQuery.mockImplementationOnce(async (sql, values) => {
+      expectSqlAssert(sql, expectSql.sql);
+      expect(values).toEqual([LogtoOidcConfigKey.PrivateKeys]);
+
+      return createMockQueryResult(rowData as never);
+    });
+
+    const result = await getPrivateSigningKeys();
+    expect(result).toEqual([
+      {
+        id: 'foo',
+        value: 'bar',
+        createdAt: 123_456_789,
+        status: OidcSigningKeyStatus.Current,
+      },
+    ]);
+  });
+
   test('updateOidcConfigsByKey', async () => {
     const targetValue = { ttl: 123_456_789 };
     const targetRowData = [{ key: LogtoOidcConfigKey.Session, value: JSON.stringify(targetValue) }];
@@ -243,6 +281,10 @@ describe('logto config transactional queries', () => {
   const methods = createMockCommonQueryMethods();
   const transactionalQueries = createLogtoConfigQueries(methods as never, new MockWellKnownCache());
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   test('updatePrivateSigningKeysAndRotationState', async () => {
     const privateKeys = [
       {
@@ -279,5 +321,50 @@ describe('logto config transactional queries', () => {
       privateKeys,
       signingKeyRotationState: rotationState,
     });
+  });
+
+  test('updatePrivateSigningKeysWithLock', async () => {
+    const currentPrivateKeys = [
+      {
+        id: 'current',
+        value: 'current-value',
+        createdAt: 123_456_789,
+        status: OidcSigningKeyStatus.Current,
+      },
+    ];
+    const updatedPrivateKeys = [
+      {
+        id: 'next-current',
+        value: 'next-value',
+        createdAt: 222_222_222,
+        status: OidcSigningKeyStatus.Current,
+      },
+      {
+        id: 'current',
+        value: 'current-value',
+        createdAt: 123_456_789,
+        status: OidcSigningKeyStatus.Previous,
+      },
+    ];
+
+    methods.transaction.mockImplementation(
+      async (handler: (transaction: typeof methods) => Promise<unknown>) => handler(methods)
+    );
+    methods.query.mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({
+      rows: [{ key: LogtoOidcConfigKey.PrivateKeys, value: currentPrivateKeys }],
+    } as never);
+    methods.one.mockResolvedValueOnce({
+      key: LogtoOidcConfigKey.PrivateKeys,
+      value: updatedPrivateKeys,
+    });
+
+    const result = await transactionalQueries.updatePrivateSigningKeysWithLock(
+      () => updatedPrivateKeys
+    );
+
+    expect(methods.transaction).toHaveBeenCalledTimes(1);
+    expect(methods.query).toHaveBeenNthCalledWith(1, expectSqlString('for update'));
+    expect(methods.one).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(updatedPrivateKeys);
   });
 });

--- a/packages/core/src/queries/logto-config.test.ts
+++ b/packages/core/src/queries/logto-config.test.ts
@@ -28,9 +28,6 @@ const {
   getAdminConsoleConfig,
   getCloudConnectionData,
   getRowsByKeys,
-  getPrivateSigningKeys,
-  lockPrivateSigningKeys,
-  upsertPrivateSigningKeys,
   updateAdminConsoleConfig,
   updateOidcConfigsByKey,
 } = createLogtoConfigQueries(pool, new MockWellKnownCache());

--- a/packages/core/src/queries/logto-config.ts
+++ b/packages/core/src/queries/logto-config.ts
@@ -21,6 +21,7 @@ import { type z } from 'zod';
 
 import { type WellKnownCache } from '#src/caches/well-known.js';
 import { DeletionError } from '#src/errors/SlonikError/index.js';
+import { normalizeOidcPrivateKeys } from '#src/libraries/oidc-private-key.js';
 import { convertToIdentifiers } from '#src/utils/sql.js';
 
 const { table, fields } = convertToIdentifiers(LogtoConfigs);
@@ -81,6 +82,38 @@ export const createLogtoConfigQueries = (
 
   const updatePrivateSigningKeys = async (privateKeys: OidcPrivateKey[]) =>
     upsertPrivateSigningKeys(pool, privateKeys);
+
+  const getPrivateSigningKeys = async (): Promise<OidcPrivateKey[]> => {
+    const { rows } = await getRowsByKeys([LogtoOidcConfigKey.PrivateKeys]);
+
+    return normalizeOidcPrivateKeys(oidcPrivateKeyGuard.array().parse(rows[0]?.value));
+  };
+
+  const updatePrivateSigningKeysWithLock = async (
+    updater: (privateKeys: OidcPrivateKey[]) => OidcPrivateKey[]
+  ): Promise<OidcPrivateKey[]> =>
+    pool.transaction(async (transaction) => {
+      await transaction.query(sql`
+        select ${fields.key}
+        from ${table}
+        where ${fields.key} = ${LogtoOidcConfigKey.PrivateKeys}
+        for update
+      `);
+
+      const { rows } = await transaction.query<LogtoConfig>(sql`
+        select ${sql.join([fields.key, fields.value], sql`,`)} from ${table}
+        where ${fields.key} = ${LogtoOidcConfigKey.PrivateKeys}
+      `);
+
+      const privateKeys = normalizeOidcPrivateKeys(
+        oidcPrivateKeyGuard.array().parse(rows[0]?.value)
+      );
+      const updatedPrivateKeys = updater(privateKeys);
+
+      await upsertPrivateSigningKeys(transaction, updatedPrivateKeys);
+
+      return updatedPrivateKeys;
+    });
 
   const updateOidcConfigsByKey = async <
     T extends Exclude<LogtoOidcConfigKey, LogtoOidcConfigKey.PrivateKeys>,
@@ -201,7 +234,9 @@ export const createLogtoConfigQueries = (
     updateAdminConsoleConfig,
     getCloudConnectionData,
     getRowsByKeys,
+    getPrivateSigningKeys,
     updatePrivateSigningKeys,
+    updatePrivateSigningKeysWithLock,
     updateOidcConfigsByKey,
     getSigningKeyRotationState,
     upsertSigningKeyRotationState,

--- a/packages/core/src/queries/logto-config.ts
+++ b/packages/core/src/queries/logto-config.ts
@@ -79,7 +79,12 @@ export const createLogtoConfigQueries = (
     }
   };
 
-  const updateOidcConfigsByKey = async <T extends LogtoOidcConfigKey>(
+  const updatePrivateSigningKeys = async (privateKeys: OidcPrivateKey[]) =>
+    upsertPrivateSigningKeys(pool, privateKeys);
+
+  const updateOidcConfigsByKey = async <
+    T extends Exclude<LogtoOidcConfigKey, LogtoOidcConfigKey.PrivateKeys>,
+  >(
     key: T,
     value: LogtoOidcConfigType[T]
   ) =>
@@ -196,6 +201,7 @@ export const createLogtoConfigQueries = (
     updateAdminConsoleConfig,
     getCloudConnectionData,
     getRowsByKeys,
+    updatePrivateSigningKeys,
     updateOidcConfigsByKey,
     getSigningKeyRotationState,
     upsertSigningKeyRotationState,

--- a/packages/core/src/queries/logto-config.ts
+++ b/packages/core/src/queries/logto-config.ts
@@ -81,12 +81,6 @@ export const createLogtoConfigQueries = (
   const updatePrivateSigningKeys = async (privateKeys: OidcPrivateKey[]) =>
     upsertPrivateSigningKeys(pool, privateKeys);
 
-  const getPrivateSigningKeys = async (): Promise<OidcPrivateKey[]> => {
-    const { rows } = await getRowsByKeys([LogtoOidcConfigKey.PrivateKeys]);
-
-    return normalizeOidcPrivateKeys(oidcPrivateKeyGuard.array().parse(rows[0]?.value));
-  };
-
   const updatePrivateSigningKeysWithLock = async (
     updater: (privateKeys: OidcPrivateKey[]) => OidcPrivateKey[]
   ): Promise<OidcPrivateKey[]> =>
@@ -170,7 +164,6 @@ export const createLogtoConfigQueries = (
     updateAdminConsoleConfig,
     getCloudConnectionData,
     getRowsByKeys,
-    getPrivateSigningKeys,
     updatePrivateSigningKeys,
     updatePrivateSigningKeysWithLock,
     updateOidcConfigsByKey,

--- a/packages/core/src/queries/logto-config.ts
+++ b/packages/core/src/queries/logto-config.ts
@@ -19,7 +19,6 @@ import { type z } from 'zod';
 
 import { type WellKnownCache } from '#src/caches/well-known.js';
 import { DeletionError } from '#src/errors/SlonikError/index.js';
-import { normalizeOidcPrivateKeys } from '#src/libraries/oidc-private-key.js';
 import { convertToIdentifiers } from '#src/utils/sql.js';
 
 const { table, fields } = convertToIdentifiers(LogtoConfigs);
@@ -28,11 +27,8 @@ export const createLogtoConfigQueries = (
   pool: CommonQueryMethods,
   wellKnownCache: WellKnownCache
 ) => {
-  const upsertPrivateSigningKeys = async (
-    executor: CommonQueryMethods,
-    privateKeys: OidcPrivateKey[]
-  ) =>
-    executor.one<{ key: LogtoOidcConfigKey.PrivateKeys; value: unknown }>(sql`
+  const upsertPrivateSigningKeys = async (privateKeys: OidcPrivateKey[]) =>
+    pool.one<{ key: LogtoOidcConfigKey.PrivateKeys; value: unknown }>(sql`
       insert into ${table} (${fields.key}, ${fields.value})
         values (${LogtoOidcConfigKey.PrivateKeys}, ${sql.jsonb(privateKeys)})
         on conflict (${fields.tenantId}, ${fields.key}) do update set ${fields.value} = ${sql.jsonb(
@@ -78,31 +74,22 @@ export const createLogtoConfigQueries = (
     }
   };
 
-  const updatePrivateSigningKeysWithLock = async (
-    updater: (privateKeys: OidcPrivateKey[]) => OidcPrivateKey[]
-  ): Promise<OidcPrivateKey[]> =>
-    pool.transaction(async (transaction) => {
-      await transaction.query(sql`
-        select ${fields.key}
-        from ${table}
-        where ${fields.key} = ${LogtoOidcConfigKey.PrivateKeys}
-        for update
-      `);
+  const lockPrivateSigningKeys = async () =>
+    pool.query(sql`
+      select ${fields.key}
+      from ${table}
+      where ${fields.key} = ${LogtoOidcConfigKey.PrivateKeys}
+      for update
+    `);
 
-      const { rows } = await transaction.query<LogtoConfig>(sql`
-        select ${sql.join([fields.key, fields.value], sql`,`)} from ${table}
-        where ${fields.key} = ${LogtoOidcConfigKey.PrivateKeys}
-      `);
+  const getPrivateSigningKeys = async (): Promise<OidcPrivateKey[]> => {
+    const { rows } = await pool.query<LogtoConfig>(sql`
+      select ${sql.join([fields.key, fields.value], sql`,`)} from ${table}
+      where ${fields.key} = ${LogtoOidcConfigKey.PrivateKeys}
+    `);
 
-      const privateKeys = normalizeOidcPrivateKeys(
-        oidcPrivateKeyGuard.array().parse(rows[0]?.value)
-      );
-      const updatedPrivateKeys = updater(privateKeys);
-
-      await upsertPrivateSigningKeys(transaction, updatedPrivateKeys);
-
-      return updatedPrivateKeys;
-    });
+    return oidcPrivateKeyGuard.array().parse(rows[0]?.value);
+  };
 
   const updateOidcConfigsByKey = async <
     T extends Exclude<LogtoOidcConfigKey, LogtoOidcConfigKey.PrivateKeys>,
@@ -161,7 +148,9 @@ export const createLogtoConfigQueries = (
     updateAdminConsoleConfig,
     getCloudConnectionData,
     getRowsByKeys,
-    updatePrivateSigningKeysWithLock,
+    lockPrivateSigningKeys,
+    getPrivateSigningKeys,
+    upsertPrivateSigningKeys,
     updateOidcConfigsByKey,
     upsertJwtCustomizer,
     deleteJwtCustomizer,

--- a/packages/core/src/queries/logto-config.ts
+++ b/packages/core/src/queries/logto-config.ts
@@ -12,8 +12,6 @@ import {
   oidcPrivateKeyGuard,
   idTokenConfigGuard,
   type LogtoOidcConfigType,
-  signingKeyRotationStateGuard,
-  type SigningKeyRotationState,
 } from '@logto/schemas';
 import type { CommonQueryMethods } from '@silverhand/slonik';
 import { sql } from '@silverhand/slonik';
@@ -128,68 +126,6 @@ export const createLogtoConfigQueries = (
         returning *
     `);
 
-  const getSigningKeyRotationState = async (): Promise<SigningKeyRotationState | undefined> => {
-    const { rows } = await getRowsByKeys([LogtoTenantConfigKey.SigningKeyRotationState]);
-
-    if (rows.length === 0) {
-      return undefined;
-    }
-
-    return signingKeyRotationStateGuard.parse(rows[0]?.value);
-  };
-
-  const upsertSigningKeyRotationState = async (
-    value: Partial<SigningKeyRotationState>
-  ): Promise<SigningKeyRotationState> => {
-    const { value: rawValue } = await pool.one<{ value: unknown }>(sql`
-      insert into ${table} (${fields.key}, ${fields.value})
-        values (${LogtoTenantConfigKey.SigningKeyRotationState}, ${sql.jsonb(value)})
-        on conflict (${fields.tenantId}, ${fields.key}) do update
-        set ${fields.value} = coalesce(${table}.${fields.value}, '{}'::jsonb) || ${sql.jsonb(value)}
-        returning ${fields.value}
-    `);
-
-    return signingKeyRotationStateGuard.parse(rawValue);
-  };
-
-  const updatePrivateSigningKeysAndRotationState = async (
-    privateKeys: OidcPrivateKey[],
-    signingKeyRotationState: Partial<SigningKeyRotationState>
-  ): Promise<{
-    privateKeys: OidcPrivateKey[];
-    signingKeyRotationState: SigningKeyRotationState;
-  }> =>
-    pool.transaction(async (transaction) => {
-      await transaction.query(sql`
-        select ${fields.key}
-        from ${table}
-        where ${fields.key} in (
-          ${LogtoOidcConfigKey.PrivateKeys},
-          ${LogtoTenantConfigKey.SigningKeyRotationState}
-        )
-        for update
-      `);
-
-      const privateKeysRow = await upsertPrivateSigningKeys(transaction, privateKeys);
-
-      const { value: rotationStateValue } = await transaction.one<{ value: unknown }>(sql`
-        insert into ${table} (${fields.key}, ${fields.value})
-          values (${LogtoTenantConfigKey.SigningKeyRotationState}, ${sql.jsonb(
-            signingKeyRotationState
-          )})
-          on conflict (${fields.tenantId}, ${fields.key}) do update
-          set ${fields.value} = coalesce(${table}.${fields.value}, '{}'::jsonb) || ${sql.jsonb(
-            signingKeyRotationState
-          )}
-          returning ${fields.value}
-      `);
-
-      return {
-        privateKeys: oidcPrivateKeyGuard.array().parse(privateKeysRow.value),
-        signingKeyRotationState: signingKeyRotationStateGuard.parse(rotationStateValue),
-      };
-    });
-
   // Can not narrow down the type of value if we utilize `buildInsertIntoWithPool` method.
   const upsertJwtCustomizer = async <T extends LogtoJwtTokenKey>(
     key: T,
@@ -238,9 +174,6 @@ export const createLogtoConfigQueries = (
     updatePrivateSigningKeys,
     updatePrivateSigningKeysWithLock,
     updateOidcConfigsByKey,
-    getSigningKeyRotationState,
-    upsertSigningKeyRotationState,
-    updatePrivateSigningKeysAndRotationState,
     upsertJwtCustomizer,
     deleteJwtCustomizer,
     getIdTokenConfig,

--- a/packages/core/src/queries/logto-config.ts
+++ b/packages/core/src/queries/logto-config.ts
@@ -6,10 +6,14 @@ import {
   type IdTokenConfig,
   type LogtoConfig,
   type LogtoConfigKey,
-  type LogtoOidcConfigKey,
+  LogtoOidcConfigKey,
   type LogtoJwtTokenKey,
+  type OidcPrivateKey,
+  oidcPrivateKeyGuard,
   idTokenConfigGuard,
   type LogtoOidcConfigType,
+  signingKeyRotationStateGuard,
+  type SigningKeyRotationState,
 } from '@logto/schemas';
 import type { CommonQueryMethods } from '@silverhand/slonik';
 import { sql } from '@silverhand/slonik';
@@ -25,6 +29,19 @@ export const createLogtoConfigQueries = (
   pool: CommonQueryMethods,
   wellKnownCache: WellKnownCache
 ) => {
+  const upsertPrivateSigningKeys = async (
+    executor: CommonQueryMethods,
+    privateKeys: OidcPrivateKey[]
+  ) =>
+    executor.one<{ key: LogtoOidcConfigKey.PrivateKeys; value: unknown }>(sql`
+      insert into ${table} (${fields.key}, ${fields.value})
+        values (${LogtoOidcConfigKey.PrivateKeys}, ${sql.jsonb(privateKeys)})
+        on conflict (${fields.tenantId}, ${fields.key}) do update set ${fields.value} = ${sql.jsonb(
+          privateKeys
+        )}
+        returning ${fields.key}, ${fields.value}
+    `);
+
   const getAdminConsoleConfig = async () =>
     pool.one<{ value: unknown }>(sql`
       select ${fields.value} from ${table}
@@ -73,6 +90,68 @@ export const createLogtoConfigQueries = (
         returning *
     `);
 
+  const getSigningKeyRotationState = async (): Promise<SigningKeyRotationState | undefined> => {
+    const { rows } = await getRowsByKeys([LogtoTenantConfigKey.SigningKeyRotationState]);
+
+    if (rows.length === 0) {
+      return undefined;
+    }
+
+    return signingKeyRotationStateGuard.parse(rows[0]?.value);
+  };
+
+  const upsertSigningKeyRotationState = async (
+    value: Partial<SigningKeyRotationState>
+  ): Promise<SigningKeyRotationState> => {
+    const { value: rawValue } = await pool.one<{ value: unknown }>(sql`
+      insert into ${table} (${fields.key}, ${fields.value})
+        values (${LogtoTenantConfigKey.SigningKeyRotationState}, ${sql.jsonb(value)})
+        on conflict (${fields.tenantId}, ${fields.key}) do update
+        set ${fields.value} = coalesce(${table}.${fields.value}, '{}'::jsonb) || ${sql.jsonb(value)}
+        returning ${fields.value}
+    `);
+
+    return signingKeyRotationStateGuard.parse(rawValue);
+  };
+
+  const updatePrivateSigningKeysAndRotationState = async (
+    privateKeys: OidcPrivateKey[],
+    signingKeyRotationState: Partial<SigningKeyRotationState>
+  ): Promise<{
+    privateKeys: OidcPrivateKey[];
+    signingKeyRotationState: SigningKeyRotationState;
+  }> =>
+    pool.transaction(async (transaction) => {
+      await transaction.query(sql`
+        select ${fields.key}
+        from ${table}
+        where ${fields.key} in (
+          ${LogtoOidcConfigKey.PrivateKeys},
+          ${LogtoTenantConfigKey.SigningKeyRotationState}
+        )
+        for update
+      `);
+
+      const privateKeysRow = await upsertPrivateSigningKeys(transaction, privateKeys);
+
+      const { value: rotationStateValue } = await transaction.one<{ value: unknown }>(sql`
+        insert into ${table} (${fields.key}, ${fields.value})
+          values (${LogtoTenantConfigKey.SigningKeyRotationState}, ${sql.jsonb(
+            signingKeyRotationState
+          )})
+          on conflict (${fields.tenantId}, ${fields.key}) do update
+          set ${fields.value} = coalesce(${table}.${fields.value}, '{}'::jsonb) || ${sql.jsonb(
+            signingKeyRotationState
+          )}
+          returning ${fields.value}
+      `);
+
+      return {
+        privateKeys: oidcPrivateKeyGuard.array().parse(privateKeysRow.value),
+        signingKeyRotationState: signingKeyRotationStateGuard.parse(rotationStateValue),
+      };
+    });
+
   // Can not narrow down the type of value if we utilize `buildInsertIntoWithPool` method.
   const upsertJwtCustomizer = async <T extends LogtoJwtTokenKey>(
     key: T,
@@ -118,6 +197,9 @@ export const createLogtoConfigQueries = (
     getCloudConnectionData,
     getRowsByKeys,
     updateOidcConfigsByKey,
+    getSigningKeyRotationState,
+    upsertSigningKeyRotationState,
+    updatePrivateSigningKeysAndRotationState,
     upsertJwtCustomizer,
     deleteJwtCustomizer,
     getIdTokenConfig,

--- a/packages/core/src/queries/logto-config.ts
+++ b/packages/core/src/queries/logto-config.ts
@@ -78,9 +78,6 @@ export const createLogtoConfigQueries = (
     }
   };
 
-  const updatePrivateSigningKeys = async (privateKeys: OidcPrivateKey[]) =>
-    upsertPrivateSigningKeys(pool, privateKeys);
-
   const updatePrivateSigningKeysWithLock = async (
     updater: (privateKeys: OidcPrivateKey[]) => OidcPrivateKey[]
   ): Promise<OidcPrivateKey[]> =>
@@ -164,7 +161,6 @@ export const createLogtoConfigQueries = (
     updateAdminConsoleConfig,
     getCloudConnectionData,
     getRowsByKeys,
-    updatePrivateSigningKeys,
     updatePrivateSigningKeysWithLock,
     updateOidcConfigsByKey,
     upsertJwtCustomizer,

--- a/packages/core/src/routes/logto-config/index.test.ts
+++ b/packages/core/src/routes/logto-config/index.test.ts
@@ -1,4 +1,9 @@
-import { LogtoOidcConfigKey, OidcSigningKeyStatus, type AdminConsoleData } from '@logto/schemas';
+import {
+  LogtoOidcConfigKey,
+  OidcSigningKeyStatus,
+  type AdminConsoleData,
+  type OidcPrivateKey,
+} from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 import { createMockUtils, pickDefault } from '@logto/shared/esm';
 import Sinon from 'sinon';
@@ -51,7 +56,10 @@ const logtoConfigQueries = {
       ...data,
     },
   }),
-  updatePrivateSigningKeys: jest.fn(),
+  updatePrivateSigningKeysWithLock: jest.fn(
+    async (updater: (privateKeys: OidcPrivateKey[]) => OidcPrivateKey[]) =>
+      updater([{ ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current }])
+  ),
   updateOidcConfigsByKey: jest.fn(),
 };
 
@@ -127,15 +135,28 @@ describe('configs routes', () => {
       routeRequester.delete(`/configs/oidc/private-keys/${mockPrivateKeys[0]!.id}`)
     ).resolves.toHaveProperty('status', 422);
 
-    expect(logtoConfigQueries.updatePrivateSigningKeys).not.toBeCalled();
+    expect(logtoConfigQueries.updatePrivateSigningKeysWithLock).toBeCalled();
     expect(logtoConfigQueries.updateOidcConfigsByKey).not.toBeCalled();
   });
 
   it('DELETE /configs/oidc/:keyType/:keyId', async () => {
+    logtoConfigQueries.updatePrivateSigningKeysWithLock.mockImplementationOnce(
+      async (updater: (privateKeys: OidcPrivateKey[]) => OidcPrivateKey[]) => {
+        const privateKeys = [
+          { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
+          { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Previous },
+        ];
+
+        expect(updater(privateKeys)).toEqual([
+          { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
+        ]);
+
+        return [{ ...newPrivateKey, status: OidcSigningKeyStatus.Current }];
+      }
+    );
     logtoConfigLibraries.getOidcConfigs.mockResolvedValue({
       [LogtoOidcConfigKey.PrivateKeys]: [
         { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
-        { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Previous },
       ],
       [LogtoOidcConfigKey.CookieKeys]: [newCookieKey, ...mockCookieKeys],
     });
@@ -144,9 +165,7 @@ describe('configs routes', () => {
       routeRequester.delete(`/configs/oidc/private-keys/${mockPrivateKeys[0]!.id}`)
     ).resolves.toHaveProperty('status', 204);
 
-    expect(logtoConfigQueries.updatePrivateSigningKeys).toBeCalledWith([
-      { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
-    ]);
+    expect(logtoConfigQueries.updatePrivateSigningKeysWithLock).toBeCalled();
 
     await expect(
       routeRequester.delete(`/configs/oidc/cookie-keys/${mockCookieKeys[0]!.id}`)
@@ -161,13 +180,13 @@ describe('configs routes', () => {
   });
 
   it('DELETE /configs/oidc/:keyType/:keyId will fail if key is not found', async () => {
-    logtoConfigLibraries.getOidcConfigs.mockResolvedValue({
-      [LogtoOidcConfigKey.PrivateKeys]: [
-        { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
-        { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Previous },
-      ],
-      [LogtoOidcConfigKey.CookieKeys]: [newCookieKey, ...mockCookieKeys],
-    });
+    logtoConfigQueries.updatePrivateSigningKeysWithLock.mockImplementation(
+      async (updater: (privateKeys: OidcPrivateKey[]) => OidcPrivateKey[]) =>
+        updater([
+          { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
+          { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Previous },
+        ])
+    );
 
     await expect(
       routeRequester.delete(`/configs/oidc/private-keys/fake_key_id`)
@@ -177,49 +196,53 @@ describe('configs routes', () => {
       routeRequester.delete(`/configs/oidc/private-keys/fake_key_id`)
     ).resolves.toHaveProperty('status', 404);
 
-    expect(logtoConfigQueries.updatePrivateSigningKeys).not.toBeCalled();
+    expect(logtoConfigQueries.updatePrivateSigningKeysWithLock).toBeCalled();
     expect(logtoConfigQueries.updateOidcConfigsByKey).not.toBeCalled();
-    logtoConfigLibraries.getOidcConfigs.mockRestore();
   });
 
   it('DELETE /configs/oidc/:keyType/:keyId only allows deleting Previous private keys', async () => {
-    logtoConfigLibraries.getOidcConfigs.mockResolvedValue({
-      [LogtoOidcConfigKey.PrivateKeys]: [
-        { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
-        { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Previous },
-      ],
-      [LogtoOidcConfigKey.CookieKeys]: mockCookieKeys,
-    });
+    logtoConfigQueries.updatePrivateSigningKeysWithLock.mockImplementationOnce(
+      async (updater: (privateKeys: OidcPrivateKey[]) => OidcPrivateKey[]) =>
+        updater([
+          { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
+          { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Previous },
+        ])
+    );
 
     await expect(
       routeRequester.delete(`/configs/oidc/private-keys/${newPrivateKey.id}`)
     ).resolves.toHaveProperty('status', 422);
 
-    expect(logtoConfigQueries.updatePrivateSigningKeys).not.toBeCalled();
+    expect(logtoConfigQueries.updatePrivateSigningKeysWithLock).toBeCalled();
     expect(logtoConfigQueries.updateOidcConfigsByKey).not.toBeCalled();
-    logtoConfigLibraries.getOidcConfigs.mockRestore();
   });
 
   it('DELETE /configs/oidc/:keyType/:keyId preserves staged Next and Current private keys', async () => {
-    logtoConfigLibraries.getOidcConfigs.mockResolvedValue({
-      [LogtoOidcConfigKey.PrivateKeys]: [
-        { ...newPrivateKey, status: OidcSigningKeyStatus.Next },
-        { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current },
-        { ...previousPrivateKey, status: OidcSigningKeyStatus.Previous },
-      ],
-      [LogtoOidcConfigKey.CookieKeys]: mockCookieKeys,
-    });
+    logtoConfigQueries.updatePrivateSigningKeysWithLock.mockImplementationOnce(
+      async (updater: (privateKeys: OidcPrivateKey[]) => OidcPrivateKey[]) => {
+        const privateKeys = [
+          { ...newPrivateKey, status: OidcSigningKeyStatus.Next },
+          { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current },
+          { ...previousPrivateKey, status: OidcSigningKeyStatus.Previous },
+        ];
+
+        expect(updater(privateKeys)).toEqual([
+          { ...newPrivateKey, status: OidcSigningKeyStatus.Next },
+          { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current },
+        ]);
+
+        return [
+          { ...newPrivateKey, status: OidcSigningKeyStatus.Next },
+          { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current },
+        ];
+      }
+    );
 
     await expect(
       routeRequester.delete(`/configs/oidc/private-keys/${previousPrivateKey.id}`)
     ).resolves.toHaveProperty('status', 204);
 
-    expect(logtoConfigQueries.updatePrivateSigningKeys).toBeCalledWith([
-      { ...newPrivateKey, status: OidcSigningKeyStatus.Next },
-      { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current },
-    ]);
-
-    logtoConfigLibraries.getOidcConfigs.mockRestore();
+    expect(logtoConfigQueries.updatePrivateSigningKeysWithLock).toBeCalled();
   });
 
   it('POST /configs/oidc/:keyType/rotate', async () => {
@@ -233,10 +256,7 @@ describe('configs routes', () => {
 
     const response = await routeRequester.post('/configs/oidc/private-keys/rotate');
     expect(response.status).toEqual(200);
-    expect(logtoConfigQueries.updatePrivateSigningKeys).toHaveBeenCalledWith([
-      { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
-      { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Previous },
-    ]);
+    expect(logtoConfigQueries.updatePrivateSigningKeysWithLock).toHaveBeenCalled();
     expect(response.body[0]).toEqual({
       id: newPrivateKey.id,
       createdAt: newPrivateKey.createdAt,
@@ -258,45 +278,51 @@ describe('configs routes', () => {
   });
 
   it('keeps the immediate rotation flow at 2 private keys', async () => {
-    logtoConfigLibraries.getOidcConfigs.mockResolvedValueOnce({
-      [LogtoOidcConfigKey.PrivateKeys]: [
-        { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
-        { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Previous },
-      ],
-      [LogtoOidcConfigKey.CookieKeys]: [newCookieKey, ...mockCookieKeys],
-    });
-
     const newPrivateKey2 = {
       id: generateStandardId(),
       value: '-----BEGIN PRIVATE KEY-----\nnew\nprivate\nkey\n-----END PRIVATE KEY-----\n',
       createdAt: Math.floor(Date.now() / 1000),
     };
+    logtoConfigQueries.updatePrivateSigningKeysWithLock.mockImplementationOnce(
+      async (updater: (privateKeys: OidcPrivateKey[]) => OidcPrivateKey[]) => {
+        const privateKeys = [
+          { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
+          { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Previous },
+        ];
+
+        expect(updater(privateKeys)).toEqual([
+          { ...newPrivateKey2, status: OidcSigningKeyStatus.Current },
+          { ...newPrivateKey, status: OidcSigningKeyStatus.Previous },
+        ]);
+
+        return [
+          { ...newPrivateKey2, status: OidcSigningKeyStatus.Current },
+          { ...newPrivateKey, status: OidcSigningKeyStatus.Previous },
+        ];
+      }
+    );
     generateOidcPrivateKey.mockResolvedValueOnce(newPrivateKey2);
 
     await routeRequester.post('/configs/oidc/private-keys/rotate');
 
-    // Only has two keys and the original mocked private keys are clamped off
-    expect(logtoConfigQueries.updatePrivateSigningKeys).toHaveBeenCalledWith([
-      { ...newPrivateKey2, status: OidcSigningKeyStatus.Current },
-      { ...newPrivateKey, status: OidcSigningKeyStatus.Previous },
-    ]);
+    expect(logtoConfigQueries.updatePrivateSigningKeysWithLock).toHaveBeenCalled();
   });
 
   it('rejects immediate private-key rotation when a staged Next key already exists', async () => {
-    logtoConfigLibraries.getOidcConfigs.mockResolvedValueOnce({
-      [LogtoOidcConfigKey.PrivateKeys]: [
-        { ...newPrivateKey, status: OidcSigningKeyStatus.Next },
-        { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current },
-        { ...previousPrivateKey, status: OidcSigningKeyStatus.Previous },
-      ],
-      [LogtoOidcConfigKey.CookieKeys]: mockCookieKeys,
-    });
+    logtoConfigQueries.updatePrivateSigningKeysWithLock.mockImplementationOnce(
+      async (updater: (privateKeys: OidcPrivateKey[]) => OidcPrivateKey[]) =>
+        updater([
+          { ...newPrivateKey, status: OidcSigningKeyStatus.Next },
+          { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current },
+          { ...previousPrivateKey, status: OidcSigningKeyStatus.Previous },
+        ])
+    );
 
     await expect(routeRequester.post('/configs/oidc/private-keys/rotate')).resolves.toHaveProperty(
       'status',
       422
     );
 
-    expect(logtoConfigQueries.updatePrivateSigningKeys).not.toHaveBeenCalled();
+    expect(logtoConfigQueries.updatePrivateSigningKeysWithLock).toHaveBeenCalled();
   });
 });

--- a/packages/core/src/routes/logto-config/index.test.ts
+++ b/packages/core/src/routes/logto-config/index.test.ts
@@ -1,14 +1,10 @@
-import {
-  LogtoOidcConfigKey,
-  OidcSigningKeyStatus,
-  type AdminConsoleData,
-  type OidcPrivateKey,
-} from '@logto/schemas';
+import { LogtoOidcConfigKey, OidcSigningKeyStatus, type AdminConsoleData } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 import { createMockUtils, pickDefault } from '@logto/shared/esm';
 import Sinon from 'sinon';
 
 import { mockAdminConsoleData, mockCookieKeys, mockPrivateKeys } from '#src/__mocks__/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
 import { createRequester } from '#src/utils/test-utils.js';
 
@@ -56,10 +52,6 @@ const logtoConfigQueries = {
       ...data,
     },
   }),
-  updatePrivateSigningKeysWithLock: jest.fn(
-    async (updater: (privateKeys: OidcPrivateKey[]) => OidcPrivateKey[]) =>
-      updater([{ ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current }])
-  ),
   updateOidcConfigsByKey: jest.fn(),
 };
 
@@ -72,10 +64,22 @@ const logtoConfigLibraries = {
   })),
 };
 
+const oidcPrivateKeyLibraries = {
+  deletePrivateSigningKey: jest.fn(async () => [
+    { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current },
+  ]),
+  rotatePrivateSigningKeys: jest.fn(async () => [
+    { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
+    { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Previous },
+  ]),
+};
+
 const settingRoutes = await pickDefault(import('./index.js'));
 
 describe('configs routes', () => {
-  const tenantContext = new MockTenant(undefined, { logtoConfigs: logtoConfigQueries });
+  const tenantContext = new MockTenant(undefined, { logtoConfigs: logtoConfigQueries }, undefined, {
+    oidcPrivateKeys: oidcPrivateKeyLibraries,
+  });
   Sinon.stub(tenantContext, 'logtoConfigs').value(logtoConfigLibraries);
 
   const routeRequester = createRequester({
@@ -131,30 +135,23 @@ describe('configs routes', () => {
   });
 
   it('DELETE /configs/oidc/:keyType/:keyId will fail if there is only one key', async () => {
+    oidcPrivateKeyLibraries.deletePrivateSigningKey.mockRejectedValueOnce(
+      new RequestError({ code: 'oidc.key_required', status: 422 })
+    );
+
     await expect(
       routeRequester.delete(`/configs/oidc/private-keys/${mockPrivateKeys[0]!.id}`)
     ).resolves.toHaveProperty('status', 422);
 
-    expect(logtoConfigQueries.updatePrivateSigningKeysWithLock).toBeCalled();
+    expect(oidcPrivateKeyLibraries.deletePrivateSigningKey).toBeCalled();
     expect(logtoConfigQueries.updateOidcConfigsByKey).not.toBeCalled();
   });
 
   it('DELETE /configs/oidc/:keyType/:keyId', async () => {
-    logtoConfigQueries.updatePrivateSigningKeysWithLock.mockImplementationOnce(
-      async (updater: (privateKeys: OidcPrivateKey[]) => OidcPrivateKey[]) => {
-        const privateKeys = [
-          { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
-          { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Previous },
-        ];
-
-        expect(updater(privateKeys)).toEqual([
-          { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
-        ]);
-
-        return [{ ...newPrivateKey, status: OidcSigningKeyStatus.Current }];
-      }
-    );
-    logtoConfigLibraries.getOidcConfigs.mockResolvedValue({
+    oidcPrivateKeyLibraries.deletePrivateSigningKey.mockResolvedValueOnce([
+      { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
+    ]);
+    logtoConfigLibraries.getOidcConfigs.mockResolvedValueOnce({
       [LogtoOidcConfigKey.PrivateKeys]: [
         { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
       ],
@@ -165,7 +162,7 @@ describe('configs routes', () => {
       routeRequester.delete(`/configs/oidc/private-keys/${mockPrivateKeys[0]!.id}`)
     ).resolves.toHaveProperty('status', 204);
 
-    expect(logtoConfigQueries.updatePrivateSigningKeysWithLock).toBeCalled();
+    expect(oidcPrivateKeyLibraries.deletePrivateSigningKey).toBeCalledWith(mockPrivateKeys[0]!.id);
 
     await expect(
       routeRequester.delete(`/configs/oidc/cookie-keys/${mockCookieKeys[0]!.id}`)
@@ -175,18 +172,16 @@ describe('configs routes', () => {
       LogtoOidcConfigKey.CookieKeys,
       [newCookieKey]
     );
-
-    logtoConfigLibraries.getOidcConfigs.mockRestore();
   });
 
   it('DELETE /configs/oidc/:keyType/:keyId will fail if key is not found', async () => {
-    logtoConfigQueries.updatePrivateSigningKeysWithLock.mockImplementation(
-      async (updater: (privateKeys: OidcPrivateKey[]) => OidcPrivateKey[]) =>
-        updater([
-          { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
-          { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Previous },
-        ])
-    );
+    oidcPrivateKeyLibraries.deletePrivateSigningKey
+      .mockRejectedValueOnce(
+        new RequestError({ code: 'oidc.key_not_found', id: 'fake_key_id', status: 404 })
+      )
+      .mockRejectedValueOnce(
+        new RequestError({ code: 'oidc.key_not_found', id: 'fake_key_id', status: 404 })
+      );
 
     await expect(
       routeRequester.delete(`/configs/oidc/private-keys/fake_key_id`)
@@ -196,57 +191,38 @@ describe('configs routes', () => {
       routeRequester.delete(`/configs/oidc/private-keys/fake_key_id`)
     ).resolves.toHaveProperty('status', 404);
 
-    expect(logtoConfigQueries.updatePrivateSigningKeysWithLock).toBeCalled();
+    expect(oidcPrivateKeyLibraries.deletePrivateSigningKey).toBeCalled();
     expect(logtoConfigQueries.updateOidcConfigsByKey).not.toBeCalled();
   });
 
   it('DELETE /configs/oidc/:keyType/:keyId only allows deleting Previous private keys', async () => {
-    logtoConfigQueries.updatePrivateSigningKeysWithLock.mockImplementationOnce(
-      async (updater: (privateKeys: OidcPrivateKey[]) => OidcPrivateKey[]) =>
-        updater([
-          { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
-          { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Previous },
-        ])
+    oidcPrivateKeyLibraries.deletePrivateSigningKey.mockRejectedValueOnce(
+      new RequestError({ code: 'oidc.only_previous_key_can_be_deleted', status: 422 })
     );
 
     await expect(
       routeRequester.delete(`/configs/oidc/private-keys/${newPrivateKey.id}`)
     ).resolves.toHaveProperty('status', 422);
 
-    expect(logtoConfigQueries.updatePrivateSigningKeysWithLock).toBeCalled();
+    expect(oidcPrivateKeyLibraries.deletePrivateSigningKey).toBeCalledWith(newPrivateKey.id);
     expect(logtoConfigQueries.updateOidcConfigsByKey).not.toBeCalled();
   });
 
   it('DELETE /configs/oidc/:keyType/:keyId preserves staged Next and Current private keys', async () => {
-    logtoConfigQueries.updatePrivateSigningKeysWithLock.mockImplementationOnce(
-      async (updater: (privateKeys: OidcPrivateKey[]) => OidcPrivateKey[]) => {
-        const privateKeys = [
-          { ...newPrivateKey, status: OidcSigningKeyStatus.Next },
-          { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current },
-          { ...previousPrivateKey, status: OidcSigningKeyStatus.Previous },
-        ];
-
-        expect(updater(privateKeys)).toEqual([
-          { ...newPrivateKey, status: OidcSigningKeyStatus.Next },
-          { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current },
-        ]);
-
-        return [
-          { ...newPrivateKey, status: OidcSigningKeyStatus.Next },
-          { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current },
-        ];
-      }
-    );
+    oidcPrivateKeyLibraries.deletePrivateSigningKey.mockResolvedValueOnce([
+      { ...newPrivateKey, status: OidcSigningKeyStatus.Next },
+      { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current },
+    ]);
 
     await expect(
       routeRequester.delete(`/configs/oidc/private-keys/${previousPrivateKey.id}`)
     ).resolves.toHaveProperty('status', 204);
 
-    expect(logtoConfigQueries.updatePrivateSigningKeysWithLock).toBeCalled();
+    expect(oidcPrivateKeyLibraries.deletePrivateSigningKey).toBeCalledWith(previousPrivateKey.id);
   });
 
   it('POST /configs/oidc/:keyType/rotate', async () => {
-    logtoConfigLibraries.getOidcConfigs.mockResolvedValue({
+    logtoConfigLibraries.getOidcConfigs.mockResolvedValueOnce({
       [LogtoOidcConfigKey.PrivateKeys]: [
         { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current },
       ],
@@ -256,7 +232,7 @@ describe('configs routes', () => {
 
     const response = await routeRequester.post('/configs/oidc/private-keys/rotate');
     expect(response.status).toEqual(200);
-    expect(logtoConfigQueries.updatePrivateSigningKeysWithLock).toHaveBeenCalled();
+    expect(oidcPrivateKeyLibraries.rotatePrivateSigningKeys).toHaveBeenCalledWith(newPrivateKey);
     expect(response.body[0]).toEqual({
       id: newPrivateKey.id,
       createdAt: newPrivateKey.createdAt,
@@ -274,7 +250,6 @@ describe('configs routes', () => {
       id: newCookieKey.id,
       createdAt: newCookieKey.createdAt,
     });
-    logtoConfigLibraries.getOidcConfigs.mockRestore();
   });
 
   it('keeps the immediate rotation flow at 2 private keys', async () => {
@@ -283,39 +258,20 @@ describe('configs routes', () => {
       value: '-----BEGIN PRIVATE KEY-----\nnew\nprivate\nkey\n-----END PRIVATE KEY-----\n',
       createdAt: Math.floor(Date.now() / 1000),
     };
-    logtoConfigQueries.updatePrivateSigningKeysWithLock.mockImplementationOnce(
-      async (updater: (privateKeys: OidcPrivateKey[]) => OidcPrivateKey[]) => {
-        const privateKeys = [
-          { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
-          { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Previous },
-        ];
-
-        expect(updater(privateKeys)).toEqual([
-          { ...newPrivateKey2, status: OidcSigningKeyStatus.Current },
-          { ...newPrivateKey, status: OidcSigningKeyStatus.Previous },
-        ]);
-
-        return [
-          { ...newPrivateKey2, status: OidcSigningKeyStatus.Current },
-          { ...newPrivateKey, status: OidcSigningKeyStatus.Previous },
-        ];
-      }
-    );
+    oidcPrivateKeyLibraries.rotatePrivateSigningKeys.mockResolvedValueOnce([
+      { ...newPrivateKey2, status: OidcSigningKeyStatus.Current },
+      { ...newPrivateKey, status: OidcSigningKeyStatus.Previous },
+    ]);
     generateOidcPrivateKey.mockResolvedValueOnce(newPrivateKey2);
 
     await routeRequester.post('/configs/oidc/private-keys/rotate');
 
-    expect(logtoConfigQueries.updatePrivateSigningKeysWithLock).toHaveBeenCalled();
+    expect(oidcPrivateKeyLibraries.rotatePrivateSigningKeys).toHaveBeenCalledWith(newPrivateKey2);
   });
 
   it('rejects immediate private-key rotation when a staged Next key already exists', async () => {
-    logtoConfigQueries.updatePrivateSigningKeysWithLock.mockImplementationOnce(
-      async (updater: (privateKeys: OidcPrivateKey[]) => OidcPrivateKey[]) =>
-        updater([
-          { ...newPrivateKey, status: OidcSigningKeyStatus.Next },
-          { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current },
-          { ...previousPrivateKey, status: OidcSigningKeyStatus.Previous },
-        ])
+    oidcPrivateKeyLibraries.rotatePrivateSigningKeys.mockRejectedValueOnce(
+      new RequestError({ code: 'oidc.invalid_request', status: 422 })
     );
 
     await expect(routeRequester.post('/configs/oidc/private-keys/rotate')).resolves.toHaveProperty(
@@ -323,6 +279,6 @@ describe('configs routes', () => {
       422
     );
 
-    expect(logtoConfigQueries.updatePrivateSigningKeysWithLock).toHaveBeenCalled();
+    expect(oidcPrivateKeyLibraries.rotatePrivateSigningKeys).toHaveBeenCalledWith(newPrivateKey);
   });
 });

--- a/packages/core/src/routes/logto-config/index.test.ts
+++ b/packages/core/src/routes/logto-config/index.test.ts
@@ -281,4 +281,22 @@ describe('configs routes', () => {
       { ...newPrivateKey, status: OidcSigningKeyStatus.Previous },
     ]);
   });
+
+  it('rejects immediate private-key rotation when a staged Next key already exists', async () => {
+    logtoConfigLibraries.getOidcConfigs.mockResolvedValueOnce({
+      [LogtoOidcConfigKey.PrivateKeys]: [
+        { ...newPrivateKey, status: OidcSigningKeyStatus.Next },
+        { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current },
+        { ...previousPrivateKey, status: OidcSigningKeyStatus.Previous },
+      ],
+      [LogtoOidcConfigKey.CookieKeys]: mockCookieKeys,
+    });
+
+    await expect(routeRequester.post('/configs/oidc/private-keys/rotate')).resolves.toHaveProperty(
+      'status',
+      422
+    );
+
+    expect(logtoConfigQueries.updatePrivateSigningKeys).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/routes/logto-config/index.test.ts
+++ b/packages/core/src/routes/logto-config/index.test.ts
@@ -21,6 +21,11 @@ const newCookieKey = {
   value: 'abcdefg',
   createdAt: Math.floor(Date.now() / 1000),
 };
+const previousPrivateKey = {
+  id: generateStandardId(),
+  value: '-----BEGIN PRIVATE KEY-----\nlegacy\nprevious\nkey\n-----END PRIVATE KEY-----\n',
+  createdAt: Math.floor(Date.now() / 1000) - 10,
+};
 
 const { exportJWK } = await mockEsmWithActual('#src/utils/jwks.js', () => ({
   exportJWK: jest.fn(async () => ({ kty: 'EC' })),
@@ -46,6 +51,7 @@ const logtoConfigQueries = {
       ...data,
     },
   }),
+  updatePrivateSigningKeys: jest.fn(),
   updateOidcConfigsByKey: jest.fn(),
 };
 
@@ -121,6 +127,7 @@ describe('configs routes', () => {
       routeRequester.delete(`/configs/oidc/private-keys/${mockPrivateKeys[0]!.id}`)
     ).resolves.toHaveProperty('status', 422);
 
+    expect(logtoConfigQueries.updatePrivateSigningKeys).not.toBeCalled();
     expect(logtoConfigQueries.updateOidcConfigsByKey).not.toBeCalled();
   });
 
@@ -137,10 +144,9 @@ describe('configs routes', () => {
       routeRequester.delete(`/configs/oidc/private-keys/${mockPrivateKeys[0]!.id}`)
     ).resolves.toHaveProperty('status', 204);
 
-    expect(logtoConfigQueries.updateOidcConfigsByKey).toBeCalledWith(
-      LogtoOidcConfigKey.PrivateKeys,
-      [{ ...newPrivateKey, status: OidcSigningKeyStatus.Current }]
-    );
+    expect(logtoConfigQueries.updatePrivateSigningKeys).toBeCalledWith([
+      { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
+    ]);
 
     await expect(
       routeRequester.delete(`/configs/oidc/cookie-keys/${mockCookieKeys[0]!.id}`)
@@ -171,6 +177,7 @@ describe('configs routes', () => {
       routeRequester.delete(`/configs/oidc/private-keys/fake_key_id`)
     ).resolves.toHaveProperty('status', 404);
 
+    expect(logtoConfigQueries.updatePrivateSigningKeys).not.toBeCalled();
     expect(logtoConfigQueries.updateOidcConfigsByKey).not.toBeCalled();
     logtoConfigLibraries.getOidcConfigs.mockRestore();
   });
@@ -188,7 +195,30 @@ describe('configs routes', () => {
       routeRequester.delete(`/configs/oidc/private-keys/${newPrivateKey.id}`)
     ).resolves.toHaveProperty('status', 422);
 
+    expect(logtoConfigQueries.updatePrivateSigningKeys).not.toBeCalled();
     expect(logtoConfigQueries.updateOidcConfigsByKey).not.toBeCalled();
+    logtoConfigLibraries.getOidcConfigs.mockRestore();
+  });
+
+  it('DELETE /configs/oidc/:keyType/:keyId preserves staged Next and Current private keys', async () => {
+    logtoConfigLibraries.getOidcConfigs.mockResolvedValue({
+      [LogtoOidcConfigKey.PrivateKeys]: [
+        { ...newPrivateKey, status: OidcSigningKeyStatus.Next },
+        { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current },
+        { ...previousPrivateKey, status: OidcSigningKeyStatus.Previous },
+      ],
+      [LogtoOidcConfigKey.CookieKeys]: mockCookieKeys,
+    });
+
+    await expect(
+      routeRequester.delete(`/configs/oidc/private-keys/${previousPrivateKey.id}`)
+    ).resolves.toHaveProperty('status', 204);
+
+    expect(logtoConfigQueries.updatePrivateSigningKeys).toBeCalledWith([
+      { ...newPrivateKey, status: OidcSigningKeyStatus.Next },
+      { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current },
+    ]);
+
     logtoConfigLibraries.getOidcConfigs.mockRestore();
   });
 
@@ -203,13 +233,10 @@ describe('configs routes', () => {
 
     const response = await routeRequester.post('/configs/oidc/private-keys/rotate');
     expect(response.status).toEqual(200);
-    expect(logtoConfigQueries.updateOidcConfigsByKey).toHaveBeenCalledWith(
-      LogtoOidcConfigKey.PrivateKeys,
-      [
-        { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
-        { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Previous },
-      ]
-    );
+    expect(logtoConfigQueries.updatePrivateSigningKeys).toHaveBeenCalledWith([
+      { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
+      { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Previous },
+    ]);
     expect(response.body[0]).toEqual({
       id: newPrivateKey.id,
       createdAt: newPrivateKey.createdAt,
@@ -249,12 +276,9 @@ describe('configs routes', () => {
     await routeRequester.post('/configs/oidc/private-keys/rotate');
 
     // Only has two keys and the original mocked private keys are clamped off
-    expect(logtoConfigQueries.updateOidcConfigsByKey).toHaveBeenCalledWith(
-      LogtoOidcConfigKey.PrivateKeys,
-      [
-        { ...newPrivateKey2, status: OidcSigningKeyStatus.Current },
-        { ...newPrivateKey, status: OidcSigningKeyStatus.Previous },
-      ]
-    );
+    expect(logtoConfigQueries.updatePrivateSigningKeys).toHaveBeenCalledWith([
+      { ...newPrivateKey2, status: OidcSigningKeyStatus.Current },
+      { ...newPrivateKey, status: OidcSigningKeyStatus.Previous },
+    ]);
   });
 });

--- a/packages/core/src/routes/logto-config/index.test.ts
+++ b/packages/core/src/routes/logto-config/index.test.ts
@@ -1,4 +1,4 @@
-import { LogtoOidcConfigKey, type AdminConsoleData } from '@logto/schemas';
+import { LogtoOidcConfigKey, OidcSigningKeyStatus, type AdminConsoleData } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 import { createMockUtils, pickDefault } from '@logto/shared/esm';
 import Sinon from 'sinon';
@@ -51,7 +51,9 @@ const logtoConfigQueries = {
 
 const logtoConfigLibraries = {
   getOidcConfigs: jest.fn(async () => ({
-    [LogtoOidcConfigKey.PrivateKeys]: mockPrivateKeys,
+    [LogtoOidcConfigKey.PrivateKeys]: [
+      { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current },
+    ],
     [LogtoOidcConfigKey.CookieKeys]: mockCookieKeys,
   })),
 };
@@ -94,11 +96,14 @@ describe('configs routes', () => {
     const response = await routeRequester.get('/configs/oidc/private-keys');
     expect(response.status).toEqual(200);
     expect(response.body).toEqual(
-      mockPrivateKeys.map(({ id, createdAt }) => ({
-        id,
-        createdAt,
-        signingKeyAlgorithm: 'EC',
-      }))
+      [{ ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current }].map(
+        ({ id, createdAt, status }) => ({
+          id,
+          createdAt,
+          signingKeyAlgorithm: 'EC',
+          status,
+        })
+      )
     );
 
     const response2 = await routeRequester.get('/configs/oidc/cookie-keys');
@@ -121,7 +126,10 @@ describe('configs routes', () => {
 
   it('DELETE /configs/oidc/:keyType/:keyId', async () => {
     logtoConfigLibraries.getOidcConfigs.mockResolvedValue({
-      [LogtoOidcConfigKey.PrivateKeys]: [newPrivateKey, ...mockPrivateKeys],
+      [LogtoOidcConfigKey.PrivateKeys]: [
+        { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
+        { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Previous },
+      ],
       [LogtoOidcConfigKey.CookieKeys]: [newCookieKey, ...mockCookieKeys],
     });
 
@@ -131,7 +139,7 @@ describe('configs routes', () => {
 
     expect(logtoConfigQueries.updateOidcConfigsByKey).toBeCalledWith(
       LogtoOidcConfigKey.PrivateKeys,
-      [newPrivateKey]
+      [{ ...newPrivateKey, status: OidcSigningKeyStatus.Current }]
     );
 
     await expect(
@@ -148,7 +156,10 @@ describe('configs routes', () => {
 
   it('DELETE /configs/oidc/:keyType/:keyId will fail if key is not found', async () => {
     logtoConfigLibraries.getOidcConfigs.mockResolvedValue({
-      [LogtoOidcConfigKey.PrivateKeys]: [newPrivateKey, ...mockPrivateKeys],
+      [LogtoOidcConfigKey.PrivateKeys]: [
+        { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
+        { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Previous },
+      ],
       [LogtoOidcConfigKey.CookieKeys]: [newCookieKey, ...mockCookieKeys],
     });
 
@@ -164,9 +175,28 @@ describe('configs routes', () => {
     logtoConfigLibraries.getOidcConfigs.mockRestore();
   });
 
+  it('DELETE /configs/oidc/:keyType/:keyId only allows deleting Previous private keys', async () => {
+    logtoConfigLibraries.getOidcConfigs.mockResolvedValue({
+      [LogtoOidcConfigKey.PrivateKeys]: [
+        { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
+        { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Previous },
+      ],
+      [LogtoOidcConfigKey.CookieKeys]: mockCookieKeys,
+    });
+
+    await expect(
+      routeRequester.delete(`/configs/oidc/private-keys/${newPrivateKey.id}`)
+    ).resolves.toHaveProperty('status', 422);
+
+    expect(logtoConfigQueries.updateOidcConfigsByKey).not.toBeCalled();
+    logtoConfigLibraries.getOidcConfigs.mockRestore();
+  });
+
   it('POST /configs/oidc/:keyType/rotate', async () => {
     logtoConfigLibraries.getOidcConfigs.mockResolvedValue({
-      [LogtoOidcConfigKey.PrivateKeys]: mockPrivateKeys,
+      [LogtoOidcConfigKey.PrivateKeys]: [
+        { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current },
+      ],
       [LogtoOidcConfigKey.CookieKeys]: mockCookieKeys,
     });
     exportJWK.mockResolvedValueOnce({ kty: 'RSA' });
@@ -175,12 +205,16 @@ describe('configs routes', () => {
     expect(response.status).toEqual(200);
     expect(logtoConfigQueries.updateOidcConfigsByKey).toHaveBeenCalledWith(
       LogtoOidcConfigKey.PrivateKeys,
-      [newPrivateKey, ...mockPrivateKeys]
+      [
+        { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
+        { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Previous },
+      ]
     );
     expect(response.body[0]).toEqual({
       id: newPrivateKey.id,
       createdAt: newPrivateKey.createdAt,
       signingKeyAlgorithm: 'RSA',
+      status: OidcSigningKeyStatus.Current,
     });
 
     const response2 = await routeRequester.post('/configs/oidc/cookie-keys/rotate');
@@ -196,9 +230,12 @@ describe('configs routes', () => {
     logtoConfigLibraries.getOidcConfigs.mockRestore();
   });
 
-  it('keeps only the last 2 recent private keys when rotating', async () => {
+  it('keeps the immediate rotation flow at 2 private keys', async () => {
     logtoConfigLibraries.getOidcConfigs.mockResolvedValueOnce({
-      [LogtoOidcConfigKey.PrivateKeys]: [newPrivateKey, ...mockPrivateKeys],
+      [LogtoOidcConfigKey.PrivateKeys]: [
+        { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
+        { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Previous },
+      ],
       [LogtoOidcConfigKey.CookieKeys]: [newCookieKey, ...mockCookieKeys],
     });
 
@@ -214,7 +251,10 @@ describe('configs routes', () => {
     // Only has two keys and the original mocked private keys are clamped off
     expect(logtoConfigQueries.updateOidcConfigsByKey).toHaveBeenCalledWith(
       LogtoOidcConfigKey.PrivateKeys,
-      [newPrivateKey2, newPrivateKey]
+      [
+        { ...newPrivateKey2, status: OidcSigningKeyStatus.Current },
+        { ...newPrivateKey, status: OidcSigningKeyStatus.Previous },
+      ]
     );
   });
 });

--- a/packages/core/src/routes/logto-config/index.ts
+++ b/packages/core/src/routes/logto-config/index.ts
@@ -6,17 +6,23 @@ import {
 } from '@logto/cli/lib/commands/database/utils.js';
 import {
   LogtoOidcConfigKey,
+  OidcSigningKeyStatus,
   adminConsoleDataGuard,
   oidcConfigKeysResponseGuard,
   SupportedSigningKeyAlgorithm,
   type OidcConfigKeysResponse,
   type OidcConfigKey,
+  type OidcPrivateKey,
   LogtoOidcConfigKeyType,
   oidcSessionConfigGuard,
 } from '@logto/schemas';
 import { z } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
+import {
+  getImmediatelyRotatedOidcPrivateKeys,
+  getOidcPrivateKeysAfterDeletion,
+} from '#src/libraries/oidc-private-key.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import defaults from '#src/oidc/defaults.js';
 import { getConsoleLogFromContext } from '#src/utils/console.js';
@@ -48,16 +54,17 @@ const oidcSessionConfigResponseGuard = oidcSessionConfigGuard.required({ ttl: tr
  */
 const getRedactedOidcKeyResponse = async (
   type: LogtoOidcConfigKey,
-  keys: OidcConfigKey[]
+  keys: Array<OidcConfigKey | OidcPrivateKey>
 ): Promise<OidcConfigKeysResponse[]> =>
   Promise.all(
-    keys.map(async ({ id, value, createdAt }) => {
+    keys.map(async ({ id, value, createdAt, ...rest }) => {
       if (type === LogtoOidcConfigKey.PrivateKeys) {
         const jwk = await exportJWK(crypto.createPrivateKey(value));
         const parseResult = oidcConfigKeysResponseGuard.safeParse({
           id,
           createdAt,
           signingKeyAlgorithm: jwk.kty,
+          status: 'status' in rest ? rest.status : undefined,
         });
         if (!parseResult.success) {
           throw new RequestError({ code: 'request.general', status: 422 });
@@ -191,7 +198,22 @@ export default function logtoConfigRoutes<T extends ManagementApiRouter>(
         throw new RequestError({ code: 'oidc.key_not_found', id: keyId, status: 404 });
       }
 
-      const updatedKeys = existingKeys.filter(({ id }) => id !== keyId);
+      const updatedKeys =
+        configKey === LogtoOidcConfigKey.PrivateKeys
+          ? (() => {
+              const privateKeys = configs[LogtoOidcConfigKey.PrivateKeys];
+              const deletingKey = privateKeys.find(({ id }) => id === keyId);
+
+              if (deletingKey?.status !== OidcSigningKeyStatus.Previous) {
+                throw new RequestError({
+                  code: 'oidc.only_previous_key_can_be_deleted',
+                  status: 422,
+                });
+              }
+
+              return getOidcPrivateKeysAfterDeletion(privateKeys, keyId);
+            })()
+          : existingKeys.filter(({ id }) => id !== keyId);
 
       await updateOidcConfigsByKey(configKey, updatedKeys);
       void tenant.invalidateCache();
@@ -226,9 +248,10 @@ export default function logtoConfigRoutes<T extends ManagementApiRouter>(
           ? await generateOidcPrivateKey(signingKeyAlgorithm)
           : generateOidcCookieKey();
 
-      // Clamp and only keep the 2 most recent private keys.
-      // Also make sure the new key is always on top of the list.
-      const updatedKeys = [newPrivateKey, ...existingKeys].slice(0, 2);
+      const updatedKeys =
+        configKey === LogtoOidcConfigKey.PrivateKeys
+          ? getImmediatelyRotatedOidcPrivateKeys(existingKeys, newPrivateKey)
+          : [newPrivateKey, ...existingKeys].slice(0, 2);
 
       await updateOidcConfigsByKey(configKey, updatedKeys);
       void tenant.invalidateCache();

--- a/packages/core/src/routes/logto-config/index.ts
+++ b/packages/core/src/routes/logto-config/index.ts
@@ -191,44 +191,44 @@ export default function logtoConfigRoutes<T extends ManagementApiRouter>(
     async (ctx, next) => {
       const { keyType, keyId } = ctx.guard.params;
       const configKey = getOidcConfigKeyDatabaseColumnName(keyType);
-      const updatedKeys =
-        configKey === LogtoOidcConfigKey.PrivateKeys
-          ? await updatePrivateSigningKeysWithLock((privateKeys) => {
-              if (privateKeys.length <= 1) {
-                throw new RequestError({ code: 'oidc.key_required', status: 422 });
-              }
+      await (configKey === LogtoOidcConfigKey.PrivateKeys
+        ? updatePrivateSigningKeysWithLock((privateKeys) => {
+            if (privateKeys.length <= 1) {
+              throw new RequestError({ code: 'oidc.key_required', status: 422 });
+            }
 
-              const deletingKey = privateKeys.find(({ id }) => id === keyId);
+            const deletingKey = privateKeys.find(({ id }) => id === keyId);
 
-              if (!deletingKey) {
-                throw new RequestError({ code: 'oidc.key_not_found', id: keyId, status: 404 });
-              }
+            if (!deletingKey) {
+              throw new RequestError({ code: 'oidc.key_not_found', id: keyId, status: 404 });
+            }
 
-              if (deletingKey.status !== OidcSigningKeyStatus.Previous) {
-                throw new RequestError({
-                  code: 'oidc.only_previous_key_can_be_deleted',
-                  status: 422,
-                });
-              }
+            if (deletingKey.status !== OidcSigningKeyStatus.Previous) {
+              throw new RequestError({
+                code: 'oidc.only_previous_key_can_be_deleted',
+                status: 422,
+              });
+            }
 
-              return getOidcPrivateKeysAfterDeletion(privateKeys, keyId);
-            })
-          : await (async () => {
-              const configs = await getOidcConfigs(getConsoleLogFromContext(ctx));
-              const existingKeys = configs[configKey];
+            return getOidcPrivateKeysAfterDeletion(privateKeys, keyId);
+          })
+        : (async () => {
+            const configs = await getOidcConfigs(getConsoleLogFromContext(ctx));
+            const existingKeys = configs[configKey];
 
-              if (existingKeys.length <= 1) {
-                throw new RequestError({ code: 'oidc.key_required', status: 422 });
-              }
+            if (existingKeys.length <= 1) {
+              throw new RequestError({ code: 'oidc.key_required', status: 422 });
+            }
 
-              if (!existingKeys.some(({ id }) => id === keyId)) {
-                throw new RequestError({ code: 'oidc.key_not_found', id: keyId, status: 404 });
-              }
+            if (!existingKeys.some(({ id }) => id === keyId)) {
+              throw new RequestError({ code: 'oidc.key_not_found', id: keyId, status: 404 });
+            }
 
-              const updatedKeys = existingKeys.filter(({ id }) => id !== keyId);
-              await updateOidcConfigsByKey(configKey, updatedKeys);
-              return updatedKeys;
-            })();
+            await updateOidcConfigsByKey(
+              configKey,
+              existingKeys.filter(({ id }) => id !== keyId)
+            );
+          })());
       void tenant.invalidateCache();
 
       ctx.status = 204;

--- a/packages/core/src/routes/logto-config/index.ts
+++ b/packages/core/src/routes/logto-config/index.ts
@@ -22,7 +22,6 @@ import RequestError from '#src/errors/RequestError/index.js';
 import {
   getImmediatelyRotatedOidcPrivateKeys,
   getOidcPrivateKeysAfterDeletion,
-  normalizeOidcPrivateKeys,
 } from '#src/libraries/oidc-private-key.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import defaults from '#src/oidc/defaults.js';
@@ -83,7 +82,7 @@ export default function logtoConfigRoutes<T extends ManagementApiRouter>(
     getAdminConsoleConfig,
     updateAdminConsoleConfig,
     updateOidcConfigsByKey,
-    updatePrivateSigningKeys,
+    updatePrivateSigningKeysWithLock,
   } = tenant.queries.logtoConfigs;
   const { getOidcConfigs } = tenant.logtoConfigs;
 
@@ -192,24 +191,20 @@ export default function logtoConfigRoutes<T extends ManagementApiRouter>(
     async (ctx, next) => {
       const { keyType, keyId } = ctx.guard.params;
       const configKey = getOidcConfigKeyDatabaseColumnName(keyType);
-      const configs = await getOidcConfigs(getConsoleLogFromContext(ctx));
-      const existingKeys = configs[configKey];
-
-      if (existingKeys.length <= 1) {
-        throw new RequestError({ code: 'oidc.key_required', status: 422 });
-      }
-
-      if (!existingKeys.some(({ id }) => id === keyId)) {
-        throw new RequestError({ code: 'oidc.key_not_found', id: keyId, status: 404 });
-      }
-
       const updatedKeys =
         configKey === LogtoOidcConfigKey.PrivateKeys
-          ? (() => {
-              const privateKeys = configs[LogtoOidcConfigKey.PrivateKeys];
+          ? await updatePrivateSigningKeysWithLock((privateKeys) => {
+              if (privateKeys.length <= 1) {
+                throw new RequestError({ code: 'oidc.key_required', status: 422 });
+              }
+
               const deletingKey = privateKeys.find(({ id }) => id === keyId);
 
-              if (deletingKey?.status !== OidcSigningKeyStatus.Previous) {
+              if (!deletingKey) {
+                throw new RequestError({ code: 'oidc.key_not_found', id: keyId, status: 404 });
+              }
+
+              if (deletingKey.status !== OidcSigningKeyStatus.Previous) {
                 throw new RequestError({
                   code: 'oidc.only_previous_key_can_be_deleted',
                   status: 422,
@@ -217,12 +212,23 @@ export default function logtoConfigRoutes<T extends ManagementApiRouter>(
               }
 
               return getOidcPrivateKeysAfterDeletion(privateKeys, keyId);
-            })()
-          : existingKeys.filter(({ id }) => id !== keyId);
+            })
+          : await (async () => {
+              const configs = await getOidcConfigs(getConsoleLogFromContext(ctx));
+              const existingKeys = configs[configKey];
 
-      await (configKey === LogtoOidcConfigKey.PrivateKeys
-        ? updatePrivateSigningKeys(updatedKeys)
-        : updateOidcConfigsByKey(configKey, updatedKeys));
+              if (existingKeys.length <= 1) {
+                throw new RequestError({ code: 'oidc.key_required', status: 422 });
+              }
+
+              if (!existingKeys.some(({ id }) => id === keyId)) {
+                throw new RequestError({ code: 'oidc.key_not_found', id: keyId, status: 404 });
+              }
+
+              const updatedKeys = existingKeys.filter(({ id }) => id !== keyId);
+              await updateOidcConfigsByKey(configKey, updatedKeys);
+              return updatedKeys;
+            })();
       void tenant.invalidateCache();
 
       ctx.status = 204;
@@ -247,8 +253,6 @@ export default function logtoConfigRoutes<T extends ManagementApiRouter>(
       const { keyType } = ctx.guard.params;
       const { signingKeyAlgorithm } = ctx.guard.body;
       const configKey = getOidcConfigKeyDatabaseColumnName(keyType);
-      const configs = await getOidcConfigs(getConsoleLogFromContext(ctx));
-      const existingKeys = configs[configKey];
 
       const newPrivateKey =
         configKey === LogtoOidcConfigKey.PrivateKeys
@@ -257,20 +261,20 @@ export default function logtoConfigRoutes<T extends ManagementApiRouter>(
 
       const updatedKeys =
         configKey === LogtoOidcConfigKey.PrivateKeys
-          ? (() => {
-              const privateKeys = normalizeOidcPrivateKeys(existingKeys);
-
+          ? await updatePrivateSigningKeysWithLock((privateKeys) => {
               if (privateKeys.some(({ status }) => status === OidcSigningKeyStatus.Next)) {
                 throw new RequestError({ code: 'oidc.invalid_request', status: 422 });
               }
 
               return getImmediatelyRotatedOidcPrivateKeys(privateKeys, newPrivateKey);
-            })()
-          : [newPrivateKey, ...existingKeys].slice(0, 2);
-
-      await (configKey === LogtoOidcConfigKey.PrivateKeys
-        ? updatePrivateSigningKeys(updatedKeys)
-        : updateOidcConfigsByKey(configKey, updatedKeys));
+            })
+          : await (async () => {
+              const configs = await getOidcConfigs(getConsoleLogFromContext(ctx));
+              const existingKeys = configs[configKey];
+              const updatedKeys = [newPrivateKey, ...existingKeys].slice(0, 2);
+              await updateOidcConfigsByKey(configKey, updatedKeys);
+              return updatedKeys;
+            })();
       void tenant.invalidateCache();
 
       // Remove actual values of the private keys from response

--- a/packages/core/src/routes/logto-config/index.ts
+++ b/packages/core/src/routes/logto-config/index.ts
@@ -6,7 +6,6 @@ import {
 } from '@logto/cli/lib/commands/database/utils.js';
 import {
   LogtoOidcConfigKey,
-  OidcSigningKeyStatus,
   adminConsoleDataGuard,
   oidcConfigKeysResponseGuard,
   SupportedSigningKeyAlgorithm,
@@ -19,10 +18,6 @@ import {
 import { z } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
-import {
-  getImmediatelyRotatedOidcPrivateKeys,
-  getOidcPrivateKeysAfterDeletion,
-} from '#src/libraries/oidc-private-key.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import defaults from '#src/oidc/defaults.js';
 import { getConsoleLogFromContext } from '#src/utils/console.js';
@@ -78,13 +73,10 @@ const getRedactedOidcKeyResponse = async (
 export default function logtoConfigRoutes<T extends ManagementApiRouter>(
   ...[router, tenant]: RouterInitArgs<T>
 ) {
-  const {
-    getAdminConsoleConfig,
-    updateAdminConsoleConfig,
-    updateOidcConfigsByKey,
-    updatePrivateSigningKeysWithLock,
-  } = tenant.queries.logtoConfigs;
+  const { getAdminConsoleConfig, updateAdminConsoleConfig, updateOidcConfigsByKey } =
+    tenant.queries.logtoConfigs;
   const { getOidcConfigs } = tenant.logtoConfigs;
+  const { oidcPrivateKeys } = tenant.libraries;
 
   router.get(
     '/configs/admin-console',
@@ -192,26 +184,7 @@ export default function logtoConfigRoutes<T extends ManagementApiRouter>(
       const { keyType, keyId } = ctx.guard.params;
       const configKey = getOidcConfigKeyDatabaseColumnName(keyType);
       await (configKey === LogtoOidcConfigKey.PrivateKeys
-        ? updatePrivateSigningKeysWithLock((privateKeys) => {
-            if (privateKeys.length <= 1) {
-              throw new RequestError({ code: 'oidc.key_required', status: 422 });
-            }
-
-            const deletingKey = privateKeys.find(({ id }) => id === keyId);
-
-            if (!deletingKey) {
-              throw new RequestError({ code: 'oidc.key_not_found', id: keyId, status: 404 });
-            }
-
-            if (deletingKey.status !== OidcSigningKeyStatus.Previous) {
-              throw new RequestError({
-                code: 'oidc.only_previous_key_can_be_deleted',
-                status: 422,
-              });
-            }
-
-            return getOidcPrivateKeysAfterDeletion(privateKeys, keyId);
-          })
+        ? oidcPrivateKeys.deletePrivateSigningKey(keyId)
         : (async () => {
             const configs = await getOidcConfigs(getConsoleLogFromContext(ctx));
             const existingKeys = configs[configKey];
@@ -261,13 +234,7 @@ export default function logtoConfigRoutes<T extends ManagementApiRouter>(
 
       const updatedKeys =
         configKey === LogtoOidcConfigKey.PrivateKeys
-          ? await updatePrivateSigningKeysWithLock((privateKeys) => {
-              if (privateKeys.some(({ status }) => status === OidcSigningKeyStatus.Next)) {
-                throw new RequestError({ code: 'oidc.invalid_request', status: 422 });
-              }
-
-              return getImmediatelyRotatedOidcPrivateKeys(privateKeys, newPrivateKey);
-            })
+          ? await oidcPrivateKeys.rotatePrivateSigningKeys(newPrivateKey)
           : await (async () => {
               const configs = await getOidcConfigs(getConsoleLogFromContext(ctx));
               const existingKeys = configs[configKey];

--- a/packages/core/src/routes/logto-config/index.ts
+++ b/packages/core/src/routes/logto-config/index.ts
@@ -78,8 +78,12 @@ const getRedactedOidcKeyResponse = async (
 export default function logtoConfigRoutes<T extends ManagementApiRouter>(
   ...[router, tenant]: RouterInitArgs<T>
 ) {
-  const { getAdminConsoleConfig, updateAdminConsoleConfig, updateOidcConfigsByKey } =
-    tenant.queries.logtoConfigs;
+  const {
+    getAdminConsoleConfig,
+    updateAdminConsoleConfig,
+    updateOidcConfigsByKey,
+    updatePrivateSigningKeys,
+  } = tenant.queries.logtoConfigs;
   const { getOidcConfigs } = tenant.logtoConfigs;
 
   router.get(
@@ -215,7 +219,9 @@ export default function logtoConfigRoutes<T extends ManagementApiRouter>(
             })()
           : existingKeys.filter(({ id }) => id !== keyId);
 
-      await updateOidcConfigsByKey(configKey, updatedKeys);
+      await (configKey === LogtoOidcConfigKey.PrivateKeys
+        ? updatePrivateSigningKeys(updatedKeys)
+        : updateOidcConfigsByKey(configKey, updatedKeys));
       void tenant.invalidateCache();
 
       ctx.status = 204;
@@ -253,7 +259,9 @@ export default function logtoConfigRoutes<T extends ManagementApiRouter>(
           ? getImmediatelyRotatedOidcPrivateKeys(existingKeys, newPrivateKey)
           : [newPrivateKey, ...existingKeys].slice(0, 2);
 
-      await updateOidcConfigsByKey(configKey, updatedKeys);
+      await (configKey === LogtoOidcConfigKey.PrivateKeys
+        ? updatePrivateSigningKeys(updatedKeys)
+        : updateOidcConfigsByKey(configKey, updatedKeys));
       void tenant.invalidateCache();
 
       // Remove actual values of the private keys from response

--- a/packages/core/src/routes/logto-config/index.ts
+++ b/packages/core/src/routes/logto-config/index.ts
@@ -22,6 +22,7 @@ import RequestError from '#src/errors/RequestError/index.js';
 import {
   getImmediatelyRotatedOidcPrivateKeys,
   getOidcPrivateKeysAfterDeletion,
+  normalizeOidcPrivateKeys,
 } from '#src/libraries/oidc-private-key.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import defaults from '#src/oidc/defaults.js';
@@ -256,7 +257,15 @@ export default function logtoConfigRoutes<T extends ManagementApiRouter>(
 
       const updatedKeys =
         configKey === LogtoOidcConfigKey.PrivateKeys
-          ? getImmediatelyRotatedOidcPrivateKeys(existingKeys, newPrivateKey)
+          ? (() => {
+              const privateKeys = normalizeOidcPrivateKeys(existingKeys);
+
+              if (privateKeys.some(({ status }) => status === OidcSigningKeyStatus.Next)) {
+                throw new RequestError({ code: 'oidc.invalid_request', status: 422 });
+              }
+
+              return getImmediatelyRotatedOidcPrivateKeys(privateKeys, newPrivateKey);
+            })()
           : [newPrivateKey, ...existingKeys].slice(0, 2);
 
       await (configKey === LogtoOidcConfigKey.PrivateKeys

--- a/packages/core/src/tenants/Libraries.ts
+++ b/packages/core/src/tenants/Libraries.ts
@@ -6,6 +6,7 @@ import { createDomainLibrary } from '#src/libraries/domain.js';
 import { createHookLibrary } from '#src/libraries/hook/index.js';
 import { JwtCustomizerLibrary } from '#src/libraries/jwt-customizer.js';
 import type { LogtoConfigLibrary } from '#src/libraries/logto-config.js';
+import { OidcPrivateKeyLibrary } from '#src/libraries/oidc-private-key.js';
 import { createOneTimeTokenLibrary } from '#src/libraries/one-time-token.js';
 import { OrganizationInvitationLibrary } from '#src/libraries/organization-invitation.js';
 import { createPasscodeLibrary } from '#src/libraries/passcode.js';
@@ -70,6 +71,8 @@ export default class Libraries {
     this.queries,
     this.connectors
   );
+
+  oidcPrivateKeys = new OidcPrivateKeyLibrary(this.queries);
 
   customProfileFields = createCustomProfileFieldsLibrary(this.queries);
 

--- a/packages/integration-tests/src/tests/api/logto-config.test.ts
+++ b/packages/integration-tests/src/tests/api/logto-config.test.ts
@@ -4,6 +4,7 @@ import {
   LogtoOidcConfigKeyType,
   LogtoJwtTokenKey,
   LogtoJwtTokenKeyType,
+  OidcSigningKeyStatus,
 } from '@logto/schemas';
 
 import {
@@ -60,15 +61,13 @@ describe('logto config', () => {
     const cookieKeys = await getOidcKeys(LogtoOidcConfigKeyType.CookieKeys);
 
     expect(privateKeys).toHaveLength(1);
-    expect(privateKeys[0]).toMatchObject(
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      { id: expect.any(String), signingKeyAlgorithm: 'EC', createdAt: expect.any(Number) }
-    );
+    expect(privateKeys[0]?.id).toEqual(expect.any(String));
+    expect(privateKeys[0]?.signingKeyAlgorithm).toBe('EC');
+    expect(privateKeys[0]?.createdAt).toEqual(expect.any(Number));
+    expect(privateKeys[0]?.status).toBe(OidcSigningKeyStatus.Current);
     expect(cookieKeys).toHaveLength(1);
-    expect(cookieKeys[0]).toMatchObject(
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      { id: expect.any(String), createdAt: expect.any(Number) }
-    );
+    expect(cookieKeys[0]?.id).toEqual(expect.any(String));
+    expect(cookieKeys[0]?.createdAt).toEqual(expect.any(Number));
   });
 
   it('should not be able to delete the only private key', async () => {
@@ -95,37 +94,39 @@ describe('logto config', () => {
     );
 
     expect(newPrivateKeys).toHaveLength(2);
-    expect(newPrivateKeys).toMatchObject([
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      { id: expect.any(String), signingKeyAlgorithm: 'RSA', createdAt: expect.any(Number) },
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      { id: expect.any(String), signingKeyAlgorithm: 'EC', createdAt: expect.any(Number) },
-    ]);
+    expect(newPrivateKeys[0]?.id).toEqual(expect.any(String));
+    expect(newPrivateKeys[0]?.signingKeyAlgorithm).toBe('RSA');
+    expect(newPrivateKeys[0]?.createdAt).toEqual(expect.any(Number));
+    expect(newPrivateKeys[0]?.status).toBe(OidcSigningKeyStatus.Current);
+    expect(newPrivateKeys[1]?.id).toEqual(expect.any(String));
+    expect(newPrivateKeys[1]?.signingKeyAlgorithm).toBe('EC');
+    expect(newPrivateKeys[1]?.createdAt).toEqual(expect.any(Number));
+    expect(newPrivateKeys[1]?.status).toBe(OidcSigningKeyStatus.Previous);
     expect(newPrivateKeys[1]?.id).toBe(existingPrivateKeys[0]?.id);
 
     const existingCookieKeys = await getOidcKeys(LogtoOidcConfigKeyType.CookieKeys);
     const newCookieKeys = await rotateOidcKeys(LogtoOidcConfigKeyType.CookieKeys);
 
     expect(newCookieKeys).toHaveLength(2);
-    expect(newCookieKeys).toMatchObject([
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      { id: expect.any(String), createdAt: expect.any(Number) },
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      { id: expect.any(String), createdAt: expect.any(Number) },
-    ]);
+    expect(newCookieKeys[0]?.id).toEqual(expect.any(String));
+    expect(newCookieKeys[0]?.createdAt).toEqual(expect.any(Number));
+    expect(newCookieKeys[1]?.id).toEqual(expect.any(String));
+    expect(newCookieKeys[1]?.createdAt).toEqual(expect.any(Number));
     expect(newCookieKeys[1]?.id).toBe(existingCookieKeys[0]?.id);
   });
 
-  it('should only keep 2 recent OIDC keys', async () => {
+  it('should keep the immediate rotation flow at 2 private keys', async () => {
     const privateKeys = await rotateOidcKeys(LogtoOidcConfigKeyType.PrivateKeys); // Defaults to 'EC' algorithm
 
     expect(privateKeys).toHaveLength(2);
-    expect(privateKeys).toMatchObject([
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      { id: expect.any(String), signingKeyAlgorithm: 'EC', createdAt: expect.any(Number) },
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      { id: expect.any(String), signingKeyAlgorithm: 'RSA', createdAt: expect.any(Number) },
-    ]);
+    expect(privateKeys[0]?.id).toEqual(expect.any(String));
+    expect(privateKeys[0]?.signingKeyAlgorithm).toBe('EC');
+    expect(privateKeys[0]?.createdAt).toEqual(expect.any(Number));
+    expect(privateKeys[0]?.status).toBe(OidcSigningKeyStatus.Current);
+    expect(privateKeys[1]?.id).toEqual(expect.any(String));
+    expect(privateKeys[1]?.signingKeyAlgorithm).toBe('RSA');
+    expect(privateKeys[1]?.createdAt).toEqual(expect.any(Number));
+    expect(privateKeys[1]?.status).toBe(OidcSigningKeyStatus.Previous);
 
     const privateKeys2 = await rotateOidcKeys(
       LogtoOidcConfigKeyType.PrivateKeys,
@@ -133,13 +134,39 @@ describe('logto config', () => {
     );
 
     expect(privateKeys2).toHaveLength(2);
-    expect(privateKeys2).toMatchObject([
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      { id: expect.any(String), signingKeyAlgorithm: 'RSA', createdAt: expect.any(Number) },
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      { id: expect.any(String), signingKeyAlgorithm: 'EC', createdAt: expect.any(Number) },
-    ]);
+    expect(privateKeys2[0]?.id).toEqual(expect.any(String));
+    expect(privateKeys2[0]?.signingKeyAlgorithm).toBe('RSA');
+    expect(privateKeys2[0]?.createdAt).toEqual(expect.any(Number));
+    expect(privateKeys2[0]?.status).toBe(OidcSigningKeyStatus.Current);
+    expect(privateKeys2[1]?.id).toEqual(expect.any(String));
+    expect(privateKeys2[1]?.signingKeyAlgorithm).toBe('EC');
+    expect(privateKeys2[1]?.createdAt).toEqual(expect.any(Number));
+    expect(privateKeys2[1]?.status).toBe(OidcSigningKeyStatus.Previous);
     expect(privateKeys2[1]?.id).toBe(privateKeys[0]?.id);
+  });
+
+  it('should only allow deleting a Previous private key', async () => {
+    const rotatedPrivateKeys = await rotateOidcKeys(LogtoOidcConfigKeyType.PrivateKeys);
+
+    await expectRejects(
+      deleteOidcKey(LogtoOidcConfigKeyType.PrivateKeys, rotatedPrivateKeys[0]!.id),
+      {
+        code: 'oidc.only_previous_key_can_be_deleted',
+        status: 422,
+      }
+    );
+
+    await expect(
+      deleteOidcKey(LogtoOidcConfigKeyType.PrivateKeys, rotatedPrivateKeys[1]!.id)
+    ).resolves.not.toThrow();
+
+    const remainingPrivateKeys = await getOidcKeys(LogtoOidcConfigKeyType.PrivateKeys);
+
+    expect(remainingPrivateKeys).toHaveLength(1);
+    expect(remainingPrivateKeys[0]).toMatchObject({
+      id: rotatedPrivateKeys[0]!.id,
+      status: OidcSigningKeyStatus.Current,
+    });
   });
 
   it('should successfully PUT/GET/DELETE a JWT customizer (access token)', async () => {

--- a/packages/phrases/src/locales/ar/errors/oidc.ts
+++ b/packages/phrases/src/locales/ar/errors/oidc.ts
@@ -19,6 +19,7 @@ const oidc = {
   custom_claims_script_error: 'خطأ في نص claims المخصص: {{error_description}}',
   key_required: 'مطلوب مفتاح واحد على الأقل.',
   key_not_found: 'لم يتم العثور على المفتاح بالمعرف {{id}}.',
+  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
   invalid_session_payload: 'حمولة الجلسة غير صالحة.',
   session_not_found: 'لم يتم العثور على الجلسة.',
   invalid_session_account_id: 'عدم توافق معرف حساب الجلسة.',

--- a/packages/phrases/src/locales/ar/errors/oidc.ts
+++ b/packages/phrases/src/locales/ar/errors/oidc.ts
@@ -19,7 +19,7 @@ const oidc = {
   custom_claims_script_error: 'خطأ في نص claims المخصص: {{error_description}}',
   key_required: 'مطلوب مفتاح واحد على الأقل.',
   key_not_found: 'لم يتم العثور على المفتاح بالمعرف {{id}}.',
-  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
+  only_previous_key_can_be_deleted: 'يمكن حذف المفتاح السابق فقط.',
   invalid_session_payload: 'حمولة الجلسة غير صالحة.',
   session_not_found: 'لم يتم العثور على الجلسة.',
   invalid_session_account_id: 'عدم توافق معرف حساب الجلسة.',

--- a/packages/phrases/src/locales/de/errors/oidc.ts
+++ b/packages/phrases/src/locales/de/errors/oidc.ts
@@ -21,6 +21,7 @@ const oidc = {
   custom_claims_script_error: 'Fehler im benutzerdefinierten Claims-Skript: {{error_description}}',
   key_required: 'Mindestens ein Schlüssel ist erforderlich.',
   key_not_found: 'Der Schlüssel mit der ID {{id}} wurde nicht gefunden.',
+  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
   invalid_session_payload: 'Ungültige Sitzungsnutzlast.',
   session_not_found: 'Sitzung nicht gefunden.',
   invalid_session_account_id: 'Sitzung accountId stimmt nicht überein.',

--- a/packages/phrases/src/locales/de/errors/oidc.ts
+++ b/packages/phrases/src/locales/de/errors/oidc.ts
@@ -21,7 +21,7 @@ const oidc = {
   custom_claims_script_error: 'Fehler im benutzerdefinierten Claims-Skript: {{error_description}}',
   key_required: 'Mindestens ein Schlüssel ist erforderlich.',
   key_not_found: 'Der Schlüssel mit der ID {{id}} wurde nicht gefunden.',
-  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
+  only_previous_key_can_be_deleted: 'Nur ein vorheriger Schlüssel kann gelöscht werden.',
   invalid_session_payload: 'Ungültige Sitzungsnutzlast.',
   session_not_found: 'Sitzung nicht gefunden.',
   invalid_session_account_id: 'Sitzung accountId stimmt nicht überein.',

--- a/packages/phrases/src/locales/en/errors/oidc.ts
+++ b/packages/phrases/src/locales/en/errors/oidc.ts
@@ -21,6 +21,7 @@ const oidc = {
   custom_claims_script_error: 'Custom claims script error: {{error_description}}',
   key_required: 'At least one key is required.',
   key_not_found: 'Key with ID {{id}} is not found.',
+  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
   invalid_session_payload: 'Invalid session payload.',
   session_not_found: 'Session not found.',
   invalid_session_account_id: 'Session accountId mismatch.',

--- a/packages/phrases/src/locales/en/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/signing-keys.ts
@@ -21,6 +21,7 @@ const signing_keys = {
     algorithm: 'Signing key algorithm',
   },
   status: {
+    next: 'Next',
     current: 'Current',
     previous: 'Previous',
   },

--- a/packages/phrases/src/locales/es/errors/oidc.ts
+++ b/packages/phrases/src/locales/es/errors/oidc.ts
@@ -20,7 +20,7 @@ const oidc = {
   custom_claims_script_error: 'Error del script de claims personalizados: {{error_description}}',
   key_required: 'Se requiere al menos una clave.',
   key_not_found: 'No se encuentra la clave con ID {{id}}.',
-  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
+  only_previous_key_can_be_deleted: 'Solo se puede eliminar una clave anterior.',
   invalid_session_payload: 'Carga útil de sesión no válida.',
   session_not_found: 'Sesión no encontrada.',
   invalid_session_account_id: 'Entidad de cuenta de sesión no coincide.',

--- a/packages/phrases/src/locales/es/errors/oidc.ts
+++ b/packages/phrases/src/locales/es/errors/oidc.ts
@@ -20,6 +20,7 @@ const oidc = {
   custom_claims_script_error: 'Error del script de claims personalizados: {{error_description}}',
   key_required: 'Se requiere al menos una clave.',
   key_not_found: 'No se encuentra la clave con ID {{id}}.',
+  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
   invalid_session_payload: 'Carga útil de sesión no válida.',
   session_not_found: 'Sesión no encontrada.',
   invalid_session_account_id: 'Entidad de cuenta de sesión no coincide.',

--- a/packages/phrases/src/locales/fr/errors/oidc.ts
+++ b/packages/phrases/src/locales/fr/errors/oidc.ts
@@ -20,6 +20,7 @@ const oidc = {
   custom_claims_script_error: 'Erreur du script de claims personnalisés : {{error_description}}',
   key_required: 'Au moins une clé est requise.',
   key_not_found: "La clé avec l'ID {{id}} n'est pas trouvée.",
+  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
   invalid_session_payload: 'Charge utile de session invalide.',
   session_not_found: 'Session non trouvée.',
   invalid_session_account_id: "incohérence de l'accountId de session.",

--- a/packages/phrases/src/locales/fr/errors/oidc.ts
+++ b/packages/phrases/src/locales/fr/errors/oidc.ts
@@ -20,7 +20,7 @@ const oidc = {
   custom_claims_script_error: 'Erreur du script de claims personnalisés : {{error_description}}',
   key_required: 'Au moins une clé est requise.',
   key_not_found: "La clé avec l'ID {{id}} n'est pas trouvée.",
-  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
+  only_previous_key_can_be_deleted: 'Seule une clé précédente peut être supprimée.',
   invalid_session_payload: 'Charge utile de session invalide.',
   session_not_found: 'Session non trouvée.',
   invalid_session_account_id: "incohérence de l'accountId de session.",

--- a/packages/phrases/src/locales/it/errors/oidc.ts
+++ b/packages/phrases/src/locales/it/errors/oidc.ts
@@ -21,6 +21,7 @@ const oidc = {
     'Errore dello script dei claims personalizzati: {{error_description}}',
   key_required: 'È richiesta almeno una chiave.',
   key_not_found: 'Chiave con ID {{id}} non trovata.',
+  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
   invalid_session_payload: 'Payload di sessione non valido.',
   session_not_found: 'Sessione non trovata.',
   invalid_session_account_id: "L'accountId della sessione non corrisponde.",

--- a/packages/phrases/src/locales/it/errors/oidc.ts
+++ b/packages/phrases/src/locales/it/errors/oidc.ts
@@ -21,7 +21,7 @@ const oidc = {
     'Errore dello script dei claims personalizzati: {{error_description}}',
   key_required: 'È richiesta almeno una chiave.',
   key_not_found: 'Chiave con ID {{id}} non trovata.',
-  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
+  only_previous_key_can_be_deleted: 'Solo una chiave precedente può essere eliminata.',
   invalid_session_payload: 'Payload di sessione non valido.',
   session_not_found: 'Sessione non trovata.',
   invalid_session_account_id: "L'accountId della sessione non corrisponde.",

--- a/packages/phrases/src/locales/ja/errors/oidc.ts
+++ b/packages/phrases/src/locales/ja/errors/oidc.ts
@@ -20,6 +20,7 @@ const oidc = {
   custom_claims_script_error: 'カスタム claims スクリプトエラー: {{error_description}}',
   key_required: '少なくとも1つのキーが必要です。',
   key_not_found: 'IDが{{id}}のキーが見つかりません。',
+  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
   invalid_session_payload: '無効なセッションペイロード。',
   session_not_found: 'セッションが見つかりません。',
   invalid_session_account_id: 'セッションの accountId が一致しません。',

--- a/packages/phrases/src/locales/ja/errors/oidc.ts
+++ b/packages/phrases/src/locales/ja/errors/oidc.ts
@@ -20,7 +20,7 @@ const oidc = {
   custom_claims_script_error: 'カスタム claims スクリプトエラー: {{error_description}}',
   key_required: '少なくとも1つのキーが必要です。',
   key_not_found: 'IDが{{id}}のキーが見つかりません。',
-  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
+  only_previous_key_can_be_deleted: '削除できるのは Previous キーのみです。',
   invalid_session_payload: '無効なセッションペイロード。',
   session_not_found: 'セッションが見つかりません。',
   invalid_session_account_id: 'セッションの accountId が一致しません。',

--- a/packages/phrases/src/locales/ko/errors/oidc.ts
+++ b/packages/phrases/src/locales/ko/errors/oidc.ts
@@ -19,7 +19,7 @@ const oidc = {
   custom_claims_script_error: '커스텀 claims 스크립트 오류: {{error_description}}',
   key_required: '최소한 하나의 키가 필요해요.',
   key_not_found: 'ID가 {{id}}인 키를 찾을 수 없어요.',
-  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
+  only_previous_key_can_be_deleted: '이전 키만 삭제할 수 있습니다.',
   invalid_session_payload: '유효하지 않은 세션 페이로드입니다.',
   session_not_found: '세션을 찾을 수 없습니다.',
   invalid_session_account_id: '세션 accountId가 일치하지 않습니다.',

--- a/packages/phrases/src/locales/ko/errors/oidc.ts
+++ b/packages/phrases/src/locales/ko/errors/oidc.ts
@@ -19,6 +19,7 @@ const oidc = {
   custom_claims_script_error: '커스텀 claims 스크립트 오류: {{error_description}}',
   key_required: '최소한 하나의 키가 필요해요.',
   key_not_found: 'ID가 {{id}}인 키를 찾을 수 없어요.',
+  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
   invalid_session_payload: '유효하지 않은 세션 페이로드입니다.',
   session_not_found: '세션을 찾을 수 없습니다.',
   invalid_session_account_id: '세션 accountId가 일치하지 않습니다.',

--- a/packages/phrases/src/locales/pl-pl/errors/oidc.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/oidc.ts
@@ -20,7 +20,7 @@ const oidc = {
   custom_claims_script_error: 'Błąd skryptu niestandardowych claims: {{error_description}}',
   key_required: 'Wymagany jest co najmniej jeden klucz.',
   key_not_found: 'Nie znaleziono klucza o ID {{id}}.',
-  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
+  only_previous_key_can_be_deleted: 'Można usunąć tylko poprzedni klucz.',
   invalid_session_payload: 'Nieprawidłowy ładunek sesji.',
   session_not_found: 'Nie znaleziono sesji.',
   invalid_session_account_id: 'Niezgodność ID konta sesji.',

--- a/packages/phrases/src/locales/pl-pl/errors/oidc.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/oidc.ts
@@ -20,6 +20,7 @@ const oidc = {
   custom_claims_script_error: 'Błąd skryptu niestandardowych claims: {{error_description}}',
   key_required: 'Wymagany jest co najmniej jeden klucz.',
   key_not_found: 'Nie znaleziono klucza o ID {{id}}.',
+  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
   invalid_session_payload: 'Nieprawidłowy ładunek sesji.',
   session_not_found: 'Nie znaleziono sesji.',
   invalid_session_account_id: 'Niezgodność ID konta sesji.',

--- a/packages/phrases/src/locales/pt-br/errors/oidc.ts
+++ b/packages/phrases/src/locales/pt-br/errors/oidc.ts
@@ -20,7 +20,7 @@ const oidc = {
   custom_claims_script_error: 'Erro de script de claims personalizados: {{error_description}}',
   key_required: 'Pelo menos uma chave é necessária.',
   key_not_found: 'Chave com ID {{id}} não encontrada.',
-  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
+  only_previous_key_can_be_deleted: 'Somente uma chave anterior pode ser excluída.',
   invalid_session_payload: 'Conteúdo de sessão inválido.',
   session_not_found: 'Sessão não encontrada.',
   invalid_session_account_id: 'Incompatibilidade de accountId da sessão.',

--- a/packages/phrases/src/locales/pt-br/errors/oidc.ts
+++ b/packages/phrases/src/locales/pt-br/errors/oidc.ts
@@ -20,6 +20,7 @@ const oidc = {
   custom_claims_script_error: 'Erro de script de claims personalizados: {{error_description}}',
   key_required: 'Pelo menos uma chave é necessária.',
   key_not_found: 'Chave com ID {{id}} não encontrada.',
+  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
   invalid_session_payload: 'Conteúdo de sessão inválido.',
   session_not_found: 'Sessão não encontrada.',
   invalid_session_account_id: 'Incompatibilidade de accountId da sessão.',

--- a/packages/phrases/src/locales/pt-pt/errors/oidc.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/oidc.ts
@@ -19,7 +19,7 @@ const oidc = {
   custom_claims_script_error: 'Erro no script de claims personalizados: {{error_description}}',
   key_required: 'Pelo menos uma chave é necessária.',
   key_not_found: 'A chave com ID {{id}} não foi encontrada.',
-  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
+  only_previous_key_can_be_deleted: 'Apenas uma chave anterior pode ser eliminada.',
   invalid_session_payload: 'Carga de sessão inválida.',
   session_not_found: 'Sessão não encontrada.',
   invalid_session_account_id: 'Incompatibilidade do accountId da sessão.',

--- a/packages/phrases/src/locales/pt-pt/errors/oidc.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/oidc.ts
@@ -19,6 +19,7 @@ const oidc = {
   custom_claims_script_error: 'Erro no script de claims personalizados: {{error_description}}',
   key_required: 'Pelo menos uma chave é necessária.',
   key_not_found: 'A chave com ID {{id}} não foi encontrada.',
+  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
   invalid_session_payload: 'Carga de sessão inválida.',
   session_not_found: 'Sessão não encontrada.',
   invalid_session_account_id: 'Incompatibilidade do accountId da sessão.',

--- a/packages/phrases/src/locales/ru/errors/oidc.ts
+++ b/packages/phrases/src/locales/ru/errors/oidc.ts
@@ -20,6 +20,7 @@ const oidc = {
   custom_claims_script_error: 'Ошибка скрипта пользовательских claims: {{error_description}}',
   key_required: 'Требуется как минимум один ключ.',
   key_not_found: 'Ключ с идентификатором {{id}} не найден.',
+  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
   invalid_session_payload: 'Недопустимая полезная нагрузка сессии.',
   session_not_found: 'Сессия не найдена.',
   invalid_session_account_id: 'Несоответствие accountId сессии.',

--- a/packages/phrases/src/locales/ru/errors/oidc.ts
+++ b/packages/phrases/src/locales/ru/errors/oidc.ts
@@ -20,7 +20,7 @@ const oidc = {
   custom_claims_script_error: 'Ошибка скрипта пользовательских claims: {{error_description}}',
   key_required: 'Требуется как минимум один ключ.',
   key_not_found: 'Ключ с идентификатором {{id}} не найден.',
-  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
+  only_previous_key_can_be_deleted: 'Удалить можно только предыдущий ключ.',
   invalid_session_payload: 'Недопустимая полезная нагрузка сессии.',
   session_not_found: 'Сессия не найдена.',
   invalid_session_account_id: 'Несоответствие accountId сессии.',

--- a/packages/phrases/src/locales/th/errors/oidc.ts
+++ b/packages/phrases/src/locales/th/errors/oidc.ts
@@ -19,7 +19,7 @@ const oidc = {
   custom_claims_script_error: 'ข้อผิดพลาดของสคริปต์ custom claims: {{error_description}}',
   key_required: 'ต้องมีคีย์อย่างน้อยหนึ่งอัน',
   key_not_found: 'ไม่พบคีย์ที่มีรหัส {{id}}',
-  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
+  only_previous_key_can_be_deleted: 'ลบได้เฉพาะคีย์ก่อนหน้าเท่านั้น',
   invalid_session_payload: 'ข้อมูลเซสชันไม่ถูกต้อง',
   session_not_found: 'ไม่พบเซสชัน',
   invalid_session_account_id: 'Session accountId ไม่ตรงกัน',

--- a/packages/phrases/src/locales/th/errors/oidc.ts
+++ b/packages/phrases/src/locales/th/errors/oidc.ts
@@ -19,6 +19,7 @@ const oidc = {
   custom_claims_script_error: 'ข้อผิดพลาดของสคริปต์ custom claims: {{error_description}}',
   key_required: 'ต้องมีคีย์อย่างน้อยหนึ่งอัน',
   key_not_found: 'ไม่พบคีย์ที่มีรหัส {{id}}',
+  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
   invalid_session_payload: 'ข้อมูลเซสชันไม่ถูกต้อง',
   session_not_found: 'ไม่พบเซสชัน',
   invalid_session_account_id: 'Session accountId ไม่ตรงกัน',

--- a/packages/phrases/src/locales/tr-tr/errors/oidc.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/oidc.ts
@@ -20,6 +20,7 @@ const oidc = {
   custom_claims_script_error: 'Özel claims betiği hatası: {{error_description}}',
   key_required: 'En az bir anahtar gereklidir.',
   key_not_found: "ID'si {{id}} olan anahtar bulunamadı.",
+  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
   invalid_session_payload: 'Geçersiz oturum yükü.',
   session_not_found: 'Oturum bulunamadı.',
   invalid_session_account_id: 'Oturum accountId uyumsuzluğu.',

--- a/packages/phrases/src/locales/tr-tr/errors/oidc.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/oidc.ts
@@ -20,7 +20,7 @@ const oidc = {
   custom_claims_script_error: 'Özel claims betiği hatası: {{error_description}}',
   key_required: 'En az bir anahtar gereklidir.',
   key_not_found: "ID'si {{id}} olan anahtar bulunamadı.",
-  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
+  only_previous_key_can_be_deleted: 'Yalnızca önceki bir anahtar silinebilir.',
   invalid_session_payload: 'Geçersiz oturum yükü.',
   session_not_found: 'Oturum bulunamadı.',
   invalid_session_account_id: 'Oturum accountId uyumsuzluğu.',

--- a/packages/phrases/src/locales/zh-cn/errors/oidc.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/oidc.ts
@@ -19,7 +19,7 @@ const oidc = {
   custom_claims_script_error: '自定义 claims 脚本错误：{{error_description}}',
   key_required: '至少需要一个密钥。',
   key_not_found: '未找到 ID 为 {{id}} 的密钥。',
-  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
+  only_previous_key_can_be_deleted: '仅可删除上一个密钥。',
   invalid_session_payload: '无效的会话负载。',
   session_not_found: '未找到会话。',
   invalid_session_account_id: '会话的 accountId 不匹配。',

--- a/packages/phrases/src/locales/zh-cn/errors/oidc.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/oidc.ts
@@ -19,6 +19,7 @@ const oidc = {
   custom_claims_script_error: '自定义 claims 脚本错误：{{error_description}}',
   key_required: '至少需要一个密钥。',
   key_not_found: '未找到 ID 为 {{id}} 的密钥。',
+  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
   invalid_session_payload: '无效的会话负载。',
   session_not_found: '未找到会话。',
   invalid_session_account_id: '会话的 accountId 不匹配。',

--- a/packages/phrases/src/locales/zh-hk/errors/oidc.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/oidc.ts
@@ -19,6 +19,7 @@ const oidc = {
   custom_claims_script_error: '自訂 claims 腳本錯誤：{{error_description}}',
   key_required: '至少需要一個金鑰。',
   key_not_found: '未找到 ID 為 {{id}} 的金鑰。',
+  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
   invalid_session_payload: '無效的會話有效載荷。',
   session_not_found: '未找到會話。',
   invalid_session_account_id: '會話帳戶 ID 不匹配。',

--- a/packages/phrases/src/locales/zh-hk/errors/oidc.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/oidc.ts
@@ -19,7 +19,7 @@ const oidc = {
   custom_claims_script_error: '自訂 claims 腳本錯誤：{{error_description}}',
   key_required: '至少需要一個金鑰。',
   key_not_found: '未找到 ID 為 {{id}} 的金鑰。',
-  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
+  only_previous_key_can_be_deleted: '僅可刪除上一個金鑰。',
   invalid_session_payload: '無效的會話有效載荷。',
   session_not_found: '未找到會話。',
   invalid_session_account_id: '會話帳戶 ID 不匹配。',

--- a/packages/phrases/src/locales/zh-tw/errors/oidc.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/oidc.ts
@@ -19,6 +19,7 @@ const oidc = {
   custom_claims_script_error: '自訂 claims 腳本錯誤：{{error_description}}',
   key_required: '至少需要一個金鑰。',
   key_not_found: '未找到 ID 為 {{id}} 的金鑰。',
+  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
   invalid_session_payload: '無效的會話負載。',
   session_not_found: '未找到會話。',
   invalid_session_account_id: '會話 accountId 不匹配。',

--- a/packages/phrases/src/locales/zh-tw/errors/oidc.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/oidc.ts
@@ -19,7 +19,7 @@ const oidc = {
   custom_claims_script_error: '自訂 claims 腳本錯誤：{{error_description}}',
   key_required: '至少需要一個金鑰。',
   key_not_found: '未找到 ID 為 {{id}} 的金鑰。',
-  only_previous_key_can_be_deleted: 'Only a previous key can be deleted.',
+  only_previous_key_can_be_deleted: '僅可刪除上一個金鑰。',
   invalid_session_payload: '無效的會話負載。',
   session_not_found: '未找到會話。',
   invalid_session_account_id: '會話 accountId 不匹配。',


### PR DESCRIPTION
## Summary
- normalize private signing key lifecycle state from explicit statuses
- derive oidc-provider private key order from explicit signing key status
- make OIDC rotate/delete routes persist and return signing key status

## Testing
- pnpm -C packages/phrases build
- pnpm -C packages/core build:test
- pnpm -C packages/core test:only -- build/libraries/oidc-private-key.test.js
- pnpm -C packages/core test:only -- build/routes/logto-config/index.test.js
- pnpm -C packages/integration-tests build