### PR TITLE
fix: skip OSS onboarding for existing users

### DIFF
--- a/packages/console/src/containers/OssOnboardingGuard/index.tsx
+++ b/packages/console/src/containers/OssOnboardingGuard/index.tsx
@@ -9,7 +9,7 @@ import { getOssOnboardingRedirectPath } from './utils';
 function OssOnboardingGuard() {
   const { tenantId } = useParams();
   const { pathname } = useLocation();
-  const { error, isLoading, isOnboardingDone } = useOssOnboardingData();
+  const { error, isLoading, isOnboardingRequired } = useOssOnboardingData();
 
   if (isLoading) {
     return <AppLoading />;
@@ -21,7 +21,7 @@ function OssOnboardingGuard() {
         isDevFeaturesEnabled,
         hasError: Boolean(error),
         isLoading,
-        isOnboardingDone,
+        isOnboardingRequired,
         tenantId,
         pathname,
       })

--- a/packages/console/src/containers/OssOnboardingGuard/utils.test.ts
+++ b/packages/console/src/containers/OssOnboardingGuard/utils.test.ts
@@ -1,40 +1,42 @@
 import { getOssOnboardingRedirectPath } from './utils';
 
 describe('OSS onboarding guard utils', () => {
-  test('redirects unfinished OSS users to the onboarding route', () => {
+  test('redirects users explicitly marked as requiring OSS onboarding to the onboarding route', () => {
     expect(
       getOssOnboardingRedirectPath({
         isCloud: false,
         isDevFeaturesEnabled: true,
         hasError: false,
         isLoading: false,
-        isOnboardingDone: false,
+        isOnboardingRequired: true,
         tenantId: 'console',
         pathname: '/console/get-started',
       })
     ).toBe('/console/onboarding');
   });
 
-  test('does not redirect when onboarding is already complete or when already on onboarding', () => {
+  test('does not redirect users without an explicit OSS onboarding requirement', () => {
     expect(
       getOssOnboardingRedirectPath({
         isCloud: false,
         isDevFeaturesEnabled: true,
         hasError: false,
         isLoading: false,
-        isOnboardingDone: true,
+        isOnboardingRequired: false,
         tenantId: 'console',
         pathname: '/console/get-started',
       })
     ).toBeUndefined();
+  });
 
+  test('does not redirect when already on onboarding', () => {
     expect(
       getOssOnboardingRedirectPath({
         isCloud: false,
         isDevFeaturesEnabled: true,
         hasError: false,
         isLoading: false,
-        isOnboardingDone: false,
+        isOnboardingRequired: true,
         tenantId: 'console',
         pathname: '/console/onboarding',
       })
@@ -48,7 +50,7 @@ describe('OSS onboarding guard utils', () => {
         isDevFeaturesEnabled: true,
         hasError: false,
         isLoading: false,
-        isOnboardingDone: false,
+        isOnboardingRequired: true,
         tenantId: 'console',
         pathname: '/console/get-started',
       })
@@ -62,7 +64,7 @@ describe('OSS onboarding guard utils', () => {
         isDevFeaturesEnabled: false,
         hasError: false,
         isLoading: false,
-        isOnboardingDone: false,
+        isOnboardingRequired: true,
         tenantId: 'console',
         pathname: '/console/get-started',
       })
@@ -76,7 +78,7 @@ describe('OSS onboarding guard utils', () => {
         isDevFeaturesEnabled: true,
         hasError: true,
         isLoading: false,
-        isOnboardingDone: false,
+        isOnboardingRequired: true,
         tenantId: 'console',
         pathname: '/console/get-started',
       })

--- a/packages/console/src/containers/OssOnboardingGuard/utils.ts
+++ b/packages/console/src/containers/OssOnboardingGuard/utils.ts
@@ -3,7 +3,7 @@ type GetOssOnboardingRedirectPathOptions = {
   isDevFeaturesEnabled: boolean;
   hasError: boolean;
   isLoading: boolean;
-  isOnboardingDone: boolean;
+  isOnboardingRequired: boolean;
   tenantId: string;
   pathname: string;
 };
@@ -15,7 +15,7 @@ export const getOssOnboardingRedirectPath = ({
   isDevFeaturesEnabled,
   hasError,
   isLoading,
-  isOnboardingDone,
+  isOnboardingRequired,
   tenantId,
   pathname,
 }: GetOssOnboardingRedirectPathOptions): string | undefined => {
@@ -24,7 +24,7 @@ export const getOssOnboardingRedirectPath = ({
     !isDevFeaturesEnabled ||
     hasError ||
     isLoading ||
-    isOnboardingDone ||
+    !isOnboardingRequired ||
     pathname.endsWith(`/${onboardingPath}`)
   ) {
     return;

--- a/packages/console/src/hooks/use-oss-onboarding-data.test.ts
+++ b/packages/console/src/hooks/use-oss-onboarding-data.test.ts
@@ -36,7 +36,6 @@ describe('useOssOnboardingData', () => {
 
     expect(result.current.hasOssOnboardingRecord).toBe(false);
     expect(result.current.isOnboardingRequired).toBe(false);
-    expect(result.current.isOnboardingDone).toBe(false);
   });
 
   it('requires onboarding only when an OSS onboarding record exists and is not done', () => {
@@ -58,6 +57,5 @@ describe('useOssOnboardingData', () => {
 
     expect(result.current.hasOssOnboardingRecord).toBe(true);
     expect(result.current.isOnboardingRequired).toBe(true);
-    expect(result.current.isOnboardingDone).toBe(false);
   });
 });

--- a/packages/console/src/hooks/use-oss-onboarding-data.test.ts
+++ b/packages/console/src/hooks/use-oss-onboarding-data.test.ts
@@ -1,0 +1,63 @@
+import { renderHook } from '@testing-library/react';
+
+import useCurrentUser from './use-current-user';
+import useOssOnboardingData from './use-oss-onboarding-data';
+
+jest.mock('@/consts/env', () => ({
+  isCloud: false,
+}));
+
+jest.mock('./use-current-user', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockedUseCurrentUser = jest.mocked(useCurrentUser);
+
+describe('useOssOnboardingData', () => {
+  beforeEach(() => {
+    mockedUseCurrentUser.mockReturnValue({
+      customData: undefined,
+      error: undefined,
+      isLoading: false,
+      isLoaded: true,
+      updateCustomData: jest.fn(),
+      user: undefined,
+      reload: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('treats missing OSS onboarding data as not required', () => {
+    const { result } = renderHook(() => useOssOnboardingData());
+
+    expect(result.current.hasOssOnboardingRecord).toBe(false);
+    expect(result.current.isOnboardingRequired).toBe(false);
+    expect(result.current.isOnboardingDone).toBe(false);
+  });
+
+  it('requires onboarding only when an OSS onboarding record exists and is not done', () => {
+    mockedUseCurrentUser.mockReturnValue({
+      customData: {
+        ossOnboarding: {
+          isOnboardingDone: false,
+        },
+      },
+      error: undefined,
+      isLoading: false,
+      isLoaded: true,
+      updateCustomData: jest.fn(),
+      user: undefined,
+      reload: jest.fn(),
+    });
+
+    const { result } = renderHook(() => useOssOnboardingData());
+
+    expect(result.current.hasOssOnboardingRecord).toBe(true);
+    expect(result.current.isOnboardingRequired).toBe(true);
+    expect(result.current.isOnboardingDone).toBe(false);
+  });
+});

--- a/packages/console/src/hooks/use-oss-onboarding-data.ts
+++ b/packages/console/src/hooks/use-oss-onboarding-data.ts
@@ -34,7 +34,7 @@ const useOssOnboardingData = (): {
 
   const update = useCallback(
     async (data: Partial<OssUserOnboardingData>) => {
-      // Note: OSS onboarding submissions currently live in user custom data only.
+      // TODO: OSS onboarding submissions currently live in user custom data only.
       await updateCustomData({
         [ossUserOnboardingDataKey]: {
           ...ossOnboardingData,

--- a/packages/console/src/hooks/use-oss-onboarding-data.ts
+++ b/packages/console/src/hooks/use-oss-onboarding-data.ts
@@ -1,28 +1,14 @@
-import { CompanySize, Project } from '@logto/schemas';
+import {
+  ossUserOnboardingDataGuard,
+  ossUserOnboardingDataKey,
+  type OssUserOnboardingData,
+} from '@logto/schemas';
 import { type Optional } from '@silverhand/essentials';
 import { useCallback, useMemo } from 'react';
-import { z } from 'zod';
 
 import { isCloud } from '@/consts/env';
 
 import useCurrentUser from './use-current-user';
-
-const ossUserOnboardingDataKey = 'ossOnboarding';
-
-const ossQuestionnaireGuard = z.object({
-  emailAddress: z.string().optional(),
-  newsletter: z.boolean().optional(),
-  project: z.nativeEnum(Project).optional(),
-  companyName: z.string().optional(),
-  companySize: z.nativeEnum(CompanySize).optional(),
-});
-
-const ossUserOnboardingDataGuard = z.object({
-  questionnaire: ossQuestionnaireGuard.optional(),
-  isOnboardingDone: z.boolean().optional(),
-});
-
-type OssUserOnboardingData = z.infer<typeof ossUserOnboardingDataGuard>;
 
 const useOssOnboardingData = (): {
   data: OssUserOnboardingData;

--- a/packages/console/src/hooks/use-oss-onboarding-data.ts
+++ b/packages/console/src/hooks/use-oss-onboarding-data.ts
@@ -1,8 +1,5 @@
-import {
-  type OssUserOnboardingData,
-  ossUserOnboardingDataGuard,
-  ossUserOnboardingDataKey,
-} from '@logto/schemas';
+import { CompanySize, Project } from '@logto/schemas';
+import { type Optional } from '@silverhand/essentials';
 import { useCallback, useMemo } from 'react';
 import { z } from 'zod';
 
@@ -10,28 +7,48 @@ import { isCloud } from '@/consts/env';
 
 import useCurrentUser from './use-current-user';
 
+const ossUserOnboardingDataKey = 'ossOnboarding';
+
+const ossQuestionnaireGuard = z.object({
+  emailAddress: z.string().optional(),
+  newsletter: z.boolean().optional(),
+  project: z.nativeEnum(Project).optional(),
+  companyName: z.string().optional(),
+  companySize: z.nativeEnum(CompanySize).optional(),
+});
+
+const ossUserOnboardingDataGuard = z.object({
+  questionnaire: ossQuestionnaireGuard.optional(),
+  isOnboardingDone: z.boolean().optional(),
+});
+
+type OssUserOnboardingData = z.infer<typeof ossUserOnboardingDataGuard>;
+
 const useOssOnboardingData = (): {
   data: OssUserOnboardingData;
   error: unknown;
+  hasOssOnboardingRecord: boolean;
   isLoading: boolean;
   isLoaded: boolean;
   isOnboardingDone: boolean;
+  isOnboardingRequired: boolean;
   update: (data: Partial<OssUserOnboardingData>) => Promise<void>;
 } => {
   const { customData, error, isLoading, isLoaded, updateCustomData } = useCurrentUser();
 
-  const ossOnboardingData = useMemo(() => {
-    const parsed = z
-      .object({ [ossUserOnboardingDataKey]: ossUserOnboardingDataGuard })
-      .safeParse(customData);
+  const ossOnboardingData = useMemo<Optional<OssUserOnboardingData>>(() => {
+    const rawOssOnboardingData = customData?.[ossUserOnboardingDataKey];
+    const parsed = ossUserOnboardingDataGuard.safeParse(rawOssOnboardingData);
 
-    return parsed.success ? parsed.data[ossUserOnboardingDataKey] : {};
+    return parsed.success ? parsed.data : undefined;
   }, [customData]);
+  const hasOssOnboardingRecord = Boolean(ossOnboardingData);
+  const isOnboardingRequired =
+    !isCloud && hasOssOnboardingRecord && !ossOnboardingData?.isOnboardingDone;
 
   const update = useCallback(
     async (data: Partial<OssUserOnboardingData>) => {
-      // TODO: sync OSS onboarding submissions to a dedicated server-side endpoint for
-      // analysis and future marketing email outreach instead of relying only on user custom data.
+      // Note: OSS onboarding submissions currently live in user custom data only.
       await updateCustomData({
         [ossUserOnboardingDataKey]: {
           ...ossOnboardingData,
@@ -43,11 +60,13 @@ const useOssOnboardingData = (): {
   );
 
   return {
-    data: ossOnboardingData,
+    data: ossOnboardingData ?? {},
     error,
+    hasOssOnboardingRecord,
     isLoading,
     isLoaded,
-    isOnboardingDone: isCloud || Boolean(ossOnboardingData.isOnboardingDone),
+    isOnboardingDone: isCloud || Boolean(ossOnboardingData?.isOnboardingDone),
+    isOnboardingRequired,
     update,
   };
 };

--- a/packages/console/src/hooks/use-oss-onboarding-data.ts
+++ b/packages/console/src/hooks/use-oss-onboarding-data.ts
@@ -16,7 +16,6 @@ const useOssOnboardingData = (): {
   hasOssOnboardingRecord: boolean;
   isLoading: boolean;
   isLoaded: boolean;
-  isOnboardingDone: boolean;
   isOnboardingRequired: boolean;
   update: (data: Partial<OssUserOnboardingData>) => Promise<void>;
 } => {
@@ -51,7 +50,6 @@ const useOssOnboardingData = (): {
     hasOssOnboardingRecord,
     isLoading,
     isLoaded,
-    isOnboardingDone: isCloud || Boolean(ossOnboardingData?.isOnboardingDone),
     isOnboardingRequired,
     update,
   };

--- a/packages/console/src/pages/OssOnboarding/index.tsx
+++ b/packages/console/src/pages/OssOnboarding/index.tsx
@@ -34,8 +34,7 @@ function OssOnboarding() {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { setThemeOverride } = useContext(AppThemeContext);
   const { getTo, navigate } = useTenantPathname();
-  const { data, isLoading, isOnboardingDone, isOnboardingRequired, update } =
-    useOssOnboardingData();
+  const { data, isLoading, isOnboardingRequired, update } = useOssOnboardingData();
   const {
     control,
     formState: { errors, isSubmitting },
@@ -81,7 +80,7 @@ function OssOnboarding() {
     return null;
   }
 
-  if (!isOnboardingRequired || isOnboardingDone) {
+  if (!isOnboardingRequired) {
     return <Navigate replace to={getTo('/get-started')} />;
   }
 

--- a/packages/console/src/pages/OssOnboarding/index.tsx
+++ b/packages/console/src/pages/OssOnboarding/index.tsx
@@ -109,13 +109,13 @@ function OssOnboarding() {
                   // eslint-disable-next-line jsx-a11y/no-autofocus
                   autoFocus
                   type="email"
-                  placeholder={String(t('oss_onboarding.email.placeholder'))}
+                  placeholder={t('oss_onboarding.email.placeholder')}
                   disabled={isSubmitting}
                   error={errors.emailAddress?.message}
                   {...register('emailAddress', {
-                    required: String(t('oss_onboarding.errors.email_required')),
+                    required: t('oss_onboarding.errors.email_required'),
                     validate: (value) =>
-                      emailRegEx.test(value) || String(t('oss_onboarding.errors.email_invalid')),
+                      emailRegEx.test(value) || t('oss_onboarding.errors.email_invalid'),
                   })}
                 />
               </FormField>
@@ -126,7 +126,7 @@ function OssOnboarding() {
                   <Checkbox
                     className={styles.checkbox}
                     checked={value}
-                    label={String(t('oss_onboarding.newsletter'))}
+                    label={t('oss_onboarding.newsletter')}
                     onChange={onChange}
                   />
                 )}
@@ -165,13 +165,12 @@ function OssOnboarding() {
               <>
                 <FormField isRequired title="oss_onboarding.company_name.label">
                   <TextInput
-                    placeholder={String(t('oss_onboarding.company_name.placeholder'))}
+                    placeholder={t('oss_onboarding.company_name.placeholder')}
                     disabled={isSubmitting}
                     error={errors.companyName?.message}
                     {...register('companyName', {
                       validate: (value) =>
-                        Boolean(value.trim()) ||
-                        String(t('oss_onboarding.errors.company_name_required')),
+                        Boolean(value.trim()) || t('oss_onboarding.errors.company_name_required'),
                     })}
                   />
                 </FormField>
@@ -181,7 +180,7 @@ function OssOnboarding() {
                     control={control}
                     rules={{
                       validate: (value) =>
-                        Boolean(value) || String(t('oss_onboarding.errors.company_size_required')),
+                        Boolean(value) || t('oss_onboarding.errors.company_size_required'),
                     }}
                     render={({ field: { onChange, value, name } }) => (
                       <>

--- a/packages/console/src/pages/OssOnboarding/index.tsx
+++ b/packages/console/src/pages/OssOnboarding/index.tsx
@@ -34,7 +34,8 @@ function OssOnboarding() {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { setThemeOverride } = useContext(AppThemeContext);
   const { getTo, navigate } = useTenantPathname();
-  const { data, isLoading, isOnboardingDone, update } = useOssOnboardingData();
+  const { data, isLoading, isOnboardingDone, isOnboardingRequired, update } =
+    useOssOnboardingData();
   const {
     control,
     formState: { errors, isSubmitting },
@@ -80,7 +81,7 @@ function OssOnboarding() {
     return null;
   }
 
-  if (isOnboardingDone) {
+  if (!isOnboardingRequired || isOnboardingDone) {
     return <Navigate replace to={getTo('/get-started')} />;
   }
 
@@ -108,13 +109,13 @@ function OssOnboarding() {
                   // eslint-disable-next-line jsx-a11y/no-autofocus
                   autoFocus
                   type="email"
-                  placeholder={t('oss_onboarding.email.placeholder')}
+                  placeholder={String(t('oss_onboarding.email.placeholder'))}
                   disabled={isSubmitting}
                   error={errors.emailAddress?.message}
                   {...register('emailAddress', {
-                    required: t('oss_onboarding.errors.email_required'),
+                    required: String(t('oss_onboarding.errors.email_required')),
                     validate: (value) =>
-                      emailRegEx.test(value) || t('oss_onboarding.errors.email_invalid'),
+                      emailRegEx.test(value) || String(t('oss_onboarding.errors.email_invalid')),
                   })}
                 />
               </FormField>
@@ -125,7 +126,7 @@ function OssOnboarding() {
                   <Checkbox
                     className={styles.checkbox}
                     checked={value}
-                    label={t('oss_onboarding.newsletter')}
+                    label={String(t('oss_onboarding.newsletter'))}
                     onChange={onChange}
                   />
                 )}
@@ -164,12 +165,13 @@ function OssOnboarding() {
               <>
                 <FormField isRequired title="oss_onboarding.company_name.label">
                   <TextInput
-                    placeholder={t('oss_onboarding.company_name.placeholder')}
+                    placeholder={String(t('oss_onboarding.company_name.placeholder'))}
                     disabled={isSubmitting}
                     error={errors.companyName?.message}
                     {...register('companyName', {
                       validate: (value) =>
-                        Boolean(value.trim()) || t('oss_onboarding.errors.company_name_required'),
+                        Boolean(value.trim()) ||
+                        String(t('oss_onboarding.errors.company_name_required')),
                     })}
                   />
                 </FormField>
@@ -179,7 +181,7 @@ function OssOnboarding() {
                     control={control}
                     rules={{
                       validate: (value) =>
-                        Boolean(value) || t('oss_onboarding.errors.company_size_required'),
+                        Boolean(value) || String(t('oss_onboarding.errors.company_size_required')),
                     }}
                     render={({ field: { onChange, value, name } }) => (
                       <>

--- a/packages/core/src/routes/experience/classes/experience-interaction.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { TemplateType } from '@logto/connector-kit';
 import {
   adminConsoleApplicationId,
@@ -196,6 +197,75 @@ describe('ExperienceInteraction class', () => {
 
   describe('new user registration', () => {
     it('First admin user provisioning', async () => {
+      setDevFeaturesEnabled(true);
+
+      const experienceInteraction = new ExperienceInteraction(
+        ctx,
+        tenant,
+        InteractionEvent.Register
+      );
+
+      experienceInteraction.setVerificationRecord(emailVerificationRecord);
+      await experienceInteraction.createUser(emailVerificationRecord.id);
+
+      expect(userLibraries.insertUser).toHaveBeenCalledWith(
+        {
+          id: 'uid',
+          primaryEmail: mockEmail,
+          customData: {
+            ossOnboarding: {
+              isOnboardingDone: false,
+            },
+          },
+          logtoConfig: {
+            mfa: { enabled: false },
+          },
+        },
+        { isInteractive: true, roleNames: ['user', 'default:admin'] }
+      );
+
+      expect(signInExperiences.updateDefaultSignInExperience).toHaveBeenCalledWith({
+        signInMode: SignInMode.SignIn,
+      });
+
+      expect(userLibraries.provisionOrganizations).toHaveBeenCalledWith({
+        userId: 'uid',
+        email: mockEmail,
+      });
+    });
+
+    it('initializes OSS onboarding for new admin tenant registrations when dev features are enabled', async () => {
+      setDevFeaturesEnabled(true);
+
+      const experienceInteraction = new ExperienceInteraction(
+        ctx,
+        tenant,
+        InteractionEvent.Register
+      );
+
+      experienceInteraction.setVerificationRecord(emailVerificationRecord);
+      await experienceInteraction.createUser(emailVerificationRecord.id);
+
+      expect(userLibraries.insertUser).toHaveBeenCalledWith(
+        {
+          id: 'uid',
+          primaryEmail: mockEmail,
+          customData: {
+            ossOnboarding: {
+              isOnboardingDone: false,
+            },
+          },
+          logtoConfig: {
+            mfa: { enabled: false },
+          },
+        },
+        { isInteractive: true, roleNames: ['user', 'default:admin'] }
+      );
+    });
+
+    it('does not initialize OSS onboarding when dev features are disabled', async () => {
+      setDevFeaturesEnabled(false);
+
       const experienceInteraction = new ExperienceInteraction(
         ctx,
         tenant,
@@ -215,15 +285,6 @@ describe('ExperienceInteraction class', () => {
         },
         { isInteractive: true, roleNames: ['user', 'default:admin'] }
       );
-
-      expect(signInExperiences.updateDefaultSignInExperience).toHaveBeenCalledWith({
-        signInMode: SignInMode.SignIn,
-      });
-
-      expect(userLibraries.provisionOrganizations).toHaveBeenCalledWith({
-        userId: 'uid',
-        email: mockEmail,
-      });
     });
   });
 
@@ -439,3 +500,4 @@ describe('ExperienceInteraction class', () => {
     });
   });
 });
+/* eslint-enable max-lines */

--- a/packages/core/src/routes/experience/classes/libraries/provision-library.ts
+++ b/packages/core/src/routes/experience/classes/libraries/provision-library.ts
@@ -21,6 +21,7 @@ import { condArray, conditional, conditionalArray, trySafe } from '@silverhand/e
 
 import { EnvSet } from '#src/env-set/index.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
+import { getInitialOssOnboardingCustomData } from '#src/utils/oss-onboarding.js';
 import { buildAppInsightsTelemetry } from '#src/utils/request.js';
 import { getTenantId } from '#src/utils/tenant.js';
 
@@ -170,7 +171,7 @@ export class ProvisionLibrary {
     /** Initial user roles for admin tenant users */
     initialUserRoles: string[];
     /** Skip onboarding flow if the new user has pending Cloud invitations */
-    customData?: { [userOnboardingDataKey]: UserOnboardingData };
+    customData?: User['customData'];
   }> {
     const {
       provider,
@@ -228,18 +229,25 @@ export class ProvisionLibrary {
     );
 
     // Skip onboarding flow if the new user has pending Cloud invitations
-    const customData = hasPendingInvitations
-      ? {
+    const customData = {
+      ...conditional(
+        hasPendingInvitations && {
           [userOnboardingDataKey]: {
             isOnboardingDone: true,
           } satisfies UserOnboardingData,
         }
-      : undefined;
+      ),
+      ...getInitialOssOnboardingCustomData({
+        isCloud,
+        isDevFeaturesEnabled: EnvSet.values.isDevFeaturesEnabled,
+        currentTenantId,
+      }),
+    };
 
     return {
       isCreatingFirstAdminUser,
       initialUserRoles,
-      customData,
+      customData: Object.keys(customData).length > 0 ? customData : undefined,
     };
   }
 

--- a/packages/core/src/routes/experience/classes/libraries/provision-library.ts
+++ b/packages/core/src/routes/experience/classes/libraries/provision-library.ts
@@ -12,16 +12,14 @@ import {
   SignInMode,
   TenantRole,
   userMfaDataKey,
-  userOnboardingDataKey,
   type User,
-  type UserOnboardingData,
 } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 import { condArray, conditional, conditionalArray, trySafe } from '@silverhand/essentials';
 
 import { EnvSet } from '#src/env-set/index.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
-import { getInitialOssOnboardingCustomData } from '#src/utils/oss-onboarding.js';
+import { getInitialUserCustomData } from '#src/utils/oss-onboarding.js';
 import { buildAppInsightsTelemetry } from '#src/utils/request.js';
 import { getTenantId } from '#src/utils/tenant.js';
 
@@ -228,26 +226,17 @@ export class ProvisionLibrary {
       isCloud
     );
 
-    // Skip onboarding flow if the new user has pending Cloud invitations
-    const customData = {
-      ...conditional(
-        hasPendingInvitations && {
-          [userOnboardingDataKey]: {
-            isOnboardingDone: true,
-          } satisfies UserOnboardingData,
-        }
-      ),
-      ...getInitialOssOnboardingCustomData({
-        isCloud,
-        isDevFeaturesEnabled: EnvSet.values.isDevFeaturesEnabled,
-        currentTenantId,
-      }),
-    };
+    const customData = getInitialUserCustomData({
+      isCloud,
+      isDevFeaturesEnabled: EnvSet.values.isDevFeaturesEnabled,
+      currentTenantId,
+      hasPendingCloudInvitations: hasPendingInvitations,
+    });
 
     return {
       isCreatingFirstAdminUser,
       initialUserRoles,
-      customData: Object.keys(customData).length > 0 ? customData : undefined,
+      customData,
     };
   }
 

--- a/packages/core/src/routes/interaction/actions/submit-interaction.mfa.test.ts
+++ b/packages/core/src/routes/interaction/actions/submit-interaction.mfa.test.ts
@@ -60,6 +60,11 @@ const { generateUserId, insertUser } = userLibraries;
 
 const submitInteraction = await pickDefault(import('./submit-interaction.js'));
 const now = Date.now();
+const ossOnboardingCustomData = {
+  ossOnboarding: {
+    isOnboardingDone: false,
+  },
+};
 
 jest.useFakeTimers().setSystemTime(now);
 
@@ -136,6 +141,7 @@ describe('submit action', () => {
       expect(insertUser).toBeCalledWith(
         {
           id: 'uid',
+          customData: ossOnboardingCustomData,
           mfaVerifications: [
             {
               type: MfaFactor.TOTP,
@@ -166,6 +172,7 @@ describe('submit action', () => {
       expect(insertUser).toBeCalledWith(
         {
           id: 'id',
+          customData: ossOnboardingCustomData,
           mfaVerifications: [
             {
               ...mockWebAuthnBind,
@@ -194,6 +201,7 @@ describe('submit action', () => {
       expect(insertUser).toBeCalledWith(
         {
           id: 'uid',
+          customData: ossOnboardingCustomData,
           mfaVerifications: [
             {
               type: MfaFactor.BackupCode,

--- a/packages/core/src/routes/interaction/actions/submit-interaction.test.ts
+++ b/packages/core/src/routes/interaction/actions/submit-interaction.test.ts
@@ -10,6 +10,7 @@ import {
 import { createMockUtils, pickDefault } from '@logto/shared/esm';
 import type { Provider } from 'oidc-provider';
 
+import { EnvSet } from '#src/env-set/index.js';
 import { type InsertUserResult } from '#src/libraries/user.js';
 import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
@@ -70,10 +71,25 @@ const { generateUserId, insertUser } = userLibraries;
 
 const submitInteraction = await pickDefault(import('./submit-interaction.js'));
 const now = Date.now();
+const ossOnboardingCustomData = {
+  ossOnboarding: {
+    isOnboardingDone: false,
+  },
+};
 
 jest.useFakeTimers().setSystemTime(now);
 
 describe('submit action', () => {
+  const originalIsCloud = EnvSet.values.isCloud;
+  const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+  const setCloud = (isCloud: boolean) => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    (EnvSet.values as { isCloud: boolean }).isCloud = isCloud;
+  };
+  const setDevFeaturesEnabled = (enabled: boolean) => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = enabled;
+  };
   const tenant = new MockTenant(
     undefined,
     { users: userQueries, signInExperiences: { updateDefaultSignInExperience: jest.fn() } },
@@ -128,6 +144,8 @@ describe('submit action', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    setCloud(originalIsCloud);
+    setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
   });
 
   it('register', async () => {
@@ -148,6 +166,7 @@ describe('submit action', () => {
       {
         id: 'uid',
         ...upsertProfile,
+        customData: ossOnboardingCustomData,
       },
       { isInteractive: true, roleNames: ['user'] }
     );
@@ -159,6 +178,7 @@ describe('submit action', () => {
       user: {
         id: 'uid',
         ...upsertProfile,
+        customData: ossOnboardingCustomData,
       },
     });
   });
@@ -182,6 +202,7 @@ describe('submit action', () => {
       {
         id: 'pending-account-id',
         ...upsertProfile,
+        customData: ossOnboardingCustomData,
       },
       { isInteractive: true, roleNames: ['user'] }
     );
@@ -193,6 +214,7 @@ describe('submit action', () => {
       user: {
         id: 'pending-account-id',
         ...upsertProfile,
+        customData: ossOnboardingCustomData,
       },
     });
   });
@@ -210,6 +232,7 @@ describe('submit action', () => {
       {
         id: 'uid',
         ...upsertProfile,
+        customData: ossOnboardingCustomData,
         logtoConfig: {
           [userMfaDataKey]: {
             skipped: true,
@@ -238,6 +261,7 @@ describe('submit action', () => {
       {
         id: 'uid',
         username: 'username',
+        customData: ossOnboardingCustomData,
         identities: {
           logto: { userId: userInfo.id, details: userInfo },
         },
@@ -272,6 +296,7 @@ describe('submit action', () => {
       {
         id: 'uid',
         username: 'username',
+        customData: ossOnboardingCustomData,
         identities: {
           logto: { userId: userInfo.id, details: userInfo },
         },
@@ -313,12 +338,78 @@ describe('submit action', () => {
       {
         id: 'uid',
         ...upsertProfile,
+        customData: ossOnboardingCustomData,
       },
       { isInteractive: true, roleNames: ['user', 'default:admin'] }
     );
     expect(assignInteractionResults).toBeCalledWith(adminConsoleCtx, tenant.provider, {
       login: { accountId: 'uid' },
     });
+  });
+
+  it('initializes OSS onboarding for new admin tenant registrations when dev features are enabled', async () => {
+    setCloud(false);
+    setDevFeaturesEnabled(true);
+
+    const adminConsoleCtx = {
+      ...ctx,
+      // @ts-expect-error mock interaction details
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      interactionDetails: {
+        params: {
+          client_id: adminConsoleApplicationId,
+        },
+      } as Awaited<ReturnType<Provider['interactionDetails']>>,
+    };
+
+    const interaction: VerifiedRegisterInteractionResult = {
+      event: InteractionEvent.Register,
+      profile,
+      identifiers,
+    };
+
+    await submitInteraction(interaction, adminConsoleCtx, tenant);
+
+    expect(insertUser).toBeCalledWith(
+      {
+        id: 'uid',
+        ...upsertProfile,
+        customData: ossOnboardingCustomData,
+      },
+      { isInteractive: true, roleNames: ['user'] }
+    );
+  });
+
+  it('does not initialize OSS onboarding outside the OSS admin-tenant dev-feature registration case', async () => {
+    setCloud(false);
+    setDevFeaturesEnabled(false);
+
+    const adminConsoleCtx = {
+      ...ctx,
+      // @ts-expect-error mock interaction details
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      interactionDetails: {
+        params: {
+          client_id: adminConsoleApplicationId,
+        },
+      } as Awaited<ReturnType<Provider['interactionDetails']>>,
+    };
+
+    const interaction: VerifiedRegisterInteractionResult = {
+      event: InteractionEvent.Register,
+      profile,
+      identifiers,
+    };
+
+    await submitInteraction(interaction, adminConsoleCtx, tenant);
+
+    expect(insertUser).toBeCalledWith(
+      {
+        id: 'uid',
+        ...upsertProfile,
+      },
+      { isInteractive: true, roleNames: ['user'] }
+    );
   });
 
   it('sign-in without new profile', async () => {

--- a/packages/core/src/routes/interaction/actions/submit-interaction.ts
+++ b/packages/core/src/routes/interaction/actions/submit-interaction.ts
@@ -1,6 +1,6 @@
 import { Component, CoreEvent, getEventName } from '@logto/app-insights/custom-event';
 import { appInsights } from '@logto/app-insights/node';
-import type { User, UserOnboardingData } from '@logto/schemas';
+import type { User } from '@logto/schemas';
 import {
   AdminTenantRole,
   InteractionEvent,
@@ -15,7 +15,6 @@ import {
   getTenantOrganizationId,
   getTenantRole,
   userMfaDataKey,
-  userOnboardingDataKey,
 } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 import { conditional, conditionalArray } from '@silverhand/essentials';
@@ -26,7 +25,7 @@ import { encryptUserPassword } from '#src/libraries/user.utils.js';
 import type { LogEntry, WithLogContext } from '#src/middleware/koa-audit-log.js';
 import type { WithInteractionDetailsContext } from '#src/middleware/koa-interaction-details.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
-import { getInitialOssOnboardingCustomData } from '#src/utils/oss-onboarding.js';
+import { getInitialUserCustomData } from '#src/utils/oss-onboarding.js';
 import { getTenantId } from '#src/utils/tenant.js';
 
 import { type WithInteractionHooksContext } from '../middleware/koa-interaction-hooks.js';
@@ -134,21 +133,12 @@ async function handleSubmitRegister(
   const hasPendingInvitations = invitations.some(
     (invitation) => invitation.status === OrganizationInvitationStatus.Pending
   );
-  const initialCustomData = {
-    ...conditional(
-      // Skip onboarding flow if the new user has pending Cloud invitations
-      hasPendingInvitations && {
-        [userOnboardingDataKey]: {
-          isOnboardingDone: true,
-        } satisfies UserOnboardingData,
-      }
-    ),
-    ...getInitialOssOnboardingCustomData({
-      isCloud,
-      isDevFeaturesEnabled: EnvSet.values.isDevFeaturesEnabled,
-      currentTenantId,
-    }),
-  };
+  const initialCustomData = getInitialUserCustomData({
+    isCloud,
+    isDevFeaturesEnabled: EnvSet.values.isDevFeaturesEnabled,
+    currentTenantId,
+    hasPendingCloudInvitations: hasPendingInvitations,
+  });
 
   const [user] = await insertUser(
     {
@@ -159,9 +149,7 @@ async function handleSubmitRegister(
           mfaVerifications,
         }
       ),
-      ...conditional(
-        Object.keys(initialCustomData).length > 0 && { customData: initialCustomData }
-      ),
+      ...conditional(initialCustomData && { customData: initialCustomData }),
       ...conditional(
         mfaSkipped && {
           logtoConfig: {

--- a/packages/core/src/routes/interaction/actions/submit-interaction.ts
+++ b/packages/core/src/routes/interaction/actions/submit-interaction.ts
@@ -26,6 +26,7 @@ import { encryptUserPassword } from '#src/libraries/user.utils.js';
 import type { LogEntry, WithLogContext } from '#src/middleware/koa-audit-log.js';
 import type { WithInteractionDetailsContext } from '#src/middleware/koa-interaction-details.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
+import { getInitialOssOnboardingCustomData } from '#src/utils/oss-onboarding.js';
 import { getTenantId } from '#src/utils/tenant.js';
 
 import { type WithInteractionHooksContext } from '../middleware/koa-interaction-hooks.js';
@@ -133,6 +134,21 @@ async function handleSubmitRegister(
   const hasPendingInvitations = invitations.some(
     (invitation) => invitation.status === OrganizationInvitationStatus.Pending
   );
+  const initialCustomData = {
+    ...conditional(
+      // Skip onboarding flow if the new user has pending Cloud invitations
+      hasPendingInvitations && {
+        [userOnboardingDataKey]: {
+          isOnboardingDone: true,
+        } satisfies UserOnboardingData,
+      }
+    ),
+    ...getInitialOssOnboardingCustomData({
+      isCloud,
+      isDevFeaturesEnabled: EnvSet.values.isDevFeaturesEnabled,
+      currentTenantId,
+    }),
+  };
 
   const [user] = await insertUser(
     {
@@ -144,14 +160,7 @@ async function handleSubmitRegister(
         }
       ),
       ...conditional(
-        // Skip onboarding flow if the new user has pending Cloud invitations
-        hasPendingInvitations && {
-          customData: {
-            [userOnboardingDataKey]: {
-              isOnboardingDone: true,
-            } satisfies UserOnboardingData,
-          },
-        }
+        Object.keys(initialCustomData).length > 0 && { customData: initialCustomData }
       ),
       ...conditional(
         mfaSkipped && {

--- a/packages/core/src/routes/interaction/utils/single-sign-on.test.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-lines */
+import { adminTenantId, ossUserOnboardingDataKey } from '@logto/schemas';
 import { createMockUtils } from '@logto/shared/esm';
 import type { Provider } from 'oidc-provider';
 import Sinon from 'sinon';
@@ -86,6 +87,9 @@ const {
 } = await import('./single-sign-on.js');
 
 describe('Single sign on util methods tests', () => {
+  const originalIsCloud = EnvSet.values.isCloud;
+  const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+
   const mockContext = {
     ...createContextWithRouteParameters(),
     ...createMockLogContext(),
@@ -136,6 +140,16 @@ describe('Single sign on util methods tests', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    (EnvSet.values as { isCloud: boolean }).isCloud = originalIsCloud;
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled =
+      originalIsDevFeaturesEnabled;
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    tenant.id = 'mock_id';
   });
 
   describe('getSsoAuthorizationUrl tests', () => {
@@ -357,6 +371,33 @@ describe('Single sign on util methods tests', () => {
         issuer: mockIssuer,
         detail: mockSsoUserInfo,
       });
+    });
+
+    it('should set OSS onboarding marker for new OSS admin-tenant SSO users', async () => {
+      insertUserMock.mockResolvedValueOnce([{ id: 'foo' }, { organizations: [] }]);
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      (EnvSet.values as { isCloud: boolean }).isCloud = false;
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = true;
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      tenant.id = adminTenantId;
+
+      await registerWithSsoAuthentication(mockContext, tenant, {
+        connectorId: wellConfiguredSsoConnector.id,
+        issuer: mockIssuer,
+        userInfo: mockSsoUserInfo,
+      });
+
+      expect(insertUserMock).toBeCalledWith(
+        expect.objectContaining({
+          customData: {
+            [ossUserOnboardingDataKey]: {
+              isOnboardingDone: false,
+            },
+          },
+        }),
+        { isInteractive: true }
+      );
     });
   });
 

--- a/packages/core/src/routes/interaction/utils/single-sign-on.ts
+++ b/packages/core/src/routes/interaction/utils/single-sign-on.ts
@@ -24,6 +24,7 @@ import { type ExtendedSocialUserInfo } from '#src/sso/types/saml.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 import { safeParseUnknownJson } from '#src/utils/json.js';
+import { getInitialUserCustomData } from '#src/utils/oss-onboarding.js';
 import { buildAppInsightsTelemetry } from '#src/utils/request.js';
 import { encryptAndSerializeTokenResponse } from '#src/utils/secret-encryption.js';
 
@@ -418,6 +419,7 @@ const signInAndLinkWithSsoAuthentication = async (
 export const registerWithSsoAuthentication = async (
   ctx: WithInteractionHooksContext<WithLogContext>,
   {
+    id: currentTenantId,
     queries: { userSsoIdentities: userSsoIdentitiesQueries },
     libraries: { users: usersLibrary },
   }: TenantContext,
@@ -433,12 +435,19 @@ export const registerWithSsoAuthentication = async (
     ...conditional(userInfo.avatar && { avatar: userInfo.avatar }),
     ...conditional(userInfo.email && { primaryEmail: userInfo.email }),
   };
+  const customData = getInitialUserCustomData({
+    isCloud: EnvSet.values.isCloud,
+    isDevFeaturesEnabled: EnvSet.values.isDevFeaturesEnabled,
+    currentTenantId,
+    hasPendingCloudInvitations: false,
+  });
 
   // Insert new user
   const [user] = await usersLibrary.insertUser(
     {
       id: await usersLibrary.generateUserId(),
       ...syncingProfile,
+      ...conditional(customData && { customData }),
       lastSignInAt: Date.now(),
     },
     { isInteractive: true }

--- a/packages/core/src/utils/oss-onboarding.ts
+++ b/packages/core/src/utils/oss-onboarding.ts
@@ -1,0 +1,23 @@
+import { adminTenantId, type User } from '@logto/schemas';
+
+const ossOnboardingDataKey = 'ossOnboarding';
+
+export const getInitialOssOnboardingCustomData = ({
+  isCloud,
+  isDevFeaturesEnabled,
+  currentTenantId,
+}: {
+  isCloud: boolean;
+  isDevFeaturesEnabled: boolean;
+  currentTenantId?: string;
+}): User['customData'] | undefined => {
+  if (isCloud || !isDevFeaturesEnabled || currentTenantId !== adminTenantId) {
+    return;
+  }
+
+  return {
+    [ossOnboardingDataKey]: {
+      isOnboardingDone: false,
+    },
+  };
+};

--- a/packages/core/src/utils/oss-onboarding.ts
+++ b/packages/core/src/utils/oss-onboarding.ts
@@ -1,6 +1,13 @@
-import { adminTenantId, ossUserOnboardingDataKey, type User } from '@logto/schemas';
+import {
+  adminTenantId,
+  ossUserOnboardingDataKey,
+  type User,
+  userOnboardingDataKey,
+  type UserOnboardingData,
+} from '@logto/schemas';
+import { conditional } from '@silverhand/essentials';
 
-export const getInitialOssOnboardingCustomData = ({
+const getInitialOssOnboardingCustomData = ({
   isCloud,
   isDevFeaturesEnabled,
   currentTenantId,
@@ -18,4 +25,33 @@ export const getInitialOssOnboardingCustomData = ({
       isOnboardingDone: false,
     },
   };
+};
+
+export const getInitialUserCustomData = ({
+  isCloud,
+  isDevFeaturesEnabled,
+  currentTenantId,
+  hasPendingCloudInvitations,
+}: {
+  isCloud: boolean;
+  isDevFeaturesEnabled: boolean;
+  currentTenantId?: string;
+  hasPendingCloudInvitations: boolean;
+}): User['customData'] | undefined => {
+  const customData = {
+    ...conditional(
+      hasPendingCloudInvitations && {
+        [userOnboardingDataKey]: {
+          isOnboardingDone: true,
+        } satisfies UserOnboardingData,
+      }
+    ),
+    ...getInitialOssOnboardingCustomData({
+      isCloud,
+      isDevFeaturesEnabled,
+      currentTenantId,
+    }),
+  };
+
+  return Object.keys(customData).length > 0 ? customData : undefined;
 };

--- a/packages/core/src/utils/oss-onboarding.ts
+++ b/packages/core/src/utils/oss-onboarding.ts
@@ -1,6 +1,4 @@
-import { adminTenantId, type User } from '@logto/schemas';
-
-const ossOnboardingDataKey = 'ossOnboarding';
+import { adminTenantId, ossUserOnboardingDataKey, type User } from '@logto/schemas';
 
 export const getInitialOssOnboardingCustomData = ({
   isCloud,
@@ -16,7 +14,7 @@ export const getInitialOssOnboardingCustomData = ({
   }
 
   return {
-    [ossOnboardingDataKey]: {
+    [ossUserOnboardingDataKey]: {
       isOnboardingDone: false,
     },
   };


### PR DESCRIPTION
## Summary
- Keep existing OSS users out of the OSS onboarding flow unless they are explicitly marked as needing onboarding.
- Initialize `customData.ossOnboarding = { isOnboardingDone: false }` only for newly registered OSS users when dev features are enabled and the registration happens in the admin tenant.
- Update the console guard and page logic to treat a missing OSS onboarding marker as exempt, and add regression tests for the console and core registration paths.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
