### PR TITLE
fix(console): use Code component in Android guide for props interpolation

### DIFF
--- a/packages/console/src/assets/docs/guides/native-android/README.mdx
+++ b/packages/console/src/assets/docs/guides/native-android/README.mdx
@@ -55,8 +55,8 @@ Since the SDK needs internet access, you need to add the following permission to
 
 Create a `LogtoViewModel.kt` and init `LogtoClient` in this view model:
 
-```kotlin title="LogtoViewModel.kt"
-//...with other imports
+<Code title="LogtoViewModel.kt" className="language-kotlin">
+    {`//...with other imports
 import io.logto.sdk.android.LogtoClient
 import io.logto.sdk.android.type.LogtoConfig
 
@@ -84,8 +84,8 @@ class LogtoViewModel(application: Application) : AndroidViewModel(application) {
             }
         }
     }
-}
-```
+}`}
+</Code>
 
 <br/>
 


### PR DESCRIPTION
## Summary

The Android guide's "Init LogtoClient" step used a markdown fenced code block (` ```kotlin `) instead of the JSX `<Code>` component. Fenced code block content is plain text and not evaluated as JavaScript, so `${props.endpoint}` and `${props.app.id}` were rendered literally instead of being interpolated with actual values.

Replaced the fenced code block with `<Code>` component + template literal to match other guides.

## Testing

Tested locally

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments