### PR TITLE
fix(core): batch oidc grant revocation deletes

### DIFF
--- a/packages/core/src/queries/oidc-model-instance.test.ts
+++ b/packages/core/src/queries/oidc-model-instance.test.ts
@@ -296,22 +296,81 @@ describe('oidc-model-instance query', () => {
 
   it('revokeInstanceByGrantId', async () => {
     const grantId = 'grant';
+    const batchSize = 1000;
 
     const expectSql = sql`
       delete from ${table}
-      where ${fields.modelName}=$1
-      and ${fields.payload} ? 'grantId'
-      and ${fields.payload}->>'grantId'=$2
+      where ${fields.id} in (
+        select ${fields.id}
+        from ${table}
+        where ${fields.modelName}=$1
+        and ${fields.payload} ? 'grantId'
+        and ${fields.payload}->>'grantId'=$2
+        limit $3
+      )
     `;
 
-    mockQuery.mockImplementationOnce(async (sql, values) => {
-      expectSqlAssert(sql, expectSql.sql);
-      expect(values).toEqual([instance.modelName, grantId]);
+    mockQuery
+      // @ts-expect-error - mock delete query
+      .mockImplementationOnce(async (sql, values) => {
+        expectSqlAssert(sql, expectSql.sql);
+        expect(values).toEqual([instance.modelName, grantId, batchSize]);
 
-      return createMockQueryResult([]);
-    });
+        return { rowCount: 1000 };
+      })
+      // @ts-expect-error - mock delete query
+      .mockImplementationOnce(async (sql, values) => {
+        expectSqlAssert(sql, expectSql.sql);
+        expect(values).toEqual([instance.modelName, grantId, batchSize]);
+
+        return { rowCount: 0 };
+      });
 
     await revokeInstanceByGrantId(instance.modelName, grantId);
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it('revokeInstanceByGrantId should continue until no rows are deleted', async () => {
+    const grantId = 'grant';
+    const batchSize = 1000;
+
+    const expectSql = sql`
+      delete from ${table}
+      where ${fields.id} in (
+        select ${fields.id}
+        from ${table}
+        where ${fields.modelName}=$1
+        and ${fields.payload} ? 'grantId'
+        and ${fields.payload}->>'grantId'=$2
+        limit $3
+      )
+    `;
+
+    mockQuery
+      // @ts-expect-error - mock delete query
+      .mockImplementationOnce(async (sql, values) => {
+        expectSqlAssert(sql, expectSql.sql);
+        expect(values).toEqual([instance.modelName, grantId, batchSize]);
+
+        return { rowCount: 500 };
+      })
+      // @ts-expect-error - mock delete query
+      .mockImplementationOnce(async (sql, values) => {
+        expectSqlAssert(sql, expectSql.sql);
+        expect(values).toEqual([instance.modelName, grantId, batchSize]);
+
+        return { rowCount: 200 };
+      })
+      // @ts-expect-error - mock delete query
+      .mockImplementationOnce(async (sql, values) => {
+        expectSqlAssert(sql, expectSql.sql);
+        expect(values).toEqual([instance.modelName, grantId, batchSize]);
+
+        return { rowCount: 0 };
+      });
+
+    await revokeInstanceByGrantId(instance.modelName, grantId);
+    expect(mockQuery).toHaveBeenCalledTimes(3);
   });
 
   it('findUserActiveApplicationGrants with thirdparty', async () => {

--- a/packages/core/src/queries/oidc-model-instance.ts
+++ b/packages/core/src/queries/oidc-model-instance.ts
@@ -30,6 +30,7 @@ const sessionModelName = 'Session';
  */
 // Hard-code this value since 3 seconds is a reasonable number for concurrency and no need for further configuration
 const refreshTokenReuseInterval = 3;
+const revokeInstanceBatchSize = 1000;
 
 const isConsumed = (modelName: string, consumedAt: Nullable<number>): boolean => {
   if (!consumedAt) {
@@ -181,12 +182,27 @@ export const createOidcModelInstanceQueries = (pool: CommonQueryMethods) => {
   };
 
   const revokeInstanceByGrantId = async (modelName: string, grantId: string) => {
-    await pool.query(sql`
-      delete from ${table}
-      where ${fields.modelName}=${modelName}
-      and ${fields.payload} ? 'grantId'
-      and ${fields.payload}->>'grantId'=${grantId}
-    `);
+    const revokeNextBatch = async (): Promise<void> => {
+      const { rowCount } = await pool.query(sql`
+        delete from ${table}
+        where ${fields.id} in (
+          select ${fields.id}
+          from ${table}
+          where ${fields.modelName}=${modelName}
+          and ${fields.payload} ? 'grantId'
+          and ${fields.payload}->>'grantId'=${grantId}
+          limit ${revokeInstanceBatchSize}
+        )
+      `);
+
+      if (rowCount === 0) {
+        return;
+      }
+
+      await revokeNextBatch();
+    };
+
+    await revokeNextBatch();
   };
 
   const revokeInstanceByUserId = async (modelName: string, userId: string) => {

--- a/packages/core/src/queries/oidc-model-instance.ts
+++ b/packages/core/src/queries/oidc-model-instance.ts
@@ -182,7 +182,10 @@ export const createOidcModelInstanceQueries = (pool: CommonQueryMethods) => {
   };
 
   const revokeInstanceByGrantId = async (modelName: string, grantId: string) => {
-    const revokeNextBatch = async (): Promise<void> => {
+    // Keep deleting bounded batches until the revoke query no longer finds matches.
+    for (;;) {
+      // Revocation batches must run serially to keep each delete bounded.
+      // eslint-disable-next-line no-await-in-loop
       const { rowCount } = await pool.query(sql`
         delete from ${table}
         where ${fields.id} in (
@@ -198,11 +201,7 @@ export const createOidcModelInstanceQueries = (pool: CommonQueryMethods) => {
       if (rowCount === 0) {
         return;
       }
-
-      await revokeNextBatch();
-    };
-
-    await revokeNextBatch();
+    }
   };
 
   const revokeInstanceByUserId = async (modelName: string, userId: string) => {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Batch OIDC grant revocation deletes to reduce the risk of statement timeouts when a single `grantId` is associated with a large number of model instances.

### Why
The previous implementation deleted all rows for a `(model_name, grantId)` pair in a single statement. On hot grants with a large token history, that can produce long-running deletes and increase the chance of `StatementTimeoutError` in the revoke path.


### Changes

1. Update `revokeInstanceByGrantId()` in `packages/core/src/queries/oidc-model-instance.ts` to delete matching rows in batches of 1000 instead of issuing one unbounded delete.
2. Keep the existing revoke contract unchanged while making the batched delete loop continue until no rows are removed, which is safer under concurrent revocation.
3. Add unit tests covering:
   - batched delete SQL shape
   - repeated execution across multiple batches
   - termination only when `rowCount` reaches 0
   
 
<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
unit test added

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
