### PR TITLE
feat(core): derive oidc provider key order from status

### DIFF
--- a/packages/core/src/env-set/oidc.ts
+++ b/packages/core/src/env-set/oidc.ts
@@ -5,12 +5,13 @@ import { LogtoOidcConfigKey } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
 import { createLocalJWKSet } from 'jose';
 
+import { getOidcProviderPrivateKeys } from '#src/libraries/oidc-private-key.js';
 import { exportJWK } from '#src/utils/jwks.js';
 
 const loadOidcValues = async (issuer: string, configs: LogtoOidcConfigType) => {
   const cookieKeys = configs[LogtoOidcConfigKey.CookieKeys].map(({ value }) => value);
-  const privateKeys = configs[LogtoOidcConfigKey.PrivateKeys].map(({ value }) =>
-    crypto.createPrivateKey(value)
+  const privateKeys = getOidcProviderPrivateKeys(configs[LogtoOidcConfigKey.PrivateKeys]).map(
+    ({ value }) => crypto.createPrivateKey(value)
   );
   const session = configs[LogtoOidcConfigKey.Session];
   const publicKeys = privateKeys.map((key) => crypto.createPublicKey(key));

--- a/packages/core/src/libraries/oidc-private-key.test.ts
+++ b/packages/core/src/libraries/oidc-private-key.test.ts
@@ -1,6 +1,6 @@
 import { OidcSigningKeyStatus } from '@logto/schemas';
 
-import { normalizeOidcPrivateKeys } from './oidc-private-key.js';
+import { getOidcProviderPrivateKeys, normalizeOidcPrivateKeys } from './oidc-private-key.js';
 
 const createPrivateKey = (id: string, createdAt: number, status?: OidcSigningKeyStatus) => ({
   id,
@@ -43,5 +43,21 @@ describe('normalizeOidcPrivateKeys', () => {
         createPrivateKey('current-b', 2, OidcSigningKeyStatus.Current),
       ])
     ).toThrow('Malformed OIDC private key status configuration');
+  });
+});
+
+describe('getOidcProviderPrivateKeys', () => {
+  it('orders private keys as Current, Next, Previous for oidc-provider signing', () => {
+    const result = getOidcProviderPrivateKeys([
+      createPrivateKey('previous', 3, OidcSigningKeyStatus.Previous),
+      createPrivateKey('current', 2, OidcSigningKeyStatus.Current),
+      createPrivateKey('next', 1, OidcSigningKeyStatus.Next),
+    ]);
+
+    expect(result).toEqual([
+      createPrivateKey('current', 2, OidcSigningKeyStatus.Current),
+      createPrivateKey('next', 1, OidcSigningKeyStatus.Next),
+      createPrivateKey('previous', 3, OidcSigningKeyStatus.Previous),
+    ]);
   });
 });

--- a/packages/core/src/libraries/oidc-private-key.ts
+++ b/packages/core/src/libraries/oidc-private-key.ts
@@ -7,18 +7,28 @@ const oidcPrivateKeyStatusOrder: Record<OidcSigningKeyStatus, number> = {
   [OidcSigningKeyStatus.Previous]: 2,
 };
 
+const oidcProviderPrivateKeyOrder: Record<OidcSigningKeyStatus, number> = {
+  [OidcSigningKeyStatus.Current]: 0,
+  [OidcSigningKeyStatus.Next]: 1,
+  [OidcSigningKeyStatus.Previous]: 2,
+};
+
+type NormalizedOidcPrivateKey = OidcPrivateKey & { status: OidcSigningKeyStatus };
+
 /**
  * Normalize private signing keys from legacy index-based lifecycle semantics into explicit statuses.
  */
 export const normalizeOidcPrivateKeys = (
   privateKeys: LogtoOidcConfigType['oidc.privateKeys']
-): OidcPrivateKey[] => {
-  const normalizedPrivateKeys = privateKeys.map((privateKey, index) => ({
-    ...privateKey,
-    status:
-      privateKey.status ??
-      (index === 0 ? OidcSigningKeyStatus.Current : OidcSigningKeyStatus.Previous),
-  }));
+): NormalizedOidcPrivateKey[] => {
+  const normalizedPrivateKeys: NormalizedOidcPrivateKey[] = privateKeys.map(
+    (privateKey, index) => ({
+      ...privateKey,
+      status:
+        privateKey.status ??
+        (index === 0 ? OidcSigningKeyStatus.Current : OidcSigningKeyStatus.Previous),
+    })
+  );
 
   const currentKeys = normalizedPrivateKeys.filter(
     ({ status }) => status === OidcSigningKeyStatus.Current
@@ -41,3 +51,14 @@ export const normalizeOidcPrivateKeys = (
       oidcPrivateKeyStatusOrder[left.status] - oidcPrivateKeyStatusOrder[right.status]
   );
 };
+
+/**
+ * Get private signing keys in the order expected by oidc-provider for active signing.
+ */
+export const getOidcProviderPrivateKeys = (
+  privateKeys: LogtoOidcConfigType['oidc.privateKeys']
+): NormalizedOidcPrivateKey[] =>
+  normalizeOidcPrivateKeys(privateKeys).toSorted(
+    (left, right) =>
+      oidcProviderPrivateKeyOrder[left.status] - oidcProviderPrivateKeyOrder[right.status]
+  );


### PR DESCRIPTION
## Summary
- derive oidc-provider private key order from explicit signing key status
- keep provider signing order as Current -> Next -> Previous instead of raw storage order
- add focused tests for provider key ordering in the signing key helper

## Testing
- pnpm -C packages/core build:test
- pnpm -C packages/core test:only -- build/libraries/oidc-private-key.test.js